### PR TITLE
flatten ExecOpts into container.exec params

### DIFF
--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -234,7 +234,7 @@ func TestContainerExecStdin(t *testing.T) {
 		`{
 			container {
 				from(address: "alpine:3.16.2") {
-					exec(args: ["cat"], opts: {stdin: "hello"}) {
+					exec(args: ["cat"], stdin: "hello") {
 						stdout {
 							contents
 						}
@@ -267,7 +267,8 @@ func TestContainerExecRedirectStdoutStderr(t *testing.T) {
 				from(address: "alpine:3.16.2") {
 					exec(
 						args: ["sh", "-c", "echo hello; echo goodbye >/dev/stderr"],
-						opts: {redirectStdout: "out", redirectStderr: "err"}
+						redirectStdout: "out",
+						redirectStderr: "err"
 					) {
 						out: file(path: "out") {
 							contents
@@ -290,7 +291,8 @@ func TestContainerExecRedirectStdoutStderr(t *testing.T) {
 				from(address: "alpine:3.16.2") {
 					exec(
 						args: ["sh", "-c", "echo hello; echo goodbye >/dev/stderr"],
-						opts: {redirectStdout: "out", redirectStderr: "err"}
+						redirectStdout: "out",
+						redirectStderr: "err"
 					) {
 						stdout {
 							contents

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -138,13 +138,11 @@ func (s *containerSchema) fs(ctx *router.Context, parent *core.Container, args a
 }
 
 type containerExecArgs struct {
-	// Args is optional. If it is nil, we the default args for the image.
-	Args *[]string
-	Opts core.ContainerExecOpts
+	core.ContainerExecOpts
 }
 
 func (s *containerSchema) exec(ctx *router.Context, parent *core.Container, args containerExecArgs) (*core.Container, error) {
-	return parent.Exec(ctx, s.gw, args.Args, args.Opts)
+	return parent.Exec(ctx, s.gw, args.ContainerExecOpts)
 }
 
 func (s *containerSchema) exitCode(ctx *router.Context, parent *core.Container, args any) (*int, error) {

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -30,11 +30,11 @@ type Container {
 
     "Initialize this container from the base image published at the given address"
     from(address: ContainerAddress!): Container!
-    
+
     "This container's root filesystem. Mounts are not included."
     fs: Directory!
 
-   "Initialize this container from this DirectoryID" 
+   "Initialize this container from this DirectoryID"
     withFS(id: DirectoryID!): Container!
 
     "Retrieve a directory at the given path. Mounts are included."
@@ -106,8 +106,16 @@ type Container {
     withoutMount(path: String!): Container!
 
     "This container after executing the specified command inside it"
-    # FIXME: verb
-    exec(args: [String!], opts: ExecOpts): Container!
+    exec(
+      "Command to run instead of the container's default command"
+      args: [String!],
+      "Content to write to the command's standard input before closing"
+      stdin: String,
+      "Redirect the command's standard output to a file in the container"
+      redirectStdout: String,
+      "Redirect the command's standard error to a file in the container"
+      redirectStderr: String,
+    ): Container!
 
     """
     Exit code of the last executed command. Zero means success.
@@ -131,31 +139,6 @@ type Container {
     #    This may actually be a good candidate for a mutation. To be discussed.
     "Publish this container as a new image"
     publish(address: ContainerAddress!): ContainerAddress!
-}
-
-"""
-Additional options for executing a command
-"""
-input ExecOpts {
-    """
-    Optionally write to the command's standard input
-
-    - Null means don't touch stdin (no redirection)
-    - Empty string means inject zero bytes to stdin, then send EOF
-    """
-    stdin: String
-
-    """
-    Optionally redirect the command's standard output to a file in the container.
-    Null means discard output.
-    """
-    redirectStdout: String
-
-    """
-    Optionally redirect the command's standard error to a file in the container.
-    Null means discard output.
-    """
-    redirectStderr: String
 }
 
 """

--- a/sdk/go/dagger/api/api.gen.go
+++ b/sdk/go/dagger/api/api.gen.go
@@ -121,23 +121,6 @@ func (s SecretID) GraphQLMarshal(ctx context.Context) (any, error) {
 	return string(s), nil
 }
 
-// Additional options for executing a command
-type ExecOpts struct {
-	// Optionally redirect the command's standard error to a file in the container.
-	// Null means discard output.
-	RedirectStderr string `json:"redirectStderr"`
-
-	// Optionally redirect the command's standard output to a file in the container.
-	// Null means discard output.
-	RedirectStdout string `json:"redirectStdout"`
-
-	// Optionally write to the command's standard input
-	//
-	// - Null means don't touch stdin (no redirection)
-	// - Empty string means inject zero bytes to stdin, then send EOF
-	Stdin string `json:"stdin"`
-}
-
 // A directory whose contents persist across runs
 type CacheVolume struct {
 	q *querybuilder.Selection
@@ -224,7 +207,11 @@ func (r *Container) EnvVariables(ctx context.Context) ([]EnvVariable, error) {
 type ContainerExecOpts struct {
 	Args []string
 
-	Opts ExecOpts
+	RedirectStderr string
+
+	RedirectStdout string
+
+	Stdin string
 }
 
 // This container after executing the specified command inside it
@@ -237,10 +224,24 @@ func (r *Container) Exec(opts ...ContainerExecOpts) *Container {
 			break
 		}
 	}
-	// `opts` optional argument
+	// `redirectStderr` optional argument
 	for i := len(opts) - 1; i >= 0; i-- {
-		if !querybuilder.IsZeroValue(opts[i].Opts) {
-			q = q.Arg("opts", opts[i].Opts)
+		if !querybuilder.IsZeroValue(opts[i].RedirectStderr) {
+			q = q.Arg("redirectStderr", opts[i].RedirectStderr)
+			break
+		}
+	}
+	// `redirectStdout` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].RedirectStdout) {
+			q = q.Arg("redirectStdout", opts[i].RedirectStdout)
+			break
+		}
+	}
+	// `stdin` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].Stdin) {
+			q = q.Arg("stdin", opts[i].Stdin)
 			break
 		}
 	}


### PR DESCRIPTION
fixes #3340 

I ended up needing this because I need to be able to pass `Stdin` but that results in setting `RedirectStdout` and `RedirectStderr` to an empty string because the `ExecOpts` struct wasn't a zero-value. Without this change I would get this from the shim:

```
15: [0.11s] panic: open : no such file or directory
15: [0.11s]
15: [0.11s] goroutine 1 [running]:
15: [0.11s] main.run()
15: [0.11s] 	/src/main.go:47 +0xad9
15: [0.11s] main.main()
15: [0.11s] 	/src/main.go:91 +0x19
```

So this promotes these params to `exec` params, removing the nesting, and removes the `""` vs. `nil` distinction for stdin, redirectStdout, and redirectStderr.

I don't think there was any difference between `stdin: ""` and `stdin: nil` before anyway; one would set it to an empty file, and the other would send it to `/dev/null`. From the process's perspective both would just yield EOF.

I decided to keep a `ContainerExecOpts` type around under `core` since it feels nicer than passing `string`, `string`, `string`. :smile: 