### PR TITLE
flow: Mirror Fills into the state

### DIFF
--- a/dagger/compiler/value.go
+++ b/dagger/compiler/value.go
@@ -30,18 +30,23 @@ func wrapValue(v cue.Value, inst *cue.Instance, cc *Compiler) *Value {
 }
 
 // Fill the value in-place, unlike Merge which returns a copy.
-func (v *Value) Fill(x interface{}) error {
+func (v *Value) Fill(x interface{}, path ...string) error {
 	v.cc.lock()
 	defer v.cc.unlock()
 
 	// If calling Fill() with a Value, we want to use the underlying
 	// cue.Value to fill.
 	if val, ok := x.(*Value); ok {
-		v.val = v.val.Fill(val.val)
+		v.val = v.val.Fill(val.val, path...)
 	} else {
-		v.val = v.val.Fill(x)
+		v.val = v.val.Fill(x, path...)
 	}
 	return v.Validate()
+}
+
+// FillPath fills the value in-place, unlike MergePath which returns a copy.
+func (v *Value) FillPath(x interface{}, p cue.Path) error {
+	return v.Fill(x, cuePathToStrings(p)...)
 }
 
 // LookupPath is a concurrency safe wrapper around cue.Value.LookupPath

--- a/dagger/pipeline.go
+++ b/dagger/pipeline.go
@@ -418,7 +418,7 @@ func (p *Pipeline) Export(ctx context.Context, op *compiler.Value) error {
 			Bytes("contents", contents).
 			Msg("exporting string")
 
-		if err := p.out.Fill(string(contents)); err != nil {
+		if err := p.out.Fill(ctx, string(contents)); err != nil {
 			return err
 		}
 	case "json":
@@ -434,7 +434,7 @@ func (p *Pipeline) Export(ctx context.Context, op *compiler.Value) error {
 			Interface("contents", o).
 			Msg("exporting json")
 
-		if err := p.out.Fill(o); err != nil {
+		if err := p.out.Fill(ctx, o); err != nil {
 			return err
 		}
 	case "yaml":
@@ -450,7 +450,7 @@ func (p *Pipeline) Export(ctx context.Context, op *compiler.Value) error {
 			Interface("contents", o).
 			Msg("exporting yaml")
 
-		if err := p.out.Fill(o); err != nil {
+		if err := p.out.Fill(ctx, o); err != nil {
 			return err
 		}
 	default:

--- a/dagger/types.go
+++ b/dagger/types.go
@@ -1,28 +1,39 @@
 package dagger
 
 import (
-	"os"
+	"context"
 
 	cueflow "cuelang.org/go/tools/flow"
+	"dagger.io/go/dagger/compiler"
+	"github.com/opentracing/opentracing-go"
 )
-
-var ErrNotExist = os.ErrNotExist
 
 // Something which can be filled in-place with a cue value
 type Fillable struct {
 	t *cueflow.Task
+	v *compiler.Value
 }
 
-func NewFillable(t *cueflow.Task) *Fillable {
+func NewFillable(t *cueflow.Task, v *compiler.Value) *Fillable {
 	return &Fillable{
 		t: t,
+		v: v,
 	}
 }
 
-func (f *Fillable) Fill(x interface{}) error {
+func (f *Fillable) Fill(ctx context.Context, x interface{}) error {
 	// Use a nil pointer receiver to discard all values
 	if f == nil {
 		return nil
 	}
-	return f.t.Fill(x)
+
+	span, _ := opentracing.StartSpanFromContext(ctx, "task fill")
+	defer span.Finish()
+
+	if err := f.t.Fill(x); err != nil {
+		return err
+	}
+
+	// Mirror the fill into the output
+	return f.v.FillPath(x, f.t.Path())
 }

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -25,9 +25,9 @@ test::stdlib() {
 
   test::one "stdlib: alpine" \
       "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute "$d"/stdlib/alpine
-  disable test::one "stdlib: yarn (FIXME: performance)" \
+  test::one "stdlib: yarn" \
       "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute "$d"/stdlib/yarn --input-dir TestData="$d"/stdlib/yarn/testdata
-  disable test::one "stdlib: go (FIXME: performance)" \
+  test::one "stdlib: go" \
       "$dagger" "${DAGGER_BINARY_ARGS[@]}" compute "$d"/stdlib/go --input-dir TestData="$d"/stdlib/go/testdata
 }
 


### PR DESCRIPTION
Rather than doing `task.Fill()`s then merging the entire `task.Value()`
back into the state, this change will mirror `task.Fill()` into
`state.Fill()`.

This is a workaround for #102
