### PR TITLE
Python: Code-only schema

### DIFF
--- a/examples/python/hello/__main__.py
+++ b/examples/python/hello/__main__.py
@@ -1,7 +1,0 @@
-"""
-FIXME: replace file with entrypoint from SDK importing `main:server` from extension and executing it
-"""
-
-from main import server
-
-server.execute()

--- a/examples/python/hello/__main__.py
+++ b/examples/python/hello/__main__.py
@@ -1,0 +1,7 @@
+"""
+FIXME: replace file with entrypoint from SDK importing `main:server` from extension and executing it
+"""
+
+from main import server
+
+server.execute()

--- a/examples/python/hello/cloak.yaml
+++ b/examples/python/hello/cloak.yaml
@@ -1,4 +1,4 @@
-name: "python"
+name: "hello"
 extensions:
   - path: .
     sdk: python

--- a/examples/python/hello/schema.graphql
+++ b/examples/python/hello/schema.graphql
@@ -1,9 +1,0 @@
-extend type Query {
-  hello(greeting: String): Hello!
-}
-
-type Hello {
-  greeting: String!
-  say(msg: String!): String!
-  html(lines: Int): String!
-}

--- a/project/pythonruntime.go
+++ b/project/pythonruntime.go
@@ -25,12 +25,10 @@ func (p *State) pythonRuntime(ctx context.Context, subpath string, gw bkgw.Clien
 	ctrSrcPath := filepath.Join(workdir, filepath.Dir(p.configPath), subpath)
 	entrypointScript := fmt.Sprintf(`#!/bin/sh
 set -exu
-# go to the workdir
-cd %q
 # redirect local unix socket (graphql server) to a bound tcp port
 socat TCP-LISTEN:8080 UNIX-CONNECT:/dagger.sock &
 # run the extension
-python3 main.py
+exec python3 %q "$@"
 `,
 		ctrSrcPath)
 	requirementsfile := filepath.Join(ctrSrcPath, "requirements.txt")

--- a/project/pythonruntime.go
+++ b/project/pythonruntime.go
@@ -25,10 +25,12 @@ func (p *State) pythonRuntime(ctx context.Context, subpath string, gw bkgw.Clien
 	ctrSrcPath := filepath.Join(workdir, filepath.Dir(p.configPath), subpath)
 	entrypointScript := fmt.Sprintf(`#!/bin/sh
 set -exu
+# go to the workdir
+cd %q
 # redirect local unix socket (graphql server) to a bound tcp port
 socat TCP-LISTEN:8080 UNIX-CONNECT:/dagger.sock &
 # run the extension
-exec python3 %q "$@"
+exec dagger-python "$@"
 `,
 		ctrSrcPath)
 	requirementsfile := filepath.Join(ctrSrcPath, "requirements.txt")

--- a/sdk/python/dagger/README.md
+++ b/sdk/python/dagger/README.md
@@ -1,0 +1,1 @@
+# Python SDK for Dagger

--- a/sdk/python/dagger/pyproject.toml
+++ b/sdk/python/dagger/pyproject.toml
@@ -8,10 +8,10 @@ version = "0.0.1"
 authors = [
   { name="Sam Alba", email="sam@dagger.io" },
 ]
-description = "Dagger client library"
+description = "Dagger library"
 #readme = "README.md"
 #license = { file="LICENSE" }
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
 #    "License :: OSI Approved :: MIT License",
@@ -20,6 +20,8 @@ classifiers = [
 dependencies = [
     "gql[requests] >= 3.4.0",
     "strawberry-graphql >= 0.130.3",
+    "attrs >= 22.1.0",
+    "cattrs >= 22.2.0",
 ]
 
 [project.urls]

--- a/sdk/python/dagger/pyproject.toml
+++ b/sdk/python/dagger/pyproject.toml
@@ -4,26 +4,29 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dagger"
-version = "0.0.1"
+version = "0.1.0"
 authors = [
   { name="Sam Alba", email="sam@dagger.io" },
 ]
 description = "Dagger library"
-#readme = "README.md"
-#license = { file="LICENSE" }
+readme = "README.md"
+license = "Apache-2.0"
 requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
-#    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
 #    "Operating System :: OS Independent",
 ]
 dependencies = [
-    "gql[requests] >= 3.4.0",
-    "strawberry-graphql >= 0.130.3",
-    "attrs >= 22.1.0",
-    "cattrs >= 22.2.0",
+    "gql[requests] ~= 3.4.0",
+    "strawberry-graphql[cli] ~= 0.133.5",
+    "attrs ~= 22.1.0",
+    "cattrs ~= 22.2.0",
 ]
 
 [project.urls]
 "Homepage" = "https://dagger.io/"
 "Bug Tracker" = "https://github.com/dagger/dagger/issues"
+
+[project.scripts]
+dagger-python = "dagger.cli:run"

--- a/sdk/python/dagger/src/dagger/__init__.py
+++ b/sdk/python/dagger/src/dagger/__init__.py
@@ -1,3 +1,9 @@
-from .client import *
-from .engine import *
-from .server import *
+from .client import Client
+from .engine import Engine
+from .server import Server
+
+__all__ = [
+    "Client",
+    "Engine",
+    "Server",
+]

--- a/sdk/python/dagger/src/dagger/cli.py
+++ b/sdk/python/dagger/src/dagger/cli.py
@@ -1,0 +1,15 @@
+import argparse
+
+from attrs import define
+
+
+@define
+class Options:
+    schema: bool = False
+
+
+def parse_args() -> Options:
+    args = Options()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-schema", action="store_true", help="Write schema file")
+    return parser.parse_args(namespace=args)

--- a/sdk/python/dagger/src/dagger/converter.py
+++ b/sdk/python/dagger/src/dagger/converter.py
@@ -1,0 +1,34 @@
+from dataclasses import fields
+from typing import Callable
+
+from cattrs.gen import make_dict_unstructure_fn, override
+from cattrs.preconf.json import make_converter
+from strawberry.field import StrawberryField
+
+converter = make_converter(omit_if_default=True)
+
+
+def is_strawberry_type(cls: type) -> bool:
+    return hasattr(cls, "_type_definition")
+
+
+def has_resolver(f) -> bool:
+    return isinstance(f, StrawberryField) and not f.is_basic_field
+
+
+def strawberry_unstructure(cls: type) -> Callable:
+    """Hook to not unstructure fields with resolvers"""
+    return make_dict_unstructure_fn(
+        cls,
+        converter,
+        **{
+            f.name: override(omit_if_default=True, omit=has_resolver(f))
+            for f in fields(cls)
+        }
+    )
+
+
+converter.register_unstructure_hook_factory(
+    is_strawberry_type,
+    strawberry_unstructure,
+)

--- a/sdk/python/dagger/src/dagger/log.py
+++ b/sdk/python/dagger/src/dagger/log.py
@@ -1,0 +1,26 @@
+import logging
+import logging.config
+
+
+def configure_logging(level: int | str = logging.INFO):
+    config = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "simple": {"format": "[{levelname}] {name}: {message}", "style": "{"},
+        },
+        "handlers": {
+            "console": {
+                "level": "DEBUG",
+                "class": "logging.StreamHandler",
+                "formatter": "simple",
+            },
+        },
+        "loggers": {
+            "dagger": {
+                "handlers": ["console"],
+                "level": level,
+            },
+        },
+    }
+    logging.config.dictConfig(config)

--- a/sdk/python/dagger/src/dagger/server.py
+++ b/sdk/python/dagger/src/dagger/server.py
@@ -1,75 +1,70 @@
-import dataclasses
-import sys
-import json
 import logging
-from collections.abc import Sequence
+from pathlib import Path
 from typing import Any
 
-# FIXME: we should have a custom logger instead of using the global one
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+from attrs import Factory, define
+from cattrs import Converter
+from strawberry import Schema
+
+from .cli import Options, parse_args
+from .converter import converter as json_converter
+from .log import configure_logging
+
+logger = logging.getLogger(__name__)
+
+inputs_path = Path("/inputs/dagger.json")
+outputs_path = Path("/outputs/dagger.json")
+schema_path = Path("/outputs/schema.graphql")
 
 
+@define
+class Inputs:
+    resolver: str
+    args: dict[str, Any]
+    parent: dict[str, Any] | None
+
+
+@define
 class Server:
+    schema: Schema
+    converter: Converter = json_converter
+    options: Options = Factory(parse_args)
+    debug: bool = False
 
-    def __init__(self, module_name: str = '__main__'):
-        self._module_name = module_name
+    def execute(self) -> None:
+        configure_logging(logging.DEBUG if self.debug else logging.INFO)
 
-    def _read_inputs(self) -> dict[str, Any]:
-        with open('/inputs/dagger.json') as f:
-            return json.loads(f.read())
+        if self.options.schema:
+            logger.debug(f"schema => \n{self.schema}")
+            self._write_schema()
+            return
 
-    def _to_dict(self, obj):
-        if dataclasses.is_dataclass(obj):
-            return dataclasses.asdict(obj)
-        if isinstance(obj, Sequence):
-            return list(map(self._to_dict, obj))
-        return obj
-
-    def _serialize(self, obj) -> str:
-        try:
-            r = json.dumps(obj)
-            return r
-        except TypeError:
-            # strawberry types are not serializable but can be converted to a dict
-            return json.dumps(self._to_dict(obj))
-
-    def _write_outputs(self, result: Any) -> None:
-        with open('/outputs/dagger.json', 'w') as f:
-            f.write(self._serialize(result))
-
-    def _call_resolver(self, inputs: dict) -> Any:
-        def check(x):
-            if x not in inputs:
-                raise RuntimeError('missing {}'.format(x))
-
-        for i in ['args', 'parent', 'resolver']:
-            check(i)
-
-        split = inputs['resolver'].split('.', 2)
-        typ, field = split[0], split[1]
-        obj = getattr(sys.modules[self._module_name], typ)
-
-        inst = None
-        try:
-            # if we have parent args, pass them to init the object
-            inst = obj(**inputs['parent']) if inputs['parent'] else obj()
-        except TypeError:
-            # Sometimes we cannot init the main obj, likely because of named args:
-            # the args passed should be used to init the sub-types
-            # and the sub-tuypes instances should be used to init the main obj)
-            # the end object should be jsonified and returned.
-            # FIXME: This is a temporary hack, ideally the object should always be initianted
-            return inputs['args']
-        resolver = getattr(inst, field)
-
-        if callable(resolver):
-            return resolver(**inputs['args'])
-
-        return resolver
-
-    def run(self) -> None:
         inputs = self._read_inputs()
-        logging.debug('sdk inputs <- {}'.format(inputs))
+        logger.debug(f"{inputs = }")
+
         result = self._call_resolver(inputs)
-        logging.debug('sdk outputs -> {}'.format(result))
-        self._write_outputs(result)
+        logger.debug(f"{result = }")
+
+        self._write_output(result)
+
+    def _write_schema(self) -> None:
+        with schema_path.open("w") as f:
+            f.write(str(self.schema))
+
+    def _read_inputs(self) -> Inputs:
+        with inputs_path.open("r") as f:
+            return self.converter.loads(f.read(), Inputs)
+
+    def _call_resolver(self, inputs: Inputs):
+        type_name, field_name = inputs.resolver.split(".", 2)
+        field = self.schema.get_field_for_type(field_name, type_name)
+        resolver = self.schema.schema_converter.from_resolver(field)
+        parent = field.origin(**inputs.parent) if inputs.parent else field.origin()
+        return resolver(parent, info=None, **inputs.args)
+
+    def _write_output(self, o) -> None:
+        output = self.converter.dumps(o, ensure_ascii=False)
+        logger.debug(f"{output = }")
+
+        with outputs_path.open("w") as f:
+            f.write(output)


### PR DESCRIPTION
Fixes #3296

## What

No more need for crafting a `schema.graphql` file nor manually generating before commit. Python extensions can declare GraphQL schemas purely in code.

## How

You need a `server: dagger.Server` instance in a `main.py` file at the root of the extension.

```diff
# main.py
-if __name__ == '__main__':
-    s = dagger.Server()
-    s.run()
+schema = strawberry.Schema(query=Query)
+server = dagger.Server(schema)
```

## Playground

I wanted to keep the strawberry code as untouched as possible so you can use examples from the [docs](https://strawberry.rocks/docs) or from the [playground](https://play.strawberry.rocks/) with just a small addition, just like any [integration](https://strawberry.rocks/docs/integrations/aiohttp). 

Example from playground, you just copy the code do your extension and make a small change for the integration:

```diff
+import dagger
import strawberry

@strawberry.type
class User:
    name: str
    age: int

-@strawberry.type
+@strawberry.type(extend=True)
class Query:
    @strawberry.field
    def user(self) -> User:
        return User(name="Patrick", age=100)

schema = strawberry.Schema(query=Query)
+server = dagger.Server(schema)
```

## Other changes (hidden)

I took the opportunity to refactor some things, mainly to cover more use cases which are battle tested by adopted libraries:
- Delegating resolver execution to schema
- Delegating serialization to popular library (customizable via hooks)
- Adopted popular library to reduce class boilerplate[^1]
- Created executable that can be used as runtime entrypoint[^2]
- Simple custom logger
- Constrained dependency versions[^3]
- Formatted touched files with Prettier[^4]

[^1]: *attrs* is the popular library that originated the built-in *dataclasses* module.
[^2]: We can easily add more subcommands or arguments later on.
[^3]: It protects somewhat from major changes but we should adopt Poetry since Hatch doesn’t have reproducible builds yet.
[^4]: Plan for adding mypy, black and isort to dev dependencies for the SDK library.

## Async

There’s also async support in another PR:
- #3301

Signed-off-by: Helder Correia