### PR TITLE
Update install procedure to support Homebrew on Linux

### DIFF
--- a/docs/1001-install.md
+++ b/docs/1001-install.md
@@ -10,9 +10,9 @@ slug: /1001/install/
 
 :::
 
-## Option 1: Use Homebrew (Mac OS only)
+## Option 1 (Mac OS and Linux): Use Homebrew
 
-From your Mac OS terminal, run the following command:
+From a terminal, run the following command:
 
 ```shell
 brew install dagger/tap/dagger
@@ -25,7 +25,7 @@ brew update
 brew upgrade dagger
 ```
 
-## Option 2: Run a shell script
+## Option 2 (Mac OS and Linux): Run a shell script
 
 From a terminal, run the following command:
 


### PR DESCRIPTION
As the homebrew formula also supports Linux, I suggest the following updates in the installation procedure.

See https://github.com/dagger/homebrew-tap/blob/main/dagger.rb#L29.
