### PR TITLE
cache go modules during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 FROM golang:1.16.2-alpine AS build
 WORKDIR /src
 RUN apk add --no-cache file
+ENV GOMODCACHE /root/.cache/gocache
 RUN --mount=target=. --mount=target=/root/.cache,type=cache \
     CGO_ENABLED=0 go build -o /out/dagger ./cmd/dagger && file /out/dagger | grep "statically linked"
 


### PR DESCRIPTION
go modules are now cached in mounted cache located at /root/.cache