### PR TITLE
Rebuild Algolia search index for docs

### DIFF
--- a/website/docsearch.config.json
+++ b/website/docsearch.config.json
@@ -1,16 +1,22 @@
 {
   "index_name": "Dagger_docs",
   "start_urls": [
-    "https://deploy-preview-929--devel-docs-dagger-io.netlify.app/"
+    "https://deploy-preview-1833--devel-docs-dagger-io.netlify.app/index.html",
+    "https://deploy-preview-1833--devel-docs-dagger-io.netlify.app/1201/ci-environment/",
+    "https://deploy-preview-1833--devel-docs-dagger-io.netlify.app/1202/plan/",
+    "https://deploy-preview-1833--devel-docs-dagger-io.netlify.app/1203/client/",
+    "https://deploy-preview-1833--devel-docs-dagger-io.netlify.app/1204/secrets/",
+    "https://deploy-preview-1833--devel-docs-dagger-io.netlify.app/1205/container-images/",
+    "https://deploy-preview-1833--devel-docs-dagger-io.netlify.app/1211/go-docker-swarm/",
+    "https://deploy-preview-1833--devel-docs-dagger-io.netlify.app/1213/api/",
+    "https://deploy-preview-1833--devel-docs-dagger-io.netlify.app/1214/migrate-from-dagger-0.1/"
   ],
-  "sitemap_urls": [
-    "https://deploy-preview-929--devel-docs-dagger-io.netlify.app/sitemap.xml"
-  ],
+  "sitemap_urls": [],
   "sitemap_alternate_links": true,
   "stop_urls": [],
   "selectors": {
     "lvl0": {
-      "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
+      "selector": "(//nav[contains(@class,'menu')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text())[last()]",
       "type": "xpath",
       "global": true,
       "default_value": "Documentation"

--- a/website/env.example
+++ b/website/env.example
@@ -1,0 +1,7 @@
+# https://www.algolia.com/apps/XSSC1LRN4S/explorer/browse/Dagger_docs
+APPLICATION_ID=XSSC1LRN4S
+# Copy your "Write API KEY" from https://www.algolia.com/account/api-keys/all?applicationId=XSSC1LRN4S
+API_KEY=
+# This will not work on an ARM Mac, the algolia/docsearch-scraper image was only built for linux 64bit
+# I am using a Docker Engine on Linux here:
+DOCKER_HOST=ssh://192.168.1.22

--- a/website/rebuild_algolia_docs_search_index.sh
+++ b/website/rebuild_algolia_docs_search_index.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+type jq
+type docker
+
+docker run -it \
+  -e API_KEY="${API_KEY:?must be set}" \
+  -e APPLICATION_ID="${APPLICATION_ID:?must be set}" \
+  -e "CONFIG=$(jq -r tostring < docsearch.config.json)" \
+  algolia/docsearch-scraper


### PR DESCRIPTION
Only include Europa (a.k.a. 0.2.0) docs in search results. Fixes #1832.

    cd website
    ./rebuild_algolia_docs_search_index.sh
    jq is /Users/gerhard/.nix-profile/bin/jq
    docker is /Users/gerhard/.nix-profile/bin/docker
    > DocSearch: https://deploy-preview-1833--devel-docs-dagger-io.netlify.app/1202/plan/ 16 records)
    > DocSearch: https://deploy-preview-1833--devel-docs-dagger-io.netlify.app/1214/migrate-from-dagger-0.1/ 5 records)
    > DocSearch: https://deploy-preview-1833--devel-docs-dagger-io.netlify.app/index.html 40 records)
    > DocSearch: https://deploy-preview-1833--devel-docs-dagger-io.netlify.app/1213/api/ 47 records)
    > DocSearch: https://deploy-preview-1833--devel-docs-dagger-io.netlify.app/1201/ci-environment/ 15 records)
    > DocSearch: https://deploy-preview-1833--devel-docs-dagger-io.netlify.app/1203/client/ 21 records)
    > DocSearch: https://deploy-preview-1833--devel-docs-dagger-io.netlify.app/1211/go-docker-swarm/ 15 records)
    > DocSearch: https://deploy-preview-1833--devel-docs-dagger-io.netlify.app/1204/secrets/ 12 records)
    > DocSearch: https://deploy-preview-1833--devel-docs-dagger-io.netlify.app/1205/container-images/ 9 records)

    Nb hits: 180

To try it out, run a few searches on https://docs.dagger.io/. This changes is already in production, we are capturing how we got it all working. As a next step, we should **not** add this to the CI, but instead setup the Algolia Crawler (requires us to upgrade to a paid account): https://www.algolia.com/doc/tools/crawler/getting-started/overview/

cc @aluzzardi for visibility into Algolia Crawler