### PR TITLE
Dockerfile: make the static binary smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ WORKDIR /src
 RUN apk add --no-cache file
 ENV GOMODCACHE /root/.cache/gocache
 RUN --mount=target=. --mount=target=/root/.cache,type=cache \
-    CGO_ENABLED=0 go build -o /out/dagger ./cmd/dagger && file /out/dagger | grep "statically linked"
+    CGO_ENABLED=0 go build -o /out/dagger -ldflags '-s -d -w' ./cmd/dagger; \
+    file /out/dagger | grep "statically linked"
 
 FROM scratch
 COPY --from=build /out/dagger /bin/dagger


### PR DESCRIPTION
This PR makes the static dagger binary smaller. The linker flags make it smaller through the removal of the unneeded symbols.