### PR TITLE
rename telemetry to analytics

### DIFF
--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -1,4 +1,4 @@
-package telemetry
+package analytics
 
 import (
 	"bytes"
@@ -23,7 +23,7 @@ import (
 
 const (
 	apiKey       = "cb9777c166aefe4b77b31f961508191c" //nolint
-	telemetryURL = "https://t.dagger.io/v1"
+	analyticsURL = "https://t.dagger.io/v1"
 )
 
 type Property struct {
@@ -46,7 +46,7 @@ func Track(ctx context.Context, eventName string, properties ...*Property) {
 		Str("event", eventName).
 		Logger()
 
-	if telemetryDisabled() {
+	if analyticsDisabled() {
 		return
 	}
 
@@ -106,7 +106,7 @@ func Track(ctx context.Context, eventName string, properties ...*Property) {
 		return
 	}
 
-	req, err := http.NewRequest("POST", telemetryURL, b)
+	req, err := http.NewRequest("POST", analyticsURL, b)
 	if err != nil {
 		lg.Trace().Err(err).Msg("failed to prepare request")
 	}
@@ -119,17 +119,17 @@ func Track(ctx context.Context, eventName string, properties ...*Property) {
 	start := time.Now()
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		lg.Trace().Err(err).Msg("failed to send telemetry event")
+		lg.Trace().Err(err).Msg("failed to send analytics event")
 		return
 	}
 	resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		lg.Trace().Str("status", resp.Status).Msg("telemetry request failed")
+		lg.Trace().Str("status", resp.Status).Msg("analytics request failed")
 		return
 	}
 
-	lg.Trace().Dur("duration", time.Since(start)).Msg("telemetry event")
+	lg.Trace().Dur("duration", time.Since(start)).Msg("analytics event")
 }
 
 type payload struct {
@@ -156,8 +156,8 @@ func isCI() bool {
 		os.Getenv("RUN_ID") != "" // TaskCluster, dsari
 }
 
-func telemetryDisabled() bool {
-	return os.Getenv("DAGGER_TELEMETRY_DISABLE") != "" || // dagger specific env
+func analyticsDisabled() bool {
+	return os.Getenv("DAGGER_DISABLE_ANALYTICS") != "" || // dagger specific env
 		os.Getenv("DO_NOT_TRACK") != "" // https://consoledonottrack.com/
 }
 

--- a/analytics/git.go
+++ b/analytics/git.go
@@ -1,4 +1,4 @@
-package telemetry
+package analytics
 
 import (
 	"fmt"

--- a/analytics/git_test.go
+++ b/analytics/git_test.go
@@ -1,4 +1,4 @@
-package telemetry
+package analytics
 
 import (
 	"testing"

--- a/cmd/dagger/cmd/common/track.go
+++ b/cmd/dagger/cmd/common/track.go
@@ -5,19 +5,19 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"go.dagger.io/dagger/telemetry"
+	"go.dagger.io/dagger/analytics"
 )
 
-// TrackCommand sends telemetry about a command execution
-func TrackCommand(ctx context.Context, cmd *cobra.Command, props ...*telemetry.Property) chan struct{} {
-	props = append([]*telemetry.Property{
+// TrackCommand sends analytics about a command execution
+func TrackCommand(ctx context.Context, cmd *cobra.Command, props ...*analytics.Property) chan struct{} {
+	props = append([]*analytics.Property{
 		{
 			Name:  "command",
 			Value: commandName(cmd),
 		},
 	}, props...)
 
-	return telemetry.TrackAsync(ctx, "Command Executed", props...)
+	return analytics.TrackAsync(ctx, "Command Executed", props...)
 }
 
 func commandName(cmd *cobra.Command) string {

--- a/cmd/dagger/cmd/do.go
+++ b/cmd/dagger/cmd/do.go
@@ -13,11 +13,11 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"go.dagger.io/dagger/analytics"
 	"go.dagger.io/dagger/cmd/dagger/cmd/common"
 	"go.dagger.io/dagger/cmd/dagger/logger"
 	"go.dagger.io/dagger/plan"
 	"go.dagger.io/dagger/solver"
-	"go.dagger.io/dagger/telemetry"
 	"golang.org/x/term"
 )
 
@@ -150,7 +150,7 @@ var doCmd = &cobra.Command{
 			}
 		})
 
-		doneCh := common.TrackCommand(ctx, cmd, &telemetry.Property{
+		doneCh := common.TrackCommand(ctx, cmd, &analytics.Property{
 			Name:  "action",
 			Value: targetPath.String(),
 		})

--- a/docs/learn/tests/helpers.bash
+++ b/docs/learn/tests/helpers.bash
@@ -10,9 +10,9 @@ common_setup() {
     #   otherwise infinite recursion when DAGGER_BINARY is not set.
     export DAGGER="${DAGGER_BINARY:-$(bash -c 'command -v dagger')}"
 
-    # Disable telemetry
-    DAGGER_TELEMETRY_DISABLE="1"
-    export DAGGER_TELEMETRY_DISABLE
+    # Disable analytics
+    DAGGER_DISABLE_ANALYTICS="1"
+    export DAGGER_DISABLE_ANALYTICS
 
     # Set the project to the universe directory (so tests can run from anywhere)
     UNIVERSE="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )"

--- a/pkg/universe.dagger.io/bats_helpers.bash
+++ b/pkg/universe.dagger.io/bats_helpers.bash
@@ -7,9 +7,9 @@ common_setup() {
     #   otherwise infinite recursion when DAGGER_BINARY is not set.
     export DAGGER="${DAGGER_BINARY:-$(bash -c 'command -v dagger')}"
 
-    # Disable telemetry
-    DAGGER_TELEMETRY_DISABLE="1"
-    export DAGGER_TELEMETRY_DISABLE
+    # Disable analytics
+    DAGGER_DISABLE_ANALYTICS="1"
+    export DAGGER_DISABLE_ANALYTICS
 
     # Force plain printing for error reporting
     DAGGER_LOG_FORMAT="plain"


### PR DESCRIPTION
This is to avoid confusion with telemetry data (e.g. we need to use the package name `telemetry` for other stuff)

/cc @marcosnils @gerhard @shykes 