### PR TITLE
Add support for input file in dagger compute

### DIFF
--- a/cmd/dagger/cmd/compute.go
+++ b/cmd/dagger/cmd/compute.go
@@ -130,6 +130,25 @@ var computeCmd = &cobra.Command{
 			}
 		}
 
+		if f := viper.GetString("input-file"); f != "" {
+			lg := lg.With().Str("path", f).Logger()
+
+			parts := strings.SplitN(f, "=", 2)
+			k, v := parts[0], parts[1]
+
+			content, err := os.ReadFile(v)
+			if err != nil {
+				lg.Fatal().Err(err).Msg("failed to read file")
+			}
+
+			if len(content) > 0 {
+				err = st.SetInput(k, dagger.FileInput(v))
+				if err != nil {
+					lg.Fatal().Err(err).Msg("failed to set input string")
+				}
+			}
+		}
+
 		deployment := common.DeploymentUp(ctx, st)
 
 		v := compiler.NewValue()
@@ -150,6 +169,7 @@ var computeCmd = &cobra.Command{
 func init() {
 	computeCmd.Flags().StringSlice("input-string", []string{}, "TARGET=STRING")
 	computeCmd.Flags().StringSlice("input-dir", []string{}, "TARGET=PATH")
+	computeCmd.Flags().String("input-file", "", "TARGET=PATH")
 	computeCmd.Flags().StringSlice("input-git", []string{}, "TARGET=REMOTE#REF")
 	computeCmd.Flags().String("input-json", "", "JSON")
 	computeCmd.Flags().String("input-yaml", "", "YAML")

--- a/dagger/compiler/value.go
+++ b/dagger/compiler/value.go
@@ -109,6 +109,11 @@ func (v *Value) Exists() bool {
 }
 
 // Proxy function to the underlying cue.Value
+func (v *Value) Bytes() ([]byte, error) {
+	return v.val.Bytes()
+}
+
+// Proxy function to the underlying cue.Value
 func (v *Value) String() (string, error) {
 	return v.val.String()
 }

--- a/stdlib/dagger/dagger.cue
+++ b/stdlib/dagger/dagger.cue
@@ -15,4 +15,6 @@ import (
 // Secret value
 // FIXME: currently aliased as a string to mark secrets
 // this requires proper support.
-#Secret: string
+#Secret: {
+	string | bytes
+}

--- a/stdlib/dagger/op/op.cue
+++ b/stdlib/dagger/op/op.cue
@@ -87,7 +87,7 @@ package op
 
 #WriteFile: {
 	do:      "write-file"
-	content: string
+	content: string | bytes
 	dest:    string
 	mode:    int | *0o644
 }


### PR DESCRIPTION
Allows a file to be injected into the cue graph.

dagger compute --input-file a.b=foo.txt dir/
