### PR TITLE
feat(engine): discard log buildkit progress by default

### DIFF
--- a/cmd/dagger/dev.go
+++ b/cmd/dagger/dev.go
@@ -25,7 +25,7 @@ func Dev(cmd *cobra.Command, args []string) {
 		Workdir:    workdir,
 		ConfigPath: configPath,
 		// TODO(dolanor): add option to configure it from flag?
-		ProgressWriter: io.Discard,
+		LogOutput: io.Discard,
 	}
 
 	err := engine.Start(context.Background(), startOpts, func(ctx context.Context, r *router.Router) error {

--- a/cmd/dagger/dev.go
+++ b/cmd/dagger/dev.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"time"
@@ -23,6 +24,8 @@ func Dev(cmd *cobra.Command, args []string) {
 		LocalDirs:  localDirs,
 		Workdir:    workdir,
 		ConfigPath: configPath,
+		// TODO(dolanor): add option to configure it from flag?
+		ProgressWriter: io.Discard,
 	}
 
 	err := engine.Start(context.Background(), startOpts, func(ctx context.Context, r *router.Router) error {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -34,8 +34,8 @@ type Config struct {
 	LocalDirs  map[string]string
 	ConfigPath string
 	// If true, do not load project extensions
-	NoExtensions   bool
-	ProgressWriter io.Writer
+	NoExtensions bool
+	LogOutput    io.Writer
 }
 
 type StartCallback func(context.Context, *router.Router) error
@@ -158,11 +158,12 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 		return err
 	})
 	eg.Go(func() error {
-		if startOpts.ProgressWriter == nil {
-			startOpts.ProgressWriter = io.Discard
+		w := startOpts.LogOutput
+		if w == nil {
+			w = io.Discard
 		}
 
-		warn, err := progressui.DisplaySolveStatus(context.TODO(), "", nil, startOpts.ProgressWriter, ch)
+		warn, err := progressui.DisplaySolveStatus(context.TODO(), "", nil, w, ch)
 		for _, w := range warn {
 			fmt.Fprintf(os.Stderr, "=> %s\n", w.Short)
 		}

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -65,7 +65,7 @@ func WithNoExtensions() ClientOpt {
 // WithLogOutput sets the progress writer
 func WithLogOutput(writer io.Writer) ClientOpt {
 	return clientOptFunc(func(cfg *engineconn.Config) {
-		cfg.ProgressWriter = writer
+		cfg.LogOutput = writer
 	})
 }
 

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -3,6 +3,7 @@ package dagger
 
 import (
 	"context"
+	"io"
 	"os"
 
 	"dagger.io/dagger/api"
@@ -58,6 +59,13 @@ func WithConfigPath(path string) ClientOpt {
 func WithNoExtensions() ClientOpt {
 	return clientOptFunc(func(cfg *engineconn.Config) {
 		cfg.NoExtensions = true
+	})
+}
+
+// WithProgressWriter sets the progress writer
+func WithProgressWriter(writer io.Writer) ClientOpt {
+	return clientOptFunc(func(cfg *engineconn.Config) {
+		cfg.ProgressWriter = writer
 	})
 }
 

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -62,8 +62,8 @@ func WithNoExtensions() ClientOpt {
 	})
 }
 
-// WithProgressWriter sets the progress writer
-func WithProgressWriter(writer io.Writer) ClientOpt {
+// WithLogOutput sets the progress writer
+func WithLogOutput(writer io.Writer) ClientOpt {
 	return clientOptFunc(func(cfg *engineconn.Config) {
 		cfg.ProgressWriter = writer
 	})

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -128,7 +128,7 @@ func TestConnectOption(t *testing.T) {
 	ctx := context.Background()
 
 	w := muWriter{}
-	c, err := Connect(ctx, WithProgressWriter(&w))
+	c, err := Connect(ctx, WithLogOutput(&w))
 	require.NoError(t, err)
 	defer c.Close()
 

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -123,13 +123,15 @@ func TestConnectOption(t *testing.T) {
 	require.NoError(t, err)
 	time.Sleep(1 * time.Second)
 
-	want := `#1 resolve image config for docker.io/library/alpine:3.16.1
-#1 DONE [0-9.]+s
+	wants := []string{
+		"#1 resolve image config for docker.io/library/alpine:3.16.1",
+		"#1 DONE [0-9.]+s",
+		"#2 docker-image://docker.io/library/alpine:3.16.1",
+		"#2 resolve docker.io/library/alpine:3.16.1 [0-9.]+s done",
+		"#2 (DONE [0-9.]+s|CACHED)",
+	}
 
-#2 docker-image://docker.io/library/alpine:3.16.1
-#2 resolve docker.io/library/alpine:3.16.1
-#2 resolve docker.io/library/alpine:3.16.1 [0-9.]+s done
-#2 (DONE [0-9.]+s|CACHED)
-`
-	require.Regexp(t, want, b.String())
+	for _, want := range wants {
+		require.Regexp(t, want, b.String())
+	}
 }

--- a/sdk/go/internal/engineconn/embedded/embedded.go
+++ b/sdk/go/internal/engineconn/embedded/embedded.go
@@ -34,10 +34,11 @@ func (c *Embedded) Connect(ctx context.Context, cfg *engineconn.Config) (*http.C
 	var client *http.Client
 
 	engineCfg := &engine.Config{
-		Workdir:      cfg.Workdir,
-		ConfigPath:   cfg.ConfigPath,
-		LocalDirs:    cfg.LocalDirs,
-		NoExtensions: cfg.NoExtensions,
+		Workdir:        cfg.Workdir,
+		ConfigPath:     cfg.ConfigPath,
+		LocalDirs:      cfg.LocalDirs,
+		NoExtensions:   cfg.NoExtensions,
+		ProgressWriter: cfg.ProgressWriter,
 	}
 	go func() {
 		defer close(c.doneCh)

--- a/sdk/go/internal/engineconn/embedded/embedded.go
+++ b/sdk/go/internal/engineconn/embedded/embedded.go
@@ -34,11 +34,11 @@ func (c *Embedded) Connect(ctx context.Context, cfg *engineconn.Config) (*http.C
 	var client *http.Client
 
 	engineCfg := &engine.Config{
-		Workdir:        cfg.Workdir,
-		ConfigPath:     cfg.ConfigPath,
-		LocalDirs:      cfg.LocalDirs,
-		NoExtensions:   cfg.NoExtensions,
-		ProgressWriter: cfg.ProgressWriter,
+		Workdir:      cfg.Workdir,
+		ConfigPath:   cfg.ConfigPath,
+		LocalDirs:    cfg.LocalDirs,
+		NoExtensions: cfg.NoExtensions,
+		LogOutput:    cfg.LogOutput,
 	}
 	go func() {
 		defer close(c.doneCh)

--- a/sdk/go/internal/engineconn/engineconn.go
+++ b/sdk/go/internal/engineconn/engineconn.go
@@ -3,6 +3,7 @@ package engineconn
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -31,10 +32,11 @@ func Get(host string) (EngineConn, error) {
 }
 
 type Config struct {
-	Workdir      string
-	ConfigPath   string
-	LocalDirs    map[string]string
-	NoExtensions bool
+	Workdir        string
+	ConfigPath     string
+	LocalDirs      map[string]string
+	NoExtensions   bool
+	ProgressWriter io.Writer
 }
 
 // Register registers new connectionhelper for scheme

--- a/sdk/go/internal/engineconn/engineconn.go
+++ b/sdk/go/internal/engineconn/engineconn.go
@@ -32,11 +32,11 @@ func Get(host string) (EngineConn, error) {
 }
 
 type Config struct {
-	Workdir        string
-	ConfigPath     string
-	LocalDirs      map[string]string
-	NoExtensions   bool
-	ProgressWriter io.Writer
+	Workdir      string
+	ConfigPath   string
+	LocalDirs    map[string]string
+	NoExtensions bool
+	LogOutput    io.Writer
 }
 
 // Register registers new connectionhelper for scheme


### PR DESCRIPTION
It is configurable programmatically with `engine.Config` passed in the `engine.Start`.