### PR TITLE
add `Secret` core API

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -15,7 +15,6 @@ var (
 	queryFile      string
 	queryVarsInput []string
 	localDirsInput []string
-	secretsInput   []string
 
 	devServerPort int
 )
@@ -34,11 +33,9 @@ func init() {
 	doCmd.Flags().StringVarP(&queryFile, "file", "f", "", "query file")
 	doCmd.Flags().StringSliceVarP(&queryVarsInput, "set", "s", []string{}, "query variable")
 	doCmd.Flags().StringSliceVarP(&localDirsInput, "local-dir", "l", []string{}, "local directory to import")
-	doCmd.Flags().StringSliceVarP(&secretsInput, "secret", "e", []string{}, "secret to import")
 
 	devCmd.Flags().IntVar(&devServerPort, "port", 8080, "dev server port")
 	devCmd.Flags().StringSliceVarP(&localDirsInput, "local-dir", "l", []string{}, "local directory to import")
-	devCmd.Flags().StringSliceVarP(&secretsInput, "secret", "e", []string{}, "secret to import")
 }
 
 var rootCmd = &cobra.Command{

--- a/core/container.go
+++ b/core/container.go
@@ -531,12 +531,13 @@ func (container *Container) Exec(ctx context.Context, gw bkgw.Client, args *[]st
 		secretOpts := []llb.SecretOption{llb.SecretID(string(secret.Secret))}
 
 		var secretDest string
-		if secret.EnvName != "" {
+		switch {
+		case secret.EnvName != "":
 			secretDest = secret.EnvName
 			secretOpts = append(secretOpts, llb.SecretAsEnv(true))
-		} else if secret.MountPath != "" {
+		case secret.MountPath != "":
 			secretDest = secret.MountPath
-		} else {
+		default:
 			return nil, fmt.Errorf("malformed secret config at index %d", i)
 		}
 

--- a/core/container.go
+++ b/core/container.go
@@ -59,6 +59,17 @@ type containerIDPayload struct {
 
 	// The platform of the container's rootfs.
 	Platform specs.Platform `json:"platform,omitempty"`
+
+	// Secrets to expose to the container.
+	Secrets []ContainerSecret `json:"secret_env,omitempty"`
+}
+
+// ContainerSecret configures a secret to expose, either as an environment
+// variable or mounted to a file path.
+type ContainerSecret struct {
+	Secret    SecretID `json:"secret"`
+	EnvName   string   `json:"env,omitempty"`
+	MountPath string   `json:"path,omitempty"`
 }
 
 // Encode returns the opaque string ID representation of the container.
@@ -241,6 +252,27 @@ func (container *Container) WithMountedTemp(ctx context.Context, target string) 
 	return &Container{ID: id}, nil
 }
 
+func (container *Container) WithMountedSecret(ctx context.Context, target string, source *Secret) (*Container, error) {
+	payload, err := container.ID.decode()
+	if err != nil {
+		return nil, err
+	}
+
+	target = absPath(payload.Config.WorkingDir, target)
+
+	payload.Secrets = append(payload.Secrets, ContainerSecret{
+		Secret:    source.ID,
+		MountPath: target,
+	})
+
+	id, err := payload.Encode()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Container{ID: id}, nil
+}
+
 func (container *Container) WithoutMount(ctx context.Context, target string) (*Container, error) {
 	payload, err := container.ID.decode()
 	if err != nil {
@@ -283,6 +315,25 @@ func (container *Container) Mounts(ctx context.Context) ([]string, error) {
 	}
 
 	return mounts, nil
+}
+
+func (container *Container) WithSecretVariable(ctx context.Context, name string, secret *Secret) (*Container, error) {
+	payload, err := container.ID.decode()
+	if err != nil {
+		return nil, err
+	}
+
+	payload.Secrets = append(payload.Secrets, ContainerSecret{
+		Secret:  secret.ID,
+		EnvName: name,
+	})
+
+	id, err := payload.Encode()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Container{ID: id}, nil
 }
 
 func (container *Container) Directory(ctx context.Context, gw bkgw.Client, dirPath string) (*Directory, error) {
@@ -476,15 +527,31 @@ func (container *Container) Exec(ctx context.Context, gw bkgw.Client, args *[]st
 		runOpts = append(runOpts, llb.AddEnv(name, val))
 	}
 
-	st, err := payload.FSState()
+	for i, secret := range payload.Secrets {
+		secretOpts := []llb.SecretOption{llb.SecretID(string(secret.Secret))}
+
+		var secretDest string
+		if secret.EnvName != "" {
+			secretDest = secret.EnvName
+			secretOpts = append(secretOpts, llb.SecretAsEnv(true))
+		} else if secret.MountPath != "" {
+			secretDest = secret.MountPath
+		} else {
+			return nil, fmt.Errorf("malformed secret config at index %d", i)
+		}
+
+		runOpts = append(runOpts, llb.AddSecret(secretDest, secretOpts...))
+	}
+
+	fsSt, err := payload.FSState()
 	if err != nil {
 		return nil, fmt.Errorf("fs state: %w", err)
 	}
 
-	execSt := st.Run(runOpts...)
+	execSt := fsSt.Run(runOpts...)
 
 	for i, mnt := range mounts {
-		st, err := mnt.SourceState()
+		srcSt, err := mnt.SourceState()
 		if err != nil {
 			return nil, fmt.Errorf("mount %s: %w", mnt.Target, err)
 		}
@@ -514,7 +581,7 @@ func (container *Container) Exec(ctx context.Context, gw bkgw.Client, args *[]st
 			mountOpts = append(mountOpts, llb.Tmpfs())
 		}
 
-		mountSt := execSt.AddMount(mnt.Target, st, mountOpts...)
+		mountSt := execSt.AddMount(mnt.Target, srcSt, mountOpts...)
 
 		// propagate any changes to regular mounts to subsequent containers
 		if !mnt.Tmpfs && mnt.CacheID == "" {

--- a/core/file.go
+++ b/core/file.go
@@ -71,6 +71,10 @@ func (file *File) Contents(ctx context.Context, gw bkgw.Client) ([]byte, error) 
 	})
 }
 
+func (file *File) Secret(ctx context.Context) (*Secret, error) {
+	return NewSecretFromFile(file.ID)
+}
+
 func (file *File) Stat(ctx context.Context, gw bkgw.Client) (*fstypes.Stat, error) {
 	st, filePath, platform, err := file.Decode()
 	if err != nil {

--- a/core/integration/file_test.go
+++ b/core/integration/file_test.go
@@ -15,7 +15,7 @@ func TestFile(t *testing.T) {
 		Directory struct {
 			WithNewFile struct {
 				File struct {
-					ID       core.DirectoryID
+					ID       core.FileID
 					Contents string
 				}
 			}
@@ -46,7 +46,7 @@ func TestDirectoryFile(t *testing.T) {
 			WithNewFile struct {
 				Directory struct {
 					File struct {
-						ID       core.DirectoryID
+						ID       core.FileID
 						Contents string
 					}
 				}
@@ -79,7 +79,7 @@ func TestFileSize(t *testing.T) {
 		Directory struct {
 			WithNewFile struct {
 				File struct {
-					ID   core.DirectoryID
+					ID   core.FileID
 					Size int
 				}
 			}

--- a/core/integration/secret_test.go
+++ b/core/integration/secret_test.go
@@ -1,0 +1,133 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dagger.io/dagger/core"
+	"go.dagger.io/dagger/internal/testutil"
+)
+
+func TestSecretEnvFromFile(t *testing.T) {
+	t.Parallel()
+
+	var secretRes struct {
+		Directory struct {
+			WithNewFile struct {
+				File struct {
+					Secret struct {
+						ID core.SecretID
+					}
+				}
+			}
+		}
+	}
+
+	err := testutil.Query(
+		`{
+			directory {
+				withNewFile(path: "some-file", contents: "some-content") {
+					file(path: "some-file") {
+						secret {
+							id
+						}
+					}
+				}
+			}
+		}`, &secretRes, nil)
+	require.NoError(t, err)
+
+	secretID := secretRes.Directory.WithNewFile.File.Secret.ID
+	require.NotEmpty(t, secretID)
+
+	var envRes struct {
+		Container struct {
+			From struct {
+				WithSecretVariable struct {
+					Exec struct {
+						Stdout struct{ Contents string }
+					}
+				}
+			}
+		}
+	}
+
+	err = testutil.Query(
+		`query Test($secret: SecretID!) {
+			container {
+				from(address: "alpine:3.16.2") {
+					withSecretVariable(name: "SECRET", secret: $secret) {
+						exec(args: ["env"]) {
+							stdout { contents }
+						}
+					}
+				}
+			}
+		}`, &envRes, &testutil.QueryOptions{Variables: map[string]any{
+			"secret": secretID,
+		}})
+	require.NoError(t, err)
+	require.Contains(t, envRes.Container.From.WithSecretVariable.Exec.Stdout.Contents, "SECRET=some-content\n")
+}
+
+func TestSecretMountFromFile(t *testing.T) {
+	t.Parallel()
+
+	var secretRes struct {
+		Directory struct {
+			WithNewFile struct {
+				File struct {
+					Secret struct {
+						ID core.SecretID
+					}
+				}
+			}
+		}
+	}
+
+	err := testutil.Query(
+		`{
+			directory {
+				withNewFile(path: "some-file", contents: "some-content") {
+					file(path: "some-file") {
+						secret {
+							id
+						}
+					}
+				}
+			}
+		}`, &secretRes, nil)
+	require.NoError(t, err)
+
+	secretID := secretRes.Directory.WithNewFile.File.Secret.ID
+	require.NotEmpty(t, secretID)
+
+	var envRes struct {
+		Container struct {
+			From struct {
+				WithMountedSecret struct {
+					Exec struct {
+						Stdout struct{ Contents string }
+					}
+				}
+			}
+		}
+	}
+
+	err = testutil.Query(
+		`query Test($secret: SecretID!) {
+			container {
+				from(address: "alpine:3.16.2") {
+					withMountedSecret(path: "/sekret", source: $secret) {
+						exec(args: ["cat", "/sekret"]) {
+							stdout { contents }
+						}
+					}
+				}
+			}
+		}`, &envRes, &testutil.QueryOptions{Variables: map[string]any{
+			"secret": secretID,
+		}})
+	require.NoError(t, err)
+	require.Contains(t, envRes.Container.From.WithMountedSecret.Exec.Stdout.Contents, "some-content")
+}

--- a/core/schema/base.go
+++ b/core/schema/base.go
@@ -12,12 +12,10 @@ import (
 	"go.dagger.io/dagger/core/filesystem"
 	"go.dagger.io/dagger/project"
 	"go.dagger.io/dagger/router"
-	"go.dagger.io/dagger/secret"
 )
 
 type InitializeArgs struct {
 	Router        *router.Router
-	SecretStore   *secret.Store
 	SSHAuthSockID string
 	WorkdirID     string
 	Gateway       bkgw.Client
@@ -30,7 +28,6 @@ type InitializeArgs struct {
 func New(params InitializeArgs) (router.ExecutableSchema, error) {
 	base := &baseSchema{
 		router:        params.Router,
-		secretStore:   params.SecretStore,
 		gw:            params.Gateway,
 		bkClient:      params.BKClient,
 		solveOpts:     params.SolveOpts,
@@ -45,6 +42,7 @@ func New(params InitializeArgs) (router.ExecutableSchema, error) {
 		&gitSchema{base},
 		&containerSchema{base},
 		&cacheSchema{base},
+		&secretSchema{base},
 		&filesystemSchema{base},
 		&projectSchema{
 			baseSchema:    base,
@@ -52,14 +50,12 @@ func New(params InitializeArgs) (router.ExecutableSchema, error) {
 		},
 		&execSchema{base},
 		&dockerBuildSchema{base},
-		&secretSchema{base},
 		&httpSchema{base},
 	)
 }
 
 type baseSchema struct {
 	router        *router.Router
-	secretStore   *secret.Store
 	gw            bkgw.Client
 	bkClient      *bkclient.Client
 	solveOpts     bkclient.SolveOpt

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -45,7 +45,7 @@ func (s *containerSchema) Resolvers() router.Resolvers {
 			"variables":            router.ToResolver(s.variables),
 			"variable":             router.ToResolver(s.variable),
 			"withVariable":         router.ToResolver(s.withVariable),
-			"withSecretVariable":   router.ErrResolver(ErrNotImplementedYet),
+			"withSecretVariable":   router.ToResolver(s.withSecretVariable),
 			"withoutVariable":      router.ToResolver(s.withoutVariable),
 			"entrypoint":           router.ToResolver(s.entrypoint),
 			"withEntrypoint":       router.ToResolver(s.withEntrypoint),
@@ -56,7 +56,7 @@ func (s *containerSchema) Resolvers() router.Resolvers {
 			"withMountedFile":      router.ToResolver(s.withMountedFile),
 			"withMountedTemp":      router.ToResolver(s.withMountedTemp),
 			"withMountedCache":     router.ToResolver(s.withMountedCache),
-			"withMountedSecret":    router.ErrResolver(ErrNotImplementedYet),
+			"withMountedSecret":    router.ToResolver(s.withMountedSecret),
 			"withoutMount":         router.ToResolver(s.withoutMount),
 			"exec":                 router.ToResolver(s.exec),
 			"exitCode":             router.ToResolver(s.exitCode),
@@ -383,4 +383,22 @@ func absPath(workDir string, containerPath string) string {
 	}
 
 	return path.Join(workDir, containerPath)
+}
+
+type containerWithSecretVariableArgs struct {
+	Name   string
+	Secret core.SecretID
+}
+
+func (s *containerSchema) withSecretVariable(ctx *router.Context, parent *core.Container, args containerWithSecretVariableArgs) (*core.Container, error) {
+	return parent.WithSecretVariable(ctx, args.Name, &core.Secret{ID: args.Secret})
+}
+
+type containerWithMountedSecretArgs struct {
+	Path   string
+	Source core.SecretID
+}
+
+func (s *containerSchema) withMountedSecret(ctx *router.Context, parent *core.Container, args containerWithMountedSecretArgs) (*core.Container, error) {
+	return parent.WithMountedSecret(ctx, args.Path, core.NewSecret(args.Source))
 }

--- a/core/schema/file.go
+++ b/core/schema/file.go
@@ -29,7 +29,7 @@ func (s *fileSchema) Resolvers() router.Resolvers {
 		},
 		"File": router.ObjectResolver{
 			"contents": router.ToResolver(s.contents),
-			"secret":   router.ErrResolver(ErrNotImplementedYet),
+			"secret":   router.ToResolver(s.secret),
 			"size":     router.ToResolver(s.size),
 		},
 	}
@@ -56,6 +56,10 @@ func (s *fileSchema) contents(ctx *router.Context, file *core.File, args any) (s
 	}
 
 	return string(content), nil
+}
+
+func (s *fileSchema) secret(ctx *router.Context, file *core.File, args any) (*core.Secret, error) {
+	return file.Secret(ctx)
 }
 
 func (s *fileSchema) size(ctx *router.Context, file *core.File, args any) (int64, error) {

--- a/core/schema/file.graphqls
+++ b/core/schema/file.graphqls
@@ -13,9 +13,8 @@ type File {
     "The contents of the file"
     contents: String!
 
-    # TODO(vito): uncomment when secrets are a thing
     # "A secret referencing the contents of this file"
-    # secret: Secret!
+    secret: Secret!
 
     "The size of the file, in bytes"
     size: Int!

--- a/core/schema/fs.go
+++ b/core/schema/fs.go
@@ -19,3 +19,6 @@ var HTTP string
 
 //go:embed cache.graphqls
 var Cache string
+
+//go:embed secret.graphqls
+var Secret string

--- a/core/schema/secret.go
+++ b/core/schema/secret.go
@@ -1,46 +1,33 @@
 package schema
 
 import (
-	"fmt"
-
+	"go.dagger.io/dagger/core"
 	"go.dagger.io/dagger/router"
 )
-
-type SecretID string
-
-var secretIDResolver = stringResolver(SecretID(""))
-
-var _ router.ExecutableSchema = &secretSchema{}
 
 type secretSchema struct {
 	*baseSchema
 }
+
+var _ router.ExecutableSchema = &secretSchema{}
 
 func (s *secretSchema) Name() string {
 	return "secret"
 }
 
 func (s *secretSchema) Schema() string {
-	return `
-scalar SecretID
-
-extend type Core {
-	"Look up a secret by ID"
-	secret(id: SecretID!): String!
-
-	"Add a secret"
-	addSecret(plaintext: String!): SecretID!
+	return Secret
 }
-`
-}
+
+var secretIDResolver = stringResolver(core.SecretID(""))
 
 func (s *secretSchema) Resolvers() router.Resolvers {
 	return router.Resolvers{
 		"SecretID": secretIDResolver,
-		"Core": router.ObjectResolver{
-			"secret":    router.ToResolver(s.secret),
-			"addSecret": router.ToResolver(s.addSecret),
+		"Query": router.ObjectResolver{
+			"secret": router.ToResolver(s.secret),
 		},
+		"Secret": router.ObjectResolver{},
 	}
 }
 
@@ -49,21 +36,11 @@ func (s *secretSchema) Dependencies() []router.ExecutableSchema {
 }
 
 type secretArgs struct {
-	ID string `json:"id"`
+	ID core.SecretID
 }
 
-func (s *secretSchema) secret(ctx *router.Context, parent any, args secretArgs) (string, error) {
-	plaintext, err := s.secretStore.GetSecret(ctx, args.ID)
-	if err != nil {
-		return "", fmt.Errorf("secret %s: %w", args.ID, err)
-	}
-	return string(plaintext), nil
-}
-
-type addSecretArgs struct {
-	Plaintext string
-}
-
-func (s *secretSchema) addSecret(ctx *router.Context, parent any, args addSecretArgs) (string, error) {
-	return s.secretStore.AddSecret(ctx, []byte(args.Plaintext)), nil
+func (s *secretSchema) secret(ctx *router.Context, parent any, args secretArgs) (*core.Secret, error) {
+	return &core.Secret{
+		ID: args.ID,
+	}, nil
 }

--- a/core/schema/secret.graphqls
+++ b/core/schema/secret.graphqls
@@ -1,7 +1,6 @@
-
 extend type Query {
-	"Load a secret from its ID"
-	secret(id: SecretID!): Secret
+  "Load a secret from its ID"
+  secret(id: SecretID!): Secret!
 }
 
 "A unique identifier for a secret"
@@ -9,6 +8,6 @@ scalar SecretID
 
 "A reference to a secret value, which can be handled more safely than the value itself"
 type Secret {
-	"The identifier for this secret"
-	id: SecretID!
+  "The identifier for this secret"
+  id: SecretID!
 }

--- a/core/secret.go
+++ b/core/secret.go
@@ -1,0 +1,82 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	bkgw "github.com/moby/buildkit/frontend/gateway/client"
+)
+
+// Secret is a content-addressed secret.
+type Secret struct {
+	ID SecretID `json:"id"`
+}
+
+func NewSecret(id SecretID) *Secret {
+	return &Secret{ID: id}
+}
+
+func NewSecretFromFile(fileID FileID) (*Secret, error) {
+	id, err := (&secretIDPayload{FromFile: fileID}).Encode()
+	if err != nil {
+		return nil, err
+	}
+
+	return NewSecret(id), nil
+}
+
+func NewSecretFromHostEnv(name string) (*Secret, error) {
+	id, err := (&secretIDPayload{FromHostEnv: name}).Encode()
+	if err != nil {
+		return nil, err
+	}
+
+	return NewSecret(id), nil
+}
+
+// SecretID is an opaque value representing a content-addressed secret.
+type SecretID string
+
+// secretIDPayload is the inner content of a SecretID.
+type secretIDPayload struct {
+	FromFile    FileID `json:"file,omitempty"`
+	FromHostEnv string `json:"host_env,omitempty"`
+}
+
+// Encode returns the opaque string ID representation of the secret.
+func (payload *secretIDPayload) Encode() (SecretID, error) {
+	id, err := encodeID(payload)
+	if err != nil {
+		return "", err
+	}
+
+	return SecretID(id), nil
+}
+
+func (id SecretID) decode() (*secretIDPayload, error) {
+	var payload secretIDPayload
+	if err := decodeID(&payload, id); err != nil {
+		return nil, err
+	}
+
+	return &payload, nil
+}
+
+func (secret *Secret) Plaintext(ctx context.Context, gw bkgw.Client) ([]byte, error) {
+	payload, err := secret.ID.decode()
+	if err != nil {
+		return nil, err
+	}
+
+	if payload.FromFile != "" {
+		file := &File{ID: payload.FromFile}
+		return file.Contents(ctx, gw)
+	}
+
+	if payload.FromHostEnv != "" {
+		return []byte(os.Getenv(payload.FromHostEnv)), nil
+	}
+
+	return nil, fmt.Errorf("plaintext: empty secret?")
+}

--- a/examples/queries/queries_test.go
+++ b/examples/queries/queries_test.go
@@ -31,13 +31,6 @@ func TestQueries(t *testing.T) {
 				Variables: map[string]any{"version": "v0.2.0"},
 			},
 		},
-		"secret.graphql": {
-			opts: &testutil.QueryOptions{
-				Secrets: map[string]string{
-					"secret": "test secret",
-				},
-			},
-		},
 		"targets.graphql": {
 			opts: &testutil.QueryOptions{
 				Operation: "test",

--- a/examples/queries/secret.graphql
+++ b/examples/queries/secret.graphql
@@ -1,5 +1,0 @@
-query GetSecret($secret: SecretID!) {
-  core {
-    secret(id: $secret)
-  }
-}


### PR DESCRIPTION
part of #3178

closes #3183

Unlike the other core API PRs, **this is a breaking change** as it replaces the old secret schema.

Removed:

```graphql
core {
  secret(id: SecretID!): String!
  addSecret(plaintext: String!): SecretID!
}
```

Added:

```graphql
secret(id: SecretID!): Secret!

container {
  withSecretVariable(name: String!, secret: SecretID!): Container!
  withMountedSecret(path: String!, source: SecretID!): Container!
}

file {
  secret: Secret!
}
```

This initial PR only supports loading secrets from files, but it has internal scaffolding in place for loading secrets from host env. There just isn't an API representation for it yet, since pulling on that thread leads me to the `Host` API, which leads to possibly a bunch more work which I'm currently investigating. (tl;dr: `Host` is a touch point for #3201 as well as the current SDK/plugin infra.)