### PR TITLE
Add blurb about large changes to CONTRIBUTION.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,8 @@ Examples:
 - Reviewing and discussing open issues and pull requests
 - Helping other users
 
+When it comes to pull requests, the bigger the contribution, the earlier you should talk to maintainers to make sure you're taking the right approach and are not wasting your effort on something that will not get merged.
+
 Extensive contribution guidelines are available in the repository at `docs/guides/1227-contributing.md`, or online at:
 
 [https://docs.dagger.io/1227/contributing](https://docs.dagger.io/1227/contributing)


### PR DESCRIPTION
This copies the line about checking with maintainers before pursuing
large changes from the website to our CONTRIBUTING.md. This is a
very important point to emphasize, so it doesn't hurt to make it clear
in as many places as possible.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>