### PR TITLE
git: support ssh agent authentication

### DIFF
--- a/pkg/dagger.io/dagger/core/git.cue
+++ b/pkg/dagger.io/dagger/core/git.cue
@@ -27,6 +27,8 @@ import "dagger.io/dagger"
 		authToken: dagger.#Secret
 	} | {
 		authHeader: dagger.#Secret
+	} | {
+		sshAgent: dagger.#Socket
 	}
 	output: dagger.#FS @dagger(generated)
 }

--- a/plan/task/gitpull.go
+++ b/plan/task/gitpull.go
@@ -72,6 +72,14 @@ func (c *gitPullTask) Run(ctx context.Context, pctx *plancontext.Context, s *sol
 		}
 		lg.Debug().Str("authHeader", "***").Msg("adding git option")
 		gitOpts = append(gitOpts, llb.AuthHeaderSecret(authHeaderSecret.ID()))
+	} else if authSocket := v.Lookup("auth.sshAgent"); plancontext.IsSocketValue(authSocket) {
+		s, err := pctx.Sockets.FromValue(authSocket)
+		if err != nil {
+			return nil, err
+		}
+
+		lg.Debug().Str("sshAgent", "***").Msg("adding git option")
+		gitOpts = append(gitOpts, llb.MountSSHSock(s.ID()))
 	}
 
 	remoteRedacted := gitPull.Remote

--- a/tests/tasks/gitpull/ssh_agent.cue
+++ b/tests/tasks/gitpull/ssh_agent.cue
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+)
+
+dagger.#Plan & {
+	client: {
+		env: SSH_AUTH_SOCK: string
+
+		network: sshAgent: {
+			address: "unix://\(client.env.SSH_AUTH_SOCK)"
+			connect: dagger.#Socket
+		}
+	}
+
+	actions: test: {
+		pull: core.#GitPull & {
+			remote: "git@github.com:dagger/test.git"
+			ref:    "main"
+			auth: sshAgent: client.network.sshAgent.connect
+		}
+
+		_image: core.#Pull & {
+			source: "alpine:3.15.0"
+		}
+
+		verify: core.#Exec & {
+			input:  _image.output
+			always: true
+			args: ["ls", "-l", "/repo/README.md"]
+			mounts: inputRepo: {
+				dest:     "/repo"
+				contents: pull.output
+			}
+		}
+	}
+}


### PR DESCRIPTION
It's functional. However I had to hardcode the `SSH_AUTH_SOCK` path, which is not going to work.

Any idea @helderco?
