### PR TITLE
Support for target & hosts (#DockerBuild)

### DIFF
--- a/dagger/pipeline.go
+++ b/dagger/pipeline.go
@@ -849,6 +849,25 @@ func dockerBuildOpts(op *compiler.Value) (map[string]string, error) {
 		}
 		opts["target"] = tgr
 	}
+
+	if hosts := op.Lookup("hosts"); hosts.Exists() {
+		p := []string{}
+		fields, err := hosts.Fields()
+		if err != nil {
+			return nil, err
+		}
+		for _, host := range fields {
+			s, err := host.Value.String()
+			if err != nil {
+				return nil, err
+			}
+			p = append(p, host.Label()+"="+s)
+		}
+		if len(p) > 0 {
+			opts["add-hosts"] = strings.Join(p, ",")
+		}
+	}
+
 	if buildArgs := op.Lookup("buildArg"); buildArgs.Exists() {
 		fields, err := buildArgs.Fields()
 		if err != nil {

--- a/stdlib/dagger/op/op.cue
+++ b/stdlib/dagger/op/op.cue
@@ -93,6 +93,7 @@ package op
 	buildArg?: [string]: string
 	label?: [string]:    string
 	target?: string
+	hosts?: [string]: string
 }
 
 #WriteFile: {


### PR DESCRIPTION
Following previous conversation, adding missing options for DockerBuild:
 - target, providing the same functionality as `docker build --target`
 - hosts, providing the same functionality as `docker build --add-host`