### PR TITLE
feat: change go.#Test.package -> packages and can be string or [...string]

### DIFF
--- a/ci/golangci/lint.cue
+++ b/ci/golangci/lint.cue
@@ -24,7 +24,7 @@ import (
 
 	go.#Container & {
 		"source": source
-		input:    _image.output
+		image:    _image.output
 		command: {
 			name: "golangci-lint"
 			flags: {

--- a/docs/plans/go-ci/plan.cue
+++ b/docs/plans/go-ci/plan.cue
@@ -11,8 +11,8 @@ dagger.#Plan & {
 
 	actions: {
 		test: go.#Test & {
-			source:  client.filesystem."./hello".read.contents
-			package: "./..."
+			source: client.filesystem."./hello".read.contents
+			packages: ["./..."]
 		}
 
 		build: go.#Build & {

--- a/pkg/universe.dagger.io/alpha/go/golangci/lint.cue
+++ b/pkg/universe.dagger.io/alpha/go/golangci/lint.cue
@@ -28,7 +28,7 @@ import (
 	go.#Container & {
 		name:     "golangci_lint"
 		"source": source
-		input:    _image.output
+		image:    _image.output
 		command: {
 			name: "golangci-lint"
 			flags: {

--- a/pkg/universe.dagger.io/alpha/go/goreleaser/release.cue
+++ b/pkg/universe.dagger.io/alpha/go/goreleaser/release.cue
@@ -23,7 +23,7 @@ import (
 	go.#Container & {
 		name:     "goreleaser"
 		"source": source
-		input:    image.output
+		"image":  image.output
 
 		entrypoint: [] // Support images that does not set goreleaser as the entrypoint
 		command: {

--- a/pkg/universe.dagger.io/alpha/go/goreleaser/release.cue
+++ b/pkg/universe.dagger.io/alpha/go/goreleaser/release.cue
@@ -12,7 +12,7 @@ import (
 	source: dagger.#FS
 
 	// Custom GoReleaser image
-	image: #Image
+	customImage: #Image
 
 	// Don't publish or announce the release
 	dryRun: bool | *false
@@ -23,7 +23,7 @@ import (
 	go.#Container & {
 		name:     "goreleaser"
 		"source": source
-		"image":  image.output
+		image:    customImage.output
 
 		entrypoint: [] // Support images that does not set goreleaser as the entrypoint
 		command: {

--- a/pkg/universe.dagger.io/alpha/go/goreleaser/test/release.cue
+++ b/pkg/universe.dagger.io/alpha/go/goreleaser/test/release.cue
@@ -19,7 +19,8 @@ dagger.#Plan & {
 
 		customImage: build: goreleaser.#Release & {
 			source: client.filesystem."./data/hello".read.contents
-			image:  goreleaser.#Image & {
+
+			customImage: goreleaser.#Image & {
 				tag: "v1.9.2"
 			}
 

--- a/pkg/universe.dagger.io/go/build.cue
+++ b/pkg/universe.dagger.io/go/build.cue
@@ -10,8 +10,11 @@ import (
 	// Source code
 	source: dagger.#FS
 
+	// DEPRECATED: use packages instead
+	package: string | *null
+
 	// Target package to build
-	package: *"." | string
+	packages: [...string]
 
 	// Target architecture
 	arch?: string
@@ -46,8 +49,22 @@ import (
 			}
 		}
 		command: {
+			_packages: [...string] | []
+			if package == null && len(packages) == 0 {
+				_packages: ["."]
+			}
+			if package != null && len(packages) == 0 {
+				_packages: [package]
+			}
+			if package == null && len(packages) > 0 {
+				_packages: packages
+			}
+			if package != null && len(packages) > 0 {
+				_packages: [package] + packages
+			}
+
 			name: "go"
-			args: [package]
+			args: _packages
 			flags: {
 				build:      true
 				"-v":       true

--- a/pkg/universe.dagger.io/go/build.cue
+++ b/pkg/universe.dagger.io/go/build.cue
@@ -38,7 +38,7 @@ import (
 
 	container: #Container & {
 		"source": source
-		input:    image
+		"image":  image
 		"env": {
 			env
 			if os != _|_ {

--- a/pkg/universe.dagger.io/go/build.cue
+++ b/pkg/universe.dagger.io/go/build.cue
@@ -49,7 +49,9 @@ import (
 			}
 		}
 		command: {
-			_packages: [...string] | []
+			//FIXME: find a better workaround with disjunction
+			//FIXME: factor with the part from test.cue
+			_packages: [...string]
 			if package == null && len(packages) == 0 {
 				_packages: ["."]
 			}

--- a/pkg/universe.dagger.io/go/container.cue
+++ b/pkg/universe.dagger.io/go/container.cue
@@ -16,20 +16,23 @@ import (
 	source: dagger.#FS
 
 	// Use go image
-	_image: #Image
+	image: *#Image | docker.#Image
 
 	_sourcePath:     "/src"
 	_modCachePath:   "/root/.cache/go-mod"
 	_buildCachePath: "/root/.cache/go-build"
 
+	_copy: docker.#Copy & {
+		input:    image.output
+		dest:     _sourcePath
+		contents: source
+	}
+
 	docker.#Run & {
-		input:   *_image.output | docker.#Image
+		input: _copy.output
+
 		workdir: _sourcePath
 		mounts: {
-			"source": {
-				dest:     _sourcePath
-				contents: source
-			}
 			"go mod cache": {
 				contents: core.#CacheDir & {
 					id: "\(name)_mod"

--- a/pkg/universe.dagger.io/go/container.cue
+++ b/pkg/universe.dagger.io/go/container.cue
@@ -15,22 +15,23 @@ import (
 	// Source code
 	source: dagger.#FS
 
-	// Use go image
-	image: *#Image | docker.#Image
+	// Counter FS not set disjunction error
+	_img: #Image
+
+	image: *_img.output | docker.#Image
 
 	_sourcePath:     "/src"
 	_modCachePath:   "/root/.cache/go-mod"
 	_buildCachePath: "/root/.cache/go-build"
 
 	_copy: docker.#Copy & {
-		input:    image.output
+		input:    image
 		dest:     _sourcePath
 		contents: source
 	}
 
 	docker.#Run & {
-		input: _copy.output
-
+		input:   _copy.output
 		workdir: _sourcePath
 		mounts: {
 			"go mod cache": {

--- a/pkg/universe.dagger.io/go/test.cue
+++ b/pkg/universe.dagger.io/go/test.cue
@@ -5,7 +5,7 @@ package go
 	// DEPRECATED: use packages instead
 	package: string | *null
 
-	// Packages to test
+	// Packages test
 	packages: [...string]
 
 	#Container & {

--- a/pkg/universe.dagger.io/go/test.cue
+++ b/pkg/universe.dagger.io/go/test.cue
@@ -10,7 +10,9 @@ package go
 
 	#Container & {
 		command: {
-			_packages: [...string] | []
+			//FIXME: find a better workaround with disjunction
+			//FIXME: factor with the part from test.cue
+			_packages: [...string]
 			if package == null && len(packages) == 0 {
 				_packages: ["."]
 			}

--- a/pkg/universe.dagger.io/go/test.cue
+++ b/pkg/universe.dagger.io/go/test.cue
@@ -2,32 +2,15 @@ package go
 
 // Test a go package
 #Test: {
-	// DEPRECATED: use packages instead
-	package: string | *null
+	package: string | *"." @deprecated("use `packages` instead")
 
-	// Packages test
-	packages: [...string]
+	// Packages to test
+	packages: [...string] | *[package]
 
 	#Container & {
 		command: {
-			//FIXME: find a better workaround with disjunction
-			//FIXME: factor with the part from test.cue
-			_packages: [...string]
-			if package == null && len(packages) == 0 {
-				_packages: ["."]
-			}
-			if package != null && len(packages) == 0 {
-				_packages: [package]
-			}
-			if package == null && len(packages) > 0 {
-				_packages: packages
-			}
-			if package != null && len(packages) > 0 {
-				_packages: [package] + packages
-			}
-
 			name: "go"
-			args: _packages
+			args: packages
 			flags: {
 				test: true
 				"-v": true

--- a/pkg/universe.dagger.io/go/test.cue
+++ b/pkg/universe.dagger.io/go/test.cue
@@ -2,13 +2,30 @@ package go
 
 // Test a go package
 #Test: {
-	// Package to test
-	package: *"." | string
+	// DEPRECATED: use packages instead
+	package: string | *null
+
+	// Packages to test
+	packages: [...string]
 
 	#Container & {
 		command: {
+			_packages: [...string] | []
+			if package == null && len(packages) == 0 {
+				_packages: ["."]
+			}
+			if package != null && len(packages) == 0 {
+				_packages: [package]
+			}
+			if package == null && len(packages) > 0 {
+				_packages: packages
+			}
+			if package != null && len(packages) > 0 {
+				_packages: [package] + packages
+			}
+
 			name: "go"
-			args: [package]
+			args: _packages
 			flags: {
 				test: true
 				"-v": true

--- a/pkg/universe.dagger.io/go/test/build.cue
+++ b/pkg/universe.dagger.io/go/test/build.cue
@@ -32,6 +32,57 @@ dagger.#Plan & {
 					source:   "/testgreet"
 				}
 			}
+			verify: core.#ReadFile & {
+				input: exec.output.rootfs
+				path:  "/output.txt"
+			} & {
+				contents: "Hi dagger!"
+			}
+		}
+		withPackage: {
+			build: go.#Build & {
+				source:  client.filesystem."./data/hello".read.contents
+				package: "."
+			}
+			exec: docker.#Run & {
+				input: _baseImage.output
+				command: {
+					name: "/bin/sh"
+					args: ["-c", "/bin/hello >> /output.txt"]
+				}
+				env: NAME: "dagger"
+				mounts: binary: {
+					dest:     "/bin/hello"
+					contents: build.output
+					source:   "/testgreet"
+				}
+			}
+
+			verify: core.#ReadFile & {
+				input: exec.output.rootfs
+				path:  "/output.txt"
+			} & {
+				contents: "Hi dagger!"
+			}
+		}
+		withPackages: {
+			build: go.#Build & {
+				source: client.filesystem."./data/hello".read.contents
+				packages: ["."]
+			}
+			exec: docker.#Run & {
+				input: _baseImage.output
+				command: {
+					name: "/bin/sh"
+					args: ["-c", "/bin/hello >> /output.txt"]
+				}
+				env: NAME: "dagger"
+				mounts: binary: {
+					dest:     "/bin/hello"
+					contents: build.output
+					source:   "/testgreet"
+				}
+			}
 
 			verify: core.#ReadFile & {
 				input: exec.output.rootfs

--- a/pkg/universe.dagger.io/go/test/build.cue
+++ b/pkg/universe.dagger.io/go/test/build.cue
@@ -2,6 +2,7 @@ package go
 
 import (
 	"dagger.io/dagger"
+	"dagger.io/dagger/core"
 
 	"universe.dagger.io/go"
 	"universe.dagger.io/docker"

--- a/pkg/universe.dagger.io/go/test/build.cue
+++ b/pkg/universe.dagger.io/go/test/build.cue
@@ -2,7 +2,7 @@ package go
 
 import (
 	"dagger.io/dagger"
-	"dagger.io/dagger/core"
+
 	"universe.dagger.io/go"
 	"universe.dagger.io/docker"
 	"universe.dagger.io/alpine"
@@ -31,14 +31,10 @@ dagger.#Plan & {
 					contents: build.output
 					source:   "/testgreet"
 				}
-			}
-			verify: core.#ReadFile & {
-				input: exec.output.rootfs
-				path:  "/output.txt"
-			} & {
-				contents: "Hi dagger!"
+				export: files: "/output.txt": string & "Hi dagger!"
 			}
 		}
+
 		withPackage: {
 			build: go.#Build & {
 				source:  client.filesystem."./data/hello".read.contents
@@ -56,15 +52,10 @@ dagger.#Plan & {
 					contents: build.output
 					source:   "/testgreet"
 				}
-			}
-
-			verify: core.#ReadFile & {
-				input: exec.output.rootfs
-				path:  "/output.txt"
-			} & {
-				contents: "Hi dagger!"
+				export: files: "/output.txt": string & "Hi dagger!"
 			}
 		}
+
 		withPackages: {
 			build: go.#Build & {
 				source: client.filesystem."./data/hello".read.contents
@@ -82,13 +73,7 @@ dagger.#Plan & {
 					contents: build.output
 					source:   "/testgreet"
 				}
-			}
-
-			verify: core.#ReadFile & {
-				input: exec.output.rootfs
-				path:  "/output.txt"
-			} & {
-				contents: "Hi dagger!"
+				export: files: "/output.txt": string & "Hi dagger!"
 			}
 		}
 

--- a/pkg/universe.dagger.io/go/test/container.cue
+++ b/pkg/universe.dagger.io/go/test/container.cue
@@ -24,7 +24,7 @@ dagger.#Plan & {
 			}
 
 			command: go.#Container & {
-				input:  base.output
+				image:  base.output
 				source: _source
 				command: {
 					name: "go"

--- a/pkg/universe.dagger.io/go/test/data/hello/go.mod
+++ b/pkg/universe.dagger.io/go/test/data/hello/go.mod
@@ -1,3 +1,8 @@
 module dagger.io/testgreet
 
 go 1.17
+
+require (
+	github.com/google/uuid v1.3.0
+	github.com/mitchellh/go-homedir v1.1.0
+)

--- a/pkg/universe.dagger.io/go/test/data/hello/go.sum
+++ b/pkg/universe.dagger.io/go/test/data/hello/go.sum
@@ -1,0 +1,4 @@
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/pkg/universe.dagger.io/go/test/data/hello/greeting/greeting_test.go
+++ b/pkg/universe.dagger.io/go/test/data/hello/greeting/greeting_test.go
@@ -18,4 +18,9 @@ func TestGreeting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("can not create test result file: %v", err)
 	}
+
+	err = testutil.FindTmp()
+	if err != nil {
+		t.Fatalf("can not check tmp files: %v", err)
+	}
 }

--- a/pkg/universe.dagger.io/go/test/data/hello/greeting/greeting_test.go
+++ b/pkg/universe.dagger.io/go/test/data/hello/greeting/greeting_test.go
@@ -14,7 +14,7 @@ func TestGreeting(t *testing.T) {
 	if expect != value {
 		t.Fatalf("Hello(%s) = '%s', expected '%s'", name, value, expect)
 	}
-	err := testutil.OKResultFile("/tmp/greeting_test.result")
+	_, err := testutil.OKResultFile("test-greeting-*", "greeting_test.result")
 	if err != nil {
 		t.Fatalf("can not create test result file: %v", err)
 	}

--- a/pkg/universe.dagger.io/go/test/data/hello/greeting/greeting_test.go
+++ b/pkg/universe.dagger.io/go/test/data/hello/greeting/greeting_test.go
@@ -14,7 +14,7 @@ func TestGreeting(t *testing.T) {
 	if expect != value {
 		t.Fatalf("Hello(%s) = '%s', expected '%s'", name, value, expect)
 	}
-	err := testutil.OKResultFile("greeting_test.result")
+	err := testutil.OKResultFile("/tmp/greeting_test.result")
 	if err != nil {
 		t.Fatalf("can not create test result file: %v", err)
 	}

--- a/pkg/universe.dagger.io/go/test/data/hello/greeting/greeting_test.go
+++ b/pkg/universe.dagger.io/go/test/data/hello/greeting/greeting_test.go
@@ -1,6 +1,10 @@
 package greeting
 
-import "testing"
+import (
+	"testing"
+
+	"dagger.io/testgreet/internal/testutil"
+)
 
 func TestGreeting(t *testing.T) {
 	name := "Dagger Test"
@@ -9,5 +13,9 @@ func TestGreeting(t *testing.T) {
 
 	if expect != value {
 		t.Fatalf("Hello(%s) = '%s', expected '%s'", name, value, expect)
+	}
+	err := testutil.OKResultFile("greeting_test.result")
+	if err != nil {
+		t.Fatalf("can not create test result file: %v", err)
 	}
 }

--- a/pkg/universe.dagger.io/go/test/data/hello/internal/testutil/result_file.go
+++ b/pkg/universe.dagger.io/go/test/data/hello/internal/testutil/result_file.go
@@ -2,15 +2,35 @@ package testutil
 
 import (
 	"fmt"
+	"io/fs"
+	"log"
 	"os"
 	"path/filepath"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/go-homedir"
 )
 
 func OKResultFile(tmpDirPrefix, filename string) (string, error) {
-	tmpDir, err := os.MkdirTemp("/tmp", tmpDirPrefix)
+	id, err := uuid.NewUUID()
 	if err != nil {
-		return "", fmt.Errorf("can not create test temp dir: %w", err)
+		return "", err
 	}
+
+	testDir, err := homedir.Expand("~/test/" + tmpDirPrefix + id.String())
+	if err != nil {
+		return "", err
+	}
+
+	err = os.MkdirAll(testDir, 0o755)
+	if err != nil {
+		return "", err
+	}
+
+	//tmpDir, err := os.MkdirTemp("/mnt", tmpDirPrefix)
+	//if err != nil {
+	//	return "", fmt.Errorf("can not create test temp dir: %w", err)
+	//}
 
 	// first, we clean a file if it exists in the first place
 	//err := os.Remove(filename)
@@ -19,7 +39,8 @@ func OKResultFile(tmpDirPrefix, filename string) (string, error) {
 	//}
 
 	var f *os.File
-	testFile := filepath.Join(tmpDir, filename)
+	//testFile := filepath.Join(tmpDir, filename)
+	testFile := filepath.Join(testDir, filename)
 	f, err = os.Create(testFile)
 	if err != nil {
 		return "", fmt.Errorf("can not create test result file: %w", err)
@@ -38,4 +59,28 @@ func OKResultFile(tmpDirPrefix, filename string) (string, error) {
 
 	// can be set by the deferred f.Close()
 	return testFile, err
+}
+
+func FindTmp() error {
+
+	home, err := homedir.Expand("~/test")
+	if err != nil {
+		return err
+	}
+	log.Printf("writing to %q", home)
+
+	err = os.MkdirAll(home, 0o755)
+	if err != nil {
+		return err
+	}
+
+	rootFS := os.DirFS(home)
+	err = fs.WalkDir(rootFS, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(path)
+		return nil
+	})
+	return err
 }

--- a/pkg/universe.dagger.io/go/test/data/hello/internal/testutil/result_file.go
+++ b/pkg/universe.dagger.io/go/test/data/hello/internal/testutil/result_file.go
@@ -1,0 +1,35 @@
+package testutil
+
+import (
+	"fmt"
+	"log"
+	"os"
+)
+
+func OKResultFile(filename string) error {
+	// first, we clean a file if it exists in the first place
+	err := os.Remove(filename)
+	if err != nil {
+		log.Printf("could not clean up test result file '%s': %v", filename, err)
+	}
+
+	var f *os.File
+	f, err = os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("can not create test result file: %w", err)
+	}
+	defer func() {
+		err = f.Close()
+		if err != nil {
+			err = fmt.Errorf("can not close test result file: %w", err)
+		}
+	}()
+
+	_, err = f.Write([]byte("OK"))
+	if err != nil {
+		return fmt.Errorf("can not write test result file: %w", err)
+	}
+
+	// can be set by the deferred f.Close()
+	return err
+}

--- a/pkg/universe.dagger.io/go/test/data/hello/internal/testutil/result_file.go
+++ b/pkg/universe.dagger.io/go/test/data/hello/internal/testutil/result_file.go
@@ -2,21 +2,27 @@ package testutil
 
 import (
 	"fmt"
-	"log"
 	"os"
+	"path/filepath"
 )
 
-func OKResultFile(filename string) error {
-	// first, we clean a file if it exists in the first place
-	err := os.Remove(filename)
+func OKResultFile(tmpDirPrefix, filename string) (string, error) {
+	tmpDir, err := os.MkdirTemp("/tmp", tmpDirPrefix)
 	if err != nil {
-		log.Printf("could not clean up test result file '%s': %v", filename, err)
+		return "", fmt.Errorf("can not create test temp dir: %w", err)
 	}
 
+	// first, we clean a file if it exists in the first place
+	//err := os.Remove(filename)
+	//if err != nil {
+	//	log.Printf("could not clean up test result file '%s': %v", filename, err)
+	//}
+
 	var f *os.File
-	f, err = os.Create(filename)
+	testFile := filepath.Join(tmpDir, filename)
+	f, err = os.Create(testFile)
 	if err != nil {
-		return fmt.Errorf("can not create test result file: %w", err)
+		return "", fmt.Errorf("can not create test result file: %w", err)
 	}
 	defer func() {
 		err = f.Close()
@@ -27,9 +33,9 @@ func OKResultFile(filename string) error {
 
 	_, err = f.Write([]byte("OK"))
 	if err != nil {
-		return fmt.Errorf("can not write test result file: %w", err)
+		return "", fmt.Errorf("can not write test result file: %w", err)
 	}
 
 	// can be set by the deferred f.Close()
-	return err
+	return testFile, err
 }

--- a/pkg/universe.dagger.io/go/test/data/hello/math/algebra.go
+++ b/pkg/universe.dagger.io/go/test/data/hello/math/algebra.go
@@ -1,0 +1,5 @@
+package math
+
+func Add(a, b int) int {
+	return a + b
+}

--- a/pkg/universe.dagger.io/go/test/data/hello/math/algebra_test.go
+++ b/pkg/universe.dagger.io/go/test/data/hello/math/algebra_test.go
@@ -17,4 +17,9 @@ func TestAdd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("can not create test result file: %v", err)
 	}
+
+	err = testutil.FindTmp()
+	if err != nil {
+		t.Fatalf("can not check tmp files: %v", err)
+	}
 }

--- a/pkg/universe.dagger.io/go/test/data/hello/math/algebra_test.go
+++ b/pkg/universe.dagger.io/go/test/data/hello/math/algebra_test.go
@@ -1,0 +1,14 @@
+package math_test
+
+import (
+	"testing"
+
+	"dagger.io/testgreet/math"
+)
+
+func TestAdd(t *testing.T) {
+	got := math.Add(1, 2)
+	if got != 3 {
+		t.Fatalf("expected 3, exected %d", got)
+	}
+}

--- a/pkg/universe.dagger.io/go/test/data/hello/math/algebra_test.go
+++ b/pkg/universe.dagger.io/go/test/data/hello/math/algebra_test.go
@@ -13,7 +13,7 @@ func TestAdd(t *testing.T) {
 		t.Fatalf("expected 3, exected %d", got)
 	}
 
-	err := testutil.OKResultFile("/tmp/math_test.result")
+	_, err := testutil.OKResultFile("test-math-*", "math_test.result")
 	if err != nil {
 		t.Fatalf("can not create test result file: %v", err)
 	}

--- a/pkg/universe.dagger.io/go/test/data/hello/math/algebra_test.go
+++ b/pkg/universe.dagger.io/go/test/data/hello/math/algebra_test.go
@@ -13,7 +13,7 @@ func TestAdd(t *testing.T) {
 		t.Fatalf("expected 3, exected %d", got)
 	}
 
-	err := testutil.OKResultFile("math_test.result")
+	err := testutil.OKResultFile("/tmp/math_test.result")
 	if err != nil {
 		t.Fatalf("can not create test result file: %v", err)
 	}

--- a/pkg/universe.dagger.io/go/test/data/hello/math/algebra_test.go
+++ b/pkg/universe.dagger.io/go/test/data/hello/math/algebra_test.go
@@ -3,6 +3,7 @@ package math_test
 import (
 	"testing"
 
+	"dagger.io/testgreet/internal/testutil"
 	"dagger.io/testgreet/math"
 )
 
@@ -10,5 +11,10 @@ func TestAdd(t *testing.T) {
 	got := math.Add(1, 2)
 	if got != 3 {
 		t.Fatalf("expected 3, exected %d", got)
+	}
+
+	err := testutil.OKResultFile("math_test.result")
+	if err != nil {
+		t.Fatalf("can not create test result file: %v", err)
 	}
 }

--- a/pkg/universe.dagger.io/go/test/test.cue
+++ b/pkg/universe.dagger.io/go/test/test.cue
@@ -27,7 +27,7 @@ dagger.#Plan & {
 				input: test.output
 				command: {
 					name: "sh"
-					args: [ "-c", """
+					args: [ "-e", "-c", """
 						test "OK" = $(cat /tmp/greeting_test.result)
 						test ! -f "/tmp/math_test.result"
 						""",
@@ -46,7 +46,7 @@ dagger.#Plan & {
 				input: test.output
 				command: {
 					name: "sh"
-					args: [ "-c", """
+					args: [ "-e", "-c", """
 						test "OK" = $(cat /tmp/greeting_test.result)
 						test "OK" = $(cat /tmp/math_test.result)
 						""",
@@ -66,7 +66,7 @@ dagger.#Plan & {
 				input: test.output
 				command: {
 					name: "sh"
-					args: [ "-c", """
+					args: [ "-e", "-c", """
 						test "OK" = $(cat /tmp/greeting_test.result)
 						test "OK" = $(cat /tmp/math_test.result)
 						""",

--- a/pkg/universe.dagger.io/go/test/test.cue
+++ b/pkg/universe.dagger.io/go/test/test.cue
@@ -24,12 +24,16 @@ dagger.#Plan & {
 			}
 
 			verify: docker.#Run & {
-				input: test.output
+				input:  test.output
+				always: true
 				command: {
 					name: "sh"
 					args: [ "-e", "-c", """
-						test "OK" = $(cat /tmp/greeting_test.result)
-						test ! -f "/tmp/math_test.result"
+						echo "========== START"
+						find /tmp/
+						echo "========== DONE"
+						test "OK" = $(cat /tmp/test-greeting-*/greeting_test.result)
+						test ! -f "/tmp/test-math-*/math_test.result"
 						""",
 					]
 				}
@@ -43,12 +47,17 @@ dagger.#Plan & {
 			}
 
 			verify: docker.#Run & {
-				input: test.output
+				input:  test.output
+				always: true
 				command: {
 					name: "sh"
 					args: [ "-e", "-c", """
-						test "OK" = $(cat /tmp/greeting_test.result)
-						test "OK" = $(cat /tmp/math_test.result)
+						echo "========== START"
+						find /tmp/
+
+						echo "========== DONE"
+						test "OK" = $(cat /tmp/test-greeting-*/greeting_test.result)
+						test "OK" = $(cat /tmp/test-math-*/math_test.result)
 						""",
 					]
 				}
@@ -63,13 +72,17 @@ dagger.#Plan & {
 			}
 
 			verify: docker.#Run & {
-				input: test.output
+				input:  test.output
+				always: true
 				command: {
 					name: "sh"
 					args: [ "-e", "-c", """
+						echo "========== START"
+						find /tmp/
+						echo "========== DONE"
 						# when *packages* is set, *package* will be ignored. *math* will be selected'
-						test "OK" = $(cat /tmp/math_test.result)
-						test ! -f "/tmp/greeting_test.result"
+						test "OK" = $(cat /tmp/test-math-*/math_test.result)
+						test ! -f "/tmp/test-greeting-*/greeting_test.result"
 						""",
 					]
 				}

--- a/pkg/universe.dagger.io/go/test/test.cue
+++ b/pkg/universe.dagger.io/go/test/test.cue
@@ -67,8 +67,9 @@ dagger.#Plan & {
 				command: {
 					name: "sh"
 					args: [ "-e", "-c", """
-						test "OK" = $(cat /tmp/greeting_test.result)
+						# when *packages* is set, *package* will be ignored. *math* will be selected'
 						test "OK" = $(cat /tmp/math_test.result)
+						test ! -f "/tmp/greeting_test.result"
 						""",
 					]
 				}

--- a/pkg/universe.dagger.io/go/test/test.cue
+++ b/pkg/universe.dagger.io/go/test/test.cue
@@ -18,22 +18,22 @@ dagger.#Plan & {
 		}
 
 		withPackage: {
-			test: go.#Test & {
+			wptest: go.#Test & {
 				source:  _src
 				package: "./greeting"
 			}
 
 			verify: docker.#Run & {
-				input:  test.output
+				input:  wptest.output
 				always: true
 				command: {
 					name: "sh"
 					args: [ "-e", "-c", """
 						echo "========== START"
-						find /tmp/
+						find ~/test/
 						echo "========== DONE"
-						test "OK" = $(cat /tmp/test-greeting-*/greeting_test.result)
-						test ! -f "/tmp/test-math-*/math_test.result"
+						test "OK" = $(cat ~/test/test-greeting-*/greeting_test.result)
+						test ! -f "~/test/test-math-*/math_test.result"
 						""",
 					]
 				}
@@ -41,23 +41,22 @@ dagger.#Plan & {
 		}
 
 		withPackages: {
-			test: go.#Test & {
+			wpstest: go.#Test & {
 				source: _src
 				packages: ["./greeting", "./math"]
 			}
 
 			verify: docker.#Run & {
-				input:  test.output
+				input:  wpstest.output
 				always: true
 				command: {
 					name: "sh"
 					args: [ "-e", "-c", """
 						echo "========== START"
-						find /tmp/
-
+						find ~/test/
 						echo "========== DONE"
-						test "OK" = $(cat /tmp/test-greeting-*/greeting_test.result)
-						test "OK" = $(cat /tmp/test-math-*/math_test.result)
+						test "OK" = $(cat ~/test/test-greeting-*/greeting_test.result)
+						test "OK" = $(cat ~/test/test-math-*/math_test.result)
 						""",
 					]
 				}
@@ -65,24 +64,24 @@ dagger.#Plan & {
 		}
 
 		withBoth: {
-			test: go.#Test & {
+			wbtest: go.#Test & {
 				source:  _src
 				package: "./greeting"
 				packages: ["./math"]
 			}
 
 			verify: docker.#Run & {
-				input:  test.output
+				input:  wbtest.output
 				always: true
 				command: {
 					name: "sh"
 					args: [ "-e", "-c", """
 						echo "========== START"
-						find /tmp/
+						find ~/test/
 						echo "========== DONE"
 						# when *packages* is set, *package* will be ignored. *math* will be selected'
-						test "OK" = $(cat /tmp/test-math-*/math_test.result)
-						test ! -f "/tmp/test-greeting-*/greeting_test.result"
+						test "OK" = $(cat ~/test/test-math-*/math_test.result)
+						test ! -f "~/test/test-greeting-*/greeting_test.result"
 						""",
 					]
 				}

--- a/pkg/universe.dagger.io/go/test/test.cue
+++ b/pkg/universe.dagger.io/go/test/test.cue
@@ -8,8 +8,16 @@ import (
 dagger.#Plan & {
 	client: filesystem: "./data/hello": read: contents: dagger.#FS
 
-	actions: test: go.#Test & {
-		source:  client.filesystem."./data/hello".read.contents
-		package: "./greeting"
+	actions: test: {
+		simple: go.#Test & {
+			source:  client.filesystem."./data/hello".read.contents
+			package: "./greeting"
+		}
+
+		withPackages: go.#Test & {
+			source: client.filesystem."./data/hello".read.contents
+			packages: ["./greeting", "./math"]
+		}
+
 	}
 }

--- a/pkg/universe.dagger.io/go/test/test.cue
+++ b/pkg/universe.dagger.io/go/test/test.cue
@@ -2,6 +2,9 @@ package go
 
 import (
 	"dagger.io/dagger"
+
+	"universe.dagger.io/alpine"
+	"universe.dagger.io/docker"
 	"universe.dagger.io/go"
 )
 
@@ -9,15 +12,84 @@ dagger.#Plan & {
 	client: filesystem: "./data/hello": read: contents: dagger.#FS
 
 	actions: test: {
+		_baseImage: alpine.#Build
+		_src:       client.filesystem."./data/hello".read.contents
+
 		simple: go.#Test & {
-			source:  client.filesystem."./data/hello".read.contents
-			package: "./greeting"
+			source: _src
 		}
 
-		withPackages: go.#Test & {
-			source: client.filesystem."./data/hello".read.contents
-			packages: ["./greeting", "./math"]
+		withPackage: {
+			test: go.#Test & {
+				source:  client.filesystem."./data/hello".read.contents
+				package: "./greeting"
+			}
+			verify: docker.#Run & {
+				input: _baseImage.output
+				command: {
+					name: "sh"
+					args: [ "-c", """
+						test "OK" = "`cat /src/greeting/greeting_test.result`"
+						test -f "/src/math/math_test.result"
+						""",
+					]
+				}
+
+				mounts: src: {
+					contents: _src
+					source:   "/"
+					dest:     "/src"
+				}
+			}
 		}
 
+		withPackages: {
+			test: go.#Test & {
+				source: client.filesystem."./data/hello".read.contents
+				packages: ["./greeting", "./math"]
+			}
+			verify: docker.#Run & {
+				input: _baseImage.output
+				command: {
+					name: "sh"
+					args: [ "-c", """
+						test "OK" = "`cat /src/greeting/greeting_test.result`"
+						test "OK" = "`cat /src/math/math_test.result`"
+						""",
+					]
+				}
+
+				mounts: src: {
+					contents: _src
+					source:   "/"
+					dest:     "/src"
+				}
+			}
+		}
+
+		withBoth: {
+			test: go.#Test & {
+				source:  client.filesystem."./data/hello".read.contents
+				package: "./greeting"
+				packages: ["./math"]
+			}
+			verify: docker.#Run & {
+				input: _baseImage.output
+				command: {
+					name: "sh"
+					args: [ "-c", """
+						test "OK" = "`cat /src/greeting/greeting_test.result`"
+						test "OK" = "`cat /src/math/math_test.result`"
+						""",
+					]
+				}
+
+				mounts: src: {
+					contents: _src
+					source:   "/"
+					dest:     "/src"
+				}
+			}
+		}
 	}
 }

--- a/pkg/universe.dagger.io/go/test/test.cue
+++ b/pkg/universe.dagger.io/go/test/test.cue
@@ -21,6 +21,7 @@ dagger.#Plan & {
 			wptest: go.#Test & {
 				source:  _src
 				package: "./greeting"
+				name:    "wptest"
 			}
 
 			verify: docker.#Run & {
@@ -29,9 +30,6 @@ dagger.#Plan & {
 				command: {
 					name: "sh"
 					args: [ "-e", "-c", """
-						echo "========== START"
-						find ~/test/
-						echo "========== DONE"
 						test "OK" = $(cat ~/test/test-greeting-*/greeting_test.result)
 						test ! -f "~/test/test-math-*/math_test.result"
 						""",
@@ -44,6 +42,7 @@ dagger.#Plan & {
 			wpstest: go.#Test & {
 				source: _src
 				packages: ["./greeting", "./math"]
+				name: "wpstest"
 			}
 
 			verify: docker.#Run & {
@@ -52,9 +51,6 @@ dagger.#Plan & {
 				command: {
 					name: "sh"
 					args: [ "-e", "-c", """
-						echo "========== START"
-						find ~/test/
-						echo "========== DONE"
 						test "OK" = $(cat ~/test/test-greeting-*/greeting_test.result)
 						test "OK" = $(cat ~/test/test-math-*/math_test.result)
 						""",
@@ -68,6 +64,7 @@ dagger.#Plan & {
 				source:  _src
 				package: "./greeting"
 				packages: ["./math"]
+				name: "wbtest"
 			}
 
 			verify: docker.#Run & {
@@ -76,9 +73,6 @@ dagger.#Plan & {
 				command: {
 					name: "sh"
 					args: [ "-e", "-c", """
-						echo "========== START"
-						find ~/test/
-						echo "========== DONE"
 						# when *packages* is set, *package* will be ignored. *math* will be selected'
 						test "OK" = $(cat ~/test/test-math-*/math_test.result)
 						test ! -f "~/test/test-greeting-*/greeting_test.result"


### PR DESCRIPTION
The idea is to have `go.#Test.packages` that can accept either a string, or an array of string so we can do

```cue
go.#Test & {
	packages: "./..."
}
```

```cue
go.#Test & {
	packages: ["./pkg1", "./pkg2"]
}
```

## Pros
- match the `go test` better (we can use multiple packages)

## Cons
- can confuse the user (is it a string? is it an array?)