### PR TITLE
fix: Bump `dagger.io` package requirement

### DIFF
--- a/pkg/pkg.go
+++ b/pkg/pkg.go
@@ -31,7 +31,7 @@ var (
 	// ModuleRequirements specifies the MINIMUM version of the module dagger requires in order to work.
 	// This must be updated whenever we make breaking changes so users are prompt to upgrade the packages.
 	ModuleRequirements = map[string]*gv.Version{
-		DaggerModule:   gv.Must(gv.NewVersion("0.2.9")),
+		DaggerModule:   gv.Must(gv.NewVersion("0.2.11")),
 		UniverseModule: gv.Must(gv.NewVersion("0.2.9")),
 	}
 


### PR DESCRIPTION
There was a change in `client: filesystem` in v0.2.11 so we need to bump the requirement. The change is backwards compatible but CUE and Go need to be in sync.

Signed-off-by: Helder Correia