### PR TITLE
fix: Improve validation around `#DecodeSecret`

### DIFF
--- a/plancontext/fs.go
+++ b/plancontext/fs.go
@@ -19,7 +19,7 @@ var fsIDPath = cue.MakePath(
 )
 
 func IsFSValue(v *compiler.Value) bool {
-	return v.LookupPath(fsIDPath).Exists()
+	return v.IncompleteKind() == cue.StructKind && v.LookupPath(fsIDPath).Exists()
 }
 
 func IsFSScratchValue(v *compiler.Value) bool {

--- a/plancontext/secret.go
+++ b/plancontext/secret.go
@@ -18,7 +18,7 @@ var (
 )
 
 func IsSecretValue(v *compiler.Value) bool {
-	return v.LookupPath(secretIDPath).Exists()
+	return v.IncompleteKind() == cue.StructKind && v.LookupPath(secretIDPath).Exists()
 }
 
 type Secret struct {

--- a/plancontext/service.go
+++ b/plancontext/service.go
@@ -18,7 +18,7 @@ var (
 )
 
 func IsSocketValue(v *compiler.Value) bool {
-	return v.LookupPath(socketIDPath).Exists()
+	return v.IncompleteKind() == cue.StructKind && v.LookupPath(socketIDPath).Exists()
 }
 
 type Socket struct {

--- a/tests/tasks.bats
+++ b/tests/tasks.bats
@@ -267,9 +267,22 @@ setup() {
     assert_failure
 }
 
-@test "task: #DecodeSecret" {
-    "$DAGGER" "do" -p ./tasks/decodesecret/decodesecret.cue test
-    "$DAGGER" "do" -p ./tasks/decodesecret/decodesecret.cue test --format json
+@test "task: #DecodeSecret in yaml (default)" {
+    "$DAGGER" "do" -p ./tasks/decodesecret/usage.cue test
+}
+
+@test "task: #DecodeSecret in json" {
+    "$DAGGER" "do" -p ./tasks/decodesecret/usage.cue test --format json
+}
+
+@test "task: #DecodeSecret with type unification" {
+    "$DAGGER" "do" -p ./tasks/decodesecret/type.cue test
+}
+
+@test "task: #DecodeSecret typo" {
+    run "$DAGGER" "do" -p ./tasks/decodesecret/typo.cue test
+    assert_failure
+    assert_line --partial '"actions.test.typo.env.FOO" is not a valid string or secret'
 }
 
 @test "task: #NewSecret" {

--- a/tests/tasks/decodesecret/mount.cue
+++ b/tests/tasks/decodesecret/mount.cue
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/yaml"
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+)
+
+dagger.#Plan & {
+	actions: test: {
+		write: core.#WriteFile & {
+			input:    dagger.#Scratch
+			path:     "/secret"
+			contents: yaml.Marshal({
+				FOO: "bar"
+			})
+		}
+
+		secret: core.#NewSecret & {
+			input: write.output
+			path:  "/secret"
+		}
+
+		decode: core.#DecodeSecret & {
+			input:  secret.output
+			format: "yaml"
+		}
+
+		image: core.#Pull & {
+			source: "alpine"
+		}
+
+		// foo: dagger.#Secret & decode.output.FOO.contents
+
+		// check if unification with dagger.#Secret doesn't fail validation
+		type: core.#Exec & {
+			input: image.output
+			args: ["sh", "-c", "test $(cat /bar) = bar"]
+			mounts: bar: {
+				type:     "secret"
+				contents: dagger.#Secret & decode.output.FOO.contents
+				dest:     "/bar"
+			}
+		}
+	}
+}

--- a/tests/tasks/decodesecret/type.cue
+++ b/tests/tasks/decodesecret/type.cue
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"encoding/yaml"
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+)
+
+dagger.#Plan & {
+	actions: test: {
+		write: core.#WriteFile & {
+			input:    dagger.#Scratch
+			path:     "/secret"
+			contents: yaml.Marshal({
+				FOO: "bar"
+			})
+		}
+
+		secret: core.#NewSecret & {
+			input: write.output
+			path:  "/secret"
+		}
+
+		decode: core.#DecodeSecret & {
+			input:  secret.output
+			format: "yaml"
+		}
+
+		image: core.#Pull & {
+			source: "alpine"
+		}
+
+		// check if unification with dagger.#Secret doesn't fail validation
+		type: core.#Exec & {
+			input: image.output
+			env: FOO: dagger.#Secret & decode.output.FOO.contents
+			args: ["sh", "-c", "test $FOO = bar"]
+		}
+	}
+}

--- a/tests/tasks/decodesecret/typo.cue
+++ b/tests/tasks/decodesecret/typo.cue
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"encoding/yaml"
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+)
+
+dagger.#Plan & {
+	actions: test: {
+		write: core.#WriteFile & {
+			input:    dagger.#Scratch
+			path:     "/secret"
+			contents: yaml.Marshal({
+				FOO: "bar"
+			})
+		}
+
+		secret: core.#NewSecret & {
+			input: write.output
+			path:  "/secret"
+		}
+
+		decode: core.#DecodeSecret & {
+			input:  secret.output
+			format: "yaml"
+		}
+
+		image: core.#Pull & {
+			source: "alpine"
+		}
+
+		typo: core.#Exec & {
+			input: image.output
+			env: FOO: decode.output.FOOT.contents
+			args: ["env"]
+		}
+	}
+}

--- a/tests/tasks/decodesecret/usage.cue
+++ b/tests/tasks/decodesecret/usage.cue
@@ -41,7 +41,7 @@ dagger.#Plan & {
 			source: "alpine"
 		}
 
-		verify: core.#Exec & {
+		usage: core.#Exec & {
 			input: image.output
 
 			mounts: {


### PR DESCRIPTION
Fixes #2789

The following issues were fixed in turn:

1. Fix panic while checking core type;
2. Fix undefined field error for `dagger.#Secret & decoded.output.FOO.contents` references;
3. Improve error message when making a typo with exec env.

Signed-off-by: Helder Correia

\cc @rawkode @marcosnils 