### PR TITLE
Add a DRAFTS section to the Europa docs sidebar

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -109,6 +109,15 @@ module.exports = {
       ],
     },
     {
+      type: "category",
+      label: "DRAFTS",
+      collapsible: true,
+      collapsed: true,
+      items: [
+        "learn/api",
+      ],
+    },
+    {
       type: "link",
       label: "🕸  pre-Europa 🕸",
       href: "/",


### PR DESCRIPTION
This is meant to act as catch-all for pages that have been written ad-hoc, but don't currently fit anywhere.

While it was initially mentioned that this should be called **Knowledgebase**, it didn't seem to accurately describe the intent.

The email & message default **DRAFTS** seemed better, so I just went with it.

Part of https://github.com/dagger/dagger/issues/1327