### PR TITLE
Add output values to plan

### DIFF
--- a/cmd/dagger/cmd/up.go
+++ b/cmd/dagger/cmd/up.go
@@ -158,16 +158,11 @@ func europaUp(ctx context.Context, cl *client.Client, args ...string) error {
 			return err
 		}
 
-		if output := viper.GetString("output"); output != "" {
-			data := computed.JSON().PrettyString()
-			if output == "-" {
-				fmt.Println(data)
-				return nil
-			}
-			err := os.WriteFile(output, []byte(data), 0600)
-			if err != nil {
-				lg.Fatal().Err(err).Str("path", output).Msg("failed to write output")
-			}
+		format := viper.GetString("output-format")
+		file := viper.GetString("output")
+
+		if err := plan.ListOutputs(ctx, p, computed, format, file); err != nil {
+			lg.Fatal().Err(err).Msg("failed to write output values")
 		}
 
 		return nil
@@ -224,7 +219,8 @@ func checkInputs(ctx context.Context, env *environment.Environment) error {
 
 func init() {
 	upCmd.Flags().BoolP("force", "f", false, "Force up, disable inputs check")
-	upCmd.Flags().String("output", "", "Write computed output. Prints on stdout if set to-")
+	upCmd.Flags().String("output", "", "Write computed output values. Prints on stdout if empty")
+	upCmd.Flags().String("output-format", "plain", "Format for output values (plain, json, yaml)")
 	upCmd.Flags().StringArrayP("with", "w", []string{}, "")
 	upCmd.Flags().StringP("target", "t", "", "Run a single target of the DAG (for debugging only)")
 	upCmd.Flags().Bool("no-vendor", false, "Force up, disable inputs check")

--- a/pkg/dagger.io/dagger/plan.cue
+++ b/pkg/dagger.io/dagger/plan.cue
@@ -18,6 +18,8 @@ package dagger
 		directories: [name=string]: _#outputDirectory
 		// Export a string to a file
 		files: [name=string]: _#outputFile
+		// Write values to stdout or a file
+		values?: [name=string]: _
 	}
 
 	// Forward network services to and from the client

--- a/plan/outputvalues.go
+++ b/plan/outputvalues.go
@@ -1,0 +1,86 @@
+package plan
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/pkg/encoding/yaml"
+	"github.com/rs/zerolog/log"
+	"go.dagger.io/dagger/cmd/dagger/cmd/common"
+	"go.dagger.io/dagger/compiler"
+)
+
+func ListOutputs(ctx context.Context, p *Plan, computed *compiler.Value, format, file string) error {
+	lg := log.Ctx(ctx)
+	path := cue.ParsePath("outputs.values")
+
+	if !p.Source().LookupPath(path).Exists() {
+		return nil
+	}
+
+	out := compiler.NewValue()
+
+	if err := out.FillPath(cue.MakePath(), p.Source()); err != nil {
+		return err
+	}
+
+	if err := out.FillPath(cue.MakePath(), computed); err != nil {
+		return err
+	}
+
+	vals := out.LookupPath(path)
+
+	// Avoid confusion on missing values by forcing concreteness
+	if err := vals.IsConcreteR(); err != nil {
+		return err
+	}
+
+	s, err := decodeOutput(vals, format)
+	if err != nil {
+		return err
+	}
+
+	if file == "" {
+		lg.Info().Msg(fmt.Sprintf("Output:\n%v", s))
+		return nil
+	}
+
+	return os.WriteFile(file, []byte(s), 0600)
+}
+
+func decodeOutput(vals *compiler.Value, format string) (string, error) {
+	switch format {
+	case "json":
+		s := vals.JSON().PrettyString()
+		return s, nil
+
+	case "yaml":
+		s, err := yaml.Marshal(vals.Cue())
+		if err != nil {
+			return "", err
+		}
+		return s, nil
+
+	// The simplest and default case is to have outputs as
+	// a struct of strings and print it as a table.
+	case "plain", "":
+		buf := new(bytes.Buffer)
+		w := tabwriter.NewWriter(buf, 0, 4, 2, ' ', 0)
+		fmt.Fprintln(w, "Field\tValue")
+
+		if fields, err := vals.Fields(); err == nil {
+			for _, out := range fields {
+				fmt.Fprintf(w, "%s\t%s\n", out.Label(), common.FormatValue(out.Value))
+			}
+		}
+
+		w.Flush()
+		return buf.String(), nil
+	}
+
+	return "", fmt.Errorf("invalid --output-format %q", format)
+}

--- a/tests/plan.bats
+++ b/tests/plan.bats
@@ -153,6 +153,30 @@ setup() {
   assert [ ! -f "./test" ]
 }
 
+@test "plan/outputs/values" {
+  cd "$TESTDIR"/plan/outputs/values
+  rm -rf "./test.json"
+
+  run "$DAGGER" --europa up ./not_exists.cue
+  refute_output --partial "Output:"
+
+  run "$DAGGER" --europa up ./non_concrete.cue
+  assert_failure
+
+  run "$DAGGER" --europa up ./computed.cue
+  assert_output --partial "Output:"
+  assert_output --partial "sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3"
+
+  run "$DAGGER" --europa up --output-format yaml ./computed.cue
+  assert_output --partial "digest: sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3"
+
+  "$DAGGER" --europa up --output-format json --output test.json ./computed.cue
+  run jq -re '.test.config.cmd[0]' "./test.json"
+  assert_output "/bin/sh"
+
+  rm -rf "./test.json"
+}
+
 @test "plan/platform" {
    cd "$TESTDIR"
 

--- a/tests/plan/outputs/values/computed.cue
+++ b/tests/plan/outputs/values/computed.cue
@@ -1,0 +1,16 @@
+package main
+
+import "dagger.io/dagger"
+
+dagger.#Plan & {
+	actions: image: dagger.#Pull & {
+		source: "alpine:3.15.0@sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3"
+	}
+	outputs: values: {
+		test: {
+			config: actions.image.config
+			foo:    "bar"
+		}
+		digest: actions.image.digest
+	}
+}

--- a/tests/plan/outputs/values/non_concrete.cue
+++ b/tests/plan/outputs/values/non_concrete.cue
@@ -1,0 +1,10 @@
+package main
+
+import "dagger.io/dagger"
+
+dagger.#Plan & {
+	outputs: values: test: {
+		ok:    "foobar"
+		notok: string
+	}
+}

--- a/tests/plan/outputs/values/not_exists.cue
+++ b/tests/plan/outputs/values/not_exists.cue
@@ -1,0 +1,9 @@
+package main
+
+import "dagger.io/dagger"
+
+dagger.#Plan & {
+	actions: image: dagger.#Pull & {
+		source: "alpine:3.15.0@sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3"
+	}
+}


### PR DESCRIPTION
Closes #1351

Signed-off-by: Helder Correia

/cc @aluzzardi

## Why

Sometimes you want to show a few generated values at the end of the execution. This isn't available in Europa yet, and before that, there's probably outputs you didn't care about.

## What

Added `outputs: values` to the plan to present referenced values at the end, or save them into a file.

## How

If you're building an image, you may want to to get the new pushed reference, with digest:

```cue
dagger.#Plan & {
    actions: {
        build: push: docker.#Push & { ... }
        run: push: docker.#Push & { ... }
    }
    outputs: values: {
        build: actions.build.push.result
        run: actions.run.push.result
    }
}
```
Which outputs:
```
Output	Value
build	"registry.example.net/repo:build@sha256:1b2bd4200d734dd3fb819faf21b9352f973f67c55cc8d59addeafc602835461a"
run	"registry.example.net/repo:run@sha256:3eaa0b49e5ed5831cfa372cd8f62615012ec87d27401c08f28c7cb1a8bae949f"
```

Or you can save to a file and work with that:

```bash
$ dagger up --output-format json --output state.json
$ jq '.build' state.json
registry.example.net/repo:build@sha256:1b2bd4200d734dd3fb819faf21b9352f973f67c55cc8d59addeafc602835461a
```