### PR TITLE
Support for async execs.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -235,7 +235,7 @@ func (c *Client) buildfn(ctx context.Context, pctx *plancontext.Context, fn DoFu
 		})
 
 		// Close events channel
-		defer s.Stop()
+		defer s.Stop(ctx)
 
 		// Compute output overlay
 		res := bkgw.NewResult()

--- a/pkg/dagger.io/dagger/core/exec.cue
+++ b/pkg/dagger.io/dagger/core/exec.cue
@@ -44,6 +44,50 @@ import "dagger.io/dagger"
 	exit: int & 0
 }
 
+// Start a command in a container asynchronously
+#Start: {
+	$dagger: task: _name: "Start"
+
+	// Container filesystem
+	input: dagger.#FS
+
+	// Transient filesystem mounts
+	//   Key is an arbitrary name, for example "app source code"
+	//   Value is mount configuration
+	mounts: [name=string]: #Mount
+
+	// Command to execute
+	// Example: ["echo", "hello, world!"]
+	args: [...string]
+
+	// Working directory
+	workdir: string | *"/"
+
+	// User ID or name
+	user: string | *"root"
+
+	// Inject hostname resolution into the container
+	// key is hostname, value is IP
+	hosts: [hostname=string]: string
+
+	// Environment variables
+	env: [key=string]: string
+
+	_id: string | null @dagger(generated)
+}
+
+// Stop an asynchronous command created by #Start
+#Stop: {
+	$dagger: task: _name: "Stop"
+
+	input: #Start
+
+	// Command exit code. If the command was still running when
+	// stopped, it will be sent SIGKILL and the exit code will
+	// thus be 137.
+	exit: uint8 @dagger(generated)
+}
+
 // A transient filesystem mount.
 #Mount: {
 	dest: string

--- a/solver/container.go
+++ b/solver/container.go
@@ -1,0 +1,123 @@
+package solver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/moby/buildkit/frontend/gateway/client"
+	gatewayapi "github.com/moby/buildkit/frontend/gateway/pb"
+	"github.com/moby/buildkit/identity"
+)
+
+type container struct {
+	id   string
+	ctr  client.Container
+	proc client.ContainerProcess
+
+	mu       sync.Mutex
+	stopped  bool
+	exitCode uint8
+	exitErr  error
+}
+
+type StartContainerRequest struct {
+	Container client.NewContainerRequest
+	Proc      client.StartRequest
+}
+
+func (s *Solver) StartContainer(ctx context.Context, req StartContainerRequest) (string, error) {
+	ctr, err := s.opts.Gateway.NewContainer(ctx, req.Container)
+	if err != nil {
+		return "", fmt.Errorf("failed to create container: %w", err)
+	}
+
+	proc, err := ctr.Start(ctx, req.Proc)
+	if err != nil {
+		return "", fmt.Errorf("failed to start container: %w", err)
+	}
+
+	id := identity.NewID()
+	s.containersMu.Lock()
+	s.containers[id] = &container{
+		id:   id,
+		ctr:  ctr,
+		proc: proc,
+	}
+	s.containersMu.Unlock()
+	return id, nil
+}
+
+func (s *Solver) StopContainer(ctx context.Context, ctrID string) (uint8, error) {
+	s.containersMu.Lock()
+	c, ok := s.containers[ctrID]
+	s.containersMu.Unlock()
+	if !ok {
+		return 0, ContainerNotFoundError{ID: ctrID}
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.stopped {
+		return c.exitCode, c.exitErr
+	}
+	c.stopped = true
+
+	// FIXME: buildkit currently leaks containers if client crashes.
+	// https://github.com/moby/buildkit/issues/2811
+	// This needs to be fixed upstream, but for now if this happens
+	// the only remidiation for users is to let the container exit
+	// on its own (if possible) or to restart buildkitd.
+
+	// Releasing the container sends SIGKILL to the process.
+	// Support for sending other signals first is not implemented yet, but can be.
+	exitCode, err := getExitCode(c.ctr.Release(ctx))
+	if err != nil {
+		c.exitErr = fmt.Errorf("failed to release container: %w", err)
+		return 0, c.exitErr
+	}
+	c.exitCode = exitCode
+
+	// Wait for the process to exit. The call doesn't accept a context, so make
+	// it cancellable with a separate goroutine.
+	waitCh := make(chan error)
+	go func() {
+		defer close(waitCh)
+		// we don't need the exit code here, but we want to ignore errors due to it being set
+		if _, err := getExitCode(c.proc.Wait()); err != nil {
+			waitCh <- fmt.Errorf("failed to wait for container process: %w", err)
+		}
+	}()
+	select {
+	case <-ctx.Done():
+		c.exitErr = ctx.Err()
+		return c.exitCode, c.exitErr
+	case err := <-waitCh:
+		c.exitErr = err
+		return c.exitCode, c.exitErr
+	}
+}
+
+func getExitCode(err error) (uint8, error) {
+	if err == nil {
+		return 0, nil
+	}
+	exitError := &gatewayapi.ExitError{}
+	if errors.As(err, &exitError) {
+		// if the only thing that went wrong was the container exiting non-zero,
+		// just return the exit code and no error
+		if exitError.ExitCode != gatewayapi.UnknownExitStatus {
+			return uint8(exitError.ExitCode), nil
+		}
+	}
+	return 0, err
+}
+
+type ContainerNotFoundError struct {
+	ID string
+}
+
+func (e ContainerNotFoundError) Error() string {
+	return fmt.Sprintf("container %s not found", e.ID)
+}

--- a/tests/tasks.bats
+++ b/tests/tasks.bats
@@ -41,6 +41,18 @@ setup() {
     "$DAGGER" "do" -p ./workdir.cue verify
 }
 
+@test "task: #Start #Stop" {
+    cd ./tasks/exec
+
+    "$DAGGER" "do" -p ./start_stop_exec.cue execParamsTest
+
+    run "$DAGGER" "do" --log-format=plain -l info -p ./start_stop_exec.cue basicTest
+    assert_line --partial 'actions.basicTest.start'
+    assert_line --regexp 'actions\.basicTest\.sleep \| .*taking a quick nap'
+    # order of start and sleep is variable, but Stop must be last
+    assert_line --partial --index 7 'actions.basicTest.stop'
+}
+
 @test "task: #Copy" {
     "$DAGGER" "do" -p ./tasks/copy/copy_exec.cue test
     "$DAGGER" "do" -p ./tasks/copy/copy_file.cue test

--- a/tests/tasks/exec/start_stop_exec.cue
+++ b/tests/tasks/exec/start_stop_exec.cue
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+)
+
+dagger.#Plan & {
+	actions: {
+		image: core.#Pull & {
+			source: "alpine:3.15"
+		}
+
+		// test basic ordering of start exec -> sync exec -> stop exec
+		basicTest: {
+			start: core.#Start & {
+				input: image.output
+				args: [
+					"sleep", "30",
+				]
+			}
+
+			sleep: core.#Exec & {
+				input: image.output
+				args: [
+					"sh", "-c",
+					#"""
+						echo taking a quick nap
+						sleep 1
+						"""#,
+				]
+				always: true
+			}
+
+			stop: core.#Stop & {
+				input: start
+				_dep:  sleep
+			}
+
+			// 137 means the process was still running and got SIGKILL
+			verify: stop.exit & 137
+		}
+
+		// test all the various parameters that can be applied to an exec
+		execParamsTest: {
+			sharedCache: core.#CacheDir & {
+				id:          "mycache"
+				concurrency: "shared"
+			}
+
+			foodir: core.#Mkdir & {
+				input: dagger.#Scratch
+				path:  "/foo"
+			}
+
+			secretFile: core.#WriteFile & {
+				input:    dagger.#Scratch
+				path:     "/secret"
+				contents: "shhh"
+			}
+			secret: core.#NewSecret & {
+				input: secretFile.output
+				path:  "/secret"
+			}
+
+			// this sets up the cache to be writable by the non-root user
+			// in the #Start below
+			initCache: core.#Exec & {
+				input: image.output
+				mounts: cache: {
+					dest:     "/cache"
+					contents: sharedCache
+				}
+				args: [
+					"chmod", "a+rwx", "/cache",
+				]
+				always: true
+			}
+
+			startExec: core.#Start & {
+				input: initCache.output
+				mounts: {
+					cache: {
+						dest:     "/cache"
+						contents: sharedCache
+					}
+					fs: {
+						dest:     "/fs"
+						contents: foodir.output
+					}
+					secretMnt: {
+						dest:     "/secret"
+						contents: secret.output
+						// "guest" user is 405 in alpine image
+						uid: 405
+					}
+					temp: {
+						dest:     "/temp"
+						contents: core.#TempDir
+					}
+				}
+				env: TEST:          "hey"
+				hosts: "unit.test": "192.0.2.1"
+				user:    "guest"
+				workdir: "/tmp"
+				args: [
+					"sh", "-e", "-c",
+					#"""
+						test -d /fs/foo
+
+						test "$(cat /secret)" = "shhh"
+						ls -l /secret | grep -- "-r--------"
+
+						test "$(stat -f -c %T /temp)" = "tmpfs"
+
+						grep -q "unit.test" /etc/hosts
+						grep -q "192.0.2.1" /etc/hosts
+
+						test "$(whoami)" = "guest"
+
+						test "$(pwd)" = "/tmp"
+
+						test "$TEST" = "hey"
+
+						echo yo > /cache/yo
+						"""#,
+				]
+			}
+
+			// verify the started exec wrote to the cache mount and it was shared
+			syncExec: core.#Exec & {
+				input: image.output
+				mounts: cache: {
+					dest:     "/cache"
+					contents: sharedCache
+				}
+				args: [
+					"sh", "-e", "-c",
+					#"""
+						for i in `seq 1 20`; do test -f /cache/yo || sleep 1; done
+						test "$(cat /cache/yo)" = yo
+						sleep 5
+						"""#,
+				]
+				always: true
+			}
+
+			stop: core.#Stop & {
+				input: startExec
+				_dep:  syncExec
+			}
+
+			verify: stop.exit & 0
+		}
+	}
+}


### PR DESCRIPTION
This adds a new task type called AsyncExec which has a similar interface
as Exec, but unblocks once the exec has started rather than waiting for
it to complete. A separate type, StopAsyncExec, can be used to stop it
explicitly. If it isn't stopped, then it will be killed once the dagger
client shutsdown.

This is intended for creating ephemeral services used by other tasks in
the DAG, such as a DB against which tests can be run in different tasks.

AsyncExecs cannot output state and any state they create while running
will be thrown away once the DAG finishes executing. The only exception
is if they use a shared cache mount, in which case state will be applied
to the cache mount and accessible by other Execs, async or not.

There is currently an issue with Buildkit where if the dagger client
exits ungracefully without running cleanups, then the container will
leak and keep running in Buildkit. There is also no way for a subsequent
client to query what containers are running and delete any leaked ones,
so the only remedy in this case would be restarting buildkitd. This is
an issue that needs to be fixed Buildkit-side.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>