### PR TITLE
docs: Add contributing guide for easier access

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing to Dagger
+
+See https://github.com/dagger/.github/blob/main/CONTRIBUTING.md


### PR DESCRIPTION
The current guide is a bit hidden and we need to rely on links. Users will find it more easily in the source code, which is where I'd search for it anyway. 

We are currently using the `dagger/.github` repo to share the guidelines amongst the organization, but there's also an argument for moving the guide here and reference this one in other places instead. Just not sure about the automatic "Contributing" links that GitHub adds automatically in some places.

Signed-off-by: Helder Correia

/cc @gerhard 