### PR TITLE
docs: migrate from 0.1

### DIFF
--- a/docs/knowledge-base/1214-migrate-from-dagger-0.1.md
+++ b/docs/knowledge-base/1214-migrate-from-dagger-0.1.md
@@ -1,0 +1,16 @@
+---
+slug: /1214/migrate-from-dagger-0.1
+displayed_sidebar: europa
+---
+
+# Migrate from Dagger 0.1
+
+We are getting ready to release dagger 0.2, codename Europa. This release has one focus: improve the developer experience. It features a redesigned CLI and powerful new APIs. The result is a completely new way to develop CI/CD pipelines: more productive, more portable… and way more fun!
+
+However, there is a downside: unfortunately, this release is not backwards compatible: plans written for dagger 0.1 will not run on version 0.2. Automatic migration is not supported, but manual migration is relatively straightforward.
+
+If you need help migrating your plan, we will be happy to assist you! Simply reply to [this thread](https://github.com/dagger/dagger/discussions/1772) with a description of your configuration. If you've already started migrating, please let us know and share details of your progress and issues you're encountering. We will do our best to assist you!
+
+Since we are a small team, we cannot promise to migrate all of your configurations on our own. But we will do our very best to help you get there. We are making this work our priority.
+
+We apologize once again for breaking compatibility. We hope you will find that the new features of Europa are worth it 😁

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -76,10 +76,7 @@ module.exports = {
       label: "Getting Started",
       collapsible: false,
       collapsed: false,
-      items: [
-        "getting-started/local-dev",
-        "getting-started/ci-environment"
-      ],
+      items: ["getting-started/local-dev", "getting-started/ci-environment"],
     },
     {
       type: "category",
@@ -95,10 +92,11 @@ module.exports = {
     },
     {
       type: "category",
-      label: "DRAFTS",
-      collapsible: true,
-      collapsed: true,
+      label: "Knowledge Base",
+      collapsible: false,
+      collapsed: false,
       items: [
+        "knowledge-base/migrate-from-dagger-0.1",
         "learn/api",
         "use-cases/go-docker-swarm",
       ],


### PR DESCRIPTION
- Temporary page that just points to the GitHub Discussion
- Goal: create a stable link we can share, update with proper content
  later
- Wasn't sure how to categorize this so I've renamed `DRAFTS` into
  `Knowledge Base`

Fixes #1759
