### PR TITLE
Second iteration of new caching API

### DIFF
--- a/core/cache.go
+++ b/core/cache.go
@@ -12,7 +12,7 @@ type CacheVolume struct {
 	ID CacheID `json:"id"`
 }
 
-var ErrInvalidCacheID = errors.New("invalid cache ID; create one using cache.withKey")
+var ErrInvalidCacheID = errors.New("invalid cache ID; create one using cacheVolume")
 
 // CacheID is an arbitrary string typically derived from a set of token
 // strings acting as the cache's "key" or "scope".

--- a/core/integration/cache_test.go
+++ b/core/integration/cache_test.go
@@ -11,9 +11,11 @@ import (
 func TestCacheVolume(t *testing.T) {
 	t.Parallel()
 
-	type createFromTokensRes struct {
-		CacheFromTokens struct {
-			ID core.CacheID
+	type createWithKeyRes struct {
+		Cache struct {
+			WithKey struct {
+				ID core.CacheID
+			}
 		}
 	}
 
@@ -25,47 +27,83 @@ func TestCacheVolume(t *testing.T) {
 
 	var idOrig, idSame, idDiff, idGiven core.CacheID
 
-	t.Run("creating from tokens", func(t *testing.T) {
-		var res createFromTokensRes
+	t.Run("creating from scratch", func(t *testing.T) {
+		var res createRes
 		err := testutil.Query(
 			`{
-				cacheFromTokens(tokens: ["a", "b"]) {
+				cache {
 					id
 				}
 			}`, &res, nil)
 		require.NoError(t, err)
 
-		idOrig = res.CacheFromTokens.ID
-		require.NotEmpty(t, res.CacheFromTokens.ID)
+		idOrig = res.Cache.ID
+		require.NotEmpty(t, res.Cache.ID)
 	})
 
-	t.Run("creating from same tokens again", func(t *testing.T) {
-		var res createFromTokensRes
+	t.Run("creating from a key", func(t *testing.T) {
+		var res createWithKeyRes
 		err := testutil.Query(
 			`{
-				cacheFromTokens(tokens: ["a", "b"]) {
-					id
+				cache {
+					withKey(key: "ab") {
+						id
+					}
 				}
 			}`, &res, nil)
 		require.NoError(t, err)
 
-		idSame = res.CacheFromTokens.ID
+		idOrig = res.Cache.WithKey.ID
+		require.NotEmpty(t, res.Cache.WithKey.ID)
+	})
+
+	t.Run("creating from a key", func(t *testing.T) {
+		var res createWithKeyRes
+		err := testutil.Query(
+			`{
+				cache {
+					withKey(key: "ab") {
+						id
+					}
+				}
+			}`, &res, nil)
+		require.NoError(t, err)
+
+		idOrig = res.Cache.WithKey.ID
+		require.NotEmpty(t, res.Cache.WithKey.ID)
+	})
+
+	t.Run("creating from same key again", func(t *testing.T) {
+		var res createWithKeyRes
+		err := testutil.Query(
+			`{
+				cache {
+					withKey(key: "ab") {
+						id
+					}
+				}
+			}`, &res, nil)
+		require.NoError(t, err)
+
+		idSame = res.Cache.WithKey.ID
 		require.NotEmpty(t, idSame)
 
 		require.Equal(t, idOrig, idSame)
 	})
 
-	t.Run("creating from different tokens", func(t *testing.T) {
-		var res createFromTokensRes
+	t.Run("creating from a different key", func(t *testing.T) {
+		var res createWithKeyRes
 		err := testutil.Query(
 			`{
-				cacheFromTokens(tokens: ["a", "c"]) {
-					id
+				cache {
+					withKey(key: "ac") {
+						id
+					}
 				}
 			}`, &res, nil)
 		require.NoError(t, err)
 
-		idDiff = res.CacheFromTokens.ID
+		idDiff = res.Cache.WithKey.ID
 		require.NotEmpty(t, idDiff)
 
 		require.NotEqual(t, idOrig, idDiff)

--- a/core/integration/cache_test.go
+++ b/core/integration/cache_test.go
@@ -11,131 +11,57 @@ import (
 func TestCacheVolume(t *testing.T) {
 	t.Parallel()
 
-	type createWithKeyRes struct {
-		Cache struct {
-			WithKey struct {
-				ID core.CacheID
-			}
-		}
-	}
-
-	type createRes struct {
-		Cache struct {
+	type creatVolumeRes struct {
+		CacheVolume struct {
 			ID core.CacheID
 		}
 	}
 
-	var idOrig, idSame, idDiff, idGiven core.CacheID
+	var idOrig, idSame, idDiff core.CacheID
 
-	t.Run("creating from scratch", func(t *testing.T) {
-		var res createRes
+	t.Run("creating from a key", func(t *testing.T) {
+		var res creatVolumeRes
 		err := testutil.Query(
 			`{
-				cache {
+				cacheVolume(key: "ab") {
 					id
 				}
 			}`, &res, nil)
 		require.NoError(t, err)
 
-		idOrig = res.Cache.ID
-		require.NotEmpty(t, res.Cache.ID)
-	})
-
-	t.Run("creating from a key", func(t *testing.T) {
-		var res createWithKeyRes
-		err := testutil.Query(
-			`{
-				cache {
-					withKey(key: "ab") {
-						id
-					}
-				}
-			}`, &res, nil)
-		require.NoError(t, err)
-
-		idOrig = res.Cache.WithKey.ID
-		require.NotEmpty(t, res.Cache.WithKey.ID)
-	})
-
-	t.Run("creating from a key", func(t *testing.T) {
-		var res createWithKeyRes
-		err := testutil.Query(
-			`{
-				cache {
-					withKey(key: "ab") {
-						id
-					}
-				}
-			}`, &res, nil)
-		require.NoError(t, err)
-
-		idOrig = res.Cache.WithKey.ID
-		require.NotEmpty(t, res.Cache.WithKey.ID)
+		idOrig = res.CacheVolume.ID
+		require.NotEmpty(t, res.CacheVolume.ID)
 	})
 
 	t.Run("creating from same key again", func(t *testing.T) {
-		var res createWithKeyRes
+		var res creatVolumeRes
 		err := testutil.Query(
 			`{
-				cache {
-					withKey(key: "ab") {
-						id
-					}
+				cacheVolume(key: "ab") {
+					id
 				}
 			}`, &res, nil)
 		require.NoError(t, err)
 
-		idSame = res.Cache.WithKey.ID
+		idSame = res.CacheVolume.ID
 		require.NotEmpty(t, idSame)
 
 		require.Equal(t, idOrig, idSame)
 	})
 
 	t.Run("creating from a different key", func(t *testing.T) {
-		var res createWithKeyRes
+		var res creatVolumeRes
 		err := testutil.Query(
 			`{
-				cache {
-					withKey(key: "ac") {
-						id
-					}
+				cacheVolume(key: "ac") {
+					id
 				}
 			}`, &res, nil)
 		require.NoError(t, err)
 
-		idDiff = res.Cache.WithKey.ID
+		idDiff = res.CacheVolume.ID
 		require.NotEmpty(t, idDiff)
 
 		require.NotEqual(t, idOrig, idDiff)
-	})
-
-	t.Run("creating from valid ID", func(t *testing.T) {
-		var res createRes
-		err := testutil.Query(
-			`query Test($id: CacheID!) {
-				cache(id: $id) {
-					id
-				}
-			}`, &res, &testutil.QueryOptions{Variables: map[string]any{
-				"id": idOrig,
-			}})
-		require.NoError(t, err)
-
-		idGiven = res.Cache.ID
-		require.Equal(t, idOrig, idGiven)
-	})
-
-	t.Run("creating from bogus ID", func(t *testing.T) {
-		var res createRes
-		err := testutil.Query(
-			`query Test($id: CacheID!) {
-				cache(id: $id) {
-					id
-				}
-			}`, &res, &testutil.QueryOptions{Variables: map[string]any{
-				"id": "bogus",
-			}})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "invalid cache ID")
 	})
 }

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -17,19 +17,15 @@ func init() {
 
 func newCache(t *testing.T) core.CacheID {
 	var res struct {
-		Cache struct {
-			WithKey struct {
-				ID core.CacheID
-			}
+		CacheVolume struct {
+			ID core.CacheID
 		}
 	}
 
 	err := testutil.Query(`
 		query CreateCache($key: String!) {
-			cache {
-				withKey(key: $key) {
-					id
-				}
+			cacheVolume(key: $key) {
+				id
 			}
 		}
 	`, &res, &testutil.QueryOptions{Variables: map[string]any{
@@ -37,7 +33,7 @@ func newCache(t *testing.T) core.CacheID {
 	}})
 	require.NoError(t, err)
 
-	return res.Cache.WithKey.ID
+	return res.CacheVolume.ID
 }
 
 func newDirWithFile(t *testing.T, path, contents string) core.DirectoryID {

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -17,23 +17,27 @@ func init() {
 
 func newCache(t *testing.T) core.CacheID {
 	var res struct {
-		CacheFromTokens struct {
-			ID core.CacheID
+		Cache struct {
+			WithKey struct {
+				ID core.CacheID
+			}
 		}
 	}
 
 	err := testutil.Query(`
-		query CreateCache($token: String!) {
-			cacheFromTokens(tokens: [$token]) {
-				id
+		query CreateCache($key: String!) {
+			cache {
+				withKey(key: $key) {
+					id
+				}
 			}
 		}
 	`, &res, &testutil.QueryOptions{Variables: map[string]any{
-		"token": identity.NewID(),
+		"key": identity.NewID(),
 	}})
 	require.NoError(t, err)
 
-	return res.CacheFromTokens.ID
+	return res.Cache.WithKey.ID
 }
 
 func newDirWithFile(t *testing.T, path, contents string) core.DirectoryID {

--- a/core/schema/cache.go
+++ b/core/schema/cache.go
@@ -25,11 +25,9 @@ func (s *cacheSchema) Resolvers() router.Resolvers {
 	return router.Resolvers{
 		"CacheID": cacheIDResolver,
 		"Query": router.ObjectResolver{
-			"cache": router.ToResolver(s.cache),
+			"cacheVolume": router.ToResolver(s.cacheVolume),
 		},
-		"CacheVolume": router.ObjectResolver{
-			"withKey": router.ToResolver(s.withKey),
-		},
+		"CacheVolume": router.ObjectResolver{},
 	}
 }
 
@@ -38,25 +36,13 @@ func (s *cacheSchema) Dependencies() []router.ExecutableSchema {
 }
 
 type cacheArgs struct {
-	ID core.CacheID
-}
-
-func (s *cacheSchema) cache(ctx *router.Context, parent any, args cacheArgs) (*core.CacheVolume, error) {
-	if args.ID == "" {
-		// TODO(vito): inject some sort of scope/session/project/user derived value
-		// here instead of a static value
-		//
-		// we have to inject something so we can tell it's a valid ID
-		return core.NewCache("cache")
-	}
-
-	return core.NewCacheFromID(args.ID)
-}
-
-type cacheWithKeyArgs struct {
 	Key string
 }
 
-func (s *cacheSchema) withKey(ctx *router.Context, parent *core.CacheVolume, args cacheWithKeyArgs) (*core.CacheVolume, error) {
-	return parent.WithKey(args.Key)
+func (s *cacheSchema) cacheVolume(ctx *router.Context, parent any, args cacheArgs) (*core.CacheVolume, error) {
+	// TODO(vito): inject some sort of scope/session/project/user derived value
+	// here instead of a static value
+	//
+	// we have to inject something so we can tell it's a valid ID
+	return core.NewCache(args.Key)
 }

--- a/core/schema/cache.go
+++ b/core/schema/cache.go
@@ -43,8 +43,10 @@ type cacheArgs struct {
 
 func (s *cacheSchema) cache(ctx *router.Context, parent any, args cacheArgs) (*core.CacheVolume, error) {
 	if args.ID == "" {
-		// TODO(vito): it would make much more sense to have some sort of scope
-		// inject an initial value here, but that's not implemented yet.
+		// TODO(vito): inject some sort of scope/session/project/user derived value
+		// here instead of a static value
+		//
+		// we have to inject something so we can tell it's a valid ID
 		return core.NewCache("cache")
 	}
 

--- a/core/schema/cache.go
+++ b/core/schema/cache.go
@@ -25,10 +25,11 @@ func (s *cacheSchema) Resolvers() router.Resolvers {
 	return router.Resolvers{
 		"CacheID": cacheIDResolver,
 		"Query": router.ObjectResolver{
-			"cache":           router.ToResolver(s.cache),
-			"cacheFromTokens": router.ToResolver(s.cacheFromTokens),
+			"cache": router.ToResolver(s.cache),
 		},
-		"CacheVolume": router.ObjectResolver{},
+		"CacheVolume": router.ObjectResolver{
+			"withKey": router.ToResolver(s.withKey),
+		},
 	}
 }
 
@@ -40,14 +41,20 @@ type cacheArgs struct {
 	ID core.CacheID
 }
 
-func (s *cacheSchema) cache(ctx *router.Context, parent any, args cacheArgs) (*core.Cache, error) {
+func (s *cacheSchema) cache(ctx *router.Context, parent any, args cacheArgs) (*core.CacheVolume, error) {
+	if args.ID == "" {
+		// TODO(vito): it would make much more sense to have some sort of scope
+		// inject an initial value here, but that's not implemented yet.
+		return core.NewCache("cache")
+	}
+
 	return core.NewCacheFromID(args.ID)
 }
 
-type cacheFromTokensArgs struct {
-	Tokens []string
+type cacheWithKeyArgs struct {
+	Key string
 }
 
-func (s *cacheSchema) cacheFromTokens(ctx *router.Context, parent any, args cacheFromTokensArgs) (*core.Cache, error) {
-	return core.NewCache(args.Tokens)
+func (s *cacheSchema) withKey(ctx *router.Context, parent *core.CacheVolume, args cacheWithKeyArgs) (*core.CacheVolume, error) {
+	return parent.WithKey(args.Key)
 }

--- a/core/schema/cache.graphqls
+++ b/core/schema/cache.graphqls
@@ -2,14 +2,11 @@
 scalar CacheID
 
 extend type Query {
-  "Construct a cache volume from its ID"
-  cache(id: CacheID): CacheVolume!
+  "Construct a cache volume for a given cache key"
+  cacheVolume(key: String!): CacheVolume!
 }
 
 "A directory whose contents persist across runs"
 type CacheVolume {
   id: CacheID!
-
-  "Create a cache with key appended to the current cache key"
-  withKey(key: String!): CacheVolume!
 }

--- a/core/schema/cache.graphqls
+++ b/core/schema/cache.graphqls
@@ -3,13 +3,13 @@ scalar CacheID
 
 extend type Query {
   "Construct a cache volume from its ID"
-  cache(id: CacheID!): CacheVolume!
-
-  "Create a new cache volume identified by an arbitrary set of tokens"
-  cacheFromTokens(tokens: [String!]!): CacheVolume!
+  cache(id: CacheID): CacheVolume!
 }
 
 "A directory whose contents persist across runs"
 type CacheVolume {
   id: CacheID!
+
+  "Create a cache with key appended to the current cache key"
+  withKey(key: String!): CacheVolume!
 }

--- a/sdk/go/dagger/api/api.gen.go
+++ b/sdk/go/dagger/api/api.gen.go
@@ -1230,21 +1230,10 @@ type Query struct {
 	c graphql.Client
 }
 
-// Construct a cache volume from its ID
-func (r *Query) Cache(id CacheID) *CacheVolume {
-	q := r.q.Select("cache")
-	q = q.Arg("id", id)
-
-	return &CacheVolume{
-		q: q,
-		c: r.c,
-	}
-}
-
-// Create a new cache volume identified by an arbitrary set of tokens
-func (r *Query) CacheFromTokens(tokens []string) *CacheVolume {
-	q := r.q.Select("cacheFromTokens")
-	q = q.Arg("tokens", tokens)
+// Construct a cache volume for a given cache key
+func (r *Query) CacheVolume(key string) *CacheVolume {
+	q := r.q.Select("cacheVolume")
+	q = q.Arg("key", key)
 
 	return &CacheVolume{
 		q: q,


### PR DESCRIPTION
follow-up to https://github.com/dagger/dagger/pull/3287 which has a lot of discussion that led to the following changes:

* ~~`cacheFromTokens` -> `cache { withKey }`; we can use this to "chain" keys from an initial scope, currently global~~
* `cacheFromTokens` -> `cacheVolume(key: String!)` - no scoping at the moment, but easy to add later
* switch from a list of tokens to a single key; a list doesn't help much at API level since it's already a separate query so you can't just reuse a param from something else
* there's still a list of keys (formerly tokens) internally, but now it's an implementation detail
