### PR TITLE
feat: generic shell.#Run that supports custom shells

### DIFF
--- a/pkg/universe.dagger.io/alpha/shell/run.cue
+++ b/pkg/universe.dagger.io/alpha/shell/run.cue
@@ -1,0 +1,92 @@
+// Helpers to run shell commands in containers
+package shell
+
+import (
+	"list"
+
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+
+	"universe.dagger.io/docker"
+	"universe.dagger.io/alpine"
+)
+
+// Like #Run, but with a pre-configured container image.
+#RunSimple: #Run & {
+	_simpleImage: #Image
+	input:        _simpleImage.output
+}
+
+// Default simple container image which can run a shell
+#Image: docker.#Pull & {
+	source: #Ref | *"alpine:latest"
+}
+
+// Run a shell script in a Docker container
+//  Since this is a thin wrapper over docker.#Run, we embed it.
+//  Whether to embed or wrap is a case-by-case decision, like in Go.
+#Run: {
+	// Ash is the default because #Image is alpine
+	shell: string | *"ash"
+
+	// The script to execute
+	script: {
+		// A directory containing one or more shell scripts
+		directory: dagger.#FS
+
+		// Name of the file to execute
+		filename: string
+
+		_directory: directory
+		_filename:  filename
+	} | {
+		// Script contents
+		contents: string
+
+		_filename: "run.sh"
+		_write:    core.#WriteFile & {
+			input:      dagger.#Scratch
+			path:       _filename
+			"contents": contents
+		}
+		_directory: _write.output
+	}
+
+	// Arguments to the script
+	args: [...string]
+	flags: [string]: string | bool
+
+	_flatFlags: list.FlattenN([
+			for k, v in flags {
+			if (v & bool) != _|_ {
+				[k]
+			}
+			if (v & string) != _|_ {
+				[k, v]
+			}
+		},
+	], 1)
+
+	// Where in the container to mount the scripts directory
+	_mountpoint: "/shell/scripts"
+
+	docker.#Run & {
+		// ignore entrypoint from image config as it can
+		// create issues if it's not exec'ing to "$@"
+		entrypoint: []
+		command: {
+			name:   shell
+			"args": ["\(_mountpoint)/\(script._filename)"] + args + _flatFlags
+			// FIXME: make default flags overrideable
+			flags: {
+				"--norc": true
+				"-e":     true
+				"-o":     "pipefail"
+			}
+		}
+		mounts: "Shell scripts": {
+			contents: script._directory
+			dest:     _mountpoint
+		}
+	}
+}

--- a/pkg/universe.dagger.io/alpha/shell/run.cue
+++ b/pkg/universe.dagger.io/alpha/shell/run.cue
@@ -8,7 +8,6 @@ import (
 	"dagger.io/dagger/core"
 
 	"universe.dagger.io/docker"
-	"universe.dagger.io/alpine"
 )
 
 // Like #Run, but with a pre-configured container image.
@@ -19,7 +18,7 @@ import (
 
 // Default simple container image which can run a shell
 #Image: docker.#Pull & {
-	source: #Ref | *"alpine:latest"
+	source: docker.#Ref | *"alpine:latest"
 }
 
 // Run a shell script in a Docker container

--- a/pkg/universe.dagger.io/alpha/shell/test/data/hello.sh
+++ b/pkg/universe.dagger.io/alpha/shell/test/data/hello.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+echo Hello, world > /out.txt

--- a/pkg/universe.dagger.io/alpha/shell/test/test.bats
+++ b/pkg/universe.dagger.io/alpha/shell/test/test.bats
@@ -1,0 +1,10 @@
+setup() {
+    load '../../bats_helpers'
+
+    common_setup
+}
+
+@test "bash" {
+    dagger "do" -p ./test.cue test
+}
+

--- a/pkg/universe.dagger.io/alpha/shell/test/test.bats
+++ b/pkg/universe.dagger.io/alpha/shell/test/test.bats
@@ -1,5 +1,5 @@
 setup() {
-    load '../../bats_helpers'
+    load '../../../bats_helpers'
 
     common_setup
 }

--- a/pkg/universe.dagger.io/alpha/shell/test/test.cue
+++ b/pkg/universe.dagger.io/alpha/shell/test/test.cue
@@ -1,0 +1,60 @@
+package shell
+
+import (
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+
+	"universe.dagger.io/docker"
+	"universe.dagger.io/shell"
+)
+
+dagger.#Plan & {
+	actions: test: {
+
+		_pull: docker.#Pull & {
+			source: "index.docker.io/debian"
+		}
+		_image: _pull.output
+
+		runSimple: {
+			run: shell.#RunSimple & {
+				script: contents: """
+					echo "hello, there!" > /out.txt
+					"""
+				export: files: "/out.txt": string
+			}
+			output: run.export.files."/out.txt" & "hello, there!\n"
+		}
+
+		// Run a script from source directory + filename
+		runFile: {
+
+			dir:   _load.output
+			_load: core.#Source & {
+				path: "./data"
+				include: ["*.sh"]
+			}
+
+			run: shell.#Run & {
+				input: _image
+				export: files: "/out.txt": _
+				script: {
+					directory: dir
+					filename:  "hello.sh"
+				}
+			}
+			output: run.export.files."/out.txt" & "Hello, world\n"
+		}
+
+		// Run a script from string
+		runString: {
+			run: shell.#Run & {
+				input: _image
+				export: files: "/output.txt": _
+				script: contents: "echo 'Hello, inlined world!' > /output.txt"
+			}
+			output: run.export.files."/output.txt" & "Hello, inlined world!\n"
+		}
+
+	}
+}

--- a/pkg/universe.dagger.io/alpha/shell/test/test.cue
+++ b/pkg/universe.dagger.io/alpha/shell/test/test.cue
@@ -5,7 +5,7 @@ import (
 	"dagger.io/dagger/core"
 
 	"universe.dagger.io/docker"
-	"universe.dagger.io/shell"
+	"universe.dagger.io/alpha/shell"
 )
 
 dagger.#Plan & {
@@ -37,6 +37,7 @@ dagger.#Plan & {
 
 			run: shell.#Run & {
 				input: _image
+				shell: "bash"
 				export: files: "/out.txt": _
 				script: {
 					directory: dir
@@ -50,6 +51,7 @@ dagger.#Plan & {
 		runString: {
 			run: shell.#Run & {
 				input: _image
+				shell: "bash"
 				export: files: "/output.txt": _
 				script: contents: "echo 'Hello, inlined world!' > /output.txt"
 			}


### PR DESCRIPTION
The problem with `bash.#Run` is that if the user provides an image without bash, it fails. This is fine, until you consider the use-case of `yarn.#Script`, which uses `bash.#Run` internally and it's a pain to use a custom image with recent versions of node, as you need to inject it into the `yarn.#Run.input` and `yarn.#Run.install.container.input`.

Now, this could be a design issue with `yarn.#Run` and I could have added the shell override to `bash.#Run` quite easily - but then it wouldn't actually be `bash.#Run`

So I opted for a generic `shell.#Run`, which could also support nix, python, perl, et al.

Signed-off-by: David Flanagan <david@rawkode.dev>