### PR TITLE
WIP: Implement exposedURL key inside Docker.#Run with test

### DIFF
--- a/stdlib/docker/tests/run-ports/ports.cue
+++ b/stdlib/docker/tests/run-ports/ports.cue
@@ -1,7 +1,9 @@
 package docker
 
 import (
+	"alpha.dagger.io/alpine"
 	"alpha.dagger.io/dagger"
+	"alpha.dagger.io/os"
 	"alpha.dagger.io/random"
 )
 
@@ -14,4 +16,16 @@ run: #Run & {
 	ref:    "nginx"
 	socket: dagger.#Stream & {unix: "/var/run/docker.sock"}
 	ports: ["8080:80"]
+	url: "http://localhost:8080/"
+}
+
+query: os.#Container & {
+	image: alpine.#Image & {
+		package: bash: "=~5.1"
+		package: curl: true
+	}
+	command: #"""
+		test "$(curl -L --fail --silent --show-error --write-out "%{http_code}" "$URL" -o /dev/null)" = "200"
+		"""#
+	env: URL: run.exposedURL
 }


### PR DESCRIPTION
When trying to implement the #graphQL package with @slumbering, and using the `docker.#Run` package with a local registry, we encountered dependency issues related to the fact that `docker.#Run` cannot expose a URL on which a dependency could be created:

```
// run our local registry
registry: docker.#Run & {
    ref:  "registry:2"
    name: "registry-local"
    ports: ["5042:5000"]
    socket: dockerSocket
    url: "localhost:5042/graphql"
}

push: docker.#Push & {
    target: "localhost:5042/graphql" // No dependency, will be run in parallel

    source: image
}
```

This PR tries to solve this issue, by requesting an `url`, and exposing it back as an `exposedURL`.

```
// run our local registry
registry: docker.#Run & {
    ref:  "registry:2"
    name: "registry-local"
    ports: ["5042:5000"]
    socket: dockerSocket
    url: "localhost:5042/graphql"
}

push: docker.#Push & {
    target: registry.exposedURL // dependency created

    source: image
}
```

The main use case is the push of an image that contains a server that will be queried right after, inside an `os.#Container`. We could implement some hacks, but we encountered it 2-3 times, and it seemed cleaner to do it that way.

PS: the current `Getting started` tutorial only works by luck, as the registry is not present as a dependency of the push, in the graph. It was related here: https://github.com/dagger/dagger/issues/940



Signed-off-by: guillaume <guillaume.derouville@gmail.com>