### PR TITLE
Update Posthog apiKey with an old one

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -117,10 +117,10 @@ module.exports = {
   plugins: [
     "docusaurus-plugin-sass",
     "docusaurus2-dotenv",
-    [ 
+    [
       "posthog-docusaurus",
       {
-        apiKey: "phc_8Onnz5zyGA8mMEia4ALiaAetunwfeoHiekU0l5ND6tg"
+        apiKey: "phc_hqwS484sDJhTnrPCANTyWX48nKL3AEucgf6w0czQtQi"
       }
     ],
     "docusaurus-plugin-image-zoom",


### PR DESCRIPTION
The PR #3434 has been merged accidentally and the docs is now using the new api key polluting analytics. 
Next step will be to recreate a new api key in Posthog and recreate a new PR that has to be merged for the launch to capture GO SKD docs analytics.

Signed-off-by: jffarge <jf@dagger.io>