### PR TITLE
Implements universe/aws and universe/aws/cli

### DIFF
--- a/pkg/universe.dagger.io/aws/_scripts/install.sh
+++ b/pkg/universe.dagger.io/aws/_scripts/install.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+ARCH=$(uname -m)
+curl -s "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}-$1.zip" -o awscliv2.zip
+unzip awscliv2.zip -x "aws/dist/awscli/examples/*" "aws/dist/docutils/*"
+./aws/install
+rm -rf awscliv2.zip aws /usr/local/aws-cli/v2/*/dist/aws_completer /usr/local/aws-cli/v2/*/dist/awscli/data/ac.index /usr/local/aws-cli/v2/*/dist/awscli/examples

--- a/pkg/universe.dagger.io/aws/aws.cue
+++ b/pkg/universe.dagger.io/aws/aws.cue
@@ -1,0 +1,103 @@
+// AWS base package
+package aws
+
+import (
+	"dagger.io/dagger"
+	"universe.dagger.io/docker"
+)
+
+#DefaultLinuxVersion: "amazonlinux:2.0.20220121.0@sha256:f3a37f84f2644095e2c6f6fdf2bf4dbf68d5436c51afcfbfa747a5de391d5d62"
+#DefaultCliVersion:   "2.4.12"
+
+// Build provides a docker.#Image with the aws cli pre-installed to Amazon Linux 2. 
+// Can be customized with packages, and can be used with docker.#Run for executing custom scripts.
+// Used by default with aws.#Run
+#Build: {
+
+	docker.#Build & {
+		steps: [
+			docker.#Pull & {
+				source: #DefaultLinuxVersion
+			},
+			// cache yum install separately
+			docker.#Run & {
+				command: {
+					name: "yum"
+					args: ["install", "unzip", "-y"]
+				}
+			},
+			docker.#Run & {
+				command: {
+					name: "/scripts/install.sh"
+					args: [version]
+				}
+				mounts: scripts: {
+					dest:     "/scripts"
+					contents: _scripts.output
+				}
+			},
+		]
+	}
+
+	_scripts: dagger.#Source & {
+		path: "_scripts"
+	}
+
+	// The version of the AWS CLI to install
+	version: string | *#DefaultCliVersion
+}
+
+// Credentials provides long or short-term credentials.
+#Credentials: {
+	// AWS access key
+	accessKeyId?: dagger.#Secret
+
+	// AWS secret key
+	secretAccessKey?: dagger.#Secret
+
+	// AWS session token (provided with temporary credentials)
+	sessionToken?: dagger.#Secret
+}
+
+// Region provides a schema to validate acceptable region value.
+#Region: "us-east-2" | "us-east-1" | "us-west-1" | "us-west-2" | "af-south-1" | "ap-east-1" | "ap-southeast-3" | "ap-south-1" | "ap-northeast-3" | "ap-northeast-2" | "ap-southeast-1" | "ap-southeast-2" | "ap-northeast-1" | "ca-central-1" | "cn-north-1" | "cn-northwest-1" | "eu-central-1" | "eu-west-1" | "eu-west-2" | "eu-south-1" | "eu-west-3" | "eu-north-1" | "me-south-1" | "sa-east-1"
+
+// Container a standalone environment pre-configured with credentials and .aws/config
+#Container: {
+	// _build provides the default image
+	_build: #Build
+
+	// configFile provides access to a config file, typically found in ~/.aws/config
+	configFile?: dagger.#FS
+
+	// credentials provides long or short-term credentials
+	credentials: #Credentials
+
+	docker.#Run & {
+		input: docker.#Image | *_build.output
+
+		env: {
+			// pass credentials as env vars
+			if credentials.accessKeyId != _|_ {
+				AWS_ACCESS_KEY_ID: credentials.accessKeyId
+			}
+
+			if credentials.secretAccessKey != _|_ {
+				AWS_SECRET_ACCESS_KEY: credentials.secretAccessKey
+			}
+
+			if credentials.sessionToken != _|_ {
+				AWS_SESSION_TOKEN: credentials.sessionToken
+			}
+		}
+
+		if configFile != _|_ {
+			mounts: aws: {
+				contents: configFile
+				dest:     "/aws"
+				ro:       true
+			}
+			env: AWS_CONFIG_FILE: "/aws/config"
+		}
+	}
+}

--- a/pkg/universe.dagger.io/aws/cli/cli.cue
+++ b/pkg/universe.dagger.io/aws/cli/cli.cue
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"list"
+	"strings"
+	"encoding/json"
+	"universe.dagger.io/aws"
+)
+
+// Command provides a declarative interface to the AWS CLI
+#Command: {
+	// "register" output.txt
+	export: files: "/output.txt": _
+
+	// Global arguments passed to the aws cli.
+	options: {
+		// Turn on debug logging.
+		debug?: bool
+
+		// Override command's default URL with the given URL.
+		"endpoint-url"?: string
+
+		// By  default, the AWS CLI uses SSL when communicating with AWS services.
+		// For each SSL connection, the AWS CLI will verify SSL certificates. This
+		// option overrides the default behavior of verifying SSL certificates.
+		"no-verify-ssl"?: bool
+
+		// Disable automatic pagination.
+		"no-paginate"?: bool
+
+		// The formatting style for command output.
+		output: *"json" | "text" | "table" | "yaml" | "yaml-stream"
+
+		// A JMESPath query to use in filtering the response data.
+		query?: string
+
+		// Use a specific profile from your credential file.
+		profile?: string
+
+		// The region to use. Overrides config/env settings.
+		region?: string
+
+		// Display the version of this tool.
+		version?: bool
+
+		// Turn on/off color output.
+		color?: "off" | "on" | "auto"
+
+		// Do  not  sign requests. Credentials will not be loaded if this argument
+		// is provided.
+		"no-sign-request"?: bool
+
+		// The CA certificate bundle to use when verifying SSL certificates. Over-
+		// rides config/env settings.
+		"ca-bundle"?: string
+
+		// The  maximum socket read time in seconds. If the value is set to 0, the
+		// socket read will be blocking and not timeout. The default value  is  60
+		// seconds.
+		"cli-read-timeout"?: int
+
+		// The  maximum  socket connect time in seconds. If the value is set to 0,
+		// the socket connect will be blocking and not timeout. The default  value
+		// is 60 seconds.
+		"cli-connect-timeout"?: int
+
+		// The formatting style to be used for binary blobs. The default format is
+		// base64. The base64 format expects binary blobs  to  be  provided  as  a
+		// base64  encoded string. The raw-in-base64-out format preserves compati-
+		// bility with AWS CLI V1 behavior and binary values must be passed liter-
+		// ally.  When  providing  contents  from a file that map to a binary blob
+		// fileb:// will always be treated as binary and  use  the  file  contents
+		// directly  regardless  of  the  cli-binary-format  setting.  When  using
+		// file:// the file contents will need to properly formatted for the  con-
+		// figured cli-binary-format.
+		"cli-binary-format"?: "base64" | "raw-in-base64-out"
+
+		// Disable cli pager for output.
+		"no-cli-pager": true
+
+		// Automatically prompt for CLI input parameters.
+		"cli-auto-prompt"?: bool
+
+		// Disable automatically prompt for CLI input parameters.
+		"no-cli-auto-prompt"?: bool
+	}
+
+	// Result will contain the cli output. If unmarshal is set to false this will be the raw string as provided by the aws cli command. If unmarshal is set to true this will be a map as returned by json.Unmarshal.
+	_unmarshalable: string | number | bool | null | [..._unmarshalable] | {[string]: _unmarshalable}
+	result:         _unmarshalable
+
+	if unmarshal != false {
+		options: output: "json"
+		result: json.Unmarshal(export.files["/output.txt"])
+	}
+
+	if unmarshal == false {
+		result: export.files["/output.txt"]
+	}
+
+	// The service to run the command against.
+	service: {
+		args: [...string]
+		name:    "accessanalyzer" | "account" | "acm" | "acm-pca" | "alexaforbusiness" | "amp" | "amplify" | "amplifybackend" | "amplifyuibuilder" | "apigateway" | "apigatewaymanagementapi" | "apigatewayv2" | "appconfig" | "appconfigdata" | "appflow" | "appintegrations" | "application-autoscaling" | "application-insights" | "applicationcostprofiler" | "appmesh" | "apprunner" | "appstream" | "appsync" | "athena" | "auditmanager" | "autoscaling" | "autoscaling-plans" | "backup" | "backup-gateway" | "batch" | "braket" | "budgets" | "ce" | "chime" | "chime-sdk-identity" | "chime-sdk-meetings" | "chime-sdk-messaging" | "cli-dev" | "cloud9" | "cloudcontrol" | "clouddirectory" | "cloudformation" | "cloudfront" | "cloudhsm" | "cloudtrail" | "cloudwatch" | "codeartifact" | "codebuild" | "codecommit" | "codeguru-reviewer" | "codeguruprofiler" | "codepipeline" | "codestar" | "codestar-connections" | "codestar-notifications" | "cognito-identity" | "cognito-idp" | "cognito-sync" | "comprehend" | "comprehendmedical" | "compute-optimizer" | "configservice" | "configure" | "connect" | "connect-contact-lens" | "connectparticipant" | "cur" | "customer-profiles" | "databrew" | "dataexchange" | "datapipeline" | "datasync" | "dax" | "ddb" | "deploy" | "detective" | "devicefarm" | "devops-guru" | "directconnect" | "discovery" | "dlm" | "dms" | "docdb" | "drs" | "ds" | "dynamodb" | "dynamodbstreams" | "ebs" | "ec2" | "ec2-instance-connect" | "ecr" | "ecr-public" | "ecs" | "efs" | "eks" | "elastic-inference" | "elasticache" | "elasticbeanstalk" | "elastictranscoder" | "elb" | "elbv2" | "emr" | "emr-containers" | "es" | "events" | "evidently" | "finspace" | "finspace-data" | "firehose" | "fis" | "fms" | "forecast" | "forecastquery" | "frauddetector" | "fsx" | "gamelift" | "glacier" | "globalaccelerator" | "glue" | "grafana" | "greengrass" | "greengrassv2" | "groundstation" | "guardduty" | "health" | "healthlake" | "help" | "history" | "honeycode" | "iam" | "identitystore" | "imagebuilder" | "importexport" | "inspector" | "inspector2" | "iot" | "iot-data" | "iot-jobs-data" | "iot1click-devices" | "iot1click-projects" | "iotanalytics" | "iotdeviceadvisor" | "iotevents" | "iotevents-data" | "iotfleethub" | "iotsecuretunneling" | "iotsitewise" | "iotthingsgraph" | "iottwinmaker" | "iotwireless" | "ivs" | "kafka" | "kafkaconnect" | "kendra" | "kinesis" | "kinesis-video-archived-media" | "kinesis-video-media" | "kinesis-video-signaling" | "kinesisanalytics" | "kinesisanalyticsv2" | "kinesisvideo" | "kms" | "lakeformation" | "lambda" | "lex-models" | "lex-runtime" | "lexv2-models" | "lexv2-runtime" | "license-manager" | "lightsail" | "location" | "logs" | "lookoutequipment" | "lookoutmetrics" | "lookoutvision" | "machinelearning" | "macie" | "macie2" | "managedblockchain" | "marketplace-catalog" | "marketplace-entitlement" | "marketplacecommerceanalytics" | "mediaconnect" | "mediaconvert" | "medialive" | "mediapackage" | "mediapackage-vod" | "mediastore" | "mediastore-data" | "mediatailor" | "memorydb" | "meteringmarketplace" | "mgh" | "mgn" | "migration-hub-refactor-spaces" | "migrationhub-config" | "migrationhubstrategy" | "mobile" | "mq" | "mturk" | "mwaa" | "neptune" | "network-firewall" | "networkmanager" | "nimble" | "opensearch" | "opsworks" | "opsworks-cm" | "organizations" | "outposts" | "panorama" | "personalize" | "personalize-events" | "personalize-runtime" | "pi" | "pinpoint" | "pinpoint-email" | "pinpoint-sms-voice" | "polly" | "pricing" | "proton" | "qldb" | "qldb-session" | "quicksight" | "ram" | "rbin" | "rds" | "rds-data" | "redshift" | "redshift-data" | "rekognition" | "resiliencehub" | "resource-groups" | "resourcegroupstaggingapi" | "robomaker" | "route53" | "route53-recovery-cluster" | "route53-recovery-control-config" | "route53-recovery-readiness" | "route53domains" | "route53resolver" | "rum" | "s3" | "s3api" | "s3control" | "s3outposts" | "sagemaker" | "sagemaker-a2i-runtime" | "sagemaker-edge" | "sagemaker-featurestore-runtime" | "sagemaker-runtime" | "savingsplans" | "schemas" | "sdb" | "secretsmanager" | "securityhub" | "serverlessrepo" | "service-quotas" | "servicecatalog" | "servicecatalog-appregistry" | "servicediscovery" | "ses" | "sesv2" | "shield" | "signer" | "sms" | "snow-device-management" | "snowball" | "sns" | "sqs" | "ssm" | "ssm-contacts" | "ssm-incidents" | "sso" | "sso-admin" | "sso-oidc" | "stepfunctions" | "storagegateway" | "sts" | "support" | "swf" | "synthetics" | "textract" | "timestream-query" | "timestream-write" | "transcribe" | "transfer" | "translate" | "voice-id" | "waf" | "waf-regional" | "wafv2" | "wellarchitected" | "wisdom" | "workdocs" | "worklink" | "workmail" | "workmailmessageflow" | "workspaces" | "workspaces-web" | "xray" | ""
+		command: string
+	}
+
+	// unmarshal determines whether to automatically json.Unmarshal() the command result. If set to true, the output field will be set to "json" and the command output will be Unmarshaled to result:
+	unmarshal: false | *true
+
+	aws.#Container & {
+		always:      true
+		_optionArgs: list.FlattenN([
+				for k, v in options {
+				if (v & bool) != _|_ {
+					["--\(k)"]
+				}
+				if (v & string) != _|_ {
+					["--\(k)", v]
+				}
+			},
+		], 1)
+
+		command: {
+			name: "/bin/sh"
+			flags: "-c": strings.Join(["aws"]+_optionArgs+[service.name, service.command]+service.args+[">", "/output.txt"], " ")
+		}
+	}
+}

--- a/pkg/universe.dagger.io/aws/cli/test/sts_get_caller_identity.cue
+++ b/pkg/universe.dagger.io/aws/cli/test/sts_get_caller_identity.cue
@@ -1,0 +1,39 @@
+package test
+
+import (
+	"dagger.io/dagger"
+	"universe.dagger.io/aws"
+	"universe.dagger.io/aws/cli"
+)
+
+dagger.#Plan & {
+	inputs: secrets: sops: command: {
+		name: "sops"
+		args: ["-d", "--extract", "[\"AWS\"]", "../../../secrets_sops.yaml"]
+	}
+
+	actions: {
+		sopsSecrets: dagger.#DecodeSecret & {
+			format: "yaml"
+			input:  inputs.secrets.sops.contents
+		}
+
+		getCallerIdentity: cli.#Command & {
+			credentials: aws.#Credentials & {
+				accessKeyId:     sopsSecrets.output.AWS_ACCESS_KEY_ID.contents
+				secretAccessKey: sopsSecrets.output.AWS_SECRET_ACCESS_KEY.contents
+			}
+			options: region: "us-east-2"
+			service: {
+				name:    "sts"
+				command: "get-caller-identity"
+			}
+		}
+
+		verify: getCallerIdentity.result & {
+			UserId:  !~"^$"
+			Account: !~"^$"
+			Arn:     !~"^$"
+		}
+	}
+}

--- a/pkg/universe.dagger.io/aws/cli/test/test.bats
+++ b/pkg/universe.dagger.io/aws/cli/test/test.bats
@@ -1,0 +1,9 @@
+setup() {
+    load '../../../bats_helpers'
+
+    common_setup
+}
+
+@test "aws/cli" {
+    dagger up ./sts_get_caller_identity.cue
+}

--- a/pkg/universe.dagger.io/aws/test/config
+++ b/pkg/universe.dagger.io/aws/test/config
@@ -1,0 +1,4 @@
+[profile ci]
+credential_source = Environment
+region = us-east-2
+role_arn = arn:aws:iam::125635003186:role/dagger-ci

--- a/pkg/universe.dagger.io/aws/test/config_file.cue
+++ b/pkg/universe.dagger.io/aws/test/config_file.cue
@@ -1,0 +1,51 @@
+package test
+
+import (
+	"encoding/json"
+	"dagger.io/dagger"
+	"universe.dagger.io/aws"
+)
+
+dagger.#Plan & {
+	inputs: {
+		directories: awsConfig: {
+			path: "./"
+			include: ["config"]
+		}
+
+		secrets: sops: command: {
+			name: "sops"
+			args: ["-d", "--extract", "[\"AWS\"]", "../../secrets_sops.yaml"]
+		}
+	}
+
+	actions: {
+		sopsSecrets: dagger.#DecodeSecret & {
+			format: "yaml"
+			input:  inputs.secrets.sops.contents
+		}
+
+		getCallerIdentity: aws.#Container & {
+			always:     true
+			configFile: inputs.directories.awsConfig.contents
+
+			credentials: aws.#Credentials & {
+				accessKeyId:     sopsSecrets.output.AWS_ACCESS_KEY_ID.contents
+				secretAccessKey: sopsSecrets.output.AWS_SECRET_ACCESS_KEY.contents
+			}
+
+			command: {
+				name: "sh"
+				flags: "-c": "aws --profile ci sts get-caller-identity > /output.txt"
+			}
+
+			export: files: "/output.txt": _
+		}
+
+		verify: json.Unmarshal(getCallerIdentity.export.files."/output.txt") & {
+			UserId:  string
+			Account: =~"^12[0-9]{8}86$"
+			Arn:     =~"^arn:aws:sts::(12[0-9]{8}86):assumed-role/dagger-ci"
+		}
+	}
+}

--- a/pkg/universe.dagger.io/aws/test/credentials.cue
+++ b/pkg/universe.dagger.io/aws/test/credentials.cue
@@ -1,0 +1,42 @@
+package test
+
+import (
+	"encoding/json"
+	"dagger.io/dagger"
+	"universe.dagger.io/aws"
+)
+
+dagger.#Plan & {
+	inputs: secrets: sops: command: {
+		name: "sops"
+		args: ["-d", "--extract", "[\"AWS\"]", "../../secrets_sops.yaml"]
+	}
+
+	actions: {
+		sopsSecrets: dagger.#DecodeSecret & {
+			format: "yaml"
+			input:  inputs.secrets.sops.contents
+		}
+
+		getCallerIdentity: aws.#Container & {
+			always:      true
+			credentials: aws.#Credentials & {
+				accessKeyId:     sopsSecrets.output.AWS_ACCESS_KEY_ID.contents
+				secretAccessKey: sopsSecrets.output.AWS_SECRET_ACCESS_KEY.contents
+			}
+
+			command: {
+				name: "sh"
+				flags: "-c": "aws --region us-east-2 sts get-caller-identity > /output.txt"
+			}
+
+			export: files: "/output.txt": _
+		}
+
+		verify: json.Unmarshal(getCallerIdentity.export.files."/output.txt") & {
+			UserId:  string & !~"^$"
+			Account: =~"^12[0-9]{8}86$"
+			Arn:     =~"(12[0-9]{8}86)"
+		}
+	}
+}

--- a/pkg/universe.dagger.io/aws/test/default_version.cue
+++ b/pkg/universe.dagger.io/aws/test/default_version.cue
@@ -1,0 +1,23 @@
+package test
+
+import (
+	"dagger.io/dagger"
+	"universe.dagger.io/aws"
+	"universe.dagger.io/docker"
+)
+
+dagger.#Plan & {
+	actions: {
+		build: aws.#Build
+
+		getVersion: docker.#Run & {
+			always: true
+			input:  build.output
+			command: {
+				name: "sh"
+				flags: "-c": "aws --version > /output.txt"
+			}
+			export: files: "/output.txt": =~"^aws-cli/\(aws.#DefaultCliVersion)"
+		}
+	}
+}

--- a/pkg/universe.dagger.io/aws/test/test.bats
+++ b/pkg/universe.dagger.io/aws/test/test.bats
@@ -1,0 +1,11 @@
+setup() {
+    load '../../bats_helpers'
+
+    common_setup
+}
+
+@test "aws" {
+    dagger up ./default_version.cue
+    dagger up ./credentials.cue
+    dagger up ./config_file.cue
+}

--- a/pkg/universe.dagger.io/secrets_sops.yaml
+++ b/pkg/universe.dagger.io/secrets_sops.yaml
@@ -1,0 +1,1 @@
+../../tests/secrets_sops.yaml

--- a/tests/secrets_sops.yaml
+++ b/tests/secrets_sops.yaml
@@ -1,5 +1,8 @@
-TestPAT: ENC[AES256_GCM,data:KYPnJTTCaEbEiBwODMDmOmZGx/Vu/4mOZPfRSjhBc239fPfHzDH75w==,iv:j9UFKfdRMfYg/3xw4dCoWbs0Zoy3czqRznlQrRvf4Sc=,tag:Pvd4UMFDOj8rLOwZJjsYpA==,type:str]
-DOCKERHUB_TOKEN: ENC[AES256_GCM,data:Nfk3PWIFHSJ73HqZmk1qG2x2A5TCZwnCez/hZJBdqG25c6D1,iv:eI7imptDvZOQdjMEfqsZAr4dXsd6fQKuXM0O9nZUBUs=,tag:Zvs0oiBYQOrSUv2a88h2Vw==,type:str]
+TestPAT: ENC[AES256_GCM,data:tLrYG8WCZah93gWkvltLzvxAhB1Tj7fmPZ/iZac8bjMo0+y74bq1qg==,iv:UD9s7flTy/FvW+NHg82l1xJruXldnSCRlRQpg5z7WO8=,tag:v35hzseqeY7V3P7J/hg28w==,type:str]
+DOCKERHUB_TOKEN: ENC[AES256_GCM,data:ZWXFsmZI/uf5VT/1Se4lvON4AK349sXclWI+kZrzabj7447U,iv:eTj0xRSwMjUUrokpIr7UohC07cO69WAsxO/NZXSsmLw=,tag:PjHp/PnIDL/dx4cjESpJgQ==,type:str]
+AWS:
+    AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:jH9qw1DFauiOILteQJP4hbcAL/A=,iv:4WBQsGoQtApT7vUgIjopq4dC1KME9wQU1I7oj6KQy/E=,tag:WbSDp5rFEVgmqprY+RcBuw==,type:str]
+    AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:oR+i0k/escdAGX0hUWTpGGQvbbiU4BWlb3983lpcA1tI1egTj6Nmpg==,iv:iXPaZvjg03htTPiOMER5+iLP2qzdOJTfnq7xSHbFTAs=,tag:fa66HZubWdceC864bjXoDQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -9,14 +12,14 @@ sops:
         - recipient: age1gxwmtwahzwdmrskhf90ppwlnze30lgpm056kuesrxzeuyclrwvpsupwtpk
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnUEhWbjV3M29oUUJyWk81
-            Wk1WQ1E0cmtuVlhNSGxkWUM3WmJXdUYvbzAwCjlFWW9IVmtmTjY1aU1LR2lxWFlT
-            am9RemNqSDRWK2FDYk1xeGNiTFlWMFUKLS0tIFVrSzBCMERQbnhYb09ReVpFK00v
-            TG5YUDlFVzlRRFBCdEhsNVlVK1dMRTgKx1TPZWWQiaU8iMni03/ekG+m4rFCcaa4
-            JI+ED2d+8411BgZtlss/ukQtwskidvYTvetyWw2jes6o1lhfDv5q2A==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVaUprdU9CUFpGdFRTazA5
+            Wll2RzVjUlhvRUVDbU1aVVhKV204Wjg3azFVCmdhYXZFTEl2TGFPTk83cmxjK2hM
+            RVNGZHBoSDZmQ1RKL0Y3S0ZHMUxEd2MKLS0tIDJaZWdsYVVuUXJPVkVCVlNPQkVG
+            eUt4NEUyVXVaa1FBVWhoeEJSTVpiWnMKJXNDKz9mf7zmb1oJ9BXgkDDfz2QUg/fJ
+            Sx2jlW7s1TuiH8GeL4jxw5Euh0DFw6YZO9j05dcygJslZWtLopUHAQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2021-12-23T01:03:48Z"
-    mac: ENC[AES256_GCM,data:ExJbBZ0tcAituM/rGZnndXPE7eXqgyo4kjgg2QxL/aYL0posX6Th0e4P9nYng36oeG86CPtlnxrPyKneP3swfOTktAvJP5GP7omNNYlyBgxui2/N9KeXAT74sLvR2MMWrpLUI+TaYHRwv7kIc9cbtWSyrFWVv/rEv4to+i5CEF4=,iv:2FiLnOuUHJciPyk9PgtLIkV7RuHu+9yqlQbs0d9eot4=,tag:i+H2jL1LO7KSQ9gFEMxSzw==,type:str]
+    lastmodified: "2022-02-18T17:21:55Z"
+    mac: ENC[AES256_GCM,data:50O/LO+8z+Dqm3wx8xaJGyL+nQ3KShQgDAYnV+GEjaacwBGhPSbwK5M/JxR98mq0PlikbHl0cv5CfUpvkShIuTdrz68QSsxn1KcVgiJeW5s8v2+0dJGEjOzy8ASnHm3uG0msB6cD00hrECc7htjaHCWk55cMlKliGUNNAh5Q28g=,iv:IujDY2mWrhfQNI1D40hev4yFNiqQSv8k4KN7kvpe7LQ=,tag:DfvoOkSxX1YIWPqAY31ifA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.1


### PR DESCRIPTION
This implements the following in `universe/aws` and `universe/aws/cli`

- `aws.#Build` provides a ready made `docker.#Image` with the CLI pre-installed to Amazon Linux 2 which avoids trust issues with installing glibc to Alpine from unknown parties
- `aws.#Container` provides an environment pre-configured with credentials and an optional config file. This is meant to execute _any_ command that uses an AWS SDK (not just CLI). Other packages under `universe/aws` will use this as a base primitive such as `aws/cli` and eventually `aws/cloudformation` and `aws/s3`. (This is generally not intended for direct use except in cases to support highly customized scripts that require the AWS SDK, but may prove very useful for teams migrating existing scripts to dagger.)
- `cli.#Command` as a declarative wrapper to the `aws` CLI. By specifying the global options, service name, and sub-command, `#Command` will automatically format the correct shell syntax and execute via `aws.#Container` storing the output in `/output.txt`. Furthermore when setting `unmarshal: true` (default) this definition will automatically `json.Unmarshal` the result into a CUE struct that can be referenced by `result.field` where `field` was present in the JSON output.

To use:

```cue
getCallerIdentity: cli.#Command & {
  credentials: aws.#Credentials & {
    accessKeyId:     inputs.secrets.AWS_ACCESS_KEY_ID.contents
    secretAccessKey: inputs.secrets.AWS_SECRET_ACCESS_KEY.contents
  }
  options: region: "us-east-2"
  service: {
    name:    "sts"
    command: "get-caller-identity"
  }
}

verify: getCallerIdentity.result & {
  UserId:  !~"^$"
  Account: !~"^$"
  Arn:     !~"^$"
}
```