### PR TITLE
solver: fix duplicate logs on export

### DIFF
--- a/solver/solver.go
+++ b/solver/solver.go
@@ -125,6 +125,13 @@ func (s *Solver) SolveRequest(ctx context.Context, req bkgw.SolveRequest) (*bkgw
 	// makes Solve() to block until LLB graph is solved. otherwise it will
 	// return result (that you can for example use for next build) that
 	// will be evaluated on export or if you access files on it.
+	//
+	// NOTE: if a future change modifies Evaluate to not always be true anymore, we
+	// will need to ensure that Solver.Export no longer sets "ignoreLogs" to true
+	// when forwarding progress events. This is because those logs will no longer
+	// necessarily be duped from the main channel published to by Solves called here.
+	// Sample code to properly handle that can be found here:
+	// https://github.com/sipsma/dagger/commit/104e0d0393b5f707ea40448736f2e0e87fb1e4ed
 	req.Evaluate = true
 	res, err := s.opts.Gateway.Solve(ctx, req)
 	if err != nil {
@@ -182,11 +189,14 @@ func (s *Solver) Solve(ctx context.Context, st llb.State, platform specs.Platfor
 // Forward events from solver to the main events channel
 // It creates a task in the solver waiting group to be
 // sure that everything will be forward to the main channel
-func (s *Solver) forwardEvents(ch chan *bk.SolveStatus) {
+func (s *Solver) forwardEvents(ch chan *bk.SolveStatus, ignoreLogs bool) {
 	s.eventsWg.Add(1)
 	defer s.eventsWg.Done()
 
 	for event := range ch {
+		if ignoreLogs {
+			event.Logs = nil
+		}
 		s.opts.Events <- event
 	}
 }
@@ -221,7 +231,10 @@ func (s *Solver) Export(ctx context.Context, st llb.State, img *dockerfile2llb.I
 
 	// Forward this build session events to the main events channel, for logging
 	// purposes.
-	go s.forwardEvents(ch)
+	// Ignore logs sent on this channel as they will just be dupes of logs sent
+	// to the main progress channel (see #449).
+	ignoreLogs := true
+	go s.forwardEvents(ch, ignoreLogs)
 
 	return s.opts.Control.Build(ctx, opts, "", func(ctx context.Context, c bkgw.Client) (*bkgw.Result, error) {
 		res, err := c.Solve(ctx, bkgw.SolveRequest{

--- a/tests/plan.bats
+++ b/tests/plan.bats
@@ -145,7 +145,7 @@ setup() {
   cd "$TESTDIR/plan/client/filesystem/write"
 
   mkdir -p ./out_files
-  rm -f ./out_files/*
+  rm -rf ./out_files/*
 
   # -- string --
 
@@ -162,6 +162,13 @@ setup() {
   assert [ "$(cat ./out_files/secret.txt)" = "foo-barab-oof" ]
   run ls -l "./out_files/secret.txt"
   assert_output --partial "-rw-------"
+
+  # -- exec --
+  # This test is focused on ensuring that the export doesn't cause
+  # duplicated output. Easiest to just use external grep for this
+  run sh -c '"$DAGGER" "do" --log-format=plain -l info -p ./ test exec 2>&1 | grep -c "hello world"'
+  assert_output 1
+  assert [ "$(cat ./out_files/execTest/output.txt)" = "hello world" ]
 
   rm -rf ./out_files
 }

--- a/tests/plan/client/filesystem/write/test.cue
+++ b/tests/plan/client/filesystem/write/test.cue
@@ -13,6 +13,7 @@ dagger.#Plan & {
 			contents:    actions.test.secret.data.output
 			permissions: 0o600
 		}
+		"out_files/execTest": write: contents: actions.test.exec.data.output
 	}
 
 	actions: {
@@ -31,6 +32,18 @@ dagger.#Plan & {
 					input:    dagger.#Scratch
 					path:     "/test"
 					contents: "foobaz"
+				}
+			}
+			exec: {
+				createOutput: core.#Exec & {
+					args: ["sh", "-c", "echo 'hello world' | tee /output.txt"]
+					input:  image.output
+					always: true
+				}
+				data: core.#Copy & {
+					input:    dagger.#Scratch
+					contents: createOutput.output
+					source:   "/output.txt"
 				}
 			}
 			secret: {


### PR DESCRIPTION
This is a simple fix for the issue of logs being duplicated when an
export is performed. The issue is caused by Buildkit's behavior of
"backfilling" newly connected clients on the progress so far of vertices
referenced by their build. This addresses it in the simplest way
possible by just filtering out progress log events from these separate
builds.

This works but is fragile. It works because we currently always set
Evaluate to true when running solves, which means that any progress logs
will already have been sent to the main solve channel and any that are
sent to the separate channel created for the export must be duplicates.

If we ever want to enable Evaluate being set to false, we will need a
different fix. I wrote that fix out, but it's a tangled web of
synchronization and to fully understand that it actually covers every
race-condition you need to know details about BuildKit's internal
implementation. Therefore, for now I just left a comment about all this
above the line where we set Evaluate to true and linked to the more
complicated fix in case it's ever needed.

The long-term, non-hacky fix to this is to add support for Export to the
GatewayAPI. For now though, this is our best option and is in fact what
Buildkit developers did when facing the same issue in buildx.

One last note, there technically are some logs that we may be dropping
due to this as it turns out buildkitd uses the progress log streams to
write temporary errors encountered during registry operations. I think
this is okay for now because retriable errors are a rare case and if
retries are exhausted the actual error message does get returned to the
client. We will only be missing out on some intermediary ones.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Fixes #449 

Opening as a draft because I am running into issues writing a test case but I want to get feedback on the simple approach here vs the more complicated one I mention in the commit message and code comments.