### PR TITLE
fix: send buildkit startup msgs to stderr

### DIFF
--- a/internal/buildkitd/buildkitd.go
+++ b/internal/buildkitd/buildkitd.go
@@ -142,7 +142,7 @@ func checkBuildkit(ctx context.Context, version string) error {
 			return err
 		}
 
-		fmt.Println("No buildkitd container found, creating one...")
+		fmt.Fprintln(os.Stderr, "No buildkitd container found, creating one...")
 
 		removeBuildkit(ctx)
 		if err := installBuildkit(ctx, version); err != nil {
@@ -152,7 +152,7 @@ func checkBuildkit(ctx context.Context, version string) error {
 	}
 
 	if config.Version != version {
-		fmt.Println("Buildkitd container is out of date, updating it...")
+		fmt.Fprintln(os.Stderr, "Buildkitd container is out of date, updating it...")
 
 		if err := removeBuildkit(ctx); err != nil {
 			return err
@@ -162,7 +162,7 @@ func checkBuildkit(ctx context.Context, version string) error {
 		}
 	}
 	if !config.IsActive {
-		fmt.Println("Buildkitd container is not running, starting it...")
+		fmt.Fprintln(os.Stderr, "Buildkitd container is not running, starting it...")
 
 		if err := startBuildkit(ctx); err != nil {
 			return err


### PR DESCRIPTION
Today, when running the `dagger` cli and providing a graphql query, if
it's a fresh environment without buildkit running, a buildkit container
will be started and a message will be emitted to stdout telling you so
which pollutes the following json output from the graphql query.

This commit sends those startup messages to stderr instead of stdout,
so things work on the first run instead of failing.

Example below:

`dagger.sh`
```
RUN="/usr/local/bin/dagger do -f ./queries.graphql"

WORKFS=$($RUN Workdir)
echo $WORKFS | jq -r '.host.workdir.read.id'
```
`queries.graphql`
```
query Workdir {
  host {
    workdir {
      read {
        id
      }
    }
  }
}
```
output from jenkins test
```
No buildkitd container found, creating one... { "host": { "workdir": { "read": { "id": "eyJsbGIiOnsiZGVmIjpbIkd2d0JDa2hzYjJOaGJEb3ZMMTlmWkdGbloyVnlYM2R2Y210a2FYSmZMMmh2YldVdm...
```

```
 ./dagger1.sh
 > git rev-parse refs/remotes/origin/main^{commit} # timeout=10
 > git config core.sparsecheckout # timeout=10
 > git checkout -f 211387b6acf04ade1e1e8d07b0d5b95725d77043 # timeout=10
time="2022-10-17T13:36:46Z" level=warning msg="commandConn.CloseWrite: commandconn: failed to wait: signal: terminated"
time="2022-10-17T13:36:46Z" level=warning msg="commandConn.CloseRead: commandconn: failed to wait: signal: terminated"
time="2022-10-17T13:36:46Z" level=warning msg="commandConn.CloseWrite: commandconn: failed to wait: signal: terminated"
parse error: Invalid numeric literal at line 1, column 3
```
`parse error` coming from `jq` receiving non-json message of `"No buildkitd container found, creating one..."`

Signed-off-by: Jeremy Adams <jeremy@dagger.io>