### PR TITLE
fix: log error when vendor pkg

### DIFF
--- a/cmd/dagger/cmd/project/update.go
+++ b/cmd/dagger/cmd/project/update.go
@@ -34,7 +34,9 @@ var updateCmd = &cobra.Command{
 
 		if len(args) == 0 {
 			lg.Debug().Msg("No package specified, updating all packages")
-			pkg.Vendor(ctx, cueModPath)
+			if err := pkg.Vendor(ctx, cueModPath); err != nil {
+				lg.Fatal().Err(err).Msg("vendor pkg failed")
+			}
 			return
 		}
 


### PR DESCRIPTION
I run dagger in my virtual machine ubuntu, when i want update dagger cue pkg, so i run `dagger project update` in my terminal, but not work

After some checking, I found that there was something wrong with the directory that mounts to the virtual machine, but the error was hidden

```bash
dagger project update                                                                            │>
6:43PM FTL system | vendor pkg failed: open /**/code/github.com/dagger-demos/cue.mod/pkg/dagger.lock: operation not permitted
```

I haven't found the real cause of this bug yet, but it has nothing to do with dagger anymore, throwing this error and leaving the rest to the developer to solve.
