### PR TITLE
stdlib: kubernetes: rename #Apply to #Resources

### DIFF
--- a/examples/kubernetes-app/main.cue
+++ b/examples/kubernetes-app/main.cue
@@ -36,7 +36,7 @@ cluster: eks.#KubeConfig & {
 }
 
 // Example of a simple `kubectl apply` using a simple config
-kubeApply: kubernetes.#Apply & {
+kubeApply: kubernetes.#Resources & {
 	manifest:   yaml.Marshal(kubeSrc)
 	namespace:  "test"
 	kubeconfig: cluster.kubeconfig

--- a/stdlib/kubernetes/kubernetes.cue
+++ b/stdlib/kubernetes/kubernetes.cue
@@ -43,8 +43,8 @@ import (
 	]
 }
 
-// Apply a Kubernetes configuration
-#Apply: {
+// Apply Kubernetes resources
+#Resources: {
 
 	// Kubernetes config to deploy
 	source?: dagger.#Artifact @dagger(input)

--- a/tests/stdlib/kubernetes/kubernetes.cue
+++ b/tests/stdlib/kubernetes/kubernetes.cue
@@ -26,7 +26,7 @@ TestKubeApply: {
 	}
 
 	// Apply deployment
-	apply: kubernetes.#Apply & {
+	apply: kubernetes.#Resources & {
 		"kubeconfig": kubeconfig
 		namespace:    "dagger-test"
 		manifest:     yaml.Marshal(kubeSrc)


### PR DESCRIPTION
Code convention: use nouns instead of verbs whenever possible.

Reasoning: One can apply just about anything to Kubernetes via this:
deployment, load balancer, RBAC policy, a custom CRD resource, etc.

Upstream those are called resources: You give `kubectl apply` one or more
manifests and it will create the corresponding resources.

Signed-off-by: Andrea Luzzardi <aluzzardi@gmail.com>
