### PR TITLE
Container: add `build`

### DIFF
--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -71,6 +71,41 @@ func TestContainerFrom(t *testing.T) {
 	require.Equal(t, res.Container.From.Fs.File.Contents, "3.16.2\n")
 }
 
+func TestContainerBuild(t *testing.T) {
+	ctx := context.Background()
+	c, err := dagger.Connect(ctx)
+	require.NoError(t, err)
+	defer c.Close()
+
+	srcID, err := c.Core().Directory().
+		WithNewFile("main.go", api.DirectoryWithNewFileOpts{
+			Contents: `package main
+import "fmt"
+import "os"
+func main() {
+	for _, env := range os.Environ() {
+		fmt.Println(env)
+	}
+}`,
+		}).
+		WithNewFile("Dockerfile", api.DirectoryWithNewFileOpts{
+			Contents: `FROM golang:1.18.2-alpine
+WORKDIR /src
+COPY main.go .
+RUN go mod init hello
+RUN go build -o /usr/bin/goenv main.go
+ENV FOO=bar
+CMD goenv
+`,
+		}).
+		ID(ctx)
+	require.NoError(t, err)
+
+	env, err := c.Core().Container().Build(srcID).Exec().Stdout().Contents(ctx)
+	require.NoError(t, err)
+	require.Contains(t, env, "FOO=bar\n")
+}
+
 func TestContainerWithFS(t *testing.T) {
 	t.Parallel()
 

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -31,6 +31,9 @@ type Container {
     "Initialize this container from the base image published at the given address"
     from(address: ContainerAddress!): Container!
 
+    "Initialize this container from a Dockerfile build"
+    build(context: DirectoryID!, dockerfile: String): Container!
+
     "This container's root filesystem. Mounts are not included."
     fs: Directory!
 

--- a/sdk/go/dagger/api/api.gen.go
+++ b/sdk/go/dagger/api/api.gen.go
@@ -155,6 +155,29 @@ type Container struct {
 	c graphql.Client
 }
 
+// ContainerBuildOpts contains options for Container.Build
+type ContainerBuildOpts struct {
+	Dockerfile string
+}
+
+// Initialize this container from a Dockerfile build
+func (r *Container) Build(context DirectoryID, opts ...ContainerBuildOpts) *Container {
+	q := r.q.Select("build")
+	q = q.Arg("context", context)
+	// `dockerfile` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].Dockerfile) {
+			q = q.Arg("dockerfile", opts[i].Dockerfile)
+			break
+		}
+	}
+
+	return &Container{
+		q: q,
+		c: r.c,
+	}
+}
+
 // Default arguments for future commands
 func (r *Container) DefaultArgs(ctx context.Context) ([]string, error) {
 	q := r.q.Select("defaultArgs")


### PR DESCRIPTION
needed for #3210 

Implements the following API, based on #3151:

```graphql
extend type Container {
  build(context: DirectoryID!, dockerfile: String): Container!
}
```

* I decided to go with `context` and `dockerfile` for the param args since they felt a bit more descriptive. They are both terms described in the [Docker docs](https://docs.docker.com/engine/reference/commandline/build/#description).
* I decided to have this live on `Container` instead of `Directory`. It's true that it always takes a `Directory`, but I like the symmetry with `container.from` and `container.withFS` as the final goal is to build a `Container`, just like them.

Also, moved `container.from` implementation to `(*core.Container).From` for consistency.