### PR TITLE
Clarify how to safely export binary data in docs.

### DIFF
--- a/docs/core-concepts/1203-client.md
+++ b/docs/core-concepts/1203-client.md
@@ -21,9 +21,21 @@ You may need to load a local directory as a `dagger.#FS` type in your plan:
 
 ```
 
-It’s also easy to write a file locally:
+It’s also easy to write a file locally.
+
+Strings can be written to local files like this:
 
 ```cue file=../tests/core-concepts/client/plans/file.cue
+
+```
+
+:::caution
+Strings in CUE are UTF-8 encoded, so the above example should never be used when handling arbitrary binary data. There is also a limit on the size of these strings (current 16MB). The next example of exporting a `dagger.#FS` shows how to handle the export of files of arbitrary size and encoding.
+:::
+
+Files and directories (in the form of a `dagger.#FS`) can be exported to the local filesystem too:
+
+```cue file=../tests/core-concepts/client/plans/file_export.cue
 
 ```
 

--- a/docs/core-concepts/1213-dagger-cue.md
+++ b/docs/core-concepts/1213-dagger-cue.md
@@ -62,7 +62,7 @@ The following core actions are available:
 | `#NewSecret`    | [secrets.cue](https://github.com/dagger/dagger/blob/v0.2.11/pkg/dagger.io/dagger/core/secrets.cue) | Create a new a secret from a filesystem tree                          |
 | `#Pull`         | [image.cue](https://github.com/dagger/dagger/blob/v0.2.11/pkg/dagger.io/dagger/core/image.cue)     | Download an image from a docker registry                              |
 | `#Push`         | [image.cue](https://github.com/dagger/dagger/blob/v0.2.11/pkg/dagger.io/dagger/core/image.cue)     | Upload an image to a docker registry                                  |
-| `#ReadFile`     | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.11/pkg/dagger.io/dagger/core/fs.cue)           | Read a file from a filesystem tree                                    |
+| `#ReadFile`     | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.11/pkg/dagger.io/dagger/core/fs.cue)           | Read the contents of a UTF-8 encoded file from a filesystem tree      |
 | `#Scratch`      | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.11/pkg/dagger.io/dagger/core/fs.cue)           | Create an empty filesystem tree                                       |
 | `#Set`          | [image.cue](https://github.com/dagger/dagger/blob/v0.2.11/pkg/dagger.io/dagger/core/image.cue)     | Modify a docker image                                                 |
 | `#Source`       | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.11/pkg/dagger.io/dagger/core/fs.cue)           | Access the source for the current CUE package                         |

--- a/docs/references/1222-core-actions-reference.md
+++ b/docs/references/1222-core-actions-reference.md
@@ -19,7 +19,7 @@ The following core actions are available:
 | `#Diff`      | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.11/pkg/dagger.io/dagger/core/fs.cue) | Extract the difference between two filesystems as its own file system |
 | `#Merge`     | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.11/pkg/dagger.io/dagger/core/fs.cue) | Merge multiple filesystem trees                                       |
 | `#Mkdir`     | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.11/pkg/dagger.io/dagger/core/fs.cue) | Create a directory in a filesystem tree                               |
-| `#ReadFile`  | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.11/pkg/dagger.io/dagger/core/fs.cue) | Read a file from a filesystem tree                                    |
+| `#ReadFile`  | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.11/pkg/dagger.io/dagger/core/fs.cue) | Read the contents of a UTF-8 encoded file from a filesystem tree      |
 | `#Source`    | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.11/pkg/dagger.io/dagger/core/fs.cue) | Access the source for the current CUE package                         |
 | `#Subdir`    | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.11/pkg/dagger.io/dagger/core/fs.cue) | Read a subdirectory from a filesystem tree                            |
 | `#WriteFile` | [fs.cue](https://github.com/dagger/dagger/blob/v0.2.11/pkg/dagger.io/dagger/core/fs.cue) | Write a file to a filesystem tree                                     |

--- a/docs/tests/core-concepts/client/plans/file_export.cue
+++ b/docs/tests/core-concepts/client/plans/file_export.cue
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+
+	"universe.dagger.io/go"
+)
+
+dagger.#Plan & {
+	client: filesystem: output: write: contents: actions.buildhello.output
+
+	actions: buildhello: {
+		_source: core.#WriteFile & {
+			input: dagger.#Scratch
+			path:  "/helloworld.go"
+			contents: """
+				package main
+				import "fmt"
+				func main() {
+				  fmt.Println("Hello, World!")
+				}
+				"""
+		}
+		go.#Build & {
+			source:  _source.output
+			package: "/src/helloworld.go"
+		}
+	}
+}

--- a/pkg/dagger.io/dagger/core/fs.cue
+++ b/pkg/dagger.io/dagger/core/fs.cue
@@ -38,6 +38,8 @@ import "dagger.io/dagger"
 	output: dagger.#FS @dagger(generated)
 }
 
+// Read the contents of a UTF-8 encoded file into a CUE string. Any non-UTF-8
+// encoded content may have UTF replacement characters instead of the expected data.
 #ReadFile: {
 	$dagger: task: _name: "ReadFile"
 


### PR DESCRIPTION
Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Fixes #2249

I ended up making the updates to the client docs since it seems more important there. The handling outputs guide is mostly focused on exporting what should always be plain text data; the most relevant section is at the end and links to the client docs anyways.

Preview here: https://deploy-preview-2526--devel-docs-dagger-io.netlify.app/1203/client