### PR TITLE
Europa: incorporate feedback to stdlib (small)

### DIFF
--- a/europa/stdlib/dagger/plan.cue
+++ b/europa/stdlib/dagger/plan.cue
@@ -8,8 +8,12 @@ package dagger
 #DAG: {
 	// Receive inputs from the client
 	input: {
+		// Receive directories
 		directories: [name=string]: _#inputDirectory
-		secrets: [name=string]:     _#inputSecret
+		// Securely receive secrets
+		secrets: [name=string]: _#inputSecret
+		// Receive runtime parameters
+		params: [name=string]: _
 	}
 
 	// Send outputs to the client


### PR DESCRIPTION
* Make some definitions private (via @talentedmrjones )
* Add `dagger.#Plan.input.params` (via @talentedmrjones )