### PR TITLE
Enable debug logs for the default buildkitd-worker.

### DIFF
--- a/util/buildkitd/buildkitd.go
+++ b/util/buildkitd/buildkitd.go
@@ -237,6 +237,7 @@ func installBuildkit(ctx context.Context) error {
 		"--name", containerName,
 		"--privileged",
 		image+":"+vendoredVersion,
+		"--debug",
 	)
 	output, err = cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
This will provide us with much more information that can be helpful for
debugging buildkit related problems. I don't expect that many users are
looking at these logs anyways, so I don't think there is much downside
to including extra information there.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>