### PR TITLE
propagate image env/dir to `exec`

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -62,20 +62,20 @@ type baseSchema struct {
 }
 
 func (r *baseSchema) Solve(ctx context.Context, st llb.State, marshalOpts ...llb.ConstraintsOpt) (*filesystem.Filesystem, error) {
-	def, err := st.Marshal(ctx, append([]llb.ConstraintsOpt{llb.Platform(r.platform)}, marshalOpts...)...)
+	info, err := filesystem.ImageFromState(ctx, st, append([]llb.ConstraintsOpt{llb.Platform(r.platform)}, marshalOpts...)...)
 	if err != nil {
 		return nil, err
 	}
+
 	_, err = r.gw.Solve(ctx, bkgw.SolveRequest{
 		Evaluate:   true,
-		Definition: def.ToPB(),
+		Definition: info.FS,
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	// FIXME: should we create a filesystem from `res.SingleRef()`?
-	return filesystem.FromDefinition(def), nil
+	return info.ToFilesystem()
 }
 
 func (r *baseSchema) Export(ctx context.Context, fs *filesystem.Filesystem, export bkclient.ExportEntry) error {

--- a/core/core.schema.go
+++ b/core/core.schema.go
@@ -99,7 +99,7 @@ func (r *coreSchema) host(p graphql.ResolveParams) (any, error) {
 func (r *coreSchema) image(p graphql.ResolveParams) (any, error) {
 	ref := p.Args["ref"].(string)
 
-	st := llb.Image(ref)
+	st := llb.Image(ref, llb.WithMetaResolver(r.gw))
 	return r.Solve(p.Context, st)
 }
 

--- a/core/filesystem/image.go
+++ b/core/filesystem/image.go
@@ -1,0 +1,94 @@
+package filesystem
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+
+	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/solver/pb"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// Image pairs a filesystem LLB definition with an image config providing
+// defaults for future commands.
+type Image struct {
+	FS     *pb.Definition    `json:"fs"`
+	Config specs.ImageConfig `json:"cfg"`
+}
+
+func (info *Image) ToFilesystem() (*Filesystem, error) {
+	jsonBytes, err := json.Marshal(info)
+	if err != nil {
+		return nil, err
+	}
+	b64Bytes := make([]byte, base64.StdEncoding.EncodedLen(len(jsonBytes)))
+	base64.StdEncoding.Encode(b64Bytes, jsonBytes)
+	return &Filesystem{
+		ID: FSID(b64Bytes),
+	}, nil
+}
+
+func (info *Image) ToState() (llb.State, error) {
+	defop, err := llb.NewDefinitionOp(info.FS)
+	if err != nil {
+		return llb.State{}, err
+	}
+
+	st := llb.NewState(defop)
+	for _, env := range info.Config.Env {
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts[0]) > 0 {
+			var v string
+			if len(parts) > 1 {
+				v = parts[1]
+			}
+			st = st.AddEnv(parts[0], v)
+		}
+	}
+
+	st = st.Dir(info.Config.WorkingDir)
+
+	return st, nil
+}
+
+// ImageFromState returns an Image using the LLB state as both the filesystem
+// and the source of image config.
+func ImageFromState(ctx context.Context, st llb.State, marshalOpts ...llb.ConstraintsOpt) (*Image, error) {
+	cfg, err := ImageConfigFromState(ctx, st)
+	if err != nil {
+		return nil, err
+	}
+	return ImageFromStateAndConfig(ctx, st, cfg, marshalOpts...)
+}
+
+// ImageConfigFromState generates an OCI image config from values configured in
+// LLB state (currently env and workdir).
+func ImageConfigFromState(ctx context.Context, st llb.State) (specs.ImageConfig, error) {
+	env, err := st.Env(ctx)
+	if err != nil {
+		return specs.ImageConfig{}, err
+	}
+	dir, err := st.GetDir(ctx)
+	if err != nil {
+		return specs.ImageConfig{}, err
+	}
+	return specs.ImageConfig{
+		Env:        env,
+		WorkingDir: dir,
+	}, nil
+}
+
+// ImageFromStateAndConfig returns an Image using the LLB state for the
+// filesystem, paired with a given image config.
+func ImageFromStateAndConfig(ctx context.Context, st llb.State, cfg specs.ImageConfig, marshalOpts ...llb.ConstraintsOpt) (*Image, error) {
+	def, err := st.Marshal(ctx, marshalOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return &Image{
+		FS:     def.ToPB(),
+		Config: cfg,
+	}, nil
+}

--- a/core/integration/core.schema_test.go
+++ b/core/integration/core.schema_test.go
@@ -92,6 +92,56 @@ func TestCoreImageConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, res.Core.Image.Exec.Stdout, "GOLANG_VERSION=banana")
 	})
+
+	t.Run("propagates dir", func(t *testing.T) {
+		res := struct {
+			Core struct {
+				Image struct {
+					Exec struct {
+						Stdout string
+					}
+				}
+			}
+		}{}
+
+		err := testutil.Query(
+			`{
+			core {
+				image(ref: "golang:1.19") {
+					exec(input: {args: ["pwd"]}) {
+						stdout
+					}
+				}
+			}
+		}`, &res, nil)
+		require.NoError(t, err)
+		require.Equal(t, res.Core.Image.Exec.Stdout, "/go\n")
+	})
+
+	t.Run("exec dir overrides", func(t *testing.T) {
+		res := struct {
+			Core struct {
+				Image struct {
+					Exec struct {
+						Stdout string
+					}
+				}
+			}
+		}{}
+
+		err := testutil.Query(
+			`{
+			core {
+				image(ref: "golang:1.19") {
+					exec(input: {args: ["pwd"], workdir: "/usr"}) {
+						stdout
+					}
+				}
+			}
+		}`, &res, nil)
+		require.NoError(t, err)
+		require.Equal(t, res.Core.Image.Exec.Stdout, "/usr\n")
+	})
 }
 
 func TestCoreGit(t *testing.T) {


### PR DESCRIPTION
fixes #3066

supersedes https://github.com/dagger/cloak/pull/220 which had a totally different approach

Introduces a new intermediate type, `filesystem.Image`, which encodes to/from `FSID`. (Name bikeshedding welcome.) This type pairs the LLB definition with an OCI image config (`{"Env":[...],"Dir":"...",...}`). It can be converted to and from an `llb.State` via the `Env`/`Dir` fields stored within. `llb.Image` is now passed `llb.WithMetaResolver` in order to populate these fields.

I'm not sure if this is considered backwards-incompatible; within a single engine session nothing should break, but the structure of `FSID` has changed, so any previously-generated `FSID`s won't work with this new code (and vice versa),

TODO:

* [x] test `Env` propagation from image
* [x] test `Dir` propagation from image