### PR TITLE
Universe: fix "cue eval"

### DIFF
--- a/pkg/universe.dagger.io/cue.mod/pkg/dagger.io
+++ b/pkg/universe.dagger.io/cue.mod/pkg/dagger.io
@@ -1,1 +1,1 @@
-../../../stdlib/europa
+../../../dagger.io


### PR DESCRIPTION
Fix a symlink from universe to local version of `dagger.io`.