### PR TITLE
Fix broken docker.#Command secrets mount

### DIFF
--- a/stdlib/.dagger/env/docker-command-ssh/values.yaml
+++ b/stdlib/.dagger/env/docker-command-ssh/values.yaml
@@ -8,6 +8,8 @@ inputs:
         secret: ENC[AES256_GCM,data:gb2yFGdX3oqjPpQmqn3gr0hqLAHMFBhzLEHI5Bi+VN5Op/SCSjfA5yEC0Olb/Brzssjp0i6PIPBPPwW+Pj/gDuSR6CqzGlAkF1Pz/Ks6R0zqWkcR0gFImXrfRzeflgpGagPBgPsRBtPcoY7WqJQ1Lue46cJe7OTNPRT+X9oDek7mk9ZiIpJCUQQVN0+alWStOPYuTjRlqcSfao+B6hnC2fMtcCWpVxz9Sj8UpSwX4EHLU5GsHr8ioD+BP7BCPlhP/aSKu1iwMaiMo6zRn6V+GtSGX4JrwN53CYSjGxi1g9RiFMCFxcWsDVA+hCnzAdzO3pMEmTL5xHZ9MoMLbOwEhN3Rnh+HX61uTq2DRfqGhKGtjXjcewOxb0NezGCj93Y0ov2TtBBo7wjYEi0AmI3ljCwoq9EDRYKg1a/w79FpGVpqoomd4XrJYbqP0SnHO0ZrsSLqKmqdIoDYbfxR7zprQQsN0ENOdDVf9WdTnHSJMSC5MTmyqAOogKZN1nNzW5LJQ2i0JUt1jl322RzdQ+brBLWiohVfenCy/23l,iv:gceSEfG6Eu2Pc9+JZpH0CLITNVnYFyN21drPneu15wk=,tag:zmYtioa5LTPZrSeFNmaBvg==,type:str]
     TestConfig.user:
         text: daggerci
+    TestPassword:
+        secret: ENC[AES256_GCM,data:8G7Cgw==,iv:+hlWzOxy4H9OYwP0x+7LIMFhQoebmP3yUGRuhPSGGgI=,tag:i+dHE+W2zud5xGvWL5PxVg==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -23,8 +25,8 @@ sops:
             UEpoZy9HZUlHOVV3M05OSkZQS1l6aXcK3NfBITvd6la6nkcIzqH69xfv9RR0Jm7x
             vU5FvGROK3Z0ZR8NNXAtNH6VQQ21TDD2MOXWOVvjnIAAOVNEyc1amA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-07-08T09:52:59Z"
-    mac: ENC[AES256_GCM,data:Xd8UhlqoC9/tix66cUPdNffUiPjsofi+a2rvMaBUkzdki4oPO5bFawBIJeOmDML47KMMBlBy4fBkHKS0zaYLDU640ahLFiWI6og/pAEk7L4waRK7Aep2g63VvJmE9dtz22JyTStJLp7gFlK/Xngov+7IkjqxpQ/H3qGE4HqlHaA=,iv:mkSv8FufpVlAycli8qqj5UkxFnpSsUpnpbs+7M7b2wE=,tag:3qRTUf9h1MQGUYihkrTahQ==,type:str]
+    lastmodified: "2021-12-03T17:55:10Z"
+    mac: ENC[AES256_GCM,data:phVOMaY+57UEzTDQ9Vf1jdcesonG0s44qXVyfFrM2xuRTDffdgmR8uzboSQ5S+5u4fg//nz17oE9qaLe1ST1X5SekZm1z4KCK7Z29bqYvrywOTlmeBpQ9vDOGjY+BBnMnWNjLrC0bQ5bfVG1c1V0PxDuvey4EoFqplecENlEVQ8=,iv:kk/X/R7cFvaLaa4YHvIUOE4VGqdxFFmtxEspP1Uzp74=,tag:XrvWLPb5w7417T8LeiGCkg==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/docker/command.cue
+++ b/stdlib/docker/command.cue
@@ -43,13 +43,10 @@ import (
 	}
 
 	// Mount content from other artifacts
-	mount: {
-		[string]: {
-			from: dagger.#Artifact
-		} | {
-			secret: dagger.#Secret
-		}
-	}
+	mount: [string]: from: dagger.#Artifact
+
+	// Mount secrets
+	secret: [string]: dagger.#Secret
 
 	// Mount persistent cache directories
 	cache: {
@@ -225,6 +222,9 @@ import (
 				}
 				for dest, o in mount {
 					"\(dest)": o
+				}
+				for dest, s in secret {
+					"\(dest)": secret: s
 				}
 				for dest, _ in cache {
 					"\(dest)": "cache"

--- a/stdlib/docker/tests/command-ssh/command.cue
+++ b/stdlib/docker/tests/command-ssh/command.cue
@@ -5,19 +5,22 @@ import (
 )
 
 TestConfig: {
-	host: string         @dagger(input)
-	user: string         @dagger(input)
-	key:  dagger.#Secret @dagger(input)
+	host: dagger.#Input & {string}
+	user: dagger.#Input & {string}
+	key:  dagger.#Input & {dagger.#Secret}
 }
+
+TestPassword: dagger.#Input & {dagger.#Secret}
 
 TestSSH: client: #Command & {
 	command: #"""
-			docker $CMD
+			docker $CMD && [ -f /run/secrets/password ]
 		"""#
 	ssh: {
 		host: TestConfig.host
 		user: TestConfig.user
 		key:  TestConfig.key
 	}
-	env: CMD: "version"
+	secret: "/run/secrets/password": TestPassword
+	env: CMD:                        "version"
 }


### PR DESCRIPTION
Adding secrets in docker.#Command is broken: 
```
// pipeline was partially executed because of missing inputs    op=0s original_cue_error=prod_image_info.ref.#up.0.from.#up.5.mount."/run/secrets/dockerhub_password": incomplete value {secret:{…
// executing operation    do=export pipeline=prod_image_info.ref
```

This PR fixes the issue by differentiating the secrets and generic mounts. @gerhard 


Signed-off-by: guillaume <guillaume.derouville@gmail.com>