### PR TITLE
Fix data race with TransformSecret

### DIFF
--- a/plan/task/transformsecret.go
+++ b/plan/task/transformsecret.go
@@ -63,7 +63,6 @@ func (c *transformSecretTask) Run(ctx context.Context, pctx *plancontext.Context
 			newLeafPath := cue.MakePath(newLeafSelectors...)
 			p := newLeafPath.String()
 			pathToSecrets[p] = plaintext
-
 		}
 	})
 


### PR DESCRIPTION
It is believed that `secret := pctx.Secrets.New(plaintext)` _within_ Walk was responsible for the data race. This change moves that to outside, after `Walk` has completed.
Signed-off-by: Richard Jones