### PR TITLE
engine: Task PreRun Hook

### DIFF
--- a/plan/task/task.go
+++ b/plan/task/task.go
@@ -29,6 +29,12 @@ type Task interface {
 	Run(ctx context.Context, pctx *plancontext.Context, s solver.Solver, v *compiler.Value) (*compiler.Value, error)
 }
 
+type PreRunner interface {
+	Task
+
+	PreRun(ctx context.Context, pctx *plancontext.Context, v *compiler.Value) error
+}
+
 // Register a task type and initializer
 func Register(typ string, f NewFunc) {
 	tasks.Store(typ, f)

--- a/tests/plan.bats
+++ b/tests/plan.bats
@@ -62,7 +62,7 @@ setup() {
   cd "$TESTDIR"
   run "$DAGGER" --europa up ./plan/inputs/directories/conflicting_values.cue
 	assert_failure
-	assert_output --partial 'failed to up environment: actions.verify.contents: conflicting values "local directory" and "local dfsadf"'
+	assert_output --partial 'conflicting values "local directory" and "local dfsadf"'
 }
 
 @test "plan/inputs/secrets exec" {


### PR DESCRIPTION
Tasks now have a PreRun hook that gets called before buildkit kicks in.
Allows to support local access without special casing.

/cc @talentedmrjones @samalba @jlongtine 