### PR TITLE
Clean up code for `engine.#Scratch`

### DIFF
--- a/plancontext/fs.go
+++ b/plancontext/fs.go
@@ -33,13 +33,9 @@ func (fs *FS) Result() bkgw.Reference {
 	return fs.result
 }
 
-// func (fs *FS) FS() *solver.BuildkitFS {
-// 	return solver.NewBuildkitFS(fs.result)
-// }
-
 func (fs *FS) State() (llb.State, error) {
 	if fs.Result() == nil {
-		return llb.State{}, nil
+		return llb.Scratch(), nil
 	}
 	return fs.Result().ToState()
 }

--- a/stdlib/europa/dagger/engine/fs.cue
+++ b/stdlib/europa/dagger/engine/fs.cue
@@ -54,7 +54,6 @@ package engine
 
 // Produce an empty directory
 #Scratch: {
-	@dagger(notimplemented)
 	$dagger: task: _name: "Scratch"
 
 	output: #FS


### PR DESCRIPTION
- Clean up plancontext/fs.go code
- remove `@dagger(notimplemented)` from `engine.#Scratch`

Signed-off-by: Joel Longtine <joel@dagger.io>