### PR TITLE
log error while removing buildkit instead of returning one

### DIFF
--- a/util/buildkitd/buildkitd.go
+++ b/util/buildkitd/buildkitd.go
@@ -65,7 +65,7 @@ func checkBuildkit(ctx context.Context) error {
 		lg.Debug().Msg("no buildkit daemon detected")
 
 		if err := removeBuildkit(ctx); err != nil {
-			lg.Debug().Msg("Error while removing Buildkit")
+			lg.Debug().Err(err).Msg("error while removing buildkit")
 		}
 
 		if err := installBuildkit(ctx); err != nil {


### PR DESCRIPTION
When use docker < 20, we get an error ```output=Error: No such container: dagger-buildkitd```
Only log an error if removeBuildkit fails (instead of returning an error) and carry on.

Signed-off-by: jffarge <jf@dagger.io>