### PR TITLE
ci: auto release: bump patch version

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -25,7 +25,7 @@ on:
     inputs:
       release_type:
         description: 'major|minor|patch|release|prerel'
-        default: 'prerel alpha..'
+        default: 'patch'
         required: true
       release_version:
         description: 'Optional release version, e.g. 0.2.0'


### PR DESCRIPTION
In preparation of releasing `0.2.0`, we need to change the auto-releaser to bump patch versions rather than prerel.
