### PR TITLE
fix: Course correct on `project update` consistency

### DIFF
--- a/mod/require.go
+++ b/mod/require.go
@@ -25,8 +25,10 @@ type Require struct {
 
 func newRequire(repoName, versionConstraint string) (*Require, error) {
 	switch {
+	case strings.HasPrefix(repoName, pkg.DaggerModule):
+		return parseDaggerRepoName(pkg.DaggerModule, repoName, versionConstraint)
 	case strings.HasPrefix(repoName, pkg.UniverseModule):
-		return parseDaggerRepoName(repoName, versionConstraint)
+		return parseDaggerRepoName(pkg.UniverseModule, repoName, versionConstraint)
 	default:
 		return parseGitRepoName(repoName, versionConstraint)
 	}
@@ -52,23 +54,22 @@ func parseGitRepoName(repoName, versionConstraint string) (*Require, error) {
 	}, nil
 }
 
-var daggerRepoNameRegex = regexp.MustCompile(pkg.UniverseModule + `([a-zA-Z0-9/_.-]*)@?([0-9a-zA-Z.-]*)`)
-
-func parseDaggerRepoName(repoName, versionConstraint string) (*Require, error) {
-	repoMatches := daggerRepoNameRegex.FindStringSubmatch(repoName)
+func parseDaggerRepoName(module, repoName, versionConstraint string) (*Require, error) {
+	nameRegex := regexp.MustCompile(module + `([a-zA-Z0-9/_.-]*)@?([0-9a-zA-Z.-]*)`)
+	repoMatches := nameRegex.FindStringSubmatch(repoName)
 
 	if len(repoMatches) < 3 {
 		return nil, fmt.Errorf("issue when parsing dagger repo")
 	}
 
 	return &Require{
-		repo:              pkg.UniverseModule,
+		repo:              module,
 		path:              repoMatches[1],
 		version:           repoMatches[2],
 		versionConstraint: versionConstraint,
 
-		cloneRepo: "github.com/dagger/examples",
-		clonePath: path.Join("/helloapp", repoMatches[1]),
+		cloneRepo: "github.com/dagger/dagger",
+		clonePath: path.Join("pkg", module),
 	}, nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/2413

## Overview

I've been assuming that:
1. `dagger project update` installs both built-in and external packages
2. When installing an external package that's already in `dagger.sum` the checksum is being checked

It's how I think it should work and both turned out be wrong, as I've realized in:
- https://github.com/dagger/dagger/issues/2315#issuecomment-1119706942

## Before

- **`dagger project update`**
	- Copies built-ins from binary to `cue.mod/pkg`
	- Does not install external packages
- **`dagger project update -u`**
	- unreachable code
- checksum not being checked when installing a package with a version that matches `dagger.mod`

## After

- Install both built-in and external packages in `dagger project update`
- Recover `dagger project update -u` which updates all packages in `dagger.mod` to latest versions
- Verify checksum
- Better reporting (info log) on what's being done

Signed-off-by: Helder Correia