### PR TITLE
localstack tests: convert back str input to bool type

### DIFF
--- a/docs/reference/universe/aws/README.md
+++ b/docs/reference/universe/aws/README.md
@@ -16,12 +16,12 @@ Re-usable aws-cli component
 
 ### aws.#CLI Inputs
 
-| Name                 | Type                 | Description           |
-| -------------        |:-------------:       |:-------------:        |
-|*config.region*       | `string`             |AWS region             |
-|*config.accessKey*    | `dagger.#Secret`     |AWS access key         |
-|*config.secretKey*    | `dagger.#Secret`     |AWS secret key         |
-|*config.localMode*    | `*null \| string`    |AWS localstack mode    |
+| Name                 | Type                | Description           |
+| -------------        |:-------------:      |:-------------:        |
+|*config.region*       | `string`            |AWS region             |
+|*config.accessKey*    | `dagger.#Secret`    |AWS access key         |
+|*config.secretKey*    | `dagger.#Secret`    |AWS secret key         |
+|*config.localMode*    | `*false \| bool`    |AWS localstack mode    |
 
 ### aws.#CLI Outputs
 
@@ -33,12 +33,12 @@ AWS Config shared by all AWS packages
 
 ### aws.#Config Inputs
 
-| Name             | Type                 | Description           |
-| -------------    |:-------------:       |:-------------:        |
-|*region*          | `string`             |AWS region             |
-|*accessKey*       | `dagger.#Secret`     |AWS access key         |
-|*secretKey*       | `dagger.#Secret`     |AWS secret key         |
-|*localMode*       | `*null \| string`    |AWS localstack mode    |
+| Name             | Type                | Description           |
+| -------------    |:-------------:      |:-------------:        |
+|*region*          | `string`            |AWS region             |
+|*accessKey*       | `dagger.#Secret`    |AWS access key         |
+|*secretKey*       | `dagger.#Secret`    |AWS secret key         |
+|*localMode*       | `*false \| bool`    |AWS localstack mode    |
 
 ### aws.#Config Outputs
 

--- a/docs/reference/universe/aws/cloudformation.md
+++ b/docs/reference/universe/aws/cloudformation.md
@@ -21,7 +21,7 @@ AWS CloudFormation Stack
 |*config.region*       | `string`                                     |AWS region                                                       |
 |*config.accessKey*    | `dagger.#Secret`                             |AWS access key                                                   |
 |*config.secretKey*    | `dagger.#Secret`                             |AWS secret key                                                   |
-|*config.localMode*    | `*null \| string`                            |AWS localstack mode                                              |
+|*config.localMode*    | `*false \| bool`                             |AWS localstack mode                                              |
 |*source*              | `string`                                     |Source is the Cloudformation template (JSON/YAML string)         |
 |*stackName*           | `string`                                     |Stackname is the cloudformation stack                            |
 |*parameters*          | `struct`                                     |Stack parameters                                                 |

--- a/docs/reference/universe/aws/ecr.md
+++ b/docs/reference/universe/aws/ecr.md
@@ -16,16 +16,16 @@ Convert ECR credentials to Docker Login format
 
 ### ecr.#Credentials Inputs
 
-| Name                           | Type                 | Description           |
-| -------------                  |:-------------:       |:-------------:        |
-|*config.region*                 | `string`             |AWS region             |
-|*config.accessKey*              | `dagger.#Secret`     |AWS access key         |
-|*config.secretKey*              | `dagger.#Secret`     |AWS secret key         |
-|*config.localMode*              | `*null \| string`    |AWS localstack mode    |
-|*ctr.image.config.region*       | `string`             |AWS region             |
-|*ctr.image.config.accessKey*    | `dagger.#Secret`     |AWS access key         |
-|*ctr.image.config.secretKey*    | `dagger.#Secret`     |AWS secret key         |
-|*ctr.image.config.localMode*    | `*null \| string`    |AWS localstack mode    |
+| Name                           | Type                | Description           |
+| -------------                  |:-------------:      |:-------------:        |
+|*config.region*                 | `string`            |AWS region             |
+|*config.accessKey*              | `dagger.#Secret`    |AWS access key         |
+|*config.secretKey*              | `dagger.#Secret`    |AWS secret key         |
+|*config.localMode*              | `*false \| bool`    |AWS localstack mode    |
+|*ctr.image.config.region*       | `string`            |AWS region             |
+|*ctr.image.config.accessKey*    | `dagger.#Secret`    |AWS access key         |
+|*ctr.image.config.secretKey*    | `dagger.#Secret`    |AWS secret key         |
+|*ctr.image.config.localMode*    | `*false \| bool`    |AWS localstack mode    |
 
 ### ecr.#Credentials Outputs
 

--- a/docs/reference/universe/aws/eks.md
+++ b/docs/reference/universe/aws/eks.md
@@ -21,7 +21,7 @@ KubeConfig config outputs a valid kube-auth-config for kubectl client
 |*config.region*       | `string`                  |AWS region             |
 |*config.accessKey*    | `dagger.#Secret`          |AWS access key         |
 |*config.secretKey*    | `dagger.#Secret`          |AWS secret key         |
-|*config.localMode*    | `*null \| string`         |AWS localstack mode    |
+|*config.localMode*    | `*false \| bool`          |AWS localstack mode    |
 |*clusterName*         | `string`                  |EKS cluster name       |
 |*version*             | `*"v1.19.9" \| string`    |Kubectl version        |
 

--- a/docs/reference/universe/aws/elb.md
+++ b/docs/reference/universe/aws/elb.md
@@ -16,13 +16,13 @@ Returns an unused rule priority (randomized in available range)
 
 ### elb.#RandomRulePriority Inputs
 
-| Name                 | Type                 | Description           |
-| -------------        |:-------------:       |:-------------:        |
-|*config.region*       | `string`             |AWS region             |
-|*config.accessKey*    | `dagger.#Secret`     |AWS access key         |
-|*config.secretKey*    | `dagger.#Secret`     |AWS secret key         |
-|*config.localMode*    | `*null \| string`    |AWS localstack mode    |
-|*listenerArn*         | `string`             |ListenerArn            |
+| Name                 | Type                | Description           |
+| -------------        |:-------------:      |:-------------:        |
+|*config.region*       | `string`            |AWS region             |
+|*config.accessKey*    | `dagger.#Secret`    |AWS access key         |
+|*config.secretKey*    | `dagger.#Secret`    |AWS secret key         |
+|*config.localMode*    | `*false \| bool`    |AWS localstack mode    |
+|*listenerArn*         | `string`            |ListenerArn            |
 
 ### elb.#RandomRulePriority Outputs
 

--- a/docs/reference/universe/aws/rds.md
+++ b/docs/reference/universe/aws/rds.md
@@ -16,16 +16,16 @@ Creates a new Database on an existing RDS Instance
 
 ### rds.#Database Inputs
 
-| Name                 | Type                 | Description                                                  |
-| -------------        |:-------------:       |:-------------:                                               |
-|*config.region*       | `string`             |AWS region                                                    |
-|*config.accessKey*    | `dagger.#Secret`     |AWS access key                                                |
-|*config.secretKey*    | `dagger.#Secret`     |AWS secret key                                                |
-|*config.localMode*    | `*null \| string`    |AWS localstack mode                                           |
-|*name*                | `string`             |DB name                                                       |
-|*dbArn*               | `string`             |ARN of the database instance                                  |
-|*secretArn*           | `string`             |ARN of the database secret (for connecting via rds api)       |
-|*dbType*              | `string`             |Database type MySQL or PostgreSQL (Aurora Serverless only)    |
+| Name                 | Type                | Description                                                  |
+| -------------        |:-------------:      |:-------------:                                               |
+|*config.region*       | `string`            |AWS region                                                    |
+|*config.accessKey*    | `dagger.#Secret`    |AWS access key                                                |
+|*config.secretKey*    | `dagger.#Secret`    |AWS secret key                                                |
+|*config.localMode*    | `*false \| bool`    |AWS localstack mode                                           |
+|*name*                | `string`            |DB name                                                       |
+|*dbArn*               | `string`            |ARN of the database instance                                  |
+|*secretArn*           | `string`            |ARN of the database secret (for connecting via rds api)       |
+|*dbType*              | `string`            |Database type MySQL or PostgreSQL (Aurora Serverless only)    |
 
 ### rds.#Database Outputs
 
@@ -39,13 +39,13 @@ Fetches information on an existing RDS Instance
 
 ### rds.#Instance Inputs
 
-| Name                 | Type                 | Description                    |
-| -------------        |:-------------:       |:-------------:                 |
-|*config.region*       | `string`             |AWS region                      |
-|*config.accessKey*    | `dagger.#Secret`     |AWS access key                  |
-|*config.secretKey*    | `dagger.#Secret`     |AWS secret key                  |
-|*config.localMode*    | `*null \| string`    |AWS localstack mode             |
-|*dbArn*               | `string`             |ARN of the database instance    |
+| Name                 | Type                | Description                    |
+| -------------        |:-------------:      |:-------------:                 |
+|*config.region*       | `string`            |AWS region                      |
+|*config.accessKey*    | `dagger.#Secret`    |AWS access key                  |
+|*config.secretKey*    | `dagger.#Secret`    |AWS secret key                  |
+|*config.localMode*    | `*false \| bool`    |AWS localstack mode             |
+|*dbArn*               | `string`            |ARN of the database instance    |
 
 ### rds.#Instance Outputs
 
@@ -61,18 +61,18 @@ Creates a new user credentials on an existing RDS Instance
 
 ### rds.#User Inputs
 
-| Name                 | Type                 | Description                                                  |
-| -------------        |:-------------:       |:-------------:                                               |
-|*config.region*       | `string`             |AWS region                                                    |
-|*config.accessKey*    | `dagger.#Secret`     |AWS access key                                                |
-|*config.secretKey*    | `dagger.#Secret`     |AWS secret key                                                |
-|*config.localMode*    | `*null \| string`    |AWS localstack mode                                           |
-|*username*            | `string`             |Username                                                      |
-|*password*            | `string`             |Password                                                      |
-|*dbArn*               | `string`             |ARN of the database instance                                  |
-|*secretArn*           | `string`             |ARN of the database secret (for connecting via rds api)       |
-|*grantDatabase*       | `*"" \| string`      |Name of the database to grants access to                      |
-|*dbType*              | `string`             |Database type MySQL or PostgreSQL (Aurora Serverless only)    |
+| Name                 | Type                | Description                                                  |
+| -------------        |:-------------:      |:-------------:                                               |
+|*config.region*       | `string`            |AWS region                                                    |
+|*config.accessKey*    | `dagger.#Secret`    |AWS access key                                                |
+|*config.secretKey*    | `dagger.#Secret`    |AWS secret key                                                |
+|*config.localMode*    | `*false \| bool`    |AWS localstack mode                                           |
+|*username*            | `string`            |Username                                                      |
+|*password*            | `string`            |Password                                                      |
+|*dbArn*               | `string`            |ARN of the database instance                                  |
+|*secretArn*           | `string`            |ARN of the database secret (for connecting via rds api)       |
+|*grantDatabase*       | `*"" \| string`     |Name of the database to grants access to                      |
+|*dbType*              | `string`            |Database type MySQL or PostgreSQL (Aurora Serverless only)    |
 
 ### rds.#User Outputs
 

--- a/docs/reference/universe/aws/s3.md
+++ b/docs/reference/universe/aws/s3.md
@@ -21,7 +21,7 @@ S3 Bucket object(s) sync
 |*config.region*       | `string`              |AWS region                                                        |
 |*config.accessKey*    | `dagger.#Secret`      |AWS access key                                                    |
 |*config.secretKey*    | `dagger.#Secret`      |AWS secret key                                                    |
-|*config.localMode*    | `*null \| string`     |AWS localstack mode                                               |
+|*config.localMode*    | `*false \| bool`      |AWS localstack mode                                               |
 |*source*              | `dagger.#Artifact`    |Source Artifact to upload to S3                                   |
 |*target*              | `string`              |Target S3 URL (eg. s3://\<bucket-name\>/\<path\>/\<sub-path\>)    |
 |*delete*              | `*false \| true`      |Delete files that already exist on remote destination             |

--- a/stdlib/.dagger/env/aws-ecr-localstack/values.yaml
+++ b/stdlib/.dagger/env/aws-ecr-localstack/values.yaml
@@ -5,7 +5,7 @@ inputs:
     TestConfig.awsConfig.accessKey:
         secret: ENC[AES256_GCM,data:t/iOlA==,iv:oLhubqSKZqn5lVPFn8On//LPj1deAFPXKVTyBKdVODQ=,tag:PORmrxDIf/MHbFDrdxnlTQ==,type:str]
     TestConfig.awsConfig.localMode:
-        text: "true"
+        bool: "true"
     TestConfig.awsConfig.secretKey:
         secret: ENC[AES256_GCM,data:2HYF9w==,iv:f/a9dy4HLJOtKdn8G+zKTboXU1YhzXBEKT1WSvrsCvk=,tag:RKQO+Pg3wg23LIMAnyXhMA==,type:str]
 sops:
@@ -23,8 +23,8 @@ sops:
             aXlvVWJVSGNTSkVyYmpZbi9nUVJZdmMK6csXZ2RMxFw5DB+Hb2TyhyoZT8c2/z7Y
             Lc9Pe8gb8aUq5Ha+wCybYvY6JWEM5A9XYJKbE7f4borTfGKS72d6pw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-08-16T20:52:50Z"
-    mac: ENC[AES256_GCM,data:31GBJoqzJOt2q29ql9xTGvhg6XaMupZliAEx2XXD19CvJuAlPdkkbdOP1quEDjHqeBfWUZlTTnqqm2HdSjJ9MgS7aSpgIwb65g/KMez/13QKqlicKaOT55uuyPmWh9+p0rSBCWTHo1vcZldXEuQ9eohwgkV1xHGU3tV+IsmlfrM=,iv:ISdTPiT3rUpZrmMoMBDYmQEB5Q6Tg5fx8leAS3B2kBU=,tag:z/4/2MS6CSlEC++9kCKn5Q==,type:str]
+    lastmodified: "2021-08-31T15:04:51Z"
+    mac: ENC[AES256_GCM,data:o/B2ZTd1ldSVkIbluXnHJ5clZ0oYVYVvmltxLw9k7OyFl9WBVBOslwrxYyrvgkKpLQIpFArh3VtMbizoTrzFWzoXMqdkLYza0IhaZekRn50NyaqOks/qAUJh0Cas6qA87nOyVw3J9Ldc1HR0lgjFLpIsPZYgVGs5BgQZ5Pg/X40=,iv:w6XNLkF2h/6JjCLFioyWImvRHiN6ILDimrxcboMRh94=,tag:k3BbcVeI9qj0NoEdQiLstg==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/.dagger/env/aws-s3-localstack/values.yaml
+++ b/stdlib/.dagger/env/aws-s3-localstack/values.yaml
@@ -5,7 +5,7 @@ inputs:
     TestConfig.awsConfig.accessKey:
         secret: ENC[AES256_GCM,data:RJY8Cw==,iv:yZW4m74SdRl5qeDfyQVJPOvAktu2qt8jJB45hWUd5p8=,tag:7DCf5ys4Cblb1V1XHMCWAQ==,type:str]
     TestConfig.awsConfig.localMode:
-        text: "true"
+        bool: "true"
     TestConfig.awsConfig.secretKey:
         secret: ENC[AES256_GCM,data:iYxBnA==,iv:7mdUXVnmMJm2pz9Kt1MwrwFeAxwqZaH9o1D2FbUD860=,tag:fj8+JJbNS3Z/L2ft+BtJ1Q==,type:str]
     TestDirectory:
@@ -26,8 +26,8 @@ sops:
             aXlvVWJVSGNTSkVyYmpZbi9nUVJZdmMK6csXZ2RMxFw5DB+Hb2TyhyoZT8c2/z7Y
             Lc9Pe8gb8aUq5Ha+wCybYvY6JWEM5A9XYJKbE7f4borTfGKS72d6pw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-08-16T20:43:09Z"
-    mac: ENC[AES256_GCM,data:suv1ImWFc+7HyrpNw66vasTf75PLu07DivxKCyuqcLFqBBs9qgxg8VFXax1hiZRp7NLTG1cqJ3JLW8DsPzhFTs2xJEDQ8BBKfqNFGgHzucaAISlfKzKKQtPb4NM+56WEmuiF7ns0jKyJH385A1qttD8pVeyLnj4ps+9iU/iA5wo=,iv:LT5XzerWt6ctuPYd/Pm7sdSQni30G5tBNQni+Nfmd3s=,tag:OO+/JhjwcZbnFCIFvOM17g==,type:str]
+    lastmodified: "2021-08-31T15:06:01Z"
+    mac: ENC[AES256_GCM,data:XrEbjWRGEn/XZMy7PntxLQETx8mpEabgR7GQlYbyCEgHPZNHe9RKEoMs+T/MyVpq/Kv+juC4iirj1TnVtTtUbgIB02nrSiSj4GVnUJ7+k/sEDa2QWPa+bp8B2nN35nAzT0BORw5Y+LK3BQSMa2qJpnIoDaLswBYNDcjFnYA38QQ=,iv:2uCU/prx0kdiUg7gijr38/JGYtlMLySyxP5preagmiY=,tag:70LPxKrdtKURzlaISlqPjw==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/aws/aws.cue
+++ b/stdlib/aws/aws.cue
@@ -16,7 +16,7 @@ import (
 	// AWS secret key
 	secretKey: dagger.#Input & {dagger.#Secret}
 	// AWS localstack mode
-	localMode: dagger.#Input & {string | *null}
+	localMode: dagger.#Input & {*false | bool}
 }
 
 // Re-usable aws-cli component
@@ -32,7 +32,7 @@ import (
 				"package": jq:        "=~1.6"
 				"package": curl:      true
 				"package": "aws-cli": "=~1.18"
-				if config.localMode != null {
+				if config.localMode != false {
 					package: "py3-pip": true
 				}
 			}
@@ -45,7 +45,7 @@ import (
 				"-eo",
 				"pipefail",
 				"-c",
-				if config.localMode == null {
+				if config.localMode == false {
 					#"""
 						aws configure set aws_access_key_id "$(cat /run/secrets/access_key)"
 						aws configure set aws_secret_access_key "$(cat /run/secrets/secret_key)"
@@ -55,7 +55,7 @@ import (
 						aws configure set default.output "json"
 						"""#
 				},
-				if config.localMode != null {
+				if config.localMode != false {
 					#"""
 						# Download awscli v3 and override aws
 						pip install awscli-local[v2]


### PR DESCRIPTION
LocalStack tests were implemented before the `bool input type` integration.

We had to find a trick to make it work : 

This PR cleans it by converting `aws.#Config.localMode` from `string | *null` to `bool | *false`, and the tests (`aws-ecr-localstack`,`aws-s3-localstack`) accordingly.

Signed-off-by: Guillaume de Rouville <guillaume.derouville@gmail.com>