### PR TITLE
Implements #DecodeSecret as a wrapper to #TransformSecret

### DIFF
--- a/pkg/dagger.io/dagger/utils.cue
+++ b/pkg/dagger.io/dagger/utils.cue
@@ -1,6 +1,8 @@
 package dagger
 
 import (
+	"encoding/yaml"
+	"encoding/json"
 	"dagger.io/dagger/engine"
 )
 
@@ -17,7 +19,7 @@ import (
 // Select a subdirectory from a filesystem tree
 #Subdir: {
 	// Input tree
-	input: #FS
+	input: engine.#FS
 
 	// Path of the subdirectory
 	// Example: "/build"
@@ -32,5 +34,27 @@ import (
 	}
 
 	// Subdirectory tree
-	output: #FS & _copy.output
+	output: engine.#FS & _copy.output
+}
+
+// DecodeSecret is a convenience wrapper around #TransformSecret. The plain text contents of input is expected to match the format
+#DecodeSecret: {
+	{
+		format: "json"
+		engine.#TransformSecret & {
+			#function: {
+				input:  _
+				output: json.Unmarshal(input)
+			}
+		}
+	} | {
+		format: "yaml"
+		engine.#TransformSecret & {
+			#function: {
+				input:  _
+				output: yaml.Unmarshal(input)
+			}
+		}
+	}
+
 }

--- a/tests/tasks/gitpull/private_repo.cue
+++ b/tests/tasks/gitpull/private_repo.cue
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"encoding/yaml"
+	"dagger.io/dagger"
 	"dagger.io/dagger/engine"
 )
 
@@ -17,12 +17,9 @@ engine.#Plan & {
 			source: "alpine:3.15.0"
 		}
 
-		repoPassword: engine.#TransformSecret & {
-			input: inputs.secrets.sops.contents
-			#function: {
-				input:  _
-				output: yaml.Unmarshal(input)
-			}
+		sopsSecrets: dagger.#DecodeSecret & {
+			format: "yaml"
+			input:  inputs.secrets.sops.contents
 		}
 
 		testRepo: engine.#GitPull & {
@@ -30,7 +27,7 @@ engine.#Plan & {
 			ref:    "main"
 			auth: {
 				username: "dagger-test"
-				password: repoPassword.output.TestPAT.contents
+				password: sopsSecrets.output.TestPAT.contents
 			}
 		}
 

--- a/tests/tasks/pull/pull_auth.cue
+++ b/tests/tasks/pull/pull_auth.cue
@@ -1,27 +1,36 @@
 package main
 
 import (
+	"dagger.io/dagger"
 	"dagger.io/dagger/engine"
 )
 
 engine.#Plan & {
-	inputs: secrets: dockerHubToken: command: {
+	inputs: secrets: sops: command: {
 		name: "sops"
-		args: ["exec-env", "../../secrets_sops.yaml", "echo $DOCKERHUB_TOKEN"]
+		args: ["-d", "../../secrets_sops.yaml"]
 	}
-	actions: pull: engine.#Pull & {
-		source: "daggerio/ci-test:private-pull@sha256:c74f1b1166784193ea6c8f9440263b9be6cae07dfe35e32a5df7a31358ac2060"
-		auth: [{
-			target:   "daggerio/ci-test:private-pull"
-			username: "daggertest"
-			secret:   inputs.secrets.dockerHubToken.contents
-		}]
-	} & {
-		// assert result
-		digest: "sha256:c74f1b1166784193ea6c8f9440263b9be6cae07dfe35e32a5df7a31358ac2060"
-		config: {
-			env: PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-			cmd: ["/bin/sh"]
+
+	actions: {
+		sopsSecrets: dagger.#DecodeSecret & {
+			format: "yaml"
+			input:  inputs.secrets.sops.contents
+		}
+
+		pull: engine.#Pull & {
+			source: "daggerio/ci-test:private-pull@sha256:c74f1b1166784193ea6c8f9440263b9be6cae07dfe35e32a5df7a31358ac2060"
+			auth: [{
+				target:   "daggerio/ci-test:private-pull"
+				username: "daggertest"
+				secret:   sopsSecrets.output.DOCKERHUB_TOKEN.contents
+			}]
+		} & {
+			// assert result
+			digest: "sha256:c74f1b1166784193ea6c8f9440263b9be6cae07dfe35e32a5df7a31358ac2060"
+			config: {
+				env: PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+				cmd: ["/bin/sh"]
+			}
 		}
 	}
 }


### PR DESCRIPTION
Provides a convenienc wrapper to get maps of secrets from YAML and JSON sources.

Without this wrapper, plan authors would need to implement `#TransformSecret` directly, which is verbose and confusing for anyone without a deep knowledge of CUE.

To use this simply pass the secret as `input:` to `#DecodeSecret`, specify the `format: "json" | "yaml"` and the `output` as a map of secrets will be automatically filled by dagger.

For secrets from `sops`

```cue
inputs: secrets: sops: command: {
  name: "sops"
  args: ["-d", "../../secrets_sops.yaml"]
}
	
actions: sopsSecrets: dagger.#DecodeSecret & {
  format: "yaml"
  input: secrets.sops.contents
}

// we can now reference sopsSecrets.output.DOCKERHUB_TOKEN.contents
// where DOCKERHUB_TOKEN was a key in the sops YAML data

```

For secrets from a JSON source, such as `aws-vault`

```cue
inputs: secrets: awsVault: command: {
  name: "aws-vault"
  args: ["exec", "--json", "myProfile"]
}
	
actions: awsCreds: dagger.#DecodeSecret & {
  format: "json"
  input: secrets.awsVault.contents
}

// we can now reference awsCreds.output.AwsAccessKey.contents
// where AwsAccessKey was a key in the JSON data

```

Closes #1496 
Closes #1497 
