### PR TITLE
[WIP] Add localstack test to S3 package

### DIFF
--- a/stdlib/aws/aws.cue
+++ b/stdlib/aws/aws.cue
@@ -14,6 +14,8 @@ import (
 	accessKey: dagger.#Secret @dagger(input)
 	// AWS secret key
 	secretKey: dagger.#Secret @dagger(input)
+	// AWS endpoint key
+	endpointURL: string | *"" @dagger(input)
 }
 
 // Re-usable aws-cli component
@@ -32,6 +34,7 @@ import (
 			}
 		},
 		op.#Exec & {
+			env: ENDPOINT_URL: config.endpointURL
 			args: [
 				"/bin/bash",
 				"--noprofile",
@@ -40,6 +43,7 @@ import (
 				"pipefail",
 				"-c",
 				#"""
+					[ -n "$ENDPOINT_URL" ] && alias aws="aws --endpoint-url='$ENDPOINT_URL'"
 					aws configure set aws_access_key_id "$(cat /run/secrets/access_key)"
 					aws configure set aws_secret_access_key "$(cat /run/secrets/secret_key)"
 

--- a/stdlib/aws/s3/s3.cue
+++ b/stdlib/aws/s3/s3.cue
@@ -53,6 +53,7 @@ import (
 				env: {
 					TARGET:       target
 					CONTENT_TYPE: contentType
+					ENDPOINT_URL: config.endpointURL
 				}
 
 				if sourceInline == _|_ {
@@ -75,10 +76,17 @@ import (
 						if [ -n "$CONTENT_TYPE" ]; then
 							opts="--content-type $CONTENT_TYPE"
 						fi
-						aws s3 $op $opts /source "$TARGET"
-						echo -n "$TARGET" \
-							| sed -E 's=^s3://([^/]*)/=https://\1.s3.amazonaws.com/=' \
-							> /url
+						if [ -n "$ENDPOINT_URL" ]; then
+							aws s3 --endpoint-url="$ENDPOINT_URL" $op $opts /source "$TARGET"
+							echo -n "$TARGET" \
+								| sed -E 's=^s3://([^/]*)/='$ENDPOINT_URL'/\1/=' \
+								> /url
+						else
+							aws s3 $op $opts /source "$TARGET"
+							echo -n "$TARGET" \
+								| sed -E 's=^s3://([^/]*)/=https://\1.s3.amazonaws.com/=' \
+								> /url
+						fi
 						"""#,
 				]
 			},

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -39,3 +39,10 @@ skip_unless_local_kube() {
         skip "local kubernetes cluster not available"
     fi
 }
+
+skip_unless_localstack_available() {
+    local url="$1"
+    
+    (curl -s -o  /dev/null "$url" && echo "localStack available") \
+    || skip "localStack not available"
+}

--- a/tests/stdlib.bats
+++ b/tests/stdlib.bats
@@ -62,6 +62,17 @@ setup() {
     "$DAGGER" up -w "$TESTDIR"/stdlib/aws/s3
 }
 
+@test "stdlib: aws: s3 localstack" {
+    local localstackURL="http://localhost:4566/"
+
+    skip_unless_localstack_available "$localstackURL"
+
+    "$DAGGER" -w "$TESTDIR"/stdlib/aws/s3 input text TestConfig.awsConfig.endpointURL "$localstackURL"
+    "$DAGGER" -w "$TESTDIR"/stdlib/aws/s3 input secret TestConfig.awsConfig.accessKey "test"
+    "$DAGGER" -w "$TESTDIR"/stdlib/aws/s3 input secret TestConfig.awsConfig.secretKey "test"
+    "$DAGGER" up -w "$TESTDIR"/stdlib/aws/s3
+}
+
 @test "stdlib: aws: eks" {
     "$DAGGER" up -w "$TESTDIR"/stdlib/aws/eks
 }

--- a/tests/stdlib/aws/s3/.dagger/env/default/plan/random.cue
+++ b/tests/stdlib/aws/s3/.dagger/env/default/plan/random.cue
@@ -1,0 +1,21 @@
+package s3
+
+import (
+	"dagger.io/alpine"
+	"dagger.io/dagger/op"
+)
+
+// Generate a random number
+random: {
+	string
+	#up: [
+		op.#Load & {from: alpine.#Image},
+		op.#Exec & {
+			always: true
+			args: ["sh", "-c", "cat /dev/urandom | tr -dc 'a-z' | fold -w 10 | head -n 1 | tr -d '\n' > /rand"]
+		},
+		op.#Export & {
+			source: "/rand"
+		},
+	]
+}

--- a/tests/stdlib/aws/s3/.dagger/env/default/plan/s3.cue
+++ b/tests/stdlib/aws/s3/.dagger/env/default/plan/s3.cue
@@ -7,7 +7,8 @@ import (
 )
 
 TestConfig: awsConfig: aws.#Config & {
-	region: "us-east-2"
+	region:      "us-east-2"
+	endpointURL: string @dagger(input)
 }
 
 bucket: "dagger-ci"
@@ -15,26 +16,30 @@ bucket: "dagger-ci"
 content: "A simple test sentence"
 
 TestS3UploadFile: {
+	randomFileName: random
+
 	deploy: s3.#Put & {
 		config:       TestConfig.awsConfig
 		sourceInline: content
-		target:       "s3://\(bucket)/test.txt"
+		target:       "s3://\(bucket)/\(randomFileName).txt"
 	}
 
 	verify: #VerifyS3 & {
 		config: TestConfig.awsConfig
 		target: deploy.target
-		file:   "test.txt"
+		file:   "\(randomFileName).txt"
 	}
 }
 
 TestDirectory: dagger.#Artifact
 
 TestS3UploadDir: {
+	randomDirName: random
+
 	deploy: s3.#Put & {
 		config: TestConfig.awsConfig
 		source: TestDirectory
-		target: "s3://\(bucket)/"
+		target: "s3://\(bucket)/\(randomDirName)/"
 	}
 
 	verifyFile: #VerifyS3 & {

--- a/tests/stdlib/aws/s3/.dagger/env/default/plan/verify.cue
+++ b/tests/stdlib/aws/s3/.dagger/env/default/plan/verify.cue
@@ -24,6 +24,8 @@ import (
 			},
 
 			op.#Exec & {
+				always: true
+				env: ENDPOINT_URL: config.endpointURL
 				args: [
 					"/bin/bash",
 					"--noprofile",
@@ -32,7 +34,12 @@ import (
 					"pipefail",
 					"-c",
 					#"""
-					aws s3 ls --recursive \#(target) > /contents
+					sleep 2
+					if [ -n "$ENDPOINT_URL" ]; then
+						aws s3 --endpoint-url="$ENDPOINT_URL" ls --recursive \#(target) > /contents
+					else
+						aws s3 ls --recursive \#(target) > /contents
+					fi
 					"""#,
 				]
 			},


### PR DESCRIPTION
Localstack test implementation.

As I didn't rebase frequently, I need to add the S3#Sync tonight, but currently stuck by the issues cited below.

I am encountering these 2 issues : 
- A race condition (Through my tests/debugging, I realized that we cp / sync a file/ folder to AWS S3, then we query it right away with a recursive ls. However, it triggered an error (not very clear) that the file doesn't exist (fixed with a sleep, but if behavior is confirmed, will need to find a better fix). According to me, it was hidden by the fact that we used to always query pre-existing files.
- The tests totally work on my personal AWS accounts, but when using CI creds, it seems to break. Seen with Sam, but I don't know how to fix it.

Prerequisites :
For the LocalStack test to run, you need to have LocalStack running on port 4566 : `pip install localstack`, then `localstack start`. Once running, you also need to create the `dagger-ci` bucket : `aws --endpoint-url=http://localhost:4566 s3 mb s3://dagger-ci`.

