### PR TITLE
Set tag-name explicitly for homebrew-core PR

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -52,10 +52,8 @@ jobs:
           running-workflow-name: "Bump version, tag & release"
           allowed-conclusions: success
 
-      - name: "Create next release tag"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SEMVER_BUMP: ${{ github.event.inputs.release_type }}
+      - name: "Generate next release version"
+        id: next_release_version
         run: |
           if [[ -n "${{ github.event.inputs.release_version }}" ]]
           then
@@ -66,11 +64,18 @@ jobs:
             # Rather than installing it on every run, we commit it locally so that we have everything we need locally
             # wget https://raw.githubusercontent.com/fsaintjacques/semver-tool/3.3.0/src/semver
             # https://github.com/fsaintjacques/semver-tool
-            next_release_version="v$(./semver bump ${SEMVER_BUMP:=patch}  $previous_release_version)"
+            next_release_version="v$(./semver bump ${SEMVER_BUMP:=patch} $previous_release_version)"
           fi
           echo "NEXT RELEASE VERSION: $next_release_version"
+          printf "::set-output name=%s::%s\n" value "$next_release_version"
+
+      - name: "Create next release tag"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SEMVER_BUMP: ${{ github.event.inputs.release_type }}
+        run: |
           gh api -X POST /repos/:owner/:repo/git/refs \
-            --field ref="refs/tags/$next_release_version" \
+            --field ref="refs/tags/${{ steps.next_release_version.outputs.value }}" \
             --field sha="$GITHUB_SHA"
 
       - name: "Fetch new tag"
@@ -102,6 +107,7 @@ jobs:
         uses: mislav/bump-homebrew-formula-action@v2
         with:
           formula-name: dagger
+          tag-name: ${{ steps.next_release_version.outputs.value }}
           commit-message: |
             {{formulaName}} {{version}}
 

--- a/.github/workflows/test-auto-release.yml
+++ b/.github/workflows/test-auto-release.yml
@@ -1,0 +1,42 @@
+# ⚠️ This is meant to serve as an integration test
+# To be deleted after it serves its purpose
+name: "Test Auto Release"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-auto-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check out"
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: "Fixed release version"
+        id: next_release_version
+        run: |
+          echo 'We are setting this explicitly to check that "Update homebrew-core formula" works as expected.'
+          echo 'We only want to run this once, and then delete the workflow.'
+          echo 'Subsequent runs should be done via the auto-release.yml workflow.'
+          next_release_version="v0.2.28"
+          echo "NEXT RELEASE VERSION: $next_release_version"
+          printf "::set-output name=%s::%s\n" value "$next_release_version"
+
+      # Open a https://github.com/Homebrew/homebrew-core PR to update the bottled formula after we release.
+      # This explains why we need to do it separately, on top of GoReleaser updating our Homebrew tap:
+      # - https://github.com/Homebrew/homebrew-core/pull/105746#issuecomment-1190522063
+      # - https://github.com/dagger/dagger/issues/2823#issuecomment-1190792261
+      - name: "Update homebrew-core formula"
+        # https://github.com/mislav/bump-homebrew-formula-action
+        uses: mislav/bump-homebrew-formula-action@v2
+        with:
+          formula-name: dagger
+          tag-name: ${{ steps.next_release_version.outputs.value }}
+          commit-message: |
+            {{formulaName}} {{version}}
+
+            Created by ${{ github.server_url }}/${{ github.repository }}/runs/${{ github.run_id }}
+        env:
+          COMMITTER_TOKEN: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}


### PR DESCRIPTION
Since this runs on the main branch, the `github.ref` value will be set to `refs/heads/main` and the
https://github.com/mislav/bump-homebrew-formula-action will fail as we have seen in this run: https://github.com/dagger/dagger/runs/7651780409?check_suite_focus=true#step:9:13

This sets the tag-name value explicitly which should fix it according to https://github.com/mislav/bump-homebrew-formula-action#manual-trigger

Follow-up to https://github.com/dagger/dagger/pull/2888