### PR TITLE
Fix nested vendoring

### DIFF
--- a/pkg/pkg.go
+++ b/pkg/pkg.go
@@ -122,6 +122,11 @@ func extractModules(dest string) error {
 			return nil
 		}
 
+		// Do not vendor the package's `cue.mod/pkg`
+		if strings.Contains(p, "cue.mod/pkg") {
+			return nil
+		}
+
 		contents, err := fs.ReadFile(FS, p)
 		if err != nil {
 			return fmt.Errorf("%s: %w", p, err)


### PR DESCRIPTION
For code embedding (e.g. deploy.sh), we've changed vendor embedding to
include all contents instead of just CUE files #1526.

The problem is we're vendoring the package's `cue.mod/pkg`.

This fixes it.

Signed-off-by: Andrea Luzzardi <aluzzardi@gmail.com>
