### PR TITLE
Docs: fix broken link

### DIFF
--- a/docs/learn/1003-get-started.md
+++ b/docs/learn/1003-get-started.md
@@ -18,7 +18,7 @@ how to share access to your infrastructure in the same way that we share access 
 
 ### Install Dagger
 
-First, make sure [you have installed Dagger on your local machine](/install).
+First, make sure [you have installed Dagger on your local machine](/1001/install).
 
 ### Setup example app
 


### PR DESCRIPTION
Fixes broken link from “getting started” to “install”.

As reported on Discord, see below:
![1C755320-4368-4D35-8F53-4E649CD27722](https://user-images.githubusercontent.com/29565/126628879-b1aaf340-f848-458c-a784-04b40e94d1a8.jpeg)
