### PR TITLE
docs: Add documentation on local cache export

### DIFF
--- a/docs/guides/1230-permanent-cache.md
+++ b/docs/guides/1230-permanent-cache.md
@@ -1,0 +1,154 @@
+---
+slug: /1230/permanent-cache-with-dagger
+displayed_sidebar: 0.2
+---
+
+# Permanent cache your CI
+
+CI that takes eternity is a real pain and can become a bottleneck when your 
+infrastructure and process grow. But Dagger, working with a Buildkit daemon, 
+have a powerful cache system that triggers actions only when it's necessary.
+
+However, sometime you can't keep the same Buildkit daemon along your CI/CD.
+For instance, if you use GitHub runner, your daemon will be created on each
+run and **cache will be lost**. 
+
+In this page, we will see how to use `--cache-from` and `--cache-to` flags 
+keep a permanent cache, from a local environment to GitHub action.
+
+## Ephemeral cache
+
+As an example, we will use a Dagger plan to build a go program.
+
+You can use any go project and the following snippet to build it in a
+standard way
+
+```cue
+package ci
+
+import (
+	"dagger.io/dagger"
+	"universe.dagger.io/go"
+)
+
+dagger.#Plan & {
+	// Retrieve source from current directory
+	// Input
+	client: filesystem: ".": read: {
+		contents: dagger.#FS
+		include: ["**/*.go", "go.mod", "go.sum"]
+	}
+
+	// Output
+	client: filesystem: "./output": write: {
+		contents: actions.build.output
+	}
+
+	actions: {
+		// Alias on source
+		_source: client.filesystem.".".read.contents
+
+        // Build go binary
+		build: go.#Build & {
+			source: _source
+		}
+	}
+}
+```
+
+To build go binary, just tip `dagger do build`, it should take some time to
+install dependencies, build binary and output it.
+
+Here's an example of a run
+
+```shell
+[✔] actions.build.container                                               338.0s
+[✔] client.filesystem.".".read                                              0.1s
+[✔] actions.build.container.export                                          0.1s
+[✔] client.filesystem."./output".write                                      0.2s
+```
+
+Indeed, Dagger has an ephemeral cache so if you rerun it, that shouldn't take
+that long.
+
+```
+[✔] actions.build.container                                                 2.9s
+[✔] client.filesystem.".".read                                              0.0s
+[✔] actions.build.container.export                                          0.0s
+[✔] client.filesystem."./output".write                                      0.1s
+```
+
+But if you stop Buildkit daemon and remove volume, cache will be lost and
+all actions will be executed again.
+
+:::info
+Now we have seen how ephemeral cache works, let's continue to understand how
+store cache in your local filesystem, so you can clean your docker engine without
+losing all your CI's cache.
+:::
+
+## Keep cache in your local filesystem
+
+To store cache in your local filesystem, you don't need much effort : just
+add `--cache-from type=local,mode=max,dest=<output folder>` to `dagger do build`.
+
+:::tip
+Using `mode=max` argument will cache **all** layers from intermediate
+steps, with is really useful in the context of Dagger where you will have
+multiple steps to execute.
+:::
+
+Here's an example that exports cache to `storage`.
+
+```shell
+dagger do build --cache-to type=local,mode=max,dest=storage 
+# ...
+
+tree storage -L 1   
+storage
+├── blobs
+├── index.json
+└── ingest
+```
+
+A new directory has been created that contains cache the run
+
+:::caution
+If you run different action in the plan, don't forget to store cache in different
+destination, so it will be not overwritten.
+:::
+
+To import the cache previously stored, you can use 
+`--cache-from type=local,src=<cache folder>`.
+
+Here's an example, using a new buildkit daemon
+
+```shell
+# Down buildkit daemon
+docker container stop dagger-buildkitd && docker container rm dagger-buildkitd && docker volume rm dagger-buildkitd
+
+# Import cache on rebuild
+dagger do build --cache-to type=local,mode=max,dest=storage --cache-from type=local,src=storage
+[✔] actions.build.container                                                 2.3s
+[✔] client.filesystem.".".read                                              0.1s
+[✔] actions.build.container.export                                          0.0s
+[✔] client.filesystem."./output".write                                      0.4s
+```
+
+:::info
+In this part, we have how to keep cache in a local filesystem, if you want
+to see more options on local export, look at [Buildkit cache documentation](https://github.com/moby/buildkit#local-directory-1)
+:::
+
+## Keep cache in a remote registry
+
+Coming soon...
+
+## Keep cache in GitHub Actions
+
+Buildkit has a great integration to store cache from GitHub Action.  
+That features is really powerful with Dagger because you can cache everything
+that has not changes in your PR.
+
+// Require integrating cache in Dagger action
+Coming soon...

--- a/docs/guides/1230-persistent-cache.md
+++ b/docs/guides/1230-persistent-cache.md
@@ -112,7 +112,7 @@ To only store the final layers of the exported result, use `mode=min`.
 Let's first deploy a simple registry in your localhost
 
 ```shell
-docker run -d -p 6000:5000 --restart=always --name cache-registry registry:2
+docker run -d -p 5000:5000 --restart=always --name cache-registry registry:2
 ```
 
 Then run `dagger do build` with export cache flags.

--- a/docs/guides/1230-persistent-cache.md
+++ b/docs/guides/1230-persistent-cache.md
@@ -23,7 +23,7 @@ As an example, we will use a Dagger plan to build a Go program.
 You can use any Go project and the following snippet to build it in a
 standard way
 
-```cue
+```cue file=../tests/guides/persistent-cache/build.cue title="build.cue"
 package ci
 
 import (

--- a/docs/tests/guides/persistent-cache/build.cue
+++ b/docs/tests/guides/persistent-cache/build.cue
@@ -1,0 +1,30 @@
+package ci
+
+import (
+	"dagger.io/dagger"
+	"universe.dagger.io/go"
+)
+
+dagger.#Plan & {
+	// Retrieve source from current directory
+	// Input
+	client: filesystem: ".": read: {
+		contents: dagger.#FS
+		// Include only contents we need to build our project
+		// Any other files or patterns can be added
+		include: ["**/*.go", "go.mod", "go.sum"]
+	}
+
+	// Output
+	client: filesystem: "./output": write: contents: actions.build.output
+
+	actions: {
+		// Alias on source
+		_source: client.filesystem.".".read.contents
+
+		// Build go binary
+		build: go.#Build & {
+			source: _source
+		}
+	}
+}

--- a/docs/tests/guides/persistent-cache/go.mod
+++ b/docs/tests/guides/persistent-cache/go.mod
@@ -1,0 +1,3 @@
+module dagger.io/persistentcache
+
+go 1.17

--- a/docs/tests/guides/persistent-cache/main.go
+++ b/docs/tests/guides/persistent-cache/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello Dagger!")
+}

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -69,6 +69,7 @@ module.exports = {
 	"guides/handling-outputs",
       	"guides/migrate-from-dagger-0.1",
         "guides/go-ci",
+        "guides/permanent-cache"
       ],
     },
     {

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -69,7 +69,7 @@ module.exports = {
 	"guides/handling-outputs",
       	"guides/migrate-from-dagger-0.1",
         "guides/go-ci",
-        "guides/permanent-cache"
+        "guides/persistent-cache"
       ],
     },
     {


### PR DESCRIPTION
Add documentation on export cache, it still requires improvement and work before merge but local cache is complete 


