### PR TITLE
Support signaling core.Start execs.

### DIFF
--- a/pkg/dagger.io/dagger/core/exec.cue
+++ b/pkg/dagger.io/dagger/core/exec.cue
@@ -76,15 +76,18 @@ import "dagger.io/dagger"
 	_id: string | null @dagger(generated)
 }
 
-// Stop an asynchronous command created by #Start
+// Stop an asynchronous command created by #Start by sending SIGKILL. If
+// the optional timeout is specified, the command will be given that duration
+// to exit on its own before being sent SIGKILL.
 #Stop: {
 	$dagger: task: _name: "Stop"
 
 	input: #Start
 
-	// Command exit code. If the command was still running when
-	// stopped, it will be sent SIGKILL and the exit code will
-	// thus be 137.
+	// Time to wait for the command to exit on its own before sending SIGKILL.
+	timeout: int64 | *0
+
+	// Command exit code
 	exit: uint8 @dagger(generated)
 }
 
@@ -125,3 +128,49 @@ import "dagger.io/dagger"
 #TempDir: {
 	size: int64 | *0
 }
+
+// Send a signal to a command created by #Start. SIGKILL is not
+// supported here. Instead, #Stop should be used to forcibly stop
+// a command.
+#SendSignal: {
+	$dagger: task: _name: "SendSignal"
+
+	input: #Start
+
+	signal: or([ for name, signal in _signals {signal}])
+}
+
+_signals: {
+	SIGHUP:    1
+	SIGINT:    2
+	SIGQUIT:   3
+	SIGILL:    4
+	SIGTRAP:   5
+	SIGABRT:   6
+	SIGBUS:    7
+	SIGFPE:    8
+	SIGUSR1:   10
+	SIGSEGV:   11
+	SIGUSR2:   12
+	SIGPIPE:   13
+	SIGALRM:   14
+	SIGTERM:   15
+	SIGTKFLT:  16
+	SIGCHLD:   17
+	SIGCONT:   18
+	SIGSTOP:   19
+	SIGTSTP:   20
+	SIGTTIN:   21
+	SIGTTOU:   22
+	SIGURG:    23
+	SIGXCPU:   24
+	SIGXFSZ:   25
+	SIGVTALRM: 26
+	SIGPROF:   27
+	SIGWINCH:  28
+	SIGIO:     29
+	SIGPWR:    30
+	SIGSYS:    31
+}
+
+_signals

--- a/solver/solver.go
+++ b/solver/solver.go
@@ -81,7 +81,7 @@ func (s *Solver) NoCache() bool {
 func (s *Solver) Stop(ctx context.Context) {
 	lg := log.Ctx(ctx)
 	for ctrID := range s.containers {
-		if _, err := s.StopContainer(ctx, ctrID); err != nil {
+		if _, err := s.StopContainer(ctx, ctrID, 0); err != nil {
 			lg.Error().Err(err).Str("container", ctrID).Msg("failed to stop container")
 		}
 	}

--- a/tests/tasks.bats
+++ b/tests/tasks.bats
@@ -88,15 +88,22 @@ setup() {
 @test "task: #Start #Stop" {
     cd ./tasks/exec
     run "$DAGGER" "do" --log-format=plain -l info -p ./start_stop_exec.cue basicTest
+    assert_success
     assert_line --partial 'actions.basicTest.start'
     assert_line --regexp 'actions\.basicTest\.sleep \| .*taking a quick nap'
-    # order of start and sleep is variable, but Stop must be last
-    assert_line --partial --index 7 'actions.basicTest.stop'
+    # order of start and sleep is variable, but Sig and Stop must be last
+    assert_line --partial --index 7 'actions.basicTest.sig'
+    assert_line --partial --index 9 'actions.basicTest.stop'
 }
 
 @test "task: #Start #Stop params" {
     cd ./tasks/exec
     "$DAGGER" "do" -p ./start_stop_exec.cue execParamsTest
+}
+
+@test "task: #Start #Stop timeout" {
+    cd ./tasks/exec
+    "$DAGGER" "do" -p ./start_stop_exec.cue stopTimeoutTest
 }
 
 @test "task: #Copy exec" {


### PR DESCRIPTION
This adds a new core.SendSignal task that enables arbitrary signals to
be sent to an async Start exec. It also adds related support to
core.Stop for specifying a timeout to wait for the exec to exit on its
own before sending SIGKILL.

The main goal here is to support ending Start execs gracefully instead
of being forced to always just SIGKILL them as part of core.Stop. It
should be useful in general for any other use cases that call for
signals to be sent to these execs (i.e. SIGWINCH for future tty
support).

Among other things, this is needed to support running Jaeger via
core.Start (without a graceful stop, its data gets corrupted).

Signed-off-by: Erik Sipsma <erik@sipsma.dev>