### PR TITLE
pkg: docker: add the command exit code

### DIFF
--- a/pkg/universe.dagger.io/docker/run.cue
+++ b/pkg/universe.dagger.io/docker/run.cue
@@ -160,4 +160,7 @@ import (
 			user: input.config.user
 		}
 	}
+
+	// Command exit code
+	exit: _exec.exit
 }


### PR DESCRIPTION
This will be useful short term to workaround explicit dependencies and longer term for execution control.