### PR TITLE
Fix trivy termcaps loop on error

### DIFF
--- a/stdlib/trivy/image.cue
+++ b/stdlib/trivy/image.cue
@@ -22,6 +22,7 @@ import (
 		"--exit-code":      *"1" | string
 		"--ignore-unfixed": *"" | string
 		"--format":         *"table" | string
+		"--output":         *"output" | string
 	}
 
 	ctr: os.#Container & {


### PR DESCRIPTION
Solves #1124

The solution is not ideal because we redirect part of the output to a file. However, it works well, both for the new logger and the `plain-format`.
It solves the simili-infinite loop due to the termcap conflict between our logs and the trivy binary + a summary remains [we just don't see the details]:

Current output, which is working:
```
PM INF TestGCPClient.verify.ctr | #39 15.73 gcr.io/dagger-ci/test:test-gcr-nakbwreqejdd (alpine 3.15.0)
11:35PM INF TestGCPClient.verify.ctr | #39 15.73 ===========================================================
11:35PM INF TestGCPClient.verify.ctr | #39 15.73 Total: 0 (HIGH: 0, CRITICAL: 0)
```

Failures basically have the same output as the one above, but don't conflict anymore

Signed-off-by: guillaume <guillaume.derouville@gmail.com>