### PR TITLE
Only run lint & test when specific files change

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,11 @@
 name: lint
 on:
   push:
-    tags:
-      - v*
-    branches:
-      - main
+    branches: [main]
+    paths:
+      - '**.go'
+      - '**.md'
+      - '.github/workflows/lint.yml'
   pull_request:
   # Enable manual trigger for easy ad-hoc debugging
   # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,21 @@
 name: test
 on:
   push:
-    tags:
-      - v*
-    branches:
-      - main
+    branches: [main]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'sdk/nodejs/**.js'
+      - '.github/workflows/test.yml'
   pull_request:
+    branches: [main]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'sdk/nodejs/**.js'
+      - '.github/workflows/test.yml'
   # Enable manual trigger for easy ad-hoc debugging
   # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs
   workflow_dispatch:
@@ -40,6 +50,7 @@ jobs:
           go-version: 1.19
       - uses: actions/setup-node@v3
         with:
+          # ⚠️  Keep this in sync with https://github.com/dagger/dagger/blob/main/package.json#L14
           node-version: 16
       - uses: actions/checkout@v3
       - run: go install $(pwd)/cmd/dagger/


### PR DESCRIPTION
Only run the test workflow when Go-related files change

Also JS files in the `sdk/nodejs` dir.

We don't want to run this unnecessarily.

We also don't want to run this on tags. If we tagged something that was not linted correctly, something is very wrong in our release workflow and should be addressed. FWIW:
https://github.com/dagger/dagger/blob/77eed15d356836981e4c0975920674069e315edf/.github/workflows/release-v0.3.x.yml#L87-L95

We want to run on larger runners so we learn quicker about potential errors.

Added a note to keep the node-version in sync with package.json. The test will fail anyways (because of the engine constraint), but the comment will hopefully make the fix more obvious.
