### PR TITLE
ignore Session.vim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ stub/stub
 # intellij
 .idea
 
+# vim-obsession
+Session.vim
+
+# js
 node_modules
 
 # python


### PR DESCRIPTION
before I accidentally commit it one day :)

context: `Session.vim` is the default filename used by [vim-obsession](https://github.com/tpope/vim-obsession), a tool for saving/restoring vim editor sessions (buffers, splits, etc.)