### PR TITLE
S3 does not update object if rollbacked to an existing layer

### DIFF
--- a/examples/simple-s3/main.cue
+++ b/examples/simple-s3/main.cue
@@ -28,6 +28,7 @@ page: """
 deploy: s3.#Put & {
 	config:       awsConfig
 	sourceInline: page
+	always:       true
 	contentType:  "text/html"
 	target:       "s3://\(bucket)/index.html"
 }

--- a/stdlib/aws/s3/s3.cue
+++ b/stdlib/aws/s3/s3.cue
@@ -26,8 +26,14 @@ import (
 	// URL of the uploaded S3 object
 	url: out
 
+	// Always write the object to S3
+	always?: bool
+
 	out: string
 	aws.#Script & {
+		if always != _|_ {
+			"always": always
+		}
 		files: {
 			if sourceInline != _|_ {
 				"/inputs/source": sourceInline


### PR DESCRIPTION
Fix a bug where you are locked with inconsistency between your intention and the reality.

**How to reproduce**
- `cd example/simple-s3`
- `dagger up`
- Modify the html body
- `dagger up` 
- Rollback the body to a previously deployed version (Ctrl+Z)
- `dagger up`
- **Nothing is sent to S3**

We cannot reuse the buildkit caching logic, maybe a more efficient way to achieve a proper caching could be to compare a checksum of local object and remote one.