### PR TITLE
docs: uniform codeblocs => use shell language + add title

### DIFF
--- a/docs/learn/101-use.md
+++ b/docs/learn/101-use.md
@@ -22,7 +22,7 @@ First, you'll need to make sure [you have installed dagger on your local machine
 
 **Step 1**: Clone the example repository
 
-```sh
+```shell
 git clone https://github.com/dagger/examples.git
 ```
 
@@ -32,7 +32,7 @@ git clone https://github.com/dagger/examples.git
 
 Go to the app directory:
 
-```sh
+```shell
 cd ./examples/todoapp
 ```
 
@@ -46,7 +46,7 @@ dagger input list || curl -sfL https://releases.dagger.io/examples/key.txt >> ~/
 
 **Step 4**: Deploy!
 
-```sh
+```shell
 dagger up
 ```
 
@@ -56,7 +56,7 @@ At the end of the deploy, you should see a list of outputs. There is one that is
 
 This repository is already configured to deploy the code in the directory `./todoapp`, so you can change some code (or replace the app code with another react app!) and re-run the following command to re-deploy when you want your changes to be live:
 
-```sh
+```shell
 dagger up
 ```
 
@@ -70,7 +70,7 @@ An Environment holds the entire deployment configuration.
 
 You can list existing environment from the `./todoapp` directory:
 
-```sh
+```shell
 dagger list
 ```
 
@@ -82,7 +82,7 @@ Each environment can have different kind of deployment code. For example, a `dev
 
 The plan is the deployment code, that includes the logic to deploy the local application to an AWS S3 bucket. From the `todoapp` directory, you can list the code of the plan:
 
-```sh
+```shell
 ls -l .dagger/env/s3/plan/
 ```
 
@@ -92,7 +92,7 @@ Any code change to the plan will be applied during the next `dagger up`.
 
 The plan can define one or several `inputs` in order to take some information from the user. Here is how to list the current inputs:
 
-```sh
+```shell
 dagger input list
 ```
 
@@ -102,7 +102,7 @@ The inputs are persisted inside the `.dagger` directory and pushed to your git r
 
 The plan defines one or several `outputs`. They can show useful information at the end of the deployment. That's how we read the deploy `url` at the end of the deployment. Here is the command to list all inputs:
 
-```sh
+```shell
 dagger output list
 ```
 

--- a/docs/learn/102-dev.md
+++ b/docs/learn/102-dev.md
@@ -77,13 +77,13 @@ If you are new to Cue, we recommend keeping the following resources in browser t
 
 You will need a local copy of the [Dagger examples repository](https://github.com/dagger/examples).
 
-```bash
+```shell
 git clone https://github.com/dagger/examples
 ```
 
 Make sure that all commands are run from the `todoapp` directory:
 
-```bash
+```shell
 cd examples/todoapp
 ```
 
@@ -95,7 +95,7 @@ Otherwise, don't worry: a Cue module is simply a directory with one or more Cue 
 
 In this guide we will use the same directory as the root of the Dagger workspace and the root of the Cue module; but you can create your Cue module anywhere inside the Dagger workspace.
 
-```bash
+```shell
 cue mod init
 ```
 
@@ -114,7 +114,7 @@ But you can call your packages anything you want.
 
 Let's layout the structure of our package by creating all the files in advance:
 
-```bash
+```shell
 touch multibucket-source.cue multibucket-yarn.cue multibucket-netlify.cue
 ```
 
@@ -129,7 +129,7 @@ In Dagger terms, this component has 2 important properties:
 
 Let's write the corresponding Cue code to `multibucket-source.cue`:
 
-```cue
+```cue title="~/examples/todoapp/multibucket-source.cue"
 package multibucket
 
 import (
@@ -148,7 +148,7 @@ The second component of our plan is the Yarn package built from the source code.
 
 Let's write it to `multibucket-yarn.cue`:
 
-```cue
+```cue title="~/examples/todoapp/multibucket-yarn.cue"
 package multibucket
 
 import (
@@ -179,7 +179,7 @@ The third component of our plan is the Netlify site to which the app will be dep
 
 Let's write it to `multibucket-netlify.cue`:
 
-```cue
+```cue title="~/examples/todoapp/multibucket-netlify.cue"
 package multibucket
 
 import (
@@ -205,7 +205,7 @@ This is very similar to the previous component:
 But wait: how did we know what fields were available in `yarn.#Package` and `netlify.#Site`?
 Answer: thanks to the `dagger doc` command, which prints the documentation of any package from [Dagger Universe](https://github.com/dagger/dagger/tree/main/stdlib).
 
-```bash
+```shell
 dagger doc dagger.io/netlify
 dagger doc dagger.io/js/yarn
 ```
@@ -218,7 +218,7 @@ You can also browse the [Dagger Universe](/reference/universe) reference in the 
 
 Now that your Cue package is ready, let's create an environment to run it,
 
-```bash
+```shell
 dagger new 'multibucket'
 ```
 
@@ -226,7 +226,7 @@ dagger new 'multibucket'
 
 Now let's configure the new environment to use our package as its plan:
 
-```bash
+```shell
 cp multibucket-*.cue .dagger/env/multibucket/plan/
 ```
 

--- a/docs/learn/107-kubernetes.md
+++ b/docs/learn/107-kubernetes.md
@@ -46,7 +46,7 @@ docker run -d -p 5000:5000 --name registry registry:2
 
 3\. Create a cluster with the local registry enabled in containerd
 
-```bash
+```shell
 cat <<EOF | kind create cluster --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4


### PR DESCRIPTION
* @shykes I saw that you used `bash` in code blocs, but `shell` is being used everywhere. So I changed to `shell` in 102 doc
* I separated textual changes from unification, here it's only unification
* I'm doing like Andrea in 108: I work directly in `.dagger`, and set the title the same way as he does
* Fixing some linting issues hidden by `.mdx` format

Signed-off-by: Guillaume de Rouville <guillaume.derouville@gmail.com>