### PR TITLE
deployment API cleanup

### DIFF
--- a/cmd/dagger/cmd/common/common.go
+++ b/cmd/dagger/cmd/common/common.go
@@ -10,23 +10,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-// GetCurrentDeployment returns the current selected deployment based on its abs path
-func GetCurrentDeployment(ctx context.Context, store *dagger.Store) *dagger.Deployment {
-	lg := log.Ctx(ctx)
-	st := GetCurrentDeploymentState(ctx, store)
-
-	deployment, err := dagger.NewDeployment(st)
-	if err != nil {
-		lg.
-			Fatal().
-			Err(err).
-			Interface("deploymentState", st).
-			Msg("failed to init deployment")
-	}
-
-	return deployment
-}
-
 func GetCurrentDeploymentState(ctx context.Context, store *dagger.Store) *dagger.DeploymentState {
 	lg := log.Ctx(ctx)
 
@@ -60,14 +43,14 @@ func GetCurrentDeploymentState(ctx context.Context, store *dagger.Store) *dagger
 
 // Re-compute a deployment (equivalent to `dagger up`).
 // If printOutput is true, print the JSON-encoded computed state to standard output
-func DeploymentUp(ctx context.Context, deployment *dagger.Deployment, printOutput bool) {
+func DeploymentUp(ctx context.Context, state *dagger.DeploymentState, printOutput bool) {
 	lg := log.Ctx(ctx)
 
 	c, err := dagger.NewClient(ctx, "")
 	if err != nil {
 		lg.Fatal().Err(err).Msg("unable to create client")
 	}
-	output, err := c.Do(ctx, deployment, func(ctx context.Context, deployment *dagger.Deployment, s dagger.Solver) error {
+	output, err := c.Do(ctx, state, func(ctx context.Context, deployment *dagger.Deployment, s dagger.Solver) error {
 		log.Ctx(ctx).Debug().Msg("bringing deployment up")
 		return deployment.Up(ctx, s, nil)
 	})

--- a/cmd/dagger/cmd/compute.go
+++ b/cmd/dagger/cmd/compute.go
@@ -127,12 +127,7 @@ var computeCmd = &cobra.Command{
 			}
 		}
 
-		deployment, err := dagger.NewDeployment(st)
-		if err != nil {
-			lg.Fatal().Err(err).Msg("unable to initialize deployment")
-		}
-
-		common.DeploymentUp(ctx, deployment, true)
+		common.DeploymentUp(ctx, st, true)
 	},
 }
 

--- a/cmd/dagger/cmd/down.go
+++ b/cmd/dagger/cmd/down.go
@@ -1,10 +1,6 @@
 package cmd
 
 import (
-	"dagger.io/go/cmd/dagger/cmd/common"
-	"dagger.io/go/cmd/dagger/logger"
-	"dagger.io/go/dagger"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -21,25 +17,7 @@ var downCmd = &cobra.Command{
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		lg := logger.New()
-		ctx := lg.WithContext(cmd.Context())
-
-		store, err := dagger.DefaultStore()
-		if err != nil {
-			lg.Fatal().Err(err).Msg("failed to load store")
-		}
-
-		deployment := common.GetCurrentDeployment(ctx, store)
-
-		// TODO: Implement options: --no-cache
-		if err := deployment.Down(ctx, nil); err != nil {
-			lg.
-				Fatal().
-				Err(err).
-				Str("deploymentName", deployment.Name()).
-				Str("deploymentId", deployment.ID()).
-				Msg("failed to up the deployment")
-		}
+		panic("not implemented")
 	},
 }
 

--- a/cmd/dagger/cmd/new.go
+++ b/cmd/dagger/cmd/new.go
@@ -62,16 +62,8 @@ var newCmd = &cobra.Command{
 			Str("deploymentName", st.Name).
 			Msg("deployment created")
 
-		deployment, err := dagger.NewDeployment(st)
-		if err != nil {
-			lg.
-				Fatal().
-				Err(err).
-				Msg("failed to initialize deployment")
-		}
-
 		if viper.GetBool("up") {
-			common.DeploymentUp(ctx, deployment, false)
+			common.DeploymentUp(ctx, st, false)
 		}
 	},
 }

--- a/cmd/dagger/cmd/query.go
+++ b/cmd/dagger/cmd/query.go
@@ -35,11 +35,11 @@ var queryCmd = &cobra.Command{
 			lg.Fatal().Err(err).Msg("failed to load store")
 		}
 
-		deployment := common.GetCurrentDeployment(ctx, store)
+		state := common.GetCurrentDeploymentState(ctx, store)
 
 		lg = lg.With().
-			Str("deploymentName", deployment.Name()).
-			Str("deploymentId", deployment.ID()).
+			Str("deploymentName", state.Name).
+			Str("deploymentId", state.ID).
 			Logger()
 
 		cuePath := cue.MakePath()
@@ -51,7 +51,7 @@ var queryCmd = &cobra.Command{
 		if err != nil {
 			lg.Fatal().Err(err).Msg("unable to create client")
 		}
-		output, err := c.Do(ctx, deployment, nil)
+		output, err := c.Do(ctx, state, nil)
 		if err != nil {
 			lg.Fatal().Err(err).Msg("failed to query deployment")
 		}

--- a/cmd/dagger/cmd/up.go
+++ b/cmd/dagger/cmd/up.go
@@ -28,10 +28,10 @@ var upCmd = &cobra.Command{
 			lg.Fatal().Err(err).Msg("failed to load store")
 		}
 
-		deployment := common.GetCurrentDeployment(ctx, store)
+		state := common.GetCurrentDeploymentState(ctx, store)
 
 		// TODO: Implement options: --no-cache
-		common.DeploymentUp(ctx, deployment, false)
+		common.DeploymentUp(ctx, state, false)
 	},
 }
 


### PR DESCRIPTION
The API was a bit confusing with code mixing the usage of Deployment and
DeploymentState.

This change marks a clear separation:

- Client is the only piece of code manipulating *Deployment
- CLI commands can manipulate DeploymentState objects and pass them to
  Client
