### PR TITLE
Remove automount use of FSID. 

### DIFF
--- a/core/integration/project_test.go
+++ b/core/integration/project_test.go
@@ -17,22 +17,18 @@ func TestExtensionMount(t *testing.T) {
 
 	err := engine.Start(context.Background(), startOpts, func(ctx engine.Context) error {
 		res := struct {
-			Core struct {
-				Filesystem struct {
-					WriteFile struct {
-						ID string `json:"id"`
-					}
+			Directory struct {
+				WithNewFile struct {
+					ID string
 				}
 			}
 		}{}
 		err := ctx.Client.MakeRequest(ctx,
 			&graphql.Request{
 				Query: `{
-					core {
-						filesystem(id: "scratch") {
-							writeFile(path: "/foo", contents: "bar") {
-								id
-							}
+					directory {
+						withNewFile(path: "foo", contents: "bar") {
+							id
 						}
 					}
 				}`,
@@ -48,13 +44,13 @@ func TestExtensionMount(t *testing.T) {
 		}{}
 		err = ctx.Client.MakeRequest(ctx,
 			&graphql.Request{
-				Query: `query TestMount($in: FSID!) {
+				Query: `query TestMount($in: DirectoryID!) {
 					test {
 						testMount(in: $in)
 					}
 				}`,
 				Variables: map[string]any{
-					"in": res.Core.Filesystem.WriteFile.ID,
+					"in": res.Directory.WithNewFile.ID,
 				},
 			},
 			&graphql.Response{Data: &res2},

--- a/core/integration/testdata/extension/main.go
+++ b/core/integration/testdata/extension/main.go
@@ -4,11 +4,12 @@ import (
 	"os"
 
 	"go.dagger.io/dagger/sdk/go/dagger"
+	"go.dagger.io/dagger/sdk/go/dagger/api"
 )
 
 type Test struct{}
 
-func (Test) TestMount(ctx dagger.Context, in dagger.FSID) (string, error) {
+func (Test) TestMount(ctx dagger.Context, in api.DirectoryID) (string, error) {
 	bytes, err := os.ReadFile("/mnt/in/foo")
 	if err != nil {
 		return "", err

--- a/core/integration/testdata/extension/schema.graphql
+++ b/core/integration/testdata/extension/schema.graphql
@@ -1,7 +1,0 @@
-extend type Query {
-  test: Test!
-}
-
-type Test {
-  testMount(in: FSID!): String!
-}

--- a/sdk/go/dagger/server.go
+++ b/sdk/go/dagger/server.go
@@ -490,6 +490,14 @@ func inputName(name string) string {
 func goReflectTypeToGraphqlType(t reflect.Type, isInput bool) *ast.Type {
 	switch t.Kind() {
 	case reflect.String:
+		/* TODO:(sipsma)
+		Huge hack: handle any scalar type from the go SDK (i.e. DirectoryID/ContainerID)
+		The much cleaner approach will come when we integrate this code w/ the
+		in-progress codegen work.
+		*/
+		if strings.HasPrefix(t.PkgPath(), "go.dagger.io/dagger/sdk/go") {
+			return ast.NonNullNamedType(t.Name(), nil)
+		}
 		return ast.NonNullNamedType("String", nil)
 	case reflect.Int:
 		return ast.NonNullNamedType("Int", nil)


### PR DESCRIPTION
This was one of the last functional uses of FSID (besides the existing extensions+examples). Also realized there was a bug with the codefirst schema parsing of these inputs, fixed that and the existing test we had for that.

Updated this issue with the followups needed in the long term to clean this up: https://github.com/dagger/dagger/issues/3074