### PR TITLE
docker.#Push: Set auth as optional

### DIFF
--- a/docs/reference/universe/docker/README.md
+++ b/docs/reference/universe/docker/README.md
@@ -74,12 +74,10 @@ Push a docker image to a remote registry
 
 ### docker.#Push Inputs
 
-| Name              | Type                  | Description                                                |
-| -------------     |:-------------:        |:-------------:                                             |
-|*target*           | `string`              |Remote target (example: "index.docker.io/alpine:latest")    |
-|*source*           | `dagger.#Artifact`    |Image source                                                |
-|*auth.username*    | `string`              |Username                                                    |
-|*auth.secret*      | `string`              |Password or secret                                          |
+| Name             | Type                  | Description                                                |
+| -------------    |:-------------:        |:-------------:                                             |
+|*target*          | `string`              |Remote target (example: "index.docker.io/alpine:latest")    |
+|*source*          | `dagger.#Artifact`    |Image source                                                |
 
 ### docker.#Push Outputs
 

--- a/stdlib/docker/docker.cue
+++ b/stdlib/docker/docker.cue
@@ -37,7 +37,7 @@ import (
 	source: dagger.#Artifact @dagger(input)
 
 	// Registry auth
-	auth: {
+	auth?: {
 		// Username
 		username: string @dagger(input)
 


### PR DESCRIPTION
docker.#Push definition has a check to see if auth is set:
```cue
if auth != _|_ {
	op.#DockerLogin & {
		"target": target
		username: auth.username
		secret:   auth.secret
	}
},
```

However, `auth` is not optional, which makes this verification obsolete.

It seems to be a useful check: when rewriting the "local build and push of docker images" for the Kubernetes doc, without this PR, the `secret` and `username` values have to be set to `""`. It's very annoying

WARNING: `docker.#Push` tests are disabled due to a race condition on CI. However, this change has been checked locally by uncommenting the tests, they pass (you should test on your own)

Signed-off-by: Guillaume de Rouville <guillaume.derouville@gmail.com>