### PR TITLE
output: merge base/input/output into a single state.cue

### DIFF
--- a/examples/tests/input/default/main.cue
+++ b/examples/tests/input/default/main.cue
@@ -1,0 +1,27 @@
+package testing
+
+X1=in: string | *"default input"
+
+test: {
+	string
+
+	#dagger: compute: [
+		{
+			do:  "fetch-container"
+			ref: "alpine"
+		},
+		{
+			do: "exec"
+			args: ["sh", "-c", """
+				echo -n "received: \(X1)" > /out
+				"""]
+			// XXX Blocked by https://github.com/blocklayerhq/dagger/issues/19
+			dir: "/"
+		},
+		{
+			do:     "export"
+			source: "/out"
+			format: "string"
+		},
+	]
+}

--- a/examples/tests/input/simple/main.cue
+++ b/examples/tests/input/simple/main.cue
@@ -1,0 +1,27 @@
+package testing
+
+X1=in: string
+
+test: {
+	string
+
+	#dagger: compute: [
+		{
+			do:  "fetch-container"
+			ref: "alpine"
+		},
+		{
+			do: "exec"
+			args: ["sh", "-c", """
+				echo -n "received: \(X1)" > /out
+				"""]
+			// XXX Blocked by https://github.com/blocklayerhq/dagger/issues/19
+			dir: "/"
+		},
+		{
+			do:     "export"
+			source: "/out"
+			format: "string"
+		},
+	]
+}

--- a/examples/tests/test.sh
+++ b/examples/tests/test.sh
@@ -163,6 +163,21 @@ test::mount(){
       "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute "$d"/mount/valid/script
 }
 
+test::input() {
+  test::one "Input: missing input should skip execution" --exit=0 --stdout='{}' \
+      "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute "$d"/input/simple
+
+  test::one "Input: simple input" --exit=0 --stdout='{"in":"foobar","test":"received: foobar"}' \
+      "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute --input 'in: "foobar"' "$d"/input/simple
+
+  test::one "Input: default values" --exit=0 --stdout='{"in":"default input","test":"received: default input"}' \
+      "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute "$d"/input/default
+
+  test::one "Input: override default value" --exit=0 --stdout='{"in":"foobar","test":"received: foobar"}' \
+      "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute --input 'in: "foobar"' "$d"/input/default
+}
+
+
 test::all(){
   local dagger="$1"
 
@@ -176,6 +191,7 @@ test::all(){
   test::fetchgit "$dagger"
   test::exec "$dagger"
   test::export "$dagger"
+  test::input "$dagger"
 }
 
 case "${1:-all}" in


### PR DESCRIPTION
Exporting base/input/output separately causes merge errors.

For instance, `foo: string | *"default foo"` gets serialized as `{"foo":"default foo"}`, which will fail to merge if output contains a different definition of `foo`.

This change temporarily merges the 3 streams together before serializing.

Fixes #51