### PR TITLE
docs: remove log-level insturctions for dagger cloud

### DIFF
--- a/docs/guides/logdebug/1241-dagger-cloud-debugging.md
+++ b/docs/guides/logdebug/1241-dagger-cloud-debugging.md
@@ -17,11 +17,8 @@ To take advantage of this feature, you will need to create an account by followi
 2. A new window will open in the browser requesting to sign-up using GitHub.
 3. After authenticating, authorize the Dagger GitHub application to finish the process.
 4. The browser window will close automatically and your CLI will be authenticated.
-5. Verify your upcoming `dagger do` commands include the `--log-level debug` flag.
+5. Consequent `dagger do` executions will now be listed in Dagger Cloud.
 
-:::tip
-For your run to show up in Dagger cloud it should take this form: `dagger do <action> [flags] --log-level debug`
-:::
 
 Once you create an account, after running your project again, you will see the following for each of your runs in a single dashboard:
 

--- a/docs/guides/logdebug/1241-dagger-cloud-debugging.md
+++ b/docs/guides/logdebug/1241-dagger-cloud-debugging.md
@@ -16,9 +16,7 @@ To take advantage of this feature, you will need to create an account by followi
 1. Initiate a login process using the CLI with `dagger login`.
 2. A new window will open in the browser requesting to sign-up using GitHub.
 3. After authenticating, authorize the Dagger GitHub application to finish the process.
-4. The browser window will close automatically and your CLI will be authenticated.
-5. Consequent `dagger do` executions will now be listed in Dagger Cloud.
-
+4. The browser window will close automatically and your CLI will be authenticated. Now,`dagger do` executions will now be listed in Dagger Cloud.
 
 Once you create an account, after running your project again, you will see the following for each of your runs in a single dashboard:
 


### PR DESCRIPTION
This is not necessary anymore as the engine will always send events once
authenticated
