### PR TITLE
Add a GitHub Workflow that auto-releases regularly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,13 @@
 name: Release
+
+# Only a single job with this concurrency can run at any given time
+concurrency: release
+
 on:
   push:
     tags:
     - v*
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -1,0 +1,66 @@
+name: "Trigger Release"
+
+# Only a single job with this concurrency can run at any given time
+concurrency: release
+
+on:
+  # This runs on a schedule by default:
+  schedule:
+    # https://crontab.guru/#6_17_*_*_2
+    # Every Tuesday at 5:06pm UTC & 9:06am US West Coast.
+    # GitHub Actions defaults to UTC:
+    - cron: '6 17 * * 2'
+    # There is high load on GitHub Actions at the top of the hour:
+    #
+    #     Note: The schedule event can be delayed during periods of high loads of
+    #     GitHub Actions workflow runs. High load times include the start of every
+    #     hour. To decrease the chance of delay, schedule your workflow to run at a
+    #     different time of the hour.
+    #
+    # So we run these at a special time, 9:06. Ask @gerhard about it.
+
+  # And it also supports manual triggering:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Custom tag (default bumps last tag) DO NOT prefix with v'
+        required: false
+
+jobs:
+  bump_version-tag-push:
+    name: "Bump version, tag & push"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check out"
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: "Ensure that all other checks have succeeded"
+        # https://github.com/lewagon/wait-on-check-action
+        uses: lewagon/wait-on-check-action@v1.0.0
+        with:
+          ref: ${{ github.ref }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10 # polls the GitHub API every 10 every seconds
+          running-workflow-name: "Bump version, tag & push"
+          allowed-conclusions: success
+
+      - name: "Tag so that a new release is triggered"
+        id: tag_version
+        # https://github.com/mathieudutour/github-tag-action
+        uses: mathieudutour/github-tag-action@v6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          fetch_all_tags: true
+          custom_tag: "${{ github.event.inputs.tag }}"
+          # This is OK for now, but let's revisit this around February 2022
+          release_branches: "there_are_only_prereleases_for_now"
+          # When we start auto-bumping patches/minors, consider removing pre-releases
+          pre_release_branches: "main"
+          append_to_pre_release_tag: "alpha"
+          # Set to true when you are testing / experimenting
+          dry_run: false
+        # This may be of interest when we need more control over the version bumps
+        # https://github.com/craig-day/compute-tag
+


### PR DESCRIPTION
Talking with @aluzzardi, we think that regular releases which happen with no intervention on our part would be a good idea.

The last Dagger release - [v0.1.0-alpha.31](https://github.com/dagger/dagger/releases/tag/v0.1.0-alpha.31) - was over 1 month ago, and there are many Europa-related changes which we want to make available in the [Dagger GitHub Action](https://github.com/marketplace/actions/dagger-action), as well as to users that do not build Dagger locally. The only thing that we need to do is create a new git tag & push. Remembering to do it, and then actually doing it doesn't always happen, and when it does, it's all ad-hoc.

We don't think that there should be more than 1 week of unreleased changes. While more often is better, and we may need to tweak this later, this is a decent starting point: **release at least every Tuesday, 5pm UTC & 9am SFO**.

The general consensus is to always be shipping. If we want to release an ad-hoc revision, we can still do it by triggering this GitHub Action manually.