### PR TITLE
stdlib: relax stdlib requirements

### DIFF
--- a/stdlib/netlify/netlify.cue
+++ b/stdlib/netlify/netlify.cue
@@ -27,7 +27,7 @@ import (
 	name: string
 
 	// Host the site at this address
-	customDomain: string
+	customDomain?: string
 
 	// Create the Netlify site if it doesn't exist?
 	create: bool | *true
@@ -39,10 +39,10 @@ import (
 		#dagger: compute: [
 			dagger.#Load & {
 				from: alpine.#Image & {
-					package: bash: "=5.1.0-r0"
-					package: jq:   "=1.6-r1"
-					package: curl: "=7.74.0-r0"
-					package: yarn: "=1.22.10-r0"
+					package: bash: "=~5.1"
+					package: jq:   "=~1.6"
+					package: curl: "=~7.74"
+					package: yarn: "=~1.22"
 				}
 			},
 			dagger.#Exec & {

--- a/stdlib/yarn/yarn.cue
+++ b/stdlib/yarn/yarn.cue
@@ -23,8 +23,8 @@ import (
 	#dagger: compute: [
 		dagger.#Load & {
 			from: alpine.#Image & {
-				package: bash: "=5.1.0-r0"
-				package: yarn: "=1.22.10-r0"
+				package: bash: "=~5.1"
+				package: yarn: "=~1.22"
 			}
 		},
 		dagger.#Exec & {


### PR DESCRIPTION
alpine packages got updated and the strict pinning broke

```
11:34AM ERR todoApp.url | failed: [apk add -U --no-cache curl=7.74.0-r0]: exit code: 1    duration=600ms
11:34AM INF todoApp.url.#dagger.compute[0].from | #11 0.548   curl-7.74.0-r1:
11:34AM INF todoApp.url.#dagger.compute[0].from | #11 0.548     breaks: world[curl=7.74.0-r0]
```