### PR TITLE
ci test: split each dagger do to own test name

### DIFF
--- a/pkg/universe.dagger.io/aws/test/test.bats
+++ b/pkg/universe.dagger.io/aws/test/test.bats
@@ -4,8 +4,14 @@ setup() {
     common_setup
 }
 
-@test "aws" {
+@test "aws default_version" {
     dagger "do" -p ./default_version.cue getVersion
+}
+
+@test "aws credentials" {
     dagger "do" -p ./credentials.cue getCallerIdentity
+}
+
+@test "aws config_file" {
     dagger "do" -p ./config_file.cue getCallerIdentity
 }

--- a/pkg/universe.dagger.io/docker/test/test.bats
+++ b/pkg/universe.dagger.io/docker/test/test.bats
@@ -4,9 +4,18 @@ setup() {
     common_setup
 }
 
-@test "docker" {
+@test "docker build" {
     dagger "do" -p ./build.cue test
+}
+
+@test "docker dockerfile" {
     dagger "do" -p ./dockerfile.cue test
+}
+
+@test "docker run" {
     dagger "do" -p ./run.cue test
+}
+
+@test "docker image" {
     dagger "do" -p ./image.cue test
 }

--- a/pkg/universe.dagger.io/go/test/test.bats
+++ b/pkg/universe.dagger.io/go/test/test.bats
@@ -4,9 +4,18 @@ setup() {
     common_setup
 }
 
-@test "go" {
+@test "go build" {
     dagger "do" -p ./build.cue test
+}
+
+@test "go container" {
     dagger "do" -p ./container.cue test
+}
+
+@test "go image" {
     dagger "do" -p ./image.cue test
+}
+
+@test "go test" {
     dagger "do" -p ./test.cue test
 }

--- a/pkg/universe.dagger.io/x/contact@kjuulh.io/rust/test/test.bats
+++ b/pkg/universe.dagger.io/x/contact@kjuulh.io/rust/test/test.bats
@@ -4,7 +4,10 @@ setup() {
     common_setup
 }
 
-@test "rust" {
+@test "rust publish" {
     dagger "do" -p ./publish.cue test
+}
+
+@test "rust image" {
     dagger "do" -p ./image.cue test
 }

--- a/pkg/universe.dagger.io/x/olli.janatuinen@gmail.com/dotnet/test/test.bats
+++ b/pkg/universe.dagger.io/x/olli.janatuinen@gmail.com/dotnet/test/test.bats
@@ -4,8 +4,14 @@ setup() {
     common_setup
 }
 
-@test "dotnet" {
+@test "dotnet publish" {
     dagger "do" -p ./publish.cue test
+}
+
+@test "dotnet image" {
     dagger "do" -p ./image.cue test
+}
+
+@test "dotnet test" {
     dagger "do" -p ./test.cue test
 }

--- a/tests/plan.bats
+++ b/tests/plan.bats
@@ -2,6 +2,11 @@ setup() {
     load 'helpers'
 
     common_setup
+
+    # These tests generally do not benefit from caching
+    # as they only create small files
+    unset DAGGER_CACHE_FROM
+    unset DAGGER_CACHE_TO
 }
 
 @test "plan/do: action sanity checks" {

--- a/tests/tasks.bats
+++ b/tests/tasks.bats
@@ -7,6 +7,9 @@ setup() {
 
 @test "task: #Pull" {
     "$DAGGER" "do" -p ./tasks/pull/pull.cue pull
+}
+
+@test "task: #Pull auth" {
     "$DAGGER" "do" -p ./tasks/pull/pull_auth.cue pull
 }
 
@@ -20,32 +23,70 @@ setup() {
 
 @test "task: #WriteFile" {
     "$DAGGER" "do" -p ./tasks/writefile/writefile.cue readfile
+}
+
+@test "task: #WriteFile failure" {
     run "$DAGGER" "do" -p ./tasks/writefile/writefile_failure_diff_contents.cue readfile
     assert_failure
 }
 
-@test "task: #Exec" {
+@test "task: #Exec args" {
     cd ./tasks/exec
     "$DAGGER" "do" -p ./args.cue verify
+}
+
+@test "task: #Exec env" {
+    cd ./tasks/exec
     "$DAGGER" "do" -p ./env.cue verify
+}
+
+@test "task: #Exec env secret" {
+    cd ./tasks/exec
     "$DAGGER" "do" -p ./env_secret.cue verify
+}
+
+@test "task: #Exec hosts" {
+    cd ./tasks/exec
     "$DAGGER" "do" -p ./hosts.cue verify
+}
 
+@test "task: #Exec mount cache" {
+    cd ./tasks/exec
     "$DAGGER" "do" -p ./mount_cache.cue test
-    "$DAGGER" "do" -p ./mount_fs.cue test
-    TESTSECRET="hello world" "$DAGGER" "do" -p ./mount_secret.cue test
-    "$DAGGER" "do" -p ./mount_tmp.cue verify
-    "$DAGGER" "do" -p ./mount_socket.cue verify
+}
 
+@test "task: #Exec mount fs" {
+    cd ./tasks/exec
+    "$DAGGER" "do" -p ./mount_fs.cue test
+}
+
+@test "task: #Exec mount secret" {
+    cd ./tasks/exec
+    TESTSECRET="hello world" "$DAGGER" "do" -p ./mount_secret.cue test
+}
+
+@test "task: #Exec mount tmp" {
+    cd ./tasks/exec
+    "$DAGGER" "do" -p ./mount_tmp.cue verify
+}
+
+@test "task: #Exec mount socket" {
+    cd ./tasks/exec
+    "$DAGGER" "do" -p ./mount_socket.cue verify
+}
+
+@test "task: #Exec user" {
+    cd ./tasks/exec
     "$DAGGER" "do" -p ./user.cue test
+}
+
+@test "task: #Exec workdir" {
+    cd ./tasks/exec
     "$DAGGER" "do" -p ./workdir.cue verify
 }
 
 @test "task: #Start #Stop" {
     cd ./tasks/exec
-
-    "$DAGGER" "do" -p ./start_stop_exec.cue execParamsTest
-
     run "$DAGGER" "do" --log-format=plain -l info -p ./start_stop_exec.cue basicTest
     assert_line --partial 'actions.basicTest.start'
     assert_line --regexp 'actions\.basicTest\.sleep \| .*taking a quick nap'
@@ -53,10 +94,20 @@ setup() {
     assert_line --partial --index 7 'actions.basicTest.stop'
 }
 
-@test "task: #Copy" {
-    "$DAGGER" "do" -p ./tasks/copy/copy_exec.cue test
-    "$DAGGER" "do" -p ./tasks/copy/copy_file.cue test
+@test "task: #Start #Stop params" {
+    cd ./tasks/exec
+    "$DAGGER" "do" -p ./start_stop_exec.cue execParamsTest
+}
 
+@test "task: #Copy exec" {
+    "$DAGGER" "do" -p ./tasks/copy/copy_exec.cue test
+}
+
+@test "task: #Copy file" {
+    "$DAGGER" "do" -p ./tasks/copy/copy_file.cue test
+}
+
+@test "task: #Copy exec invalid" {
     run "$DAGGER" "do" -p ./tasks/copy/copy_exec_invalid.cue test
     assert_failure
 }
@@ -64,10 +115,14 @@ setup() {
 @test "task: #Mkdir" {
     # Make directory
     "$DAGGER" "do" -p ./tasks/mkdir/mkdir.cue readChecker
+}
 
+@test "task: #Mkdir parents" {
     # Create parents
     "$DAGGER" "do" -p ./tasks/mkdir/mkdir_parents.cue readChecker
+}
 
+@test "task: #Mkdir parents failure" {
     # Disable parents creation
     run "$DAGGER" "do" -p ./tasks/mkdir/mkdir_failure_disable_parents.cue readChecker
     assert_failure
@@ -76,47 +131,106 @@ setup() {
 @test "task: #Dockerfile" {
     cd "$TESTDIR"/tasks/dockerfile
     "$DAGGER" "do" -p ./dockerfile.cue verify
+}
+
+@test "task: #Dockerfile inlined" {
+    cd "$TESTDIR"/tasks/dockerfile
     "$DAGGER" "do" -p ./inlined_dockerfile.cue verify
+}
+
+@test "task: #Dockerfile inlined heredoc" {
+    cd "$TESTDIR"/tasks/dockerfile
     "$DAGGER" "do" -p ./inlined_dockerfile_heredoc.cue verify
+}
+
+@test "task: #Dockerfile path" {
+    cd "$TESTDIR"/tasks/dockerfile
     "$DAGGER" "do" -p ./dockerfile_path.cue verify
+}
+
+@test "task: #Dockerfile build args" {
+    cd "$TESTDIR"/tasks/dockerfile
     "$DAGGER" "do" -p ./build_args.cue build
+}
+
+@test "task: #Dockerfile image config" {
+    cd "$TESTDIR"/tasks/dockerfile
     "$DAGGER" "do" -p ./image_config.cue build
+}
+
+@test "task: #Dockerfile labels" {
+    cd "$TESTDIR"/tasks/dockerfile
     "$DAGGER" "do" -p ./labels.cue build
+}
+
+@test "task: #Dockerfile platform" {
+    cd "$TESTDIR"/tasks/dockerfile
     "$DAGGER" "do" -p ./platform.cue build
+}
+
+@test "task: #Dockerfile build auth" {
+    cd "$TESTDIR"/tasks/dockerfile
     "$DAGGER" "do" -p ./build_auth.cue build
 }
 
 @test "task: #Scratch" {
     "$DAGGER" "do" -p ./tasks/scratch/scratch.cue exec
+}
+
+@test "task: #Scratch build" {
     "$DAGGER" "do" -p ./tasks/scratch/scratch_build_scratch.cue build
+}
+
+@test "task: #Scratch writefile" {
     "$DAGGER" "do" -p ./tasks/scratch/scratch_writefile.cue readfile
 }
 
 @test "task: #Subdir" {
     "$DAGGER" "do" -p ./tasks/subdir/subdir_simple.cue verify
+}
 
+@test "task: #Subdir invalid path" {
     run "$DAGGER" "do" -p ./tasks/subdir/subdir_invalid_path.cue verify
     assert_failure
+}
 
+@test "task: #Subdir invalid exec" {
     run "$DAGGER" "do" -p ./tasks/subdir/subdir_invalid_exec.cue verify
     assert_failure
 }
 
 @test "task: #GitPull" {
     "$DAGGER" "do" -p ./tasks/gitpull/exists.cue gitPull
-    "$DAGGER" "do" -p ./tasks/gitpull/git_dir.cue verify
-    "$DAGGER" "do" -p ./tasks/gitpull/private_repo.cue testContent
+}
 
+@test "task: #GitPull dir" {
+    "$DAGGER" "do" -p ./tasks/gitpull/git_dir.cue verify
+}
+
+@test "task: #GitPull private repo" {
+    "$DAGGER" "do" -p ./tasks/gitpull/private_repo.cue testContent
+}
+
+@test "task: #GitPull invalid" {
     run "$DAGGER" "do" -p ./tasks/gitpull/invalid.cue invalid
     assert_failure
+}
+
+@test "task: #GitPull bad remote" {
     run "$DAGGER" "do" -p ./tasks/gitpull/bad_remote.cue badremote
     assert_failure
+}
+
+@test "task: #GitPull bad ref" {
     run "$DAGGER" "do" -p ./tasks/gitpull/bad_ref.cue badref
     assert_failure
 }
 
 @test "task: #HTTPFetch" {
     "$DAGGER" "do" -p ./tasks/httpfetch/exist.cue fetch
+}
+
+@test "task: #HTTPFetch not exist" {
     run "$DAGGER" "do" -p ./tasks/httpfetch/not_exist.cue fetch
     assert_failure
 }
@@ -132,12 +246,22 @@ setup() {
 
 @test "task: #Source" {
     "$DAGGER" "do" -p ./tasks/source/source.cue test
-    "$DAGGER" "do" -p ./tasks/source/source_include_exclude.cue test
-    "$DAGGER" "do" -p ./tasks/source/source_relative.cue verifyHello
+}
 
+@test "task: #Source include exclude" {
+    "$DAGGER" "do" -p ./tasks/source/source_include_exclude.cue test
+}
+
+@test "task: #Source relative" {
+    "$DAGGER" "do" -p ./tasks/source/source_relative.cue verifyHello
+}
+
+@test "task: #Source invalid path" {
     run "$DAGGER" "do" -p ./tasks/source/source_invalid_path.cue source
     assert_failure
+}
 
+@test "task: #Source not exist" {
     run "$DAGGER" "do" -p ./tasks/source/source_not_exist.cue source
     assert_failure
 }


### PR DESCRIPTION
Even though we export to GHA using per-test scopes, there are often
multiple invocations of dagger do within a single test, each of which
will use the same export target and thus overwrite each other's cache
manifests.

This meant that we would pay the price to export cache (quite expensive
for large blobs), eat up our bandwidth limit uploading that cache
(causing more throttles) and then never actually reuse the cache
because the manifest got overwritten.

For one example, the ./container.cue test in the go universe package
would take ~8 seconds to execute w/out cache hits, but then spend ~30
seconds exporting cache. If you run the test on its own in GHA so that
the cache manifest doesn't get overwritten, it will only take 3 seconds
to run. So in this single test case we were wasting ~37 seconds most
runs. There are many other test cases in the same boat.

This immediately solves the problem in order to stop our CI from taking
forever and getting so many throttles from GHA cache. In general, we
need a better way of configuring cache that's easy to turn on and off
per-plan.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Related to #2140 and #2365

Also, another lesson from this is that it was very difficult to find out any of this; our current observability into cache performance is next to nothing. I hacked together in my fork a bunch of stuff for collecting Jaeger traces in GHA that can be exported and orchestrating tests that let you more easily compare multiple test runs with different cache settings. I will prioritize productionizing this so we can more quickly diagnose these types of issues in the future.