### PR TITLE
filter out useless commandConn.CloseWrite warning message

### DIFF
--- a/cmd/dagger/cmd/root.go
+++ b/cmd/dagger/cmd/root.go
@@ -4,7 +4,9 @@ import (
 	"os"
 	"strings"
 
+	"github.com/docker/buildx/util/logutil"
 	"github.com/moby/buildkit/util/appcontext"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.dagger.io/dagger/cmd/dagger/cmd/project"
@@ -21,6 +23,16 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
+	// filter out useless commandConn.CloseWrite warning message that can occur
+	// when dagger runs for the first time. This should be fixed upstream:
+	// unreachable: "commandConn.CloseWrite: commandconn: failed to wait: signal: killed"
+	// https://github.com/docker/cli/blob/3fb4fb83dfb5db0c0753a8316f21aea54dab32c5/cli/connhelper/commandconn/commandconn.go#L203-L214
+	logrus.AddHook(logutil.NewFilter([]logrus.Level{
+		logrus.WarnLevel,
+	},
+		"commandConn.CloseWrite:",
+	))
+
 	rootCmd.PersistentFlags().String("log-format", "auto", "Log format (auto, plain, tty, json)")
 	rootCmd.PersistentFlags().StringP("log-level", "l", "info", "Log level")
 	rootCmd.PersistentFlags().Bool("experimental", false, "Enable experimental features")

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799
 	github.com/rs/zerolog v1.26.1
 	github.com/sergi/go-diff v1.2.0
+	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.10.0
 	github.com/stretchr/testify v1.7.1


### PR DESCRIPTION
fixes #1689

encounter this issue while making a review for the GitHub Action: https://github.com/dagger/dagger-for-github/pull/47

```
  /opt/hostedtoolcache/dagger/0.2.6/x64/dagger do test --log-format plain
  time="2022-04-13T00:09:40Z" level=warning msg="commandConn.CloseWrite: commandconn: failed to wait: signal: terminated"
  time="2022-04-13T00:09:40Z" level=warning msg="commandConn.CloseRead: commandconn: failed to wait: signal: terminated"
  time="2022-04-13T00:09:40Z" level=warning msg="commandConn.CloseWrite: commandconn: failed to wait: signal: terminated"
  12:09AM INF actions.test.script._write | computing
  12:09AM INF actions.test.image._dag."0"._op | computing
  12:09AM INF actions.test.script._write | completed    duration=0s
```

for now filter out `commandConn.CloseWrite` warning message that can occur when dagger runs for the first time. this should be fixed upstream: https://github.com/docker/cli/blob/3fb4fb83dfb5db0c0753a8316f21aea54dab32c5/cli/connhelper/commandconn/commandconn.go#L203-L214

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>