### PR TITLE
updated the install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ Using Dagger, software teams can develop powerful CICD pipelines with minimal ef
 ## Useful links
 
 * [Join the Dagger community on Discord](https://discord.gg/ufnyBtc8uY)
-* [Install from a binary release](https://docs.dagger.io/1001/install/)
+* [Install from a binary release](https://docs.dagger.io/install)
 * [Build from source](https://docs.dagger.io/1001/install/#option-4-install-from-source)
 * [How to contribute](https://docs.dagger.io/1227/contributing/)


### PR DESCRIPTION
It pointed to the Dagger 0.1 docs. 

I didn't find the "build from source" content on the new install page, so I didn't change that link yet. 

Signed-off-by: Miranda Carter <101831275+mircubed@users.noreply.github.com>

<a href="https://gitpod.io/#https://github.com/dagger/dagger/pull/2834"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

