### PR TITLE
example: implements a bash example

### DIFF
--- a/examples/bash/README.md
+++ b/examples/bash/README.md
@@ -1,0 +1,9 @@
+# Yarn build
+
+This is a port of the todoapp demo (build phase only) in bash.
+
+This is to show how to instrument dagger graphql calls from a bash script.
+
+This example does not use extension but any extension can be used like in the playground.
+
+This example assumes you have a valid `package.json` in your working directory.

--- a/examples/bash/yarn-build.sh
+++ b/examples/bash/yarn-build.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+set -eu
+
+
+# Load app source code from working directory
+source=$({ cloak do <<EOF
+{
+    host {
+        workdir {
+            read {
+                id
+            }
+        }
+    }
+}
+EOF
+} | jq -r .host.workdir.read.id)
+
+
+# Install yarn in a container
+image=$({ cloak do <<EOF
+{
+    core {
+        image(ref: "index.docker.io/alpine") {
+            exec(input: { args: ["apk", "add", "yarn", "git", "openssh"] }) {
+                fs {
+                    id
+                }
+            }
+        }
+    }
+}
+EOF
+} | jq -r .core.image.exec.fs.id)
+
+
+# Run `yarn install` in a container
+sourceAfterInstall=$({ cloak do --set image="$image" --set source="$source" <<EOF
+query (\$image: FSID!, \$source: FSID!) {
+    core {
+        filesystem(id: \$image) {
+            exec(
+                input: {
+                    args: ["yarn", "install"]
+                    mounts: [{ fs: \$source, path: "/src" }]
+                    workdir: "/src"
+                    env: [
+                        { name: "YARN_CACHE_FOLDER", value: "/cache" }
+                        {
+                            name: "GIT_SSH_COMMAND"
+                            value: "ssh -o StrictHostKeyChecking=no"
+                        }
+                    ]
+                    cacheMounts: {
+                        name: "yarn"
+                        path: "/cache"
+                        sharingMode: "locked"
+                    }
+                    sshAuthSock: "/ssh-agent"
+                }
+            ) {
+                # Retrieve modified source
+                mount(path: "/src") {
+                    id
+                }
+            }
+        }
+    }
+}
+EOF
+} | jq -r .core.filesystem.exec.mount.id)
+
+
+sourceAfterBuild=$({ cloak do --set image="$image" --set sourceAfterInstall="$sourceAfterInstall" <<EOF
+query (\$image: FSID!, \$sourceAfterInstall: FSID!) {
+    core {
+        filesystem(id: \$image) {
+            exec(
+                input: {
+                    args: ["yarn", "run", "react-scripts", "build"]
+                    mounts: [{ fs: \$sourceAfterInstall, path: "/src" }]
+                    workdir: "/src"
+                    env: [
+                        { name: "YARN_CACHE_FOLDER", value: "/cache" }
+                        {
+                            name: "GIT_SSH_COMMAND"
+                            value: "ssh -o StrictHostKeyChecking=no"
+                        }
+                    ]
+                    cacheMounts: {
+                        name: "yarn"
+                        path: "/cache"
+                        sharingMode: "locked"
+                    }
+                    sshAuthSock: "/ssh-agent"
+                }
+            ) {
+                # Retrieve modified source
+                mount(path: "/src") {
+                    id
+                }
+            }
+        }
+    }
+}
+EOF
+} | jq -r .core.filesystem.exec.mount.id)


### PR DESCRIPTION
This is a port of the todoapp demo (build phase only) in bash. This is to show how to instrument dagger graphql calls from a bash script. This example does not use extension but any extension can be used like in the playground. It example assumes you have a valid `package.json` in your working directory.

It's a poc to bring data to #3213