### PR TITLE
Implemented --no-vendor

### DIFF
--- a/cmd/dagger/cmd/up.go
+++ b/cmd/dagger/cmd/up.go
@@ -146,6 +146,7 @@ func europaUp(ctx context.Context, cl *client.Client, args ...string) error {
 		Args:   args,
 		With:   viper.GetStringSlice("with"),
 		Target: viper.GetString("target"),
+		Vendor: !viper.GetBool("no-vendor"),
 	})
 	if err != nil {
 		lg.Fatal().Err(err).Msg("failed to load plan")
@@ -226,6 +227,7 @@ func init() {
 	upCmd.Flags().String("output", "", "Write computed output. Prints on stdout if set to-")
 	upCmd.Flags().StringArrayP("with", "w", []string{}, "")
 	upCmd.Flags().StringP("target", "t", "", "Run a single target of the DAG (for debugging only)")
+	upCmd.Flags().Bool("no-vendor", false, "Force up, disable inputs check")
 
 	if err := viper.BindPFlags(upCmd.Flags()); err != nil {
 		panic(err)

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -29,14 +29,17 @@ type Config struct {
 	Args   []string
 	With   []string
 	Target string
+	Vendor bool
 }
 
 func Load(ctx context.Context, cfg Config) (*Plan, error) {
 	log.Ctx(ctx).Debug().Interface("args", cfg.Args).Msg("loading plan")
 
-	// FIXME: vendoring path
-	if err := pkg.Vendor(ctx, ""); err != nil {
-		return nil, err
+	if cfg.Vendor {
+		// FIXME: vendoring path
+		if err := pkg.Vendor(ctx, ""); err != nil {
+			return nil, err
+		}
 	}
 
 	v, err := compiler.Build("", nil, cfg.Args...)


### PR DESCRIPTION
Adds `--no-vendor` to `dagger up` to prevent rewriting contents of `cue.mod`

Closes #1328 

Signed-off-by: Richard Jones