### PR TITLE
Adds support for op.#FetchHTTP

### DIFF
--- a/docs/reference/universe/dagger/op.md
+++ b/docs/reference/universe/dagger/op.md
@@ -82,6 +82,16 @@ _No input._
 
 _No output._
 
+## op.#FetchHTTP
+
+### op.#FetchHTTP Inputs
+
+_No input._
+
+### op.#FetchHTTP Outputs
+
+_No output._
+
 ## op.#Load
 
 ### op.#Load Inputs

--- a/stdlib/dagger/op/op.cue
+++ b/stdlib/dagger/op/op.cue
@@ -85,6 +85,16 @@ package op
 	authHeaderSecret?: string | bytes
 }
 
+#FetchHTTP: {
+	do:        "fetch-http"
+	url:       string
+	checksum?: string
+	filename?: string
+	mode?:     int | *0o644
+	uid?:      int
+	gid?:      int
+}
+
 #Copy: {
 	do:   "copy"
 	from: _

--- a/stdlib/dagger/op/op_fullop.cue
+++ b/stdlib/dagger/op/op_fullop.cue
@@ -7,6 +7,7 @@ package op
 	#FetchContainer |
 	#PushContainer |
 	#FetchGit |
+	#FetchHTTP |
 	#Exec |
 	#Local |
 	#Copy |

--- a/tests/ops.bats
+++ b/tests/ops.bats
@@ -113,6 +113,14 @@ setup() {
     # assert_failure
 }
 
+@test "op.#FetchHTTP" {
+    run "$DAGGER" compute "$TESTDIR"/ops/fetch-http/exist
+    assert_success
+
+    run "$DAGGER" compute "$TESTDIR"/ops/fetch-http/nonexistent
+    assert_failure
+}
+
 @test "op.#Exec" {
     run "$DAGGER" compute "$TESTDIR"/ops/exec/invalid
     assert_failure

--- a/tests/ops/fetch-http/exist/main.cue
+++ b/tests/ops/fetch-http/exist/main.cue
@@ -1,0 +1,9 @@
+package testing
+
+import "alpha.dagger.io/dagger/op"
+
+#up: [
+	op.#FetchHTTP & {
+		url: "https://releases.dagger.io/dagger/latest_version"
+	},
+]

--- a/tests/ops/fetch-http/nonexistent/main.cue
+++ b/tests/ops/fetch-http/nonexistent/main.cue
@@ -1,0 +1,9 @@
+package testing
+
+import "alpha.dagger.io/dagger/op"
+
+#up: [
+	op.#FetchHTTP & {
+		url: "https://releases.dagger.io/dagger/nonexistent_version"
+	},
+]


### PR DESCRIPTION
Fixes #376 

---

Example:
```sh
❯ cat .dagger/env/playground/plan/main.cue
package playground

import (
	"alpha.dagger.io/dagger/op"
)

version: {
	string

	#up: [
		op.#FetchHTTP & {
			url: "https://releases.dagger.io/dagger/latest_version"
			checksum: "sha256:a309e76efa4550350a29cd41e6cbaf434ae94317bb6652297c79b691230e6abd"
			mode: 0o600
			uid: 1000
			gid: 1000
		},
		op.#Export & {
			source: "/latest_version"
		},
	]
} @dagger(output)

❯ dagger up
2:32PM INF version | computing
2:32PM INF version | completed    duration=0s
Output   Value  Description
version  """\n  0.1.0-alpha.17\n  \n  """  -
```