### PR TITLE
feat(lsp): update lsp import + fix incompatibilities

### DIFF
--- a/cmd/dagger/cmd/lsp.go
+++ b/cmd/dagger/cmd/lsp.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/dagger/daggerlsp/server"
+	"github.com/dagger/cuelsp/server"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.dagger.io/dagger/cmd/dagger/logger"
@@ -11,7 +11,7 @@ import (
 )
 
 var lspCmd = &cobra.Command{
-	Use:    "lsp",
+	Use:    "cuelsp",
 	Short:  "Run Dagger CUE Language Server",
 	Hidden: true,
 	Args:   cobra.NoArgs,
@@ -25,7 +25,10 @@ var lspCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		lg := logger.New()
 
-		s := server.New(server.PROD)
+		s, err := server.New(server.WithMode(server.ModeProd))
+		if err != nil {
+			lg.Fatal().Err(err).Msg("could not init Dagger Language Server")
+		}
 
 		lg.Info().Msg("Running Dagger CUE Language Server")
 		if err := s.Run(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 )
 
 require (
-	github.com/dagger/daggerlsp v0.3.2
+	github.com/dagger/cuelsp v0.3.3
 	github.com/tliron/kutil v0.1.61
 )
 

--- a/go.sum
+++ b/go.sum
@@ -488,8 +488,8 @@ github.com/d2g/dhcp4server v0.0.0-20181031114812-7d4a0a7f59a5/go.mod h1:Eo87+Kg/
 github.com/d2g/hardwareaddr v0.0.0-20190221164911-e7d9fbe030e4/go.mod h1:bMl4RjIciD2oAxI7DmWRx6gbeqrkoLqv3MV0vzNad+I=
 github.com/dagger/cue v0.4.1-rc.1.0.20220121023213-66df011a52c2 h1:L2vtsG/SF/VOcVGcjS1hoZl8SpgX97TBVuezKc0eUqA=
 github.com/dagger/cue v0.4.1-rc.1.0.20220121023213-66df011a52c2/go.mod h1:P09/R4UfAEzLkV9DXxwlxQnIZbkaT4uIhiEgs6Vsz2Q=
-github.com/dagger/daggerlsp v0.3.2 h1:hcmJBVRSk6oXFAfNUBcBvYsLzpUFmcDDwgb08AIgwD0=
-github.com/dagger/daggerlsp v0.3.2/go.mod h1:YIDlFWDGROCUgjiQrvZOm17yJW0XbqNxf1ys/cbju60=
+github.com/dagger/cuelsp v0.3.3 h1:gwfPdKUXpywGDYYka5p4Av5Z19GfwK93iRctMq7Iu50=
+github.com/dagger/cuelsp v0.3.3/go.mod h1:wd3dc66JuSwRM4kMY9iIO+r93nf4FfxTsSoPU/LzjRI=
 github.com/daixiang0/gci v0.2.9/go.mod h1:+4dZ7TISfSmqfAGv59ePaHfNzgGtIkHAhhdKggP1JAc=
 github.com/danieljoos/wincred v1.1.0/go.mod h1:XYlo+eRTsVA9aHGp7NGjFkPla4m+DCL7hqDjlFjiygg=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
- Change hidden Dagger subcommand to `dagger cuelsp`.
- Update LSP imports
- Update server Mode initialization to work with functional server initialization paradigm + server initialization error management

Signed-off-by: guillaume