### PR TITLE
Implements dagger project init

### DIFF
--- a/cmd/dagger/cmd/mod/get.go
+++ b/cmd/dagger/cmd/mod/get.go
@@ -27,7 +27,7 @@ var getCmd = &cobra.Command{
 		var err error
 
 		cueModPath := pkg.GetCueModParent()
-		err = pkg.CueModInit(ctx, cueModPath)
+		err = pkg.CueModInit(ctx, cueModPath, "")
 		if err != nil {
 			lg.Fatal().Err(err).Msg("failed to initialize cue.mod")
 			panic(err)

--- a/cmd/dagger/cmd/project/root.go
+++ b/cmd/dagger/cmd/project/root.go
@@ -1,0 +1,29 @@
+package project
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "project",
+	Short: "Manage a Dagger project",
+	// Args:  cobra.NoArgs,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		// Fix Viper bug for duplicate flags:
+		// https://github.com/spf13/viper/issues/233
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			panic(err)
+		}
+	},
+}
+
+func init() {
+	if err := viper.BindPFlags(Cmd.Flags()); err != nil {
+		panic(err)
+	}
+
+	Cmd.AddCommand(
+		initCmd,
+	)
+}

--- a/cmd/dagger/cmd/root.go
+++ b/cmd/dagger/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.dagger.io/dagger/cmd/dagger/cmd/mod"
+	"go.dagger.io/dagger/cmd/dagger/cmd/project"
 	"go.dagger.io/dagger/cmd/dagger/logger"
 
 	"go.opentelemetry.io/otel"
@@ -40,12 +41,12 @@ func init() {
 	}
 
 	rootCmd.AddCommand(
-		initCmd,
 		upCmd,
 		versionCmd,
 		docCmd,
 		mod.Cmd,
 		doCmd,
+		project.Cmd,
 	)
 
 	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {

--- a/pkg/pkg.go
+++ b/pkg/pkg.go
@@ -57,7 +57,7 @@ func Vendor(ctx context.Context, p string) error {
 	}()
 
 	// ensure cue module is initialized
-	if err := CueModInit(ctx, p); err != nil {
+	if err := CueModInit(ctx, p, ""); err != nil {
 		return err
 	}
 
@@ -165,11 +165,16 @@ func GetCueModParent() string {
 	return parentDir
 }
 
-func CueModInit(ctx context.Context, parentDir string) error {
+func CueModInit(ctx context.Context, parentDir, module string) error {
 	lg := log.Ctx(ctx)
 
-	modDir := path.Join(parentDir, "cue.mod")
-	if err := os.Mkdir(modDir, 0755); err != nil {
+	absParentDir, err := filepath.Abs(parentDir)
+	if err != nil {
+		return err
+	}
+
+	modDir := path.Join(absParentDir, "cue.mod")
+	if err := os.MkdirAll(modDir, 0755); err != nil {
 		if !errors.Is(err, os.ErrExist) {
 			return err
 		}
@@ -183,8 +188,8 @@ func CueModInit(ctx context.Context, parentDir string) error {
 		}
 
 		lg.Debug().Str("mod", parentDir).Msg("initializing cue.mod")
-
-		if err := os.WriteFile(modFile, []byte("module: \"\"\n"), 0600); err != nil {
+		contents := fmt.Sprintf(`module: "%s"`, module)
+		if err := os.WriteFile(modFile, []byte(contents), 0600); err != nil {
 			return err
 		}
 	}

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -39,6 +39,7 @@ type Config struct {
 func Load(ctx context.Context, cfg Config) (*Plan, error) {
 	log.Ctx(ctx).Debug().Interface("args", cfg.Args).Msg("loading plan")
 
+	// FIXME: move vendoring to explicit project update command
 	if cfg.Vendor {
 		// FIXME: vendoring path
 		if err := pkg.Vendor(ctx, ""); err != nil {

--- a/tests/project.bats
+++ b/tests/project.bats
@@ -1,0 +1,16 @@
+setup() {
+	load 'helpers'
+
+	common_setup
+}
+
+@test "project init" {
+	cd "$TESTDIR"
+	# mkdir -p ./project/init
+	"$DAGGER" project init ./project/init --name "github.com/foo/bar"
+	test -d ./project/init/cue.mod/pkg
+	test -d ./project/init/cue.mod/usr
+	test -f ./project/init/cue.mod/module.cue
+	contents=$(cat ./project/init/cue.mod/module.cue)
+	[ "$contents" == 'module: "github.com/foo/bar"' ]
+}


### PR DESCRIPTION
`dagger project init` will initialize a new empty Dagger project.

To use:
```bash
dagger project init [path] [--name]
```

`path` will default to current working directory
`--name` will default to empty string and used to set `module:` name in `module.cue` just like `cue mod init`

If `path` does not exist it will be created.

Closes #1684 

Signed-off-by: Richard Jones