### PR TITLE
Docs: 102: use new dagger.#Input in sample code

### DIFF
--- a/docs/learn/102-dev.md
+++ b/docs/learn/102-dev.md
@@ -140,10 +140,10 @@ import (
 )
 
 // Source code of the sample application
-src: dagger.#Artifact @dagger(input)
+src: dagger.#Artifact & dagger.#Input
 ```
 
-This defines a component at the key `src`, of type `dagger.#Artifact`, annotated as an user input.
+This defines a component at the key `src`, and specifies that it is both an artifact and an input.
 
 ### Component 2: yarn package
 


### PR DESCRIPTION
Taking advantage of the new `dagger.#Input` definition to simplify the “introduction to Dagger development” tutorial.

* Before: 2 concepts to learn: Cue definitions `#Foo`, and Cue annotations `@foo)
* After: 1 concept to learn: Cue definitions: `#Foo`