### PR TITLE
europa: up: support --output

### DIFF
--- a/cmd/dagger/cmd/up.go
+++ b/cmd/dagger/cmd/up.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 
 	"cuelang.org/go/cue"
@@ -121,8 +122,21 @@ func europaUp(ctx context.Context, cl *client.Client, args ...string) error {
 	}
 
 	return cl.Do(ctx, p.Context(), func(ctx context.Context, s solver.Solver) error {
-		if err := p.Up(ctx, s); err != nil {
+		computed, err := p.Up(ctx, s)
+		if err != nil {
 			return err
+		}
+
+		if output := viper.GetString("output"); output != "" {
+			data := computed.JSON().PrettyString()
+			if output == "-" {
+				fmt.Println(data)
+				return nil
+			}
+			err := os.WriteFile(output, []byte(data), 0600)
+			if err != nil {
+				lg.Fatal().Err(err).Str("path", output).Msg("failed to write output")
+			}
 		}
 
 		return nil
@@ -179,6 +193,7 @@ func checkInputs(ctx context.Context, env *environment.Environment) error {
 
 func init() {
 	upCmd.Flags().BoolP("force", "f", false, "Force up, disable inputs check")
+	upCmd.Flags().String("output", "", "Write computed output. Prints on stdout if set to-")
 
 	if err := viper.BindPFlags(upCmd.Flags()); err != nil {
 		panic(err)

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -86,7 +86,7 @@ func (p *Plan) registerLocalDirs() error {
 }
 
 // Up executes the plan
-func (p *Plan) Up(ctx context.Context, s solver.Solver) error {
+func (p *Plan) Up(ctx context.Context, s solver.Solver) (*compiler.Value, error) {
 	ctx, span := otel.Tracer("dagger").Start(ctx, "plan.Up")
 	defer span.End()
 
@@ -98,7 +98,7 @@ func (p *Plan) Up(ctx context.Context, s solver.Solver) error {
 		newRunner(p.context, s, computed),
 	)
 	if err := flow.Run(ctx); err != nil {
-		return err
+		return nil, err
 	}
 
 	if src, err := computed.Source(); err == nil {
@@ -109,9 +109,9 @@ func (p *Plan) Up(ctx context.Context, s solver.Solver) error {
 	// Check explicitly if the context is canceled.
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return nil, ctx.Err()
 	default:
-		return nil
+		return computed, nil
 	}
 }
 


### PR DESCRIPTION
Support `dagger up --output <file.json>` or `-` for stdout. This will
write the computed layer.

Can be used for tests, e.g.

```
run dagger up --output -
assert_output --partial foobar
```

Fixes #1220

/cc @samalba @talentedmrjones @jlongtine 