### PR TITLE
Add Container/File `export` and check for workdir escaping

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -1006,6 +1006,11 @@ func (container *Container) Export(
 	solveOpts bkclient.SolveOpt,
 	solveCh chan<- *bkclient.SolveStatus,
 ) error {
+	dest, err := host.NormalizeDest(dest)
+	if err != nil {
+		return err
+	}
+
 	payload, err := container.ID.decode()
 	if err != nil {
 		return err

--- a/core/container.go
+++ b/core/container.go
@@ -882,86 +882,8 @@ func (container *Container) Publish(
 	ch, wg := mirrorCh(solveCh)
 	defer wg.Wait()
 
-	var payloads []*containerIDPayload
-	if container.ID != "" {
-		payload, err := container.ID.decode()
-		if err != nil {
-			return "", err
-		}
-		if payload.FS != nil {
-			payloads = append(payloads, payload)
-		}
-	}
-	for _, id := range platformVariants {
-		payload, err := id.decode()
-		if err != nil {
-			return "", err
-		}
-		if payload.FS != nil {
-			payloads = append(payloads, payload)
-		}
-	}
-
-	if len(payloads) == 0 {
-		// Could also just ignore and do nothing, airing on side of error until proven otherwise.
-		return "", errors.New("no containers to publish")
-	}
-
 	res, err := bkClient.Build(ctx, solveOpts, "", func(ctx context.Context, gw bkgw.Client) (*bkgw.Result, error) {
-		res := bkgw.NewResult()
-		expPlatforms := &exptypes.Platforms{
-			Platforms: make([]exptypes.Platform, len(payloads)),
-		}
-
-		for i, payload := range payloads {
-			st, err := payload.FSState()
-			if err != nil {
-				return nil, err
-			}
-
-			stDef, err := st.Marshal(ctx)
-			if err != nil {
-				return nil, err
-			}
-
-			r, err := gw.Solve(ctx, bkgw.SolveRequest{
-				Definition: stDef.ToPB(),
-			})
-			if err != nil {
-				return nil, err
-			}
-			ref, err := r.SingleRef()
-			if err != nil {
-				return nil, err
-			}
-
-			platformKey := platforms.Format(payload.Platform)
-			res.AddRef(platformKey, ref)
-			expPlatforms.Platforms[i] = exptypes.Platform{
-				ID:       platformKey,
-				Platform: payload.Platform,
-			}
-
-			cfgBytes, err := json.Marshal(specs.Image{
-				Architecture: payload.Platform.Architecture,
-				OS:           payload.Platform.OS,
-				OSVersion:    payload.Platform.OSVersion,
-				OSFeatures:   payload.Platform.OSFeatures,
-				Config:       payload.Config,
-			})
-			if err != nil {
-				return nil, err
-			}
-			res.AddMeta(fmt.Sprintf("%s/%s", exptypes.ExporterImageConfigKey, platformKey), cfgBytes)
-		}
-
-		platformBytes, err := json.Marshal(expPlatforms)
-		if err != nil {
-			return nil, err
-		}
-		res.AddMeta(exptypes.ExporterPlatformsKey, platformBytes)
-
-		return res, nil
+		return container.export(ctx, gw, platformVariants)
 	}, ch)
 	if err != nil {
 		return "", err
@@ -1002,37 +924,12 @@ func (container *Container) Export(
 	ctx context.Context,
 	host *Host,
 	dest string,
+	platformVariants []ContainerID,
 	bkClient *bkclient.Client,
 	solveOpts bkclient.SolveOpt,
 	solveCh chan<- *bkclient.SolveStatus,
 ) error {
 	dest, err := host.NormalizeDest(dest)
-	if err != nil {
-		return err
-	}
-
-	payload, err := container.ID.decode()
-	if err != nil {
-		return err
-	}
-
-	st, err := payload.FSState()
-	if err != nil {
-		return err
-	}
-
-	stDef, err := st.Marshal(ctx, llb.Platform(payload.Platform))
-	if err != nil {
-		return err
-	}
-
-	cfgBytes, err := json.Marshal(specs.Image{
-		Architecture: payload.Platform.Architecture,
-		OS:           payload.Platform.OS,
-		OSVersion:    payload.Platform.OSVersion,
-		OSFeatures:   payload.Platform.OSFeatures,
-		Config:       payload.Config,
-	})
 	if err != nil {
 		return err
 	}
@@ -1050,6 +947,53 @@ func (container *Container) Export(
 			return out, nil
 		},
 	}, dest, bkClient, solveOpts, solveCh, func(ctx context.Context, gw bkgw.Client) (*bkgw.Result, error) {
+		return container.export(ctx, gw, platformVariants)
+	})
+}
+
+func (container *Container) export(
+	ctx context.Context,
+	gw bkgw.Client,
+	platformVariants []ContainerID,
+) (*bkgw.Result, error) {
+	var payloads []*containerIDPayload
+	if container.ID != "" {
+		payload, err := container.ID.decode()
+		if err != nil {
+			return nil, err
+		}
+		if payload.FS != nil {
+			payloads = append(payloads, payload)
+		}
+	}
+	for _, id := range platformVariants {
+		payload, err := id.decode()
+		if err != nil {
+			return nil, err
+		}
+		if payload.FS != nil {
+			payloads = append(payloads, payload)
+		}
+	}
+
+	if len(payloads) == 0 {
+		// Could also just ignore and do nothing, airing on side of error until proven otherwise.
+		return nil, errors.New("no containers to export")
+	}
+
+	if len(payloads) == 1 {
+		payload := payloads[0]
+
+		st, err := payload.FSState()
+		if err != nil {
+			return nil, err
+		}
+
+		stDef, err := st.Marshal(ctx, llb.Platform(payload.Platform))
+		if err != nil {
+			return nil, err
+		}
+
 		res, err := gw.Solve(ctx, bkgw.SolveRequest{
 			Evaluate:   true,
 			Definition: stDef.ToPB(),
@@ -1057,9 +1001,77 @@ func (container *Container) Export(
 		if err != nil {
 			return nil, err
 		}
+
+		cfgBytes, err := json.Marshal(specs.Image{
+			Architecture: payload.Platform.Architecture,
+			OS:           payload.Platform.OS,
+			OSVersion:    payload.Platform.OSVersion,
+			OSFeatures:   payload.Platform.OSFeatures,
+			Config:       payload.Config,
+		})
+		if err != nil {
+			return nil, err
+		}
 		res.AddMeta(exptypes.ExporterImageConfigKey, cfgBytes)
+
 		return res, nil
-	})
+	}
+
+	res := bkgw.NewResult()
+	expPlatforms := &exptypes.Platforms{
+		Platforms: make([]exptypes.Platform, len(payloads)),
+	}
+
+	for i, payload := range payloads {
+		st, err := payload.FSState()
+		if err != nil {
+			return nil, err
+		}
+
+		stDef, err := st.Marshal(ctx, llb.Platform(payload.Platform))
+		if err != nil {
+			return nil, err
+		}
+
+		r, err := gw.Solve(ctx, bkgw.SolveRequest{
+			Evaluate:   true,
+			Definition: stDef.ToPB(),
+		})
+		if err != nil {
+			return nil, err
+		}
+		ref, err := r.SingleRef()
+		if err != nil {
+			return nil, err
+		}
+
+		platformKey := platforms.Format(payload.Platform)
+		res.AddRef(platformKey, ref)
+		expPlatforms.Platforms[i] = exptypes.Platform{
+			ID:       platformKey,
+			Platform: payload.Platform,
+		}
+
+		cfgBytes, err := json.Marshal(specs.Image{
+			Architecture: payload.Platform.Architecture,
+			OS:           payload.Platform.OS,
+			OSVersion:    payload.Platform.OSVersion,
+			OSFeatures:   payload.Platform.OSFeatures,
+			Config:       payload.Config,
+		})
+		if err != nil {
+			return nil, err
+		}
+		res.AddMeta(fmt.Sprintf("%s/%s", exptypes.ExporterImageConfigKey, platformKey), cfgBytes)
+	}
+
+	platformBytes, err := json.Marshal(expPlatforms)
+	if err != nil {
+		return nil, err
+	}
+	res.AddMeta(exptypes.ExporterPlatformsKey, platformBytes)
+
+	return res, nil
 }
 
 type ContainerExecOpts struct {

--- a/core/directory.go
+++ b/core/directory.go
@@ -423,6 +423,11 @@ func (dir *Directory) Export(
 	solveOpts bkclient.SolveOpt,
 	solveCh chan<- *bkclient.SolveStatus,
 ) error {
+	dest, err := host.NormalizeDest(dest)
+	if err != nil {
+		return err
+	}
+
 	srcPayload, err := dir.ID.Decode()
 	if err != nil {
 		return err

--- a/core/directory.go
+++ b/core/directory.go
@@ -428,7 +428,10 @@ func (dir *Directory) Export(
 		return err
 	}
 
-	return host.Export(ctx, dest, bkClient, solveOpts, solveCh, func(ctx context.Context, gw bkgw.Client) (*bkgw.Result, error) {
+	return host.Export(ctx, bkclient.ExportEntry{
+		Type:      bkclient.ExporterLocal,
+		OutputDir: dest,
+	}, dest, bkClient, solveOpts, solveCh, func(ctx context.Context, gw bkgw.Client) (*bkgw.Result, error) {
 		src, err := srcPayload.State()
 		if err != nil {
 			return nil, err

--- a/core/file.go
+++ b/core/file.go
@@ -108,6 +108,11 @@ func (file *File) Export(
 	solveOpts bkclient.SolveOpt,
 	solveCh chan<- *bkclient.SolveStatus,
 ) error {
+	dest, err := host.NormalizeDest(dest)
+	if err != nil {
+		return err
+	}
+
 	srcPayload, err := file.ID.decode()
 	if err != nil {
 		return err

--- a/core/host.go
+++ b/core/host.go
@@ -105,3 +105,29 @@ func (host *Host) Export(
 	_, err := bkClient.Build(ctx, solveOpts, "", buildFn, ch)
 	return err
 }
+
+func (host *Host) NormalizeDest(dest string) (string, error) {
+	if filepath.IsAbs(dest) {
+		return dest, nil
+	}
+
+	wd, err := filepath.EvalSymlinks(host.Workdir)
+	if err != nil {
+		return "", err
+	}
+
+	dest = filepath.Clean(filepath.Join(wd, dest))
+
+	if dest == wd {
+		// writing directly to workdir
+		return dest, nil
+	}
+
+	if !strings.HasPrefix(dest, wd+"/") {
+		// writing outside of workdir
+		return "", fmt.Errorf("destination %q escapes workdir", dest)
+	}
+
+	// writing within workdir
+	return dest, nil
+}

--- a/core/host.go
+++ b/core/host.go
@@ -86,6 +86,7 @@ func (host *Host) Directory(ctx context.Context, dirPath string, platform specs.
 
 func (host *Host) Export(
 	ctx context.Context,
+	export bkclient.ExportEntry,
 	dest string,
 	bkClient *bkclient.Client,
 	solveOpts bkclient.SolveOpt,
@@ -96,15 +97,10 @@ func (host *Host) Export(
 		return ErrHostRWDisabled
 	}
 
-	solveOpts.Exports = []bkclient.ExportEntry{
-		{
-			Type:      bkclient.ExporterLocal,
-			OutputDir: dest,
-		},
-	}
-
 	ch, wg := mirrorCh(solveCh)
 	defer wg.Wait()
+
+	solveOpts.Exports = []bkclient.ExportEntry{export}
 
 	_, err := bkClient.Build(ctx, solveOpts, "", buildFn, ch)
 	return err

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -2504,7 +2504,7 @@ func TestContainerMultiPlatformExport(t *testing.T) {
 
 	startRegistry(ctx, c, t)
 
-	variants := make([]dagger.ContainerID, 0, len(platformToUname))
+	variants := make([]*dagger.Container, 0, len(platformToUname))
 	for platform := range platformToUname {
 		ctr := c.Container(dagger.ContainerOpts{Platform: platform}).
 			From("alpine:3.16.2").
@@ -2512,9 +2512,7 @@ func TestContainerMultiPlatformExport(t *testing.T) {
 				Args: []string{"uname", "-m"},
 			})
 
-		id, err := ctr.ID(ctx)
-		require.NoError(t, err)
-		variants = append(variants, id)
+		variants = append(variants, ctr)
 	}
 
 	dest := filepath.Join(t.TempDir(), "image.tar")

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -2460,7 +2460,7 @@ func TestContainerExport(t *testing.T) {
 
 	dest := filepath.Join(t.TempDir(), "image.tar")
 
-	ok, err := c.Core().Container().From("alpine:3.16.2").Export(ctx, dest)
+	ok, err := c.Container().From("alpine:3.16.2").Export(ctx, dest)
 	require.NoError(t, err)
 	require.True(t, ok)
 

--- a/core/integration/file_test.go
+++ b/core/integration/file_test.go
@@ -1,8 +1,12 @@
 package core
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"dagger.io/dagger"
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/internal/testutil"
 	"github.com/stretchr/testify/require"
@@ -100,4 +104,28 @@ func TestFileSize(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, res.Directory.WithNewFile.File.ID)
 	require.Equal(t, len("some-content"), res.Directory.WithNewFile.File.Size)
+}
+
+func TestFileExport(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	c, err := dagger.Connect(ctx)
+	require.NoError(t, err)
+	defer c.Close()
+
+	dest := filepath.Join(t.TempDir(), "image.tar")
+
+	ok, err := c.Container().From("alpine:3.16.2").File("/etc/alpine-release").Export(ctx, dest)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	contents, err := os.ReadFile(filepath.Join(dest, "alpine-release"))
+	require.NoError(t, err)
+	require.Equal(t, "3.16.2\n", string(contents))
+
+	entries, err := os.ReadDir(dest)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
 }

--- a/core/integration/host_test.go
+++ b/core/integration/host_test.go
@@ -226,29 +226,6 @@ func TestHostDirectoryExcludeInclude(t *testing.T) {
 	})
 }
 
-func TestHostDirectoryReadWrite(t *testing.T) {
-	t.Parallel()
-
-	dir1 := t.TempDir()
-	err := os.WriteFile(filepath.Join(dir1, "foo"), []byte("bar"), 0600)
-	require.NoError(t, err)
-
-	dir2 := t.TempDir()
-
-	ctx := context.Background()
-	c, err := dagger.Connect(ctx)
-	require.NoError(t, err)
-	defer c.Close()
-
-	exported, err := c.Host().Directory(dir1).Export(ctx, dir2)
-	require.NoError(t, err)
-	require.True(t, exported)
-
-	content, err := os.ReadFile(filepath.Join(dir2, "foo"))
-	require.NoError(t, err)
-	require.Equal(t, "bar", string(content))
-}
-
 func TestHostVariable(t *testing.T) {
 	t.Parallel()
 

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"dagger.io/dagger"
@@ -186,4 +187,17 @@ func startRegistry(ctx context.Context, c *dagger.Client, t *testing.T) {
 		}).
 		ExitCode(ctx)
 	require.NoError(t, err)
+}
+
+func ls(dir string) ([]string, error) {
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	var names []string
+	for _, ent := range ents {
+		names = append(names, ent.Name())
+	}
+	return names, nil
 }

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -1,7 +1,10 @@
 package core
 
 import (
+	"archive/tar"
 	"context"
+	"errors"
+	"io"
 	"os"
 	"testing"
 
@@ -200,4 +203,25 @@ func ls(dir string) ([]string, error) {
 		names[i] = ent.Name()
 	}
 	return names, nil
+}
+
+func tarEntries(t *testing.T, path string) []string {
+	f, err := os.Open(path)
+	require.NoError(t, err)
+
+	entries := []string{}
+	tr := tar.NewReader(f)
+	for {
+		hdr, err := tr.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			require.NoError(t, err)
+		}
+
+		entries = append(entries, hdr.Name)
+	}
+
+	return entries
 }

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -195,9 +195,9 @@ func ls(dir string) ([]string, error) {
 		return nil, err
 	}
 
-	var names []string
-	for _, ent := range ents {
-		names = append(names, ent.Name())
+	names := make([]string, len(ents))
+	for i, ent := range ents {
+		names[i] = ent.Name()
 	}
 	return names, nil
 }

--- a/core/schema/base.go
+++ b/core/schema/base.go
@@ -34,7 +34,7 @@ func New(params InitializeArgs) (router.ExecutableSchema, error) {
 	host := core.NewHost(params.Workdir, params.DisableHostRW)
 	return router.MergeExecutableSchemas("core",
 		&directorySchema{base, host},
-		&fileSchema{base},
+		&fileSchema{base, host},
 		&gitSchema{base},
 		&containerSchema{base, host},
 		&cacheSchema{base},

--- a/core/schema/base.go
+++ b/core/schema/base.go
@@ -36,7 +36,7 @@ func New(params InitializeArgs) (router.ExecutableSchema, error) {
 		&directorySchema{base, host},
 		&fileSchema{base},
 		&gitSchema{base},
-		&containerSchema{base},
+		&containerSchema{base, host},
 		&cacheSchema{base},
 		&secretSchema{base},
 		&hostSchema{base, host},

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -429,11 +429,12 @@ func (s *containerSchema) platform(ctx *router.Context, parent *core.Container, 
 }
 
 type containerExportArgs struct {
-	Path string
+	Path             string
+	PlatformVariants []core.ContainerID
 }
 
 func (s *containerSchema) export(ctx *router.Context, parent *core.Container, args containerExportArgs) (bool, error) {
-	if err := parent.Export(ctx, s.host, args.Path, s.bkClient, s.solveOpts, s.solveCh); err != nil {
+	if err := parent.Export(ctx, s.host, args.Path, args.PlatformVariants, s.bkClient, s.solveOpts, s.solveCh); err != nil {
 		return false, err
 	}
 

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -63,6 +63,7 @@ func (s *containerSchema) Resolvers() router.Resolvers {
 			"stderr":               router.ToResolver(s.stderr),
 			"publish":              router.ToResolver(s.publish),
 			"platform":             router.ToResolver(s.platform),
+			"export":               router.ToResolver(s.export),
 		},
 	}
 }
@@ -423,4 +424,16 @@ func (s *containerSchema) withMountedSecret(ctx *router.Context, parent *core.Co
 
 func (s *containerSchema) platform(ctx *router.Context, parent *core.Container, args any) (specs.Platform, error) {
 	return parent.Platform()
+}
+
+type containerExportArgs struct {
+	Path string
+}
+
+func (s *containerSchema) export(ctx *router.Context, parent *core.Container, args containerExportArgs) (bool, error) {
+	if err := parent.Export(ctx, s.rootSession, args.Path); err != nil {
+		return false, err
+	}
+
+	return true, nil
 }

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -12,6 +12,8 @@ import (
 
 type containerSchema struct {
 	*baseSchema
+
+	host *core.Host
 }
 
 var _ router.ExecutableSchema = &containerSchema{}
@@ -431,7 +433,7 @@ type containerExportArgs struct {
 }
 
 func (s *containerSchema) export(ctx *router.Context, parent *core.Container, args containerExportArgs) (bool, error) {
-	if err := parent.Export(ctx, s.rootSession, args.Path); err != nil {
+	if err := parent.Export(ctx, s.host, args.Path, s.bkClient, s.solveOpts, s.solveCh); err != nil {
 		return false, err
 	}
 

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -140,7 +140,7 @@ type Container {
   publish(address: String!, platformVariants: [ContainerID!]): String!
 
   "Write the container as an OCI tarball to the destination file path on the host"
-  export(path: String!): Boolean!
+  export(path: String!, platformVariants: [ContainerID!]): Boolean!
 }
 
 """

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -138,6 +138,9 @@ type Container {
   #    This may actually be a good candidate for a mutation. To be discussed.
   "Publish this container as a new image, returning a fully qualified ref"
   publish(address: String!, platformVariants: [ContainerID!]): String!
+
+  "Export the container an OCI tarball to the destination path."
+  export(path: String!): Boolean!
 }
 
 """

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -139,7 +139,7 @@ type Container {
   "Publish this container as a new image, returning a fully qualified ref"
   publish(address: String!, platformVariants: [ContainerID!]): String!
 
-  "Export the container an OCI tarball to the destination path."
+  "Write the container as an OCI tarball to the destination file path on the host"
   export(path: String!): Boolean!
 }
 

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -144,11 +144,11 @@ func (s *directorySchema) diff(ctx *router.Context, parent *core.Directory, args
 	return parent.Diff(ctx, &core.Directory{ID: args.Other})
 }
 
-type exportArgs struct {
+type dirExportArgs struct {
 	Path string
 }
 
-func (s *directorySchema) export(ctx *router.Context, parent *core.Directory, args exportArgs) (bool, error) {
+func (s *directorySchema) export(ctx *router.Context, parent *core.Directory, args dirExportArgs) (bool, error) {
 	err := parent.Export(ctx, s.host, args.Path, s.bkClient, s.solveOpts, s.solveCh)
 	if err != nil {
 		return false, err

--- a/core/schema/file.go
+++ b/core/schema/file.go
@@ -7,6 +7,8 @@ import (
 
 type fileSchema struct {
 	*baseSchema
+
+	host *core.Host
 }
 
 var _ router.ExecutableSchema = &fileSchema{}
@@ -31,6 +33,7 @@ func (s *fileSchema) Resolvers() router.Resolvers {
 			"contents": router.ToResolver(s.contents),
 			"secret":   router.ToResolver(s.secret),
 			"size":     router.ToResolver(s.size),
+			"export":   router.ToResolver(s.export),
 		},
 	}
 }
@@ -69,4 +72,17 @@ func (s *fileSchema) size(ctx *router.Context, file *core.File, args any) (int64
 	}
 
 	return info.Size_, nil
+}
+
+type fileExportArgs struct {
+	Path string
+}
+
+func (s *fileSchema) export(ctx *router.Context, parent *core.File, args fileExportArgs) (bool, error) {
+	err := parent.Export(ctx, s.host, args.Path, s.bkClient, s.solveOpts, s.solveCh)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
 }

--- a/core/schema/file.graphqls
+++ b/core/schema/file.graphqls
@@ -19,6 +19,6 @@ type File {
     "The size of the file, in bytes"
     size: Int!
 
-    "Write the file to a directory on the host"
+    "Write the file to a file path on the host"
     export(path: String!): Boolean!
 }

--- a/core/schema/file.graphqls
+++ b/core/schema/file.graphqls
@@ -18,4 +18,7 @@ type File {
 
     "The size of the file, in bytes"
     size: Int!
+
+    "Write the file to a directory on the host"
+    export(path: String!): Boolean!
 }

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -757,7 +757,7 @@ func (r *File) Contents(ctx context.Context) (string, error) {
 	return response, q.Execute(ctx, r.c)
 }
 
-// Write the contents of the file to a file or directory path on the host
+// Write the file to a directory on the host
 func (r *File) Export(ctx context.Context, path string) (bool, error) {
 	q := r.q.Select("export")
 	q = q.Arg("path", path)

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -186,6 +186,16 @@ func (r *Container) ExitCode(ctx context.Context) (int, error) {
 	return response, q.Execute(ctx, r.c)
 }
 
+// Export the container an OCI tarball to the destination path.
+func (r *Container) Export(ctx context.Context, path string) (bool, error) {
+	q := r.q.Select("export")
+	q = q.Arg("path", path)
+
+	var response bool
+	q = q.Bind(&response)
+	return response, q.Execute(ctx, r.c)
+}
+
 // Retrieve a file at the given path. Mounts are included.
 func (r *Container) File(path string) *File {
 	q := r.q.Select("file")

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -188,7 +188,7 @@ func (r *Container) ExitCode(ctx context.Context) (int, error) {
 
 // ContainerExportOpts contains options for Container.Export
 type ContainerExportOpts struct {
-	PlatformVariants []ContainerID
+	PlatformVariants []*Container
 }
 
 // Write the container as an OCI tarball to the destination file path on the host

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -757,6 +757,16 @@ func (r *File) Contents(ctx context.Context) (string, error) {
 	return response, q.Execute(ctx, r.c)
 }
 
+// Write the contents of the file to a file or directory path on the host
+func (r *File) Export(ctx context.Context, path string) (bool, error) {
+	q := r.q.Select("export")
+	q = q.Arg("path", path)
+
+	var response bool
+	q = q.Bind(&response)
+	return response, q.Execute(ctx, r.c)
+}
+
 // The content-addressed identifier of the file
 func (r *File) ID(ctx context.Context) (FileID, error) {
 	q := r.q.Select("id")

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -186,10 +186,22 @@ func (r *Container) ExitCode(ctx context.Context) (int, error) {
 	return response, q.Execute(ctx, r.c)
 }
 
-// Export the container an OCI tarball to the destination path.
-func (r *Container) Export(ctx context.Context, path string) (bool, error) {
+// ContainerExportOpts contains options for Container.Export
+type ContainerExportOpts struct {
+	PlatformVariants []ContainerID
+}
+
+// Write the container as an OCI tarball to the destination file path on the host
+func (r *Container) Export(ctx context.Context, path string, opts ...ContainerExportOpts) (bool, error) {
 	q := r.q.Select("export")
 	q = q.Arg("path", path)
+	// `platformVariants` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].PlatformVariants) {
+			q = q.Arg("platformVariants", opts[i].PlatformVariants)
+			break
+		}
+	}
 
 	var response bool
 	q = q.Bind(&response)
@@ -757,7 +769,7 @@ func (r *File) Contents(ctx context.Context) (string, error) {
 	return response, q.Execute(ctx, r.c)
 }
 
-// Write the file to a directory on the host
+// Write the file to a file path on the host
 func (r *File) Export(ctx context.Context, path string) (bool, error) {
 	q := r.q.Select("export")
 	q = q.Arg("path", path)


### PR DESCRIPTION
Adds the following schema:

```graphql
extend type Container {
  "Export the container an OCI tarball to the destination path."
  export(path: String!): Boolean!
}

extend type File {
  "Write the file to a directory on the host"
  export(path: String!): Boolean!
}
```

Side note: I thought about supporting `export(path: String!, address: ContainerAddress!)` so you can set a name for the exported image, but supporting that isn't possible with the OCI exporter until Buildkit ships a new version (possibly v0.11?) with annotation support (https://github.com/moby/buildkit/pull/2879).