### PR TITLE
dogfood: Build `cloak` using `cloak`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/klauspost/compress v1.15.9 // indirect
-	github.com/kr/pretty v0.2.1 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -451,9 +451,8 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
-github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=

--- a/magefile.go
+++ b/magefile.go
@@ -1,0 +1,108 @@
+//go:build mage
+// +build mage
+
+package main
+
+import (
+	"context"
+	"runtime"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/dagger/cloak/engine"
+	"github.com/dagger/cloak/sdk/go/dagger"
+)
+
+// Default target to run when none is specified
+// If not set, running mage will list available targets
+// var Default = Build
+
+func Build(ctx context.Context) error {
+	return engine.Start(ctx, nil, func(ctx engine.Context) error {
+		wd, err := workdir(ctx)
+		if err != nil {
+			return err
+		}
+
+		buildResponse := struct {
+			Core struct {
+				Image struct {
+					Exec struct {
+						Mount struct {
+							ID string
+						}
+					}
+				}
+			}
+		}{}
+		err = ctx.Client.MakeRequest(ctx.Context, &graphql.Request{
+			Query: `
+			query($source: FSID!, $os: String!, $arch: String!) {
+				core {
+					image(ref: "golang:1.19-alpine") {
+						exec(input: {
+							args: ["/usr/local/go/bin/go", "build", "-o", "bin/cloak", "./cmd/cloak"],
+							mounts: [{fs: $source, path: "/src"}],
+							env: [{name: "GOOS", value: $os}, {name: "GOARCH", value: $arch}],
+							workdir: "/src",
+						}) {
+							mount(path: "/src") {
+								id
+							}
+						}
+					}
+				}
+			}
+			`,
+			Variables: map[string]interface{}{
+				"source": wd,
+				"os":     runtime.GOOS,
+				"arch":   runtime.GOARCH,
+			},
+		}, &graphql.Response{Data: &buildResponse})
+		if err != nil {
+			return err
+		}
+
+		// FIXME: need to only write the binary, this will overwrite every file.
+		return ctx.Client.MakeRequest(ctx.Context, &graphql.Request{
+			Query: `
+			query($build: FSID!) {
+				host {
+					workdir {
+						write(contents: $build)
+					}
+				}
+			}
+			`,
+			Variables: map[string]interface{}{
+				"build": buildResponse.Core.Image.Exec.Mount.ID,
+			},
+		}, &graphql.Response{})
+	})
+}
+
+func workdir(ctx engine.Context) (dagger.FSID, error) {
+	resp := struct {
+		Host struct {
+			Workdir struct {
+				Read struct {
+					ID dagger.FSID
+				}
+			}
+		}
+	}{}
+	err := ctx.Client.MakeRequest(ctx.Context, &graphql.Request{
+		Query: `
+		query {
+			host {
+				workdir {
+					read {
+						id
+					}
+				}
+			}
+		}
+		`,
+	}, &graphql.Response{Data: &resp})
+	return resp.Host.Workdir.Read.ID, err
+}


### PR DESCRIPTION
dogfood: Build `cloak` using `cloak`

This is the beginning of dogfood and eventually will encompass building, testing,
linting, etc for cloak, SDKs, universe, etc.

For the CLI "handling" of the workflows, I'm using magefiles. I didn't
want to bother writing my own CLI parsing and mage fits the bill just
fine.

```console
$ mage
Targets:
	build
$ mage build
```
