### PR TITLE
Simplify docker.#Run

### DIFF
--- a/pkg/universe.dagger.io/alpine/alpine.cue
+++ b/pkg/universe.dagger.io/alpine/alpine.cue
@@ -27,7 +27,7 @@ import (
 			},
 			for pkgName, pkg in packages {
 				docker.#Run & {
-					cmd: {
+					command: {
 						name: "apk"
 						args: ["add", "\(pkgName)\(pkg.version)"]
 						flags: {

--- a/pkg/universe.dagger.io/alpine/test/package-install.cue
+++ b/pkg/universe.dagger.io/alpine/test/package-install.cue
@@ -17,10 +17,13 @@ dagger.#Plan & {
 
 		check: docker.#Run & {
 			image: build.output
-			script: """
-				jq --version > /jq-version.txt
-				curl --version > /curl-version.txt
-				"""
+			command: {
+				name: "sh"
+				flags: "-c": """
+					jq --version > /jq-version.txt
+					curl --version > /curl-version.txt
+					"""
+			}
 
 			export: files: {
 				"/jq-version.txt": contents:   =~"^jq"

--- a/pkg/universe.dagger.io/bash/bash.cue
+++ b/pkg/universe.dagger.io/bash/bash.cue
@@ -6,16 +6,21 @@ import (
 )
 
 // Run a bash command or script in a container
-#Run: docker.#Run & {
+#Run: {
+	// Contents of the bash script
 	script: string
-	cmd: {
-		name: "bash"
-		flags: {
-			"-c":          script
-			"--noprofile": true
-			"--norc":      true
-			"-e":          true
-			"-o":          "pipefail"
+
+	// FIXME: don't pass the script as argument: write to filesystme instead
+	docker.#Run & {
+		command: {
+			name: "bash"
+			flags: {
+				"-c":          script
+				"--noprofile": true
+				"--norc":      true
+				"-e":          true
+				"-o":          "pipefail"
+			}
 		}
 	}
 }

--- a/pkg/universe.dagger.io/docker/run.cue
+++ b/pkg/universe.dagger.io/docker/run.cue
@@ -36,7 +36,7 @@ import (
 	}
 
 	// Command to execute
-	cmd?: {
+	command?: {
 		// Name of the command to execute
 		// Examples: "ls", "/bin/bash"
 		name: string
@@ -59,17 +59,6 @@ import (
 				}
 			},
 		], 1)
-	}
-
-	// Optionally pass a script to interpret
-	// Example: "echo hello\necho world"
-	script?: string
-	if script != _|_ {
-		// Default interpreter is /bin/sh -c
-		cmd: *{
-			name: "/bin/sh"
-			flags: "-c": script
-		} | {}
 	}
 
 	// Environment variables
@@ -133,10 +122,10 @@ import (
 		"always": always
 		"mounts": mounts
 
-		if cmd != _|_ {
-			args: [cmd.name] + cmd._flatFlags + cmd.args
+		if command != _|_ {
+			args: [command.name] + command._flatFlags + command.args
 		}
-		if cmd == _|_ {
+		if command == _|_ {
 			args: list.Concat([
 				if _image.config.entrypoint != _|_ {
 					_image.config.entrypoint

--- a/pkg/universe.dagger.io/docker/test/build-multi-steps.cue
+++ b/pkg/universe.dagger.io/docker/test/build-multi-steps.cue
@@ -16,19 +16,28 @@ dagger.#Plan & {
 			steps: [
 				alpine.#Build,
 				docker.#Run & {
-					script: """
+					command: {
+						name: "sh"
+						flags: "-c": """
 							echo -n hello > /bar.txt
-						"""
+							"""
+					}
 				},
 				docker.#Run & {
-					script: """
+					command: {
+						name: "sh"
+						flags: "-c": """
 							echo -n $(cat /bar.txt) world > /foo.txt
-						"""
+							"""
+					}
 				},
 				docker.#Run & {
-					script: """
+					command: {
+						name: "sh"
+						flags: "-c": """
 							echo -n $(cat /foo.txt) >> /test.txt
-						"""
+							"""
+					}
 				},
 			]
 		}

--- a/pkg/universe.dagger.io/docker/test/build-simple.cue
+++ b/pkg/universe.dagger.io/docker/test/build-simple.cue
@@ -17,9 +17,10 @@ dagger.#Plan & {
 			steps: [
 				alpine.#Build,
 				docker.#Run & {
-					script: """
-							echo -n $TEST >> /test.txt
-						"""
+					command: {
+						name: "sh"
+						flags: "-c": "echo -n $TEST >> /test.txt"
+					}
 					env: TEST: #testValue
 				},
 			]

--- a/pkg/universe.dagger.io/docker/test/image-config-test.cue
+++ b/pkg/universe.dagger.io/docker/test/image-config-test.cue
@@ -27,7 +27,7 @@ dagger.#Plan & {
 		}
 		run: docker.#Run & {
 			image: myimage
-			cmd: name: "ls"
+			command: name: "ls"
 			export: files: {
 				"/dagger.txt": _ & {
 					contents: "not hello from dagger"
@@ -57,9 +57,12 @@ dagger.#Plan & {
 
 		verify_working_directory: docker.#Run & {
 			image: myimage
-			script: #"""
-				pwd > dir.txt
-				"""#
+			command: {
+				name: "sh"
+				flags: "-c": #"""
+					pwd > dir.txt
+					"""#
+			}
 			export: files: "/bin/dir.txt": _ & {
 				contents: "/bin\n"
 			}
@@ -67,9 +70,12 @@ dagger.#Plan & {
 		verify_working_directory_is_overridden: docker.#Run & {
 			image:   myimage
 			workdir: "/"
-			script: #"""
-				pwd > dir.txt
-				"""#
+			command: {
+				name: "sh"
+				flags: "-c": #"""
+					pwd > dir.txt
+					"""#
+			}
 			export: files: "/dir.txt": _ & {
 				contents: "/\n"
 			}

--- a/pkg/universe.dagger.io/docker/test/multi-nested-build-test.cue
+++ b/pkg/universe.dagger.io/docker/test/multi-nested-build-test.cue
@@ -5,6 +5,7 @@ import (
 	"universe.dagger.io/docker"
 )
 
+// FIXME: this test is currently broken (see docker.bats)
 dagger.#Plan & {
 	actions: build: docker.#Build & {
 		steps: [
@@ -16,17 +17,17 @@ dagger.#Plan & {
 								source: "alpine"
 							},
 							docker.#Run & {
-								cmd: name: "ls"
+								command: name: "ls"
 							},
 						]
 					},
 					docker.#Run & {
-						cmd: name: "ls"
+						command: name: "ls"
 					},
 				]
 			},
 			docker.#Run & {
-				cmd: name: "ls"
+				command: name: "ls"
 			},
 		]
 	}

--- a/pkg/universe.dagger.io/docker/test/nested-build-test.cue
+++ b/pkg/universe.dagger.io/docker/test/nested-build-test.cue
@@ -14,12 +14,12 @@ dagger.#Plan & {
 						source: "alpine"
 					},
 					docker.#Run & {
-						cmd: name: "ls"
+						command: name: "ls"
 					},
 				]
 			},
 			docker.#Run & {
-				cmd: name: "ls"
+				command: name: "ls"
 			},
 		]
 	}

--- a/pkg/universe.dagger.io/docker/test/run-command-test.cue
+++ b/pkg/universe.dagger.io/docker/test/run-command-test.cue
@@ -13,7 +13,7 @@ dagger.#Plan & {
 
 		run: docker.#Run & {
 			"image": image.output
-			cmd: {
+			command: {
 				name: "/bin/sh"
 				args: ["-c", "echo -n hello world >> /output.txt"]
 			}

--- a/pkg/universe.dagger.io/docker/test/run-export-directory-test.cue
+++ b/pkg/universe.dagger.io/docker/test/run-export-directory-test.cue
@@ -13,10 +13,13 @@ dagger.#Plan & {
 
 		run: docker.#Run & {
 			"image": image.output
-			script: #"""
-				mkdir -p test
-				echo -n hello world >> /test/output.txt
-				"""#
+			command: {
+				name: "sh"
+				flags: "-c": #"""
+					mkdir -p test
+					echo -n hello world >> /test/output.txt
+					"""#
+			}
 			export: {
 				directories: "/test":      _
 				files: "/test/output.txt": _ & {

--- a/pkg/universe.dagger.io/docker/test/run-export-file-test.cue
+++ b/pkg/universe.dagger.io/docker/test/run-export-file-test.cue
@@ -12,9 +12,12 @@ dagger.#Plan & {
 
 		run: docker.#Run & {
 			"image": image.output
-			script: #"""
-				echo -n hello world >> /output.txt
-				"""#
+			command: {
+				name: "sh"
+				flags: "-c": #"""
+					echo -n hello world >> /output.txt
+					"""#
+			}
 			export: files: "/output.txt": _ & {
 				contents: "hello world"
 			}

--- a/pkg/universe.dagger.io/docker/test/run-script-test.cue
+++ b/pkg/universe.dagger.io/docker/test/run-script-test.cue
@@ -13,9 +13,12 @@ dagger.#Plan & {
 
 		run: docker.#Run & {
 			"image": image.output
-			script: #"""
-				echo -n $TEST_MESSAGE >> /output.txt
-				"""#
+			command: {
+				name: "sh"
+				flags: "-c": #"""
+					echo -n $TEST_MESSAGE >> /output.txt
+					"""#
+			}
 			env: TEST_MESSAGE: "hello world"
 		}
 

--- a/pkg/universe.dagger.io/examples/changelog.com/highlevel/ci.cue
+++ b/pkg/universe.dagger.io/examples/changelog.com/highlevel/ci.cue
@@ -38,7 +38,10 @@ dagger.#Plan & {
 				dev.assets,
 				// 2. Mix magical command
 				mix.#Run & {
-					script: "mix phx.digest"
+					command: {
+						name: "mix"
+						args: ["phx.digest"]
+					}
 					mix: {
 						env:        "prod"
 						app:        _appName
@@ -94,7 +97,12 @@ dagger.#Plan & {
 						}
 						// FIXME: run 'yarn install' and 'yarn run compile' separately, with different caching?
 						// FIXME: can we reuse universe.dagger.io/yarn ???? 0:-)
-						script:  "yarn install --frozen-lockfile && yarn run compile"
+						command: {
+							name: "sh"
+							flags: "-c": """
+								yarn install --frozen-lockfile && yarn run compile"
+								"""
+						}
 						workdir: "/app/assets"
 					},
 				]
@@ -110,8 +118,11 @@ dagger.#Plan & {
 
 			// Run tests
 			run: docker.#Run & {
-				image:  build.output
-				script: "mix test"
+				image: build.output
+				command: {
+					name: "mix"
+					args: ["test"]
+				}
 				// Don't cache running tests
 				// Just because we've tested a version before, doesn't mean we don't
 				// want to test it again.

--- a/pkg/universe.dagger.io/examples/changelog.com/highlevel/elixir/mix/mix.cue
+++ b/pkg/universe.dagger.io/examples/changelog.com/highlevel/elixir/mix/mix.cue
@@ -42,7 +42,10 @@ import (
 					depsCache: "locked"
 				}
 				workdir: "/app"
-				script:  "mix deps.get"
+				command: {
+					name: "mix"
+					args: ["deps.get"]
+				}
 			},
 			// 4. Build!
 			// FIXME: step 5 is to add image data, see issue 1339
@@ -54,7 +57,10 @@ import (
 					buildCache: "locked"
 				}
 				workdir: "/app"
-				script:  "mix do deps.compile, compile"
+				command: {
+					name: "mix"
+					args: ["do", "deps.compile,compile"]
+				}
 			},
 		]
 	}

--- a/pkg/universe.dagger.io/netlify/netlify.cue
+++ b/pkg/universe.dagger.io/netlify/netlify.cue
@@ -51,7 +51,7 @@ import (
 				}
 			},
 			docker.#Run & {
-				cmd: {
+				command: {
 					name: "yarn"
 					args: ["global", "add", "netlify-cli@8.6.21"]
 				}
@@ -76,7 +76,10 @@ import (
 		//    yarn: version: "=~1.22"
 		//   }
 		//   steps: [{
-		//    run: script: "yarn global add netlify-cli@3.38.10"
+		//    run: command: {
+		//      name: "sh"
+		//      flags: "-c": "yarn global add netlify-cli@3.38.10"
+		//    }
 		//   }]
 		//  }
 
@@ -111,7 +114,7 @@ import (
 				contents: token
 			}
 		}
-		cmd: name: "/app/deploy.sh"
+		command: name: "/app/deploy.sh"
 
 		export: files: {
 			"/netlify/url":       _

--- a/pkg/universe.dagger.io/netlify/test/netlify-test.cue
+++ b/pkg/universe.dagger.io/netlify/test/netlify-test.cue
@@ -54,8 +54,8 @@ dagger.#Plan & {
 		verify: bash.#Run & {
 			input:  image.output
 			script: #"""
-		  test "$(curl \#(deploy.deployUrl))" = "\#(marker)"
-		  """#
+			  test "$(curl \#(deploy.deployUrl))" = "\#(marker)"
+			  """#
 		}
 	}
 }

--- a/pkg/universe.dagger.io/python/python.cue
+++ b/pkg/universe.dagger.io/python/python.cue
@@ -8,17 +8,22 @@ import (
 )
 
 // Run a python script in a container
-#Run: docker.#Run & {
+#Run: {
+	// Contents of the python script
 	script: string
-	cmd: {
-		name: "python"
-		flags: "-c": script
-	}
 
-	// As a convenience, image defaults to a ready-to-use python environment
-	image: docker.#Image | *_defaultImage
+	// FIXME: don't pass the script as argument: write to filesystme instead
+	docker.#Run & {
+		command: {
+			name: "python"
+			flags: "-c": script
+		}
 
-	_defaultImage: alpine.#Image & {
-		packages: python: version: "3"
+		// As a convenience, image defaults to a ready-to-use python environment
+		image: docker.#Image | *_defaultImage
+
+		_defaultImage: alpine.#Image & {
+			packages: python: version: "3"
+		}
 	}
 }


### PR DESCRIPTION
This is an incremental change spun out of #1520 to get the simplest but most disruptive change merged quickly, and avoid a rebase storm.

* `cmd` is renamed to `command` for readability
* `script` is removed. Feature moves up the stack (bash.#Run,
    python.#Run)

Improvements to `bash.#Run` will follow in a separate PR. Then I will close #1520 without merging.