### PR TITLE
Europa: engine.#Mkdir (spec)

### DIFF
--- a/docs/reference/europa/dagger/engine/spec/engine.md
+++ b/docs/reference/europa/dagger/engine/spec/engine.md
@@ -132,6 +132,18 @@ _No input._
 
 _No output._
 
+## engine.#Mkdir
+
+Create a directory
+
+### engine.#Mkdir Inputs
+
+_No input._
+
+### engine.#Mkdir Outputs
+
+_No output._
+
 ## engine.#Mount
 
 A transient filesystem mount.

--- a/stdlib/europa/dagger/engine/spec/engine/fs.cue
+++ b/stdlib/europa/dagger/engine/spec/engine/fs.cue
@@ -31,6 +31,23 @@ package engine
 	output:   #FS
 }
 
+// Create a directory
+#Mkdir: {
+	_mkdir: {}
+
+	input: #FS
+
+	// Path of the directory
+	path: string
+	// FIXME: this is not very dev friendly, as Cue does not support octal notation.
+	// What is a better option?
+	mode: int
+	// Create parent directories as needed?
+	parents: *true | false
+
+	output: #FS
+}
+
 #Copy: {
 	_copy: {}
 


### PR DESCRIPTION
Add `engine.#Mkdir` to the Europa Engine API spec.

NOTE: this PR depends on #1214, please review and merge that first.