### PR TITLE
ci: fix cache key creation on main

### DIFF
--- a/.github/workflows/dagger-ci.yml
+++ b/.github/workflows/dagger-ci.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           echo "DAGGER_CACHE_TO=type=gha,mode=max,scope=${{env.DAGGER_CACHE_BASE}}-main" >> $GITHUB_ENV
           echo "DAGGER_CACHE_FROM=type=gha,scope=${{env.DAGGER_CACHE_BASE}}-main" >> $GITHUB_ENV
-        if: ${{ github.event_name == 'push' && github.base_ref == 'main' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Sets env vars on pull request
         run: |

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           echo "DAGGER_CACHE_TO=type=gha,mode=max,scope=${{env.DAGGER_CACHE_BASE}}-main" >> $GITHUB_ENV
           echo "DAGGER_CACHE_FROM=type=gha,scope=${{env.DAGGER_CACHE_BASE}}-main" >> $GITHUB_ENV
-        if: ${{ github.event_name == 'push' && github.base_ref == 'main' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Sets env vars on pull request
         run: |

--- a/.github/workflows/test-universe.yml
+++ b/.github/workflows/test-universe.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           echo "DAGGER_CACHE_TO=type=gha,mode=max,scope=${{env.DAGGER_CACHE_BASE}}-main" >> $GITHUB_ENV
           echo "DAGGER_CACHE_FROM=type=gha,scope=${{env.DAGGER_CACHE_BASE}}-main" >> $GITHUB_ENV
-        if: ${{ github.event_name == 'push' && github.base_ref == 'main' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Sets env vars on pull request
         run: |


### PR DESCRIPTION
There was a typo in `Sets env var on push to main` on condition statement.
Branch was checked with `github.base_ref == 'main'` but the correct condition
was `github.ref == 'refs/heads/main'`

CI should now works on main and in PR

Related to: #2305 

Tested on:  https://github.com/TomChv/jsonrpc2/runs/6173846049?check_suite_focus=true

Signed-off-by: Vasek - Tom C <tom.chauveau@epitech.eu>