### PR TITLE
Don't print the config at the end of 'dagger up'

### DIFF
--- a/cmd/dagger/cmd/common/common.go
+++ b/cmd/dagger/cmd/common/common.go
@@ -58,7 +58,9 @@ func GetCurrentDeploymentState(ctx context.Context, store *dagger.Store) *dagger
 	return st
 }
 
-func DeploymentUp(ctx context.Context, deployment *dagger.Deployment) {
+// Re-compute a deployment (equivalent to `dagger up`).
+// If printOutput is true, print the JSON-encoded computed state to standard output
+func DeploymentUp(ctx context.Context, deployment *dagger.Deployment, printOutput bool) {
 	lg := log.Ctx(ctx)
 
 	c, err := dagger.NewClient(ctx, "")
@@ -72,5 +74,7 @@ func DeploymentUp(ctx context.Context, deployment *dagger.Deployment) {
 	if err != nil {
 		lg.Fatal().Err(err).Msg("failed to up deployment")
 	}
-	fmt.Println(output.JSON())
+	if printOutput {
+		fmt.Println(output.JSON())
+	}
 }

--- a/cmd/dagger/cmd/compute.go
+++ b/cmd/dagger/cmd/compute.go
@@ -132,7 +132,7 @@ var computeCmd = &cobra.Command{
 			lg.Fatal().Err(err).Msg("unable to initialize deployment")
 		}
 
-		common.DeploymentUp(ctx, deployment)
+		common.DeploymentUp(ctx, deployment, true)
 	},
 }
 

--- a/cmd/dagger/cmd/new.go
+++ b/cmd/dagger/cmd/new.go
@@ -70,7 +70,7 @@ var newCmd = &cobra.Command{
 		}
 
 		if viper.GetBool("up") {
-			common.DeploymentUp(ctx, deployment)
+			common.DeploymentUp(ctx, deployment, false)
 		}
 	},
 }

--- a/cmd/dagger/cmd/up.go
+++ b/cmd/dagger/cmd/up.go
@@ -31,7 +31,7 @@ var upCmd = &cobra.Command{
 		deployment := common.GetCurrentDeployment(ctx, store)
 
 		// TODO: Implement options: --no-cache
-		common.DeploymentUp(ctx, deployment)
+		common.DeploymentUp(ctx, deployment, false)
 	},
 }
 


### PR DESCRIPTION
Now that we have `dagger query`, we don’t need to print the contents of the config every time we re-up it.