### PR TITLE
Remove incorrect installer documentation

### DIFF
--- a/docs/getting-started/1200-local-dev.md
+++ b/docs/getting-started/1200-local-dev.md
@@ -215,8 +215,7 @@ From a powershell terminal, run:
 Invoke-WebRequest -UseBasicParsing -Uri https://dl.dagger.io/dagger/install.ps1 | Invoke-Expression
 ```
 
-We try to move the dagger binary under `C:\Windows\System32` but
-in case we miss the necessary permissions, we'll save everything under `<your home folder>/dagger`
+ We'll save everything under `<your home folder>/dagger`
 
 Check that `dagger` is installed correctly by opening a `Command Prompt` terminal and run:
 


### PR DESCRIPTION
In the installer instruction for Windows it is claimed that the dagger binary is placed inside the System32 folder if permissions allow it, which seems to be no longer part of the install.ps1 script (and seems like a bad idea anyways).