### PR TITLE
cloak docs authentication

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -14,7 +14,11 @@ module.exports = {
   stylesheets: [
     "https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400&display=swap",
   ],
-  customFields: {},
+  customFields: {
+    OAUTH_ENABLE: process.env.OAUTH_ENABLE,
+    REACT_APP_GITHUB_AUTHORIZE_URI: process.env.REACT_APP_GITHUB_AUTHORIZE_URI,
+    REACT_APP_DAGGER_SITE_URI: process.env.REACT_APP_DAGGER_SITE_URI
+  },
   themeConfig: {
     sidebarCollapsed: false,
     prism: {
@@ -88,5 +92,13 @@ module.exports = {
       },
     ],
   ],
-  plugins: ["docusaurus-plugin-sass", "docusaurus2-dotenv"],
+  plugins: [
+    "docusaurus-plugin-sass",
+    [
+      "docusaurus2-dotenv",
+      {
+        systemvars: true,
+      },
+    ]
+  ],
 };

--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -26,13 +26,12 @@
   from = "/github-api-proxy/*"
   to = "https://api.github.com/:splat"
   status = 200
+  force = true
+  headers = {X-From = "Netlify"}
 
 [[redirects]]
   from = "/docs-access/*"
   to = "https://j20f3pfq11.execute-api.us-east-1.amazonaws.com/Prod/u/:splat"
   status = 200
-
-[[headers]]
-  for = "/*"
-  [headers.values]
-    Referrer-policy = "no-referrer-when-downgrade"
+  force = true
+  headers = {X-From = "Netlify"}

--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -17,6 +17,21 @@
   status = 302
   force = true
 
+[[redirects]]
+  from = "/github-proxy/*"
+  to = "https://github.com/:splat"
+  status = 200
+
+[[redirects]]
+  from = "/github-api-proxy/*"
+  to = "https://api.github.com/:splat"
+  status = 200
+
+[[redirects]]
+  from = "/docs-access/*"
+  to = "https://j20f3pfq11.execute-api.us-east-1.amazonaws.com/Prod/u/:splat"
+  status = 200
+
 [[headers]]
   for = "/*"
   [headers.values]

--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -35,3 +35,8 @@
   status = 200
   force = true
   headers = {X-From = "Netlify"}
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Referrer-policy = "no-referrer-when-downgrade"

--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build",
+    "build": "OAUTH_ENABLE=true docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/website/src/api/github.js
+++ b/website/src/api/github.js
@@ -1,0 +1,67 @@
+import axios from 'axios';
+
+const AxiosInstance = axios.create({
+    headers: { 'Accept': 'application/vnd.github.v3+json' },
+});
+
+function bindApiCall({ url, config, errorMessage }) {
+    try {
+        const apiCall = AxiosInstance.get(url, {
+            ...config,
+            validateStatus: function (status) {
+                return status < 500; // Resolve only if the status code is less than 500
+            }
+        })
+
+        return apiCall
+    } catch (error) {
+        console.log(errorMessage, error.message)
+    }
+}
+
+async function getAccessToken(code) {
+    const accessToken = await bindApiCall({
+        url: `${process.env.REACT_APP_API_PROXY_ENABLE == 'true' ? '/github-proxy' : 'https://github.com'}/login/oauth/access_token`,
+        config: {
+            params: {
+                code,
+                client_id: process.env.REACT_APP_CLIENT_ID,
+                client_secret: process.env.REACT_APP_CLIENT_SECRET,
+            },
+            errorMessage: 'error getAccessToken'
+        }
+    })
+
+    return accessToken.data
+}
+
+export async function getUser(access_token) {
+    const user = await bindApiCall({
+        url: `${process.env.REACT_APP_API_PROXY_ENABLE == 'true' ? '/github-api-proxy' : 'https://api.github.com'}/user`,
+        config: {
+            headers: { Authorization: `token ${access_token}` },
+        },
+        errorMessage: 'error getUser'
+    })
+
+    return {
+        login: user.data?.login,
+        error: user.data?.error_description,
+        status: user.status
+    }
+}
+
+export async function checkUserCollaboratorStatus(code) {
+    const { access_token } = await getAccessToken(code)
+    const { login } = await getUser(access_token)
+
+    const isUserCollaborator = await bindApiCall({
+        url: `${process.env.REACT_APP_API_PROXY_ENABLE == 'true' ? '/docs-access' : 'https://j20f3pfq11.execute-api.us-east-1.amazonaws.com/Prod/u'}/${login}`,
+        errorMessage: 'error checkUserCollaboratorStatus'
+    })
+
+    return {
+        permission: isUserCollaborator.data,
+        login
+    }
+}

--- a/website/src/components/pages/DocPageAuthentication.js
+++ b/website/src/components/pages/DocPageAuthentication.js
@@ -1,0 +1,19 @@
+import React from "react";
+import { GithubLoginButton } from 'react-social-login-buttons';
+import style from '../../css/pages/DocPageAuthentication.module.css'
+
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
+export default function DocAuthentication() {
+    const {siteConfig} = useDocusaurusContext();
+
+    return (
+        <div data-cy="cy-signin" className={style.container}>
+            <h1 className={style.h1}>Welcome to the Dagger documentation</h1>
+            <p>Please Sign In to Github to get access to the doc</p>
+            <div data-cy="cy-btn-signin">
+                <GithubLoginButton className={style.btn__github} onClick={() => window.location.href = siteConfig.customFields.REACT_APP_GITHUB_AUTHORIZE_URI} />
+            </div>
+        </div>
+    )
+}

--- a/website/src/components/pages/DocPageCustom.js
+++ b/website/src/components/pages/DocPageCustom.js
@@ -13,19 +13,24 @@ function DocPageCustom({ location, userAccessStatus, setUserAccessStatus }) {
   const authQuery = qs.parse(location.search);
 
   useEffect(async () => {
-    NProgress.start()
-    if (!isEmpty(authQuery?.code) && userAccessStatus === null) { //callback after successful auth with github
-      const user = await checkUserCollaboratorStatus(authQuery?.code);
-      setUserAccessStatus(user)
-      if (user?.permission) {
-        window.localStorage.setItem('user', JSON.stringify(user));
+    try {
+      NProgress.start()
+      if (!isEmpty(authQuery?.code) && userAccessStatus === null) { //callback after successful auth with github
+        const user = await checkUserCollaboratorStatus(authQuery?.code);
+        setUserAccessStatus(user)
+        if (user?.permission) {
+          window.localStorage.setItem('user', JSON.stringify(user));
+        }
       }
-    }
       NProgress.done();
       setIsLoading(false)
+    } catch(error) {
+      console.log(error)
+    }
   }, [])
 
   if(isLoading) return <p>...</p>
+
 
   if (userAccessStatus?.permission === false) {
     return <DocPageRedirect />
@@ -34,6 +39,8 @@ function DocPageCustom({ location, userAccessStatus, setUserAccessStatus }) {
   if (userAccessStatus === null) {
     return <DocPageAuthentication />
   }
+
+  return null
 }
 
 export default DocPageCustom

--- a/website/src/components/pages/DocPageCustom.js
+++ b/website/src/components/pages/DocPageCustom.js
@@ -1,0 +1,39 @@
+import React, { useState, useEffect } from 'react';
+import qs from 'querystringify';
+import isEmpty from 'lodash/isEmpty';
+import NProgress from "nprogress";
+
+import { checkUserCollaboratorStatus } from '../../api/github'
+import DocPageAuthentication from './DocPageAuthentication';
+import DocPageRedirect from './DocPageRedirect';
+
+function DocPageCustom({ location, userAccessStatus, setUserAccessStatus }) {
+  const [isLoading, setIsLoading] = useState(true)
+  const [redirectState, setRedirectState] = useState()
+  const authQuery = qs.parse(location.search);
+
+  useEffect(async () => {
+    NProgress.start()
+    if (!isEmpty(authQuery?.code) && userAccessStatus === null) { //callback after successful auth with github
+      const user = await checkUserCollaboratorStatus(authQuery?.code);
+      setUserAccessStatus(user)
+      if (user?.permission) {
+        window.localStorage.setItem('user', JSON.stringify(user));
+      }
+    }
+      NProgress.done();
+      setIsLoading(false)
+  }, [])
+
+  if(isLoading) return <p>...</p>
+
+  if (userAccessStatus?.permission === false) {
+    return <DocPageRedirect />
+  }
+
+  if (userAccessStatus === null) {
+    return <DocPageAuthentication />
+  }
+}
+
+export default DocPageCustom

--- a/website/src/components/pages/DocPageRedirect.js
+++ b/website/src/components/pages/DocPageRedirect.js
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from "react";
+import style from '../../css/pages/DocPageRedirect.module.css'
+
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
+export default function DocPageRedirect() {
+    const [counter, setCounter] = useState(10)
+    const {siteConfig} = useDocusaurusContext();
+
+    useEffect(() => {
+        setTimeout(() => window.location.href = siteConfig.customFields.REACT_APP_DAGGER_SITE_URI, 10000)
+        setInterval(() => setCounter((prevState) => prevState - 1), 1000)
+    }, [])
+
+    return (
+        <div data-cy="cy-page-redirect" className={`container ${style.wrapper}`}>
+            <div className={`row ${style.row}`}>
+                <div className="col col--4 col--offset-2">
+                    <h1 className={style.h1}>Oups!</h1>
+                    <p>It seems you don't have the permission to see Dagger's documentation. But don't worry you can request an Eary Access :). You'll be redirect to Dagger website in {counter} seconds </p>
+                    <p>See you soon !</p>
+                    <br />
+                    <small><strong>If nothing happen, <a href={siteConfig.customFields.REACT_APP_DAGGER_SITE_URI}>click here</a> to go to Dagger website</strong></small>
+                </div>
+                <div className="col col--4">
+                    <img src="/img/dagger-astronaute.png" alt="" />
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/website/src/components/pages/DocPageRedirect.js
+++ b/website/src/components/pages/DocPageRedirect.js
@@ -13,7 +13,7 @@ export default function DocPageRedirect() {
     }, [])
 
     return (
-        <div data-cy="cy-page-redirect" className={`container ${style.wrapper}`}>
+        <div data-cy="cy-page-redirect" className={style.wrapper}>
             <div className={`row ${style.row}`}>
                 <div className="col col--4 col--offset-2">
                     <h1 className={style.h1}>Oups!</h1>

--- a/website/src/css/pages/DocPageAuthentication.module.css
+++ b/website/src/css/pages/DocPageAuthentication.module.css
@@ -1,0 +1,18 @@
+.container {
+  background: url("/img/Dagger_Website_Space_Uranus.png") no-repeat;
+  background-size: cover;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.btn__github {
+  width: 240px !important;
+  border-radius: 0 !important;
+}
+
+.btn__github > div {
+  display: inline-flex !important;
+}

--- a/website/src/css/pages/DocPageRedirect.module.css
+++ b/website/src/css/pages/DocPageRedirect.module.css
@@ -1,0 +1,25 @@
+.wrapper {
+  background: linear-gradient(180deg, #131226, #0e2b3d);
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  color: var(--ifm-color-primary-light);
+  max-width: 100%;
+}
+
+.wrapper a {
+  color: var(--ifm-color-primary-light);
+  text-decoration: underline;
+}
+
+.h1 {
+  margin-bottom: 2rem;
+}
+
+.row {
+  justify-content: center;
+  align-content: center;
+  align-items: center;
+}

--- a/website/src/theme/DocPage/index.js
+++ b/website/src/theme/DocPage/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import clsx from 'clsx';
 import {HtmlClassNameProvider, ThemeClassNames} from '@docusaurus/theme-common';
 import {
@@ -13,6 +13,7 @@ import SearchMetadata from '@theme/SearchMetadata';
 
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import {useLocation} from '@docusaurus/router';
+import DocPageCustom from "../../components/pages/DocPageCustom"
 import amplitude from 'amplitude-js';
 
 export default function DocPage(props) {
@@ -22,6 +23,12 @@ export default function DocPage(props) {
   // DocPage Swizzle
   const {siteConfig} = useDocusaurusContext();
   const location = useLocation();
+  const [userAccessStatus, setUserAccessStatus] = useState(
+    (() => {
+      if (typeof window !== 'undefined')
+        return JSON.parse(window.localStorage.getItem('user'));
+    })(),
+  );
   
   useEffect(() => {
       if(siteConfig.customFields.AMPLITUDE_ID) {
@@ -31,6 +38,10 @@ export default function DocPage(props) {
         amplitude.getInstance().logEvent('Docs Viewed', { "hostname": window.location.hostname, "path": location.pathname });
       }
   }, [location.pathname])
+
+  if (siteConfig.customFields.OAUTH_ENABLE == 'true' && userAccessStatus?.permission !== true) {
+    return <DocPageCustom location={location} userAccessStatus={userAccessStatus} setUserAccessStatus={setUserAccessStatus} />
+  }
   // End DocPageSwizzle
 
   if (!currentDocRouteMetadata) {


### PR DESCRIPTION
This PR is resurrecting Github authentication that we used to use for Europa (Dagger 0.2).
Only users that have access to dagger/cloak repo can see cloak docs.
