### PR TITLE
Add #TrimSecret task

### DIFF
--- a/pkg/dagger.io/dagger/secrets.cue
+++ b/pkg/dagger.io/dagger/secrets.cue
@@ -27,3 +27,14 @@ package dagger
 	// Contents of the secret
 	output: #Secret
 }
+
+// Trim leading and trailing space characters from a secret
+#TrimSecret: {
+	$dagger: task: _name: "TrimSecret"
+
+	// Original secret
+	input: #Secret
+
+	// New trimmed secret
+	output: #Secret
+}

--- a/plan/task/trimsecret.go
+++ b/plan/task/trimsecret.go
@@ -1,0 +1,31 @@
+package task
+
+import (
+	"context"
+	"strings"
+
+	"go.dagger.io/dagger/compiler"
+	"go.dagger.io/dagger/plancontext"
+	"go.dagger.io/dagger/solver"
+)
+
+func init() {
+	Register("TrimSecret", func() Task { return &trimSecretTask{} })
+}
+
+type trimSecretTask struct {
+}
+
+func (t *trimSecretTask) Run(ctx context.Context, pctx *plancontext.Context, s solver.Solver, v *compiler.Value) (*compiler.Value, error) {
+	input, err := pctx.Secrets.FromValue(v.Lookup("input"))
+	if err != nil {
+		return nil, err
+	}
+
+	plaintext := strings.TrimSpace(input.PlainText())
+	secret := pctx.Secrets.New(plaintext)
+
+	return compiler.NewValue().FillFields(map[string]interface{}{
+		"output": secret.MarshalCUE(),
+	})
+}

--- a/tests/tasks.bats
+++ b/tests/tasks.bats
@@ -32,7 +32,7 @@ setup() {
 @test "task: #WriteFile failure: different contents" {
     cd "$TESTDIR"/tasks/writefile
     run "$DAGGER" up ./writefile_failure_diff_contents.cue
-    assert_failure 
+    assert_failure
 }
 
 @test "task: #Exec" {
@@ -102,7 +102,7 @@ setup() {
 
     run "$DAGGER" up ./subdir_invalid_path.cue
     assert_failure
-    
+
     run "$DAGGER" up ./subdir_invalid_exec.cue
     assert_failure
 }
@@ -132,6 +132,12 @@ setup() {
     cd "$TESTDIR"/tasks/newsecret
 
     "$DAGGER" up ./newsecret.cue
+}
+
+@test "task: #TrimSecret" {
+    cd "$TESTDIR"/tasks/trimsecret
+
+    "$DAGGER" up ./trimsecret.cue
 }
 
 @test "task: #Source" {

--- a/tests/tasks/trimsecret/trimsecret.cue
+++ b/tests/tasks/trimsecret/trimsecret.cue
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"dagger.io/dagger"
+)
+
+dagger.#Plan & {
+	actions: {
+		image: dagger.#Pull & {
+			source: "alpine:3.15.0@sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3"
+		}
+
+		generate: dagger.#Exec & {
+			input: image.output
+			args: ["sh", "-c", "echo ' test ' > /secret"]
+		}
+
+		load: dagger.#NewSecret & {
+			input:     generate.output
+			trimSpace: false
+			path:      "/secret"
+		}
+
+		trim: dagger.#TrimSecret & {
+			input: load.output
+		}
+
+		verify: dagger.#Exec & {
+			input: image.output
+			mounts: secret: {
+				dest:     "/run/secrets/test"
+				contents: trim.output
+			}
+			args: [
+				"sh", "-c",
+				#"""
+					test "$(cat /run/secrets/test)" = "test"
+					"""#,
+			]
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Helder Correia

/cc @talentedmrjones 

## Why 

Secret inputs are going to be replaced by the new [Client API](https://github.com/dagger/dagger/issues/1597) in #1668, and with it the common `trimSpace` option.

## What

Added new task to trim leading and trailing space characters from any secret, no matter how they were loaded.