### PR TITLE
Ensure dockerfile frontend requests are Solved

### DIFF
--- a/plan/task/build.go
+++ b/plan/task/build.go
@@ -116,13 +116,11 @@ func (t *buildTask) dockerfile(ctx context.Context, pctx *plancontext.Context, s
 	}
 
 	st, err := ref.ToState()
-
 	if err != nil {
 		return nil, err
 	}
 
 	solvedRef, err := s.Solve(ctx, st, pctx.Platform.Get())
-
 	if err != nil {
 		return nil, err
 	}

--- a/solver/solver.go
+++ b/solver/solver.go
@@ -120,6 +120,9 @@ func (s Solver) ResolveImageConfig(ctx context.Context, ref string, opts llb.Res
 
 // Solve will block until the state is solved and returns a Reference.
 func (s Solver) SolveRequest(ctx context.Context, req bkgw.SolveRequest) (*bkgw.Result, error) {
+	// makes Solve() to block until LLB graph is solved. otherwise it will
+	// return result (that you can for example use for next build) that
+	// will be evaluated on export or if you access files on it.
 	req.Evaluate = true
 	res, err := s.opts.Gateway.Solve(ctx, req)
 	if err != nil {
@@ -150,11 +153,6 @@ func (s Solver) Solve(ctx context.Context, st llb.State, platform specs.Platform
 	// call solve
 	res, err := s.SolveRequest(ctx, bkgw.SolveRequest{
 		Definition: def,
-
-		// makes Solve() to block until LLB graph is solved. otherwise it will
-		// return result (that you can for example use for next build) that
-		// will be evaluated on export or if you access files on it.
-		Evaluate: true,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Force another solve, so that the LLB created by the
dockerfile.v0 frontend actually runs, as we expect it to.

Also, enforce Evaluate: true on SolveRequests that run through the Solver

Signed-off-by: Joel Longtine <joel@dagger.io>