### PR TITLE
Add `docker.#Scratch` image

### DIFF
--- a/pkg/universe.dagger.io/docker/image.cue
+++ b/pkg/universe.dagger.io/docker/image.cue
@@ -14,6 +14,12 @@ import (
 	config: core.#ImageConfig
 }
 
+// An empty container image (same as `FROM scratch` in a Dockerfile)
+#Scratch: #Image & {
+	rootfs: dagger.#Scratch
+	config: {}
+}
+
 // A ref is an address for a remote container image
 // Examples:
 //   - "index.docker.io/dagger"


### PR DESCRIPTION
This adds a premade `FROM SCRATCH` image to the docker package. 
```cue
#Scratch: #Image & {
    rootfs: dagger.#Scratch
    config: {}
}
```

The idea came from @helderco in [this discussion](https://github.com/dagger/dagger/discussions/2517#discussioncomment-2828726). I personally find it helpful, and think it could be good to have in the package.

It's useful in builds like this:
```cue
_build_docker: docker.#Build & {
    steps: [
        docker.#Copy & {
            input: docker.#Scratch & {}
            contents: _build_exe.export.directories."/server"
            dest: "/"
        },
        ...
    ]
}
```

Or, you can make it into a first build step like:
```cue
_build_docker: docker.#Build & {
    steps: [
        {output: docker.#Scratch&{}},
        ...
    ]
}
```

Sorry that I didn't add a test, but I am not really sure how to do it. In real life, I just check that the image size is very small & that I can't exec any commands inside of it.