### PR TITLE
docs:  make dev-cue-package example naming consitant

### DIFF
--- a/docs/learn/1010-dev-cue-package.md
+++ b/docs/learn/1010-dev-cue-package.md
@@ -51,7 +51,7 @@ Let's write the package logic. It is basically what we've seen in the 106-cloudr
 touch cue.mod/pkg/github.com/username/gcpcloudrun/source.cue
 ```
 
-```cue file=./tests/dev-cue-package/source.cue title="cue.mod/pkg/github.com/tjovicic/gcpcloudrun/source.cue"
+```cue file=./tests/dev-cue-package/source.cue title="cue.mod/pkg/github.com/username/gcpcloudrun/source.cue"
 ```
 
 ### Running the package

--- a/docs/learn/tests/dev-cue-package/script.sh
+++ b/docs/learn/tests/dev-cue-package/script.sh
@@ -6,7 +6,7 @@ cat > test/source.cue << EOF
 package test
 
 import (
-  "github.com/tjovicic/gcpcloudrun"
+  "github.com/username/gcpcloudrun"
 )
 
 run: gcpcloudrun.#Run

--- a/docs/learn/tests/doc.bats
+++ b/docs/learn/tests/doc.bats
@@ -263,8 +263,8 @@ setup() {
 
   # # Writing package
   # # dagger init # The sandbox is already init
-  # mkdir -p "$DAGGER_SANDBOX"/cue.mod/pkg/github.com/tjovicic/gcpcloudrun
-  # cp "$DAGGER_PROJECT"/dev-cue-package/source.cue "$DAGGER_SANDBOX"/cue.mod/pkg/github.com/tjovicic/gcpcloudrun/source.cue
+  # mkdir -p "$DAGGER_SANDBOX"/cue.mod/pkg/github.com/username/gcpcloudrun
+  # cp "$DAGGER_PROJECT"/dev-cue-package/source.cue "$DAGGER_SANDBOX"/cue.mod/pkg/github.com/username/gcpcloudrun/source.cue
   # cp "$DAGGER_PROJECT"/dev-cue-package/script.sh "$DAGGER_SANDBOX"/project/script.sh
 
   # # We remove the last line of the script, as bats cannot expand dagger


### PR DESCRIPTION
Documentation of `dev-cue-package` example has both `username` and `tjovicic` witch may be confusing.

That PR update `tjovicic` to `username` for better consistency.
