### PR TITLE
Remove usage of go.#Test.package and go.#Build.package

### DIFF
--- a/ci.cue
+++ b/ci.cue
@@ -43,10 +43,10 @@ dagger.#Plan & {
 
 		build: {
 			"go": go.#Build & {
-				source:  _source
+				source: _source
 				packages: ["./cmd/dagger/"]
-				os:      *client.platform.os | "linux"
-				arch:    client.platform.arch
+				os:   *client.platform.os | "linux"
+				arch: client.platform.arch
 
 				ldflags: "-s -w"
 
@@ -66,7 +66,7 @@ dagger.#Plan & {
 		test: {
 			// Go unit tests
 			unit: go.#Test & {
-				source:  _source
+				source: _source
 				packages: ["./..."]
 
 				command: flags: "-race": true
@@ -134,9 +134,9 @@ dagger.#Plan & {
 				core: #BatsIntegrationTest & {
 					path:         "tests"
 					daggerBinary: go.#Build & {
-						source:  _source
+						source: _source
 						packages: ["./cmd/dagger/"]
-						arch:    client.platform.arch
+						arch: client.platform.arch
 						container: command: flags: "-race": true
 					}
 				}

--- a/ci.cue
+++ b/ci.cue
@@ -44,7 +44,7 @@ dagger.#Plan & {
 		build: {
 			"go": go.#Build & {
 				source:  _source
-				package: "./cmd/dagger/"
+				packages: ["./cmd/dagger/"]
 				os:      *client.platform.os | "linux"
 				arch:    client.platform.arch
 
@@ -67,7 +67,7 @@ dagger.#Plan & {
 			// Go unit tests
 			unit: go.#Test & {
 				source:  _source
-				package: "./..."
+				packages: ["./..."]
 
 				command: flags: "-race": true
 				env: DAGGER_LOG_FORMAT: client.env.DAGGER_LOG_FORMAT
@@ -135,7 +135,7 @@ dagger.#Plan & {
 					path:         "tests"
 					daggerBinary: go.#Build & {
 						source:  _source
-						package: "./cmd/dagger/"
+						packages: ["./cmd/dagger/"]
 						arch:    client.platform.arch
 						container: command: flags: "-race": true
 					}

--- a/docs/tests/core-concepts/client/plans/file_export.cue
+++ b/docs/tests/core-concepts/client/plans/file_export.cue
@@ -23,7 +23,7 @@ dagger.#Plan & {
 				"""
 		}
 		go.#Build & {
-			source:  _source.output
+			source: _source.output
 			packages: ["/src/helloworld.go"]
 		}
 	}

--- a/docs/tests/core-concepts/client/plans/file_export.cue
+++ b/docs/tests/core-concepts/client/plans/file_export.cue
@@ -24,7 +24,7 @@ dagger.#Plan & {
 		}
 		go.#Build & {
 			source:  _source.output
-			package: "/src/helloworld.go"
+			packages: ["/src/helloworld.go"]
 		}
 	}
 }

--- a/docs/tests/use-cases/ci-cd-for-go-project/complete-ci-cd/dagger.cue
+++ b/docs/tests/use-cases/ci-cd-for-go-project/complete-ci-cd/dagger.cue
@@ -33,7 +33,7 @@ dagger.#Plan & {
 		// Run go unit tests
 		unitTest: go.#Test & {
 			source:  _code
-			package: "./..."
+			packages: ["./..."]
 			input:   _base.output
 		}
 

--- a/docs/tests/use-cases/ci-cd-for-go-project/complete-ci-cd/dagger.cue
+++ b/docs/tests/use-cases/ci-cd-for-go-project/complete-ci-cd/dagger.cue
@@ -32,9 +32,9 @@ dagger.#Plan & {
 
 		// Run go unit tests
 		unitTest: go.#Test & {
-			source:  _code
+			source: _code
 			packages: ["./..."]
-			input:   _base.output
+			input: _base.output
 		}
 
 		// Build go project


### PR DESCRIPTION
This merge request removes usage of the deprecated field `package` from universe/go.
The `package` field is removed, besides in the tests to keep backward compatibility in check.