### PR TITLE
Always deploy the docs

### DIFF
--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -4,9 +4,11 @@
   environment = { NODE_VERSION = "16.13.1" }
 
 [context.production]
+  ignore = "false"
 
 [context.deploy-preview]
   command = "yarn build:withoutAuth"
+  ignore = "false"
 
 [[redirects]]
   # Embargoes compliance. DO NOT REMOVE


### PR DESCRIPTION
The default ignore gets applied and then we have a similar behaviour to what https://github.com/dagger/dagger/pull/1591 was attempting to fix.

We hope that this will fix it for good.