### PR TITLE
universe: bash: #RunSimple

### DIFF
--- a/pkg/universe.dagger.io/bash/bash.cue
+++ b/pkg/universe.dagger.io/bash/bash.cue
@@ -2,12 +2,25 @@
 package bash
 
 import (
+	"list"
+
 	"dagger.io/dagger"
 	"dagger.io/dagger/core"
 
 	"universe.dagger.io/docker"
-	"list"
+	"universe.dagger.io/alpine"
 )
+
+// Like #Run, but with a pre-configured container image.
+#RunSimple: #Run & {
+	_simpleImage: #SimpleImage
+	input:        _simpleImage.output
+}
+
+// Build a simple container image which can run bash
+#SimpleImage: alpine.#Build & {
+	packages: bash: _
+}
 
 // Run a bash script in a Docker container
 //  Since this is a thin wrapper over docker.#Run, we embed it.

--- a/pkg/universe.dagger.io/bash/test/test.cue
+++ b/pkg/universe.dagger.io/bash/test/test.cue
@@ -16,6 +16,16 @@ dagger.#Plan & {
 		}
 		_image: _pull.output
 
+		runSimple: {
+			run: bash.#RunSimple & {
+				script: contents: """
+					echo "hello, there!" > /out.txt
+					"""
+				export: files: "/out.txt": string
+			}
+			output: run.export.files."/out.txt" & "hello, there!\n"
+		}
+
 		// Run a script from source directory + filename
 		runFile: {
 


### PR DESCRIPTION

* `bash.#SimpleImage` is a simple container image capable of running bash. It is meant for convenience and is not customizable, on purpose.
* `bash.#RunSimple` is a version of `bash.#Run` that uses `#SimpleImage`. Ideally, this would be implemented with a default value to `bash.#Run`, but because of [limitations in how CUE handles default values](https://github.com/dagger/dagger/discussions/857), that is not possible.