### PR TITLE
docs: move dagger cloud under logdebug docs section

### DIFF
--- a/docs/guides/logdebug/1241-dagger-cloud-debugging.md
+++ b/docs/guides/logdebug/1241-dagger-cloud-debugging.md
@@ -1,9 +1,9 @@
 ---
-slug: /1241/dagger-cloud
+slug: /1241/dagger-cloud-debugging
 displayed_sidebar: "0.2"
 ---
 
-# Dagger Cloud
+# Debugging with Dagger Cloud
 
 Dagger Cloud is under development, but we have just released the first telemetry feature!
 


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger.io/issues/432

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
