### PR TITLE
properly close buildkit connection

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -63,6 +63,10 @@ func New(ctx context.Context, host string, noCache bool) (*Client, error) {
 	}, nil
 }
 
+func (c *Client) Close() error {
+	return c.c.Close()
+}
+
 type DoFunc func(context.Context, *environment.Environment, solver.Solver) error
 
 // FIXME: return completed *Route, instead of *compiler.Value

--- a/cmd/dagger/cmd/common/common.go
+++ b/cmd/dagger/cmd/common/common.go
@@ -84,13 +84,9 @@ func CurrentEnvironmentState(ctx context.Context, workspace *state.Workspace) *s
 }
 
 // Re-compute an environment (equivalent to `dagger up`).
-func EnvironmentUp(ctx context.Context, state *state.State, noCache bool) *environment.Environment {
+func EnvironmentUp(ctx context.Context, c *client.Client, state *state.State) *environment.Environment {
 	lg := log.Ctx(ctx)
 
-	c, err := client.New(ctx, "", noCache)
-	if err != nil {
-		lg.Fatal().Err(err).Msg("unable to create client")
-	}
 	result, err := c.Do(ctx, state, func(ctx context.Context, environment *environment.Environment, s solver.Solver) error {
 		log.Ctx(ctx).Debug().Msg("bringing environment up")
 		return environment.Up(ctx, s)

--- a/cmd/dagger/cmd/compute.go
+++ b/cmd/dagger/cmd/compute.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"cuelang.org/go/cue"
+	"go.dagger.io/dagger/client"
 	"go.dagger.io/dagger/cmd/dagger/cmd/common"
 	"go.dagger.io/dagger/cmd/dagger/logger"
 	"go.dagger.io/dagger/compiler"
@@ -34,6 +35,12 @@ var computeCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		lg := logger.New()
 		ctx := lg.WithContext(cmd.Context())
+
+		c, err := client.New(ctx, "", false)
+		if err != nil {
+			lg.Fatal().Err(err).Msg("unable to create client")
+		}
+		defer c.Close()
 
 		st := &state.State{
 			Name: "FIXME",
@@ -161,7 +168,7 @@ var computeCmd = &cobra.Command{
 			}
 		}
 
-		environment := common.EnvironmentUp(ctx, st, viper.GetBool("no-cache"))
+		environment := common.EnvironmentUp(ctx, c, st)
 
 		v := compiler.NewValue()
 		if err := v.FillPath(cue.MakePath(), environment.Plan()); err != nil {

--- a/cmd/dagger/cmd/input/list.go
+++ b/cmd/dagger/cmd/input/list.go
@@ -44,6 +44,7 @@ var listCmd = &cobra.Command{
 		if err != nil {
 			lg.Fatal().Err(err).Msg("unable to create client")
 		}
+		defer c.Close()
 
 		_, err = c.Do(ctx, st, func(ctx context.Context, env *environment.Environment, s solver.Solver) error {
 			inputs, err := env.ScanInputs(ctx, false)

--- a/cmd/dagger/cmd/output/list.go
+++ b/cmd/dagger/cmd/output/list.go
@@ -49,6 +49,7 @@ func ListOutputs(ctx context.Context, st *state.State, isTTY bool) {
 	if err != nil {
 		lg.Fatal().Err(err).Msg("unable to create client")
 	}
+	defer c.Close()
 
 	_, err = c.Do(ctx, st, func(ctx context.Context, env *environment.Environment, s solver.Solver) error {
 		outputs, err := env.ScanOutputs(ctx)

--- a/cmd/dagger/cmd/query.go
+++ b/cmd/dagger/cmd/query.go
@@ -46,6 +46,7 @@ var queryCmd = &cobra.Command{
 		if err != nil {
 			lg.Fatal().Err(err).Msg("unable to create client")
 		}
+		defer c.Close()
 
 		environment, err := c.Do(ctx, state, nil)
 		if err != nil {

--- a/cmd/dagger/cmd/up.go
+++ b/cmd/dagger/cmd/up.go
@@ -38,10 +38,16 @@ var upCmd = &cobra.Command{
 		workspace := common.CurrentWorkspace(ctx)
 		st := common.CurrentEnvironmentState(ctx, workspace)
 
-		// check that all inputs are set
-		checkInputs(ctx, st)
+		c, err := client.New(ctx, "", viper.GetBool("no-cache"))
+		if err != nil {
+			lg.Fatal().Err(err).Msg("unable to create client")
+		}
+		defer c.Close()
 
-		result := common.EnvironmentUp(ctx, st, viper.GetBool("no-cache"))
+		// check that all inputs are set
+		checkInputs(ctx, c, st)
+
+		result := common.EnvironmentUp(ctx, c, st)
 
 		st.Computed = result.Computed().JSON().PrettyString()
 		if err := workspace.Save(ctx, st); err != nil {
@@ -52,19 +58,12 @@ var upCmd = &cobra.Command{
 	},
 }
 
-func checkInputs(ctx context.Context, st *state.State) {
+func checkInputs(ctx context.Context, c *client.Client, st *state.State) {
 	lg := log.Ctx(ctx)
 	warnOnly := viper.GetBool("force") || !term.IsTerminal(int(os.Stdout.Fd()))
 
-	// FIXME: find a way to merge this with the EnvironmentUp client to avoid
-	// creating the client + solver twice
-	c, err := client.New(ctx, "", false)
-	if err != nil {
-		lg.Fatal().Err(err).Msg("unable to create client")
-	}
-
 	notConcreteInputs := []*compiler.Value{}
-	_, err = c.Do(ctx, st, func(ctx context.Context, env *environment.Environment, s solver.Solver) error {
+	_, err := c.Do(ctx, st, func(ctx context.Context, env *environment.Environment, s solver.Solver) error {
 		inputs, err := env.ScanInputs(ctx, true)
 		if err != nil {
 			return err


### PR DESCRIPTION
properly close buildkit connection

Should get rid of `commandConn.CloseWrite` errors.