### PR TITLE
feat: Validate against nested core actions

### DIFF
--- a/pkg/dagger.io/dagger/plan.cue
+++ b/pkg/dagger.io/dagger/plan.cue
@@ -19,7 +19,7 @@ package dagger
 				// if we read and write to the same path, under the same key,
 				// assume we want to make an update
 				if (read.path & write.path) != _|_ {
-					_after: read
+					_after: read.contents
 				}
 			}
 		}

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -269,5 +269,9 @@ func (p *Plan) validate(ctx context.Context) error {
 	_, span := otel.Tracer("dagger").Start(ctx, "plan.Validate")
 	defer span.End()
 
+	if _, err := checkNestedTasks(p.source); err != nil {
+		return err
+	}
+
 	return isPlanConcrete(p.source, p.source)
 }

--- a/tests/plan.bats
+++ b/tests/plan.bats
@@ -408,6 +408,15 @@ foo.txt"
   assert_output --partial "actions.test.site: undefined field: NONEXISTENT:"
 }
 
+@test "plan/validate/nested" {
+  run "$DAGGER" "do" -p ./plan/validate/nested/nested.cue test
+  assert_failure
+  assert_output --partial 'actions.test.shallow: found nested core action: actions.test.shallow._write'
+  assert_output --partial 'actions.test.deep: found nested core action: actions.test.deep._op.write'
+  assert_output --partial 'actions.test.nested: found nested core action: actions.test.nested._copy'
+  assert_output --partial 'actions.test.nested._copy: found nested core action: actions.test.nested._copy._write'
+}
+
 @test "plan/validate/undefined" {
   run "$DAGGER" "do" -p ./plan/validate/undefined/undefined.cue test
   assert_failure

--- a/tests/plan/validate/nested/nested.cue
+++ b/tests/plan/validate/nested/nested.cue
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+)
+
+dagger.#Plan & {
+	actions: test: {
+		shallow: core.#ReadFile & {
+			_write: core.#WriteFile & {
+				input:    dagger.#Scratch
+				path:     "/hello.txt"
+				contents: "hello world"
+			}
+			input: _write.output
+			path:  "/hello.txt"
+		}
+		deep: core.#ReadFile & {
+			_op: write: core.#WriteFile & {
+				input:    dagger.#Scratch
+				path:     "/hello.txt"
+				contents: "hello world"
+			}
+			input: _op.write.output
+			path:  "/hello.txt"
+		}
+		nested: core.#ReadFile & {
+			_copy: core.#Copy & {
+				_write: core.#WriteFile & {
+					input:    dagger.#Scratch
+					path:     "/hello.txt"
+					contents: "hello world"
+				}
+				input:    dagger.#Scratch
+				contents: _write.output
+			}
+			input: _copy.output
+			path:  "/hello.txt"
+		}
+	}
+}

--- a/tests/tasks/exec/start_stop_exec.cue
+++ b/tests/tasks/exec/start_stop_exec.cue
@@ -42,13 +42,13 @@ dagger.#Plan & {
 			sig: core.#SendSignal & {
 				input:  start
 				signal: core.SIGHUP
-				_dep:   sleep
+				_dep:   sleep.exit
 			}
 
 			stop: core.#Stop & {
 				input:   start
 				timeout: time.Second
-				_dep:    sig
+				_dep:    sig.signal
 			}
 
 			verify: stop.exit & 99
@@ -175,7 +175,7 @@ dagger.#Plan & {
 
 			stop: core.#Stop & {
 				input: startExec
-				_dep:  syncExec
+				_dep:  syncExec.exit
 			}
 
 			verify: stop.exit & 0


### PR DESCRIPTION
Resolves #2303 

## Overview

Nested core actions are ignored in cue/flow and some users get confused by this. We can validate this and error early.

## Error example

From running the `tests/plan/validate/nested/nested.cue` test:

```console
actions.test.shallow: found nested core action: actions.test.shallow._write:
    ./tests/plan/validate/nested/nested.cue:10:3
    ./tests/plan/validate/nested/nested.cue:11:4
actions.test.deep: found nested core action: actions.test.deep._op.write:
    ./tests/plan/validate/nested/nested.cue:19:3
    ./tests/plan/validate/nested/nested.cue:20:9
actions.test.nested: found nested core action: actions.test.nested._copy:
    ./tests/plan/validate/nested/nested.cue:28:3
    ./tests/plan/validate/nested/nested.cue:29:4
actions.test.nested._copy: found nested core action: actions.test.nested._copy._write:
    ./tests/plan/validate/nested/nested.cue:29:4
    ./tests/plan/validate/nested/nested.cue:30:5
```

## Remaining tasks

- [ ] #2776

Signed-off-by: Helder Correia