### PR TITLE
ci: Split Experimental tests from Universe tests

### DIFF
--- a/.github/workflows/test-experimental-universe.yml
+++ b/.github/workflows/test-experimental-universe.yml
@@ -1,0 +1,79 @@
+name: "Test Experimental Universe"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**.sh"
+      - "**.bash"
+      - "**.go"
+      - "**.cue"
+      - "**.bats"
+      - "Makefile"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/test-experimental-universe.yml"
+      - "!docs/**"
+      - "docs/tests/**"
+
+  pull_request:
+    branches: [main]
+    paths:
+      - "**.sh"
+      - "**.bash"
+      - "**.go"
+      - "**.cue"
+      - "**.bats"
+      - "Makefile"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/test-experimental-universe.yml"
+      - "!docs/**"
+      - "docs/tests/**"
+
+env:
+  DAGGER_CACHE_BASE: dagger-ci-experimental-universe
+
+jobs:
+  experimental-universe-tests:
+    name: "Experimental Universe Tests - Europa"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: "Check out"
+        uses: actions/checkout@v2
+
+      - name: "Set up Go"
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.16
+
+      - name: "Install SOPS"
+        run: |
+          sudo curl -L -o /usr/local/bin/sops https://github.com/mozilla/sops/releases/download/v3.7.1/sops-v3.7.1.linux
+          sudo chmod +x /usr/local/bin/sops
+
+      - name: "Expose GitHub Runtime"
+        uses: crazy-max/ghaction-github-runtime@v1
+
+      - name: Sets env vars on push to main
+        run: |
+          echo "DAGGER_CACHE_TO=type=gha,mode=max,scope=${{env.DAGGER_CACHE_BASE}}-main" >> $GITHUB_ENV
+          echo "DAGGER_CACHE_FROM=type=gha,scope=${{env.DAGGER_CACHE_BASE}}-main" >> $GITHUB_ENV
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+
+      - name: Sets env vars on pull request
+        run: |
+          echo "DAGGER_CACHE_TO=type=gha,mode=max,scope=${{env.DAGGER_CACHE_BASE}}-${{github.event.number}}" >> $GITHUB_ENV
+          echo "DAGGER_CACHE_FROM=type=gha,scope=${{env.DAGGER_CACHE_BASE}}-main type=gha,scope=${{env.DAGGER_CACHE_BASE}}-${{github.event.number}}" >> $GITHUB_ENV
+        if: ${{ github.event_name == 'pull_request' }}
+
+      - name: Test
+        run: |
+          export DAGGER_LOG_FORMAT=plain
+          make experimental-universe-tests
+
+      - name: Print Buildkitd Logs
+        if: ${{ failure() }}
+        run: |
+          docker logs dagger-buildkitd

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,10 @@ core-integration: dagger # Run core integration tests
 universe-test: dagger # Run universe tests
 	./cmd/dagger/dagger do test integration universe
 
+.PHONY: experimental-universe-tests
+experimental-universe-tests: dagger # Run experimental universe tests
+	./cmd/dagger/dagger do test integration experimental
+
 .PHONY: doc-test
 doc-test: dagger # Test docs
 	./cmd/dagger/dagger do test integration doc

--- a/ci.cue
+++ b/ci.cue
@@ -176,6 +176,13 @@ dagger.#Plan & {
 					daggerBinary: build.go & {os: "linux"}
 					testDir:      "universe.dagger.io"
 					env: TESTDIR: client.env.TESTDIR
+					extraArgs: "$(find ${TESTDIR:-.} -type f -name '*.bats' -not -path '*/node_modules/*' -not -path '*/cue.mod/*' -not -path '*/x/*')"
+				}
+				experimental: #BatsIntegrationTest & {
+					path:         "pkg"
+					daggerBinary: build.go & {os: "linux"}
+					testDir:      "universe.dagger.io/x"
+					env: TESTDIR: client.env.TESTDIR
 					extraArgs: "$(find ${TESTDIR:-.} -type f -name '*.bats' -not -path '*/node_modules/*' -not -path '*/cue.mod/*')"
 				}
 			}

--- a/pkg/universe.dagger.io/package.json
+++ b/pkg/universe.dagger.io/package.json
@@ -1,7 +1,8 @@
 {
   "license": "Apache-2.0",
   "scripts": {
-    "test": "bats --report-formatter junit --print-output-on-failure --jobs 4 $(find ${TESTDIR:-.} -type f -name '*.bats' -not -path '*/node_modules/*')"
+    "test": "bats --report-formatter junit --print-output-on-failure --jobs 4 $(find ${TESTDIR:-.} -type f -name '*.bats' -not -path '*/node_modules/*' -not -path '*/x/*')",
+    "test-experimental": "bats --report-formatter junit --print-output-on-failure --jobs 4 $(find ${TESTDIR:-./x} -type f -name '*.bats' -not -path '*/node_modules/*')"
   },
   "devDependencies": {
     "bats": "^1.5.0",


### PR DESCRIPTION
Closes #2375 

A new workflow has been created to run the experimental packages "x" inside "universe.dagger.io".
This workflow is named `test-experimental-universe.yml` and its based on `test-universe.yml`.

The `package.json` in the "universe.dagger.io" folder has been modified to add another script to only test the experimental packages and the original "test" script now ignores the tests in folder "x".

Main `Makefile` has been modified to add a new task for this.

After reviewing and merging this PR when all is ready, we need to ensure that in the repo settings, in "Branch protection rules", the "Status checks that are required" does not contain this workflow, so PRs can be merged when this tests fail:

![Settings to modify in repo](https://user-images.githubusercontent.com/11027628/168479258-179dc5de-36ad-4182-9793-4f5f24e94bd4.png)


Signed-off-by: piraces <raul.piraces@gmail.com>