### PR TITLE
Proper support for Docker Image metadata

### DIFF
--- a/tests/llb/dockerbuild/main.cue
+++ b/tests/llb/dockerbuild/main.cue
@@ -91,3 +91,32 @@ TestBuildPlatform: #up: [
 		platforms: ["linux/amd64"]
 	},
 ]
+
+TestImageMetadata: #up: [
+	op.#DockerBuild & {
+		dockerfile: """
+			FROM alpine:latest@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d
+			ENV CHECK foobar
+			ENV DOUBLECHECK test
+			"""
+	},
+	op.#Exec & {
+		args: ["sh", "-c", #"""
+			env
+			test "$CHECK" = "foobar"
+			"""#]
+	},
+]
+
+// Make sure the metadata is carried over with a `Load`
+TestImageMetadataIndirect: #up: [
+	op.#Load & {
+		from: TestImageMetadata
+	},
+	op.#Exec & {
+		args: ["sh", "-c", #"""
+			env
+			test "$DOUBLECHECK" = "test"
+			"""#]
+	},
+]

--- a/tests/llb/push-container/main.cue
+++ b/tests/llb/push-container/main.cue
@@ -54,3 +54,79 @@ TestPushContainer: {
 		},
 	]
 }
+
+// Ensures image metadata is preserved in a push
+TestPushContainerMetadata: {
+	// Generate a random number
+	random: {
+		string
+		#up: [
+			op.#Load & {from: alpine.#Image},
+			op.#Exec & {
+				args: ["sh", "-c", "echo -n $RANDOM > /rand"]
+			},
+			op.#Export & {
+				source: "/rand"
+			},
+		]
+	}
+
+	// `docker build` using an `ENV` and push the image
+	push: {
+		ref: "daggerio/ci-test:\(random)-dockerbuild"
+		#up: [
+			op.#DockerBuild & {
+				dockerfile: #"""
+					FROM alpine:latest@sha256:ab00606a42621fb68f2ed6ad3c88be54397f981a7b70a79db3d1172b11c4367d
+					ENV CHECK \#(random)
+					"""#
+			},
+			op.#PushContainer & {
+				"ref": ref
+			},
+		]
+	}
+
+	// Pull the image down and make sure the ENV is preserved
+	check: #up: [
+		op.#FetchContainer & {
+			ref: push.ref
+		},
+		op.#Exec & {
+			args: [
+				"sh", "-c", #"""
+                env
+                test "$CHECK" = "\#(random)"
+                """#,
+			]
+		},
+	]
+
+	// Do a FetchContainer followed by a PushContainer, make sure
+	// the ENV is preserved
+	pullPush: {
+		ref: "daggerio/ci-test:\(random)-pullpush"
+
+		#up: [
+			op.#FetchContainer & {
+				ref: push.ref
+			},
+			op.#PushContainer & {
+				"ref": ref
+			},
+		]
+	}
+
+	pullPushCheck: #up: [
+		op.#FetchContainer & {
+			ref: pullPush.ref
+		},
+		op.#Exec & {
+			args: [
+				"sh", "-c", #"""
+                test "$CHECK" = "\#(random)"
+                """#,
+			]
+		},
+	]
+}


### PR DESCRIPTION
- Both FetchContainer and DockerBuild read the image metadata and
  convert to LLB (e.g. `ENV foo bar` in Dockerfile shows up in
  `op.#Exec`)
- Image metadata is "sticky" between Pipelines (e.g. `op.#Load` will
  re-use the same metadata)
- Image metadata is injected back to #PushContainer, so that
  DockerBuild+PushContainer and FetchContainer+PushContainer do not lose
  any metadata.
- Tests for all the above

Fixes #142
