### PR TITLE
Fix netlify test

### DIFF
--- a/pkg/alpha.dagger.io/netlify/netlify.cue
+++ b/pkg/alpha.dagger.io/netlify/netlify.cue
@@ -68,7 +68,7 @@ import (
 			}
 		}
 		setup: [
-			"yarn global add netlify-cli@8.6.1",
+			"yarn global add netlify-cli@8.6.21",
 		]
 		// set in netlify.sh.cue
 		// FIXME: use embedding once cue supports it

--- a/pkg/alpha.dagger.io/universe.bats
+++ b/pkg/alpha.dagger.io/universe.bats
@@ -43,7 +43,6 @@ setup() {
 }
 
 @test "netlify" {
-  skip "Temporary skip due to a regression in one of netlify's libraries"
   dagger -e netlify up
 }
 


### PR DESCRIPTION
Netlify test was breaking due to a regression in prettyjson library.
The Netlify team fixed the cli, upgrading it to version 8.6.21 solves the issue

Closes #1385

pairs: @jlongtine

Signed-off-by: guillaume <guillaume.derouville@gmail.com>