### PR TITLE
P0: Fix bug in default store location

### DIFF
--- a/dagger/store.go
+++ b/dagger/store.go
@@ -18,7 +18,7 @@ var (
 )
 
 const (
-	defaultStoreRoot = "$HOME/.config/dagger/deployments"
+	defaultStoreRoot = "$HOME/.data/share/dagger/deployments"
 )
 
 type Store struct {


### PR DESCRIPTION
Currently in main `dagger` creates an actual directory called `’$HOME’` instead of expanding the value of `$HOME`.

Also changing the location of the default store to follow the xdg spec. This will cause all deployment to be “forgotten”, better do it now before anyone is using it seriously.