### PR TITLE
Netlify: leverage `--fail-with-body` to finally print error's output

### DIFF
--- a/stdlib/netlify/tests/netlify.cue
+++ b/stdlib/netlify/tests/netlify.cue
@@ -22,7 +22,7 @@ TestNetlify: {
 	// Deploy to netlify
 	deploy: #Site & {
 		contents: html
-		name:     "dagger-test-\(data.out)"
+		name:     "dagger-test"
 	}
 
 	// Check if the deployed site has the random marker


### PR DESCRIPTION
@solomon#4104, I know why @rawkode's push to netlify failed. It's not linked to his key, but because of the naming of his site, which had to be globally unique.

Netlify package currently doesn't print errors properly, which is very very confusing. This made me crazy yesterday while moving packages. This PR fixes it

Signed-off-by: Guillaume de Rouville <guillaume.derouville@gmail.com>