### PR TITLE
Initial support for logging the plan

### DIFF
--- a/cmd/dagger/cmd/do.go
+++ b/cmd/dagger/cmd/do.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -69,12 +70,6 @@ var doCmd = &cobra.Command{
 
 		targetPath := getTargetPath(cmd.Flags().Args())
 
-		lg.
-			Debug().
-			Str("targetAction", targetPath.String()).
-			Strs("args", os.Args[1:]).
-			Msg("running plan")
-
 		daggerPlan, err := loadPlan(ctx, viper.GetString("plan"))
 		if err != nil {
 			lg.Error().Err(err).Msgf("failed to load plan")
@@ -86,6 +81,15 @@ var doCmd = &cobra.Command{
 			doHelpCmd(cmd, nil, nil, nil, targetPath, []string{err.Error()})
 			os.Exit(1)
 		}
+
+		lg.
+			Debug().
+			Str("targetAction", targetPath.String()).
+			Str("plan", base64.StdEncoding.EncodeToString(
+				[]byte(fmt.Sprintf("%#v", daggerPlan.Source().Cue()))),
+			).
+			Strs("args", os.Args[1:]).
+			Msg("running plan")
 
 		action := daggerPlan.Action().FindByPath(targetPath)
 

--- a/cmd/dagger/logger/cloud.go
+++ b/cmd/dagger/logger/cloud.go
@@ -20,39 +20,38 @@ func NewCloud(tm *telemetry.Telemetry) *Cloud {
 }
 
 type LogEvent struct {
-	Arch           string   `json:"arch"`
-	Args           []string `json:"args"`
-	Caller         string   `json:"caller"`
-	DaggerRevision string   `json:"daggerRevision"`
-	DaggerVersion  string   `json:"daggerVersion"`
-	Duration       float64  `json:"duration,omitempty"`
-	EngineID       string   `json:"engineId"`
-	Error          string   `json:"error,omitempty"`
-	Level          string   `json:"level"`
-	Message        string   `json:"message,omitempty"`
-	OS             string   `json:"os"`
-	RunID          string   `json:"runId"`
-	State          string   `json:"state,omitempty"`
-	Task           string   `json:"task,omitempty"`
-	Time           string   `json:"time"`
+	Args         []string          `json:"args,omitempty"`
+	Caller       string            `json:"caller"`
+	Duration     float64           `json:"duration,omitempty"`
+	Environment  map[string]string `json:"environment"`
+	EngineID     string            `json:"engineId"`
+	Error        string            `json:"error,omitempty"`
+	Level        string            `json:"level"`
+	Message      string            `json:"message,omitempty"`
+	RunID        string            `json:"runId"`
+	State        string            `json:"state,omitempty"`
+	Task         string            `json:"task,omitempty"`
+	Time         string            `json:"time"`
+	Plan         string            `json:"plan,omitempty"`
+	TargetAction string            `json:"targetAction,omitempty"`
 }
 
 func (c *Cloud) Write(p []byte) (int, error) {
 	event := LogEvent{
-		RunID:          c.tm.RunID(),
-		EngineID:       c.tm.EngineID(),
-		Arch:           runtime.GOARCH,
-		OS:             runtime.GOOS,
-		DaggerVersion:  version.Version,
-		DaggerRevision: version.Revision,
+		RunID:    c.tm.RunID(),
+		EngineID: c.tm.EngineID(),
+		Environment: map[string]string{
+			"Arch":            runtime.GOARCH,
+			"OS":              runtime.GOOS,
+			"Dagger version":  version.Version,
+			"Dagger revision": version.Revision,
+		},
 	}
 	if err := json.Unmarshal(p, &event); err != nil {
 		return 0, fmt.Errorf("cannot unmarshal event: %s", err)
 	}
-	fmt.Printf("🐟 EVENT: %#v\n", event)
 
 	jsonData, err := json.Marshal(event)
-	fmt.Printf("🐔 JSON: %#v\n", string(jsonData))
 	if err != nil {
 		return 0, fmt.Errorf("cannot marshal event: %s", err)
 	}

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"os"
 
@@ -92,12 +91,10 @@ func (t *Telemetry) send() {
 	for e := range t.queueCh {
 		reqBody := bytes.NewBuffer(e)
 		req, err := http.NewRequest(http.MethodPost, t.url, reqBody)
-		fmt.Printf("🐝 REQUEST: %#v\n", req)
 		if err != nil {
 			continue
 		}
 		if resp, err := t.client.Do(req.Context(), req); err == nil {
-			fmt.Printf("🐶 RESPONSE: %#v\n", resp)
 			resp.Body.Close()
 		} else {
 			// TODO: re-auth does not seem to work as expected


### PR DESCRIPTION
Base64 encodes the plan using the %#v fmt.State into a `plan` logger
key.

Additionally moved the "running plan" event after the plan has been
evaluated to avoid unecessary logging.

Last change has been grouping all environment attributes into an
`environtment` key so we can dynamically add fields later.

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
