### PR TITLE
Better ux for inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,7 @@ which hide the complexity of `dagger compute` (but it will always be available t
 Here is an example command, using an example configuration:
 
 ```
-$ dagger compute \
-	./examples/simple \
-	--input 'www: hostname: "www.mysuperapp.com"' \
-	--input 'www: source: #dagger: compute: [{do:"fetch-git", remote:"https://github.com/samalba/hello-go", ref:"master"}]'
+$ dagger compute ./examples/simple --input-string www.host=mysuperapp.com --input-dir www.source=.
 ```
 
 

--- a/dagger/compute.go
+++ b/dagger/compute.go
@@ -27,8 +27,11 @@ func Compute(ctx context.Context, c bkgw.Client) (r *bkgw.Result, err error) {
 	if o, exists := c.BuildOpts().Opts[bkUpdaterKey]; exists {
 		updater = o
 	}
-	env, err := NewEnv(updater)
+	env, err := NewEnv()
 	if err != nil {
+		return nil, err
+	}
+	if err := env.SetUpdater(updater); err != nil {
 		return nil, err
 	}
 	if err := env.Update(ctx, s); err != nil {

--- a/dagger/env_test.go
+++ b/dagger/env_test.go
@@ -1,0 +1,71 @@
+package dagger
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSimpleEnvSet(t *testing.T) {
+	env, err := NewEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := env.SetInput(`hello: "world"`); err != nil {
+		t.Fatal(err)
+	}
+	hello, err := env.State().Get("hello").String()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hello != "world" {
+		t.Fatal(hello)
+	}
+}
+
+func TestSimpleEnvSetFromInputValue(t *testing.T) {
+	env, err := NewEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v, err := env.Compiler().Compile("", `hello: "world"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := env.SetInput(v); err != nil {
+		t.Fatal(err)
+	}
+	hello, err := env.State().Get("hello").String()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hello != "world" {
+		t.Fatal(hello)
+	}
+}
+
+func TestEnvInputComponent(t *testing.T) {
+	env, err := NewEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v, err := env.Compiler().Compile("", `foo: #dagger: compute: [{do:"local",dir:"."}]`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := env.SetInput(v); err != nil {
+		t.Fatal(err)
+	}
+
+	localdirs, err := env.LocalDirs(context.TODO())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(localdirs) != 1 {
+		t.Fatal(localdirs)
+	}
+	if dir, ok := localdirs["."]; !ok || dir != "." {
+		t.Fatal(localdirs)
+	}
+}

--- a/dagger/input.go
+++ b/dagger/input.go
@@ -1,0 +1,239 @@
+package dagger
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"cuelang.org/go/cue"
+	"github.com/spf13/pflag"
+)
+
+// A mutable cue value with an API suitable for user inputs,
+// such as command-line flag parsing.
+type InputValue struct {
+	root *Value
+	cc   *Compiler
+}
+
+func (iv *InputValue) Value() *Value {
+	return iv.root
+}
+
+func (iv *InputValue) String() string {
+	s, _ := iv.root.SourceString()
+	return s
+}
+
+func NewInputValue(cc *Compiler, base interface{}) (*InputValue, error) {
+	root, err := cc.Compile("base", base)
+	if err != nil {
+		return nil, err
+	}
+	return &InputValue{
+		cc:   cc,
+		root: root,
+	}, nil
+}
+
+func (iv *InputValue) Set(s string, enc func(string, *Compiler) (interface{}, error)) error {
+	// Split from eg. 'foo.bar={bla:"bla"}`
+	k, vRaw := splitkv(s)
+	v, err := enc(vRaw, iv.cc)
+	if err != nil {
+		return err
+	}
+	root, err := iv.root.MergePath(v, k)
+	if err != nil {
+		return err
+	}
+	iv.root = root
+	return nil
+}
+
+// Adapter to receive string values from pflag
+func (iv *InputValue) StringFlag() pflag.Value {
+	return stringFlag{
+		iv: iv,
+	}
+}
+
+type stringFlag struct {
+	iv *InputValue
+}
+
+func (sf stringFlag) Set(s string) error {
+	return sf.iv.Set(s, func(s string, _ *Compiler) (interface{}, error) {
+		return s, nil
+	})
+}
+
+func (sf stringFlag) String() string {
+	return sf.iv.String()
+}
+
+func (sf stringFlag) Type() string {
+	return "STRING"
+}
+
+// DIR FLAG
+// Receive a local directory path and translate it into a component
+func (iv *InputValue) DirFlag(include ...string) pflag.Value {
+	if include == nil {
+		include = []string{}
+	}
+	return dirFlag{
+		iv:      iv,
+		include: include,
+	}
+}
+
+type dirFlag struct {
+	iv      *InputValue
+	include []string
+}
+
+func (f dirFlag) Set(s string) error {
+	return f.iv.Set(s, func(s string, cc *Compiler) (interface{}, error) {
+		// FIXME: this is a hack because cue API can't merge into a list
+		include, err := json.Marshal(f.include)
+		if err != nil {
+			return nil, err
+		}
+		return cc.Compile("", fmt.Sprintf(
+			`#dagger: compute: [{do:"local",dir:"%s", include:%s}]`,
+			s,
+			include,
+		))
+	})
+}
+
+func (f dirFlag) String() string {
+	return f.iv.String()
+}
+
+func (f dirFlag) Type() string {
+	return "PATH"
+}
+
+// GIT FLAG
+// Receive a git repository reference and translate it into a component
+func (iv *InputValue) GitFlag() pflag.Value {
+	return gitFlag{
+		iv: iv,
+	}
+}
+
+type gitFlag struct {
+	iv *InputValue
+}
+
+func (f gitFlag) Set(s string) error {
+	return f.iv.Set(s, func(s string, cc *Compiler) (interface{}, error) {
+		u, err := url.Parse(s)
+		if err != nil {
+			return nil, fmt.Errorf("invalid git url")
+		}
+		ref := u.Fragment // eg. #main
+		u.Fragment = ""
+		remote := u.String()
+
+		return cc.Compile("", fmt.Sprintf(
+			`#dagger: compute: [{do:"fetch-git", remote:"%s", ref:"%s"}]`,
+			remote,
+			ref,
+		))
+	})
+}
+
+func (f gitFlag) String() string {
+	return f.iv.String()
+}
+
+func (f gitFlag) Type() string {
+	return "REMOTE,REF"
+}
+
+// SOURCE FLAG
+// Adapter to receive a simple source description and translate it to a loader script.
+// For example 'git+https://github.com/cuelang/cue#master` -> [{do:"git",remote:"https://github.com/cuelang/cue",ref:"master"}]
+
+func (iv *InputValue) SourceFlag() pflag.Value {
+	return sourceFlag{
+		iv: iv,
+	}
+}
+
+type sourceFlag struct {
+	iv *InputValue
+}
+
+func (f sourceFlag) Set(s string) error {
+	return f.iv.Set(s, func(s string, cc *Compiler) (interface{}, error) {
+		u, err := url.Parse(s)
+		if err != nil {
+			return nil, err
+		}
+		switch u.Scheme {
+		case "", "file":
+			return cc.Compile(
+				"source",
+				// FIXME: include only cue files as a shortcut. Make this configurable somehow.
+				fmt.Sprintf(`[{do:"local",dir:"%s",include:["*.cue","cue.mod"]}]`, u.Host+u.Path),
+			)
+		default:
+			return nil, fmt.Errorf("unsupported source scheme: %q", u.Scheme)
+		}
+	})
+}
+
+func (f sourceFlag) String() string {
+	return f.iv.String()
+}
+
+func (f sourceFlag) Type() string {
+	return "PATH | file://PATH | git+ssh://HOST/PATH | git+https://HOST/PATH"
+}
+
+// RAW CUE FLAG
+// Adapter to receive raw cue values from pflag
+func (iv *InputValue) CueFlag() pflag.Value {
+	return cueFlag{
+		iv: iv,
+	}
+}
+
+type cueFlag struct {
+	iv *InputValue
+}
+
+func (f cueFlag) Set(s string) error {
+	return f.iv.Set(s, func(s string, cc *Compiler) (interface{}, error) {
+		return cc.Compile("cue input", s)
+	})
+}
+
+func (f cueFlag) String() string {
+	return f.iv.String()
+}
+
+func (f cueFlag) Type() string {
+	return "CUE"
+}
+
+// UTILITIES
+
+func splitkv(kv string) (cue.Path, string) {
+	parts := strings.SplitN(kv, "=", 2)
+	if len(parts) == 2 {
+		if parts[0] == "." || parts[0] == "" {
+			return cue.MakePath(), parts[1]
+		}
+		return cue.ParsePath(parts[0]), parts[1]
+	}
+	if len(parts) == 1 {
+		return cue.MakePath(), parts[0]
+	}
+	return cue.MakePath(), ""
+}

--- a/dagger/input_test.go
+++ b/dagger/input_test.go
@@ -1,0 +1,35 @@
+package dagger
+
+import (
+	"context"
+	"testing"
+)
+
+func TestEnvInputFlag(t *testing.T) {
+	env, err := NewEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	input, err := NewInputValue(env.Compiler(), `{}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := input.DirFlag().Set("www.source=."); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.SetInput(input.Value()); err != nil {
+		t.Fatal(err)
+	}
+
+	localdirs, err := env.LocalDirs(context.TODO())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(localdirs) != 1 {
+		t.Fatal(localdirs)
+	}
+	if dir, ok := localdirs["."]; !ok || dir != "." {
+		t.Fatal(localdirs)
+	}
+}

--- a/dagger/script.go
+++ b/dagger/script.go
@@ -101,6 +101,11 @@ func (s *Script) Walk(ctx context.Context, fn func(op *Op) error) error {
 }
 
 func (s *Script) LocalDirs(ctx context.Context) (map[string]string, error) {
+	lg := log.Ctx(ctx)
+	lg.Debug().
+		Str("func", "Script.LocalDirs").
+		Str("location", s.Value().Path().String()).
+		Msg("starting")
 	dirs := map[string]string{}
 	err := s.Walk(ctx, func(op *Op) error {
 		if err := op.Validate("#Local"); err != nil {
@@ -114,5 +119,11 @@ func (s *Script) LocalDirs(ctx context.Context) (map[string]string, error) {
 		dirs[dir] = dir
 		return nil
 	})
+	lg.Debug().
+		Str("func", "Script.LocalDirs").
+		Str("location", s.Value().Path().String()).
+		Interface("err", err).
+		Interface("result", dirs).
+		Msg("done")
 	return dirs, err
 }

--- a/dagger/value.go
+++ b/dagger/value.go
@@ -32,8 +32,7 @@ func wrapValue(v cue.Value, inst *cue.Instance, cc *Compiler) *Value {
 	}
 }
 
-// Fill is a concurrency safe wrapper around cue.Value.Fill()
-// This is the only method which changes the value in-place.
+// Fill the value in-place, unlike Merge which returns a copy.
 func (v *Value) Fill(x interface{}) error {
 	v.cc.Lock()
 	defer v.cc.Unlock()
@@ -94,6 +93,11 @@ func (v *Value) Exists() bool {
 // Proxy function to the underlying cue.Value
 func (v *Value) String() (string, error) {
 	return v.val.String()
+}
+
+func (v *Value) SourceUnsafe() string {
+	s, _ := v.SourceString()
+	return s
 }
 
 // Proxy function to the underlying cue.Value

--- a/examples/tests/test.sh
+++ b/examples/tests/test.sh
@@ -94,7 +94,7 @@ test::exec(){
   test::one "Exec: env valid" --exit=0 --stdout={} \
       "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute  "$d"/exec/env/valid
   test::one "Exec: env with overlay" --exit=0 \
-      "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute --input 'bar: "overlay environment"' "$d"/exec/env/overlay
+      "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute --input-cue 'bar: "overlay environment"' "$d"/exec/env/overlay
 
   test::one "Exec: non existent dir" --exit=0 --stdout={} \
       "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute  "$d"/exec/dir/doesnotexist
@@ -191,13 +191,13 @@ test::input() {
       "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute "$d"/input/simple
 
   test::one "Input: simple input" --exit=0 --stdout='{"in":"foobar","test":"received: foobar"}' \
-      "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute --input 'in: "foobar"' "$d"/input/simple
+      "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute --input-cue 'in: "foobar"' "$d"/input/simple
 
   test::one "Input: default values" --exit=0 --stdout='{"in":"default input","test":"received: default input"}' \
       "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute "$d"/input/default
 
   test::one "Input: override default value" --exit=0 --stdout='{"in":"foobar","test":"received: foobar"}' \
-      "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute --input 'in: "foobar"' "$d"/input/default
+      "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute --input-cue 'in: "foobar"' "$d"/input/default
 }
 
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.20.0
 	github.com/spf13/cobra v1.0.0
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
 	github.com/tonistiigi/fsutil v0.0.0-20201103201449-0834f99b7b85
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9


### PR DESCRIPTION
This adds new flags to `dagger compute` which are much more user-friendly.

`--input-dir TARGET=DIR` to add a local directory as input. For example `—input-dir www.source=./src`
`--input-string TARGET=STRING` to add a string value as input. For example `—input-string www.host=localhost`
`--input-cue CUE` to add a raw cue expression (same as the old `--input`)
`--input-git REMOTE#REF` to add a remote git repository as input. For example `--input-git https://github.com/cuelang/cue#0.2.2`
