### PR TITLE
Print Dagger Cloud URL when starting plan

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -53,7 +53,7 @@ func New() *Telemetry {
 }
 
 func (t *Telemetry) EnableLogToFile() {
-	lw, err := os.OpenFile(t.logFile(), os.O_APPEND|os.O_CREATE|os.O_RDWR, 0644)
+	lw, err := os.OpenFile(t.logFile(), os.O_APPEND|os.O_CREATE|os.O_RDWR, 0o644)
 	if err == nil {
 		t.log = zerolog.New(lw).
 			With().
@@ -83,6 +83,10 @@ func (t *Telemetry) Push(ctx context.Context, props event.Properties) {
 	e := event.New(props)
 	e.Engine.ID = t.engineID
 	e.Run.ID = t.runID
+
+	if _, ok := props.(event.RunStarted); ok && t.enable {
+		fmt.Printf("\nDagger Cloud URL: https://dagger.cloud/runs/%s\n\n", e.Run.ID)
+	}
 
 	if err := e.Validate(); err != nil {
 		panic(err)


### PR DESCRIPTION
prints the dagger cloud URL when starting plan if the CLI is authenticated.  Example:

```
marcos:Projects/dagger (main) (⎈ |kind-kind)$ ./cmd/dagger/dagger do version

Dagger Cloud URL: https://dagger.cloud/runs/72a52e3c-ad33-468d-97f4-623572632806

[✔] actions.version                                                                                                       3.1s
[✔] client.filesystem.".".read                                                                                            1.2s
Field   Value
output  "39bfe53e"
marcos:Projects/dagger (main) (⎈ |kind-kind)$```
