### PR TITLE
logger: collapse logs for hidden fields

### DIFF
--- a/pkg/universe.dagger.io/netlify/test/netlify-test.cue
+++ b/pkg/universe.dagger.io/netlify/test/netlify-test.cue
@@ -43,7 +43,7 @@ dagger.#Plan & {
 			contents: data.output
 		}
 
-		_alpine: alpine.#Build & {
+		image: alpine.#Build & {
 			packages: {
 				bash: {}
 				curl: {}
@@ -52,7 +52,7 @@ dagger.#Plan & {
 
 		// Check if the website was deployed
 		verify: bash.#Run & {
-			input:  _alpine.output
+			input:  image.output
 			script: #"""
 		  test "$(curl \#(deploy.deployUrl))" = "\#(marker)"
 		  """#


### PR DESCRIPTION
This change "collapses" together log "groups" containing hidden fields
for the TTY logger.

e.g. `actions.foo._a` and `actions.foo_b` will show up as a combined `actions.foo`.

Caveats: Since we don't know in advance how many tasks are in a group, the state will change back and forth.
For each task in a group, the state will transition from computing to complete (e.g. blue to green), then back to computing and so on.
The transition is fast enough not to be visibile.

Signed-off-by: Andrea Luzzardi <aluzzardi@gmail.com>
