### PR TITLE
docs: fix typo, shadowing not shodowing

### DIFF
--- a/docs/guides/actions/1241-field-shadowing.md
+++ b/docs/guides/actions/1241-field-shadowing.md
@@ -27,7 +27,7 @@ test: "hello world"
 
 // We concretise our definition and assign key test to value defined in 
 // outer key test
-// This will produce a shodowing 
+// This will produce a shadowing 
 shadow: #Def & {
    test: test
 }


### PR DESCRIPTION
Quick typo fix,  `shodowing` => `shadowing`