### PR TITLE
windows: Fixed infinite loop in GetCueModParent

### DIFF
--- a/pkg/pkg.go
+++ b/pkg/pkg.go
@@ -167,7 +167,7 @@ func GetCueModParent() (string, bool) {
 
 		parentDir = filepath.Dir(parentDir)
 
-		if parentDir == string(os.PathSeparator) {
+		if parentDir == fmt.Sprintf("%s%s", filepath.VolumeName(parentDir), string(os.PathSeparator)) {
 			// reached the root
 			parentDir = cwd // reset to working directory
 			break


### PR DESCRIPTION
Fixes #1848

I did not add build flags for windows or if on `runtime.GOOS` because filepath.VolumeName is already cross-platforms (returns "" when not supported).