### PR TITLE
add `CacheID` and `CacheVolume`

### DIFF
--- a/core/cache.go
+++ b/core/cache.go
@@ -3,7 +3,8 @@ package core
 import (
 	"crypto/sha256"
 	"encoding/base64"
-	"encoding/json"
+
+	"github.com/pkg/errors"
 )
 
 // Cache is a persistent volume with a globally scoped identifier.
@@ -11,9 +12,24 @@ type Cache struct {
 	ID CacheID `json:"id"`
 }
 
+var ErrInvalidCacheID = errors.New("invalid cache ID; create one using cacheFromTokens")
+
 // CacheID is an arbitrary string typically derived from a set of token
 // strings acting as the cache's "key" or "scope".
 type CacheID string
+
+func (id CacheID) decode() (*cacheIDPayload, error) {
+	var payload cacheIDPayload
+	if err := decodeID(&payload, id); err != nil {
+		return nil, ErrInvalidCacheID
+	}
+
+	if len(payload.Tokens) == 0 {
+		return nil, ErrInvalidCacheID
+	}
+
+	return &payload, nil
+}
 
 // cacheIDPayload is the inner content of a CacheID.
 type cacheIDPayload struct {
@@ -22,8 +38,18 @@ type cacheIDPayload struct {
 	Tokens []string `json:"tokens"`
 }
 
+// Sum returns a checksum of the cache tokens suitable for use as a cache key.
+func (payload cacheIDPayload) Sum() string {
+	hash := sha256.New()
+	for _, tok := range payload.Tokens {
+		_, _ = hash.Write([]byte(tok + "\x00"))
+	}
+
+	return base64.StdEncoding.EncodeToString(hash.Sum(nil))
+}
+
 func NewCache(tokens []string) (*Cache, error) {
-	id, err := hashID(cacheIDPayload{
+	id, err := encodeID(cacheIDPayload{
 		Tokens: tokens,
 	})
 	if err != nil {
@@ -35,18 +61,11 @@ func NewCache(tokens []string) (*Cache, error) {
 	}, nil
 }
 
-func hashID(payload any) (string, error) {
-	jsonBytes, err := json.Marshal(payload)
+func NewCacheFromID(id CacheID) (*Cache, error) {
+	_, err := id.decode() // sanity check
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	hash := sha256.New()
-	_, err = hash.Write(jsonBytes)
-	if err != nil {
-		return "", err
-	}
-
-	sum := hash.Sum(nil)
-	return base64.StdEncoding.EncodeToString(sum[:]), nil
+	return &Cache{ID: id}, nil
 }

--- a/core/cache.go
+++ b/core/cache.go
@@ -1,0 +1,52 @@
+package core
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+)
+
+// Cache is a persistent volume with a globally scoped identifier.
+type Cache struct {
+	ID CacheID `json:"id"`
+}
+
+// CacheID is an arbitrary string typically derived from a set of token
+// strings acting as the cache's "key" or "scope".
+type CacheID string
+
+// cacheIDPayload is the inner content of a CacheID.
+type cacheIDPayload struct {
+	// TODO(vito): right now this is a bit goofy, but if we ever want to add
+	// extra server-provided fields, this is where we'd do it.
+	Tokens []string `json:"tokens"`
+}
+
+func NewCache(tokens []string) (*Cache, error) {
+	id, err := hashID(cacheIDPayload{
+		Tokens: tokens,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &Cache{
+		ID: CacheID(id),
+	}, nil
+}
+
+func hashID(payload any) (string, error) {
+	jsonBytes, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+
+	hash := sha256.New()
+	_, err = hash.Write(jsonBytes)
+	if err != nil {
+		return "", err
+	}
+
+	sum := hash.Sum(nil)
+	return base64.StdEncoding.EncodeToString(sum[:]), nil
+}

--- a/core/container.go
+++ b/core/container.go
@@ -182,11 +182,16 @@ func (container *Container) WithMountedCache(ctx context.Context, target string,
 		return nil, err
 	}
 
+	cachePayload, err := cache.decode()
+	if err != nil {
+		return nil, err
+	}
+
 	target = absPath(payload.Config.WorkingDir, target)
 
 	mount := ContainerMount{
 		Target:           target,
-		CacheID:          string(cache),
+		CacheID:          cachePayload.Sum(),
 		CacheSharingMode: "shared", // TODO(vito): add param
 	}
 

--- a/core/container.go
+++ b/core/container.go
@@ -176,7 +176,7 @@ func (container *Container) WithMountedFile(ctx context.Context, target string, 
 	return container.withMounted(ctx, target, source)
 }
 
-func (container *Container) WithMountedCache(ctx context.Context, target string, source *Directory) (*Container, error) {
+func (container *Container) WithMountedCache(ctx context.Context, target string, cache CacheID, source *Directory) (*Container, error) {
 	payload, err := container.ID.decode()
 	if err != nil {
 		return nil, err
@@ -186,7 +186,7 @@ func (container *Container) WithMountedCache(ctx context.Context, target string,
 
 	mount := ContainerMount{
 		Target:           target,
-		CacheID:          fmt.Sprintf("%s:%s", container.ID, target),
+		CacheID:          string(cache),
 		CacheSharingMode: "shared", // TODO(vito): add param
 	}
 

--- a/core/integration/cache_test.go
+++ b/core/integration/cache_test.go
@@ -1,0 +1,108 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dagger.io/dagger/core"
+	"go.dagger.io/dagger/internal/testutil"
+)
+
+func TestCacheVolume(t *testing.T) {
+	t.Parallel()
+
+	type createFromTokensRes struct {
+		CacheFromTokens struct {
+			ID core.CacheID
+		}
+	}
+
+	type createRes struct {
+		Cache struct {
+			ID core.CacheID
+		}
+	}
+
+	var idOrig, idSame, idDiff, idLong, idGiven core.CacheID
+
+	t.Run("creating from tokens", func(t *testing.T) {
+		var res createFromTokensRes
+		err := testutil.Query(
+			`{
+				cacheFromTokens(tokens: ["a", "b"]) {
+					id
+				}
+			}`, &res, nil)
+		require.NoError(t, err)
+
+		idOrig = res.CacheFromTokens.ID
+		require.NotEmpty(t, res.CacheFromTokens.ID)
+	})
+
+	t.Run("creating from same tokens again", func(t *testing.T) {
+		var res createFromTokensRes
+		err := testutil.Query(
+			`{
+				cacheFromTokens(tokens: ["a", "b"]) {
+					id
+				}
+			}`, &res, nil)
+		require.NoError(t, err)
+
+		idSame = res.CacheFromTokens.ID
+		require.NotEmpty(t, idSame)
+
+		require.Equal(t, idOrig, idSame)
+	})
+
+	t.Run("creating from different tokens", func(t *testing.T) {
+		var res createFromTokensRes
+		err := testutil.Query(
+			`{
+				cacheFromTokens(tokens: ["a", "c"]) {
+					id
+				}
+			}`, &res, nil)
+		require.NoError(t, err)
+
+		idDiff = res.CacheFromTokens.ID
+		require.NotEmpty(t, idDiff)
+
+		require.NotEqual(t, idOrig, idDiff)
+	})
+
+	t.Run("creating from bigger tokens", func(t *testing.T) {
+		var res createFromTokensRes
+		err := testutil.Query(
+			`{
+				cacheFromTokens(tokens: ["aaaaa", "bbbbb"]) {
+					id
+				}
+			}`, &res, nil)
+		require.NoError(t, err)
+
+		idLong = res.CacheFromTokens.ID
+		require.NotEmpty(t, idLong)
+
+		require.NotEqual(t, idOrig, idLong)
+
+		// test that we're hashing to result in equal-size IDs
+		require.Equal(t, len(idOrig), len(idLong))
+	})
+
+	t.Run("creating from given ID", func(t *testing.T) {
+		var res createRes
+		err := testutil.Query(
+			`query Test($id: CacheID!) {
+				cache(id: $id) {
+					id
+				}
+			}`, &res, &testutil.QueryOptions{Variables: map[string]any{
+				"id": idOrig,
+			}})
+		require.NoError(t, err)
+
+		idGiven = res.Cache.ID
+		require.Equal(t, idOrig, idGiven)
+	})
+}

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -1,9 +1,37 @@
 package core
 
-import "go.dagger.io/dagger/internal/testutil"
+import (
+	"testing"
+
+	"github.com/moby/buildkit/identity"
+	"github.com/stretchr/testify/require"
+	"go.dagger.io/dagger/core"
+	"go.dagger.io/dagger/internal/testutil"
+)
 
 func init() {
 	if err := testutil.SetupBuildkitd(); err != nil {
 		panic(err)
 	}
+}
+
+func newCache(t *testing.T) core.CacheID {
+	var res struct {
+		CacheFromTokens struct {
+			ID core.CacheID
+		}
+	}
+
+	err := testutil.Query(`
+		query CreateCache($token: String!) {
+			cacheFromTokens(tokens: [$token]) {
+				id
+			}
+		}
+	`, &res, &testutil.QueryOptions{Variables: map[string]any{
+		"token": identity.NewID(),
+	}})
+	require.NoError(t, err)
+
+	return res.CacheFromTokens.ID
 }

--- a/core/schema/base.go
+++ b/core/schema/base.go
@@ -44,6 +44,7 @@ func New(params InitializeArgs) (router.ExecutableSchema, error) {
 		&fileSchema{base},
 		&gitSchema{base},
 		&containerSchema{base},
+		&cacheSchema{base},
 		&filesystemSchema{base},
 		&projectSchema{
 			baseSchema:    base,

--- a/core/schema/cache.go
+++ b/core/schema/cache.go
@@ -41,9 +41,7 @@ type cacheArgs struct {
 }
 
 func (s *cacheSchema) cache(ctx *router.Context, parent any, args cacheArgs) (*core.Cache, error) {
-	return &core.Cache{
-		ID: args.ID,
-	}, nil
+	return core.NewCacheFromID(args.ID)
 }
 
 type cacheFromTokensArgs struct {

--- a/core/schema/cache.go
+++ b/core/schema/cache.go
@@ -1,0 +1,55 @@
+package schema
+
+import (
+	"go.dagger.io/dagger/core"
+	"go.dagger.io/dagger/router"
+)
+
+type cacheSchema struct {
+	*baseSchema
+}
+
+var _ router.ExecutableSchema = &cacheSchema{}
+
+func (s *cacheSchema) Name() string {
+	return "cache"
+}
+
+func (s *cacheSchema) Schema() string {
+	return Cache
+}
+
+var cacheIDResolver = stringResolver(core.CacheID(""))
+
+func (s *cacheSchema) Resolvers() router.Resolvers {
+	return router.Resolvers{
+		"CacheID": cacheIDResolver,
+		"Query": router.ObjectResolver{
+			"cache":           router.ToResolver(s.cache),
+			"cacheFromTokens": router.ToResolver(s.cacheFromTokens),
+		},
+		"CacheVolume": router.ObjectResolver{},
+	}
+}
+
+func (s *cacheSchema) Dependencies() []router.ExecutableSchema {
+	return nil
+}
+
+type cacheArgs struct {
+	ID core.CacheID
+}
+
+func (s *cacheSchema) cache(ctx *router.Context, parent any, args cacheArgs) (*core.Cache, error) {
+	return &core.Cache{
+		ID: args.ID,
+	}, nil
+}
+
+type cacheFromTokensArgs struct {
+	Tokens []string
+}
+
+func (s *cacheSchema) cacheFromTokens(ctx *router.Context, parent any, args cacheFromTokensArgs) (*core.Cache, error) {
+	return core.NewCache(args.Tokens)
+}

--- a/core/schema/cache.graphqls
+++ b/core/schema/cache.graphqls
@@ -1,0 +1,15 @@
+"A global cache volume identifier"
+scalar CacheID
+
+extend type Query {
+  "Construct a cache volume from its ID"
+  cache(id: CacheID!): CacheVolume!
+
+  "Create a new cache volume identified by an arbitrary set of tokens"
+  cacheFromTokens(tokens: [String!]!): CacheVolume!
+}
+
+"A directory whose contents persist across runs"
+type CacheVolume {
+  id: CacheID!
+}

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -332,6 +332,7 @@ func (s *containerSchema) withMountedFile(ctx *router.Context, parent *core.Cont
 
 type containerWithMountedCacheArgs struct {
 	Path   string
+	Cache  core.CacheID
 	Source core.DirectoryID
 }
 
@@ -341,7 +342,7 @@ func (s *containerSchema) withMountedCache(ctx *router.Context, parent *core.Con
 		dir = &core.Directory{ID: args.Source}
 	}
 
-	return parent.WithMountedCache(ctx, args.Path, dir)
+	return parent.WithMountedCache(ctx, args.Path, args.Cache, dir)
 }
 
 type containerWithMountedTempArgs struct {

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -88,8 +88,8 @@ type Container {
     "This container plus a temporary directory mounted at the given path"
     withMountedTemp(path: String!): Container!
 
-	  "This container plus a cache directory mounted at the given path"
-    withMountedCache(path: String!, source: DirectoryID): Container!
+    "This container plus a cache volume mounted at the given path"
+    withMountedCache(path: String!, cache: CacheID!, source: DirectoryID): Container!
 
     "This container plus a secret mounted into a file at the given path"
     withMountedSecret(path: String!, source: SecretID!): Container!

--- a/core/schema/fs.go
+++ b/core/schema/fs.go
@@ -16,3 +16,6 @@ var Container string
 
 //go:embed http.graphqls
 var HTTP string
+
+//go:embed cache.graphqls
+var Cache string


### PR DESCRIPTION
fixes #3270 

Implements the following:

```graphql
"A global cache volume identifier"
scalar CacheID

extend type Query {
  "Construct a cache volume from its ID"
  cache(id: CacheID!): CacheVolume!

  "Create a new cache volume identified by an arbitrary set of tokens"
  cacheFromTokens(tokens: [String!]!): CacheVolume!
}

"A directory whose contents persist across runs"
type CacheVolume {
  id: CacheID!
}

extend type Container {
  withMountedCache(path: String!, cache: CacheID!, source: DirectoryID): Container!
}
```

(Bikeshedding welcome.)

Prior discussions were in Discord, crystallized in this comment: https://github.com/dagger/dagger/pull/3217#discussion_r988029723

The basic idea is to re-introduce `CacheID` but with an API for creating them rather than having the user provide such a low-level and far-reaching identifier directly.

Rather than an arbitrary string value, a `CacheID` is a special encoded payload, just like other IDs, containing arbitrary string tokens the user provides for controlling cache busting.

The idea is to prevent users from accidentally passing in a `CacheID("banana")` without realizing the API exists. There's no state anywhere, so it's _possible_ to create one client-side if you know the structure, but I don't think we really care yet. If/when we do care, and we want to prevent users from accessing each other's caches, we can just augment the tokens with a user-scoped value.