### PR TITLE
Refactor op/script/component loading and spec validation

### DIFF
--- a/dagger/client.go
+++ b/dagger/client.go
@@ -114,7 +114,7 @@ func (cfg *ClientConfig) Finalize(ctx context.Context) (map[string]string, error
 		return nil, errors.Wrap(err, "invalid client config")
 	}
 	// Finalize boot script
-	boot, err := v.Get("boot").Script()
+	boot, err := NewScript(v.Get("boot"))
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid env boot script")
 	}

--- a/dagger/compiler.go
+++ b/dagger/compiler.go
@@ -35,7 +35,7 @@ func (cc *Compiler) Spec() *Spec {
 	if err != nil {
 		panic(err)
 	}
-	cc.spec, err = v.Spec()
+	cc.spec, err = newSpec(v)
 	if err != nil {
 		panic(err)
 	}
@@ -56,12 +56,15 @@ func (cc *Compiler) Compile(name string, src interface{}) (*Value, error) {
 	return cc.Wrap(inst.Value(), inst), nil
 }
 
+// Compile a cue configuration, and load it as a script.
+// If the cue configuration is invalid, or does not match the script spec,
+//  return an error.
 func (cc *Compiler) CompileScript(name string, src interface{}) (*Script, error) {
 	v, err := cc.Compile(name, src)
 	if err != nil {
 		return nil, err
 	}
-	return v.Script()
+	return NewScript(v)
 }
 
 // Build a cue configuration tree from the files in fs.

--- a/dagger/component_test.go
+++ b/dagger/component_test.go
@@ -5,6 +5,38 @@ import (
 	"testing"
 )
 
+func TestComponentNotExist(t *testing.T) {
+	cc := &Compiler{}
+	root, err := cc.Compile("root.cue", `
+foo: hello: "world"
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = NewComponent(root.Get("bar")) // non-existent key
+	if err != ErrNotExist {
+		t.Fatal(err)
+	}
+	_, err = NewComponent(root.Get("foo")) // non-existent #dagger
+	if err != ErrNotExist {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadEmptyComponent(t *testing.T) {
+	cc := &Compiler{}
+	root, err := cc.Compile("root.cue", `
+foo: #dagger: {}
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = NewComponent(root.Get("foo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 // Test that default values in spec are applied at the component level
 // See issue #19
 func TestComponentDefaults(t *testing.T) {
@@ -28,7 +60,7 @@ func TestComponentDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c, err := v.Component()
+	c, err := NewComponent(v)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +85,7 @@ func TestValidateEmptyComponent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = v.Component()
+	_, err = NewComponent(v)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +97,7 @@ func TestValidateSimpleComponent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c, err := v.Component()
+	c, err := NewComponent(v)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dagger/env.go
+++ b/dagger/env.go
@@ -187,8 +187,9 @@ func (env *Env) Walk(ctx context.Context, fn EnvWalkFunc) (*Value, error) {
 		ctx := lg.WithContext(ctx)
 
 		lg.Debug().Msg("Env.Walk: processing")
+		// FIXME: get directly from state Value ? Locking issue?
 		val := env.cc.Wrap(v, flowInst)
-		c, err := val.Component()
+		c, err := NewComponent(val)
 		if os.IsNotExist(err) {
 			// Not a component: skip
 			return nil, nil
@@ -206,4 +207,10 @@ func (env *Env) Walk(ctx context.Context, fn EnvWalkFunc) (*Value, error) {
 		return out, err
 	}
 	return out, nil
+}
+
+// Return the component at the specified path in the config, eg. `www`
+// If the component does not exist, os.ErrNotExist is returned.
+func (env *Env) Component(target string) (*Component, error) {
+	return NewComponent(env.state.Get(target))
 }

--- a/dagger/gen.go
+++ b/dagger/gen.go
@@ -117,9 +117,4 @@ package dagger
 	src:  string | *"/"
 	dest: string | *"/"
 }
-
-#TestScript: #Script & [
-		{do: "fetch-container", ref: "alpine:latest"},
-		{do: "exec", args: ["echo", "hello", "world"]},
-]
 `

--- a/dagger/mount.go
+++ b/dagger/mount.go
@@ -13,6 +13,16 @@ type Mount struct {
 	v    *Value
 }
 
+func newMount(v *Value, dest string) (*Mount, error) {
+	if !v.Exists() {
+		return nil, ErrNotExist
+	}
+	return &Mount{
+		v:    v,
+		dest: dest,
+	}, nil
+}
+
 func (mnt *Mount) Validate(defs ...string) error {
 	return mnt.v.Validate(append(defs, "#Mount")...)
 }
@@ -26,7 +36,7 @@ func (mnt *Mount) LLB(ctx context.Context, s Solver) (llb.RunOption, error) {
 		return nil, fmt.Errorf("FIXME: cache mount not yet implemented")
 	}
 	// Compute source component or script, discarding fs writes & output value
-	from, err := mnt.v.Lookup("from").Executable()
+	from, err := newExecutable(mnt.v.Lookup("from"))
 	if err != nil {
 		return nil, errors.Wrap(err, "from")
 	}

--- a/dagger/op_test.go
+++ b/dagger/op_test.go
@@ -14,7 +14,7 @@ func TestLocalMatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	op, err := v.Op()
+	op, err := newOp(v)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +40,7 @@ func TestCopyMatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	op, err := v.Op()
+	op, err := newOp(v)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dagger/script.go
+++ b/dagger/script.go
@@ -3,6 +3,7 @@ package dagger
 import (
 	"context"
 
+	"cuelang.org/go/cue"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
@@ -15,13 +16,44 @@ type Script struct {
 	v *Value
 }
 
-func (s *Script) Validate() error {
-	// FIXME this crashes when a script is incomplete or empty
-	return s.Value().Validate("#Script")
+func NewScript(v *Value) (*Script, error) {
+	spec := v.cc.Spec().Get("#Script")
+	final, err := spec.Merge(v)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid script")
+	}
+	return newScript(final)
+}
+
+// Same as newScript, but without spec merge + validation.
+func newScript(v *Value) (*Script, error) {
+	if !v.Exists() {
+		return nil, ErrNotExist
+	}
+	// Assume script is valid.
+	// Spec validation is already done at component creation.
+	return &Script{
+		v: v,
+	}, nil
 }
 
 func (s *Script) Value() *Value {
 	return s.v
+}
+
+// Return the operation at index idx
+func (s *Script) Op(idx int) (*Op, error) {
+	v := s.v.LookupPath(cue.MakePath(cue.Index(idx)))
+	if !v.Exists() {
+		return nil, ErrNotExist
+	}
+	return newOp(v)
+}
+
+// Return the number of operations in the script
+func (s *Script) Len() uint64 {
+	l, _ := s.v.Len().Uint64()
+	return l
 }
 
 // Run a dagger script
@@ -38,7 +70,7 @@ func (s *Script) Execute(ctx context.Context, fs FS, out *Fillable) (FS, error) 
 				Msg("script is unspecified, aborting execution")
 			return ErrAbortExecution
 		}
-		op, err := v.Op()
+		op, err := newOp(v)
 		if err != nil {
 			return errors.Wrapf(err, "validate op %d/%d", idx+1, s.v.Len())
 		}
@@ -58,7 +90,7 @@ func (s *Script) Execute(ctx context.Context, fs FS, out *Fillable) (FS, error) 
 
 func (s *Script) Walk(ctx context.Context, fn func(op *Op) error) error {
 	return s.v.RangeList(func(idx int, v *Value) error {
-		op, err := v.Op()
+		op, err := newOp(v)
 		if err != nil {
 			return errors.Wrapf(err, "validate op %d/%d", idx+1, s.v.Len())
 		}

--- a/dagger/spec.cue
+++ b/dagger/spec.cue
@@ -112,8 +112,3 @@ package dagger
 	src:  string | *"/"
 	dest: string | *"/"
 }
-
-#TestScript: #Script & [
-		{do: "fetch-container", ref: "alpine:latest"},
-		{do: "exec", args: ["echo", "hello", "world"]},
-]

--- a/dagger/spec.go
+++ b/dagger/spec.go
@@ -10,6 +10,16 @@ type Spec struct {
 	root *Value
 }
 
+func newSpec(v *Value) (*Spec, error) {
+	// Spec contents must be a struct
+	if _, err := v.Struct(); err != nil {
+		return nil, err
+	}
+	return &Spec{
+		root: v,
+	}, nil
+}
+
 // eg. Validate(op, "#Op")
 func (s Spec) Validate(v *Value, defpath string) error {
 	// Lookup def by name, eg. "#Script" or "#Copy"

--- a/dagger/types.go
+++ b/dagger/types.go
@@ -2,14 +2,33 @@ package dagger
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	cueflow "cuelang.org/go/tools/flow"
 )
+
+var ErrNotExist = os.ErrNotExist
 
 // Implemented by Component, Script, Op
 type Executable interface {
 	Execute(context.Context, FS, *Fillable) (FS, error)
 	Walk(context.Context, func(*Op) error) error
+}
+
+func newExecutable(v *Value) (Executable, error) {
+	// NOTE: here we need full spec validation,
+	//   so we call NewScript, NewComponent, NewOp.
+	if script, err := NewScript(v); err == nil {
+		return script, nil
+	}
+	if component, err := NewComponent(v); err == nil {
+		return component, nil
+	}
+	if op, err := NewOp(v); err == nil {
+		return op, nil
+	}
+	return nil, fmt.Errorf("value is not executable")
 }
 
 // Something which can be filled in-place with a cue value

--- a/dagger/value_test.go
+++ b/dagger/value_test.go
@@ -29,28 +29,10 @@ func TestJSON(t *testing.T) {
 	}
 }
 
-func TestCompileBootScript(t *testing.T) {
-	cc := &Compiler{}
-	cfg, err := cc.Compile("boot.cue", baseClientConfig)
-	if err != nil {
-		t.Fatal(err)
-	}
-	s, err := cfg.Get("bootscript").Script()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := s.Validate(); err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestCompileSimpleScript(t *testing.T) {
 	cc := &Compiler{}
-	s, err := cc.CompileScript("simple.cue", `[{do: "local", dir: "."}]`)
+	_, err := cc.CompileScript("simple.cue", `[{do: "local", dir: "."}]`)
 	if err != nil {
-		t.Fatal(err)
-	}
-	if err := s.Validate(); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/examples/tests/compute/noop/main.cue
+++ b/examples/tests/compute/noop/main.cue
@@ -9,11 +9,3 @@ realempty: {
 empty: {
 	#dagger: compute: []
 }
-
-// additional prop, should not error
-withprops: {
-	#dagger: {
-		compute: []
-		foo: bar: "foo"
-	}
-}

--- a/examples/tests/compute/undefined_prop/main.cue
+++ b/examples/tests/compute/undefined_prop/main.cue
@@ -4,17 +4,14 @@ hello: "world"
 
 bar: string
 
-#dagger: {
-	compute: [
-		{
-			do:  "fetch-container"
-			ref: "alpine"
-		},
-		{
-			do:  "exec"
-			dir: "/"
-			args: ["sh", "-c", "echo \(foo.bar)"]
-		},
-	]
-	foo: bar: bar
-}
+#dagger: compute: [
+	{
+		do:  "fetch-container"
+		ref: "alpine"
+	},
+	{
+		do:  "exec"
+		dir: "/"
+		args: ["sh", "-c", "echo \(bar)"]
+	},
+]

--- a/examples/tests/test.sh
+++ b/examples/tests/test.sh
@@ -25,11 +25,11 @@ test::compute(){
       "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute "$d"/compute/invalid/int
   test::one "Compute: invalid struct should fail" --exit=1 --stdout= \
       "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute "$d"/compute/invalid/struct
-  test::one "Compute: noop should succeed" --exit=0 --stdout='{"empty":{},"realempty":{},"withprops":{}}'  \
+  test::one "Compute: noop should succeed" --exit=0 --stdout='{"empty":{},"realempty":{}}'  \
       "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute "$d"/compute/noop
   test::one "Compute: simple should succeed" --exit=0 --stdout="{}" \
       "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute "$d"/compute/simple
-  test::one "Compute: unresolved should be ignored" --exit=0 --stdout='{"hello":"world"}'  \
+  test::one "Compute: script with undefined values should not fail" --exit=0 --stdout='{"hello":"world"}'  \
       "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute "$d"/compute/undefined_prop
 }
 


### PR DESCRIPTION
Cleanup and simplify the code which loads and validates a `Component`, `Script` or `Op` from a `Value`.

- Spec is now correctly merged at the component level, which *should* fix several open issues (to be confirmed before merging)
- More fine-grained control of when to merge spec, and when not to: `NewXXX` merges - `newXXX` does not.
- As a side effect, user-defined props are no longer tolerated inside `#dagger`: fixed integration tests accordingly.
- Added unit tests as needed to track down and fix various issues uncovered during implementation

- As requested by @aluzzardi ,  it should now be easier to split up `dagger` into sub-modules as needed.