### PR TITLE
chore: Remove Revision from GoReleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,6 @@ builds:
     ldflags:
       - -s -w
       - -X go.dagger.io/dagger/version.Version={{.Version}}
-      - -X go.dagger.io/dagger/version.Revision={{.ShortCommit}}
     goos:
       - linux
       - windows

--- a/version/version.go
+++ b/version/version.go
@@ -22,7 +22,7 @@ func Revision() string {
 	}
 	for _, s := range bi.Settings {
 		if s.Key == "vcs.revision" {
-			return s.Value
+			return s.Value[:9]
 		}
 	}
 


### PR DESCRIPTION
This is now picked up from Go's 1.18 debug.Buildinfo.

Keep the short git SHAs in the version.

Follow-up to https://github.com/dagger/dagger/pull/2749
