### PR TITLE
Pin Node.js version for TypeScript SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "exports": {
     ".": "./sdk/nodejs/dagger/dist/index.js"
   },
+  "engines": {
+    "node": "~16"
+  },
   "dependencies": {
     "@lifeomic/axios-fetch": "^3.0.0",
     "axios": "^0.27.2",
@@ -24,7 +27,7 @@
     "test-sdk": "timeout 60 node sdk/nodejs/test/index.mjs"
   },
   "devDependencies": {
-    "@types/node": "^18.7.18",
+    "@types/node": "~16",
     "typescript": "^4.8.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,10 +22,15 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@^18.7.18":
+"@types/node@*":
   version "18.7.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.18.tgz#633184f55c322e4fb08612307c274ee6d5ed3154"
   integrity sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==
+
+"@types/node@~16":
+  version "16.11.64"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.64.tgz#9171f327298b619e2c52238b120c19056415d820"
+  integrity sha512-z5hPTlVFzNwtJ2LNozTpJcD1Cu44c4LNuzaq1mwxmiHWQh2ULdR6Vjwo1UGldzRpzL0yUEdZddnfqGW2G70z6Q==
 
 asynckit@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Require Node.js v16 LTS in dev & everywhere else. We want to pin to the current Node.js LTS version - Oct. 2022.

This is a follow-up to https://github.com/dagger/dagger/pull/3292#issuecomment-1273546614