### PR TITLE
fix: reverse `go.mod` change in merged PR

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/rs/zerolog v1.27.0
 	github.com/sergi/go-diff v1.2.0
 	github.com/sirupsen/logrus v1.8.1
-	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.12.0


### PR DESCRIPTION
This broke github workflows, from #2290.

Signed-off-by: Helder Correia