### PR TITLE
Support for partially running a DAG

### DIFF
--- a/cmd/dagger/cmd/up.go
+++ b/cmd/dagger/cmd/up.go
@@ -143,10 +143,10 @@ func europaUp(ctx context.Context, cl *client.Client, args ...string) error {
 	lg := log.Ctx(ctx)
 
 	p, err := plan.Load(ctx, plan.Config{
-		Args: args,
-		With: viper.GetStringSlice("with"),
+		Args:   args,
+		With:   viper.GetStringSlice("with"),
+		Target: viper.GetString("target"),
 	})
-
 	if err != nil {
 		lg.Fatal().Err(err).Msg("failed to load plan")
 	}
@@ -225,6 +225,7 @@ func init() {
 	upCmd.Flags().BoolP("force", "f", false, "Force up, disable inputs check")
 	upCmd.Flags().String("output", "", "Write computed output. Prints on stdout if set to-")
 	upCmd.Flags().StringArrayP("with", "w", []string{}, "")
+	upCmd.Flags().StringP("target", "t", "", "Run a single target of the DAG (for debugging only)")
 
 	if err := viper.BindPFlags(upCmd.Flags()); err != nil {
 		panic(err)


### PR DESCRIPTION
Based of @samalba's proposal for CI https://github.com/dagger/dagger/discussions/1230

- This adds a `-t` / `--target` (placeholder name) flag to `dagger up`
- Only that part of the DAG will execute
- All the necessary dependencies will be executed as well

Example:

```cue
engine.#Plan & {
	actions: {
		image: engine.#Pull & {
			source: "alpine:3.15.0@sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3"
		}

		exec: engine.#Exec & {
			input: image.output
			args: ["sh", "-c", "echo -n hello world > /output.txt"]
		}
	}
}
```

- `dagger up -t actions.image` will only run `actions.image`
- `dagger up -t actions.exec` will run `actions.image` and then `actions.exec` (because `actions.image` is necessary to run `actions.exec`)
