### PR TITLE
Explain bash package import in Europa Docs - Core Concepts - It all starts with a plan

### DIFF
--- a/docs/core-concepts/1202-plan.md
+++ b/docs/core-concepts/1202-plan.md
@@ -58,11 +58,12 @@ import (
 )
 ```
 
-Since we are using the plan definition from the dagger package - `dagger.#Plan` - we also need to declare it at the top of the pipeline configuration:
+Since we are using the plan definition from the dagger package - `dagger.#Plan` - we also need to declare it at the top of the pipeline configuration, as well as the bash package - `bash.#Run`:
 
 ```cue
 import (
   "dagger.io/dagger"
+  "universe.dagger.io/bash"
   "universe.dagger.io/docker"
 )
 ```


### PR DESCRIPTION
In the cue fragment, we have references to `bash.#Run`. Letting the user know that this comes from another package as well could avoid some implicit idea of some builtin commands.