### PR TITLE
Add Feature to leverage custom command inside Docker.#Run

### DIFF
--- a/pkg/alpha.dagger.io/docker/docker.cue
+++ b/pkg/alpha.dagger.io/docker/docker.cue
@@ -214,6 +214,9 @@ import (
 	// Container name
 	name?: dagger.#Input & {string}
 
+	// Custom Command overriding entrypoint of the Image
+	containerCommand?: dagger.#Input & {string}
+
 	// Recreate container?
 	recreate: dagger.#Input & {bool | *true}
 
@@ -230,6 +233,7 @@ import (
 	#command: #"""
 		# Run detach container
 		OPTS=""
+		CMD=""
 
 		if [ ! -z "$CONTAINER_NAME" ]; then
 			OPTS="$OPTS --name $CONTAINER_NAME"
@@ -250,7 +254,11 @@ import (
 			OPTS="$OPTS -p $CONTAINER_PORTS"
 		fi
 
-		docker container run -d $OPTS "$IMAGE_REF"
+		if [ ! -z "$CONTAINER_CMD" ]; then
+			CMD="$CONTAINER_CMD"
+		fi
+
+		docker container run -d $OPTS "$IMAGE_REF" $CMD
 		"""#
 
 	run: #Command & {
@@ -278,6 +286,11 @@ import (
 			if ports != _|_ {
 				CONTAINER_PORTS: strings.Join(ports, " -p ")
 			}
+
+			if containerCommand != _|_ {
+				CONTAINER_CMD: containerCommand
+			}
+
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: sw360cab <sw360cab@gmail.com>

Actually it is not possible to set a custom command for `Docker.#Run`, in the same way it is possible with the `docker run` command in the form `docker run ... IMAGE CMD`, in order to override the entrypoint of a pulled image.

In a CI/CD scenario this is particularly useful when building an image which afterward will be reused in different steps (eg. build, test-suite, doc building).

In Dagger a similar behaviour is possible using `Os.#Container`

```bash
run: os.#Container & {
    image: dagger.#Artifact
    command: string
}
```

However the same is not possible using Docker.#Run. For example when reusing a built&pushed image.

```bash
run: docker.#Run & {
    ref:  push.ref
    name: "hello"
    ports: ["3000:3000"]
    socket: dockerSocket
}
```

In this case there is no way to `run` with a custom command.

The proposal introduces `containerCommand` which allows exactly what currently is not possible

```bash
run: docker.#Run & {
    ref:  push.ref
    name: "nodejs-hello"
    ports: ["3000:3000"]
    socket: dockerSocket
    containerCommand: string 
}
```

The container now is successfully spawned with the given `containerCommand`.





