### PR TITLE
universe: Use `bash.#Image` convention

### DIFF
--- a/pkg/universe.dagger.io/bash/bash.cue
+++ b/pkg/universe.dagger.io/bash/bash.cue
@@ -13,14 +13,17 @@ import (
 
 // Like #Run, but with a pre-configured container image.
 #RunSimple: #Run & {
-	_simpleImage: #SimpleImage
+	_simpleImage: #Image
 	input:        _simpleImage.output
 }
 
-// Build a simple container image which can run bash
-#SimpleImage: alpine.#Build & {
+// Default simple container image which can run bash
+#Image: alpine.#Build & {
 	packages: bash: _
 }
+
+// DEPRECATED: Use bash.#Image instead
+#SimpleImage: #Image
 
 // Run a bash script in a Docker container
 //  Since this is a thin wrapper over docker.#Run, we embed it.


### PR DESCRIPTION
There's a sort of convention that if a package has a default image, then it's accessible as `<package>.#Image`.

Signed-off-by: Helder Correia