### PR TITLE
Change markdown linter in Github action to a more up-to-date one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,10 @@ jobs:
           make shellcheck cuelint check-buildkit-version docslint
 
       - name: Markdown Lint
-        uses: nosborn/github-action-markdown-cli@v1.1.1
+        uses: avto-dev/markdown-lint@v1
         with:
-          files: ./docs README.md
-          config_file: ".markdownlint.yaml"
+          config: ".markdownlint.yaml"
+          args: ./docs README.md
 
   test:
     name: Test

--- a/docs/user/user.md
+++ b/docs/user/user.md
@@ -102,6 +102,6 @@ The plan defines one or several `outputs`. They can show useful information at t
 dagger output list
 ```
 
-## What's next
+## What's next?
 
 At this point, you have deployed your first application using dagger and learned some dagger commands. You are now ready to [learn more about how to program dagger](/programming).


### PR DESCRIPTION
@samalba faced some linting issues because of a disparity in the `markdown-cli` binary version. The prior markdownlint-cli Github Action used is using an older version than the one installed by default.

This old version doesn't automatically consider headers ending with `?` as a valid syntax. However, the last two versions do.

The new action is using markdown-cli version 0.26, so not the last one, but is updated regularly.