### PR TITLE
[WIP] Add docker engine client

### DIFF
--- a/pkg/universe.dagger.io/docker/test/client.cue
+++ b/pkg/universe.dagger.io/docker/test/client.cue
@@ -1,0 +1,74 @@
+package docker
+
+#Client: {
+	#RunSocket | #RunSSH | #RunTCP
+
+	_image: #Pull & {
+		source: "docker:20.10.13-alpine3.15"
+	}
+
+	input: _image.output
+}
+
+// Connect via local docker socket
+#RunSocket: {
+	host: dagger.#Service
+
+	#Run & {
+		mounts: docker: {
+			dest:     "/var/run/docker.sock"
+			contents: host
+		}
+	}
+}
+
+// Connect via SSH
+#RunSSH: {
+	host: =~"^ssh://.+"
+
+	ssh: {
+		// Private SSH key
+		key?: dagger.#Secret
+
+		// Known hosts file contents
+		knownHosts?: dagger.#Secret
+	}
+
+	#Run & {
+		env: DOCKER_HOST: host
+
+		if ssh.key != _|_ {
+			mounts: ssh_key: {
+				dest:     "/root/.ssh/id_rsa"
+				contents: ssh.key
+			}
+		}
+
+		if ssh.knownHosts != _|_ {
+			mounts: ssh_hosts: {
+				dest:     "/root/.ssh/known_hosts"
+				contents: ssh.knownHosts
+			}
+		}
+	}
+}
+
+// Connect via HTTP/HTTPS
+#RunTCP: {
+	host: =~"^tcp://.+"
+
+	#Run & {
+		env: DOCKER_HOST: host
+
+		// Directory with certificates to verify ({ca,cert,key}.pem files).
+		// This enables HTTPS.
+		certs?: dagger.#FS
+
+		if certs != _|_ {
+			mounts: "certs": {
+				dest:     "/certs/client"
+				contents: certs
+			}
+		}
+	}
+}


### PR DESCRIPTION
@shykes, WDYT?

I meant to put it in `universe.dagger.io/docker/client` but `docker.#Load` needs it (#1842) and it would create a circular import. Maybe move to `client.#Load`?

It's also flexible in the way you can compose these.

The default allows for local socket, http/https or ssh:

```cue
run: docker.#Client & {
    host: "ssh://root@93.184.216.34"
    ssh: {
        key:        client.filesystem."/home/user/.ssh/id_rsa".read.contents
        knownHosts: client.filesystem."/home/user/.ssh/known_hosts".read.contents
    }
    command: name: "info"
}
```

Just want to run in local daemon with another image?

```cue
_image: alpine.#Build & {
    packages: "docker-cli": {}
}
run: docker.#RunSocket & {
    input: _image.output
    host: client.filesystem."/var/run/docker.sock".read.contents
    command: {
        name: "docker"
        args: ["info"]
    }
}
```
This client was already discussed multiple times. We talked about it with @TomChv and @grouville on deploying to docker swarm. Also asked in https://github.com/dagger/dagger/issues/1650#issuecomment-1050685326.