### PR TITLE
Add #Secret type to Docker #Build args

### DIFF
--- a/stdlib/dagger/op/op.cue
+++ b/stdlib/dagger/op/op.cue
@@ -116,8 +116,11 @@ package op
 	dockerfile?:     string
 
 	platforms?: [...string]
-	buildArg?: [string]: string
-	label?: [string]:    string
+	buildArg?: {
+		// FIXME: should be `[string]: string | #Secret` (circular import)
+		[string]: string | _ @dagger(secret)
+	}
+	label?: [string]: string
 	target?: string
 	hosts?: [string]: string
 }

--- a/stdlib/docker/docker.cue
+++ b/stdlib/docker/docker.cue
@@ -14,7 +14,7 @@ import (
 	// Dockerfile passed as a string
 	dockerfile: dagger.#Input & {*null | string}
 
-	args?: [string]: string
+	args?: [string]: string | dagger.#Secret
 
 	#up: [
 		op.#DockerBuild & {


### PR DESCRIPTION
Temporary fix to allow dagger `#Secret` on `docker.#Build` args

Usage example:
```cue
// NPM token
npmToken: dagger.#Input & {dagger.#Secret}

image: docker.#Build & {
    "source": source,
    args: NPM_TOKEN: npmToken
    args: FOO: "bar"
}
```