### PR TITLE
Dagger: unset input

### DIFF
--- a/cmd/dagger/cmd/input/root.go
+++ b/cmd/dagger/cmd/input/root.go
@@ -80,20 +80,3 @@ func readInput(ctx context.Context, source string) string {
 
 	return string(data)
 }
-
-func removeEnvironmentInput(ctx context.Context, key string) {
-	lg := log.Ctx(ctx)
-
-	store, err := dagger.DefaultStore()
-	if err != nil {
-		lg.Fatal().Err(err).Msg("failed to load store")
-	}
-
-	st := common.GetCurrentEnvironmentState(ctx, store)
-	st.RemoveInputs(key)
-
-	if err := store.UpdateEnvironment(ctx, st, nil); err != nil {
-		lg.Fatal().Err(err).Str("environmentId", st.ID).Str("environmentName", st.Name).Msg("cannot update environment")
-	}
-	lg.Info().Str("environmentId", st.ID).Str("environmentName", st.Name).Msg("updated environment")
-}

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -119,6 +119,13 @@ setup() {
     assert_success
     assert_output '"my input"'
 
+    # unset simple input
+    "$DAGGER" input -e "input" unset "input"
+    "$DAGGER" up -e "input"
+    run "$DAGGER" -l error query -e "input" input
+    assert_success
+    assert_output 'null'
+
     # nested input
     "$DAGGER" input -e "input" text "nested.input" "nested input"
     "$DAGGER" up -e "input"
@@ -128,12 +135,26 @@ setup() {
   "input": "nested input"
 }'
 
+    # unset nested input
+    "$DAGGER" input -e "input" unset "nested.input"
+    "$DAGGER" up -e "input"
+    run "$DAGGER" -l error query -e "input" nested
+    assert_success
+    assert_output 'null'
+
     # file input
     "$DAGGER" input -e "input" text "input" -f "$TESTDIR"/cli/input/simple/testdata/input.txt
     "$DAGGER" up -e "input"
     run "$DAGGER" -l error query -e "input" input
     assert_success
     assert_output '"from file\n"'
+
+    # unset file input
+    "$DAGGER" input -e "input" unset "input"
+    "$DAGGER" up -e "input"
+    run "$DAGGER" -l error query -e "input" input
+    assert_success
+    assert_output 'null'
 
     # invalid file
     run "$DAGGER" input -e "input" text "input" -f "$TESTDIR"/cli/input/simple/testdata/notexist
@@ -145,11 +166,19 @@ setup() {
     run "$DAGGER" -l error query -e "input" input
     assert_success
     assert_output '"from stdin"'
+
+    # unset stdin input
+    "$DAGGER" input -e "input" unset "input"
+    "$DAGGER" up -e "input"
+    run "$DAGGER" -l error query -e "input" input
+    assert_success
+    assert_output 'null'
 }
 
 @test "dagger input json" {
     "$DAGGER" new --plan-dir "$TESTDIR"/cli/input/simple "input"
 
+    # simple json
     "$DAGGER" input -e "input" json "structured" '{"a": "foo", "b": 42}'
     "$DAGGER" up -e "input"
     run "$DAGGER" -l error query -e "input" structured
@@ -159,6 +188,14 @@ setup() {
   "b": 42
 }'
 
+    # unset simple json
+    "$DAGGER" input -e "input" unset "structured"
+    "$DAGGER" up -e "input"
+    run "$DAGGER" -l error query -e "input" structured
+    assert_success
+    assert_output 'null'
+
+    # json from file
     "$DAGGER" input -e "input" json "structured" -f "$TESTDIR"/cli/input/simple/testdata/input.json
     "$DAGGER" up -e "input"
     run "$DAGGER" -l error query -e "input" structured
@@ -167,11 +204,19 @@ setup() {
   "a": "from file",
   "b": 42
 }'
+
+    # unset json from file
+    "$DAGGER" input -e "input" unset "structured"
+    "$DAGGER" up -e "input"
+    run "$DAGGER" -l error query -e "input" structured
+    assert_success
+    assert_output 'null'
 }
 
 @test "dagger input yaml" {
     "$DAGGER" new --plan-dir "$TESTDIR"/cli/input/simple "input"
 
+    # simple yaml
     "$DAGGER" input -e "input" yaml "structured" '{"a": "foo", "b": 42}'
     "$DAGGER" up -e "input"
     run "$DAGGER" -l error query -e "input" structured
@@ -181,6 +226,14 @@ setup() {
   "b": 42
 }'
 
+    # unset simple yaml
+    "$DAGGER" input -e "input" unset "structured"
+    "$DAGGER" up -e "input"
+    run "$DAGGER" -l error query -e "input" structured
+    assert_success
+    assert_output 'null'
+
+    # yaml from file
     "$DAGGER" input -e "input" yaml "structured" -f "$TESTDIR"/cli/input/simple/testdata/input.yaml
     "$DAGGER" up -e "input"
     run "$DAGGER" -l error query -e "input" structured
@@ -189,11 +242,19 @@ setup() {
   "a": "from file",
   "b": 42
 }'
+
+    # unset yaml from file
+    "$DAGGER" input -e "input" unset "structured"
+    "$DAGGER" up -e "input"
+    run "$DAGGER" -l error query -e "input" structured
+    assert_success
+    assert_output 'null'
 }
 
 @test "dagger input dir" {
     "$DAGGER" new --plan-dir "$TESTDIR"/cli/input/artifact "input"
 
+    # input dir
     "$DAGGER" input -e "input" dir "source" "$TESTDIR"/cli/input/artifact/testdata
     "$DAGGER" up -e "input"
     run "$DAGGER" -l error query -e "input"
@@ -203,11 +264,21 @@ setup() {
   "foo": "bar",
   "source": {}
 }'
+
+    # unset dir
+    "$DAGGER" input -e "input" unset "source"
+    "$DAGGER" up -e "input"
+    run "$DAGGER" -l error query -e "input"
+    assert_success
+    assert_output '{
+  "foo": "bar"
+}'
 }
 
 @test "dagger input git" {
     "$DAGGER" new --plan-dir "$TESTDIR"/cli/input/artifact "input"
 
+    # input git
     "$DAGGER" input -e "input" git "source" https://github.com/samalba/dagger-test-simple.git
     "$DAGGER" up -e "input"
     run "$DAGGER" -l error query -e "input"
@@ -216,11 +287,20 @@ setup() {
   "foo": "bar",
   "source": {}
 }'
+
+    # unset input git
+    "$DAGGER" input -e "input" unset "source"
+    "$DAGGER" up -e "input"
+    run "$DAGGER" -l error query -e "input"
+    assert_output '{
+  "foo": "bar"
+}'
 }
 
 @test "dagger input scan" {
     "$DAGGER" new --plan-dir "$TESTDIR"/cli/input/scan "scan"
+
+    # TODO "scan" option isn't implemented
     run "$DAGGER" input scan -e "input"
     assert_success
-
 }


### PR DESCRIPTION
## TL;DR

Resolve #364 

## Changes

### Features

It's now possible to remove input from environement through `dagger input unset <key>`.
@aluzzardi has already develop the feature in dagger. I've only linked it to CLI.

### Tests

All `input` tests now `unset` the input after run.
It was the simplest and more effective way to test all types of input with `unset` command.