### PR TITLE
 ci: re-enable localstack tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
   universe:
     name: Universe
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
     services:
       localstack:
         image: localstack/localstack:0.12.16

--- a/stdlib/aws/aws.cue
+++ b/stdlib/aws/aws.cue
@@ -58,7 +58,7 @@ import (
 				if config.localMode != null {
 					#"""
 						# Download awscli v3 and override aws
-						pip install awscli-local[v2]
+						pip install awscli-local==0.14
 						mv /usr/bin/awslocal /usr/bin/aws
 
 						# Configure

--- a/stdlib/helpers.bash
+++ b/stdlib/helpers.bash
@@ -1,20 +1,3 @@
-# Instead of setup, this just runs once
-setup_file() {
-    # Cleanup local Localstack instances
-    if [ "$(curl -s http://localhost:4566)" = '{"status": "running"}' ] && \
-        [ "$GITHUB_ACTIONS" != "true" ]; then
-        echo "Cleanup local LOCALSTACK"
-        
-        # S3 buckets cleanup
-        aws --endpoint-url=http://localhost:4566 s3 rm s3://dagger-ci 2>/dev/null || true
-        aws --endpoint-url=http://localhost:4566 s3 mb s3://dagger-ci 2>/dev/null || true
-        
-        # ECR repositories cleanup
-        aws --endpoint-url=http://localhost:4566 ecr delete-repository --repository-name dagger-ci 2>/dev/null || true
-        aws --endpoint-url=http://localhost:4566 ecr create-repository --repository-name dagger-ci 2>/dev/null || true
-    fi
-}
-
 common_setup() {
     load 'node_modules/bats-support/load'
     load 'node_modules/bats-assert/load'
@@ -94,5 +77,21 @@ skip_unless_local_kube() {
         echo "Kubernetes available"
     else
         skip "local kubernetes cluster not available"
+    fi
+}
+
+# Cleanup local Localstack instances
+setup_localstack() {
+    if [ "$(curl -s http://localhost:4566)" = '{"status": "running"}' ] && \
+        [ "$GITHUB_ACTIONS" != "true" ]; then
+        echo "Cleanup local LOCALSTACK"
+        
+        # S3 buckets cleanup
+        aws --endpoint-url=http://localhost:4566 s3 rm s3://dagger-ci || true
+        aws --endpoint-url=http://localhost:4566 s3 mb s3://dagger-ci || true
+        
+        # ECR repositories cleanup
+        aws --endpoint-url=http://localhost:4566 ecr delete-repository --repository-name dagger-ci || true
+        aws --endpoint-url=http://localhost:4566 ecr create-repository --repository-name dagger-ci || true
     fi
 }

--- a/stdlib/universe.bats
+++ b/stdlib/universe.bats
@@ -1,3 +1,10 @@
+# Instead of setup, this runs only once
+setup_file() {
+    load 'helpers'
+
+    setup_localstack
+}
+
 setup() {
     load 'helpers'
 
@@ -45,10 +52,9 @@ setup() {
 }
 
 @test "aws: ecr/localstack" {
-    skip "disabled because of inifinit loop"
-    # skip_unless_local_localstack
+    skip_unless_local_localstack
 
-    # dagger -e aws-ecr-localstack up
+    dagger -e aws-ecr-localstack up
 }
 
 @test "aws: s3" {
@@ -56,10 +62,9 @@ setup() {
 }
 
 @test "aws: s3/localstack" {
-    skip "disabled because of inifinit loop"
-    # skip_unless_local_localstack
+    skip_unless_local_localstack
 
-    # dagger -e aws-s3-localstack up
+    dagger -e aws-s3-localstack up
 }
 
 @test "aws: eks" {


### PR DESCRIPTION
Localstack tests were breaking the doc due to: https://github.com/localstack/awscli-local/issues/44.

The current fix is to avoid using the latest version, and reuse `awslocal-cli 0.14`. This PR also includes some changes to implementation of the `setup_file` bats helper.

Due to the previous fails, the CI's `timeout-minutes` has been set to 20 minutes, to avoid spending too much in case of failure. It currently takes about 13 minutes, so it shouldn't interfere atm

Signed-off-by: Guillaume de Rouville <guillaume.derouville@gmail.com>