### PR TITLE
op.#Exec hack: performance improvement

### DIFF
--- a/environment/pipeline.go
+++ b/environment/pipeline.go
@@ -512,6 +512,10 @@ func (p *Pipeline) mount(ctx context.Context, dest string, mnt *compiler.Value) 
 	}
 
 	// eg. mount: "/foo": { from: www.source }
+	if !mnt.Lookup("from").Exists() {
+		return nil, fmt.Errorf("invalid mount: should have %s structure",
+			"{from: _, path: string | *\"/\"}")
+	}
 	from := NewPipeline(mnt.Lookup("from"), p.s)
 	if err := from.Run(ctx); err != nil {
 		return nil, err

--- a/stdlib/dagger/op/op.cue
+++ b/stdlib/dagger/op/op.cue
@@ -50,7 +50,13 @@ package op
 	// `true` means also ignoring the mount cache volumes
 	always?: true | *false
 	dir:     string | *"/"
-	mount: [string]: "tmpfs" | "cache" | {from: _, path: string | *"/"} | {secret: _}
+	// HACK: FIXME later [Performance related]
+	// mount: [string]: "tmpfs" | "cache" | {from: _, path: string | *"/"} | {secret: _}
+	// https://github.com/dagger/dagger/issues/856
+	mount: [string]: {
+		_
+		...
+	}
 	// Map of hostnames to ip
 	hosts?: [string]: string
 	// User to exec with (if left empty, will default to the set user in the image)


### PR DESCRIPTION
As seen with @TomChv and @aluzzardi: on big configs, Cue copies the definitions a lot of times, especially when fields with multiple options are present.

Here, the PR hacks the `op.#Exec` definition by replacing `"tmpfs" | "cache" | {from: _, path: string | *"/"} | {secret: _}` to `mount: [string]: {
		_
		...
	}`
	
> This hack turned a 100s. `cue eval` into a 1s one.

Signed-off-by: Guillaume de Rouville <guillaume.derouville@gmail.com>