### PR TITLE
Do not run lint & tests on unrelated file changes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,30 +3,28 @@ name: Lint
 on:
   push:
     branches: [main]
-    ignore-paths:
+    paths:
+      - '**.go'
+      - '**.sh'
+      - '**.bash'
+      - '**.cue'
       - 'docs/**'
-      - 'infra/**'
-      - 'website/**'
-      - '.gitignore'
       - '.golangci.yml'
-      - '.goreleaser.yml'
-      - 'Dockerfile'
-      - 'install.ps1'
-      - 'semver'
-      - 'tracing.compose.yaml'
+      - 'Makefile'
+      - 'README.md'
+      - '.github/workflows/lint.yml'
   pull_request:
     branches: [main]
-    ignore-paths:
+    paths:
+      - '**.go'
+      - '**.sh'
+      - '**.bash'
+      - '**.cue'
       - 'docs/**'
-      - 'infra/**'
-      - 'website/**'
-      - '.gitignore'
       - '.golangci.yml'
-      - '.goreleaser.yml'
-      - 'Dockerfile'
-      - 'install.ps1'
-      - 'semver'
-      - 'tracing.compose.yaml'
+      - 'Makefile'
+      - 'README.md'
+      - '.github/workflows/lint.yml'
 
 jobs:
   everything:

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -3,30 +3,20 @@ name: "Test Docs"
 on:
   push:
     branches: [main]
-    ignore-paths:
-      - 'infra/**'
-      - 'website/**'
-      - '.gitignore'
-      - '.golangci.yml'
-      - '.goreleaser.yml'
-      - 'Dockerfile'
-      - 'README.md'
-      - 'install.ps1'
-      - 'semver'
-      - 'tracing.compose.yaml'
+    paths:
+      - '**.go'
+      - '**.cue'
+      - 'docs/**'
+      - 'Makefile'
+      - '.github/workflows/test-docs.yml'
   pull_request:
     branches: [main]
-    ignore-paths:
-      - 'infra/**'
-      - 'website/**'
-      - '.gitignore'
-      - '.golangci.yml'
-      - '.goreleaser.yml'
-      - 'Dockerfile'
-      - 'README.md'
-      - 'install.ps1'
-      - 'semver'
-      - 'tracing.compose.yaml'
+    paths:
+      - '**.go'
+      - '**.cue'
+      - 'docs/**'
+      - 'Makefile'
+      - '.github/workflows/test-docs.yml'
 
 jobs:
   docs:

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -3,32 +3,26 @@ name: "Test Integration"
 on:
   push:
     branches: [main]
-    ignore-paths:
-      - 'docs/**'
-      - 'infra/**'
-      - 'website/**'
-      - '.gitignore'
-      - '.golangci.yml'
-      - '.goreleaser.yml'
-      - 'Dockerfile'
-      - 'README.md'
-      - 'install.ps1'
-      - 'semver'
-      - 'tracing.compose.yaml'
+    paths:
+      - '**.sh'
+      - '**.bash'
+      - '**.go'
+      - '**.cue'
+      - 'Makefile'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/test-integration.yml'
   pull_request:
     branches: [main]
-    ignore-paths:
-      - 'docs/**'
-      - 'infra/**'
-      - 'website/**'
-      - '.gitignore'
-      - '.golangci.yml'
-      - '.goreleaser.yml'
-      - 'Dockerfile'
-      - 'README.md'
-      - 'install.ps1'
-      - 'semver'
-      - 'tracing.compose.yaml'
+    paths:
+      - '**.sh'
+      - '**.bash'
+      - '**.go'
+      - '**.cue'
+      - 'Makefile'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/test-integration.yml'
 
 jobs:
   integration:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -3,32 +3,20 @@ name: "Test Unit"
 on:
   push:
     branches: [main]
-    ignore-paths:
-      - 'docs/**'
-      - 'infra/**'
-      - 'website/**'
-      - '.gitignore'
-      - '.golangci.yml'
-      - '.goreleaser.yml'
-      - 'Dockerfile'
-      - 'README.md'
-      - 'install.ps1'
-      - 'semver'
-      - 'tracing.compose.yaml'
+    paths:
+      - '**.go'
+      - 'Makefile'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/test-unit.yml'
   pull_request:
     branches: [main]
-    ignore-paths:
-      - 'docs/**'
-      - 'infra/**'
-      - 'website/**'
-      - '.gitignore'
-      - '.golangci.yml'
-      - '.goreleaser.yml'
-      - 'Dockerfile'
-      - 'README.md'
-      - 'install.ps1'
-      - 'semver'
-      - 'tracing.compose.yaml'
+    paths:
+      - '**.go'
+      - 'Makefile'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/test-unit.yml'
 
 jobs:
   unit:

--- a/.github/workflows/test-universe.yml
+++ b/.github/workflows/test-universe.yml
@@ -3,32 +3,26 @@ name: "Test Universe"
 on:
   push:
     branches: [main]
-    ignore-paths:
-      - 'docs/**'
-      - 'infra/**'
-      - 'website/**'
-      - '.gitignore'
-      - '.golangci.yml'
-      - '.goreleaser.yml'
-      - 'Dockerfile'
-      - 'README.md'
-      - 'install.ps1'
-      - 'semver'
-      - 'tracing.compose.yaml'
+    paths:
+      - '**.sh'
+      - '**.bash'
+      - '**.go'
+      - '**.cue'
+      - 'Makefile'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/test-universe.yml'
   pull_request:
     branches: [main]
-    ignore-paths:
-      - 'docs/**'
-      - 'infra/**'
-      - 'website/**'
-      - '.gitignore'
-      - '.golangci.yml'
-      - '.goreleaser.yml'
-      - 'Dockerfile'
-      - 'README.md'
-      - 'install.ps1'
-      - 'semver'
-      - 'tracing.compose.yaml'
+    paths:
+      - '**.sh'
+      - '**.bash'
+      - '**.go'
+      - '**.cue'
+      - 'Makefile'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/test-universe.yml'
 
 jobs:
   universe:


### PR DESCRIPTION
This will help us iterate quicker by not making us wait on the result of unrelated workflows. The corollary is that we should **never** merge a pull request when there are failing checks (a.k.a. failed workflows). This change makes the workflows that run more relevant for the type of change. I assume that this change will save us a lot of time as we accelerate the docs refinements.

I am not sure if I got all the `ignore-paths` values right, or if I have missed any. @aluzzardi will know, for sure 🤓

---
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-paths