### PR TITLE
feat: add GitHub Codespaces support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,22 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.224.3/containers/go/.devcontainer/base.Dockerfile
+
+# [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.16, 1.17, 1-bullseye, 1.16-bullseye, 1.17-bullseye, 1-buster, 1.16-buster, 1.17-buster
+ARG VARIANT="1.18-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
+
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment the next lines to use go get to install anything else you need
+# USER vscode
+# RUN go get -x <your-dependency-or-tool>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
+
+COPY post-install.sh /usr/local/bin/post-install.sh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,51 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.224.3/containers/go
+{
+	"name": "Dagger",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			// Update the VARIANT arg to pick a version of Go: 1, 1.18, 1.17
+			// Append -bullseye or -buster to pin to an OS version.
+			// Use -bullseye variants on local arm64/Apple Silicon.
+			"VARIANT": "1.18-bullseye",
+			// Options
+			"NODE_VERSION": "lts/*"
+		}
+	},
+	"runArgs": [
+		"--cap-add=SYS_PTRACE",
+		"--security-opt",
+		"seccomp=unconfined"
+	],
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		// https://code.visualstudio.com/docs/editor/integrated-terminal#_why-is-my-terminal-showing-a-multicolored-triangle-or-a-completely-black-rectangle
+		"terminal.integrated.gpuAcceleration": "off",
+		"go.toolsManagement.checkForUpdates": "local",
+		"go.useLanguageServer": true,
+		"go.gopath": "/go",
+		"extensions.ignoreRecommendations": true,
+		"[cue]": {
+			"editor.useTabStops": true
+		}
+	},
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"golang.Go",
+		"nickgo.cuelang",
+		"jallen7usa.vscode-cue-fmt",
+		"yzhang.markdown-all-in-one"
+	],
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "/usr/local/bin/post-install.sh",
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode",
+	"features": {
+		"docker-from-docker": "20.10",
+		"sshd": "latest",
+		"powershell": "7.1"
+	}
+}

--- a/.devcontainer/post-install.sh
+++ b/.devcontainer/post-install.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -exo pipefail
+
+make install
+go install -mod=readonly cuelang.org/go/cmd/cue

--- a/docs/guides/1227-contributing.md
+++ b/docs/guides/1227-contributing.md
@@ -172,3 +172,13 @@ git commit --amend -s
 # Force push the new commit to re-run all GitHub Actions jobs:
 git push -f mybranch
 ```
+
+### Can I use a remote development environment?
+
+Yes! The Dagger repository has Github Codespaces configuration included to help help you get started contributing directly from GitHub.
+
+The versions of `dagger` and `cue` you are working against will be pre-installed so you can develop your packages, plans and tests with the right tools.
+
+You will also have basic syntax highlighting and formatting for CUE in Visual Studio Code via pre-installed extensions.
+
+Support for other platforms, such as Gitpod, may be added if there is demand. Visit the [developer experience](https://github.com/dagger/dagger/discussions/2052) discussion on GitHub to show your interest.


### PR DESCRIPTION
Signed-off-by: Berry Phillips <berryphillips@gmail.com>

Closes #2216

The configs are auto-generated by Visual Studio Code and I have added additional configuration to support the basic needs of this repository. I added a section in the FAQ for this. I don't know if that's the best place or if there should be a dedicated doc for this 🤷🏻‍♂️

## Testing

Spin up a new Codespace from my branch and ensure the following:
* Visual Studio Code loads without errors or warnings
* The `dagger` and `cue` commands are available in the terminal and are the correct versions (`dagger` should be compiled from the branch source and `cue` should be the same version as specified in `go.mod`)
* `.cue` files have syntax highlighting and can be auto formatted
* You can run dagger commands that interact with buildkit
