### PR TITLE
Disable default completion command

### DIFF
--- a/cmd/dagger/cmd/root.go
+++ b/cmd/dagger/cmd/root.go
@@ -44,6 +44,7 @@ func init() {
 		doCmd,
 		project.Cmd,
 	)
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
 
 	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {
 		panic(err)


### PR DESCRIPTION
```
jeremyadams@Jeremys-MBP-2 dagger % cmd/dagger/dagger
A programmable deployment system

Usage:
  dagger [command]

Available Commands:
  do          Execute a dagger action.
  help        Help about any command
  project     Manage a Dagger project
  version     Print dagger version
  ```
  
  https://github.com/dagger/dagger/issues/1698