### PR TITLE
[cloak] Implement git core API

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -27,38 +27,38 @@ type InitializeArgs struct {
 
 func New(params InitializeArgs) (router.ExecutableSchema, error) {
 	base := &baseSchema{
-		router:      params.Router,
-		secretStore: params.SecretStore,
-		gw:          params.Gateway,
-		bkClient:    params.BKClient,
-		solveOpts:   params.SolveOpts,
-		solveCh:     params.SolveCh,
-		platform:    params.Platform,
+		router:        params.Router,
+		secretStore:   params.SecretStore,
+		gw:            params.Gateway,
+		bkClient:      params.BKClient,
+		solveOpts:     params.SolveOpts,
+		solveCh:       params.SolveCh,
+		platform:      params.Platform,
+		sshAuthSockID: params.SSHAuthSockID,
 	}
 	return router.MergeExecutableSchemas("core",
-		&coreSchema{base, params.SSHAuthSockID, params.WorkdirID},
-
+		&coreSchema{base, params.WorkdirID},
+		&gitSchema{base},
 		&filesystemSchema{base},
 		&projectSchema{
 			baseSchema:      base,
 			compiledSchemas: make(map[string]*project.CompiledRemoteSchema),
-			sshAuthSockID:   params.SSHAuthSockID,
 		},
-		&execSchema{base, params.SSHAuthSockID},
+		&execSchema{base},
 		&dockerBuildSchema{base},
-
 		&secretSchema{base},
 	)
 }
 
 type baseSchema struct {
-	router      *router.Router
-	secretStore *secret.Store
-	gw          bkgw.Client
-	bkClient    *bkclient.Client
-	solveOpts   bkclient.SolveOpt
-	solveCh     chan *bkclient.SolveStatus
-	platform    specs.Platform
+	router        *router.Router
+	secretStore   *secret.Store
+	gw            bkgw.Client
+	bkClient      *bkclient.Client
+	solveOpts     bkclient.SolveOpt
+	solveCh       chan *bkclient.SolveStatus
+	platform      specs.Platform
+	sshAuthSockID string
 }
 
 func (r *baseSchema) Solve(ctx context.Context, st llb.State, marshalOpts ...llb.ConstraintsOpt) (*filesystem.Filesystem, error) {

--- a/core/core.schema.go
+++ b/core/core.schema.go
@@ -16,8 +16,7 @@ var _ router.ExecutableSchema = &coreSchema{}
 
 type coreSchema struct {
 	*baseSchema
-	sshAuthSockID string
-	workdirID     string
+	workdirID string
 }
 
 func (r *coreSchema) Name() string {
@@ -38,9 +37,6 @@ extend type Query {
 type Core {
 	"Fetch an OCI image"
 	image(ref: String!): Filesystem!
-
-	"Fetch a git repository"
-	git(remote: String!, ref: String): Filesystem!
 }
 
 "Interactions with the user's host filesystem"
@@ -71,7 +67,6 @@ func (r *coreSchema) Resolvers() router.Resolvers {
 		},
 		"Core": router.ObjectResolver{
 			"image": r.image,
-			"git":   r.git,
 		},
 		"Host": router.ObjectResolver{
 			"workdir": r.workdir,
@@ -100,18 +95,6 @@ func (r *coreSchema) image(p graphql.ResolveParams) (any, error) {
 	ref := p.Args["ref"].(string)
 
 	st := llb.Image(ref, llb.WithMetaResolver(r.gw))
-	return r.Solve(p.Context, st)
-}
-
-func (r *coreSchema) git(p graphql.ResolveParams) (any, error) {
-	remote := p.Args["remote"].(string)
-	ref, _ := p.Args["ref"].(string)
-
-	var opts []llb.GitOption
-	if r.sshAuthSockID != "" {
-		opts = append(opts, llb.MountSSHSock(r.sshAuthSockID))
-	}
-	st := llb.Git(remote, ref, opts...)
 	return r.Solve(p.Context, st)
 }
 

--- a/core/exec.schema.go
+++ b/core/exec.schema.go
@@ -55,7 +55,6 @@ var _ router.ExecutableSchema = &filesystemSchema{}
 
 type execSchema struct {
 	*baseSchema
-	sshAuthSockID string
 }
 
 func (s *execSchema) Name() string {

--- a/core/git.schema.go
+++ b/core/git.schema.go
@@ -1,0 +1,146 @@
+package core
+
+import (
+	"fmt"
+
+	"github.com/graphql-go/graphql"
+	"github.com/moby/buildkit/client/llb"
+	"go.dagger.io/dagger/router"
+)
+
+var _ router.ExecutableSchema = &gitSchema{}
+
+type gitSchema struct {
+	*baseSchema
+}
+
+func (s *gitSchema) Name() string {
+	return "git"
+}
+
+func (s *gitSchema) Schema() string {
+	return `
+	extend type Query {
+		"Query a git repository"
+		git(url: String!): GitRepository!
+	}
+	
+	"A git repository"
+	type GitRepository {
+		"List of branches on the repository"
+		branches: [String!]!
+		"Details on one branch"
+		branch(name: String!): GitRef!
+		"List of tags on the repository"
+		tags: [String!]!
+		"Details on one tag"
+		tag(name: String!): GitRef!
+	}
+	
+	"A git ref (tag or branch)"
+	type GitRef {
+		"The digest of the current value of this ref"
+		digest: String!
+		"The filesystem tree at this ref"
+		tree: Filesystem!
+	}
+
+	# Compat with old API
+	extend type Core {
+		git(remote: String!, ref: String): Filesystem! @deprecated(reason: "use top-level 'query { git }'")
+	}
+`
+}
+
+func (s *gitSchema) Resolvers() router.Resolvers {
+	return router.Resolvers{
+		"Query": router.ObjectResolver{
+			"git": s.git,
+		},
+		"GitRepository": router.ObjectResolver{
+			"branches": s.branches,
+			"branch":   s.branch,
+			"tags":     s.tags,
+			"tag":      s.tag,
+		},
+		"GitRef": router.ObjectResolver{
+			"digest": s.digest,
+			"tree":   s.tree,
+		},
+		"Core": router.ObjectResolver{
+			"git": s.gitOld,
+		},
+	}
+}
+
+func (s *gitSchema) Dependencies() []router.ExecutableSchema {
+	return nil
+}
+
+// Compat with old git API
+func (s *gitSchema) gitOld(p graphql.ResolveParams) (any, error) {
+	remote := p.Args["remote"].(string)
+	ref, _ := p.Args["ref"].(string)
+
+	var opts []llb.GitOption
+	if s.sshAuthSockID != "" {
+		opts = append(opts, llb.MountSSHSock(s.sshAuthSockID))
+	}
+	st := llb.Git(remote, ref, opts...)
+	return s.Solve(p.Context, st)
+}
+
+type gitRepository struct {
+	url string
+}
+
+type gitRef struct {
+	repository gitRepository
+	name       string
+}
+
+func (s *gitSchema) git(p graphql.ResolveParams) (any, error) {
+	url := p.Args["url"].(string)
+
+	return gitRepository{
+		url: url,
+	}, nil
+}
+
+func (s *gitSchema) branch(p graphql.ResolveParams) (any, error) {
+	repo := p.Source.(gitRepository)
+	return gitRef{
+		repository: repo,
+		name:       p.Args["name"].(string),
+	}, nil
+}
+
+func (s *gitSchema) branches(p graphql.ResolveParams) (any, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *gitSchema) tag(p graphql.ResolveParams) (any, error) {
+	repo := p.Source.(gitRepository)
+	return gitRef{
+		repository: repo,
+		name:       p.Args["name"].(string),
+	}, nil
+}
+
+func (s *gitSchema) tags(p graphql.ResolveParams) (any, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *gitSchema) digest(p graphql.ResolveParams) (any, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *gitSchema) tree(p graphql.ResolveParams) (any, error) {
+	ref := p.Source.(gitRef)
+	var opts []llb.GitOption
+	if s.sshAuthSockID != "" {
+		opts = append(opts, llb.MountSSHSock(s.sshAuthSockID))
+	}
+	st := llb.Git(ref.repository.url, ref.name, opts...)
+	return s.Solve(p.Context, st)
+}

--- a/core/integration/core.schema_test.go
+++ b/core/integration/core.schema_test.go
@@ -144,29 +144,6 @@ func TestCoreImageConfig(t *testing.T) {
 	})
 }
 
-func TestCoreGit(t *testing.T) {
-	t.Parallel()
-
-	res := struct {
-		Core struct {
-			Git struct {
-				File string
-			}
-		}
-	}{}
-
-	err := testutil.Query(
-		`{
-			core {
-				git(remote: "github.com/dagger/dagger") {
-					file(path: "README.md", lines: 1)
-				}
-			}
-		}`, &res, nil)
-	require.NoError(t, err)
-	require.Contains(t, res.Core.Git.File, "Dagger")
-}
-
 func TestFilesystemCopy(t *testing.T) {
 	t.Parallel()
 

--- a/core/integration/git.schema_test.go
+++ b/core/integration/git.schema_test.go
@@ -1,0 +1,59 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dagger.io/dagger/internal/testutil"
+)
+
+func TestGit(t *testing.T) {
+	t.Parallel()
+
+	res := struct {
+		Git struct {
+			Branch struct {
+				Tree struct {
+					File string
+				}
+			}
+		}
+	}{}
+
+	err := testutil.Query(
+		`{
+			git(url: "github.com/dagger/dagger") {
+				branch(name: "main") {
+					tree {
+						file(path: "README.md", lines: 1)
+					}
+				}
+			}
+		}`, &res, nil)
+	require.NoError(t, err)
+	require.Contains(t, res.Git.Branch.Tree.File, "Dagger")
+}
+
+// Test backwards compatibility with old git API
+func TestGitOld(t *testing.T) {
+	t.Parallel()
+
+	res := struct {
+		Core struct {
+			Git struct {
+				File string
+			}
+		}
+	}{}
+
+	err := testutil.Query(
+		`{
+			core {
+				git(remote: "github.com/dagger/dagger") {
+					file(path: "README.md", lines: 1)
+				}
+			}
+		}`, &res, nil)
+	require.NoError(t, err)
+	require.Contains(t, res.Core.Git.File, "Dagger")
+}


### PR DESCRIPTION
* Implement `{ query { git } }` from [new core API](./api/git.gql)
* Keep backwards compat with old `{ query { core { git } } }`
* Simplify passing of ssh auth socket across schemas
* ~~The git "builtin" now lives in a sub-directory. A small first step towards modularizing the core api into "built extensions"~~ (*removed from this PR to keep diff minimal*)