### PR TITLE
fix: Validator not detecting an edge case with valid FS reference

### DIFF
--- a/pkg/universe.dagger.io/docker/run.cue
+++ b/pkg/universe.dagger.io/docker/run.cue
@@ -118,7 +118,7 @@ import (
 		}
 
 		export: {
-			rootfs: dagger.#FS & _exec.output
+			rootfs: _exec.output
 			files: [path=string]: string
 			_files: {
 				for path, _ in files {


### PR DESCRIPTION
Partially resolves #2802.

Transforms the `export` key of `docker.#Run` from `rootfs: dagger.#FS & _exec.output` to `rootfs: _exec.output`.

The previous unification made Cue not return any selector for the given expression.

To give more context, the below plan, with or without the first `bar` key commented, retrieves the same `refPath`. However, one has `Selectors`, the other is `nil`:

```
dagger.#Plan & {
	actions: test: #Foo & {
		// commenting this line fixes the error
		bar: #Bar
	}
}

#Foo: {
	bar: #Bar
}

#Bar: {
	_image: alpine.#Build
	_run: docker.#Run & {
		input: _image.output
		command: name: "date"
	}
}
```

The issue seems to come from the `docker.#Run.export` field. The unification in the assignment `rootfs: dagger.#FS & _exec.output` makes the evaluator not consider it as a value containing selectors, but as a completely new value. The cause might be that the expression, with the unification, becomes: `dagger.#FS & _exec.output & dagger.#FS & _exec.output`, which confuses the evaluator.

Issue #2802 is special because it is a chain of checks not being triggered by the `isPlanConcrete` function :
1. the field `export` is a generated field (contains a `@generated` attribute), via the `_exec.output`. So it should have been caught by this code:
```
// Always assume generated fields are concrete.
	if v.HasAttr("generated") {
		return nil
	}
```
2. It is being considered as an `FS` value, so it enters:
`case plancontext.IsFSValue(v) || plancontext.IsSecretValue(v) || plancontext.IsSocketValue(v):`

3. The `IsReference()` function returns `false`, because the referencePath doesn't have any selector for this very particular use case

Due to the chain of events, we can, we great confidence, assume that the value is not a reference but a new value (or copy) for the evaluator. Due to that, modifying the `isReference()` function is not trivial, as it doesn't totally depend on us, but on the understanding of the evaluator.

@aluzzardi suggested that we just remove the unification `dagger.#FS &`, whose usefulness is not proven. The last change was made by @helderco, who reused the previous declaration. We didn't see any particular reason for the use of the unification in the `export` field.

> Integration tests still work with this change

Peers: @aluzzardi, @marcosnils, @helderco

Signed-off-by: guillaume