### PR TITLE
For discussion: Alternative to #dagger:compute syntax

### DIFF
--- a/dagger/compiler/value.go
+++ b/dagger/compiler/value.go
@@ -73,6 +73,11 @@ func (v *Value) Fields() (*cue.Iterator, error) {
 }
 
 // Proxy function to the underlying cue.Value
+func (v *Value) Attribute(key string) cue.Attribute {
+	return v.val.Attribute(key)
+}
+
+// Proxy function to the underlying cue.Value
 func (v *Value) Struct() (*cue.Struct, error) {
 	return v.val.Struct()
 }
@@ -90,6 +95,10 @@ func (v *Value) String() (string, error) {
 func (v *Value) SourceUnsafe() string {
 	s, _ := v.SourceString()
 	return s
+}
+
+func (v *Value) Kind() cue.Kind {
+	return v.val.Kind()
 }
 
 // Proxy function to the underlying cue.Value

--- a/dagger/input.go
+++ b/dagger/input.go
@@ -102,7 +102,7 @@ func (f dirFlag) Set(s string) error {
 			return nil, err
 		}
 		return compiler.Compile("", fmt.Sprintf(
-			`#dagger: compute: [{do:"local",dir:"%s", include:%s}]`,
+			`#run: [{do:"local",dir:"%s", include:%s}] @dagger()`,
 			s,
 			include,
 		))

--- a/dagger/pipeline.go
+++ b/dagger/pipeline.go
@@ -36,7 +36,7 @@ func ops(code ...*compiler.Value) ([]*compiler.Value, error) {
 	// 1. Decode 'code' into a single flat array of operations.
 	for _, x := range code {
 		// 1. attachment array
-		if xops, err := x.Get("#dagger.compute").List(); err == nil {
+		if xops, err := x.Get("#run").List(); err == nil {
 			// 'from' has an executable attached
 			ops = append(ops, xops...)
 			continue

--- a/stdlib/dagger/dagger.cue
+++ b/stdlib/dagger/dagger.cue
@@ -4,6 +4,10 @@ package dagger
 // every dagger script outputs a filesystem state (aka a directory)
 #Dir: #dagger: compute: [...#Op]
 
+#Component: {
+	#run: [...#Op] @dagger()
+}
+
 // One operation in a script
 #Op: #FetchContainer | #FetchGit | #Export | #Exec | #Local | #Copy | #Load | #Subdir
 

--- a/stdlib/netlify/netlify.cue
+++ b/stdlib/netlify/netlify.cue
@@ -30,10 +30,10 @@ import "dagger.io/dagger"
 	create: bool | *true
 
 	// Deployment url
-	url: {
-		string
+	url: string
 
-		#dagger: compute: [
+	dagger.#Component & {
+		#run: [
 			dagger.#FetchContainer & {
 				ref: "alpine@sha256:08d6ca16c60fe7490c03d10dc339d9fd8ea67c6466dea8d558526b1330a85930"
 			},
@@ -77,8 +77,8 @@ import "dagger.io/dagger"
 				mount: "/src": from: contents
 			},
 			dagger.#Export & {
-				source: "/url"
-				format: "string"
+				source: "/output"
+				format: "json"
 			},
 		]
 	}
@@ -122,5 +122,5 @@ let code = #"""
 	    --prod \
 	| tee /tmp/stdout
 
-	</tmp/stdout sed -n -e 's/^Website URL:.*\(https:\/\/.*\)$/\1/p' | tr -d '\n' > /url
+	</tmp/stdout sed -n -e 's/^Website URL:.*\(https:\/\/.*\)$/\1/p' | tr -d '\n' | jq -R '{url: .}' > /output
 	"""#

--- a/stdlib/yarn/yarn.cue
+++ b/stdlib/yarn/yarn.cue
@@ -19,46 +19,48 @@ import (
 	// Set these environment variables during the build
 	env?: [string]: string
 
-	#dagger: compute: [
-		dagger.#FetchContainer & {
-			ref: "alpine@sha256:08d6ca16c60fe7490c03d10dc339d9fd8ea67c6466dea8d558526b1330a85930"
-		},
-		dagger.#Exec & {
-			args: ["apk", "add", "-U", "--no-cache", "bash=5.1.0-r0"]
-		},
-		dagger.#Exec & {
-			args: ["apk", "add", "-U", "--no-cache", "yarn=1.22.10-r0"]
-		},
-		dagger.#Exec & {
-			args: [
-				"/bin/bash",
-				"--noprofile",
-				"--norc",
-				"-eo",
-				"pipefail",
-				"-c",
-				"""
-					yarn install --production false
-					yarn run "$YARN_BUILD_SCRIPT"
-					mv "$YARN_BUILD_DIRECTORY" /build
-					""",
-			]
-			if env != _|_ {
-				"env": env
-			}
-			"env": {
-				YARN_BUILD_SCRIPT:    run
-				YARN_CACHE_FOLDER:    "/cache/yarn"
-				YARN_BUILD_DIRECTORY: buildDirectory
-			}
-			dir: "/src"
-			mount: {
-				"/src": from: source
-				"/cache/yarn": "cache"
-			}
-		},
-		dagger.#Subdir & {
-			dir: "/build"
-		},
-	]
+	dagger.#Component & {
+		#run: [
+			dagger.#FetchContainer & {
+				ref: "alpine@sha256:08d6ca16c60fe7490c03d10dc339d9fd8ea67c6466dea8d558526b1330a85930"
+			},
+			dagger.#Exec & {
+				args: ["apk", "add", "-U", "--no-cache", "bash=5.1.0-r0"]
+			},
+			dagger.#Exec & {
+				args: ["apk", "add", "-U", "--no-cache", "yarn=1.22.10-r0"]
+			},
+			dagger.#Exec & {
+				args: [
+					"/bin/bash",
+					"--noprofile",
+					"--norc",
+					"-eo",
+					"pipefail",
+					"-c",
+					"""
+						yarn install --production false
+						yarn run "$YARN_BUILD_SCRIPT"
+						mv "$YARN_BUILD_DIRECTORY" /build
+						""",
+				]
+				if env != _|_ {
+					"env": env
+				}
+				"env": {
+					YARN_BUILD_SCRIPT:    run
+					YARN_CACHE_FOLDER:    "/cache/yarn"
+					YARN_BUILD_DIRECTORY: buildDirectory
+				}
+				dir: "/src"
+				mount: {
+					"/src": from: source
+					"/cache/yarn": "cache"
+				}
+			},
+			dagger.#Subdir & {
+				dir: "/build"
+			},
+		]
+	}
 }


### PR DESCRIPTION
NOTE: this PR is for illustration purposes only, tests etc are broken.

This is a follow up to #118 (read that PR for context) and a mashup of:

- @shykes's #run proposal 
- @dubo-dubon-duponey's feedback of "less black magic" (e.g. use the imported dagger library for everything, no special magic values)
- @verdverm's suggestion of using annotations


What this does is provide a `dagger.#Component` definition that users embed into their Cue types to add dagger computation (no "magic" `#dagger` anymore)

The embedded `dagger.#Component` defines a `#run` -- from this point on it's exactly the same as #118 with a twist: the `#run` definition has a `@dagger()` annotation. The runtime specifically checks for this annotation, ignores everything that doesn't have it.

This is to avoid namespace collisions: The downside of using `#run` instead of `#dagger` is we might clash with user configuration that has nothing to do with dagger. Because of the (internal) `@dagger()` annotation, user config can make use of the keyword `#run` for their own purposes without clashing.

The syntax needs some work, I think it can look better. Here's an example:

```
import (
  "dagger.io/dagger"
)

foo: {
  url: string

  dagger.#Component & {
    #run: [
      dagger.#FetchContainer & {
        ref: "alpine@sha256:08d6ca16c60fe7490c03d10dc339d9fd8ea67c6466dea8d558526b1330a85930"
      },
    ]
  }
}
```

For "data-less" components it looks like this:
```
repository: dagger.#Component & {
	#run: [
		dagger.#FetchGit & {
			remote: "https://github.com/kabirbaidhya/react-todo-app.git"
			ref:    "624041b17bd62292143f99bce474a0e3c2d2dd61"
		},
	]
}
```

The `#Component` definition is as simple as
```
#Component: {
	#run: [...#Op] @dagger()
}
```

I have a feeling annotations are super powerful and might unlock an even better UX, I just don't see it yet. @shykes @verdverm any thoughts?

For instance, half baked idea: we could have a definition like `#Run: [...#Op] @dagger()`, which would allow to write anywhere in the config `dagger.#Run & [dagger.#FetchContainer{ ... }]`.