### PR TITLE
bump up docusaurus preset classic theme

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^2.0.0-beta.18",
-    "@docusaurus/preset-classic": "^2.0.0-beta.17",
+    "@docusaurus/preset-classic": "^2.0.0-beta.18",
     "@mdx-js/react": "^1.6.22",
     "@svgr/webpack": "^6.2.1",
     "amplitude-js": "^8.17.0",

--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -279,9 +279,9 @@ h1[class^="h1Heading"] {
   line-height: 36px;
   @include desktop {
     width: 48px;
-    span {
-      display: none;
-    }
+    text-indent: 9999px;
+    white-space: nowrap;
+    overflow: hidden;
   }
 }
 


### PR DESCRIPTION
while dependabot automatically bump up docusaurus core, the package preset-classic is ignore.

Signed-off-by: jffarge <jf@dagger.io>