### PR TITLE
dagger.#Nop: work around bugs in the DAG resolver

### DIFF
--- a/pkg/dagger.io/dagger/nop.cue
+++ b/pkg/dagger.io/dagger/nop.cue
@@ -1,0 +1,10 @@
+package dagger
+
+// A core action that does nothing
+// Useful to work around bugs in the DAG resolver.
+//  See for example https://github.com/dagger/dagger/issues/1789
+#Nop: {
+	$dagger: task: _name: "Nop"
+	input:  _
+	output: input
+}

--- a/plan/task/nop.go
+++ b/plan/task/nop.go
@@ -1,0 +1,20 @@
+package task
+
+import (
+	"context"
+
+	"go.dagger.io/dagger/compiler"
+	"go.dagger.io/dagger/plancontext"
+	"go.dagger.io/dagger/solver"
+)
+
+func init() {
+	Register("Nop", func() Task { return &nopTask{} })
+}
+
+type nopTask struct {
+}
+
+func (t *nopTask) Run(ctx context.Context, pctx *plancontext.Context, s solver.Solver, v *compiler.Value) (*compiler.Value, error) {
+	return v, nil
+}


### PR DESCRIPTION
This does not fix #1789, but it does allow working around it. A pure cue action can wrap its output in `dagger.#Nop`, which will trigger client filesystem writes.