### PR TITLE
solver: fixed npipe support on Windows

### DIFF
--- a/solver/socketprovider_windows.go
+++ b/solver/socketprovider_windows.go
@@ -13,7 +13,7 @@ import (
 )
 
 func dialStream(id string) (net.Conn, error) {
-	if !strings.HasPrefix(id, unixPrefix) {
+	if !strings.HasPrefix(id, npipePrefix) {
 		return nil, fmt.Errorf("invalid socket forward key %s", id)
 	}
 


### PR DESCRIPTION
It took me a while to figure this out (no CI on Windows yet!).

This typo got introduced during the build split before the `alpha.28` release...