### PR TITLE
use ~/.config/dagger rather than ~/.dagger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,8 @@ jobs:
         env:
           DAGGER_AGE_KEY: ${{ secrets.DAGGER_AGE_KEY }}
         run: |
-          mkdir ~/.dagger
-          echo "$DAGGER_AGE_KEY" > ~/.dagger/keys.txt
+          mkdir -p ~/.config/dagger
+          echo "$DAGGER_AGE_KEY" > ~/.config/dagger/keys.txt
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1

--- a/cmd/dagger/cmd/version.go
+++ b/cmd/dagger/cmd/version.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	defaultVersion = "devel"
-	versionFile    = "~/.dagger/version-check"
+	versionFile    = "~/.config/dagger/version-check"
 	versionURL     = "https://releases.dagger.io/dagger/latest_version"
 )
 
@@ -168,7 +168,7 @@ func checkVersion() {
 	baseDir := path.Dir(versionFilePath)
 
 	if _, err := os.Stat(baseDir); os.IsNotExist(err) {
-		if err := os.MkdirAll(baseDir, 0755); err != nil {
+		if err := os.MkdirAll(baseDir, 0700); err != nil {
 			// mkdir fails, ignore silently
 			return
 		}

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -13,7 +13,7 @@ common_setup() {
     DAGGER_WORKSPACE="$(mktemp -d -t dagger-workspace-XXXXXX)"
     export DAGGER_WORKSPACE
 
-    SOPS_AGE_KEY_FILE=~/.dagger/keys.txt
+    SOPS_AGE_KEY_FILE=~/.config/dagger/keys.txt
     export SOPS_AGE_KEY_FILE
 }
 


### PR DESCRIPTION
since `.dagger` directories have a special meaning now because of gitflow,
it's better not to have a `~/.dagger` since it's not a workspace and
it confuses dagger (e.g. `dagger new` from $HOME).

We don't store state there anymore, just keys and the last version
check, so it's okay to be in ~/.config IMO

Looking at my system, in ~/.config there's `gcloud`, `gatsby`, `gh`,
`yarn`, and others so it seems like a pretty common location.

/cc @crazy-max 