### PR TITLE
Feat/improve windows install script

### DIFF
--- a/docs/getting-started/1242-install.mdx
+++ b/docs/getting-started/1242-install.mdx
@@ -92,13 +92,29 @@ dagger 0.2.19 (GIT_SHA) linux/amd64
 
 `dagger` can be installed in Windows via an installation powershell script, [Chocolatey](https://community.chocolatey.org/packages/dagger) or [Scoop](https://scoop.sh/#/apps?q=dagger).
 
-If you want to use the installation script, from a powershell terminal, run:
+If you want to use the installation script, powershell 7.0 or newer is required. From powershell, run:
 
-```shell
+```Powershell
 Invoke-WebRequest -UseBasicParsing -Uri https://dl.dagger.io/dagger/install.ps1 | Invoke-Expression
 ```
 
-We'll save everything under `<your home folder>/dagger`
+If you want to install dagger to a different location, pass in a location to the script with the `-InstallPath` parameter.
+
+```Powershell
+$script = Invoke-WebRequest -UseBasicParsing -Uri https://dl.dagger.io/dagger/install.ps1
+$params = "-InstallPath C:\temp"
+"$script $params" | Invoke-Expression
+```
+
+If you want to install a specific version of `dagger`, pass in a version number with the `-DaggerVersion` parameter.
+
+```Powershell
+$script = Invoke-WebRequest -UseBasicParsing -Uri https://dl.dagger.io/dagger/install.ps1
+$params = "-DaggerVersion 0.2.28"
+"$script $params" | Invoke-Expression
+```
+
+Without passing in the `-InstallPath`, We'll save everything under `<your home folder>\dagger`
 
 Check that `dagger` is installed correctly by opening a `Command Prompt` terminal and run:
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,50 +1,58 @@
-# param (
-#     [Parameter(Mandatory)] $PersonalToken  
-# )
+#Requires -Version 7.0
+
+param (
+    # [Parameter(Mandatory)] $PersonalToken  
+    [Parameter(Mandatory = $false)] [System.Management.Automation.SemanticVersion]$DaggerVersion,
+    [Parameter(Mandatory = $false)] [System.Boolean]$InteractiveInstall = $false,
+    [Parameter(Mandatory = $false)] [string]$InstallPath = $env:HOMEPATH + '\dagger'
+)
 Clear-Host
 @"
 
 ---------------------------------------------------------------------------------
 Author: Alessandro Festa
+Co Author: Brittan DeYoung
 Dagger Installation Utility  for Windows users
 ---------------------------------------------------------------------------------
 
 "@
 
 # Since we are already authenticated we may directly download latest version.
-$name="dagger"
-$base="https://dagger-io.s3.amazonaws.com"
+$name = "dagger"
+$base = "https://dagger-io.s3.amazonaws.com"
 function http_download {
-    $version=Get_Version
-    $version=$version -replace '[""]'
-    $version=$version -replace '\n'
-    $fileName="dagger_v" + $version + "_windows_amd64"
+    $version = Get_Version
+    $version = $version -replace '[""]'
+    $version = $version -replace '\n'
+    $fileName = "dagger_v" + $version + "_windows_amd64"
     Clear-Host
     $url = $base + "/" + $name + "/releases/" + $version + "/" + $fileName + ".zip"
     write-host $url
-    Pause
+    if ($InteractiveInstall) {
+        Pause
+    }
     
 
     Invoke-WebRequest -Uri $url -OutFile $env:temp/$fileName.zip -ErrorAction Stop
-    Expand-Archive -Path $env:temp/$fileName.zip -DestinationPath $env:HOMEPATH/dagger -Force -ErrorVariable ProcessError;
-    If ($ProcessError)
-    {
-    Clear-Host
-@"
+    Expand-Archive -Path $env:temp/$fileName.zip -DestinationPath $InstallPath -Force -ErrorVariable ProcessError;
+    If ($ProcessError) {
+        Clear-Host
+        @"
 Whoops apparently we had an issue in unzipping the file, please check
 you have the right permission to do so and try to unzip manually the file.
 Currently we saved Dagger at your temp folder.
 "@
-exit
-    } else {
+        exit
+    }
+    else {
         Clear-Host
     
-@"
+        @"
 
 Thank You for downloading Dagger!
 
 -----------------------------------------------------
-Dagger has been saved at <YOUR HOME FOLDER>/dagger/
+Dagger has been saved in $InstallPath
 Please add dagger.exe to your PATH in order to use it
 ----------------------------------------------------
 
@@ -54,11 +62,14 @@ Please add dagger.exe to your PATH in order to use it
 }
 
 function Get_Version { 
-    $response = Invoke-RestMethod 'http://releases.dagger.io/dagger/latest_version' -Method 'GET'  -Body $body -ErrorAction SilentlyContinue -ErrorVariable DownloadError
-    If ($DownloadError)
-    {
-    Clear-Host
-@"
+    if ($DaggerVersion) {
+        $version = $DaggerVersion
+    }
+    else {
+        $response = Invoke-RestMethod 'http://releases.dagger.io/dagger/latest_version' -Method 'GET'  -Body $body -ErrorAction SilentlyContinue -ErrorVariable DownloadError
+        If ($DownloadError) {
+            Clear-Host
+            @"
 
 ---------------------------------------------------------------------------
 Houston we have a problem!
@@ -68,9 +79,11 @@ run the script and if it still fail please open an issue on the Dagger repo.
 ----------------------------------------------------------------------------
 
 "@
-exit
+            exit
+        }
+        $version = $response
     }
-    return $response
+    return $version
     
 }
 


### PR DESCRIPTION
Added optional parameters to improve the install script and updated the documentation to reflect this update:

* `-DaggerVersion`: allows specifying the version to install. Will default to `latest`
* `-InteractiveInstall`: Allows running the script unattended. Defaults to `$false`
* `-InstallPath`: Allows passing in a specific location for installing the `dagger.exe` binary.