### PR TITLE
Exclude docs from universe and integration tests

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -4,27 +4,30 @@ on:
   push:
     branches: [main]
     paths:
-      - '**.sh'
-      - '**.bash'
-      - '**.go'
-      - '**.cue'
-      - '**.bats'
-      - 'Makefile'
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/test-integration.yml'
+      - "**.sh"
+      - "**.bash"
+      - "**.go"
+      - "**.cue"
+      - "**.bats"
+      - "Makefile"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/test-integration.yml"
+      - "!docs/**"
+
   pull_request:
     branches: [main]
     paths:
-      - '**.sh'
-      - '**.bash'
-      - '**.go'
-      - '**.cue'
-      - '**.bats'
-      - 'Makefile'
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/test-integration.yml'
+      - "**.sh"
+      - "**.bash"
+      - "**.go"
+      - "**.cue"
+      - "**.bats"
+      - "Makefile"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/test-integration.yml"
+      - "!docs/**"
 
 jobs:
   test-integration:

--- a/.github/workflows/test-universe.yml
+++ b/.github/workflows/test-universe.yml
@@ -4,27 +4,30 @@ on:
   push:
     branches: [main]
     paths:
-      - '**.sh'
-      - '**.bash'
-      - '**.go'
-      - '**.cue'
-      - '**.bats'
-      - 'Makefile'
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/test-universe.yml'
+      - "**.sh"
+      - "**.bash"
+      - "**.go"
+      - "**.cue"
+      - "**.bats"
+      - "Makefile"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/test-universe.yml"
+      - "!docs/**"
+
   pull_request:
     branches: [main]
     paths:
-      - '**.sh'
-      - '**.bash'
-      - '**.go'
-      - '**.cue'
-      - '**.bats'
-      - 'Makefile'
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/test-universe.yml'
+      - "**.sh"
+      - "**.bash"
+      - "**.go"
+      - "**.cue"
+      - "**.bats"
+      - "Makefile"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/test-universe.yml"
+      - "!docs/**"
 
 jobs:
   universe-europa-tests:


### PR DESCRIPTION
Any cue file created in the docs triggered these tests. It shouldn't.

Contributor: @dolanor 
Signed-off-by: guillaume