### PR TITLE
Fix tty log panic issue

### DIFF
--- a/cmd/dagger/logger/tty.go
+++ b/cmd/dagger/logger/tty.go
@@ -332,7 +332,7 @@ func (c *TTYOutput) printGroup(group *Group, width, maxLines int) int {
 	case task.StateComputing:
 		printEvents = group.Events
 		// for computing tasks, show only last N
-		if len(printEvents) > maxLines {
+		if len(printEvents) > maxLines && maxLines >= 0 {
 			printEvents = printEvents[len(printEvents)-maxLines:]
 		}
 	case task.StateCanceled:


### PR DESCRIPTION
I hit this issue when I was manually testing #2294.
For more details, see : https://github.com/dagger/dagger/issues/1728#issuecomment-1109727011

By adding a condition when `maxLines` goes negative, I didn't hit that issue anymore. 

Resolves: #1728

Signed-off-by: Vasek - Tom C <tom.chauveau@epitech.eu>