### PR TITLE
gitpod: mark /src directory as safe to use

### DIFF
--- a/ci/gitpod/test.cue
+++ b/ci/gitpod/test.cue
@@ -27,11 +27,16 @@ import (
 		}
 		workdir: "/src"
 		script: contents: """
+			set -ex
+
+			# Mark the /src directory as safe to use even if its owned by a different user
+			git config --global --add safe.directory /src
+
 			# Create Go cache dir
 			sudo mkdir -p /workspace/go && sudo chown gitpod:gitpod /workspace/go
 
 			# Read the shell script from config and execute it
-			yq ".tasks[0].init" .gitpod.yml | bash -
+			yq ".tasks[0].init" .gitpod.yml | bash -x -e -
 			
 			# Ensure the expected tools were installed
 			make install


### PR DESCRIPTION
More recent versions of git include extra safety checks on the owner of
directories before doing any operations on them. This meant that various
calls to git would fail due to being copied from the host, where the
source code is most often not owned by root (the user in the container).

This fixes the issue by just telling git it's okay to use the /src
directory anyways.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>