### PR TITLE
Set the version when installing via make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ dagger-debug: # Build a debug version of the dev dagger binary
 	go build -race -o ./cmd/dagger/dagger-debug -ldflags '-X go.dagger.io/dagger/version.Revision=$(GIT_REVISION)' ./cmd/dagger/
 
 .PHONY: install
-install: dagger # Build & install a dev dagger binary
-	go install ./cmd/dagger
+install: # Install a dev dagger binary
+	go install -ldflags '-X go.dagger.io/dagger/version.Revision=$(GIT_REVISION)' ./cmd/dagger
 
 .PHONY: test
 test: # Run all tests


### PR DESCRIPTION
Before: `dagger devel () darwin/amd64`

After: `dagger devel (1d1b9083) darwin/amd64`

Also removed the dependency on the dagger target, since go install is very similar to go build, the only difference in this context is that it places the binary in `$GOPATH/bin`.