### PR TITLE
feat: allow http modules

### DIFF
--- a/cmd/dagger/cmd/project/update.go
+++ b/cmd/dagger/cmd/project/update.go
@@ -77,6 +77,7 @@ var updateCmd = &cobra.Command{
 func init() {
 	updateCmd.Flags().String("private-key-file", "", "Private ssh key")
 	updateCmd.Flags().String("private-key-password", "", "Private ssh key password")
+	updateCmd.Flags().String("authorization-header", "", "The authorization header to send for HTTP")
 	updateCmd.Flags().BoolP("update", "u", false, "Update specified package")
 
 	if err := viper.BindPFlags(updateCmd.Flags()); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Microsoft/go-winio v0.5.2
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.6.3-0.20220401172941-5ff8fce1fcc6
+	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/docker/buildx v0.8.2
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/emicklei/proto v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -455,6 +455,7 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
+github.com/cyphar/filepath-securejoin v0.2.3 h1:YX6ebbZCZP7VkM3scTTokDgBL2TY741X51MTk3ycuNI=
 github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1SMSibvLzxjeJLnrYEVLULFNiHY9YfQ=
 github.com/d2g/dhcp4client v1.0.0/go.mod h1:j0hNfjhrt2SxUOw55nL0ATM/z4Yt3t2Kd1mW34z5W5s=

--- a/mod/http_repo.go
+++ b/mod/http_repo.go
@@ -1,0 +1,86 @@
+package mod
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	securejoin "github.com/cyphar/filepath-securejoin"
+)
+
+func download(ctx context.Context, require *Require, dir string, auth string) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", require.cloneRepo, nil)
+	if err != nil {
+		return fmt.Errorf("error downloading %s: %w", require.cloneRepo, err)
+	}
+
+	if auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("error downloading %s: %w", require.cloneRepo, err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != 200 {
+		return fmt.Errorf("error downloading %s: status code %d", require.cloneRepo, response.StatusCode)
+	}
+
+	stream, err := gzip.NewReader(response.Body)
+	if err != nil {
+		return err
+	}
+
+	return extractTar(stream, dir)
+}
+
+func extractTar(stream io.Reader, dir string) error {
+	tarReader := tar.NewReader(stream)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		if header.Typeflag != tar.TypeDir && header.Typeflag != tar.TypeReg {
+			continue
+		}
+
+		path, err := securejoin.SecureJoin(dir, header.Name)
+		if err != nil {
+			return err
+		}
+
+		info := header.FileInfo()
+		if info.IsDir() {
+			if err = os.MkdirAll(path, info.Mode()); err != nil {
+				return err
+			}
+			continue
+		}
+
+		parent := filepath.Dir(path)
+		if err = os.MkdirAll(parent, 0o777); err != nil {
+			return err
+		}
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, info.Mode())
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		_, err = io.CopyN(file, tarReader, 100*1024*1024)
+		if err != nil && err != io.EOF {
+			return err
+		}
+	}
+	return nil
+}

--- a/mod/http_repo_test.go
+++ b/mod/http_repo_test.go
@@ -1,0 +1,41 @@
+package mod
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestDownload(t *testing.T) {
+	cases := []struct {
+		name    string
+		require Require
+		auth    string
+	}{
+		{
+			name: "download archives",
+			require: Require{
+				cloneRepo: "https://github.com/dagger/dagger/archive/refs/tags/v0.2.7.tar.gz",
+				clonePath: "",
+				version:   "main",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tmpDir, err := ioutil.TempDir("", "clone")
+			if err != nil {
+				t.Fatal("error creating tmp dir")
+			}
+
+			defer os.Remove(tmpDir)
+
+			err = download(context.TODO(), &c.require, tmpDir, c.auth)
+			if err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/mod/require_test.go
+++ b/mod/require_test.go
@@ -148,6 +148,66 @@ func TestParseArgument(t *testing.T) {
 				version: "v5",
 			},
 		},
+		{
+			name: "HTTPS Dagger repo",
+			in:   "https://github.com/dagger/dagger#/archive/refs/tags/v0.2.7.tar.gz",
+			want: &Require{
+				repo:      "github.com/dagger/dagger",
+				path:      "",
+				version:   "",
+				cloneRepo: "https://github.com/dagger/dagger/archive/refs/tags/v0.2.7.tar.gz",
+			},
+		},
+		{
+			name: "HTTPS Dagger repo without hash-slash",
+			in:   "https://github.com/dagger/dagger#archive/refs/tags/v0.2.7.tar.gz",
+			want: &Require{
+				repo:      "github.com/dagger/dagger",
+				path:      "",
+				version:   "",
+				cloneRepo: "https://github.com/dagger/dagger/archive/refs/tags/v0.2.7.tar.gz",
+			},
+		},
+		{
+			name: "HTTP Dagger repo",
+			in:   "http://github.com/dagger/dagger#/archive/refs/tags/v0.2.7.tar.gz",
+			want: &Require{
+				repo:      "github.com/dagger/dagger",
+				path:      "",
+				version:   "",
+				cloneRepo: "http://github.com/dagger/dagger/archive/refs/tags/v0.2.7.tar.gz",
+			},
+		},
+		{
+			name: "HTTP Dagger repo without hash-slash",
+			in:   "http://github.com/dagger/dagger#archive/refs/tags/v0.2.7.tar.gz",
+			want: &Require{
+				repo:      "github.com/dagger/dagger",
+				path:      "",
+				version:   "",
+				cloneRepo: "http://github.com/dagger/dagger/archive/refs/tags/v0.2.7.tar.gz",
+			},
+		},
+		{
+			name: "HTTP Dagger repo with at",
+			in:   "http://test:foo@github.com/dagger/dagger#/archive/refs/tags/v0.2.7.tar.gz",
+			want: &Require{
+				repo:      "github.com/dagger/dagger",
+				path:      "",
+				version:   "",
+				cloneRepo: "http://test:foo@github.com/dagger/dagger/archive/refs/tags/v0.2.7.tar.gz",
+			},
+		},
+		{
+			name: "HTTP Dagger repo with port",
+			in:   "http://github.com:1234/dagger/dagger#/archive/refs/tags/v0.2.7.tar.gz",
+			want: &Require{
+				repo:      "github.com:1234/dagger/dagger",
+				path:      "",
+				version:   "",
+				cloneRepo: "http://github.com:1234/dagger/dagger/archive/refs/tags/v0.2.7.tar.gz",
+			},
+		},
 		// TODO: Add more tests for ports!
 	}
 
@@ -172,6 +232,14 @@ func TestParseArgument(t *testing.T) {
 
 			if got.version != c.want.version {
 				t.Errorf("versions differ (%q): want %s, got %s", c.in, c.want.version, got.version)
+			}
+
+			if c.want.cloneRepo != "" && got.cloneRepo != c.want.cloneRepo {
+				t.Errorf("clone repos differ (%q): want %s, got %s", c.in, c.want.cloneRepo, got.cloneRepo)
+			}
+
+			if c.want.clonePath != "" && got.clonePath != c.want.clonePath {
+				t.Errorf("clone paths differ (%q): want %s, got %s", c.in, c.want.clonePath, got.clonePath)
 			}
 		})
 	}


### PR DESCRIPTION
This allows `project update` to download .tar.gz modules from an HTTP server. The module name is derived from the host and path portions of the URL. The fragment portion of the URL is used to define the actual download path. For example, `https://github.com/dagger/dagger#/archive/refs/tags/v0.2.7.tar.gz` results in the `github.com/dagger/dagger` module name and `https://github.com/dagger/dagger/archive/refs/tags/v0.2.7.tar.gz` download URL.

Support for providing a _full_ authentication header has also been added. This is done with the `--authorization-header` flag. For example, `--authorization-header 'token ghp_...'`.

Finally, some of the require_tests were broken. The tests seemed to represent desired behavior, so I updated`parseDaggerRepoName`.

Signed-off-by: Jonathan Dickinson