### PR TITLE
Use progress group to track components of vertices.

### DIFF
--- a/plan/task/dockerfile.go
+++ b/plan/task/dockerfile.go
@@ -77,6 +77,7 @@ func (t *DockerfileTask) Run(ctx context.Context, pctx *plancontext.Context, s *
 			llb.Scratch().File(
 				llb.Mkfile("/Dockerfile", 0o644, []byte(contents)),
 			),
+			withCustomName(v, "Create inline Dockerfile"),
 		)
 		if err != nil {
 			return nil, err
@@ -111,11 +112,31 @@ func (t *DockerfileTask) Run(ctx context.Context, pctx *plancontext.Context, s *
 
 	solvedRef := ref
 	if ref != nil {
+		// get the LLB for the build specified by the Dockerfile
 		st, err := ref.ToState()
 		if err != nil {
 			return nil, err
 		}
 
+		// Override the progress group of every LLB vertex in the DAG.
+		// FIXME: this can't be done in a normal way because Buildkit doesn't currently
+		// allow overriding the metadata of DefinitionOp. See this PR and comment:
+		// https://github.com/moby/buildkit/pull/2819
+		def, err := st.Marshal(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for dgst, metadata := range def.Metadata {
+			metadata.ProgressGroup = progressGroup(v)
+			def.Metadata[dgst] = metadata
+		}
+		defOp, err := llb.NewDefinitionOp(def.ToPB())
+		if err != nil {
+			return nil, err
+		}
+		st = llb.NewState(defOp.Output())
+
+		// get the result of the build
 		solvedRef, err = s.Solve(ctx, st, pctx.Platform.Get())
 		if err != nil {
 			return nil, err

--- a/plan/task/pull.go
+++ b/plan/task/pull.go
@@ -75,7 +75,7 @@ func (c *pullTask) Run(ctx context.Context, pctx *plancontext.Context, s *solver
 	// Load image metadata and convert to to LLB.
 	platform := pctx.Platform.Get()
 	image, digest, err := s.ResolveImageConfig(ctx, ref.String(), llb.ResolveImageConfigOpt{
-		LogName:     vertexNamef(v, "load metadata for %s", ref.String()),
+		LogName:     resolveImageConfigLogName(v, "load metadata for %s", ref.String()),
 		Platform:    &platform,
 		ResolveMode: resolveMode.String(),
 	})

--- a/plan/task/util.go
+++ b/plan/task/util.go
@@ -3,20 +3,49 @@ package task
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/solver/pb"
 	"go.dagger.io/dagger/compiler"
 )
 
-func vertexNamef(v *compiler.Value, format string, a ...interface{}) string {
-	prefix := fmt.Sprintf("@%s@", v.Path().String())
+func withCustomName(v *compiler.Value, format string, a ...interface{}) llb.ConstraintsOpt {
+	pg := progressGroup(v)
+	return combineConstraints(
+		llb.ProgressGroup(pg.Id, pg.Name, pg.Weak),
+		llb.WithCustomName(fmt.Sprintf(format, a...)),
+	)
+}
+
+func progressGroup(v *compiler.Value) *pb.ProgressGroup {
+	return &pb.ProgressGroup{Id: v.Path().String()}
+}
+
+// FIXME: ResolveImageConfig is missing support for setting ProgressGroup, so we have to
+// fallback to putting both the component and vertex name into the name. This needs to
+// be fixed upstream in Buildkit.
+func resolveImageConfigLogName(v *compiler.Value, format string, a ...interface{}) string {
+	pg := progressGroup(v)
+	prefix := fmt.Sprintf("@%s@", pg.Id)
 	name := fmt.Sprintf(format, a...)
 	return prefix + " " + name
 }
 
-func withCustomName(v *compiler.Value, format string, a ...interface{}) llb.ConstraintsOpt {
-	return llb.WithCustomName(vertexNamef(v, format, a...))
+func ParseResolveImageConfigLog(name string) (string, string) {
+	// Pattern: `@name@ message`. Minimal length is len("@X@ ")
+	if len(name) < 2 || !strings.HasPrefix(name, "@") {
+		return "", name
+	}
+
+	prefixEndPos := strings.Index(name[1:], "@")
+	if prefixEndPos == -1 {
+		return "", name
+	}
+
+	component := name[1 : prefixEndPos+1]
+	return component, name[prefixEndPos+3:]
 }
 
 func clientFilePath(path string) (string, error) {
@@ -25,4 +54,39 @@ func clientFilePath(path string) (string, error) {
 		return "", err
 	}
 	return filepath.Abs(expanded)
+}
+
+func combineConstraints(cs ...llb.ConstraintsOpt) llb.ConstraintsOpt {
+	return constraintsOptFunc(func(m *llb.Constraints) {
+		for _, c := range cs {
+			c.SetConstraintsOption(m)
+		}
+	})
+}
+
+// FIXME: this is in Buildkit too but isn't public, should be made so
+type constraintsOptFunc func(m *llb.Constraints)
+
+func (fn constraintsOptFunc) SetConstraintsOption(m *llb.Constraints) {
+	fn(m)
+}
+
+func (fn constraintsOptFunc) SetRunOption(ei *llb.ExecInfo) {
+	fn(&ei.Constraints)
+}
+
+func (fn constraintsOptFunc) SetLocalOption(li *llb.LocalInfo) {
+	fn(&li.Constraints)
+}
+
+func (fn constraintsOptFunc) SetHTTPOption(hi *llb.HTTPInfo) {
+	fn(&hi.Constraints)
+}
+
+func (fn constraintsOptFunc) SetImageOption(ii *llb.ImageInfo) {
+	fn(&ii.Constraints)
+}
+
+func (fn constraintsOptFunc) SetGitOption(gi *llb.GitInfo) {
+	fn(&gi.Constraints)
 }


### PR DESCRIPTION
This change replaces the use of `@<component name>@-<name>` for tracking
which cue fields progress status updates from Buildkit should be logged
with. Now, the ProgressGroup metadata field is used to track the
component part (i.e. cue field) and the vertex name can just be the name
again.

This fixes the issue where Dockerfile builds showed up under the
"system" group. It also is more performant as statuses don't all need to
be parsed anymore.

The only exception that remains are the progress logs written for
ResolveImageConfig calls. This Buildkit API is missing support for
ProgressGroup right now, so it still uses the '@%s@' mechanism as
before. This can be fixed once Buildkit has been updated upstream to
support the field.

This exception includes our own call to ResolveImageConfig but also one
done by the Dockerfile frontend. For this reason, some of the previous
changes that have special handling for logging the Dockerfile task are
left in place for now.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Helps but doesn't totally address #2224 because of the remaining issues with ResolveImageConfig.

Opened an issue in Buildkit about supporting ProgressGroup in ResolveImageConfig. I suspect it should be a very easy change, but will need to wait for upstream to release it: https://github.com/moby/buildkit/issues/2826