### PR TITLE
docs: fixed misleading example code in FAQ

### DIFF
--- a/docs/faq/1232-chain-actions.md
+++ b/docs/faq/1232-chain-actions.md
@@ -42,7 +42,7 @@ bar: bash.#Run & {
     script: contents: #"""
         echo "hello"
         """#
-    env: HACK: "\(test.success)" // <== HACK: CHAINING of action happening here
+    env: HACK: "\(foo.success)" // <== HACK: CHAINING of action happening here
 }
 ```
 


### PR DESCRIPTION
I was confused by [this FAQ](https://docs.dagger.io/1232/chain-actions) until I realised it had misleading code. This is a tiny PR to fix the misleading code. 