### PR TITLE
Bump golangci-lint to latest

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,7 +52,7 @@ jobs:
       - name: "Lint go"
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.39
+          version: v1.45
           skip-go-installation: true
           args: --timeout=3m
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,7 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - golint
+    - revive
     - goprintffuncname
     - gosec
     - gosimple


### PR DESCRIPTION
Golint is replaced with revive since the former has been archived and
replaced with the latter.

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>