### PR TITLE
[WIP] pipeline caching: Re-use previous Pipeline results rather than relying on BuildKit caching.

### DIFF
--- a/dagger/compiler/value.go
+++ b/dagger/compiler/value.go
@@ -112,6 +112,10 @@ func (v *Value) Decode(x interface{}) error {
 	return v.val.Decode(x)
 }
 
+func (v *Value) Dereference() *Value {
+	return v.Wrap(cue.Dereference(v.val))
+}
+
 func (v *Value) List() ([]*Value, error) {
 	l := []*Value{}
 	it, err := v.val.List()

--- a/dagger/manager.go
+++ b/dagger/manager.go
@@ -1,0 +1,69 @@
+package dagger
+
+import (
+	"context"
+	"sync"
+
+	"dagger.io/go/dagger/compiler"
+	"github.com/rs/zerolog/log"
+)
+
+type cacheEntry struct {
+	p      *Pipeline
+	doneCh chan struct{}
+}
+
+func (e *cacheEntry) wait() {
+	<-e.doneCh
+}
+
+func (e *cacheEntry) done() {
+	close(e.doneCh)
+}
+
+type PipelineManager struct {
+	l     sync.Mutex
+	cache map[string]*cacheEntry
+	s     Solver
+}
+
+func NewPipelineManager(s Solver) *PipelineManager {
+	return &PipelineManager{
+		s:     s,
+		cache: make(map[string]*cacheEntry),
+	}
+}
+
+func (m *PipelineManager) Do(ctx context.Context, v *compiler.Value, out *Fillable) (*Pipeline, error) {
+	pv := v.Dereference()
+	name := pv.Path().String()
+
+	log.Ctx(ctx).Debug().Str("name", v.Path().String()).Msg("====> " + name)
+
+	// check if the pipeline was already computed and if so, return the cached version
+	m.l.Lock()
+	if e, ok := m.cache[name]; ok {
+		m.l.Unlock()
+
+		// the pipeline could still be in progress, wait for completion
+		e.wait()
+		return e.p, nil
+	}
+
+	// otherwise, create a new pipeline and add it to the cache
+	p := NewPipeline(name, m.s, out, m)
+	e := &cacheEntry{
+		p:      p,
+		doneCh: make(chan struct{}),
+	}
+	m.cache[name] = e
+	m.l.Unlock()
+
+	// Compute the pipeline
+	defer e.done()
+	if err := p.Do(ctx, pv); err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}


### PR DESCRIPTION
**WIP: For discussion, please do not merge**

With the current approach, everytime a pipeline is referenced (e.g.
`mount: "/src": from: bar`) a new Pipeline is created and *bar* is
re-computed. We rely on BuildKit to figure out the operations already
happened and return the same result.

However:
- When something goes wrong, the Pipeline is executed twice (or more).
  Either because of a buildkit hiccup (e.g. `llb.Local` producing a different
  vertex digest on consecutive run), or because of a consistency issue
  on our end (e.g. `always: true` adds a cache buster)
- Logs can be confusing: the Pipeline will produce logs any time it's
  referenced, with a `CACHED` status

This change attepts a different approach:
- Keep a cache of all executed Pipelines, keyed by de-referenced Value
  (e.g. for `mount: "/src": from: bar`, the key will be bar's path)
- Lazy compute Pipelines, re-use the result of previous run if already
  computed

Signed-off-by: Andrea Luzzardi <aluzzardi@gmail.com>