### PR TITLE
Expand user home dir in client filesystem

### DIFF
--- a/docs/drafts/plans/docker-cli-load/ssh.cue
+++ b/docs/drafts/plans/docker-cli-load/ssh.cue
@@ -8,8 +8,8 @@ import (
 
 dagger.#Plan & {
 	client: filesystem: {
-		"/home/user/.ssh/id_rsa": read: contents:      dagger.#Secret
-		"/home/user/.ssh/known_hosts": read: contents: dagger.#Secret
+		"~/.ssh/id_rsa": read: contents:      dagger.#Secret
+		"~/.ssh/known_hosts": read: contents: dagger.#Secret
 	}
 
 	actions: {
@@ -22,8 +22,8 @@ dagger.#Plan & {
 			tag:   "myimage:v2"
 			host:  "ssh://root@93.184.216.34"
 			ssh: {
-				key:        client.filesystem."/home/user/.ssh/id_rsa".read.contents
-				knownHosts: client.filesystem."/home/user/.ssh/known_hosts".read.contents
+				key:        client.filesystem."~/.ssh/id_rsa".read.contents
+				knownHosts: client.filesystem."~/.ssh/known_hosts".read.contents
 			}
 		}
 	}

--- a/docs/drafts/plans/docker-cli-run/ssh.cue
+++ b/docs/drafts/plans/docker-cli-run/ssh.cue
@@ -7,15 +7,15 @@ import (
 
 dagger.#Plan & {
 	client: filesystem: {
-		"/home/user/.ssh/id_rsa": read: contents:      dagger.#Secret
-		"/home/user/.ssh/known_hosts": read: contents: dagger.#Secret
+		"~/.ssh/id_rsa": read: contents:      dagger.#Secret
+		"~/.ssh/known_hosts": read: contents: dagger.#Secret
 	}
 
 	actions: run: cli.#Run & {
 		host: "ssh://root@93.184.216.34"
 		ssh: {
-			key:        client.filesystem."/home/user/.ssh/id_rsa".read.contents
-			knownHosts: client.filesystem."/home/user/.ssh/known_hosts".read.contents
+			key:        client.filesystem."~/.ssh/id_rsa".read.contents
+			knownHosts: client.filesystem."~/.ssh/known_hosts".read.contents
 		}
 		command: name: "info"
 	}

--- a/plan/task/clientfilesystemread.go
+++ b/plan/task/clientfilesystemread.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"cuelang.org/go/cue"
 	"github.com/moby/buildkit/client/llb"
@@ -66,10 +65,7 @@ func (t clientFilesystemReadTask) parsePath(v *compiler.Value) (path string, err
 		return
 	}
 
-	path, err = filepath.Abs(path)
-	if err != nil {
-		return
-	}
+	path, err = clientFilePath(path)
 
 	return
 }

--- a/plan/task/clientfilesystemwrite.go
+++ b/plan/task/clientfilesystemwrite.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"path/filepath"
 
 	"cuelang.org/go/cue"
 	bk "github.com/moby/buildkit/client"
@@ -28,7 +27,7 @@ func (t clientFilesystemWriteTask) Run(ctx context.Context, pctx *plancontext.Co
 		return nil, err
 	}
 
-	path, err = filepath.Abs(path)
+	path, err = clientFilePath(path)
 	if err != nil {
 		return nil, err
 	}

--- a/plan/task/util.go
+++ b/plan/task/util.go
@@ -2,7 +2,9 @@ package task
 
 import (
 	"fmt"
+	"path/filepath"
 
+	"github.com/mitchellh/go-homedir"
 	"github.com/moby/buildkit/client/llb"
 	"go.dagger.io/dagger/compiler"
 )
@@ -15,4 +17,12 @@ func vertexNamef(v *compiler.Value, format string, a ...interface{}) string {
 
 func withCustomName(v *compiler.Value, format string, a ...interface{}) llb.ConstraintsOpt {
 	return llb.WithCustomName(vertexNamef(v, format, a...))
+}
+
+func clientFilePath(path string) (string, error) {
+	expanded, err := homedir.Expand(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Abs(expanded)
 }


### PR DESCRIPTION
This just allows expanding `~/` into the user home dir to make paths shorter and more portable:

```diff
-client: filesystem: "/home/user/.ssh/id_rsa": read: contents: dagger.#Secret
+client: filesystem: "~/.ssh/id_rsa": read: contents: dagger.#Secret
```

Signed-off-by: Helder Correia