### PR TITLE
refacto/doc: remove 'cue init' step from doc

### DIFF
--- a/docs/learn/1004-first-env.md
+++ b/docs/learn/1004-first-env.md
@@ -95,11 +95,13 @@ Developing for Dagger takes place in a [Cue module](https://cuelang.org/docs/con
 If you are familiar with Go, Cue modules are directly inspired by Go modules.
 Otherwise, don't worry: a Cue module is simply a directory with one or more Cue packages in it. For example, a Cue module has a `cue.mod` directory at its root.
 
-This guide will use the same directory as the root of the Dagger workspace and the Cue module, but you can create your Cue module anywhere inside the Dagger workspace.
+This guide will use the same directory as the root of the Dagger workspace and the Cue module, but you can create your Cue module anywhere inside the Dagger workspace. In general, you won't have to worry about it at all. You will initialize a dagger workspace with the following command.
 
 ```shell
-cue mod init
+dagger init # Optional, already present in `todoapp`
 ```
+
+> In our case, `todoapp` already contains a workspace, so this step is optional.
 
 ### Create a Cue package
 

--- a/docs/learn/1006-google-cloud-run.md
+++ b/docs/learn/1006-google-cloud-run.md
@@ -25,14 +25,6 @@ Make sure that all commands are being run from the todoapp directory:
 cd examples/todoapp
 ```
 
-### (optional) Initialize a Cue module
-
-This guide will use the same directory as the root of the Dagger workspace and the root of the Cue module, but you can create your Cue module anywhere inside the Dagger workspace.
-
-```shell
-cue mod init
-```
-
 ### Organize your package
 
 Let's create a new directory for our Cue package:

--- a/docs/learn/1007-kubernetes.md
+++ b/docs/learn/1007-kubernetes.md
@@ -97,15 +97,6 @@ Make sure that all commands are run from the todoapp directory:
 cd examples/todoapp
 ```
 
-### (optional) Initialize a Cue module
-
-This guide will use the same directory as the root of the Dagger workspace and the root of the Cue module, but you can
-create your Cue module anywhere inside the Dagger workspace.
-
-```shell
-cue mod init
-```
-
 ### Organize your package
 
 Let's create a new directory for our Cue package:

--- a/docs/learn/1008-aws-cloudformation.md
+++ b/docs/learn/1008-aws-cloudformation.md
@@ -36,14 +36,6 @@ Make sure to run all commands from the todoapp directory:
 cd examples/todoapp
 ```
 
-### (optional) Initialize a Cue module
-
-This guide will use the same directory as the root of the Dagger workspace and the root of the Cue module, but you can create your Cue module anywhere inside the Dagger workspace.
-
-```shell
-cue mod init
-```
-
 ### Organize your package
 
 Let's create a new directory for our Cue package:


### PR DESCRIPTION
* Change to be merged in parallel to https://github.com/dagger/examples/pull/41

Several users have been confused with the `cue init` part of the doc's tutorials.

This PR removes them and explains the `go-to` way of initializing the cue modules : through the `dagger init` command

Signed-off-by: Guillaume de Rouville <guillaume.derouville@gmail.com>