### PR TITLE
stdlib: put full definition of #Op behind a build attribute

### DIFF
--- a/stdlib/dagger/op/op.cue
+++ b/stdlib/dagger/op/op.cue
@@ -3,26 +3,15 @@ package op
 
 // One operation in a pipeline
 //
-// #Op does not enforce the op spec at full resolution, to avoid triggering performance issues.
-// See https://github.com/dagger/dagger/issues/445
+// #Op does not current enforce the op spec at full resolution, to avoid
+// triggering performance issues. See
+// https://github.com/dagger/dagger/issues/445
+//
+// To enforce the full #Op spec (see op_fullop.cue), run with "-t fullop"
 #Op: {
 	do: string
 	...
 }
-
-// Full resolution schema enforciong the complete op spec
-#OpFull: #Export |
-	#FetchContainer |
-	#PushContainer |
-	#FetchGit |
-	#Exec |
-	#Local |
-	#Copy |
-	#Load |
-	#Subdir |
-	#WriteFile |
-	#Mkdir |
-	#DockerBuild
 
 // Export a value from fs state to cue
 #Export: {

--- a/stdlib/dagger/op/op_fullop.cue
+++ b/stdlib/dagger/op/op_fullop.cue
@@ -1,0 +1,17 @@
+@if(fullop)
+
+package op
+
+// Full resolution schema enforciong the complete op spec
+#Op: (#Export |
+	#FetchContainer |
+	#PushContainer |
+	#FetchGit |
+	#Exec |
+	#Local |
+	#Copy |
+	#Load |
+	#Subdir |
+	#WriteFile |
+	#Mkdir |
+	#DockerBuild) & {do: string}


### PR DESCRIPTION
This allows dagger.io/dagger/op.#Op to be maintained in regular
uncommented CUE, but not participate by default in normal dagger
evaluation (given the performance problems it currently introduces).

The "full" #Op can be enabled by passing the "-t fullop" flag:

    cue eval -t fullop ./examples/react

(which currently triggers the performance issue).