### PR TITLE
Don’t rely on default docker/cli entrypoint for setting up https

### DIFF
--- a/pkg/universe.dagger.io/docker/cli/client.cue
+++ b/pkg/universe.dagger.io/docker/cli/client.cue
@@ -75,6 +75,10 @@ import (
 		certs?: dagger.#FS
 
 		if certs != _|_ {
+			env: {
+				DOCKER_TLS_VERIFY: "1"
+				DOCKER_CERT_PATH:  "/certs/client"
+			}
 			mounts: "certs": {
 				dest:     "/certs/client"
 				contents: certs


### PR DESCRIPTION
Signed-off-by: Helder Correia