### PR TITLE
filter out commandConn.CloseRead warning log message

### DIFF
--- a/cmd/dagger/cmd/root.go
+++ b/cmd/dagger/cmd/root.go
@@ -30,6 +30,7 @@ func init() {
 	logrus.AddHook(logutil.NewFilter([]logrus.Level{
 		logrus.WarnLevel,
 	},
+		"commandConn.CloseRead:",
 		"commandConn.CloseWrite:",
 	))
 


### PR DESCRIPTION
follow-up #2161

forgot to also filter out `commandConn.CloseRead` in previous PR: https://github.com/dagger/dagger-for-github/runs/6092884799?check_suite_focus=true#step:3:14

```
 /opt/hostedtoolcache/dagger/0.2.7/x64/dagger do test
  time="2022-04-20T10:01:52Z" level=warning msg="commandConn.CloseRead: commandconn: failed to wait: signal: terminated"
  10:01AM INF actions.test.script._write | computing
  10:01AM INF actions.test.image._dag."0"._op | computing
  10:01AM INF actions.test.script._write | completed    duration=0s
  10:01AM INF actions.test.image._dag."0"._op | completed    duration=1.7s
  10:01AM INF actions.test.image._dag."1"._exec | computing
  ...
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>