### PR TITLE
initial `Directory` + `File` implementations

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -39,6 +39,7 @@ func New(params InitializeArgs) (router.ExecutableSchema, error) {
 	return router.MergeExecutableSchemas("core",
 		&coreSchema{base, params.WorkdirID},
 		&directorySchema{base},
+		&fileSchema{base},
 		&gitSchema{base},
 		&filesystemSchema{base},
 		&projectSchema{

--- a/core/core.go
+++ b/core/core.go
@@ -38,6 +38,7 @@ func New(params InitializeArgs) (router.ExecutableSchema, error) {
 	}
 	return router.MergeExecutableSchemas("core",
 		&coreSchema{base, params.WorkdirID},
+		&directorySchema{base},
 		&gitSchema{base},
 		&filesystemSchema{base},
 		&projectSchema{

--- a/core/directory.go
+++ b/core/directory.go
@@ -1,0 +1,203 @@
+package core
+
+import (
+	"context"
+	"path"
+
+	"github.com/moby/buildkit/client/llb"
+	bkgw "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/solver/pb"
+	"go.dagger.io/dagger/core/schema"
+	"go.dagger.io/dagger/router"
+)
+
+// Directory is a content-addressed directory.
+type Directory struct {
+	ID DirectoryID `json:"id"`
+}
+
+// DirectoryID is an opaque value representing a content-addressed directory.
+type DirectoryID string
+
+// TODO(vito): this might need to include a path to pass to llb.SourcePath when
+// mounting the directory in, to support container { directory("./foo") }
+type directoryIDPayload struct {
+	LLB *pb.Definition `json:"llb"`
+}
+
+func (id DirectoryID) decode() (*directoryIDPayload, error) {
+	var payload directoryIDPayload
+	if err := decodeID(&payload, id); err != nil {
+		return nil, err
+	}
+
+	return &payload, nil
+}
+
+func DirectoryFromState(ctx context.Context, st llb.State, marshalOpts ...llb.ConstraintsOpt) (*Directory, error) {
+	def, err := st.Marshal(ctx, marshalOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	id, err := encodeID(directoryIDPayload{
+		LLB: def.ToPB(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &Directory{
+		ID: DirectoryID(id),
+	}, nil
+}
+
+func (dir *Directory) Contents(ctx context.Context, gw bkgw.Client, path string) ([]string, error) {
+	st, err := dir.ToState()
+	if err != nil {
+		return nil, err
+	}
+
+	def, err := st.Marshal(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := gw.Solve(ctx, bkgw.SolveRequest{
+		Definition: def.ToPB(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	ref, err := res.SingleRef()
+	if err != nil {
+		return nil, err
+	}
+
+	if ref == nil {
+		// empty directory, i.e. llb.Scratch()
+		return []string{}, nil
+	}
+
+	entries, err := ref.ReadDir(ctx, bkgw.ReadDirRequest{
+		Path: path,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	paths := []string{}
+	for _, entry := range entries {
+		paths = append(paths, entry.GetPath())
+	}
+
+	return paths, nil
+}
+
+func (dir *Directory) WithNewFile(ctx context.Context, gw bkgw.Client, dest string, content []byte) (*Directory, error) {
+	st, err := dir.ToState()
+	if err != nil {
+		return nil, err
+	}
+
+	parent, _ := path.Split(dest)
+	if parent != "" {
+		st = st.File(llb.Mkdir(parent, 0755, llb.WithParents(true)))
+	}
+
+	st = st.File(
+		llb.Mkfile(
+			dest,
+			0644, // TODO(vito): expose, issue: #3167
+			content,
+		),
+	)
+
+	return DirectoryFromState(ctx, st)
+}
+
+func (dir *Directory) ToState() (llb.State, error) {
+	if dir.ID == "" {
+		return llb.Scratch(), nil
+	}
+
+	payload, err := dir.ID.decode()
+	if err != nil {
+		return llb.State{}, err
+	}
+
+	defop, err := llb.NewDefinitionOp(payload.LLB)
+	if err != nil {
+		return llb.State{}, err
+	}
+
+	return llb.NewState(defop), nil
+}
+
+type directorySchema struct {
+	*baseSchema
+}
+
+var _ router.ExecutableSchema = &directorySchema{}
+
+func (s *directorySchema) Name() string {
+	return "directory"
+}
+
+func (s *directorySchema) Schema() string {
+	return schema.Directory
+}
+
+var directoryIDResolver = stringResolver(DirectoryID(""))
+
+func (s *directorySchema) Resolvers() router.Resolvers {
+	return router.Resolvers{
+		"DirectoryID": directoryIDResolver,
+		"Query": router.ObjectResolver{
+			"directory": router.ToResolver(s.directory),
+		},
+		"Directory": router.ObjectResolver{
+			"contents":         router.ToResolver(s.contents),
+			"file":             router.ErrResolver(ErrNotImplementedYet),
+			"secret":           router.ErrResolver(ErrNotImplementedYet),
+			"withNewFile":      router.ToResolver(s.withNewFile),
+			"withCopiedFIle":   router.ErrResolver(ErrNotImplementedYet),
+			"withoutFile":      router.ErrResolver(ErrNotImplementedYet),
+			"directory":        router.ErrResolver(ErrNotImplementedYet),
+			"withDirectory":    router.ErrResolver(ErrNotImplementedYet),
+			"withoutDirectory": router.ErrResolver(ErrNotImplementedYet),
+			"diff":             router.ErrResolver(ErrNotImplementedYet),
+		},
+	}
+}
+
+func (s *directorySchema) Dependencies() []router.ExecutableSchema {
+	return nil
+}
+
+type directoryArgs struct {
+	ID DirectoryID
+}
+
+func (s *directorySchema) directory(ctx *router.Context, parent any, args directoryArgs) (*Directory, error) {
+	return &Directory{
+		ID: args.ID,
+	}, nil
+}
+
+type contentArgs struct {
+	Path string
+}
+
+func (s *directorySchema) contents(ctx *router.Context, parent *Directory, args contentArgs) ([]string, error) {
+	return parent.Contents(ctx, s.gw, args.Path)
+}
+
+type withNewFileArgs struct {
+	Path     string
+	Contents string
+}
+
+func (s *directorySchema) withNewFile(ctx *router.Context, parent *Directory, args withNewFileArgs) (*Directory, error) {
+	return parent.WithNewFile(ctx, s.gw, args.Path, []byte(args.Contents))
+}

--- a/core/directory.go
+++ b/core/directory.go
@@ -129,6 +129,15 @@ func (dir *Directory) Directory(ctx context.Context, subdir string) (*Directory,
 	return NewDirectory(ctx, st, path.Join(cwd, subdir))
 }
 
+func (dir *Directory) File(ctx context.Context, file string) (*File, error) {
+	st, cwd, err := dir.Decode()
+	if err != nil {
+		return nil, err
+	}
+
+	return NewFile(ctx, st, path.Join(cwd, file))
+}
+
 func (dir *Directory) WithDirectory(ctx context.Context, subdir string, src *Directory) (*Directory, error) {
 	st, cwd, err := dir.Decode()
 	if err != nil {
@@ -187,10 +196,10 @@ func (s *directorySchema) Resolvers() router.Resolvers {
 		},
 		"Directory": router.ObjectResolver{
 			"contents":         router.ToResolver(s.contents),
-			"file":             router.ErrResolver(ErrNotImplementedYet),
+			"file":             router.ToResolver(s.file),
 			"secret":           router.ErrResolver(ErrNotImplementedYet),
 			"withNewFile":      router.ToResolver(s.withNewFile),
-			"withCopiedFIle":   router.ErrResolver(ErrNotImplementedYet),
+			"withCopiedFile":   router.ErrResolver(ErrNotImplementedYet),
 			"withoutFile":      router.ErrResolver(ErrNotImplementedYet),
 			"directory":        router.ToResolver(s.subdirectory),
 			"withDirectory":    router.ToResolver(s.withDirectory),
@@ -237,6 +246,14 @@ type contentArgs struct {
 
 func (s *directorySchema) contents(ctx *router.Context, parent *Directory, args contentArgs) ([]string, error) {
 	return parent.Contents(ctx, s.gw, args.Path)
+}
+
+type dirFileArgs struct {
+	Path string
+}
+
+func (s *directorySchema) file(ctx *router.Context, parent *Directory, args dirFileArgs) (*File, error) {
+	return parent.File(ctx, args.Path)
 }
 
 type withNewFileArgs struct {

--- a/core/directory.go
+++ b/core/directory.go
@@ -149,7 +149,9 @@ func (dir *Directory) WithDirectory(ctx context.Context, subdir string, src *Dir
 		return nil, err
 	}
 
-	st = st.File(llb.Copy(srcSt, srcCwd, path.Join(cwd, subdir)))
+	st = st.File(llb.Copy(srcSt, srcCwd, path.Join(cwd, subdir), &llb.CopyInfo{
+		CreateDestPath: true,
+	}))
 
 	return NewDirectory(ctx, st, cwd)
 }

--- a/core/file.go
+++ b/core/file.go
@@ -1,0 +1,193 @@
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/moby/buildkit/client/llb"
+	bkgw "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/solver/pb"
+	fstypes "github.com/tonistiigi/fsutil/types"
+	"go.dagger.io/dagger/core/schema"
+	"go.dagger.io/dagger/router"
+)
+
+// File is a content-addressed file.
+type File struct {
+	ID FileID `json:"id"`
+}
+
+// FileID is an opaque value representing a content-addressed file.
+type FileID string
+
+// fileIDPayload is the inner content of a FileID.
+type fileIDPayload struct {
+	LLB  *pb.Definition `json:"llb"`
+	File string         `json:"file"`
+}
+
+func (id FileID) decode() (*fileIDPayload, error) {
+	var payload fileIDPayload
+	if err := decodeID(&payload, id); err != nil {
+		return nil, err
+	}
+
+	return &payload, nil
+}
+
+func NewFile(ctx context.Context, st llb.State, file string) (*File, error) {
+	def, err := st.Marshal(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	id, err := encodeID(fileIDPayload{
+		LLB:  def.ToPB(),
+		File: file,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &File{
+		ID: FileID(id),
+	}, nil
+}
+
+func (file *File) Contents(ctx context.Context, gw bkgw.Client) ([]byte, error) {
+	st, filePath, err := file.Decode()
+	if err != nil {
+		return nil, err
+	}
+
+	ref, err := file.ref(ctx, gw, st)
+	if err != nil {
+		return nil, err
+	}
+
+	return ref.ReadFile(ctx, bkgw.ReadRequest{
+		Filename: filePath,
+	})
+}
+
+func (file *File) Stat(ctx context.Context, gw bkgw.Client) (*fstypes.Stat, error) {
+	st, filePath, err := file.Decode()
+	if err != nil {
+		return nil, err
+	}
+
+	ref, err := file.ref(ctx, gw, st)
+	if err != nil {
+		return nil, err
+	}
+
+	return ref.StatFile(ctx, bkgw.StatRequest{
+		Path: filePath,
+	})
+}
+
+func (dir *File) Decode() (llb.State, string, error) {
+	if dir.ID == "" {
+		return llb.Scratch(), "", nil
+	}
+
+	payload, err := dir.ID.decode()
+	if err != nil {
+		return llb.State{}, "", err
+	}
+
+	defop, err := llb.NewDefinitionOp(payload.LLB)
+	if err != nil {
+		return llb.State{}, "", err
+	}
+
+	return llb.NewState(defop), payload.File, nil
+}
+
+func (file *File) ref(ctx context.Context, gw bkgw.Client, st llb.State) (bkgw.Reference, error) {
+	def, err := st.Marshal(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := gw.Solve(ctx, bkgw.SolveRequest{
+		Definition: def.ToPB(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	ref, err := res.SingleRef()
+	if err != nil {
+		return nil, err
+	}
+
+	if ref == nil {
+		// empty file, i.e. llb.Scratch()
+		return nil, fmt.Errorf("empty reference")
+	}
+
+	return ref, nil
+}
+
+type fileSchema struct {
+	*baseSchema
+}
+
+var _ router.ExecutableSchema = &fileSchema{}
+
+func (s *fileSchema) Name() string {
+	return "file"
+}
+
+func (s *fileSchema) Schema() string {
+	return schema.File
+}
+
+var fileIDResolver = stringResolver(FileID(""))
+
+func (s *fileSchema) Resolvers() router.Resolvers {
+	return router.Resolvers{
+		"FileID": fileIDResolver,
+		"Query": router.ObjectResolver{
+			"file": router.ToResolver(s.file),
+		},
+		"File": router.ObjectResolver{
+			"contents": router.ToResolver(s.contents),
+			"secret":   router.ErrResolver(ErrNotImplementedYet),
+			"size":     router.ToResolver(s.size),
+		},
+	}
+}
+
+func (s *fileSchema) Dependencies() []router.ExecutableSchema {
+	return nil
+}
+
+type fileArgs struct {
+	ID FileID
+}
+
+func (s *fileSchema) file(ctx *router.Context, parent any, args fileArgs) (*File, error) {
+	return &File{
+		ID: args.ID,
+	}, nil
+}
+
+func (s *fileSchema) contents(ctx *router.Context, file *File, args any) (string, error) {
+	content, err := file.Contents(ctx, s.gw)
+	if err != nil {
+		return "", err
+	}
+
+	return string(content), nil
+}
+
+func (s *fileSchema) size(ctx *router.Context, file *File, args any) (int64, error) {
+	info, err := file.Stat(ctx, s.gw)
+	if err != nil {
+		return 0, err
+	}
+
+	return info.Size_, nil
+}

--- a/core/file.go
+++ b/core/file.go
@@ -86,12 +86,8 @@ func (file *File) Stat(ctx context.Context, gw bkgw.Client) (*fstypes.Stat, erro
 	})
 }
 
-func (dir *File) Decode() (llb.State, string, error) {
-	if dir.ID == "" {
-		return llb.Scratch(), "", nil
-	}
-
-	payload, err := dir.ID.decode()
+func (file *File) Decode() (llb.State, string, error) {
+	payload, err := file.ID.decode()
 	if err != nil {
 		return llb.State{}, "", err
 	}

--- a/core/filesystem.schema.go
+++ b/core/filesystem.schema.go
@@ -5,39 +5,13 @@ import (
 	"io/fs"
 	"strconv"
 
-	"github.com/graphql-go/graphql/language/ast"
 	bkclient "github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
 	"go.dagger.io/dagger/core/filesystem"
 	"go.dagger.io/dagger/router"
 )
 
-var fsIDResolver = router.ScalarResolver{
-	Serialize: func(value any) any {
-		switch v := value.(type) {
-		case filesystem.FSID, string:
-			return v
-		default:
-			panic(fmt.Sprintf("unexpected fsid type %T", v))
-		}
-	},
-	ParseValue: func(value any) any {
-		switch v := value.(type) {
-		case string:
-			return filesystem.FSID(v)
-		default:
-			panic(fmt.Sprintf("unexpected fsid value type %T: %+v", v, v))
-		}
-	},
-	ParseLiteral: func(valueAST ast.Value) any {
-		switch valueAST := valueAST.(type) {
-		case *ast.StringValue:
-			return filesystem.FSID(valueAST.Value)
-		default:
-			panic(fmt.Sprintf("unexpected fsid literal type: %T", valueAST))
-		}
-	},
-}
+var fsIDResolver = stringResolver(filesystem.FSID(""))
 
 var _ router.ExecutableSchema = &filesystemSchema{}
 

--- a/core/filesystem.schema.go
+++ b/core/filesystem.schema.go
@@ -93,12 +93,12 @@ func (s *filesystemSchema) filesystem(ctx *router.Context, parent any, args file
 	return filesystem.New(args.ID), nil
 }
 
-type fileArgs struct {
+type fsFileArgs struct {
 	Path  string
 	Lines *int
 }
 
-func (s *filesystemSchema) file(ctx *router.Context, parent *filesystem.Filesystem, args fileArgs) (string, error) {
+func (s *filesystemSchema) file(ctx *router.Context, parent *filesystem.Filesystem, args fsFileArgs) (string, error) {
 	output, err := parent.ReadFile(ctx, s.gw, args.Path)
 	if err != nil {
 		return "", fmt.Errorf("failed to read file: %w", err)

--- a/core/git.go
+++ b/core/git.go
@@ -112,11 +112,11 @@ func (s *gitSchema) digest(ctx *router.Context, parent any, args any) (any, erro
 	return nil, ErrNotImplementedYet
 }
 
-func (s *gitSchema) tree(ctx *router.Context, parent gitRef, args any) (*filesystem.Filesystem, error) {
+func (s *gitSchema) tree(ctx *router.Context, parent gitRef, args any) (*Directory, error) {
 	var opts []llb.GitOption
 	if s.sshAuthSockID != "" {
 		opts = append(opts, llb.MountSSHSock(s.sshAuthSockID))
 	}
 	st := llb.Git(parent.Repository.URL, parent.Name, opts...)
-	return s.Solve(ctx, st)
+	return NewDirectory(ctx, st, "")
 }

--- a/core/integration/core.schema_test.go
+++ b/core/integration/core.schema_test.go
@@ -11,12 +11,6 @@ import (
 	"go.dagger.io/dagger/internal/testutil"
 )
 
-func init() {
-	if err := testutil.SetupBuildkitd(); err != nil {
-		panic(err)
-	}
-}
-
 func TestContainerFrom(t *testing.T) {
 	t.Skip("not implemented yet")
 

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -229,6 +229,21 @@ func TestDirectoryWithDirectory(t *testing.T) {
 		})
 	require.NoError(t, err)
 	require.Equal(t, []string{"sub-file"}, res2.Directory.WithDirectory.Contents)
+
+	err = testutil.Query(
+		`query Test($src: DirectoryID!) {
+			directory {
+				withDirectory(path: "sub-dir/sub-sub-dir/with-dir", directory: $src) {
+					contents(path: "sub-dir/sub-sub-dir/with-dir")
+				}
+			}
+		}`, &res2, &testutil.QueryOptions{
+			Variables: map[string]any{
+				"src": res.Directory.WithNewFile.WithNewFile.Directory.ID,
+			},
+		})
+	require.NoError(t, err)
+	require.Equal(t, []string{"sub-file"}, res2.Directory.WithDirectory.Contents)
 }
 
 func TestDirectoryWithCopiedFile(t *testing.T) {

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -1,0 +1,111 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dagger.io/dagger/core"
+	"go.dagger.io/dagger/internal/testutil"
+)
+
+func TestEmptyDirectory(t *testing.T) {
+	t.Parallel()
+
+	var res struct {
+		Directory struct {
+			ID       core.DirectoryID
+			Contents []string
+		}
+	}
+
+	err := testutil.Query(
+		`{
+			directory {
+				id
+				contents
+			}
+		}`, &res, nil)
+	require.NoError(t, err)
+	require.Empty(t, res.Directory.ID)
+	require.Empty(t, res.Directory.Contents)
+}
+
+func TestDirectoryWithNewFile(t *testing.T) {
+	t.Parallel()
+
+	var res struct {
+		Directory struct {
+			WithNewFile struct {
+				ID       core.DirectoryID
+				Contents []string
+			}
+		}
+	}
+
+	err := testutil.Query(
+		`{
+			directory {
+				withNewFile(path: "some-file", contents: "some-content") {
+					id
+					contents
+				}
+			}
+		}`, &res, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, res.Directory.WithNewFile.ID)
+	require.Equal(t, []string{"some-file"}, res.Directory.WithNewFile.Contents)
+}
+
+func TestDirectoryContents(t *testing.T) {
+	t.Parallel()
+
+	var res struct {
+		Directory struct {
+			WithNewFile struct {
+				WithNewFile struct {
+					Contents []string
+				}
+			}
+		}
+	}
+
+	err := testutil.Query(
+		`{
+			directory {
+				withNewFile(path: "some-file", contents: "some-content") {
+					withNewFile(path: "some-dir/sub-file", contents: "some-content") {
+						contents
+					}
+				}
+			}
+		}`, &res, nil)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"some-file", "some-dir"}, res.Directory.WithNewFile.WithNewFile.Contents)
+}
+
+func TestDirectoryContentsOfPath(t *testing.T) {
+	t.Parallel()
+
+	var res struct {
+		Directory struct {
+			WithNewFile struct {
+				WithNewFile struct {
+					Contents []string
+				}
+			}
+		}
+	}
+
+	err := testutil.Query(
+		`{
+			directory {
+				withNewFile(path: "some-file", contents: "some-content") {
+					withNewFile(path: "some-dir/sub-file", contents: "some-content") {
+						contents(path: "some-dir")
+					}
+				}
+			}
+		}`, &res, nil)
+	require.NoError(t, err)
+	require.Equal(t, []string{"sub-file"}, res.Directory.WithNewFile.WithNewFile.Contents)
+}

--- a/core/integration/file_test.go
+++ b/core/integration/file_test.go
@@ -1,0 +1,103 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dagger.io/dagger/core"
+	"go.dagger.io/dagger/internal/testutil"
+)
+
+func TestFile(t *testing.T) {
+	t.Parallel()
+
+	var res struct {
+		Directory struct {
+			WithNewFile struct {
+				File struct {
+					ID       core.DirectoryID
+					Contents string
+				}
+			}
+		}
+	}
+
+	err := testutil.Query(
+		`{
+			directory {
+				withNewFile(path: "some-file", contents: "some-content") {
+					file(path: "some-file") {
+						id
+						contents
+					}
+				}
+			}
+		}`, &res, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, res.Directory.WithNewFile.File.ID)
+	require.Equal(t, "some-content", res.Directory.WithNewFile.File.Contents)
+}
+
+func TestDirectoryFile(t *testing.T) {
+	t.Parallel()
+
+	var res struct {
+		Directory struct {
+			WithNewFile struct {
+				Directory struct {
+					File struct {
+						ID       core.DirectoryID
+						Contents string
+					}
+				}
+			}
+		}
+	}
+
+	err := testutil.Query(
+		`{
+			directory {
+				withNewFile(path: "some-dir/some-file", contents: "some-content") {
+					directory(path: "some-dir") {
+						file(path: "some-file") {
+							id
+							contents
+						}
+					}
+				}
+			}
+		}`, &res, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, res.Directory.WithNewFile.Directory.File.ID)
+	require.Equal(t, "some-content", res.Directory.WithNewFile.Directory.File.Contents)
+}
+
+func TestFileSize(t *testing.T) {
+	t.Parallel()
+
+	var res struct {
+		Directory struct {
+			WithNewFile struct {
+				File struct {
+					ID   core.DirectoryID
+					Size int
+				}
+			}
+		}
+	}
+
+	err := testutil.Query(
+		`{
+			directory {
+				withNewFile(path: "some-file", contents: "some-content") {
+					file(path: "some-file") {
+						id
+						size
+					}
+				}
+			}
+		}`, &res, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, res.Directory.WithNewFile.File.ID)
+	require.Equal(t, len("some-content"), res.Directory.WithNewFile.File.Size)
+}

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -14,7 +14,9 @@ func TestGit(t *testing.T) {
 		Git struct {
 			Branch struct {
 				Tree struct {
-					File string
+					File struct {
+						Contents string
+					}
 				}
 			}
 		}
@@ -25,13 +27,15 @@ func TestGit(t *testing.T) {
 			git(url: "github.com/dagger/dagger") {
 				branch(name: "main") {
 					tree {
-						file(path: "README.md", lines: 1)
+						file(path: "README.md") {
+							contents
+						}
 					}
 				}
 			}
 		}`, &res, nil)
 	require.NoError(t, err)
-	require.Contains(t, res.Git.Branch.Tree.File, "Dagger")
+	require.Contains(t, res.Git.Branch.Tree.File.Contents, "Dagger")
 }
 
 // Test backwards compatibility with old git API

--- a/core/integration/old_core.schema_test.go
+++ b/core/integration/old_core.schema_test.go
@@ -11,12 +11,6 @@ import (
 	"go.dagger.io/dagger/internal/testutil"
 )
 
-func init() {
-	if err := testutil.SetupBuildkitd(); err != nil {
-		panic(err)
-	}
-}
-
 func TestCoreImage(t *testing.T) {
 	t.Parallel()
 

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -1,0 +1,9 @@
+package core
+
+import "go.dagger.io/dagger/internal/testutil"
+
+func init() {
+	if err := testutil.SetupBuildkitd(); err != nil {
+		panic(err)
+	}
+}

--- a/core/schema/directory.graphqls
+++ b/core/schema/directory.graphqls
@@ -8,11 +8,15 @@ scalar DirectoryID
 
 "A directory"
 type Directory {
-    "Return a list of files and directories at the given path"
-    contents(path: String=null): [String!]!
+    "The content-addressed identifier of the directory"
+    id: DirectoryID!
 
-    "Retrieve a file at the given path"
-    file(path: String!): File!
+    "Return a list of files and directories at the given path"
+    contents(path: String): [String!]!
+
+    # TODO(vito): add when File is implemented
+    # "Retrieve a file at the given path"
+    # file(path: String!): File!
 
     "A secret backed by the file at the given path"
     secret(path: String!): SecretID!
@@ -20,8 +24,9 @@ type Directory {
     "This directory plus a new file written at the given path"
     withNewFile(path: String!, contents: String): Directory!
 
-    "This directory plus the contents of the given file copied to the given path"
-    withCopiedFile(path: String!, source: FileID!): Directory!
+    # TODO(vito): add when File is implemented
+    # "This directory plus the contents of the given file copied to the given path"
+    # withCopiedFile(path: String!, source: FileID!): Directory!
 
     "This directory with the file at the given path removed"
     withoutFile(path: String!): Directory!

--- a/core/schema/directory.graphqls
+++ b/core/schema/directory.graphqls
@@ -14,9 +14,8 @@ type Directory {
     "Return a list of files and directories at the given path"
     contents(path: String): [String!]!
 
-    # TODO(vito): add when File is implemented
-    # "Retrieve a file at the given path"
-    # file(path: String!): File!
+    "Retrieve a file at the given path"
+    file(path: String!): File!
 
     "A secret backed by the file at the given path"
     secret(path: String!): SecretID!
@@ -24,9 +23,8 @@ type Directory {
     "This directory plus a new file written at the given path"
     withNewFile(path: String!, contents: String): Directory!
 
-    # TODO(vito): add when File is implemented
-    # "This directory plus the contents of the given file copied to the given path"
-    # withCopiedFile(path: String!, source: FileID!): Directory!
+    "This directory plus the contents of the given file copied to the given path"
+    withCopiedFile(path: String!, source: FileID!): Directory!
 
     "This directory with the file at the given path removed"
     withoutFile(path: String!): Directory!

--- a/core/schema/file.graphqls
+++ b/core/schema/file.graphqls
@@ -13,8 +13,9 @@ type File {
     "The contents of the file"
     contents: String!
 
-    "A secret referencing the contents of this file"
-    secret: Secret!
+    # TODO(vito): uncomment when secrets are a thing
+    # "A secret referencing the contents of this file"
+    # secret: Secret!
 
     "The size of the file, in bytes"
     size: Int!

--- a/core/schema/fs.go
+++ b/core/schema/fs.go
@@ -7,3 +7,6 @@ var Git string
 
 //go:embed directory.graphqls
 var Directory string
+
+//go:embed file.graphqls
+var File string

--- a/core/schema/fs.go
+++ b/core/schema/fs.go
@@ -4,3 +4,6 @@ import _ "embed"
 
 //go:embed git.graphqls
 var Git string
+
+//go:embed directory.graphqls
+var Directory string

--- a/core/schema/git.graphqls
+++ b/core/schema/git.graphqls
@@ -20,7 +20,7 @@ type GitRef {
     "The digest of the current value of this ref"
     digest: String!
     "The filesystem tree at this ref"
-    tree: Filesystem! # TODO(vito): replace with Directory!
+    tree: Directory!
 }
 
 # Compat with old API

--- a/core/secret.schema.go
+++ b/core/secret.schema.go
@@ -3,36 +3,12 @@ package core
 import (
 	"fmt"
 
-	"github.com/graphql-go/graphql/language/ast"
 	"go.dagger.io/dagger/router"
 )
 
-var secretIDResolver = router.ScalarResolver{
-	Serialize: func(value interface{}) interface{} {
-		switch v := value.(type) {
-		case string:
-			return v
-		default:
-			panic(fmt.Sprintf("unexpected secret type %T", v))
-		}
-	},
-	ParseValue: func(value interface{}) interface{} {
-		switch v := value.(type) {
-		case string:
-			return v
-		default:
-			panic(fmt.Sprintf("unexpected secret value type %T: %+v", v, v))
-		}
-	},
-	ParseLiteral: func(valueAST ast.Value) interface{} {
-		switch valueAST := valueAST.(type) {
-		case *ast.StringValue:
-			return valueAST.Value
-		default:
-			panic(fmt.Sprintf("unexpected secret literal type: %T", valueAST))
-		}
-	},
-}
+type SecretID string
+
+var secretIDResolver = stringResolver(SecretID(""))
 
 var _ router.ExecutableSchema = &secretSchema{}
 

--- a/router/schema.go
+++ b/router/schema.go
@@ -113,3 +113,9 @@ func PassthroughResolver(p graphql.ResolveParams) (any, error) {
 		return struct{}{}, nil
 	})(p)
 }
+
+func ErrResolver(err error) graphql.FieldResolveFn {
+	return ToResolver(func(ctx *Context, parent any, args any) (any, error) {
+		return nil, err
+	})
+}


### PR DESCRIPTION
Implements the following portions of the API:

```graphql
directory(id: DirectoryID)

type Directory {
  id: DirectoryID!
  contents(path: String!): String!
  file(path: String!): File!
  withNewFile(path: String!, contents: String): Directory!
  withCopiedFile(path: String!, source: FileID!): Directory!
  directory(path: String!): Directory!
  withDirectory(path: String!, directory: DirectoryID!): Directory!
}

type File {
  id: FileID!
  contents: String!
  size: Int!
}
```

The rest of the spec is stubbed out to return errors. Also changes `git { tree }` to return a `Directory!` instead of a `Filesystem!`.

Also introduces some utilities for encoding/decoding IDs and defining ID scalar types in the schema. I went a little ham with generics here, probably didn't need to, but they're shiny.