### PR TITLE
feat(universe): add experimental kustomization

### DIFF
--- a/pkg/universe.dagger.io/x/tom.chauveau.pro@icloud.com/kubernetes/kustomize.cue
+++ b/pkg/universe.dagger.io/x/tom.chauveau.pro@icloud.com/kubernetes/kustomize.cue
@@ -1,0 +1,84 @@
+package kubernetes
+
+import (
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+
+	"universe.dagger.io/docker"
+)
+
+_#kustomizationType: "inline" | "directory" | "url" | "manual"
+
+// Build manifest from kustomization
+#Kustomize: {
+	// Kubernetes manifests source
+	source: dagger.#FS
+
+	// Type of kustomization
+	// - inline: inline kustomization file
+	// - directory: source already contains kustomization.yaml
+	// - url: build from GitHub
+	// - manual: configure execution manually
+	type: _#kustomizationType
+
+	{
+		type: "inline"
+
+		// Raw Kustomization
+		kustomization: string
+
+		_source: core.#WriteFile & {
+			input:    source
+			path:     "/kustomization.yaml"
+			contents: kustomization
+		}
+
+		run: mounts: kustomization: {
+			contents: _source.output
+			dest:     "/source"
+		}
+	} | {
+		type: "directory"
+
+		// Directory that contains kustomization
+		// It will be merged with source
+		kustomization: dagger.#FS
+
+		_source: core.#Merge & {
+			inputs: [source, kustomization]
+		}
+
+		run: mounts: kustomization: {
+			type:     "fs"
+			contents: _source.output
+			dest:     "/source"
+		}
+	} | {
+		type: "url"
+
+		source: dagger.#Scratch
+
+		// Url of the kustomization
+		// E.g., https://github.com/kubernetes-sigs/kustomize.git/examples/helloWorld?ref=v1.0.6
+		url: string
+
+		run: command: args: [url]
+	} | *{
+		type: "manual"
+	}
+
+	_baseImage: #Kubectl
+
+	run: docker.#Run & {
+		user:    "root"
+		input:   *_baseImage.output | docker.#Image
+		workdir: "/source"
+		command: {
+			name: "kustomize"
+			flags: "-o": "/result.txt"
+		}
+		export: files: "/result.txt": string
+	}
+
+	result: run.export.files."/result.txt"
+}

--- a/pkg/universe.dagger.io/x/tom.chauveau.pro@icloud.com/kubernetes/test/kustomization.cue
+++ b/pkg/universe.dagger.io/x/tom.chauveau.pro@icloud.com/kubernetes/test/kustomization.cue
@@ -1,0 +1,95 @@
+package kubernetes
+
+import (
+	"dagger.io/dagger"
+
+	"universe.dagger.io/x/tom.chauveau.pro@icloud.com/kubernetes"
+)
+
+dagger.#Plan & {
+	client: filesystem: "./data/hello-kustomize": read: contents: dagger.#FS
+
+	actions: test: {
+		_source: client.filesystem."./data/hello-kustomize".read.contents
+
+		// FIXME(TomChv): Depends on https://github.com/bitnami/bitnami-docker-kubectl/pull/43
+		// url: kustomization: kubernetes.#Kustomize & {
+		//  type: "url"
+		//  url:  "https://github.com/kubernetes-sigs/kustomize.git/examples/helloWorld?ref=v1.0.6"
+		// }
+
+		inline: kubernetes.#Kustomize & {
+			type:   "inline"
+			source: _source
+			kustomization: """
+				apiVersion: kustomize.config.k8s.io/v1beta1
+				kind: Kustomization
+				resources:
+				  - service.yaml
+				namePrefix: inline-
+				"""
+			result: """
+				apiVersion: v1
+				kind: Service
+				metadata:
+				  labels:
+				    dagger-test: dagger-test
+				  name: inline-dagger-nginx-service
+				spec:
+				  ports:
+				  - name: http
+				    port: 80
+				    protocol: TCP
+				    targetPort: 80
+				  selector:
+				    app: dagger-nginx
+				  type: ClusterIP\n
+				"""
+		}
+
+		directory: kubernetes.#Kustomize & {
+			type:          "directory"
+			source:        _source
+			kustomization: _source
+			result: """
+				apiVersion: v1
+				kind: Service
+				metadata:
+				  labels:
+				    dagger-test: dagger-test
+				  name: kustom-dagger-nginx-service
+				spec:
+				  ports:
+				  - name: http
+				    port: 80
+				    protocol: TCP
+				    targetPort: 80
+				  selector:
+				    app: dagger-nginx
+				  type: ClusterIP
+				---
+				apiVersion: apps/v1
+				kind: Deployment
+				metadata:
+				  labels:
+				    dagger-test: dagger-test
+				  name: kustom-dagger-nginx
+				spec:
+				  replicas: 3
+				  selector:
+				    matchLabels:
+				      app: dagger-nginx
+				  template:
+				    metadata:
+				      labels:
+				        app: dagger-nginx
+				    spec:
+				      containers:
+				      - image: nginx:alpine
+				        name: dagger-nginx
+				        ports:
+				        - containerPort: 80\n
+				"""
+		}
+	}
+}


### PR DESCRIPTION
Add experimental `#Kustomize` to experimental kubernetes package.
This definition handle `url`, `directory`, `inline` and `manual` configuration.

Signed-off-by: Vasek - Tom C <tom.chauveau@epitech.eu>