### PR TITLE
Adds support for 32bit armv7 devices.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,6 +20,9 @@ builds:
     goarch:
       - amd64
       - arm64
+      - arm
+    goarm:
+      - 7
 
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"


### PR DESCRIPTION
This allows running Dagger in armv7 32 bit architectures.

Fixes #2007

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>