### PR TITLE
Rename dagger.#Dir to dagger.#Artifact

### DIFF
--- a/examples/dagger-dev/main.cue
+++ b/examples/dagger-dev/main.cue
@@ -13,7 +13,7 @@ import (
 	"dagger.io/docker"
 )
 
-repository: dagger.#Dir
+repository: dagger.#Artifact
 
 // Build `dagger` using Go
 build: go.#Build & {

--- a/stdlib/dagger/dagger.cue
+++ b/stdlib/dagger/dagger.cue
@@ -1,8 +1,11 @@
 package dagger
 
-// Any component can be referenced as a directory, since
-// every dagger script outputs a filesystem state (aka a directory)
-#Dir: #compute: [...#Op]
+// An artifact such as source code checkout, container image, binary archive...
+// May be passed as user input, or computed by a buildkit pipeline
+#Artifact: #compute: [...#Op]
+
+// deprecated, use #Artifact instead.
+#Dir: #Artifact
 
 // Secret value
 // FIXME: currently aliased as a string to mark secrets

--- a/stdlib/go/go.cue
+++ b/stdlib/go/go.cue
@@ -12,7 +12,7 @@ import (
 	args: [...string]
 
 	// Source Directory to build
-	source: dagger.#Dir
+	source: dagger.#Artifact
 
 	// Environment variables
 	env: [string]: string
@@ -40,7 +40,7 @@ import (
 	version: *#Go.version | string
 
 	// Source Directory to build
-	source: dagger.#Dir
+	source: dagger.#Artifact
 
 	// Packages to build
 	packages: *"." | string
@@ -81,7 +81,7 @@ import (
 	version: *#Go.version | string
 
 	// Source Directory to build
-	source: dagger.#Dir
+	source: dagger.#Artifact
 
 	// Packages to test
 	packages: *"." | string

--- a/stdlib/netlify/netlify.cue
+++ b/stdlib/netlify/netlify.cue
@@ -21,7 +21,7 @@ import (
 	account: #Account
 
 	// Contents of the application to deploy
-	contents: dagger.#Dir
+	contents: dagger.#Artifact
 
 	// Deploy to this Netlify site
 	name: string

--- a/stdlib/yarn/yarn.cue
+++ b/stdlib/yarn/yarn.cue
@@ -8,7 +8,7 @@ import (
 // Yarn Script
 #Script: {
 	// Source code of the javascript application
-	source: dagger.#Dir
+	source: dagger.#Artifact
 
 	// Run this yarn script
 	run: string | *"build"

--- a/tests/dockerbuild/main.cue
+++ b/tests/dockerbuild/main.cue
@@ -3,7 +3,7 @@ package test
 import "dagger.io/dagger"
 
 // Set to `--input-dir=./tests/dockerbuild/testdata`
-TestData: dagger.#Dir
+TestData: dagger.#Artifact
 
 TestInlinedDockerfile: #compute: [
 	dagger.#DockerBuild & {

--- a/tests/stdlib/go/go.cue
+++ b/tests/stdlib/go/go.cue
@@ -6,7 +6,7 @@ import (
 	"dagger.io/alpine"
 )
 
-TestData: dagger.#Dir
+TestData: dagger.#Artifact
 
 TestGoBuild: {
 	build: go.#Build & {

--- a/tests/stdlib/yarn/yarn.cue
+++ b/tests/stdlib/yarn/yarn.cue
@@ -6,7 +6,7 @@ import (
 	"dagger.io/alpine"
 )
 
-TestData: dagger.#Dir
+TestData: dagger.#Artifact
 
 TestYarn: {
 	run: yarn.#Script & {


### PR DESCRIPTION
The term “artifact” is more accurate than “directory” to describe a config value with a computed buildkit state attached it via `#compute`.

An artifact could be a source code checkout, a container image, the result of a build, machine learning model, database export, etc. This matches the intended use of `#compute`.

An artifact can be loaded from an external source (`dagger input`), or computed by a pipeline (`#compute`).