### PR TITLE
remove what seems to be an unused package

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,6 @@
     "@docusaurus/core": "^2.2.0",
     "@docusaurus/preset-classic": "^2.2.0",
     "@docusaurus/theme-mermaid": "^2.2.0",
-    "@mdx-js/react": "^1.6.22",
     "@svgr/webpack": "^6.5.1",
     "amplitude-js": "^8.21.2",
     "clsx": "^1.2.1",


### PR DESCRIPTION
mdx-js/react seems to be not used anymore.

Signed-off-by: jffarge <jf@dagger.io>