### PR TITLE
[Docs] Move snippets outside of markdown

### DIFF
--- a/docs/core-concepts/1203-client.md
+++ b/docs/core-concepts/1203-client.md
@@ -17,37 +17,12 @@ displayed_sidebar: europa
 
 You may need to load a local directory as a `dagger.#FS` type in your plan:
 
-```cue
-dagger.#Plan & {
-    // Path may be absolute, or relative to current working directory
-    client: filesystem: ".": read: {
-        // CUE type defines expected content
-        contents: dagger.#FS
-        exclude: ["node_modules"]
-    }
-    actions: {
-        ...
-        copy: docker.Copy & {
-            contents: client.filesystem.".".read.contents
-        }
-        ...
-    }
-}
+```cue file=../tests/core-concepts/client/plans/fs.cue
 ```
 
 It’s also easy to write a file locally:
 
-```cue
-dagger.#Plan & {
-    client: filesystem: "config.yaml": write: {
-        contents: yaml.Marshal(actions.pull.output.config)
-    }
-    actions: {
-        pull: docker.#Pull & {
-            source: "alpine"
-        }
-    }
-}
+```cue file=../tests/core-concepts/client/plans/file.cue
 ```
 
 ## Using a local socket
@@ -61,59 +36,14 @@ import TabItem from '@theme/TabItem';
 
 <TabItem value="unix" label="Linux/macOS">
 
-```cue
-dagger.#Plan & {
-    client: filesystem: "/var/run/docker.sock": read: {
-        contents: dagger.#Service
-    }
-
-    actions: {
-        image: alpine.#Build & {
-            packages: "docker-cli": {}
-        }
-        run: docker.#Run & {
-            input: image.output
-            mounts: docker: {
-                dest:     "/var/run/docker.sock"
-                contents: client.filesystem."/var/run/docker.sock".read.contents
-            }
-            command: {
-                name: "docker"
-                args: ["info"]
-            }
-        }
-    }
-}
+```cue file=../tests/core-concepts/client/plans/unix.cue
 ```
 
 </TabItem>
 
 <TabItem value="windows" label="Windows">
 
-```cue
-dagger.#Plan & {
-    client: filesystem: "//./pipe/docker_engine": read: {
-        contents: dagger.#Service
-        type: "npipe"
-    }
-
-    actions: {
-        image: alpine.#Build & {
-            packages: "docker-cli": {}
-        }
-        run: docker.#Run & {
-            input: image.output
-            mounts: docker: {
-                dest:     "/var/run/docker.sock"
-                contents: client.filesystem."//./pipe/docker_engine".read.contents
-            }
-            command: {
-                name: "docker"
-                args: ["info"]
-            }
-        }
-    }
-}
+```cue file=../tests/core-concepts/client/plans/windows.cue
 ```
 
 </TabItem>
@@ -123,68 +53,23 @@ dagger.#Plan & {
 
 Environment variables can be read from the local machine as strings or secrets, just specify the type:
 
-```cue
-dagger.#Plan & {
-    client: env: {
-        GITLAB_USER: string
-        GITLAB_TOKEN: dagger.#Secret
-    }
-    actions: {
-        pull: docker.#Pull & {
-            source: "registry.gitlab.com/myuser/myrepo"
-            auth: {
-                username: client.env.GITLAB_USR
-                secret: client.env.GITLAB_TOKEN
-            }
-        }
-    }
-}
+```cue file=../tests/core-concepts/client/plans/env.cue
 ```
 
 ## Running commands
 
 Sometimes you need something more advanced that only a local command can give you:
 
-```cue
-dagger.#Plan & {
-    client: commands: {
-        os: {
-            name: "uname"
-            args: ["-s"]
-        }
-        arch: {
-            name: "uname"
-            args: ["-m"]
-        }
-    }
-    actions: {
-        build: docker.#Run & {
-            env: {
-                CLIENT_OS: client.commands.os.stdout
-                CLIENT_ARCH: client.commands.arch.stdout
-            }
-        }
-    }
-}
+```cue file=../tests/core-concepts/client/plans/cmd.cue
 ```
 
+:::tip
 You can also capture `stderr` for errors and provide `stdin` for input.
+:::
 
 ## Platform
 
 If you need the current platform though, there’s a more portable way than running `uname` like in the previous example:
 
-```cue
-dagger.#Plan & {
-    client: platform: _
-
-    actions: {
-        build: docker.#Run & {
-            env: {
-                CLIENT_OS: client.platform.os
-                CLIENT_ARCH: client.platform.arch
-            }
-        }
-    }
-}
+```cue file=../tests/core-concepts/client/plans/platform.cue
 ```

--- a/docs/core-concepts/1204-secrets.md
+++ b/docs/core-concepts/1204-secrets.md
@@ -27,26 +27,7 @@ dagger.#Plan & {
 
 You may need to trim the whitespace, especially when reading from a file:
 
-```cue
-dagger.#Plan & {
-    // Path may be absolute, or relative to current working directory
-    client: filesystem: ".registry": read: {
-        // CUE type defines expected content
-        contents: dagger.#Secret
-    }
-    actions: {
-        registry: dagger.#TrimSecret & {
-            input: client.filesystem.".registry".read.contents
-        }
-        pull: docker.#Pull & {
-            source: "myprivate/image"
-            auth: {
-                username: "_token_"
-                secret: registry.output
-            }
-        }
-    }
-}
+```cue file=../tests/core-concepts/secrets/plans/file.cue
 ```
 
 ## SOPS
@@ -59,30 +40,5 @@ sops:
     ...
 ```
 
-```cue title="main.cue"
-dagger.#Plan & {
-    client: commands: sops: {
-        name: "sops"
-        args: ["-d", "./secrets.yaml"]
-        stdout: dagger.#Secret
-    }
-
-    actions: {
-        // Makes the yaml keys easily accessible
-        secrets: dagger.#DecodeSecret & {
-            input: client.commands.sops.stdout
-            format: "yaml"
-        }
-
-        run: docker.#Run & {
-            mounts: secret: {
-                dest:     "/run/secrets/token"
-                contents: secrets.output.myToken
-            }
-            // Do something with `/run/secrets/token`
-            ...
-        }
-    }
-}
-
+```cue file=../tests/core-concepts/secrets/plans/sops.cue title="main.cue"
 ```

--- a/docs/tests/core-concepts/client/plans/cmd.cue
+++ b/docs/tests/core-concepts/client/plans/cmd.cue
@@ -1,0 +1,18 @@
+dagger.#Plan & {
+	client: commands: {
+		os: {
+			name: "uname"
+			args: ["-s"]
+		}
+		arch: {
+			name: "uname"
+			args: ["-m"]
+		}
+	}
+
+	actions: build: go.#Build & {
+		os:   client.commands.os.stdout
+		arch: client.commands.arch.stdout
+		// ...
+	}
+}

--- a/docs/tests/core-concepts/client/plans/env.cue
+++ b/docs/tests/core-concepts/client/plans/env.cue
@@ -1,0 +1,14 @@
+dagger.#Plan & {
+	client: env: {
+		REGISTRY_USER:  string
+		REGISTRY_TOKEN: dagger.#Secret
+	}
+
+	actions: pull: docker.#Pull & {
+		source: "registry.example.com/image"
+		auth: {
+			username: client.env.REGISTRY_USER
+			secret:   client.env.REGISTRY_TOKEN
+		}
+	}
+}

--- a/docs/tests/core-concepts/client/plans/file.cue
+++ b/docs/tests/core-concepts/client/plans/file.cue
@@ -1,0 +1,15 @@
+import (
+	"encoding/yaml"
+	// ...
+)
+
+dagger.#Plan & {
+	client: filesystem: "config.yaml": write: {
+		// Convert a CUE value into a YAML formatted string
+		contents: yaml.Marshal(actions.pull.output.config)
+	}
+
+	actions: pull: docker.#Pull & {
+		source: "alpine"
+	}
+}

--- a/docs/tests/core-concepts/client/plans/fs.cue
+++ b/docs/tests/core-concepts/client/plans/fs.cue
@@ -1,0 +1,15 @@
+dagger.#Plan & {
+	// Path may be absolute, or relative to current working directory
+	client: filesystem: ".": read: {
+		// CUE type defines expected content
+		contents: dagger.#FS
+		exclude: ["node_modules"]
+	}
+
+	actions: {
+		copy: docker.Copy & {
+			contents: client.filesystem.".".read.contents
+		}
+		// ...
+	}
+}

--- a/docs/tests/core-concepts/client/plans/platform.cue
+++ b/docs/tests/core-concepts/client/plans/platform.cue
@@ -1,0 +1,9 @@
+dagger.#Plan & {
+	client: _
+
+	actions: build: go.#Build & {
+		os:   client.platform.os
+		arch: client.platform.arch
+		// ...
+	}
+}

--- a/docs/tests/core-concepts/client/plans/unix.cue
+++ b/docs/tests/core-concepts/client/plans/unix.cue
@@ -1,0 +1,20 @@
+dagger.#Plan & {
+	client: filesystem: "/var/run/docker.sock": read: contents: dagger.#Service
+
+	actions: {
+		image: alpine.#Build & {
+			packages: "docker-cli": {}
+		}
+		run: docker.#Run & {
+			input: image.output
+			mounts: docker: {
+				dest:     "/var/run/docker.sock"
+				contents: client.filesystem."/var/run/docker.sock".read.contents
+			}
+			command: {
+				name: "docker"
+				args: ["info"]
+			}
+		}
+	}
+}

--- a/docs/tests/core-concepts/client/plans/windows.cue
+++ b/docs/tests/core-concepts/client/plans/windows.cue
@@ -1,0 +1,23 @@
+dagger.#Plan & {
+	client: filesystem: "//./pipe/docker_engine": read: {
+		contents: dagger.#Service
+		type:     "npipe"
+	}
+
+	actions: {
+		image: alpine.#Build & {
+			packages: "docker-cli": {}
+		}
+		run: docker.#Run & {
+			input: image.output
+			mounts: docker: {
+				dest:     "/var/run/docker.sock"
+				contents: client.filesystem."//./pipe/docker_engine".read.contents
+			}
+			command: {
+				name: "docker"
+				args: ["info"]
+			}
+		}
+	}
+}

--- a/docs/tests/core-concepts/container-images/plans/src/app.go
+++ b/docs/tests/core-concepts/container-images/plans/src/app.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, 世界")
+}

--- a/docs/tests/core-concepts/container-images/plans/src/go.mod
+++ b/docs/tests/core-concepts/container-images/plans/src/go.mod
@@ -1,0 +1,3 @@
+module dagger.io/test
+
+go 1.17

--- a/docs/tests/core-concepts/secrets/plans/file.cue
+++ b/docs/tests/core-concepts/secrets/plans/file.cue
@@ -1,0 +1,19 @@
+dagger.#Plan & {
+	// Path may be absolute, or relative to current working directory
+	client: filesystem: ".registry": read: {
+		// CUE type defines expected content
+		contents: dagger.#Secret
+	}
+	actions: {
+		registry: dagger.#TrimSecret & {
+			input: client.filesystem.".registry".read.contents
+		}
+		pull: docker.#Pull & {
+			source: "registry.example.com/image"
+			auth: {
+				username: "_token_"
+				secret:   registry.output
+			}
+		}
+	}
+}

--- a/docs/tests/core-concepts/secrets/plans/sops.cue
+++ b/docs/tests/core-concepts/secrets/plans/sops.cue
@@ -1,0 +1,23 @@
+dagger.#Plan & {
+	client: commands: sops: {
+		name: "sops"
+		args: ["-d", "./secrets.yaml"]
+		stdout: dagger.#Secret
+	}
+
+	actions: {
+		// Makes the yaml keys easily accessible
+		secrets: dagger.#DecodeSecret & {
+			input:  client.commands.sops.stdout
+			format: "yaml"
+		}
+
+		run: docker.#Run & {
+			mounts: secret: {
+				dest:     "/run/secrets/token"
+				contents: secrets.output.myToken
+			}
+			// Do something with `/run/secrets/token`
+		}
+	}
+}


### PR DESCRIPTION
Related to #1715, this moves contributed docs from #1668 outside of markdown to allow linting.

There's still tests missing, to be added later. We need a new bats in `docs/tests`.

Even though most of these snippets are incomplete to keep them shorter, the multi-stage build in [Building container images](https://github.com/dagger/dagger/blob/cf0505614f2888652a3a5ab2fd93dfff246a2864/docs/tests/core-concepts/container-images/plans/multi-stage.cue) has been tested manually with attached data files.

Signed-off-by: Helder Correia