### PR TITLE
feat: Add global auth env variables to `core.#Pull`

### DIFF
--- a/docs/guides/concepts/1244-docker.md
+++ b/docs/guides/concepts/1244-docker.md
@@ -68,6 +68,8 @@ In most cases, you'll need to pull a docker image from a docker registry in orde
 ```cue file=../../tests/guides/docker/pull.cue
 ```
 
+When pulling images from the official Docker Hub registry (`docker.io`), you can set the `DOCKERHUB_AUTH_USER` and `DOCKERHUB_AUTH_SECRET` environment variables to authenticate. This will help fix docker hub rate limit issues when pulling images unauthenticated.
+
 ### `docker.#Set`
 
 The image metadata (i.e., [image config](https://github.com/dagger/dagger/blob/main/pkg/dagger.io/dagger/core/image.cue)) can be changed with the `docker.#Set` action. It takes an `#Image` as input, configurations to change, and outputs a new image with the changed metadata. The files in the image (`dagger.#FS`) are untouched.

--- a/pkg/dagger.io/dagger/core/image.cue
+++ b/pkg/dagger.io/dagger/core/image.cue
@@ -71,6 +71,8 @@ import (
 	source: #Ref
 
 	// Authentication
+	// You can alternatively set DOCKERHUB_AUTH_USER and DOCKERHUB_AUTH_PASSWORD env vars on your host
+	// However, these global env vars only work for the "docker.io" registry
 	auth?: {
 		username: string
 		secret:   dagger.#Secret

--- a/tests/tasks.bats
+++ b/tests/tasks.bats
@@ -13,6 +13,13 @@ setup() {
     "$DAGGER" "do" -p ./tasks/pull/pull_auth.cue pull
 }
 
+@test "task: #Pull auth env" {
+    export DOCKERHUB_AUTH_USER=foo DOCKERHUB_AUTH_PASSWORD=bar
+    run "$DAGGER" "do" -p ./tasks/pull/pull_auth_env.cue pull
+    assert_failure
+    assert_line --partial 'failed to fetch oauth token: unexpected status: 401 Unauthorized'
+}
+
 @test "task: #Push" {
     "$DAGGER" "do" -p ./tasks/push/push.cue pullOutputFile
 }

--- a/tests/tasks/pull/pull_auth_env.cue
+++ b/tests/tasks/pull/pull_auth_env.cue
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+)
+
+dagger.#Plan & {
+	actions: pull: core.#Pull & {
+		source: "unknownimage"
+	}
+}


### PR DESCRIPTION
Add global `dockerhub_auth_user` and `dockerhub_auth_password` env variables, to enable login to docker hub (only) and avoid being limited by rate-limiting free accounts.

Fixes #2804 

Signed-off-by: guillaume