### PR TITLE
docs: specify env when using dagger + fix docs_101 issues

### DIFF
--- a/docs/learn/101-use.md
+++ b/docs/learn/101-use.md
@@ -5,20 +5,20 @@ slug: /learn/101-basics
 # Dagger 101: basic usage
 
 In this guide, you will learn the basics of Dagger by interacting with a pre-configured environment.
-Then you will move on to creating your own environment from scratch.
+Then you will move on to creating your environment from scratch.
 
 Our pre-configured environment deploys a simple [React](https://reactjs.org/)
-application to a special hosting environment created and managed by us, the Dagger team, for the purpose of this tutorial.
-This will allow you to deploy something "real" right away, without having to configure your own infrastructure first.
+application to a unique hosting environment created and managed by us, the Dagger team, for this tutorial.
+This will allow you to deploy something "real" right away without configuring your infrastructure first.
 
-In later guides, you will learn how to configure Dagger to deploy to your own infrastructure. And, for advanced users,
-how to share access to your infrastructure in the same way that we are sharing access to ours now.
+In later guides, you will learn how to configure Dagger to deploy to your infrastructure. And, for advanced users,
+how to share access to your infrastructure in the same way that we share access to ours now.
 
 ## Initial setup
 
 ### Install Dagger
 
-First, make sure [you have installed dagger on your local machine](/install).
+First, make sure [you have installed Dagger on your local machine](/install).
 
 ### Setup example app
 
@@ -38,15 +38,15 @@ cd examples/todoapp
 ### Import the tutorial key
 
 Dagger natively supports encrypted secrets: when a user inputs a value marked as secret
-(for example a password, API token or ssh key) it is automatically encrypted with that user's key,
+(for example, a password, API token, or ssh key) it is automatically encrypted with that user's key,
 and no other user can access that value unless they are explicitly given access.
 
 In the interest of security, Dagger has no way _not_ to encrypt a secret value.
-But this causes a dilemma for this tutorial: how do we give unrestricted public access to our
-(carefully sandboxed) infrastructure, so that anyone can deploy to it?
+But this causes a dilemma for this tutorial: how do we give unrestricted, public access to our
+(carefully sandboxed) infrastructure so that anyone can deploy to it?
 
 To solve this dilemma, we included the private key used to encrypt the tutorial's secret inputs.
-Simply import the key to your Dagger installation, and you're good to go:
+Import the key to your Dagger installation, and you're good to go:
 
 ```shell
 ./import-tutorial-key.sh
@@ -54,7 +54,7 @@ Simply import the key to your Dagger installation, and you're good to go:
 
 ## First deployment
 
-Now that your environment is setup, you are ready to deploy:
+Now that your environment is set up, you are ready to deploy:
 
 ```shell
 dagger up
@@ -75,7 +75,7 @@ NOTE: you don't have to commit your changes to the git repository before deployi
 
 ## Under the hood
 
-This example showed you how to deploy and develop on an application that is already configured with dagger. Now, let's learn a few concepts to help you understand how this was put together.
+This example showed you how to deploy and develop an application that is already configured with Dagger. Now, let's learn a few concepts to help you understand how this was put together.
 
 ### The Environment
 
@@ -87,13 +87,13 @@ You can list existing environment from the `./todoapp` directory:
 dagger list
 ```
 
-You should see an environment named `s3`. You can have many environments within your app. For instance one for `staging`, one for `dev`, etc...
+You should see an environment named `s3`. You can have many environments within your app. For instance, one for `staging`, one for `dev`, etc...
 
-Each environment can have different kind of deployment code. For example, a `dev` environment can deploy locally, a `staging` environment can deploy to a remote infrastructure, and so on.
+Each environment can have a different kind of deployment code. For example, a `dev` environment can deploy locally; a `staging` environment can deploy to a remote infrastructure, and so on.
 
 ### The plan
 
-The plan is the deployment code, that includes the logic to deploy the local application to an AWS S3 bucket. From the `todoapp` directory, you can list the code of the plan:
+The plan is the deployment code that includes the logic to deploy the local application to an AWS S3 bucket. From the `todoapp` directory, you can list the code of the plan:
 
 ```shell
 ls -l .dagger/env/s3/plan/
@@ -103,7 +103,7 @@ Any code change to the plan will be applied during the next `dagger up`.
 
 ### The inputs
 
-The plan can define one or several `inputs` in order to take some information from the user. Here is how to list the current inputs:
+The plan can define one or several `inputs`. Inputs may be configuration values, artifacts, or encrypted secrets provided by the user. Here is how to list the current inputs:
 
 ```shell
 dagger input list
@@ -113,7 +113,7 @@ The inputs are persisted inside the `.dagger` directory and pushed to your git r
 
 ### The outputs
 
-The plan defines one or several `outputs`. They can show useful information at the end of the deployment. That's how we read the deploy `url` at the end of the deployment. Here is the command to list all inputs:
+The plan defines one or several `outputs`. They can show helpful information at the end of the deployment. That's how we read the deploy `url` at the end of the deployment. Here is the command to list all inputs:
 
 ```shell
 dagger output list
@@ -121,4 +121,4 @@ dagger output list
 
 ## What's next?
 
-At this point, you have deployed your first application using dagger and learned some dagger commands. You are now ready to [learn more about how to program dagger](/learn/102-dev).
+At this point, you have deployed your first application using Dagger and learned some dagger commands. You are now ready to [learn more about how to program Dagger](/learn/102-dev).

--- a/docs/learn/102-dev.md
+++ b/docs/learn/102-dev.md
@@ -116,7 +116,7 @@ But you can call your packages anything you want.
 Let's create a new directory for our Cue package:
 
 ```shell
-mkdir multibucket
+mkdir cue.mod/multibucket
 ```
 
 ### Component 1: app source code
@@ -130,7 +130,7 @@ In Dagger terms, this component has two essential properties:
 
 Let's write the corresponding Cue code to a new file in our package:
 
-```cue title="todoapp/multibucket/source.cue"
+```cue title="todoapp/cue.mod/multibucket/source.cue"
 package multibucket
 
 import (
@@ -147,7 +147,7 @@ This code defines a component at the key `src`, and specifies that it is both an
 
 The second component of our plan is the Yarn package built from the app source code:
 
-```cue title="todoapp/multibucket/yarn.cue"
+```cue title="todoapp/cue.mod/multibucket/yarn.cue"
 package multibucket
 
 import (
@@ -176,7 +176,7 @@ _FIXME_: this section is not yet available because the [Amazon S3 package](https
 
 The third component of our plan is the Netlify site to which the app will be deployed:
 
-```cue title="todoapp/multibucket/netlify.cue"
+```cue title="todoapp/cue.mod/multibucket/netlify.cue"
 package multibucket
 
 import (
@@ -216,26 +216,55 @@ You can also browse the [Dagger Universe](../reference/universe/README.md) refer
 Now that your Cue package is ready, let's create an environment to run it:
 
 ```shell
-dagger new 'multibucket'
+dagger new 'multibucket' -m cue.mod/multibucket
 ```
-
-### Load the plan into the environment
-
-Now let's configure the new environment to use our package as its plan:
-
-```shell
-cp multibucket/*.cue .dagger/env/multibucket/plan/
-```
-
-Note: you need to copy the files from your package into the environment, as shown above.
-If you make more changes to your package, you will need to copy the new version, or it will not be used.
-In the future, we will add the ability to reference your Cue package directory, making this manual copy unnecessary.
 
 ### Configure user inputs
 
-[This section is not yet written](https://github.com/dagger/dagger/blob/main/CONTRIBUTING.md)
+You can inspect the list of inputs (both required and optional) using dagger input list:
+
+```shell
+dagger input list -e multibucket
+# Input                       Value              Set by user  Description
+# site.netlify.account.name   *"" | string       false        Use this Netlify account name (also referred to as "team" in the Netlify docs)
+# site.netlify.account.token  dagger.#Secret     false        Netlify authentication token
+# site.netlify.name           string             false        Deploy to this Netlify site
+# site.netlify.create         *true | bool       false        Create the Netlify site if it doesn't exist?
+# src                         dagger.#Artifact   false        Source code of the sample application
+# app.cwd                     *"." | string      false        working directory to use
+# app.writeEnvFile            *"" | string       false        Write the contents of `environment` to this file, in the "envfile" format
+# app.buildDir                *"build" | string  false        Read build output from this directory (path must be relative to working directory)
+# app.script                  *"build" | string  false        Run this yarn script
+# app.args                    *[] | []           false        Optional arguments for the script
+```
+
+All the values without default values (without `*`) have to be specified by the user. Here, required fields are:
+
+- `site.netlify.account.token`, your access token
+- `site.netlify.name`, name of the published website
+- `src`, source code of the app
+
+Please note the type of the user inputs: a string, a #Secret and an artifact. Let's see how to input them:
+
+```shell
+# As a string input is expected for `site.netlify.name`, we set a `text` input
+dagger input text site.netlify.name <GLOBALLY-UNIQUE-NAME> -e multibucket
+
+# As a secret input is expected for `site.netlify.account.token`, we set a `secret` input
+dagger input secret site.netlify.account.token <PERSONAL-ACCESS-TOKEN> -e multibucket
+
+# As an Artifact is exepected for `src`, we set a `dir` input (dagger input list for alternatives)
+dagger input dir src . -e multibucket
+
+```
 
 ### Deploy
+
+Now that everything is properly set, let's deploy on Netlify:
+
+```shell
+dagger up -e multibucket
+```
 
 [This section is not yet written](https://github.com/dagger/dagger/blob/main/CONTRIBUTING.md)
 


### PR DESCRIPTION
* Fixes English mistakes in docs_101 (using Grammarly)
* Specify `dagger -e` everywhere `dagger` is being used

Fixes #740 
Fixes #739 partially (Kubes env part is being handled in PR#720) 

Signed-off-by: Guillaume de Rouville <guillaume.derouville@gmail.com>