### PR TITLE
Fix/Netlify package: reinsert always:true

### DIFF
--- a/stdlib/netlify/netlify.cue
+++ b/stdlib/netlify/netlify.cue
@@ -73,6 +73,7 @@ import (
 		// set in netlify.sh.cue
 		// FIXME: use embedding once cue supports it
 		command: _
+		always:  true
 		env: {
 			NETLIFY_SITE_NAME: name
 			if (create) {


### PR DESCRIPTION
Netlify package doesn't have the `always:true` option set anymore.
It might have been deleted when being ported from `up` instructions to an `os.#Container` definition

This PR reverts it.

Signed-off-by: Guillaume de Rouville <guillaume.derouville@gmail.com>