### PR TITLE
Add link to Europa docs

### DIFF
--- a/docs/core-concepts/1202-plan.md
+++ b/docs/core-concepts/1202-plan.md
@@ -1,6 +1,6 @@
 ---
 slug: /1202/plan
-displayed_sidebar: europaSidebar
+displayed_sidebar: europa
 ---
 
 # It all starts with a plan

--- a/docs/core-concepts/1203-inputs.md
+++ b/docs/core-concepts/1203-inputs.md
@@ -1,6 +1,6 @@
 ---
 slug: /1203/inputs
-displayed_sidebar: europaSidebar
+displayed_sidebar: europa
 ---
 
 # Configuring inputs

--- a/docs/core-concepts/1204-secrets.md
+++ b/docs/core-concepts/1204-secrets.md
@@ -1,6 +1,6 @@
 ---
 slug: /1204/secrets
-displayed_sidebar: europaSidebar
+displayed_sidebar: europa
 ---
 
 # How to use secrets

--- a/docs/core-concepts/1205-container-images.md
+++ b/docs/core-concepts/1205-container-images.md
@@ -1,6 +1,6 @@
 ---
 slug: /1205/container-images
-displayed_sidebar: europaSidebar
+displayed_sidebar: europa
 ---
 
 # Building container images

--- a/docs/core-concepts/1206-caching.md
+++ b/docs/core-concepts/1206-caching.md
@@ -1,6 +1,6 @@
 ---
 slug: /1206/caching
-displayed_sidebar: europaSidebar
+displayed_sidebar: europa
 ---
 
 # Make your builds fast

--- a/docs/core-concepts/1207-packages.md
+++ b/docs/core-concepts/1207-packages.md
@@ -1,6 +1,6 @@
 ---
 slug: /1207/packages
-displayed_sidebar: europaSidebar
+displayed_sidebar: europa
 ---
 
 # Create your own package

--- a/docs/getting-started/1200-local-ci.md
+++ b/docs/getting-started/1200-local-ci.md
@@ -1,6 +1,6 @@
 ---
 slug: /1200/local-ci
-displayed_sidebar: europaSidebar
+displayed_sidebar: europa
 ---
 
 # Local CI setup

--- a/docs/getting-started/1201-ci-cd-platform.md
+++ b/docs/getting-started/1201-ci-cd-platform.md
@@ -1,6 +1,6 @@
 ---
 slug: /1201/ci-cd-platform
-displayed_sidebar: europaSidebar
+displayed_sidebar: europa
 ---
 
 # From local dev to CI/CD platform

--- a/docs/learn/1213-api.md
+++ b/docs/learn/1213-api.md
@@ -1,6 +1,6 @@
 ---
 slug: /1213/api
-displayed_sidebar: europaSidebar
+displayed_sidebar: europa
 ---
 
 # Dagger CUE API (0.2+)

--- a/docs/use-cases/1208-phoenix-kubernetes.md
+++ b/docs/use-cases/1208-phoenix-kubernetes.md
@@ -1,6 +1,6 @@
 ---
 slug: /1208/phoenix-kubernetes
-displayed_sidebar: europaSidebar
+displayed_sidebar: europa
 ---
 
 # Elixir/Phoenix on Kubernetes

--- a/docs/use-cases/1209-docusaurus-netlify.md
+++ b/docs/use-cases/1209-docusaurus-netlify.md
@@ -1,6 +1,6 @@
 ---
 slug: /1209/docusaurus-netlify
-displayed_sidebar: europaSidebar
+displayed_sidebar: europa
 ---
 
 # Docusaurus on Netlify

--- a/docs/use-cases/1210-go-goreleaser.md
+++ b/docs/use-cases/1210-go-goreleaser.md
@@ -1,6 +1,6 @@
 ---
 slug: /1210/go-goreleaser
-displayed_sidebar: europaSidebar
+displayed_sidebar: europa
 ---
 
 # Go with GoReleaser

--- a/docs/use-cases/1211-go-docker-swarm.md
+++ b/docs/use-cases/1211-go-docker-swarm.md
@@ -1,6 +1,6 @@
 ---
 slug: /1211/go-docker-swarm
-displayed_sidebar: europaSidebar
+displayed_sidebar: europa
 ---
 
 # Go on Docker Swarm

--- a/docs/use-cases/1212-svelte-vercel.md
+++ b/docs/use-cases/1212-svelte-vercel.md
@@ -1,6 +1,6 @@
 ---
 slug: /1212/svelte-vercel
-displayed_sidebar: europaSidebar
+displayed_sidebar: europa
 ---
 
 # Svelte on Vercel

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -10,7 +10,7 @@
  */
 
 module.exports = {
-  tutorialSidebar: [
+  preEuropa: [
     {
       type: "category",
       label: "Introduction",
@@ -64,8 +64,13 @@ module.exports = {
       collapsed: true,
       items: ["administrator/operator-manual"],
     },
+    {
+      type: "link",
+      label: "🆕 Dagger Europa 🆕",
+      href: "/1201/ci-cd-platform",
+    },
   ],
-  europaSidebar: [
+  europa: [
     {
       type: "category",
       label: "Getting Started",
@@ -102,6 +107,11 @@ module.exports = {
         "use-cases/go-docker-swarm",
         "use-cases/svelte-vercel",
       ],
+    },
+    {
+      type: "link",
+      label: "🕸  pre-Europa 🕸",
+      href: "/",
     },
   ],
 };


### PR DESCRIPTION
So that it's easy for anyone to jump to the new docs that we are currently working on, and intend to replace the existing docs with.

While I would have preferred to link to the local dev page, it's still stuck in the PR state, currently blocked on another PR: https://github.com/dagger/dagger/pull/1586

Also added a link to the pre-Europa docs, so that it's easy to go back.

While at it, drop "Sidebar" from the name of sidebars, and replace tutorial with a more descriptive name.

Part of https://github.com/dagger/dagger/issues/1327