### PR TITLE
fix wrong gcpcloudrun package url

### DIFF
--- a/docs/learn/1011-package-manager.md
+++ b/docs/learn/1011-package-manager.md
@@ -39,7 +39,7 @@ That will create 2 directories: `.dagger` and `cue.mod` where our package will r
 
 ### Install
 
-In our example we will use `gcpcloudrun` package from [github](https://github.com/dagger/packages/blob/main/gcpcloudrun/source.cue)
+In our example we will use `gcpcloudrun` package from [github](https://github.com/tjovicic/dagger-modules/tree/main/gcpcloudrun)
 Let's first add it to our `source.cue` file:
 
 ```cue title="./source.cue"


### PR DESCRIPTION
Issues closed by this change: https://github.com/dagger/dagger/issues/1218

Signed-off-by: jffarge <jf@dagger.io>