### PR TITLE
core.#WriteFile: default permissions to 0o644

### DIFF
--- a/pkg/dagger.io/dagger/core/fs.cue
+++ b/pkg/dagger.io/dagger/core/fs.cue
@@ -60,7 +60,7 @@ import "dagger.io/dagger"
 	// Contents to write
 	contents: string
 	// Permissions of the file
-	permissions: *0o600 | int
+	permissions: *0o644 | int
 	// Output filesystem tree
 	output: dagger.#FS
 }


### PR DESCRIPTION
Defaulting to 0o600 makes the file inaccessible to `core.#Exec` actions
running with a `user` field.

Ideally `#WriteFile` should support user/group in addition to
permissions.
