### PR TITLE
Fail auto-release if no changes since previous release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -42,6 +42,38 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: "Generate next release version"
+        id: release_version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SEMVER_BUMP: ${{ github.event.inputs.release_type }}
+        run: |
+          previous_release_version="$(gh api /repos/:owner/:repo/releases --jq '.[0].tag_name')"
+          echo "PREVIOUS RELEASE VERSION: $previous_release_version"
+          printf "::set-output name=%s::%s\n" previous "$previous_release_version"
+          if [[ -n "${{ github.event.inputs.release_version }}" ]]
+          then
+            next_release_version="v${{ github.event.inputs.release_version }}"
+          else
+            # Rather than introducing an external dependency on `semver` on every run, we commit & use a specific version locally
+            # wget https://raw.githubusercontent.com/fsaintjacques/semver-tool/3.3.0/src/semver
+            # https://github.com/fsaintjacques/semver-tool
+            next_release_version="v$(./semver bump ${SEMVER_BUMP:=patch} $previous_release_version)"
+          fi
+          echo "NEXT RELEASE VERSION: $next_release_version"
+          printf "::set-output name=%s::%s\n" next "$next_release_version"
+
+      - name: "Fail if no changes since previous release"
+        run: |
+          echo "Changes since previous release:"
+          git diff --color --stat ${{ steps.release_version.outputs.previous }}...$GITHUB_SHA
+          if [ -z "$(git diff --color --stat ${{ steps.release_version.outputs.previous }}...$GITHUB_SHA)" ]
+          then
+            echo "This auto-release was failed on purpose: there have been no changes since ${{ steps.release_version.outputs.previous }}."
+            echo "While this can happen, it is rare and we should take notice of it, hence the failure."
+            exit 1
+          fi
+
       - name: "Ensure that all other checks have succeeded"
         # https://github.com/lewagon/wait-on-check-action
         uses: lewagon/wait-on-check-action@v1.0.0
@@ -52,32 +84,12 @@ jobs:
           running-workflow-name: "Bump version, tag & release"
           allowed-conclusions: success
 
-      - name: "Generate next release version"
-        id: next_release_version
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SEMVER_BUMP: ${{ github.event.inputs.release_type }}
-        run: |
-          if [[ -n "${{ github.event.inputs.release_version }}" ]]
-          then
-            next_release_version="v${{ github.event.inputs.release_version }}"
-          else
-            previous_release_version="$(gh api /repos/:owner/:repo/releases --jq '.[0].tag_name')"
-            echo "PREVIOUS RELEASE VERSION: $previous_release_version"
-            # Rather than installing it on every run, we commit it locally so that we have everything we need locally
-            # wget https://raw.githubusercontent.com/fsaintjacques/semver-tool/3.3.0/src/semver
-            # https://github.com/fsaintjacques/semver-tool
-            next_release_version="v$(./semver bump ${SEMVER_BUMP:=patch} $previous_release_version)"
-          fi
-          echo "NEXT RELEASE VERSION: $next_release_version"
-          printf "::set-output name=%s::%s\n" value "$next_release_version"
-
       - name: "Create next release tag"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh api -X POST /repos/:owner/:repo/git/refs \
-            --field ref="refs/tags/${{ steps.next_release_version.outputs.value }}" \
+            --field ref="refs/tags/${{ steps.release_version.outputs.next }}" \
             --field sha="$GITHUB_SHA"
 
       - name: "Fetch new tag"
@@ -110,7 +122,7 @@ jobs:
         with:
           download-url: https://github.com/dagger/dagger.git
           formula-name: dagger
-          tag-name: ${{ steps.next_release_version.outputs.value }}
+          tag-name: ${{ steps.release_version.outputs.next }}
           commit-message: |
             {{formulaName}} {{version}}
 


### PR DESCRIPTION
We want to fail auto-releases on purpose if there have been no changes since the previous release. While this can happen, it is rare and we should take notice of it, hence the failure.

For more context, see this Discord thread:
https://discord.com/channels/707636530424053791/796905486145683506/1022141805468328027

My intention has been to update this to Dagger for a long time now. It kept getting trumped by other priorities, and while now is the wrong time to do it, every time I have to touch this YAML, I sigh and tell myself: "one day...". Not today though.

I checked that this works as expected via https://github.com/gerhard/dagger/actions/runs/3103289111/jobs/5026460988

FWIW, these are the temporary changes which I used for that check:

```diff
diff --git a/.github/workflows/auto-release.yml b/.github/workflows/auto-release.yml
index ea78cfee..6db172af 100644
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -48,7 +48,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEMVER_BUMP: ${{ github.event.inputs.release_type }}
         run: |
-          previous_release_version="$(gh api /repos/gerhard/:repo/tags --jq '.[0].name')"
+          previous_release_version="$(gh api /repos/:owner/:repo/releases --jq '.[0].tag_name')"
           echo "PREVIOUS RELEASE VERSION: $previous_release_version"
           printf "::set-output name=%s::%s\n" previous "$previous_release_version"
           if [[ -n "${{ github.event.inputs.release_version }}" ]]
@@ -65,10 +65,9 @@ jobs:
 
       - name: "Fail if no changes since previous release"
         run: |
-          git fetch origin main
           echo "Changes since previous release:"
-          git diff --color --stat ${{ steps.release_version.outputs.previous }}...origin/main
-          if [ -z "$(git diff --color --stat ${{ steps.release_version.outputs.previous }}...origin/main)" ]
+          git diff --color --stat ${{ steps.release_version.outputs.previous }}...$GITHUB_SHA
+          if [ -z "$(git diff --color --stat ${{ steps.release_version.outputs.previous }}...$GITHUB_SHA)" ]
           then
             echo "This auto-release was failed on purpose: there have been no changes since ${{ steps.release_version.outputs.previous }}."
             echo "While this can happen, it is rare and we should take notice of it, hence the failure."

```

---

BTW, my intention has been to update this to Dagger for a long time now. It kept getting trumped by other priorities, and while now is the wrong time to do it, every time I have to touch this YAML, I sigh and tell myself: one day... Not today though.