### PR TITLE
First try at fixing #428

### DIFF
--- a/dagger/pipeline.go
+++ b/dagger/pipeline.go
@@ -721,6 +721,7 @@ func (p *Pipeline) DockerBuild(ctx context.Context, op *compiler.Value, st llb.S
 	var (
 		dockerContext = op.Lookup("context")
 		dockerfile    = op.Lookup("dockerfile")
+		dockerfileDir    = op.Lookup("dockerfileDir")
 
 		contextDef    *bkpb.Definition
 		dockerfileDef *bkpb.Definition
@@ -744,6 +745,17 @@ func (p *Pipeline) DockerBuild(ctx context.Context, op *compiler.Value, st llb.S
 			return st, err
 		}
 		dockerfileDef = contextDef
+
+		if dockerfileDir.Exists(){
+			from = NewPipeline(op.Lookup("dockerfileDir").Path().String(), p.s)
+			if err = from.Do(ctx, dockerfileDir); err != nil {
+				return st, err
+			}
+			dockerfileDef, err = p.s.Marshal(ctx, from.State())
+			if err != nil {
+				return st, err
+			}
+		}
 	}
 
 	// Inlined dockerfile: need to be converted to LLB

--- a/stdlib/dagger/op/op.cue
+++ b/stdlib/dagger/op/op.cue
@@ -86,6 +86,7 @@ package op
 	do: "docker-build"
 	// We accept either a context, a Dockerfile or both together
 	context?:        _
+	dockerfileDir?:  _
 	dockerfilePath?: string // path to the Dockerfile (defaults to "Dockerfile")
 	dockerfile?:     string
 


### PR DESCRIPTION
This requires UX discussion.

The reason why `filename` was represented as `dockerfilePath` is not clear to me, and to what extent there is a desire to diverge (or not) from buildkit options and default behavior overall.

Furthermore, all of this requires a lot more tests, as there is a lot of possible combinations.