### PR TITLE
docker.#Run: remove redundant `image` field

### DIFF
--- a/pkg/universe.dagger.io/alpine/test/test.cue
+++ b/pkg/universe.dagger.io/alpine/test/test.cue
@@ -34,7 +34,7 @@ dagger.#Plan & {
 			}
 
 			check: docker.#Run & {
-				image: build.output
+				input: build.output
 				command: {
 					name: "sh"
 					flags: "-c": """

--- a/pkg/universe.dagger.io/bash/test/test.cue
+++ b/pkg/universe.dagger.io/bash/test/test.cue
@@ -25,7 +25,7 @@ dagger.#Plan & {
 			}
 
 			run: bash.#Run & {
-				image: _image
+				input: _image
 				export: files: "/out.txt": _
 				script: {
 					directory: dir
@@ -38,7 +38,7 @@ dagger.#Plan & {
 		// Run a script from string
 		runString: {
 			run: bash.#Run & {
-				image: _image
+				input: _image
 				export: files: "/output.txt": _
 				script: contents: "echo 'Hello, inlined world!' > /output.txt"
 			}

--- a/pkg/universe.dagger.io/docker/run.cue
+++ b/pkg/universe.dagger.io/docker/run.cue
@@ -9,16 +9,8 @@ import (
 
 // Run a command in a container
 #Run: {
-	_image: #Image
-
-	{
-		image:  #Image
-		_image: image
-	} | {
-		// For compatibility with #Build
-		input:  #Image
-		_image: input
-	}
+	// Docker image to execute
+	input: #Image
 
 	always: bool | *false
 
@@ -113,12 +105,12 @@ import (
 	// For compatibility with #Build
 	output: #Image & {
 		rootfs: _exec.output
-		config: _image.config
+		config: input.config
 	}
 
 	// Actually execute the command
 	_exec: engine.#Exec & {
-		input:    _image.rootfs
+		"input":  input.rootfs
 		"always": always
 		"mounts": mounts
 
@@ -127,29 +119,29 @@ import (
 		}
 		if command == _|_ {
 			args: list.Concat([
-				if _image.config.entrypoint != _|_ {
-					_image.config.entrypoint
+				if input.config.entrypoint != _|_ {
+					input.config.entrypoint
 				},
-				if _image.config.cmd != _|_ {
-					_image.config.cmd
+				if input.config.cmd != _|_ {
+					input.config.cmd
 				},
 			])
 		}
 		"env": env
-		if _image.config.env != _|_ {
-			for key, val in _image.config.env {
+		if input.config.env != _|_ {
+			for key, val in input.config.env {
 				if env[key] == _|_ {
 					env: "\(key)": val
 				}
 			}
 		}
 		"workdir": workdir
-		if workdir == _|_ && _image.config.workdir != _|_ {
-			workdir: _image.config.workdir
+		if workdir == _|_ && input.config.workdir != _|_ {
+			workdir: input.config.workdir
 		}
 		"user": user
-		if user == _|_ && _image.config.user != _|_ {
-			user: _image.config.user
+		if user == _|_ && input.config.user != _|_ {
+			user: input.config.user
 		}
 	}
 }

--- a/pkg/universe.dagger.io/docker/test/image.cue
+++ b/pkg/universe.dagger.io/docker/test/image.cue
@@ -62,7 +62,7 @@ dagger.#Plan & {
 				config: build.config
 			}
 			run: docker.#Run & {
-				image: myimage
+				input: myimage
 				command: name: "ls"
 				export: files: {
 					"/dagger.txt": _ & {
@@ -78,13 +78,13 @@ dagger.#Plan & {
 				}
 			}
 			verify_cmd_is_run: docker.#Run & {
-				image: myimage
+				input: myimage
 				export: files: "/dagger.txt": _ & {
 					contents: "hello from dagger"
 				}
 			}
 			verify_env_is_overridden: docker.#Run & {
-				image: myimage
+				input: myimage
 				export: files: "/dagger.txt": _ & {
 					contents: "hello from europa"
 				}
@@ -92,7 +92,7 @@ dagger.#Plan & {
 			}
 
 			verify_working_directory: docker.#Run & {
-				image: myimage
+				input: myimage
 				command: {
 					name: "sh"
 					flags: "-c": #"""
@@ -104,7 +104,7 @@ dagger.#Plan & {
 				}
 			}
 			verify_working_directory_is_overridden: docker.#Run & {
-				image:   myimage
+				input:   myimage
 				workdir: "/"
 				command: {
 					name: "sh"

--- a/pkg/universe.dagger.io/docker/test/run.cue
+++ b/pkg/universe.dagger.io/docker/test/run.cue
@@ -18,7 +18,7 @@ dagger.#Plan & {
 			image: alpine.#Build
 
 			run: docker.#Run & {
-				image: _image
+				input: _image
 				command: {
 					name: "/bin/sh"
 					args: ["-c", "echo -n hello world >> /output.txt"]
@@ -50,7 +50,7 @@ dagger.#Plan & {
 		// Test: export a directory
 		exportDirectory: {
 			run: docker.#Run & {
-				image: _image
+				input: _image
 				command: {
 					name: "sh"
 					flags: "-c": #"""

--- a/pkg/universe.dagger.io/netlify/netlify.cue
+++ b/pkg/universe.dagger.io/netlify/netlify.cue
@@ -59,6 +59,7 @@ import (
 
 	// Run the netlify client in a container
 	container: bash.#Run & {
+		input: _build.output
 		script: {
 			_load: engine.#Source & {
 				path: "."
@@ -67,8 +68,6 @@ import (
 			directory: _load.output
 			filename:  "deploy.sh"
 		}
-
-		image: _build.output
 
 		always: true
 		env: {

--- a/pkg/universe.dagger.io/yarn/yarn.cue
+++ b/pkg/universe.dagger.io/yarn/yarn.cue
@@ -59,7 +59,7 @@ import (
 
 	// Run yarn in a docker container
 	container: bash.#Run & {
-		image: _buildImage.output
+		input: _buildImage.output
 
 		// FIXME: move shell script to its own file
 		script: contents: #"""


### PR DESCRIPTION
This PR removes the `image` field in `docker.#Run`: one must use `input` everywhere.

## Context

* Initially `docker.#Run` has an `image` field
* Later we wanted to allow using `docker.#Run` as a step to `docker.#Build`. This requires an `input` field
* We decided that `image` was better, but `input` was necessary, so we kept both, thanks to a nice disjunction by @helderco 
* After some more mileage: the convenience is not worth the added complexity, especially since disjunctions are often the source of CUE issues.

