### PR TITLE
Docs: more robust link

### DIFF
--- a/docs/learn/1003-get-started.md
+++ b/docs/learn/1003-get-started.md
@@ -18,7 +18,7 @@ how to share access to your infrastructure in the same way that we share access 
 
 ### Install Dagger
 
-First, make sure [you have installed Dagger on your local machine](/1001/install).
+First, make sure [you have installed Dagger on your local machine](../1001-install.md).
 
 ### Setup example app
 


### PR DESCRIPTION
Link to local markdown file instead of final slug location, so that docusaurus can catch broken links at build.