### PR TITLE
docs: Add project update to local dev docs

### DIFF
--- a/docs/getting-started/tutorial/1200-local-dev.md
+++ b/docs/getting-started/tutorial/1200-local-dev.md
@@ -42,7 +42,7 @@ With Docker running, we are ready to download our example app and run its CI/CD 
 ```shell
 git clone https://github.com/dagger/todoapp
 cd todoapp
-
+dagger project update
 dagger do build
 ```
 
@@ -108,7 +108,7 @@ With Docker Engine running, we are ready to download our example app and run its
 ```shell
 git clone https://github.com/dagger/todoapp
 cd todoapp
-
+dagger project update
 dagger do build
 ```
 
@@ -173,6 +173,7 @@ Still in your `Command Prompt` terminal:
 ```shell
 git clone https://github.com/dagger/todoapp
 cd todoapp
+dagger project update
 dagger do build
 ```
 


### PR DESCRIPTION
Added a step in the getting started docs to indicate that running `dagger project update` is expected in order to get the example app running after initial download. I also made this same update to the example app readme file and have an open PR on that repo.


Closes: #2438

Signed-off-by: Brittan DeYoung <32572259+brittandeyoung@users.noreply.github.com>