### PR TITLE
remove name field from manifest

### DIFF
--- a/.dagger/env/test-core/values.yaml
+++ b/.dagger/env/test-core/values.yaml
@@ -1,6 +1,5 @@
 plan:
     module: .dagger/env/test-core/plan
-name: test-core
 inputs:
     dir:
         dir:
@@ -20,8 +19,8 @@ sops:
             MlM1Ukdqbi9SQ0pqTi9FZ3MxN2E2QmsKHwd7P6KHPVdynOoto1jf3G4+5+vf87wU
             HX1KD7Od5wRdBwn7r3OS8mdvuNIYpJDUb5YDrfjQypt020ohLocNiA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-06-17T14:07:53Z"
-    mac: ENC[AES256_GCM,data:afYut7wdvsJQgxlBg6NEV6DWk8vPi81mZgQAuWb4oe4WJeI1T9cYdtjOHPlmIpjqb86VQHJ29YTzektei2+k+VBawQxcsvefK7X1QboJTfMKLfsiug4qzNWjc7JZDvTb6dsDFM1U96gjSoAIVwdLMnucbu3681Fd7qSQgqNS61Q=,iv:ZQDHzXp0RJcUI4RtOVjdepV8zTa2kIHQhAltLkudDck=,tag:AnSFi1mKrEuXSqE4R+g7dw==,type:str]
+    lastmodified: "2021-07-01T16:40:28Z"
+    mac: ENC[AES256_GCM,data:lBPIqi0r/R1VYNwEtj9gnrZA1gFkMjzxy1nbwyEJkn552np8wrp57S+FkpmyfW/NWvJyRs7ead8osbkZ61m/TTGWu5V1WDa4wfumS73kJ8LjZGaHjmCZCJaYURST7rpwgwVRqiBKZ7HeZks82mTy/OK/WoxPTc8w34zvNTn9i7M=,iv:RQnq/PPjTFVR62/j9wP5D1xp8jDKDM2ygqRLdOVvdT8=,tag:1Q8/b4P68+iChyHD+aYlNg==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/state/state.go
+++ b/state/state.go
@@ -2,6 +2,9 @@ package state
 
 // Contents of an environment serialized to a file
 type State struct {
+	// Environment name.
+	Name string `yaml:"-"`
+
 	// State path
 	Path string `yaml:"-"`
 
@@ -10,11 +13,6 @@ type State struct {
 
 	// Plan
 	Plan Plan `yaml:"plan"`
-
-	// Human-friendly environment name.
-	// A environment may have more than one name.
-	// FIXME: store multiple names?
-	Name string `yaml:"name,omitempty"`
 
 	// User Inputs
 	Inputs map[string]Input `yaml:"inputs,omitempty"`

--- a/state/workspace.go
+++ b/state/workspace.go
@@ -160,6 +160,7 @@ func (w *Workspace) Get(ctx context.Context, name string) (*State, error) {
 	if err := yaml.Unmarshal(manifest, &st); err != nil {
 		return nil, err
 	}
+	st.Name = name
 	st.Path = envPath
 	// Backward compat: if no plan module has been provided,
 	// use `.dagger/env/<name>/plan`

--- a/stdlib/.dagger/env/alpine/values.yaml
+++ b/stdlib/.dagger/env/alpine/values.yaml
@@ -1,7 +1,6 @@
 plan:
     module: ./alpine
     package: ./tests
-name: alpine
 sops:
     kms: []
     gcp_kms: []
@@ -17,8 +16,8 @@ sops:
             N0JOK1FwdzkrcGR5V0xhUDdNOFNvYk0KetOvulxA0Hilyhv+eWBqYO3GXNvm38Y1
             9Pa7HYazNyi0qMcZpecWlp4QsOoL876dj1rE62cYHT2hkt2J2ijAUw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-06-24T15:12:38Z"
-    mac: ENC[AES256_GCM,data:nDngshXQgLAIMAllALoPFQk2HbtnapzDud4LXqZLmHVUZP2LaAES9dGRbWwYc4iLVB1M+Gryk/FdI5/eafsvhSAytGXr6A6CEsrweHc4XPKfyxGS40LVZkxa0ntKUNQDZhlu+NTX333h8NEh99Xx3b7tfg+BtU9fvjnpv7zilW4=,iv:l5A2Bfvb4iT/IER0b2SMV42+7h9+YOIsMuMGG9jhq6E=,tag:v5yE3hZvs5Y5fK9JKaKUSQ==,type:str]
+    lastmodified: "2021-07-01T16:37:28Z"
+    mac: ENC[AES256_GCM,data:5du0I7VsWIb/2jHxdrJ6hKQ2oplkjHl1HhXGa90FOzQKyUf6Li2lOMrO5xKVuCQFFrr3NH+45eIYmGOMokSorluvPZ8I+R96t4NOPwm0A7fDIi/zRYU6CwwNdE5j81HnCunS7rraHVKou1jOrM4dLLFX6m4m5lYuVS4sP5CpfAA=,iv:Kpr5V0UTdhi5j1Ws9mh3CP4TsSyZdHgUF69PbkZISQk=,tag:CT991+qc0LRlthR3DPjSPA==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/.dagger/env/aws-ecr/values.yaml
+++ b/stdlib/.dagger/env/aws-ecr/values.yaml
@@ -1,7 +1,6 @@
 plan:
     module: ./aws/ecr
     package: ./tests
-name: aws-ecr
 inputs:
     TestConfig.awsConfig.accessKey:
         secret: ENC[AES256_GCM,data:iu6LfQNgGZUVnHVeMRYPrcBtlZk=,iv:U5PLxDKXwJnUDdk1ayFGvvJfWdVqh1PK5ujb20YYPP0=,tag:QyqIJRiR6nE16ZDV0CP7Pw==,type:str]
@@ -22,8 +21,8 @@ sops:
             aXlvVWJVSGNTSkVyYmpZbi9nUVJZdmMK6csXZ2RMxFw5DB+Hb2TyhyoZT8c2/z7Y
             Lc9Pe8gb8aUq5Ha+wCybYvY6JWEM5A9XYJKbE7f4borTfGKS72d6pw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-06-24T15:15:54Z"
-    mac: ENC[AES256_GCM,data:gH9/NLLJEEX+dYKmHS44aa9ENtN6dUJHcMgpdygPZVnqYYku7UF7ZZYF9FFw6VittsDUaTXPKsA4oXHXBxPws8uFOJ6t3B/WQAXCoSXe/3t7Z99RlaetZEWzAmfecGG1AcQnihwr7ymO6uuZ36s9q+LS1wZ81LG70gCqLR5c+kQ=,iv:kXnb23lkKVnyn3ewfvJhStGEGvT/OUNv5rSzfyV2kJc=,tag:q9IjsV9Yi4J7LS5wLQtx/A==,type:str]
+    lastmodified: "2021-07-01T16:38:35Z"
+    mac: ENC[AES256_GCM,data:eixHdMaEsb8oHkRwhNxDmHou8Jq/oKEJ3bVlHMXFnoobvtOYPk0Dvvp+VJnhNCCaAUQO3q1BwY+/c/r44cBW3zgefmXlR+9vDgeorXqEB0Uixofx8D9nqRhQddFjiKrJd89O7puKPM9aoIwykx7q8Na5HUNu6UzERWvILaYdnC8=,iv:kt7A48dKz/kHyH09pGIUgLhqpxMBG1vmSCAk+4oxqqw=,tag:EGhIUgU9XhH70cbr/lpeCw==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/.dagger/env/aws-eks/values.yaml
+++ b/stdlib/.dagger/env/aws-eks/values.yaml
@@ -1,7 +1,6 @@
 plan:
     module: ./aws/eks
     package: ./tests
-name: aws-eks
 inputs:
     TestConfig.awsConfig.accessKey:
         secret: ENC[AES256_GCM,data:ZiNdgkTZlOyWht2CDpmYKN+ViTE=,iv:wdRiBw65BgSia9z//tUDirkkhw9O29ZoerX6eZnYx9k=,tag:S/0i/fRtQJg4Qp7tmUK4ag==,type:str]
@@ -22,8 +21,8 @@ sops:
             M3U4UFV5REQzYko3QjlXVE02Z0J4WUkK8uHC67Mutls4drXbCi8AwuFqbRXeb69P
             ZnOFZEB4NoayoOojr1mY9ssDTywHF4KwR4E9ZmJ3V3hlEAgMkqfvSA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-06-24T15:24:06Z"
-    mac: ENC[AES256_GCM,data:zRB7rhRuH95k2IxAbpf8FBfn0tiXKG4xEOv/M7qHxvexNhZWcBp1GnGnMI53CkzCMtTZcsdzquJJhQct2oyqXGbD9XNk9njC/hamtPVeXXtvDm2FTK8eHbb70tqIFCwspFXvfFMoNWCIZ5+CZTggTIOExnvAqsQ6QAN+FV3o25o=,iv:aghslE9r7hx1zmm2j/XznCyOJEoIs8CgUr5Wy/kuki0=,tag:6e701Vdjg+hnJElvZFnX7Q==,type:str]
+    lastmodified: "2021-07-01T16:38:44Z"
+    mac: ENC[AES256_GCM,data:IBpAJSzkjSLo0G82CCewkMq8lTROEvsIo1aIK7RqsZ4VGtSvjyDc9qTtYiqYcDDTuJCga091TV5t6eI4cl00uYi0+2E8bbJnvdnfb2wt30lxL3VItyePqZr7gS9l2D4F88D43dXoRIRr3IvapHO2yrAbQaHIdl9JM9SsBh3odB4=,iv:CLAnjw5ZCBGP29Ff/Vk+m65AMV1jmKzLf2faI0s2hv8=,tag:mXhG+tEReYW54qLNvTeX1Q==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/.dagger/env/aws-s3/values.yaml
+++ b/stdlib/.dagger/env/aws-s3/values.yaml
@@ -1,7 +1,6 @@
 plan:
     module: ./aws/s3/
     package: ./tests
-name: aws-s3
 inputs:
     TestConfig.awsConfig.accessKey:
         secret: ENC[AES256_GCM,data:iu6LfQNgGZUVnHVeMRYPrcBtlZk=,iv:U5PLxDKXwJnUDdk1ayFGvvJfWdVqh1PK5ujb20YYPP0=,tag:QyqIJRiR6nE16ZDV0CP7Pw==,type:str]
@@ -25,8 +24,8 @@ sops:
             aXlvVWJVSGNTSkVyYmpZbi9nUVJZdmMK6csXZ2RMxFw5DB+Hb2TyhyoZT8c2/z7Y
             Lc9Pe8gb8aUq5Ha+wCybYvY6JWEM5A9XYJKbE7f4borTfGKS72d6pw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-06-24T15:29:49Z"
-    mac: ENC[AES256_GCM,data:tv+8xGY5Q2TkrO9qLxgtvUzfQG50ugCWGZZ7qIyYu2MB4Am88SVUG95GX/zHt5BGRMZQ/FJRnog7SiprC91wAgCjWR+kykhKeE7lygpVZpJTN0TD72a1X1vQKU7729KxPlu266q47Zc/w1N2tfx3krkQth2AjF12hokdZh93hhc=,iv:BPY2WVnKvxo2MYi58TW/gYPnfnFsOPIupSB7Hlh3y78=,tag:wBtD7PALUBAvO5OUGPuSbg==,type:str]
+    lastmodified: "2021-07-01T16:38:23Z"
+    mac: ENC[AES256_GCM,data:d4ZtcLkkhvdhPNX+2mU7FDQDvO1/IMXpHxoJkAzegfabNWk3IjDSljP1YnS6/+5WH6ejaI6BNCkTbijbeOR3D3a4zvUnXhRxkI8B/b1Wdz+5DhbAvt6t2OZO97xtlOKT+4KKM0vuEpsfOsufp/0GiwsAQC8oIADBSZkZZBt1HpM=,iv:2BFyvxR1Gd+m8UtB5/wBCVEVH2xBJNi1r199pNtHR9g=,tag:KD/dD7HJ9YWh+Tam7RDCng==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/.dagger/env/docker-build/values.yaml
+++ b/stdlib/.dagger/env/docker-build/values.yaml
@@ -1,7 +1,6 @@
 plan:
     module: ./docker
     package: ./tests/build
-name: docker-build
 inputs:
     TestSourceBuild:
         dir:
@@ -24,8 +23,8 @@ sops:
             Mm5vT1dHbFViK2ZIakNnVkZTd2lhUHMK63jJsJVLJMbQE2NkAB8qv8JnPHpvcNes
             z17EJgl0lCLqeNHtfrTfSiIP4wq8gNLK4avCKK+WGDOIMsXPzK6RNw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-06-24T15:44:20Z"
-    mac: ENC[AES256_GCM,data:zJsFrUaGd2Germ5nzov/0nDFBgtEL8W1Q9iYg3jQmOQhE6n91r4XipKHMuySbznHPqrZPPDeMabJXzMKlvqhAaWXOBAz9FRxSPlKH/UgdeNr9/YyMj25tqF4oycUAZUm6FZ6YCsEVsj7QIZnKKGR1oivE1Qe2gW9brpBzzu9JSU=,iv:ORQlfXm7+NjNA0tKtVVQMvvflS8p4mxZGk7bmzAiOfc=,tag:IKoqSXxl0zuQAcFW7RF1lA==,type:str]
+    lastmodified: "2021-07-01T16:38:56Z"
+    mac: ENC[AES256_GCM,data:31OtjxfEKdVjC13D1k1LDDsDbf1/OQcTyL51+78B3RYtdTQlnM65Hvax0C1XmfVHQ3BDQQhmBrJRaw1AT/QgmxtB1U17v5BceNs+ZUenuSGrVwbMozrHx0kgNbrRyP+jo2EifsCbvSBFDCaimA6Ts1t+NTwpfX/YwQ9cq3+ll6s=,iv:LB0VwXltpOOKPRA3iKjQNx9ZQhzB2kP2bFNPGBCky4k=,tag:FXHDfV50UAYn04I11zSyiA==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/.dagger/env/docker-command-ssh-key-passphrase/values.yaml
+++ b/stdlib/.dagger/env/docker-command-ssh-key-passphrase/values.yaml
@@ -1,7 +1,6 @@
 plan:
     module: ./docker
     package: ./tests/command-ssh-key-passphrase
-name: docker-command-ssh-key-passphrase
 inputs:
     TestConfig.host:
         text: 143.198.64.230
@@ -26,8 +25,8 @@ sops:
             cW1kbGZveVlkQkJDL2xYbmFRNjZEK0UKrSrOB/RL5lki54j4GUCE2G3CCO/8jpMU
             jfYkl7Yowb7kK3kKSNWORhB4ne3MEeGRZpJC8cvH7zjGvt/YYeU14A==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-06-24T15:57:03Z"
-    mac: ENC[AES256_GCM,data:YqGUjsf7fG8lMv791l5Td9a2oTbg1DVvZt4Dt1q7+L5opaAxhKoDwSimR7WsYuJJxEqkMoyB4X+7+SNzoAarMWqg20sFjUut6wMgi0iUOhym9OX76UYlC5AvsJ6zbIalgKktiece+3j9vwcqB7rR1ArwddbflRvxkw5VSpVXqj4=,iv:ch01NpT3K14dHrEZ3yigH8S3QlvpAK5Myjhh2P1CRpE=,tag:DjjxGwrGIeMeOaaVJx7DMA==,type:str]
+    lastmodified: "2021-07-01T16:39:08Z"
+    mac: ENC[AES256_GCM,data:wZtBlQC4fG4F5RIaV3yvHkh7c28cQYg0j9+WMS/hPjAmPIdaBYVha9j7uY+OT5S70WFHX/yHztvtrvf0yffw14x/NxsmDmro/XKkBtX4vuwMYwD0NfiA4jDdJFhvNurQqsYH9vR3Nl0Ho8A+qndmz+IeSCO33auAMZ0sGZHYsYg=,iv:lZwdu33rDrpYfIT/AOpgKxQoZxL2h8DZwNSPHIQxOzs=,tag:TMw+6kpz/UcFK4xKsNHUZw==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/.dagger/env/docker-command-ssh/values.yaml
+++ b/stdlib/.dagger/env/docker-command-ssh/values.yaml
@@ -1,7 +1,6 @@
 plan:
     module: ./docker
     package: ./tests/command-ssh
-name: docker-command-ssh
 inputs:
     TestConfig.host:
         text: 143.198.64.230
@@ -24,8 +23,8 @@ sops:
             UEpoZy9HZUlHOVV3M05OSkZQS1l6aXcK3NfBITvd6la6nkcIzqH69xfv9RR0Jm7x
             vU5FvGROK3Z0ZR8NNXAtNH6VQQ21TDD2MOXWOVvjnIAAOVNEyc1amA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-06-24T15:50:11Z"
-    mac: ENC[AES256_GCM,data:smCRgqcXPpgI909GOomUGrPfj5b0cNfha3CTicV7uzj675tTNqEVJTpgZiOWNUv3pQ535nhGuF4WRESZj+TuNabCWj0sMMU1EGvxUXuaV/TSXo3JtdFeU8tpn549UtcHez71sjKHiCTfGDdESPsAsYDLkkMBZkb9UE409on1Ypk=,iv:odHs0ukQTqfWb9ARFHpAh1qTZ/AZMLMQ6ZtVOged97k=,tag:sev1dRKD/7ZBgJamRCHqhQ==,type:str]
+    lastmodified: "2021-07-01T16:38:59Z"
+    mac: ENC[AES256_GCM,data:BzODn+DQZ5vSeJyHrDvcda1GeL/3+HlQLmIhzBa/vgkDMZtZfDi5w8da5BugYZAy2mL+h275xBxI48A12l/oX0Z6C93Sn8K9UECUQRdOzLse6xkj88/ZwCX+uoy7DJdtlIs1pHS/86pFgHBFpjhFB7XzhzhqZObG24HvzSeG/io=,iv:OV3kalnqZ0HYuV16L+qmf+YpJLo5pXP5yHWS73MLIVU=,tag:zwyWSsAhnEJZsi/6445G8w==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/.dagger/env/docker-compose/values.yaml
+++ b/stdlib/.dagger/env/docker-compose/values.yaml
@@ -1,7 +1,6 @@
 plan:
     module: ./docker/compose
     package: ./tests
-name: docker-compose
 inputs:
     TestSSH.host:
         text: 143.198.64.230
@@ -27,8 +26,8 @@ sops:
             bEY3N3ZLTFpUNzZVWVBOK3VNRk9hWlUKd9db3j7FqFW4t7TxFyzudKDPTVqr66v2
             KqedhRYCjF4ZozN0H++xQPH24RBRnwc6Uq0Vm38UYv1ozDN2L/l5DA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-06-25T13:17:45Z"
-    mac: ENC[AES256_GCM,data:RclYzWUgBU06881KztfHdaeBtHLOiQZ5xNp0taaxS152rUxyXCXEAFlOu/yqE3RvEoorUp473wDwFUa9DudHidY88YNdfdk5AUuZdsOXW4bRMFPF4eiFugqZJNPepaW1YBDUMeH7XQBN1jyEkFOvzyk2KKQhoUshWyrU5QDR2kc=,iv:MjhUSjzVm6nV2PnSNi346GxkirmF3yAti3Jmb94gLGg=,tag:t4fHAYh60//PlkwUPQh2uA==,type:str]
+    lastmodified: "2021-07-01T16:39:45Z"
+    mac: ENC[AES256_GCM,data:wNobsnx5pAGSJXX1a1/VbyW1j4S5eMCGErI6yvXAgHxRCTIN+3XY5TfqguP1S845zZQMyOgKYtIPiZD8mY8CLBomBAWAeiPqVIqVDfChWQEtkpGt2m1HhJLYm/2HnTdMS0cfb70OvxF0MaHacrBD7eY3wJIbMvHo2DTHfXs8XNo=,iv:0htpQKAlTzaNjKn9fH7XrfGqGk5Y6e28x2GaXltjhQw=,tag:C9V7UbOH47qIhZNNPCRcKQ==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/.dagger/env/docker-run-ssh/values.yaml
+++ b/stdlib/.dagger/env/docker-run-ssh/values.yaml
@@ -1,7 +1,6 @@
 plan:
     module: ./docker
     package: ./tests/run-ssh
-name: docker-run-ssh
 inputs:
     TestConfig.host:
         text: 143.198.64.230
@@ -24,8 +23,8 @@ sops:
             cnh2eHU5TzFjVkNvTzUyczFBL0pwTDQK60+wrLmTaD3Ws5ZAXdqBkMjaVP7Iz69k
             UrkqkMbaUlvvSKK7dB5MuTGEEN6A1viAGal9ZjDHlSobkNPuE24QEA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-06-24T16:03:21Z"
-    mac: ENC[AES256_GCM,data:sTXjqAY5c6jD8alHiGNwM/nHxNWFxD/mJ9mY5L8mAkA2BR/633/JShlMRDMUeUX+fYPDpwDdG5QEy4XT2EsqMdN2+N6SNNpHikg7T6iIbdY4XYY9Toil8Gv3ahXoCQoZyek7uXKUi9mXQiSpI2u4cLsHNDvL5IhWE7maR++403Q=,iv:SLqSa/k+e66kOs1IhKUxj2YQJRUQZYIXacqhTDSefvQ=,tag:fUBQ5vns81L/DFV18HfhEw==,type:str]
+    lastmodified: "2021-07-01T16:39:18Z"
+    mac: ENC[AES256_GCM,data:FPRw0t9HfkH7dlw18gLRuf++5xmb8uBfWzTn5P40nHJFhyTmYRHUZlzodwoAR9lirCIm84LWypqN6Y3yh6/6AwxfLeNAZsBOdqi8bULL4bR3dSF0VKd6bP/5xZAerxUT5+HnfyITS6vpdRKODX4Hm0Ofd5Su5Zim0Sm3O/5IY1s=,iv:OrT1Ft63hPhIe4tpbdzb/VQ0NQdNeOBNT/gnv3uuCPM=,tag:rRZ/IC5lMe1YBUA9HaabEQ==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/.dagger/env/git/values.yaml
+++ b/stdlib/.dagger/env/git/values.yaml
@@ -1,7 +1,6 @@
 plan:
     module: ./git
     package: ./tests
-name: git
 sops:
     kms: []
     gcp_kms: []
@@ -17,8 +16,8 @@ sops:
             TmhJNisyamw3d244aGVJSEVFVUVLZGsKvd+nowA0CLXQbdvyI4J0lBjs9vdISWlo
             gGvR49uul3Z8raVWXFUzsyQ8xTvYNg0ovynFG2KdagSKr1DlhKMBEQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-06-24T16:14:47Z"
-    mac: ENC[AES256_GCM,data:3UHY8Jg+qnbaqTmqzdbmV08zXIFQ8141KMT4Zl3ud5d7PABqQnVAPaL3b7/UvnNo6+ssjnlMVUbKG6duZpqw3scWyrGfUgWfGM6VASoy+LCyquuPuOVzImBeZw19FZsUVzqr79NnzL353KRCz+fM68ZGryZpsyXsl+t6wgd1gpM=,iv:EosxY4VFRGLeIDJ9dNehFK2yey+dKnggbWwRwuORWtI=,tag:R5cvDSq/9GkhhF1fz3e5aQ==,type:str]
+    lastmodified: "2021-07-01T16:37:46Z"
+    mac: ENC[AES256_GCM,data:1rp1KlNUeo6HlvZZx+nBSuQQddHC56/72Fe3esc3H8eu/HjIXXAuSBGTJBvhO7qA3q90zv82rQ+ZY1T2TXvocnj/R85ltRNsQEqpGOro89sdUbqM9rzS99/6FtIJYzAF6s2nHZMGN5FtxGFScE2NgJGIEWieyYtGLNCQUSVcRWM=,iv:vQrpjZg+ha6EZdfycU/mv+V7QJEtWFUCdu2L8n+vwNI=,tag:AAGbDKwdvkPEyzxKVRUhZg==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/.dagger/env/go/values.yaml
+++ b/stdlib/.dagger/env/go/values.yaml
@@ -1,7 +1,6 @@
 plan:
     module: ./go
     package: ./tests
-name: go
 inputs:
     TestData:
         dir:
@@ -21,8 +20,8 @@ sops:
             R0o3dlptazJPTmp3OFo5RDcxOVg1VVkK1lLu/wrPvgzXa8Ym3qdvcuYCj8csbtOG
             T4HjRvA0EEF8jmFEuqS8Y/N0vQiezoZR7JU9PbjOoD1B5bLHtJcryQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-06-24T16:19:27Z"
-    mac: ENC[AES256_GCM,data:3dJTQZFlzj4sJkIB99zHMgH7MsTcHiGKwT5GykEzjzq4OH8KOkKyFx0uVrvw4ePYhHMjAcTKcJFWRD+ebrRusKF5yZ19Si7IleCSh4y/IzRE0fWfzCDCYSN2MVwreE9Q10UeL/vBw51cK/k7kCF2DNGkIr5et5wO9R3eStuHfDE=,iv:QJlR6fIRD0AfWneMhCY6HpXpVSFt6431dJuWzXplfB4=,tag:h43ENEs/oVkd/ZtSfgmlmg==,type:str]
+    lastmodified: "2021-07-01T16:37:24Z"
+    mac: ENC[AES256_GCM,data:dJZVNk9QH7gc7hRny7cxWUXp5b2qpaExwSOkbFD4UNAz5bwiyLA4SZg/8bGGO0vlMVwQz1soXgdxxvtBXkwBL0PvVQrrYL1EjdtElYW0pXhXWDXRLgpKvqrlzXIXpqFg8fEI0JQO1tg4MUHIxdhzYm7AySgPUPZebUKWVO6x158=,iv:WfSQ/0zs4CNpQL2vNzaIk4dHsiRJyg21AWWpYXznzns=,tag:6757aNNrNJQNEboptcrwRQ==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/.dagger/env/google-gcr/values.yaml
+++ b/stdlib/.dagger/env/google-gcr/values.yaml
@@ -1,7 +1,6 @@
 plan:
     module: ./gcp/gcr/
     package: ./tests
-name: google-gcr
 inputs:
     TestConfig.gcpConfig.project:
         text: dagger-ci
@@ -24,8 +23,8 @@ sops:
             ZXd6Qmd1YUtxMnVTVkYybWgrV3pVK2MKowMeOZU3j3BxERT0DwhQYCGUDBK6gCdo
             WByubiBATdsb7h7ytCC4HutWppynK4MpU+Ya9NP83AZuXo+Wa2u6aQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-06-24T16:22:49Z"
-    mac: ENC[AES256_GCM,data:8VyOUX7cwS6VCrLJi1luMag+vgh9WA0nxi3WqNMpI+w//SVHVtYaZ0wnzof+yictU0+PECwGFWS0ircpmLvLDUGENv2T3fCNgQj4x3TnYRdgHpd1na2XSzc/J1+uWP1FyYBR/ipvY6LnDIY4u7IWpjGNcSs+Iq+gm3S4Hc2e/Eo=,iv:UaYq9P0Y7MvW3DucgpBgc3n/n7vo+itaMhz1umIfOYI=,tag:j1suX3zEBSdRzsDexXNBVA==,type:str]
+    lastmodified: "2021-07-01T16:39:36Z"
+    mac: ENC[AES256_GCM,data:lIcyiEaTyYtD2Lu7tZ+2hqtDmrExjVM7IF8RYRpnBr9WWND0vJIPXrE1Umj/ENsfNLQBEB9xwhcn+u2grbYkPZRCnSMa7xrIn2Jjq1Gh8iVqnG/ZrP2aNGeEcxQuEnFAMZ1pyXpCzHUupBKSr0h8hp1s5JfNaAX2o3nX/QH3Prk=,iv:suXzeCk+hXuDq/69dc/IspMk+cT45B2g9Dj+lwHziwQ=,tag:kEGZO4ULKn+t7ua8DFlBKQ==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/.dagger/env/google-gcs/values.yaml
+++ b/stdlib/.dagger/env/google-gcs/values.yaml
@@ -1,7 +1,6 @@
 plan:
     module: ./gcp/gcs/
     package: ./tests
-name: google-gcs
 inputs:
     TestConfig.bucket:
         text: dagger-ci
@@ -29,8 +28,8 @@ sops:
             ZXd6Qmd1YUtxMnVTVkYybWgrV3pVK2MKowMeOZU3j3BxERT0DwhQYCGUDBK6gCdo
             WByubiBATdsb7h7ytCC4HutWppynK4MpU+Ya9NP83AZuXo+Wa2u6aQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-06-30T10:44:08Z"
-    mac: ENC[AES256_GCM,data:bVjVtONv7ILxZ3UkYy/l3MnuJB8g4EG++fBfeL/CQPHyembwBURC3nxfB0IdqQmPsa0/ahycNawIvB/owy+Sw6yyaDWGtd/8Jn0CILLZ4Nyx9lNN95J4Ad0FbUKr24Fu17I339rB1GrEjAaTs1qcle53sp4Wq9Blg26Vkut9jmc=,iv:TdFDptBZrScOfywWsIhoLijSFQL18DF94bKMh5DfW5s=,tag:wVoa1K/Nyx05nu+Op0Viuw==,type:str]
+    lastmodified: "2021-07-01T16:39:45Z"
+    mac: ENC[AES256_GCM,data:62VsPf5q3OaCWW2UEUiYRNP6cGsmWSI7hZtdd3UBt23J4H/HnFW3zN5Wts1EQK/gNs1Yzzs2SheX2bxKEaLshmLH+aJy6fGHL9HkssrImN8IdCAZ44Nw1N1UK4p2rVoT5Z4PO4UsFgezPipsoBGyylQSi9QycGQ65A+mtm9PZuk=,iv:jg4hDDNPDnNw8+BL4UqTRClqQxUT8/jQXqtDVnpNO5c=,tag:RPiKc+H1VBHpj3WVDQ7Aqg==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/.dagger/env/google-gke/values.yaml
+++ b/stdlib/.dagger/env/google-gke/values.yaml
@@ -1,7 +1,6 @@
 plan:
     module: ./gcp/gke
     package: ./tests
-name: google-gke
 inputs:
     TestConfig.gcpConfig.project:
         text: dagger-ci
@@ -24,8 +23,8 @@ sops:
             ZXd6Qmd1YUtxMnVTVkYybWgrV3pVK2MKowMeOZU3j3BxERT0DwhQYCGUDBK6gCdo
             WByubiBATdsb7h7ytCC4HutWppynK4MpU+Ya9NP83AZuXo+Wa2u6aQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-06-24T16:23:14Z"
-    mac: ENC[AES256_GCM,data:xUwP0iRtKFl159PD5u8byQbxMyPHYuQvGQLuplUJMZs/OMSd+YWiWoJRhup4j9/sZbq4Ob6uHr37HMmwbNgieiGX6qabS90Je/1UiufCOWwfVswnT+iUMHyudnS0r+Gh81vwl2eP3xLr6Odm2FbFh8kwF3Yw+NNi3wgei+yZIjU=,iv:tNI8ti2zAem+dcWVdciPLqdpJ6SDIK3CoeQUchlWE58=,tag:MgTShPwKT565cJV2BJLi2g==,type:str]
+    lastmodified: "2021-07-01T16:39:55Z"
+    mac: ENC[AES256_GCM,data:gNRq8/pPEFtICidk4lCaEE8ccbvOXzX7gnpLDZAcL7mwApUGDbNind58m/OziDWzjVgl7ikxyyLgWjxWhV243KvVgirLUGzFywZkEgV/p3ZNUsulgfmmX5z9dEK778Rr2wgIY4sFrNVag/iBhey4xLciiqAgcyKBVjKMwfk7NN8=,iv:/kdORRnKBVZyVs4Xfc9Ou+e29IfXIKN00wEJAVMt27Q=,tag:VrWj2CQVIpU4rCeoAx9FdQ==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/.dagger/env/java-maven/values.yaml
+++ b/stdlib/.dagger/env/java-maven/values.yaml
@@ -1,7 +1,6 @@
 plan:
     module: ./java/maven
     package: ./tests
-name: java-maven
 inputs:
     TestData:
         dir:
@@ -21,8 +20,8 @@ sops:
             UjFhYnZNdUxBNEtzWkVvMUoweUFnREEKbs/IGlNmDk8e3ibJSoIcE95txghXwsso
             DL281EMf0V+ARsJY2CiehZsZB+xX7y+YfyQyoWx0xMN7bCgPu2snGg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-06-29T16:06:47Z"
-    mac: ENC[AES256_GCM,data:DudrYOLr/ymf10B4UzjRfe1+n/hw7KCSSIbzAGcc3kmN/KplkCPYi3n5HCX1XkMOB1mQp9QD+UOQGL5CYPtqnZZKu62JNfbeSqU26BKU97aqL0F2+lPqaYsjSeCAbgUs9O/30A7QErlJiXuzTYC1WcTjpTr0RTeNoHmWKsqZ5ug=,iv:7e1XmOfxyKIOguzDxqQ75nFnV3GZ1vpvz5S5P1O+4Xo=,tag:f6Vb8e721uLyvLfCwE/JEg==,type:str]
+    lastmodified: "2021-07-01T16:38:41Z"
+    mac: ENC[AES256_GCM,data:FMURWwT+ab+kOSYRXugdpo65d8NG9VN45Z2RlduPeBr5sqQvSPjreXZ8ghF1Wdg1hSbuyBsSyMWsUafsCxjCjAelVMI/uZlri4AFcRqe1/1qu1zbxmf5YDpLH5zXIhN38WNGZd36/e5a/qOWDToWL7eLXOZ2ksFkxCkCyBQNpX0=,iv:msiMffCBCGeGq/SMRkXPjY5BfjOGJblETEi0OCILLg4=,tag:MJTXi9yQ6A7m98hiPWJKvg==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/.dagger/env/js-yarn/values.yaml
+++ b/stdlib/.dagger/env/js-yarn/values.yaml
@@ -1,7 +1,6 @@
 plan:
     module: ./js/yarn
     package: ./tests
-name: js-yarn
 inputs:
     TestData:
         dir:
@@ -21,8 +20,8 @@ sops:
             S2JsNXRkbWVERHM0WWk0bXBJSXJIK1kK9R3gMDcbeKRRlt0HHM+w2kcs+sGfASmE
             0YhxbFF2qQPFwHHR7aPmM+L1ML8cXOrxOOyWmmWhXNgtURCJ9/SO3A==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-06-24T16:32:39Z"
-    mac: ENC[AES256_GCM,data:jAgt/buOF8cUAT0bQJ3icGI8qR8cOg0ZQqZFuut1VhggLGZTr92Z7XZcChfBdpfPIE98fVuoemTdddEBWKp9g/LjXHyoK4kJxtgTLiH0CGkynVIE01bQUTCQBwaE3KHoRTYuu8xWFw5RpqEgCvlpZnvCGwwMG08NR+hSJJ5j7oY=,iv:+fkJT11KX3xD8OL7NXj+Rs1nuXK8J1AnfF6ZWGGtTTY=,tag:o9xcgR/nLt7hxvMeH1saoQ==,type:str]
+    lastmodified: "2021-07-01T16:37:14Z"
+    mac: ENC[AES256_GCM,data:TiacGHnxvk7XMF0hX0Fd3iYu/dpHMMlkHonHb/aNSSOH3dIKraTVXhSc2VdOVL8b3xeAqjNz2dlPVZEb4ZsH6vLOboc17deuYJENHRHDYKUqykyGQom8EnTEx+YLaaHIcKHqJJCI3JBlUGJieYn0MTnFkM+/bWa+3bOW7+hulHg=,iv:/zIylWOGHCnjsPCcQAXXMCpfmsqni84pb3cjkeH3mKs=,tag:G/40Owo+Ny2DBkjATsNnfg==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/.dagger/env/kubernetes-kustomize/values.yaml
+++ b/stdlib/.dagger/env/kubernetes-kustomize/values.yaml
@@ -1,7 +1,6 @@
 plan:
     module: ./kubernetes/kustomize
     package: ./tests
-name: kubernetes-kustomize
 inputs:
     TestKustomize.testdata:
         dir:
@@ -21,8 +20,8 @@ sops:
             OFllMEh3cVJZZnFxbW4xS1RtcFQzcFUKo/1WcYp4nPBXba8wQBe3DMt6pYQJGoSu
             ja5BiCffN5wOoW9WT0j8Clx21w7BXcl46+T5GYpXDQDcqf6nCv1kYQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-06-24T18:16:21Z"
-    mac: ENC[AES256_GCM,data:eq7Eev6taZJnkl2SoqihKo9tfAMA3IOnLO9tBoppUeg1LSLe6vZ8QmN7s1Z0gyWNWttnNTdMOvTQTI2PGrayQpLRGzryChcQsuCL7hnij6bQf16IcGn9jbq7NVQ1EreS8iPZYuyYlR5Z9kSARtfAKFALim8ccF+BmR9+X7yBfZ4=,iv:7kovyOERH0dx0NONhmUwOUI39nK5N1rT9o+gi9ol3f4=,tag:6HrkHbiCwrgO7hukxtsXVA==,type:str]
+    lastmodified: "2021-07-01T16:39:23Z"
+    mac: ENC[AES256_GCM,data:4r+fRhR9R8UWEF6BQcovnEmEz9Zlehpaih2McNOMiQdkN1jhi84VDn8brs7KpvXJZiJejm+MZllF5UkTPv2HhhV9JMVb0u26C4xpKhGotyudif/3oiK+OBweMoEB6TMzHfZ/l6GGRnqnWc4JygF7Qf2GXiTPQl6Ra6OdOo9qs0g=,iv:9l9UoXWg12dR3aL4MsqjaHIE3suCcAK//k9ronoFqMI=,tag:WHcxrOWonLL2sBBNF8V9Xw==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/.dagger/env/netlify/values.yaml
+++ b/stdlib/.dagger/env/netlify/values.yaml
@@ -1,7 +1,6 @@
 plan:
     module: ./netlify
     package: ./tests
-name: netlify
 inputs:
     TestNetlify.deploy.account.name:
         text: blocklayer
@@ -22,8 +21,8 @@ sops:
             SEdUK2RsaUxuVWg2aXUwdVJ0eUtrWWMKWkQDBuL5e4QDx5Wy6+fHiD+J4fp7QdMm
             lsqgmxRvJMWgEvm1U+hDAo/Pkn8PFUFJf0KxEvkdF4qGuguQePgzFQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-06-24T18:29:56Z"
-    mac: ENC[AES256_GCM,data:rDg4tHAp9rxUJRPTmnW3R69JnGfVMnYOBraRX84BRbhFNVS2S4MwK5xjZ5E0ZVBGQDyjmr9ApOMzI2bTFsnCO01FmkISo/V0fR/nPPTz6NABkc/JUFzhi4DAONAV7TXLBv1mwhKoAP9JL26MTYaOfnxehDVrvwciANQMdgqnp/E=,iv:7IHISgR50guk6r3etF+A3AWOn6LZxhE96MWgDMHf8IU=,tag:Bs18JGNWKBjAHzrfFJnL2A==,type:str]
+    lastmodified: "2021-07-01T16:40:11Z"
+    mac: ENC[AES256_GCM,data:wcAheEmSjJLOlni/zRtX86Rj+S/+qQH6tqZf5Nz5V6ApaWYWYsPMQR2f1bmTqmBxI8WCHSbK8dGUYd+Wbz0nyWz0pJCfYmuyQu0NTsTucy2AQ4mZd2FvfVci5zTuY+5TdqyizZnTzTiADN5THGPQGMJ1fuZfxXBpZ0lzoku++ws=,iv:z6DpkoRJe+MLf3PE1EMJJjZRFRomzUN9dUAaTMU0B3M=,tag:MeiNSea3JCXg4dhrERjKVQ==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/.dagger/env/os-container/values.yaml
+++ b/stdlib/.dagger/env/os-container/values.yaml
@@ -1,7 +1,6 @@
 plan:
     module: ./os
     package: ./tests/container
-name: os-container
 inputs:
     SimpleSecret.cleartext:
         text: hello, world!
@@ -22,8 +21,8 @@ sops:
             azJIU2lIVlF4N1VxT2tVWDBPU2RsOEkKqkfxeT/mnnDxdvv/vhXMj2Zl8ogaAHa6
             xbBUOaCZ8stwj4Zz4/iKdrPspQQKo7/QuxxAcFUfyuK3fULqJHPXPQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-06-24T18:33:56Z"
-    mac: ENC[AES256_GCM,data:0uCRRnDFpow8TTkSZFM5Jn8GZp6C1muLrnHvBUb5/rQ54x+G5lbgqS+rOfgFUgU1/qvKVevO0m96jfo4ZetNLnPscvK8p1oSUGBtk6iQ61tLeIQQFJR82gO2mzqVj0g0KYYeX+1QPglePimYuFy6lRGpqGEPNyxjlhq/EGhHOgU=,iv:7Lrph3Cum9H+2UuAIwCHh/wkVft2fadZ+a2F4aoCZLk=,tag:6Q60ujt3o+mvVErih2dLzg==,type:str]
+    lastmodified: "2021-07-01T16:37:54Z"
+    mac: ENC[AES256_GCM,data:vXrCGyQnaD/RxSPZu3tgU/JeFXsYRNWxgltaRTpm1bcrxBAkrwbFq6OFfv/ol0UiOCvUixpthqM2TPfyFoxWA2pePorzyd0GRmUkUCc+bZXfRQavCORW8ipbQvTe7am2A4pQYHNFzbzo2NNaCyqX+ZyV2ujqCnE37h6lGz2K4/M=,iv:DWAIYb7+hLBrfFt02Zq3mlPqHlLklrokmQzaE2chbc4=,tag:QUSoyi5LPJrfy3S8vZdDRw==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/.dagger/env/os/values.yaml
+++ b/stdlib/.dagger/env/os/values.yaml
@@ -1,7 +1,6 @@
 plan:
     module: ./os
     package: ./tests/os
-name: os
 sops:
     kms: []
     gcp_kms: []
@@ -17,8 +16,8 @@ sops:
             STlrbFNHZGFRUVQ1S1RIaGVyWktNV0kKo9AFURi/BKI+JuGYVuOrsw3eJU3s66Im
             FCc5YCzrsjX+Y26Su+XW81fTWkcC910e/g+tlZbEFWKZYa8qu1VkqA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-06-24T18:33:15Z"
-    mac: ENC[AES256_GCM,data:8/GzJKtH7GONYbtBDqaSj5HdK8csmwoE7fNx2tRAwUs1uYCaZT4n1NBFuxDj/iFtVKB/St2Ba4thEE6+99azLnmMoC1Ss/1v9ZPfINzZuEZBFf3+ufVNSdI49c8DOeRfPNieupPdmPwHFBUN1nPpaK3bYmgr8CaVkdY3+iq4hX8=,iv:lIMOnbJr1gBoCdlbRWTOg2jA57fhZLu970k5QqV+1Yk=,tag:IziUm3K+8IdBJ5XYoeHhjg==,type:str]
+    lastmodified: "2021-07-01T16:37:09Z"
+    mac: ENC[AES256_GCM,data:brbrEz/VIP3QKZtBg4EcSljSgdxKDpiNDVPLseYJDZA5yhs9OnI0EyPRxbA8vi1Pv7S/8mbG/dhnvksYz4SIoqqbBGYIf/paR8yRaJhWJ3fM/b1c05Vj+Z1yKfa1KcXNtMuuxUdupMbZRHTdjPi83uoeCczlRsVU4pY6a+YXb6c=,iv:EP0FzYKBG8QlDOFYEYCTUXt3WUTddNMftNqGO6e0zvg=,tag:LIjPM3szC0DR6AhWw/TGOQ==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/.dagger/env/sanity-check/values.yaml
+++ b/stdlib/.dagger/env/sanity-check/values.yaml
@@ -1,6 +1,5 @@
 plan:
     module: .dagger/env/sanity-check/plan
-name: sanity-check
 inputs:
     universe:
         dir:
@@ -20,8 +19,8 @@ sops:
             RE1BR1ZvSlpRWnpZVERFQlB5ckhPYk0KMm8XjFKgcjWaXh9F542NXyv9dBZQdZJC
             rn5YittfEOwRkrlqBCVwPtU+nhE5oDxnt9a0n8JMUgvB0Nnd6tgP+A==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-06-24T15:27:51Z"
-    mac: ENC[AES256_GCM,data:SDJPXr1NjGSOcHMLmKrzJ9XkFjfXOg7g5pdgXS3fQ4sSALVBqhHSfHJnH2m4NVSJPyOd35ia2/BivTWTGw1oguovLSfSvlptPUDqbwsXQoB2NEFcAJ6eJeDyz8Bx98OrBliyJaVOVYzF4y5dWwW2BGuevW097PbY/Sv3p6x8fyY=,iv:IftNBSOvEn3nGRQlD47At8pvundsXdk68yz+cWct/tU=,tag:XUPxsP39xSjPgvIZNBV09w==,type:str]
+    lastmodified: "2021-07-01T16:37:59Z"
+    mac: ENC[AES256_GCM,data:oM763HAMBrm7xH9BjkzGuwqmn3Q8ssdpZj6Ci8bQl6LnSbEYI/e54umxfO7Nnpar1tCGy78W882BbhOmBbdWJ+ovNcNobTmM8A0uKgoPDKQEylPdbyG4eBQLcw/8XqfoRfPqKcrz91TIg16TVfqp5qeYBLWIzE+7FLGESYo1xTg=,iv:G4xg2a6PZUMW9SMHGyu4i7dSty1jKHuMvJkncZMiD1E=,tag:/vsbKAKzl8beJEpXNlPjwg==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/tests/compute/exclude/.dagger/env/default/values.yaml
+++ b/tests/compute/exclude/.dagger/env/default/values.yaml
@@ -1,6 +1,5 @@
 plan:
     module: .dagger/env/default/plan
-name: default
 inputs:
     TestData:
         dir:
@@ -23,8 +22,8 @@ sops:
             L0NzY0RIMWNkc3k2WStOUGg4SndNRm8Kk7QSP/8spn1Set08VejVW9k4ZwBFqR0T
             Ff/N73yNvo633hrfEJtTkhA/aZYyG9bPJy9s9vRDoNFkdTLSFcYX5g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-06-15T16:27:05Z"
-    mac: ENC[AES256_GCM,data:XQyAun4JVQxzV9eqte3dpQb8YP9ylWhnW5gLB3avpOZks/CVUN4Ewgob5tA4FB5S4x1Syk/D8ts32nQoEd0HUkdqTMjnGjcXdNiH/iT+k+LrVX30uAZ3JLXmzBfP9WnfJXlKVYaWXWSokiQJmYjXtmotr9rMl7rQeixGZfYcsns=,iv:LyfYlgbiiTh1oapa/h7FUGjd8xGlrD0M9+bxkP5HT6A=,tag:bhw5k2/4zGCxC0nnV4zwDw==,type:str]
+    lastmodified: "2021-07-01T16:40:59Z"
+    mac: ENC[AES256_GCM,data:lRNhhlT3znan+ZXeefmkQ08bJ34yxX5RvGAs4PGFbcyFhoJ0Q2Txvt7LLndfPezpc48hP7sQ4grVrPoPZTEHFOcrt/uK0S0V5JdfxiMqTBI6iWzkpta/q0GDMPlCxd9Iz45Su0MYEyeS9qKwrsDmIxuomFBcWWB9Im9CMMtkSC8=,iv:acptiAl0NU3XVGeU8v29oCWLl5ad6I6SV4jQL3ZfD1s=,tag:+7Jm8LbXTr97q+YuJATQPw==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1


### PR DESCRIPTION
`name: ` was an old relic from historical reason, we don't need it anymore.

This will also lazily remove it from existing `values.yaml` on `dagger {up,edit,input,...}`