### PR TITLE
Europa: reconcile engine.#Exec spec with implementation

### DIFF
--- a/europa-universe/docker/docker.cue
+++ b/europa-universe/docker/docker.cue
@@ -28,6 +28,7 @@ import (
 	mounts: [name=string]: engine.#Mount
 
 	// Expose network ports
+	// FIXME: investigate feasibility
 	ports: [name=string]: {
 		frontend: dagger.#Service
 		backend: {
@@ -84,12 +85,7 @@ import (
 	// Username or UID to ad
 	// User identity for this command
 	// Examples: "root", "0", "1002"
-	user: string
-
-	// Optionally attach to command standard streams
-	stdin:  dagger.#Stream | *null
-	stdout: dagger.#Stream | *null
-	stderr: dagger.#Stream | *null
+	user: string | *"root"
 
 	// Output fields
 	{
@@ -131,13 +127,12 @@ import (
 
 	// Actually execute the command
 	_exec: engine.#Exec & {
-		args:  [cmd.name] + cmd._flatFlags + cmd.args
-		input: image.rootfs
-		"mounts": [ for mnt in mounts {mnt}]
-		environ: [ for k, v in env {"\(k)=\(v)"}]
+		args:      [cmd.name] + cmd._flatFlags + cmd.args
+		input:     image.rootfs
+		"mounts":  mounts
+		"env":     env
 		"workdir": workdir
-		"stdin":   stdin
-		// FIXME: user
+		"user":    user
 	}
 }
 

--- a/stdlib/europa/dagger/engine/spec/engine/exec.cue
+++ b/stdlib/europa/dagger/engine/spec/engine/exec.cue
@@ -7,32 +7,39 @@ package engine
 	// Container filesystem
 	input: #FS
 
-	// Mounts
-	mounts: [...#Mount]
+	// Transient filesystem mounts
+	//   Key is an arbitrary name, for example "app source code"
+	//   Value is mount configuration
+	mounts: [name=string]: #Mount
 
 	// Command to execute
-	args: [...string] | string
+	// Example: ["echo", "hello, world!"]
+	args: [...string]
 
 	// Environment variables
-	environ: [...string]
+	env: [key=string]: string
 
 	// Working directory
-	workdir?: string
+	workdir: string | *"/"
 
-	// Optionally attach to command standard input stream
-	stdin?: #Stream
+	// User ID or name
+	user: string | *"root"
 
-	// Optionally attach to command standard output stream
-	stdout?: #Stream
-
-	// Optionally attach to command standard error stream
-	stderr?: #Stream
+	// If set, always execute even if the operation could be cached
+	always: true | *false
 
 	// Modified filesystem
 	output: #FS
 
 	// Command exit code
-	exit: int
+	// Currently this field can only ever be zero.
+	// If the command fails, DAG execution is immediately terminated.
+	// FIXME: expand API to allow custom handling of failed commands
+	exit: int & 0
+
+	// Inject hostname resolution into the container
+	// key is hostname, value is IP
+	hosts: [hostname=string]: string
 }
 
 // A transient filesystem mount.


### PR DESCRIPTION
This addresses several points from #1211 : 

* Add missing `user`
* Add missing `always`
* Add missing `hosts`
* Remove `stdin`, `stdout`, `stderr` until API design questions are resolved. See #1222 .
* Clean up `args`: only supports `[…string]`, add example in comment to clarify use.
* Rename `environ` to `env`, and make it a map
* Change `mounts` to a map
* Hardcode `exit` to 0 to make current API limitation explicit, while hinting at future expansion