### PR TITLE
Tests AWS Eks

### DIFF
--- a/stdlib/aws/eks/eks.cue
+++ b/stdlib/aws/eks/eks.cue
@@ -1,7 +1,6 @@
 package eks
 
 import (
-	// "dagger.io/dagger"
 	"dagger.io/dagger/op"
 	"dagger.io/aws"
 )
@@ -19,7 +18,8 @@ import (
 
 	// kubeconfig is the generated kube configuration file
 	kubeconfig: {
-		string// FIXME There is a problem with dagger.#Artifact type
+		// FIXME There is a problem with dagger.#Secret type
+		string
 
 		#up: [
 			op.#Load & {

--- a/tests/stdlib.bats
+++ b/tests/stdlib.bats
@@ -43,3 +43,8 @@ setup() {
 
     "$DAGGER" compute "$TESTDIR"/stdlib/aws/s3 --input-dir TestDirectory="$TESTDIR"/stdlib/aws/s3/testdata --input-yaml "$TESTDIR"/stdlib/aws/inputs.yaml
 }
+@test "stdlib: aws" {
+    skip_unless_secrets_available "$TESTDIR"/stdlib/aws/inputs.yaml
+
+    "$DAGGER" compute "$TESTDIR"/stdlib/aws/eks --input-yaml "$TESTDIR"/stdlib/aws/inputs.yaml
+}

--- a/tests/stdlib/aws/eks/eks.cue
+++ b/tests/stdlib/aws/eks/eks.cue
@@ -1,0 +1,53 @@
+package eks
+
+import (
+	"dagger.io/aws"
+	"dagger.io/aws/eks"
+	"dagger.io/kubernetes"
+	"dagger.io/dagger/op"
+)
+
+TestConfig: awsConfig: aws.#Config & {
+	region: "us-east-2"
+}
+
+TestCluster: eks.#KubeConfig & {
+	config:      TestConfig.awsConfig
+	clusterName: *"dagger-example-eks-cluster" | string
+}
+
+TestEks: {
+	#GetPods:
+		"""
+				kubectl get pods -A
+			"""
+
+	#up: [
+		op.#Load & {
+			from: kubernetes.#Kubectl
+		},
+
+		op.#WriteFile & {
+			dest:    "/kubeconfig"
+			content: TestCluster.kubeconfig
+		},
+
+		op.#WriteFile & {
+			dest:    "/getPods.sh"
+			content: #GetPods
+		},
+
+		op.#Exec & {
+			always: true
+			args: [
+				"/bin/bash",
+				"--noprofile",
+				"--norc",
+				"-eo",
+				"pipefail",
+				"/getPods.sh",
+			]
+			env: KUBECONFIG: "/kubeconfig"
+		},
+	]
+}


### PR DESCRIPTION
## TL;DR
 - Add tests on AWS eks
 - Fix kubeconfig type from `aws/eks` package
 
## Tests made
 - Verify that we can execute a `kubectl get pods -A` on the aws cluster

> It's not necessary to do more, we already wrote tests for kubernetes.

## Fix

There is a problem with the `dagger.#Secret` type. It wasn't possible to generate the `kubeconfig`.

<details>
<summary>Click to see an example</summary>
Here is a simple example : 

```cue
import (
	"dagger.io/aws"
	"dagger.io/dagger/op"
)

#Def: {
	conf: {
		string

		#up: [
			op.#Load & {
				from: aws.#CLI
			},

			op.#WriteFile & {
				dest: "/test"
				content: "Test"
			},

			op.#Export & {
				source: "/test"
				format: "string"
			}
		]
	}
}

res: #Def
```

Generate the configuration

```shell
{"res":{"conf":"Test"}}
```

**BUT**

```cue
#Def: {
	conf: {
		string | bytes // === dagger.#Secret

		#up: [
			op.#Load & {
				from: aws.#CLI
			},

			op.#WriteFile & {
				dest: "/test"
				content: "Test"
			},

			op.#Export & {
				source: "/test"
				format: "string"
			}
		]
	}
}

res: #Def
```

Generate 
```shell
{}
```

</details>


To fix that problem, I changed the kubeconfig type to `string`.
