### PR TITLE
plan: unquote actions names

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"cuelang.org/go/cue"
@@ -247,8 +248,12 @@ func (p *Plan) fillAction(ctx context.Context) {
 			a := prevAction.FindByPath(path)
 			if a == nil {
 				v := p.Source().LookupPath(path)
+				name := s.String()
+				if n, err := strconv.Unquote(name); err == nil {
+					name = n
+				}
 				a = &Action{
-					Name:          s.String(),
+					Name:          name,
 					Hidden:        s.PkgPath() != "",
 					Path:          path,
 					Documentation: v.DocSummary(),


### PR DESCRIPTION
When specifying actions with quoted identifiers in the plan such as:

actions: "build-image": _

The help of dagger do will be:

Available Actions:
 build
 "build-image"
 ...

Which is a bit strange for a CLI action.

This patch will try to unquote action names if they are.

Signed-off-by: Jean-Philippe Braun <eon@patapon.info>