### PR TITLE
Add kustomize to Kubernetes stdlib

### DIFF
--- a/stdlib/kubernetes/kustomize/kustomization.cue
+++ b/stdlib/kubernetes/kustomize/kustomization.cue
@@ -1,0 +1,98 @@
+package kustomize
+
+import (
+	"dagger.io/dagger/op"
+	"dagger.io/dagger"
+	"dagger.io/alpine"
+)
+
+#Kustomization: {
+	// Kustomize binary version
+	version: *"v3.8.7" | string
+
+	#code: #"""
+		[ -e /usr/local/bin/kubectl ] || {
+			curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash && mv kustomize /usr/local/bin
+		}
+		"""#
+
+	#up: [
+		op.#Load & {
+			from: alpine.#Image & {
+				package: bash: "=~5.1"
+				package: jq:   "=~1.6"
+				package: curl: "=~7.76"
+			}
+		},
+
+		op.#WriteFile & {
+			dest:    "/entrypoint.sh"
+			content: #code
+		},
+
+		op.#Exec & {
+			args: [
+				"/bin/bash",
+				"--noprofile",
+				"--norc",
+				"-eo",
+				"pipefail",
+				"/entrypoint.sh",
+			]
+		},
+	]
+}
+
+// Apply a Kubernetes Kustomize folder
+#Kustomize: {
+	// Kubernetes source
+	source: dagger.#Artifact
+
+	// Optional Kustomization file
+	kustomization: string
+
+	// Kustomize binary version
+	version: *"v3.8.7" | string
+
+	#code: #"""
+		cp /kustomization.yaml /source | true
+		mkdir -p /output
+		kustomize build /source >> /output/result.yaml
+		"""#
+
+	#up: [
+		op.#Load & {
+			from: #Kustomization & {"version": version}
+		},
+
+		op.#WriteFile & {
+			dest:    "/entrypoint.sh"
+			content: #code
+		},
+
+		if kustomization != _|_ {
+			op.#WriteFile & {
+				dest:    "/kustomization.yaml"
+				content: kustomization
+				mode:    0o600
+			}
+		},
+
+		op.#Exec & {
+			always: true
+			args: [
+				"/bin/bash",
+				"--noprofile",
+				"--norc",
+				"-eo",
+				"pipefail",
+				"/entrypoint.sh",
+			]
+			mount: "/source": from: source
+		},
+
+		op.#Subdir & {
+			dir: "/output"
+		},
+	]
+}

--- a/tests/stdlib.bats
+++ b/tests/stdlib.bats
@@ -32,6 +32,10 @@ setup() {
     "$DAGGER" compute "$TESTDIR"/stdlib/kubernetes --input-dir kubeconfig=~/.kube
 }
 
+@test "stdlib: kustomize" {
+    "$DAGGER" compute "$TESTDIR"/stdlib/kubernetes/kustomize --input-dir TestKustomize.kustom.source="$TESTDIR"/stdlib/kubernetes/kustomize/testdata
+}
+
 @test "stdlib: helm" {
     skip_unless_local_kube
 

--- a/tests/stdlib/kubernetes/kustomize/kustomize.cue
+++ b/tests/stdlib/kubernetes/kustomize/kustomize.cue
@@ -1,0 +1,32 @@
+package kustomize
+
+import (
+	"encoding/yaml"
+	"dagger.io/dagger"
+	"dagger.io/kubernetes/kustomize"
+)
+
+TestKustomize: {
+	testdata: dagger.#Artifact
+
+	// Run Kustomize
+	kustom: kustomize.#Kustomize & {
+		source:        testdata
+		kustomization: yaml.Marshal({
+			resources: ["deployment.yaml", "pod.yaml"]
+			images: [{
+				name:   "nginx"
+				newTag: "v1"
+			}]
+			replicas: [{
+				name:  "nginx-deployment"
+				count: 2
+			}]
+		})
+	}
+
+	// Verify kustomization generation
+	verify: #VerifyKustomize & {
+		source: kustom
+	}
+}

--- a/tests/stdlib/kubernetes/kustomize/testdata/deployment.yaml
+++ b/tests/stdlib/kubernetes/kustomize/testdata/deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx-deployment
+spec:
+  replicas: 1
+  template:
+    metadata:
+      name: nginx-deployment
+      labels:
+        app: nginx-deployment
+    spec:
+      containers:
+        - name: nginx-deployment
+          image: nginx
+          imagePullPolicy: IfNotPresent
+      restartPolicy: Always
+  selector:
+    matchLabels:
+      app: nginx-deployment

--- a/tests/stdlib/kubernetes/kustomize/testdata/pod.yaml
+++ b/tests/stdlib/kubernetes/kustomize/testdata/pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  labels:
+    app: test-pod
+spec:
+  containers:
+    - name: test-pod
+      image: nginx
+      imagePullPolicy: IfNotPresent
+  restartPolicy: Always

--- a/tests/stdlib/kubernetes/kustomize/verify.cue
+++ b/tests/stdlib/kubernetes/kustomize/verify.cue
@@ -1,0 +1,72 @@
+package kustomize
+
+import (
+	"dagger.io/dagger/op"
+	"dagger.io/dagger"
+	"dagger.io/alpine"
+)
+
+#VerifyKustomize: {
+	source: dagger.#Artifact
+
+	#up: [
+		op.#Load & {
+			from: alpine.#Image & {
+				package: bash: "=~5.1"
+			}
+		},
+
+		// Check files
+		op.#Exec & {
+			always: true
+			args: [
+				"sh", "-c", "test $(ls /source | wc -l) = 1",
+			]
+			mount: "/source": from: source
+		},
+
+		// Check image tag kustomization
+		op.#Exec & {
+			always: true
+			args: [
+				"sh", "-c", #"""
+						grep -q "\- image: nginx:v1" /source/result.yaml
+					"""#,
+			]
+			mount: "/source": from: source
+		},
+
+		// Check replicas kustomization
+		op.#Exec & {
+			always: true
+			args: [
+				"sh", "-c", #"""
+						grep -q "replicas: 2" /source/result.yaml
+					"""#,
+			]
+			mount: "/source": from: source
+		},
+
+		// Check pod merge by kustomization
+		op.#Exec & {
+			always: true
+			args: [
+				"sh", "-c", #"""
+						grep -q "kind: Pod" /source/result.yaml
+					"""#,
+			]
+			mount: "/source": from: source
+		},
+
+		// Check pod name
+		op.#Exec & {
+			always: true
+			args: [
+				"sh", "-c", #"""
+						grep -q "name: test-pod" /source/result.yaml
+					"""#,
+			]
+			mount: "/source": from: source
+		},
+	]
+}

--- a/tom_test/tmp/main.cue
+++ b/tom_test/tmp/main.cue
@@ -1,0 +1,3 @@
+package tom
+
+name: string


### PR DESCRIPTION
Add the `kustomize` command in the package.

I used the "real" `kustomize` binary because `kubectl -k` is [outdated](https://github.com/kubernetes-sigs/kustomize/issues/2047#issuecomment-713030249).

Something strange I met during the development is that container can mount volumes from nested compute...
It create some errors because the `kustomization.yaml` was interpreted as yaml by the `kubectl apply`  command.

To dodge this problem, I remove the file after the compute.

> I tried to export it but it created type error in cue.

This PR is a first draft and should be improve with time.