### PR TITLE
ci: goreleaser: exclude `deps-dev` commits from changelog

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,6 +54,7 @@ changelog:
       - "^infra:"
       - "^chore:"
       - "^build\\(deps\\):"
+      - "^build\\(deps-dev\\):"
       - "^Merge pull request"
   groups:
     - title: Breaking Changes


### PR DESCRIPTION
This excludes `build(deps-dev)` in addition to `build(deps)` commits
from the changelog. `deps-dev` affect yarn (`package.json`) dev
dependencies (i.e. the docs website)
