### PR TITLE
Cover packages before caching

### DIFF
--- a/docs/core-concepts/1206-packages.md
+++ b/docs/core-concepts/1206-packages.md
@@ -1,5 +1,5 @@
 ---
-slug: /1207/packages
+slug: /1206/packages
 displayed_sidebar: europa
 ---
 

--- a/docs/core-concepts/1207-caching.md
+++ b/docs/core-concepts/1207-caching.md
@@ -1,5 +1,5 @@
 ---
-slug: /1206/caching
+slug: /1207/caching
 displayed_sidebar: europa
 ---
 


### PR DESCRIPTION
We are still figuring out caching, specifically Buildkit go client caching, while packages is something that users can start creating right away.