### PR TITLE
Revert "stdlib: dagger.io/dagger/op: stricter typing for load, mount, copy"

### DIFF
--- a/stdlib/dagger/op/op.cue
+++ b/stdlib/dagger/op/op.cue
@@ -1,11 +1,6 @@
 // op: low-level operations for Dagger processing pipelines
 package op
 
-// Cue data which can be executed as code
-#Runnable: [...#Op] | {#up: [...#Op]
-	...
-}
-
 // One operation in a pipeline
 #Op: #Export |
 	#FetchContainer |
@@ -38,7 +33,7 @@ package op
 
 #Load: {
 	do:   "load"
-	from: #Runnable
+	from: _
 }
 
 #Subdir: {
@@ -53,7 +48,7 @@ package op
 	// `true` means also ignoring the mount cache volumes
 	always?: true | *false
 	dir:     string | *"/"
-	mount: [string]: "tmpfs" | "cache" | {from: #Runnable, path: string | *"/"}
+	mount: [string]: "tmpfs" | "cache" | {from: _, path: string | *"/"}
 }
 
 #FetchContainer: {
@@ -74,7 +69,7 @@ package op
 
 #Copy: {
 	do:   "copy"
-	from: #Runnable
+	from: _
 	src:  string | *"/"
 	dest: string | *"/"
 }
@@ -82,7 +77,7 @@ package op
 #DockerBuild: {
 	do: "docker-build"
 	// We accept either a context, a Dockerfile or both together
-	context?:        #Runnable
+	context?:        _
 	dockerfilePath?: string // path to the Dockerfile (defaults to "Dockerfile")
 	dockerfile?:     string
 


### PR DESCRIPTION
Reverts dagger/dagger#347

Fixes #353 

After reverting the commit, my `dagger query` goes from 7.5 seconds to 0.9 second (MBP with M1)