### PR TITLE
Experimental: improved yarn package

### DIFF
--- a/pkg/universe.dagger.io/x/solomon@dagger.io/yarn/test/data/bar/package.json
+++ b/pkg/universe.dagger.io/x/solomon@dagger.io/yarn/test/data/bar/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "test",
+	"main": "index.js",
+	"license": {
+	  "type": "Apache-2.0",
+	  "url": "https://opensource.org/licenses/apache2.0.php"
+	},
+	"scripts": {
+		"build": "mkdir -p ./build && cp /.env ./build/env"
+	}
+  }
+  

--- a/pkg/universe.dagger.io/x/solomon@dagger.io/yarn/test/data/foo/package.json
+++ b/pkg/universe.dagger.io/x/solomon@dagger.io/yarn/test/data/foo/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test",
+  "main": "index.js",
+  "license": {
+    "type": "Apache-2.0",
+    "url": "https://opensource.org/licenses/apache2.0.php"
+  },
+  "scripts": {
+	  "build": "mkdir -p ./build && echo output > ./build/test && touch .env && cp .env ./build/"
+  }
+}

--- a/pkg/universe.dagger.io/x/solomon@dagger.io/yarn/test/test.bats
+++ b/pkg/universe.dagger.io/x/solomon@dagger.io/yarn/test/test.bats
@@ -1,0 +1,9 @@
+setup() {
+    load '../../../../bats_helpers'
+
+    common_setup
+}
+
+@test "yarn" {
+    dagger "do" test
+}

--- a/pkg/universe.dagger.io/x/solomon@dagger.io/yarn/test/test.cue
+++ b/pkg/universe.dagger.io/x/solomon@dagger.io/yarn/test/test.cue
@@ -1,0 +1,119 @@
+package yarn
+
+import (
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+
+	"universe.dagger.io/docker"
+	"universe.dagger.io/git"
+)
+
+// Tests for the yarn package, grouped together in a reusable action.
+#Tests: {
+	// Test data, packaged alongside this cue file
+	data: {
+		contents: _load.output
+
+		_load: core.#Source & {
+			path: "./data/foo"
+		}
+	}
+
+	// Run yarn.#Build
+	simple: {
+		build: #Build & {
+			source: data.contents
+		}
+
+		verify: #AssertFile & {
+			input:    build.output
+			path:     "test"
+			contents: "output\n"
+		}
+	}
+
+	// Run yarn.#Build with a custom project name
+	customName: {
+		build: #Build & {
+			project: "My Build"
+			source:  data.contents
+		}
+		verify: #AssertFile & {
+			input:    build.output
+			path:     "test"
+			contents: "output\n"
+		}
+	}
+
+	// Build mdn/todo-react
+	todoreact: {
+		pull: git.#Pull & {
+			remote: "https://github.com/mdn/todo-react"
+			ref:    "4c1ad2bc5d50f96265693be50997c306081b0964"
+		}
+		install: #Run & {
+			source: pull.output
+			args: ["install"]
+		}
+		build: #Run & {
+			source: pull.output
+			args: ["run", "build"]
+			requires: [install.code]
+		}
+		verify: #AssertFile & {
+			input: build.output
+			path:  "robots.txt"
+			contents: """
+				# https://www.robotstxt.org/robotstxt.html
+				User-agent: *
+				Disallow:
+
+				"""
+		}
+	}
+
+	// Run yarn.#Build with a custom docker image
+	customImage: {
+		buildImage: docker.#Build & {
+			steps: [
+				docker.#Pull & {
+					source: "alpine"
+				},
+				docker.#Run & {
+					command: {
+						name: "apk"
+						args: ["add", "yarn", "bash"]
+					}
+				},
+			]
+		}
+
+		image: build.output
+
+		build: #Build & {
+			source: data.contents
+			container: #input: buildImage.output
+		}
+	}
+}
+
+// Make an assertion on the contents of a file
+#AssertFile: {
+	input:    dagger.#FS
+	path:     string
+	contents: string
+
+	_read: core.#ReadFile & {
+		"input": input
+		"path":  path
+	}
+
+	actual: _read.contents
+
+	// Assertion
+	contents: actual
+}
+
+dagger.#Plan & {
+	actions: test: #Tests
+}

--- a/pkg/universe.dagger.io/x/solomon@dagger.io/yarn/yarn.cue
+++ b/pkg/universe.dagger.io/x/solomon@dagger.io/yarn/yarn.cue
@@ -1,0 +1,101 @@
+// Use [Yarn](https://yarnpkg.com) in a Dagger action
+package yarn
+
+import (
+	"strings"
+
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+
+	"universe.dagger.io/alpine"
+	"universe.dagger.io/bash"
+)
+
+#Build: #Run & {
+	args: *["run", "build"] | _
+}
+
+// Run a yarn command or script
+#Run: {
+	// Source code to build
+	source: dagger.#FS
+
+	// Arguments to yarn
+	args: [...string]
+
+	// Project name, used for cache scoping
+	project: string | *"default"
+
+	// Path of the yarn script's output directory
+	// May be absolute, or relative to the workdir
+	outputDir: string | *"./build"
+
+	// Output directory
+	output: container.export.directories."/output"
+
+	// Logs produced by the yarn script
+	logs: container.export.files."/logs"
+
+	// Other actions required to run before this one
+	requires: [...string]
+
+	// Yarn exit code.
+	code: container.export.files."/code"
+
+	container: bash.#Run & {
+		input:  _image.output
+		_image: alpine.#Build & {
+			packages: {
+				bash: {}
+				yarn: {}
+				git: {}
+			}
+		}
+
+		"args":  args
+		workdir: "/src"
+		mounts: Source: {
+			dest:     "/src"
+			contents: source
+		}
+		script: contents: """
+			set -x
+			yarn "$@" | tee /logs
+			echo $$ > /code
+			if [ -e "$YARN_OUTPUT_FOLDER" ]; then
+				mv "$YARN_OUTPUT_FOLDER" /output
+			else
+				mkdir /output
+			fi
+			"""
+		export: {
+			directories: "/output": dagger.#FS
+			files: {
+				"/logs": string
+				"/code": string
+			}
+		}
+
+		// Setup caching
+		env: {
+			YARN_CACHE_FOLDER:  "/cache/yarn"
+			YARN_OUTPUT_FOLDER: outputDir
+			REQUIRES:           "\(strings.Join(requires, "_"))"
+		}
+		mounts: {
+			"Yarn cache": {
+				dest:     "/cache/yarn"
+				contents: core.#CacheDir & {
+					id: "\(project)-yarn"
+				}
+			}
+			"NodeJS cache": {
+				dest:     "/src/node_modules"
+				type:     "cache"
+				contents: core.#CacheDir & {
+					id: "\(project)-nodejs"
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
An experimental alternative to the official `yarn` package. This is based on my work spinning out and cleaning up [our todoapp example](https://github.com/dagger/dagger/tree/main/pkg/universe.dagger.io/examples/todoapp). For now, that work is happening [on a personal repo](https://github.com/shykes/todoapp). This package is extracted from that repo, with some light clean up + tests.