### PR TITLE
ci: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,29 @@
+# CODEOWNERS is a tool to encode PR approval rules.
+#
+# When a PR is opened, at least one code owner is required to approve it
+# before being merged.
+#
+# It does **not**:
+#
+# - Limit reviewers: Everyone is welcome and encouraged to review any PR.
+#   But at least one CODEOWNER must approve before merging.
+#
+# - Limit contributions or ownership: Every maintainer is responsible for
+#   the entire project. CODEOWNERs are there to review PRs for
+#   consistency.
+#
+# By default, any maintainer can approve any PR. There's a couple of
+# exceptions for consistency/specialty.
+
+# Default owners for everything in the repo
+# Later matches takes precedence
+*                           @dagger/maintainers
+
+# Core CUE API
+/pkg/dagger.io/             @helderco @shykes
+
+# Universe
+/pkg/universe.dagger.io/    @helderco @shykes
+
+# Documentation website
+/website/                   @slumbering


### PR DESCRIPTION
CODEOWNERS is a tool to encode PR approval rules.

When a PR is opened, at least one code owner is required to approve it
before being merged.

It does **not**:

- Limit reviewers: Everyone is welcome and encouraged to review any PR.
  But at least one CODEOWNER must approve before merging.
- Limit contributions or ownership: Every maintainer is responsible for
  the entire project. CODEOWNERs are there to review PRs for
  consistency.

By default, any maintainer can approve any PR. There's a couple of
exceptions for consistency/specialty:

- Core API: The core API must be consistent and changes are hard
  to reverse
- Universe API: Similar to the Core API, it must be kept consistent. In
  the future, we will have specialized code owners (e.g. universe/aws)
- Docs website: Requires specialized (frontend) skills to maintain for
  visual consistency.


/cc @dagger/mantainers 
/cc @shykes @helderco @slumbering 
