### PR TITLE
Fix out-of-the-blue linter errors

### DIFF
--- a/dagger/fs.go
+++ b/dagger/fs.go
@@ -170,7 +170,7 @@ func bkCleanError(err error) error {
 	msg := err.Error()
 
 	for _, s := range noise {
-		msg = strings.Replace(msg, s, "", -1)
+		msg = strings.ReplaceAll(msg, s, "")
 	}
 
 	return errors.New(msg)

--- a/dagger/spec_test.go
+++ b/dagger/spec_test.go
@@ -17,40 +17,6 @@ func TestMatch(t *testing.T) {
 			Src: `do: "fetch-git", remote: "github.com/shykes/tests"`,
 			Def: "#FetchGit",
 		},
-		//FIXME: load is temporarily disabled
-		//		{
-		//			Src: `do: "load", from: [{do: "exec", args: ["echo", "hello"]}]`,
-		//			Def: "#Load",
-		//		},
-		//		{
-		//			Src: `do: "load", from: #dagger: compute: [{do: "exec", args: ["echo", "hello"]}]`,
-		//			Def: "#Load",
-		//		},
-		//		// Make sure an empty op does NOT match
-		//		{
-		//			Src: ``,
-		//			Def: "",
-		//		},
-		//		{
-		//			Src: `do: "load"
-		//let package={bash:">3.0"}
-		//from: foo
-		//let foo={#dagger: compute: [
-		//	{do: "fetch-container", ref: "alpine"},
-		//	for pkg, info in package {
-		//		if (info & true) != _|_ {
-		//			do: "exec"
-		//			args: ["echo", "hello", pkg]
-		//		}
-		//		if (info & string) != _|_ {
-		//			do: "exec"
-		//			args: ["echo", "hello", pkg, info]
-		//		}
-		//	}
-		//]}
-		//`,
-		//			Def: "#Load",
-		//		},
 	}
 	for _, d := range data {
 		testMatch(t, d.Src, d.Def)


### PR DESCRIPTION
My new dev setup has new linter errors. I don’t know why, but it’s easier to just fix them :)

```
For some reason `make lint` fails on `main`, on my new dev setup.

```
$ make lint
golangci-lint run
dagger/fs.go:173:9: wrapperFunc: use strings.ReplaceAll method in `strings.Replace(msg, s, "", -1)` (gocritic)
                msg = strings.Replace(msg, s, "", -1)
                      ^
dagger/spec_test.go:20:3: commentFormatting: put a space between `//` and comment text (gocritic)
                //FIXME: load is temporarily disabled
                ^
make: *** [Makefile:26: lint] Error 1
```