### PR TITLE
Update go pkg DefaultVersion

### DIFF
--- a/pkg/universe.dagger.io/go/image.cue
+++ b/pkg/universe.dagger.io/go/image.cue
@@ -5,11 +5,11 @@ import (
 )
 
 // Go image default version
-#DefaultVersion: "1.16"
+#_DefaultVersion: "1.18"
 
 // Build a go base image
 #Image: {
-	version: *#DefaultVersion | string
+	version: *#_DefaultVersion | string
 
 	packages: [pkgName=string]: version: string | *""
 

--- a/pkg/universe.dagger.io/go/image.cue
+++ b/pkg/universe.dagger.io/go/image.cue
@@ -5,11 +5,11 @@ import (
 )
 
 // Go image default version
-#_DefaultVersion: "1.18"
+_#DefaultVersion: "1.18"
 
 // Build a go base image
 #Image: {
-	version: *#_DefaultVersion | string
+	version: *_#DefaultVersion | string
 
 	packages: [pkgName=string]: version: string | *""
 

--- a/pkg/universe.dagger.io/go/test/image.cue
+++ b/pkg/universe.dagger.io/go/test/image.cue
@@ -18,7 +18,7 @@ dagger.#Plan & {
 				command: {
 					name: "/bin/sh"
 					args: ["-c", """
-							go version | grep "1.16"
+							go version | grep "1.18"
 						"""]
 				}
 			}

--- a/pkg/universe.dagger.io/go/test/test.bats
+++ b/pkg/universe.dagger.io/go/test/test.bats
@@ -4,7 +4,7 @@ setup() {
     common_setup
 }
 
-@test "bash" {
+@test "go" {
     dagger "do" -p ./build.cue test
     dagger "do" -p ./container.cue test
     dagger "do" -p ./image.cue test


### PR DESCRIPTION
Minor changes to the `DefaultVersion` definition in the go package.

- Change the default go version (1.16 -> 1.18)
- Hid the `#_DefaultVersion` field
- Changed the bats test name (bash -> go)