### PR TITLE
solver: solve synchronously

### DIFF
--- a/dagger/component.go
+++ b/dagger/component.go
@@ -57,7 +57,10 @@ func (c *Component) Compute(ctx context.Context, s Solver, out Fillable) (FS, er
 	if err != nil {
 		return fs, err
 	}
-	_, err = fs.ReadDir(ctx, "/")
+
+	// Force a `Solve()` in case it hasn't been called earlier.
+	// If the FS is already solved, this is a noop.
+	_, err = fs.Solve(ctx)
 	return fs, err
 }
 

--- a/dagger/fs.go
+++ b/dagger/fs.go
@@ -105,10 +105,6 @@ func (fs FS) walk(ctx context.Context, p string, fn WalkFunc) error {
 type WalkFunc func(string, Stat) error
 
 func (fs FS) Walk(ctx context.Context, fn WalkFunc) error {
-	// Lazy solve
-	if err := (&fs).solve(ctx); err != nil {
-		return err
-	}
 	return fs.walk(ctx, "/", fn)
 }
 

--- a/dagger/solver.go
+++ b/dagger/solver.go
@@ -30,6 +30,7 @@ func (s Solver) Scratch() FS {
 	return s.FS(llb.Scratch())
 }
 
+// Solve will block until the state is solved and returns a Reference.
 func (s Solver) Solve(ctx context.Context, st llb.State) (bkgw.Reference, error) {
 	// marshal llb
 	def, err := st.Marshal(ctx, llb.LinuxAmd64)
@@ -37,7 +38,14 @@ func (s Solver) Solve(ctx context.Context, st llb.State) (bkgw.Reference, error)
 		return nil, err
 	}
 	// call solve
-	res, err := s.c.Solve(ctx, bkgw.SolveRequest{Definition: def.ToPB()})
+	res, err := s.c.Solve(ctx, bkgw.SolveRequest{
+		Definition: def.ToPB(),
+
+		// makes Solve() to block until LLB graph is solved. otherwise it will
+		// return result (that you can for example use for next build) that
+		// will be evaluated on export or if you access files on it.
+		Evaluate: true,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This forces Solve() to be synchronous and ensures operations don't get
discarded because of optimizations.

Improves fix for #14

Signed-off-by: Andrea Luzzardi <aluzzardi@gmail.com>