### PR TITLE
expand symlinks in configured workdir

### DIFF
--- a/core/host.go
+++ b/core/host.go
@@ -58,6 +58,11 @@ func (dir *HostDirectory) Write(
 	if err != nil {
 		return false, err
 	}
+	// Ensure that we also eval the localDir
+	localDir, err = filepath.EvalSymlinks(localDir)
+	if err != nil {
+		return false, err
+	}
 	if !strings.HasPrefix(dest, localDir) {
 		return false, fmt.Errorf("path %q is outside workdir", dest)
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -183,6 +183,10 @@ func NormalizePaths(workdir, configPath string) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
+	workdir, err = filepath.EvalSymlinks(workdir)
+	if err != nil {
+		return "", "", err
+	}
 
 	if configPath == "" {
 		configPath = os.Getenv("DAGGER_CONFIG")

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -201,6 +201,10 @@ func NormalizePaths(workdir, configPath string) (string, string, error) {
 			return "", "", err
 		}
 	}
+	// Eval configPath if symlink
+	if configPath, err := filepath.EvalSymlinks(configPath); err == nil {
+		return workdir, configPath, nil
+	}
 	return workdir, configPath, nil
 }
 


### PR DESCRIPTION
otherwise host path escape assertion can fail if the workdir uses a symlink (e.g. /tmp on macOS)