### PR TITLE
feat: extend core.#Dockerfile + core.#Pull to accept DOCKERHUB_AUTH env var + docs

### DIFF
--- a/docs/guides/buildkit/1237-persistent-cache.md
+++ b/docs/guides/buildkit/1237-persistent-cache.md
@@ -129,6 +129,10 @@ dagger do build --cache-to type=registry,mode=max,ref=localhost:5000/cache --cac
 See more options on registry export at [Buildkit cache documentation](https://github.com/moby/buildkit/blob/v0.10.3/README.md#registry-push-image-and-cache-separately)
 :::
 
+:::warning
+In order to pass the registry's auth informations to Buildkit, at least one of the actions of your plan has to pull or push an image from it (using the `auth` key in either `#Pull` or `#Push` definitions). For Docker Hub registries, you can also rely on the `DOCKERHUB_AUTH_USER` and `DOCKERHUB_AUTH_PASSWORD` env variables
+:::
+
 ## Persistent cache in your local filesystem
 
 To store cache in your local filesystem, you just need to change flags values to match `type=local`.

--- a/plan/task/pull.go
+++ b/plan/task/pull.go
@@ -3,8 +3,6 @@ package task
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/docker/distribution/reference"
 	"github.com/moby/buildkit/client/llb"
@@ -44,27 +42,6 @@ func (c *pullTask) Run(ctx context.Context, pctx *plancontext.Context, s *solver
 
 		s.AddCredentials(target, a.Username, a.Secret.PlainText())
 		lg.Debug().Str("target", target).Msg("add target credentials")
-	} else if target == "docker.io" {
-		// Collect DOCKERHUB_AUTH_USER && DOCKERHUB_AUTH_PASSWORD env vars
-		username, secret := "", ""
-		for _, envVar := range os.Environ() {
-			split := strings.SplitN(envVar, "=", 2)
-			if len(split) != 2 {
-				continue
-			}
-			key, val := split[0], split[1]
-			if strings.EqualFold(key, "dockerhub_auth_user") {
-				username = val
-			}
-			if strings.EqualFold(key, "dockerhub_auth_password") {
-				secret = val
-			}
-		}
-
-		if username != "" && secret != "" {
-			s.AddCredentials(target, username, secret)
-			lg.Debug().Str("target", target).Msg("add global credentials from DOCKERHUB_AUTH_USER and DOCKERHUB_AUTH_PASSWORD env vars")
-		}
 	}
 
 	ref, err := reference.ParseNormalizedNamed(rawRef)


### PR DESCRIPTION
Move `core.#Pull`'s env var logic to `registryauth.go`'s `AddCredentials` function.
    
Useful for:
1. Easy Docker Hub registry `429 Too Many Requests` management. Discussion #2997
2. Enables user to easily push cache layers to Dockerhub registry

Context: some users have been facing 429 requests + users have been unable to push permanent cache layers to registries. 

There is no easy way to pass the registry's info to Buildkit. This PR extends the env var retrieval logic from just `core.#Pull` to `core.#Pull`, `core.#Dockerfile` and `core.#Push` for a smoothless experience (and less breaking cases)

cc @gerhard @aluzzardi 