### PR TITLE
doc(router): add description to ToResolver

### DIFF
--- a/router/schema.go
+++ b/router/schema.go
@@ -74,6 +74,8 @@ type Context struct {
 	ResolveParams graphql.ResolveParams
 }
 
+// ToResolver transforms any function f with a *Context, a parent P and some args A that returns a Response R and an error
+// into a graphql resolver graphql.FieldResolveFn.
 func ToResolver[P any, A any, R any](f func(*Context, P, A) (R, error)) graphql.FieldResolveFn {
 	return func(p graphql.ResolveParams) (any, error) {
 		ctx := Context{


### PR DESCRIPTION
Without some description, it requires some back and forth to get the
role of P, A and R types.
