### PR TITLE
fix --log-* flags

### DIFF
--- a/cmd/dagger/cmd/compute.go
+++ b/cmd/dagger/cmd/compute.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"fmt"
 
+	"dagger.io/go/cmd/dagger/logger"
 	"dagger.io/go/dagger"
 
-	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -27,8 +27,8 @@ var computeCmd = &cobra.Command{
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := cmd.Context()
-		lg := log.Ctx(ctx)
+		lg := logger.New()
+		ctx := lg.WithContext(cmd.Context())
 
 		env, err := dagger.NewEnv()
 		if err != nil {

--- a/cmd/dagger/cmd/root.go
+++ b/cmd/dagger/cmd/root.go
@@ -44,9 +44,10 @@ func init() {
 
 func Execute() {
 	var (
-		lg  = logger.New()
-		ctx = lg.WithContext(appcontext.Context())
-
+		ctx = appcontext.Context()
+		// `--log-*` flags have not been parsed yet at this point so we get a
+		// default logger. Therefore, we can't store the logger into the context.
+		lg     = logger.New()
 		closer = logger.InitTracing()
 		span   opentracing.Span
 	)


### PR DESCRIPTION
Have each command create their own logger rather than using the one from
`cmd.Context()`. This is because that one gets created "too early" when
`--log-*` flags have not been parsed yet.

Fixes #181

Signed-off-by: Andrea Luzzardi <aluzzardi@gmail.com>