### PR TITLE
Add completion documentation in 1001-install.md

### DIFF
--- a/docs/1001-install.md
+++ b/docs/1001-install.md
@@ -73,3 +73,20 @@ cd dagger; make
 ```shell
 cp ./cmd/dagger/dagger /usr/local/bin
 ```
+
+## Enable autocompletion manually
+
+You can generate an auto completion script using `dagger completion <your shell>`
+
+```sh
+Usage:
+  dagger completion [command]
+
+Available Commands:
+  bash        generate the autocompletion script for bash
+  fish        generate the autocompletion script for fish
+  powershell  generate the autocompletion script for powershell
+  zsh         generate the autocompletion script for zsh
+```
+
+Depending on your shell, add the output script belong your other completions' script.


### PR DESCRIPTION
## Changes

Related to #1159 

I've added a piece of information about `dagger completion`, I didn't provide examples because there are many ways to install completions scripts, (.eg zsh/oh-my-zsh...).

