### PR TITLE
stdlib package: llb

### DIFF
--- a/stdlib/alpine/alpine.cue
+++ b/stdlib/alpine/alpine.cue
@@ -1,7 +1,7 @@
 package alpine
 
 import (
-	"dagger.io/dagger"
+	"dagger.io/llb"
 )
 
 let defaultVersion = "3.13.2@sha256:a75afd8b57e7f34e4dad8d65e2c7ba2e1975c795ce1ee22fa34f8cf46f96a3be"
@@ -11,17 +11,17 @@ let defaultVersion = "3.13.2@sha256:a75afd8b57e7f34e4dad8d65e2c7ba2e1975c795ce1e
 	version: string | *defaultVersion
 
 	#compute: [
-		dagger.#FetchContainer & {
+		llb.#FetchContainer & {
 			ref: "index.docker.io/alpine:\(version)"
 		},
 		for pkg, info in package {
 			if (info & true) != _|_ {
-				dagger.#Exec & {
+				llb.#Exec & {
 					args: ["apk", "add", "-U", "--no-cache", pkg]
 				}
 			}
 			if (info & string) != _|_ {
-				dagger.#Exec & {
+				llb.#Exec & {
 					args: ["apk", "add", "-U", "--no-cache", "\(pkg)\(info)"]
 				}
 			}

--- a/stdlib/aws/cloudformation/cloudformation.cue
+++ b/stdlib/aws/cloudformation/cloudformation.cue
@@ -3,9 +3,9 @@ package cloudformation
 import (
 	"encoding/json"
 
-	"dagger.io/dagger"
 	"dagger.io/alpine"
 	"dagger.io/aws"
+	"dagger.io/llb"
 )
 
 // AWS CloudFormation Stack
@@ -49,23 +49,23 @@ import (
 		[string]: string
 
 		#compute: [
-			dagger.#Load & {
+			llb.#Load & {
 				from: alpine.#Image & {
 					package: bash:      "=5.1.0-r0"
 					package: jq:        "=1.6-r1"
 					package: "aws-cli": "=1.18.177-r0"
 				}
 			},
-			dagger.#Mkdir & {
+			llb.#Mkdir & {
 				path: "/src"
 			},
 			for dest, content in #files {
-				dagger.#WriteFile & {
+				llb.#WriteFile & {
 					"dest":    dest
 					"content": content
 				}
 			},
-			dagger.#Exec & {
+			llb.#Exec & {
 				args: [
 					"/bin/bash",
 					"--noprofile",
@@ -92,7 +92,7 @@ import (
 				dir: "/src"
 				mount: "/cache/aws": "cache"
 			},
-			dagger.#Export & {
+			llb.#Export & {
 				source: "/outputs.json"
 				format: "json"
 			},

--- a/stdlib/dagger/dagger.cue
+++ b/stdlib/dagger/dagger.cue
@@ -1,8 +1,12 @@
 package dagger
 
+import (
+	"dagger.io/llb"
+)
+
 // An artifact such as source code checkout, container image, binary archive...
 // May be passed as user input, or computed by a buildkit pipeline
-#Artifact: #compute: [...#Op]
+#Artifact: #compute: [...llb.#Op]
 
 // deprecated, use #Artifact instead.
 #Dir: #Artifact
@@ -11,90 +15,3 @@ package dagger
 // FIXME: currently aliased as a string to mark secrets
 // this requires proper support.
 #Secret: string
-
-// One operation in a script
-#Op: #FetchContainer | #FetchGit | #Export | #Exec | #Local | #Copy | #Load | #Subdir | #WriteFile | #Mkdir
-
-// Export a value from fs state to cue
-#Export: {
-	do: "export"
-	// Source path in the container
-	source: string
-	format: "json" | "yaml" | *"string"
-}
-
-#Local: {
-	do:  "local"
-	dir: string
-	include: [...string]
-}
-
-// FIXME: bring back load (more efficient than copy)
-
-#Load: {
-	do:   "load"
-	from: _
-}
-
-#Subdir: {
-	do:  "subdir"
-	dir: string | *"/"
-}
-
-#Exec: {
-	do: "exec"
-	args: [...string]
-	env?: [string]: string
-	always?: true | *false
-	dir:     string | *"/"
-	mount: [string]: "tmpfs" | "cache" | {from: _, path: string | *"/"}
-}
-
-#FetchContainer: {
-	do:  "fetch-container"
-	ref: string
-}
-
-#PushContainer: {
-	do:  "push-container"
-	ref: string
-}
-
-#FetchGit: {
-	do:     "fetch-git"
-	remote: string
-	ref:    string
-}
-
-#Copy: {
-	do:   "copy"
-	from: _
-	src:  string | *"/"
-	dest: string | *"/"
-}
-
-#DockerBuild: {
-	do: "docker-build"
-	// We accept either a context, a Dockerfile or both together
-	context?:        _
-	dockerfilePath?: string // path to the Dockerfile (defaults to "Dockerfile")
-	dockerfile?:     string
-
-	platforms?: [...string]
-	buildArg?: [string]: string
-	label?: [string]:    string
-}
-
-#WriteFile: {
-	do:      "write-file"
-	content: string
-	dest:    string
-	mode:    int | *0o644
-}
-
-#Mkdir: {
-	do:   "mkdir"
-	dir:  *"/" | string
-	path: string
-	mode: int | *0o755
-}

--- a/stdlib/docker/docker.cue
+++ b/stdlib/docker/docker.cue
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"dagger.io/dagger"
+	"dagger.io/llb"
 )
 
 #Ref: string
@@ -11,7 +12,7 @@ import (
 	source: dagger.#Dir
 
 	image: #compute: [
-		dagger.#DockerBuild & {context: source},
+		llb.#DockerBuild & {context: source},
 	]
 }
 
@@ -22,15 +23,15 @@ import (
 	{
 		image: #Ref
 		out: #compute: [
-			dagger.#FetchContainer & {ref: image},
-			dagger.#Exec & {"args":        args},
+			llb.#FetchContainer & {ref: image},
+			llb.#Exec & {"args":        args},
 		]
 
 	} | {
 		image: _
 		out: #compute: [
-			dagger.#Load & {from:   image},
-			dagger.#Exec & {"args": args},
+			llb.#Load & {from:   image},
+			llb.#Exec & {"args": args},
 		]
 	}
 }

--- a/stdlib/file/file.cue
+++ b/stdlib/file/file.cue
@@ -3,6 +3,7 @@ package file
 import (
 	"strings"
 	"dagger.io/dagger"
+	"dagger.io/llb"
 )
 
 #Create: {
@@ -11,7 +12,7 @@ import (
 	contents:    string | bytes
 
 	#compute: [
-		dagger.#WriteFile & {dest: filename, content: contents, mode: permissions},
+		llb.#WriteFile & {dest: filename, content: contents, mode: permissions},
 	]
 }
 
@@ -24,7 +25,7 @@ import (
 	orig: (#read & {path: filename, "from": from}).data
 
 	#compute: [
-		dagger.#WriteFile & {dest: filename, content: "\(orig)\(contents)", mode: permissions},
+		llb.#WriteFile & {dest: filename, content: "\(orig)\(contents)", mode: permissions},
 	]
 }
 
@@ -40,8 +41,8 @@ import (
 	data: {
 		string
 		#compute: [
-			dagger.#Load & {"from":   from},
-			dagger.#Export & {source: path},
+			llb.#Load & {"from":   from},
+			llb.#Export & {source: path},
 		]
 	}
 }
@@ -62,11 +63,11 @@ _#glob: {
 		string
 		_tmppath: "/tmp/ls.out"
 		#compute: [
-			dagger.#Load & {"from": from},
-			dagger.#Exec & {
+			llb.#Load & {"from": from},
+			llb.#Exec & {
 				args: ["sh", "-c", "ls \(glob) > \(_tmppath)"]
 			},
-			dagger.#Export & {source: _tmppath},
+			llb.#Export & {source: _tmppath},
 		]
 	}
 }

--- a/stdlib/git/git.cue
+++ b/stdlib/git/git.cue
@@ -1,7 +1,7 @@
 package git
 
 import (
-	"dagger.io/dagger"
+	"dagger.io/llb"
 )
 
 // A git repository
@@ -11,7 +11,7 @@ import (
 	ref:    string
 
 	#compute: [
-		dagger.#FetchGit & {
+		llb.#FetchGit & {
 			"remote": remote
 			"ref":    ref
 		},

--- a/stdlib/go/go.cue
+++ b/stdlib/go/go.cue
@@ -2,6 +2,7 @@ package go
 
 import (
 	"dagger.io/dagger"
+	"dagger.io/llb"
 )
 
 #Go: {
@@ -18,10 +19,10 @@ import (
 	env: [string]: string
 
 	#compute: [
-		dagger.#FetchContainer & {
+		llb.#FetchContainer & {
 			ref: "docker.io/golang:\(version)-alpine"
 		},
-		dagger.#Exec & {
+		llb.#Exec & {
 			"args": ["go"] + args
 
 			"env": env
@@ -63,7 +64,7 @@ import (
 	env: [string]: string
 
 	#compute: [
-		dagger.#Copy & {
+		llb.#Copy & {
 			from: #Go & {
 				"version": version
 				"source":  source

--- a/stdlib/llb/llb.cue
+++ b/stdlib/llb/llb.cue
@@ -1,0 +1,89 @@
+// llb: compile LLB graphs executable by buildkit
+package llb
+
+// One operation in a script
+#Op: #FetchContainer | #FetchGit | #Export | #Exec | #Local | #Copy | #Load | #Subdir | #WriteFile | #Mkdir
+
+// Export a value from fs state to cue
+#Export: {
+	do: "export"
+	// Source path in the container
+	source: string
+	format: "json" | "yaml" | *"string"
+}
+
+#Local: {
+	do:  "local"
+	dir: string
+	include: [...string]
+}
+
+// FIXME: bring back load (more efficient than copy)
+
+#Load: {
+	do:   "load"
+	from: _
+}
+
+#Subdir: {
+	do:  "subdir"
+	dir: string | *"/"
+}
+
+#Exec: {
+	do: "exec"
+	args: [...string]
+	env?: [string]: string
+	always?: true | *false
+	dir:     string | *"/"
+	mount: [string]: "tmpfs" | "cache" | {from: _, path: string | *"/"}
+}
+
+#FetchContainer: {
+	do:  "fetch-container"
+	ref: string
+}
+
+#PushContainer: {
+	do:  "push-container"
+	ref: string
+}
+
+#FetchGit: {
+	do:     "fetch-git"
+	remote: string
+	ref:    string
+}
+
+#Copy: {
+	do:   "copy"
+	from: _
+	src:  string | *"/"
+	dest: string | *"/"
+}
+
+#DockerBuild: {
+	do: "docker-build"
+	// We accept either a context, a Dockerfile or both together
+	context?:        _
+	dockerfilePath?: string // path to the Dockerfile (defaults to "Dockerfile")
+	dockerfile?:     string
+
+	platforms?: [...string]
+	buildArg?: [string]: string
+	label?: [string]:    string
+}
+
+#WriteFile: {
+	do:      "write-file"
+	content: string
+	dest:    string
+	mode:    int | *0o644
+}
+
+#Mkdir: {
+	do:   "mkdir"
+	dir:  *"/" | string
+	path: string
+	mode: int | *0o755
+}

--- a/stdlib/netlify/netlify.cue
+++ b/stdlib/netlify/netlify.cue
@@ -3,6 +3,7 @@ package netlify
 import (
 	"dagger.io/dagger"
 	"dagger.io/alpine"
+	"dagger.io/llb"
 )
 
 // A Netlify account
@@ -37,7 +38,7 @@ import (
 		string
 
 		#compute: [
-			dagger.#Load & {
+			llb.#Load & {
 				from: alpine.#Image & {
 					package: bash: "=~5.1"
 					package: jq:   "=~1.6"
@@ -45,10 +46,10 @@ import (
 					package: yarn: "=~1.22"
 				}
 			},
-			dagger.#Exec & {
+			llb.#Exec & {
 				args: ["yarn", "global", "add", "netlify-cli@2.47.0"]
 			},
-			dagger.#Exec & {
+			llb.#Exec & {
 				args: [
 					"/bin/bash",
 					"--noprofile",
@@ -72,7 +73,7 @@ import (
 				dir: "/src"
 				mount: "/src": from: contents
 			},
-			dagger.#Export & {
+			llb.#Export & {
 				source: "/url"
 				format: "string"
 			},

--- a/stdlib/yarn/yarn.cue
+++ b/stdlib/yarn/yarn.cue
@@ -3,6 +3,7 @@ package yarn
 import (
 	"dagger.io/dagger"
 	"dagger.io/alpine"
+	"dagger.io/llb"
 )
 
 // Yarn Script
@@ -21,13 +22,13 @@ import (
 	env?: [string]: string
 
 	#compute: [
-		dagger.#Load & {
+		llb.#Load & {
 			from: alpine.#Image & {
 				package: bash: "=~5.1"
 				package: yarn: "=~1.22"
 			}
 		},
-		dagger.#Exec & {
+		llb.#Exec & {
 			args: [
 				"/bin/bash",
 				"--noprofile",
@@ -55,7 +56,7 @@ import (
 				"/cache/yarn": "cache"
 			}
 		},
-		dagger.#Subdir & {
+		llb.#Subdir & {
 			dir: "/build"
 		},
 	]

--- a/tests/stdlib/alpine/alpine.cue
+++ b/tests/stdlib/alpine/alpine.cue
@@ -1,8 +1,8 @@
 package alpine
 
 import (
-	"dagger.io/dagger"
 	"dagger.io/alpine"
+	"dagger.io/llb"
 )
 
 TestImageVersion: {
@@ -12,8 +12,8 @@ TestImageVersion: {
 	}
 
 	test: #compute: [
-		dagger.#Load & {from: image},
-		dagger.#Exec & {
+		llb.#Load & {from: image},
+		llb.#Exec & {
 			args: [
 				"sh",
 				"-ec",
@@ -32,11 +32,11 @@ TestPackageInstall: {
 	}
 
 	test: #compute: [
-		dagger.#Load & {from: image},
-		dagger.#Exec & {
+		llb.#Load & {from: image},
+		llb.#Exec & {
 			args: ["jq", "--version"]
 		},
-		dagger.#Exec & {
+		llb.#Exec & {
 			args: ["sh", "-ec", "curl --version | grep -q 7.74.0"]
 		},
 	]

--- a/tests/stdlib/go/go.cue
+++ b/tests/stdlib/go/go.cue
@@ -4,6 +4,7 @@ import (
 	"dagger.io/dagger"
 	"dagger.io/go"
 	"dagger.io/alpine"
+	"dagger.io/llb"
 )
 
 TestData: dagger.#Artifact
@@ -15,8 +16,8 @@ TestGoBuild: {
 	}
 
 	test: #compute: [
-		dagger.#Load & {from: alpine.#Image},
-		dagger.#Exec & {
+		llb.#Load & {from: alpine.#Image},
+		llb.#Exec & {
 			args: [
 				"sh",
 				"-ec",

--- a/tests/stdlib/yarn/yarn.cue
+++ b/tests/stdlib/yarn/yarn.cue
@@ -4,6 +4,7 @@ import (
 	"dagger.io/dagger"
 	"dagger.io/yarn"
 	"dagger.io/alpine"
+	"dagger.io/llb"
 )
 
 TestData: dagger.#Artifact
@@ -14,10 +15,10 @@ TestYarn: {
 	}
 
 	test: #compute: [
-		dagger.#Load & {from: alpine.#Image & {
+		llb.#Load & {from: alpine.#Image & {
 			package: bash: "=5.1.0-r0"
 		}},
-		dagger.#Exec & {
+		llb.#Exec & {
 			mount: "/build": from: run
 			args: [
 				"/bin/bash",


### PR DESCRIPTION
Move llb definitions to `dagger.io/llb`. This has the benefit of cleanly splitting core features in 2 parts:

1) Basic features in `dagger.io/dagger`. May be imported by either a top-level stack or a reusable package. Does not require understanding of buildkit, llb, embedded definitions like `#compute` etc.

2) Advanced features in `dagger.io/llb`. For developers of low-level packages only. Requires learning additional concepts.

Also it’s shorter to type when writing llb pipelines :)