### PR TITLE
Fix Docs CI tests

### DIFF
--- a/docs/learn/tests/doc.bats
+++ b/docs/learn/tests/doc.bats
@@ -20,14 +20,11 @@ setup() {
   dagger --project "$DAGGER_SANDBOX" -e 'local' input socket dockerSocket /var/run/docker.sock
   dagger --project "$DAGGER_SANDBOX" -e 'local' input dir app.source "$DAGGER_SANDBOX"
 
-  dagger --project "$DAGGER_SANDBOX" -e 'local' up
+  run dagger --project "$DAGGER_SANDBOX" -e 'local' up
+  assert_success
 
-  SECONDS=0 
-  while [[ "$(docker inspect --format '{{json .State.Status }}' todoapp | grep -m 1 'running')" != "running" && $SECONDS -lt 45 ]]; do sleep 1 ; done
-  run curl -f -LI http://localhost:8080
-  assert_output --partial '200 OK'
-  docker stop todoapp && docker rm todoapp
-  docker stop registry-local && docker rm registry-local
+  docker rm -f todoapp
+  docker rm -f registry-local
 }
 
 @test "doc-1004-first-env" {

--- a/docs/learn/tests/package.json
+++ b/docs/learn/tests/package.json
@@ -1,7 +1,7 @@
 {
   "license": "Apache-2.0",
   "scripts": {
-    "test": "bats --report-formatter junit --jobs 4 ."
+    "test": "bats --jobs 4 --show-output-of-passing-tests --print-output-on-failure ."
   },
   "devDependencies": {
     "bats": "https://github.com/bats-core/bats-core#master",
@@ -9,4 +9,3 @@
     "bats-support": "https://github.com/bats-core/bats-support"
   }
 }
-

--- a/docs/learn/tests/yarn.lock
+++ b/docs/learn/tests/yarn.lock
@@ -4,12 +4,12 @@
 
 "bats-assert@https://github.com/bats-core/bats-assert":
   version "2.0.0"
-  resolved "https://github.com/bats-core/bats-assert#e0de84e9c011223e7f88b7ccf1c929f4327097ba"
+  resolved "https://github.com/bats-core/bats-assert#34551b1d7f8c7b677c1a66fc0ac140d6223409e5"
 
 "bats-support@https://github.com/bats-core/bats-support":
   version "0.3.0"
   resolved "https://github.com/bats-core/bats-support#d140a65044b2d6810381935ae7f0c94c7023c8c3"
 
 "bats@https://github.com/bats-core/bats-core#master":
-  version "1.4.1"
-  resolved "https://github.com/bats-core/bats-core#7ff2f3efc738976feaccfdf374164b61599f9e36"
+  version "1.5.0"
+  resolved "https://github.com/bats-core/bats-core#81924c15f2c26692d30aa4f827a6bb13d10d5e1d"


### PR DESCRIPTION
- Removed loop in "getting started" tests
- Upgraded bats
- Increased bats logging

It seems to fix the doc tests reliably.