### PR TITLE
Don't redact secret if it's an empty string.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -266,7 +266,9 @@ func (c *Client) logSolveStatus(ctx context.Context, pctx *plancontext.Context, 
 
 		s := fmt.Sprintf(format, a...)
 		for _, secret := range secrets {
-			s = strings.ReplaceAll(s, secret.PlainText(), "***")
+			if secretText := secret.PlainText(); secretText != "" {
+				s = strings.ReplaceAll(s, secretText, "***")
+			}
 		}
 		return s
 	}

--- a/tests/tasks.bats
+++ b/tests/tasks.bats
@@ -110,7 +110,8 @@ setup() {
 }
 
 @test "task: #NewSecret" {
-    "$DAGGER" "do" -p ./tasks/newsecret/newsecret.cue verify
+    run "$DAGGER" "do" -p ./tasks/newsecret/newsecret.cue verify
+    assert_line --partial HELLOWORLD
 }
 
 @test "task: #TrimSecret" {


### PR DESCRIPTION
Before this, a secret which ended up being set to an empty string would
still be "redacted" using strings.ReplaceAll, which has the (surprising)
behavior of putting the replacement chars around+between every char in
the string being replaced.

This meant that if you ended up with an empty secret, then all your logs
would look like `***t***h***i***s***`.

This change just skips redacting if the string is "". I also considered
whether it should be an error for a secret to be an empty string, but
that's backwards incompatible and I can imagine scenarios where users
could want that to not be an error. E.g. they try to read a secret from
somewhere, it ends up empty and they then fallback to a secret from a
different source.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Noticed this while working on something else. Didn't find an existing issue for it but let me know if I missed one.