### PR TITLE
ci: Group changelog entries for breaking changes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,6 +53,12 @@ changelog:
       - "^infra:"
       - "^build\\(deps\\):"
       - "^Merge pull request"
+  groups:
+    - title: Breaking Changes
+      regexp: "^.*!:+.*$"
+      order: 0
+    - title: Changes
+      order: 999
 
 brews:
   - tap:


### PR DESCRIPTION
## Overview

If there's a change that requires migrations from users, an easy thing we can do right now is to make them clear in the changelog. In Python, I'm used to read the release notes for packages before updating them.

The convention, according to https://www.conventionalcommits.org is to add a `!` before the `:`:

- `chore!: Move packages to core`
- `feat!: Rename field X`

## RFCs

1. I thought about using  `break:` instead, but decided to go with the convention above in case we decide to adhere more to it later. WDYT?

2. Not sure about the title for the "other" group: _Changes_. We need to consider there will be logs without breaking changes, so it needs to make sense on its own.

3. We could also group by features and bug fixes, but I think we need to have the discipline to add these prefixes to all commits for that (basically adhering to the conventions above).

Signed-off-by: Helder Correia