### PR TITLE
Replace HTTPS endpoint with npipe in #Socket description

### DIFF
--- a/pkg/dagger.io/dagger/types.cue
+++ b/pkg/dagger.io/dagger/types.cue
@@ -25,10 +25,10 @@ package dagger
 	$dagger: secret: _id: string
 }
 
-// A reference to a network service endpoint, for example:
-//  - A unix socket
+// A reference to a network socket, for example:
+//  - A UNIX socket
 //  - A TCP or UDP port
-//  - An HTTPS endpoint
+//  - A Windows named pipe
 #Socket: {
 	$dagger: service: _id: string
 }


### PR DESCRIPTION
This was mixing layer 4 & 7 concerns. It's clearer now.

Discovered via https://github.com/dagger/dagger/pull/1896
