### PR TITLE
docs: update github actions workflow example

### DIFF
--- a/docs/tests/getting-started/github-actions.yml
+++ b/docs/tests/getting-started/github-actions.yml
@@ -11,10 +11,6 @@ env:
   # This needs to be unique across all of netlify.app
   APP_NAME: todoapp-dagger-europa
   NETLIFY_TEAM: dagger
-  # Get one from https://app.netlify.com/user/applications/personal
-  NETLIFY_TOKEN: ${{ secrets.NETLIFY_TOKEN }}
-  # GitHub Actions friendly logs
-  DAGGER_LOG_FORMAT: plain
 
 jobs:
   dagger:
@@ -24,15 +20,15 @@ jobs:
         uses: actions/checkout@v2
 
       # You need to run `dagger project init` locally before and commit the cue.mod directory to the repository with its contents
-      - name: Project update
-        uses: dagger/dagger-for-github@v2
-        with:
-          version: 0.2
-          # To pin external dependencies, you can use `project update github.com/[package-source]@v[n]`
-          args: project update
-
       - name: Deploy to Netlify
         uses: dagger/dagger-for-github@v2
         # See all options at https://github.com/dagger/dagger-for-github
         with:
-          args: do deploy
+          version: 0.2
+          # To pin external dependencies, you can use `project update github.com/[package-source]@v[n]`
+          cmds: |
+            project update
+            do deploy
+        env:
+          # Get one from https://app.netlify.com/user/applications/personal
+          NETLIFY_TOKEN: ${{ secrets.NETLIFY_TOKEN }}


### PR DESCRIPTION
With the upcoming release of our GitHub Actions, `args` has been replaced with `cmds` input allowing multi dagger commands within a single step.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>