### PR TITLE
feat: use "." as default for core.#Source

### DIFF
--- a/pkg/dagger.io/dagger/core/fs.cue
+++ b/pkg/dagger.io/dagger/core/fs.cue
@@ -8,7 +8,7 @@ import "dagger.io/dagger"
 	$dagger: task: _name: "Source"
 
 	// Relative path to source.
-	path: string
+	path: string | *"."
 	// Optionally exclude certain files
 	include: [...string]
 	// Optionally include certain files


### PR DESCRIPTION
This feels like a good sensible default and will keep pipelines clean of many:

```CUE
source: core.#Source & { path: "." }
```