### PR TITLE
Shape of the new Europa docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ bin/
 
 # Local environment variables
 .env
+
+# Local configuration
+.config

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,7 +1,7 @@
 # Default state for all rules
 default: true
 
-# MD013/line-length - Line length
+# MD013/line-length - Allow long lines
 MD013: false
 
 # MD033 - Inline HTML. Needed for tabs in docusaurus

--- a/docs/core-concepts/1202-plan.md
+++ b/docs/core-concepts/1202-plan.md
@@ -1,0 +1,6 @@
+---
+slug: /1202/plan
+displayed_sidebar: europaSidebar
+---
+
+# It all starts with a plan

--- a/docs/core-concepts/1203-inputs.md
+++ b/docs/core-concepts/1203-inputs.md
@@ -1,0 +1,6 @@
+---
+slug: /1203/inputs
+displayed_sidebar: europaSidebar
+---
+
+# Configuring inputs

--- a/docs/core-concepts/1204-secrets.md
+++ b/docs/core-concepts/1204-secrets.md
@@ -1,0 +1,6 @@
+---
+slug: /1204/secrets
+displayed_sidebar: europaSidebar
+---
+
+# How to use secrets

--- a/docs/core-concepts/1205-container-images.md
+++ b/docs/core-concepts/1205-container-images.md
@@ -1,0 +1,6 @@
+---
+slug: /1205/container-images
+displayed_sidebar: europaSidebar
+---
+
+# Building container images

--- a/docs/core-concepts/1206-caching.md
+++ b/docs/core-concepts/1206-caching.md
@@ -1,0 +1,6 @@
+---
+slug: /1206/caching
+displayed_sidebar: europaSidebar
+---
+
+# Make your builds fast

--- a/docs/core-concepts/1207-packages.md
+++ b/docs/core-concepts/1207-packages.md
@@ -1,0 +1,6 @@
+---
+slug: /1207/packages
+displayed_sidebar: europaSidebar
+---
+
+# Create your own package

--- a/docs/getting-started/1200-local-ci.md
+++ b/docs/getting-started/1200-local-ci.md
@@ -1,0 +1,6 @@
+---
+slug: /1200/local-ci
+displayed_sidebar: europaSidebar
+---
+
+# Local CI setup

--- a/docs/getting-started/1201-github-actions.md
+++ b/docs/getting-started/1201-github-actions.md
@@ -1,0 +1,6 @@
+---
+slug: /1201/github-actions
+displayed_sidebar: europaSidebar
+---
+
+# From local CI to GitHub Actions

--- a/docs/use-cases/1208-phoenix-kubernetes.md
+++ b/docs/use-cases/1208-phoenix-kubernetes.md
@@ -1,0 +1,8 @@
+---
+slug: /1208/phoenix-kubernetes
+displayed_sidebar: europaSidebar
+---
+
+# Elixir/Phoenix on Kubernetes
+
+[changelog.com](https://changelog.com)

--- a/docs/use-cases/1209-docusaurus-netlify.md
+++ b/docs/use-cases/1209-docusaurus-netlify.md
@@ -1,0 +1,8 @@
+---
+slug: /1209/docusaurus-netlify
+displayed_sidebar: europaSidebar
+---
+
+# Docusaurus on Netlify
+
+[docs.dagger.io](https://docs.dagger.io)

--- a/docs/use-cases/1210-go-goreleaser.md
+++ b/docs/use-cases/1210-go-goreleaser.md
@@ -1,0 +1,8 @@
+---
+slug: /1210/go-goreleaser
+displayed_sidebar: europaSidebar
+---
+
+# Go with GoReleaser
+
+[github.com/dagger/dagger/releases](https://github.com/dagger/dagger/releases)

--- a/docs/use-cases/1211-go-docker-swarm.md
+++ b/docs/use-cases/1211-go-docker-swarm.md
@@ -1,0 +1,8 @@
+---
+slug: /1211/go-docker-swarm
+displayed_sidebar: europaSidebar
+---
+
+# Go on Docker Swarm
+
+[particubes.com](https://particubes.com)

--- a/docs/use-cases/1212-svelte-vercel.md
+++ b/docs/use-cases/1212-svelte-vercel.md
@@ -1,0 +1,8 @@
+---
+slug: /1212/svelte-vercel
+displayed_sidebar: europaSidebar
+---
+
+# Svelte on Vercel
+
+[rawkode.dev](https://rawkode.dev)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -65,4 +65,43 @@ module.exports = {
       items: ["administrator/operator-manual"],
     },
   ],
+  europaSidebar: [
+    {
+      type: "category",
+      label: "Getting Started",
+      collapsible: false,
+      collapsed: false,
+      items: [
+        "getting-started/local-ci",
+        "getting-started/github-actions"
+      ],
+    },
+    {
+      type: "category",
+      label: "Core Concepts",
+      collapsible: false,
+      collapsed: false,
+      items: [
+        "core-concepts/plan",
+        "core-concepts/inputs",
+        "core-concepts/secrets",
+        "core-concepts/caching",
+        "core-concepts/container-images",
+        "core-concepts/packages",
+      ],
+    },
+    {
+      type: "category",
+      label: "Use Cases",
+      collapsible: false,
+      collapsed: false,
+      items: [
+        "use-cases/phoenix-kubernetes",
+        "use-cases/docusaurus-netlify",
+        "use-cases/go-goreleaser",
+        "use-cases/go-docker-swarm",
+        "use-cases/svelte-vercel",
+      ],
+    },
+  ],
 };


### PR DESCRIPTION
This is a starting point, the new pages are placeholders for now. As a first step, we care about "the shape" of the new docs:

![image](https://user-images.githubusercontent.com/3342/153370337-b62ecba1-efea-4755-8de4-e7a77b78f38c.png)

The goal is to capture the shape of the new docs. It is not meant to be final, but it should be as close as possible.

As a first step, we only want the bare minimum for new users that on-board with Dagger Europa. As soon as the new `europaSidebar` replaces replaces the existing one, the previous docs will still remain available - doc IDs are unique and permanent. We will do this by simply changing the default `slug: /` to point to the Europa Docs entrypoint, which is doc 1200.

| 💡 Helpful Docusaurus multiple sidebars reference: https://docusaurus.io/docs/sidebar/multiple-sidebars

The new pages are numbered from `1200` onwards. This is meant to reflect the `0.2.0` Dagger version. This numbering felt more meaningful than just continuing to increment existing numbers. I didn't want to be "wasteful" with the digits and start at `2000`, but that was my first instinct.

I am keen on seeing this live on https://docs.dagger.io/1200/local-ci. If it's not in production, it is inventory, which is a form of waste. That is obviously bad, and this explains why: [The Goal](https://en.wikipedia.org/wiki/The_Goal_(novel)). Yes, I know, we are not a factory, but see the big picture.

The goal is to allow anyone that has a link to get a feel for the new docs so that we can all see how they improve in real-time, and steer them continuously towards the desired state. We should be aware of timelines and milestones, and do the minimum work possible. Thinking of it as a form of experimentation - a.k.a. "the journey towards better" - is a great way of framing it.

Remember, the best releases are those where switches are flipped (e.g. `--europa)`. The feature will have been out there for weeks (maybe even months), continuously refined by user feedback (including our own!). One day, we realise that we are ready to release, and then we just enable it by default. That is the principle behind these docs.
