### PR TITLE
Fix env & log global flags are no longer hidden.

### DIFF
--- a/cmd/dagger/cmd/version.go
+++ b/cmd/dagger/cmd/version.go
@@ -59,10 +59,6 @@ var versionCmd = &cobra.Command{
 func init() {
 	versionCmd.Flags().Bool("check", false, "check if dagger is up to date")
 
-	versionCmd.InheritedFlags().MarkHidden("environment")
-	versionCmd.InheritedFlags().MarkHidden("log-level")
-	versionCmd.InheritedFlags().MarkHidden("log-format")
-
 	if err := viper.BindPFlags(versionCmd.Flags()); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Changes

There was a hack in `version.go` that was hiding unused flag from that command.
The problem is that the effect has spread to all commands.
The original purpose was simply to hide those flags when user tip `dagger version --help`.

I've removed that trick to correctly display all flags because it's important for users to know how select an environment and configure log format.

## Example

#### Before

```bash
dagger input list --help
List the inputs of an environment

Usage:
  dagger input list [TARGET] [flags]

Flags:
  -a, --all             List all inputs (include non-overridable)
  -h, --help            help for list
      --show-optional   List optional inputs (those with default values)

Global Flags:
      --cache-from stringArray   External cache sources (eg. user/app:cache, type=local,src=path/to/dir)
      --cache-to stringArray     Cache export destinations (eg. user/app:cache, type=local,dest=path/to/dir)
      --no-cache                 Disable caching
  -w, --workspace string         Specify a workspace (defaults to current git repository)
```

#### After

```bash
dagger input list --help            
List the inputs of an environment

Usage:
  dagger input list [TARGET] [flags]

Flags:
  -a, --all             List all inputs (include non-overridable)
  -h, --help            help for list
      --show-optional   List optional inputs (those with default values)

Global Flags:
      --cache-from stringArray   External cache sources (eg. user/app:cache, type=local,src=path/to/dir)
      --cache-to stringArray     Cache export destinations (eg. user/app:cache, type=local,dest=path/to/dir)
  -e, --environment string       Select an environment
      --log-format string        Log format (json, pretty). Defaults to json if the terminal is not a tty
  -l, --log-level string         Log level (default "info")
      --no-cache                 Disable caching
  -w, --workspace string         Specify a workspace (defaults to current git repository)

```