### PR TITLE
Always deploy the docs website when a Netlify build gets triggered

### DIFF
--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -4,18 +4,8 @@
   environment = { NODE_VERSION = "16.13.1" }
 
 [context.production]
-  # Do not build the site if there's no site-related changes since the last
-  # commit.
-  # This assumes PRs to `main` only contain merge commits, so it's safe to
-  # compare the current commit to the previous.
-  # We can't use `$CACHED_COMMIT_REF` because that points to the PR preview
-  # that was built before merging.
-  ignore = "git diff --quiet HEAD^ HEAD -- . ../docs/"
 
 [context.deploy-preview]
-  # Do not build the site if there's no site-related changes since the last
-  # deploy.
-  ignore = "git diff --quiet $COMMIT_REF $CACHED_COMMIT_REF -- ./ ../docs/"
   command = "yarn build:withoutAuth"
 
 [[redirects]]


### PR DESCRIPTION
If we trigger a deploy, then we want the deploy to actually run.

I am assuming that this was in place when there was a single GitHub Actions workflow that would trigger this all the time, even when nothing changed in `docs/**`. Since https://github.com/dagger/dagger/pull/1498, we no longer have this problem.

After merging https://github.com/dagger/dagger/pull/1591, I was caught by this behaviour which to me seemed surprising. This change should make docs deploy via Netlify behave in a more predictable way.

cc @aluzzardi 