### PR TITLE
Default user to "root:root" rather than "root".

### DIFF
--- a/pkg/dagger.io/dagger/core/exec.cue
+++ b/pkg/dagger.io/dagger/core/exec.cue
@@ -25,7 +25,7 @@ import "dagger.io/dagger"
 	workdir: string | *"/"
 
 	// User ID or name
-	user: string | *"root"
+	user: string | *"root:root"
 
 	// If set, always execute even if the operation could be cached
 	always: true | *false
@@ -64,7 +64,7 @@ import "dagger.io/dagger"
 	workdir: string | *"/"
 
 	// User ID or name
-	user: string | *"root"
+	user: string | *"root:root"
 
 	// Inject hostname resolution into the container
 	// key is hostname, value is IP

--- a/pkg/universe.dagger.io/docker/run.cue
+++ b/pkg/universe.dagger.io/docker/run.cue
@@ -76,7 +76,7 @@ import (
 			entrypoint: []
 			cmd: []
 			workdir: "/"
-			user:    "root"
+			user:    "root:root"
 		}
 		config: input.config
 	}

--- a/tests/tasks/exec/user.cue
+++ b/tests/tasks/exec/user.cue
@@ -10,6 +10,14 @@ dagger.#Plan & {
 		image: core.#Pull & {
 			source: "alpine:3.15.0@sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3"
 		}
+		_imageMinusPasswd: core.#Rm & {
+			input: image.output
+			path:  "/etc/passwd"
+		}
+		imageMinusPasswdGroup: core.#Rm & {
+			input: _imageMinusPasswd.output
+			path:  "/etc/group"
+		}
 
 		addUser: core.#Exec & {
 			input: image.output
@@ -34,6 +42,17 @@ dagger.#Plan & {
 					"sh", "-c",
 					#"""
 						test "$(whoami)" = "test"
+						"""#,
+				]
+			}
+
+			verifyDefaultsNoPasswdGroup: core.#Exec & {
+				input: imageMinusPasswdGroup.output
+				args: [
+					"sh", "-exc",
+					#"""
+						test "$(id -u)" = "0"
+						test "$(id -g)" = "0"
 						"""#,
 				]
 			}


### PR DESCRIPTION
Defaulting the user of an exec to "root" causes errors when using images
that don't have /etc/passwd ("distroless" and similar type images).

BuildKit's logic is bit surprising here. If we instead provide
"root:root", then it has a codepath that will automatically default to
using uid/gid 0 without needing to check /etc/passwd or /etc/group.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

User in discord encountered this, also seems to have been reported previously, fixes #1659