### PR TITLE
Automatically detect target platform based on buildkit worker

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -123,7 +123,7 @@ func (p *Plan) configPlatform() error {
 	}
 
 	// Set platform to context
-	err = p.context.Platform.Set(platform)
+	err = p.context.Platform.SetString(platform)
 	if err != nil {
 		return err
 	}

--- a/plancontext/context.go
+++ b/plancontext/context.go
@@ -17,9 +17,7 @@ type Context struct {
 
 func New() *Context {
 	return &Context{
-		Platform: &platformContext{
-			platform: defaultPlatform,
-		},
+		Platform: &platformContext{},
 		FS: &fsContext{
 			store: make(map[string]*FS),
 		},

--- a/plancontext/platform.go
+++ b/plancontext/platform.go
@@ -5,28 +5,27 @@ import (
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-var (
-	// Default platform.
-	// FIXME: This should be auto detected using buildkit
-	defaultPlatform = specs.Platform{
-		OS:           "linux",
-		Architecture: "amd64",
-	}
-)
-
 type platformContext struct {
-	platform specs.Platform
+	platform *specs.Platform
 }
 
 func (c *platformContext) Get() specs.Platform {
-	return c.platform
+	return *c.platform
 }
 
-func (c *platformContext) Set(platform string) error {
+func (c *platformContext) SetString(platform string) error {
 	p, err := platforms.Parse(platform)
 	if err != nil {
 		return err
 	}
-	c.platform = p
+	c.platform = &p
 	return nil
+}
+
+func (c *platformContext) Set(p specs.Platform) {
+	c.platform = &p
+}
+
+func (c *platformContext) IsSet() bool {
+	return c.platform != nil
 }


### PR DESCRIPTION
Query Buildkit's daemon and fetch available platform. Additionally try
to match the user's native platform if possible or fallback to
buildkit's outputs

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>