### PR TITLE
ci: Pass cache env vars through to integ tests.

### DIFF
--- a/ci.cue
+++ b/ci.cue
@@ -27,7 +27,14 @@ dagger.#Plan & {
 	]
 	client: filesystem: "./bin": write: contents: actions.build."go".output
 	client: network: "unix:///var/run/docker.sock": connect: dagger.#Socket
-	client: env: DAGGER_LOG_FORMAT: string | *"auto"
+	client: env: {
+		DAGGER_LOG_FORMAT:      string | *"auto"
+		DAGGER_CACHE_FROM?:     string
+		DAGGER_CACHE_TO?:       string
+		GITHUB_ACTIONS?:        string
+		ACTIONS_RUNTIME_TOKEN?: string
+		ACTIONS_CACHE_URL?:     string
+	}
 
 	actions: {
 		_source: client.filesystem["."].read.contents
@@ -110,8 +117,13 @@ dagger.#Plan & {
 					]
 				}
 				env: {
-					DAGGER_BINARY:     "/src/dagger"
-					DAGGER_LOG_FORMAT: client.env.DAGGER_LOG_FORMAT
+					DAGGER_BINARY:          "/src/dagger"
+					DAGGER_LOG_FORMAT:      client.env.DAGGER_LOG_FORMAT
+					DAGGER_CACHE_FROM?:     client.env.DAGGER_CACHE_FROM
+					DAGGER_CACHE_TO?:       client.env.DAGGER_CACHE_TO
+					GITHUB_ACTIONS?:        client.env.GITHUB_ACTIONS
+					ACTIONS_RUNTIME_TOKEN?: client.env.ACTIONS_RUNTIME_TOKEN
+					ACTIONS_CACHE_URL?:     client.env.ACTIONS_CACHE_URL
 				}
 				source: _mergeFS.output
 				initScript: #"""


### PR DESCRIPTION
The DAGGER_CACHE_{FROM,TO} env vars are set by a GHA step and
previously were just passed transparently to our integ tests. However,
after updating those tests to run in dagger, they were not being passed
along anymore.

This just updates ci.cue to explicitly pass them to the integ test
invocation.

In the long-term, it would probably be better to move the setting of
these env vars from a GHA step to within ci.cue. However, right now
since porting the universe tests to run inside dagger is still WIP it's
probably cleaner to just leave that in GHA rather than maintain it in
two places. Once everything's in dagger, it can migrate to ci.cue.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

cc @samalba 