### PR TITLE
ci: run go unit tests from the dagger plan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ install: # Install a dev dagger binary
 	go install -ldflags '-X go.dagger.io/dagger/version.Revision=$(GIT_REVISION)' ./cmd/dagger
 
 .PHONY: test
-test: # Run all tests
-	go test -race -v ./...
+test: dagger # Run all tests
+	./cmd/dagger/dagger do test
 
 .PHONY: golint
 golint: dagger # Go lint

--- a/ci.cue
+++ b/ci.cue
@@ -73,13 +73,7 @@ dagger.#Plan & {
 			source:  _source
 			package: "./..."
 
-			// FIXME: doesn't work with CGO_ENABLED=0
-			// command: flags: "-race": true
-
-			env: {
-				// FIXME: removing this complains about lack of gcc
-				CGO_ENABLED: "0"
-			}
+			command: flags: "-race": true
 		}
 
 		lint: {

--- a/pkg/universe.dagger.io/go/image.cue
+++ b/pkg/universe.dagger.io/go/image.cue
@@ -13,7 +13,11 @@ _#DefaultVersion: "1.18"
 
 	packages: [pkgName=string]: version: string | *""
 	// FIXME Remove once golang image include 1.18 *or* go compiler is smart with -buildvcs
-	packages: git: _
+	packages: {
+		git: _
+		// For GCC and other possible build dependencies
+		"alpine-sdk": _
+	}
 
 	// FIXME Basically a copy of alpine.#Build with a different image
 	// Should we create a special definition?


### PR DESCRIPTION
This moves the go unit test from the Makefile to the dagger Plan. The issue was the GCC dependency and CGO. I added build dependencies to the base image, I was tempted to add a `packages` key to `go.#Container` but I don't want to leak alpine-specific package names in the higher api (we could technically build Go apps without Alpine). Also I think it makes sense to have access to the build packages in a container image that's only used for building.