### PR TITLE
Fix naming for fs operation

### DIFF
--- a/plan/task/mkdir.go
+++ b/plan/task/mkdir.go
@@ -24,8 +24,8 @@ func (t *mkdirTask) Run(ctx context.Context, pctx *plancontext.Context, s solver
 		return nil, err
 	}
 
-	// Mode (int)
-	mode, err := v.Lookup("mode").Int64()
+	// Permissions (int)
+	permissions, err := v.Lookup("permissions").Int64()
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (t *mkdirTask) Run(ctx context.Context, pctx *plancontext.Context, s solver
 
 	// Add Mkdir operation on input llb state
 	outputState := inputState.File(
-		llb.Mkdir(path, fs.FileMode(mode), mkdirOpts...),
+		llb.Mkdir(path, fs.FileMode(permissions), mkdirOpts...),
 		withCustomName(v, "Mkdir %s", path),
 	)
 

--- a/plan/task/writefile.go
+++ b/plan/task/writefile.go
@@ -48,7 +48,7 @@ func (t *writeFileTask) Run(ctx context.Context, pctx *plancontext.Context, s so
 		return nil, err
 	}
 
-	mode, err := v.Lookup("mode").Int64()
+	permissions, err := v.Lookup("permissions").Int64()
 
 	if err != nil {
 		return nil, err
@@ -67,7 +67,7 @@ func (t *writeFileTask) Run(ctx context.Context, pctx *plancontext.Context, s so
 	}
 
 	outputState := inputState.File(
-		llb.Mkfile(path, fs.FileMode(mode), contents),
+		llb.Mkfile(path, fs.FileMode(permissions), contents),
 		withCustomName(v, "WriteFile %s", path),
 	)
 
@@ -77,11 +77,11 @@ func (t *writeFileTask) Run(ctx context.Context, pctx *plancontext.Context, s so
 		return nil, err
 	}
 
-	fs := pctx.FS.New(result)
+	outputFS := pctx.FS.New(result)
 
 	output := compiler.NewValue()
 
-	if err := output.FillPath(cue.ParsePath("output"), fs.MarshalCUE()); err != nil {
+	if err := output.FillPath(cue.ParsePath("output"), outputFS.MarshalCUE()); err != nil {
 		return nil, err
 	}
 

--- a/stdlib/europa/dagger/engine/fs.cue
+++ b/stdlib/europa/dagger/engine/fs.cue
@@ -11,8 +11,8 @@ package engine
 	// It can be nested (e.g : "/foo" or "/foo/bar")
 	path: string
 
-	// Permissions to set
-	mode: *0o755 | int
+	// Permissions of the directory
+	permissions: *0o755 | int
 
 	// If set, it creates parents' directory if they do not exist
 	parents: *true | false
@@ -43,8 +43,7 @@ package engine
 	// Contents to write
 	contents: string
 	// Permissions of the file
-	// FIXME: rename to 'permissions' for consistency
-	mode: int
+	permissions: int
 	// Output filesystem tree
 	output: #FS
 }

--- a/tests/tasks/mkdir/mkdir.cue
+++ b/tests/tasks/mkdir/mkdir.cue
@@ -16,10 +16,10 @@ engine.#Plan & {
 		}
 
 		writeChecker: engine.#WriteFile & {
-			input:    mkdir.output
-			path:     "/test/foo"
-			contents: "bar"
-			mode:     700
+			input:       mkdir.output
+			path:        "/test/foo"
+			contents:    "bar"
+			permissions: 700
 		}
 
 		readChecker: engine.#ReadFile & {

--- a/tests/tasks/mkdir/mkdir_failure_disable_parents.cue
+++ b/tests/tasks/mkdir/mkdir_failure_disable_parents.cue
@@ -17,10 +17,10 @@ engine.#Plan & {
 		}
 
 		writeChecker: engine.#WriteFile & {
-			input:    mkdir.output
-			path:     "/test/baz/foo"
-			contents: "bar"
-			mode:     700
+			input:       mkdir.output
+			path:        "/test/baz/foo"
+			contents:    "bar"
+			permissions: 700
 		}
 
 		readChecker: engine.#ReadFile & {

--- a/tests/tasks/mkdir/mkdir_parents.cue
+++ b/tests/tasks/mkdir/mkdir_parents.cue
@@ -16,10 +16,10 @@ engine.#Plan & {
 		}
 
 		writeChecker: engine.#WriteFile & {
-			input:    mkdir.output
-			path:     "/test/baz/foo"
-			contents: "bar"
-			mode:     700
+			input:       mkdir.output
+			path:        "/test/baz/foo"
+			contents:    "bar"
+			permissions: 700
 		}
 
 		readChecker: engine.#ReadFile & {

--- a/tests/tasks/writefile/writefile.cue
+++ b/tests/tasks/writefile/writefile.cue
@@ -10,10 +10,10 @@ engine.#Plan & {
 			source: "alpine:3.15.0@sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3"
 		}
 		write: engine.#WriteFile & {
-			input:    pull.output
-			path:     "/testing"
-			contents: "1,2,3"
-			mode:     700
+			input:       pull.output
+			path:        "/testing"
+			contents:    "1,2,3"
+			permissions: 700
 		}
 		readfile: engine.#ReadFile & {
 			input: write.output

--- a/tests/tasks/writefile/writefile_failure_diff_contents.cue
+++ b/tests/tasks/writefile/writefile_failure_diff_contents.cue
@@ -10,10 +10,10 @@ engine.#Plan & {
 			source: "alpine:3.15.0@sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3"
 		}
 		write: engine.#WriteFile & {
-			input:    pull.output
-			path:     "/testing"
-			contents: "1,2,3,4"
-			mode:     700
+			input:       pull.output
+			path:        "/testing"
+			contents:    "1,2,3,4"
+			permissions: 700
 		}
 		readfile: engine.#ReadFile & {
 			input: write.output


### PR DESCRIPTION
## Changes

- Rename `mode` to `permissions`
- Remove `output` from `#ReadFile`