### PR TITLE
fix: rename _op to _pull for better log UX

### DIFF
--- a/pkg/universe.dagger.io/docker/pull.cue
+++ b/pkg/universe.dagger.io/docker/pull.cue
@@ -20,7 +20,7 @@ import (
 		secret:   dagger.#Secret
 	}
 
-	_op: core.#Pull & {
+	_pull: core.#Pull & {
 		"source":      source
 		"resolveMode": resolveMode
 		if auth != _|_ {
@@ -30,8 +30,8 @@ import (
 
 	// Downloaded image
 	image: #Image & {
-		rootfs: _op.output
-		config: _op.config
+		rootfs: _pull.output
+		config: _pull.config
 	}
 
 	// FIXME: compat with Build API


### PR DESCRIPTION
Logs will now show:
```
6:59PM INF actions._alpine._dag."0"._pull | completed duration=3.7s
```

rather than the less self-evident
```
6:59PM INF actions._alpine._dag."0"._op | completed duration=3.7s
```

Resolves #2536 