### PR TITLE
ci: Deploy todoapp with dev dagger AND ALSO latest 0.2.x release

### DIFF
--- a/.github/workflows/todoapp.yml
+++ b/.github/workflows/todoapp.yml
@@ -2,41 +2,77 @@ name: todoapp
 
 on:
   push:
+    # Trigger for new commits to any branch ONLY IF
+    # they introduce changes in the following paths:
     branches:
-      - main
     paths:
       - '.github/workflows/todoapp.yml'
       - 'pkg/universe.dagger.io/examples/todoapp/**'
 
 env:
-  # This needs to be unique across all of Netlify
+  # ⚠️ APP_NAME must be unique across all of Netlify ⚠️
+  # The deploy action will fail with a curl error if this is not the case
+  # TODO: make app name optional in the Netlify package and generate one by default
   APP_NAME: todoapp-dagger-europa
+  # Set this to your Netlify team:
   NETLIFY_TEAM: blocklayer
+  # Configure NETLIFY_TOKEN as a GitHub Actions secret after you create one via:
   # https://app.netlify.com/user/applications/personal
   NETLIFY_TOKEN: ${{ secrets.NETLIFY_TOKEN }}
+  # GitHub Actions friendly logs
   DAGGER_LOG_FORMAT: plain
 
 jobs:
-  dagger:
-    name: "Deploy todoapp to Netlify"
+  dagger-dev:
+    # a.k.a. Did we break anything?
+    name: Deploy with dagger dev
     runs-on: ubuntu-latest
     steps:
-      - name: "Clone repository"
+
+      - name: Clone repository
         uses: actions/checkout@v2
+        # this repository has many commits,
+        # we only care about the last one
         with:
           fetch-depth: 0
 
-      # TODO: maybe use Dagger action post 0.2.0-beta.1
-      - name: "Setup Go"
+        # We want to test with the current dev version of Dagger,
+        # so we need to install Go AND
+        # building a dev version of Dagger from source
+      - name: Setup Go
         uses: actions/setup-go@v1
         with:
           go-version: 1.16
-
-      - name: "Install dev Dagger"
+      - name: Build dev version of Dagger
         run: |
           make dagger
 
-      - name: "Dagger"
+      - name: dagger do deploy
         run: |
           cd pkg/universe.dagger.io/examples/todoapp
           ${{ github.workspace }}/cmd/dagger/dagger do deploy
+
+  dagger-0-2-x:
+    # a.k.a. Does it still work?
+    name: Deploy with dagger 0.2.x last release
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Clone repository
+        uses: actions/checkout@v2
+        # this repository has many commits,
+        # we only care about the last one
+        with:
+          fetch-depth: 0
+
+      - name: dagger do deploy
+        # https://github.com/dagger/dagger-for-github
+        uses: dagger/dagger-for-github@v2
+        with:
+          # Use latest Dagger 0.2.x release
+          version: 0.2
+          workdir: pkg/universe.dagger.io/examples/todoapp
+          # To pin external dependencies, use `project update github.com/[package-source]@v[n]`
+          cmds: |
+            project update
+            do deploy


### PR DESCRIPTION
Thanks to a great community contribution, we are improving the GitHub Actions integration further. We should probably do the same for the GitLab integration doc as a follow-up to this.

This should be merged **after** https://github.com/dagger/dagger/pull/1962. Maybe @ekinbarut wants to take a look at it 👋🏻