### PR TITLE
Doc: fix broken link to 'it all begins with a plan' page

### DIFF
--- a/docs/core-concepts/1221-action.md
+++ b/docs/core-concepts/1221-action.md
@@ -111,7 +111,7 @@ dagger.#Plan & {
 
 Note that `#AddHello` was integrated *directly* into the plan, whereas `core.#WriteFile` was integrated *indirectly*, by virtue of being a sub-action of `#AddHello`.
 
-To learn more about the structure of a plan, see [it all begins with a plan](./1202-plan).
+To learn more about the structure of a plan, see [it all begins with a plan](./1202-plan.md).
 
 ### Discovery
 


### PR DESCRIPTION
Hi,
In https://docs.dagger.io/1221/action the link to `it all begins with a plan` is broken and goes to https://docs.dagger.io/1221/1202-plan.

<img width="954" alt="Screenshot 2022-04-08 at 14 39 41" src="https://user-images.githubusercontent.com/6226037/162437430-3bddf955-d4b5-43f8-80f9-2f06b5dda6f3.png">
