### PR TITLE
Temporarly disable netlify and EKS tests

### DIFF
--- a/stdlib/universe.bats
+++ b/stdlib/universe.bats
@@ -80,6 +80,7 @@ setup() {
 }
 
 @test "aws: eks" {
+  skip "Temporary skip until porting to localstack"
   dagger -e aws-eks up
 }
 


### PR DESCRIPTION
Netlify-cli got a regression from one of its libraries: prettyjson.
Cf. https://github.com/rafeca/prettyjson/issues/58

This PR comments the test until netlify gets fixed. Shouldn't take that long
Cf. https://github.com/netlify/cli/issues/4011

Signed-off-by: guillaume <guillaume.derouville@gmail.com>