### PR TITLE
Improve tty error logging when buildkit vertex is unknown

### DIFF
--- a/cmd/dagger/logger/plain.go
+++ b/cmd/dagger/logger/plain.go
@@ -23,6 +23,8 @@ type PlainOutput struct {
 	Out io.Writer
 }
 
+const systemGroup = "system"
+
 func (c *PlainOutput) Write(p []byte) (int, error) {
 	event := map[string]interface{}{}
 	d := json.NewDecoder(bytes.NewReader(p))
@@ -117,7 +119,7 @@ func formatMessage(event map[string]interface{}) string {
 }
 
 func parseSource(event map[string]interface{}) string {
-	source := "system"
+	source := systemGroup
 	if task, ok := event["task"].(string); ok && task != "" {
 		source = task
 	}

--- a/cmd/dagger/logger/tty.go
+++ b/cmd/dagger/logger/tty.go
@@ -43,8 +43,14 @@ func (l *Logs) Add(event Event) error {
 	l.l.Lock()
 	defer l.l.Unlock()
 
+	// same thing as in plain.go group all the non-identified tasks
+	// into a general group called system
+	source := systemGroup
 	taskPath, ok := event["task"].(string)
-	if !ok {
+
+	if ok && len(taskPath) > 0 {
+		source = taskPath
+	} else if !ok {
 		l.Messages = append(l.Messages, Message{
 			Event: event,
 		})
@@ -53,7 +59,7 @@ func (l *Logs) Add(event Event) error {
 	}
 
 	// Hide hidden fields (e.g. `._*`) from log group names
-	groupKey := strings.Split(taskPath, "._")[0]
+	groupKey := strings.Split(source, "._")[0]
 
 	group := l.groups[groupKey]
 
@@ -262,51 +268,56 @@ func (c *TTYOutput) printLine(w io.Writer, event Event, width int) int {
 func (c *TTYOutput) printGroup(group *Group, width, maxLines int) int {
 	lineCount := 0
 
-	prefix := ""
-	switch group.State {
-	case task.StateComputing:
-		prefix = "[+]"
-	case task.StateCanceled:
-		prefix = "[✗]"
-	case task.StateFailed:
-		prefix = "[✗]"
-	case task.StateCompleted:
-		prefix = "[✔]"
+	var out string
+	// treat the "system" group as a special case as we don't
+	// want it to be displayed as an action in the output
+	if group.Name != systemGroup {
+		prefix := ""
+		switch group.State {
+		case task.StateComputing:
+			prefix = "[+]"
+		case task.StateCanceled:
+			prefix = "[✗]"
+		case task.StateFailed:
+			prefix = "[✗]"
+		case task.StateCompleted:
+			prefix = "[✔]"
+		}
+
+		out = prefix + " " + group.Name
+
+		endTime := time.Now()
+		if group.Completed != nil {
+			endTime = *group.Completed
+		}
+
+		dt := endTime.Sub(*group.Started).Seconds()
+		if dt < 0.05 {
+			dt = 0
+		}
+		timer := fmt.Sprintf("%3.1fs", dt)
+
+		// align
+		out += strings.Repeat(" ", width-utf8.RuneCountInString(out)-len(timer))
+		out += timer
+		out += "\n"
+
+		// color
+		switch group.State {
+		case task.StateComputing:
+			out = aec.Apply(out, aec.LightBlueF)
+		case task.StateCanceled:
+			out = aec.Apply(out, aec.LightYellowF)
+		case task.StateFailed:
+			out = aec.Apply(out, aec.LightRedF)
+		case task.StateCompleted:
+			out = aec.Apply(out, aec.LightGreenF)
+		}
+
+		// Print
+		fmt.Fprint(c.cons, out)
+		lineCount++
 	}
-
-	out := prefix + " " + group.Name
-
-	endTime := time.Now()
-	if group.Completed != nil {
-		endTime = *group.Completed
-	}
-
-	dt := endTime.Sub(*group.Started).Seconds()
-	if dt < 0.05 {
-		dt = 0
-	}
-	timer := fmt.Sprintf("%3.1fs", dt)
-
-	// align
-	out += strings.Repeat(" ", width-utf8.RuneCountInString(out)-len(timer))
-	out += timer
-	out += "\n"
-
-	// color
-	switch group.State {
-	case task.StateComputing:
-		out = aec.Apply(out, aec.LightBlueF)
-	case task.StateCanceled:
-		out = aec.Apply(out, aec.LightYellowF)
-	case task.StateFailed:
-		out = aec.Apply(out, aec.LightRedF)
-	case task.StateCompleted:
-		out = aec.Apply(out, aec.LightGreenF)
-	}
-
-	// Print
-	fmt.Fprint(c.cons, out)
-	lineCount++
 
 	printEvents := []Event{}
 	switch group.State {

--- a/plan/runner.go
+++ b/plan/runner.go
@@ -160,7 +160,7 @@ func (r *Runner) taskFunc(flowVal cue.Value) (cueflow.Runner, error) {
 		defer span.End()
 
 		taskLog(taskPath, &lg, handler, func(lg zerolog.Logger) {
-			lg.Info().Str("state", string(task.StateComputing)).Msg(string(task.StateComputing))
+			lg.Info().Str("state", task.StateComputing.String()).Msg(task.StateComputing.String())
 		})
 
 		// Debug: dump dependencies
@@ -178,15 +178,19 @@ func (r *Runner) taskFunc(flowVal cue.Value) (cueflow.Runner, error) {
 			// we don't wrap taskLog here since in some cases, actions could still be
 			// running in goroutines which will scramble outputs.
 			if strings.Contains(err.Error(), "context canceled") {
-				lg.Error().Dur("duration", time.Since(start)).Str("task", taskPath).Str("state", string(task.StateCanceled)).Msg(string(task.StateCanceled))
+				taskLog(taskPath, &lg, handler, func(lg zerolog.Logger) {
+					lg.Error().Dur("duration", time.Since(start)).Str("state", task.StateCanceled.String()).Msg(task.StateCanceled.String())
+				})
 			} else {
-				lg.Error().Dur("duration", time.Since(start)).Err(compiler.Err(err)).Str("task", taskPath).Str("state", string(task.StateFailed)).Msg(string(task.StateFailed))
+				taskLog(taskPath, &lg, handler, func(lg zerolog.Logger) {
+					lg.Error().Dur("duration", time.Since(start)).Err(compiler.Err(err)).Str("state", task.StateFailed.String()).Msg(task.StateFailed.String())
+				})
 			}
 			return fmt.Errorf("%s: %w", t.Path().String(), compiler.Err(err))
 		}
 
 		taskLog(taskPath, &lg, handler, func(lg zerolog.Logger) {
-			lg.Info().Dur("duration", time.Since(start)).Str("state", string(task.StateCompleted)).Msg(string(task.StateCompleted))
+			lg.Info().Dur("duration", time.Since(start)).Str("state", task.StateCompleted.String()).Msg(task.StateCompleted.String())
 		})
 
 		// If the result is not concrete (e.g. empty value), there's nothing to merge.

--- a/plan/task/dockerfile.go
+++ b/plan/task/dockerfile.go
@@ -22,13 +22,12 @@ import (
 )
 
 func init() {
-	Register("Dockerfile", func() Task { return &dockerfileTask{} })
+	Register("Dockerfile", func() Task { return &DockerfileTask{} })
 }
 
-type dockerfileTask struct {
-}
+type DockerfileTask struct{}
 
-func (t *dockerfileTask) Run(ctx context.Context, pctx *plancontext.Context, s *solver.Solver, v *compiler.Value) (*compiler.Value, error) {
+func (t *DockerfileTask) Run(ctx context.Context, pctx *plancontext.Context, s *solver.Solver, v *compiler.Value) (*compiler.Value, error) {
 	lg := log.Ctx(ctx)
 	auths, err := v.Lookup("auth").Fields()
 	if err != nil {
@@ -76,7 +75,7 @@ func (t *dockerfileTask) Run(ctx context.Context, pctx *plancontext.Context, s *
 		}
 		dockerfileDef, err = s.Marshal(ctx,
 			llb.Scratch().File(
-				llb.Mkfile("/Dockerfile", 0644, []byte(contents)),
+				llb.Mkfile("/Dockerfile", 0o644, []byte(contents)),
 			),
 		)
 		if err != nil {
@@ -139,7 +138,7 @@ func (t *dockerfileTask) Run(ctx context.Context, pctx *plancontext.Context, s *
 	})
 }
 
-func (t *dockerfileTask) dockerBuildOpts(v *compiler.Value, pctx *plancontext.Context) (map[string]string, error) {
+func (t *DockerfileTask) dockerBuildOpts(v *compiler.Value, pctx *plancontext.Context) (map[string]string, error) {
 	opts := map[string]string{}
 
 	if dockerfilePath := v.Lookup("dockerfile.path"); dockerfilePath.Exists() {

--- a/plan/task/task.go
+++ b/plan/task/task.go
@@ -28,13 +28,36 @@ var (
 )
 
 // State is the state of the task.
-type State string
+type State int8
+
+func (s State) String() string {
+	return [...]string{"computing", "cancelled", "failed", "completed"}[s]
+}
+
+func ParseState(s string) (State, error) {
+	switch s {
+	case "computing":
+		return StateComputing, nil
+	case "cancelled":
+		return StateCanceled, nil
+	case "failed":
+		return StateFailed, nil
+	case "completed":
+		return StateCompleted, nil
+	}
+
+	return -1, fmt.Errorf("invalid state [%s]", s)
+}
+
+func (s State) CanTransition(t State) bool {
+	return s == StateComputing && s <= t
+}
 
 const (
-	StateComputing = State("computing")
-	StateCanceled  = State("canceled")
-	StateFailed    = State("failed")
-	StateCompleted = State("completed")
+	StateComputing State = iota
+	StateCanceled
+	StateFailed
+	StateCompleted
 )
 
 type NewFunc func() Task

--- a/plancontext/fs.go
+++ b/plancontext/fs.go
@@ -12,12 +12,10 @@ import (
 	"go.dagger.io/dagger/pkg"
 )
 
-var (
-	fsIDPath = cue.MakePath(
-		cue.Str("$dagger"),
-		cue.Str("fs"),
-		cue.Hid("_id", pkg.DaggerPackage),
-	)
+var fsIDPath = cue.MakePath(
+	cue.Str("$dagger"),
+	cue.Str("fs"),
+	cue.Hid("_id", pkg.DaggerPackage),
 )
 
 func IsFSValue(v *compiler.Value) bool {

--- a/util/progressui/display.go
+++ b/util/progressui/display.go
@@ -25,9 +25,11 @@ const (
 	defaultDisplayTimeout = 100 * time.Millisecond
 )
 
-type VertexPrintFunc func(v *client.Vertex, index int)
-type StatusPrintFunc func(v *client.Vertex, format string, a ...interface{})
-type LogPrintFunc func(v *client.Vertex, stream int, partial bool, format string, a ...interface{})
+type (
+	VertexPrintFunc func(v *client.Vertex, index int)
+	StatusPrintFunc func(v *client.Vertex, format string, a ...interface{})
+	LogPrintFunc    func(v *client.Vertex, stream int, partial bool, format string, a ...interface{})
+)
 
 func PrintSolveStatus(ctx context.Context, ch chan *client.SolveStatus, vertexPrintCb VertexPrintFunc, statusPrintCb StatusPrintFunc, logPrintCb LogPrintFunc) error {
 	printer := &textMux{
@@ -148,8 +150,10 @@ func DisplaySolveStatus(ctx context.Context, phase string, c console.Console, w 
 	}
 }
 
-const termHeight = 6
-const termPad = 10
+const (
+	termHeight = 6
+	termPad    = 10
+)
 
 type displayInfo struct {
 	startTime      time.Time

--- a/util/progressui/printer.go
+++ b/util/progressui/printer.go
@@ -11,10 +11,12 @@ import (
 	"github.com/tonistiigi/units"
 )
 
-const antiFlicker = 5 * time.Second
-const maxDelay = 10 * time.Second
-const minTimeDelta = 5 * time.Second
-const minProgressDelta = 0.05 // %
+const (
+	antiFlicker      = 5 * time.Second
+	maxDelay         = 10 * time.Second
+	minTimeDelta     = 5 * time.Second
+	minProgressDelta = 0.05 // %
+)
 
 type lastStatus struct {
 	Current   int64


### PR DESCRIPTION
Creates a generic "system" group in the tty output similarly to the plain one which captures
buildkit events that report a non-dagger vertex name. This happens
currently when using core.#Dockerfile actions since Dagger delegates the
LLB generation to buildkit through it's frontend and we don't get
meaningful events that we can correlate from Dagger's side. 

Given the following dockerfile:

```Dockerfile
FROM node:10-alpine
RUN apk update
RUN some_error
```


Old output :

```
dagger do hello
[✔] client.filesystem.".".read                                                                         0.0s
[✗] actions.hello                                                                                      6.9s
                                                                                                       0.8s
5:18PM FTL failed to execute plan: task failed: actions.hello._build: process "/bin/sh -c some_error" did not complete successfully: exit code: 127
```

New output:

```
dagger do  hello
[✔] client.filesystem.".".read                                                                         0.1s
[✗] actions.hello                                                                                      1.8s
#5 0.083 fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/main/x86_64/APKINDEX.tar.gz
#5 0.605 fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/community/x86_64/APKINDEX.tar.gz
#5 0.858 v3.11.13-8-gaf7d80ff31 [http://dl-cdn.alpinelinux.org/alpine/v3.11/main]
#5 0.858 v3.11.11-124-gf2729ece5a [http://dl-cdn.alpinelinux.org/alpine/v3.11/community]
#5 0.858 OK: 11280 distinct packages available
#6 0.052 /bin/sh: some_error: not found
5:16PM FTL failed to execute plan: task failed: actions.hello._build: process "/bin/sh -c some_error" did not complete successfully: exit code: 127
```

cc @aluzzardi @helderco 

Fixes #2044 
Related #613 