### PR TITLE
exec: mount: improve error reporting on non-concrete mounts

### DIFF
--- a/plan/task/exec.go
+++ b/plan/task/exec.go
@@ -139,6 +139,10 @@ func (t execTask) mountAll(pctx *plancontext.Context, mounts *compiler.Value) ([
 		return nil, err
 	}
 	for _, mnt := range fields {
+		if mnt.Value.Lookup("dest").IsConcreteR() != nil {
+			return nil, fmt.Errorf("mount %q is not concrete", mnt.Selector.String())
+		}
+
 		dest, err := mnt.Value.Lookup("dest").String()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Because of the mount disjunction, passing a non-concrete #FS results in
CUE being confused as to what type of mount it is (Cache, FS, Secret,
...).

This adds an explicit error check.

Signed-off-by: Andrea Luzzardi <aluzzardi@gmail.com>
