### PR TITLE
docs: splitting a dagger plan / exporting packages

### DIFF
--- a/docs/guides/1238-project-file-organization.md
+++ b/docs/guides/1238-project-file-organization.md
@@ -5,17 +5,17 @@ displayed_sidebar: "0.2"
 
 # Project file organization
 
-As time will pass, your actions will get bigger and bigger. You will feel the need to better organize your file structure by moving some parts in subfolders.
+As time will pass, your Dagger configuration will grow. You will feel the need to better organise your config by splitting it into multiple files.
 
-The easiest way, when iterating fast, is to rely on the root module.
+The simplest next step is to rely on the root module.
 
-## CUE Module
+## What is the root module?
 
 A module in CUE is any directory including a `cue.mod` folder. It makes for the prefix/root of importable packages (e.g, `universe.dagger.io` is a module)
 
 ### Anonymous module (default)
 
-The default module name is an empty string, which means it's anonymous. That's when you don't need to import other packages inside your module. It represents most cases where someone has a Dagger plan and imports everything from third-party packages, like universe.
+The default module name is an empty string, which means that it's an anonymous module. Anonymous modules are used when we don't need to import other packages. All Dagger configs start here: a plan represented by a single CUE file, e.g. `plan.cue`, which imports everything from third-party packages, like `universe.dagger.io/docker`.
 
 ### When to use a module
 
@@ -38,7 +38,7 @@ root                    // <- this is a module because it includes a cue.mod dir
 
 ### Summary
 
-Consider the root module as the URL to access the root of your project. Any subfolder inside this module needs to have Cue files with a package name equivalent to the dirname. The filename inside each folder is not important, the package name is:
+Consider the root module as the URL to access the root of your project. Any subfolder inside this module needs to have CUE files with a package name equivalent to the directory name. File names inside each directory are not important, the package name is:
 
 ```console
 $  ls
@@ -52,7 +52,7 @@ $ cat bar/anything.cue
 package bar
 ```
 
-To reference any of the code lying inside each of these packages:
+To reference CUE code from within these packages:
 
 ```cue
 import(
@@ -65,9 +65,9 @@ import(
 
 ### Project non initialized
 
-Dagger holds a way to set a module name at project initialization: `dagger project init --name <NAME>`.
+The module name can be set during project initialisation: `dagger project init --name <NAME>`.
 
-As said above, the name has to at least follow the structure of a domain: `domain.extension` or `domain.extension/project`. Email addresses are also accepted, and the referenced domain doesn't necessarly have to exist.
+As mentioned above, the module name has to at least follow the structure of a domain: `domain.extension` or `domain.extension/project`. Email addresses can also be used for the module name, and the referenced domain doesn't necessarly have to exist.
 
 In our case, let's use a fake email address, for convenience purposes:
 
@@ -149,7 +149,7 @@ import (
 }
 ```
 
-Our `#Foo` definition is just a wrapper around `bash.#Run` that prefills the `input` field with a `bash` image (`_img` key above). Please notice that the `_img` step needs to reside inside the `#Foo` scope as it needs to exist inside the `action` to be executed.
+Our `#Foo` definition is just a wrapper around `bash.#Run` that sets the input field to the `bash` image (`_img` key above). Please notice that the `_img` step needs to reside inside the `#Foo` definition so that it is available to the action context.
 
 For example, this doesn't work:
 

--- a/docs/guides/1238-project-file-organization.md
+++ b/docs/guides/1238-project-file-organization.md
@@ -1,0 +1,242 @@
+---
+slug: /1238/project-file-organization
+displayed_sidebar: "0.2"
+---
+
+# Project file organization
+
+As time will pass, your actions will get bigger and bigger. You will feel the need to better organize your file structure by moving some parts in subfolders.
+
+The easiest way, when iterating fast, is to rely on the root module.
+
+## CUE Module
+
+A module in CUE is any directory including a `cue.mod` folder. It makes for the prefix/root of importable packages (e.g, `universe.dagger.io` is a module)
+
+### Anonymous module (default)
+
+The default module name is an empty string, which means it's anonymous. That's when you don't need to import other packages inside your module. It represents most cases where someone has a Dagger plan and imports everything from third-party packages, like universe.
+
+### When to use a module
+
+You can add a different module name if you want to import other packages from inside your module. This is required so you have a prefix/root before your imports. This is when you want to split your code into multiple files.
+
+The module path becomes the import path prefix for packages in the module. This might be the name of a domain you own or another name you control (such as your company name), even your email, followed optionally by a descriptive path (e.g., project name).
+
+You import packages by prefixing the module name they're a part of, plus the path to them, relative to the `cue.mod` directory.
+
+```console
+root                    // <- this is a module because it includes a cue.mod dir
+|-- cue.mod
+|   |-- module.cue      // module: "example.com/pkg"
+|-- schemas
+|   |-- compose         // <- this is a package because it includes files with a package directive
+|   |   |-- spec.cue    // package compose
+...
+|-- plan.cue            // import "example.com/pkg/schemas/compose"
+```
+
+### Summary
+
+Consider the root module as the URL to access the root of your project. Any subfolder inside this module needs to have Cue files with a package name equivalent to the dirname. The filename inside each folder is not important, the package name is:
+
+```console
+$  ls
+bar       cue.mod   foo
+
+$ cat foo/main.cue
+cat foo/main.cue 
+package foo
+
+$ cat bar/anything.cue
+package bar
+```
+
+To reference any of the code lying inside each of these packages:
+
+```cue
+import(
+    "info@foo.bar/foo" // imports CUE code inside `/foo`
+    "info@foo.bar/bar" // imports CUE code inside `/bar`
+)
+```
+
+## Initializing the root module
+
+### Project non initialized
+
+Dagger holds a way to set a module name at project initialization: `dagger project init --name <NAME>`.
+
+As said above, the name has to at least follow the structure of a domain: `domain.extension` or `domain.extension/project`. Email addresses are also accepted, and the referenced domain doesn't necessarly have to exist.
+
+In our case, let's use a fake email address, for convenience purposes:
+
+```console
+dagger project init --name "info@foo.bar"
+```
+
+### Project already initialized
+
+Manually edit the `cue.mod/module.cue` with the desired name:
+
+```console
+$ cat cue.mod/module.cue
+module: "info@foo.bar"
+```
+
+## Creating packages in subdirectories
+
+### Practice
+
+Let's put everything above into practice:
+
+- Initialize the workdir environment
+
+```console
+mkdir daggerTest && cd daggerTest
+```
+
+- Initialize the project
+
+```console
+dagger project init --name "info@foo.bar"
+```
+
+- Update `dagger` and `universe` dependencies
+
+```console
+dagger project update
+```
+
+- Create 2 subfolders: `foo` and `bar`:
+
+```console
+mkdir foo bar
+```
+
+- Inside the `bar` folder, create a CUE file with any name and whose package is `bar` (same as parent directory):
+
+```cue title="bar/anything.cue"
+package bar
+
+#Test: "world"
+```
+
+- Inside the `foo` folder, create a CUE file with any name and whose package is `foo` (same as parent directory):
+
+```cue title="foo/main.cue"
+package foo
+
+import (
+        "universe.dagger.io/alpine"
+        "universe.dagger.io/bash"
+
+        "info@foo.bar/bar"
+)
+
+#Foo: {
+    _img: alpine.#Build & {
+            packages: {
+                    bash: _
+            }
+    }
+
+    bash.#Run & {
+        env: TEST: bar.#Test
+        always: true
+        input:  _img.output
+    }
+}
+```
+
+Our `#Foo` definition is just a wrapper around `bash.#Run` that prefills the `input` field with a `bash` image (`_img` key above). Please notice that the `_img` step needs to reside inside the `#Foo` scope as it needs to exist inside the `action` to be executed.
+
+For example, this doesn't work:
+
+```cue title="foo/main.cue"
+package foo
+
+import (
+        "universe.dagger.io/alpine"
+        "universe.dagger.io/bash"
+
+        "info@foo.bar/bar" // reference to the bar package
+)
+
+// _img is not being passed to the action as it lives outside #Foo
+_img: alpine.#Build & {
+        packages: {
+                bash: _
+        }
+}
+
+#Foo: bash.#Run & {
+    env: TEST: bar.#Test // here, we reference the #Test definition present in the bar directory
+    always: true
+    input:  _img.output
+}
+```
+
+- At the root of the project, create your `main.cue` file (file and package names are arbitrary):
+
+```cue title="main.cue"
+package main
+
+import (
+    "dagger.io/dagger"
+
+    "info@foo.bar/foo" // reference to the foo package
+)
+
+dagger.#Plan & {
+    actions: {
+        hello: foo.#Foo & {
+            script: contents: "echo \"Hello, inlined $TEST!\""
+        }
+    }
+}
+```
+
+### Recap
+
+We now have the directory structure shown below:
+
+```console
+$ tree  -L 2 .
+.
+├── bar
+│   └── anything.cue
+├── cue.mod
+│   ├── module.cue
+│   ├── pkg
+│   └── usr
+├── foo
+│   └── main.cue
+└── main.cue
+
+5 directories, 3 files
+```
+
+And the expected output is:
+
+```console
+$ dagger do hello --log-format plain
+4:20PM INF actions.hello._img._dag."0"._op | computing
+4:20PM INF actions.hello.script._write | computing
+4:20PM INF actions.hello.script._write | completed    duration=0s
+4:20PM INF actions.hello._img._dag."0"._op | completed    duration=1s
+4:20PM INF actions.hello._img._dag."1"._exec | computing
+4:20PM INF actions.hello._img._dag."1"._exec | #4 0.141 fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/main/x86_64/APKINDEX.tar.gz
+4:20PM INF actions.hello._img._dag."1"._exec | #4 0.366 fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/community/x86_64/APKINDEX.tar.gz
+4:20PM INF actions.hello._img._dag."1"._exec | #4 0.611 (1/4) Installing ncurses-terminfo-base (6.3_p20211120-r0)
+4:20PM INF actions.hello._img._dag."1"._exec | #4 0.674 (2/4) Installing ncurses-libs (6.3_p20211120-r0)
+4:20PM INF actions.hello._img._dag."1"._exec | #4 0.706 (3/4) Installing readline (8.1.1-r0)
+4:20PM INF actions.hello._img._dag."1"._exec | #4 0.728 (4/4) Installing bash (5.1.16-r0)
+4:20PM INF actions.hello._img._dag."1"._exec | #4 0.805 Executing bash-5.1.16-r0.post-install
+4:20PM INF actions.hello._img._dag."1"._exec | #4 0.817 Executing busybox-1.34.1-r3.trigger
+4:20PM INF actions.hello._img._dag."1"._exec | #4 0.900 OK: 8 MiB in 18 packages
+4:20PM INF actions.hello._img._dag."1"._exec | completed    duration=1s
+4:20PM INF actions.hello._exec | computing
+4:20PM INF actions.hello._exec | completed    duration=200ms
+4:20PM INF actions.hello._exec | #5 0.155 Hello, inlined world! # <== It was properly executed
+```

--- a/docs/guides/1239-making-reusable-package.md
+++ b/docs/guides/1239-making-reusable-package.md
@@ -1,0 +1,180 @@
+---
+slug: /1239/making-reusable-package
+displayed_sidebar: "0.2"
+---
+
+# Making reusable packages
+
+Whilst splitting your plan into several files is a good idea, you will sometimes need to create standalone packages aiming to be reusable and shared. Let's explore how to do that.
+
+## Packages, modules, and Dagger projects
+
+Understanding the difference between a package, a module and a Dagger project is an important distinction, as it will help better organizing your work:
+
+- **CUE Package**: directory with CUE files, each including a package definition on top, making it importable (e.g, `universe.dagger.io/docker` is a package, `universe.dagger.io/docker/cli` is another package);
+- **CUE Module**: directory with a `cue.mod` directory which makes for the prefix/root of importable packages (e.g, `universe.dagger.io` is a module);
+- **Dagger Project**: a CUE module that includes dagger plans and dependencies for running the dagger CLI.
+
+## End-to-End example
+
+Instead of splitting all of our files in the the same project with a module, we could directly make reusable components from our plan as standalone packages. For the sake of the exercise, we will use Github as a version control system, but it will work with any alternative.
+
+### Create the base Dagger project
+
+First, let's start with a basic plan:
+
+- Create the root directory
+
+```console
+mkdir rootProject && cd rootProject
+```
+
+- Initialize the project
+
+```console
+dagger project init
+```
+
+- Update `dagger` and `universe` dependencies
+
+```console
+dagger project update
+```
+
+- At the root of the project, create your `main.cue` file (file and package names are arbitrary):
+
+```cue title="rootProject/main.cue"
+package main
+
+import (
+    "dagger.io/dagger"
+)
+
+dagger.#Plan & {
+    actions: {
+        hello: #Run & {
+            script: contents: "echo \"Hello!\""
+        }
+    }
+}
+```
+
+We are currently calling a `#Run` definition that doesn't exist yet. We will declare it in a new package right below: it will wrap the `bash.#Run` definition with a custom image.
+
+### Create the package
+
+Let's see how to create the `#Run` definition in its own package:
+
+- Create a completely new directory next to `rootProject`: it will be a new git repository.
+You can directly `git clone` or initialize a new one with:
+
+```console
+cd .. && mkdir personal && cd personal && git init
+```
+
+- At the root of this new folder, create the CUE file that will contain the `#Run` package. The name of the file is not important, but the package name shall follow the name of the remote repo (best practice convention):
+
+```cue title=personal/main.cue
+package personal
+
+import(
+  "universe.dagger.io/alpine"
+  "universe.dagger.io/bash"
+)
+
+#Run: {
+    _img: alpine.#Build & {
+        packages: bash: _
+    }
+
+    bash.#Run & {
+        always: true
+        input:  _img.output
+    }
+}
+```
+
+You should now have this file and directory structure:
+
+```console
+$ tree -L 2
+.
+├── personal
+│   └── main.cue
+└── rootProject
+    ├── cue.mod
+    └── main.cue
+
+3 directories, 2 files
+```
+
+### Link package to the project
+
+- We first need to include the newly created package in the project. In order to do that, we will create a symlink similar to what `dagger project update` would create once we push the package on Github:
+
+```console
+$ ls -l
+total 0
+drwxr-xr-x  4 home  wheel  128  9 mai 16:04 personal
+drwxr-xr-x  4 home  wheel  128  9 mai 16:01 rootProject
+
+$ mkdir -p rootProject/cue.mod/pkg/github.com/your-username/
+
+$ ln -s "$(pwd)/personal" "$(pwd)/rootProject/cue.mod/pkg/github.com/your-username/personal"
+```
+
+When using your package from `dagger project update` in the `rootProject` directory, the actual packager manager would copy the files from the repository in the `rootProject/cue.mod/pkg/github.com/your-username/personal` folder.
+
+- We then need to change the project's `main.cue` to call the `#Run` definition in the `personal` package that we just built:
+
+```cue title="rootProject/main.cue"
+package main
+
+import (
+    "dagger.io/dagger"
+
+    "github.com/your-username/personal" // import personal package
+)
+
+dagger.#Plan & {
+    actions: {
+        hello: personal.#Run & { // reference #Run definition from personal package imported above
+            script: contents: "echo \"Hello!\""
+        }
+    }
+}
+```
+
+### Run the project
+
+Now that we have connected all the dots, let's run our plan to see if it works:
+
+```console
+$ cd rootProject
+
+$ dagger do hello --log-format plain
+4:42PM INF actions.hello.script._write | computing
+4:42PM INF actions.hello._img._dag."0"._op | computing
+4:42PM INF actions.hello.script._write | completed    duration=0s
+4:42PM INF actions.hello._img._dag."0"._op | completed    duration=0s
+4:42PM INF actions.hello._img._dag."1"._exec | computing
+4:42PM INF actions.hello._img._dag."1"._exec | completed    duration=0s
+4:42PM INF actions.hello._exec | computing
+4:42PM INF actions.hello._exec | completed    duration=200ms
+4:42PM INF actions.hello._exec | #5 0.123 Hello!
+```
+
+### Push package on repository
+
+Now that we made sure we correctly built our package, we only need to push it to the repository:
+
+- Add
+- Commit
+- Tag
+- Push
+
+On another project, you will directly be able to retrieve the `personal` package using the `dagger project update url@tag` command.
+
+<u>Reminder:</u>
+
+*The name of the repository should follow the name of the created folder and the package name (`personal` in the above example)*

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -71,6 +71,7 @@ module.exports = {
         "guides/go-ci",
         "guides/persistent-cache",
         "guides/project-file-organization",
+        "guides/making-reusable-package",
       ],
     },
     {

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -16,9 +16,9 @@ module.exports = {
       label: "Introduction",
       collapsible: false,
       items: [
-	      "introduction/what",
-	      "introduction/vs",
-	],
+        "introduction/what",
+        "introduction/vs",
+      ],
       link: {
         type: 'doc',
         id: 'introduction/index'
@@ -66,10 +66,11 @@ module.exports = {
         "guides/custom-buildkit",
         "guides/self-signed-certificates",
         "guides/pushing-plan-dependencies",
-	"guides/handling-outputs",
-      	"guides/migrate-from-dagger-0.1",
+        "guides/handling-outputs",
+        "guides/migrate-from-dagger-0.1",
         "guides/go-ci",
-        "guides/persistent-cache"
+        "guides/persistent-cache",
+        "guides/project-file-organization",
       ],
     },
     {


### PR DESCRIPTION
Fixes #2220
Fixes #2186
Fixes #2340

Doc explaining how to install/update dagger/external packages.
It contains 4 docs all inter-related. This should give our users enough knowledge on the subject to be autonomous

Signed-off-by: guillaume