### PR TITLE
dagger do now uses --plan instead of --project

### DIFF
--- a/cmd/dagger/cmd/root.go
+++ b/cmd/dagger/cmd/root.go
@@ -31,8 +31,6 @@ func init() {
 	rootCmd.PersistentFlags().StringArray("cache-from", []string{},
 		"External cache sources (eg. user/app:cache, type=local,src=path/to/dir)")
 
-	rootCmd.PersistentFlags().StringP("project", "p", "./", "Specify a project directory (defaults to current)")
-
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, _ []string) {
 		go checkVersion()
 	}


### PR DESCRIPTION
This PR changes the behavior of `dagger do` to use a `--plan` flag to denote the location of the plan and deprecates the global flag `--project`

It also enforces that `--plan` points to an existing local filesystem even though Cue supports loading things like module or package names

Signed-off-by: Richard Jones