### PR TITLE
Fix ECR typo on localMode leading to CI Failure

### DIFF
--- a/stdlib/aws/ecr/tests/ecr.cue
+++ b/stdlib/aws/ecr/tests/ecr.cue
@@ -18,10 +18,10 @@ TestECR: {
 	}
 
 	repository: string
-	if localMode == null {
+	if localMode == false {
 		repository: "125635003186.dkr.ecr.\(TestConfig.awsConfig.region).amazonaws.com/dagger-ci"
 	}
-	if localMode != null {
+	if localMode == true {
 		repository: "localhost:4510/dagger-ci"
 	}
 	tag: "test-ecr-\(suffix.out)"


### PR DESCRIPTION
`aws-ecr` tests are currently failing because of a typo (type assertion) not triggered by Cue.
```bash
localMode: TestConfig.awsConfig.localMode // Bool type

if localMode == null {}
if localMode != null {}
```
* `localMode` is of `bool` type, and I was doing a `null` comparison

It probably didn't break before because of the env isolation issue on the bats test suite.

Signed-off-by: Guillaume de Rouville <guillaume.derouville@gmail.com>