### PR TITLE
Fix dagger-for-github version

### DIFF
--- a/docs/getting-started/1201-ci-environment.md
+++ b/docs/getting-started/1201-ci-environment.md
@@ -60,11 +60,10 @@ jobs:
 
       - name: Deploy to Netlify
         # https://github.com/dagger/dagger-for-github
-        uses: dagger/dagger-for-github@v0.2
+        uses: dagger/dagger-for-github@v2
         with:
           workdir: pkg/universe.dagger.io/examples/todoapp
-          plan: .
-          do: deploy
+          args: do deploy
 ```
 
 </TabItem>


### PR DESCRIPTION
We assume that this will be out by then.

The latest version is v1 (v1.2.1 specifically). Since we cannot undo the versioning, and go back to v0.2, we capture the breaking change in `with` properties, and the new version default value (`0.2/latest` after https://github.com/dagger/dagger/pull/1733) and go to the next version that we can: `v2`

cc @crazy-max @grouville 