### PR TITLE
test: bump node version check

### DIFF
--- a/pkg/universe.dagger.io/alpha/aws/cdk/python/test/image.cue
+++ b/pkg/universe.dagger.io/alpha/aws/cdk/python/test/image.cue
@@ -18,9 +18,9 @@ dagger.#Plan & {
 				command: {
 					name: "/bin/sh"
 					args: ["-c", """
-							python version | grep "3.8"
+							python --version | grep "3.8"
 							npm -v | grep "8.10.0"
-							node -v | grep "16.15.0"
+							node -v | grep "16.16.0"
 						"""]
 				}
 			}
@@ -37,9 +37,9 @@ dagger.#Plan & {
 				command: {
 					name: "/bin/bash"
 					args: ["-c", """
-							python version | grep "3.9"
+							python --version | grep "\(_image.version)"
 							npm -v | grep "8.10.0"
-							node -v | grep "16.15.0"
+							node -v | grep "16.16.0"
 						"""]
 				}
 			}


### PR DESCRIPTION
Tests on my branch were failing because of weirdness in this script.

First the `python version` didn't find the `version` file.
Then the node version bumped and made the test fail.