### PR TITLE
feat: Support Helm upgrade and custom namespace

### DIFF
--- a/pkg/universe.dagger.io/alpha/kubernetes/helm/install.cue
+++ b/pkg/universe.dagger.io/alpha/kubernetes/helm/install.cue
@@ -5,10 +5,13 @@ import (
 	"universe.dagger.io/docker"
 )
 
+_#DefaultNamespace: "default"
+
 #Install: {
 	// Name of your release
 	name:       string | *""
 	kubeconfig: dagger.#Secret
+	namespace:  *_#DefaultNamespace | string
 	source:     *"repository" | "URL"
 	{
 		source:     "repository"
@@ -24,7 +27,7 @@ import (
 			_script: #"""
 				helm repo add $REPO_NAME $REPOSITORY
 				helm repo update
-				helm install $NAME $REPO_NAME/$CHART $GENERATE_NAME
+				helm upgrade --install --create-namespace --namespace $NAMESPACE $NAME $REPO_NAME/$CHART $GENERATE_NAME
 				"""#
 		}
 	} | {
@@ -33,7 +36,7 @@ import (
 		run: {
 			env: "URL": URL
 			_script: #"""
-				helm install $NAME $URL $GENERATE_NAME
+				helm upgrade --install --create-namespace --namespace $NAMESPACE $NAME $URL $GENERATE_NAME
 				"""#
 		}
 	}
@@ -44,6 +47,7 @@ import (
 		env: {
 			NAME:          name
 			GENERATE_NAME: _generateName
+			NAMESPACE:     namespace
 		}
 		mounts: "/root/.kube/config": {
 			dest:     "/root/.kube/config"

--- a/pkg/universe.dagger.io/alpha/kubernetes/helm/test/test.cue
+++ b/pkg/universe.dagger.io/alpha/kubernetes/helm/test/test.cue
@@ -2,7 +2,7 @@ package helm
 
 import (
 	"dagger.io/dagger"
-	"universe.dagger.io/x/vgjm456@qq.com/helm"
+	"universe.dagger.io/alpha/kubernetes/helm"
 )
 
 dagger.#Plan & {


### PR DESCRIPTION
This PR contains three changes:
1. Using `helm upgrade --install` instead of `helm install` because it support both new installation and upgrade scenarios.
2. Let user define custom namespace and Helm create it if needed.
3. Using correct package in test.

FYI @vgjm