### PR TITLE
Initial conversion to use typed resolver methods.

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -42,6 +42,7 @@ func New(params InitializeArgs) (router.ExecutableSchema, error) {
 		&filesystemSchema{base},
 		&projectSchema{
 			baseSchema:      base,
+			remoteSchemas:   make(map[string]*project.RemoteSchema),
 			compiledSchemas: make(map[string]*project.CompiledRemoteSchema),
 		},
 		&execSchema{base},

--- a/core/dockerbuild.schema.go
+++ b/core/dockerbuild.schema.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"github.com/containerd/containerd/platforms"
-	"github.com/graphql-go/graphql"
 	dockerfilebuilder "github.com/moby/buildkit/frontend/dockerfile/builder"
 	bkgw "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/solver/pb"
@@ -32,7 +31,7 @@ extend type Filesystem {
 func (s *dockerBuildSchema) Resolvers() router.Resolvers {
 	return router.Resolvers{
 		"Filesystem": router.ObjectResolver{
-			"dockerbuild": s.dockerbuild,
+			"dockerbuild": router.ToResolver(s.dockerbuild),
 		},
 	}
 }
@@ -41,13 +40,12 @@ func (s *dockerBuildSchema) Dependencies() []router.ExecutableSchema {
 	return nil
 }
 
-func (s *dockerBuildSchema) dockerbuild(p graphql.ResolveParams) (any, error) {
-	obj, err := filesystem.FromSource(p.Source)
-	if err != nil {
-		return nil, err
-	}
+type dockerbuildArgs struct {
+	Dockerfile string
+}
 
-	def, err := obj.ToDefinition()
+func (s *dockerBuildSchema) dockerbuild(ctx *router.Context, parent *filesystem.Filesystem, args dockerbuildArgs) (any, error) {
+	def, err := parent.ToDefinition()
 	if err != nil {
 		return nil, err
 	}
@@ -55,14 +53,14 @@ func (s *dockerBuildSchema) dockerbuild(p graphql.ResolveParams) (any, error) {
 	opts := map[string]string{
 		"platform": platforms.Format(s.platform),
 	}
-	if dockerfile, ok := p.Args["dockerfile"].(string); ok {
+	if dockerfile := args.Dockerfile; dockerfile != "" {
 		opts["filename"] = dockerfile
 	}
 	inputs := map[string]*pb.Definition{
 		dockerfilebuilder.DefaultLocalNameContext:    def,
 		dockerfilebuilder.DefaultLocalNameDockerfile: def,
 	}
-	res, err := s.gw.Solve(p.Context, bkgw.SolveRequest{
+	res, err := s.gw.Solve(ctx, bkgw.SolveRequest{
 		Frontend:       "dockerfile.v0",
 		FrontendOpt:    opts,
 		FrontendInputs: inputs,
@@ -80,5 +78,5 @@ func (s *dockerBuildSchema) dockerbuild(p graphql.ResolveParams) (any, error) {
 		return nil, err
 	}
 
-	return filesystem.FromState(p.Context, st, s.platform)
+	return filesystem.FromState(ctx, st, s.platform)
 }

--- a/core/filesystem/filesystem.go
+++ b/core/filesystem/filesystem.go
@@ -125,27 +125,6 @@ func FromState(ctx context.Context, st llb.State, platform specs.Platform) (*Fil
 	return info.ToFilesystem()
 }
 
-func FromSource(source any) (*Filesystem, error) {
-	fs, ok := source.(*Filesystem)
-	if ok {
-		return fs, nil
-	}
-
-	// TODO: when returned by user actions, Filesystem is just a map[string]interface{}, need to fix, hack for now:
-
-	m, ok := source.(map[string]interface{})
-	if !ok {
-		return nil, fmt.Errorf("invalid source type: %T", source)
-	}
-	id, ok := m["id"].(string)
-	if !ok {
-		return nil, fmt.Errorf("invalid source id: %T %v", source, source)
-	}
-	return &Filesystem{
-		ID: FSID(id),
-	}, nil
-}
-
 func Merged(ctx context.Context, filesystems []*Filesystem, platform specs.Platform) (*Filesystem, error) {
 	states := make([]llb.State, 0, len(filesystems))
 	for _, fs := range filesystems {

--- a/core/util.go
+++ b/core/util.go
@@ -1,26 +1,16 @@
 package core
 
 import (
-	"encoding/json"
 	"strings"
 )
 
-func convertArg(arg any, dest any) error {
-	marshalled, err := json.Marshal(arg)
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(marshalled, dest)
-}
-
-func truncate(s string, args map[string]any) string {
-	lines, ok := args["lines"].(int)
-	if !ok {
+func truncate(s string, lines *int) string {
+	if lines == nil {
 		return s
 	}
-	l := strings.SplitN(s, "\n", lines+1)
-	if lines > len(l) {
-		lines = len(l)
+	l := strings.SplitN(s, "\n", *lines+1)
+	if *lines > len(l) {
+		*lines = len(l)
 	}
-	return strings.Join(l[0:lines], "\n")
+	return strings.Join(l[0:*lines], "\n")
 }

--- a/project/config.go
+++ b/project/config.go
@@ -12,16 +12,14 @@ type Config struct {
 }
 
 type Script struct {
-	Path string `yaml:"path"`
-	SDK  string `yaml:"sdk"`
+	Path string `yaml:"path" json:"path"`
+	SDK  string `yaml:"sdk" json:"sdk"`
 }
 
 type Extension struct {
-	Path string `yaml:"path"`
-	SDK  string `yaml:"sdk"`
-
-	// internal-only fields for tracking state
-	Schema string `yaml:"-"`
+	Path   string `yaml:"path" json:"path"`
+	SDK    string `yaml:"sdk" json:"sdk"`
+	Schema string `yaml:"schema" json:"schema"`
 }
 
 type Dependency struct {


### PR DESCRIPTION
Signed-off-by: Erik Sipsma <erik@sipsma.dev>

This is just a first batch of conversions; I will convert the rest of our resolvers once I've gotten confirmation everyone else is on board.

Found this approach during multiplatform (turned out to not be strictly necessary there so I separated it out). Basically lets us use actual types in our resolver methods and convert each of them to the graphql resolver type by just wrapping them in `router.ToResolver`. That `ToResolver` helper is an ugly generic function, but go's type inference is just powerful enough that it's the only place generics are needed; users don't have to specify params when using it.

This makes it much easier+safer to write resolvers since there's no more having to manually cast+convert types when accessing parents and args. Also lets us be sure we are returning consistent objects.