### PR TITLE
Move random string generation from tests to his own file

### DIFF
--- a/tests/ops/push-container/main.cue
+++ b/tests/ops/push-container/main.cue
@@ -12,20 +12,6 @@ registry: {
 }
 
 TestPushContainer: {
-	// Generate a random number
-	random: {
-		string
-		#up: [
-			op.#Load & {from: alpine.#Image},
-			op.#Exec & {
-				args: ["sh", "-c", "echo -n $RANDOM > /rand"]
-			},
-			op.#Export & {
-				source: "/rand"
-			},
-		]
-	}
-
 	// Push an image with a random tag
 	push: {
 		ref: "daggerio/ci-test:\(random)"
@@ -66,20 +52,6 @@ TestPushContainer: {
 
 // Ensures image metadata is preserved in a push
 TestPushContainerMetadata: {
-	// Generate a random number
-	random: {
-		string
-		#up: [
-			op.#Load & {from: alpine.#Image},
-			op.#Exec & {
-				args: ["sh", "-c", "echo -n $RANDOM > /rand"]
-			},
-			op.#Export & {
-				source: "/rand"
-			},
-		]
-	}
-
 	// `docker build` using an `ENV` and push the image
 	push: {
 		ref: "daggerio/ci-test:\(random)-dockerbuild"

--- a/tests/ops/push-container/random.cue
+++ b/tests/ops/push-container/random.cue
@@ -1,0 +1,20 @@
+package testing
+
+import (
+	"dagger.io/alpine"
+	"dagger.io/dagger/op"
+)
+
+// Generate a random number
+random: {
+	string
+	#up: [
+		op.#Load & {from: alpine.#Image},
+		op.#Exec & {
+			args: ["sh", "-c", "cat /dev/urandom | tr -dc 'a-z' | fold -w 10 | head -n 1 | tr -d '\n' > /rand"]
+		},
+		op.#Export & {
+			source: "/rand"
+		},
+	]
+}

--- a/tests/stdlib/aws/ecr/ecr.cue
+++ b/tests/stdlib/aws/ecr/ecr.cue
@@ -3,26 +3,11 @@ package ecr
 import (
 	"dagger.io/aws"
 	"dagger.io/aws/ecr"
-	"dagger.io/alpine"
 	"dagger.io/dagger/op"
 )
 
 TestConfig: awsConfig: aws.#Config & {
 	region: "us-east-2"
-}
-
-// Generate a random number
-random: {
-	string
-	#up: [
-		op.#Load & {from: alpine.#Image},
-		op.#Exec & {
-			args: ["sh", "-c", "cat /dev/urandom | tr -dc 'a-z' | fold -w 10 | head -n 1 | tr -d '\n' > /rand"]
-		},
-		op.#Export & {
-			source: "/rand"
-		},
-	]
 }
 
 TestECR: {

--- a/tests/stdlib/aws/ecr/random.cue
+++ b/tests/stdlib/aws/ecr/random.cue
@@ -1,0 +1,20 @@
+package ecr
+
+import (
+	"dagger.io/alpine"
+	"dagger.io/dagger/op"
+)
+
+// Generate a random number
+random: {
+	string
+	#up: [
+		op.#Load & {from: alpine.#Image},
+		op.#Exec & {
+			args: ["sh", "-c", "cat /dev/urandom | tr -dc 'a-z' | fold -w 10 | head -n 1 | tr -d '\n' > /rand"]
+		},
+		op.#Export & {
+			source: "/rand"
+		},
+	]
+}

--- a/tests/stdlib/docker/push-pull/push-pull.cue
+++ b/tests/stdlib/docker/push-pull/push-pull.cue
@@ -15,20 +15,6 @@ registry: {
 }
 
 TestPushAndPull: {
-	// Generate a random number
-	random: {
-		string
-		#up: [
-			op.#Load & {from: alpine.#Image},
-			op.#Exec & {
-				args: ["sh", "-c", "cat /dev/urandom | tr -dc 'a-z' | fold -w 10 | head -n 1 | tr -d '\n' > /rand"]
-			},
-			op.#Export & {
-				source: "/rand"
-			},
-		]
-	}
-
 	ref: "daggerio/ci-test:\(random)"
 
 	// Create image

--- a/tests/stdlib/docker/push-pull/random.cue
+++ b/tests/stdlib/docker/push-pull/random.cue
@@ -1,0 +1,20 @@
+package docker
+
+import (
+	"dagger.io/alpine"
+	"dagger.io/dagger/op"
+)
+
+// Generate a random number
+random: {
+	string
+	#up: [
+		op.#Load & {from: alpine.#Image},
+		op.#Exec & {
+			args: ["sh", "-c", "cat /dev/urandom | tr -dc 'a-z' | fold -w 10 | head -n 1 | tr -d '\n' > /rand"]
+		},
+		op.#Export & {
+			source: "/rand"
+		},
+	]
+}

--- a/tests/stdlib/gcp/gcr/gcr.cue
+++ b/tests/stdlib/gcp/gcr/gcr.cue
@@ -3,25 +3,10 @@ package gcr
 import (
 	"dagger.io/gcp"
 	"dagger.io/gcp/gcr"
-	"dagger.io/alpine"
 	"dagger.io/dagger/op"
 )
 
 TestConfig: gcpConfig: gcp.#Config
-
-// Generate a random number
-random: {
-	string
-	#up: [
-		op.#Load & {from: alpine.#Image},
-		op.#Exec & {
-			args: ["sh", "-c", "cat /dev/urandom | tr -dc 'a-z' | fold -w 10 | head -n 1 | tr -d '\n' > /rand"]
-		},
-		op.#Export & {
-			source: "/rand"
-		},
-	]
-}
 
 TestGCR: {
 	repository: "gcr.io/dagger-ci/test"

--- a/tests/stdlib/gcp/gcr/random.cue
+++ b/tests/stdlib/gcp/gcr/random.cue
@@ -1,0 +1,20 @@
+package gcr
+
+import (
+	"dagger.io/alpine"
+	"dagger.io/dagger/op"
+)
+
+// Generate a random number
+random: {
+	string
+	#up: [
+		op.#Load & {from: alpine.#Image},
+		op.#Exec & {
+			args: ["sh", "-c", "cat /dev/urandom | tr -dc 'a-z' | fold -w 10 | head -n 1 | tr -d '\n' > /rand"]
+		},
+		op.#Export & {
+			source: "/rand"
+		},
+	]
+}

--- a/tests/stdlib/kubernetes/helm/helm.cue
+++ b/tests/stdlib/kubernetes/helm/helm.cue
@@ -2,8 +2,6 @@ package helm
 
 import (
 	"dagger.io/dagger"
-	"dagger.io/dagger/op"
-	"dagger.io/alpine"
 	"dagger.io/file"
 	"dagger.io/kubernetes/helm"
 )
@@ -16,20 +14,6 @@ kubeconfig: dagger.#Artifact
 config: file.#Read & {
 	filename: "config"
 	from:     kubeconfig
-}
-
-// Generate random string
-random: {
-	string
-	#up: [
-		op.#Load & {from: alpine.#Image},
-		op.#Exec & {
-			args: ["sh", "-c", "cat /dev/urandom | tr -dc 'a-z' | fold -w 10 | head -n 1 | tr -d '\n' > /rand"]
-		},
-		op.#Export & {
-			source: "/rand"
-		},
-	]
 }
 
 // Deploy user local chart

--- a/tests/stdlib/kubernetes/helm/random.cue
+++ b/tests/stdlib/kubernetes/helm/random.cue
@@ -1,0 +1,20 @@
+package helm
+
+import (
+	"dagger.io/alpine"
+	"dagger.io/dagger/op"
+)
+
+// Generate a random number
+random: {
+	string
+	#up: [
+		op.#Load & {from: alpine.#Image},
+		op.#Exec & {
+			args: ["sh", "-c", "cat /dev/urandom | tr -dc 'a-z' | fold -w 10 | head -n 1 | tr -d '\n' > /rand"]
+		},
+		op.#Export & {
+			source: "/rand"
+		},
+	]
+}

--- a/tests/stdlib/kubernetes/kubernetes.cue
+++ b/tests/stdlib/kubernetes/kubernetes.cue
@@ -3,8 +3,6 @@ package kubernetes
 import (
 	"encoding/yaml"
 	"dagger.io/dagger"
-	"dagger.io/dagger/op"
-	"dagger.io/alpine"
 	"dagger.io/file"
 	"dagger.io/kubernetes"
 )
@@ -17,22 +15,6 @@ kubeconfig: dagger.#Artifact
 config: file.#Read & {
 	filename: "config"
 	from:     kubeconfig
-}
-
-// Generate a random number
-// It trigger a "cycle error" if I put it in TestKubeApply ?!
-// failed to up deployment: buildkit solve: TestKubeApply.#up: cycle error
-random: {
-	string
-	#up: [
-		op.#Load & {from: alpine.#Image},
-		op.#Exec & {
-			args: ["sh", "-c", "cat /dev/urandom | tr -dc 'a-z' | fold -w 10 | head -n 1 | tr -d '\n' > /rand"]
-		},
-		op.#Export & {
-			source: "/rand"
-		},
-	]
 }
 
 TestKubeApply: {

--- a/tests/stdlib/kubernetes/random.cue
+++ b/tests/stdlib/kubernetes/random.cue
@@ -1,0 +1,20 @@
+package kubernetes
+
+import (
+	"dagger.io/alpine"
+	"dagger.io/dagger/op"
+)
+
+// Generate a random number
+random: {
+	string
+	#up: [
+		op.#Load & {from: alpine.#Image},
+		op.#Exec & {
+			args: ["sh", "-c", "cat /dev/urandom | tr -dc 'a-z' | fold -w 10 | head -n 1 | tr -d '\n' > /rand"]
+		},
+		op.#Export & {
+			source: "/rand"
+		},
+	]
+}

--- a/tests/stdlib/netlify/netlify.cue
+++ b/tests/stdlib/netlify/netlify.cue
@@ -7,20 +7,6 @@ import (
 )
 
 TestNetlify: {
-	// Generate a random number
-	random: {
-		string
-		#up: [
-			op.#Load & {from: alpine.#Image},
-			op.#Exec & {
-				args: ["sh", "-c", "echo -n $RANDOM > /rand"]
-			},
-			op.#Export & {
-				source: "/rand"
-			},
-		]
-	}
-
 	// Generate a website containing the random number
 	html: #up: [
 		op.#WriteFile & {

--- a/tests/stdlib/netlify/random.cue
+++ b/tests/stdlib/netlify/random.cue
@@ -1,0 +1,20 @@
+package netlify
+
+import (
+	"dagger.io/alpine"
+	"dagger.io/dagger/op"
+)
+
+// Generate a random number
+random: {
+	string
+	#up: [
+		op.#Load & {from: alpine.#Image},
+		op.#Exec & {
+			args: ["sh", "-c", "cat /dev/urandom | tr -dc 'a-z' | fold -w 10 | head -n 1 | tr -d '\n' > /rand"]
+		},
+		op.#Export & {
+			source: "/rand"
+		},
+	]
+}


### PR DESCRIPTION
## Changes

Add `random.cue` file on each tests that needs random string generation.

## Reason

In order to avoid code duplicate directly in tests, I've move the random string generation in his own file that we could repleace later with a private tests library for example.
 