### PR TITLE
feat(project info): output available plans

### DIFF
--- a/cmd/dagger/cmd/project/info.go
+++ b/cmd/dagger/cmd/project/info.go
@@ -63,7 +63,8 @@ func setTable(children []*plan.Action) *tablewriter.Table {
 	}
 
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"action", "comment"})
+	table.SetHeader([]string{"ACTION", "DESCRIPTION"})
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	for _, v := range row {
 		table.Append(v)
 	}

--- a/cmd/dagger/cmd/project/info.go
+++ b/cmd/dagger/cmd/project/info.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/olekukonko/tablewriter"
@@ -52,10 +53,13 @@ var infoCmd = &cobra.Command{
 	},
 }
 
+// Action name starting with plan.HiddenActionNamePrefix are not displayed
 func setTable(children []*plan.Action) *tablewriter.Table {
 	row := [][]string{}
 	for _, ac := range children {
-		row = append(row, []string{ac.Name, ac.Documentation})
+		if !strings.HasPrefix(ac.Name, plan.HiddenActionNamePrefix) {
+			row = append(row, []string{ac.Name, ac.Documentation})
+		}
 	}
 
 	table := tablewriter.NewWriter(os.Stdout)

--- a/docs/getting-started/1242-install.mdx
+++ b/docs/getting-started/1242-install.mdx
@@ -35,7 +35,7 @@ We assume that you have [Homebrew](https://brew.sh/) installed.
 If you do, you can install `dagger` with a single command:
 
 ```shell
-brew install dagger/tap/dagger
+brew install dagger
 ```
 
 This installs `dagger` in:

--- a/docs/references/13ec8-dagger-env-reference.md
+++ b/docs/references/13ec8-dagger-env-reference.md
@@ -54,8 +54,8 @@ As Dagger relies on Viper to manage the CLI inputs, all its option can be replac
 
 #### info
 
-| option       | Usage                           | Description           |
-| :----------- | ------------------------------- | --------------------- |
+| option       | Usage                           | Description                                                |
+| :----------- | ------------------------------- | -----------------------------------------------------------|
 | `--plan`     | export `DAGGER_PLAN=string`     | Path to plan (defaults to current directory) (default ".") |
 
 ### dagger do

--- a/docs/references/13ec8-dagger-env-reference.md
+++ b/docs/references/13ec8-dagger-env-reference.md
@@ -52,6 +52,12 @@ As Dagger relies on Viper to manage the CLI inputs, all its option can be replac
 | `--private-key-password` | export `DAGGER_PRIVATE_KEY_PASSWORD=string` | Private ssh key password                       |
 | `--update`               | export `DAGGER_UPDATE=1`                    | Update to latest version of specified packages |
 
+#### info
+
+| option       | Usage                           | Description           |
+| :----------- | ------------------------------- | --------------------- |
+| `--plan`     | export `DAGGER_PLAN=string`     | Path to plan (defaults to current directory) (default ".") |
+
 ### dagger do
 
 | option            | Usage                                | Description                                                              |

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -26,6 +26,8 @@ var (
 	ClientSelector      = cue.Str("client")
 )
 
+const HiddenActionNamePrefix string = "_"
+
 type Plan struct {
 	config Config
 

--- a/tests/project.bats
+++ b/tests/project.bats
@@ -3,7 +3,7 @@ setup() {
   common_setup
 }
 
-@test "project init and update and info" {
+@test "project init, update and info" {
   TEMPDIR=$(mktemp -d)
   TEMPDIR2=$(mktemp -d)
   cd "$TEMPDIR" || exit 1
@@ -37,7 +37,6 @@ setup() {
   assert_output --partial "dagger project not found. Run \`dagger project init\`"
 }
 
-
 @test "project init with template" {
   TEMPDIR=$(mktemp -d)
   cd "$TEMPDIR" || exit 1
@@ -57,10 +56,23 @@ setup() {
     echo "./hello.cue file was not created by the template flag"
     exit 1
   fi
+}
 
-  #FIXME: disabled this test (the second diff argument points to a file outside of the test directory, not reachable when running inside dagger)
-  #cd -
-  #diff --unified "$TEMPDIR/hello.cue" "$TESTDIR/../cmd/dagger/cmd/project/templates/hello.cue"
+@test "project info list actions" {
+  TEMPDIR=$(mktemp -d)
+  cd "$TEMPDIR" || exit 1
+
+  run "$DAGGER" project init -t hello
+  run "$DAGGER" project update
+
+  run "$DAGGER" project info
+  assert_success
+
+  assert_output --partial "ACTION"
+  assert_output --partial "hello"
+
+  assert_output --partial "DESCRIPTION"
+  assert_output --partial "Hello world"
 }
 
 @test "todoapp project with absolute path" {


### PR DESCRIPTION
I found the following documentation with [TODO commented out](https://github.com/dagger/dagger/blob/main/cmd/dagger/cmd/project/info.go#L33). Therefore, I added a function to output Plans in the following format.


example: For a dagger.cue file

### success
input
```cue
package todoapp

import (
	"dagger.io/dagger"

	"dagger.io/dagger/core"
	"universe.dagger.io/netlify"
	"universe.dagger.io/yarn"
)

dagger.#Plan & {
	actions: {
		// Load the todoapp source code 
		source: core.#Source & {
			path: "."
			exclude: [
				"node_modules",
				"build",
				"*.cue",
				"*.md",
				".git",
			]
		}

		// Build todoapp
		build: yarn.#Script & {
			name:   "build"
			source: actions.source.output
		}

		// Test todoapp
		test: yarn.#Script & {
			name:   "test"
			source: actions.source.output

			// This environment variable disables watch mode
			// in "react-scripts test".
			// We don't set it for all commands, because it causes warnings
			// to be treated as fatal errors.
			// See https://create-react-app.dev/docs/advanced-configuration
			container: env: CI: "true"
		}

		// Deploy todoapp
		deploy: netlify.#Deploy & {
			contents: actions.build.output
			site:     string | *"dagger-todoapp"
		}
	}
}

```
output
```
❯ ./dagger-debug project info

Current dagger project in: /Users/uyas/go/src/go.dagger.io/dagger/todoapp
+--------+------------------------------+
| ACTION |           COMMENT            |
+--------+------------------------------+
| source | Load the todoapp source code |
| build  | Build todoapp                |
| test   | Test todoapp                 |
| deploy | Deploy todoapp               |
+--------+------------------------------+

```


### failed
input
```
package todoapp

import (
	"dagger.io/dagger"

	"dagger.io/dagger/core"
	"universe.dagger.io/netlify"
	"universe.dagger.io/yarn"
)

dagger.#Plan & {
	actions: {
	// 	// Load the todoapp source code 
	// 	source: core.#Source & {
	// 		path: "."
	// 		exclude: [
	// 			"node_modules",
	// 			"build",
	// 			"*.cue",
	// 			"*.md",
	// 			".git",
	// 		]
	// 	}

	// 	// Build todoapp
	// 	build: yarn.#Script & {
	// 		name:   "build"
	// 		source: actions.source.output
	// 	}

	// 	// Test todoapp
	// 	test: yarn.#Script & {
	// 		name:   "test"
	// 		source: actions.source.output

	// 		// This environment variable disables watch mode
	// 		// in "react-scripts test".
	// 		// We don't set it for all commands, because it causes warnings
	// 		// to be treated as fatal errors.
	// 		// See https://create-react-app.dev/docs/advanced-configuration
	// 		container: env: CI: "true"
	// 	}

	// 	// Deploy todoapp
	// 	deploy: netlify.#Deploy & {
	// 		contents: actions.build.output
	// 		site:     string | *"dagger-todoapp"
	// 	}
	// }
}
```

output
```
❯ ./dagger-debug project info

Current dagger project in: /Users/uyas/go/src/go.dagger.io/dagger/todoapp
Failed to load dagger plan

imported and not used: "dagger.io/dagger/core":
    ./dagger.cue:6:2
imported and not used: "universe.dagger.io/netlify":
    ./dagger.cue:7:2
imported and not used: "universe.dagger.io/yarn":
    ./dagger.cue:8:2
```