### PR TITLE
Schema fixes for new API

### DIFF
--- a/api/container.gql
+++ b/api/container.gql
@@ -53,13 +53,13 @@ type Container {
     variables: [String!]
 
     "The value of the specified environment variable"
-    variable(name: String!) String
+    variable(name: String!): String
 
     "This container plus the given environment variable"
     withVariable(name: String!, value: String!): Container!
 
     "This container plus an env variable containing the given secret"
-    withSecretVariable(name: String!, secret: SecretID!) Container!
+    withSecretVariable(name: String!, secret: SecretID!): Container!
 
     "This container minus the given environment variable"
     withoutVariable(name: String): Container!
@@ -68,16 +68,16 @@ type Container {
     entrypoint: [String!]
 
     "This container but with a different command entrypoint"
-    withEntrypoint(args: [String!])
+    withEntrypoint(args: [String!]): Container!
 
     "List of paths where a directory is mounted"
     mounts: [String!]!
 
     "This container plus a directory mounted at the given path"
-    withMountedDirectory(path: String!, source: DirectoryID!) Container!
+    withMountedDirectory(path: String!, source: DirectoryID!): Container!
 
     "This container plus a file mounted at the given path"
-    withMountedFile(path: String!, source: FileID!) Container!
+    withMountedFile(path: String!, source: FileID!): Container!
 
     "This container plus a temporary directory mounted at the given path"
     withMountedTemp(path: String!): Container!
@@ -86,7 +86,7 @@ type Container {
     withMountedCache(path: String!, source: DirectoryID): Container!
 
     "This container plus a secret mounted into a file at the given path"
-    withMountedSecret(path: String!, source: SecretID!) Container!
+    withMountedSecret(path: String!, source: SecretID!): Container!
 
     """
     This container after unmounting everything at the given path.
@@ -95,13 +95,13 @@ type Container {
 
     "This container after executing the specified command inside it"
     # FIXME: verb
-    exec(args: [String!]!, opts: execOpts) Container!
+    exec(args: [String!]!, opts: ExecOpts): Container!
 
     """
     Exit code of the last executed command. Zero means success.
     Null if no command has been executed.
     """
-    exitCode: Integer
+    exitCode: Int
 
     """
     The output stream of the last executed command.
@@ -116,7 +116,7 @@ type Container {
     # FIXME: this is the last case of an actual "verb" that cannot cleanly go away.
     #    This may actually be a good candidate for a mutation. To be discussed.
     "Publish this container as a new image"
-    publish(address: ContainerAddress!) ContainerAddress!
+    publish(address: ContainerAddress!): ContainerAddress!
 }
 
 """

--- a/api/directory.gql
+++ b/api/directory.gql
@@ -21,7 +21,7 @@ type Directory {
     withNewFile(path: String!, contents: String): Directory!
 
     "This directory plus the contents of the given file copied to the given path"
-    withCopiedFile(path: String!, source: FileID!)
+    withCopiedFile(path: String!, source: FileID!): Directory!
 
     "This directory with the file at the given path removed"
     withoutFile(path: String!): Directory!
@@ -30,7 +30,7 @@ type Directory {
     directory(path: String!): Directory!
 
     "This directory plus a directory written at the given path"
-    withDirectory(path: String!, directory: DirectoryID!) Directory!
+    withDirectory(path: String!, directory: DirectoryID!): Directory!
 
     "This directory with the directory at the given path removed"
     withoutDirectory(path: String!): Directory!

--- a/api/file.gql
+++ b/api/file.gql
@@ -17,5 +17,5 @@ type File {
     secret: Secret!
 
     "The size of the file, in bytes"
-    size: Integer!
+    size: Int!
 }

--- a/api/host.gql
+++ b/api/host.gql
@@ -9,7 +9,7 @@ type Host {
     workdir: Directory!
 
     "Lookup the value of an environment variable. Null if the variable is not available."
-    variable(name: String!) HostVariable
+    variable(name: String!): HostVariable
 }
 
 "An environment variable on the host environment"

--- a/api/http.gql
+++ b/api/http.gql
@@ -1,7 +1,7 @@
 
 extend type Query {
     "An http remote"
-    http(url: String!) HTTPRemote!
+    http(url: String!): HTTPRemote!
 }
 
 "An HTTP remote endpoint"

--- a/api/root.gql
+++ b/api/root.gql
@@ -1,0 +1,1 @@
+type Query

--- a/api/secret.gql
+++ b/api/secret.gql
@@ -1,7 +1,7 @@
 
 extend type Query {
 	"Load a secret from its ID"
-	secret(id: SecretID!) Secret
+	secret(id: SecretID!): Secret
 }
 
 "A unique identifier for a secret"


### PR DESCRIPTION
Correct some syntax (e.g. missing colons), type names (e.g. Integer -> Int) to make things 
consistent.
Adds a root.gql with an empty Query (needed to be without {} like this 
https://stackoverflow.com/questions/54322029/graphqljs-query-root-type-must-be-provided).
