### PR TITLE
git package - add keepGitDir option

### DIFF
--- a/stdlib/git/git.cue
+++ b/stdlib/git/git.cue
@@ -11,19 +11,25 @@ import (
 #Repository: {
 	// Git remote.
 	// Example: `"https://github.com/dagger/dagger"`
-	remote: string @dagger(input)
+	remote: string & dagger.#Input
 
 	// Git ref: can be a commit, tag or branch.
 	// Example: "main"
-	ref: string @dagger(input)
+	ref: string & dagger.#Input
 
 	// (optional) Subdirectory
-	subdir: string | *null @dagger(input)
+	subdir: *null | string & dagger.#Input
+
+	// (optional) Keep .git directory
+	keepGitDir: *false | bool
 
 	#up: [
 		op.#FetchGit & {
 			"remote": remote
 			"ref":    ref
+			if (keepGitDir) {
+				keepGitDir: true
+			}
 		},
 		if subdir != null {
 			op.#Subdir & {

--- a/stdlib/git/tests/git.cue
+++ b/stdlib/git/tests/git.cue
@@ -6,18 +6,19 @@ import (
 	"alpha.dagger.io/git"
 	"alpha.dagger.io/alpine"
 	"alpha.dagger.io/os"
-	"alpha.dagger.io/dagger/op"
 )
 
 repo: git.#Repository & {
-	remote: "https://github.com/blocklayerhq/acme-clothing.git"
-	ref:    "master"
+	remote:     "https://github.com/blocklayerhq/acme-clothing.git"
+	ref:        "master"
+	keepGitDir: true
+}
 
-	#up: [
-		op.#FetchGit & {
-			keepGitDir: true
-		},
-	]
+repoSubDir: git.#Repository & {
+	remote:     "https://github.com/dagger/examples.git"
+	ref:        "main"
+	subdir:     "todoapp"
+	keepGitDir: true
 }
 
 branch: git.#CurrentBranch & {
@@ -37,6 +38,18 @@ TestRepository: os.#Container & {
 	dir: "/repo1"
 	command: """
 		[ -d .git ]
+		"""
+}
+
+TestSubRepository: os.#Container & {
+	image: alpine.#Image & {
+		package: bash: "=5.1.0-r0"
+		package: git:  true
+	}
+	mount: "/repo1": from: repoSubDir
+	dir: "/repo1"
+	command: """
+		[ -d src ]
 		"""
 }
 


### PR DESCRIPTION
Git package didn't have the `keepGitDir` option.

However, this option was directly leveraged in the tests using `op.FetchGit`.
Leveraging the `keepGitDir` option that way with the `subdir` command led to `incompatible list lengths (1 and 2)` issue.

To fix it, we could either add `...` every time we would use `op.#FetchGit`
```subdir: "todoapp/src"

        #up: [
            op.#FetchGit & {
                keepGitDir: true
            },
           ... <-- like that
        ]
  ```

Or directly add this field into the package (solution chosen in this PR)

* Test for subdirectory field has been added
* `@dagger(input)` has been changed to `& dagger.#Input`

Signed-off-by: Guillaume de Rouville <guillaume.derouville@gmail.com>