### PR TITLE
universe: go: add git by default in go.#Image

### DIFF
--- a/pkg/universe.dagger.io/go/image.cue
+++ b/pkg/universe.dagger.io/go/image.cue
@@ -12,6 +12,8 @@ _#DefaultVersion: "1.18"
 	version: *_#DefaultVersion | string
 
 	packages: [pkgName=string]: version: string | *""
+	// FIXME Remove once golang image include 1.18 *or* go compiler is smart with -buildvcs
+	packages: git: _
 
 	// FIXME Basically a copy of alpine.#Build with a different image
 	// Should we create a special definition?

--- a/pkg/universe.dagger.io/go/test/image.cue
+++ b/pkg/universe.dagger.io/go/test/image.cue
@@ -18,7 +18,7 @@ dagger.#Plan & {
 				command: {
 					name: "/bin/sh"
 					args: ["-c", """
-							go version | grep "1.18"
+							go version | grep "1.18" ; git version
 						"""]
 				}
 			}
@@ -35,7 +35,7 @@ dagger.#Plan & {
 				command: {
 					name: "/bin/bash"
 					args: ["-c", """
-							go version | grep "1.17"
+							go version | grep "1.17" ; git version
 						"""]
 				}
 			}


### PR DESCRIPTION
This adds git to the default `go.#Image` image so that 1.18 "just
works".

Fixes https://github.com/dagger/dagger/issues/1965

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
