### PR TITLE
docs: Update the URLs for certain CUE SDK pages

### DIFF
--- a/docs/current/sdk/cue/232322-guides.md
+++ b/docs/current/sdk/cue/232322-guides.md
@@ -1,5 +1,5 @@
 ---
-slug: /232322/guides
+slug: /sdk/cue/232322/guides
 ---
 
 # Guides

--- a/docs/current/sdk/cue/852645-usage-examples.md
+++ b/docs/current/sdk/cue/852645-usage-examples.md
@@ -1,5 +1,5 @@
 ---
-slug: /852645/usage-examples
+slug: /sdk/cue/852645/usage-examples
 ---
 
 # Dagger CUE SDK Usage Examples


### PR DESCRIPTION
Some of the page URLs in the CUE SDK docs did not begin with /sdk/cue. This commit corrects those URLs.

Closes #3493

Signed-off-by: Vikram Vaswani <vikram@dagger.io>