### PR TITLE
universe: Add kubernetes package

### DIFF
--- a/pkg/universe.dagger.io/x/tom.chauveau.pro@icloud.com/kubernetes/apply.cue
+++ b/pkg/universe.dagger.io/x/tom.chauveau.pro@icloud.com/kubernetes/apply.cue
@@ -1,0 +1,61 @@
+package kubernetes
+
+import (
+	"dagger.io/dagger"
+	"universe.dagger.io/docker"
+)
+
+_#Location: "directory" | "url"
+
+#Apply: {
+	// Kubeconfig
+	kubeconfig: dagger.#Secret
+
+	// location of manifest
+	location: _#Location
+
+	// Namespace to apply config
+	namespace: *"default" | string
+
+	{
+		location: "directory"
+
+		source: dagger.#FS
+
+		// Customize docker.#Run
+		command: flags: "-f": "/manifest"
+
+		mounts: manifest: {
+			type:     "fs" // Resolve disjunction
+			dest:     "/manifest"
+			contents: source
+		}
+	} | {
+		location: "url"
+
+		url: string
+
+		// Customize docker.#Run
+		command: {
+			flags: "-f": url
+		}
+	}
+
+	_baseImage: #Kubectl
+
+	docker.#Run & {
+		user:  "root"
+		input: *_baseImage.output | docker.#Image
+		command: {
+			name: "apply"
+			flags: {
+				"--namespace": namespace
+				"-R":          true
+			}
+		}
+		mounts: "kubeconfig": {
+			dest:     "/.kube/config"
+			contents: kubeconfig
+		}
+	}
+}

--- a/pkg/universe.dagger.io/x/tom.chauveau.pro@icloud.com/kubernetes/kubectl.cue
+++ b/pkg/universe.dagger.io/x/tom.chauveau.pro@icloud.com/kubernetes/kubectl.cue
@@ -1,0 +1,16 @@
+package kubernetes
+
+import (
+	"universe.dagger.io/docker"
+)
+
+_#DefaultVersion: "1.23.5"
+
+// Kubectl client
+#Kubectl: {
+	version: *_#DefaultVersion | string
+
+	docker.#Pull & {
+		source: "index.docker.io/bitnami/kubectl:\(version)"
+	}
+}

--- a/pkg/universe.dagger.io/x/tom.chauveau.pro@icloud.com/kubernetes/test/apply.cue
+++ b/pkg/universe.dagger.io/x/tom.chauveau.pro@icloud.com/kubernetes/test/apply.cue
@@ -1,0 +1,36 @@
+package kubernetes
+
+import (
+	"dagger.io/dagger"
+
+	"universe.dagger.io/x/tom.chauveau.pro@icloud.com/kubernetes"
+)
+
+dagger.#Plan & {
+	// Kubeconfig must be in current directory
+	client: {
+		filesystem: "./data": read: contents: dagger.#FS
+		commands: kubeconfig: {
+			name: "kubectl"
+			args: ["config", "view", "--raw"]
+			stdout: dagger.#Secret
+		}
+	}
+
+	actions: test: apply: {
+		// Alias on kubeconfig
+		_kubeconfig: client.commands.kubeconfig.stdout
+
+		url: kubernetes.#Apply & {
+			kubeconfig: _kubeconfig
+			location:   "url"
+			url:        "https://gist.githubusercontent.com/grouville/04402633618f3289a633f652e9e4412c/raw/293fa6197b78ba3fad7200fa74b52c62ec8e6703/hello-world-pod.yaml"
+		}
+
+		directory: kubernetes.#Apply & {
+			kubeconfig: _kubeconfig
+			location:   "directory"
+			source:     client.filesystem."./data".read.contents
+		}
+	}
+}

--- a/pkg/universe.dagger.io/x/tom.chauveau.pro@icloud.com/kubernetes/test/data/hello-pod/hello.yaml
+++ b/pkg/universe.dagger.io/x/tom.chauveau.pro@icloud.com/kubernetes/test/data/hello-pod/hello.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello-dagger
+spec:
+  containers:
+    - name: hello
+      image: "alpine:3"
+      command: ["/bin/echo", "hello Dagger"]

--- a/pkg/universe.dagger.io/x/tom.chauveau.pro@icloud.com/kubernetes/test/kubectl.cue
+++ b/pkg/universe.dagger.io/x/tom.chauveau.pro@icloud.com/kubernetes/test/kubectl.cue
@@ -1,0 +1,48 @@
+package kubernetes
+
+import (
+	"dagger.io/dagger"
+
+	"universe.dagger.io/docker"
+	"universe.dagger.io/x/tom.chauveau.pro@icloud.com/kubernetes"
+)
+
+dagger.#Plan & {
+	actions: test: kubectl: {
+		simple: {
+			_image: kubernetes.#Kubectl
+
+			verify: docker.#Run & {
+				input: _image.output
+				user:  "root"
+				command: {
+					name: "-c"
+					args: ["""
+							kubectl version >> /version.txt || true
+						"""]
+				}
+				entrypoint: ["/bin/sh"]
+				export: files: "/version.txt": _ & =~"v1.23.5"
+			}
+		}
+
+		custom: {
+			_image: kubernetes.#Kubectl & {
+				version: "1.21.12"
+			}
+
+			verify: docker.#Run & {
+				input: _image.output
+				user:  "root"
+				command: {
+					name: "-c"
+					args: ["""
+							kubectl version >> /version.txt || true
+						"""]
+				}
+				entrypoint: ["/bin/sh"]
+				export: files: "/version.txt": _ & =~"v1.21.12"
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Changes

Related to #1951

- Add `#Kubectl`
- Add `#Apply`
- Add tests for both

### Test

#### URL

```shell
dagger do -p ./apply.cue test apply url           
[✔] [✔] actions.test.apply.url                                                                                                                                        
[✔] actions.test.apply.url                                                                                                                                        0.7s
[✔] client.filesystem."./kubeconfig".read                                                                                                                         0.0s

kubectl get pods                       
NAME          READY   STATUS             RESTARTS     AGE
hello-world   0/1     CrashLoopBackOff   1 (8s ago)   9s

```

#### Directory

See issue below


### Issue

I'm currently hitting an issue with `directory` test, I do not understand why, it's related to client API, may @helderco can help me

```shell
dagger do -p ./apply.cue test apply directory
[✔] actions.test.apply.directory                                                                                                                                  1.2s
[✔] client.filesystem."./kubeconfig".read                                                                                                                         0.0s
2:00AM FTL failed to execute plan: task failed: actions.test.apply.directory._exec: invalid FS at path "actions.test.apply.directory._exec.mounts.manifest.contents": FS is not set

ls
ls -R ./data 
hello-pod

./data/hello-pod:
hello.yaml
```

As you see, file exist but it doesn't works :/

[See the plan here](https://github.com/dagger/dagger/blob/7f46ae46789b1560bdea73ce652b741bbba4b8b2/pkg/universe.dagger.io/x/tom.chauveau.pro%40icloud.com/kubernetes/test/apply.cue#L13)

Signed-off-by: Vasek - Tom C <tom.chauveau@epitech.eu>