### PR TITLE
Revert netlify's use of transformSecret in test

### DIFF
--- a/pkg/universe.dagger.io/netlify/test/netlify-test.cue
+++ b/pkg/universe.dagger.io/netlify/test/netlify-test.cue
@@ -1,8 +1,6 @@
 package yarn
 
 import (
-	"encoding/yaml"
-
 	"dagger.io/dagger"
 	"dagger.io/dagger/engine"
 
@@ -12,20 +10,12 @@ import (
 )
 
 dagger.#Plan & {
-	inputs: secrets: test: command: {
+	inputs: secrets: testSecrets: command: {
 		name: "sops"
-		args: ["-d", "../../test_secrets.yaml"]
+		args: ["exec-env", "../../test_secrets.yaml", "echo $netlifyToken"]
 	}
 
 	actions: {
-		testSecrets: engine.#TransformSecret & {
-			input: inputs.secrets.test.contents
-			#function: {
-				input:  _
-				output: yaml.Unmarshal(input)
-			}
-		}
-
 		marker: "hello world"
 
 		data: engine.#WriteFile & {
@@ -37,7 +27,7 @@ dagger.#Plan & {
 		// Deploy to netlify
 		deploy: netlify.#Deploy & {
 			team:  "blocklayer"
-			token: testSecrets.output.netlifyToken.contents
+			token: inputs.secrets.testSecrets.contents
 
 			site:     "dagger-test"
 			contents: data.output


### PR DESCRIPTION
`#transformSecret` brings a race condition which @talentedmrjones is aware of. The CI breaks from time-to-time because of this very test. This PR reverts the test to its previous implementation, at least temporarly

Signed-off-by: guillaume <guillaume.derouville@gmail.com>