### PR TITLE
{do:"subdir"} to select a subdirectory in a script

### DIFF
--- a/dagger/gen.go
+++ b/dagger/gen.go
@@ -60,7 +60,7 @@ package dagger
 #Script: [...#Op]
 
 // One operation in a script
-#Op: #FetchContainer | #FetchGit | #Export | #Exec | #Local | #Copy | #Load
+#Op: #FetchContainer | #FetchGit | #Export | #Exec | #Local | #Copy | #Load | #Subdir
 
 // Export a value from fs state to cue
 #Export: {
@@ -81,6 +81,11 @@ package dagger
 #Load: {
 	do:   "load"
 	from: #Component | #Script
+}
+
+#Subdir: {
+	do:  "subdir"
+	dir: string | *"/"
 }
 
 #Exec: {

--- a/dagger/spec.cue
+++ b/dagger/spec.cue
@@ -55,7 +55,7 @@ package dagger
 #Script: [...#Op]
 
 // One operation in a script
-#Op: #FetchContainer | #FetchGit | #Export | #Exec | #Local | #Copy | #Load
+#Op: #FetchContainer | #FetchGit | #Export | #Exec | #Local | #Copy | #Load | #Subdir
 
 // Export a value from fs state to cue
 #Export: {
@@ -76,6 +76,11 @@ package dagger
 #Load: {
 	do:   "load"
 	from: #Component | #Script
+}
+
+#Subdir: {
+	do:  "subdir"
+	dir: string | *"/"
 }
 
 #Exec: {

--- a/tests/subdir/simple/main.cue
+++ b/tests/subdir/simple/main.cue
@@ -1,0 +1,29 @@
+package main
+
+hello: {
+	string
+
+	#dagger: compute: [
+		{
+			do:  "fetch-container"
+			ref: "alpine"
+		},
+		{
+			do: "exec"
+			args: ["mkdir", "-p", "/tmp/foo"]
+		},
+		{
+			do: "exec"
+			args: ["sh", "-c", "echo -n world > /tmp/foo/hello"]
+		},
+		{
+			do:  "subdir"
+			dir: "/tmp/foo"
+		},
+		{
+			do:     "export"
+			source: "/hello"
+			format: "string"
+		},
+	]
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -217,6 +217,11 @@ test::input() {
 }
 
 
+test::subdir() {
+  test::one "Subdir: simple usage" --exit=0 --stdout='{"hello":"world"}' \
+      "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute "$d"/subdir/simple
+}
+
 test::all(){
   local dagger="$1"
 
@@ -231,6 +236,7 @@ test::all(){
   test::exec "$dagger"
   test::export "$dagger"
   test::input "$dagger"
+  test::subdir "$dagger"
 }
 
 case "${1:-all}" in


### PR DESCRIPTION
Note: this relies on `llb.Copy` under the hood, which means a copy will be performed even if it is not needed (for example if the subdirectory is only used to mount). This can be further optimized later, by carrying subdir information as metadata along with the filesystem state, and applying it only when needed: at mount, copy or load. There is a FIXME noting this.