### PR TITLE
Prevents files to be used as input of dagger.#FS

### DIFF
--- a/plan/task/clientfilesystemread.go
+++ b/plan/task/clientfilesystemread.go
@@ -18,8 +18,7 @@ func init() {
 	Register("ClientFilesystemRead", func() Task { return &clientFilesystemReadTask{} })
 }
 
-type clientFilesystemReadTask struct {
-}
+type clientFilesystemReadTask struct{}
 
 func (t clientFilesystemReadTask) PreRun(_ context.Context, pctx *plancontext.Context, v *compiler.Value) error {
 	path, err := t.parsePath(v)
@@ -27,8 +26,10 @@ func (t clientFilesystemReadTask) PreRun(_ context.Context, pctx *plancontext.Co
 		return err
 	}
 
-	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+	if pi, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("path %q does not exist", path)
+	} else if !pi.IsDir() && plancontext.IsFSValue(v.Lookup("contents")) {
+		return fmt.Errorf("path %q is not a directory", path)
 	}
 
 	if plancontext.IsFSValue(v.Lookup("contents")) {

--- a/plan/task/clientfilesystemread.go
+++ b/plan/task/clientfilesystemread.go
@@ -26,10 +26,15 @@ func (t clientFilesystemReadTask) PreRun(_ context.Context, pctx *plancontext.Co
 		return err
 	}
 
-	if pi, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+	isFS := plancontext.IsFSValue(v.Lookup("contents"))
+
+	switch pi, err := os.Stat(path); {
+	case errors.Is(err, os.ErrNotExist):
 		return fmt.Errorf("path %q does not exist", path)
-	} else if !pi.IsDir() && plancontext.IsFSValue(v.Lookup("contents")) {
+	case !pi.IsDir() && isFS:
 		return fmt.Errorf("path %q is not a directory", path)
+	case pi.IsDir() && !isFS:
+		return fmt.Errorf("path %q cannot be a directory", path)
 	}
 
 	if plancontext.IsFSValue(v.Lookup("contents")) {

--- a/tests/plan.bats
+++ b/tests/plan.bats
@@ -84,6 +84,15 @@ setup() {
   assert_output --partial 'path "/foobar" does not exist'
 }
 
+
+@test "plan/client/filesystem/read/fs/invalid" {
+  cd "$TESTDIR/plan/client/filesystem/read/fs/invalid"
+
+  run "$DAGGER" "do" -p . test
+  assert_failure
+  assert_output --partial 'test.txt" is not a directory'
+}
+
 @test "plan/client/filesystem/read/fs/relative" {
   cd "$TESTDIR/plan/client/filesystem/read/fs/relative"
 

--- a/tests/plan.bats
+++ b/tests/plan.bats
@@ -85,12 +85,21 @@ setup() {
 }
 
 
-@test "plan/client/filesystem/read/fs/invalid" {
-  cd "$TESTDIR/plan/client/filesystem/read/fs/invalid"
+@test "plan/client/filesystem/read/fs/invalid_fs_input" {
+  cd "$TESTDIR/plan/client/filesystem/read/fs/invalid_fs_input"
 
   run "$DAGGER" "do" -p . test
   assert_failure
   assert_output --partial 'test.txt" is not a directory'
+}
+
+
+@test "plan/client/filesystem/read/fs/invalid_fs_type" {
+  cd "$TESTDIR/plan/client/filesystem/read/fs/invalid_fs_type"
+
+  run "$DAGGER" "do" -p . test
+  assert_failure
+  assert_output --partial 'rootfs" cannot be a directory'
 }
 
 @test "plan/client/filesystem/read/fs/relative" {

--- a/tests/plan/client/filesystem/read/fs/invalid/test.cue
+++ b/tests/plan/client/filesystem/read/fs/invalid/test.cue
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"dagger.io/dagger"
+)
+
+dagger.#Plan & {
+	client: filesystem: "../rootfs/test.txt": read: contents: dagger.#FS
+	actions: test: {
+	}
+}

--- a/tests/plan/client/filesystem/read/fs/invalid_fs_input/test.cue
+++ b/tests/plan/client/filesystem/read/fs/invalid_fs_input/test.cue
@@ -5,6 +5,7 @@ import (
 )
 
 dagger.#Plan & {
+	// Reading a file into a dagger.#FS should not be possbile
 	client: filesystem: "../rootfs/test.txt": read: contents: dagger.#FS
 	actions: test: {
 	}

--- a/tests/plan/client/filesystem/read/fs/invalid_fs_type/test.cue
+++ b/tests/plan/client/filesystem/read/fs/invalid_fs_type/test.cue
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+)
+
+dagger.#Plan & {
+	// Reading a directory into a non-fs should fail
+	client: filesystem: "../rootfs": read: contents: string
+	actions: {
+		image: core.#Pull & {
+			source: "alpine:3.15.0@sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3"
+		}
+		test: core.#Exec & {
+			input: image.output
+			args: ["test", client.filesystem."../rootfs".read.contents]
+		}
+
+	}
+}


### PR DESCRIPTION
Errors out in the PreRun phase of the clientfilesystemreader task since
otherwise, dagger execution would hang
Fixes #1977

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>