### PR TITLE
docs: Mention macOS ARM vs Intel Homebrew dagger install path diff

### DIFF
--- a/docs/getting-started/1200-local-dev.md
+++ b/docs/getting-started/1200-local-dev.md
@@ -33,11 +33,14 @@ If you do, you can install `dagger` with a single command:
 brew install dagger/tap/dagger
 ```
 
-This installs `dagger` in `/opt/homebrew/bin`:
+This installs `dagger` in:
 
 ```shell
 type dagger
+# macOS ARM:
 dagger is /opt/homebrew/bin/dagger
+# macOS Intel:
+dagger is /usr/local/bin/dagger
 ```
 
 If you do not have Homebrew installed, or you want to install a specific version of `dagger`, you can run:


### PR DESCRIPTION
This supersedes https://github.com/dagger/dagger/pull/1998. We appreciate the contribution @sauzy34 and want to get it merged. Thank you!