### PR TITLE
Allow sending to DC invalid dagger plans that don't evaluate.

### DIFF
--- a/cmd/dagger/cmd/do.go
+++ b/cmd/dagger/cmd/do.go
@@ -61,6 +61,7 @@ var doCmd = &cobra.Command{
 			ctx = lg.WithContext(cmd.Context())
 			tty *logger.TTYOutput
 		)
+
 		defer tm.Flush()
 		ctx = tm.WithContext(ctx)
 
@@ -83,7 +84,7 @@ var doCmd = &cobra.Command{
 
 		targetAction := cue.MakePath(targetPath.Selectors()[1:]...).String()
 
-		if !viper.GetBool("help") && len(targetAction) > 0 {
+		if !viper.GetBool("help") && (err != nil || len(targetAction) > 0) {
 			// we send the RunStarted event regardless if `loadPlan` fails since we also want to capture
 			// and provide assistance when plan fails to evaluate
 			var plan string

--- a/telemetry/event/run.go
+++ b/telemetry/event/run.go
@@ -16,9 +16,6 @@ func (e RunStarted) EventVersion() string {
 }
 
 func (e RunStarted) Validate() error {
-	if e.Action == "" {
-		return errEvent("Action", "cannot be empty")
-	}
 	return nil
 }
 


### PR DESCRIPTION
Before this commit, if user has an invalid Dagger plan and runs `dagger
do` without any arguments, they'll get an error and the execution won't be uploaded to Dagger Cloud. This allows uploading the user's plan even though it's invalid.

This change will very likely help new users trying to create plans
without too much knowledge of the dagger CUE specific definitions.

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
