### PR TITLE
Improve dagger input UX 

### DIFF
--- a/cmd/dagger/cmd/input/list.go
+++ b/cmd/dagger/cmd/input/list.go
@@ -62,6 +62,13 @@ var listCmd = &cobra.Command{
 					}
 				}
 
+				if !viper.GetBool("show-optional") && !viper.GetBool("all") {
+					// skip input if there is already a default value
+					if hasDefault {
+						continue
+					}
+				}
+
 				fmt.Fprintf(w, "%s\t%s\t%t\t%s\n",
 					inp.Path(),
 					common.FormatValue(inp),
@@ -95,6 +102,7 @@ func isUserSet(env *state.State, val *compiler.Value) bool {
 
 func init() {
 	listCmd.Flags().BoolP("all", "a", false, "List all inputs (include non-overridable)")
+	listCmd.Flags().Bool("show-optional", false, "List optional inputs (those with default values)")
 
 	if err := viper.BindPFlags(listCmd.Flags()); err != nil {
 		panic(err)

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -364,28 +364,41 @@ setup() {
     "$DAGGER" input text cfg.str "foobar" -e "list"
 
     out="$("$DAGGER" input list -e "list")"
+    outOpt="$("$DAGGER" input list --show-optional -e "list")"
     outAll="$("$DAGGER" input list --all -e "list")"
 
     #note: this is the recommended way to use pipes with bats
-    run bash -c "echo \"$out\" | grep awsConfig.accessKey | grep 'dagger.#Secret' | grep 'AWS access key'"
+    run bash -c "echo \"$out\" | grep awsConfig.accessKey | grep 'dagger.#Secret' | grep false | grep 'AWS access key'"
     assert_success
 
     run bash -c "echo \"$out\" | grep cfgInline.source | grep 'dagger.#Artifact' | grep false | grep 'source dir'"
+    assert_success
+
+    run bash -c "echo \"$outOpt\" | grep awsConfig.accessKey | grep 'dagger.#Secret' | grep 'AWS access key'"
+    assert_success
+
+    run bash -c "echo \"$outOpt\" | grep cfgInline.source | grep 'dagger.#Artifact' | grep false | grep 'source dir'"
     assert_success
 
     run bash -c "echo \"$outAll\" | grep cfg2"
     assert_failure
 
     run bash -c "echo \"$out\" | grep cfgInline.strDef | grep '*yolo | string' | grep false"
+    assert_failure
+
+    run bash -c "echo \"$outOpt\" | grep cfgInline.strDef | grep '*yolo | string' | grep false"
     assert_success
 
     run bash -c "echo \"$out\" | grep cfg.num"
     assert_failure
 
+    run bash -c "echo \"$outOpt\" | grep cfg.num"
+    assert_failure
+
     run bash -c "echo \"$outAll\" | grep cfg.num | grep 21 | grep -v int"
     assert_success
 
-    run bash -c "echo \"$out\" | grep cfg.strSet"
+    run bash -c "echo \"$outOpt\" | grep cfg.strSet"
     assert_failure
 
     run bash -c "echo \"$outAll\" | grep cfg.strSet | grep pipo"

--- a/tests/core.bats
+++ b/tests/core.bats
@@ -20,7 +20,7 @@ setup() {
     dagger_new_with_plan test-core "$TESTDIR"/core/inputs-outputs
 
     # List available inputs
-    run dagger -e test-core input list
+    run dagger -e test-core input list --show-optional
     assert_success
     assert_output --partial 'name'
     assert_output --partial 'dir'


### PR DESCRIPTION
## TL;DR

- solve #874

## Changes

Add new argument `--show-optional` to `dagger input list`.
Now by default, `dagger input list` will only show required input.
To get all inputs (including those with default value), you can use
that new argument.

Test has been updated to support changes.

## Demo 

With the `docker-compose` test from universe.

```shell
# Path
pwd
dagger/universe

# Default input list
dagger -e docker-compose input list                
Input         Value             Set by user  Description
repo          dagger.#Artifact  true         -
TestSSH.key   dagger.#Secret    true         -
TestSSH.host  string            true         -
TestSSH.user  string            true         -

# With optional argument
dagger -e docker-compose input list --show-optional
Input                                Value             Set by user  Description
repo                                 dagger.#Artifact  true         -
TestSSH.key                          dagger.#Secret    true         -
TestSSH.host                         string            true         -
TestSSH.user                         string            true         -
TestCompose.suffix.length            *12 | number      false        length of the string
TestCompose.up.ssh.port              *22 | int         false        ssh port
TestCompose.up.registries            []                false        Image registries
TestCompose.verify.registries        []                false        Image registries
TestInlineCompose.suffix.length      *12 | number      false        length of the string
TestInlineCompose.up.ssh.port        *22 | int         false        ssh port
TestInlineCompose.up.registries      []                false        Image registries
TestInlineCompose.verify.registries  []                false        Image registries
```

