### PR TITLE
sdk: go: codegen all types

### DIFF
--- a/codegen/generator/generator.go
+++ b/codegen/generator/generator.go
@@ -23,17 +23,6 @@ func Generate(ctx context.Context, schema *introspection.Schema, cfg Config) ([]
 		}
 	}
 
-	// FIXME: explicitly remove the old API from codegen. Remove once the API has been migrated.
-	q := schema.Query()
-	fields := []*introspection.Field{}
-	for _, f := range q.Fields {
-		if f.Name == "core" || f.Name == "host" {
-			continue
-		}
-		fields = append(fields, f)
-	}
-	q.Fields = fields
-
 	gen := &GoGenerator{
 		cfg:    cfg,
 		schema: schema,
@@ -87,34 +76,6 @@ func (g *GoGenerator) Generate(_ context.Context) ([]byte, error) {
 			}
 			render = append(render, out.String())
 			return nil
-		},
-		// FIXME: temporary limit on the generation
-		Allowed: map[string]struct{}{
-			// Scalars
-			"DirectoryID":      {},
-			"SecretID":         {},
-			"ContainerID":      {},
-			"FileID":           {},
-			"ContainerAddress": {},
-			"CacheID":          {},
-
-			// Inputs
-			"ExecOpts": {},
-
-			// Objects
-			"Query":         {},
-			"File":          {},
-			"Directory":     {},
-			"Container":     {},
-			"GitRepository": {},
-			"GitRef":        {},
-			"Secret":        {},
-			"CacheVolume":   {},
-
-			// Project API
-			"Project":   {},
-			"Extension": {},
-			"Script":    {},
 		},
 	})
 	if err != nil {

--- a/codegen/generator/templates/lint_name.go
+++ b/codegen/generator/templates/lint_name.go
@@ -118,4 +118,8 @@ var commonInitialisms = map[string]bool{
 	"XMPP":  true,
 	"XSRF":  true,
 	"XSS":   true,
+
+	// Custom added for dagger
+	"FS":  true,
+	"SDK": true,
 }


### PR DESCRIPTION
This removes all limits to codegen, will also generate old API bindings.
