### PR TITLE
fix build break in store_test.go

### DIFF
--- a/dagger/store_test.go
+++ b/dagger/store_test.go
@@ -105,7 +105,7 @@ func TestStoreLookupByPath(t *testing.T) {
 	otherSt := &DeploymentState{
 		Name: "test2",
 	}
-	require.NoError(t, otherSt.AddInput("foo", DirInput("/test/anotherpath", []string{})))
+	require.NoError(t, otherSt.SetInput("foo", DirInput("/test/anotherpath", []string{})))
 	require.NoError(t, store.CreateDeployment(ctx, otherSt))
 
 	// Lookup by path should return both deployments


### PR DESCRIPTION
Fixes a build break in test.

```
--- FAIL: TestInputDir (0.00s)
    input_test.go:20: 
        	Error Trace:	input_test.go:20
        	Error:      	"map[/Users/fkautz/dagger/dagger:/Users/fkautz/dagger/dagger /tmp/source:/tmp/source]" does not contain "."
        	Test:       	TestInputDir
```