### PR TITLE
ci: disable GHA cache for buildkit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,13 +89,7 @@ jobs:
           mkdir -p ~/.config/dagger
           echo "$DAGGER_AGE_KEY" > ~/.config/dagger/keys.txt
 
-      - name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v1
-
       - name: Integration test
-        env:
-          DAGGER_CACHE_TO: "type=gha,scope=integration"
-          DAGGER_CACHE_FROM: "type=gha,scope=integration"
         run: |
           env
           make core-integration
@@ -123,12 +117,6 @@ jobs:
           mkdir -p ~/.config/dagger
           echo "$DAGGER_AGE_KEY" > ~/.config/dagger/keys.txt
 
-      - name: Expose GitHub Runtime
-        uses: crazy-max/ghaction-github-runtime@v1
-
       - name: Universe Test
-        env:
-          DAGGER_CACHE_TO: "type=gha,scope=universe"
-          DAGGER_CACHE_FROM: "type=gha,scope=universe"
         run: |
           make universe-test


### PR DESCRIPTION
Kept hitting this error:

```
 #   10:24AM FTL system | failed to up environment: failed to parse error response 429: ﻿{"$id":"1","innerException":null,"message":"Request was blocked due to exceeding usage of resource 'Count' in namespace ''.","typeName":"Microsoft.TeamFoundation.Framework.Server.RequestBlockedException, Microsoft.TeamFoundation.Framework.Server","typeKey":"RequestBlockedException","errorCode":0,"eventId":3000}: invalid character 'ï' looking for beginning of value
```

See https://github.com/moby/buildkit/issues/2276

/cc @samalba @crazy-max 