### PR TITLE
Chore: generate numerical IDs for docs articles

### DIFF
--- a/docs/new.sh
+++ b/docs/new.sh
@@ -10,7 +10,7 @@ function new() {
 		return 1
 	fi
 	local next
-	next=$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c5)
+	next=$(LC_ALL=C tr -dc '0-9' < /dev/urandom | head -c6)
 
 	local filename="$next-$name.md"
 	echo "Creating $filename"


### PR DESCRIPTION
Rationale: the non-numerical IDs look like garbled words,. my brain keeps trying to parse them which trips me up ever so slightly each time I glance at the url.