### PR TITLE
Re-enable GHA Cache (not tested since latest Buildkit release)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,8 @@ jobs:
       - name: Integration test
         env:
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        #   DAGGER_CACHE_TO: "type=gha,mode=max,scope=test-integration"
-        #   DAGGER_CACHE_FROM: "type=gha,mode=max,scope=test-integration"
+          DAGGER_CACHE_TO: "type=gha,mode=max,scope=test-integration"
+          DAGGER_CACHE_FROM: "type=gha,mode=max,scope=test-integration"
         run: |
           env
           make core-integration
@@ -162,9 +162,9 @@ jobs:
         uses: crazy-max/ghaction-github-runtime@v1
 
       - name: Universe Test
-        # env:
-        #   DAGGER_CACHE_TO: "type=gha,mode=max,scope=test-universe"
-        #   DAGGER_CACHE_FROM: "type=gha,mode=max,scope=test-universe"
+        env:
+          DAGGER_CACHE_TO: "type=gha,mode=max,scope=test-universe"
+          DAGGER_CACHE_FROM: "type=gha,mode=max,scope=test-universe"
         run: |
           make universe-test
 
@@ -240,8 +240,8 @@ jobs:
         uses: crazy-max/ghaction-github-runtime@v1
 
       - name: Documentation Test
-        # env:
-        #   DAGGER_CACHE_TO: "type=gha,mode=max,scope=test-docs"
-        #   DAGGER_CACHE_FROM: "type=gha,mode=max,scope=test-docs"
+        env:
+          DAGGER_CACHE_TO: "type=gha,mode=max,scope=test-docs"
+          DAGGER_CACHE_FROM: "type=gha,mode=max,scope=test-docs"
         run: |
           make doc-test


### PR DESCRIPTION
From @samalba :
```
- Github actions's cache is still disabled on the CI, we should check if it now works with the latest buildkit and possibly enable it (it'll fix a bunch of CI slowness)
```
This PR re-enables it, let's hope it works 🤞 

Signed-off-by: guillaume <guillaume.derouville@gmail.com>