### PR TITLE
stdlib/docker: Add args option to Docker #Build

### DIFF
--- a/stdlib/docker/docker.cue
+++ b/stdlib/docker/docker.cue
@@ -10,9 +10,14 @@ import (
 #Build: {
 	source: dagger.#Input & {dagger.#Artifact}
 
+	args?: [string]: string
+
 	#up: [
 		op.#DockerBuild & {
 			context: source
+			if args != _|_ {
+				buildArg: args
+			}
 		},
 	]
 


### PR DESCRIPTION
Example:

```cue
image: docker.#Build & {
    "source": source,
    "args": GENERATE_SOURCEMAP: "true"
}
```