### PR TITLE
feat: add Gitpod support

### DIFF
--- a/.github/workflows/test-gitpod.yml
+++ b/.github/workflows/test-gitpod.yml
@@ -1,0 +1,49 @@
+name: "Gitpod"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".gitpod.yml"
+      - ".gitpod.Dockerfile"
+      - "**.go"
+      - "**.cue"
+      - "Makefile"
+      - "go.mod"
+      - "go.sum"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".gitpod.yml"
+      - ".gitpod.Dockerfile"
+      - "**.go"
+      - "**.cue"
+      - "Makefile"
+      - "go.mod"
+      - "go.sum"
+
+env:
+  DAGGER_LOG_FORMAT: plain
+
+jobs:
+  build:
+    name: "Build"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: "Expose GitHub Runtime"
+        uses: crazy-max/ghaction-github-runtime@v1
+
+      - name: "Set up dagger"
+        uses: dagger/dagger-for-github@v2
+        with:
+          install-only: true
+
+      - name: Build
+        env:
+          DAGGER_LOG_LEVEL: "debug"
+          DAGGER_LOG_FORMAT: "plain"
+        run: |
+          dagger do gitpod

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,17 @@
+FROM gitpod/workspace-go
+
+RUN sudo mkdir -p /workspace/go/.cache && sudo chown -R gitpod:gitpod /workspace \
+    && go install -v github.com/mikefarah/yq/v4@latest \
+    && go install -v honnef.co/go/tools/cmd/staticcheck@latest \
+    && sudo apt-add-repository ppa:fish-shell/release-3 \
+    && sudo apt-add-repository ppa:neovim-ppa/unstable \
+    && sudo add-apt-repository ppa:lazygit-team/release \
+    && sudo apt update && sudo install-packages \
+        fish \
+        fzf \
+        lazygit \
+        luajit \
+        neovim \
+        shellcheck \
+        tmux \
+        tree

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,38 @@
+image:
+  file: .gitpod.Dockerfile
+
+ports:
+  # Docusaurus
+  # Run `gp url 3000` to get the URL
+  - port: 3000
+
+tasks:
+  # Install missing extensions, Cue and Dagger
+  # FIXME: Gitpod uses the Open VSX registry for but the following
+  #        have not been ported over yet. Once the issues are resolved
+  #        remove from this task and add to the extensions config below.
+  # https://github.com/cue-sh/vscode-cue/issues/19
+  # https://github.com/johnallen3d/vscode-cue-fmt/issues/9
+  - init: |
+      EXTDIR=/workspace/.vscode-remote/extensions
+      [[ -z $EXTDIR/cuelang.org.cue.0.0.1 ]] && git clone https://github.com/cue-sh/vscode-cue $EXTDIR/cuelang.org.cue.0.0.1
+      [[ -z $EXTDIR/johnallen3d.cue-fmt.0.0.1 ]] && git clone https://github.com/johnallen3d/vscode-cue-fmt.git $EXTDIR/johnallen3d.cue-fmt.0.0.1
+      go install -mod=readonly cuelang.org/go/cmd/cue
+      make install
+
+vscode:
+  extensions:
+    - golang.go
+    - yzhang.markdown-all-in-one
+
+gitConfig:
+  alias.st: status
+  alias.ci: commit -s
+  alias.co: checkout
+
+github:
+  prebuilds:
+    master: true
+    branches: true
+    pullRequests: true
+    addBadge: true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "editor.formatOnSave": true,
+    "extensions.ignoreRecommendations": true,
+    "[cue]": {
+        "editor.useTabStops": true
+    }
+}

--- a/ci.cue
+++ b/ci.cue
@@ -13,6 +13,7 @@ import (
 	"github.com/dagger/dagger/ci/markdownlint"
 	"github.com/dagger/dagger/ci/cue"
 	"github.com/dagger/dagger/ci/bats"
+	"github.com/dagger/dagger/ci/gitpod"
 )
 
 dagger.#Plan & {
@@ -146,6 +147,10 @@ dagger.#Plan & {
 			"cue": cue.#Lint & {
 				source: _source
 			}
+		}
+
+		"gitpod": gitpod.#Test & {
+			source: _source
 		}
 	}
 }

--- a/ci/gitpod/test.cue
+++ b/ci/gitpod/test.cue
@@ -1,0 +1,42 @@
+package gitpod
+
+import (
+	"dagger.io/dagger"
+
+	"universe.dagger.io/bash"
+	"universe.dagger.io/docker"
+)
+
+// This plan ensures the Gitpod image builds and scripts
+// specified in the Gitpod config are executed successfully.
+#Test: {
+	source: dagger.#FS
+
+	_image: docker.#Dockerfile & {
+		"source": source
+
+		dockerfile: path: ".gitpod.Dockerfile"
+	}
+
+	bash.#Run & {
+		input: _image.output
+		mounts: "source": {
+			contents: source
+			dest:     "/src"
+			ro:       false
+		}
+		workdir: "/src"
+		script: contents: """
+			# Create Go cache dir
+			sudo mkdir -p /workspace/go && sudo chown gitpod:gitpod /workspace/go
+
+			# Read the shell script from config and execute it
+			yq ".tasks[0].init" .gitpod.yml | bash -
+			
+			# Ensure the expected tools were installed
+			make install
+			cue version
+			dagger version
+			"""
+	}
+}


### PR DESCRIPTION
Signed-off-by: Berry Phillips <berryphillips@gmail.com>

Closes #2347

This environment includes all Gitpod supported languages and tools, as well as some additional terminal tools that are popular.

I went back and forth on using the full base image vs. the slimmer Go image. The full image contains all supported languages and tools - including Docker ([see here](https://github.com/gitpod-io/workspace-images/tree/main/chunks)) - whilst the Go image contains just Go. Using a custom Docker file to install Docker and other desirable tools just adds to load times and complexity. I also think there is merit in having other languages and tools available to devs in the environment. So, I opted for the full image.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/berryp/dagger/tree/2347-add-gitpod-support)
