### PR TITLE
Proposal to fix #442

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ check-buildkit-version:
 
 .PHONY: integration
 integration: dagger-debug
+	$(shell command -v sops > /dev/null || { echo "You need sops. On macOS: brew install sops"; exit 1; })
+	$(shell command -v parallel > /dev/null || { echo "You need gnu parallel. On macOS: brew install parallel"; exit 1; })
 	yarn --cwd "./tests" install
 	DAGGER_BINARY="../cmd/dagger/dagger-debug" yarn --cwd "./tests" test
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,10 +4,20 @@
 
 ```
 # Install dependancies
-yarn --cwd install
+yarn install
+
+# Install gnu parallel if needed
+# macOS
+brew install parallel
+# Debian derivatives
+# apt-get install parallel
+
+# Install sops if needed
+# macOS
+brew install sops
 
 # Run all tests
-yarn --cwd test
+yarn test
 ```
 
 By default, the `dagger` binary is expected to be found in `../cmd/dagger/dagger` relative to the `tests` directory.


### PR DESCRIPTION
Fix #442 

Make installing sops and parallel mandatory (is there any scenario where it should be possible to run tests without these?)

Plus minor changes to test/README:
 * fix for borked yarn call
 * word about parallel and sops