### PR TITLE
fix: Use brew install from core instead of tap

### DIFF
--- a/docs/getting-started/1242-install.mdx
+++ b/docs/getting-started/1242-install.mdx
@@ -35,7 +35,7 @@ We assume that you have [Homebrew](https://brew.sh/) installed.
 If you do, you can install `dagger` with a single command:
 
 ```shell
-brew install dagger/tap/dagger
+brew install dagger
 ```
 
 This installs `dagger` in:


### PR DESCRIPTION
Signed-off-by: Jeremy Adams <jeremy@dagger.io>

<a href="https://gitpod.io/#https://github.com/dagger/dagger/pull/3142"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

