### PR TITLE
performance: reduce the number of fills

### DIFF
--- a/dagger/client.go
+++ b/dagger/client.go
@@ -162,10 +162,7 @@ func (c *Client) outputfn(ctx context.Context, r io.Reader) (*compiler.Value, er
 	lg := log.Ctx(ctx)
 
 	// FIXME: merge this into env output.
-	out, err := compiler.EmptyStruct()
-	if err != nil {
-		return nil, err
-	}
+	out := compiler.EmptyStruct()
 
 	tr := tar.NewReader(r)
 	for {

--- a/dagger/compiler/compiler.go
+++ b/dagger/compiler/compiler.go
@@ -17,7 +17,7 @@ func Compile(name string, src interface{}) (*Value, error) {
 	return DefaultCompiler.Compile(name, src)
 }
 
-func EmptyStruct() (*Value, error) {
+func EmptyStruct() *Value {
 	return DefaultCompiler.EmptyStruct()
 }
 
@@ -63,8 +63,12 @@ func (c *Compiler) Cue() *cue.Runtime {
 }
 
 // Compile an empty struct
-func (c *Compiler) EmptyStruct() (*Value, error) {
-	return c.Compile("", "")
+func (c *Compiler) EmptyStruct() *Value {
+	empty, err := c.Compile("", "")
+	if err != nil {
+		panic(err)
+	}
+	return empty
 }
 
 func (c *Compiler) Compile(name string, src interface{}) (*Value, error) {

--- a/dagger/compiler/compiler_test.go
+++ b/dagger/compiler/compiler_test.go
@@ -38,14 +38,6 @@ func TestDefNotExist(t *testing.T) {
 	}
 }
 
-func TestSimple(t *testing.T) {
-	c := &Compiler{}
-	_, err := c.EmptyStruct()
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestJSON(t *testing.T) {
 	c := &Compiler{}
 	v, err := c.Compile("", `foo: hello: "world"`)

--- a/dagger/compiler/value.go
+++ b/dagger/compiler/value.go
@@ -68,6 +68,11 @@ func (v *Value) Len() cue.Value {
 }
 
 // Proxy function to the underlying cue.Value
+func (v *Value) Kind() cue.Kind {
+	return v.val.Kind()
+}
+
+// Proxy function to the underlying cue.Value
 func (v *Value) Fields() (*cue.Iterator, error) {
 	return v.val.Fields()
 }


### PR DESCRIPTION
- Remove unnecessary Fill() in Export()
- Change `set()` and the way we store outputs so we don't fill
  intermediaries as much
- WIP: Scan the tree only once. Changed LocalDirs to use cueflow rather than
  doing our own Walk. In a follow up we should use the same flow
  instance.

Signed-off-by: Andrea Luzzardi <aluzzardi@gmail.com>