### PR TITLE
docs: update reference to jreleaser package

### DIFF
--- a/pkg/universe.dagger.io/alpha/jreleaser/README.md
+++ b/pkg/universe.dagger.io/alpha/jreleaser/README.md
@@ -14,7 +14,7 @@ package main
 import (
     "dagger.io/dagger"
     "dagger.io/dagger/core"
-    "universe.dagger.io/jreleaser"
+    "universe.dagger.io/alpha/jreleaser"
 )
 
 dagger.#Plan & {
@@ -44,7 +44,7 @@ package main
 import (
     "dagger.io/dagger"
     "dagger.io/dagger/core"
-    "universe.dagger.io/jreleaser"
+    "universe.dagger.io/alpha/jreleaser"
 )
 
 dagger.#Plan & {


### PR DESCRIPTION
Docs for the jreleaser package were missing "alpha" in import statements.

Signed-off-by: Andres Almiray <aalmiray@gmail.com>