### PR TITLE
fix: broken CI due to alpha/aws/cdk test

### DIFF
--- a/pkg/universe.dagger.io/alpha/aws/cdk/python/test/image.cue
+++ b/pkg/universe.dagger.io/alpha/aws/cdk/python/test/image.cue
@@ -18,9 +18,9 @@ dagger.#Plan & {
 				command: {
 					name: "/bin/sh"
 					args: ["-c", """
-							python version | grep "3.8"
+							python --version | grep "3.8"
 							npm -v | grep "8.10.0"
-							node -v | grep "16.15.0"
+							node -v | grep "16.16.0"
 						"""]
 				}
 			}
@@ -37,9 +37,9 @@ dagger.#Plan & {
 				command: {
 					name: "/bin/bash"
 					args: ["-c", """
-							python version | grep "3.9"
+							python --version | grep "3.9"
 							npm -v | grep "8.10.0"
-							node -v | grep "16.15.0"
+							node -v | grep "16.16.0"
 						"""]
 				}
 			}


### PR DESCRIPTION
CI seems to be broken due to a test on the `universe/alpha/aws/cdk/python` package: https://github.com/dagger/dagger/runs/7408582632?check_suite_focus=true#step:8:1327

* It checks the python version with `python version` command which doesn't seem to exist.
* the node version retrieved from apt just got upgraded

Peer: @gerhard 

Signed-off-by: guillaume