### PR TITLE
Fix docker.#Run compatibility with docker.#Build

### DIFF
--- a/pkg/universe.dagger.io/docker/build.cue
+++ b/pkg/universe.dagger.io/docker/build.cue
@@ -11,19 +11,19 @@ import (
 	output: #Image
 
 	// Generate build DAG from linerar steps
-	dag: {
+	_dag: {
 		for idx, step in steps {
 			"\(idx)": step & {
 				// connect input to previous output
 				if idx > 0 {
-					input: dag["\(idx-1)"].output
+					input: _dag["\(idx-1)"].output
 				}
 			}
 		}
 	}
 
-	if len(dag) > 0 {
-		output: dag["\(len(dag)-1)"].output
+	if len(_dag) > 0 {
+		output: _dag["\(len(_dag)-1)"].output
 	}
 }
 


### PR DESCRIPTION
This is an alternative to #1434, by keeping `docker.#Run` compatible with `docker.#Build`.

More context in https://github.com/dagger/dagger/pull/1434#issuecomment-1013719632.

Signed-off-by: Helder Correia

/cc @shykes