### PR TITLE
Europa: The Great Compromise of December 16, 2021. (spec).

### DIFF
--- a/stdlib/europa/dagger/engine/spec/engine/exec.cue
+++ b/stdlib/europa/dagger/engine/spec/engine/exec.cue
@@ -2,7 +2,7 @@ package engine
 
 // Execute a command in a container
 #Exec: {
-	_exec: {}
+	$dagger: task: _name: "Exec"
 
 	// Container filesystem
 	input: #FS

--- a/stdlib/europa/dagger/engine/spec/engine/fs.cue
+++ b/stdlib/europa/dagger/engine/spec/engine/fs.cue
@@ -2,19 +2,19 @@ package engine
 
 // A filesystem state
 #FS: {
-	_fs: ID: string
+	$dagger: fs: _id: string
 }
 
 // Produce an empty directory
 // FIXME: replace with a null value for #FS?
 #Scratch: {
-	_scratch: {}
+	$dagger: task: _name: "Scratch"
 
 	output: #FS
 }
 
 #ReadFile: {
-	_readFile: {}
+	$dagger: task: _name: "ReadFile"
 
 	input:    #FS
 	path:     string
@@ -23,7 +23,7 @@ package engine
 }
 
 #WriteFile: {
-	_writeFile: {}
+	$dagger: task: _name: "WriteFile"
 
 	input:    #FS
 	path:     string
@@ -33,7 +33,7 @@ package engine
 
 // Create a directory
 #Mkdir: {
-	_mkdir: {}
+	$dagger: task: _name: "Mkdir"
 
 	input: #FS
 
@@ -49,7 +49,7 @@ package engine
 }
 
 #Copy: {
-	_copy: {}
+	$dagger: task: _name: "Copy"
 
 	input: #FS
 	#CopyInfo
@@ -65,7 +65,7 @@ package engine
 }
 
 #Merge: {
-	_merge: {}
+	$dagger: task: _name: "Merge"
 
 	input: #FS
 	layers: [...#CopyInfo]

--- a/stdlib/europa/dagger/engine/spec/engine/git.cue
+++ b/stdlib/europa/dagger/engine/spec/engine/git.cue
@@ -2,7 +2,7 @@ package engine
 
 // Push a directory to a git remote
 #GitPush: {
-	gitPush: {}
+	$dagger: task: _name: "GitPush"
 
 	input:  #FS
 	remote: string
@@ -11,7 +11,7 @@ package engine
 
 // Pull a directory from a git remote
 #GitPull: {
-	gitPull: {}
+	$dagger: task: _name: "GitPull"
 
 	remote: string
 	ref:    string

--- a/stdlib/europa/dagger/engine/spec/engine/image.cue
+++ b/stdlib/europa/dagger/engine/spec/engine/image.cue
@@ -11,7 +11,7 @@ package engine
 
 // Upload a container image to a remote repository
 #Push: {
-	push: {}
+	$dagger: task: _name: "Push"
 
 	// Target repository address
 	dest: #Ref
@@ -35,7 +35,7 @@ package engine
 
 // Download a container image from a remote repository
 #Pull: {
-	pull: {}
+	$dagger: task: _name: "Pull"
 
 	// Repository source ref
 	source: #Ref
@@ -66,8 +66,9 @@ package engine
 #Ref: string
 
 // Build a container image using buildkit
+// FIXME: rename to #Dockerfile to clarify scope
 #Build: {
-	build: {}
+	$dagger: task: _name: "Build"
 
 	// Source directory to build
 	source: #FS

--- a/stdlib/europa/dagger/engine/spec/engine/secret.cue
+++ b/stdlib/europa/dagger/engine/spec/engine/secret.cue
@@ -2,5 +2,5 @@ package engine
 
 // An external secret
 #Secret: {
-	_secret: ID: string
+	$dagger: secret: _id: string
 }

--- a/stdlib/europa/dagger/engine/spec/engine/service.cue
+++ b/stdlib/europa/dagger/engine/spec/engine/service.cue
@@ -1,6 +1,7 @@
 package engine
 
 // An external network service
+// FIXME: rename to endpoint?
 #Service: {
-	_service: ID: string
+	$dagger: service: _id: string
 }

--- a/stdlib/europa/dagger/engine/spec/engine/stream.cue
+++ b/stdlib/europa/dagger/engine/spec/engine/stream.cue
@@ -2,5 +2,5 @@ package engine
 
 // A stream of bytes
 #Stream: {
-	_stream: ID: string
+	$dagger: stream: _id: string
 }


### PR DESCRIPTION
## Summary

This PR implements the *Great Design Compromise of December 16, 2021*, [summarized below](https://github.com/dagger/dagger/pull/1234#issuecomment-996166161).

Note I am incorporating the tweak suggested by @talentedmrjones of using `task: _name` rather than `task: _id`.

```
// Core types (e.g. #FS)
#FS: {
  $dagger: fs: _id: string
}

// Tasks (e.g. #Exec)
#Exec: {
  $dagger: task: _name: "Exec"
}
```


## Related PRs

* Spec change: #1234 (this PR)
* Implementation change: #1242.

## Future issues

See #1241 . Note that we are kicking this can down the road.

## Original proposal

Below is my original proposal, for historical record. Most of the comments below are in response to this.

> This is our plan B, in case it is confirmed that we can’t rely on hidden fields for matching internal types in disjunctions, the way we hoped to.
> 
> Context from Discord:
> 
> > Quick summary of next steps:
> > 
> > 1. [Joel] is going to check with CUE devs whether this is a bug or feature. If we’re lucky, it’s a bug, they fix it next week, and we can pretend this conversation never happened.
> > 
> > 2. We discussed plan B. There are some variations & bikeshedding opportunities, but basically it revolves around using a visible field, while making it as non-intrusive as possible to the developer, and minimizing risk of dev error. [Solomon] will draft a proposal to kickoff bikeshedding.
> > 
> > TLDR: we have a path to shipping Europa no matter what, without major changes to the codebase or APIs.
> 
> ## Rationale
> 
> In preparation for bikeshedding, here is my rationale for this design.
> 
> * We are making “10x better DX” a key differentiator of Dagger. Therefore we should take every opportunity to make the DX better, even to the last detail.
> * In this case, the opportunity is to make our internal type system as easy to understand and consistent as possible, for 2 audiences: 1) developers who will evaluate their Dagger config in full detail (for debug, testing, learning etc), and 2) developers that will bother to read the CUE files of our engine API. Yes, those will be mostly advanced developers. But that doesn’t mean they don’t appreciate consistency and clarity. Experts aren’t masochists.
> * With that in mind: we are forced to transform some hidden fields into public fields, because we can’t rely on hidden fields for matching as we hoped.
> * One option is to change only some of the fields (so-called “core types”: FS, Secret, Service, Stream) since they are the only ones affected by the limitation of hidden fields. This would result in an inconsistent set of fields: some hidden, some visible.
> * This inconsistency would compound an existing inconsistency in the current type system. Specifically: there are 2 types of hidden fields: `_type: “Foo”` and `_foo: {}`.
>   * The inconsistency between field naming schemes is a problem: all these fields are looked up in some way by our Go implementation; it’s not sufficient to say “we use those fields in two different ways internally, so the inconsistency makes sense to us. Read the go code base and it will make sense to you too”.
>   * Additionally, the choice of `_type` itself is also a problem. It creates confusion with our term “core types” (which don’t have a `_type` field), and it’s generally too broad: does lack of `_type` indicate the lack of a type? This will cause confusion.
> * TLDR: rather than add an extra layer of inconsistency with this change, let’s use it as an opportunity to clean up inconsistency
> 
> Hence the proposed design rules:
> 
> * If a CUE type is special to the Go engine implementation, it must always have a `$dagger` field. This field is used to differentiate between specific tasks, FS trees, sefrets, etc. It also holds additional information filled by the runtime, eg. IDs.
> * If a CUE type does not have a `$dagger` field, it is not special to the Go engine implementation
> * There are no hidden fields. This PR does not remove the hidden fields under `inputs`, because they have been created outside of the spec, but I recommend removing them too.
> 
> cc @samalba @aluzzardi @jlongtine @talentedmrjones hopefully this clarifies my thinking, it’s been a long day and we spent most of it talking about intricate abstract concepts. Hopefully async written discussion will help clarify and digest.