### PR TITLE
Track latest version by Major.Minor when releasing via GoReleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -67,8 +67,24 @@ blobs:
     folder: "dagger/releases/{{ .Version }}"
 
 publishers:
-  - name: publish-version
+  - name: publish-latest-version
     cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://dagger-io/dagger/latest_version"
+    env:
+      - PATH={{ .Env.PATH }}
+      - AWS_EC2_METADATA_DISABLED=true
+      - AWS_ACCESS_KEY_ID={{ .Env.AWS_ACCESS_KEY_ID }}
+      - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
+      - AWS_REGION={{ .Env.AWS_REGION }}
+  - name: publish-latest
+    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://dagger-io/dagger/versions/latest"
+    env:
+      - PATH={{ .Env.PATH }}
+      - AWS_EC2_METADATA_DISABLED=true
+      - AWS_ACCESS_KEY_ID={{ .Env.AWS_ACCESS_KEY_ID }}
+      - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
+      - AWS_REGION={{ .Env.AWS_REGION }}
+  - name: publish-latest-major-minor
+    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://dagger-io/dagger/versions/{{ .Major }}.{{ .Minor }}"
     env:
       - PATH={{ .Env.PATH }}
       - AWS_EC2_METADATA_DISABLED=true


### PR DESCRIPTION
We want to be able to download the latest published version for a specific Major.Minor. In the Dagger GitHub Action, we want to be able to restrict the versions to e.g. latest 0.2.

This is what we have today:

```
curl https://dl.dagger.io/dagger/versions/latest
0.2.0-alpha.6

curl https://dl.dagger.io/dagger/versions/0.2
0.2.0-alpha.6

curl https://dl.dagger.io/dagger/versions/0.1
0.1.0
```

After we merge this pull request and create a new release with GoReleaser, the above will change to:

```
curl https://dl.dagger.io/dagger/versions/latest
0.2.0-beta.1

curl https://dl.dagger.io/dagger/versions/0.2
0.2.0-beta.1

curl https://dl.dagger.io/dagger/versions/0.1
0.1.0
```

cc @crazy-max @grouville @aluzzardi 