### PR TITLE
Add env var support on GCP cloudrun

### DIFF
--- a/stdlib/gcp/cloudrun/tests/cloudrun.cue
+++ b/stdlib/gcp/cloudrun/tests/cloudrun.cue
@@ -11,4 +11,8 @@ TestCloudRun: deploy: cloudrun.#Service & {
 	config: TestConfig.gcpConfig
 	name:   "todoapp"
 	image:  "gcr.io/dagger-ci/todoapp:latest"
+	env: {
+		FOO: "foo"
+		BAR: "bar"
+	}
 }


### PR DESCRIPTION
This PR provides the possibility to add environment variables to a deployed cloud run service.