### PR TITLE
Dagger List cmd : change error message to a more comprehensible one when privatekey not present

### DIFF
--- a/keychain/encrypt.go
+++ b/keychain/encrypt.go
@@ -131,6 +131,9 @@ func Decrypt(_ context.Context, encrypted []byte) ([]byte, error) {
 	}
 	key, err := tree.Metadata.GetDataKey()
 	if err != nil {
+		if userErr, ok := err.(sops.UserError); ok {
+			err = fmt.Errorf(userErr.UserError())
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Fixes #532 

The PR aims to change the error message when `dagger list` is being used inside a workspace for which we don't have the corresponding private key.
Prior message :
* `failed to load environment: unable to decrypt state: Error getting data key: 0 successful groups required, got 0`
New message :
* `failed to load environment: workspace's private key not present`

