### PR TITLE
Fix Kubernetes hello-world-example URL 404

### DIFF
--- a/stdlib/kubernetes/tests/kubernetes.cue
+++ b/stdlib/kubernetes/tests/kubernetes.cue
@@ -50,7 +50,7 @@ TestLinkApply: {
 	resources: #Resources & {
 		kubeconfig: TestKubeconfig
 		namespace:  "dagger-test"
-		url:        "https://raw.githubusercontent.com/mstrzele/intro-to-k8s/master/hello-world-pod.yaml"
+		url:        "https://gist.githubusercontent.com/grouville/04402633618f3289a633f652e9e4412c/raw/293fa6197b78ba3fad7200fa74b52c62ec8e6703/hello-world-pod.yaml"
 	}
 
 	// Verify deployment


### PR DESCRIPTION
CI failed: https://github.com/dagger/dagger/runs/4683947291?check_suite_focus=true#step:9:372

It is due to a 404 on a Kubernetes config, which I forked on my personal GitHub account to avoid happening again on the future.
This PR fixes it

Signed-off-by: guillaume <guillaume.derouville@gmail.com>