### PR TITLE
Manually flush events in case of exiting without returning from function.

### DIFF
--- a/cmd/dagger/cmd/do.go
+++ b/cmd/dagger/cmd/do.go
@@ -121,7 +121,10 @@ var doCmd = &cobra.Command{
 				tm.Push(ctx, rce)
 			}
 
-			err = fmt.Errorf("failed to load plan: %w", err)
+			// manually flush events since otherwise they could be skipped as
+			// the program is exiting.
+			tm.Flush()
+
 			doHelpCmd(cmd, nil, nil, nil, targetPath, []string{err.Error()})
 			os.Exit(1)
 		}


### PR DESCRIPTION
Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
