### PR TITLE
Update sops version to fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Install Dependencies
         run: |
           # SOPS
-          sudo curl -L -o /usr/local/bin/sops https://github.com/mozilla/sops/releases/download/v3.6.1/sops-v3.6.1.linux
+          sudo curl -L -o /usr/local/bin/sops https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux
           sudo chmod +x /usr/local/bin/sops
 
       - name: Import Dagger private key

--- a/tests/ops/push-container/main.cue
+++ b/tests/ops/push-container/main.cue
@@ -1,7 +1,6 @@
 package testing
 
 import (
-	"dagger.io/dagger"
 	"dagger.io/dagger/op"
 	"dagger.io/alpine"
 )


### PR DESCRIPTION
## Changes

There was a problem with #512 CI, some tests were skipped because sops couldn't read `inputs.yaml`.

Here is the [trace](https://github.com/dagger/dagger/runs/2697754981?check_suite_focus=true)

With @grouville, we explored that problem and discovered that it was just the `sops` version that was outdated `3.6.1` -> `3.7.1`.

:warning: We should take care about that kind of problems because there were some tests that failed for people with the latest version (but not in the CI).