### PR TITLE
Fix: update github PAT as last one is outdated

### DIFF
--- a/stdlib/.dagger/env/git-commit/values.yaml
+++ b/stdlib/.dagger/env/git-commit/values.yaml
@@ -3,7 +3,7 @@ plan:
 name: git-commit
 inputs:
     TestAuthToken:
-        secret: ENC[AES256_GCM,data:1Cmlm9+Hg1kwskssscbC3INAB38J1dro+PASRZK+4B/2WkRGTbBTMg==,iv:3nvZxc95XVCzFFxMAdljOhRRoHmAGYCbeJ7EZUuXud4=,tag:qZOtm5BDjqQRHel0/PaKfA==,type:str]
+        secret: ENC[AES256_GCM,data:1F5Km+lgtvwkMIOoNRvnjbxUkeFp7xgNrk20Rbd0vlJGFurHpwSO6g==,iv:DgwDFxbMs80U8ICOdAWIWfPy9BLIzM6sSPHXe5gE+y8=,tag:sQ0al8wERZdvtgUZYe4pTA==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -19,8 +19,8 @@ sops:
             M3RnUDF5QlhhZUV4NHF5ZWhkcHVrNmcKUJIummOk3FX1Bert7gaMtbMpbosIf/d3
             HBATJRng4VNmcSimSh14pDRxyW0NdIPA+oL4tidwLVbQQv/74+IGKg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-12-02T22:20:28Z"
-    mac: ENC[AES256_GCM,data:9BqOV7es6wzCTRPqPyM35z8MMKbVNjmqZhaS+zXib2IKSNIE0D3WvpAhWVmKUZnTTwvEBj0in/Dgv12DxfjQ1Q7dLDARLaB01T3lB7nrgWiePIOl8CEiB7gf8IPv08Md5V0+pCOL2bZ6RSd4byl0JJ5lIVr3v+AupotcecYb9cU=,iv:CMrEJ/RPjVJrOlrQqO7ks3ByWbzfB4y/Z3g6kOxezbQ=,tag:d0WfZbbEGpakPaWlMLYCgA==,type:str]
+    lastmodified: "2022-01-03T17:48:06Z"
+    mac: ENC[AES256_GCM,data:EamKomihsz84e/FyyVRAOAxzI1CsWstMfTa4DDIouO/7Z3+70KLm82IfS/FAiv8dYhj8d7z13JFXCJIpaBwalt7KhagCGza8xcaEMteDvO17SPwhD82mZNqmxmiv6504UXhjRoG5nF/uRRC6WDmt6IAFtEHWfdw44Hu1PMAlhaM=,iv:Pr+RgNvQTRjEHop1BKbAJ4ASZRj8wox7pmlpUeUGk9Y=,tag:FXrUTLYQLSxPajQ+MoKmLw==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1

--- a/stdlib/.dagger/env/git-repo/values.yaml
+++ b/stdlib/.dagger/env/git-repo/values.yaml
@@ -3,7 +3,7 @@ plan:
 name: git-repo
 inputs:
     TestPAT:
-        secret: ENC[AES256_GCM,data:6yF+JIrsRkdWWNDCiHTUomepoi3lJsDevFghc+mQW692elAi/ZCyuQ==,iv:u9/OKUBmjMTyPBtB5DjZea1uPO6dmOqS7/34U6y1Y6Q=,tag:W/Irs3Dq2pSJ+jG6WQ9Tvg==,type:str]
+        secret: ENC[AES256_GCM,data:SvsXkYYhHr89mL1Szg5vDJVemUXVkZvz8g697jTmt2ug61rrDD2ipA==,iv:a7pRsZvawsxqWXPvqCMilOoLdHwdG85m48FkD6ACSh4=,tag:8xkQ/ESO0oqtv99eAPfjdw==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -19,8 +19,8 @@ sops:
             TmhJNisyamw3d244aGVJSEVFVUVLZGsKvd+nowA0CLXQbdvyI4J0lBjs9vdISWlo
             gGvR49uul3Z8raVWXFUzsyQ8xTvYNg0ovynFG2KdagSKr1DlhKMBEQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-12-02T22:22:03Z"
-    mac: ENC[AES256_GCM,data:4M+/4o85QGxJaBpExMHmKGLGLBW9FKOkQ4njBGV//gklYuYCy7sdAF4/r0J96R5DDL9KWiN49SlAKoBx5j5w3MyIWsZcNSrAFH0gsezNlTYsFh3sVXtIL3F4FTVMV6kV795NDTAY9inyOoX7MgoHtE9mvf8voYmj8YPJGOmP8nw=,iv:tgfXXxH2iuNuJCkJUN2RZqCw+r5KAcGfScV6+f89Sws=,tag:wiNhGbDjXwzdQ3EQn1r/PA==,type:str]
+    lastmodified: "2022-01-03T17:42:22Z"
+    mac: ENC[AES256_GCM,data:sbdzqKrYToYjG44St3I/TeYGVowCTFmzMGvf0EASAtRApo5Zj04Ezv7yoNwMq+hzTky9PUxLhpjhXTUzKCDP70NE3XzJlYm0f4GK4H75/oZ28++kg8O9I0lUPES/Vrmeg5qwYEqoS5J5B5bYWLDBXMnBZxDTkOzSXUCgcrg60vU=,iv:s9c5tRvaROW30Zwc5U+W7qBtFH7C/OBa3ZF9c9yioYI=,tag:ZYI2Xbg2PMBsonrFo6OhMA==,type:str]
     pgp: []
     encrypted_suffix: secret
     version: 3.7.1


### PR DESCRIPTION
Updates Github PAT used as the previous one is outdated

Signed-off-by: guillaume <guillaume.derouville@gmail.com>