### PR TITLE
doc#108: complete refacto of CF's guide (now follows Andrea's writing style) + Fix CF relay's output issue

### DIFF
--- a/docs/reference/universe/aws/cloudformation.md
+++ b/docs/reference/universe/aws/cloudformation.md
@@ -30,6 +30,4 @@ AWS CloudFormation Stack
 
 ### cloudformation.#Stack Outputs
 
-| Name             | Type              | Description        |
-| -------------    |:-------------:    |:-------------:     |
-|*outputs*         | `struct`          |-                   |
+_No output._

--- a/stdlib/aws/cloudformation/cloudformation.cue
+++ b/stdlib/aws/cloudformation/cloudformation.cue
@@ -48,8 +48,8 @@ import (
 	}
 
 	outputs: {
-		[string]: string
-	} @dagger(output)
+		[string]: string @dagger(output)
+	}
 
 	outputs: #up: [
 		op.#Load & {


### PR DESCRIPTION
Complete refacto of the CF doc.

* For consistence, it follows at 99% Andrea's writing style. The process is the same. Learnings are similar, even more detailed
* `dagger.#Input` is now used
* Also fixes an output issue on the Cloudformation's relay: we didn't have the Name of the provisioned bucket
* Grammarly has been used, for English consistency

100% working as of now!