### PR TITLE
feat(universe): add codecov uploader to alpha

### DIFF
--- a/pkg/universe.dagger.io/alpha/codecov/image.cue
+++ b/pkg/universe.dagger.io/alpha/codecov/image.cue
@@ -1,0 +1,69 @@
+package codecov
+
+import (
+	"universe.dagger.io/bash"
+	"universe.dagger.io/docker"
+)
+
+// Build a codecov base image
+#Image: {
+	// Codecov uploader version
+	version: string | *"latest"
+
+	// FIXME once nested build works
+	// https://github.com/dagger/dagger/issues/1466
+	_packages: [pkgName=string]: version: string | *""
+	_packages: {
+		bash:         _
+		curl:         _
+		git:          _
+		gnupg:        _
+		coreutils:    _
+		"perl-utils": _
+	}
+
+	docker.#Build & {
+		steps: [
+			// FIXME once nested build works
+			// https://github.com/dagger/dagger/issues/1466
+			docker.#Pull & {
+				source: "index.docker.io/alpine:3.15.0@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300"
+			},
+			for pkgName, pkg in _packages {
+				docker.#Run & {
+					command: {
+						name: "apk"
+						args: ["add", "\(pkgName)\(pkg.version)"]
+						flags: {
+							"-U":         true
+							"--no-cache": true
+						}
+					}
+				}
+			},
+			bash.#Run & {
+				script: contents: """
+					curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+					"""
+			},
+			bash.#Run & {
+				script: contents: """
+					curl -Os https://uploader.codecov.io/\(version)/alpine/codecov
+
+					curl -Os https://uploader.codecov.io/\(version)/alpine/codecov.SHA256SUM
+
+					curl -Os https://uploader.codecov.io/\(version)/alpine/codecov.SHA256SUM.sig
+
+					gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+
+					shasum -a 256 -c codecov.SHA256SUM
+
+					chmod +x codecov
+
+					mv codecov /usr/local/bin
+					rm codecov.SHA256SUM codecov.SHA256SUM.sig
+					"""
+			},
+		]
+	}
+}

--- a/pkg/universe.dagger.io/alpha/codecov/test/image.cue
+++ b/pkg/universe.dagger.io/alpha/codecov/test/image.cue
@@ -1,0 +1,11 @@
+package codecov
+
+import (
+	"dagger.io/dagger"
+
+	"universe.dagger.io/alpha/codecov"
+)
+
+dagger.#Plan & {
+	actions: test: codecov.#Image & {}
+}

--- a/pkg/universe.dagger.io/alpha/codecov/test/image.cue
+++ b/pkg/universe.dagger.io/alpha/codecov/test/image.cue
@@ -2,10 +2,8 @@ package codecov
 
 import (
 	"dagger.io/dagger"
-
-	"universe.dagger.io/alpha/codecov"
 )
 
 dagger.#Plan & {
-	actions: test: codecov.#Image & {}
+	actions: test: #Image & {}
 }

--- a/pkg/universe.dagger.io/alpha/codecov/upload.cue
+++ b/pkg/universe.dagger.io/alpha/codecov/upload.cue
@@ -1,0 +1,52 @@
+package codecov
+
+import (
+	"dagger.io/dagger"
+
+	"universe.dagger.io/docker"
+)
+
+#Upload: {
+	// Source code
+	source: dagger.#FS
+
+	// Coverage files
+	file: string
+
+	// Codecov token (required for local runs and private repos)
+	token?: dagger.#Secret
+
+	// Don't upload files to Codecov
+	dryRun: bool | *false
+
+	_image: #Image
+
+	_sourcePath: "/src"
+
+	docker.#Run & {
+		input: *_image.output | docker.#Image
+		command: {
+			name: "codecov"
+			flags: {
+				"--file":    file
+				"--verbose": true
+
+				if dryRun {
+					"--dryRun": true
+				}
+			}
+		}
+		env: {
+			if token != _|_ {
+				CODECOV_TOKEN: token
+			}
+		}
+		workdir: _sourcePath
+		mounts: {
+			"source": {
+				dest:     _sourcePath
+				contents: source
+			}
+		}
+	}
+}

--- a/pkg/universe.dagger.io/alpha/codecov/upload.cue
+++ b/pkg/universe.dagger.io/alpha/codecov/upload.cue
@@ -42,11 +42,9 @@ import (
 			}
 		}
 		workdir: _sourcePath
-		mounts: {
-			"source": {
-				dest:     _sourcePath
-				contents: source
-			}
+		mounts: "source": {
+			dest:     _sourcePath
+			contents: source
 		}
 	}
 }


### PR DESCRIPTION
This PR adds Codecov uploader to the alpha channel of universe as seen in [my blog post](https://dev.to/sagikazarmark/building-a-ci-pipeline-for-a-go-library-with-dagger-2an7).

The uploader comes with a lot more option, but I thought I'd open a PR first and more options later as required.

```
  -B, --branch                  Specify the branch manually
  -b, --build                   Specify the build number manually
  -c, --clean                   Move discovered coverage reports to the trash
                                              [boolean] [alapértelmezett: false]
  -C, --sha                     Specify the commit SHA mannually
      --changelog, --CL         Display a link for the current changelog
  -d, --dryRun                  Don't upload files to Codecov
                                              [boolean] [alapértelmezett: false]
  -e, --env                     Specify environment variables to be included
                                with this build.
                                Also accepting environment variables:
                                CODECOV_ENV=VAR,VAR2
  -f, --file                    Target file(s) to upload
  -F, --flags                   Flag the upload to group coverage metrics
                                                           [alapértelmezett: ""]
  -g, --gcov                    Run with gcov support
                                              [boolean] [alapértelmezett: false]
      --gcovArgs, --ga          Extra arguments to pass to gcov         [szöveg]
      --gcovIgnore, --gi        Paths to ignore during gcov gathering   [szöveg]
      --gcovInclude, --gI       Paths to include during gcov gathering  [szöveg]
  -i, --networkFiler            Specify a filter on the files listed in the
                                network section of the Codecov report. Useful
                                for upload-specific path fixing         [szöveg]
  -k, --networkPrefix           Specify a prefix on files listed in the network
                                section of the Codecov report. Useful to help
                                resolve path fixing                     [szöveg]
  -n, --name                    Custom defined name of the upload. Visible in
                                Codecov UI                 [alapértelmezett: ""]
  -N, --parent                  The commit SHA of the parent for which you are
                                uploading coverage. If not present, the parent
                                will be determined using the API of your
                                repository provider. When using the repository
                                provider's API, the parent is determined via
                                finding the closest ancestor to the commit.
  -P, --pr                      Specify the pull request number mannually
  -Q, --source                  Used internally by Codecov, this argument helps
                                track
                                wrappers of the uploader (e.g. GitHub Action,
                                CircleCI Orb)     [szöveg] [alapértelmezett: ""]
  -R, --rootDir                 Specify the project root directory when not in a
                                git repo
  -r, --slug                    Specify the slug manually
                                                  [szöveg] [alapértelmezett: ""]
  -s, --dir                     Directory to search for coverage reports.
                                Already searches project root and current
                                working directory
  -T, --tag                     Specify the git tag        [alapértelmezett: ""]
  -t, --token                   Codecov upload token       [alapértelmezett: ""]
  -U, --upstream                The upstream http proxy server to connect
                                through           [szöveg] [alapértelmezett: ""]
  -u, --url                     Change the upload host (Enterprise use)
                                [szöveg] [alapértelmezett: "https://codecov.io"]
  -v, --verbose                 Run with verbose logging               [boolean]
  -X, --feature                 Toggle functionalities. Separate multiple ones
                                by comma: -X network,search
                                -X network       Disable uploading the file
                                network
                                -X search        Disable searching for coverage
                                files                                   [szöveg]
      --xcode, --xc             Run with xcode support
                                              [boolean] [alapértelmezett: false]
      --xcodeArchivePath, --xp  Specify the xcode archive path. Likely specified
                                as the -resultBundlePath and should end in
                                .xcresult                               [szöveg]
  -Z, --nonZero                 Should errors exit with a non-zero (default:
                                false)        [boolean] [alapértelmezett: false]
```

I'm not convinced that all options have to be added to the definition.

Also, most (if not all) of them can be controlled via environment variables as well which is generally better for CI integration anyway.