### PR TITLE
universe(go): revert of part of #2632

### DIFF
--- a/pkg/universe.dagger.io/go/image.cue
+++ b/pkg/universe.dagger.io/go/image.cue
@@ -4,20 +4,12 @@ import (
 	"universe.dagger.io/docker"
 )
 
-// Go image default name
-_#DefaultName: "golang"
-
-// Go image default repository
-_#DefaultRepository: "index.docker.io"
-
 // Go image default version
 _#DefaultVersion: "1.18"
 
 // Build a go base image
 #Image: {
-	name:       *_#DefaultName | string
-	repository: *_#DefaultRepository | string
-	version:    *_#DefaultVersion | string
+	version: *_#DefaultVersion | string
 
 	packages: [pkgName=string]: version: string | *""
 	// FIXME Remove once golang image include 1.18 *or* go compiler is smart with -buildvcs
@@ -32,7 +24,7 @@ _#DefaultVersion: "1.18"
 	docker.#Build & {
 		steps: [
 			docker.#Pull & {
-				source: "\(repository)/\(name):\(version)-alpine"
+				source: "index.docker.io/golang:\(version)-alpine"
 			},
 			for pkgName, pkg in packages {
 				docker.#Run & {

--- a/pkg/universe.dagger.io/go/test/build.cue
+++ b/pkg/universe.dagger.io/go/test/build.cue
@@ -46,7 +46,7 @@ dagger.#Plan & {
 				source: client.filesystem."./data/hello".read.contents
 
 				_image: go.#Image & {
-					version: "1.17"
+					version: "1.18"
 				}
 				image: _image.output
 			}
@@ -77,7 +77,7 @@ dagger.#Plan & {
 				source: client.filesystem."./data/hello".read.contents
 
 				_image: go.#Image & {
-					version: "1.17"
+					version: "1.18"
 				}
 				image:      _image.output
 				binaryName: "greeter"

--- a/pkg/universe.dagger.io/go/test/build.cue
+++ b/pkg/universe.dagger.io/go/test/build.cue
@@ -46,9 +46,7 @@ dagger.#Plan & {
 				source: client.filesystem."./data/hello".read.contents
 
 				_image: go.#Image & {
-					name:       "docker/library/golang"
-					repository: "public.ecr.aws"
-					version:    "1.18"
+					version: "1.17"
 				}
 				image: _image.output
 			}
@@ -79,9 +77,7 @@ dagger.#Plan & {
 				source: client.filesystem."./data/hello".read.contents
 
 				_image: go.#Image & {
-					name:       "docker/library/golang"
-					repository: "public.ecr.aws"
-					version:    "1.18"
+					version: "1.17"
 				}
 				image:      _image.output
 				binaryName: "greeter"

--- a/pkg/universe.dagger.io/go/test/image.cue
+++ b/pkg/universe.dagger.io/go/test/image.cue
@@ -26,9 +26,7 @@ dagger.#Plan & {
 
 		custom: {
 			_image: go.#Image & {
-				name:       "docker/library/golang"
-				repository: "public.ecr.aws"
-				version:    "1.17"
+				version: "1.17"
 				packages: bash: _
 			}
 


### PR DESCRIPTION
This commit revert a change of API in `universe/go`.
A recent PR added 2 fields: `name` and `repository` to customize the image to
pull when calling `go.#Image`.
The problem is that change does not fit with the purpose of `go.#Image`, this
one should be used as default image to cover simple workflow with the simplest
possible API. That's why it's usually only possible to configure some packages
and a version of the official image.

If the user want to provide a custom image, he can override the field `input`
(or image sometime) of other definition.
To do so, he can use `docker.#Pull` or create his own definition to cover his
proper use case.

Signed-off-by: Vasek - Tom C <tom.chauveau@epitech.eu>