### PR TITLE
feat: Add install directory customization

### DIFF
--- a/docs/1001-install.md
+++ b/docs/1001-install.md
@@ -45,10 +45,16 @@ curl -sfL https://releases.dagger.io/dagger/install.sh | sh
 
 You now have the dagger binary in the local directory under `./bin/dagger`.
 
-You can then install it globally on your system:
+You can also install it globally on your system:
 
 ```shell
-sudo mv ./bin/dagger /usr/local/bin
+curl -sfL https://releases.dagger.io/dagger/install.sh | sudo BIN_DIR=/usr/local/bin sh
+```
+
+or
+
+```shell
+curl -sfLo install.sh https://releases.dagger.io/dagger/install.sh; sudo BIN_DIR=/usr/local/bin sh ./install.sh
 ```
 
 ## Option 2 (Windows): Run a shell script

--- a/install.sh
+++ b/install.sh
@@ -291,7 +291,7 @@ execute() {
     tarball_url="${base_url}/${tarball}"
     checksum="checksums.txt"
     checksum_url="${base_url}/${checksum}"
-    bin_dir="./bin"
+    bin_dir="${BIN_DIR:-./bin}"
     binexe="dagger"
 
     tmpdir=$(mktemp -d)


### PR DESCRIPTION
Use an optional environment variable BIN_DIR to customize the final
install directory of the dagger binary.

Update documentation to show how to use the environment variable

Signed-off-by: Connor Kelly <connor.r.kelly@gmail.com>