### PR TITLE
validate plan concreteness before execution

### DIFF
--- a/compiler/build.go
+++ b/compiler/build.go
@@ -7,7 +7,6 @@ import (
 	"path"
 	"path/filepath"
 
-	cueerrors "cuelang.org/go/cue/errors"
 	cueload "cuelang.org/go/cue/load"
 )
 
@@ -61,11 +60,11 @@ func Build(src string, overlays map[string]fs.FS, args ...string) (*Value, error
 	}
 	v, err := c.Context.BuildInstances(instances)
 	if err != nil {
-		return nil, Err(errors.New(cueerrors.Details(err, &cueerrors.Config{})))
+		return nil, c.Err(err)
 	}
 	for _, value := range v {
 		if value.Err() != nil {
-			return nil, Err(value.Err())
+			return nil, c.Err(value.Err())
 		}
 	}
 	if len(v) != 1 {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -2,6 +2,7 @@ package compiler
 
 import (
 	"errors"
+	"os"
 	"sync"
 
 	"cuelang.org/go/cue"
@@ -127,5 +128,11 @@ func (c *Compiler) Err(err error) error {
 	if err == nil {
 		return nil
 	}
-	return errors.New(cueerrors.Details(err, &cueerrors.Config{}))
+
+	cfg := &cueerrors.Config{}
+	if cwd, err := os.Getwd(); err == nil {
+		cfg.Cwd = cwd
+	}
+
+	return errors.New(cueerrors.Details(err, cfg))
 }

--- a/pkg/dagger.io/dagger/core/exec.cue
+++ b/pkg/dagger.io/dagger/core/exec.cue
@@ -35,7 +35,7 @@ import "dagger.io/dagger"
 	hosts: [hostname=string]: string
 
 	// Modified filesystem
-	output: dagger.#FS
+	output: dagger.#FS @dagger(generated)
 
 	// Command exit code
 	// Currently this field can only ever be zero.

--- a/pkg/dagger.io/dagger/core/fs.cue
+++ b/pkg/dagger.io/dagger/core/fs.cue
@@ -14,7 +14,7 @@ import "dagger.io/dagger"
 	// Optionally exclude certain files
 	exclude: [...string]
 
-	output: dagger.#FS
+	output: dagger.#FS @dagger(generated)
 }
 
 // Create one or multiple directory in a container
@@ -35,7 +35,7 @@ import "dagger.io/dagger"
 	parents: *true | false
 
 	// Modified filesystem
-	output: dagger.#FS
+	output: dagger.#FS @dagger(generated)
 }
 
 #ReadFile: {
@@ -46,7 +46,7 @@ import "dagger.io/dagger"
 	// Path of the file to read
 	path: string
 	// Contents of the file
-	contents: string
+	contents: string @dagger(generated)
 }
 
 // Write a file to a filesystem tree, creating it if needed
@@ -62,7 +62,7 @@ import "dagger.io/dagger"
 	// Permissions of the file
 	permissions: *0o644 | int
 	// Output filesystem tree
-	output: dagger.#FS
+	output: dagger.#FS @dagger(generated)
 }
 
 // Copy files from one FS tree to another
@@ -81,7 +81,7 @@ import "dagger.io/dagger"
 	// Optionally exclude certain files
 	exclude: [...string]
 	// Output of the operation
-	output: dagger.#FS
+	output: dagger.#FS @dagger(generated)
 }
 
 #CopyInfo: {
@@ -96,7 +96,7 @@ import "dagger.io/dagger"
 #Merge: {
 	$dagger: task: _name: "Merge"
 	inputs: [...dagger.#FS]
-	output: dagger.#FS
+	output: dagger.#FS @dagger(generated)
 }
 
 // Extract the difference from lower FS to upper FS as its own FS
@@ -104,7 +104,7 @@ import "dagger.io/dagger"
 	$dagger: task: _name: "Diff"
 	lower:  dagger.#FS
 	upper:  dagger.#FS
-	output: dagger.#FS
+	output: dagger.#FS @dagger(generated)
 }
 
 // Select a subdirectory from a filesystem tree
@@ -125,5 +125,5 @@ import "dagger.io/dagger"
 	}
 
 	// Subdirectory tree
-	output: dagger.#FS & _copy.output
+	output: dagger.#FS & _copy.output @dagger(generated)
 }

--- a/pkg/dagger.io/dagger/core/git.cue
+++ b/pkg/dagger.io/dagger/core/git.cue
@@ -28,5 +28,5 @@ import "dagger.io/dagger"
 	} | {
 		authHeader: dagger.#Secret
 	}
-	output: dagger.#FS
+	output: dagger.#FS @dagger(generated)
 }

--- a/pkg/dagger.io/dagger/core/http.cue
+++ b/pkg/dagger.io/dagger/core/http.cue
@@ -45,5 +45,5 @@ import "dagger.io/dagger"
 	gid?: int
 
 	// New filesystem state containing the downloaded file
-	output: dagger.#FS
+	output: dagger.#FS @dagger(generated)
 }

--- a/pkg/dagger.io/dagger/core/image.cue
+++ b/pkg/dagger.io/dagger/core/image.cue
@@ -60,7 +60,7 @@ import (
 	}
 
 	// Complete ref of the pushed image, including digest
-	result: #Ref
+	result: #Ref @dagger(generated)
 }
 
 // Download a container image from a remote repository
@@ -77,13 +77,13 @@ import (
 	}
 
 	// Root filesystem of downloaded image
-	output: dagger.#FS
+	output: dagger.#FS @dagger(generated)
 
 	// Image digest
-	digest: string
+	digest: string @dagger(generated)
 
 	// Downloaded container image config
-	config: #ImageConfig
+	config: #ImageConfig @dagger(generated)
 }
 
 // Build a container image using a Dockerfile
@@ -112,10 +112,10 @@ import (
 	hosts?: [string]:    string
 
 	// Root filesystem produced
-	output: dagger.#FS
+	output: dagger.#FS @dagger(generated)
 
 	// Container image config produced
-	config: #ImageConfig
+	config: #ImageConfig @dagger(generated)
 }
 
 // Export an image as a tar archive
@@ -138,10 +138,10 @@ import (
 	path: string | *"/image.tar"
 
 	// Exported image ID
-	imageID: string
+	imageID: string @dagger(generated)
 
 	// Root filesystem with exported file
-	output: dagger.#FS
+	output: dagger.#FS @dagger(generated)
 }
 
 // Change image config

--- a/pkg/dagger.io/dagger/core/secrets.cue
+++ b/pkg/dagger.io/dagger/core/secrets.cue
@@ -13,7 +13,7 @@ import "dagger.io/dagger"
 	format: "json" | "yaml"
 
 	// A new secret or (map of secrets) derived from unmarshaling the input secret's plain text
-	output: dagger.#Secret | {[string]: output}
+	output: dagger.#Secret | {[string]: output} @dagger(generated)
 }
 
 // Create a new a secret from a filesystem tree
@@ -27,7 +27,7 @@ import "dagger.io/dagger"
 	// Whether to trim leading and trailing space characters from secret value
 	trimSpace: *true | false
 	// Contents of the secret
-	output: dagger.#Secret
+	output: dagger.#Secret @dagger(generated)
 }
 
 // Trim leading and trailing space characters from a secret
@@ -38,5 +38,5 @@ import "dagger.io/dagger"
 	input: dagger.#Secret
 
 	// New trimmed secret
-	output: dagger.#Secret
+	output: dagger.#Secret @dagger(generated)
 }

--- a/pkg/dagger.io/dagger/plan.cue
+++ b/pkg/dagger.io/dagger/plan.cue
@@ -43,9 +43,7 @@ package dagger
 	// platform?: string
 
 	// Execute actions in containers
-	actions: {
-		...
-	}
+	actions: _
 }
 
 _#clientFilesystemRead: {
@@ -58,11 +56,11 @@ _#clientFilesystemRead: {
 		// CUE type defines expected content:
 		//     string: contents of a regular file
 		//     #Secret: secure reference to the file contents
-		contents: string | #Secret
+		contents: string | #Secret @dagger(generated)
 	} | {
 		// CUE type defines expected content:
 		//     #FS: contents of a directory
-		contents: #FS
+		contents: #FS @dagger(generated)
 
 		// Filename patterns to include
 		// Example: ["*.go", "Dockerfile"]
@@ -81,14 +79,14 @@ _#clientFilesystemWrite: {
 	path: string
 	{
 		// File contents to export (as a string or secret)
-		contents: string | #Secret
+		contents: string | #Secret @dagger(generated)
 
 		// File permissions (defaults to 0o644)
 		permissions?: int
 	} | {
 		// Filesystem contents to export
 		// Reference an #FS field produced by an action
-		contents: #FS
+		contents: #FS @dagger(generated)
 	}
 }
 
@@ -101,7 +99,7 @@ _#clientNetwork: {
 
 	{
 		// unix socket or npipe
-		connect: #Socket
+		connect: #Socket @dagger(generated)
 		// } | {
 		//  // FIXME: not yet implemented
 		//  listen: #Socket
@@ -115,7 +113,7 @@ _#clientEnv: {
 	$dagger: task: _name: "ClientEnv"
 
 	// CUE type defines expected content
-	[!~"\\$dagger"]: *string | #Secret
+	[!~"\\$dagger"]: *string | #Secret @dagger(generated)
 }
 
 _#clientCommand: {
@@ -138,20 +136,20 @@ _#clientCommand: {
 	env: [string]: string | #Secret
 
 	// Capture standard output (as a string or secret)
-	stdout?: *string | #Secret
+	stdout?: *string | #Secret @dagger(generated)
 
 	// Capture standard error (as a string or secret)
-	stderr?: *string | #Secret
+	stderr?: *string | #Secret @dagger(generated)
 
 	// Inject standard input (from a string or secret)
-	stdin?: string | #Secret
+	stdin?: string | #Secret @dagger(generated)
 }
 
 _#clientPlatform: {
 	$dagger: task: _name: "ClientPlatform"
 
 	// Operating system of the client machine
-	os: string
+	os: string @dagger(generated)
 	// Hardware architecture of the client machine
-	arch: string
+	arch: string @dagger(generated)
 }

--- a/pkg/universe.dagger.io/alpine/test/test.cue
+++ b/pkg/universe.dagger.io/alpine/test/test.cue
@@ -44,8 +44,8 @@ dagger.#Plan & {
 				}
 
 				export: files: {
-					"/jq-version.txt": contents:   =~"^jq"
-					"/curl-version.txt": contents: =~"^curl"
+					"/jq-version.txt":   =~"^jq"
+					"/curl-version.txt": =~"^curl"
 				}
 			}
 		}

--- a/pkg/universe.dagger.io/aws/cli/cli.cue
+++ b/pkg/universe.dagger.io/aws/cli/cli.cue
@@ -86,8 +86,8 @@ import (
 	}
 
 	// Result will contain the cli output. If unmarshal is set to false this will be the raw string as provided by the aws cli command. If unmarshal is set to true this will be a map as returned by json.Unmarshal.
-	_unmarshalable: string | number | bool | null | [..._unmarshalable] | {[string]: _unmarshalable}
-	result:         _unmarshalable
+	#_unmarshalable: string | number | bool | null | [...#_unmarshalable] | {[string]: #_unmarshalable}
+	result:          #_unmarshalable
 
 	if unmarshal != false {
 		options: output: "json"

--- a/pkg/universe.dagger.io/docker/run.cue
+++ b/pkg/universe.dagger.io/docker/run.cue
@@ -12,7 +12,7 @@ import (
 	// Docker image to execute
 	input: #Image
 
-	always: bool | *false
+	always?: bool
 
 	// Filesystem mounts
 	mounts: [name=string]: core.#Mount
@@ -62,12 +62,12 @@ import (
 
 	// Working directory for the command
 	// Example: "/src"
-	workdir: string
+	workdir?: string
 
 	// Username or UID to ad
 	// User identity for this command
 	// Examples: "root", "0", "1002"
-	user: string
+	user?: string
 
 	// Add defaults to image config
 	// This ensures these values are present
@@ -161,8 +161,10 @@ import (
 
 	// Actually execute the command
 	_exec: core.#Exec & {
-		"input":  input.rootfs
-		"always": always
+		"input": input.rootfs
+		if always != _|_ {
+			"always": always
+		}
 		"mounts": mounts
 		args:     _config.output.entrypoint + _config.output.cmd
 		workdir:  _config.output.workdir

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -70,7 +70,7 @@ func Load(ctx context.Context, cfg Config) (*Plan, error) {
 		log.Ctx(ctx).Debug().Interface("with", param).Msg("filling overlay")
 		fillErr := v.FillPath(cue.MakePath(), paramV)
 		if fillErr != nil {
-			return nil, fillErr
+			return nil, compiler.Err(fillErr)
 		}
 	}
 
@@ -78,6 +78,10 @@ func Load(ctx context.Context, cfg Config) (*Plan, error) {
 		config:  cfg,
 		context: plancontext.New(),
 		source:  v,
+	}
+
+	if err := p.validate(); err != nil {
+		return nil, compiler.Err(err)
 	}
 
 	p.fillAction()
@@ -230,4 +234,8 @@ func (p *Plan) fillAction() {
 			prevAction = a
 		}
 	}
+}
+
+func (p *Plan) validate() error {
+	return isPlanConcrete(p.source, p.source)
 }

--- a/plan/validate.go
+++ b/plan/validate.go
@@ -1,0 +1,122 @@
+package plan
+
+import (
+	"cuelang.org/go/cue"
+	cueerrors "cuelang.org/go/cue/errors"
+	"cuelang.org/go/cue/token"
+	"go.dagger.io/dagger/compiler"
+	"go.dagger.io/dagger/plancontext"
+)
+
+const (
+	ScalarKind cue.Kind = cue.StringKind | cue.NumberKind | cue.BoolKind
+)
+
+func isReference(v *compiler.Value) bool {
+	// FIXME: this expands an expression into parts and checks if any of them are references.
+	// Use case:
+	// docker/run.cue: `rootfs: dagger.#FS & _exec.output`
+	// This was tricking reference checking into thinking it is NOT a reference.
+	// However, this approach can have false positives as well (`dagger.#FS` IS a reference on its own)
+	_, expr := v.Expr()
+	for _, i := range expr {
+		_, refPath := i.ReferencePath()
+		if len(refPath.Selectors()) > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+func fieldMissingErr(p *compiler.Value, field *compiler.Value) error {
+	missingErr := cueerrors.Newf(field.Pos(), "%q is not set", field.Path().String())
+
+	// Wrap the error with the position of the parent value.
+	//
+	// For instance, given `actions: foo: docker.#Run & {}`,
+	// if `actions.foo.input` is missing, grab the position of `actions.foo`
+	// for the stack trace.
+	selectors := field.Path().Selectors()
+	if len(selectors) == 0 {
+		return missingErr
+	}
+
+	parentSelectors := selectors[0 : len(selectors)-1]
+	parent := p.LookupPath(cue.MakePath(parentSelectors...))
+	parentPos := parent.Pos()
+	if !parent.Exists() || parentPos == token.NoPos {
+		return missingErr
+	}
+
+	return cueerrors.Wrap(cueerrors.Newf(parentPos, ""), missingErr)
+}
+
+func isDockerImage(v *compiler.Value) bool {
+	return plancontext.IsFSValue(v.Lookup("rootfs")) && v.Lookup("config").Kind().IsAnyOf(cue.StructKind)
+}
+
+func isPlanConcrete(p *compiler.Value, v *compiler.Value) error {
+	kind := v.IncompleteKind()
+
+	switch {
+	// Scalar types (string, int, etc)
+	// Make sure the value is either:
+	// - Concrete (e.g. `foo: "bar"`) OR
+	// - Has a default (e.g. `foo: *"bar" | string`) OR
+	// - Is a reference (e.g. `foo: bar`)
+	// Otherwise, abort.
+	case kind.IsAnyOf(ScalarKind):
+		_, hasDefault := v.Default()
+
+		if !v.IsConcrete() && !hasDefault && !isReference(v) {
+			return fieldMissingErr(p, v)
+		}
+	// Core types (FS, Secret, Socket): make sure they are references, otherwise abort.
+	case plancontext.IsFSValue(v) || plancontext.IsSecretValue(v) || plancontext.IsSocketValue(v):
+		// Special case: `dagger.#Scratch` is always concrete
+		if plancontext.IsFSScratchValue(v) {
+			return nil
+		}
+
+		// For the rest, ensure they're references.
+		if isReference(v) {
+			return nil
+		}
+
+		return fieldMissingErr(p, v)
+	// Docker images: make sure the `rootfs` is a reference
+	case isDockerImage(v):
+		if isReference(v.Lookup("rootfs")) {
+			return nil
+		}
+		return fieldMissingErr(p, v)
+
+	// For structures, recursively call this function to check sub-fields
+	case kind.IsAnyOf(cue.StructKind):
+		it, err := v.Cue().Fields(cue.All())
+		if err != nil {
+			return err
+		}
+
+		for it.Next() {
+			if it.IsOptional() {
+				continue
+			}
+			if it.Selector().IsDefinition() {
+				continue
+			}
+
+			if compiler.Wrap(it.Value()).HasAttr("generated") {
+				continue
+			}
+
+			if err := isPlanConcrete(p, compiler.Wrap(it.Value())); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Ignore all other types.
+	return nil
+}

--- a/plancontext/fs.go
+++ b/plancontext/fs.go
@@ -22,6 +22,10 @@ func IsFSValue(v *compiler.Value) bool {
 	return v.LookupPath(fsIDPath).Exists()
 }
 
+func IsFSScratchValue(v *compiler.Value) bool {
+	return IsFSValue(v) && v.LookupPath(fsIDPath).Kind() == cue.NullKind
+}
+
 type FS struct {
 	id     string
 	result bkgw.Reference
@@ -80,7 +84,7 @@ func (c *fsContext) FromValue(v *compiler.Value) (*FS, error) {
 	}
 
 	// This is #Scratch, so we'll return an empty FS
-	if v.LookupPath(fsIDPath).Kind() == cue.NullKind {
+	if IsFSScratchValue(v) {
 		return &FS{}, nil
 	}
 

--- a/tests/plan.bats
+++ b/tests/plan.bats
@@ -238,11 +238,7 @@ setup() {
 
   run "$DAGGER" "do" --with 'actions: params: foo:1' -p ./plan/with test params
   assert_failure
-  assert_output --partial "conflicting values string and 1"
-
-  run "$DAGGER" "do" -p ./plan/with test params
-  assert_failure
-  assert_output --partial "actions.test.params.env.FOO: non-concrete value string"
+  assert_output --partial "conflicting values"
 }
 
 @test "plan/platform" {
@@ -275,4 +271,43 @@ setup() {
    run timeout 30 "$DAGGER" "do" -p ./plan/do/actions.cue frontend test
    assert_failure
    assert_output --partial "Unavailable: connection error"
+}
+
+@test "plan/concrete" {
+  cd "$TESTDIR"
+
+  run "$DAGGER" "do" -p ./plan/concrete/definition.cue test
+  assert_failure
+  assert_output --partial '"actions.test.required" is not set'
+  assert_output --partial './plan/concrete/definition.cue'
+
+  run "$DAGGER" "do" -p ./plan/concrete/reference.cue test
+  assert_failure
+  assert_output --partial '"actions.test._ref" is not set'
+  assert_output --partial './plan/concrete/reference.cue'
+
+  run "$DAGGER" "do" -p ./plan/concrete/fs.cue test
+  assert_failure
+  assert_output --partial '"actions.test.required" is not set'
+  assert_output --partial './plan/concrete/fs.cue'
+
+  run "$DAGGER" "do" -p ./plan/concrete/task.cue test
+  assert_failure
+  assert_output --partial '"actions.test.path" is not set'
+  assert_output --partial './plan/concrete/task.cue'
+
+  run "$DAGGER" "do" -p ./plan/concrete/multitype.cue test
+  assert_failure
+  assert_output --partial '"actions.test.required" is not set'
+  assert_output --partial './plan/concrete/multitype.cue'
+
+  run "$DAGGER" "do" -p ./plan/concrete/docker_image.cue test
+  assert_failure
+  assert_output --partial '"actions.test.input" is not set'
+  assert_output --partial './plan/concrete/docker_image.cue'
+
+  run "$DAGGER" "do" -p ./plan/concrete/yarn.cue test
+  assert_failure
+  assert_output --partial '"actions.test.source" is not set'
+  assert_output --partial './plan/concrete/yarn.cue'
 }

--- a/tests/plan/concrete/definition.cue
+++ b/tests/plan/concrete/definition.cue
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+)
+
+// BEFORE: failed to execute plan: task failed: actions.test._op: actions.test._op.source: non-concrete value string
+//  AFTER: failed to load plan: "actions.test.required" is not concrete: string
+
+#Test: {
+	required: string
+	_op:      core.#Pull & {
+		source: required
+	}
+}
+
+dagger.#Plan & {
+	actions: test: #Test & {}
+}

--- a/tests/plan/concrete/docker_image.cue
+++ b/tests/plan/concrete/docker_image.cue
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"dagger.io/dagger"
+	"universe.dagger.io/docker"
+)
+
+// BEFORE: failed to execute plan: task failed: actions.test._exec: invalid FS at path "actions.test._exec.input": FS is not set
+//  AFTER: failed to load plan: "actions.test.input" is not set:
+//    ../../cue.mod/pkg/universe.dagger.io/docker/run.cue:13:2
+
+dagger.#Plan & {
+	actions: test: docker.#Run
+}

--- a/tests/plan/concrete/fs.cue
+++ b/tests/plan/concrete/fs.cue
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+)
+
+// BEFORE: failed to execute plan: task failed: actions.test._op: actions.test._op.source: non-concrete value string
+//  AFTER: failed to load plan: "actions.test.required" is not concrete: string
+
+#Test: {
+	required: dagger.#FS
+	_op:      core.#WriteFile & {
+		input:    required
+		path:     "/test"
+		contents: "test"
+	}
+}
+
+dagger.#Plan & {
+	actions: test: #Test & {}
+}

--- a/tests/plan/concrete/multitype.cue
+++ b/tests/plan/concrete/multitype.cue
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+)
+
+#Test: {
+	required: string | int
+	_op:      core.#Pull & {
+		source: required
+	}
+}
+
+dagger.#Plan & {
+	actions: test: #Test & {}
+}

--- a/tests/plan/concrete/reference.cue
+++ b/tests/plan/concrete/reference.cue
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+)
+
+// BEFORE: failed to execute plan: task failed: actions.test._op: actions.test._op.source: non-concrete value string
+//  AFTER: failed to load plan: "actions.test._ref" is not concrete: string
+
+#Test: {
+	required: string
+	_op:      core.#Pull & {
+		source: required
+	}
+}
+
+dagger.#Plan & {
+	actions: test: #Test & {
+		_ref:     string
+		required: _ref
+	}
+}

--- a/tests/plan/concrete/task.cue
+++ b/tests/plan/concrete/task.cue
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+)
+
+// BEFORE: failed to execute plan: task failed: actions.test: actions.test.path: non-concrete value string
+//  AFTER: failed to load plan: "actions.test.path" is not set:
+//     ../../cue.mod/pkg/dagger.io/dagger/core/fs.cue:59:2
+// "actions.test.contents" is not set:
+//     ../../cue.mod/pkg/dagger.io/dagger/core/fs.cue:61:2
+
+dagger.#Plan & {
+	actions: test: core.#WriteFile & {
+		input: dagger.#Scratch
+	}
+}

--- a/tests/plan/concrete/yarn.cue
+++ b/tests/plan/concrete/yarn.cue
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"dagger.io/dagger"
+	"universe.dagger.io/yarn"
+)
+
+// BEFORE: failed to execute plan: task failed: actions.test._exec: invalid FS at path "actions.test._exec.input": FS is not set
+//  AFTER: failed to load plan: "actions.test.input" is not set:
+//    ../../cue.mod/pkg/universe.dagger.io/docker/run.cue:13:2
+
+dagger.#Plan & {
+	actions: test: yarn.#Run
+}

--- a/tests/plan/do/actions.cue
+++ b/tests/plan/do/actions.cue
@@ -12,63 +12,67 @@ dagger.#Plan & {
 	actions: {
 
 		// Run core integration tests
-		"core-integration": _
+		"core-integration": {}
 
 		// Format all cue files
-		cuefmt: _
+		cuefmt: {}
 
 		// Lint and format all cue files
-		cuelint: _
+		cuelint: {}
 
 		// Build a debug version of the dev dagger binary
-		"dagger-debug": _
+		"dagger-debug": {}
 
 		// Test docs
-		"doc-test": _
+		"doc-test": {}
 
 		// Generate docs
-		docs: _
+		docs: {}
 
 		// Generate & lint docs
-		docslint: _
+		docslint: {}
 
 		// Run Europa universe tests
-		"europa-universe-test": _
+		"europa-universe-test": {}
 
 		// Go lint
-		golint: _
+		golint: {}
 
 		// Show how to get started & what targets are available
-		help: _
+		help: {}
 
 		// Install a dev dagger binary
-		install: _
+		install: {}
 
 		// Run all integration tests
-		integration: _
+		integration: {}
 
 		// Lint everything
-		lint: _
+		lint: {}
 
 		// Run shellcheck
-		shellcheck: _
+		shellcheck: {}
 
 		// Run all tests
-		test: _
+		test: {}
 
 		// Find all TODO items
-		todo: _
+		todo: {}
 
 		// Run universe tests
-		"universe-test": _
+		"universe-test": {}
 
 		// Build, test and deploy frontend web client
 		frontend: {
 			// Build via yarn
-			build: yarn.#Build
+			build: yarn.#Build & {
+				source: dagger.#Scratch
+			}
 
 			// Test via headless browser
-			test: docker.#Run
+			test: docker.#Run & {
+				input: docker.#Image
+			}
 		}
 	}
 }

--- a/tests/plan/do/do_flags.cue
+++ b/tests/plan/do/do_flags.cue
@@ -22,13 +22,13 @@ dagger.#Plan & {
 			// Which name?
 			name: string | *"World"
 			// What message?
-			message: string
+			message?: string
 			// How many?
-			num: float
+			num?: float
 			// on or off?
 			doit: bool | *true
 			// this is foo2
-			foo2: foo
+			foo2?: foo
 			// do the first thing
 			one: bash.#Run & {
 				input: image.output

--- a/tests/plan/with/with.cue
+++ b/tests/plan/with/with.cue
@@ -7,7 +7,7 @@ import (
 
 dagger.#Plan & {
 	actions: {
-		params: foo: string
+		params: foo?: string
 
 		_image: core.#Pull & {
 			source: "alpine:3.15.0@sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3"
@@ -25,7 +25,7 @@ dagger.#Plan & {
 				]
 			}
 
-			direct: {}
+			direct: env: FOO:   *"direct" | string
 			"params": env: FOO: params.foo
 		}
 	}


### PR DESCRIPTION
Related to #613

This attempts to validate plan concreteness (e.g. missing fields) before execution.

The objective is to provide nicer errors when fields are missing: instead of complaining about low-level task fields (e.g. `foo._bar._exec.input`), this will provide the "source" error (e.g. `foo.source`).

There are some heuristics in place:

- Recursively walk the entire tree (avoiding definitions and optional fields)
- Scalars (`string`, `bool`, etc): Make sure they're concrete, or have default values, or is a reference
- Core types (`#FS`, `#Secret`, etc): Make sure they're references
- Core actions (e.g. `core.#ReadFile`): validate, but skip generated fields

### Example In Action

Given this config:

```cue
#Test: {
	required: string
	_op: core.#Pull & {
		source: required
	}
}

dagger.#Plan & {
	actions: test: #Test & {}
}
```

Before:

```console
$ dagger do -p ./definition.cue test
[✗] actions.test
6:08PM FTL failed to execute plan: task failed: actions.test._op: actions.test._op.source: non-concrete value string
```

After:

```console
$ dagger do -p ./definition.cue test
failed to load plan: "actions.test.required" is not set:
    ./definition.cue:12:2
```

- Validation happens **before** execution (e.g. Parse error rather than Runtime error)
- Error is caught at the **source** (e.g. complains about `test.required` field rather than `test._op.source`
- Error includes **stack trace** (where it happened). **NOTE** This will always be the file where the field is DEFINED, not where it's missing. **UPDATE**: Improved! https://github.com/dagger/dagger/pull/2266#issuecomment-1106817508

## Notes

- **Every** field now must either be *concrete*, a *reference*, *optional* or come with a *default* value. If that's not the case, the validation will fail. We had a couple of instances of that in universe which I had to tweak
- **Core Actions** are a special case: some fields will be made concrete by the runtime at execution. Those fields are now flagged with `@dagger(generated)`. This instructs the validator that it's okay if they're not concrete.

/cc @helderco @jlongtine @shykes @dolanor 