### PR TITLE
test: reset the dagger-ci PAT to fix the test infra

### DIFF
--- a/stdlib/.dagger/env/git-commit/values.yaml
+++ b/stdlib/.dagger/env/git-commit/values.yaml
@@ -3,7 +3,7 @@ plan:
 name: git-commit
 inputs:
     TestAuthToken:
-        secret: ENC[AES256_GCM,data:LiafjwWyVhTLpUEk8DXRN7xqWx7jcSH7yIZrTCkLV4P/yJeYu9G1rg==,iv:U0yksHX9AtVsHXZV08kmxa7IgVV6W+UltDfSYczsiP0=,tag:fTz9Bjq1mbE6ZX4ii7O7wg==,type:str]
+        secret: ENC[AES256_GCM,data:1Cmlm9+Hg1kwskssscbC3INAB38J1dro+PASRZK+4B/2WkRGTbBTMg==,iv:3nvZxc95XVCzFFxMAdljOhRRoHmAGYCbeJ7EZUuXud4=,tag:qZOtm5BDjqQRHel0/PaKfA==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -19,8 +19,8 @@ sops:
             M3RnUDF5QlhhZUV4NHF5ZWhkcHVrNmcKUJIummOk3FX1Bert7gaMtbMpbosIf/d3
             HBATJRng4VNmcSimSh14pDRxyW0NdIPA+oL4tidwLVbQQv/74+IGKg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-09-22T19:38:08Z"
-    mac: ENC[AES256_GCM,data:AL3/BLYy8fCfkwqZsEc3m5tW5VIM17nS9KbL+ww3rnvxzr+mtzrRDxEZZhzQ5b/JR8VW3v+veSX1yFEWpMs1EK/SXuvIZYRTe0JdBGBs+l4Rn5CWeflQ5gJKsTGv2OYaQ46/mVucDlia0CX+W+Skn9591fzkopTE4sGJYAEnUR0=,iv:lJ+d/4CmH5ElP470OaDiDTloYoS0NXzDIosCYZqi+fk=,tag:DqXqsEAcuLSFAfZiSbWxcg==,type:str]
+    lastmodified: "2021-12-02T22:20:28Z"
+    mac: ENC[AES256_GCM,data:9BqOV7es6wzCTRPqPyM35z8MMKbVNjmqZhaS+zXib2IKSNIE0D3WvpAhWVmKUZnTTwvEBj0in/Dgv12DxfjQ1Q7dLDARLaB01T3lB7nrgWiePIOl8CEiB7gf8IPv08Md5V0+pCOL2bZ6RSd4byl0JJ5lIVr3v+AupotcecYb9cU=,iv:CMrEJ/RPjVJrOlrQqO7ks3ByWbzfB4y/Z3g6kOxezbQ=,tag:d0WfZbbEGpakPaWlMLYCgA==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/.dagger/env/git-repo/values.yaml
+++ b/stdlib/.dagger/env/git-repo/values.yaml
@@ -3,7 +3,7 @@ plan:
 name: git-repo
 inputs:
     TestPAT:
-        secret: ENC[AES256_GCM,data:7s1tSIpIDNBhAFupdjb7KtPbjKrCd5tXupr3RQF2N3Xu5XGuTZMgoQ==,iv:I+SVYLnjgMffvNg6BMB6m1lj+VVH5sDK0aIEAWPcyLY=,tag:TcfJ6LVps8dXVZGZy3T2ew==,type:str]
+        secret: ENC[AES256_GCM,data:6yF+JIrsRkdWWNDCiHTUomepoi3lJsDevFghc+mQW692elAi/ZCyuQ==,iv:u9/OKUBmjMTyPBtB5DjZea1uPO6dmOqS7/34U6y1Y6Q=,tag:W/Irs3Dq2pSJ+jG6WQ9Tvg==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -19,8 +19,8 @@ sops:
             TmhJNisyamw3d244aGVJSEVFVUVLZGsKvd+nowA0CLXQbdvyI4J0lBjs9vdISWlo
             gGvR49uul3Z8raVWXFUzsyQ8xTvYNg0ovynFG2KdagSKr1DlhKMBEQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-09-01T08:40:49Z"
-    mac: ENC[AES256_GCM,data:UgryTszQf7YgFfXL8YhzJekPIOymtd8adyijOp6AQW8JGXu989JtlXeUKvLpRkbyjZD8+oTTX1iK7Ssj/hJKgo0yklLc7O9sSQGhxjo/3WYTcKUcHd5Tj9yoZp+RFH1qZxpnkAexZoM2rwOT9FAhdV3/AJV2ekY2Qe3JbrGJr6s=,iv:DXiIE1oNDPGhXcL2aPXA2TcvY6Jee4mFypq3bELnAx4=,tag:qfHMnpGr6yFLSQHqIvyglA==,type:str]
+    lastmodified: "2021-12-02T22:22:03Z"
+    mac: ENC[AES256_GCM,data:4M+/4o85QGxJaBpExMHmKGLGLBW9FKOkQ4njBGV//gklYuYCy7sdAF4/r0J96R5DDL9KWiN49SlAKoBx5j5w3MyIWsZcNSrAFH0gsezNlTYsFh3sVXtIL3F4FTVMV6kV795NDTAY9inyOoX7MgoHtE9mvf8voYmj8YPJGOmP8nw=,iv:tgfXXxH2iuNuJCkJUN2RZqCw+r5KAcGfScV6+f89Sws=,tag:wiNhGbDjXwzdQ3EQn1r/PA==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1


### PR DESCRIPTION
Updated gh user @dagger-ci personal access token (pretty sure it was using @TomChv's token that was recently removed). All failing PRs on this test can be rebased on `main` once this PR is merged.