### PR TITLE
use default system font

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -12,7 +12,7 @@ module.exports = {
   organizationName: "Dagger",
   projectName: "Dagger",
   stylesheets: [
-    "https://fonts.googleapis.com/css2?family=Karla&family=Source+Code+Pro:wght@400&family=Montserrat:wght@700&display=swap",
+    "https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400&display=swap",
   ],
   customFields: {
     AMPLITUDE_ID: process.env.REACT_APP_AMPLITUDE_ID

--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -48,10 +48,12 @@ $desktop-xl-width: 1160px;
   --ifm-color-info: #40b9bc;
   --ifm-color-warning: #ef7b1a;
   --ifm-color-danger: #be1d43;
-  --ifm-container-width-xl: 100%;
+  --ifm-container-width-xl: 990px;
   --ifm-font-color-base: var(--ifm-color-primary-dark);
-  --ifm-font-family-base: "Karla", sans-serif;
-  --ifm-font-family-title: "Montserrat", "Arial", sans-serif;
+  --ifm-font-family-base: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  --ifm-font-family-title: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
   --ifm-font-family-monospace: "Source Code Pro", monospace;
   --ifm-h2-font-size: 2rem;
   --ifm-leading-desktop: 1;


### PR DESCRIPTION
“system” fonts matches what the current OS uses, so it can be a comfortable look.
Reduce main container width to improve readability

Signed-off-by: user.email <jf@dagger.io>