### PR TITLE
docs: rephrase the value prop to run CI workflows using dagger

### DIFF
--- a/docs/use-cases/1012-ci.md
+++ b/docs/use-cases/1012-ci.md
@@ -2,17 +2,25 @@
 slug: /1012/ci
 ---
 
-# Continuous Integration
+# Make your CI workflow portable
 
-Dagger is the perfect tool for CI workflows.
+## Problems with existing CIs
 
-## Benefits
+- The CI code is sticky to the underlying CI infrastructure.
+- It's hard to migrate the CI from a runner to another.
+- The CI syntax is different with each CI runner.
+- Most CI workflows are reprensented using YAML.
 
-- **Develop and run your CI pipeline locally.** No need to create a Pull Request
-  to trigger CI, you can run the pipeline locally. Since dagger workflows
-  are containerized, you can expect the same results no matter where the pipeline
-  is executed.
-- **Write once, Run anywhere.** The same pipeline can run in any CI, goodbye
+Implement the CI workflow using dagger solves all of those problems.
+
+## Benefits of defining your CI workflow in Dagger
+
+- **Your CI only runs dagger.** It moves all the CI logic from the non-portable
+  CI syntax, to a dagger plan, that runs the same way everywhere.
+- **Develop and run your CI workflow locally.** No need to create a Pull Request
+  to trigger CI, you can run the workflow locally. Since dagger workflows
+  are containerized, you can expect the same results no matter where the workflow is executed.
+- **Write once, Run anywhere.** The same workflow can run in any CI, goodbye
   vendor lock in.
 - **Blazing Fast**: Dagger will automatically build an optimized execution
   graph, completing the job as fast as possible. Spend less time staring at CI to


### PR DESCRIPTION
This is a minimal rephrasing to emphasize that CI **is not** a CI system, but instead helps make CI systems portable and more efficient.