### PR TITLE
Add `Container { withMountedDirectory }`

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -74,12 +74,7 @@ func (payload *containerIDPayload) FSState() (llb.State, error) {
 		return llb.Scratch(), nil
 	}
 
-	fsOp, err := llb.NewDefinitionOp(payload.FS)
-	if err != nil {
-		return llb.State{}, err
-	}
-
-	return llb.NewState(fsOp), nil
+	return defToState(payload.FS)
 }
 
 // metaMount is the special path that the shim writes metadata to.
@@ -92,12 +87,10 @@ func (payload *containerIDPayload) MetaState() (*llb.State, error) {
 		return nil, nil
 	}
 
-	metaOp, err := llb.NewDefinitionOp(payload.Meta)
+	metaSt, err := defToState(payload.Meta)
 	if err != nil {
 		return nil, err
 	}
-
-	metaSt := llb.NewState(metaOp)
 
 	return &metaSt, nil
 }
@@ -116,12 +109,7 @@ type ContainerMount struct {
 
 // SourceState returns the state of the source of the mount.
 func (mnt ContainerMount) SourceState() (llb.State, error) {
-	defop, err := llb.NewDefinitionOp(mnt.Source)
-	if err != nil {
-		return llb.State{}, err
-	}
-
-	return llb.NewState(defop), nil
+	return defToState(mnt.Source)
 }
 
 func (container *Container) FS(ctx context.Context) (*Directory, error) {

--- a/core/file.go
+++ b/core/file.go
@@ -92,12 +92,12 @@ func (file *File) Decode() (llb.State, string, error) {
 		return llb.State{}, "", err
 	}
 
-	defop, err := llb.NewDefinitionOp(payload.LLB)
+	st, err := defToState(payload.LLB)
 	if err != nil {
 		return llb.State{}, "", err
 	}
 
-	return llb.NewState(defop), payload.File, nil
+	return st, payload.File, nil
 }
 
 func (file *File) ref(ctx context.Context, gw bkgw.Client, st llb.State) (bkgw.Reference, error) {

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -486,6 +486,74 @@ func TestContainerWithMountedDirectory(t *testing.T) {
 	require.Equal(t, "sub-content", execRes.Container.From.WithMountedDirectory.Exec.Exec.Stdout.Contents)
 }
 
+func TestContainerWithMountedDirectorySourcePath(t *testing.T) {
+	t.Parallel()
+
+	dirRes := struct {
+		Directory struct {
+			WithNewFile struct {
+				WithNewFile struct {
+					Directory struct {
+						ID string
+					}
+				}
+			}
+		}
+	}{}
+
+	err := testutil.Query(
+		`{
+			directory {
+				withNewFile(path: "some-file", contents: "some-content") {
+					withNewFile(path: "some-dir/sub-file", contents: "sub-content") {
+						directory(path: "some-dir") {
+							id
+						}
+					}
+				}
+			}
+		}`, &dirRes, nil)
+	require.NoError(t, err)
+
+	id := dirRes.Directory.WithNewFile.WithNewFile.Directory.ID
+
+	execRes := struct {
+		Container struct {
+			From struct {
+				WithMountedDirectory struct {
+					Exec struct {
+						Exec struct {
+							Stdout struct {
+								Contents string
+							}
+						}
+					}
+				}
+			}
+		}
+	}{}
+	err = testutil.Query(
+		`query Test($id: DirectoryID!) {
+			container {
+				from(address: "alpine:3.16.2") {
+					withMountedDirectory(path: "/mnt", source: $id) {
+						exec(args: ["sh", "-c", "echo >> /mnt/sub-file; echo -n more-content >> /mnt/sub-file"]) {
+							exec(args: ["cat", "/mnt/sub-file"]) {
+								stdout {
+									contents
+								}
+							}
+						}
+					}
+				}
+			}
+		}`, &execRes, &testutil.QueryOptions{Variables: map[string]any{
+			"id": id,
+		}})
+	require.NoError(t, err)
+	require.Equal(t, "sub-content\nmore-content", execRes.Container.From.WithMountedDirectory.Exec.Exec.Stdout.Contents)
+}
+
 func TestContainerWithMountedDirectoryPropagation(t *testing.T) {
 	t.Parallel()
 

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -688,7 +688,8 @@ func TestContainerMultiFrom(t *testing.T) {
 			"id": id,
 		}})
 	require.NoError(t, err)
-	require.Equal(t, "v18.10.0\ngo version go1.18.2 linux/amd64\n", execRes.Container.From.WithMountedDirectory.Exec.From.Exec.Exec.Stdout.Contents)
+	require.Contains(t, execRes.Container.From.WithMountedDirectory.Exec.From.Exec.Exec.Stdout.Contents, "v18.10.0\n")
+	require.Contains(t, execRes.Container.From.WithMountedDirectory.Exec.From.Exec.Exec.Stdout.Contents, "go version go1.18.2")
 }
 
 func TestContainerImageExport(t *testing.T) {

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -413,100 +413,44 @@ func TestContainerWithWorkdir(t *testing.T) {
 	require.Equal(t, res.Container.From.WithWorkdir.Exec.Stdout.Contents, "/usr\n")
 }
 
-func TestCopiedFile(t *testing.T) {
-	t.Skip("not implemented yet")
-
+func TestContainerWithMountedDirectory(t *testing.T) {
 	t.Parallel()
 
-	alpine := struct {
-		Container struct {
-			From struct {
-				Rootfs struct {
-					File struct {
-						ID string
-					}
-				}
-			}
-		}
-	}{}
-
-	err := testutil.Query(
-		`{
-			container {
-				from(address: "alpine:3.16.2") {
-					rootfs {
-						file(path: "/etc/alpine-release") {
-							id
-						}
-					}
-				}
-			}
-		}`, &alpine, nil)
-	require.NoError(t, err)
-	require.NotEmpty(t, alpine.Container.From.Rootfs.File.ID)
-
-	res := struct {
+	dirRes := struct {
 		Directory struct {
-			WithCopiedFile struct {
-				File struct {
-					Contents string
-				}
-			}
-		}
-	}{}
-
-	testutil.Query(
-		`query ($from: FileID!) {
-			directory {
-				withCopiedFile(path: "/test", source: $from) {
-					file(path: "/test") {
-						contents
-					}
-				}
-			}
-		}`, &res, &testutil.QueryOptions{
-			Variables: map[string]any{
-				"from": alpine.Container.From.Rootfs.File.ID,
-			},
-		})
-	require.NoError(t, err)
-	require.Equal(t, "3.16.2\n", res.Directory.WithCopiedFile.File.Contents)
-}
-
-func TestContainerMountExec(t *testing.T) {
-	t.Skip("not implemented yet")
-
-	t.Parallel()
-
-	ctrRes := struct {
-		Container struct {
-			From struct {
-				Rootfs struct {
+			WithNewFile struct {
+				WithNewFile struct {
 					ID string
 				}
 			}
 		}
 	}{}
+
 	err := testutil.Query(
 		`{
-			container {
-				from(address: "alpine:3.16.2") {
-					rootfs {
+			directory {
+				withNewFile(path: "some-file", contents: "some-content") {
+					withNewFile(path: "some-dir/sub-file", contents: "sub-content") {
 						id
 					}
 				}
 			}
-		}`, &ctrRes, nil)
+		}`, &dirRes, nil)
 	require.NoError(t, err)
-	id := ctrRes.Container.From.Rootfs.ID
+
+	id := dirRes.Directory.WithNewFile.WithNewFile.ID
 
 	execRes := struct {
 		Container struct {
 			From struct {
 				WithMountedDirectory struct {
 					Exec struct {
-						Directory struct {
-							File struct {
+						Stdout struct {
+							Contents string
+						}
+
+						Exec struct {
+							Stdout struct {
 								Contents string
 							}
 						}
@@ -516,13 +460,17 @@ func TestContainerMountExec(t *testing.T) {
 		}
 	}{}
 	err = testutil.Query(
-		`query TestExec($id: DirectoryID!) {
+		`query Test($id: DirectoryID!) {
 			container {
 				from(address: "alpine:3.16.2") {
 					withMountedDirectory(path: "/mnt", source: $id) {
-						exec(args: ["sh", "-c", "echo hi > /mnt/hello"]) {
-							directory(path: "/mnt") {
-								file(path: "/hello") {
+						exec(args: ["cat", "/mnt/some-file"]) {
+							stdout {
+								contents
+							}
+
+							exec(args: ["cat", "/mnt/some-dir/sub-file"]) {
+								stdout {
 									contents
 								}
 							}
@@ -534,7 +482,80 @@ func TestContainerMountExec(t *testing.T) {
 			"id": id,
 		}})
 	require.NoError(t, err)
-	require.Equal(t, "hi\n", execRes.Container.From.WithMountedDirectory.Exec.Directory.File.Contents)
+	require.Equal(t, "some-content", execRes.Container.From.WithMountedDirectory.Exec.Stdout.Contents)
+	require.Equal(t, "sub-content", execRes.Container.From.WithMountedDirectory.Exec.Exec.Stdout.Contents)
+}
+
+func TestContainerWithMountedDirectoryPropagation(t *testing.T) {
+	t.Parallel()
+
+	dirRes := struct {
+		Directory struct {
+			WithNewFile struct {
+				WithNewFile struct {
+					ID string
+				}
+			}
+		}
+	}{}
+
+	err := testutil.Query(
+		`{
+			directory {
+				withNewFile(path: "some-file", contents: "some-content") {
+					withNewFile(path: "some-dir/sub-file", contents: "sub-content") {
+						id
+					}
+				}
+			}
+		}`, &dirRes, nil)
+	require.NoError(t, err)
+
+	id := dirRes.Directory.WithNewFile.WithNewFile.ID
+
+	execRes := struct {
+		Container struct {
+			From struct {
+				WithMountedDirectory struct {
+					Exec struct {
+						Exec struct {
+							Exec struct {
+								Exec struct {
+									Stdout struct {
+										Contents string
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}{}
+	err = testutil.Query(
+		`query Test($id: DirectoryID!) {
+			container {
+				from(address: "alpine:3.16.2") {
+					withMountedDirectory(path: "/mnt", source: $id) {
+						exec(args: ["sh", "-c", "test $(cat /mnt/some-file) = some-content"]) {
+							exec(args: ["sh", "-c", "test $(cat /mnt/some-dir/sub-file) = sub-content"]) {
+								exec(args: ["sh", "-c", "echo -n hi > /mnt/hello"]) {
+									exec(args: ["cat", "/mnt/hello"]) {
+										stdout {
+											contents
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}`, &execRes, &testutil.QueryOptions{Variables: map[string]any{
+			"id": id,
+		}})
+	require.NoError(t, err)
+	require.Equal(t, "hi", execRes.Container.From.WithMountedDirectory.Exec.Exec.Exec.Exec.Stdout.Contents)
 }
 
 func TestContainerImageExport(t *testing.T) {

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Khan/genqlient/graphql"
 	"github.com/moby/buildkit/identity"
 	"github.com/stretchr/testify/require"
+	"go.dagger.io/dagger/core"
 	"go.dagger.io/dagger/engine"
 	"go.dagger.io/dagger/internal/testutil"
 )
@@ -631,27 +632,19 @@ func TestContainerMultiFrom(t *testing.T) {
 
 	dirRes := struct {
 		Directory struct {
-			WithNewFile struct {
-				WithNewFile struct {
-					ID string
-				}
-			}
+			ID core.DirectoryID
 		}
 	}{}
 
 	err := testutil.Query(
 		`{
 			directory {
-				withNewFile(path: "some-file", contents: "some-content") {
-					withNewFile(path: "some-dir/sub-file", contents: "sub-content") {
-						id
-					}
-				}
+				id
 			}
 		}`, &dirRes, nil)
 	require.NoError(t, err)
 
-	id := dirRes.Directory.WithNewFile.WithNewFile.ID
+	id := dirRes.Directory.ID
 
 	execRes := struct {
 		Container struct {

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -159,6 +159,38 @@ func TestContainerExecStdoutStderr(t *testing.T) {
 	require.Equal(t, res.Container.From.Exec.Stderr.Contents, "goodbye\n")
 }
 
+func TestContainerNullStdoutStderr(t *testing.T) {
+	t.Parallel()
+
+	res := struct {
+		Container struct {
+			From struct {
+				Stdout, Stderr *struct {
+					Contents string
+				}
+			}
+		}
+	}{}
+
+	err := testutil.Query(
+		`{
+			container {
+				from(address: "alpine:3.16.2") {
+					stdout {
+						contents
+					}
+
+					stderr {
+						contents
+					}
+				}
+			}
+		}`, &res, nil)
+	require.NoError(t, err)
+	require.Nil(t, res.Container.From.Stdout)
+	require.Nil(t, res.Container.From.Stderr)
+}
+
 func TestContainerExecWithWorkdir(t *testing.T) {
 	t.Parallel()
 

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -105,13 +105,15 @@ type Container {
 
     """
     The output stream of the last executed command.
+    Null if no command has been executed.
     """
-    stdout: File!
+    stdout: File
 
     """
     The error stream of the last executed command.
+    Null if no command has been executed.
     """
-    stderr: File!
+    stderr: File
 
     # FIXME: this is the last case of an actual "verb" that cannot cleanly go away.
     #    This may actually be a good candidate for a mutation. To be discussed.


### PR DESCRIPTION
part of #3183

* Track the exec metadata mount point (`/dagger`) in a separate field within `ContainerID` since its lifecycle differs from regular mounts
* Add `Container { withMountedDirectory }` and propagate changes to mounts from parent `Container` to child
* Respect sub-directory configuration within source `DirectoryID`
* Make `Container { stdout, stderr }` nullable (same reason `exitCode` is nullable)
* Allow `container { from }` to propagate mounts