### PR TITLE
stdlib: simplify os.#File API

### DIFF
--- a/docs/reference/universe/os.md
+++ b/docs/reference/universe/os.md
@@ -34,7 +34,7 @@ _No output._
 
 ## os.#File
 
-Built-in file implementation, using buildkit
+Built-in file implementation, using buildkit A single file
 
 ### os.#File Inputs
 

--- a/stdlib/.dagger/env/os/.gitignore
+++ b/stdlib/.dagger/env/os/.gitignore
@@ -1,0 +1,2 @@
+# dagger state
+state/**

--- a/stdlib/.dagger/env/os/plan/main.cue
+++ b/stdlib/.dagger/env/os/plan/main.cue
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"dagger.io/os"
+	"dagger.io/alpine"
+)
+
+// Write a file to an empty dir
+EmptyDir: {
+	f: os.#File & {
+		path: "/foo.txt"
+		write: data: "hello world!"
+	}
+	f: contents: "hello world!"
+}
+
+// Read from a pre-existing file
+Read: {
+	f: os.#File & {
+		from: alpine.#Image & {
+			version: "3.13.4"
+		}
+		path: "/etc/alpine-release"
+	}
+	f: contents: "3.13.4\n"
+}

--- a/stdlib/.dagger/env/os/values.yaml
+++ b/stdlib/.dagger/env/os/values.yaml
@@ -1,0 +1,21 @@
+name: os
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1gxwmtwahzwdmrskhf90ppwlnze30lgpm056kuesrxzeuyclrwvpsupwtpk
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0bDM5blE0cC9LNHkxZmEy
+            bitYcjhMOHhrWE5pRm90Qyt4S200ZTN0Q1d3Clh2VmdKQjdGUGdKaThmaktwN1F6
+            aXZpellwbHpkb3pMb1NMNXVJYnFUMmMKLS0tIFNiZGlBNjE3UjlXWnBjZ3hwSWto
+            STlrbFNHZGFRUVQ1S1RIaGVyWktNV0kKo9AFURi/BKI+JuGYVuOrsw3eJU3s66Im
+            FCc5YCzrsjX+Y26Su+XW81fTWkcC910e/g+tlZbEFWKZYa8qu1VkqA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2021-06-09T18:19:29Z"
+    mac: ENC[AES256_GCM,data:G/D+9UqwJXhqVHAq8rXP7YxubzGKNxjguUVuVpnxKN7awzYaAD2E5plBFDqCw++5qFSZ7HMlWZUseyKOfaOxtkT0CTRAZf8cYLXHIjzKKCFP632nLN0zCPQCMqdrhOLtWkLovtHJ94Xvd3C3Mb+bVi1YmOC6nQHhpglwTVjDw9I=,iv:0GN4vAO5QMXUTODDKYpPD/UmxjfI+RyCdYz9UXQNCso=,tag:RacQNrAUhJHtKeu5ugUadA==,type:str]
+    pgp: []
+    encrypted_suffix: secret
+    version: 3.7.1

--- a/stdlib/aws/ecr/ecr.cue
+++ b/stdlib/aws/ecr/ecr.cue
@@ -28,5 +28,5 @@ import (
 				from: ctr
 				path: "/out"
 			}
-	}.read.data @dagger(output)
+	}.contents @dagger(output)
 }

--- a/stdlib/dagger/op/op.cue
+++ b/stdlib/dagger/op/op.cue
@@ -107,7 +107,8 @@ package op
 }
 
 #WriteFile: {
-	do:      "write-file"
+	do: "write-file"
+	// FIXME: "contents" to follow english convention
 	content: string | bytes
 	dest:    string
 	mode:    int | *0o644

--- a/stdlib/netlify/netlify.cue
+++ b/stdlib/netlify/netlify.cue
@@ -40,7 +40,7 @@ import (
 				from: ctr
 				path: "/netlify/url"
 			}
-	}.read.data @dagger(output)
+	}.contents @dagger(output)
 
 	// Unique Deploy URL
 	deployUrl: {
@@ -48,7 +48,7 @@ import (
 				from: ctr
 				path: "/netlify/deployUrl"
 			}
-	}.read.data @dagger(output)
+	}.contents @dagger(output)
 
 	// Logs URL for this deployment
 	logsUrl: {
@@ -56,7 +56,7 @@ import (
 				from: ctr
 				path: "/netlify/logsUrl"
 			}
-	}.read.data @dagger(output)
+	}.contents @dagger(output)
 
 	ctr: os.#Container & {
 		image: alpine.#Image & {

--- a/stdlib/universe.bats
+++ b/stdlib/universe.bats
@@ -4,6 +4,11 @@ setup() {
     common_setup
 }
 
+
+@test "os" {
+    dagger -e os up
+}
+
 @test "go" {
     dagger -e go up
 }


### PR DESCRIPTION
This simplifies the `os.#File` API to make it less verbose and more intuitive. It’s a breaking change. Dependencies in stdlib have been fixed, but I may have missed some.