### PR TITLE
Universe: new and improved yarn package

### DIFF
--- a/tests/plan/validate/concrete/yarn.cue
+++ b/tests/plan/validate/concrete/yarn.cue
@@ -10,5 +10,5 @@ import (
 //    ../../cue.mod/pkg/universe.dagger.io/docker/run.cue:13:2
 
 dagger.#Plan & {
-	actions: test: yarn.#Run
+	actions: test: yarn.#Command
 }


### PR DESCRIPTION
This is a rewrite of the official yarn package. It is based on my experimental version (`universe.dagger.io/x/solomon@dagger.io/yarn`).

NOTE: this PR depends on #2480 , please merge that first.

Improvements include:

* Usable by the example todoapp plan (which includes a custom inline implementation with hacks). See #2482
* More granular API
  * `#Script` to run a yarn script (`yarn run ...`)
  * `#Install` to install dependencies (`yarn install`)
  * `#Command` to run any command (`yarn ...`)
* Proper use of yarn cache, configurable with project name
* App source code is mounted instead of copied (more efficient)
* Action container can be customized, including with custom image (to run a custom `yarn` binary)
* Tests are improved and self-contained (use `core.#Source`)

Note: one small breaking change: `yarn.#Build.name` is now `yarn.#Build.project`. I tried to add reverse compat but ran into mystical CUE errors... And could not find any configuration that actually used that field.