### PR TITLE
client: use lock file to dedupe buildkitd creation.

### DIFF
--- a/pkg/universe.dagger.io/package.json
+++ b/pkg/universe.dagger.io/package.json
@@ -1,7 +1,7 @@
 {
   "license": "Apache-2.0",
   "scripts": {
-    "test": "bats --report-formatter junit --print-output-on-failure --jobs 1 $(find . -type f -name '*.bats' -not -path '*/node_modules/*')"
+    "test": "bats --report-formatter junit --print-output-on-failure --jobs 4 $(find . -type f -name '*.bats' -not -path '*/node_modules/*')"
   },
   "devDependencies": {
     "bats": "^1.5.0",

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,7 +1,7 @@
 {
   "license": "Apache-2.0",
   "scripts": {
-    "test": "bats --jobs 1 --print-output-on-failure --verbose-run ."
+    "test": "bats --jobs 4 --print-output-on-failure --verbose-run ."
   },
   "devDependencies": {
     "bats": "https://github.com/bats-core/bats-core#v1.6.0",


### PR DESCRIPTION
Before this, there was a race condition where parallel dagger clients
could race while checking+starting buildkitd, which sometimes lead to
one removing the buildkitd container created by the other.

Now a lock file is used to ensure the process of checking+starting
buildkitd is transactional.

This doesn't fix the case where dockerd is remote and clients are
running on parallel machines, but that's more obscure and much tougher
to fix as dockerd doesn't appear to have any mechanisms for idempotently
creating a container.

The lock file is under ~/.config/dagger for now. Technically, the
correct place to put this according to the FHS would be /var/lock, but
in my experience /var/lock doesn't always exist and I want to avoid
having to create a directory under /var if possible for now.

Also, there is a long timeout on waiting to acquire the lock. This is
set in order to avoid code that could block for infinity, but is quite
long to account for any users that are trying to pull the buildkitd
image on a particularly slow internet connection.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

For now, the test is just that CI passes w/ parallel bats jobs. This isn't ideal but tests for this are tricky to write as I found in my attempts to have a dedicated integration test that it was very rare to reproduce locally and involves managing state in dockerd (which is also used by other tests).