### PR TITLE
[POC] Secret Providers

### DIFF
--- a/core/secret.schema.go
+++ b/core/secret.schema.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/dagger/cloak/router"
 	"github.com/graphql-go/graphql"
@@ -55,6 +56,12 @@ extend type Core {
 
 	"Add a secret"
 	addSecret(plaintext: String!): SecretID!
+
+	secrets: Secrets!
+}
+
+type Secrets {
+	env(name: String!): String!
 }
 `
 }
@@ -65,6 +72,10 @@ func (s *secretSchema) Resolvers() router.Resolvers {
 		"Core": router.ObjectResolver{
 			"secret":    s.secret,
 			"addSecret": s.addSecret,
+			"secrets":   s.secrets,
+		},
+		"Secrets": router.ObjectResolver{
+			"env": s.env,
 		},
 	}
 }
@@ -85,4 +96,12 @@ func (s *secretSchema) secret(p graphql.ResolveParams) (any, error) {
 func (s *secretSchema) addSecret(p graphql.ResolveParams) (any, error) {
 	plaintext := p.Args["plaintext"].(string)
 	return s.secretStore.AddSecret(p.Context, []byte(plaintext)), nil
+}
+
+func (s *secretSchema) secrets(p graphql.ResolveParams) (any, error) {
+	return struct{}{}, nil
+}
+
+func (s *secretSchema) env(p graphql.ResolveParams) (any, error) {
+	return os.Getenv(p.Args["name"].(string)), nil
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -98,7 +98,7 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 	}
 
 	router := router.New()
-	secretStore := secret.NewStore()
+	secretStore := secret.NewStore(router)
 
 	socketProviders := MergedSocketProviders{
 		project.DaggerSockName: project.NewAPIProxy(router),

--- a/router/router.go
+++ b/router/router.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"context"
 	"io"
 	"net"
 	"net/http"
@@ -62,6 +63,20 @@ func (r *Router) Add(schema ExecutableSchema) error {
 		Schema: s,
 	})
 	return nil
+}
+
+func (r *Router) Do(ctx context.Context, query string, variables map[string]any) *graphql.Result {
+	r.l.RLock()
+	schema := *r.s
+	r.l.RUnlock()
+
+	params := graphql.Params{
+		Context:        ctx,
+		Schema:         schema,
+		RequestString:  query,
+		VariableValues: variables,
+	}
+	return graphql.Do(params)
 }
 
 func (r *Router) add(schema ExecutableSchema) {

--- a/secret/store.go
+++ b/secret/store.go
@@ -4,12 +4,18 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
 
+	"github.com/dagger/cloak/router"
 	"github.com/moby/buildkit/session/secrets"
 )
 
-func NewStore() *Store {
+func NewStore(r *router.Router) *Store {
 	return &Store{
+		r:       r,
 		secrets: make(map[string][]byte),
 	}
 }
@@ -17,6 +23,7 @@ func NewStore() *Store {
 var _ secrets.SecretStore = &Store{}
 
 type Store struct {
+	r       *router.Router
 	secrets map[string][]byte
 }
 
@@ -31,5 +38,41 @@ func (p *Store) GetSecret(ctx context.Context, id string) ([]byte, error) {
 	if secret, ok := p.secrets[id]; ok {
 		return secret, nil
 	}
-	return nil, secrets.ErrNotFound
+
+	idParts := strings.SplitN(id, "://", 2)
+	protocol, id := idParts[0], idParts[1]
+
+	query := fmt.Sprintf(`
+	query {
+		core {
+			secrets {
+				plaintext: %s(name: %q)
+			}
+		}
+	}
+	`, protocol, id)
+	fmt.Fprintf(os.Stderr, "QUERY: %s\n", query)
+	result := p.r.Do(ctx, query, map[string]any{})
+	if result.HasErrors() {
+		fmt.Fprintf(os.Stderr, "%+v\n", result.Errors)
+		return nil, secrets.ErrNotFound
+	}
+
+	resp := struct {
+		Core struct {
+			Secrets struct {
+				Plaintext string
+			}
+		}
+	}{}
+
+	marshalled, err := json.Marshal(result.Data)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(marshalled, &resp); err != nil {
+		return nil, err
+	}
+
+	return []byte(resp.Core.Secrets.Plaintext), nil
 }


### PR DESCRIPTION
**[NOTE: for discussion only, not meant to be merged]**

This PR introduces the concept of "secret providers".

Example:

```graphql
{
  core {
    image(ref: "alpine") {
      exec(input: {
        secretEnv: {name:"SECRET", id:"env://MY_SECRET"},
        args: ["printenv", "SECRET"]}
      ) {
        stdout
      }
    }
  }
}
```

In this basic example, `env://MY_VARIABLE` can be passed in place of any `SecretID`.

**How does it work?**

1) Secrets are retrieved **just in time**, when buildkit requests them (through the secrets gRPC "callback")

2) Cloak's secret provider turns around and issues a query against the API to resolve the secret, like so:

```graphql
query {
  core {
    secrets {
      # in our example, this is going to be `env(name: "MY_SECRET")`
      plaintext: $PROTOCOL(name: $name)
    }
  }
}
```

e.g. For a given `<protocol>://<key>` SecretID, the query becomes `core { secrets { <protocol>(name: <key>) }`


**Extensions**

Let's imagine a hypothetical `vault` extension.

All the extension would have to do is **extend** `Secrets` with the new provider, like this:

```graphql
extend type Secrets {
  vault(name: String!): String!
}
```

Then, automatically, `vault://my_token` will be a valid `SecretID` out of the box.

Cloak has a few built-in providers (`env`, `file`, ...) and extensions can add more on top.

**Caveats**

- Caching needs to be disabled, otherwise all those secrets end up on disk
  - I have a potential solution in mind
- The "interface" (`extend type Secrets`) is quick and dirty
  - We could do better, especially since cloak is "privileged" (e.g. don't need for the provider to be reachable through top-level `Query`

For instance, this **might** work:

```graphql
# Provided by Core
interface SecretsProvider {
  protocol: String!
  plaintext(key: String!): String!
}

# An extension could look like this:
type VaultAlthoughTheTypeNameDoesntMatter implements SecretsProvider {
  protocol: String!
  plaintext(key: String!): String!
}
```

cloak can then scan the schema for types that implement `SecretsProvider`, query them for their `protocol`, and just-in-time resolve `plaintext` when a secret is needed.
