### PR TITLE
Add workflow for v0.3.x pre-releases

### DIFF
--- a/.github/workflows/release-v0.3.x.yml
+++ b/.github/workflows/release-v0.3.x.yml
@@ -1,0 +1,146 @@
+name: "Release v0.3.x"
+
+# Only a single job with this concurrency can run at any given time
+concurrency: release-v0.3.x
+
+on:
+  # TODO: we may run this on a schedule at some point - just manual for now - Oct. 2022
+  # This runs on a schedule by default:
+  # schedule:
+    # https://crontab.guru/#6_17_*_*_2
+    # Every Tuesday at 5:06pm UTC & 9:06am US West Coast.
+    # GitHub Actions defaults to UTC:
+    # - cron: "6 17 * * 2"
+    # There is high load on GitHub Actions at the top of the hour:
+    #
+    #     Note: The schedule event can be delayed during periods of high loads of
+    #     GitHub Actions workflow runs. High load times include the start of every
+    #     hour. To decrease the chance of delay, schedule your workflow to run at a
+    #     different time of the hour.
+    #
+    # So we run these at a special time, 9:06. Ask @gerhard about it.
+
+  # And it also supports manual triggering:
+  # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: "major|minor|patch|release|prerel"
+        # TODO: change this to `patch` when we are finished publishing pre-releases.
+        # ⚠️  Remember to update SEMVER_BUMP default to `patch`.
+        default: "prerel"
+        required: true
+      release_version:
+        # ⚠️  For the first release, this will need to be set to `0.3.0-alpha.1` explicitly
+        description: "Optional version, e.g. 0.3.0-rc.1"
+        required: false
+
+jobs:
+  release:
+    # ⚠️  If `name` changes, remember to update the `running-workflow-name` property too
+    name: "Bump version, tag & release"
+    runs-on: ubuntu-22.04
+    # ☑️  runs-on: ubuntu-22.04-16c-64g-600gb
+    steps:
+      - name: "Check out"
+        # https://github.com/actions/checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: "Generate next release version"
+        id: release_version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SEMVER_BUMP: ${{ github.event.inputs.release_type }}
+        run: |
+          # previous_release_version="$(gh api /repos/:owner/:repo/releases --jq '.[0].tag_name')"
+          # 🧰 comment the above line 👆 & uncomment the line below 👇 when debugging on a fork without any releases
+          previous_release_version="$(gh api /repos/:owner/:repo/tags --jq '.[0].name')"
+          echo "PREVIOUS RELEASE VERSION: $previous_release_version"
+          printf "::set-output name=%s::%s\n" previous "$previous_release_version"
+          if [[ -n "${{ github.event.inputs.release_version }}" ]]
+          then
+            next_release_version="v${{ github.event.inputs.release_version }}"
+          else
+            # Rather than introducing an external dependency on `semver` on every run, we commit & use a specific version locally
+            # wget https://raw.githubusercontent.com/fsaintjacques/semver-tool/3.3.0/src/semver
+            # https://github.com/fsaintjacques/semver-tool
+            next_release_version="v$(./semver bump ${SEMVER_BUMP:=prerel} $previous_release_version)"
+          fi
+          echo "NEXT RELEASE VERSION: $next_release_version"
+          printf "::set-output name=%s::%s\n" next "$next_release_version"
+
+      - name: "Fail if no changes since previous release"
+        run: |
+          echo "Changes since previous release:"
+          git diff --color --stat ${{ steps.release_version.outputs.previous }}...$GITHUB_SHA
+          if [ -z "$(git diff --color --stat ${{ steps.release_version.outputs.previous }}...$GITHUB_SHA)" ]
+          then
+            echo "This auto-release was failed on purpose: there have been no changes since ${{ steps.release_version.outputs.previous }}."
+            echo "While this can happen, it is rare and we should take notice of it, hence the failure."
+            exit 1
+          fi
+
+      # ☑️  Uncomment this step
+      # - name: "Ensure that all other checks have succeeded"
+      #   # https://github.com/lewagon/wait-on-check-action
+      #   uses: lewagon/wait-on-check-action@v1.0.0
+      #   with:
+      #     ref: ${{ github.ref }}
+      #     repo-token: ${{ secrets.GITHUB_TOKEN }}
+      #     wait-interval: 10 # polls the GitHub API every 10 every seconds
+      #     running-workflow-name: "Bump version, tag & release"
+      #     allowed-conclusions: success
+
+      - name: "Create next release tag"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X POST /repos/:owner/:repo/git/refs \
+            --field ref="refs/tags/${{ steps.release_version.outputs.next }}" \
+            --field sha="$GITHUB_SHA"
+
+      - name: "Fetch new tag"
+        # https://github.com/actions/checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: "Install Go"
+        # https://github.com/actions/setup-go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+
+      - name: "Release"
+        # https://github.com/goreleaser/goreleaser-action
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          args: release --rm-dist --debug
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.RELEASE_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RELEASE_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.RELEASE_AWS_REGION }}
+
+      # Open a https://github.com/Homebrew/homebrew-core PR to update the bottled formula after we release.
+      # This explains why we need to do it separately, on top of GoReleaser updating our Homebrew tap:
+      # - https://github.com/Homebrew/homebrew-core/pull/105746#issuecomment-1190522063
+      # - https://github.com/dagger/dagger/issues/2823#issuecomment-1190792261
+      # ☑️  Uncomment this step
+      # - name: "Update homebrew-core formula"
+      #   # https://github.com/mislav/bump-homebrew-formula-action
+      #   uses: mislav/bump-homebrew-formula-action@v2
+      #   with:
+      #     download-url: https://github.com/dagger/dagger.git
+      #     formula-name: dagger
+      #     tag-name: ${{ steps.release_version.outputs.next }}
+      #     commit-message: |
+      #       {{formulaName}} {{version}}
+
+      #       Created by ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      #       If there is problem with this PR, [open an issue](https://github.com/dagger/dagger/issues/new). The right people will be automatically notified.
+      #   env:
+      #     COMMITTER_TOKEN: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}

--- a/.github/workflows/release-v0.3.x.yml
+++ b/.github/workflows/release-v0.3.x.yml
@@ -4,13 +4,14 @@ name: "Release v0.3.x"
 concurrency: release-v0.3.x
 
 on:
-  # TODO: we may run this on a schedule at some point - just manual for now - Oct. 2022
   # This runs on a schedule by default:
+  # TODO: vvvvvvvvvvvvvvvv we may run this on a schedule at some point - just manual for now - Oct. 13, 2022
   # schedule:
+  #   - cron: "6 17 * * 2"
+  # TODO: ^^^^^^^^^^^^^^^^ we may run this on a schedule at some point - just manual for now - Oct. 13, 2022
     # https://crontab.guru/#6_17_*_*_2
     # Every Tuesday at 5:06pm UTC & 9:06am US West Coast.
     # GitHub Actions defaults to UTC:
-    # - cron: "6 17 * * 2"
     # There is high load on GitHub Actions at the top of the hour:
     #
     #     Note: The schedule event can be delayed during periods of high loads of
@@ -39,8 +40,9 @@ jobs:
   release:
     # ⚠️  If `name` changes, remember to update the `running-workflow-name` property too
     name: "Bump version, tag & release"
-    runs-on: ubuntu-22.04
-    # ☑️  runs-on: ubuntu-22.04-16c-64g-600gb
+    runs-on: ubuntu-22.04-16c-64g-600gb
+    # 🧰 comment the line above 👆 & uncomment the line below 👇 when debugging on a fork
+    # runs-on: ubuntu-22.04
     steps:
       - name: "Check out"
         # https://github.com/actions/checkout
@@ -54,9 +56,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEMVER_BUMP: ${{ github.event.inputs.release_type }}
         run: |
-          # previous_release_version="$(gh api /repos/:owner/:repo/releases --jq '.[0].tag_name')"
+          previous_release_version="$(gh api /repos/:owner/:repo/releases --jq '.[0].tag_name')"
           # 🧰 comment the above line 👆 & uncomment the line below 👇 when debugging on a fork without any releases
-          previous_release_version="$(gh api /repos/:owner/:repo/tags --jq '.[0].name')"
+          # previous_release_version="$(gh api /repos/:owner/:repo/tags --jq '.[0].name')"
           echo "PREVIOUS RELEASE VERSION: $previous_release_version"
           printf "::set-output name=%s::%s\n" previous "$previous_release_version"
           if [[ -n "${{ github.event.inputs.release_version }}" ]]
@@ -129,7 +131,12 @@ jobs:
       # This explains why we need to do it separately, on top of GoReleaser updating our Homebrew tap:
       # - https://github.com/Homebrew/homebrew-core/pull/105746#issuecomment-1190522063
       # - https://github.com/dagger/dagger/issues/2823#issuecomment-1190792261
-      # ☑️  Uncomment this step
+      #
+      # TODO: Uncomment this step AFTER we are producing final releases
+      # This will not be accepted by Homebrew maintainers otherwise: 
+      # > Unstable versions (alpha, beta, development versions) are not acceptable for versioned (or unversioned) formulae.
+      # > Excerpt from https://docs.brew.sh/Versions
+      #
       # - name: "Update homebrew-core formula"
       #   # https://github.com/mislav/bump-homebrew-formula-action
       #   uses: mislav/bump-homebrew-formula-action@v2

--- a/.github/workflows/release-v0.3.x.yml
+++ b/.github/workflows/release-v0.3.x.yml
@@ -82,16 +82,15 @@ jobs:
             exit 1
           fi
 
-      # ☑️  Uncomment this step
-      # - name: "Ensure that all other checks have succeeded"
-      #   # https://github.com/lewagon/wait-on-check-action
-      #   uses: lewagon/wait-on-check-action@v1.0.0
-      #   with:
-      #     ref: ${{ github.ref }}
-      #     repo-token: ${{ secrets.GITHUB_TOKEN }}
-      #     wait-interval: 10 # polls the GitHub API every 10 every seconds
-      #     running-workflow-name: "Bump version, tag & release"
-      #     allowed-conclusions: success
+      - name: "Ensure that all other checks have succeeded"
+        # https://github.com/lewagon/wait-on-check-action
+        uses: lewagon/wait-on-check-action@v1.0.0
+        with:
+          ref: ${{ github.ref }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10 # polls the GitHub API every 10 every seconds
+          running-workflow-name: "Bump version, tag & release"
+          allowed-conclusions: success
 
       - name: "Create next release tag"
         env:
@@ -123,6 +122,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.RELEASE_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.RELEASE_AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.RELEASE_AWS_REGION }}
+          AWS_BUCKET: ${{ secrets.RELEASE_AWS_BUCKET }}
+          ARTEFACTS_FQDN: ${{ secrets.RELEASE_FQDN }}
 
       # Open a https://github.com/Homebrew/homebrew-core PR to update the bottled formula after we release.
       # This explains why we need to do it separately, on top of GoReleaser updating our Homebrew tap:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -64,7 +64,8 @@ changelog:
 # https://goreleaser.com/customization/homebrew/
 brews:
   - tap:
-      owner: dagger
+      # ☑️  replace `gerhard` owner with `dagger`
+      owner: gerhard
       name: homebrew-tap
     name: dagger@0.3
     commit_author:
@@ -78,13 +79,14 @@ brews:
 
 blobs:
   - provider: s3
-    region: us-east-1
-    bucket: dagger-io
+    region: eu-west-1
+    # ☑️  replace all instances of `gerhard-dagger` with `dagger-io`
+    bucket: gerhard-dagger
     folder: "dagger/releases/{{ .Version }}"
 
 publishers:
   - name: publish-latest-version
-    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://dagger-io/dagger/latest_version"
+    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://gerhard-dagger/dagger/latest_version"
     env:
       - PATH={{ .Env.PATH }}
       - AWS_EC2_METADATA_DISABLED=true
@@ -92,7 +94,7 @@ publishers:
       - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
       - AWS_REGION={{ .Env.AWS_REGION }}
   - name: publish-latest
-    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://dagger-io/dagger/versions/latest"
+    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://gerhard-dagger/dagger/versions/latest"
     env:
       - PATH={{ .Env.PATH }}
       - AWS_EC2_METADATA_DISABLED=true
@@ -100,7 +102,7 @@ publishers:
       - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
       - AWS_REGION={{ .Env.AWS_REGION }}
   - name: publish-latest-major-minor
-    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://dagger-io/dagger/versions/{{ .Major }}.{{ .Minor }}"
+    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://gerhard-dagger/dagger/versions/{{ .Major }}.{{ .Minor }}"
     env:
       - PATH={{ .Env.PATH }}
       - AWS_EC2_METADATA_DISABLED=true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,8 +61,7 @@ changelog:
 # https://goreleaser.com/customization/homebrew/
 brews:
   - tap:
-      # ☑️  replace `gerhard` owner with `dagger`
-      owner: gerhard
+      owner: dagger
       name: homebrew-tap
     name: dagger@{{ .Major }}.{{ .Minor }}
     commit_author:
@@ -76,7 +75,7 @@ brews:
 
 blobs:
   - provider: s3
-    region: eu-west-1
+    region: us-east-1
     bucket: "{{ .Env.AWS_BUCKET }}"
     folder: "dagger/releases/{{ .Version }}"
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,7 @@ builds:
     binary: dagger
     ldflags:
       - -s -w
-      - -X go.dagger.io/dagger/version.Version={{.Version}}
+      - -X main.version={{.Version}}
     goos:
       - linux
       - windows
@@ -43,17 +43,14 @@ changelog:
   sort: asc
   filters:
     exclude:
-      - "^docs:"
-      - "^doc:"
-      - "^test:"
-      - "^tests:"
-      - "^ci:"
-      - "^website:"
-      - "^infra:"
-      - "^chore:"
-      - "^build\\(deps\\):"
-      - "^build\\(deps-dev\\):"
-      - "^Merge pull request"
+      - "^doc"
+      - "^test"
+      - "^ci"
+      - "^website"
+      - "^infra"
+      - "^chore"
+      - "^build"
+      - "^Merge"
   groups:
     - title: Breaking Changes
       regexp: "^.*!:+.*$"
@@ -67,11 +64,11 @@ brews:
       # ☑️  replace `gerhard` owner with `dagger`
       owner: gerhard
       name: homebrew-tap
-    name: dagger@0.3
+    name: dagger@{{ .Major }}.{{ .Minor }}
     commit_author:
       name: dagger-bot
       email: noreply@dagger.io
-    url_template: "https://dl.dagger.io/dagger/releases/{{ .Version }}/{{ .ArtifactName }}"
+    url_template: "https://{{ .Env.ARTEFACTS_FQDN }}/dagger/releases/{{ .Version }}/{{ .ArtifactName }}"
     homepage: "https://github.com/dagger/dagger"
     description: "Dagger is a programmable deployment system."
     test: |
@@ -79,14 +76,13 @@ brews:
 
 blobs:
   - provider: s3
-    region: eu-west-1
-    # ☑️  replace all instances of `gerhard-dagger` with `dagger-io`
-    bucket: gerhard-dagger
+    region: "{{ .Env.AWS_REGION }}"
+    bucket: "{{ .Env.AWS_BUCKET }}"
     folder: "dagger/releases/{{ .Version }}"
 
 publishers:
   - name: publish-latest-version
-    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://gerhard-dagger/dagger/latest_version"
+    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://{{ .Env.AWS_BUCKET }}/dagger-v{{ .Major }}.{{ .Minor }}.x/latest_version"
     env:
       - PATH={{ .Env.PATH }}
       - AWS_EC2_METADATA_DISABLED=true
@@ -94,7 +90,7 @@ publishers:
       - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
       - AWS_REGION={{ .Env.AWS_REGION }}
   - name: publish-latest
-    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://gerhard-dagger/dagger/versions/latest"
+    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://{{ .Env.AWS_BUCKET }}/dagger-v{{ .Major }}.{{ .Minor }}.x/versions/latest"
     env:
       - PATH={{ .Env.PATH }}
       - AWS_EC2_METADATA_DISABLED=true
@@ -102,7 +98,7 @@ publishers:
       - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
       - AWS_REGION={{ .Env.AWS_REGION }}
   - name: publish-latest-major-minor
-    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://gerhard-dagger/dagger/versions/{{ .Major }}.{{ .Minor }}"
+    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://{{ .Env.AWS_BUCKET }}/dagger/versions/{{ .Major }}.{{ .Minor }}"
     env:
       - PATH={{ .Env.PATH }}
       - AWS_EC2_METADATA_DISABLED=true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -80,22 +80,23 @@ blobs:
     folder: "dagger/releases/{{ .Version }}"
 
 publishers:
-  - name: publish-latest-version
-    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://{{ .Env.AWS_BUCKET }}/dagger-v{{ .Major }}.{{ .Minor }}.x/latest_version"
-    env:
-      - PATH={{ .Env.PATH }}
-      - AWS_EC2_METADATA_DISABLED=true
-      - AWS_ACCESS_KEY_ID={{ .Env.AWS_ACCESS_KEY_ID }}
-      - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
-      - AWS_REGION={{ .Env.AWS_REGION }}
-  - name: publish-latest
-    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://{{ .Env.AWS_BUCKET }}/dagger-v{{ .Major }}.{{ .Minor }}.x/versions/latest"
-    env:
-      - PATH={{ .Env.PATH }}
-      - AWS_EC2_METADATA_DISABLED=true
-      - AWS_ACCESS_KEY_ID={{ .Env.AWS_ACCESS_KEY_ID }}
-      - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
-      - AWS_REGION={{ .Env.AWS_REGION }}
+  # TODO: uncomment publishers below 👇 when we are finished publishing pre-releases.
+  # - name: publish-latest-version
+  #   cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://{{ .Env.AWS_BUCKET }}/dagger/latest_version"
+  #   env:
+  #     - PATH={{ .Env.PATH }}
+  #     - AWS_EC2_METADATA_DISABLED=true
+  #     - AWS_ACCESS_KEY_ID={{ .Env.AWS_ACCESS_KEY_ID }}
+  #     - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
+  #     - AWS_REGION={{ .Env.AWS_REGION }}
+  # - name: publish-latest
+  #   cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://{{ .Env.AWS_BUCKET }}/dagger/versions/latest"
+  #   env:
+  #     - PATH={{ .Env.PATH }}
+  #     - AWS_EC2_METADATA_DISABLED=true
+  #     - AWS_ACCESS_KEY_ID={{ .Env.AWS_ACCESS_KEY_ID }}
+  #     - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
+  #     - AWS_REGION={{ .Env.AWS_REGION }}
   - name: publish-latest-major-minor
     cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://{{ .Env.AWS_BUCKET }}/dagger/versions/{{ .Major }}.{{ .Minor }}"
     env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,119 @@
+project_name: dagger
+
+before:
+  hooks:
+    - go mod download
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    main: ./cmd/dagger
+    binary: dagger
+    ldflags:
+      - -s -w
+      - -X go.dagger.io/dagger/version.Version={{.Version}}
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    goarm:
+      - "7"
+
+archives:
+  - name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
+    files:
+      - LICENSE
+      - examples/**/*
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: "checksums.txt"
+
+snapshot:
+  name_template: "{{ .Tag }}-next"
+
+changelog:
+  use: github
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^doc:"
+      - "^test:"
+      - "^tests:"
+      - "^ci:"
+      - "^website:"
+      - "^infra:"
+      - "^chore:"
+      - "^build\\(deps\\):"
+      - "^build\\(deps-dev\\):"
+      - "^Merge pull request"
+  groups:
+    - title: Breaking Changes
+      regexp: "^.*!:+.*$"
+      order: 0
+    - title: Changes
+      order: 999
+
+# https://goreleaser.com/customization/homebrew/
+brews:
+  - tap:
+      owner: dagger
+      name: homebrew-tap
+    name: dagger@0.3
+    commit_author:
+      name: dagger-bot
+      email: noreply@dagger.io
+    url_template: "https://dl.dagger.io/dagger/releases/{{ .Version }}/{{ .ArtifactName }}"
+    homepage: "https://github.com/dagger/dagger"
+    description: "Dagger is a programmable deployment system."
+    test: |
+      system "#{bin}/dagger version"
+
+blobs:
+  - provider: s3
+    region: us-east-1
+    bucket: dagger-io
+    folder: "dagger/releases/{{ .Version }}"
+
+publishers:
+  - name: publish-latest-version
+    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://dagger-io/dagger/latest_version"
+    env:
+      - PATH={{ .Env.PATH }}
+      - AWS_EC2_METADATA_DISABLED=true
+      - AWS_ACCESS_KEY_ID={{ .Env.AWS_ACCESS_KEY_ID }}
+      - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
+      - AWS_REGION={{ .Env.AWS_REGION }}
+  - name: publish-latest
+    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://dagger-io/dagger/versions/latest"
+    env:
+      - PATH={{ .Env.PATH }}
+      - AWS_EC2_METADATA_DISABLED=true
+      - AWS_ACCESS_KEY_ID={{ .Env.AWS_ACCESS_KEY_ID }}
+      - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
+      - AWS_REGION={{ .Env.AWS_REGION }}
+  - name: publish-latest-major-minor
+    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://dagger-io/dagger/versions/{{ .Major }}.{{ .Minor }}"
+    env:
+      - PATH={{ .Env.PATH }}
+      - AWS_EC2_METADATA_DISABLED=true
+      - AWS_ACCESS_KEY_ID={{ .Env.AWS_ACCESS_KEY_ID }}
+      - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
+      - AWS_REGION={{ .Env.AWS_REGION }}
+
+# https://goreleaser.com/customization/release/
+release:
+  prerelease: "true"
+  footer: |
+    **Full Changelog**: https://github.com/dagger/dagger/compare/{{ .PreviousTag }}...{{ .Tag }}
+    ## What to do next?
+    - Read the [documentation](https://docs.dagger.io)
+    - Join our [Discord server](https://discord.gg/dagger-io)
+    - Follow us on [Twitter](https://twitter.com/dagger_io)

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,7 +76,7 @@ brews:
 
 blobs:
   - provider: s3
-    region: "{{ .Env.AWS_REGION }}"
+    region: eu-west-1
     bucket: "{{ .Env.AWS_BUCKET }}"
     folder: "dagger/releases/{{ .Version }}"
 


### PR DESCRIPTION
This is the beginning of v0.3.x release automation. We start by producing pre-releases (a.k.a. technical preview releases), specifically `v0.3.0-alpha.N`.

I have setup a parallel AWS S3 & GitHub & Homebrew tap to test how this works together. This is the successful run that produced an **unofficial** `v0.3.0-alpha.1` release in this parallel stack: https://github.com/gerhard/dagger/actions/runs/3244062096

This is what we end up with in AWS S3:

<img width="671" alt="image" src="https://user-images.githubusercontent.com/3342/195666693-cc89bcc1-611e-4a82-8f55-691a40798cb3.png">

Here is the **unofficial** GitHub pre-release: https://github.com/gerhard/dagger/releases/tag/v0.3.0-alpha.1

<img width="1413" alt="image" src="https://user-images.githubusercontent.com/3342/195666932-84eb8d99-1806-420e-8728-8c4a4d61f7b3.png">

The **unofficial** Homebrew tap is here: https://github.com/gerhard/homebrew-tap/blob/main/dagger%400.3.rb

<img width="1420" alt="image" src="https://user-images.githubusercontent.com/3342/195667453-4d7cf709-bb5a-4b35-9c3a-96316cd8efad.png">

This is what happened when I installed it via `brew install gerhard/tap/dagger@0.3`:

<img width="1126" alt="image" src="https://user-images.githubusercontent.com/3342/195667618-e867dee8-3d33-47b1-a851-12a269e3d2aa.png">

Notice that the alpha binary is available via `/usr/local/Cellar/dagger@0.3/0.3.0-alpha.1/bin/dagger`.

### What happens next?

After we merge this, we should do it for real and produce an **official** `v0.3.0-alpha.1` release.

**Open Questions:**

1. Do we want to add `examples` to the release?
![image](https://user-images.githubusercontent.com/3342/195670636-d6cda299-5e3f-4e6f-b476-3bc49a001743.png)

---

Part of https://github.com/dagger/dagger/issues/3283