### PR TITLE
Update yarn to new API. 

### DIFF
--- a/examples/yarn/index.ts
+++ b/examples/yarn/index.ts
@@ -1,86 +1,71 @@
-import { client, DaggerServer, gql, FSID } from "@dagger.io/dagger";
+import { client, DaggerServer, gql } from "@dagger.io/dagger";
 
 const resolvers = {
   Yarn: {
-    script: async (args: { source: FSID; runArgs: Array<string> }) => {
-      const base = await client
+    // TODO: support actual types for the new scalars like DirectoryID
+    script: async (args: { source: string; runArgs: Array<string> }) => {
+      const cacheId = await client
         .request(
           gql`
             {
-              alpine {
-                build(pkgs: ["yarn", "git", "openssh-client"]) {
-                  id
-                }
+              cacheVolume(key: "yarn-cache") {
+                id
               }
             }
           `
         )
-        .then((result: any) => result.alpine.build);
+        .then((result: any) => result.cacheVolume.id);
 
       // NOTE: running install and then run is a great example of how explicit dependencies are no longer an issue
-      // FIXME:(sipsma) need a better solution than just disabling ssh host key checking
-      const yarnInstall = await client
-        .request(
-          gql`
-            {
-              core {
-                filesystem(id: "${base.id}") {
-                  exec(input: {
-                    args: ["yarn", "install"], 
-                    mounts: [{path: "/src", fs: "${args.source}"}],
-                    workdir: "/src",
-                    env: [
-                      {name: "YARN_CACHE_FOLDER", value: "/cache"}
-                      {name: "GIT_SSH_COMMAND", value: "ssh -o StrictHostKeyChecking=no"}
-                    ],
-                    cacheMounts:{name:"yarn", path:"/cache", sharingMode:"locked"},
-                    sshAuthSock: "/ssh-agent"
-                  }) {
-                    mount(path: "/src") {
-                      id
-                    }
-                  }
-                }
-              }
-            }
-          `
-        )
-        .then((result: any) => result.core.filesystem.exec.mount);
-
-      const cmd = JSON.stringify(["yarn", "run", ...args.runArgs]);
+      const cmd = ["yarn", "run", ...args.runArgs];
       const yarnRun = await client
         .request(
           gql`
-            {
-              core {
-                filesystem(id: "${base.id}") {
-                  exec(input: {
-                    args: ${cmd},
-                    mounts: [{path: "/src", fs: "${yarnInstall.id}"}],
-                    workdir: "/src",
-                    env: [
-                      {name: "YARN_CACHE_FOLDER", value: "/cache"},
-                      {name: "GIT_SSH_COMMAND", value: "ssh -o StrictHostKeyChecking=no"}
-                    ],
-                    cacheMounts:{name:"yarn", path:"/cache", sharingMode:"locked"},
-                    sshAuthSock: "/ssh-agent"
-                  }) {
-                    mount(path: "/src") {
-                      id
+            query YarnRun(
+              $source: DirectoryID!
+              $cacheId: CacheID!
+              $cmd: [String!]
+            ) {
+              alpine {
+                build(pkgs: ["yarn", "git", "openssh-client"]) {
+                  withMountedDirectory(path: "/src", source: $source) {
+                    withMountedCache(path: "/cache", cache: $cacheId) {
+                      withWorkdir(path: "/src") {
+                        withEnvVariable(
+                          name: "YARN_CACHE_FOLDER"
+                          value: "/cache"
+                        ) {
+                          exec(args: ["yarn", "install"]) {
+                            exec(args: $cmd) {
+                              directory(path: "/src") {
+                                id
+                              }
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 }
               }
             }
-          `
+          `,
+          {
+            source: args.source,
+            cacheId,
+            cmd,
+          }
         )
-        .then((result: any) => result.core.filesystem.exec.mount);
-
+        .then(
+          (result: any) =>
+            result.alpine.build.withMountedDirectory.withMountedCache
+              .withWorkdir.withEnvVariable.exec.exec.directory
+        );
       return yarnRun;
     },
   },
-  Filesystem: {
-    yarn: async (args: { runArgs: Array<string> }, parent: { id: FSID }) => {
+  Directory: {
+    yarn: async (args: { runArgs: Array<string> }, parent: { id: string }) => {
       return resolvers.Yarn.script({
         source: parent.id,
         runArgs: args.runArgs,

--- a/examples/yarn/schema.graphql
+++ b/examples/yarn/schema.graphql
@@ -3,9 +3,9 @@ extend type Query {
 }
 
 type Yarn {
-  script(source: FSID!, runArgs: [String!]): Filesystem!
+  script(source: DirectoryID!, runArgs: [String!]): Directory!
 }
 
-extend type Filesystem {
-  yarn(runArgs: [String!]): Filesystem!
+extend type Directory {
+  yarn(runArgs: [String!]): Directory!
 }


### PR DESCRIPTION
Also has commit from @aluzzardi PR here just so that alpine (used by yarn) returns container type: https://github.com/dagger/dagger/pull/3392