### PR TITLE
docs: Link to markdown files

### DIFF
--- a/docs/core-concepts/1221-action.md
+++ b/docs/core-concepts/1221-action.md
@@ -111,7 +111,7 @@ dagger.#Plan & {
 
 Note that `#AddHello` was integrated *directly* into the plan, whereas `core.#WriteFile` was integrated *indirectly*, by virtue of being a sub-action of `#AddHello`.
 
-To learn more about the structure of a plan, see [it all begins with a plan](./1202-plan).
+To learn more about the structure of a plan, see [it all begins with a plan](./1202-plan.md).
 
 ## Discovery
 

--- a/docs/references/1222-core-actions-reference.md
+++ b/docs/references/1222-core-actions-reference.md
@@ -7,7 +7,7 @@ displayed_sidebar: europa
 
 Core Actions are primitives implemented by the Dagger Engine itself. They can be combined into higher-level composite actions. Their definitions can be imported in the `dagger.io/dagger/core` package.
 
-For more information about Dagger Actions, see [Dagger Actions](../core-concepts/1221-action).
+For more information about Dagger Actions, see [Dagger Actions](../core-concepts/1221-action.md).
 
 The following core actions are available:
 


### PR DESCRIPTION
The docs **must** link to `.md` files, rather than relative HTTP path.

This lets the compiler figure out the link URLs at compile time and fail the build if it cannot be resolved.

The link "it all begins with a plan" on "Dagger Actions" was broken (https://docs.dagger.io/1221/action#integration), leading to a 404.

/cc @dagger/maintainers 

Fixes #2111