### PR TITLE
ci: print Buildkitd logs on failure

### DIFF
--- a/.github/workflows/dagger-ci.yml
+++ b/.github/workflows/dagger-ci.yml
@@ -75,3 +75,8 @@ jobs:
           DAGGER_LOG_LEVEL: "debug"
         run: |
           dagger do build
+
+      - name: Print Buildkitd Logs
+        if: ${{ failure() }}
+        run: |
+          docker logs dagger-buildkitd

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,3 +62,8 @@ jobs:
           DAGGER_CACHE_FROM: "type=gha,scope=dagger-ci-lint"
         run: |
           dagger do lint
+
+      - name: Print Buildkitd Logs
+        if: ${{ failure() }}
+        run: |
+          docker logs dagger-buildkitd

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -83,3 +83,8 @@ jobs:
         run: |
           env
           make core-integration
+
+      - name: Print Buildkitd Logs
+        if: ${{ failure() }}
+        run: |
+          docker logs dagger-buildkitd

--- a/.github/workflows/test-universe.yml
+++ b/.github/workflows/test-universe.yml
@@ -74,3 +74,8 @@ jobs:
       - name: Test
         run: |
           make universe-test
+
+      - name: Print Buildkitd Logs
+        if: ${{ failure() }}
+        run: |
+          docker logs dagger-buildkitd

--- a/pkg/universe.dagger.io/package.json
+++ b/pkg/universe.dagger.io/package.json
@@ -1,7 +1,7 @@
 {
   "license": "Apache-2.0",
   "scripts": {
-    "test": "bats --report-formatter junit --print-output-on-failure --jobs 4 $(find . -type f -name '*.bats' -not -path '*/node_modules/*')"
+    "test": "bats --report-formatter junit --print-output-on-failure --jobs 1 $(find . -type f -name '*.bats' -not -path '*/node_modules/*')"
   },
   "devDependencies": {
     "bats": "^1.5.0",

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,7 +1,7 @@
 {
   "license": "Apache-2.0",
   "scripts": {
-    "test": "bats --jobs 4 --print-output-on-failure --verbose-run ."
+    "test": "bats --jobs 1 --print-output-on-failure --verbose-run ."
   },
   "devDependencies": {
     "bats": "https://github.com/bats-core/bats-core#v1.6.0",


### PR DESCRIPTION
If an error happened, the buildkitd logs could be helpful in debugging.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Trying to debug the `failed to execute plan: error detecting platform failed to list workers: Unavailable: connection closed before server preface received` error we've been getting.