### PR TITLE
Fix link to todoapp example in universe

### DIFF
--- a/pkg/universe.dagger.io/README.md
+++ b/pkg/universe.dagger.io/README.md
@@ -42,7 +42,7 @@ The Dagger container API defines the following types:
 
 This package contains examples of complete Dagger configurations, including the result of following tutorials in the documentations.
 
-For example, [the todoapp example](./examples/todoapp) corresponds to the [Getting Started tutorial](https://docs.dagger.io/1003/get-started/)
+For example, [the todoapp example](https://github.com/dagger/todoapp) corresponds to the [Getting Started tutorial](https://docs.dagger.io/1003/get-started/)
 
 ## Coding Style
 


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX10Pft3mJ0qSFVpTuyNObgh95BUS8bzh48%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=s9LDGu6)
Signed-off-by: Avinash Upadhyaya <avinashupadhya99@gmail.com>

Fix link to the todoapp example in the universe README since the examples were moved out of the universe directory