### PR TITLE
universe: skip sanity check (done twice)

### DIFF
--- a/stdlib/universe.bats
+++ b/stdlib/universe.bats
@@ -12,6 +12,7 @@ setup() {
 }
 
 @test "cue-sanity-check" {
+  skip "Docs generation already validates the cue code of the library - disabled to avoid duplication"
   dagger -e sanity-check up
 }
 


### PR DESCRIPTION
I found out that the longest test on universe is this one (cue-sanity-check), ~3-4 minutes. This is test is no more necessary given that we are already checking the code syntax while generating the documentation.