### PR TITLE
Make changelog.com highlevel Europa have fewer failures

### DIFF
--- a/pkg/universe.dagger.io/examples/changelog.com/highlevel/ci.cue
+++ b/pkg/universe.dagger.io/examples/changelog.com/highlevel/ci.cue
@@ -42,8 +42,8 @@ dagger.#Plan & {
 					mix: {
 						env:        "prod"
 						app:        _appName
-						depsCache:  "readonly"
-						buildCache: "readonly"
+						depsCache:  "private"
+						buildCache: "private"
 					}
 					workdir: _
 					// FIXME: remove copy-pasta
@@ -52,7 +52,7 @@ dagger.#Plan & {
 							// FIXME: do we need an ID here?
 							id: "\(mix.app)_assets_node_modules"
 							// FIXME: does this command need write access to node_modules cache?
-							concurrency: "readonly"
+							concurrency: "private"
 						}
 						dest: "\(workdir)/node_modules"
 					}
@@ -71,14 +71,16 @@ dagger.#Plan & {
 			assets: docker.#Build & {
 				steps: [
 					// 1. Start from dev runtime build
-					build,
+					{
+						output: build.output
+					},
 					// 2. Build web assets
 					mix.#Run & {
 						mix: {
 							env:        "dev"
 							app:        _appName
-							depsCache:  "readonly"
-							buildCache: "readonly"
+							depsCache:  "private"
+							buildCache: "private"
 						}
 						// FIXME: move this to a reusable def (yarn package? or private?)
 						mounts: nodeModules: {

--- a/pkg/universe.dagger.io/examples/changelog.com/highlevel/elixir/mix/mix.cue
+++ b/pkg/universe.dagger.io/examples/changelog.com/highlevel/elixir/mix/mix.cue
@@ -71,9 +71,9 @@ import (
 	}
 	docker.#Run
 	env: MIX_ENV: mix.env
+	workdir: string
 	{
 		mix: depsCache: string
-		workdir: string
 		mounts: depsCache: {
 			contents: engine.#CacheDir & {
 				id:          "\(mix.app)_deps"
@@ -84,7 +84,6 @@ import (
 	} | {}
 	{
 		mix: buildCache: string
-		workdir: string
 		mounts: buildCache: {
 			contents: engine.#CacheDir & {
 				id:          "\(mix.app)_deps"

--- a/pkg/universe.dagger.io/examples/changelog.com/highlevel/gerhard/config.cue
+++ b/pkg/universe.dagger.io/examples/changelog.com/highlevel/gerhard/config.cue
@@ -1,0 +1,3 @@
+package ci
+
+inputs: directories: app: path: "/Users/gerhard/github.com/thechangelog/changelog.com/"


### PR DESCRIPTION
We fixed a few issues with @shykes & @jlongtine, and @talentedmrjones
gave us this great command to run:

```console
    cd pkg/universe.dagger.io/examples/changelog.com/highlevel
    dagger up --europa ./gerhard --log debug --log-format plain
    7:42PM DBG system | detected buildkit config    haveHostNetwork=true isActive=true version=v0.9.3
    7:42PM DBG system | loading plan    args=[
        "./gerhard/"
    ]
    7:42PM DBG system | vendoring packages    mod=/Users/gerhard/github.com/gerhard/dagger/pkg/universe.dagger.io
    7:42PM DBG system | spawning buildkit job    attrs=null localdirs={
        "/Users/gerhard/github.com/thechangelog/changelog.com/": "/Users/gerhard/github.com/thechangelog/changelog.com"
    }
    7:42PM INF actions.test.db.pull._op | computing
    7:42PM INF actions.test.run._exec | computing
    7:42PM INF inputs.directories.app | computing
    7:42PM INF actions.dev.build._dag."0"._op | computing
    7:42PM INF actions.test.build._dag."0"._op | computing
    7:42PM ERR actions.test.run._exec | failed: invalid FS at path "actions.test.run._exec.input": FS is not set    duration=0s
    7:42PM DBG inputs.directories.app | loading local directory    path=/Users/gerhard/github.com/thechangelog/changelog.com/
    7:42PM ERR actions.dev.build._dag."0"._op | canceled    duration=0s
    7:42PM ERR actions.test.db.pull._op | canceled    duration=0s
    7:42PM ERR actions.test.build._dag."0"._op | canceled    duration=0s
    7:42PM ERR inputs.directories.app | canceled    duration=0s
    7:42PM FTL system | failed to up environment: task failed: actions.test.run._exec: invalid FS at path "actions.test.run._exec.input": FS is not set
```

The next step is to figure out why this is failing @jlongtine.