### PR TITLE
stdlib/s3: fixes always flag (fixes #676)

### DIFF
--- a/stdlib/aws/s3/s3.cue
+++ b/stdlib/aws/s3/s3.cue
@@ -41,7 +41,7 @@ import (
 
 			op.#Exec & {
 				if always {
-					always: true
+					"always": true
 				}
 				env: {
 					TARGET:           target


### PR DESCRIPTION
`always: true` is no more mandatory in the example app.

For docs clarity, I replaced `always: *true | bool` with `always: *true | false` - which broke the if in the `s3.cue`.

This PR solves the issue.