### PR TITLE
docs: Resolve Dagger version dynamically

### DIFF
--- a/docs/core-concepts/1202-plan.md
+++ b/docs/core-concepts/1202-plan.md
@@ -4,6 +4,7 @@ displayed_sidebar: "0.2"
 ---
 
 import DaggerCloudCTA from '../includes/\_dagger-cloud-cta.md';
+import {DaggerVersionLatestReleased} from '@site/src/components/DaggerVersionLatestReleased';
 
 # It all starts with a plan
 
@@ -85,7 +86,11 @@ The second import is for `netlify.#Deploy` to work.
 :::info
 Which other imports we are missing?
 Look at all the actions in the plan structure at the top of this page.
-Now check all the available packages in [universe.dagger.io](https://github.com/dagger/dagger/tree/v0.2.19/pkg/universe.dagger.io).
+<DaggerVersionLatestReleased>
+{daggerVersionLatestRelease =>
+<>Now check all the available packages in <a href={`https://github.com/dagger/dagger/tree/${daggerVersionLatestRelease}/pkg/universe.dagger.io`}>universe.dagger.io</a>.</>
+}
+</DaggerVersionLatestReleased>
 :::
 
 We now understand that the `deploy` action is the deploy definition from the netlify package, written as `deploy: netlify.#Deploy`

--- a/docs/getting-started/1200-local-dev.md
+++ b/docs/getting-started/1200-local-dev.md
@@ -1,9 +1,11 @@
 ---
 slug: /1200/local-dev
-displayed_sidebar: "0.2"
+displayed_sidebar: '0.2'
 ---
 
 import DaggerCloudCTA from '../includes/\_dagger-cloud-cta.md';
+import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';
+import BrowserOnly from '@docusaurus/BrowserOnly';
 
 # Build & run locally...then in CI
 
@@ -18,9 +20,6 @@ Before we can build & test our example app with `dagger`, we need to have [Dagge
 :::tip
 [The Dagger engine/CLI is available for install](/install) on macOS, Linux, and Windows to run locally or in CI
 :::
-
-import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';
-import BrowserOnly from '@docusaurus/BrowserOnly';
 
 <BrowserOnly>
 {() =>

--- a/docs/getting-started/1201-ci-environment.md
+++ b/docs/getting-started/1201-ci-environment.md
@@ -45,7 +45,7 @@ language: minimal
 
 env:
   global:
-    - DAGGER_VERSION: 0.2.19
+    - DAGGER_VERSION: 0.2.25
     - DAGGER_LOG_FORMAT: plain
     - DAGGER_CACHE_PATH: .dagger-cache
 
@@ -131,7 +131,7 @@ workflows:
 .dagger:
   extends: [.docker]
   variables:
-    DAGGER_VERSION: 0.2.24
+    DAGGER_VERSION: 0.2.25
     DAGGER_LOG_FORMAT: plain
     DAGGER_CACHE_PATH: .dagger-cache
 

--- a/docs/guides/buildkit/1237-persistent-cache.md
+++ b/docs/guides/buildkit/1237-persistent-cache.md
@@ -126,7 +126,7 @@ dagger do build --cache-to type=registry,mode=max,ref=localhost:5000/cache --cac
 ```
 
 :::info
-See more options on registry export at [Buildkit cache documentation](https://github.com/moby/buildkit/blob/v0.10.1/README.md#registry-push-image-and-cache-separately)
+See more options on registry export at [Buildkit cache documentation](https://github.com/moby/buildkit/blob/v0.10.3/README.md#registry-push-image-and-cache-separately)
 :::
 
 ## Persistent cache in your local filesystem
@@ -175,7 +175,7 @@ dagger do build --cache-to type=local,mode=max,dest=storage --cache-from type=lo
 
 :::info
 In this part, we have learned to export and import cache using a local filesystem, if you want
-to see more options on local export, look at [Buildkit cache documentation](https://github.com/moby/buildkit/blob/v0.10.1/README.md#local-directory-1)
+to see more options on local export, look at [Buildkit cache documentation](https://github.com/moby/buildkit/blob/v0.10.3/README.md#local-directory-1)
 :::
 
 ## Persistent cache in GitHub Actions
@@ -212,9 +212,9 @@ jobs:
 ```
 
 :::warning
-To avoid invalidating cache between your PR, you can take inspiration from [Dagger ci](https://github.com/dagger/dagger/blob/v0.2.19/.github/workflows/dagger-ci.yml#L61)
+To avoid invalidating cache between your PR, you can take inspiration from [dagger-ci.yml](https://github.com/dagger/dagger/blob/v0.2.25/.github/workflows/dagger-ci.yml#L61) GitHub Actions workflow.
 :::
 
 :::info
-See more options on GitHub export at [Buildkit cache documentation](https://github.com/moby/buildkit/blob/v0.10.1/README.md#github-actions-cache-experimental)
+See more options on GitHub export at [Buildkit cache documentation](https://github.com/moby/buildkit/blob/v0.10.3/README.md#github-actions-cache-experimental)
 :::

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -87,5 +87,6 @@ module.exports = {
     "docusaurus-plugin-sass",
     "docusaurus2-dotenv",
     path.resolve(__dirname, "plugins/docusaurus-plugin-hotjar"),
+    path.resolve(__dirname, "plugins/docusaurus-plugin-dagger-version"),
   ],
 };

--- a/website/plugins/docusaurus-plugin-dagger-version/index.js
+++ b/website/plugins/docusaurus-plugin-dagger-version/index.js
@@ -1,0 +1,18 @@
+const fetch = require("node-fetch");
+
+module.exports = function () {
+    return {
+        name: 'docusaurus-plugin-dagger-version',
+        async loadContent() {
+            var response = await fetch("https://dl.dagger.io/dagger/latest_version");
+            var releases = await response.text();
+            const version = `v${releases}` || 'VERSION';
+
+            return version;
+        },
+        async contentLoaded({content, actions}) {
+            const {setGlobalData} = actions;
+            setGlobalData({daggerVersionLatestRelease: content});
+        },
+    };
+};

--- a/website/src/components/DaggerVersionLatestReleased.js
+++ b/website/src/components/DaggerVersionLatestReleased.js
@@ -1,0 +1,16 @@
+import React, {ReactNode} from 'react';
+import {usePluginData} from '@docusaurus/useGlobalData';
+
+const VersionContext = React.createContext()
+
+export const DaggerVersionLatestReleased = ({children}) => {
+
+
+  const {daggerVersionLatestRelease} = usePluginData('docusaurus-plugin-dagger-version');
+
+  return  <VersionContext.Provider value={daggerVersionLatestRelease}>
+      <VersionContext.Consumer>
+        {children}
+      </VersionContext.Consumer>
+    </VersionContext.Provider>
+}


### PR DESCRIPTION
This will fetch the version from https://dl.dagger.io/dagger/latest_version and template it in all doc pages on deploy.

Resolves https://github.com/dagger/dagger/issues/1854
Resolves https://github.com/dagger/dagger/issues/2205
Resolves https://github.com/dagger/dagger/issues/2351

The only thing which remains is to figure out how to template this version in the YAML snippets, e.g. https://github.com/dagger/dagger/pull/2369/files#diff-e309255ddd52101788f3de79596d0b93496c72d4b04059e44154f9e12b63e4d0R134