### PR TITLE
feat: add support for HTTP, HTTPS proxy

### DIFF
--- a/plan/task/exec.go
+++ b/plan/task/exec.go
@@ -298,17 +298,20 @@ func (e execCommon) runOpts() ([]llb.RunOption, error) {
 		if len(split) != 2 {
 			continue
 		}
-		key, val := strings.ToLower(split[0]), split[1]
-		switch key {
-		case "no_proxy":
+		key, val := split[0], split[1]
+		if strings.EqualFold(key, "no_proxy") {
 			proxyEnv.NoProxy = val
-		case "all_proxy":
+		}
+		if strings.EqualFold(key, "all_proxy") {
 			proxyEnv.AllProxy = val
-		case "http_proxy":
+		}
+		if strings.EqualFold(key, "http_proxy") {
 			proxyEnv.HTTPProxy = val
-		case "https_proxy":
+		}
+		if strings.EqualFold(key, "https_proxy") {
 			proxyEnv.HTTPSProxy = val
-		case "ftp_proxy":
+		}
+		if strings.EqualFold(key, "ftp_proxy") {
 			proxyEnv.FTPProxy = val
 		}
 	}

--- a/tests/tasks.bats
+++ b/tests/tasks.bats
@@ -103,10 +103,8 @@ setup() {
 
 @test "task: #Exec with HTTP proxy" {
     cd ./tasks/exec
-    export HTTPS_PROXY="https://localhost:4242/"
-    run "$DAGGER" "do" -p ./http_proxy.cue curlProxy
+    HTTPS_PROXY="https://localhost:4242/" run "$DAGGER" "do" -p ./http_proxy.cue curlProxy
     assert_failure
-    unset HTTP_PROXY
 }
 
 @test "task: #Start #Stop params" {

--- a/tests/tasks.bats
+++ b/tests/tasks.bats
@@ -101,6 +101,14 @@ setup() {
     assert_line --partial --index 9 'actions.basicTest.stop'
 }
 
+@test "task: #Exec with HTTP proxy" {
+    cd ./tasks/exec
+    export HTTPS_PROXY="https://localhost:4242/"
+    run "$DAGGER" "do" -p ./http_proxy.cue curlProxy
+    assert_failure
+    unset HTTP_PROXY
+}
+
 @test "task: #Start #Stop params" {
     cd ./tasks/exec
     "$DAGGER" "do" -p ./start_stop_exec.cue execParamsTest

--- a/tests/tasks/exec/http_proxy.cue
+++ b/tests/tasks/exec/http_proxy.cue
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+)
+
+dagger.#Plan & {
+	actions: {
+		image: core.#Pull & {
+			source: "alpine:3.15.0@sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3"
+		}
+
+		curlProxy: core.#Exec & {
+			input: image.output
+			args: [
+				"sh", "-c",
+				"""
+					apk add --no-cache curl
+					curl -sfL -o /dev/null https://www.google.com/
+					""",
+			]
+		}
+	}
+}


### PR DESCRIPTION
Adds support for HTTP and HTTPS Proxy. It translates the right env vars to LLB Run options.

- Closes #2053 
- Closes #1369 