### PR TITLE
ci: close stale PRs automatically

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+name: "Close stale PRs"
+permissions:
+  issues: write
+  pull-requests: write
+
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          debug-only: true
+          stale-pr-label: stale
+          stale-pr-message: "This PR is stale because it has been open 14 days with no activity. Remove stale label or comment or this will be closed in 7 days."
+          close-pr-message: "This PR was closed because it has been stalled for 7 days with no activity."
+          days-before-pr-stale: 14
+          days-before-pr-close: 7
+          stale-issue-label: stale
+          days-before-issue-stale: -1
+          days-before-issue-close: -1


### PR DESCRIPTION
Label PRs as `stale` after 14 days, close them 7 days after.
