### PR TITLE
stdio dialer support

### DIFF
--- a/cmd/dagger/dial_stdio.go
+++ b/cmd/dagger/dial_stdio.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/dagger/dagger/engine"
+	"github.com/dagger/dagger/router"
+	"github.com/spf13/cobra"
+)
+
+var dialStdioCmd = &cobra.Command{
+	Use:    "dial-stdio",
+	Run:    DialStdio,
+	Hidden: true,
+}
+
+func DialStdio(cmd *cobra.Command, args []string) {
+	localDirs := getKVInput(localDirsInput)
+	startOpts := &engine.Config{
+		LocalDirs:  localDirs,
+		Workdir:    workdir,
+		ConfigPath: configPath,
+	}
+
+	err := engine.Start(context.Background(), startOpts, func(ctx context.Context, r *router.Router) error {
+		srv := http.Server{
+			Handler:           r,
+			ReadHeaderTimeout: 30 * time.Second,
+		}
+
+		closeCh := make(chan struct{})
+
+		l := &stdioConnListener{
+			closeCh: closeCh,
+		}
+
+		go func() {
+			err := srv.Serve(l)
+			if err != nil && err != http.ErrServerClosed {
+				fmt.Fprintf(os.Stderr, "http serve: error: %v\n", err)
+			}
+		}()
+
+		<-closeCh
+
+		return srv.Shutdown(ctx)
+	})
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+var _ net.Listener = &stdioConnListener{}
+
+type stdioConnListener struct {
+	once    sync.Once
+	closeCh chan struct{}
+}
+
+func (l *stdioConnListener) Accept() (net.Conn, error) {
+	var conn net.Conn
+	l.once.Do(func() {
+		conn = &stdioConn{
+			closeCh: l.closeCh,
+		}
+	})
+	// Return stdio connection ONLY on the first `Accept()`
+	// since we can't multiplex on stdio.
+	if conn != nil {
+		return conn, nil
+	}
+
+	// For the other `Accept()`, block until the server is closed
+	<-l.closeCh
+	return nil, net.ErrClosed
+}
+
+func (l *stdioConnListener) Addr() net.Addr {
+	return nil
+}
+
+func (l *stdioConnListener) Close() error {
+	return nil
+}
+
+var _ net.Conn = &stdioConn{}
+
+type stdioConn struct {
+	closeCh chan struct{}
+}
+
+func (c *stdioConn) Read(b []byte) (n int, err error) {
+	return os.Stdin.Read(b)
+}
+
+func (c *stdioConn) Write(b []byte) (n int, err error) {
+	return os.Stdout.Write(b)
+}
+
+func (c *stdioConn) Close() error {
+	close(c.closeCh)
+	return nil
+}
+
+func (c *stdioConn) LocalAddr() net.Addr {
+	return &net.IPAddr{}
+}
+
+func (c *stdioConn) RemoteAddr() net.Addr {
+	return &net.IPAddr{}
+}
+
+func (c *stdioConn) SetDeadline(t time.Time) error {
+	return nil
+}
+
+func (c *stdioConn) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (c *stdioConn) SetWriteDeadline(t time.Time) error {
+	return nil
+}

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -26,6 +26,7 @@ func init() {
 	rootCmd.AddCommand(
 		doCmd,
 		devCmd,
+		dialStdioCmd,
 		versionCmd,
 		clientGenCmd,
 		projectCmd,
@@ -37,6 +38,8 @@ func init() {
 
 	devCmd.Flags().IntVar(&devServerPort, "port", 8080, "dev server port")
 	devCmd.Flags().StringSliceVarP(&localDirsInput, "local-dir", "l", []string{}, "local directory to import")
+
+	dialStdioCmd.Flags().StringSliceVarP(&localDirsInput, "local-dir", "l", []string{}, "local directory to import")
 
 	projectCmd.AddCommand(
 		initCmd,

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"dagger.io/dagger/internal/engineconn"
+	_ "dagger.io/dagger/internal/engineconn/bin"      // binary connection
 	_ "dagger.io/dagger/internal/engineconn/embedded" // embedded connection
 	_ "dagger.io/dagger/internal/engineconn/unix"     // unix connection
 	"dagger.io/dagger/internal/querybuilder"

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -80,7 +80,9 @@ func Connect(ctx context.Context, opts ...ClientOpt) (_ *Client, rerr error) {
 		}
 	}()
 
-	cfg := &engineconn.Config{}
+	cfg := &engineconn.Config{
+		LogOutput: io.Discard,
+	}
 
 	for _, o := range opts {
 		o.setClientOpt(cfg)

--- a/sdk/go/internal/engineconn/bin/bin.go
+++ b/sdk/go/internal/engineconn/bin/bin.go
@@ -43,7 +43,7 @@ func (c *Bin) Connect(ctx context.Context, cfg *engineconn.Config) (*http.Client
 	return &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-				return commandconn.New(ctx, c.path, args...)
+				return commandconn.New(ctx, cfg.LogOutput, c.path, args...)
 			},
 		},
 	}, nil

--- a/sdk/go/internal/engineconn/bin/bin.go
+++ b/sdk/go/internal/engineconn/bin/bin.go
@@ -1,0 +1,54 @@
+package embedded
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+
+	"dagger.io/dagger/internal/engineconn"
+	"github.com/docker/cli/cli/connhelper/commandconn"
+)
+
+func init() {
+	engineconn.Register("bin", New)
+}
+
+var _ engineconn.EngineConn = &Bin{}
+
+type Bin struct {
+	path string
+}
+
+func New(u *url.URL) (engineconn.EngineConn, error) {
+	return &Bin{
+		path: u.Host + u.Path,
+	}, nil
+}
+
+func (c *Bin) Connect(ctx context.Context, cfg *engineconn.Config) (*http.Client, error) {
+	args := []string{
+		"dial-stdio",
+	}
+	if cfg.Workdir != "" {
+		args = append(args, "--workdir", cfg.Workdir)
+	}
+	if cfg.ConfigPath != "" {
+		args = append(args, "--project", cfg.ConfigPath)
+	}
+	for id, path := range cfg.LocalDirs {
+		args = append(args, "--local-dir", fmt.Sprintf("%s=%s", id, path))
+	}
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return commandconn.New(ctx, c.path, args...)
+			},
+		},
+	}, nil
+}
+
+func (c *Bin) Close() error {
+	return nil
+}

--- a/sdk/go/internal/engineconn/bin/bin.go
+++ b/sdk/go/internal/engineconn/bin/bin.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 
 	"dagger.io/dagger/internal/engineconn"
-	"github.com/docker/cli/cli/connhelper/commandconn"
+	"dagger.io/dagger/internal/engineconn/bin/commandconn"
 )
 
 func init() {

--- a/sdk/go/internal/engineconn/bin/commandconn/commandconn.go
+++ b/sdk/go/internal/engineconn/bin/commandconn/commandconn.go
@@ -1,0 +1,287 @@
+// Package commandconn provides a net.Conn implementation that can be used for
+// proxying (or emulating) stream via a custom command.
+//
+// For example, to provide an http.Client that can connect to a Docker daemon
+// running in a Docker container ("DIND"):
+//
+//	httpClient := &http.Client{
+//		Transport: &http.Transport{
+//			DialContext: func(ctx context.Context, _network, _addr string) (net.Conn, error) {
+//				return commandconn.New(ctx, "docker", "exec", "-it", containerID, "docker", "system", "dial-stdio")
+//			},
+//		},
+//	}
+package commandconn
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	exec "golang.org/x/sys/execabs"
+)
+
+// New returns net.Conn
+func New(ctx context.Context, cmd string, args ...string) (net.Conn, error) {
+	var (
+		c   commandConn
+		err error
+	)
+	c.cmd = exec.CommandContext(ctx, cmd, args...)
+	// we assume that args never contains sensitive information
+	logrus.Debugf("commandconn: starting %s with %v", cmd, args)
+	c.cmd.Env = os.Environ()
+	c.cmd.SysProcAttr = &syscall.SysProcAttr{}
+	setPdeathsig(c.cmd)
+	createSession(c.cmd)
+	c.stdin, err = c.cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	c.stdout, err = c.cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	c.cmd.Stderr = &stderrWriter{
+		stderrMu:    &c.stderrMu,
+		stderr:      &c.stderr,
+		debugPrefix: fmt.Sprintf("commandconn (%s):", cmd),
+	}
+	c.localAddr = dummyAddr{network: "dummy", s: "dummy-0"}
+	c.remoteAddr = dummyAddr{network: "dummy", s: "dummy-1"}
+	return &c, c.cmd.Start()
+}
+
+// commandConn implements net.Conn
+type commandConn struct {
+	cmd           *exec.Cmd
+	cmdExited     bool
+	cmdWaitErr    error
+	cmdMutex      sync.Mutex
+	stdin         io.WriteCloser
+	stdout        io.ReadCloser
+	stderrMu      sync.Mutex
+	stderr        bytes.Buffer
+	stdioClosedMu sync.Mutex // for stdinClosed and stdoutClosed
+	stdinClosed   bool
+	stdoutClosed  bool
+	localAddr     net.Addr
+	remoteAddr    net.Addr
+}
+
+// killIfStdioClosed kills the cmd if both stdin and stdout are closed.
+func (c *commandConn) killIfStdioClosed() error {
+	c.stdioClosedMu.Lock()
+	stdioClosed := c.stdoutClosed && c.stdinClosed
+	c.stdioClosedMu.Unlock()
+	if !stdioClosed {
+		return nil
+	}
+	return c.kill()
+}
+
+// killAndWait tries sending SIGTERM to the process before sending SIGKILL.
+func killAndWait(cmd *exec.Cmd) error {
+	var werr error
+	if runtime.GOOS != "windows" {
+		werrCh := make(chan error)
+		go func() { werrCh <- cmd.Wait() }()
+		cmd.Process.Signal(syscall.SIGTERM)
+		select {
+		case werr = <-werrCh:
+		case <-time.After(3 * time.Second):
+			cmd.Process.Kill()
+			werr = <-werrCh
+		}
+	} else {
+		cmd.Process.Kill()
+		werr = cmd.Wait()
+	}
+	return werr
+}
+
+// kill returns nil if the command terminated, regardless to the exit status.
+func (c *commandConn) kill() error {
+	var werr error
+	c.cmdMutex.Lock()
+	if c.cmdExited {
+		werr = c.cmdWaitErr
+	} else {
+		werr = killAndWait(c.cmd)
+		c.cmdWaitErr = werr
+		c.cmdExited = true
+	}
+	c.cmdMutex.Unlock()
+	if werr == nil {
+		return nil
+	}
+	wExitErr, ok := werr.(*exec.ExitError)
+	if ok {
+		if wExitErr.ProcessState.Exited() {
+			return nil
+		}
+	}
+	return errors.Wrapf(werr, "commandconn: failed to wait")
+}
+
+func (c *commandConn) onEOF(eof error) error {
+	// when we got EOF, the command is going to be terminated
+	var werr error
+	c.cmdMutex.Lock()
+	if c.cmdExited {
+		werr = c.cmdWaitErr
+	} else {
+		werrCh := make(chan error)
+		go func() { werrCh <- c.cmd.Wait() }()
+		select {
+		case werr = <-werrCh:
+			c.cmdWaitErr = werr
+			c.cmdExited = true
+		case <-time.After(10 * time.Second):
+			c.cmdMutex.Unlock()
+			c.stderrMu.Lock()
+			stderr := c.stderr.String()
+			c.stderrMu.Unlock()
+			return errors.Errorf("command %v did not exit after %v: stderr=%q", c.cmd.Args, eof, stderr)
+		}
+	}
+	c.cmdMutex.Unlock()
+	if werr == nil {
+		return eof
+	}
+	c.stderrMu.Lock()
+	stderr := c.stderr.String()
+	c.stderrMu.Unlock()
+	return errors.Errorf("command %v has exited with %v, please make sure the URL is valid, and Docker 18.09 or later is installed on the remote host: stderr=%s", c.cmd.Args, werr, stderr)
+}
+
+func ignorableCloseError(err error) bool {
+	errS := err.Error()
+	ss := []string{
+		os.ErrClosed.Error(),
+	}
+	for _, s := range ss {
+		if strings.Contains(errS, s) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *commandConn) CloseRead() error {
+	// NOTE: maybe already closed here
+	if err := c.stdout.Close(); err != nil && !ignorableCloseError(err) {
+		logrus.Warnf("commandConn.CloseRead: %v", err)
+	}
+	c.stdioClosedMu.Lock()
+	c.stdoutClosed = true
+	c.stdioClosedMu.Unlock()
+	if err := c.killIfStdioClosed(); err != nil {
+		logrus.Warnf("commandConn.CloseRead: %v", err)
+	}
+	return nil
+}
+
+func (c *commandConn) Read(p []byte) (int, error) {
+	n, err := c.stdout.Read(p)
+	if err == io.EOF {
+		err = c.onEOF(err)
+	}
+	return n, err
+}
+
+func (c *commandConn) CloseWrite() error {
+	// NOTE: maybe already closed here
+	if err := c.stdin.Close(); err != nil && !ignorableCloseError(err) {
+		logrus.Warnf("commandConn.CloseWrite: %v", err)
+	}
+	c.stdioClosedMu.Lock()
+	c.stdinClosed = true
+	c.stdioClosedMu.Unlock()
+	if err := c.killIfStdioClosed(); err != nil {
+		logrus.Warnf("commandConn.CloseWrite: %v", err)
+	}
+	return nil
+}
+
+func (c *commandConn) Write(p []byte) (int, error) {
+	n, err := c.stdin.Write(p)
+	if err == io.EOF {
+		err = c.onEOF(err)
+	}
+	return n, err
+}
+
+func (c *commandConn) Close() error {
+	var err error
+	if err = c.CloseRead(); err != nil {
+		logrus.Warnf("commandConn.Close: CloseRead: %v", err)
+	}
+	if err = c.CloseWrite(); err != nil {
+		logrus.Warnf("commandConn.Close: CloseWrite: %v", err)
+	}
+	return err
+}
+
+func (c *commandConn) LocalAddr() net.Addr {
+	return c.localAddr
+}
+
+func (c *commandConn) RemoteAddr() net.Addr {
+	return c.remoteAddr
+}
+
+func (c *commandConn) SetDeadline(t time.Time) error {
+	logrus.Debugf("unimplemented call: SetDeadline(%v)", t)
+	return nil
+}
+
+func (c *commandConn) SetReadDeadline(t time.Time) error {
+	logrus.Debugf("unimplemented call: SetReadDeadline(%v)", t)
+	return nil
+}
+
+func (c *commandConn) SetWriteDeadline(t time.Time) error {
+	logrus.Debugf("unimplemented call: SetWriteDeadline(%v)", t)
+	return nil
+}
+
+type dummyAddr struct {
+	network string
+	s       string
+}
+
+func (d dummyAddr) Network() string {
+	return d.network
+}
+
+func (d dummyAddr) String() string {
+	return d.s
+}
+
+type stderrWriter struct {
+	stderrMu    *sync.Mutex
+	stderr      *bytes.Buffer
+	debugPrefix string
+}
+
+func (w *stderrWriter) Write(p []byte) (int, error) {
+	logrus.Debugf("%s%s", w.debugPrefix, string(p))
+	w.stderrMu.Lock()
+	if w.stderr.Len() > 4096 {
+		w.stderr.Reset()
+	}
+	n, err := w.stderr.Write(p)
+	w.stderrMu.Unlock()
+	return n, err
+}

--- a/sdk/go/internal/engineconn/bin/commandconn/commandconn_unix_test.go
+++ b/sdk/go/internal/engineconn/bin/commandconn/commandconn_unix_test.go
@@ -1,0 +1,45 @@
+//go:build !windows
+// +build !windows
+
+package commandconn
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+// For https://github.com/docker/cli/pull/1014#issuecomment-409308139
+func TestEOFWithError(t *testing.T) {
+	ctx := context.TODO()
+	cmd := "sh"
+	args := []string{"-c", "echo hello; echo some error >&2; exit 42"}
+	c, err := New(ctx, cmd, args...)
+	assert.NilError(t, err)
+	b := make([]byte, 32)
+	n, err := c.Read(b)
+	assert.Check(t, is.Equal(len("hello\n"), n))
+	assert.NilError(t, err)
+	n, err = c.Read(b)
+	assert.Check(t, is.Equal(0, n))
+	assert.ErrorContains(t, err, "some error")
+	assert.ErrorContains(t, err, "42")
+}
+
+func TestEOFWithoutError(t *testing.T) {
+	ctx := context.TODO()
+	cmd := "sh"
+	args := []string{"-c", "echo hello; echo some debug log >&2; exit 0"}
+	c, err := New(ctx, cmd, args...)
+	assert.NilError(t, err)
+	b := make([]byte, 32)
+	n, err := c.Read(b)
+	assert.Check(t, is.Equal(len("hello\n"), n))
+	assert.NilError(t, err)
+	n, err = c.Read(b)
+	assert.Check(t, is.Equal(0, n))
+	assert.Check(t, is.Equal(io.EOF, err))
+}

--- a/sdk/go/internal/engineconn/bin/commandconn/pdeathsig_linux.go
+++ b/sdk/go/internal/engineconn/bin/commandconn/pdeathsig_linux.go
@@ -1,0 +1,10 @@
+package commandconn
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func setPdeathsig(cmd *exec.Cmd) {
+	cmd.SysProcAttr.Pdeathsig = syscall.SIGKILL
+}

--- a/sdk/go/internal/engineconn/bin/commandconn/pdeathsig_nolinux.go
+++ b/sdk/go/internal/engineconn/bin/commandconn/pdeathsig_nolinux.go
@@ -1,0 +1,11 @@
+//go:build !linux
+// +build !linux
+
+package commandconn
+
+import (
+	"os/exec"
+)
+
+func setPdeathsig(cmd *exec.Cmd) {
+}

--- a/sdk/go/internal/engineconn/bin/commandconn/session_unix.go
+++ b/sdk/go/internal/engineconn/bin/commandconn/session_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+// +build !windows
+
+package commandconn
+
+import (
+	"os/exec"
+)
+
+func createSession(cmd *exec.Cmd) {
+	// for supporting ssh connection helper with ProxyCommand
+	// https://github.com/docker/cli/issues/1707
+	cmd.SysProcAttr.Setsid = true
+}

--- a/sdk/go/internal/engineconn/bin/commandconn/session_windows.go
+++ b/sdk/go/internal/engineconn/bin/commandconn/session_windows.go
@@ -1,0 +1,8 @@
+package commandconn
+
+import (
+	"os/exec"
+)
+
+func createSession(cmd *exec.Cmd) {
+}


### PR DESCRIPTION
- engine: stdio dialer support (e.g. `dagger dial-stdio` command)
- Go SDK: dial stdio support

**NOTE**: Go SDK **still** uses the embedded engine. the stdio dialer is for testing purposes, the real user are going to be the TS/Python SDKs.

In action:

```console
$ dagger do -f git.graphql
{
    "core": {
        "git": {
        }
    }
}

$ DAGGER_HOST=bin:///Users/al/.bin/dagger dagger do -f git.graphql
{
    "core": {
        "git": {
        }
    }
}
```

/cc @helderco 