### PR TITLE
Update the version in docs to next release

### DIFF
--- a/docs/core-concepts/1202-plan.md
+++ b/docs/core-concepts/1202-plan.md
@@ -82,7 +82,7 @@ The second import is for `netlify.#Deploy` to work.
 :::info
 Which other imports we are missing?
 Look at all the actions in the plan structure at the top of this page.
-Now check all the available packages in [universe.dagger.io](https://github.com/dagger/dagger/tree/v0.2.0/pkg/universe.dagger.io).
+Now check all the available packages in [universe.dagger.io](https://github.com/dagger/dagger/tree/v0.2.3/pkg/universe.dagger.io).
 :::
 
 We now understand that the `deploy` action is the deploy definition from the netlify package, written as `deploy: netlify.#Deploy`

--- a/docs/core-concepts/1213-dagger-cue.md
+++ b/docs/core-concepts/1213-dagger-cue.md
@@ -5,7 +5,7 @@ displayed_sidebar: europa
 
 # Dagger CUE API (0.2+)
 
-As of Dagger 0.2 (codename Europa), the Dagger CUE API can be imported via `dagger.io/dagger`
+As of Dagger 0.2 (codename Europa), the Dagger CUE API can be imported via `dagger.io/dagger` & `dagger.io/dagger/core`
 
 The Dagger CUE API is the set of CUE packages released alongside the Dagger engine.
 
@@ -17,25 +17,25 @@ Developers of other Dagger packages are expected to build on top of these core p
 
 | Definition | File                                                                                   | Description                                          |
 | :--        | :--                                                                                    | :--                                                  |
-| `#Plan`    | [plan.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/plan.cue) | A special kind of program which `dagger` can execute |
+| `#Plan`    | [plan.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/plan.cue) | A special kind of program which `dagger` can execute |
 
 ### Core types
 
 Dagger extends the CUE type system with the following core types:
 
-| Definition     | File                                                                                     | Description                                 |
-| :--            | :--                                                                                      | :--                                         |
-| `#Address`     | [types.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/types.cue) | Network service address                     |
-| `#CacheDir`    | [exec.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/exec.cue)   | A (best effort) persistent cache dir        |
-| `#FS`          | [types.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/types.cue) | Reference to a filesystem tree              |
-| `#HealthCheck` | [image.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/image.cue) | Container health check                      |
-| `#ImageConfig` | [image.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/image.cue) | Container image config                      |
-| `#Mount`       | [exec.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/exec.cue)   | Transient filesystem mount                  |
-| `#Ref`         | [image.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/image.cue) | An address for a remote container image     |
-| `#Scratch`     | [types.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/types.cue) | An empty directory                          |
-| `#Secret`      | [types.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/types.cue) | Secure reference to an external secret      |
-| `#Service`     | [types.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/types.cue) | Reference to network service endpoints      |
-| `#TempDir`     | [exec.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/exec.cue)   | A temporary directory for command execution |
+| Definition     | File                                                                                        | Description                                           |
+| :--            | :--                                                                                         | :--                                                   |
+| `#Address`     | [types.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/types.cue)    | Network service address                               |
+| `#CacheDir`    | [exec.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/core/exec.cue) | A (best effort) persistent cache dir                  |
+| `#FS`          | [types.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/types.cue)    | Reference to a filesystem tree                        |
+| `#HealthCheck` | [image.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/image.cue)    | Container health check                                |
+| `#ImageConfig` | [image.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/image.cue)    | Container image config                                |
+| `#Mount`       | [exec.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/core/exec.cue) | Transient filesystem mount                            |
+| `#Ref`         | [image.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/image.cue)    | An address for a remote container image               |
+| `#Scratch`     | [types.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/types.cue)    | An empty directory                                    |
+| `#Secret`      | [types.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/types.cue)    | Secure reference to an external secret                |
+| `#Socket`      | [types.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/types.cue)    | Reference to a network socket: unix, tcp/udp or npipe |
+| `#TempDir`     | [exec.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/core/exec.cue) | A temporary directory for command execution           |
 
 ### Core actions
 
@@ -47,23 +47,25 @@ are implemented by Dagger itself, and are always available.
 
 The following core actions are available:
 
-| Definition      | File                                                                                         | Description                                              |
-| :--             | :--                                                                                          | :--                                                      |
-| `#Copy`         | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/fs.cue)           | Copy files between two filesystem trees                  |
-| `#DecodeSecret` | [secrets.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/secrets.cue) | Decode a secret without leaking its contents             |
-| `#Dockerfile`   | [image.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/image.cue)     | Build a container image using a Dockerfile               |
-| `#Exec`         | [exec.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/exec.cue)       | Execute a command in a docker-compatible container       |
-| `#GitPull`      | [git.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/git.cue)         | Download a repository from a remote git server           |
-| `#GitPush`      | [git.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/git.cue)         | Upload a repository to a remote git server               |
-| `#HTTPFetch`    | [http.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/http.cue)       | Download an archive from an HTTP server                  |
-| `#Mkdir`        | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/fs.cue)           | Create a directory in a filesystem tree                  |
-| `#NewSecret`    | [secrets.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/secrets.cue) | Dynamically create a new secret                          |
-| `#Pull`         | [image.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/image.cue)     | Download an image from a docker registry                 |
-| `#Push`         | [image.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/image.cue)     | Upload an image to a docker registry                     |
-| `#ReadFile`     | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/fs.cue)           | Read a file from a filesystem tree                       |
-| `#Scratch`      | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/fs.cue)           | Create an empty filesystem tree                          |
-| `#Set`          | [image.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/image.cue)     | Modify a docker image                                    |
-| `#Source`       | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/fs.cue)           | Access the source for the current CUE package            |
-| `#Subdir`       | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/fs.cue)           | Read a subdirectory from a filesystem tree               |
-| `#TrimSecret`   | [secrets.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/secrets.cue) | Trim leading and trailing space characters from a secret |
-| `#WriteFile`    | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.0/pkg/dagger.io/dagger/fs.cue)           | Write a file to a filesystem tree                        |
+| Definition      | File                                                                                              | Description                                                           |
+| :--             | :--                                                                                               | :--                                                                   |
+| `#Copy`         | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/core/fs.cue)           | Copy files between two filesystem trees                               |
+| `#DecodeSecret` | [secrets.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/core/secrets.cue) | Decode a secret without leaking its contents                          |
+| `#Diff`         | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/core/fs.cue)           | Extract the difference between two filesystems as its own file system |
+| `#Dockerfile`   | [image.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/core/image.cue)     | Build a container image using a Dockerfile                            |
+| `#Exec`         | [exec.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/core/exec.cue)       | Execute a command in a docker-compatible container                    |
+| `#Export`       | [image.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/core/image.cue)     | Export an image as a tar archive                                      |
+| `#GitPull`      | [git.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/core/git.cue)         | Download a repository from a remote git server                        |
+| `#HTTPFetch`    | [http.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/core/http.cue)       | Get a file from an HTTP server                                        |
+| `#Merge`        | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/core/fs.cue)           | Merge multiple filesystem trees                                       |
+| `#Mkdir`        | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/core/fs.cue)           | Create a directory in a filesystem tree                               |
+| `#NewSecret`    | [secrets.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/core/secrets.cue) | Create a new a secret from a filesystem tree                          |
+| `#Pull`         | [image.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/core/image.cue)     | Download an image from a docker registry                              |
+| `#Push`         | [image.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/core/image.cue)     | Upload an image to a docker registry                                  |
+| `#ReadFile`     | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/core/fs.cue)           | Read a file from a filesystem tree                                    |
+| `#Scratch`      | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/core/fs.cue)           | Create an empty filesystem tree                                       |
+| `#Set`          | [image.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/core/image.cue)     | Modify a docker image                                                 |
+| `#Source`       | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/core/fs.cue)           | Access the source for the current CUE package                         |
+| `#Subdir`       | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/core/fs.cue)           | Read a subdirectory from a filesystem tree                            |
+| `#TrimSecret`   | [secrets.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/core/secrets.cue) | Trim leading and trailing space characters from a secret              |
+| `#WriteFile`    | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.3/pkg/dagger.io/dagger/core/fs.cue)           | Write a file to a filesystem tree                                     |

--- a/docs/getting-started/1200-local-dev.md
+++ b/docs/getting-started/1200-local-dev.md
@@ -58,7 +58,7 @@ With Docker running, we are ready to download our example app and run its CI/CD 
 ```shell
 git clone https://github.com/dagger/dagger
 cd dagger
-git checkout v0.2.0
+git checkout v0.2.3
 
 cd pkg/universe.dagger.io/examples/todoapp
 dagger do build
@@ -151,7 +151,7 @@ With Docker Engine running, we are ready to download our example app and run its
 ```shell
 git clone https://github.com/dagger/dagger
 cd dagger
-git checkout v0.2.0
+git checkout v0.2.3
 
 cd pkg/universe.dagger.io/examples/todoapp
 dagger do build
@@ -237,7 +237,7 @@ Still in your `Command Prompt` terminal:
 ```shell
 git clone https://github.com/dagger/dagger
 cd dagger
-git checkout v0.2.0
+git checkout v0.2.3
 
 cd pkg/universe.dagger.io/examples/todoapp
 dagger do build

--- a/docs/update-version.sh
+++ b/docs/update-version.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -ex
+
+if ! sed --version | grep "GNU"
+then
+  echo "Please install GNU sed, a.k.a. gnused"
+  exit 1
+fi
+
+sed --in-place --regexp-extended --expression \
+  's/v'"${DAGGER_VERSION_FROM:-0.2.0}"'/v'"${DAGGER_VERSION_TO:-0.2.3}"'/g' \
+  ./*/*.md


### PR DESCRIPTION
We should hold this merge until we are ready to cut the release, otherwise links & some instructions will be broken until we release `v0.2.3`.

Even though I would have preferred to have `docs/update-version.sh` in Dagger, this is the quickest thing for now.