### PR TITLE
solver: trace LLB

### DIFF
--- a/dagger/solver.go
+++ b/dagger/solver.go
@@ -2,9 +2,14 @@ package dagger
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/moby/buildkit/client/llb"
 	bkgw "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 )
 
 // Polyfill for buildkit gateway client
@@ -37,6 +42,18 @@ func (s Solver) Solve(ctx context.Context, st llb.State) (bkgw.Reference, error)
 	if err != nil {
 		return nil, err
 	}
+
+	llb, err := dumpLLB(def)
+	if err != nil {
+		return nil, err
+	}
+
+	log.
+		Ctx(ctx).
+		Trace().
+		RawJSON("llb", llb).
+		Msg("solving")
+
 	// call solve
 	res, err := s.c.Solve(ctx, bkgw.SolveRequest{
 		Definition: def.ToPB(),
@@ -51,4 +68,24 @@ func (s Solver) Solve(ctx context.Context, st llb.State) (bkgw.Reference, error)
 	}
 	// always use single reference (ignore multiple outputs & metadata)
 	return res.SingleRef()
+}
+
+type llbOp struct {
+	Op         pb.Op
+	Digest     digest.Digest
+	OpMetadata pb.OpMetadata
+}
+
+func dumpLLB(def *llb.Definition) ([]byte, error) {
+	ops := make([]llbOp, 0, len(def.Def))
+	for _, dt := range def.Def {
+		var op pb.Op
+		if err := (&op).Unmarshal(dt); err != nil {
+			return nil, errors.Wrap(err, "failed to parse op")
+		}
+		dgst := digest.FromBytes(dt)
+		ent := llbOp{Op: op, Digest: dgst, OpMetadata: def.Metadata[dgst]}
+		ops = append(ops, ent)
+	}
+	return json.Marshal(ops)
 }


### PR DESCRIPTION
Enabled LLB json serialization for debugging.

This is only visible with TRACE level logs (`-l trace`):

```
$ dagger compute ./examples/simple -l trace
[...]
3:06PM TRC solving LLB llb="[{\"Op\":{\"Op\":{\"source\":{\"identifier\":\"docker-image://docker.io/library/alpine:latest\"}},\"platform\":{\"Architecture\":\"amd64\",\"OS\":\"linux\"},\"constraints\":{}},\"Digest\":\"sha256:665ba8b2cdc0cb0200e2a42a6b3c0f8f684089f4cd1b81494fbb9805879120f7\",\"OpMetadata\":{\"caps\":{\"source.image\":true}}},{\"Op\":{\"inputs\":[{\"digest\":\"sha256:665ba8b2cdc0cb0200e2a42a6b3c0f8f684089f4cd1b81494fbb9805879120f7\",\"index\":0}],\"Op\":{\"exec\":{\"meta\":{\"args\":[\"sh\",\"-c\",\"tr -dc A-Za-z0-9 \\u003c/dev/urandom | head -c 13 \\u003e /id\"],\"env\":[\"DAGGER_CACHEBUSTER=01ea44dbd46947a1\"],\"cwd\":\"/\"},\"mounts\":[{\"input\":0,\"dest\":\"/\",\"output\":0}]}},\"platform\":{\"Architecture\":\"amd64\",\"OS\":\"linux\"},\"constraints\":{}},\"Digest\":\"sha256:d43cb9d251bd2aafdc301301d56d1d2c5ac2d8ec5220c7354317212faca1cd98\",\"OpMetadata\":{\"description\":{\"llb.customname\":\"component.#dagger.compute[1]\"},\"caps\":{\"exec.meta.base\":true,\"exec.mount.bind\":true}}},{\"Op\":{\"inputs\":[{\"digest\":\"sha256:d43cb9d251bd2aafdc301301d56d1d2c5ac2d8ec5220c7354317212faca1cd98\",\"index\":0}],\"Op\":null},\"Digest\":\"sha256:03874eebbbb7145145953f97dd6ca5bfb47a6950e8cd37d810fc509812d7e4be\",\"OpMetadata\":{\"caps\":{\"constraints\":true,\"meta.description\":true,\"platform\":true}}}]" path=component
```