### PR TITLE
test: re-enable undefined prop test

### DIFF
--- a/examples/tests/compute/undefined_prop/main.cue
+++ b/examples/tests/compute/undefined_prop/main.cue
@@ -1,5 +1,7 @@
 package testing
 
+hello: "world"
+
 bar: string
 
 #dagger: {

--- a/examples/tests/test.sh
+++ b/examples/tests/test.sh
@@ -29,9 +29,8 @@ test::compute(){
       "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute "$d"/compute/noop
   test::one "Compute: simple should succeed" --exit=0 --stdout="{}" \
       "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute "$d"/compute/simple
-
-  disable test::one "Compute: unresolved should fail (FIXME https://github.com/blocklayerhq/dagger/issues/28)" --exit=1 --stdout=  \
-      "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute "$d"/compute/invalid/undefined_prop
+  test::one "Compute: unresolved should be ignored" --exit=0 --stdout='{"hello":"world"}'  \
+      "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute "$d"/compute/undefined_prop
 }
 
 test::fetchcontainer(){


### PR DESCRIPTION
Rather than checking for failure, we verify that the computable part of
the configuration gets outputted.

Signed-off-by: Andrea Luzzardi <aluzzardi@gmail.com>