### PR TITLE
stdlib: kubernetes: misc fixes

### DIFF
--- a/examples/kubernetes-app/main.cue
+++ b/examples/kubernetes-app/main.cue
@@ -37,9 +37,9 @@ cluster: eks.#KubeConfig & {
 
 // Example of a simple `kubectl apply` using a simple config
 kubeApply: kubernetes.#Apply & {
-	sourceInline: yaml.Marshal(kubeSrc)
-	namespace:    "test"
-	kubeconfig:   cluster.kubeconfig
+	manifest:   yaml.Marshal(kubeSrc)
+	namespace:  "test"
+	kubeconfig: cluster.kubeconfig
 }
 
 // Example of a `helm install` using a local chart

--- a/tests/stdlib/kubernetes/kubernetes.cue
+++ b/tests/stdlib/kubernetes/kubernetes.cue
@@ -34,9 +34,9 @@ TestKubeApply: {
 
 	// Apply deployment
 	apply: kubernetes.#Apply & {
-		kubeconfig:   config.contents
-		namespace:    "dagger-test"
-		sourceInline: yaml.Marshal(kubeSrc)
+		kubeconfig: config.contents
+		namespace:  "dagger-test"
+		manifest:   yaml.Marshal(kubeSrc)
 	}
 
 	// Verify deployment


### PR DESCRIPTION
- `source` is now optional
- `sourceInline` renamed to `manifest`
- `kubeconfig` is a `string` rather than a `dagger.#Secret`
