### PR TITLE
fix build for non-cgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: dagger
 
 .PHONY: dagger
 dagger:
-	go build -o ./cmd/dagger/ ./cmd/dagger/
+	CGO_ENABLED=0 go build -o ./cmd/dagger/ -ldflags '-s -w' ./cmd/dagger/
 
 .PHONY: dagger-debug
 dagger-debug:

--- a/cmd/dagger/cmd/version.go
+++ b/cmd/dagger/cmd/version.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	goVersion "github.com/hashicorp/go-version"
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/term"
@@ -20,7 +21,7 @@ import (
 
 const (
 	defaultVersion = "devel"
-	versionFile    = "$HOME/.dagger/version-check"
+	versionFile    = "~/.dagger/version-check"
 	versionURL     = "https://releases.dagger.io/dagger/latest_version"
 )
 
@@ -49,7 +50,12 @@ var versionCmd = &cobra.Command{
 		)
 
 		if check := viper.GetBool("check"); check {
-			_ = os.Remove(os.ExpandEnv(versionFile))
+			versionFilePath, err := homedir.Expand(versionFile)
+			if err != nil {
+				panic(err)
+			}
+
+			_ = os.Remove(versionFilePath)
 			checkVersion()
 			if !warnVersion() {
 				fmt.Println("dagger is up to date.")
@@ -155,7 +161,10 @@ func checkVersion() {
 		return
 	}
 
-	versionFilePath := os.ExpandEnv(versionFile)
+	versionFilePath, err := homedir.Expand(versionFile)
+	if err != nil {
+		panic(err)
+	}
 	baseDir := path.Dir(versionFilePath)
 
 	if _, err := os.Stat(baseDir); os.IsNotExist(err) {

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/jaguilar/vt100 v0.0.0-20150826170717-2703a27b14ea
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/buildkit v0.8.3
 	github.com/morikuni/aec v1.0.0
 	github.com/opencontainers/go-digest v1.0.0

--- a/keychain/keys.go
+++ b/keychain/keys.go
@@ -5,22 +5,22 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/user"
 	"path"
 	"path/filepath"
 	"time"
 
 	"filippo.io/age"
+	"github.com/mitchellh/go-homedir"
 	"github.com/rs/zerolog/log"
 )
 
 func Path() (string, error) {
-	usr, err := user.Current()
+	h, err := homedir.Dir()
 	if err != nil {
 		return "", err
 	}
 
-	return path.Join(usr.HomeDir, ".dagger", "keys.txt"), nil
+	return path.Join(h, ".dagger", "keys.txt"), nil
 }
 
 func Default(ctx context.Context) (string, error) {


### PR DESCRIPTION
- use mitchellh/go-homedir rather than os/user to work on non cgo
  enabled builds (e.g. release binaries)
- updated Makefile to disable cgo on dev binaries

Fixes #519

/cc @samalba 