### PR TITLE
docs: fix cue file path for gcp doc part

### DIFF
--- a/docs/learn/1006-google-cloud-run.md
+++ b/docs/learn/1006-google-cloud-run.md
@@ -35,7 +35,7 @@ mkdir gcpcloudrun
 
 ### Create a basic plan
 
-```cue file=./tests/gcpcloudrun/source.cue title="todoapp/cue.mod/gcpcloudrun/source.cue"
+```cue file=./tests/gcpcloudrun/source.cue title="todoapp/gcpcloudrun/source.cue"
 
 ```
 


### PR DESCRIPTION
In the documentation the specified path for the source.cue indicates
it under the cue.mod folder, meanwhile everything is set up outside of
it. Puting the source.cue file in its specified folder resulted in the
example not working, meanwhile puting it in the gcpcloudrun folder
directly resulted in the example perfectly working

Signed-off-by: Benjamin Reigner <benjamin.reigner@epitech.eu>