### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/getting-started/f44rm-how-it-works.mdx
+++ b/docs/getting-started/f44rm-how-it-works.mdx
@@ -25,12 +25,12 @@ The technical reference is a great resource to have at hand while using Dagger.
 
 <LinkCTA
   label="Core Actions Reference"
-  url="1222/core-actions-reference"
+  url="/1222/core-actions-reference"
   textDecoration="false"
 />
 <LinkCTA
   label="Dagger Types Reference"
-  url="1234/dagger-types-reference"
+  url="/1234/dagger-types-reference"
   textDecoration="false"
 />
 
@@ -40,7 +40,7 @@ Want to know more about how Dagger can solve real-life problems? Check clients t
 
 <LinkCTA
   label="Particubes: Go on Docker Swarm"
-  url="1211/go-docker-swarm"
+  url="/1211/go-docker-swarm"
   textDecoration="false"
 />
 
@@ -57,34 +57,34 @@ export const data = {
       description:
         "A config declared in Dagger starts with a plan. Learn more about how they work.",
       imgFilename: "dagger-plan.jpg",
-      url: "1202/plan",
+      url: "/1202/plan",
     },
     {
       label: "Actions",
       description:
         "Actions are the basic building block of the Dagger platform. Learn more here. ",
       imgFilename: "dagger-actions.jpg",
-      url: "1221/action",
+      url: "/1221/action",
     },
     {
       label: "Clients",
       description:
         "Learn how to use the client field to interact with the local machine. ",
       imgFilename: "dagger-clients.jpg",
-      url: "1203/client",
+      url: "/1203/client",
     },
     {
       label: "Secrets",
       description:
         "Learn how to use secrets with Dagger to utilize confidential information.",
       imgFilename: "dagger-secrets.jpg",
-      url: "1204/secrets",
+      url: "/1204/secrets",
     },
     {
       label: "What is CUE",
       description: "Learn more about CUE and how Dagger integrates with it.",
       imgFilename: "dagger-what_is_cue.jpg",
-      url: "1215/what-is-cue",
+      url: "/1215/what-is-cue",
     },
   ],
 };


### PR DESCRIPTION
The `How-it-works` page has some bad redirects. This is the fix

Signed-off-by: Guillaume de Rouville