### PR TITLE
ci: add lint error header in log

### DIFF
--- a/ci/cue/lint.cue
+++ b/ci/cue/lint.cue
@@ -50,7 +50,8 @@ import (
 					git status
 
 					find . -name '*.cue' -not -path '*/cue.mod/*' -print | time xargs -t -n 1 -P 8 cue fmt -s
-					test -z "$(git status -s . | grep -e "^ M"  | grep "\.cue" | cut -d ' ' -f3 | tee /dev/stderr)"
+					modified="$(git status -s . | grep -e "^ M"  | grep "\.cue" | cut -d ' ' -f3 || true)"
+					test -z "$modified" || (echo -e "linting error in:\n${modified}" > /dev/stderr ; false)
 					"""#
 			},
 		]


### PR DESCRIPTION
So we can see/grep more clearly what is the issue from the CI log.

**Before**
```
11:42AM INF actions.lint.cue._dag."4"._exec | #22 1.983 cue fmt -s ./ci/cue/lint.cue
11:42AM INF actions.lint.cue._dag."4"._exec | #22 1.993 cue fmt -s ./ci/markdownlint/markdownlint.cue
11:42AM INF actions.lint.cue._dag."4"._exec | #22 1.994 cue fmt -s ./ci/golangci/lint.cue
11:42AM INF actions.lint.cue._dag."4"._exec | #22 1.999 cue fmt -s ./ci/shellcheck/shellcheck.cue
11:42AM INF actions.lint.cue._dag."4"._exec | #22 2.045 real	0m 1.88s
11:42AM INF actions.lint.cue._dag."4"._exec | #22 2.045 user	0m 7.36s
11:42AM INF actions.lint.cue._dag."4"._exec | #22 2.045 sys	0m 2.00s
11:42AM ERR actions.lint.cue._dag."4"._exec | failed: process "bash --norc -e -o pipefail /bash/scripts/run.sh" did not complete successfully: exit code: 1
    duration=2.1s
11:42AM ERR actions.lint.go._exec | canceled    duration=1s
11:42AM INF actions.lint.cue._dag."4"._exec | #22 2.056 ci/cue/lint.cue
11:42AM FTL system | failed to execute plan: task failed: actions.lint.cue._dag."4"._exec: process "bash --norc -e -o pipefail /bash/scripts/run.sh" did not complete successfully: exit code: 1

```

**After**
```
11:01AM INF actions.lint.cue._dag."4"._exec | #25 2.651 cue fmt -s ./ci/markdownlint/markdownlint.cue
11:01AM INF actions.lint.cue._dag."4"._exec | #25 2.664 cue fmt -s ./ci/golangci/lint.cue
11:01AM INF actions.lint.cue._dag."4"._exec | #25 2.673 cue fmt -s ./ci/shellcheck/shellcheck.cue
11:01AM INF actions.lint.cue._dag."4"._exec | #25 2.720 real	0m 2.49s
11:01AM INF actions.lint.cue._dag."4"._exec | #25 2.720 user	0m 6.24s
11:01AM INF actions.lint.cue._dag."4"._exec | #25 2.720 sys	0m 1.65s
11:01AM ERR actions.lint.cue._dag."4"._exec | failed: process "bash --norc -e -o pipefail /bash/scripts/run.sh" did not complete successfully: exit code: 1
    duration=2.8s
11:01AM ERR actions.lint.go._exec | canceled    duration=3s
11:01AM INF actions.lint.cue._dag."4"._exec | #25 2.757 linting error in:
11:01AM INF actions.lint.cue._dag."4"._exec | #25 2.757 ci/cue/lint.cue