### PR TITLE
Add env vars inside http.#Wait package to enable env dependency hacks

### DIFF
--- a/stdlib/http/http.cue
+++ b/stdlib/http/http.cue
@@ -103,6 +103,9 @@ import (
 	// Time until timeout (sec.)
 	timeout: int | *30
 
+	// Env variables
+	env: [string]: string
+
 	#up: [
 		op.#Load & {
 			from: alpine.#Image & {
@@ -141,12 +144,15 @@ import (
 					"""#,
 			]
 			always: true
-			env: {
+			"env": {
 				HEALTH_URL:   url
 				INTERVAL:     "\(interval)"
 				NB_RETRIES:   "\(retries)"
 				START_PERIOD: "\(startPeriod)"
 				TIMEOUT:      "\(timeout)"
+				for k, v in env {
+					"\(k)": v
+				}
 			}
 		},
 	]


### PR DESCRIPTION
This is a required step until we find a better dependency API solution.

We need to enable env var dependency hacks with this package, as a rerun of a plan always re-executes a `docker.#Run`. 

Signed-off-by: guillaume <guillaume.derouville@gmail.com>