### PR TITLE
changing package.json files absolute path

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "types": "./sdk/nodejs/dagger/dist/index.d.ts",
   "files": [
-    "./sdk/nodejs/dagger/dist/"
+    "/sdk/nodejs/dagger/dist/"
   ],
   "exports": {
     ".": "./sdk/nodejs/dagger/dist/index.js"


### PR DESCRIPTION
Node 16.15.0 which use npm 8.5.5 seems to have trouble to import @dagger.io/dagger dependencies (related issue #3163)
Changing the absolute path should fixe this issue.

Signed-off-by: jffarge <jf@dagger.io>