### PR TITLE
universe: yarn: use the same container for running and installing

### DIFF
--- a/pkg/universe.dagger.io/yarn/yarn.cue
+++ b/pkg/universe.dagger.io/yarn/yarn.cue
@@ -59,9 +59,15 @@ import (
 		}
 	}
 
+	container: _
 	install: #Install & {
 		"source":  source
 		"project": project
+		// Use the same container image for the install command
+		"container": {
+			input: container.input
+			script: container.script
+		}
 	}
 
 }


### PR DESCRIPTION
This ensures that `yarn.#Script` uses the same container image to 1) run the desired yarn script, and 2) run `yarn install` prior to that.

Thanks @rawkode for reporting this issue.