### PR TITLE
getting-started guide: api.ContainerAddress cast no longer needed in Container.From

### DIFF
--- a/docs/v0.3/sdk/go/8g34z-get-started.md
+++ b/docs/v0.3/sdk/go/8g34z-get-started.md
@@ -285,7 +285,7 @@ func build(repoUrl string) error {
   for _, version := range goVersions {
     // 3. Determine the golang image to use
     imageTag := fmt.Sprintf("golang:%s", version)
-    golang := client.Core().Container().From(api.ContainerAddress(imageTag)) // <-- Updated with the formatted image tag
+    golang := client.Core().Container().From(imageTag) // <-- Updated with the formatted image tag
 
     for _, goos := range oses {
       for _, goarch := range arches {
@@ -461,7 +461,7 @@ func build(repoUrl string) error {
 
   for _, version := range goVersions {
     imageTag := fmt.Sprintf("golang:%s", version)
-    golang := client.Core().Container().From(api.ContainerAddress(imageTag))
+    golang := client.Core().Container().From(imageTag)
     golang = golang.WithMountedDirectory("/src", src).WithWorkdir("/src")
 
     for _, goos := range oses {


### PR DESCRIPTION
Casting is no longer required with https://github.com/dagger/dagger/commit/3cc1b24a6afbc35b56b214eec642eb4acaedb2a3

Signed-off-by: kpenfound <kyle@dagger.io>