### PR TITLE
feat: add golangci to alpha universe

### DIFF
--- a/pkg/universe.dagger.io/alpha/go/golangci/lint.cue
+++ b/pkg/universe.dagger.io/alpha/go/golangci/lint.cue
@@ -1,0 +1,48 @@
+package golangci
+
+import (
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+
+	"universe.dagger.io/docker"
+	"universe.dagger.io/go"
+)
+
+// Lint using golangci-lint
+#Lint: {
+	// Source code
+	source: dagger.#FS
+
+	// golangci-lint version
+	version: *"1.46" | string
+
+	// Timeout
+	timeout: *"5m" | string
+
+	_image: docker.#Pull & {
+		source: "index.docker.io/golangci/golangci-lint:v\(version)"
+	}
+
+	_cachePath: "/root/.cache/golangci-lint"
+
+	go.#Container & {
+		name:     "golangci_lint"
+		"source": source
+		input:    _image.output
+		command: {
+			name: "golangci-lint"
+			flags: {
+				run:         true
+				"-v":        true
+				"--timeout": timeout
+			}
+		}
+		mounts: "golangci cache": {
+			contents: core.#CacheDir & {
+				id: "\(name)_golangci"
+			}
+			dest: _cachePath
+		}
+		env: GOLANGCI_LINT_CACHE: _cachePath
+	}
+}

--- a/pkg/universe.dagger.io/alpha/go/golangci/test/data/hello/go.mod
+++ b/pkg/universe.dagger.io/alpha/go/golangci/test/data/hello/go.mod
@@ -1,0 +1,3 @@
+module test
+
+go 1.18

--- a/pkg/universe.dagger.io/alpha/go/golangci/test/data/hello/main.go
+++ b/pkg/universe.dagger.io/alpha/go/golangci/test/data/hello/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello World!")
+}

--- a/pkg/universe.dagger.io/alpha/go/golangci/test/lint.cue
+++ b/pkg/universe.dagger.io/alpha/go/golangci/test/lint.cue
@@ -1,0 +1,15 @@
+package golangci
+
+import (
+	"dagger.io/dagger"
+
+	"universe.dagger.io/alpha/go/golangci"
+)
+
+dagger.#Plan & {
+	client: filesystem: "./data/hello": read: contents: dagger.#FS
+
+	actions: test: golangci.#Lint & {
+		source: client.filesystem."./data/hello".read.contents
+	}
+}


### PR DESCRIPTION
This PR adds GolangCI linter to alpha universe.

@jpadams originally suggested to add it under `universe.dagger.io/alpha/go/lint.cue`, but Go has a plethora of lint tools (including the now deprecated, but official golint), so it didn't seem fair to make golangci THE linter and therefor I moved under a subdirectory.

Let me know what you think.