### PR TITLE
Fix #9

### DIFF
--- a/dagger/gen.go
+++ b/dagger/gen.go
@@ -114,8 +114,8 @@ package dagger
 #Copy: {
 	do:    "copy"
 	from:  #Script | #Component
-	src?:  string | *"/"
-	dest?: string | *"/"
+	src:  string | *"/"
+	dest: string | *"/"
 }
 
 #TestScript: #Script & [

--- a/dagger/spec.cue
+++ b/dagger/spec.cue
@@ -109,8 +109,8 @@ package dagger
 #Copy: {
 	do:    "copy"
 	from:  #Script | #Component
-	src?:  string | *"/"
-	dest?: string | *"/"
+	src:  string | *"/"
+	dest: string | *"/"
 }
 
 #TestScript: #Script & [


### PR DESCRIPTION
Since src and dest are mandatory (and already provide defaults), this seem to make more sense to not mark them as optional in the schema.

This will fix #9