### PR TITLE
Fix/dagger edit: wrong dir Path leads to infinite loop

### DIFF
--- a/cmd/dagger/cmd/input/dir.go
+++ b/cmd/dagger/cmd/input/dir.go
@@ -34,7 +34,7 @@ var dirCmd = &cobra.Command{
 
 		// Check that directory exists
 		if _, err := os.Stat(p); os.IsNotExist(err) {
-			lg.Fatal().Err(err).Str("path", args[1]).Msg("dir doesn't exists")
+			lg.Fatal().Err(err).Str("path", args[1]).Msg("dir doesn't exist")
 		}
 
 		project := common.CurrentProject(ctx)

--- a/state/input.go
+++ b/state/input.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -112,6 +113,10 @@ func (dir dirInput) Compile(_ string, state *State) (*compiler.Value, error) {
 	}
 	if !strings.HasPrefix(p, state.Project) {
 		return nil, fmt.Errorf("%q is outside the project", dir.Path)
+	}
+	// Check that directory exists
+	if _, err := os.Stat(p); os.IsNotExist(err) {
+		return nil, fmt.Errorf("%q dir doesn't exist", dir.Path)
 	}
 
 	llb := fmt.Sprintf(

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -320,7 +320,7 @@ setup() {
   
   run "$DAGGER" input dir src xxx -e "input"
   assert_failure
-  assert_output --partial "dir doesn't exists"
+  assert_output --partial "dir doesn't exist"
 }
 
 @test "dagger input dir: ignore .dagger" {


### PR DESCRIPTION
Dagger input dir checks wether the Path of the directory exists.
* However, inside a `dagger edit`, the check wasn't applied, which led to infinite loops.
> This PR also fixes some English typos and its corresponding test

Signed-off-by: Guillaume de Rouville <guillaume.derouville@gmail.com>