### PR TITLE
ci: filter goreleaser changelog

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,6 +45,10 @@ changelog:
       - "^doc:"
       - "^test:"
       - "^tests:"
+      - "^ci:"
+      - "^website:"
+      - "^infra:"
+      - "^build\\(deps\\):"
       - "^Merge pull request"
 
 brews:


### PR DESCRIPTION
Ignore `ci:`, `website:`, and dependabot commits
