### PR TITLE
docs: fix typo in snippet

### DIFF
--- a/docs/tests/core-concepts/client/plans/fs.cue
+++ b/docs/tests/core-concepts/client/plans/fs.cue
@@ -7,7 +7,7 @@ dagger.#Plan & {
 	}
 
 	actions: {
-		copy: docker.Copy & {
+		copy: docker.#Copy & {
 			contents: client.filesystem.".".read.contents
 		}
 		// ...


### PR DESCRIPTION
Minor issue I spotted while reading the docs for the first time, apologies for the nitpick!

The reference to `docker.Copy` does not exist and should be `docker.#Copy` instead. This also leads to a confusing error message (possibly related to #493) as it isn't found while CUE is compiled, and instead results in the following runtime error:

```
[✗] actions.deps                                                                                                                                  2.1s
9:16PM FTL failed to execute plan: task failed: actions.deps._dag."2"._exec: invalid FS at path "actions.deps._dag.\"2\"._exec.input": FS is not set
```