### PR TITLE
ci: Add changelog exclusion for chores

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,6 +51,7 @@ changelog:
       - "^ci:"
       - "^website:"
       - "^infra:"
+      - "^chore:"
       - "^build\\(deps\\):"
       - "^Merge pull request"
 


### PR DESCRIPTION
For tasks that souldn’t be in the changelog but don’t match the other stuff.

Signed-off-by: Helder Correia