### PR TITLE
Dagger mod get now work without environment

### DIFF
--- a/cmd/dagger/cmd/mod/get.go
+++ b/cmd/dagger/cmd/mod/get.go
@@ -26,8 +26,7 @@ var getCmd = &cobra.Command{
 		ctx := lg.WithContext(cmd.Context())
 
 		project := common.CurrentProject(ctx)
-		st := common.CurrentEnvironmentState(ctx, project)
-		doneCh := common.TrackProjectCommand(ctx, cmd, project, st, &telemetry.Property{
+		doneCh := common.TrackProjectCommand(ctx, cmd, project, nil, &telemetry.Property{
 			Name:  "packages",
 			Value: args,
 		})


### PR DESCRIPTION
## Changes

`dagger mod get` doesn't need an environment anymore to work.

Previously, it was not possible to execute `dagger mod get` if no environment was set.

```sh
# Init dagger
dagger init

# Download universe
dagger mod get alpha.dagger.io
4:08PM FTL system | no environments
```

With this PR, it doesn't required an environment anymore

 ```sh
# Init
dagger init

 # Download universe
 dagger mod get alpha.dagger.io
4:10PM INF system | installing specified packages...
4:10PM INF system | installed/updated package alpha.dagger.io@v0.1.0
```
