### PR TITLE
Default semver bump type when scheduled

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -6,10 +6,10 @@ concurrency: release
 on:
   # This runs on a schedule by default:
   schedule:
-    # https://crontab.guru/#6_17_*_*_2
-    # Every Tuesday at 5:06pm UTC & 9:06am US West Coast.
+    # https://crontab.guru/#6_21_*_*_2
+    # Every Tuesday at 9:06pm UTC & 1:06pm US West Coast.
     # GitHub Actions defaults to UTC:
-    - cron: '6 17 * * 2'
+    - cron: '6 21 * * 2'
     # There is high load on GitHub Actions at the top of the hour:
     #
     #     Note: The schedule event can be delayed during periods of high loads of
@@ -55,6 +55,7 @@ jobs:
       - name: "Create next release tag"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SEMVER_BUMP: ${{ github.event.inputs.release_type }}
         run: |
           if [[ -n "${{ github.event.inputs.release_version }}" ]]
           then
@@ -65,7 +66,7 @@ jobs:
             # Rather than installing it on every run, we commit it locally so that we have everything we need locally
             # wget https://raw.githubusercontent.com/fsaintjacques/semver-tool/3.3.0/src/semver
             # https://github.com/fsaintjacques/semver-tool
-            next_release_version="v$(./semver bump ${{ github.event.inputs.release_type }} $previous_release_version)"
+            next_release_version="v$(./semver bump ${SEMVER_BUMP:=prerel alpha..}  $previous_release_version)"
           fi
           echo "NEXT RELEASE VERSION: $next_release_version"
           gh api -X POST /repos/:owner/:repo/git/refs \


### PR DESCRIPTION
When this workflow is scheduled, instead of triggered manually, we need a default bump type, otherwise it will fail:
https://github.com/dagger/dagger/runs/4942069177?check_suite_focus=true#step:5:11

If the SEMVER_BUMP environment variable is not set via an input, which will be the case for all scheduled runs, default to the same 'prerel alpha..' value.

This is a Ship & Show follow-up to https://github.com/dagger/dagger/pull/1476

cc @aluzzardi 

---
[What is Ship / Show / Ask?](https://martinfowler.com/articles/ship-show-ask.html)