### PR TITLE
README: fix linter errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Using Dagger, software teams can develop powerful CICD pipelines with minimal ef
 
 ## Useful links
 
-- [Join the Dagger community on Discord](https://discord.gg/ufnyBtc8uY)
-- [Install from a binary release](https://docs.dagger.io/1001/install/)
-- [Build from source](https://docs.dagger.io/1001/install/#option-4-install-from-source)
-- [How to contribute](CONTRIBUTING.md)
+* [Join the Dagger community on Discord](https://discord.gg/ufnyBtc8uY)
+* [Install from a binary release](https://docs.dagger.io/1001/install/)
+* [Build from source](https://docs.dagger.io/1001/install/#option-4-install-from-source)
+* [How to contribute](CONTRIBUTING.md)


### PR DESCRIPTION
For some reason, these linter errors just started appearing, even though those lines have been present for a long time. It looks like my last PR on README triggered it, even though I didn’t touch those lines.