### PR TITLE
fix: Default to a rootless Buildkit container

### DIFF
--- a/util/buildkitd/buildkitd.go
+++ b/util/buildkitd/buildkitd.go
@@ -43,7 +43,7 @@ func init() {
 
 	for _, d := range bi.Deps {
 		if d.Path == "github.com/moby/buildkit" {
-			vendoredVersion = d.Version
+			vendoredVersion = d.Version + "-rootless"
 			break
 		}
 	}


### PR DESCRIPTION
Instead of using `--privileged` with the default buildkit container, use a rootless one which makes it safer: https://github.com/moby/buildkit/blob/master/docs/rootless.md#docker

One reason to **not** remove remove privileged is that our pipelines will break, as well as our users'.

This is the first step towards attempting to start addressing https://github.com/dagger/dagger/issues/151.

While this does not solve the issue, it will inform us if this is a step in the right direction and, more importantly, if this is still worth fixing.

We (+@slumbering)  are on a mission to close old issues!