### PR TITLE
[Installation] - Improve Installation for Windows Users

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -37,16 +37,10 @@ sudo mv ./bin/dagger /usr/local/bin
 
 ## Option 2 (Windows): Run a shell script
 
-Since Dagger repository is currently private, we have to use a workaround
-to be able to run the script and match the latest release.
-This workaround will be removed once the repo will become public.
-To generate a personal access token on GitHub follow the guidelines  at [Create a personal access token](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token)
-
 From a terminal, run the following command:
 
 ```shell
-$personalToken= <INSERT YOUR PERSONAL TOKEN>
-curl https://releases.dagger.io/dagger/install.ps1 -OutFile install.ps1 ; ./install.ps1 -PersonalToken $personalToken; rm install.ps1
+curl https://releases.dagger.io/dagger/install.ps1 -OutFile install.ps1 ; ./install.ps1; rm install.ps1
 ```
 
 We try to move the dagger binary under `C:\Windows\System32` but

--- a/install.ps1
+++ b/install.ps1
@@ -1,14 +1,12 @@
-param (
-    [Parameter(Mandatory)] $PersonalToken  
-)
+# param (
+#     [Parameter(Mandatory)] $PersonalToken  
+# )
 Clear-Host
 @"
 
 ---------------------------------------------------------------------------------
 Author: Alessandro Festa
-Usage: To run using your GH personal developer token simply use the flag as below
-./install.ps1 -PersonalToken 1234567891213
-Dagger executable will be save under the folder "dagger" in your home folder.
+Dagger Installation Utility  for Windows users
 ---------------------------------------------------------------------------------
 
 "@
@@ -17,11 +15,14 @@ Dagger executable will be save under the folder "dagger" in your home folder.
 $name="dagger"
 $base="https://dagger-io.s3.amazonaws.com"
 function http_download {
-    Clear-Host
     $version=Get_Version
-    $version= $version -replace '[""]'
-    $url = $base + "/" + $name + "/releases/" + $version.substring(1) + "/dagger_" + $version + "_windows_amd64.zip"
-    $fileName="dagger_" + $version + "_windows_amd64"
+    $version=$version -replace '[""]'
+    $version=$version -replace '\n'
+    $fileName="dagger_v" + $version + "_windows_amd64"
+    Clear-Host
+    $url = $base + "/" + $name + "/releases/" + $version + "/" + $fileName + ".zip"
+    write-host $url
+    Pause
     
 
     Invoke-WebRequest -Uri $url -OutFile $env:temp/$fileName.zip -ErrorAction Stop
@@ -52,13 +53,8 @@ Please add dagger.exe to your PATH in order to use it
 
 }
 
-function Get_Version {
-
-    $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
-    $headers.Add("Authorization", "token $PersonalToken")
-    $headers.Add("Accept", "application/vnd.github.VERSION.raw")
-    
-    $response = Invoke-RestMethod 'https://api.github.com/repos/dagger/dagger/releases/latest' -Method 'GET' -Headers $headers -Body $body -ErrorAction SilentlyContinue -ErrorVariable DownloadError
+function Get_Version { 
+    $response = Invoke-RestMethod 'http://releases.dagger.io/dagger/latest_version' -Method 'GET'  -Body $body -ErrorAction SilentlyContinue -ErrorVariable DownloadError
     If ($DownloadError)
     {
     Clear-Host
@@ -74,8 +70,7 @@ run the script and if it still fail please open an issue on the Dagger repo.
 "@
 exit
     }
-    
-    return $response.tag_name| ConvertTo-Json
+    return $response
     
 }
 


### PR DESCRIPTION
- **What this feature does**:
Windows users should be able to use the dagger binary getting a similar experience to the one proposed for Linux in the docs.
- **What has been changed**: the feature implements a PowerShell script similar to `install.sh` logic. More specifically I've updated `install.md` and added `install.ps1`

I'm not sure if the  URL `releases.dagger.io` is currently pointing at the content of GH repo or something else so the documented steps may need a review.

---
**NOTE**
As a better alternative, a single script that works for both Windows and Linux may be implemented similar to https://github.com/kf5i/k3ai/blob/master/install-core.ps1. Through this approach, users would have the same experience on both Windows and Posix systems.
