### PR TITLE
Container: add `file`

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -344,25 +344,33 @@ func (container *Container) Directory(ctx context.Context, gw bkgw.Client, dirPa
 
 	// check that the directory actually exists so the user gets an error earlier
 	// rather than when the dir is used
-	_, err = dir.Stat(ctx, gw, ".")
+	info, err := dir.Stat(ctx, gw, ".")
 	if err != nil {
 		return nil, err
+	}
+
+	if !info.IsDir() {
+		return nil, fmt.Errorf("path %s is a file, not a directory", dirPath)
 	}
 
 	return dir, nil
 }
 
-func (container *Container) File(ctx context.Context, gw bkgw.Client, dirPath string) (*File, error) {
-	file, err := locatePath(ctx, container, dirPath, gw, NewFile)
+func (container *Container) File(ctx context.Context, gw bkgw.Client, filePath string) (*File, error) {
+	file, err := locatePath(ctx, container, filePath, gw, NewFile)
 	if err != nil {
 		return nil, err
 	}
 
 	// check that the file actually exists so the user gets an error earlier
 	// rather than when the file is used
-	_, err = file.Stat(ctx, gw)
+	info, err := file.Stat(ctx, gw)
 	if err != nil {
 		return nil, err
+	}
+
+	if info.IsDir() {
+		return nil, fmt.Errorf("path %s is a directory, not a file", filePath)
 	}
 
 	return file, nil

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -1860,6 +1860,24 @@ func TestContainerFileErrors(t *testing.T) {
 		}})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "bogus: cannot retrieve path from cache")
+
+	secretID := newSecret(t, "some-secret")
+	err = testutil.Query(
+		`query Test($secret: SecretID!) {
+			container {
+				from(address: "alpine:3.16.2") {
+					withMountedSecret(path: "/sekret", source: $secret) {
+						file(path: "/sekret") {
+							contents
+						}
+					}
+				}
+			}
+		}`, nil, &testutil.QueryOptions{Variables: map[string]any{
+			"secret": secretID,
+		}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "sekret: no such file or directory")
 }
 
 func TestContainerFSDirectory(t *testing.T) {

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -1426,7 +1426,7 @@ func TestContainerStackedMounts(t *testing.T) {
 	require.Equal(t, "lower-content", execRes.Container.From.WithMountedDirectory.Exec.WithMountedDirectory.Exec.WithoutMount.Exec.Stdout.Contents)
 }
 
-func TestContainerMountDirectory(t *testing.T) {
+func TestContainerDirectory(t *testing.T) {
 	t.Parallel()
 
 	dirRes := struct {
@@ -1524,7 +1524,7 @@ func TestContainerMountDirectory(t *testing.T) {
 	require.Equal(t, "hello\n", execRes.Container.From.WithMountedDirectory.Exec.Stdout.Contents)
 }
 
-func TestContainerMountDirectoryErrors(t *testing.T) {
+func TestContainerDirectoryErrors(t *testing.T) {
 	t.Parallel()
 
 	dirRes := struct {
@@ -1581,7 +1581,7 @@ func TestContainerMountDirectoryErrors(t *testing.T) {
 			}
 		}`, nil, nil)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "bogus: cannot retrieve directory from tmpfs")
+	require.Contains(t, err.Error(), "bogus: cannot retrieve path from tmpfs")
 
 	cacheID := newCache(t)
 	err = testutil.Query(
@@ -1599,10 +1599,10 @@ func TestContainerMountDirectoryErrors(t *testing.T) {
 			"cache": cacheID,
 		}})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "bogus: cannot retrieve directory from cache")
+	require.Contains(t, err.Error(), "bogus: cannot retrieve path from cache")
 }
 
-func TestContainerMountDirectorySourcePath(t *testing.T) {
+func TestContainerDirectorySourcePath(t *testing.T) {
 	t.Parallel()
 
 	dirRes := struct {
@@ -1694,6 +1694,178 @@ func TestContainerMountDirectorySourcePath(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "sub-content\nmore-content\n", execRes.Container.From.WithMountedDirectory.Exec.Stdout.Contents)
+}
+
+func TestContainerFile(t *testing.T) {
+	t.Parallel()
+
+	dirRes := struct {
+		Directory struct {
+			WithNewFile struct {
+				ID core.FileID
+			}
+		}
+	}{}
+
+	err := testutil.Query(
+		`{
+			directory {
+				withNewFile(path: "some-file", contents: "some-content-") {
+					id
+				}
+			}
+		}`, &dirRes, nil)
+	require.NoError(t, err)
+
+	id := dirRes.Directory.WithNewFile.ID
+
+	writeRes := struct {
+		Container struct {
+			From struct {
+				WithMountedDirectory struct {
+					WithMountedDirectory struct {
+						Exec struct {
+							File struct {
+								ID core.FileID
+							}
+						}
+					}
+				}
+			}
+		}
+	}{}
+	err = testutil.Query(
+		`query Test($id: DirectoryID!) {
+			container {
+				from(address: "alpine:3.16.2") {
+					withMountedDirectory(path: "/mnt/dir", source: $id) {
+						withMountedDirectory(path: "/mnt/dir/overlap", source: $id) {
+							exec(args: ["sh", "-c", "echo -n appended >> /mnt/dir/overlap/some-file"]) {
+								file(path: "/mnt/dir/overlap/some-file") {
+									id
+								}
+							}
+						}
+					}
+				}
+			}
+		}`, &writeRes, &testutil.QueryOptions{Variables: map[string]any{
+			"id": id,
+		}})
+	require.NoError(t, err)
+
+	writtenID := writeRes.Container.From.WithMountedDirectory.WithMountedDirectory.Exec.File.ID
+
+	execRes := struct {
+		Container struct {
+			From struct {
+				WithMountedFile struct {
+					Exec struct {
+						Stdout struct {
+							Contents string
+						}
+					}
+				}
+			}
+		}
+	}{}
+	err = testutil.Query(
+		`query Test($id: FileID!) {
+			container {
+				from(address: "alpine:3.16.2") {
+					withMountedFile(path: "/mnt/file", source: $id) {
+						exec(args: ["cat", "/mnt/file"]) {
+							stdout {
+								contents
+							}
+						}
+					}
+				}
+			}
+		}`, &execRes, &testutil.QueryOptions{Variables: map[string]any{
+			"id": writtenID,
+		}})
+	require.NoError(t, err)
+
+	require.Equal(t, "some-content-appended", execRes.Container.From.WithMountedFile.Exec.Stdout.Contents)
+}
+
+func TestContainerFileErrors(t *testing.T) {
+	t.Parallel()
+
+	dirRes := struct {
+		Directory struct {
+			WithNewFile struct {
+				WithNewFile struct {
+					ID core.DirectoryID
+				}
+			}
+		}
+	}{}
+
+	err := testutil.Query(
+		`{
+			directory {
+				withNewFile(path: "some-file", contents: "some-content") {
+					withNewFile(path: "some-dir/sub-file", contents: "sub-content") {
+						id
+					}
+				}
+			}
+		}`, &dirRes, nil)
+	require.NoError(t, err)
+
+	id := dirRes.Directory.WithNewFile.WithNewFile.ID
+
+	err = testutil.Query(
+		`query Test($id: DirectoryID!) {
+			container {
+				from(address: "alpine:3.16.2") {
+					withMountedDirectory(path: "/mnt/dir", source: $id) {
+						file(path: "/mnt/dir/bogus") {
+							id
+						}
+					}
+				}
+			}
+		}`, nil, &testutil.QueryOptions{Variables: map[string]any{
+			"id": id,
+		}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bogus: no such file or directory")
+
+	err = testutil.Query(
+		`{
+			container {
+				from(address: "alpine:3.16.2") {
+					withMountedTemp(path: "/mnt/tmp") {
+						file(path: "/mnt/tmp/bogus") {
+							id
+						}
+					}
+				}
+			}
+		}`, nil, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bogus: cannot retrieve path from tmpfs")
+
+	cacheID := newCache(t)
+	err = testutil.Query(
+		`query Test($cache: CacheID!) {
+			container {
+				from(address: "alpine:3.16.2") {
+					withMountedCache(path: "/mnt/cache", cache: $cache) {
+						file(path: "/mnt/cache/bogus") {
+							id
+						}
+					}
+				}
+			}
+		}`, nil, &testutil.QueryOptions{Variables: map[string]any{
+			"cache": cacheID,
+		}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bogus: cannot retrieve path from cache")
 }
 
 func TestContainerFSDirectory(t *testing.T) {

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -60,3 +60,70 @@ func dirWithFileID(t *testing.T, path string, contents string) core.DirectoryID 
 
 	return dirRes.Directory.WithNewFile.ID
 }
+
+func newSecret(t *testing.T, content string) core.SecretID {
+	var secretRes struct {
+		Directory struct {
+			WithNewFile struct {
+				File struct {
+					Secret struct {
+						ID core.SecretID
+					}
+				}
+			}
+		}
+	}
+
+	err := testutil.Query(
+		`query Test($content: String!) {
+			directory {
+				withNewFile(path: "some-file", contents: $content) {
+					file(path: "some-file") {
+						secret {
+							id
+						}
+					}
+				}
+			}
+		}`, &secretRes, &testutil.QueryOptions{Variables: map[string]any{
+			"content": content,
+		}})
+	require.NoError(t, err)
+
+	secretID := secretRes.Directory.WithNewFile.File.Secret.ID
+	require.NotEmpty(t, secretID)
+
+	return secretID
+}
+
+func newFile(t *testing.T, path, contents string) core.FileID {
+	var secretRes struct {
+		Directory struct {
+			WithNewFile struct {
+				File struct {
+					ID core.FileID
+				}
+			}
+		}
+	}
+
+	err := testutil.Query(
+		`query Test($path: String!, $contents: String!) {
+			directory {
+				withNewFile(path: $path, contents: $contents) {
+					file(path: "some-file") {
+						id
+					}
+				}
+			}
+		}`, &secretRes, &testutil.QueryOptions{Variables: map[string]any{
+			"path":     path,
+			"contents": contents,
+		}})
+	require.NoError(t, err)
+
+	fileID := secretRes.Directory.WithNewFile.File.ID
+	require.NotEmpty(t, fileID)
+
+	return fileID
+}

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -35,3 +35,28 @@ func newCache(t *testing.T) core.CacheID {
 
 	return res.CacheFromTokens.ID
 }
+
+func dirWithFileID(t *testing.T, path string, contents string) core.DirectoryID {
+	dirRes := struct {
+		Directory struct {
+			WithNewFile struct {
+				ID core.DirectoryID
+			}
+		}
+	}{}
+
+	err := testutil.Query(
+		`query Test($path: String!, $contents: String!) {
+			directory {
+				withNewFile(path: $path, contents: $contents) {
+					id
+				}
+			}
+		}`, &dirRes, &testutil.QueryOptions{Variables: map[string]any{
+			"path":     path,
+			"contents": contents,
+		}})
+	require.NoError(t, err)
+
+	return dirRes.Directory.WithNewFile.ID
+}

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -37,6 +37,7 @@ func (s *containerSchema) Resolvers() router.Resolvers {
 		"Container": router.ObjectResolver{
 			"from":                 router.ToResolver(s.from),
 			"rootfs":               router.ToResolver(s.rootfs),
+			"file":                 router.ToResolver(s.file),
 			"directory":            router.ToResolver(s.directory),
 			"user":                 router.ToResolver(s.user),
 			"withUser":             router.ToResolver(s.withUser),
@@ -371,6 +372,14 @@ type containerDirectoryArgs struct {
 
 func (s *containerSchema) directory(ctx *router.Context, parent *core.Container, args containerDirectoryArgs) (*core.Directory, error) {
 	return parent.Directory(ctx, s.gw, args.Path)
+}
+
+type containerFileArgs struct {
+	Path string
+}
+
+func (s *containerSchema) file(ctx *router.Context, parent *core.Container, args containerFileArgs) (*core.File, error) {
+	return parent.File(ctx, s.gw, args.Path)
 }
 
 func absPath(workDir string, containerPath string) string {

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -37,6 +37,9 @@ type Container {
     "Retrieve a directory at the given path. Mounts are included."
     directory(path: String!): Directory!
 
+    "Retrieve a file at the given path. Mounts are included."
+    file(path: String!): File!
+
     "The user to be set for all commands"
     user: String
 


### PR DESCRIPTION
fixes #3266 

Symmetrical to `directory`; retrieves a `File` by looking through all mount points.