### PR TITLE
re-enable spec generation

### DIFF
--- a/dagger/spec.go
+++ b/dagger/spec.go
@@ -1,3 +1,5 @@
+//go:generate sh gen.sh
+
 package dagger
 
 import (


### PR DESCRIPTION
`//go:generate` got lost in translation in  #107 