### PR TITLE
tty logger: fix group status for hidden sub-actions

### DIFF
--- a/plan/task/task.go
+++ b/plan/task/task.go
@@ -31,7 +31,7 @@ var (
 type State int8
 
 func (s State) String() string {
-	return [...]string{"computing", "cancelled", "failed", "completed"}[s]
+	return [...]string{"computing", "completed", "cancelled", "failed"}[s]
 }
 
 func ParseState(s string) (State, error) {
@@ -55,9 +55,9 @@ func (s State) CanTransition(t State) bool {
 
 const (
 	StateComputing State = iota
+	StateCompleted
 	StateCanceled
 	StateFailed
-	StateCompleted
 )
 
 type NewFunc func() Task


### PR DESCRIPTION
This adds a group counter used to mark log groups as completed.

The problem is when having `actions.test._a` and `actions.test_b`, as
soon as one completes it will mark the entire `actions.test` as
completed.

This can be repro'ed using our own CI (e.g. `dagger do test`)

