### PR TITLE
Fix FAQ broken links

### DIFF
--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -22,7 +22,7 @@ export const FaqItems = () => {
                 type: "link",
                 label: result.title,
                 description: result.description,
-                href: customPropsItem.href,
+                href: customPropsItem.href.replace('/faq',''),
                 docId: customPropsItem.docId
             }
     })


### PR DESCRIPTION
Signed-off-by: Jeremy Adams <jeremy@dagger.io>

Quick fix for FAQ link URLs that currently have `/faq` in them, which is causing broken links. This commit removes that string in the URL.