### PR TITLE
docs/1203: keep code sample on topic

### DIFF
--- a/docs/tests/core-concepts/client/plans/file.cue
+++ b/docs/tests/core-concepts/client/plans/file.cue
@@ -8,8 +8,4 @@ dagger.#Plan & {
 		// Convert a CUE value into a YAML formatted string
 		contents: yaml.Marshal(actions.pull.output.config)
 	}
-
-	actions: pull: docker.#Pull & {
-		source: "alpine"
-	}
 }


### PR DESCRIPTION
Shorten one of the code samples, keeping only the part that speaks to the topic in the docs.