### PR TITLE
Temporarily remove Use Cases from the Europa docs sidebar

### DIFF
--- a/docs/use-cases/1211-go-docker-swarm.md
+++ b/docs/use-cases/1211-go-docker-swarm.md
@@ -58,7 +58,7 @@ dagger.#Plan & {
         // - stop container
       }
 
-      push: docker.#Push {
+      push: docker.#Push & {
         dest: inputs.params.image.ref
         image: build.output
       }

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -97,24 +97,12 @@ module.exports = {
     },
     {
       type: "category",
-      label: "Use Cases",
-      collapsible: false,
-      collapsed: false,
-      items: [
-        "use-cases/phoenix-kubernetes",
-        "use-cases/docusaurus-netlify",
-        "use-cases/go-goreleaser",
-        "use-cases/go-docker-swarm",
-        "use-cases/svelte-vercel",
-      ],
-    },
-    {
-      type: "category",
       label: "DRAFTS",
       collapsible: true,
       collapsed: true,
       items: [
         "learn/api",
+        "use-cases/go-docker-swarm",
       ],
     },
     {


### PR DESCRIPTION
The current plan is to add them post 0.2.0 shipping, for now the focus
is on **Getting Started** & **Core Concepts**.

Part of #1327