### PR TITLE
swapping order of test and integration tests, unit tests should be 1st

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,11 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Test
+        run: |
+          make test
+
       - name: Integration test
         run: |
           make integration
 
-      - name: Test
-        run: |
-          make test


### PR DESCRIPTION
currently, integration tests run first then unit tests.

This patch should swap the order.