### PR TITLE
Fix english typo in Cloudformation package

### DIFF
--- a/stdlib/aws/cloudformation/cloudformation.cue
+++ b/stdlib/aws/cloudformation/cloudformation.cue
@@ -27,7 +27,7 @@ import (
 	// Behavior when failure to create/update the Stack
 	onFailure: *"DO_NOTHING" | "ROLLBACK" | "DELETE" @dagger(input)
 
-	// Timeout for waiting for the stack to be created/updated (in minutes)
+	// Maximum waiting time until stack creation/update (in minutes)
 	timeout: *10 | uint @dagger(input)
 
 	// Never update the stack if already exists


### PR DESCRIPTION
Fixing an English typo leading to some ugly AWS CLI help :
```bash
➜  plan dagger input list
Input                 Value                  Set by user  Description
...
cfnStack.timeout      *10 | >=0 & int        false        Timeout for waiting for the stack to be created/updated (in minutes) <--

to 

cfnStack.timeout      *10 | >=0 & int        false        Maximum waiting time until stack creation/update (in minutes)
```
Signed-off-by: Guillaume de Rouville <guillaume.derouville@gmail.com>