### PR TITLE
fix: should show cue error details when WriteFile contents not set

### DIFF
--- a/plan/task/writefile.go
+++ b/plan/task/writefile.go
@@ -28,18 +28,19 @@ func (t *writeFileTask) Run(ctx context.Context, pctx *plancontext.Context, s *s
 		return nil, err
 	}
 
-	switch kind := v.Lookup("contents").Kind(); kind {
+	contentsVal := v.Lookup("contents")
+	switch kind := contentsVal.Kind(); kind {
 	// TODO: support bytes?
 	// case cue.BytesKind:
 	// 	contents, err = v.Lookup("contents").Bytes()
 	case cue.StringKind:
 		var str string
-		str, err = v.Lookup("contents").String()
+		str, err = contentsVal.String()
 		if err == nil {
 			contents = []byte(str)
 		}
 	case cue.BottomKind:
-		err = fmt.Errorf("%s: WriteFile contents is not set", path)
+		err = fmt.Errorf("%s: WriteFile contents is not set:\n\n%s", path, compiler.Err(contentsVal.Cue().Err()))
 	default:
 		err = fmt.Errorf("%s: unhandled data type in WriteFile: %s", path, kind)
 	}


### PR DESCRIPTION
Now could show clear errors why contents is not set

```shell
11:20AM FTL system | failed to execute plan: task failed: actions.k3s.amd64._airgap._export._kubepkg_spec_json_file: kubepkg.json: WriteFile contents is not set:
actions.k3s.amd64._airgap._export.spec.spec.manifests.registry.deployments."container-registry".spec.template.spec.containers.0.image: invalid interpolation: unresolved disjunction "latest" | string | "93f3e3d" (type string):
    components/kubepkg/registry.cue:43:21
```