### PR TITLE
examples: alpine: use new Go SDK

### DIFF
--- a/codegen/generator/templates/src/header.go.tmpl
+++ b/codegen/generator/templates/src/header.go.tmpl
@@ -16,3 +16,11 @@ func New(c graphql.Client) *{{ .Schema.QueryType.Name }} {
 		c: c,
 	}
 }
+
+// GraphQLMarshaller is an interface for marshalling an object into GraphQL.
+type GraphQLMarshaller interface {
+	// GraphQLType returns the native GraphQL type name
+	GraphQLType() string
+	// GraphQLMarshal serializes the structure into GraphQL
+	GraphQLMarshal(ctx context.Context) (any, error)
+}

--- a/codegen/generator/templates/src/object.go.tmpl
+++ b/codegen/generator/templates/src/object.go.tmpl
@@ -43,4 +43,20 @@ type {{ $field | FieldOptionsStructName }} struct {
 	return response, q.Execute(ctx, r.c)
 	{{- end }}
 }
+
+{{ if eq $field.Name "id" }}
+// GraphQLType returns the native GraphQL type name
+func (r *{{ $.Name | FormatName }}) GraphQLType() string {
+	return "{{ $.Name }}"
+}
+
+// GraphQLMarshal serializes the structure into GraphQL
+func (r *{{ $.Name | FormatName }}) GraphQLMarshal(ctx context.Context) (any, error) {
+    id, err := r.ID(ctx)
+    if err != nil {
+        return nil, err
+    }
+    return map[string]any{"id": id}, nil
+}
+{{ end }}
 {{ end -}}

--- a/codegen/generator/templates/src/scalar.go.tmpl
+++ b/codegen/generator/templates/src/scalar.go.tmpl
@@ -1,2 +1,12 @@
 {{ .Description | Comment }}
 type {{ .Name | FormatName }} string
+
+// GraphQLType returns the native GraphQL type name
+func (s {{ .Name | FormatName }}) GraphQLType() string {
+	return "{{ .Name }}"
+}
+
+// GraphQLMarshal serializes the structure into GraphQL
+func (s {{ .Name | FormatName }}) GraphQLMarshal(ctx context.Context) (any, error) {
+    return string(s), nil
+}

--- a/core/integration/examples_test.go
+++ b/core/integration/examples_test.go
@@ -22,7 +22,9 @@ func TestExtensionAlpine(t *testing.T) {
 		Alpine struct {
 			Build struct {
 				Exec struct {
-					Stdout string
+					Stdout struct {
+						Contents string
+					}
 				}
 			}
 		}
@@ -34,8 +36,10 @@ func TestExtensionAlpine(t *testing.T) {
 				query {
 					alpine {
 						build(pkgs: ["curl"]) {
-							exec(input:{args: ["curl", "--version"]}) {
-								stdout
+							exec(args: ["curl", "--version"]) {
+								stdout {
+									contents
+								}
 							}
 						}
 					}
@@ -44,7 +48,7 @@ func TestExtensionAlpine(t *testing.T) {
 		resp,
 	)
 	require.NoError(t, err)
-	require.NotEmpty(t, data.Alpine.Build.Exec.Stdout)
+	require.NotEmpty(t, data.Alpine.Build.Exec.Stdout.Contents)
 }
 
 func TestExtensionNetlifyGo(t *testing.T) {

--- a/examples/alpine/main.go
+++ b/examples/alpine/main.go
@@ -1,9 +1,8 @@
 package main
 
 import (
-	"context"
-
 	"go.dagger.io/dagger/sdk/go/dagger"
+	"go.dagger.io/dagger/sdk/go/dagger/api"
 )
 
 func main() {
@@ -15,7 +14,7 @@ func main() {
 type Alpine struct {
 }
 
-func (a Alpine) Build(ctx dagger.Context, pkgs []string) (*dagger.Filesystem, error) {
+func (a Alpine) Build(ctx dagger.Context, pkgs []string) (*api.Container, error) {
 	client, err := dagger.Connect(ctx)
 	if err != nil {
 		return nil, err
@@ -23,88 +22,14 @@ func (a Alpine) Build(ctx dagger.Context, pkgs []string) (*dagger.Filesystem, er
 	defer client.Close()
 
 	// start with Alpine base
-	fsid, err := image(ctx, client, "alpine:3.15")
-	if err != nil {
-		return nil, err
-	}
+	alpine := client.Core().Container().From("alpine:3.15")
 
 	// install each of the requested packages
 	for _, pkg := range pkgs {
-		fsid, err = addPkg(ctx, client, fsid, pkg)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return &dagger.Filesystem{ID: fsid}, nil
-}
-
-func image(ctx context.Context, client *dagger.Client, ref string) (dagger.FSID, error) {
-	req := &dagger.Request{
-		Query: `
-query Image ($ref: String!) {
-	core {
-		image(ref: $ref) {
-			id
-		}
-	}
-}
-`,
-		Variables: map[string]any{
-			"ref": ref,
-		},
-	}
-	resp := struct {
-		Core struct {
-			Image struct {
-				ID dagger.FSID
-			}
-		}
-	}{}
-	err := client.Do(ctx, req, &dagger.Response{Data: &resp})
-	if err != nil {
-		return "", err
+		alpine = alpine.Exec(api.ContainerExecOpts{
+			Args: []string{"apk", "add", "-U", "--no-cache", pkg},
+		})
 	}
 
-	return resp.Core.Image.ID, nil
-}
-
-func addPkg(ctx context.Context, client *dagger.Client, root dagger.FSID, pkg string) (dagger.FSID, error) {
-	req := &dagger.Request{
-		Query: `
-query AddPkg ($root: FSID!, $pkg: String!) {
-	core {
-		filesystem(id: $root) {
-			exec(input: {
-				args: ["apk", "add", "-U", "--no-cache", $pkg]
-			}) {
-				fs {
-					id
-				}
-			}
-		}
-	}
-}
-`,
-		Variables: map[string]any{
-			"root": root,
-			"pkg":  pkg,
-		},
-	}
-	resp := struct {
-		Core struct {
-			Filesystem struct {
-				Exec struct {
-					FS struct {
-						ID dagger.FSID
-					}
-				}
-			}
-		}
-	}{}
-	err := client.Do(ctx, req, &dagger.Response{Data: &resp})
-	if err != nil {
-		return "", err
-	}
-
-	return resp.Core.Filesystem.Exec.FS.ID, nil
+	return alpine, nil
 }

--- a/sdk/go/dagger/api/api.gen.go
+++ b/sdk/go/dagger/api/api.gen.go
@@ -17,8 +17,26 @@ func New(c graphql.Client) *Query {
 	}
 }
 
+// GraphQLMarshaller is an interface for marshalling an object into GraphQL.
+type GraphQLMarshaller interface {
+	// GraphQLType returns the native GraphQL type name
+	GraphQLType() string
+	// GraphQLMarshal serializes the structure into GraphQL
+	GraphQLMarshal(ctx context.Context) (any, error)
+}
+
 // A global cache volume identifier
 type CacheID string
+
+// GraphQLType returns the native GraphQL type name
+func (s CacheID) GraphQLType() string {
+	return "CacheID"
+}
+
+// GraphQLMarshal serializes the structure into GraphQL
+func (s CacheID) GraphQLMarshal(ctx context.Context) (any, error) {
+	return string(s), nil
+}
 
 // The address (also known as "ref") of a container published as an OCI image.
 //
@@ -29,21 +47,91 @@ type CacheID string
 //   - "index.docker.io/alpine:latest@sha256deadbeefdeadbeefdeadbeef"
 type ContainerAddress string
 
+// GraphQLType returns the native GraphQL type name
+func (s ContainerAddress) GraphQLType() string {
+	return "ContainerAddress"
+}
+
+// GraphQLMarshal serializes the structure into GraphQL
+func (s ContainerAddress) GraphQLMarshal(ctx context.Context) (any, error) {
+	return string(s), nil
+}
+
 // A unique container identifier. Null designates an empty container (scratch).
 type ContainerID string
+
+// GraphQLType returns the native GraphQL type name
+func (s ContainerID) GraphQLType() string {
+	return "ContainerID"
+}
+
+// GraphQLMarshal serializes the structure into GraphQL
+func (s ContainerID) GraphQLMarshal(ctx context.Context) (any, error) {
+	return string(s), nil
+}
 
 // A content-addressed directory identifier
 type DirectoryID string
 
+// GraphQLType returns the native GraphQL type name
+func (s DirectoryID) GraphQLType() string {
+	return "DirectoryID"
+}
+
+// GraphQLMarshal serializes the structure into GraphQL
+func (s DirectoryID) GraphQLMarshal(ctx context.Context) (any, error) {
+	return string(s), nil
+}
+
 type FSID string
 
+// GraphQLType returns the native GraphQL type name
+func (s FSID) GraphQLType() string {
+	return "FSID"
+}
+
+// GraphQLMarshal serializes the structure into GraphQL
+func (s FSID) GraphQLMarshal(ctx context.Context) (any, error) {
+	return string(s), nil
+}
+
 type FileID string
+
+// GraphQLType returns the native GraphQL type name
+func (s FileID) GraphQLType() string {
+	return "FileID"
+}
+
+// GraphQLMarshal serializes the structure into GraphQL
+func (s FileID) GraphQLMarshal(ctx context.Context) (any, error) {
+	return string(s), nil
+}
 
 // An identifier for a directory on the host
 type HostDirectoryID string
 
+// GraphQLType returns the native GraphQL type name
+func (s HostDirectoryID) GraphQLType() string {
+	return "HostDirectoryID"
+}
+
+// GraphQLMarshal serializes the structure into GraphQL
+func (s HostDirectoryID) GraphQLMarshal(ctx context.Context) (any, error) {
+	return string(s), nil
+}
+
 // A unique identifier for a secret
 type SecretID string
+
+// GraphQLType returns the native GraphQL type name
+func (s SecretID) GraphQLType() string {
+	return "SecretID"
+}
+
+// GraphQLMarshal serializes the structure into GraphQL
+func (s SecretID) GraphQLMarshal(ctx context.Context) (any, error) {
+	return string(s), nil
+}
 
 type CacheMountInput struct {
 	// Cache mount name
@@ -133,6 +221,20 @@ func (r *CacheVolume) ID(ctx context.Context) (CacheID, error) {
 	var response CacheID
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
+}
+
+// GraphQLType returns the native GraphQL type name
+func (r *CacheVolume) GraphQLType() string {
+	return "CacheVolume"
+}
+
+// GraphQLMarshal serializes the structure into GraphQL
+func (r *CacheVolume) GraphQLMarshal(ctx context.Context) (any, error) {
+	id, err := r.ID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"id": id}, nil
 }
 
 // An OCI-compatible container, also known as a docker container
@@ -269,6 +371,20 @@ func (r *Container) ID(ctx context.Context) (ContainerID, error) {
 	var response ContainerID
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
+}
+
+// GraphQLType returns the native GraphQL type name
+func (r *Container) GraphQLType() string {
+	return "Container"
+}
+
+// GraphQLMarshal serializes the structure into GraphQL
+func (r *Container) GraphQLMarshal(ctx context.Context) (any, error) {
+	id, err := r.ID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"id": id}, nil
 }
 
 // List of paths where a directory is mounted
@@ -632,6 +748,20 @@ func (r *Directory) ID(ctx context.Context) (DirectoryID, error) {
 	return response, q.Execute(ctx, r.c)
 }
 
+// GraphQLType returns the native GraphQL type name
+func (r *Directory) GraphQLType() string {
+	return "Directory"
+}
+
+// GraphQLMarshal serializes the structure into GraphQL
+func (r *Directory) GraphQLMarshal(ctx context.Context) (any, error) {
+	id, err := r.ID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"id": id}, nil
+}
+
 // load a project's metadata
 func (r *Directory) LoadProject(configPath string) *Project {
 	q := r.q.Select("loadProject")
@@ -838,6 +968,20 @@ func (r *File) ID(ctx context.Context) (FileID, error) {
 	return response, q.Execute(ctx, r.c)
 }
 
+// GraphQLType returns the native GraphQL type name
+func (r *File) GraphQLType() string {
+	return "File"
+}
+
+// GraphQLMarshal serializes the structure into GraphQL
+func (r *File) GraphQLMarshal(ctx context.Context) (any, error) {
+	id, err := r.ID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"id": id}, nil
+}
+
 func (r *File) Secret() *Secret {
 	q := r.q.Select("secret")
 
@@ -980,6 +1124,20 @@ func (r *Filesystem) ID(ctx context.Context) (FSID, error) {
 	var response FSID
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
+}
+
+// GraphQLType returns the native GraphQL type name
+func (r *Filesystem) GraphQLType() string {
+	return "Filesystem"
+}
+
+// GraphQLMarshal serializes the structure into GraphQL
+func (r *Filesystem) GraphQLMarshal(ctx context.Context) (any, error) {
+	id, err := r.ID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"id": id}, nil
 }
 
 // push a filesystem as an image to a registry
@@ -1398,4 +1556,18 @@ func (r *Secret) ID(ctx context.Context) (SecretID, error) {
 	var response SecretID
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
+}
+
+// GraphQLType returns the native GraphQL type name
+func (r *Secret) GraphQLType() string {
+	return "Secret"
+}
+
+// GraphQLMarshal serializes the structure into GraphQL
+func (r *Secret) GraphQLMarshal(ctx context.Context) (any, error) {
+	id, err := r.ID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"id": id}, nil
 }


### PR DESCRIPTION
- Add support in extension API to directly return a codegen'd type
- Convert alpine to the new SDK
