### PR TITLE
dagger compute out-of-bound

### DIFF
--- a/cmd/dagger/cmd/compute.go
+++ b/cmd/dagger/cmd/compute.go
@@ -43,6 +43,10 @@ var computeCmd = &cobra.Command{
 
 		for _, input := range viper.GetStringSlice("input-string") {
 			parts := strings.SplitN(input, "=", 2)
+			if len(parts) != 2 {
+				lg.Fatal().Msgf("failed to parse input: input-string")
+			}
+
 			k, v := parts[0], parts[1]
 			err := st.SetInput(k, state.TextInput(v))
 			if err != nil {
@@ -56,6 +60,10 @@ var computeCmd = &cobra.Command{
 
 		for _, input := range viper.GetStringSlice("input-dir") {
 			parts := strings.SplitN(input, "=", 2)
+			if len(parts) != 2 {
+				lg.Fatal().Msgf("failed to parse input: input-dir")
+			}
+
 			k, v := parts[0], parts[1]
 			err := st.SetInput(k, state.DirInput(v, []string{}, []string{}))
 			if err != nil {
@@ -69,6 +77,10 @@ var computeCmd = &cobra.Command{
 
 		for _, input := range viper.GetStringSlice("input-git") {
 			parts := strings.SplitN(input, "=", 2)
+			if len(parts) != 2 {
+				lg.Fatal().Msgf("failed to parse input: input-git")
+			}
+
 			k, v := parts[0], parts[1]
 			err := st.SetInput(k, state.GitInput(v, "", ""))
 			if err != nil {

--- a/tests/compute.bats
+++ b/tests/compute.bats
@@ -65,6 +65,18 @@ setup() {
     run "$DAGGER" compute --input-string 'in=foobar' "$TESTDIR"/compute/input/default
     assert_success
     assert_line '{"in":"foobar","test":"received: foobar"}'
+    
+    run "$DAGGER" compute --input-string=foobar "$TESTDIR"/compute/input/default
+    assert_failure
+    assert_output --partial 'failed to parse input: input-string'
+    
+    run "$DAGGER" compute --input-dir=foobar "$TESTDIR"/compute/input/default
+    assert_failure
+    assert_output --partial 'failed to parse input: input-dir'
+
+    run "$DAGGER" compute --input-git=foobar "$TESTDIR"/compute/input/default
+    assert_failure
+    assert_output --partial 'failed to parse input: input-git'
 }
 
 @test "compute: secrets" {


### PR DESCRIPTION
First PR :
- Implements a small fix for the out-of-bound parsing error on `dagger compute --input-[string,dir,git]`, when a wrong command is written
- First test usage

Signed-off-by: Guillaume de Rouville <guillaume.derouville@gmail.com>