### PR TITLE
Fix broken API references in universe/python

### DIFF
--- a/pkg/universe.dagger.io/python/test/data/helloworld.py
+++ b/pkg/universe.dagger.io/python/test/data/helloworld.py
@@ -1,0 +1,2 @@
+with open('out.txt', 'w') as f:
+    f.write("Hello, world\n")

--- a/pkg/universe.dagger.io/python/test/test.bats
+++ b/pkg/universe.dagger.io/python/test/test.bats
@@ -1,0 +1,9 @@
+setup() {
+    load '../../bats_helpers'
+
+    common_setup
+}
+
+@test "python" {
+    dagger "do" -p ./test.cue test
+}

--- a/pkg/universe.dagger.io/python/test/test.cue
+++ b/pkg/universe.dagger.io/python/test/test.cue
@@ -1,0 +1,44 @@
+package python
+
+import (
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+
+	"universe.dagger.io/python"
+)
+
+dagger.#Plan & {
+	actions: test: {
+
+		// Run a script from source directory + filename
+		runFile: {
+
+			dir:   _load.output
+			_load: core.#Source & {
+				path: "./data"
+				include: ["*.py"]
+			}
+
+			run: python.#Run & {
+				export: files: "/out.txt": _
+				script: {
+					directory: dir
+					filename:  "helloworld.py"
+				}
+			}
+			output: run.export.files."/out.txt" & "Hello, world\n"
+		}
+
+		// Run a script from string
+		runString: {
+			run: python.#Run & {
+				export: files: "/output.txt": _
+				script: contents: #"""
+					with open("output.txt", 'w') as f:
+					    f.write("Hello, inlined world!\n")
+					"""#
+			}
+			output: run.export.files."/output.txt" & "Hello, inlined world!\n"
+		}
+	}
+}


### PR DESCRIPTION
Update some API references that had fallen out of use.

Notably this no longer ran, since docker.#Run now asks for an "input" not an "image," alpine.#Image became alpine.#Build and you have to reference its output. Additionally, fix up the FIXME tag in the simplest way possible, though a better solution may exist.