### PR TITLE
fix: rename duplicates Go modules

### DIFF
--- a/docs/tests/guides/container-images/multi-stage/dagger.cue
+++ b/docs/tests/guides/container-images/multi-stage/dagger.cue
@@ -30,7 +30,7 @@ dagger.#Plan & {
 					dest:     "/opt"
 				},
 				docker.#Set & {
-					config: cmd: ["/opt/app"]
+					config: cmd: ["/opt/testmulti"]
 				},
 			]
 		}

--- a/docs/tests/guides/container-images/multi-stage/src/go.mod
+++ b/docs/tests/guides/container-images/multi-stage/src/go.mod
@@ -1,3 +1,3 @@
-module dagger.io/test
+module dagger.io/testmulti
 
 go 1.17

--- a/pkg/universe.dagger.io/go/test/build.cue
+++ b/pkg/universe.dagger.io/go/test/build.cue
@@ -29,7 +29,7 @@ dagger.#Plan & {
 				mounts: binary: {
 					dest:     "/bin/hello"
 					contents: build.output
-					source:   "/test"
+					source:   "/testgreet"
 				}
 			}
 

--- a/pkg/universe.dagger.io/go/test/data/hello/go.mod
+++ b/pkg/universe.dagger.io/go/test/data/hello/go.mod
@@ -1,3 +1,3 @@
-module dagger.io/test
+module dagger.io/testgreet
 
 go 1.17

--- a/pkg/universe.dagger.io/go/test/data/hello/main.go
+++ b/pkg/universe.dagger.io/go/test/data/hello/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"dagger.io/test/greeting"
+	"dagger.io/testgreet/greeting"
 )
 
 func main() {


### PR DESCRIPTION
They create conflict in gopls (for the govim plugin)