### PR TITLE
Remove entrypoint from `bash.#Run`

### DIFF
--- a/pkg/universe.dagger.io/bash/bash.cue
+++ b/pkg/universe.dagger.io/bash/bash.cue
@@ -42,10 +42,12 @@ import (
 	_mountpoint: "/bash/scripts"
 
 	docker.#Run & {
-		entrypoint: ["/bin/bash"]
+		// ignore entrypoint from image config as it can
+		// create issues if it's not exec'ing to "$@"
+		entrypoint: []
 		command: {
-			name:   "\(_mountpoint)/\(script._filename)"
-			"args": args
+			name:   "bash"
+			"args": ["\(_mountpoint)/\(script._filename)"] + args
 			// FIXME: make default flags overrideable
 			flags: {
 				"--norc": true


### PR DESCRIPTION
Revert #2289

Flags were broken because they are inserted between `name` and `args`. To ignore an entrypoint from image config, just override with an empty entrypoint. Don’t move the command `name` there.

Signed-off-by: Helder Correia