### PR TITLE
Revert specific case to handle dockerfile actions

### DIFF
--- a/plan/task/dockerfile.go
+++ b/plan/task/dockerfile.go
@@ -22,12 +22,12 @@ import (
 )
 
 func init() {
-	Register("Dockerfile", func() Task { return &DockerfileTask{} })
+	Register("Dockerfile", func() Task { return &dockerfileTask{} })
 }
 
-type DockerfileTask struct{}
+type dockerfileTask struct{}
 
-func (t *DockerfileTask) Run(ctx context.Context, pctx *plancontext.Context, s *solver.Solver, v *compiler.Value) (*compiler.Value, error) {
+func (t *dockerfileTask) Run(ctx context.Context, pctx *plancontext.Context, s *solver.Solver, v *compiler.Value) (*compiler.Value, error) {
 	lg := log.Ctx(ctx)
 	auths, err := v.Lookup("auth").Fields()
 	if err != nil {
@@ -159,7 +159,7 @@ func (t *DockerfileTask) Run(ctx context.Context, pctx *plancontext.Context, s *
 	})
 }
 
-func (t *DockerfileTask) dockerBuildOpts(v *compiler.Value, pctx *plancontext.Context) (map[string]string, error) {
+func (t *dockerfileTask) dockerBuildOpts(v *compiler.Value, pctx *plancontext.Context) (map[string]string, error) {
 	opts := map[string]string{}
 
 	if dockerfilePath := v.Lookup("dockerfile.path"); dockerfilePath.Exists() {

--- a/plan/task/task.go
+++ b/plan/task/task.go
@@ -50,10 +50,13 @@ func ParseState(s string) (State, error) {
 }
 
 func (s State) CanTransition(t State) bool {
-	return s == StateComputing && s <= t
+	return s <= t
 }
 
 const (
+	// state order is important here since it defines the  order
+	// on how states can transition only forwards
+	// computing > completed > canceled > failed
 	StateComputing State = iota
 	StateCompleted
 	StateCanceled


### PR DESCRIPTION
After the changes introduced by sipsma in
https://github.com/dagger/dagger/commit/86e798a36bc93d19ac33631d0cb466ab771fa164
Dockerfile logs are now displaying correctly and don't require the
system hack. Additionally, I'm removing the CanTransition method and
going back to the previous behavior since it's not required anymore and
it also introduces a bug when displaying logs for actions that contain
hidden sub-actions.
