### PR TITLE
Prepare to publish dagger-cue artefacts

### DIFF
--- a/.github/workflows/release-dagger-cue.yml
+++ b/.github/workflows/release-dagger-cue.yml
@@ -1,0 +1,86 @@
+name: "Release dagger-cue"
+
+# Only a single job with this concurrency can run at any given time
+concurrency: release-dagger-cue
+
+on:
+  # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs
+  #
+  # This workflow can only be triggered manually.
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: "E.g. 0.2.37"
+        required: true
+
+jobs:
+  bump_version-tag-release:
+    # ⚠️ If this changes, remember to update the running-workflow-name property
+    name: "Tag & release"
+    runs-on: ubuntu-22.04-16c-64g-600gb
+    steps:
+      - name: "Check out"
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: "Ensure that all other checks have succeeded"
+        # https://github.com/lewagon/wait-on-check-action
+        uses: lewagon/wait-on-check-action@v1.0.0
+        with:
+          ref: ${{ github.ref }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10 # polls the GitHub API every 10 every seconds
+          running-workflow-name: "Tag & release"
+          allowed-conclusions: success
+
+      - name: "Create release tag"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X POST /repos/:owner/:repo/git/refs \
+            --field ref="refs/tags/${{ github.event.inputs.release_version }}" \
+            --field sha="$GITHUB_SHA"
+
+      - name: "Fetch new tag"
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: "Install Go"
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+
+      - name: "Release"
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          args: release --rm-dist --debug
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.RELEASE_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RELEASE_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-east-1
+
+      # Open a https://github.com/Homebrew/homebrew-core PR to update the bottled formula after we release.
+      # This explains why we need to do it separately, on top of GoReleaser updating our Homebrew tap:
+      # - https://github.com/Homebrew/homebrew-core/pull/105746#issuecomment-1190522063
+      # - https://github.com/dagger/dagger/issues/2823#issuecomment-1190792261
+      #
+      # TODO: This is temporarily disabled, until we finalise the dagger -> dagger-cue rename
+      # https://github.com/dagger/dagger/issues/3471
+      # - name: "Update homebrew-core formula"
+      #   # https://github.com/mislav/bump-homebrew-formula-action
+      #   uses: mislav/bump-homebrew-formula-action@v2
+      #   with:
+      #     download-url: https://github.com/dagger/dagger.git
+      #     formula-name: dagger
+      #     tag-name: ${{ github.event.inputs.release_version }}
+      #     commit-message: |
+      #       {{formulaName}} {{version}}
+
+      #       Created by ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      #       If there is problem with this PR, [open an issue](https://github.com/dagger/dagger/issues/new). The right people will be automatically notified.
+      #   env:
+      #     COMMITTER_TOKEN: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}

--- a/.github/workflows/release-dagger-cue.yml
+++ b/.github/workflows/release-dagger-cue.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       release_version:
-        description: "E.g. 0.2.37"
+        description: "E.g. 0.1.0"
         required: true
 
 jobs:
@@ -39,7 +39,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh api -X POST /repos/:owner/:repo/git/refs \
-            --field ref="refs/tags/${{ github.event.inputs.release_version }}" \
+            --field ref="refs/tags/sdk/cue/v${{ github.event.inputs.release_version }}" \
             --field sha="$GITHUB_SHA"
 
       - name: "Fetch new tag"

--- a/.github/workflows/release-dagger-cue.yml
+++ b/.github/workflows/release-dagger-cue.yml
@@ -63,26 +63,3 @@ jobs:
           AWS_REGION: ${{ secrets.RELEASE_AWS_REGION }}
           AWS_BUCKET: ${{ secrets.RELEASE_AWS_BUCKET }}
           ARTEFACTS_FQDN: ${{ secrets.RELEASE_FQDN }}
-
-      # Open a https://github.com/Homebrew/homebrew-core PR to update the bottled formula after we release.
-      # This explains why we need to do it separately, on top of GoReleaser updating our Homebrew tap:
-      # - https://github.com/Homebrew/homebrew-core/pull/105746#issuecomment-1190522063
-      # - https://github.com/dagger/dagger/issues/2823#issuecomment-1190792261
-      #
-      # TODO: This is temporarily disabled, until we finalise the dagger -> dagger-cue rename
-      # https://github.com/dagger/dagger/issues/3471
-      # - name: "Update homebrew-core formula"
-      #   # https://github.com/mislav/bump-homebrew-formula-action
-      #   uses: mislav/bump-homebrew-formula-action@v2
-      #   with:
-      #     download-url: https://github.com/dagger/dagger.git
-      #     formula-name: dagger
-      #     tag-name: ${{ github.event.inputs.release_version }}
-      #     commit-message: |
-      #       {{formulaName}} {{version}}
-
-      #       Created by ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-      #       If there is problem with this PR, [open an issue](https://github.com/dagger/dagger/issues/new). The right people will be automatically notified.
-      #   env:
-      #     COMMITTER_TOKEN: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}

--- a/.github/workflows/release-dagger-cue.yml
+++ b/.github/workflows/release-dagger-cue.yml
@@ -60,7 +60,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.RELEASE_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.RELEASE_AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: us-east-1
+          AWS_REGION: ${{ secrets.RELEASE_AWS_REGION }}
+          AWS_BUCKET: ${{ secrets.RELEASE_AWS_BUCKET }}
+          ARTEFACTS_FQDN: ${{ secrets.RELEASE_FQDN }}
 
       # Open a https://github.com/Homebrew/homebrew-core PR to update the bottled formula after we release.
       # This explains why we need to do it separately, on top of GoReleaser updating our Homebrew tap:

--- a/.github/workflows/release-dagger-cue.yml
+++ b/.github/workflows/release-dagger-cue.yml
@@ -17,7 +17,7 @@ jobs:
   bump_version-tag-release:
     # ⚠️ If this changes, remember to update the running-workflow-name property
     name: "Tag & release"
-    runs-on: ubuntu-22.04-16c-64g-600gb
+    runs-on: ubuntu-latest
     steps:
       - name: "Check out"
         uses: actions/checkout@v2

--- a/.github/workflows/release-dagger-cue.yml
+++ b/.github/workflows/release-dagger-cue.yml
@@ -55,8 +55,10 @@ jobs:
       - name: "Release"
         uses: goreleaser/goreleaser-action@v2
         with:
+          distribution: goreleaser-pro
           args: release --rm-dist --debug
         env:
+          GORELEASER_KEY: ${{ secrets.GORELEASER_PRO_LICENSE_KEY }}
           GITHUB_TOKEN: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.RELEASE_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.RELEASE_AWS_SECRET_ACCESS_KEY }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,7 @@ builds:
   - env:
       - CGO_ENABLED=0
     main: ./cmd/dagger
-    binary: dagger
+    binary: dagger-cue
     ldflags:
       - -s -w
       - -X go.dagger.io/dagger/version.Version={{.Version}}
@@ -21,11 +21,10 @@ builds:
       - arm64
       - arm
     goarm:
-      - 7
+      - "7"
 
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
-    replacements:
     files:
       - LICENSE
       - examples/**/*
@@ -62,28 +61,30 @@ changelog:
     - title: Changes
       order: 999
 
+# https://goreleaser.com/customization/homebrew/
 brews:
   - tap:
       owner: dagger
       name: homebrew-tap
+    name: dagger-cue
     commit_author:
       name: dagger-bot
       email: noreply@dagger.io
-    url_template: "https://dl.dagger.io/dagger/releases/{{ .Version }}/{{ .ArtifactName }}"
+    url_template: "https://{{ .Env.ARTEFACTS_FQDN }}/dagger/releases/{{ .Version }}/{{ .ArtifactName }}"
     homepage: "https://github.com/dagger/dagger"
     description: "Dagger is a programmable deployment system."
     test: |
-      system "#{bin}/dagger version"
+      system "#{bin}/dagger-cue version"
 
 blobs:
   - provider: s3
-    region: us-east-1
-    bucket: dagger-io
+    region: "{{ .Env.AWS_REGION }}"
+    bucket: "{{ .Env.AWS_BUCKET }}"
     folder: "dagger/releases/{{ .Version }}"
 
 publishers:
   - name: publish-latest-version
-    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://dagger-io/dagger/latest_version"
+    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://{{ .Env.AWS_BUCKET }}/dagger/latest_version"
     env:
       - PATH={{ .Env.PATH }}
       - AWS_EC2_METADATA_DISABLED=true
@@ -91,7 +92,7 @@ publishers:
       - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
       - AWS_REGION={{ .Env.AWS_REGION }}
   - name: publish-latest
-    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://dagger-io/dagger/versions/latest"
+    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://{{ .Env.AWS_BUCKET }}/dagger/versions/latest"
     env:
       - PATH={{ .Env.PATH }}
       - AWS_EC2_METADATA_DISABLED=true
@@ -99,7 +100,7 @@ publishers:
       - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
       - AWS_REGION={{ .Env.AWS_REGION }}
   - name: publish-latest-major-minor
-    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://dagger-io/dagger/versions/{{ .Major }}.{{ .Minor }}"
+    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://{{ .Env.AWS_BUCKET }}/dagger/versions/{{ .Major }}.{{ .Minor }}"
     env:
       - PATH={{ .Env.PATH }}
       - AWS_EC2_METADATA_DISABLED=true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -67,7 +67,7 @@ changelog:
 # https://goreleaser.com/customization/homebrew/
 brews:
   - tap:
-      owner: dagger
+      owner: "{{ .Env.GITHUB_REPOSITORY_OWNER }}"
       name: homebrew-tap
     name: dagger-cue
     commit_author:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 project_name: dagger-cue
 
 monorepo:
-  tag_prefix: sdk/cue/v
+  tag_prefix: sdk/cue/
 
 before:
   hooks:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,4 @@
-project_name: dagger
+project_name: dagger-cue
 
 before:
   hooks:
@@ -70,7 +70,7 @@ brews:
     commit_author:
       name: dagger-bot
       email: noreply@dagger.io
-    url_template: "https://{{ .Env.ARTEFACTS_FQDN }}/dagger/releases/{{ .Version }}/{{ .ArtifactName }}"
+    url_template: "https://{{ .Env.ARTEFACTS_FQDN }}/dagger-cue/releases/{{ .Version }}/{{ .ArtifactName }}"
     homepage: "https://github.com/dagger/dagger"
     description: "Dagger is a programmable deployment system."
     test: |
@@ -80,11 +80,11 @@ blobs:
   - provider: s3
     region: "{{ .Env.AWS_REGION }}"
     bucket: "{{ .Env.AWS_BUCKET }}"
-    folder: "dagger/releases/{{ .Version }}"
+    folder: "dagger-cue/releases/{{ .Version }}"
 
 publishers:
   - name: publish-latest-version
-    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://{{ .Env.AWS_BUCKET }}/dagger/latest_version"
+    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://{{ .Env.AWS_BUCKET }}/dagger-cue/latest_version"
     env:
       - PATH={{ .Env.PATH }}
       - AWS_EC2_METADATA_DISABLED=true
@@ -92,7 +92,7 @@ publishers:
       - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
       - AWS_REGION={{ .Env.AWS_REGION }}
   - name: publish-latest
-    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://{{ .Env.AWS_BUCKET }}/dagger/versions/latest"
+    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://{{ .Env.AWS_BUCKET }}/dagger-cue/versions/latest"
     env:
       - PATH={{ .Env.PATH }}
       - AWS_EC2_METADATA_DISABLED=true
@@ -100,7 +100,7 @@ publishers:
       - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
       - AWS_REGION={{ .Env.AWS_REGION }}
   - name: publish-latest-major-minor
-    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://{{ .Env.AWS_BUCKET }}/dagger/versions/{{ .Major }}.{{ .Minor }}"
+    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://{{ .Env.AWS_BUCKET }}/dagger-cue/versions/{{ .Major }}.{{ .Minor }}"
     env:
       - PATH={{ .Env.PATH }}
       - AWS_EC2_METADATA_DISABLED=true
@@ -108,10 +108,6 @@ publishers:
       - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
       - AWS_REGION={{ .Env.AWS_REGION }}
 
+# We do not want to publish dagger-cue as a GitHub release until we have clarified the other SDKs
 release:
-  footer: |
-    **Full Changelog**: https://github.com/dagger/dagger/compare/{{ .PreviousTag }}...{{ .Tag }}
-    ## What to do next?
-    - Read the [documentation](https://docs.dagger.io)
-    - Join our [Discord server](https://discord.gg/dagger-io)
-    - Follow us on [Twitter](https://twitter.com/dagger_io)
+  disable: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,8 @@
 project_name: dagger-cue
 
+monorepo:
+  tag_prefix: sdk/cue/v
+
 before:
   hooks:
     - go mod download

--- a/client/client.go
+++ b/client/client.go
@@ -57,7 +57,7 @@ type Config struct {
 }
 
 func New(ctx context.Context, host string, cfg Config) (*Client, error) {
-	ctx, span := otel.Tracer("dagger").Start(ctx, "client.New")
+	ctx, span := otel.Tracer("dagger-cue").Start(ctx, "client.New")
 	defer span.End()
 
 	if host == "" {
@@ -100,7 +100,7 @@ type DoFunc func(context.Context, *solver.Solver) error
 
 // FIXME: return completed *Route, instead of *compiler.Value
 func (c *Client) Do(ctx context.Context, pctx *plancontext.Context, fn DoFunc) error {
-	ctx, span := otel.Tracer("dagger").Start(ctx, "client.Do")
+	ctx, span := otel.Tracer("dagger-cue").Start(ctx, "client.Do")
 	defer span.End()
 
 	eg, gctx := errgroup.WithContext(ctx)
@@ -132,7 +132,7 @@ func (c *Client) Do(ctx context.Context, pctx *plancontext.Context, fn DoFunc) e
 // detectPlatform tries using Buildkit's target platform;
 // if not possible, default platform will be used.
 func (c *Client) detectPlatform(ctx context.Context) (*specs.Platform, error) {
-	ctx, span := otel.Tracer("dagger").Start(ctx, "client.DetectPlatform")
+	ctx, span := otel.Tracer("dagger-cue").Start(ctx, "client.DetectPlatform")
 	defer span.End()
 
 	w, err := c.c.ListWorkers(ctx)
@@ -166,7 +166,7 @@ func convertCacheOptionEntries(ims []bk.CacheOptionsEntry) []bkgw.CacheOptionsEn
 }
 
 func (c *Client) buildfn(ctx context.Context, pctx *plancontext.Context, fn DoFunc, ch chan *bk.SolveStatus) error {
-	ctx, span := otel.Tracer("dagger").Start(ctx, "client.Build")
+	ctx, span := otel.Tracer("dagger-cue").Start(ctx, "client.Build")
 	defer span.End()
 
 	wg := sync.WaitGroup{}

--- a/cmd/dagger/cmd/do.go
+++ b/cmd/dagger/cmd/do.go
@@ -351,7 +351,7 @@ func doHelpCmd(cmd *cobra.Command, daggerPlan *plan.Plan, action *plan.Action, a
 			targetStr = "<action> [subaction...]"
 		}
 
-		fmt.Printf("Usage: \n  dagger do %s [flags]\n\n", targetStr)
+		fmt.Printf("Usage: \n  dagger-cue do %s [flags]\n\n", targetStr)
 		if actionFlags != nil {
 			fmt.Println("Options")
 			actionFlags.VisitAll(func(flag *pflag.Flag) {
@@ -363,7 +363,7 @@ func doHelpCmd(cmd *cobra.Command, daggerPlan *plan.Plan, action *plan.Action, a
 			})
 		}
 	} else {
-		fmt.Println("Usage: \n  dagger do <action> [subaction...] [flags]")
+		fmt.Println("Usage: \n  dagger-cue do <action> [subaction...] [flags]")
 	}
 
 	var err error

--- a/cmd/dagger/cmd/project/info.go
+++ b/cmd/dagger/cmd/project/info.go
@@ -32,7 +32,7 @@ var infoCmd = &cobra.Command{
 
 		cueModPath, cueModExists := pkg.GetCueModParent()
 		if !cueModExists {
-			lg.Fatal().Msg("dagger project not found. Run `dagger project init`")
+			lg.Fatal().Msg("dagger project not found. Run `dagger-cue project init`")
 		}
 
 		fmt.Printf("\nCurrent dagger project in: %s\n", cueModPath)

--- a/cmd/dagger/cmd/project/init.go
+++ b/cmd/dagger/cmd/project/init.go
@@ -52,9 +52,9 @@ var initCmd = &cobra.Command{
 		}
 
 		if dir == "." {
-			fmt.Println("Project initialized! To install dagger packages, run `dagger project update`")
+			fmt.Println("Project initialized! To install dagger packages, run `dagger-cue project update`")
 		} else {
-			fmt.Printf("Project initialized in \"%s\"! To install dagger packages, go to subfolder \"%s\" and run \"dagger project update\"", dir, dir)
+			fmt.Printf("Project initialized in \"%s\"! To install dagger packages, go to subfolder \"%s\" and run \"dagger-cue project update\"", dir, dir)
 		}
 	},
 }

--- a/cmd/dagger/cmd/project/update.go
+++ b/cmd/dagger/cmd/project/update.go
@@ -29,7 +29,7 @@ var updateCmd = &cobra.Command{
 
 		cueModPath, cueModExists := pkg.GetCueModParent()
 		if !cueModExists {
-			lg.Fatal().Msg("dagger project not found. Run `dagger project init`")
+			lg.Fatal().Msg("dagger project not found. Run `dagger-cue project init`")
 		}
 
 		var update = viper.GetBool("update")

--- a/cmd/dagger/cmd/root.go
+++ b/cmd/dagger/cmd/root.go
@@ -18,7 +18,7 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "dagger",
+	Use:   "dagger-cue",
 	Short: "A programmable deployment system",
 }
 
@@ -80,7 +80,7 @@ func Execute() {
 		if overrideName := os.Getenv("DAGGER_TRACE_SPAN_NAME"); overrideName != "" {
 			spanName = overrideName
 		}
-		ctx, span = otel.Tracer("dagger").Start(ctx, spanName)
+		ctx, span = otel.Tracer("dagger-cue").Start(ctx, spanName)
 		// Record the action
 		span.AddEvent("command", trace.WithAttributes(
 			attribute.String("args", strings.Join(os.Args, " ")),

--- a/cmd/dagger/cmd/version.go
+++ b/cmd/dagger/cmd/version.go
@@ -174,7 +174,7 @@ func warnVersion() bool {
 		if p, err := os.Readlink(binPath); err == nil {
 			// Homebrew detected, print custom message
 			if strings.Contains(p, "/Cellar/") {
-				fmt.Println("\nA new version is available, please run:\n\nbrew update && brew upgrade dagger")
+				fmt.Println("\nA new version is available, please run:\n\nbrew update && brew upgrade dagger/tap/dagger-cue")
 				return true
 			}
 		}

--- a/cmd/dagger/cmd/version.go
+++ b/cmd/dagger/cmd/version.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	versionFile = "~/.config/dagger/version-check"
-	versionURL  = "https://releases.dagger.io/dagger/latest_version"
+	versionFile = "~/.config/dagger-cue/version-check"
+	versionURL  = "https://releases.dagger.io/dagger-cue/latest_version"
 )
 
 var (

--- a/cmd/dagger/cmd/version.go
+++ b/cmd/dagger/cmd/version.go
@@ -29,7 +29,7 @@ var (
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Print dagger version",
+	Short: "Print dagger-cue version",
 	// Disable version hook here to avoid double version check
 	PersistentPreRun:  func(*cobra.Command, []string) {},
 	PersistentPostRun: func(*cobra.Command, []string) {},
@@ -46,14 +46,14 @@ var versionCmd = &cobra.Command{
 			_ = os.Remove(versionFilePath)
 			checkVersion()
 			if !warnVersion() {
-				fmt.Println("dagger is up to date.")
+				fmt.Println("dagger-cue is up to date.")
 			}
 		}
 	},
 }
 
 func init() {
-	versionCmd.Flags().Bool("check", false, "check if dagger is up to date")
+	versionCmd.Flags().Bool("check", false, "check if dagger-cue is up to date")
 
 	if err := viper.BindPFlags(versionCmd.Flags()); err != nil {
 		panic(err)
@@ -90,7 +90,7 @@ func getLatestVersion(currentVersion *goVersion.Version) (*goVersion.Version, er
 	}
 
 	// dagger/<version> (<OS>; <ARCH>)
-	agent := fmt.Sprintf("dagger/%s (%s; %s)", currentVersion.String(), runtime.GOOS, runtime.GOARCH)
+	agent := fmt.Sprintf("dagger-cue/%s (%s; %s)", currentVersion.String(), runtime.GOOS, runtime.GOARCH)
 	req.Header.Set("User-Agent", agent)
 
 	resp, err := http.DefaultClient.Do(req)

--- a/cmd/dagger/cmd/version.go
+++ b/cmd/dagger/cmd/version.go
@@ -157,7 +157,7 @@ func checkVersion() {
 	}
 
 	if latestVersion != "" {
-		versionMessage = fmt.Sprintf("\nA new version is available (%s), please go to https://docs.dagger.io/1200/local-dev for instructions.", latestVersion)
+		versionMessage = fmt.Sprintf("\nA new version is available (%s), please go to https://docs.dagger.io/sdk/cue/526369/install for instructions.", latestVersion)
 	}
 
 	// Update check timestamps file

--- a/compiler/build.go
+++ b/compiler/build.go
@@ -14,7 +14,7 @@ import (
 
 // Build a cue configuration tree from the files in fs.
 func Build(ctx context.Context, src string, overlays map[string]fs.FS, args ...string) (*Value, error) {
-	_, span := otel.Tracer("dagger").Start(ctx, "compiler.Build")
+	_, span := otel.Tracer("dagger-cue").Start(ctx, "compiler.Build")
 	defer span.End()
 
 	c := DefaultCompiler

--- a/install.ps1
+++ b/install.ps1
@@ -4,7 +4,7 @@ param (
     # [Parameter(Mandatory)] $PersonalToken  
     [Parameter(Mandatory = $false)] [System.Management.Automation.SemanticVersion]$DaggerVersion,
     [Parameter(Mandatory = $false)] [System.Boolean]$InteractiveInstall = $false,
-    [Parameter(Mandatory = $false)] [string]$InstallPath = $env:HOMEPATH + '\dagger'
+    [Parameter(Mandatory = $false)] [string]$InstallPath = $env:HOMEPATH + '\dagger-cue'
 )
 Clear-Host
 @"
@@ -12,19 +12,19 @@ Clear-Host
 ---------------------------------------------------------------------------------
 Author: Alessandro Festa
 Co Author: Brittan DeYoung
-Dagger Installation Utility  for Windows users
+Dagger CUE Installation Utility for Windows users
 ---------------------------------------------------------------------------------
 
 "@
 
 # Since we are already authenticated we may directly download latest version.
-$name = "dagger"
+$name = "dagger-cue"
 $base = "https://dagger-io.s3.amazonaws.com"
 function http_download {
     $version = Get_Version
     $version = $version -replace '[""]'
     $version = $version -replace '\n'
-    $fileName = "dagger_v" + $version + "_windows_amd64"
+    $fileName = $name + "_v" + $version + "_windows_amd64"
     Clear-Host
     $url = $base + "/" + $name + "/releases/" + $version + "/" + $fileName + ".zip"
     write-host $url
@@ -40,7 +40,7 @@ function http_download {
         @"
 Whoops apparently we had an issue in unzipping the file, please check
 you have the right permission to do so and try to unzip manually the file.
-Currently we saved Dagger at your temp folder.
+Currently we saved Dagger CUE at your temp folder.
 "@
         exit
     }
@@ -49,11 +49,11 @@ Currently we saved Dagger at your temp folder.
     
         @"
 
-Thank You for downloading Dagger!
+Thank You for downloading Dagger CUE!
 
 -----------------------------------------------------
-Dagger has been saved in $InstallPath
-Please add dagger.exe to your PATH in order to use it
+Dagger CUE has been saved in $InstallPath
+Please add dagger-cue.exe to your PATH in order to use it
 ----------------------------------------------------
 
 "@
@@ -66,7 +66,7 @@ function Get_Version {
         $version = $DaggerVersion
     }
     else {
-        $response = Invoke-RestMethod 'http://releases.dagger.io/dagger/latest_version' -Method 'GET'  -Body $body -ErrorAction SilentlyContinue -ErrorVariable DownloadError
+        $response = Invoke-RestMethod 'http://releases.dagger.io/dagger-cue/latest_version' -Method 'GET'  -Body $body -ErrorAction SilentlyContinue -ErrorVariable DownloadError
         If ($DownloadError) {
             Clear-Host
             @"

--- a/install.sh
+++ b/install.sh
@@ -326,7 +326,7 @@ execute() {
     checksum="checksums.txt"
     checksum_url="${base_url}/${checksum}"
     bin_dir="${BIN_DIR:-./bin}"
-    binexe="dagger"
+    binexe="${name}"
 
     tmpdir=$(mktemp -d)
     log_debug "downloading files into ${tmpdir}"

--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-name="dagger"
 base="https://dagger-io.s3.amazonaws.com"
+name="dagger-cue"
 
 cat /dev/null <<EOF
 ------------------------------------------------------------------------

--- a/install.sh
+++ b/install.sh
@@ -267,7 +267,7 @@ latest_version() {
 base_url() {
     os="$(uname_os)"
     arch="$(uname_arch)"
-    version="${DAGGER_VERSION:-$(latest_version)}"
+    version="${VERSION:-$(latest_version)}"
     url="${base}/${name}/releases/${version}"
     echo "$url"
 }
@@ -275,7 +275,7 @@ base_url() {
 tarball() {
     os="$(uname_os)"
     arch="$(uname_arch)"
-    version="${DAGGER_VERSION:-$(latest_version)}"
+    version="${VERSION:-$(latest_version)}"
     name="${name}_v${version}_${os}_${arch}"
     if [ "$os" = "windows" ]; then
         name="${name}.zip"

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -54,7 +54,7 @@ func (e ErrorValidation) Error() string {
 }
 
 func Load(ctx context.Context, cfg Config) (*Plan, error) {
-	ctx, span := otel.Tracer("dagger").Start(ctx, "plan.Load")
+	ctx, span := otel.Tracer("dagger-cue").Start(ctx, "plan.Load")
 	defer span.End()
 
 	planFileInfo, _ := os.Stat(cfg.Args[0])
@@ -177,7 +177,7 @@ func (p *Plan) Action() *Action {
 
 // prepare executes the pre-run hooks of tasks
 func (p *Plan) prepare(ctx context.Context) error {
-	_, span := otel.Tracer("dagger").Start(ctx, "plan.Prepare")
+	_, span := otel.Tracer("dagger-cue").Start(ctx, "plan.Prepare")
 	defer span.End()
 
 	flow := cueflow.New(
@@ -217,7 +217,7 @@ func (p *Plan) prepare(ctx context.Context) error {
 
 // Do executes an action in the plan
 func (p *Plan) Do(ctx context.Context, path cue.Path, s *solver.Solver) error {
-	ctx, span := otel.Tracer("dagger").Start(ctx, "plan.Do")
+	ctx, span := otel.Tracer("dagger-cue").Start(ctx, "plan.Do")
 	defer span.End()
 
 	r := NewRunner(p.context, path, s, p.config.DryRun)
@@ -232,7 +232,7 @@ func (p *Plan) Do(ctx context.Context, path cue.Path, s *solver.Solver) error {
 }
 
 func (p *Plan) fillAction(ctx context.Context) {
-	_, span := otel.Tracer("dagger").Start(ctx, "plan.FillAction")
+	_, span := otel.Tracer("dagger-cue").Start(ctx, "plan.FillAction")
 	defer span.End()
 
 	cfg := &cueflow.Config{
@@ -292,7 +292,7 @@ func (p *Plan) fillAction(ctx context.Context) {
 }
 
 func (p *Plan) validate(ctx context.Context) error {
-	_, span := otel.Tracer("dagger").Start(ctx, "plan.Validate")
+	_, span := otel.Tracer("dagger-cue").Start(ctx, "plan.Validate")
 	defer span.End()
 
 	return isPlanConcrete(p.source, p.source)

--- a/plan/runner.go
+++ b/plan/runner.go
@@ -164,7 +164,7 @@ func (r *Runner) taskFunc(flowVal cue.Value) (cueflow.Runner, error) {
 		taskPath := t.Path().String()
 		lg := log.Ctx(ctx).With().Str("task", taskPath).Logger()
 		ctx = lg.WithContext(ctx)
-		ctx, span := otel.Tracer("dagger").Start(ctx, taskPath)
+		ctx, span := otel.Tracer("dagger-cue").Start(ctx, taskPath)
 		defer span.End()
 		tm := telemetry.Ctx(ctx)
 

--- a/util/buildkitd/buildkitd.go
+++ b/util/buildkitd/buildkitd.go
@@ -50,7 +50,7 @@ func init() {
 }
 
 func Start(ctx context.Context) (string, error) {
-	ctx, span := otel.Tracer("dagger").Start(ctx, "buildkitd.Start")
+	ctx, span := otel.Tracer("dagger-cue").Start(ctx, "buildkitd.Start")
 	defer span.End()
 
 	if vendoredVersion == "" {


### PR DESCRIPTION
This PR is:

- part of https://github.com/dagger/dagger/issues/3471
- supersedes https://github.com/dagger/dagger/pull/3483
- partial follow-up to https://github.com/dagger/dagger/pull/3356

It changes the `release-v0.2.x.yml` workflow to publish `dagger-cue` binaries.

Linux `install.sh` & Windows `install.ps1` have been updated too. The Linux variant has been tested.

**Help wanted for the Windows one**.

This was tested via https://github.com/gerhard/dagger/actions/runs/3316263177/jobs/5477850676 & it published:

### 1/2. AWS S3 files

<img width="814" alt="image" src="https://user-images.githubusercontent.com/3342/197635253-fe076233-a711-4b44-b814-cecbcc19c3c6.png">

Tested with `./install.sh`

<img width="1101" alt="image" src="https://user-images.githubusercontent.com/3342/197636070-0feccb97-6fa0-443b-b53d-6b9a36ad3b93.png">

### 2/2. Homebrew tap

![image](https://user-images.githubusercontent.com/3342/197635374-a35935af-711d-4249-a855-d8b0c5cf96ba.png)

Tested with `brew install gerhard/tap/dagger-cue`

<img width="1046" alt="image" src="https://user-images.githubusercontent.com/3342/197635779-77a9a661-6260-4a04-9a1d-9db4493415d3.png">

---

## Next steps

- [x] review & merge https://github.com/dagger/dagger/pull/3506
- [x] review & merge https://github.com/dagger/dagger/pull/3505
- [ ] review & merge this PR
- [ ] publish an official `dagger-cue`
- [ ] @vikram-dagger to update Dagger CUE SDK documentation (it will also ensure that it works as expected)

---

FWIW we ended up upgrading to GoReleaser Pro with @aluzzardi so that we get the monorepo support. It has a bunch of other useful features too that we might want to look into https://beckersoft.gumroad.com/l/goreleaser. The license key has been configured in GitHub Actions. The source of truth is the shared 1Password vault.