### PR TITLE
Hide unused flag for version command

### DIFF
--- a/cmd/dagger/cmd/version.go
+++ b/cmd/dagger/cmd/version.go
@@ -61,6 +61,10 @@ var versionCmd = &cobra.Command{
 func init() {
 	versionCmd.Flags().Bool("check", false, "check if dagger is up to date")
 
+	versionCmd.InheritedFlags().MarkHidden("environment")
+	versionCmd.InheritedFlags().MarkHidden("log-level")
+	versionCmd.InheritedFlags().MarkHidden("log-format")
+
 	if err := viper.BindPFlags(versionCmd.Flags()); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## TL;DR
Fix #460 

## Fix

`dagger help version` now print :
```
Print dagger version

Usage:
  dagger version [flags]

Flags:
      --check   check if dagger is up to date
  -h, --help    help for version
```
