### PR TITLE
core: refactor away from multi-return-value `Decode()`

### DIFF
--- a/core/host.go
+++ b/core/host.go
@@ -10,6 +10,7 @@ import (
 	bkclient "github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
 	bkgw "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/solver/pb"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -82,25 +83,35 @@ func (dir *HostDirectory) Write(
 	}()
 
 	_, err = bkClient.Build(ctx, solveOpts, "", func(ctx context.Context, gw bkgw.Client) (*bkgw.Result, error) {
-		src, rel, platform, err := source.Decode()
+		srcPayload, err := source.ID.Decode()
 		if err != nil {
 			return nil, err
 		}
 
-		if rel != "" {
-			src = llb.Scratch().File(llb.Copy(src, rel, ".", &llb.CopyInfo{
+		src, err := srcPayload.State()
+		if err != nil {
+			return nil, err
+		}
+
+		var defPB *pb.Definition
+		if srcPayload.Dir != "" {
+			src = llb.Scratch().File(llb.Copy(src, srcPayload.Dir, ".", &llb.CopyInfo{
 				CopyDirContentsOnly: true,
 			}))
-		}
 
-		def, err := src.Marshal(ctx, llb.Platform(platform))
-		if err != nil {
-			return nil, err
+			def, err := src.Marshal(ctx, llb.Platform(srcPayload.Platform))
+			if err != nil {
+				return nil, err
+			}
+
+			defPB = def.ToPB()
+		} else {
+			defPB = srcPayload.LLB
 		}
 
 		return gw.Solve(ctx, bkgw.SolveRequest{
 			Evaluate:   true,
-			Definition: def.ToPB(),
+			Definition: defPB,
 		})
 	}, ch)
 	if err != nil {

--- a/project/dockerfileruntime.go
+++ b/project/dockerfileruntime.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 
 	"github.com/containerd/containerd/platforms"
-	"github.com/moby/buildkit/client/llb"
 	dockerfilebuilder "github.com/moby/buildkit/frontend/dockerfile/builder"
 	bkgw "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/solver/pb"
@@ -15,12 +14,7 @@ import (
 
 func (p *State) dockerfileRuntime(ctx context.Context, subpath string, gw bkgw.Client, platform specs.Platform) (*core.Directory, error) {
 	// TODO(vito): handle relative path + platform?
-	st, _, _, err := p.workdir.Decode()
-	if err != nil {
-		return nil, err
-	}
-
-	def, err := st.Marshal(ctx, llb.Platform(platform))
+	payload, err := p.workdir.ID.Decode()
 	if err != nil {
 		return nil, err
 	}
@@ -30,8 +24,8 @@ func (p *State) dockerfileRuntime(ctx context.Context, subpath string, gw bkgw.C
 		"filename": filepath.ToSlash(filepath.Join(filepath.Dir(p.configPath), subpath, "Dockerfile")),
 	}
 	inputs := map[string]*pb.Definition{
-		dockerfilebuilder.DefaultLocalNameContext:    def.ToPB(),
-		dockerfilebuilder.DefaultLocalNameDockerfile: def.ToPB(),
+		dockerfilebuilder.DefaultLocalNameContext:    payload.LLB,
+		dockerfilebuilder.DefaultLocalNameDockerfile: payload.LLB,
 	}
 	res, err := gw.Solve(ctx, bkgw.SolveRequest{
 		Frontend:       "dockerfile.v0",

--- a/project/goruntime.go
+++ b/project/goruntime.go
@@ -13,10 +13,16 @@ import (
 
 func (p *State) goRuntime(ctx context.Context, subpath string, gw bkgw.Client, platform specs.Platform) (*core.Directory, error) {
 	// TODO(vito): handle platform?
-	contextState, rel, _, err := p.workdir.Decode()
+	payload, err := p.workdir.ID.Decode()
 	if err != nil {
 		return nil, err
 	}
+
+	contextState, err := payload.State()
+	if err != nil {
+		return nil, err
+	}
+
 	workdir := "/src"
 	return core.NewDirectory(ctx,
 		goBase(gw).Run(llb.Shlex(
@@ -26,7 +32,7 @@ func (p *State) goRuntime(ctx context.Context, subpath string, gw bkgw.Client, p
 			)),
 			llb.Dir(workdir),
 			llb.AddEnv("CGO_ENABLED", "0"),
-			llb.AddMount("/src", contextState, llb.SourcePath(rel)),
+			llb.AddMount("/src", contextState, llb.SourcePath(payload.Dir)),
 			withGoCaching(),
 		).Root(),
 		"",

--- a/project/project.go
+++ b/project/project.go
@@ -123,20 +123,33 @@ func (p *State) Schema(ctx context.Context, gw bkgw.Client, platform specs.Platf
 			return
 		}
 		// TODO(sipsma): handle relative path + platform?
-		fsState, _, _, err := runtimeFS.Decode()
+		fsPayload, err := runtimeFS.ID.Decode()
 		if err != nil {
 			rerr = err
 			return
 		}
 
-		workdirSt, _, _, err := p.workdir.Decode()
+		wdPayload, err := p.workdir.ID.Decode()
 		if err != nil {
 			rerr = err
 			return
 		}
+
+		fsState, err := fsPayload.State()
+		if err != nil {
+			rerr = err
+			return
+		}
+
+		wdState, err := wdPayload.State()
+		if err != nil {
+			rerr = err
+			return
+		}
+
 		st := fsState.Run(
 			llb.Args([]string{entrypointPath, "-schema"}),
-			llb.AddMount("/src", workdirSt, llb.Readonly),
+			llb.AddMount("/src", wdState, llb.Readonly),
 			llb.ReadonlyRootFS(),
 		)
 		outputMnt := st.AddMount(outputMountPath, llb.Scratch())
@@ -285,13 +298,23 @@ func (p *State) resolver(runtimeFS *core.Directory, sdk string, gw bkgw.Client, 
 		input := llb.Scratch().File(llb.Mkfile(inputFile, 0644, inputBytes))
 
 		// TODO(vito): handle relative path + platform?
-		fsState, _, _, err := runtimeFS.Decode()
+		fsPayload, err := runtimeFS.ID.Decode()
+		if err != nil {
+			return nil, err
+		}
+
+		fsState, err := fsPayload.State()
 		if err != nil {
 			return nil, err
 		}
 
 		// TODO(vito): handle relative path + platform?
-		workdirSt, _, _, err := p.workdir.Decode()
+		wdPayload, err := p.workdir.ID.Decode()
+		if err != nil {
+			return nil, err
+		}
+
+		wdState, err := wdPayload.State()
 		if err != nil {
 			return nil, err
 		}
@@ -310,19 +333,23 @@ func (p *State) resolver(runtimeFS *core.Directory, sdk string, gw bkgw.Client, 
 
 		// TODO:
 		if sdk == "go" {
-			st.AddMount("/src", workdirSt, llb.Readonly) // TODO: not actually needed here, just makes go server code easier at moment
+			st.AddMount("/src", wdState, llb.Readonly) // TODO: not actually needed here, just makes go server code easier at moment
 		}
 
 		// TODO: /mnt should maybe be configurable?
 		for path, dirID := range collectDirPaths(ctx.ResolveParams.Args, fsMountPath, nil) {
-			dir := core.Directory{ID: dirID}
-			dirSt, subdir, _, err := dir.Decode()
+			dirPayload, err := dirID.Decode()
+			if err != nil {
+				return nil, err
+			}
+
+			dirSt, err := dirPayload.State()
 			if err != nil {
 				return nil, err
 			}
 			// TODO: it should be possible for this to be outputtable by the action; the only question
 			// is how to expose that ability in a non-confusing way, just needs more thought
-			st.AddMount(path, dirSt, llb.SourcePath(subdir), llb.ForceNoOutput)
+			st.AddMount(path, dirSt, llb.SourcePath(dirPayload.Dir), llb.ForceNoOutput)
 		}
 
 		// Mount in the parent type if it is a Filesystem
@@ -340,7 +367,12 @@ func (p *State) resolver(runtimeFS *core.Directory, sdk string, gw bkgw.Client, 
 			}
 
 			// TODO(vito): handle relative path + platform?
-			fsState, _, _, err := parentFS.Decode()
+			fsPayload, err := parentFS.ID.Decode()
+			if err != nil {
+				return nil, err
+			}
+
+			fsState, err := fsPayload.State()
 			if err != nil {
 				return nil, err
 			}

--- a/project/tsruntime.go
+++ b/project/tsruntime.go
@@ -12,7 +12,11 @@ import (
 )
 
 func (p *State) tsRuntime(ctx context.Context, subpath string, gw bkgw.Client, platform specs.Platform, sshAuthSockID string) (*core.Directory, error) {
-	contextState, rel, _, err := p.workdir.Decode()
+	payload, err := p.workdir.ID.Decode()
+	if err != nil {
+		return nil, err
+	}
+	contextState, err := payload.State()
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +43,7 @@ func (p *State) tsRuntime(ctx context.Context, subpath string, gw bkgw.Client, p
 			llb.Image("node:16-alpine", llb.WithMetaResolver(gw)).
 				Run(llb.Shlex(`apk add --no-cache file git openssh-client`)).Root(),
 			llb.Scratch().
-				File(llb.Copy(contextState, rel, "/src")),
+				File(llb.Copy(contextState, payload.Dir, "/src")),
 		}).
 			Run(llb.Shlex(fmt.Sprintf(`sh -c 'cd %s && yarn install'`, ctrSrcPath)), baseRunOpts).
 			Run(llb.Shlex(fmt.Sprintf(`sh -c 'cd %s && yarn build'`, ctrSrcPath)), baseRunOpts).


### PR DESCRIPTION
This same refactor has already been applied to Container because one day we needed to add another value to return. The Go linter complains (justifiably) once you hit 4 non-error return values.

Another refactor I'm starting on will result in needing another value in the File and Directory payloads, so this just does an initial structural refactor in preparation of that.