### PR TITLE
Improve/git: Git.#Repository's origin now uses the provided URL

### DIFF
--- a/stdlib/git/tests/git/git.cue
+++ b/stdlib/git/tests/git/git.cue
@@ -96,3 +96,16 @@ TestPrivateRepository: os.#Container & {
 		[ -d .git ]
 		"""
 }
+
+TestReferenceFormat: os.#Container & {
+	image: alpine.#Image & {
+		package: bash: "=5.1.0-r0"
+		package: git:  true
+	}
+	mount: "/repo1": from: privateRepo
+	dir: "/repo1"
+	command: """
+		URL="$(git ls-remote --get-url origin)"
+		[[ "$URL" = "https://github.com/dagger/dagger.git" ]]
+		"""
+}


### PR DESCRIPTION
Fixes #1032 

PS: The PR checks wether the .git is present (the keepgitdir is set to `true`), otherwise, changing the remote is useless.

Signed-off-by: Guillaume de Rouville <guillaume.derouville@gmail.com>