### PR TITLE
fixed plan test 

### DIFF
--- a/tests/plan.bats
+++ b/tests/plan.bats
@@ -7,6 +7,6 @@ setup() {
 @test "plan: hello" {
   # Europa loader handles the cwd differently, therefore we need to CD into the tree at or below the parent of cue.mod
   cd "$TESTDIR"
-  run dagger --europa up ./plan/hello-europa
+  run "$DAGGER" --europa up ./plan/hello-europa
   assert_success
 }


### PR DESCRIPTION
europa plan needed to ensure it was using the right plan directory. Passing absolute path didnt work because the cwd needs to be at or beneath the parent of cue.mod. 

Signed-off-by: Richard Jones <richard@dagger.io>