### PR TITLE
universe: Add Terraform package

### DIFF
--- a/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/apply.cue
+++ b/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/apply.cue
@@ -1,0 +1,8 @@
+package terraform
+
+// Run `terraform apply`
+#Apply: #Run & {
+  cmd: "apply"
+  withinCmdArgs: ["-auto-approve", planFile]
+  planFile: _#defaultPlanFile
+}

--- a/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/apply.cue
+++ b/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/apply.cue
@@ -2,7 +2,20 @@ package terraform
 
 // Run `terraform apply`
 #Apply: #Run & {
-  cmd: "apply"
-  withinCmdArgs: ["-auto-approve", planFile]
-  planFile: _#defaultPlanFile
+	// Terraform `apply` command
+	cmd: "apply"
+
+	// Internal pre-defined arguments for `terraform apply`
+	withinCmdArgs: [
+		if autoApprove {
+			"-auto-approve"
+		},
+		planFile,
+	]
+
+	// Flag to indicate whether or not to auto-approve (i.e. -auto-approve flag)
+	autoApprove: bool | *true
+
+	// Path to a Terraform plan file
+	planFile: string | *_#DefaultPlanFile
 }

--- a/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/destroy.cue
+++ b/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/destroy.cue
@@ -1,0 +1,7 @@
+package terraform
+
+// Run `terraform destroy`
+#Destroy: #Run & {
+  cmd: "destroy"
+  withinCmdArgs: ["-auto-approve"]
+}

--- a/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/destroy.cue
+++ b/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/destroy.cue
@@ -2,6 +2,16 @@ package terraform
 
 // Run `terraform destroy`
 #Destroy: #Run & {
-  cmd: "destroy"
-  withinCmdArgs: ["-auto-approve"]
+	// Terraform `destroy` command
+	cmd: "destroy"
+
+	// Internal pre-defined arguments for `terraform destroy`
+	withinCmdArgs: [
+		if autoApprove {
+			"-auto-approve"
+		},
+	]
+
+	// Flag to indicate whether or not to auto-approve (i.e. -auto-approve flag)
+	autoApprove: bool | *true
 }

--- a/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/fmt.cue
+++ b/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/fmt.cue
@@ -1,0 +1,6 @@
+package terraform
+
+// Run `terraform fmt`
+#Fmt: #Run & {
+  cmd: "fmt"
+}

--- a/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/fmt.cue
+++ b/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/fmt.cue
@@ -2,5 +2,6 @@ package terraform
 
 // Run `terraform fmt`
 #Fmt: #Run & {
-  cmd: "fmt"
+	// Terraform `fmt` command
+	cmd: "fmt"
 }

--- a/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/image.cue
+++ b/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/image.cue
@@ -1,0 +1,22 @@
+package terraform
+
+import (
+	"universe.dagger.io/docker"
+)
+
+// Terraform image default version
+_#DefaultVersion: "1.1.8"
+
+// Terraform base image
+#Image: {
+	// Terraform version
+	version: *_#DefaultVersion | string
+
+	docker.#Build & {
+		steps: [
+			docker.#Pull & {
+				source: "hashicorp/terraform:\(version)"
+			},
+		]
+	}
+}

--- a/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/init.cue
+++ b/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/init.cue
@@ -2,5 +2,6 @@ package terraform
 
 // Run `terraform init`
 #Init: #Run & {
-  cmd: "init"
+	// Terraform `init` command
+	cmd: "init"
 }

--- a/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/init.cue
+++ b/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/init.cue
@@ -1,0 +1,6 @@
+package terraform
+
+// Run `terraform init`
+#Init: #Run & {
+  cmd: "init"
+}

--- a/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/plan.cue
+++ b/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/plan.cue
@@ -1,11 +1,16 @@
 package terraform
 
 // File to write the output plan
-_#defaultPlanFile: string | *"./out.tfplan"
+_#DefaultPlanFile: "./out.tfplan"
 
 // Run `terraform plan`
 #Plan: #Run & {
-  cmd: "plan"
-  withinCmdArgs: ["-out=\(planFile)"]
-  planFile: _#defaultPlanFile
+	// Terraform `plan` command
+	cmd: "plan"
+
+	// Internal pre-defined arguments for `terraform plan`
+	withinCmdArgs: ["-out=\(planFile)"]
+
+	// Path to a Terraform plan file
+	planFile: string | *_#DefaultPlanFile
 }

--- a/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/plan.cue
+++ b/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/plan.cue
@@ -1,0 +1,11 @@
+package terraform
+
+// File to write the output plan
+_#defaultPlanFile: string | *"./out.tfplan"
+
+// Run `terraform plan`
+#Plan: #Run & {
+  cmd: "plan"
+  withinCmdArgs: ["-out=\(planFile)"]
+  planFile: _#defaultPlanFile
+}

--- a/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/run.cue
+++ b/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/run.cue
@@ -1,102 +1,92 @@
 package terraform
 
 import (
-  "dagger.io/dagger"
-  "dagger.io/dagger/core"
-  "universe.dagger.io/docker"
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+	"universe.dagger.io/docker"
 )
 
-_#logLevel: "off" | "info" | "warn" | "error" | "debug" | "trace"
+// Terraform log level
+#LogLevel: "off" | "info" | "warn" | "error" | "debug" | "trace"
+
+// Default log level
+_#DefaultLogLevel: "off"
 
 // Run `terraform CMD`
 #Run: {
-  // Hashicorp Terraform container
-  containerRef: dagger.#Ref | *"hashicorp/terraform:latest"
+	// Terraform source code
+	source: dagger.#FS
 
-  // Terraform source code
-  source: dagger.#FS
+	// Terraform command (i.e. init, plan, apply)
+	cmd: string
 
-  // Terraform command (i.e. init, plan, apply)
-  cmd: string
+	// Arguments for the Terraform command (i.e. -var-file, -var)
+	cmdArgs: [...string]
 
-  // Arguments for the Terraform command (i.e. -var-file, -var)
-  cmdArgs: [...string] | *[]
+	// Arguments set internally from other actions
+	withinCmdArgs: [...string]
 
-  // Arguments set internally from other actions
-  withinCmdArgs: [...string] | *[]
+	// Terraform workspace
+	workspace: string | *"default"
 
-  // Terraform workspace
-  workspace: string | *"default"
+	// Data directory (i.e. ./.terraform)
+	dataDir: string | *".terraform"
 
-  // Data directory (i.e. ./.terraform)
-  dataDir: string | *".terraform"
+	// Log level
+	logLevel: #LogLevel | *_#DefaultLogLevel
 
-  // Log level
-  logLevel: _#logLevel | *"off"
+	// Log path
+	logPath: string | *""
 
-  // Log path
-  logPath: string | *""
+	// Environment variables
+	env: [string]: string | dagger.#Secret
 
-  // Environment variables
-  env: [string]: string | dagger.#Secret
+	// Environment variables set internally from other actions
+	withinEnv: [string]: string | dagger.#Secret
 
-  // Environment variables set internally from other actions
-  withinEnv: [string]: string | dagger.#Secret
+	// Joins user and internal command arguments
+	_thisCmdArgs: cmdArgs + withinCmdArgs
 
-  // Run command within a container
-  _run: docker.#Build & {
-    steps: [
-      docker.#Pull & {
-        source: containerRef
-      },
+	// Joins user and internal environment variables
+	_thisEnv: env & withinEnv & {
+		TF_WORKSPACE:     workspace
+		TF_DATA_DIR:      dataDir
+		TF_LOG:           logLevel
+		TF_LOG_PATH:      logPath
+		TF_IN_AUTOMATION: "true"
+		TF_INPUT:         "0"
+	}
 
-      docker.#Copy & {
-        dest:     "/src"
-        contents: source
-      },
+	// Hashicorp Terraform container
+	container: #input: docker.#Image | #Image
 
-      docker.#Run & {
-        workdir: "/src"
-        command: {
-          name: cmd
-          args: _thisCmdArgs
-        }
-        env: _thisEnv
-      }
-    ]
-  }
+	// Run command within a container
+	_run: docker.#Build & {
+		steps: [
+			container.#input,
+			docker.#Copy & {
+				dest:     "/src"
+				contents: source
+			},
+			docker.#Run & {
+				workdir: "/src"
+				command: {
+					name: cmd
+					args: _thisCmdArgs
+				}
+				env: _thisEnv
+			},
+		]
+	}
 
-  _afterSource: core.#Subdir & {
-    input: _run.output.rootfs
-    path: "/src"
-  }
+	_afterSource: core.#Subdir & {
+		input: _run.output.rootfs
+		path:  "/src"
+	}
 
-  // Terraform image
-  outputImage: _run.output
+	// Terraform image
+	outputImage: _run.output
 
-  // Modified Terraform files
-  output: _afterSource.output
-  
-  // -*- this -*-
-  _thisCmdArgs: cmdArgs + withinCmdArgs
-  _thisEnv: env & withinEnv & {
-    if workspace != "default" {
-      TF_WORKSPACE: workspace
-    }
-
-    if dataDir != ".terraform" {
-      TF_DATA_DIR: dataDir
-    }
-
-    if logLevel != "off" {
-      TF_LOG: logLevel
-    }
-
-    if logPath != "" {
-      TF_LOG_PATH: logPath
-    }
-
-    TF_IN_AUTOMATION: "true"
-    TF_INPUT: "0"
-  }
+	// Modified Terraform files
+	output: _afterSource.output
 }

--- a/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/run.cue
+++ b/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/run.cue
@@ -1,0 +1,102 @@
+package terraform
+
+import (
+  "dagger.io/dagger"
+  "dagger.io/dagger/core"
+  "universe.dagger.io/docker"
+)
+
+_#logLevel: "off" | "info" | "warn" | "error" | "debug" | "trace"
+
+// Run `terraform CMD`
+#Run: {
+  // Hashicorp Terraform container
+  containerRef: dagger.#Ref | *"hashicorp/terraform:latest"
+
+  // Terraform source code
+  source: dagger.#FS
+
+  // Terraform command (i.e. init, plan, apply)
+  cmd: string
+
+  // Arguments for the Terraform command (i.e. -var-file, -var)
+  cmdArgs: [...string] | *[]
+
+  // Arguments set internally from other actions
+  withinCmdArgs: [...string] | *[]
+
+  // Terraform workspace
+  workspace: string | *"default"
+
+  // Data directory (i.e. ./.terraform)
+  dataDir: string | *".terraform"
+
+  // Log level
+  logLevel: _#logLevel | *"off"
+
+  // Log path
+  logPath: string | *""
+
+  // Environment variables
+  env: [string]: string | dagger.#Secret
+
+  // Environment variables set internally from other actions
+  withinEnv: [string]: string | dagger.#Secret
+
+  // Run command within a container
+  _run: docker.#Build & {
+    steps: [
+      docker.#Pull & {
+        source: containerRef
+      },
+
+      docker.#Copy & {
+        dest:     "/src"
+        contents: source
+      },
+
+      docker.#Run & {
+        workdir: "/src"
+        command: {
+          name: cmd
+          args: _thisCmdArgs
+        }
+        env: _thisEnv
+      }
+    ]
+  }
+
+  _afterSource: core.#Subdir & {
+    input: _run.output.rootfs
+    path: "/src"
+  }
+
+  // Terraform image
+  outputImage: _run.output
+
+  // Modified Terraform files
+  output: _afterSource.output
+  
+  // -*- this -*-
+  _thisCmdArgs: cmdArgs + withinCmdArgs
+  _thisEnv: env & withinEnv & {
+    if workspace != "default" {
+      TF_WORKSPACE: workspace
+    }
+
+    if dataDir != ".terraform" {
+      TF_DATA_DIR: dataDir
+    }
+
+    if logLevel != "off" {
+      TF_LOG: logLevel
+    }
+
+    if logPath != "" {
+      TF_LOG_PATH: logPath
+    }
+
+    TF_IN_AUTOMATION: "true"
+    TF_INPUT: "0"
+  }
+}

--- a/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/test/data/resource.tf
+++ b/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/test/data/resource.tf
@@ -1,0 +1,4 @@
+resource "local_file" "test" {
+    content  = "Hello, world!"
+    filename = "${path.module}/out.txt"
+}

--- a/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/test/test.bats
+++ b/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/test/test.bats
@@ -1,0 +1,9 @@
+setup() {
+    load '../../bats_helpers'
+
+    common_setup
+}
+
+@test "terraform" {
+    dagger "do" test
+}

--- a/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/test/test.bats
+++ b/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/test/test.bats
@@ -1,5 +1,5 @@
 setup() {
-    load '../../bats_helpers'
+    load '../../../../bats_helpers'
 
     common_setup
 }

--- a/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/test/test.cue
+++ b/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/test/test.cue
@@ -2,48 +2,48 @@ package terraform
 
 import (
 	"dagger.io/dagger"
-  "dagger.io/dagger/core"
+	"dagger.io/dagger/core"
 
 	"universe.dagger.io/x/ezequiel@foncubierta.com/terraform"
 )
 
 dagger.#Plan & {
 	actions: test: {
-    tfSource: core.#Source & {
-      path: "./data"
-    }
+		tfSource: core.#Source & {
+			path: "./data"
+		}
 
-    applyWorkflow: {
-      init: terraform.#Init & {
-        source: tfSource.output
-      }
+		applyWorkflow: {
+			init: terraform.#Init & {
+				source: tfSource.output
+			}
 
-      validate: terraform.#Validate & {
-        source: init.output
-      }
+			validate: terraform.#Validate & {
+				source: init.output
+			}
 
-      plan: terraform.#Plan & {
-        source: validate.output
-      }
+			plan: terraform.#Plan & {
+				source: validate.output
+			}
 
-      apply: terraform.#Apply & {
-        source: plan.output
-      }
+			apply: terraform.#Apply & {
+				source: plan.output
+			}
 
-      verify: #AssertFile & {
-        input:    apply.output
-        path:     "./out.txt"
-        contents: "Hello, world!"
-      }
-    }
+			verify: #AssertFile & {
+				input:    apply.output
+				path:     "./out.txt"
+				contents: "Hello, world!"
+			}
+		}
 
-    destroyWorkflow: {
-      destroy: terraform.#Destroy & {
-        source: applyWorkflow.apply.output
-      }
+		destroyWorkflow: {
+			destroy: terraform.#Destroy & {
+				source: applyWorkflow.apply.output
+			}
 
-      // TODO assert out.txt doesn't exist
-    }
+			// TODO assert out.txt doesn't exist
+		}
 	}
 }
 

--- a/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/test/test.cue
+++ b/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/test/test.cue
@@ -1,0 +1,65 @@
+package terraform
+
+import (
+	"dagger.io/dagger"
+  "dagger.io/dagger/core"
+
+	"universe.dagger.io/x/ezequiel@foncubierta.com/terraform"
+)
+
+dagger.#Plan & {
+	actions: test: {
+    tfSource: core.#Source & {
+      path: "./data"
+    }
+
+    applyWorkflow: {
+      init: terraform.#Init & {
+        source: tfSource.output
+      }
+
+      validate: terraform.#Validate & {
+        source: init.output
+      }
+
+      plan: terraform.#Plan & {
+        source: validate.output
+      }
+
+      apply: terraform.#Apply & {
+        source: plan.output
+      }
+
+      verify: #AssertFile & {
+        input:    apply.output
+        path:     "./out.txt"
+        contents: "Hello, world!"
+      }
+    }
+
+    destroyWorkflow: {
+      destroy: terraform.#Destroy & {
+        source: applyWorkflow.apply.output
+      }
+
+      // TODO assert out.txt doesn't exist
+    }
+	}
+}
+
+// Make an assertion on the contents of a file
+#AssertFile: {
+	input:    dagger.#FS
+	path:     string
+	contents: string
+
+	_read: core.#ReadFile & {
+		"input": input
+		"path":  path
+	}
+
+	actual: _read.contents
+
+	// Assertion
+	contents: actual
+}

--- a/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/validate.cue
+++ b/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/validate.cue
@@ -2,5 +2,6 @@ package terraform
 
 // Run `terraform validate`
 #Validate: #Run & {
-  cmd: "validate"
+	// Terraform `validate` command
+	cmd: "validate"
 }

--- a/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/validate.cue
+++ b/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/validate.cue
@@ -1,0 +1,6 @@
+package terraform
+
+// Run `terraform validate`
+#Validate: #Run & {
+  cmd: "validate"
+}

--- a/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/workspace.cue
+++ b/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/workspace.cue
@@ -1,0 +1,9 @@
+package terraform
+
+_#workspaceSubcmd: "new" | "select" | "delete"
+
+// Run `terraform workspace`
+#Workspace: #Run & {
+  cmd: "workspace " + subCmd
+  subCmd: _#workspaceSubcmd
+}

--- a/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/workspace.cue
+++ b/pkg/universe.dagger.io/x/ezequiel@foncubierta.com/terraform/workspace.cue
@@ -1,9 +1,13 @@
 package terraform
 
-_#workspaceSubcmd: "new" | "select" | "delete"
+// Subcommands of `terraform workspace` command
+#WorkspaceSubcmd: "new" | "select" | "delete"
 
 // Run `terraform workspace`
 #Workspace: #Run & {
-  cmd: "workspace " + subCmd
-  subCmd: _#workspaceSubcmd
+	// Terraform `workspace` command
+	cmd: "workspace \(subCmd)"
+
+	// Terraform `workspace` subcommand (i.e. new, select, delete)
+	subCmd: #WorkspaceSubcmd
 }


### PR DESCRIPTION
Signed-off-by: Ezequiel Foncubierta <ezequiel@foncubierta.com>

I know there is another contribution for a Terraform package ([#2110](https://github.com/dagger/dagger/pull/2110)), but this one we are currently using and implementing at work, and supports a lot more features. The approach is similar to Nico's implementation, so feel free to merge it into his package, or the other way around, if necessary.

### Implementation details

There is a `terraform.#Run` action to wrap the Terraform command and run it within the official Terraform container image, from Hashicorp. You can set the Terraform command you want to run (i.e. plan, apply), the arguments (i.e. -var-file, -var), and environment variables. For common environment variables or arguments, there is a field in `terraform.#Run` you can use. For example, the `workspace` fields will become a `TF_WORKSPACE` environment variable.

For each particular Terraform command (i.e. plan, apply) there is an action (i.e. `terraform.#Plan`) that extends `terraform.#Run`. These actions override the command field and define additional fields when necessary. For example, a `planFile` field.

For things that are not "yet supported", you can always fall back to the `terraform.#Run` action.

The `terraform.#Run` actions have two outputs:

-   `output`: A `dagger.#FS` with the modified Terraform workspace.
-   `outputImage`: The `docker.#Image` that was used to run the command.

### Not yet supported

-   Authentication in Terraform Cloud: [https://www.terraform.io/cli/auth](https://www.terraform.io/cli/auth)
-   Explicit actions (you can still use `terraform.#Run` though):
    - to import infrastructure: [https://www.terraform.io/cli/import](https://www.terraform.io/cli/import)
    - to inspect infrastructure: [https://www.terraform.io/cli/inspect](https://www.terraform.io/cli/inspect)
    - to manipulate state: [https://www.terraform.io/cli/state](https://www.terraform.io/cli/state)
    - to manage plugins: [https://www.terraform.io/cli/plugins](https://www.terraform.io/cli/plugins)
-   Use a container as input for `terraform.#Run` so you can chain multiple commands within the same container?
