### PR TITLE
fix: linter not working in git-worktrees

### DIFF
--- a/ci/cue/lint.cue
+++ b/ci/cue/lint.cue
@@ -6,10 +6,15 @@ import (
 	"universe.dagger.io/alpine"
 	"universe.dagger.io/docker"
 	"universe.dagger.io/bash"
+
+	"github.com/dagger/dagger/ci/git"
 )
 
 #Lint: {
 	source: dagger.#FS
+
+	// update git worktree source
+	_source: git.#Worktree & {"source": source}
 
 	docker.#Build & {
 		steps: [
@@ -20,8 +25,8 @@ import (
 			},
 
 			docker.#Copy & {
-				contents: source
-				"source": "go.mod"
+				contents: _source.output
+				source:   "go.mod"
 				dest:     "go.mod"
 			},
 
@@ -38,7 +43,7 @@ import (
 
 			// CACHE: copy only *.cue files
 			docker.#Copy & {
-				contents: source
+				contents: _source.output
 				include: [".git", "*.cue", "**/*.cue"]
 				dest: "/cue"
 			},

--- a/ci/git/worktree.cue
+++ b/ci/git/worktree.cue
@@ -1,0 +1,47 @@
+package git
+
+import (
+	"dagger.io/dagger"
+
+	"universe.dagger.io/alpine"
+	"universe.dagger.io/docker"
+	"universe.dagger.io/bash"
+)
+
+#Worktree: {
+	source: dagger.#FS
+
+	_img: docker.#Build & {
+		steps: [
+			alpine.#Build & {
+				packages: bash: _
+				packages: git:  _
+			},
+
+			docker.#Copy & {
+				contents: source
+				dest:     "/cue"
+			},
+		]
+	}
+
+	// Create Git repository for worktree folders
+	_container: bash.#Run & {
+		input:   _img.output
+		workdir: "/cue"
+		script: contents: #"""
+			# `.git` directory not present in git worktrees
+			if [[ ! -d ".git" ]]; then
+				rm .git
+				git init --quiet
+				git config --global user.name 'Dagger Linter'
+				git config --global user.email '<>'
+				git add -A 1>/dev/null 2>/dev/null
+				git commit -m "Initial linter commit" --quiet
+			fi
+			"""#
+		export: directories: "/cue": _
+	}
+
+	output: _container.export.directories."/cue"
+}

--- a/ci/golangci/lint.cue
+++ b/ci/golangci/lint.cue
@@ -5,6 +5,8 @@ import (
 
 	"universe.dagger.io/docker"
 	"universe.dagger.io/go"
+
+	"github.com/dagger/dagger/ci/git"
 )
 
 // Lint using golangci-lint
@@ -22,9 +24,12 @@ import (
 		source: "golangci/golangci-lint:v\(version)"
 	}
 
-	go.#Container & {
-		"source": source
-		image:    _image.output
+	// update git worktree source
+	_source: git.#Worktree & {"source": source}
+
+	run: go.#Container & {
+		source: _source.output
+		image:  _image.output
 		command: {
 			name: "golangci-lint"
 			flags: {


### PR DESCRIPTION
Inside git worktrees, linter is not working, as the `.git` directory is located elsewhere.
Extend the `ci` library with new `git.#Worktree` package that creates a git repo (if we `dagger do lint` from a `git worktree`) to avoid breaks

Signed-off-by: Guillaume de Rouville