### PR TITLE
Fix naming convention about arch and platform

### DIFF
--- a/cmd/dagger/cmd/compute.go
+++ b/cmd/dagger/cmd/compute.go
@@ -43,9 +43,9 @@ var computeCmd = &cobra.Command{
 		doneCh := common.TrackCommand(ctx, cmd)
 
 		st := &state.State{
-			Name:         "FIXME",
-			Architecture: platforms.Format(specs.Platform{OS: "linux", Architecture: "amd64"}),
-			Path:         args[0],
+			Name:     "FIXME",
+			Platform: platforms.Format(specs.Platform{OS: "linux", Architecture: "amd64"}),
+			Path:     args[0],
 			Plan: state.Plan{
 				Module: args[0],
 			},

--- a/cmd/dagger/cmd/edit.go
+++ b/cmd/dagger/cmd/edit.go
@@ -73,7 +73,7 @@ var editCmd = &cobra.Command{
 			lg.Fatal().Err(err).Msg("failed to decode file")
 		}
 		st.Name = newState.Name
-		st.Architecture = newState.Architecture
+		st.Platform = newState.Platform
 		st.Plan = newState.Plan
 		st.Inputs = newState.Inputs
 

--- a/cmd/dagger/cmd/new.go
+++ b/cmd/dagger/cmd/new.go
@@ -34,7 +34,7 @@ var newCmd = &cobra.Command{
 
 		st, err := project.Create(ctx, name, state.Plan{
 			Package: viper.GetString("package"),
-		}, viper.GetString("architecture"))
+		}, viper.GetString("platform"))
 
 		if err != nil {
 			lg.Fatal().Err(err).Msg("failed to create environment")
@@ -46,7 +46,7 @@ var newCmd = &cobra.Command{
 
 func init() {
 	newCmd.Flags().StringP("package", "p", "", "references the name of the Cue package within the module to use as a plan. Default: defer to cue loader")
-	newCmd.Flags().StringP("architecture", "a", "", "architecture of the running pipeline. Default: host architecture")
+	newCmd.Flags().String("platform", "", "platform of the running pipeline. Default: host platform")
 	if err := viper.BindPFlags(newCmd.Flags()); err != nil {
 		panic(err)
 	}

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -139,7 +139,7 @@ func (e *Environment) Up(ctx context.Context, s solver.Solver) error {
 	flow := cueflow.New(
 		&cueflow.Config{},
 		e.src.Cue(),
-		newTaskFunc(newPipelineRunner(e.computed, s, e.state.Architecture)),
+		newTaskFunc(newPipelineRunner(e.computed, s, e.state.Platform)),
 	)
 	if err := flow.Run(ctx); err != nil {
 		return err
@@ -200,6 +200,7 @@ func newPipelineRunner(computed *compiler.Value, s solver.Solver, platform strin
 		}
 		v := compiler.Wrap(t.Value())
 
+		fmt.Println(platform)
 		var pipelinePlatform specs.Platform
 		if platform == "" {
 			pipelinePlatform = specs.Platform{OS: "linux", Architecture: "amd64"}

--- a/environment/pipeline.go
+++ b/environment/pipeline.go
@@ -46,7 +46,7 @@ type Pipeline struct {
 	name     string
 	s        solver.Solver
 	state    llb.State
-	platform specs.Platform // Architecture constraint
+	platform specs.Platform // Platform constraint
 	result   bkgw.Reference
 	image    dockerfile2llb.Image
 	computed *compiler.Value

--- a/solver/solver.go
+++ b/solver/solver.go
@@ -127,7 +127,7 @@ func (s Solver) SolveRequest(ctx context.Context, req bkgw.SolveRequest) (*bkgw.
 }
 
 // Solve will block until the state is solved and returns a Reference.
-// It takes a platform as argument which correspond to the architecture.
+// It takes a platform as argument which correspond to the targeted platform.
 func (s Solver) Solve(ctx context.Context, st llb.State, platform specs.Platform) (bkgw.Reference, error) {
 	def, err := s.Marshal(ctx, st, llb.Platform(platform))
 	if err != nil {

--- a/state/project.go
+++ b/state/project.go
@@ -235,7 +235,7 @@ func (w *Project) Save(ctx context.Context, st *State) error {
 	return nil
 }
 
-func (w *Project) Create(ctx context.Context, name string, plan Plan, arch string) (*State, error) {
+func (w *Project) Create(ctx context.Context, name string, plan Plan, platform string) (*State, error) {
 	if _, err := w.Get(ctx, name); err == nil {
 		return nil, ErrExist
 	}
@@ -263,8 +263,8 @@ func (w *Project) Create(ctx context.Context, name string, plan Plan, arch strin
 		Plan: Plan{
 			Package: pkg,
 		},
-		Name:         name,
-		Architecture: arch,
+		Name:     name,
+		Platform: platform,
 	}
 
 	data, err := yaml.Marshal(st)

--- a/state/project_test.go
+++ b/state/project_test.go
@@ -35,7 +35,7 @@ func TestProject(t *testing.T) {
 	}, "linux/amd64")
 	require.NoError(t, err)
 	require.Equal(t, "test", st.Name)
-	require.Equal(t, "linux/amd64", st.Architecture)
+	require.Equal(t, "linux/amd64", st.Platform)
 
 	// Open
 	project, err = Open(ctx, root)
@@ -52,7 +52,7 @@ func TestProject(t *testing.T) {
 	env, err := project.Get(ctx, "test")
 	require.NoError(t, err)
 	require.Equal(t, "test", env.Name)
-	require.Equal(t, "linux/amd64", env.Architecture)
+	require.Equal(t, "linux/amd64", env.Platform)
 
 	// Save
 	require.NoError(t, env.SetInput("foo", TextInput("bar")))

--- a/state/state.go
+++ b/state/state.go
@@ -24,8 +24,8 @@ type State struct {
 	// FIXME: store multiple names?
 	Name string `yaml:"name,omitempty"`
 
-	// Architecture execution
-	Architecture string `yaml:"architecture,omitempty"`
+	// Platform execution
+	Platform string `yaml:"platform,omitempty"`
 
 	// User Inputs
 	Inputs map[string]Input `yaml:"inputs,omitempty"`

--- a/tests/core.bats
+++ b/tests/core.bats
@@ -159,26 +159,26 @@ setup() {
     "$DAGGER" up
 }
 
-@test "core: arch config" {
+@test "core: platform config" {
   dagger init
 
-  # Test for amd64 architecture
-  dagger_new_with_plan test-amd "$TESTDIR"/core/arch-config "linux/amd64"
+  # Test for amd64 platform
+  dagger_new_with_plan test-amd "$TESTDIR"/core/platform-config "linux/amd64"
 
   # Set arch expected value
   "$DAGGER" -e test-amd input text targetArch "x86_64"
 
   # Up amd
-  "$DAGGER" -e test-amd up
+  "$DAGGER" -e test-amd up --no-cache
 
-  # Test for amd64 architecture
-  dagger_new_with_plan test-arm "$TESTDIR"/core/arch-config "linux/arm64"
+  # Test for amd64 platform
+  dagger_new_with_plan test-arm "$TESTDIR"/core/platform-config "linux/arm64"
 
   # Set arch expected value
   "$DAGGER" -e test-arm input text targetArch "aarch64"
 
   # Up arm
-  "$DAGGER" -e test-arm up
+  "$DAGGER" -e test-arm up --no-cache
 }
 
 @test "compute: exclude" {

--- a/tests/core/platform-config/platform-config.cue
+++ b/tests/core/platform-config/platform-config.cue
@@ -13,13 +13,13 @@ TestFetch: #up: [
 	},
 
 	op.#Exec & {
-		args: ["/bin/sh", "-c", "echo $(uname -a) >> /arch.txt"]
+		args: ["/bin/sh", "-c", "echo $(uname -a) >> /platform.txt"]
 		always: true
 	},
 
 	op.#Exec & {
 		args: ["/bin/sh", "-c", """
-			cat /arch.txt | grep "$TARGET_ARCH"
+			cat /platform.txt | grep "$TARGET_ARCH"
 			"""]
 		env: TARGET_ARCH: targetArch
 	},
@@ -30,13 +30,13 @@ TestBuild: #up: [
 		dockerfile: """
 				FROM alpine
 				
-				RUN echo $(uname -a) > /arch.txt
+				RUN echo $(uname -a) > /platform.txt
 			"""
 	},
 
 	op.#Exec & {
 		args: ["/bin/sh", "-c", """
-			cat /arch.txt | grep "$TARGET_ARCH"
+			cat /platform.txt | grep "$TARGET_ARCH"
 			"""]
 		env: TARGET_ARCH: targetArch
 	},
@@ -49,7 +49,7 @@ TestLoad: #up: [
 
 	// Compare arch
 	op.#Exec & {
-		args: ["/bin/sh", "-c", "diff /build/arch.txt /fetch/arch.txt"]
+		args: ["/bin/sh", "-c", "diff /build/platform.txt /fetch/platform.txt"]
 		mount: {
 			"/build": from: TestBuild
 			"/fetch": from: TestFetch

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -20,17 +20,17 @@ common_setup() {
 dagger_new_with_plan() {
     local name="$1"
     local sourcePlan="$2"
-    local arch="$3"
+    local platform="$3"
 
     cp -a "$sourcePlan"/* "$DAGGER_PROJECT"
 
     local opts=""
-    if [ -n "$arch" ];
+    if [ -n "$platform" ];
     then
-      opts="-a $arch"
+      opts="--platform $platform"
     fi
 
-    # Need word splitting to take in account "-a" and "$arch"
+    # Need word splitting to take in account "-a" and "$platform"
     # shellcheck disable=SC2086
     "$DAGGER" new "$name" ${opts}
 }


### PR DESCRIPTION
## Changes

@samalba told me that using `arch` was a language abuse because we currently handle platform (`OS`/`arch`).

- Changed `arch` into `platform` because it's more accurate.

Signed-off-by: Tom Chauveau <tom.chauveau@epitech.eu>