### PR TITLE
Fix Build from source instructions

### DIFF
--- a/docs/1001-install.md
+++ b/docs/1001-install.md
@@ -71,7 +71,7 @@ git clone https://github.com/dagger/dagger.git
 2\. Build the `dagger` binary.
 
 ```shell
-cd dagger; make
+cd dagger; make dagger
 ```
 
 3\. Copy the `dagger` tool to a location listed in your `$PATH`. For example, to copy it to `/usr/local/bin`:


### PR DESCRIPTION
The build from source instructions were deprecated since it prints the
available make targets when running `make` whereas, before it built
dagger in dev mode.
Now to build dagger in dev mode, you have to run `make dagger`.
The doc is now up to date with this.