### PR TITLE
dagger query [--format cue|json|text|yaml] (default is json)

### DIFF
--- a/cmd/dagger/cmd/query.go
+++ b/cmd/dagger/cmd/query.go
@@ -64,12 +64,27 @@ var queryCmd = &cobra.Command{
 			}
 		}
 
-		out, err := cueVal.Source(cueOpts...)
-		if err != nil {
-			lg.Fatal().Err(err).Msg("failed to lookup source")
+		format := viper.GetString("format")
+		switch format {
+		case "cue":
+			out, err := cueVal.Source(cueOpts...)
+			if err != nil {
+				lg.Fatal().Err(err).Msg("failed to lookup source")
+			}
+			fmt.Println(string(out))
+		case "json":
+			fmt.Println(cueVal.JSON().PrettyString())
+		case "yaml":
+			lg.Fatal().Err(err).Msg("yaml format not yet implemented")
+		case "text":
+			out, err := cueVal.String()
+			if err != nil {
+				lg.Fatal().Err(err).Msg("value can't be formatted as text")
+			}
+			fmt.Println(out)
+		default:
+			lg.Fatal().Msgf("unsupported format: %q", format)
 		}
-
-		fmt.Println(string(out))
 	},
 }
 
@@ -95,12 +110,12 @@ func parseQueryFlags() []cue.Option {
 
 func init() {
 	queryCmd.Flags().BoolP("concrete", "c", false, "Require the evaluation to be concrete")
-	queryCmd.Flags().BoolP("show-optional", "O", false, "Display optional fields")
-	queryCmd.Flags().BoolP("show-attributes", "A", false, "Display field attributes")
+	queryCmd.Flags().BoolP("show-optional", "O", false, "Display optional fields (cue format only)")
+	queryCmd.Flags().BoolP("show-attributes", "A", false, "Display field attributes (cue format only)")
 
 	// FIXME: implement the flags below
 	// queryCmd.Flags().String("revision", "latest", "Query a specific version of the deployment")
-	// queryCmd.Flags().StringP("format", "f", "", "Output format (json|yaml|cue|text|env)")
+	queryCmd.Flags().StringP("format", "f", "json", "Output format (json|yaml|cue|text|env)")
 	// queryCmd.Flags().BoolP("no-input", "I", false, "Exclude inputs from query")
 	// queryCmd.Flags().BoolP("no-output", "O", false, "Exclude outputs from query")
 	// queryCmd.Flags().BoolP("no-plan", "P", false, "Exclude outputs from query")

--- a/cmd/dagger/cmd/root.go
+++ b/cmd/dagger/cmd/root.go
@@ -17,7 +17,7 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use:   "dagger",
-	Short: "A system for application delivery as code (ADC)",
+	Short: "A programmable deployment system",
 }
 
 func init() {

--- a/dagger/compiler/json.go
+++ b/dagger/compiler/json.go
@@ -1,6 +1,8 @@
 package compiler
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 
 	"cuelang.org/go/cue"
@@ -134,4 +136,14 @@ func (s JSON) String() string {
 		return "{}"
 	}
 	return string(s)
+}
+
+func (s JSON) PrettyString() string {
+	raw := s.String()
+	b := &bytes.Buffer{}
+	// If indenting fails, return raw string
+	if err := json.Indent(b, []byte(raw), "", "  "); err != nil {
+		return raw
+	}
+	return b.String()
 }

--- a/tests/test-cli.sh
+++ b/tests/test-cli.sh
@@ -51,7 +51,7 @@ test::cli::newdir() {
     foo: "value"
     bar: "another value"
 }' \
-      "$dagger" "${DAGGER_BINARY_ARGS[@]}" query -d "simple" -c
+      "$dagger" "${DAGGER_BINARY_ARGS[@]}" query -f cue -d "simple" -c
 }
 
 test::cli::query() {
@@ -69,14 +69,14 @@ test::cli::query() {
     foo: "value"
     bar: "another value"
 }' \
-      "$dagger" "${DAGGER_BINARY_ARGS[@]}" query -d "simple" -c
+      "$dagger" "${DAGGER_BINARY_ARGS[@]}" query -f cue -d "simple" -c
 
   test::one "CLI: query: target" --stdout='"value"' \
-      "$dagger" "${DAGGER_BINARY_ARGS[@]}" query -d "simple" foo
+      "$dagger" "${DAGGER_BINARY_ARGS[@]}" query -f cue -d "simple" foo
 
   test::one "CLI: query: initialize nonconcrete" \
       "$dagger" "${DAGGER_BINARY_ARGS[@]}" new --plan-dir "$d"/cli/nonconcrete nonconcrete
 
   test::one "CLI: query: non concrete" --exit=1 \
-      "$dagger" "${DAGGER_BINARY_ARGS[@]}" query -d "nonconcrete" -c
+      "$dagger" "${DAGGER_BINARY_ARGS[@]}" query -f cue -d "nonconcrete" -c
 }


### PR DESCRIPTION
Previously `dagger eval` always returned the cue output. This makes sense for cue debugging, but not to get quick information about the current state.

The previous behavior is still available with `dagger query -f cue`. All cue flags have been preserved.