### PR TITLE
Directory: rename `contents` to `entries`

### DIFF
--- a/core/directory.go
+++ b/core/directory.go
@@ -130,7 +130,7 @@ func (dir *Directory) Stat(ctx context.Context, gw bkgw.Client, src string) (*fs
 	return stat, nil
 }
 
-func (dir *Directory) Contents(ctx context.Context, gw bkgw.Client, src string) ([]string, error) {
+func (dir *Directory) Entries(ctx context.Context, gw bkgw.Client, src string) ([]string, error) {
 	payload, err := dir.ID.Decode()
 	if err != nil {
 		return nil, err

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -21,7 +21,7 @@ func TestContainerScratch(t *testing.T) {
 		Container struct {
 			ID string
 			Fs struct {
-				Contents []string
+				Entries []string
 			}
 		}
 	}{}
@@ -31,13 +31,13 @@ func TestContainerScratch(t *testing.T) {
 			container {
 				id
 				fs {
-					contents
+					entries
 				}
 			}
 		}`, &res, nil)
 	require.NoError(t, err)
 	require.Empty(t, res.Container.ID)
-	require.Empty(t, res.Container.Fs.Contents)
+	require.Empty(t, res.Container.Fs.Entries)
 }
 
 func TestContainerFrom(t *testing.T) {

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -13,8 +13,8 @@ func TestEmptyDirectory(t *testing.T) {
 
 	var res struct {
 		Directory struct {
-			ID       core.DirectoryID
-			Contents []string
+			ID      core.DirectoryID
+			Entries []string
 		}
 	}
 
@@ -22,12 +22,12 @@ func TestEmptyDirectory(t *testing.T) {
 		`{
 			directory {
 				id
-				contents
+				entries
 			}
 		}`, &res, nil)
 	require.NoError(t, err)
 	require.Empty(t, res.Directory.ID)
-	require.Empty(t, res.Directory.Contents)
+	require.Empty(t, res.Directory.Entries)
 }
 
 func TestDirectoryWithNewFile(t *testing.T) {
@@ -36,8 +36,8 @@ func TestDirectoryWithNewFile(t *testing.T) {
 	var res struct {
 		Directory struct {
 			WithNewFile struct {
-				ID       core.DirectoryID
-				Contents []string
+				ID      core.DirectoryID
+				Entries []string
 			}
 		}
 	}
@@ -47,23 +47,23 @@ func TestDirectoryWithNewFile(t *testing.T) {
 			directory {
 				withNewFile(path: "some-file", contents: "some-content") {
 					id
-					contents
+					entries
 				}
 			}
 		}`, &res, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, res.Directory.WithNewFile.ID)
-	require.Equal(t, []string{"some-file"}, res.Directory.WithNewFile.Contents)
+	require.Equal(t, []string{"some-file"}, res.Directory.WithNewFile.Entries)
 }
 
-func TestDirectoryContents(t *testing.T) {
+func TestDirectoryEntries(t *testing.T) {
 	t.Parallel()
 
 	var res struct {
 		Directory struct {
 			WithNewFile struct {
 				WithNewFile struct {
-					Contents []string
+					Entries []string
 				}
 			}
 		}
@@ -74,23 +74,23 @@ func TestDirectoryContents(t *testing.T) {
 			directory {
 				withNewFile(path: "some-file", contents: "some-content") {
 					withNewFile(path: "some-dir/sub-file", contents: "some-content") {
-						contents
+						entries
 					}
 				}
 			}
 		}`, &res, nil)
 	require.NoError(t, err)
-	require.ElementsMatch(t, []string{"some-file", "some-dir"}, res.Directory.WithNewFile.WithNewFile.Contents)
+	require.ElementsMatch(t, []string{"some-file", "some-dir"}, res.Directory.WithNewFile.WithNewFile.Entries)
 }
 
-func TestDirectoryContentsOfPath(t *testing.T) {
+func TestDirectoryEntriesOfPath(t *testing.T) {
 	t.Parallel()
 
 	var res struct {
 		Directory struct {
 			WithNewFile struct {
 				WithNewFile struct {
-					Contents []string
+					Entries []string
 				}
 			}
 		}
@@ -101,13 +101,13 @@ func TestDirectoryContentsOfPath(t *testing.T) {
 			directory {
 				withNewFile(path: "some-file", contents: "some-content") {
 					withNewFile(path: "some-dir/sub-file", contents: "some-content") {
-						contents(path: "some-dir")
+						entries(path: "some-dir")
 					}
 				}
 			}
 		}`, &res, nil)
 	require.NoError(t, err)
-	require.Equal(t, []string{"sub-file"}, res.Directory.WithNewFile.WithNewFile.Contents)
+	require.Equal(t, []string{"sub-file"}, res.Directory.WithNewFile.WithNewFile.Entries)
 }
 
 func TestDirectoryDirectory(t *testing.T) {
@@ -118,7 +118,7 @@ func TestDirectoryDirectory(t *testing.T) {
 			WithNewFile struct {
 				WithNewFile struct {
 					Directory struct {
-						Contents []string
+						Entries []string
 					}
 				}
 			}
@@ -131,14 +131,14 @@ func TestDirectoryDirectory(t *testing.T) {
 				withNewFile(path: "some-file", contents: "some-content") {
 					withNewFile(path: "some-dir/sub-file", contents: "some-content") {
 						directory(path: "some-dir") {
-							contents
+							entries
 						}
 					}
 				}
 			}
 		}`, &res, nil)
 	require.NoError(t, err)
-	require.Equal(t, []string{"sub-file"}, res.Directory.WithNewFile.WithNewFile.Directory.Contents)
+	require.Equal(t, []string{"sub-file"}, res.Directory.WithNewFile.WithNewFile.Directory.Entries)
 }
 
 func TestDirectoryDirectoryWithNewFile(t *testing.T) {
@@ -150,7 +150,7 @@ func TestDirectoryDirectoryWithNewFile(t *testing.T) {
 				WithNewFile struct {
 					Directory struct {
 						WithNewFile struct {
-							Contents []string
+							Entries []string
 						}
 					}
 				}
@@ -165,7 +165,7 @@ func TestDirectoryDirectoryWithNewFile(t *testing.T) {
 					withNewFile(path: "some-dir/sub-file", contents: "some-content") {
 						directory(path: "some-dir") {
 							withNewFile(path: "another-file", contents: "more-content") {
-								contents
+								entries
 							}
 						}
 					}
@@ -175,7 +175,7 @@ func TestDirectoryDirectoryWithNewFile(t *testing.T) {
 	require.NoError(t, err)
 	require.ElementsMatch(t,
 		[]string{"sub-file", "another-file"},
-		res.Directory.WithNewFile.WithNewFile.Directory.WithNewFile.Contents)
+		res.Directory.WithNewFile.WithNewFile.Directory.WithNewFile.Entries)
 }
 
 func TestDirectoryWithDirectory(t *testing.T) {
@@ -210,7 +210,7 @@ func TestDirectoryWithDirectory(t *testing.T) {
 	var res2 struct {
 		Directory struct {
 			WithDirectory struct {
-				Contents []string
+				Entries []string
 			}
 		}
 	}
@@ -219,7 +219,7 @@ func TestDirectoryWithDirectory(t *testing.T) {
 		`query Test($src: DirectoryID!) {
 			directory {
 				withDirectory(path: "with-dir", directory: $src) {
-					contents(path: "with-dir")
+					entries(path: "with-dir")
 				}
 			}
 		}`, &res2, &testutil.QueryOptions{
@@ -228,13 +228,13 @@ func TestDirectoryWithDirectory(t *testing.T) {
 			},
 		})
 	require.NoError(t, err)
-	require.Equal(t, []string{"sub-file"}, res2.Directory.WithDirectory.Contents)
+	require.Equal(t, []string{"sub-file"}, res2.Directory.WithDirectory.Entries)
 
 	err = testutil.Query(
 		`query Test($src: DirectoryID!) {
 			directory {
 				withDirectory(path: "sub-dir/sub-sub-dir/with-dir", directory: $src) {
-					contents(path: "sub-dir/sub-sub-dir/with-dir")
+					entries(path: "sub-dir/sub-sub-dir/with-dir")
 				}
 			}
 		}`, &res2, &testutil.QueryOptions{
@@ -243,7 +243,7 @@ func TestDirectoryWithDirectory(t *testing.T) {
 			},
 		})
 	require.NoError(t, err)
-	require.Equal(t, []string{"sub-file"}, res2.Directory.WithDirectory.Contents)
+	require.Equal(t, []string{"sub-file"}, res2.Directory.WithDirectory.Entries)
 }
 
 func TestDirectoryWithCopiedFile(t *testing.T) {
@@ -312,7 +312,7 @@ func TestDirectoryWithoutDirectory(t *testing.T) {
 		Directory struct {
 			WithDirectory struct {
 				WithoutDirectory struct {
-					Contents []string
+					Entries []string
 				}
 			}
 		}
@@ -323,7 +323,7 @@ func TestDirectoryWithoutDirectory(t *testing.T) {
 			directory {
 				withDirectory(path: "with-dir", directory: $src) {
 					withoutDirectory(path: "with-dir/some-dir") {
-						contents(path: "with-dir")
+						entries(path: "with-dir")
 					}
 				}
 			}
@@ -333,7 +333,7 @@ func TestDirectoryWithoutDirectory(t *testing.T) {
 			},
 		})
 	require.NoError(t, err)
-	require.Equal(t, []string{"some-file"}, res2.Directory.WithDirectory.WithoutDirectory.Contents)
+	require.Equal(t, []string{"some-file"}, res2.Directory.WithDirectory.WithoutDirectory.Entries)
 }
 
 func TestDirectoryWithoutFile(t *testing.T) {
@@ -347,7 +347,7 @@ func TestDirectoryWithoutFile(t *testing.T) {
 		Directory struct {
 			WithDirectory struct {
 				WithoutFile struct {
-					Contents []string
+					Entries []string
 				}
 			}
 		}
@@ -358,7 +358,7 @@ func TestDirectoryWithoutFile(t *testing.T) {
 			directory {
 				withDirectory(path: "with-dir", directory: $src) {
 					withoutFile(path: "with-dir/some-file") {
-						contents(path: "with-dir")
+						entries(path: "with-dir")
 					}
 				}
 			}
@@ -368,7 +368,7 @@ func TestDirectoryWithoutFile(t *testing.T) {
 			},
 		})
 	require.NoError(t, err)
-	require.Equal(t, []string{"some-dir"}, res2.Directory.WithDirectory.WithoutFile.Contents)
+	require.Equal(t, []string{"some-dir"}, res2.Directory.WithDirectory.WithoutFile.Entries)
 }
 
 func TestDirectoryDiff(t *testing.T) {
@@ -380,7 +380,7 @@ func TestDirectoryDiff(t *testing.T) {
 	var res struct {
 		Directory struct {
 			Diff struct {
-				Contents []string
+				Entries []string
 			}
 		}
 	}
@@ -388,7 +388,7 @@ func TestDirectoryDiff(t *testing.T) {
 	diff := `query Diff($id: DirectoryID!, $other: DirectoryID!) {
 			directory(id: $id) {
 				diff(other: $other) {
-					contents
+					entries
 				}
 			}
 		}`
@@ -400,7 +400,7 @@ func TestDirectoryDiff(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, []string{"b-file"}, res.Directory.Diff.Contents)
+	require.Equal(t, []string{"b-file"}, res.Directory.Diff.Entries)
 
 	err = testutil.Query(diff, &res, &testutil.QueryOptions{
 		Variables: map[string]any{
@@ -410,7 +410,7 @@ func TestDirectoryDiff(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, []string{"a-file"}, res.Directory.Diff.Contents)
+	require.Equal(t, []string{"a-file"}, res.Directory.Diff.Entries)
 
 	/*
 		This triggers a nil panic in Buildkit!
@@ -427,6 +427,6 @@ func TestDirectoryDiff(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		require.Empty(t, res.Directory.Diff.Contents)
+		require.Empty(t, res.Directory.Diff.Entries)
 	*/
 }

--- a/core/integration/examples_test.go
+++ b/core/integration/examples_test.go
@@ -129,7 +129,7 @@ func TestExtensionYarn(t *testing.T) {
 	data := struct {
 		Yarn struct {
 			Script struct {
-				Contents []string
+				Entries []string
 			}
 		}
 	}{}
@@ -139,7 +139,7 @@ func TestExtensionYarn(t *testing.T) {
 			Query: `query TestYarn($source: DirectoryID!) {
 				yarn {
 					script(source: $source, runArgs: ["build"]) {
-						contents(path: "sdk/nodejs/dagger/dist")
+						entries(path: "sdk/nodejs/dagger/dist")
 					}
 				}
 			}`,
@@ -150,12 +150,12 @@ func TestExtensionYarn(t *testing.T) {
 		resp,
 	)
 	require.NoError(t, err)
-	require.NotEmpty(t, data.Yarn.Script.Contents)
+	require.NotEmpty(t, data.Yarn.Script.Entries)
 
 	data2 := struct {
 		Directory struct {
 			Yarn struct {
-				Contents []string
+				Entries []string
 			}
 		}
 	}{}
@@ -165,7 +165,7 @@ func TestExtensionYarn(t *testing.T) {
 			Query: `query TestYarn($source: DirectoryID!) {
 				directory(id: $source) {
 					yarn(runArgs: ["build"]) {
-						contents(path: "sdk/nodejs/dagger/dist")
+						entries(path: "sdk/nodejs/dagger/dist")
 					}
 				}
 			}`,
@@ -176,5 +176,5 @@ func TestExtensionYarn(t *testing.T) {
 		resp2,
 	)
 	require.NoError(t, err)
-	require.NotEmpty(t, data2.Directory.Yarn.Contents)
+	require.NotEmpty(t, data2.Directory.Yarn.Entries)
 }

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -28,7 +28,7 @@ func (s *directorySchema) Resolvers() router.Resolvers {
 			"directory": router.ToResolver(s.directory),
 		},
 		"Directory": router.ObjectResolver{
-			"contents":         router.ToResolver(s.contents),
+			"entries":          router.ToResolver(s.entries),
 			"file":             router.ToResolver(s.file),
 			"withNewFile":      router.ToResolver(s.withNewFile),
 			"withCopiedFile":   router.ToResolver(s.withCopiedFile),
@@ -72,12 +72,12 @@ func (s *directorySchema) withDirectory(ctx *router.Context, parent *core.Direct
 	return parent.WithDirectory(ctx, args.Path, &core.Directory{ID: args.Directory})
 }
 
-type contentArgs struct {
+type entriesArgs struct {
 	Path string
 }
 
-func (s *directorySchema) contents(ctx *router.Context, parent *core.Directory, args contentArgs) ([]string, error) {
-	return parent.Contents(ctx, s.gw, args.Path)
+func (s *directorySchema) entries(ctx *router.Context, parent *core.Directory, args entriesArgs) ([]string, error) {
+	return parent.Entries(ctx, s.gw, args.Path)
 }
 
 type dirFileArgs struct {

--- a/core/schema/directory.graphqls
+++ b/core/schema/directory.graphqls
@@ -12,7 +12,7 @@ type Directory {
     id: DirectoryID!
 
     "Return a list of files and directories at the given path"
-    contents(path: String): [String!]!
+    entries(path: String): [String!]!
 
     "Retrieve a file at the given path"
     file(path: String!): File!

--- a/sdk/go/dagger/api/api.gen.go
+++ b/sdk/go/dagger/api/api.gen.go
@@ -565,27 +565,6 @@ type Directory struct {
 	c graphql.Client
 }
 
-// DirectoryContentsOpts contains options for Directory.Contents
-type DirectoryContentsOpts struct {
-	Path string
-}
-
-// Return a list of files and directories at the given path
-func (r *Directory) Contents(ctx context.Context, opts ...DirectoryContentsOpts) ([]string, error) {
-	q := r.q.Select("contents")
-	// `path` optional argument
-	for i := len(opts) - 1; i >= 0; i-- {
-		if !querybuilder.IsZeroValue(opts[i].Path) {
-			q = q.Arg("path", opts[i].Path)
-			break
-		}
-	}
-
-	var response []string
-	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.c)
-}
-
 // The difference between this directory and an another directory
 func (r *Directory) Diff(other DirectoryID) *Directory {
 	q := r.q.Select("diff")
@@ -606,6 +585,27 @@ func (r *Directory) Directory(path string) *Directory {
 		q: q,
 		c: r.c,
 	}
+}
+
+// DirectoryEntriesOpts contains options for Directory.Entries
+type DirectoryEntriesOpts struct {
+	Path string
+}
+
+// Return a list of files and directories at the given path
+func (r *Directory) Entries(ctx context.Context, opts ...DirectoryEntriesOpts) ([]string, error) {
+	q := r.q.Select("entries")
+	// `path` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].Path) {
+			q = q.Arg("path", opts[i].Path)
+			break
+		}
+	}
+
+	var response []string
+	q = q.Bind(&response)
+	return response, q.Execute(ctx, r.c)
 }
 
 // Retrieve a file at the given path

--- a/sdk/go/dagger/client_test.go
+++ b/sdk/go/dagger/client_test.go
@@ -42,7 +42,7 @@ func TestGit(t *testing.T) {
 		Branch("main").
 		Tree()
 
-	files, err := tree.Contents(ctx)
+	files, err := tree.Entries(ctx)
 	require.NoError(t, err)
 	require.Contains(t, files, "README.md")
 


### PR DESCRIPTION
fixes #3397 