### PR TITLE
stdlib/kubernetes: split source with dagger.#Artifact and string

### DIFF
--- a/examples/kubernetes-app/main.cue
+++ b/examples/kubernetes-app/main.cue
@@ -37,9 +37,9 @@ cluster: eks.#KubeConfig & {
 
 // Example of a simple `kubectl apply` using a simple config
 kubeApply: kubernetes.#Apply & {
-	source:     yaml.Marshal(kubeSrc)
-	namespace:  "test"
-	kubeconfig: cluster.kubeconfig
+	sourceInline: yaml.Marshal(kubeSrc)
+	namespace:    "test"
+	kubeconfig:   cluster.kubeconfig
 }
 
 // Example of a `helm install` using a local chart

--- a/stdlib/kubernetes/helm/helm.cue
+++ b/stdlib/kubernetes/helm/helm.cue
@@ -14,7 +14,10 @@ import (
 	name: string
 
 	// Helm chart to install
-	chart: string | dagger.#Artifact
+	chart: dagger.#Artifact
+
+	// Helm chart to install inlined
+	chartInline?: string
 
 	// Helm chart repository (defaults to stable)
 	repository: *"https://charts.helm.sh/stable" | string
@@ -86,7 +89,7 @@ import (
 			content: kubeconfig
 			mode:    0o600
 		},
-		if (chart & string) != _|_ {
+		if chartInline != _|_ {
 			op.#WriteFile & {
 				dest:    "/helm/chart"
 				content: chart
@@ -117,7 +120,7 @@ import (
 				if (values & string) != _|_ {
 					"/helm/values.yaml": values
 				}
-				if (chart & dagger.#Artifact) != _|_ {
+				if chartInline == _|_ {
 					"/helm/chart": from: chart
 				}
 			}


### PR DESCRIPTION
Fixes #263

The current definit of `dagger.#Artifact` matches anything (`_`), then it's not possible to differentiate a `#Artifact` from a string (`if (source & string) & _|_` is always true).

This workaround splits both types in 2 separate keys to restore the lib and the example.