### PR TITLE
docs: fix color contrast of admonitions

### DIFF
--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -636,6 +636,3 @@ img[alt="github-contribute"] {
   $caution: "/img/Dagger_Icons_Caution.svg",
   $danger: "/img/Dagger_Icons_Danger.svg"
 );
-
-$alert: secondary, success, info, warning, danger;
-


### PR DESCRIPTION
Color contrast in adomonitions is so low:

* Light mode : `<code>`
* Dark mode : `<div class="admonition-content">`

This happens because custom style for `<code>` overrides original colors.
Fix this.


<details>

|  Mode |before   | after  |
|---|---|---|
| Light  | ![スクリーンショット 2022-01-02 19 41 18](https://user-images.githubusercontent.com/9415800/147873818-e9e31fa1-a552-4aea-b9ed-ce931269ea52.png) |![スクリーンショット 2022-01-02 19 46 09](https://user-images.githubusercontent.com/9415800/147873825-88221d7b-7ad6-41ea-8303-2d495a8e5570.png)|
| Dark  | ![スクリーンショット 2022-01-02 19 41 36](https://user-images.githubusercontent.com/9415800/147873821-f9650c58-782c-4af2-87b4-ef3d6debbba7.png)  | ![スクリーンショット 2022-01-02 19 46 23](https://user-images.githubusercontent.com/9415800/147873826-09899a5d-feca-4664-a98b-a508353384bb.png) |




</details>

Signed-off-by: satotake <doublequotation@gmail.com>