### PR TITLE
Fix caching issues with Local

### DIFF
--- a/dagger/solver.go
+++ b/dagger/solver.go
@@ -35,6 +35,10 @@ func (s Solver) Scratch() FS {
 	return s.FS(llb.Scratch())
 }
 
+func (s Solver) SessionID() string {
+	return s.c.BuildOpts().SessionID
+}
+
 // Solve will block until the state is solved and returns a Reference.
 func (s Solver) SolveRequest(ctx context.Context, req bkgw.SolveRequest) (bkgw.Reference, error) {
 	// call solve


### PR DESCRIPTION
Workaround to fix `dagger.#Local` caching.

There are 2 issues:
- Within the same `dagger compute`, multiple `llb.Local` on the path appear to have a different result. Fixed by using a SessionID and SharedKeyHint
- On every run of `dagger compute`, `llb.Local` on the same path WITHOUT MODIFICATION appear to have a different result. Hack: Do a copy.

I don't know what the underlying cause is, `docker build` doesn't seem to have the same issue.
