### PR TITLE
Simplify writing to host filesystem + export container to OCI archive

### DIFF
--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -131,6 +131,27 @@ type Container {
     #    This may actually be a good candidate for a mutation. To be discussed.
     "Publish this container as a new image"
     publish(address: ContainerAddress!): ContainerAddress!
+
+    """
+    Export the container to an OCI image archive, and write it to the given
+    path on the host filesystem.
+
+    - Relative path is written to the current workdir on the host
+    - Relative paths are not allowed to leave workdir. For example "foo/../bar" is allowed, but ".." is not.
+    - Absolute path is written to the host filesystem root
+
+    NOTE: this is a stopgap implementation, to be deprecated by `Container { archive { export } }`
+    """
+    export(path: String!): Boolean!
+
+
+    """
+    The contents to an OCI image archive.
+
+    NOTE: this deprecates `export`
+    """
+    # FIXME: this is for future implementation (harder to do)
+    archive: Directory!
 }
 
 """

--- a/core/schema/directory.graphqls
+++ b/core/schema/directory.graphqls
@@ -37,4 +37,15 @@ type Directory {
 
     "The difference between this directory and an another directory"
     diff(other: DirectoryID!): Directory!
+
+    """
+    Write the contents of this directory to the host filesystem, at the given path.
+
+    Path may be absolute or relative:
+
+    - Relative path is scoped to the host workdir. Relative paths may not leave the workdir. For example '..' is forbidden
+
+    - Absolute path os scoped to the entire host filesystem. FIXME: there are security and trust considerations here.
+    """
+    export(path: String!): Boolean!
 }

--- a/core/schema/file.graphqls
+++ b/core/schema/file.graphqls
@@ -18,4 +18,13 @@ type File {
 
     "The size of the file, in bytes"
     size: Int!
+
+    """
+    Write the contents of this file to the given path on the host filesystem.
+
+    Path may be absolute or relative:
+    - Relative path is scoped to the host workdir. Relative paths may not leave the workdir. For example '..' is forbidden
+    - Absolute path os scoped to the entire host filesystem. FIXME: there are security and trust considerations here.
+    """
+    export(path: String!): Boolean!
 }

--- a/core/schema/host.graphqls
+++ b/core/schema/host.graphqls
@@ -6,27 +6,14 @@ extend type Query {
 "Information about the host execution environment"
 type Host {
   "The current working directory on the host"
-  workdir: HostDirectory!
+  workdir: Directory!
 
-  "Access a directory on the host"
-  directory(id: HostDirectoryID!): HostDirectory!
+  "The root filesystem on the host"
+  fs: Directory!
 
   "Lookup the value of an environment variable. Null if the variable is not available."
   variable(name: String!): HostVariable
 }
-
-"An identifier for a directory on the host"
-scalar HostDirectoryID
-
-"A directory on the host"
-type HostDirectory {
-  "Read the contents of the directory"
-  read: Directory!
-
-  "Write the contents of another directory to the directory"
-  write(contents: DirectoryID!, path: String): Boolean!
-}
-
 "An environment variable on the host environment"
 type HostVariable {
   "The value of this variable"


### PR DESCRIPTION
This is a proposal for improving the Graphql API, following up on [this discussion](https://github.com/dagger/dagger/pull/3348). It only modifies graphql schema files without consideration for implementation.

## Write to host filesystem

  * Proposal for a simpler and more dev-friendly API
  * Also allow writing a file to the host filesystem

## Export container to OCI archive

  * Short-term implementation built on simpler host filesystem API
  * Longer-term implementation to make things even simpler
