### PR TITLE
.gitignore: fix cloak path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,4 @@ venv
 __pycache__
 
 # Built Binary
-cloak
+/cloak


### PR DESCRIPTION
It was ignoring the whole cmd/cloak directory
