### PR TITLE
ci: use same source everywhere

### DIFF
--- a/ci.cue
+++ b/ci.cue
@@ -21,11 +21,8 @@ dagger.#Plan & {
 		"**/node_modules",
 		"cmd/dagger/dagger",
 		"cmd/dagger/dagger-debug",
+		"website",
 	]
-	client: filesystem: "./": read: {
-		contents: dagger.#FS
-		exclude: ["website"]
-	}
 	client: filesystem: "./bin": write: contents: actions.build."go".output
 
 	actions: {
@@ -73,7 +70,7 @@ dagger.#Plan & {
 				}
 			}
 			docker: core.#Dockerfile & {
-				source: client.filesystem["./"].read.contents
+				source: _source
 				dockerfile: path: "Dockerfile"
 			}
 		}


### PR DESCRIPTION
Speeds up CI considerably.

/cc @marcosnils @crazy-max 

I did see the history of this here https://github.com/dagger/dagger/pull/2288#pullrequestreview-951005783 but I didn't quite understand.

We were ending up uploading the context twice with different excludes, the other upload not excluding `node_modules` which is pretty massive