### PR TITLE
Fix error printing regression w/ wrong Cue

### DIFF
--- a/cmd/dagger/cmd/compute.go
+++ b/cmd/dagger/cmd/compute.go
@@ -195,7 +195,7 @@ var computeCmd = &cobra.Command{
 
 		env, err := environment.New(st)
 		if err != nil {
-			lg.Fatal().Msg("unable to create environment")
+			lg.Fatal().Err(err).Msg("unable to create environment")
 		}
 
 		err = cl.Do(ctx, env.Context(), func(ctx context.Context, s solver.Solver) error {

--- a/cmd/dagger/cmd/edit.go
+++ b/cmd/dagger/cmd/edit.go
@@ -79,7 +79,7 @@ var editCmd = &cobra.Command{
 
 		env, err := environment.New(st)
 		if err != nil {
-			lg.Fatal().Msg("unable to create environment")
+			lg.Fatal().Err(err).Msg("unable to create environment")
 		}
 
 		cl := common.NewClient(ctx)

--- a/cmd/dagger/cmd/input/list.go
+++ b/cmd/dagger/cmd/input/list.go
@@ -43,7 +43,7 @@ var listCmd = &cobra.Command{
 
 		env, err := environment.New(st)
 		if err != nil {
-			lg.Fatal().Msg("unable to create environment")
+			lg.Fatal().Err(err).Msg("unable to create environment")
 		}
 
 		cl := common.NewClient(ctx)

--- a/cmd/dagger/cmd/input/root.go
+++ b/cmd/dagger/cmd/input/root.go
@@ -55,7 +55,7 @@ func updateEnvironmentInput(ctx context.Context, cmd *cobra.Command, target stri
 
 	env, err := environment.New(st)
 	if err != nil {
-		lg.Fatal().Msg("unable to create environment")
+		lg.Fatal().Err(err).Msg("unable to create environment")
 	}
 
 	cl := common.NewClient(ctx)

--- a/cmd/dagger/cmd/output/list.go
+++ b/cmd/dagger/cmd/output/list.go
@@ -42,7 +42,7 @@ var listCmd = &cobra.Command{
 
 		env, err := environment.New(st)
 		if err != nil {
-			lg.Fatal().Msg("unable to create environment")
+			lg.Fatal().Err(err).Msg("unable to create environment")
 		}
 
 		cl := common.NewClient(ctx)

--- a/cmd/dagger/cmd/up.go
+++ b/cmd/dagger/cmd/up.go
@@ -63,7 +63,7 @@ var upCmd = &cobra.Command{
 
 		env, err := environment.New(st)
 		if err != nil {
-			lg.Fatal().Msg("unable to create environment")
+			lg.Fatal().Err(err).Msg("unable to create environment")
 		}
 
 		err = cl.Do(ctx, env.Context(), func(ctx context.Context, s solver.Solver) error {


### PR DESCRIPTION
We are facing a small regression on Dagger lately: any package importing an unknown definition cannot be edited, listed...

```
package main

#test
```

would lead to:

```
dagger input list
11:57PM FTL system | unable to create environment
```

This is very blocking, as we don't know anything about the issue.

This PR fixes it:

```
dagger input list
11:58PM FTL system | unable to create environment: reference "#test" not found:
    /tmp/test/main.cue:4:1
```



Signed-off-by: guillaume <guillaume.derouville@gmail.com>