### PR TITLE
logger: serialize unknown fields to json

### DIFF
--- a/cmd/dagger/logger/console.go
+++ b/cmd/dagger/logger/console.go
@@ -163,6 +163,12 @@ func (c *Console) formatFields(entry map[string]interface{}) string {
 			fields = append(fields, fmt.Sprintf("%s=%s", key, s))
 		case nil:
 			fields = append(fields, fmt.Sprintf("%s=null", key))
+		default:
+			o, err := json.MarshalIndent(v, "", "    ")
+			if err != nil {
+				panic(err)
+			}
+			fields = append(fields, fmt.Sprintf("%s=%s", key, o))
 		}
 	}
 


### PR DESCRIPTION
This fixes logging of unknown zerolog types (e.g. `RawJSON`)