### PR TITLE
website: make quotes visible in dark mode

### DIFF
--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -86,7 +86,8 @@ html[data-theme="dark"] {
   --ifm-code-background: var(--ifm-color-primary-dark);
   --ifm-heading-color: var(--ifm-color-primary-light);
   --ifm-menu-color-background-hover: var(--ifm-color-primary);
-  --ifm-blockquote-color: var(--ifm-menu-color-background-hover);
+  --ifm-blockquote-color: var(--ifm-color-primary-light);
+  --ifm-blockquote-border-color: var(--ifm-color-primary-light);
   --ifm-color-emphasis-300: var(--ifm-menu-color-background-hover);
 }
 


### PR DESCRIPTION
Signed-off-by: crjm <julian@dagger.io>

Quoted text is barely visible in dark mode: https://docs.dagger.io/1226/coding-style#use-top-to-match-anything
This fix makes the text white as the rest of the body.
