### PR TITLE
[WIP] dagger tests

### DIFF
--- a/cmd/dagger/cmd/compute.go
+++ b/cmd/dagger/cmd/compute.go
@@ -1,11 +1,14 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
 	"dagger.io/go/dagger"
 
+	bkgw "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/rs/zerolog/log"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -49,7 +52,38 @@ var computeCmd = &cobra.Command{
 		if err != nil {
 			lg.Fatal().Err(err).Msg("unable to create client")
 		}
-		output, err := c.Compute(ctx, env)
+		test := viper.GetBool("test")
+		target := viper.GetString("target")
+		output, err := c.Session(ctx, env, func(ctx context.Context, s dagger.Solver) (*bkgw.Result, error) {
+			lg.Debug().Msg("loading configuration")
+			if err := env.Update(ctx, s, test); err != nil {
+				return nil, err
+			}
+
+			if !test {
+				// Compute output overlay
+				lg.Debug().Msg("computing env")
+				if err := env.Compute(ctx, s, target); err != nil {
+					return nil, err
+				}
+			} else {
+				// Compute output overlay
+				lg.Debug().Msg("running tests")
+				if err := env.Test(ctx, s, target); err != nil {
+					return nil, err
+				}
+			}
+
+			// Export env to a cue directory
+			lg.Debug().Msg("exporting env")
+			outdir, err := env.Export(ctx, s.Scratch())
+			if err != nil {
+				return nil, err
+			}
+
+			// Wrap cue directory in buildkit result
+			return outdir.Result(ctx)
+		})
 		if err != nil {
 			lg.Fatal().Err(err).Msg("failed to compute")
 		}
@@ -68,6 +102,9 @@ func init() {
 	computeCmd.Flags().Var(input.DirFlag(), "input-dir", "TARGET=PATH")
 	computeCmd.Flags().Var(input.GitFlag(), "input-git", "TARGET=REMOTE#REF")
 	computeCmd.Flags().Var(input.CueFlag(), "input-cue", "CUE")
+
+	computeCmd.Flags().StringP("target", "t", "", "target")
+	computeCmd.Flags().Bool("test", false, "Run tests")
 
 	// Setup (future) --from-* flags
 	updater, err = dagger.NewInputValue("[...{do:string, ...}]")

--- a/cmd/dagger/cmd/root.go
+++ b/cmd/dagger/cmd/root.go
@@ -23,6 +23,7 @@ func init() {
 
 	rootCmd.AddCommand(
 		computeCmd,
+		targetsCmd,
 		// Create an env
 		// Change settings on an env
 		// View or edit env serti

--- a/cmd/dagger/cmd/targets.go
+++ b/cmd/dagger/cmd/targets.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"dagger.io/go/cmd/dagger/logger"
+	"dagger.io/go/dagger"
+
+	bkgw "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/util/appcontext"
+	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var targetsCmd = &cobra.Command{
+	Use:   "targets CONFIG",
+	Short: "List targets of a configuration",
+	Args:  cobra.ExactArgs(1),
+	PreRun: func(cmd *cobra.Command, args []string) {
+		// Fix Viper bug for duplicate flags:
+		// https://github.com/spf13/viper/issues/233
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			panic(err)
+		}
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		lg := logger.
+			New().
+			Level(zerolog.InfoLevel) // force to level to INFO
+		ctx := lg.WithContext(appcontext.Context())
+
+		env, err := dagger.NewEnv()
+		if err != nil {
+			lg.Fatal().Err(err).Msg("unable to initialize environment")
+		}
+		if err := updater.SourceFlag().Set(args[0]); err != nil {
+			lg.Fatal().Err(err).Msg("invalid local source")
+		}
+
+		if err := env.SetUpdater(updater.Value()); err != nil {
+			lg.Fatal().Err(err).Msg("invalid updater script")
+		}
+
+		c, err := dagger.NewClient(ctx, "")
+		if err != nil {
+			lg.Fatal().Err(err).Msg("unable to create client")
+		}
+		_, err = c.Session(ctx, env, func(ctx context.Context, s dagger.Solver) (*bkgw.Result, error) {
+			if err := env.Update(ctx, s, true); err != nil {
+				return nil, err
+			}
+
+			targets := env.Targets()
+			for _, t := range targets {
+				fmt.Println(t)
+			}
+			return s.Scratch().Result(ctx)
+		})
+		if err != nil {
+			lg.Fatal().Err(err).Msg("failed to compute")
+		}
+	},
+}
+
+func init() {
+	if err := viper.BindPFlags(targetsCmd.Flags()); err != nil {
+		panic(err)
+	}
+}

--- a/dagger/build.go
+++ b/dagger/build.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Build a cue configuration tree from the files in fs.
-func CueBuild(ctx context.Context, fs FS, args ...string) (*compiler.Value, error) {
+func CueBuild(ctx context.Context, fs FS, includeTests bool, args ...string) (*compiler.Value, error) {
 	var (
 		err error
 		lg  = log.Ctx(ctx)
@@ -26,7 +26,8 @@ func CueBuild(ctx context.Context, fs FS, args ...string) (*compiler.Value, erro
 		// The CUE overlay needs to be prefixed by a non-conflicting path with the
 		// local filesystem, otherwise Cue will merge the Overlay with whatever Cue
 		// files it finds locally.
-		Dir: "/config",
+		Dir:   "/config",
+		Tests: includeTests,
 	}
 
 	// Start by creating an overlay with the stdlib

--- a/dagger/input.go
+++ b/dagger/input.go
@@ -180,7 +180,7 @@ func (f sourceFlag) Set(s string) error {
 			return compiler.Compile(
 				"source",
 				// FIXME: include only cue files as a shortcut. Make this configurable somehow.
-				fmt.Sprintf(`[{do:"local",dir:"%s",include:["*.cue","cue.mod"]}]`, u.Host+u.Path),
+				fmt.Sprintf(`[{do:"local",dir:"%s"}]`, u.Host+u.Path),
 			)
 		default:
 			return nil, fmt.Errorf("unsupported source scheme: %q", u.Scheme)


### PR DESCRIPTION
**WIP**: The code is so so, and the commands/flags need refinement.

- Add a `--test` flag to `dagger compute`. This is not ideal, should be a `dagger test` command or something (a la `go test`), however that entails too much copy/pasting at this point
- In test mode, dagger will load `_test.cue` files (in addition to regular `.cue` files) and execute `Test*` targets
- Also add a `compute --target` flag to specify which target to test (or compute), along with a `dagger targets` command that prints available targets. Syntax still up in the air. Will need some mechanism like this in the future for all debugging/testing purposes (e.g. exec a command inside a target, export a target's filesystem)
- Implemented basic tests for `alpine`, `go` and `yarn` and integrated them into the CI. Unfortunately, both `go` and `yarn` are disabled because of performance issues (/cc @verdverm)