### PR TITLE
engine: make progress configurable

### DIFF
--- a/cmd/cloak/dev.go
+++ b/cmd/cloak/dev.go
@@ -25,7 +25,7 @@ func Dev(cmd *cobra.Command, args []string) {
 		DisableHostRW: disableHostRW,
 	}
 
-	err := engine.Start(context.Background(), startOpts, func(ctx context.Context, r *router.Router) error {
+	err := engine.StartAndDisplay(context.Background(), startOpts, func(ctx context.Context, r *router.Router) error {
 		srv := http.Server{
 			Addr:              fmt.Sprintf(":%d", devServerPort),
 			Handler:           r,

--- a/cmd/cloak/dev.go
+++ b/cmd/cloak/dev.go
@@ -25,7 +25,7 @@ func Dev(cmd *cobra.Command, args []string) {
 		DisableHostRW: disableHostRW,
 	}
 
-	err := engine.StartAndDisplay(context.Background(), startOpts, func(ctx context.Context, r *router.Router) error {
+	err := engine.Start(context.Background(), startOpts, func(ctx context.Context, r *router.Router) error {
 		srv := http.Server{
 			Addr:              fmt.Sprintf(":%d", devServerPort),
 			Handler:           r,

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -36,7 +36,10 @@ type Config struct {
 	NoExtensions  bool
 	LogOutput     io.Writer
 	DisableHostRW bool
-	Progress      chan *bkclient.SolveStatus
+
+	// WARNING: this is currently exposed directly but will be removed or
+	// replaced with something incompatible in the future.
+	RawBuildkitStatus chan *bkclient.SolveStatus
 }
 
 type StartCallback func(context.Context, *router.Router) error
@@ -117,7 +120,7 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 			Gateway:       gw,
 			BKClient:      c,
 			SolveOpts:     solveOpts,
-			SolveCh:       startOpts.Progress,
+			SolveCh:       startOpts.RawBuildkitStatus,
 			Platform:      *platform,
 			DisableHostRW: startOpts.DisableHostRW,
 		})
@@ -148,7 +151,7 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 		}
 
 		return bkgw.NewResult(), nil
-	}, startOpts.Progress)
+	}, startOpts.RawBuildkitStatus)
 
 	return err
 }
@@ -159,7 +162,7 @@ func StartAndDisplay(ctx context.Context, startOpts *Config, fn StartCallback) e
 	}
 
 	ch := make(chan *bkclient.SolveStatus)
-	startOpts.Progress = ch
+	startOpts.RawBuildkitStatus = ch
 
 	eg, ctx := errgroup.WithContext(ctx)
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -94,7 +94,7 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 		Session: []session.Attachable{
 			secretsprovider.NewSecretProvider(secretStore),
 			socketProviders,
-			authprovider.NewDockerAuthProvider(os.Stderr),
+			authprovider.NewDockerAuthProvider(startOpts.LogOutput),
 		},
 	}
 


### PR DESCRIPTION
closes #3218

also adds StartAndDisplay for preserving the previous behavior and updates all existing call sites to use it instead.

by making this configurable, other projects can use their own progress UI by reading from the channel.