### PR TITLE
2nd performance hack - Reduce os.#Container.image

### DIFF
--- a/stdlib/os/container.cue
+++ b/stdlib/os/container.cue
@@ -19,7 +19,10 @@ import (
 #Container: {
 
 	// Container image
-	image: dagger.#Artifact | *#DefaultImage
+	// image: dagger.#Artifact | *#DefaultImage
+	// CUE PERFORMANCE HACK
+	// FIXME LATER: https://github.com/dagger/dagger/issues/856
+	image?: dagger.#Artifact
 	//     {
 	//      // Optionally fetch a remote image
 	//      // eg. "index.docker.io/alpine"
@@ -84,7 +87,17 @@ import (
 	env: PATH: string | *strings.Join([ for p, v in shell.search if v {p}], ":")
 
 	#up: [
-		op.#Load & {from: image},
+		// op.#Load & {from: image},
+		// CUE PERFORMANCE HACK
+		// FIXME LATER: https://github.com/dagger/dagger/issues/856
+		op.#Load & {
+			if image != _|_ {
+				from: image
+			}
+			if image == _|_ {
+				from: #DefaultImage
+			}
+		},
 		// Copy volumes with type=copy
 		for dest, o in copy {
 			op.#Copy & {


### PR DESCRIPTION
As seen with @TomChv and @aluzzardi: on big configs, Cue copies the definitions a lot of times, especially when fields with multiple options are present.

Here, the PR hacks the `os.#Container` definition by replacing `image: dagger.#Artifact | *#DefaultImage`  to `image?: dagger.#Artifact`

This hack turned a 4s cue eval into a >1s one.

Signed-off-by: Guillaume de Rouville <guillaume.derouville@gmail.com>