### PR TITLE
ci: moving universe and docs integration tests to the dagger CI plan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,11 +59,6 @@ integration: core-integration universe-test doc-test # Run all integration tests
 core-integration: dagger # Run core integration tests
 	./cmd/dagger/dagger do test integration core
 
-# .PHONY: universe-test
-# universe-test: dagger-debug # Run universe tests
-# yarn --cwd "./pkg/universe.dagger.io" install
-# TESTDIR=$(UNIVERSE_TESTDIR) DAGGER_BINARY="$(shell pwd)/cmd/dagger/dagger" yarn --cwd "./pkg/universe.dagger.io" test
-
 .PHONY: universe-test
 universe-test: dagger # Run universe tests
 	./cmd/dagger/dagger do test integration universe

--- a/Makefile
+++ b/Makefile
@@ -57,22 +57,20 @@ integration: core-integration universe-test doc-test # Run all integration tests
 
 .PHONY: core-integration
 core-integration: dagger # Run core integration tests
-	./cmd/dagger/dagger do test integration
+	./cmd/dagger/dagger do test integration core
 
 # .PHONY: universe-test
 # universe-test: dagger-debug # Run universe tests
-# 	yarn --cwd "./universe" install
-# 	DAGGER_BINARY="$(shell pwd)/cmd/dagger/dagger-debug" yarn --cwd "./universe" test
+# yarn --cwd "./pkg/universe.dagger.io" install
+# TESTDIR=$(UNIVERSE_TESTDIR) DAGGER_BINARY="$(shell pwd)/cmd/dagger/dagger" yarn --cwd "./pkg/universe.dagger.io" test
 
 .PHONY: universe-test
 universe-test: dagger # Run universe tests
-	yarn --cwd "./pkg/universe.dagger.io" install
-	TESTDIR=$(UNIVERSE_TESTDIR) DAGGER_BINARY="$(shell pwd)/cmd/dagger/dagger" yarn --cwd "./pkg/universe.dagger.io" test
+	./cmd/dagger/dagger do test integration universe
 
 .PHONY: doc-test
-doc-test: dagger-debug # Test docs
-	yarn --cwd "./docs/learn/tests" install
-	DAGGER_BINARY="$(shell pwd)/cmd/dagger/dagger-debug" yarn --cwd "./docs/learn/tests" test
+doc-test: dagger # Test docs
+	./cmd/dagger/dagger do test integration doc
 
 .PHONY: docs
 docs: dagger # Generate docs

--- a/ci.cue
+++ b/ci.cue
@@ -92,7 +92,6 @@ dagger.#Plan & {
 		test: {
 			// Go unit tests
 			unit: go.#Test & {
-				// container: image: _goImage.output
 				source:  _source
 				package: "./..."
 
@@ -104,12 +103,9 @@ dagger.#Plan & {
 				// Directory containing the basts files
 				path: string
 
-				_daggerLinuxBin: go.#Build & {
-					source:  _source
-					package: "./cmd/dagger/"
-					arch:    client.platform.arch
-					container: command: flags: "-race": true
-				}
+				// dagger binary
+				daggerBinary: _
+
 				_testDir: core.#Subdir & {
 					input:  _source
 					"path": path
@@ -119,7 +115,7 @@ dagger.#Plan & {
 						// directory containing integration tests
 						_testDir.output,
 						// dagger binary
-						_daggerLinuxBin.output,
+						daggerBinary.output,
 					]
 				}
 
@@ -162,15 +158,23 @@ dagger.#Plan & {
 
 			integration: {
 				core: #BatsIntegrationTest & {
-					path: "tests"
+					path:         "tests"
+					daggerBinary: go.#Build & {
+						source:  _source
+						package: "./cmd/dagger/"
+						arch:    client.platform.arch
+						container: command: flags: "-race": true
+					}
 				}
 				doc: #BatsIntegrationTest & {
-					path: "docs/learn/tests"
+					path:         "docs/learn/tests"
+					daggerBinary: build.go
 				}
 				universe: #BatsIntegrationTest & {
-					path:      "pkg"
-					testDir:   "universe.dagger.io"
-					extraArgs: "$(find . -type f -name '*.bats' -not -path '*/node_modules/*' -not -path '*/cue.mod/*')"
+					path:         "pkg"
+					daggerBinary: build.go
+					testDir:      "universe.dagger.io"
+					extraArgs:    "$(find . -type f -name '*.bats' -not -path '*/node_modules/*' -not -path '*/cue.mod/*')"
 				}
 			}
 		}

--- a/ci.cue
+++ b/ci.cue
@@ -37,6 +37,7 @@ dagger.#Plan & {
 		GITHUB_ACTIONS:                string | *""
 		ACTIONS_RUNTIME_TOKEN:         string | *""
 		ACTIONS_CACHE_URL:             string | *""
+		TESTDIR:                       string | *"."
 	}
 
 	actions: {
@@ -168,13 +169,14 @@ dagger.#Plan & {
 				}
 				doc: #BatsIntegrationTest & {
 					path:         "docs/learn/tests"
-					daggerBinary: build.go
+					daggerBinary: build.go & {os: "linux"}
 				}
 				universe: #BatsIntegrationTest & {
 					path:         "pkg"
-					daggerBinary: build.go
+					daggerBinary: build.go & {os: "linux"}
 					testDir:      "universe.dagger.io"
-					extraArgs:    "$(find . -type f -name '*.bats' -not -path '*/node_modules/*' -not -path '*/cue.mod/*')"
+					env: TESTDIR: client.env.TESTDIR
+					extraArgs: "$(find ${TESTDIR:-.} -type f -name '*.bats' -not -path '*/node_modules/*' -not -path '*/cue.mod/*')"
 				}
 			}
 		}

--- a/ci/bats/bats.cue
+++ b/ci/bats/bats.cue
@@ -22,9 +22,16 @@ import (
 	// Mount points for the bats container
 	mounts: [name=string]: _
 
+	// args to the bats cli
+	extraArgs: string | *""
+
+	// test directory containing bats files
+	testDir: string | *""
+
 	docker.#Build & {
 		_packages: ["yarn", "git", "docker", "curl"]
 		_batsMods: ["bats-support", "bats-assert"]
+		_workDir: "/src/\(testDir)"
 
 		steps: [
 			docker.#Pull & {
@@ -58,7 +65,7 @@ import (
 			for mod in _batsMods {
 				docker.#Run & {
 					entrypoint: []
-					workdir: "/src"
+					workdir: _workDir
 					command: {
 						name: "yarn"
 						args: ["add", mod]
@@ -69,7 +76,7 @@ import (
 			if initScript != null {
 				bash.#Run & {
 					"env":   env
-					workdir: "/src"
+					workdir: _workDir
 					script: contents: initScript
 				}
 			},
@@ -77,9 +84,9 @@ import (
 			bash.#Run & {
 				"env":    env
 				"mounts": mounts
-				workdir:  "/src"
+				workdir:  _workDir
 				script: contents: """
-					bats --jobs 4 --print-output-on-failure --verbose-run .
+					bats --jobs 4 --print-output-on-failure --verbose-run \(extraArgs) .
 					"""
 			},
 		]

--- a/pkg/universe.dagger.io/age_key.txt
+++ b/pkg/universe.dagger.io/age_key.txt
@@ -1,0 +1,6 @@
+# To manually use this AGE key with sops, run
+#   export SOPS_AGE_KEY_FILE="$(git rev-parse --show-toplevel)/tests/age_key.txt"
+# Dagger CI
+# created: 2021-05-26T17:10:52-07:00
+# public key: age1gxwmtwahzwdmrskhf90ppwlnze30lgpm056kuesrxzeuyclrwvpsupwtpk
+AGE-SECRET-KEY-1R8RRCL7NXA5SHW6HEZCJ5FJG2JJECSNVDHCF533W3CNDJGQL0AVQEA0JK7

--- a/pkg/universe.dagger.io/bats_helpers.bash
+++ b/pkg/universe.dagger.io/bats_helpers.bash
@@ -7,9 +7,9 @@ common_setup() {
     #   otherwise infinite recursion when DAGGER_BINARY is not set.
     export DAGGER="${DAGGER_BINARY:-$(bash -c 'command -v dagger')}"
 
-    # Disable analytics
-    DAGGER_DISABLE_ANALYTICS="1"
-    export DAGGER_DISABLE_ANALYTICS
+    # Disable telemetry
+    DAGGER_TELEMETRY_DISABLE="1"
+    export DAGGER_TELEMETRY_DISABLE
 
     # Force plain printing for error reporting
     DAGGER_LOG_FORMAT="plain"
@@ -22,7 +22,7 @@ common_setup() {
         export DAGGER_CACHE_FROM="$DAGGER_CACHE_FROM-$BATS_TEST_NAME"
     fi
 
-    SOPS_AGE_KEY_FILE="$(dirname "${BASH_SOURCE[0]}")/../../tests/age_key.txt"
+    SOPS_AGE_KEY_FILE="$(dirname "${BASH_SOURCE[0]}")/age_key.txt"
     export SOPS_AGE_KEY_FILE
 
     # cd into the directory containing the bats file

--- a/pkg/universe.dagger.io/secrets_sops.yaml
+++ b/pkg/universe.dagger.io/secrets_sops.yaml
@@ -1,1 +1,26 @@
-../../tests/secrets_sops.yaml
+TestPAT: ENC[AES256_GCM,data:R6yLIJWAdXBiXtNewC9TNZoG92Stzebvc94XHaTjdg1H3iLkV9/J4w==,iv:TDIkf+YNFnqj1f9UFPcMfHblcpLT56cOlShpm5JaMkY=,tag:urFpg9cSg+7+nsf9DON1Fw==,type:str]
+NETLIFY_TOKEN: ENC[AES256_GCM,data:AyLLlXC3FuAwHuQLM5RRhzwKIZyFkucKBABLXeWBYLnF9oaEfhn/xBRCbw==,iv:QyMGzxp4NY2jgFgj6ZEW7sGXQdPBWHPfRrs196EHnLg=,tag:/IJYM6C/g9iNcY+IQrUvbA==,type:str]
+DOCKERHUB_TOKEN: ENC[AES256_GCM,data:oYROIHQZfR7c28aGvdDU3mURR/SBGhlbRsd84mNVAuxdy6S8,iv:RsVszAOxF19Z3i4HbWw4BKHCJdly8IT2gVOrQwE5Fgk=,tag:oks5BXxcU3UzoawzNkX7uw==,type:str]
+AWS:
+    AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:KahWpPHbl+rv1RGOJHfl+g76FgQ=,iv:iDAYBuCJ4xMKLf4dHM50hq7B22nVXRd/nxAynwgjlns=,tag:+aBqWay5U//pT5b3RSGYWw==,type:str]
+    AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:mlEQJPJxsnaaXvB0L3SeNbAbY+rsKP4J01NzCvtQsyOMN35COXETDQ==,iv:NH5zhV5akMXcH+Gx/DvVHdOrl31kaIDwtyw1IF0gzHg=,tag:NL3uBHqHDFT80FqbflMVtw==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1gxwmtwahzwdmrskhf90ppwlnze30lgpm056kuesrxzeuyclrwvpsupwtpk
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTa2ZOR3U1YzRNNGhwMHZx
+            dG5yUFlyK2VMZGVaWkcxdzRwMk5oQjB1MVY4CnJKMTVONksvZHIrQkJIcWZpVXhK
+            aUR1N0dtazM1ODFzS01CVmlVeERKeUEKLS0tIHh4OEVtc1BMbU9MRXRoOGJQakhj
+            cjgrby94cDZ0SW51UFNjVmpjVFNCeE0K9/OH1T2xiNSu27uTE6fqyzZfAIzpSNdL
+            q/1B8YeDrRGg/jYYW53bLlwmcBzAK89JdE/RtFnLnqJ203mhrnpIWw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2022-03-30T20:59:45Z"
+    mac: ENC[AES256_GCM,data:lfCIakVD8rd5PV38i9uz1z0btv/EQdlDbluxnZ+7fH9TDaKzLEgMhBrI/uOT8JImzVkgLB084nRPvfmIDQneAsE+lNakcWkUYHibxSjMr9fibaRnBSUFh3MfXf1zogKdIYjeoOdHyOAC7xus303ASJbebF45BiRVun+rjLIf1Pk=,iv:3K9RJzPymURK58zuHRil412rLmkQ4Mbz3B7zXW74aMw=,tag:haRsB73PQ9FPp1h265J3ew==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.2


### PR DESCRIPTION
This is a follow-up of PR #2284

It adds integration tests for:
- documentation
- universe packages

Closes #1522