### PR TITLE
script: abort execution with a warning when the op is not concrete

### DIFF
--- a/dagger/value.go
+++ b/dagger/value.go
@@ -167,30 +167,8 @@ func (v *Value) MergeTarget(x interface{}, target string) (*Value, error) {
 }
 
 // Recursive concreteness check.
-// Return false if v is not concrete, or contains any
-// non-concrete fields or items.
-func (v *Value) IsConcreteR() bool {
-	// FIXME: use Value.Walk
-	if it, err := v.Fields(); err == nil {
-		for it.Next() {
-			w := v.Wrap(it.Value())
-			if !w.IsConcreteR() {
-				return false
-			}
-		}
-		return true
-	}
-	if it, err := v.List(); err == nil {
-		for it.Next() {
-			w := v.Wrap(it.Value())
-			if !w.IsConcreteR() {
-				return false
-			}
-		}
-		return true
-	}
-	dv, _ := v.val.Default()
-	return v.val.IsConcrete() || dv.IsConcrete()
+func (v *Value) IsConcreteR() error {
+	return v.val.Validate(cue.Concrete(true))
 }
 
 // Export concrete values to JSON. ignoring non-concrete values.


### PR DESCRIPTION
This will:

- Abort the script rather than continuing into the next op, resulting in weird errors (e.g. `Unknown desc = open /tmp/buildkit-mount998455317/out: no such file or directory`)
- Issue a warning
- Display the validation error

Example:
```
5:17PM WRN script is not concrete, aborting execution error="invalid interpolation: test.#dagger.compute.1.args.2: non-concrete value string (type string)" path=test
```