### PR TITLE
chore: Don’t create `cue.mod/usr` on init

### DIFF
--- a/pkg/pkg.go
+++ b/pkg/pkg.go
@@ -276,11 +276,6 @@ func CueModInit(ctx context.Context, parentDir, module string) error {
 		}
 	}
 
-	if err := os.Mkdir(path.Join(modDir, "usr"), 0755); err != nil {
-		if !errors.Is(err, os.ErrExist) {
-			return err
-		}
-	}
 	if err := os.Mkdir(path.Join(modDir, "pkg"), 0755); err != nil {
 		if !errors.Is(err, os.ErrExist) {
 			return err

--- a/tests/project.bats
+++ b/tests/project.bats
@@ -12,7 +12,6 @@ setup() {
 
 	"$DAGGER" project init ./ --name "github.com/foo/bar"
 	test -d ./cue.mod/pkg
-	test -d ./cue.mod/usr
 	test -f ./cue.mod/module.cue
 	contents=$(cat ./cue.mod/module.cue)
 	[ "$contents" == 'module: "github.com/foo/bar"' ]


### PR DESCRIPTION
It confuses users and is only needed in an advanced case.

Signed-off-by: Helder Correia