### PR TITLE
docs: move plan out of cue.mod

### DIFF
--- a/docs/learn/102-dev.md
+++ b/docs/learn/102-dev.md
@@ -68,7 +68,7 @@ Although not strictly necessary, for an optimal development experience, we recom
 
 If you are new to Cue, we recommend keeping the following resources in browser tabs:
 
-- The unofficial but excellent [Cuetorials](https://cuetorials.com/overview/foundations/) in a browser tab, to look up Cue concepts as they appear.
+The unofficial but excellent [Cuetorials](https://cuetorials.com/overview/foundations/) in a browser tab, to look up Cue concepts as they appear.
 
 - The official [Cue interactive sandbox](https://cuelang.org/play) for easy experimentation.
 
@@ -116,7 +116,7 @@ But you can call your packages anything you want.
 Let's create a new directory for our Cue package:
 
 ```shell
-mkdir cue.mod/multibucket
+mkdir multibucket
 ```
 
 ### Component 1: app source code
@@ -130,7 +130,7 @@ In Dagger terms, this component has two essential properties:
 
 Let's write the corresponding Cue code to a new file in our package:
 
-```cue title="todoapp/cue.mod/multibucket/source.cue"
+```cue title="todoapp/multibucket/source.cue"
 package multibucket
 
 import (
@@ -141,13 +141,13 @@ import (
 src: dagger.#Artifact & dagger.#Input
 ```
 
-This code defines a component at the key `src`, and specifies that it is both an artifact and an input.
+This code defines a component at the key `src` and specifies that it is both an artifact and an input.
 
 ### Component 2: yarn package
 
 The second component of our plan is the Yarn package built from the app source code:
 
-```cue title="todoapp/cue.mod/multibucket/yarn.cue"
+```cue title="todoapp/multibucket/yarn.cue"
 package multibucket
 
 import (
@@ -176,7 +176,7 @@ _FIXME_: this section is not yet available because the [Amazon S3 package](https
 
 The third component of our plan is the Netlify site to which the app will be deployed:
 
-```cue title="todoapp/cue.mod/multibucket/netlify.cue"
+```cue title="todoapp/multibucket/netlify.cue"
 package multibucket
 
 import (
@@ -216,7 +216,7 @@ You can also browse the [Dagger Universe](../reference/universe/README.md) refer
 Now that your Cue package is ready, let's create an environment to run it:
 
 ```shell
-dagger new 'multibucket' -m cue.mod/multibucket
+dagger new 'multibucket' -m multibucket
 ```
 
 ### Configure user inputs
@@ -244,7 +244,7 @@ All the values without default values (without `*`) have to be specified by the 
 - `site.netlify.name`, name of the published website
 - `src`, source code of the app
 
-Please note the type of the user inputs: a string, a #Secret and an artifact. Let's see how to input them:
+Please note the type of the user inputs: a string, a #Secret, and an artifact. Let's see how to input them:
 
 ```shell
 # As a string input is expected for `site.netlify.name`, we set a `text` input
@@ -253,20 +253,18 @@ dagger input text site.netlify.name <GLOBALLY-UNIQUE-NAME> -e multibucket
 # As a secret input is expected for `site.netlify.account.token`, we set a `secret` input
 dagger input secret site.netlify.account.token <PERSONAL-ACCESS-TOKEN> -e multibucket
 
-# As an Artifact is exepected for `src`, we set a `dir` input (dagger input list for alternatives)
+# As an Artifact is expected for `src`, we set a `dir` input (dagger input list for alternatives)
 dagger input dir src . -e multibucket
 
 ```
 
 ### Deploy
 
-Now that everything is properly set, let's deploy on Netlify:
+Now that everything is appropriately set, let's deploy on Netlify:
 
 ```shell
 dagger up -e multibucket
 ```
-
-[This section is not yet written](https://github.com/dagger/dagger/blob/main/CONTRIBUTING.md)
 
 ### Using the environment
 

--- a/docs/learn/106-cloudrun.md
+++ b/docs/learn/106-cloudrun.md
@@ -19,7 +19,7 @@ You will need the local copy of the [Dagger examples repository](https://github.
 git clone https://github.com/dagger/examples
 ```
 
-Make sure that all commands are being ran from the todoapp directory:
+Make sure that all commands are being run from the todoapp directory:
 
 ```shell
 cd examples/todoapp
@@ -27,7 +27,7 @@ cd examples/todoapp
 
 ### (optional) Initialize a Cue module
 
-In this guide we will use the same directory as the root of the Dagger workspace and the root of the Cue module; but you can create your Cue module anywhere inside the Dagger workspace.
+This guide will use the same directory as the root of the Dagger workspace and the root of the Cue module, but you can create your Cue module anywhere inside the Dagger workspace.
 
 ```shell
 cue mod init
@@ -38,12 +38,12 @@ cue mod init
 Let's create a new directory for our Cue package:
 
 ```shell
-mkdir cue.mod/gcpcloudrun
+mkdir gcpcloudrun
 ```
 
 ### Create a basic plan
 
-```cue title="todoapp/cue.mod/gcpcloudrun/source.cue"
+```cue title="todoapp/gcpcloudrun/source.cue"
 package gcpcloudrun
 
 import (
@@ -92,7 +92,7 @@ deploy: cloudrun.#Service & {
 Now that your Cue package is ready, let's create an environment to run it:
 
 ```shell
-dagger new 'gcpcloudrun' -m cue.mod/gcpcloudrun
+dagger new 'gcpcloudrun' -m gcpcloudrun
 ```
 
 ### Configure user inputs
@@ -108,7 +108,7 @@ dagger input secret gcpConfig.serviceKey -f ./gcp-sa-key.json -e gcpcloudrun
 
 ## Deploy
 
-Now that everything is properly set, let's deploy on Cloud Run:
+Now that everything is set correctly, let's deploy on Cloud Run:
 
 ```shell
 dagger up -e gcpcloudrun

--- a/docs/learn/108-cloudformation.md
+++ b/docs/learn/108-cloudformation.md
@@ -49,7 +49,7 @@ cue mod init
 Let's create a new directory for our Cue package:
 
 ```shell
-mkdir cue.mod/cloudformation
+mkdir cloudformation
 ```
 
 ## Create a basic plan
@@ -66,7 +66,7 @@ The idea here is to follow best practices in [S3 buckets](https://docs.aws.amazo
 
 Create a file named `template.cue` and add the following configuration to it.
 
-```cue title="todoapp/cue.mod/cloudformation/template.cue"
+```cue title="todoapp/cloudformation/template.cue"
 package cloudformation
 
 // inlined s3 cloudformation template as a string
@@ -164,7 +164,7 @@ The config values are all part of the `aws` relay. Regarding this package, as yo
 
 Let's implement the first step, use the `aws.#Config` relay, and request its first inputs: the region to deploy and the AWS credentials.
 
-```cue title="todoapp/cue.mod/cloudformation/source.cue"
+```cue title="todoapp/cloudformation/source.cue"
 package cloudformation
 
 import (
@@ -186,7 +186,7 @@ This defines:
 Now that the Cue package is ready, let's create an environment to run it:
 
 ```shell
-dagger new 'cloudformation' -m cue.mod/cloudformation
+dagger new 'cloudformation' -m cloudformation
 ```
 
 ##### 2. Check plan
@@ -214,7 +214,7 @@ dagger up -e cloudformation # Try to run the plan. As expected, we encounter a f
 
 Now that we have the `config` definition properly configured, let's modify the Cloudformation one:
 
-```cue title="todoapp/cue.mod/cloudformation/source.cue"
+```cue title="todoapp/cloudformation/source.cue"
 package cloudformation
 
 import (
@@ -368,7 +368,7 @@ import TabItem from "@theme/TabItem";
 }>
 <TabItem value="sv">
 
-```cue title="todoapp/cue.mod/cloudformation/convert.cue"
+```cue title="todoapp/cloudformation/convert.cue"
 package cloudformation
 import "encoding/json"
 
@@ -378,7 +378,7 @@ s3Template: json.Unmarshal(template)
 </TabItem>
 <TabItem value="yv">
 
-```cue title="todoapp/cue.mod/cloudformation/convert.cue"
+```cue title="todoapp/cloudformation/convert.cue"
 package cloudformation
 import "encoding/yaml"
 
@@ -395,7 +395,7 @@ This defines:
 You need to empty the plan and copy the `convert.cue` file to the plan for Dagger to reference it
 
 ```shell
-rm cue.mod/cloudformation/source.cue
+rm cloudformation/source.cue
 ```
 
 ### 2. Retrieve the Unmarshalled JSON
@@ -421,14 +421,14 @@ The commented output above is the cue version of the JSON Template, copy it
 ### 3. Remove convert.cue
 
 ```shell
-rm cue.mod/cloudformation/convert.cue
+rm cloudformation/convert.cue
 ```
 
 ### 4. Store the output
 
 Open `cloudformation/template.cue` and append below elements with copied Cue definition of the JSON:
 
-```cue title="todoapp/cue.mod/cloudformation/template.cue"
+```cue title="todoapp/cloudformation/template.cue"
 // Add this line, to make it part to the cloudformation template
 package cloudformation
 import "encoding/json"
@@ -510,7 +510,7 @@ Now that the template is defined in CUE, we can use the language to add more fle
 
 Let's define a re-usable `#Deployment` definition in `todoapp/cloudformation/deployment.cue`:
 
-```cue title="todoapp/cue.mod/cloudformation/deployment.cue"
+```cue title="todoapp/cloudformation/deployment.cue"
 package cloudformation
 
 #Deployment: {
@@ -598,7 +598,7 @@ package cloudformation
 
 `template.cue` can be rewritten as follows:
 
-```cue title="todoapp/cue.mod/cloudformation/template.cue"
+```cue title="todoapp/cloudformation/template.cue"
 package cloudformation
 import "encoding/json"
 


### PR DESCRIPTION
Following #772, I moved the plans out of `cue.mod` (due to a misunderstanding on 102/108. This time, shall be good.

Partially fixes #742. Kubernetes doc will directly enforce it, so no need to change now. Last blocking point on the closure of #742 will be Tiho's doc

Signed-off-by: Guillaume de Rouville <guillaume.derouville@gmail.com>