### PR TITLE
docs: Fix Go on DockerHub id & filename + remove from sidebar

### DIFF
--- a/docs/use-cases/1219-go-docker-hub.md
+++ b/docs/use-cases/1219-go-docker-hub.md
@@ -1,5 +1,5 @@
 ---
-slug: /1216/ci-cd-for-go-project
+slug: /1219/go-docker-hub
 displayed_sidebar: europa
 ---
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -125,7 +125,6 @@ module.exports = {
       },
       items: [
         "use-cases/go-docker-swarm",
-        "use-cases/go-on-docker-hub"
       ],
     },
   ],


### PR DESCRIPTION
ID 1216 was clashing with docker-cli-load doc.

The filename follows the convention of the other use cases.

Remove from docs sidebar until we do the quick fixes.
