### PR TITLE
fix(universe/docker): support exporting relative to working directory

### DIFF
--- a/pkg/universe.dagger.io/docker/run.cue
+++ b/pkg/universe.dagger.io/docker/run.cue
@@ -2,7 +2,7 @@ package docker
 
 import (
 	"list"
-	"path"
+	stdpath "path"
 
 	"dagger.io/dagger"
 	"dagger.io/dagger/core"
@@ -103,11 +103,11 @@ import (
 
 	_workDirRelativePath: {
 		_path: string
-		if path.IsAbs(_path) {
+		if stdpath.IsAbs(_path) {
 			path: _path
 		}
-		if !path.IsAbs(_path) {
-			path: path.Join([_config.output.workdir, _path])
+		if !stdpath.IsAbs(_path) {
+			path: stdpath.Join([_config.output.workdir, _path])
 		}
 	}
 

--- a/pkg/universe.dagger.io/docker/run.cue
+++ b/pkg/universe.dagger.io/docker/run.cue
@@ -104,10 +104,10 @@ import (
 	_workDirRelativePath: {
 		_path: string
 		if path.IsAbs(_path) {
-			"path": _path
+			path: _path
 		}
 		if !path.IsAbs(_path) {
-			"path": path.Join([_config.output.workdir, _path])
+			path: path.Join([_config.output.workdir, _path])
 		}
 	}
 

--- a/pkg/universe.dagger.io/docker/run.cue
+++ b/pkg/universe.dagger.io/docker/run.cue
@@ -130,14 +130,14 @@ import (
 
 		export: {
 			rootfs: _exec.output
-			files: [p=string]: string
+			files: [path=string]: string
 			_files: {
-				for p, _ in files {
-					"\(p)": {
+				for path, _ in files {
+					"\(path)": {
 						contents: string & _read.contents
 						_read:    core.#ReadFile & _workDirRelativePath & {
 							input: _exec.output
-							_path: p
+							_path: path
 						}
 					}
 				}
@@ -146,36 +146,36 @@ import (
 				files: "\(path)": output.contents
 			}
 
-			directories: [p=string]: dagger.#FS
+			directories: [path=string]: dagger.#FS
 			_directories: {
-				for p, _ in directories {
-					"\(p)": {
+				for path, _ in directories {
+					"\(path)": {
 						contents: dagger.#FS & _subdir.output
 						_subdir:  core.#Subdir & _workDirRelativePath & {
 							input: _exec.output
-							_path: p
+							_path: path
 						}
 					}
 				}
 			}
-			for p, output in _directories {
-				directories: "\(p)": output.contents
+			for path, output in _directories {
+				directories: "\(path)": output.contents
 			}
 
-			secrets: [p=string]: dagger.#Secret
+			secrets: [path=string]: dagger.#Secret
 			_secrets: {
-				for p, _ in secrets {
-					"\(p)": {
+				for path, _ in secrets {
+					"\(path)": {
 						contents: dagger.#Secret & _read.output
 						_read:    core.#NewSecret & _workDirRelativePath & {
 							input: _exec.output
-							_path: p
+							_path: path
 						}
 					}
 				}
 			}
-			for p, output in _secrets {
-				secrets: "\(p)": output.contents
+			for path, output in _secrets {
+				secrets: "\(path)": output.contents
 			}
 		}
 	}

--- a/pkg/universe.dagger.io/docker/test/run.cue
+++ b/pkg/universe.dagger.io/docker/test/run.cue
@@ -94,11 +94,11 @@ dagger.#Plan & {
 						echo -n hello world >> /usr/test/output.txt
 						"""#
 				}
-				export: directories: "test": _
+				export: directories: test: _
 			}
 
 			verify: core.#ReadFile & {
-				input: run.export.directories."test"
+				input: run.export.directories.test
 				path:  "/output.txt"
 			}
 			verify: contents: "hello world"

--- a/pkg/universe.dagger.io/docker/test/run.cue
+++ b/pkg/universe.dagger.io/docker/test/run.cue
@@ -46,6 +46,21 @@ dagger.#Plan & {
 			}
 		}
 
+		// Test: export a file relative to workdir
+		exportRelativeFile: {
+			run: docker.#Run & {
+				input:   _image
+				workdir: "/usr"
+				command: {
+					name: "sh"
+					flags: "-c": #"""
+						echo -n hello world >> /usr/output.txt
+						"""#
+				}
+				export: files: "output.txt": string & "hello world"
+			}
+		}
+
 		// Test: export a directory
 		exportDirectory: {
 			run: docker.#Run & {
@@ -62,6 +77,28 @@ dagger.#Plan & {
 
 			verify: core.#ReadFile & {
 				input: run.export.directories."/test"
+				path:  "/output.txt"
+			}
+			verify: contents: "hello world"
+		}
+
+		// Test: export a directory relative to workdir
+		exportRelativeDirectory: {
+			run: docker.#Run & {
+				input:   _image
+				workdir: "/usr"
+				command: {
+					name: "sh"
+					flags: "-c": #"""
+						mkdir -p /usr/test
+						echo -n hello world >> /usr/test/output.txt
+						"""#
+				}
+				export: directories: "test": _
+			}
+
+			verify: core.#ReadFile & {
+				input: run.export.directories."test"
 				path:  "/output.txt"
 			}
 			verify: contents: "hello world"
@@ -100,6 +137,44 @@ dagger.#Plan & {
 				mounts: secrets: {
 					dest:     "/secret.txt"
 					contents: run.export.secrets."/secret2.txt"
+				}
+			}
+		}
+
+		// Test: export a secret relative to workDir
+		exportRelativeSecret: {
+			run: docker.#Run & {
+				input:   _image
+				workdir: "/usr"
+				command: {
+					name: "sh"
+					flags: "-c": """
+							echo test1 >> /usr/secret1.txt
+							echo test2 >> /usr/secret2.txt
+						"""
+				}
+				export: secrets: {
+					"secret1.txt": _
+					"secret2.txt": _
+				}
+			}
+
+			verify: docker.#Run & {
+				input: _image
+				command: {
+					name: "sh"
+					flags: {
+						"-e": true
+						"-c": """
+							test "$SECRET_ENV" = "test1"
+							test "$(cat /usr/secret.txt)" = "test2"
+						"""
+					}
+				}
+				env: SECRET_ENV: run.export.secrets."secret1.txt"
+				mounts: secrets: {
+					dest:     "/usr/secret.txt"
+					contents: run.export.secrets."secret2.txt"
 				}
 			}
 		}


### PR DESCRIPTION
Unsure if this is a desired or not, but thought I would propose it.
I got stuck using `docker` package, after assuming `export` would resolve relative to `workdir`.

I started a little thread in the [help](https://discord.com/channels/707636530424053791/709803368318632038/1007931064876019753) channel in discord for my issue.
Eventually, I figured out what I was doing wrong and solved it with an absolute path.

This change updates `files`, `directories` and `secrets` within `export` to resolve any relative paths against the `workdir` base.

