### PR TITLE
Guard against wrong dagger binary in Python SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ Session.vim
 node_modules
 
 # python
-venv
+.venv
 __pycache__
 
 # Built Binary

--- a/examples/python/client-simple/README.md
+++ b/examples/python/client-simple/README.md
@@ -1,11 +1,8 @@
 # How to use this example
 
 ```sh
-(
-    cd ../../
-    python3 -m venv venv
-    source ./venv/bin/activate
-)
+python3 -m venv ../../.venv
+source ../../.venv/bin/activate
 pip3 install -r requirements.txt
 python3 query.py
 ```

--- a/examples/python/client-simple/cloak.yaml
+++ b/examples/python/client-simple/cloak.yaml
@@ -1,0 +1,1 @@
+name: "python"

--- a/sdk/python/dagger/src/dagger/client.py
+++ b/sdk/python/dagger/src/dagger/client.py
@@ -9,7 +9,7 @@ FSID = NewType('FSID', str)
 
 class Client(gqlClient):
 
-    def __init__(self, host: str = "localhost", port: int = "8080"):
+    def __init__(self, host: str = "localhost", port: str = "8080"):
         transport = requests.RequestsHTTPTransport(
             url='http://{}:{}/query'.format(host, port),
             timeout=30,

--- a/sdk/python/dagger/src/dagger/engine.py
+++ b/sdk/python/dagger/src/dagger/engine.py
@@ -1,4 +1,5 @@
 import os
+import logging
 import subprocess
 
 from .client import Client
@@ -30,7 +31,15 @@ class Engine:
         ]
         self._process = subprocess.Popen(args)
 
+    def _fail_if_incorrect_dagger_binary(self) -> None:
+        null = open(os.devnull, 'w')
+        completedProcess = subprocess.run(["dagger", "dev", "--help"], stdout=null, stderr=null)
+        if completedProcess.returncode != 0:
+            logging.error("⚠️  Please ensure that dagger binary in $PATH is v0.3.0 or newer - a.k.a. Cloak")
+            exit(127)
+
     def __enter__(self) -> Client:
+        self._fail_if_incorrect_dagger_binary()
         self._spawn()
         # FIXME: do a simple gql request to make sure the server is ready
         return Client(host="localhost", port=self._config['port'])

--- a/sdk/python/dagger/src/dagger/engine.py
+++ b/sdk/python/dagger/src/dagger/engine.py
@@ -8,8 +8,8 @@ class Engine:
 
     def __init__(self,
                  port: int = 8080,
-                 workdir: str = None,
-                 configPath: str = None):
+                 workdir: str | None = None,
+                 configPath: str | None = None):
         if workdir is None:
             workdir = os.environ.get('DAGGER_WORKDIR', os.getcwd())
         if configPath is None:


### PR DESCRIPTION
We want to fail if the "wrong" dagger is used. Versions prior to 0.3.x will not have commands that these SDKs depend on.

Follow-up to https://github.com/dagger/dagger/pull/3285
Part of https://github.com/dagger/dagger/issues/3176