### PR TITLE
feat: export secrets with `docker.#Run`

### DIFF
--- a/pkg/universe.dagger.io/docker/run.cue
+++ b/pkg/universe.dagger.io/docker/run.cue
@@ -150,6 +150,22 @@ import (
 			for path, output in _directories {
 				directories: "\(path)": output.contents
 			}
+
+			secrets: [path=string]: dagger.#Secret
+			_secrets: {
+				for path, _ in secrets {
+					"\(path)": {
+						contents: dagger.#Secret & _read.output
+						_read:    core.#NewSecret & {
+							input:  _exec.output
+							"path": path
+						}
+					}
+				}
+			}
+			for path, output in _secrets {
+				secrets: "\(path)": output.contents
+			}
 		}
 	}
 


### PR DESCRIPTION
`docker.#Run` can use `export` field to export files or directories from the
container.
With this commit, it will also be possible to export `#Secret`.

This will simplify action, like onepassword in #2395.

Resolves #2428

Signed-off-by: Vasek - Tom C <tom.chauveau@epitech.eu>