### PR TITLE
Universe: docker: remove leftover hack

### DIFF
--- a/pkg/universe.dagger.io/docker/build.cue
+++ b/pkg/universe.dagger.io/docker/build.cue
@@ -32,7 +32,7 @@ import (
 	input?: #Image
 	output: #Image
 	...
-} | #Run
+}
 
 // Build step that copies files into the container image
 #Copy: {


### PR DESCRIPTION
Remove a leftover from a hack (since removed) in `docker.#Run`. The hack was to explicitly detect `docker.#Run` in the implementation of `docker.#Build`, to allow using it as a build step even though it did not match the interface.

I have since replaced this hack with another hack: `docker.#Run` implements the build step interface (but at the cost of making the interface slightly less readable. This can be resolved separately).