### PR TITLE
Extract yarn install into a separate step

### DIFF
--- a/pkg/universe.dagger.io/yarn/test/test.cue
+++ b/pkg/universe.dagger.io/yarn/test/test.cue
@@ -66,7 +66,7 @@ dagger.#Plan & {
 
 			build: yarn.#Build & {
 				source: common.data
-				container: input: buildImage.output
+				container: #input: buildImage.output
 			}
 		}
 	}


### PR DESCRIPTION
If multiple `yarn.#Run` commands run in parallel, they will corrupt each other's `yarn cache` mount. Because we extract yarn install into a separate step, LLB will dedup the yarn install step and only run it once, regardless how many `yarn.#Run` commands run in parallel.

Fixes https://github.com/dagger/dagger/issues/1670
