### PR TITLE
feature: Add ability to filter universe tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ core-integration: dagger # Run core integration tests
 .PHONY: universe-test
 universe-test: dagger-debug # Run universe tests
 	yarn --cwd "./pkg/universe.dagger.io" install
-	DAGGER_BINARY="$(shell pwd)/cmd/dagger/dagger-debug" yarn --cwd "./pkg/universe.dagger.io" test
+	TESTDIR=$(UNIVERSE_TESTDIR) DAGGER_BINARY="$(shell pwd)/cmd/dagger/dagger-debug" yarn --cwd "./pkg/universe.dagger.io" test
 
 .PHONY: doc-test
 doc-test: dagger-debug # Test docs

--- a/pkg/universe.dagger.io/package.json
+++ b/pkg/universe.dagger.io/package.json
@@ -1,7 +1,7 @@
 {
   "license": "Apache-2.0",
   "scripts": {
-    "test": "bats --report-formatter junit --print-output-on-failure --jobs 4 $(find . -type f -name '*.bats' -not -path '*/node_modules/*')"
+    "test": "bats --report-formatter junit --print-output-on-failure --jobs 4 $(find ${TESTDIR:-.} -type f -name '*.bats' -not -path '*/node_modules/*')"
   },
   "devDependencies": {
     "bats": "^1.5.0",


### PR DESCRIPTION
This adds a makefile `UNIVERSE_TESTDIR` variable which, when set, will
be passed to `find` to filter the tests.

Example:

```
make universe-test UNIVERSE_TESTDIR=x
```

This will filter out anything under under the `x` dir in universe.

One can also set something like `UNIVERSE_TESTDIR=x/<email>` to test
only packages under a certain author or just `UNIVERSE_TESTDIR=alpine`
to test the main alpine pacakge.

Signed-off-by: Brian Goff <cpuguy83@gmail.com>