### PR TITLE
Python: update examples to new API

### DIFF
--- a/examples/python/client-simple/dagger.json
+++ b/examples/python/client-simple/dagger.json
@@ -1,0 +1,3 @@
+{
+    "name": "cowsay"
+}

--- a/examples/python/client-simple/query.py
+++ b/examples/python/client-simple/query.py
@@ -1,24 +1,35 @@
-from gql import gql
+import sys
 from dagger import Engine
+from gql.dsl import DSLQuery, DSLSchema, dsl_gql
+from graphql.language import print_ast
+
+
+def main(msg: str):
+    with Engine() as client:
+        with client as session:
+            assert session.client.schema is not None
+            ds = DSLSchema(session.client.schema)
+
+            query = dsl_gql(DSLQuery(
+                ds.Query.container.select(
+                    # `from` is a reserved keyword so use getattr
+                    getattr(ds.Container, "from")(address="python:alpine").select(
+                        ds.Container.exec(args=["pip", "install", "cowsay"]).select(
+                            ds.Container.exec(args=["cowsay", msg]).select(
+                                ds.Container.stdout.select(
+                                    ds.File.contents
+                                )
+                            )
+                        )
+                    )
+                )
+            ))
+
+            result = session.execute(query)
+
+            print(f"query = {print_ast(query)}")
+            print(result['container']['from']['exec']['exec']['stdout']['contents'])
+
 
 if __name__ == "__main__":
-    query = """
-    {
-        core {
-            image(ref: "alpine") {
-                exec(input: { args: ["apk", "add", "curl"] }) {
-                    fs {
-                        exec(input: { args: ["curl", "https://dagger.io/"] }) {
-                            stdout(lines: 1)
-                        }
-                    }
-                }
-            }
-        }
-    }
-    """
-
-    with Engine() as client:
-        result = client.execute(gql(query))
-        content = result['core']['image']['exec']['fs']['exec']['stdout']
-        print(content)
+    main(sys.argv[1] if len(sys.argv) > 1 else "Hey there!")

--- a/examples/python/hello/dagger.json
+++ b/examples/python/hello/dagger.json
@@ -1,4 +1,4 @@
 {
-  "name": "python",
+  "name": "hello",
   "sdk": "python"
 }

--- a/examples/python/hello/main.py
+++ b/examples/python/hello/main.py
@@ -18,23 +18,22 @@ class Hello:
         c = dagger.Client()
         result = c.execute(
             gql(
-                """query ($lines: Int) {
-                    core {
-                        image(ref: "alpine") {
-                            exec(input: {args: ["apk", "add", "curl"]}) {
-                                fs {
-                                    exec(input: {args: ["curl", "https://dagger.io/"]}) {
-                                        stdout(lines: $lines)
+                """{
+                    container {
+                        from(address: "alpine") {
+                            exec(args: ["apk", "add", "curl"]) {
+                                exec(args: ["curl", "https://dagger.io/"]) {
+                                    stdout {
+                                        contents
                                     }
                                 }
                             }
                         }
                     }
                 }"""
-            ),
-            variable_values={"lines": lines},
+            )
         )
-        return result["core"]["image"]["exec"]["fs"]["exec"]["stdout"]
+        return result["container"]["from"]["exec"]["exec"]["stdout"]["contents"]
 
 
 @strawberry.type(extend=True)

--- a/examples/python/hello/requirements.txt
+++ b/examples/python/hello/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/dagger/dagger.git@cloak#subdirectory=sdk/python/dagger&egg=dagger
+git+https://github.com/dagger/dagger.git@main#subdirectory=sdk/python/dagger&egg=dagger


### PR DESCRIPTION
Needed so we can remove the old one.

Note: Took the chance to give an example on using the query builder. We will replace these examples later with something more useful and using the forthcoming codegen api.

Signed-off-by: Helder Correia