### PR TITLE
Update gen.sh to remove redundant error check

### DIFF
--- a/dagger/gen.sh
+++ b/dagger/gen.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -e
-cue eval spec.cue >/dev/null
 (
 cat <<'EOF'
 package dagger


### PR DESCRIPTION
cue eval spec.cue >/dev/null removed (redunant per @shykes)

Signed-off-by: Dan POP <dan.papandrea@sysdig.com>