### PR TITLE
ci: cue linter: include all CUE files

### DIFF
--- a/ci/cue/lint.cue
+++ b/ci/cue/lint.cue
@@ -39,7 +39,7 @@ import (
 			// CACHE: copy only *.cue files
 			docker.#Copy & {
 				contents: source
-				include: ["*.cue"]
+				include: ["*.cue", "**/*.cue"]
 				dest: "/cue"
 			},
 


### PR DESCRIPTION
Regression -- we were linting only top-level files