### PR TITLE
[Docs] Redirect deprecated Dagger Cloud page

### DIFF
--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -27,6 +27,11 @@ from = "/reference"
 to = "/reference/alpine"
 status = 302
 
+[[redirects]]
+from = "/1241/dagger-cloud"
+to = "/1243/dagger-cloud"
+status = 302
+
 [[headers]]
   for = "/*"
   [headers.values]


### PR DESCRIPTION
This change in the Netlify.toml will redirect https://docs.dagger.io/1241/dagger-cloud/ to https://docs.dagger.io/1243/dagger-cloud/

Signed-off-by: crjm <julian@dagger.io>