### PR TITLE
enable kubernetes and podman connection drivers

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -20,7 +20,10 @@ import (
 
 	// buildkit
 	bk "github.com/moby/buildkit/client"
-	_ "github.com/moby/buildkit/client/connhelper/dockercontainer" // import the container connection driver
+	_ "github.com/moby/buildkit/client/connhelper/dockercontainer" // import the docker connection driver
+	_ "github.com/moby/buildkit/client/connhelper/kubepod"         // import the kubernetes connection driver
+	_ "github.com/moby/buildkit/client/connhelper/podmancontainer" // import the podman connection driver
+
 	bkgw "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/session"
 


### PR DESCRIPTION
As reported on Discord

> Hello - I'm trying to use Dagger without Docker installed and instead using Buildkit running on podman. When I attempt to use BUILDKIT_HOST set as podman-container://buildkitd , I see Dagger throw errors about Error while dialing dial podman-container: unknown network podman-container . Would anyone have suggestions on things to try towards troubleshooting this? For context, I've verified buildctl is able to run okay referencing buildkitd from podman. Thanks in advance!
