### PR TITLE
experimental `do --dry-run` mode

### DIFF
--- a/cmd/dagger/logger/tty.go
+++ b/cmd/dagger/logger/tty.go
@@ -288,6 +288,8 @@ func (c *TTYOutput) printGroup(group *Group, width, maxLines int) int {
 		switch group.CurrentState {
 		case task.StateComputing:
 			prefix = "[+]"
+		case task.StateSkipped:
+			prefix = "[-]"
 		case task.StateCanceled:
 			prefix = "[✗]"
 		case task.StateFailed:
@@ -318,6 +320,8 @@ func (c *TTYOutput) printGroup(group *Group, width, maxLines int) int {
 		switch group.CurrentState {
 		case task.StateComputing:
 			out = aec.Apply(out, aec.LightBlueF)
+		case task.StateSkipped:
+			out = aec.Apply(out, aec.LightCyanF)
 		case task.StateCanceled:
 			out = aec.Apply(out, aec.LightYellowF)
 		case task.StateFailed:
@@ -339,6 +343,9 @@ func (c *TTYOutput) printGroup(group *Group, width, maxLines int) int {
 		if len(printEvents) > maxLines && maxLines >= 0 {
 			printEvents = printEvents[len(printEvents)-maxLines:]
 		}
+	case task.StateSkipped:
+		// for skipped tasks, don't show any logs
+		printEvents = []Event{}
 	case task.StateCanceled:
 		// for completed tasks, don't show any logs
 		printEvents = []Event{}

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -36,6 +36,7 @@ type Config struct {
 	Args   []string
 	With   []string
 	Target string
+	DryRun bool
 }
 
 func Load(ctx context.Context, cfg Config) (*Plan, error) {
@@ -194,7 +195,7 @@ func (p *Plan) Do(ctx context.Context, path cue.Path, s *solver.Solver) error {
 	ctx, span := otel.Tracer("dagger").Start(ctx, "plan.Do")
 	defer span.End()
 
-	r := NewRunner(p.context, path, s)
+	r := NewRunner(p.context, path, s, p.config.DryRun)
 	final, err := r.Run(ctx, p.source)
 	if err != nil {
 		return err

--- a/plan/task/task.go
+++ b/plan/task/task.go
@@ -31,13 +31,15 @@ var (
 type State int8
 
 func (s State) String() string {
-	return [...]string{"computing", "completed", "cancelled", "failed"}[s]
+	return [...]string{"computing", "skipped", "completed", "cancelled", "failed"}[s]
 }
 
 func ParseState(s string) (State, error) {
 	switch s {
 	case "computing":
 		return StateComputing, nil
+	case "skipped":
+		return StateSkipped, nil
 	case "cancelled":
 		return StateCanceled, nil
 	case "failed":
@@ -58,6 +60,7 @@ const (
 	// on how states can transition only forwards
 	// computing > completed > canceled > failed
 	StateComputing State = iota
+	StateSkipped
 	StateCompleted
 	StateCanceled
 	StateFailed


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/2299

Related to https://github.com/dagger/dagger/issues/2331

This adds an experimental `--dry-run` **experimental** flag to `dagger do` that doesn't actually execute tasks. Can be used to validate the plan.

```console
$ dagger do build --experimental --dry-run
[✔] client.filesystem.".".read
[✔] actions.build.go.container
[✔] actions.version
[✔] client.platform
[✔] client.filesystem."./".read
[✔] actions.build.docker
[✔] actions.build.go.container.export
[✔] client.filesystem."./bin".write
```