### PR TITLE
feat: Add 1password package

### DIFF
--- a/pkg/universe.dagger.io/x/berryphillips@gmail.com/onepassword/example/plan.cue
+++ b/pkg/universe.dagger.io/x/berryphillips@gmail.com/onepassword/example/plan.cue
@@ -1,0 +1,61 @@
+package example
+
+import (
+	"dagger.io/dagger"
+
+	"universe.dagger.io/alpine"
+	"universe.dagger.io/docker"
+	"universe.dagger.io/x/berryphillips@gmail.com/onepassword"
+)
+
+// Build an alpine base image
+image: alpine.#Build
+
+dagger.#Plan & {
+	// Get the values from environment variables
+	client: env: {
+		OP_ADDRESS:    dagger.#Secret
+		OP_EMAIL:      dagger.#Secret
+		OP_SECRET_KEY: dagger.#Secret
+		OP_PASSWORD:   dagger.#Secret
+	}
+
+	// Create a credentials config
+	_opCreds: onepassword.#Credentials & {
+		address:   client.env.OP_ADDRESS
+		email:     client.env.OP_EMAIL
+		secretKey: client.env.OP_SECRET_KEY
+		password:  client.env.OP_PASSWORD
+	}
+
+	actions: {
+		// Get the secret from 1Password
+		mySecret: onepassword.#Read & {
+			credentials: _opCreds
+			reference:   onepassword.#Reference & {
+				vault: "MyVault"
+				item:  "MyItem"
+				field: "MyField"
+			}
+		}
+
+		// Use the secret
+		example: docker.#Run & {
+			input: image.output
+
+			// You can mount the secret in a file
+			mounts: secret: {
+				dest:     "/secret.txt"
+				contents: mySecret.output
+			}
+
+			// or set an environment variable
+			env: MY_SECRET: mySecret.output
+
+			command: {
+				name: "cat"
+				args: [ "/secret.txt"]
+			}
+		}
+	}
+}

--- a/pkg/universe.dagger.io/x/berryphillips@gmail.com/onepassword/onepassword.cue
+++ b/pkg/universe.dagger.io/x/berryphillips@gmail.com/onepassword/onepassword.cue
@@ -1,0 +1,37 @@
+package onepassword
+
+import (
+	"dagger.io/dagger"
+)
+
+#Credentials: {
+	// The sign-in address for the account
+	address: dagger.#Secret
+
+	// The email adress associated with the account
+	email: dagger.#Secret
+
+	// The secret key
+	secretKey: dagger.#Secret
+
+	// The password
+	password: dagger.#Secret
+}
+
+#Reference: {
+	// The vault name
+	vault: string
+
+	// The item name
+	item: string
+
+	// The section label (optional)
+	section: string | *""
+
+	// The field label
+	field: string
+
+	output: "op://\(vault)/\(item)/\(section)/\(field)"
+}
+
+_#Version: "2"

--- a/pkg/universe.dagger.io/x/berryphillips@gmail.com/onepassword/read.cue
+++ b/pkg/universe.dagger.io/x/berryphillips@gmail.com/onepassword/read.cue
@@ -1,0 +1,51 @@
+package onepassword
+
+import (
+	"dagger.io/dagger/core"
+
+	"universe.dagger.io/docker"
+)
+
+// Read a secret by secret reference
+#Read: {
+	// The 1Password account login credentials
+	credentials: #Credentials
+
+	// The reference to the 1Password secret
+	reference: #Reference
+
+	_image: docker.#Pull & {
+		source: "1password/op:\(_#Version)"
+	}
+
+	container: docker.#Run & {
+		input: _image.output
+
+		command: {
+			name: "bash"
+			flags: "-c": "/scripts/read.sh > /tmp/secret.txt"
+		}
+
+		export: secrets: "/tmp/secret.txt": _
+
+		_scripts: core.#Source & {
+			path: "."
+			include: ["*.sh"]
+		}
+
+		mounts: scripts: {
+			contents: _scripts.output
+			dest:     "/scripts"
+		}
+
+		env: {
+			ADDRESS:    credentials.address
+			EMAIL:      credentials.email
+			SECRET_KEY: credentials.secretKey
+			PASSWORD:   credentials.password
+			REFERENCE:  reference.output
+		}
+	}
+
+	output: container.export.secrets["/tmp/secret.txt"]
+}

--- a/pkg/universe.dagger.io/x/berryphillips@gmail.com/onepassword/read.sh
+++ b/pkg/universe.dagger.io/x/berryphillips@gmail.com/onepassword/read.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+set -u
+: "$ADDRESS"
+: "$EMAIL"
+: "$SECRET_KEY"
+: "$PASSWORD"
+: "$REFERENCE"
+
+OP_DEVICE=$(head -c 16 /dev/urandom | base32 | tr -d = | tr '[:upper:]' '[:lower:]')
+export OP_DEVICE
+
+eval "$(echo "$PASSWORD" | op account add --signin --address "$ADDRESS" --email "$EMAIL" --secret-key "$SECRET_KEY")"
+
+op read --force --no-newline "$REFERENCE" > /tmp/secret.txt


### PR DESCRIPTION
Signed-off-by: Berry Phillips <berryphillips@gmail.com>

This adds support for pulling secret values from 1Password vaults. Requires 1Password subscription and currently only supports reading single secrets. Future updates would provide more flexibility in the types of data returned (e.g. multiple secrets).