### PR TITLE
state: moved stdlib lock to upper function to fix race condition

### DIFF
--- a/stdlib/stdlib.go
+++ b/stdlib/stdlib.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-
-	"github.com/gofrs/flock"
 )
 
 var (
@@ -20,21 +18,9 @@ var (
 	ModuleName    = "alpha.dagger.io"
 	EnginePackage = fmt.Sprintf("%s/europa/dagger/engine", ModuleName)
 	Path          = path.Join("cue.mod", "pkg", ModuleName)
-	lockFilePath  = path.Join("cue.mod", "dagger.lock")
 )
 
 func Vendor(ctx context.Context, mod string) error {
-	lockFilePath := path.Join(mod, lockFilePath)
-	fileLock := flock.New(lockFilePath)
-	if err := fileLock.Lock(); err != nil {
-		return err
-	}
-
-	defer func() {
-		fileLock.Unlock()
-		os.Remove(lockFilePath)
-	}()
-
 	// Remove any existing copy of the universe
 	if err := os.RemoveAll(path.Join(mod, Path)); err != nil {
 		return err


### PR DESCRIPTION
This is to fix an issue occurring regularly on the CI with a race condition on fs operations.

```
# (in test file ./tasks.bats, line 9)
#   `"$DAGGER" --europa up ./pull.cue' failed
# 5:50PM FTL system | failed to load plan: import failed: load: open 
/home/runner/work/dagger/dagger/tests/tasks/pull/cue.mod/pkg/alpha.dagger.io/europa/dagger/engine/types.cue: 
no such file or directory
```