### PR TITLE
telemetry: event type system

### DIFF
--- a/telemetry/context.go
+++ b/telemetry/context.go
@@ -1,0 +1,23 @@
+package telemetry
+
+import (
+	"context"
+)
+
+var contextKey struct{}
+
+func Ctx(ctx context.Context) *Telemetry {
+	// Return the contextual telemetry
+	if t, ok := ctx.Value(contextKey).(*Telemetry); ok {
+		return t
+	}
+
+	// If not available, return a brand new *disabled* telemetry
+	return New(Config{
+		Enable: false,
+	})
+}
+
+func (t *Telemetry) WithContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, contextKey, t)
+}

--- a/telemetry/event/action.go
+++ b/telemetry/event/action.go
@@ -1,0 +1,125 @@
+package event
+
+// ActionPending signals a discovered action, not yet executed.
+type ActionPending struct {
+	Name string `json:"name"`
+}
+
+func (a ActionPending) EventName() string {
+	return "action.pending"
+}
+
+func (a ActionPending) EventVersion() string {
+	return eventVersion
+}
+
+func (a ActionPending) Validate() error {
+	if a.Name == "" {
+		return ErrMalformedEvent
+	}
+	return nil
+}
+
+// ActionStarted signals the start of an action
+type ActionStarted struct {
+	Name string `json:"name"`
+}
+
+func (a ActionStarted) EventName() string {
+	return "action.started"
+}
+
+func (a ActionStarted) EventVersion() string {
+	return eventVersion
+}
+
+func (a ActionStarted) Validate() error {
+	if a.Name == "" {
+		return ErrMalformedEvent
+	}
+	return nil
+}
+
+// ActionSkipped signals a skipped action.
+type ActionSkipped struct {
+	Name string `json:"name"`
+}
+
+func (a ActionSkipped) EventName() string {
+	return "action.skipped"
+}
+
+func (a ActionSkipped) EventVersion() string {
+	return eventVersion
+}
+
+func (a ActionSkipped) Validate() error {
+	if a.Name == "" {
+		return ErrMalformedEvent
+	}
+	return nil
+}
+
+// ActionCancelled signals a cancelled action.
+type ActionCancelled struct {
+	Name string `json:"name"`
+}
+
+func (a ActionCancelled) EventName() string {
+	return "action.cancelled"
+}
+
+func (a ActionCancelled) EventVersion() string {
+	return eventVersion
+}
+
+func (a ActionCancelled) Validate() error {
+	if a.Name == "" {
+		return ErrMalformedEvent
+	}
+	return nil
+}
+
+// ActionFailed signals a failed action.
+type ActionFailed struct {
+	Name  string `json:"name"`
+	Error string `json:"error"`
+}
+
+func (a ActionFailed) EventName() string {
+	return "action.failed"
+}
+
+func (a ActionFailed) EventVersion() string {
+	return eventVersion
+}
+
+func (a ActionFailed) Validate() error {
+	if a.Name == "" {
+		return ErrMalformedEvent
+	}
+	if a.Error == "" {
+		return ErrMalformedEvent
+	}
+	return nil
+}
+
+// ActionCompleted signals a completed action.
+type ActionCompleted struct {
+	Name string `json:"name"`
+}
+
+func (a ActionCompleted) EventName() string {
+	return "action.completed"
+}
+
+func (a ActionCompleted) EventVersion() string {
+	return eventVersion
+}
+
+func (a ActionCompleted) Validate() error {
+	if a.Name == "" {
+		return ErrMalformedEvent
+	}
+	return nil
+}

--- a/telemetry/event/event.go
+++ b/telemetry/event/event.go
@@ -1,0 +1,107 @@
+package event
+
+import (
+	"errors"
+	"runtime"
+	"strings"
+	"time"
+
+	"go.dagger.io/dagger/version"
+)
+
+var (
+	ErrMalformedEvent = errors.New("malformed event properties")
+)
+
+const eventVersion = "2022-05-25.01"
+
+type Event struct {
+	// Name is the type of the events
+	// Format is as such: `<object>.<action>`, e.g. `action.started`
+	Name string `json:"name"`
+
+	Version   string `json:"v"`
+	Timestamp int64  `json:"ts"`
+
+	Data Properties `json:"data,omitempty"`
+
+	Engine engineProperties `json:"engine"`
+	Run    runProperties    `json:"run,omitempty"`
+}
+
+type engineProperties struct {
+	ID string `json:"id"`
+
+	Version  string `json:"version"`
+	Revision string `json:"revision"`
+
+	OS   string `json:"os"`
+	Arch string `json:"arch"`
+}
+
+type runProperties struct {
+	ID string `json:"id,omitempty"`
+}
+
+func (e engineProperties) Validate() error {
+	switch {
+	// FIXME: not implemented
+	// case e.ID == "":
+	// 	return ErrMalformedEvent
+	case e.Version == "":
+		return ErrMalformedEvent
+	case e.OS == "":
+		return ErrMalformedEvent
+	case e.Arch == "":
+		return ErrMalformedEvent
+	}
+	return nil
+}
+
+type Properties interface {
+	EventName() string
+	EventVersion() string
+	Validate() error
+}
+
+func (e *Event) Validate() error {
+	switch {
+	case e.Name == "":
+		return ErrMalformedEvent
+	case !strings.Contains(e.Name, "."):
+		return ErrMalformedEvent
+	case e.Version == "":
+		return ErrMalformedEvent
+	case e.Timestamp == 0:
+		return ErrMalformedEvent
+	}
+
+	if err := e.Engine.Validate(); err != nil {
+		return err
+	}
+
+	if err := e.Data.Validate(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func New(props Properties) *Event {
+	return &Event{
+		Name: props.EventName(),
+
+		Version:   props.EventVersion(),
+		Timestamp: time.Now().UTC().UnixNano(),
+
+		Data: props,
+
+		Engine: engineProperties{
+			Version:  version.Version,
+			Revision: version.Revision,
+
+			OS:   runtime.GOOS,
+			Arch: runtime.GOARCH,
+		},
+	}
+}

--- a/telemetry/event/event_test.go
+++ b/telemetry/event/event_test.go
@@ -1,0 +1,15 @@
+package event
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvent(t *testing.T) {
+	require.ErrorIs(t, New(ActionStarted{}).Validate(), ErrMalformedEvent)
+
+	require.NoError(t, New(ActionStarted{
+		Name: "myaction",
+	}).Validate())
+}

--- a/telemetry/event/log.go
+++ b/telemetry/event/log.go
@@ -1,0 +1,29 @@
+package event
+
+// LogEmitted represents a log message
+type LogEmitted struct {
+	Message string `json:"message"`
+	Level   string `json:"level"`
+
+	Fields map[string]interface{} `json:"fields"`
+}
+
+func (e LogEmitted) EventName() string {
+	return "log.emitted"
+}
+
+func (e LogEmitted) EventVersion() string {
+	return eventVersion
+}
+
+func (e LogEmitted) Validate() error {
+	switch {
+	case e.Message == "":
+		return ErrMalformedEvent
+	case e.Level == "":
+		return ErrMalformedEvent
+	case e.Fields == nil:
+		return ErrMalformedEvent
+	}
+	return nil
+}

--- a/telemetry/event/run.go
+++ b/telemetry/event/run.go
@@ -1,0 +1,51 @@
+package event
+
+// RunStarted represents the start of a run
+type RunStarted struct {
+	Action string   `json:"action"`
+	Args   []string `json:"args"`
+}
+
+func (e RunStarted) EventName() string {
+	return "run.started"
+}
+
+func (e RunStarted) EventVersion() string {
+	return eventVersion
+}
+
+func (e RunStarted) Validate() error {
+	if e.Action == "" {
+		return ErrMalformedEvent
+	}
+	return nil
+}
+
+type RunCompletedState string
+
+const (
+	RunCompletedStateSuccess RunCompletedState = "success"
+	RunCompletedStateFailed  RunCompletedState = "failed"
+)
+
+// RunCompleted represents the completion of a run
+type RunCompleted struct {
+	State   RunCompletedState `json:"state"`
+	Error   string            `json:"error,omitempty"`
+	Outputs map[string]string `json:"outputs,omitempty"`
+}
+
+func (e RunCompleted) EventName() string {
+	return "run.completed"
+}
+
+func (e RunCompleted) EventVersion() string {
+	return eventVersion
+}
+
+func (e RunCompleted) Validate() error {
+	if e.State != RunCompletedStateSuccess && e.State != RunCompletedStateFailed {
+		return ErrMalformedEvent
+	}
+	return nil
+}

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -1,0 +1,70 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+	"go.dagger.io/dagger/telemetry/event"
+)
+
+const queueSize = 2048
+
+type Config struct {
+	Enable bool
+}
+
+type Telemetry struct {
+	cfg Config
+
+	runID   string
+	queueCh chan []byte
+	doneCh  chan struct{}
+}
+
+func New(cfg Config) *Telemetry {
+	t := &Telemetry{
+		cfg:     cfg,
+		runID:   uuid.NewString(),
+		queueCh: make(chan []byte, queueSize),
+		doneCh:  make(chan struct{}),
+	}
+	go t.send()
+	return t
+}
+
+func (t *Telemetry) Push(ctx context.Context, props event.Properties) {
+	e := event.New(props)
+	if err := e.Validate(); err != nil {
+		panic(err)
+	}
+	e.Run.ID = t.runID
+
+	encoded, err := json.Marshal(e)
+	if err != nil {
+		panic(err)
+	}
+
+	if t.cfg.Enable {
+		t.queueCh <- encoded
+	}
+}
+
+func (t *Telemetry) send() {
+	defer close(t.doneCh)
+
+	for e := range t.queueCh {
+		// FIXME: send the event
+		fmt.Println(string(e))
+	}
+}
+
+func (t *Telemetry) Flush() {
+	// Stop accepting new events
+	t.cfg.Enable = false
+	// Flush events in queue
+	close(t.queueCh)
+	// Wait for completion
+	<-t.doneCh
+}


### PR DESCRIPTION
This defines:

- Strongly typed, versioned telemetry events
- Event format (base properties and event-specific properties)
- A few events as example
- Contextual plumbing to be able to push telemetry events from anywhere
- **NOTE**: this defines the plumbing and API for typed events, it's not actually pushing anything

Example to send an event:

```go
// telemetry is available through the context (just like the logger)
tm := telemetry.Ctx(ctx)

// pushing a (strongly typed) event
tm.Push(ctx, event.ActionFailed{
	Name:  v.Path().String(),
	Error: err.Error(),
})
```

The event format is as follows:

```json
{
    "name": "action.failed",
    "data": {
        # data contains event specific properties
        "action_name": "actions.test.integration.core",
        "error": "command yarn failed with exit code 123"
    },
    "engine": {
        # engine metadata that triggered the event
        "id": "XXX",
        "version": "devel",
        "revision": "a8c18f90",
        "os": "darwin",
        "arch": "arm64"
    },
    "ts": "2022-05-25T18:52:40.481673-07:00",
    # event version
    "v": "2022-05-25.01"
}
```

Defining a new event in Go looks like this:

```go
// This defines EVENT SPECIFIC properties ONLY, the common ones are handled by telemetry already
type ActionFailed struct {
	Name  string `json:"action_name"`
	Error string `json:"error"`
}

func (a ActionFailed) EventName() string {
	return "action.failed"
}

func (a ActionFailed) EventVersion() string {
	return  "2022-05-25.01"
}

func (a ActionFailed) Validate() error {
	if a.Name == "" {
		return ErrMalformedEvent
	}
	if a.Error == "" {
		return ErrMalformedEvent
	}
	return nil
}
```