### PR TITLE
goreleaser: fixed version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,7 @@ builds:
     binary: dagger
     ldflags:
       - -s -w
-      - -X dagger.io/go/cmd/dagger/cmd.version={{.Version}}
+      - -X go.dagger.io/dagger/cmd/dagger/cmd.version={{.Version}}
     goos:
       - linux
       - windows


### PR DESCRIPTION
versioning was broken by https://github.com/dagger/dagger/commit/af776b8abe5a18290abfcdcce2aa1c5b3b6e507b

cc @aluzzardi 