### PR TITLE
stdlib: fixed aws double execution because of cache volumes

### DIFF
--- a/stdlib/aws/aws.cue
+++ b/stdlib/aws/aws.cue
@@ -95,7 +95,6 @@ import (
 				]
 				"env": env
 				"env": {
-					AWS_CONFIG_FILE:       "/cache/aws/config"
 					AWS_ACCESS_KEY_ID:     config.accessKey
 					AWS_SECRET_ACCESS_KEY: config.secretKey
 					AWS_DEFAULT_REGION:    config.region
@@ -103,7 +102,6 @@ import (
 					AWS_DEFAULT_OUTPUT:    "json"
 					AWS_PAGER:             ""
 				}
-				mount: "/cache/aws": "cache"
 				if dir != _|_ {
 					mount: "/inputs/source": from: dir
 				}

--- a/stdlib/aws/ecr/ecr.cue
+++ b/stdlib/aws/ecr/ecr.cue
@@ -14,8 +14,7 @@ import (
 
 	// ECR credentials
 	username: "AWS"
-	// FIXME Exected twice and trigger error : "TestECR.creds.secret: 2 errors in empty disjunction"
-	// Happend because of v0.8.3 of buildkit container
+
 	secret: out
 
 	aws.#Script & {


### PR DESCRIPTION
Recent buildkit changes broke the cache, causing double execution when an Exec has cache volumes. This breaks aws.#ECR auth and aws.#ELB.

This change removes the cache volume to workaround this problem.