### PR TITLE
Avoid multiple packages in examples

### DIFF
--- a/docs/core-concepts/1221-action.md
+++ b/docs/core-concepts/1221-action.md
@@ -41,7 +41,7 @@ A new action is _defined_ in a declarative template called a [CUE definition](ht
 Here is an example of a simple action definition:
 
 ```cue
-package hello
+package main
 
 import (
     "dagger.io/dagger"


### PR DESCRIPTION
The Dagger `Core Concepts` > `Dagger Actions` page shows a hello world example dependent on two packages (main + hello) but this is confusing if the reader doesn't understand how packaging works.  https://docs.dagger.io/1221/action

Packaging has yet to be explained: [#2220](https://github.com/dagger/dagger/issues/2220). We should avoid showing this too early in the documentation. 
