### PR TITLE
Add go action to install/configure go into image

### DIFF
--- a/pkg/universe.dagger.io/go/configure.cue
+++ b/pkg/universe.dagger.io/go/configure.cue
@@ -23,47 +23,73 @@ import (
 	// In most cases you want to use the default value provided here.
 	gopath: string | *#DefaultGoEnvs.GOPATH
 
-	// filesystem with go in it.
-	// This will be copied into the image at the path specified by `goroot`
-	// if `source` is specified just the path to the source will be copied.
-	contents: dagger.#FS
-	// path to go root in the `contents` filesystem
+	// path to go root in the specified filesystem (be it an image ref or a dagger.#FS)
 	source: string | *#DefaultGoEnvs.GOROOT
 
-	docker.#Build & {
-		steps: [
-			{output: input},
-			{
-				input:   docker.#Image
-				_subDir: core.#Subdir & {
-					input: contents
-					path:  "\(source)"
-				}
-
-				_goWithRoot: core.#Copy & {
-					input:    dagger.#Scratch
-					contents: _subDir.output
-					dest:     "\(goroot)"
-				}
-
-				_merge: core.#Merge & {
-					inputs: [input.rootfs, _goWithRoot.output]
-				}
-				output: docker.#Image & {
-					config: input.config
-					rootfs: _merge.output
-				}
-			},
-			docker.#Set & {
-				input:  docker.#Image
-				config: core.#ImageConfig & {
-					env: {
-						GOROOT: goroot
-						GOPATH: gopath
-						PATH:   "\(gopath)/bin:\(goroot)/bin:\(input.config.env.PATH)"
-					}
-				}
-			},
-		]
+	_cfg: _#Configure & {
+		"input":  input
+		"source": source
+		"goroot": goroot
+		"gopath": gopath
 	}
+
+	{
+		// filesystem with go in it.
+		// This will be copied into the image at the path specified by `goroot`
+		// if `source` is specified just the path to the source will be copied.
+		contents: dagger.#FS
+		_cfg:     _#Configure & {
+			"contents": contents
+		}
+	} | {
+		// ref to an image with go in it.
+		// e.g. docker.io/library/golang:latest
+		ref:   core.#Ref
+		_pull: docker.#Pull & {
+			source: ref
+		}
+		_cfg: _#Configure & {
+			contents: _pull.output.rootfs
+		}
+	}
+
+	output: _cfg.output
+}
+
+_#Configure: {
+	input:    docker.#Image
+	contents: dagger.#FS
+	goroot:   string
+	gopath:   string
+	source:   string
+
+	_subDir: core.#Subdir & {
+		input: contents
+		path:  "\(source)"
+	}
+
+	_goWithRoot: core.#Copy & {
+		input:    dagger.#Scratch
+		contents: _subDir.output
+		dest:     "\(goroot)"
+	}
+
+	_merge: core.#Merge & {
+		inputs: [input.rootfs, _goWithRoot.output]
+	}
+
+	_set: docker.#Set & {
+		"input": docker.#Image & {
+			rootfs: _merge.output
+			config: input.config
+		}
+		config: core.#ImageConfig & {
+			env: {
+				GOROOT: goroot
+				GOPATH: gopath
+				PATH:   "\(gopath)/bin:\(goroot)/bin:\(input.config.env.PATH)"
+			}
+		}
+	}
+	output: _set.output
 }

--- a/pkg/universe.dagger.io/go/configure.cue
+++ b/pkg/universe.dagger.io/go/configure.cue
@@ -1,0 +1,69 @@
+package go
+
+import (
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+	"universe.dagger.io/docker"
+)
+
+// Default values used for #Configure.
+#DefaultGoEnvs: {
+	GOROOT: "/usr/local/go"
+	GOPATH: "/go"
+}
+
+// Configure installs go into the given input image.
+// It sets GOROOT, GOPATH, and adds the relevent go bin paths to PATH.
+#Configure: {
+	input: docker.#Image
+	// path to install go to in `input` and set the GOROOT env var to
+	// In most cases you want to use the default value provided here.
+	goroot: string | *#DefaultGoEnvs.GOROOT
+	// path for GOPATH to be set to
+	// In most cases you want to use the default value provided here.
+	gopath: string | *#DefaultGoEnvs.GOPATH
+
+	// filesystem with go in it.
+	// This will be copied into the image at the path specified by `goroot`
+	// if `source` is specified just the path to the source will be copied.
+	contents: dagger.#FS
+	// path to go root in the `contents` filesystem
+	source: string | *#DefaultGoEnvs.GOROOT
+
+	docker.#Build & {
+		steps: [
+			{output: input},
+			{
+				input:   docker.#Image
+				_subDir: core.#Subdir & {
+					input: contents
+					path:  "\(source)"
+				}
+
+				_goWithRoot: core.#Copy & {
+					input:    dagger.#Scratch
+					contents: _subDir.output
+					dest:     "\(goroot)"
+				}
+
+				_merge: core.#Merge & {
+					inputs: [input.rootfs, _goWithRoot.output]
+				}
+				output: docker.#Image & {
+					config: input.config
+					rootfs: _merge.output
+				}
+			},
+			docker.#Set & {
+				input:  docker.#Image
+				config: core.#ImageConfig & {
+					env: {
+						GOROOT: goroot
+						GOPATH: gopath
+						PATH:   "\(gopath)/bin:\(goroot)/bin:\(input.config.env.PATH)"
+					}
+				}
+			},
+		]
+	}
+}

--- a/pkg/universe.dagger.io/go/test/configure.cue
+++ b/pkg/universe.dagger.io/go/test/configure.cue
@@ -1,0 +1,80 @@
+package go
+
+import (
+	"dagger.io/dagger"
+	"dagger.io/dagger/core"
+	"universe.dagger.io/go"
+	"universe.dagger.io/docker"
+	"universe.dagger.io/alpine"
+)
+
+dagger.#Plan & {
+	actions: test: {
+		_goImg: docker.#Pull & {
+			source: "index.docker.io/golang:1.18-alpine"
+		}
+
+		simple: {
+			_gopath: "/go"
+
+			_build: docker.#Build & {
+				steps: [
+					alpine.#Build & {},
+					go.#Configure & {
+						contents: _goImg.output.rootfs
+					},
+				]
+			}
+
+			verify: docker.#Run & {
+				input: _build.output
+				command: {
+					name: "/bin/sh"
+					args: ["-c", """
+							set -e
+							go version | grep "1.18"
+							go env GOROOT | grep '\(go.#DefaultGoEnvs.GOROOT)'
+							go env GOPATH | grep '\(go.#DefaultGoEnvs.GOPATH)'
+							echo $PATH | grep -E '^\(go.#DefaultGoEnvs.GOROOT)/bin:|:\(go.#DefaultGoEnvs.GOROOT)/bin:'
+							echo $PATH | grep -E '^\(go.#DefaultGoEnvs.GOPATH)/bin:|:\(go.#DefaultGoEnvs.GOPATH)/bin:'
+						"""]
+				}
+			}
+		}
+		custom: {
+			_customGoroot: "/usr/local/gocustom"
+			_customGopath: "/gocustom"
+
+			_goContents: core.#Subdir & {
+				input: _goImg.output.rootfs
+				path:  go.#DefaultGoEnvs.GOROOT
+			}
+			_build: docker.#Build & {
+				steps: [
+					alpine.#Build & {},
+					go.#Configure & {
+						contents: _goContents.output
+						source:   "/"
+						goroot:   _customGoroot
+						gopath:   _customGopath
+					},
+				]
+			}
+
+			verify: docker.#Run & {
+				input: _build.output
+				command: {
+					name: "/bin/sh"
+					args: ["-c", """
+							set -e
+							go version | grep "1.18"
+							go env GOROOT | grep '\(_customGoroot)'
+							go env GOPATH | grep '\(_customGopath)'
+							echo $PATH | grep -E '^\(_customGoroot)/bin:|:\(_customGoroot)/bin:'
+							echo $PATH | grep -E '^\(_customGopath)/bin:|:\(_customGopath)/bin:'
+						"""]
+				}
+			}
+		}
+	}
+}

--- a/pkg/universe.dagger.io/go/test/test.bats
+++ b/pkg/universe.dagger.io/go/test/test.bats
@@ -19,3 +19,7 @@ setup() {
 @test "go test" {
     dagger "do" -p ./test.cue test
 }
+
+@test "configure go" {
+    dagger "do" -p ./configure.cue test
+}


### PR DESCRIPTION
A helpful action to add go to any image.
Expects the caller to pass in a rootfs that already has go init that we
can extract and put into the passed in image.