### PR TITLE
x/pulumi: add support for stack outputs 

### DIFF
--- a/pkg/universe.dagger.io/x/david@rawkode.dev/pulumi/pulumi.cue
+++ b/pkg/universe.dagger.io/x/david@rawkode.dev/pulumi/pulumi.cue
@@ -2,6 +2,8 @@
 package pulumi
 
 import (
+	"encoding/json"
+
 	"dagger.io/dagger"
 	"dagger.io/dagger/core"
 	"universe.dagger.io/docker"
@@ -40,6 +42,7 @@ import (
 	// Run Pulumi up
 	container: bash.#Run & {
 		input: *_pull_image.output | docker.#Image
+		export: files: "/outputs.json": string
 		script: {
 			_load: core.#Source & {
 				path: "."
@@ -77,4 +80,6 @@ import (
 			}
 		}
 	}
+
+	outputs: json.Unmarshal(container.export.files["/outputs.json"])
 }

--- a/pkg/universe.dagger.io/x/david@rawkode.dev/pulumi/up.sh
+++ b/pkg/universe.dagger.io/x/david@rawkode.dev/pulumi/up.sh
@@ -11,7 +11,7 @@ fi
 # If it exists, refresh the config
 # If it doesn't, create the stack
 if test -v PULUMI_ACCESS_TOKEN; then
-  if (pulumi stack ls | grep -e "^${STACK_NAME}"); then
+  if (pulumi stack ls | grep -e "^${PULUMI_STACK}"); then
     echo "Stack exists, let's refresh"
     pulumi stack select "${PULUMI_STACK}"
     # Could be first deployment, so let's not worry about this failing

--- a/pkg/universe.dagger.io/x/david@rawkode.dev/pulumi/up.sh
+++ b/pkg/universe.dagger.io/x/david@rawkode.dev/pulumi/up.sh
@@ -38,3 +38,5 @@ case "$PULUMI_RUNTIME" in
 esac
 
 pulumi up --stack "${PULUMI_STACK}" --yes
+
+pulumi stack output -j > /outputs.json || echo '{}' > /outputs.json


### PR DESCRIPTION
This adds support to the pulumi package for obtaining stack outputs, which is very useful for getting the values of resources created by pulumi, e.g. an AWS Lambda URL.

There also appears to have been a typo in up.sh in the pulumi package where a
non-existent env var "STACK_NAME" was referenced. This fixes it to what
was likely intended, "PULUMI_STACK".