### PR TITLE
docs: fix typo in what-is-cue docs 

### DIFF
--- a/docs/core-concepts/1215-what-is-cue.md
+++ b/docs/core-concepts/1215-what-is-cue.md
@@ -286,7 +286,7 @@ A valid use of that template would be:
 
 ```cue
 flags: {
-    "--foo": "bar:
+    "--foo": "bar"
     "baz": true
 }
 ```


### PR DESCRIPTION
Hey,

There were a small typo in this page.

Cheers