### PR TITLE
cmd/up: deprecate `dagger up` with a warning

### DIFF
--- a/cmd/dagger/cmd/up.go
+++ b/cmd/dagger/cmd/up.go
@@ -18,6 +18,10 @@ import (
 )
 
 var upCmd = &cobra.Command{
+	// FIXME: this command will be removed soon
+	Hidden:     true,
+	Deprecated: "please use `dagger do ACTION` instead",
+
 	Use:   "up",
 	Short: "Bring an environment online with latest plan and inputs",
 	Args:  cobra.MaximumNArgs(1),


### PR DESCRIPTION
Deprecate `dagger up` + hid it from the help message.

Preview:
<img width="484" alt="Screen Shot 2022-03-08 at 5 17 20 PM" src="https://user-images.githubusercontent.com/216487/157353459-d13c2bcd-ae58-4f2b-9444-17fd2d4c695b.png">

