### PR TITLE
value.Walk: fix data race

### DIFF
--- a/compiler/value.go
+++ b/compiler/value.go
@@ -185,7 +185,10 @@ func (v *Value) IsConcreteR(opts ...cue.Option) error {
 }
 
 func (v *Value) Walk(before func(*Value) bool, after func(*Value)) {
-	// FIXME: lock?
+	// FIXME: this is a long lock
+	v.cc.rlock()
+	defer v.cc.runlock()
+
 	var (
 		llBefore func(cue.Value) bool
 		llAfter  func(cue.Value)


### PR DESCRIPTION
Acquire a read lock when walking through a CUE value.

Fixes #1494

Signed-off-by: Andrea Luzzardi <aluzzardi@gmail.com>
