### PR TITLE
Fix regression when printing 0.1 compat error msg

### DIFF
--- a/cmd/dagger/cmd/do.go
+++ b/cmd/dagger/cmd/do.go
@@ -81,7 +81,9 @@ var doCmd = &cobra.Command{
 
 		daggerPlan, err := loadPlan(ctx, viper.GetString("plan"))
 
-		if !viper.GetBool("help") {
+		targetAction := cue.MakePath(targetPath.Selectors()[1:]...).String()
+
+		if !viper.GetBool("help") && len(targetAction) > 0 {
 			// we send the RunStarted event regardless if `loadPlan` fails since we also want to capture
 			// and provide assistance when plan fails to evaluate
 			var plan string
@@ -90,7 +92,7 @@ var doCmd = &cobra.Command{
 			}
 			// Fire "run started" event once we know there is an action to run (ie. not calling --help)
 			tm.Push(ctx, event.RunStarted{
-				Action: cue.MakePath(targetPath.Selectors()[1:]...).String(),
+				Action: targetAction,
 				Args:   os.Args[1:],
 				Plan:   plan,
 			})


### PR DESCRIPTION
Fixes an issue when trying to get feedback about 0.1 plans which are not
supported. Telemetry was trying to create an empty run which is not
currently possible.

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
