### PR TITLE
feature: install completion script for bash, zsh and fish

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -285,20 +285,37 @@ tarball() {
     echo "$name"
 }
 
-install_completion() {
-    # discovery of currently used shell is too error prone, I install all of them
-    # - echo $SHELL rarely works
-    # - echo $0 doesn't work if you use the script as the runner
-    # - echo $$ to get the pid of the process sometimes fail as well
+install_shell_completion() {
+    echo "
+${binexe} has built-in shell completion. This is how you can install it for:
 
-    # This should work on debian derived distributions
-    # FIXME: make it work with other distribution: use $XDG_DATA_DIRS?
-    #
-    # the && true will get us user complain about their setup, we want that for now to make it work everywhere
-    ${binexe} completion bash > /usr/share/bash-completion/completions/dagger    && true
-    ${binexe} completion zsh  > /usr/share/zsh/vendor-completions/_dagger        && true
-    ${binexe} completion fish > /usr/share/fish/vendor_completions.d/dagger.fish && true
+  BASH:
 
+    1. Ensure that you install bash-completion using your package manager.
+
+    2. Add this line to your ~/.bash_profile:
+
+      eval \"\$(${binexe} completion bash)\"
+
+  ZSH:
+
+    1. Generate a _dagger completion script and write it to a file within your \$FPATH, e.g.:
+
+      ${binexe} completion zsh > /usr/local/share/zsh/site-functions/_dagger
+
+    2. Ensure that the following is present in your ~/.zshrc:
+
+      autoload -U compinit
+      compinit -i
+
+    zsh version 5.7 or later is recommended.
+
+  FISH:
+
+    1. Generate a dagger.fish completion script and write it to a file within fish completions, e.g.:
+
+      ${binexe} completion fish > ~/.config/fish/completions/dagger.fish
+    "
 }
 
 execute() {
@@ -319,7 +336,8 @@ execute() {
     (cd "${tmpdir}" && untar "${tarball}")
     test ! -d "${bin_dir}" && install -d "${bin_dir}"
     install "${srcdir}/${binexe}" "${bin_dir}"
-    install_completion
+    log_debug "display shell completion instructions"
+    install_shell_completion
     log_info "installed ${bin_dir}/${binexe}"
     rm -rf "${tmpdir}"
 }

--- a/install.sh
+++ b/install.sh
@@ -293,9 +293,10 @@ ${binexe} has built-in shell completion. This is how you can install it for:
 
     1. Ensure that you install bash-completion using your package manager.
 
-    2. Add this line to your ~/.bash_profile:
+    2. Add dagger completion to your personal bash completions dir
 
-      eval \"\$(${binexe} completion bash)\"
+      mkdir -p $XDG_DATA_HOME/bash-completion/completions
+      ${binexe} completion bash > $XDG_DATA_HOME/bash-completion/completions/dagger
 
   ZSH:
 

--- a/install.sh
+++ b/install.sh
@@ -295,9 +295,9 @@ install_completion() {
     # FIXME: make it work with other distribution: use $XDG_DATA_DIRS?
     #
     # the && true will get us user complain about their setup, we want that for now to make it work everywhere
-    ${binexe} completion bash > /usr/share/bash-completion/completions/dagger && true
-    ${binexe} completion zsh  > /usr/share/zsh/functions/Completion/dagger    && true
-    ${binexe} completion fish > /usr/share/fish/vendor_completions.d/dagger   && true
+    ${binexe} completion bash > /usr/share/bash-completion/completions/dagger    && true
+    ${binexe} completion zsh  > /usr/share/zsh/vendor-completions/_dagger        && true
+    ${binexe} completion fish > /usr/share/fish/vendor_completions.d/dagger.fish && true
 
 }
 

--- a/install.sh
+++ b/install.sh
@@ -285,6 +285,22 @@ tarball() {
     echo "$name"
 }
 
+install_completion() {
+    # discovery of currently used shell is too error prone, I install all of them
+    # - echo $SHELL rarely works
+    # - echo $0 doesn't work if you use the script as the runner
+    # - echo $$ to get the pid of the process sometimes fail as well
+
+    # This should work on debian derived distributions
+    # FIXME: make it work with other distribution: use $XDG_DATA_DIRS?
+    #
+    # the && true will get us user complain about their setup, we want that for now to make it work everywhere
+    ${binexe} completion bash > /usr/share/bash-completion/completions/dagger && true
+    ${binexe} completion zsh  > /usr/share/zsh/functions/Completion/dagger    && true
+    ${binexe} completion fish > /usr/share/fish/vendor_completions.d/dagger   && true
+
+}
+
 execute() {
     base_url="$(base_url)"
     tarball="$(tarball)"
@@ -303,6 +319,7 @@ execute() {
     (cd "${tmpdir}" && untar "${tarball}")
     test ! -d "${bin_dir}" && install -d "${bin_dir}"
     install "${srcdir}/${binexe}" "${bin_dir}"
+    install_completion
     log_info "installed ${bin_dir}/${binexe}"
     rm -rf "${tmpdir}"
 }


### PR DESCRIPTION
For now, it works on debian derived system.

I need people to test on Mac OS to tell me if that works as well.

<a href="https://gitpod.io/#https://github.com/dagger/dagger/pull/2950"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

