### PR TITLE
Move dockerhub envvar to sops store

### DIFF
--- a/tests/secrets_sops.yaml
+++ b/tests/secrets_sops.yaml
@@ -1,4 +1,5 @@
 TestPAT: ENC[AES256_GCM,data:KYPnJTTCaEbEiBwODMDmOmZGx/Vu/4mOZPfRSjhBc239fPfHzDH75w==,iv:j9UFKfdRMfYg/3xw4dCoWbs0Zoy3czqRznlQrRvf4Sc=,tag:Pvd4UMFDOj8rLOwZJjsYpA==,type:str]
+DOCKERHUB_TOKEN: ENC[AES256_GCM,data:Nfk3PWIFHSJ73HqZmk1qG2x2A5TCZwnCez/hZJBdqG25c6D1,iv:eI7imptDvZOQdjMEfqsZAr4dXsd6fQKuXM0O9nZUBUs=,tag:Zvs0oiBYQOrSUv2a88h2Vw==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -14,8 +15,8 @@ sops:
             TG5YUDlFVzlRRFBCdEhsNVlVK1dMRTgKx1TPZWWQiaU8iMni03/ekG+m4rFCcaa4
             JI+ED2d+8411BgZtlss/ukQtwskidvYTvetyWw2jes6o1lhfDv5q2A==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-12-22T22:23:53Z"
-    mac: ENC[AES256_GCM,data:twjo6LyD0QFJoD1h5qh8SFy4XC5+2JHl6mUiUxOjLnSBwft1Ntnto3+2tzZBU6+o+v/Uo++vRoSrIkLARFt74x2xA7jZjc81e5yCkcS79bWSpZ8bA7e8/5hgkyYP5SlMAYsWKXPodmhgN7bwCa6vjZb4ZlFkJuBZrHtLeziVY1E=,iv:kgDj5lnLTgLPK38CcUVYdtE11d/gpFdHPP9hgoZQO9U=,tag:tP2E3t/jKoh2Fx6Z2X/+Tw==,type:str]
+    lastmodified: "2021-12-23T01:03:48Z"
+    mac: ENC[AES256_GCM,data:ExJbBZ0tcAituM/rGZnndXPE7eXqgyo4kjgg2QxL/aYL0posX6Th0e4P9nYng36oeG86CPtlnxrPyKneP3swfOTktAvJP5GP7omNNYlyBgxui2/N9KeXAT74sLvR2MMWrpLUI+TaYHRwv7kIc9cbtWSyrFWVv/rEv4to+i5CEF4=,iv:2FiLnOuUHJciPyk9PgtLIkV7RuHu+9yqlQbs0d9eot4=,tag:i+H2jL1LO7KSQ9gFEMxSzw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.1

--- a/tests/tasks.bats
+++ b/tests/tasks.bats
@@ -10,13 +10,13 @@ setup() {
 }
 
 @test "task: #Pull with auth" {
-    cd "$TESTDIR"/tasks/pull
-    "$DAGGER" --europa up ./pull_auth.cue
+    cd "$TESTDIR"
+    "$DAGGER" --europa up ./tasks/pull/pull_auth.cue
 }
 
 @test "task: #Push" {
-    cd "$TESTDIR"/tasks/push
-    "$DAGGER" --europa up ./push.cue
+    cd "$TESTDIR"
+    "$DAGGER" --europa up ./tasks/push/push.cue
 }
 
 @test "task: #ReadFile" {
@@ -86,7 +86,8 @@ setup() {
     "$DAGGER" --europa up ./labels.cue
     "$DAGGER" --europa up ./platform.cue
 
-    "$DAGGER" --europa up ./build_auth.cue
+    cd "$TESTDIR"
+    "$DAGGER" --europa up ./tasks/build/build_auth.cue
 }
 @test "task: #Scratch" {
     cd "$TESTDIR"/tasks/scratch

--- a/tests/tasks/build/build_auth.cue
+++ b/tests/tasks/build/build_auth.cue
@@ -6,8 +6,11 @@ import (
 
 engine.#Plan & {
 	inputs: {
-		directories: testdata: path:     "./testdata"
-		secrets: dockerHubToken: envvar: "DOCKERHUB_TOKEN"
+		directories: testdata: path: "./tasks/build/testdata"
+		secrets: dockerHubToken: command: {
+			name: "sops"
+			args: ["exec-env", "./secrets_sops.yaml", "echo $DOCKERHUB_TOKEN"]
+		}
 	}
 
 	actions: build: engine.#Build & {

--- a/tests/tasks/pull/pull_auth.cue
+++ b/tests/tasks/pull/pull_auth.cue
@@ -5,7 +5,10 @@ import (
 )
 
 engine.#Plan & {
-	inputs: secrets: dockerHubToken: envvar: "DOCKERHUB_TOKEN"
+	inputs: secrets: dockerHubToken: command: {
+		name: "sops"
+		args: ["exec-env", "./secrets_sops.yaml", "echo $DOCKERHUB_TOKEN"]
+	}
 	actions: pull: engine.#Pull & {
 		source: "daggerio/ci-test:private-pull@sha256:c74f1b1166784193ea6c8f9440263b9be6cae07dfe35e32a5df7a31358ac2060"
 		auth: [{

--- a/tests/tasks/push/push.cue
+++ b/tests/tasks/push/push.cue
@@ -6,7 +6,10 @@ import (
 )
 
 engine.#Plan & {
-	inputs: secrets: dockerHubToken: envvar: "DOCKERHUB_TOKEN"
+	inputs: secrets: dockerHubToken: command: {
+		name: "sops"
+		args: ["exec-env", "./secrets_sops.yaml", "echo $DOCKERHUB_TOKEN"]
+	}
 
 	#auth: [{
 		target:   "daggerio/ci-test:private-pull"


### PR DESCRIPTION
Some of our tasks require the DOCKERHUB_TOKEN env var.
This PR ports it to a sops secret

Currently, a weird behavior is happening on the `push` test. When secret is imported as an `envvar`, it works. Whereas, in `sops` format, it seems to break: 
```
3:12AM FTL system | failed to up environment: task failed: failed to authorize: failed to fetch oauth token: unexpected status: 401 Unauthorized
```

Signed-off-by: guillaume <guillaume.derouville@gmail.com>