### PR TITLE
feat: add resolveMode for `core.Pull`

### DIFF
--- a/pkg/dagger.io/dagger/core/image.cue
+++ b/pkg/dagger.io/dagger/core/image.cue
@@ -76,6 +76,9 @@ import (
 		secret:   dagger.#Secret
 	}
 
+	// When to pull the image
+	resolveMode: *"default" | "forcePull" | "preferLocal"
+
 	// Root filesystem of downloaded image
 	output: dagger.#FS @dagger(generated)
 

--- a/pkg/universe.dagger.io/docker/pull.cue
+++ b/pkg/universe.dagger.io/docker/pull.cue
@@ -11,6 +11,9 @@ import (
 	// Source ref.
 	source: #Ref
 
+	// When to pull the image
+	resolveMode: *"default" | "forcePull" | "preferLocal"
+
 	// Registry authentication
 	auth?: {
 		username: string
@@ -18,7 +21,8 @@ import (
 	}
 
 	_op: core.#Pull & {
-		"source": source
+		"source":      source
+		"resolveMode": resolveMode
 		if auth != _|_ {
 			"auth": auth
 		}


### PR DESCRIPTION
This exposes the LLB pull policy to `core.#Pull`. This allows the build script to explicitly indicate whether a new image should be downloaded. Only `preferLocal` is tested, as the other two options are not deterministic. Example:

```cue
core.#Pull & {
    source: "myimage:latest"
    resolveMode: "preferLocal"
}
```

The three options are `default`, `preferLocal`, and `forcePull`.

Signed-off-by: Jonathan Dickinson