### PR TITLE
ci: fix typo in bin output field

### DIFF
--- a/ci.cue
+++ b/ci.cue
@@ -26,7 +26,7 @@ dagger.#Plan & {
 		contents: dagger.#FS
 		exclude: ["website"]
 	}
-	client: filesystem: "./bin": write: contents: actions.build.output
+	client: filesystem: "./bin": write: contents: actions.build."go".output
 
 	actions: {
 		_source: client.filesystem["."].read.contents


### PR DESCRIPTION
Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Without this change my PR CI runs are getting errors like these: https://github.com/dagger/dagger/runs/6164267748?check_suite_focus=true