### PR TITLE
Log core.Start output. 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/gofrs/flock v0.8.1
-	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/mattn/go-colorable v0.1.12
@@ -21,7 +20,6 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/buildkit v0.10.3
 	github.com/morikuni/aec v1.0.0
-	github.com/muesli/ansi v0.0.0-20211031195517-c9f0611b6c70
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
@@ -53,6 +51,7 @@ require (
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/alecthomas/chroma v0.10.0 // indirect
+	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.2 // indirect
 	github.com/cockroachdb/apd/v2 v2.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -730,7 +730,6 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
-github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-containerregistry v0.0.0-20191010200024-a3d713f9b7f8/go.mod h1:KyKXa9ciM8+lgMXwOVsXi7UxGrsf9mM61Mzs+xKUrKE=
 github.com/google/go-containerregistry v0.1.2/go.mod h1:GPivBPgdAyd2SU+vf6EpsgOtWDuPqjW0hJZt4rNdTZ4=
 github.com/google/go-containerregistry v0.5.1/go.mod h1:Ct15B4yir3PLOP5jsy0GNeYVaIZs/MK/Jz5any1wFW0=
@@ -1073,8 +1072,6 @@ github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de h1:D5x39vF5KCwKQaw+OC9
 github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de/go.mod h1:kJun4WP5gFuHZgRjZUWWuH1DTxCtxbHDOIJsudS8jzY=
 github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976/go.mod h1:x8F1gnqOkIEiO4rqoeEEEqQbo7HjGMTvyoq3gej4iT0=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
-github.com/muesli/ansi v0.0.0-20211031195517-c9f0611b6c70 h1:kMlmsLSbjkikxQJ1IPwaM+7LJ9ltFu/fi8CRzvSnQmA=
-github.com/muesli/ansi v0.0.0-20211031195517-c9f0611b6c70/go.mod h1:fQuZ0gauxyBcmsdE3ZT4NasjaRdxmbCS0jRHsrWu3Ho=
 github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
 github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
 github.com/muesli/termenv v0.9.0 h1:wnbOaGz+LUR3jNT0zOzinPnyDaCZUQRZj9GxK8eRVl8=

--- a/go.sum
+++ b/go.sum
@@ -199,6 +199,7 @@ github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
+github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2 h1:7Ip0wMmLHLRJdrloDxZfhMm0xrLXZS8+COSu2bXmEQs=
 github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/pkg/dagger.io/dagger/core/exec.cue
+++ b/pkg/dagger.io/dagger/core/exec.cue
@@ -44,53 +44,6 @@ import "dagger.io/dagger"
 	exit: int & 0
 }
 
-// Start a command in a container asynchronously
-#Start: {
-	$dagger: task: _name: "Start"
-
-	// Container filesystem
-	input: dagger.#FS
-
-	// Transient filesystem mounts
-	//   Key is an arbitrary name, for example "app source code"
-	//   Value is mount configuration
-	mounts: [name=string]: #Mount
-
-	// Command to execute
-	// Example: ["echo", "hello, world!"]
-	args: [...string]
-
-	// Working directory
-	workdir: string | *"/"
-
-	// User ID or name
-	user: string | *"root:root"
-
-	// Inject hostname resolution into the container
-	// key is hostname, value is IP
-	hosts: [hostname=string]: string
-
-	// Environment variables
-	env: [key=string]: string
-
-	_id: string | null @dagger(generated)
-}
-
-// Stop an asynchronous command created by #Start by sending SIGKILL. If
-// the optional timeout is specified, the command will be given that duration
-// to exit on its own before being sent SIGKILL.
-#Stop: {
-	$dagger: task: _name: "Stop"
-
-	input: #Start
-
-	// Time to wait for the command to exit on its own before sending SIGKILL.
-	timeout: int64 | *0
-
-	// Command exit code
-	exit: uint8 @dagger(generated)
-}
-
 // A transient filesystem mount.
 #Mount: {
 	dest: string
@@ -132,49 +85,3 @@ import "dagger.io/dagger"
 #TempDir: {
 	size: int64 | *0
 }
-
-// Send a signal to a command created by #Start. SIGKILL is not
-// supported here. Instead, #Stop should be used to forcibly stop
-// a command.
-#SendSignal: {
-	$dagger: task: _name: "SendSignal"
-
-	input: #Start
-
-	signal: or([ for name, signal in _signals {signal}])
-}
-
-_signals: {
-	SIGHUP:    1
-	SIGINT:    2
-	SIGQUIT:   3
-	SIGILL:    4
-	SIGTRAP:   5
-	SIGABRT:   6
-	SIGBUS:    7
-	SIGFPE:    8
-	SIGUSR1:   10
-	SIGSEGV:   11
-	SIGUSR2:   12
-	SIGPIPE:   13
-	SIGALRM:   14
-	SIGTERM:   15
-	SIGTKFLT:  16
-	SIGCHLD:   17
-	SIGCONT:   18
-	SIGSTOP:   19
-	SIGTSTP:   20
-	SIGTTIN:   21
-	SIGTTOU:   22
-	SIGURG:    23
-	SIGXCPU:   24
-	SIGXFSZ:   25
-	SIGVTALRM: 26
-	SIGPROF:   27
-	SIGWINCH:  28
-	SIGIO:     29
-	SIGPWR:    30
-	SIGSYS:    31
-}
-
-_signals

--- a/pkg/dagger.io/dagger/core/start.cue
+++ b/pkg/dagger.io/dagger/core/start.cue
@@ -1,0 +1,96 @@
+package core
+
+import "dagger.io/dagger"
+
+// Start a command in a container asynchronously
+#Start: {
+	$dagger: task: _name: "Start"
+
+	// Container filesystem
+	input: dagger.#FS
+
+	// Transient filesystem mounts
+	//   Key is an arbitrary name, for example "app source code"
+	//   Value is mount configuration
+	mounts: [name=string]: #Mount
+
+	// Command to execute
+	// Example: ["echo", "hello, world!"]
+	args: [...string]
+
+	// Working directory
+	workdir: string | *"/"
+
+	// User ID or name
+	user: string | *"root:root"
+
+	// Inject hostname resolution into the container
+	// key is hostname, value is IP
+	hosts: [hostname=string]: string
+
+	// Environment variables
+	env: [key=string]: string
+
+	_id: string | null @dagger(generated)
+}
+
+// Stop an asynchronous command created by #Start by sending SIGKILL. If
+// the optional timeout is specified, the command will be given that duration
+// to exit on its own before being sent SIGKILL.
+#Stop: {
+	$dagger: task: _name: "Stop"
+
+	input: #Start
+
+	// Time to wait for the command to exit on its own before sending SIGKILL.
+	timeout: int64 | *0
+
+	// Command exit code
+	exit: uint8 @dagger(generated)
+}
+
+// Send a signal to a command created by #Start. SIGKILL is not
+// supported here. Instead, #Stop should be used to forcibly stop
+// a command.
+#SendSignal: {
+	$dagger: task: _name: "SendSignal"
+
+	input: #Start
+
+	signal: or([ for name, signal in _signals {signal}])
+}
+
+_signals: {
+	SIGHUP:    1
+	SIGINT:    2
+	SIGQUIT:   3
+	SIGILL:    4
+	SIGTRAP:   5
+	SIGABRT:   6
+	SIGBUS:    7
+	SIGFPE:    8
+	SIGUSR1:   10
+	SIGSEGV:   11
+	SIGUSR2:   12
+	SIGPIPE:   13
+	SIGALRM:   14
+	SIGTERM:   15
+	SIGTKFLT:  16
+	SIGCHLD:   17
+	SIGCONT:   18
+	SIGSTOP:   19
+	SIGTSTP:   20
+	SIGTTIN:   21
+	SIGTTOU:   22
+	SIGURG:    23
+	SIGXCPU:   24
+	SIGXFSZ:   25
+	SIGVTALRM: 26
+	SIGPROF:   27
+	SIGWINCH:  28
+	SIGIO:     29
+	SIGPWR:    30
+	SIGSYS:    31
+}
+
+_signals

--- a/plan/task/exec.go
+++ b/plan/task/exec.go
@@ -8,25 +8,17 @@ import (
 	"net"
 	"os"
 	"strings"
-	"syscall"
-	"time"
 
-	"cuelang.org/go/cue"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/solver/pb"
-	"github.com/rs/zerolog/log"
 	"go.dagger.io/dagger/compiler"
-	"go.dagger.io/dagger/pkg"
 	"go.dagger.io/dagger/plancontext"
 	"go.dagger.io/dagger/solver"
 )
 
 func init() {
 	Register("Exec", func() Task { return &execTask{} })
-	Register("Start", func() Task { return &asyncExecTask{} })
-	Register("Stop", func() Task { return &stopAsyncExecTask{} })
-	Register("SendSignal", func() Task { return &sendSignalTask{} })
 }
 
 type execTask struct {
@@ -98,101 +90,6 @@ func (t *execTask) Run(ctx context.Context, pctx *plancontext.Context, s *solver
 		"output": resultFS.MarshalCUE(),
 		"exit":   0,
 	})
-}
-
-type asyncExecTask struct {
-}
-
-func (t *asyncExecTask) Run(ctx context.Context, pctx *plancontext.Context, s *solver.Solver, v *compiler.Value) (*compiler.Value, error) {
-	common, err := parseCommon(pctx, v)
-	if err != nil {
-		return nil, err
-	}
-	req, err := common.containerRequest()
-	if err != nil {
-		return nil, err
-	}
-
-	// env
-	envVal, err := v.Lookup("env").Fields()
-	if err != nil {
-		return nil, err
-	}
-
-	for _, env := range envVal {
-		s, err := env.Value.String()
-		if err != nil {
-			return nil, err
-		}
-		req.Proc.Env = append(req.Proc.Env, fmt.Sprintf("%s=%s", env.Label(), s))
-	}
-
-	// platform
-	platform := pb.PlatformFromSpec(pctx.Platform.Get())
-	req.Container.Platform = &platform
-
-	ctrID, err := s.StartContainer(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-
-	lg := log.Ctx(ctx)
-	lg.Debug().Msgf("started async exec %s", ctrID)
-
-	// Fill result
-	if err := v.FillPath(cue.MakePath(cue.Hid("_id", pkg.DaggerPackage)), ctrID); err != nil {
-		return nil, err
-	}
-	return v, nil
-}
-
-type stopAsyncExecTask struct {
-}
-
-func (t *stopAsyncExecTask) Run(ctx context.Context, _ *plancontext.Context, s *solver.Solver, v *compiler.Value) (*compiler.Value, error) {
-	ctrID, err := v.LookupPath(cue.MakePath(cue.Str("input"), cue.Hid("_id", pkg.DaggerPackage))).String()
-	if err != nil {
-		return nil, err
-	}
-
-	timeout, err := v.Lookup("timeout").Int64()
-	if err != nil {
-		return nil, err
-	}
-
-	lg := log.Ctx(ctx)
-
-	exitCode, err := s.StopContainer(ctx, ctrID, time.Duration(timeout))
-	if err != nil {
-		return nil, fmt.Errorf("failed to stop exec %s: %w", ctrID, err)
-	}
-	lg.Debug().Msgf("exec %s stopped with exit code %d", ctrID, exitCode)
-
-	return compiler.NewValue().FillFields(map[string]interface{}{
-		"exit": exitCode,
-	})
-}
-
-type sendSignalTask struct {
-}
-
-func (t *sendSignalTask) Run(ctx context.Context, pctx *plancontext.Context, s *solver.Solver, v *compiler.Value) (*compiler.Value, error) {
-	ctrID, err := v.LookupPath(cue.MakePath(cue.Str("input"), cue.Hid("_id", pkg.DaggerPackage))).String()
-	if err != nil {
-		return nil, err
-	}
-
-	sigVal, err := v.Lookup("signal").Int64()
-	if err != nil {
-		return nil, err
-	}
-	sig := syscall.Signal(sigVal)
-
-	if err := s.SignalContainer(ctx, ctrID, sig); err != nil {
-		return nil, fmt.Errorf("failed to send signal %d to exec %s: %w", sig, ctrID, err)
-	}
-
-	return compiler.NewValue(), nil
 }
 
 func parseCommon(pctx *plancontext.Context, v *compiler.Value) (*execCommon, error) {
@@ -319,37 +216,6 @@ func (e execCommon) runOpts() ([]llb.RunOption, error) {
 		opts = append(opts, llb.WithProxy(proxyEnv))
 	}
 	return opts, nil
-}
-
-func (e execCommon) containerRequest() (solver.StartContainerRequest, error) {
-	req := solver.StartContainerRequest{
-		Container: client.NewContainerRequest{
-			Mounts: []client.Mount{{
-				Dest:      "/",
-				MountType: pb.MountType_BIND,
-				Ref:       e.root.Result(),
-			}},
-		},
-		Proc: client.StartRequest{
-			Args: e.args,
-			User: e.user,
-			Cwd:  e.workdir,
-		},
-	}
-
-	for _, mnt := range e.mounts {
-		m, err := mnt.containerMount()
-		if err != nil {
-			return req, err
-		}
-		req.Container.Mounts = append(req.Container.Mounts, m)
-	}
-
-	for k, v := range e.hosts {
-		req.Container.ExtraHosts = append(req.Container.ExtraHosts, &pb.HostIP{Host: k, IP: v})
-	}
-
-	return req, nil
 }
 
 func parseMount(pctx *plancontext.Context, v *compiler.Value) (mount, error) {

--- a/plan/task/startExec.go
+++ b/plan/task/startExec.go
@@ -1,0 +1,150 @@
+package task
+
+import (
+	"context"
+	"fmt"
+	"syscall"
+	"time"
+
+	"cuelang.org/go/cue"
+	"github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/rs/zerolog/log"
+	"go.dagger.io/dagger/compiler"
+	"go.dagger.io/dagger/pkg"
+	"go.dagger.io/dagger/plancontext"
+	"go.dagger.io/dagger/solver"
+)
+
+func init() {
+	Register("Start", func() Task { return &startTask{} })
+	Register("Stop", func() Task { return &stopTask{} })
+	Register("SendSignal", func() Task { return &sendSignalTask{} })
+}
+
+type startTask struct {
+}
+
+func (t *startTask) Run(ctx context.Context, pctx *plancontext.Context, s *solver.Solver, v *compiler.Value) (*compiler.Value, error) {
+	common, err := parseCommon(pctx, v)
+	if err != nil {
+		return nil, err
+	}
+	req, err := common.containerRequest()
+	if err != nil {
+		return nil, err
+	}
+
+	// env
+	envVal, err := v.Lookup("env").Fields()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, env := range envVal {
+		s, err := env.Value.String()
+		if err != nil {
+			return nil, err
+		}
+		req.Proc.Env = append(req.Proc.Env, fmt.Sprintf("%s=%s", env.Label(), s))
+	}
+
+	// platform
+	platform := pb.PlatformFromSpec(pctx.Platform.Get())
+	req.Container.Platform = &platform
+
+	req.Name = v.Path().String()
+	ctrID, err := s.StartContainer(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	lg := log.Ctx(ctx)
+	lg.Debug().Msgf("started exec %s", ctrID)
+
+	// Fill result
+	if err := v.FillPath(cue.MakePath(cue.Hid("_id", pkg.DaggerPackage)), ctrID); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+type stopTask struct {
+}
+
+func (t *stopTask) Run(ctx context.Context, pctx *plancontext.Context, s *solver.Solver, v *compiler.Value) (*compiler.Value, error) {
+	ctrID, err := v.LookupPath(cue.MakePath(cue.Str("input"), cue.Hid("_id", pkg.DaggerPackage))).String()
+	if err != nil {
+		return nil, err
+	}
+
+	timeout, err := v.Lookup("timeout").Int64()
+	if err != nil {
+		return nil, err
+	}
+
+	lg := log.Ctx(ctx)
+
+	exitCode, err := s.StopContainer(ctx, ctrID, time.Duration(timeout))
+	if err != nil {
+		return nil, fmt.Errorf("failed to stop exec %s: %w", ctrID, err)
+	}
+	lg.Debug().Msgf("exec %s stopped with exit code %d", ctrID, exitCode)
+
+	return compiler.NewValue().FillFields(map[string]interface{}{
+		"exit": exitCode,
+	})
+}
+
+type sendSignalTask struct {
+}
+
+func (t *sendSignalTask) Run(ctx context.Context, pctx *plancontext.Context, s *solver.Solver, v *compiler.Value) (*compiler.Value, error) {
+	ctrID, err := v.LookupPath(cue.MakePath(cue.Str("input"), cue.Hid("_id", pkg.DaggerPackage))).String()
+	if err != nil {
+		return nil, err
+	}
+
+	sigVal, err := v.Lookup("signal").Int64()
+	if err != nil {
+		return nil, err
+	}
+	sig := syscall.Signal(sigVal)
+
+	if err := s.SignalContainer(ctx, ctrID, sig); err != nil {
+		return nil, fmt.Errorf("failed to send signal %d to exec %s: %w", sig, ctrID, err)
+	}
+
+	return compiler.NewValue(), nil
+}
+
+func (e execCommon) containerRequest() (solver.StartContainerRequest, error) {
+	req := solver.StartContainerRequest{
+		Container: client.NewContainerRequest{
+			Mounts: []client.Mount{{
+				Dest:      "/",
+				MountType: pb.MountType_BIND,
+				Ref:       e.root.Result(),
+			}},
+		},
+		Proc: client.StartRequest{
+			Args: e.args,
+			User: e.user,
+			Cwd:  e.workdir,
+		},
+	}
+
+	for _, mnt := range e.mounts {
+		m, err := mnt.containerMount()
+		if err != nil {
+			return req, err
+		}
+		req.Container.Mounts = append(req.Container.Mounts, m)
+	}
+
+	for k, v := range e.hosts {
+		req.Container.ExtraHosts = append(req.Container.ExtraHosts, &pb.HostIP{Host: k, IP: v})
+	}
+
+	return req, nil
+}

--- a/solver/container.go
+++ b/solver/container.go
@@ -4,17 +4,27 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"sync"
 	"syscall"
 	"time"
 
+	bk "github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/frontend/gateway/client"
 	gatewayapi "github.com/moby/buildkit/frontend/gateway/pb"
 	"github.com/moby/buildkit/identity"
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/progress"
+	"github.com/moby/buildkit/util/progress/logs"
+	"github.com/opencontainers/go-digest"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
 
 type container struct {
-	id   string
+	id   string // unique random id
+	name string // human-readable (possibly not unique) name
+
 	ctr  client.Container
 	proc client.ContainerProcess
 
@@ -22,9 +32,14 @@ type container struct {
 	stopped  bool
 	exitCode uint8
 	exitErr  error
+
+	progressWriter progress.Writer
+	cancelProgress func()
+	started        *time.Time
 }
 
 type StartContainerRequest struct {
+	Name      string
 	Container client.NewContainerRequest
 	Proc      client.StartRequest
 }
@@ -35,20 +50,53 @@ func (s *Solver) StartContainer(ctx context.Context, req StartContainerRequest) 
 		return "", fmt.Errorf("failed to create container: %w", err)
 	}
 
+	id := digest.FromString(identity.NewID())
+	if req.Name == "" {
+		req.Name = string(id)
+	}
+
+	progressWriter, stdout, stderr, cancelProgress := s.forwardProgress(id, log.Ctx(ctx))
+	req.Proc.Stdout = stdout
+	req.Proc.Stderr = stderr
+
+	lg := log.Ctx(ctx)
+	started := time.Now()
+	if err := progressWriter.Write(identity.NewID(), bk.Vertex{
+		Digest:        id,
+		Started:       &started,
+		ProgressGroup: &pb.ProgressGroup{Id: req.Name, Name: req.Name},
+	}); err != nil {
+		lg.Error().Err(err).Msg("failed to write progress")
+	}
+
 	proc, err := ctr.Start(ctx, req.Proc)
 	if err != nil {
+		cancelProgress()
 		return "", fmt.Errorf("failed to start container: %w", err)
 	}
 
-	id := identity.NewID()
 	s.containersMu.Lock()
-	s.containers[id] = &container{
-		id:   id,
-		ctr:  ctr,
-		proc: proc,
+	s.containers[id.String()] = &container{
+		id:             id.String(),
+		name:           req.Name,
+		ctr:            ctr,
+		proc:           proc,
+		progressWriter: progressWriter,
+		cancelProgress: cancelProgress,
+		started:        &started,
 	}
 	s.containersMu.Unlock()
-	return id, nil
+	return id.String(), nil
+}
+
+func (s *Solver) ContainerName(ctrID string) (string, error) {
+	s.containersMu.RLock()
+	defer s.containersMu.RUnlock()
+	c, ok := s.containers[ctrID]
+	if !ok {
+		return "", ContainerNotFoundError{ID: ctrID}
+	}
+	return c.name, nil
 }
 
 func (s *Solver) SignalContainer(ctx context.Context, ctrID string, sig syscall.Signal) error {
@@ -82,6 +130,20 @@ func (s *Solver) StopContainer(ctx context.Context, ctrID string, timeout time.D
 		return c.exitCode, c.exitErr
 	}
 	c.stopped = true
+
+	lg := log.Ctx(ctx)
+	defer func() {
+		stopped := time.Now()
+		if err := c.progressWriter.Write(identity.NewID(), bk.Vertex{
+			Digest:        digest.Digest(c.id),
+			Started:       c.started,
+			Completed:     &stopped,
+			ProgressGroup: &pb.ProgressGroup{Id: c.name, Name: c.name},
+		}); err != nil {
+			lg.Error().Err(err).Msg("failed to write progress")
+		}
+		c.cancelProgress()
+	}()
 
 	// FIXME: buildkit currently leaks containers if client crashes.
 	// https://github.com/moby/buildkit/issues/2811
@@ -119,6 +181,62 @@ func getExitCode(err error) (uint8, error) {
 		}
 	}
 	return 0, err
+}
+
+func (s *Solver) forwardProgress(id digest.Digest, lg *zerolog.Logger) (progress.Writer, io.WriteCloser, io.WriteCloser, func()) {
+	reader, readerCtx, stopReader := progress.NewContext(context.Background())
+	// for some reason, stopReader is a cancel associated with a different context,
+	// so we have to use both that and a separate readerCancel created here
+	readerCtx, readerCancel := context.WithCancel(readerCtx)
+
+	writer, _, writerCtx := progress.NewFromContext(readerCtx, progress.WithMetadata("vertex", id))
+
+	stdout, stderr, flushLogs := logs.NewLogStreams(writerCtx, false)
+
+	cancelAll := func() {
+		writer.Close()
+		flushLogs()
+		stopReader()
+		readerCancel()
+	}
+
+	s.eventsWg.Add(1)
+	go func() {
+		defer s.eventsWg.Done()
+
+		for {
+			pgresses, err := reader.Read(readerCtx)
+			if err != nil {
+				if !errors.Is(err, context.Canceled) && !errors.Is(err, io.EOF) {
+					lg.Error().Err(err).Msg("failed to read progress")
+				}
+				return
+			}
+			statuses := &bk.SolveStatus{}
+			for _, pgress := range pgresses {
+				switch v := pgress.Sys.(type) {
+				case bk.Vertex:
+					statuses.Vertexes = append(statuses.Vertexes, &v)
+				case bk.VertexLog:
+					vtx, ok := pgress.Meta("vertex")
+					if !ok {
+						lg.Debug().Msg("failed to find vertex in progress")
+						continue
+					}
+					v.Vertex = vtx.(digest.Digest)
+					v.Timestamp = pgress.Timestamp
+					statuses.Logs = append(statuses.Logs, &v)
+				}
+			}
+			select {
+			case <-readerCtx.Done():
+				return
+			case s.opts.Events <- statuses:
+			}
+		}
+	}()
+
+	return writer, stdout, stderr, cancelAll
 }
 
 type ContainerNotFoundError struct {

--- a/solver/solver.go
+++ b/solver/solver.go
@@ -29,7 +29,7 @@ type Solver struct {
 	l        sync.RWMutex
 
 	containers   map[string]*container
-	containersMu sync.Mutex
+	containersMu sync.RWMutex
 }
 
 type Opts struct {

--- a/tests/tasks.bats
+++ b/tests/tasks.bats
@@ -117,6 +117,13 @@ setup() {
     "$DAGGER" "do" -p ./start_stop_exec.cue stopTimeoutTest
 }
 
+@test "task: #Start #Stop output" {
+    cd ./tasks/exec
+    run "$DAGGER" "do" -p ./start_stop_exec.cue outputTest
+    assert_success
+    assert_line --partial 'hello from core.#Start'
+}
+
 @test "task: #Copy exec" {
     "$DAGGER" "do" -p ./tasks/copy/copy_exec.cue test
 }

--- a/tests/tasks/exec/start_stop_exec.cue
+++ b/tests/tasks/exec/start_stop_exec.cue
@@ -71,6 +71,20 @@ dagger.#Plan & {
 			verify: stop.exit & 137
 		}
 
+		outputTest: {
+			start: core.#Start & {
+				input: image.output
+				args: [
+					"echo", "hello from core.#Start",
+				]
+			}
+
+			stop: core.#Stop & {
+				input:   start
+				timeout: 3 * time.Second
+			}
+		}
+
 		// test all the various parameters that can be applied to an exec
 		execParamsTest: {
 			sharedCache: core.#CacheDir & {
@@ -133,7 +147,7 @@ dagger.#Plan & {
 				user:    "guest"
 				workdir: "/tmp"
 				args: [
-					"sh", "-e", "-c",
+					"sh", "-e", "-x", "-c",
 					#"""
 						test -d /fs/foo
 


### PR DESCRIPTION
Before this, core.Start output was just dropped entirely. Now, its
stdout and stderr are logged in the same way core.Exec output is
logged.

This requires importing some Buildkit code that it uses for collecting
and publishing log streams efficiently (internally uses a circular
buffer). The interface is a bit clunky but gets us parity between
core.Start and core.Exec.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Note: this also has a separate commit that refactors the code to split it amongst separate files, as requested in a previous PR: https://github.com/dagger/dagger/pull/2460

Will be somewhat easier to review by looking at the `Log core.Start output` commit by itself.

Fixes #2469