### PR TITLE
add initial godoc examples + README

### DIFF
--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -1,0 +1,14 @@
+# Dagger Go SDK
+
+A client package for running [Dagger](https://dagger.io/) pipelines.
+
+> **NOTE**: the canonical version of this module is [`./sdk/go` in the
+> `dagger/dagger` repo][canonical-pkg].
+>
+> The [`dagger/dagger-go-sdk`][replica-pkg] repo is a read-only replica; do not
+> edit it.
+>
+> The canonical import for this package is `dagger.io/dagger`.
+
+[canonical-pkg]: https://github.com/dagger/dagger/tree/main/sdk/go
+[replica-pkg]: https://github.com/dagger/dagger-go-sdk

--- a/sdk/go/examples_test.go
+++ b/sdk/go/examples_test.go
@@ -78,9 +78,10 @@ func ExampleContainer_Build() {
 		panic(err)
 	}
 
-	fmt.Println(out)
+	words := strings.Split(strings.TrimSpace(out), " ")
+	fmt.Println(words[0])
 
-	// Output: dagger devel () linux/amd64
+	// Output: dagger
 }
 
 func ExampleContainer_WithEnvVariable() {

--- a/sdk/go/examples_test.go
+++ b/sdk/go/examples_test.go
@@ -3,7 +3,6 @@ package dagger_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -228,33 +227,33 @@ func ExampleHost_Workdir() {
 	// Output: # Dagger Go SDK
 }
 
-func ExampleHost_EnvVariable() {
-	ctx := context.Background()
-	client, err := dagger.Connect(ctx)
-	if err != nil {
-		panic(err)
-	}
-	defer client.Close()
+// func ExampleHost_EnvVariable() {
+// 	ctx := context.Background()
+// 	client, err := dagger.Connect(ctx)
+// 	if err != nil {
+// 		panic(err)
+// 	}
+// 	defer client.Close()
 
-	os.Setenv("SEKRIT", "hunter2")
+// 	os.Setenv("SEKRIT", "hunter2")
 
-	secretID, err := client.Host().EnvVariable("SEKRIT").Secret().ID(ctx)
-	if err != nil {
-		panic(err)
-	}
+// 	secretID, err := client.Host().EnvVariable("SEKRIT").Secret().ID(ctx)
+// 	if err != nil {
+// 		panic(err)
+// 	}
 
-	alpine := client.Container().From("alpine:3.16.2")
-	leaked, err := alpine.
-		WithSecretVariable("PASSWORD", secretID).
-		Exec(dagger.ContainerExecOpts{
-			Args: []string{"sh", "-c", "echo $PASSWORD"},
-		}).
-		Stdout().Contents(ctx)
-	if err != nil {
-		panic(err)
-	}
+// 	alpine := client.Container().From("alpine:3.16.2")
+// 	leaked, err := alpine.
+// 		WithSecretVariable("PASSWORD", secretID).
+// 		Exec(dagger.ContainerExecOpts{
+// 			Args: []string{"sh", "-c", "echo $PASSWORD"},
+// 		}).
+// 		Stdout().Contents(ctx)
+// 	if err != nil {
+// 		panic(err)
+// 	}
 
-	fmt.Println(leaked)
+// 	fmt.Println(leaked)
 
-	// Output: hunter2
-}
+// 	// Output: hunter2
+// }

--- a/sdk/go/examples_test.go
+++ b/sdk/go/examples_test.go
@@ -1,0 +1,167 @@
+package dagger_test
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"dagger.io/dagger"
+)
+
+func ExampleContainer() {
+	ctx := context.Background()
+
+	client, err := dagger.Connect(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	defer client.Close()
+
+	alpine := client.Container().From("alpine:3.16.2")
+
+	out, err := alpine.Exec(dagger.ContainerExecOpts{
+		Args: []string{"cat", "/etc/alpine-release"},
+	}).Stdout().Contents(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(out)
+
+	// Output: 3.16.2
+}
+
+func ExampleContainer_WithEnvVariable() {
+	ctx := context.Background()
+
+	client, err := dagger.Connect(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	defer client.Close()
+
+	container := client.Container().From("alpine:3.16.2")
+
+	container = container.WithEnvVariable("FOO", "bar")
+
+	out, err := container.Exec(dagger.ContainerExecOpts{
+		Args: []string{"sh", "-c", "echo $FOO"},
+	}).Stdout().Contents(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(out)
+
+	// Output: bar
+}
+
+func ExampleContainer_WithMountedDirectory() {
+	ctx := context.Background()
+
+	client, err := dagger.Connect(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	defer client.Close()
+
+	dir := client.Directory().
+		WithNewFile("hello.txt", dagger.DirectoryWithNewFileOpts{
+			Contents: "Hello, world!",
+		}).
+		WithNewFile("goodbye.txt", dagger.DirectoryWithNewFileOpts{
+			Contents: "Goodbye, world!",
+		})
+
+	dirID, err := dir.ID(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	container := client.Container().From("alpine:3.16.2")
+
+	container = container.WithMountedDirectory("/mnt", dirID)
+
+	out, err := container.Exec(dagger.ContainerExecOpts{
+		Args: []string{"ls", "/mnt"},
+	}).Stdout().Contents(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%q", out)
+
+	// Output: "goodbye.txt\nhello.txt\n"
+}
+
+func ExampleContainer_WithMountedCache() {
+	ctx := context.Background()
+
+	client, err := dagger.Connect(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	defer client.Close()
+
+	cacheKey := "example-" + time.Now().Format(time.RFC3339)
+
+	cacheID, err := client.CacheVolume(cacheKey).ID(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	container := client.Container().From("alpine:3.16.2")
+
+	container = container.WithMountedCache(cacheID, "/cache")
+
+	var out string
+	for i := 0; i < 5; i++ {
+		out, err = container.Exec(dagger.ContainerExecOpts{
+			Args: []string{
+				"sh", "-c",
+				"echo $0 >> /cache/x.txt; cat /cache/x.txt",
+				strconv.Itoa(i),
+			},
+		}).Stdout().Contents(ctx)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	fmt.Printf("%q", out)
+
+	// Output: "0\n1\n2\n3\n4\n"
+}
+
+func ExampleDirectory() {
+	ctx := context.Background()
+
+	client, err := dagger.Connect(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	defer client.Close()
+
+	dir := client.Directory().
+		WithNewFile("hello.txt", dagger.DirectoryWithNewFileOpts{
+			Contents: "Hello, world!",
+		}).
+		WithNewFile("goodbye.txt", dagger.DirectoryWithNewFileOpts{
+			Contents: "Goodbye, world!",
+		})
+
+	entries, err := dir.Entries(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(entries)
+
+	// Output: [goodbye.txt hello.txt]
+}


### PR DESCRIPTION
Adds some examples for common use cases of the Dagger Go SDK. The examples will run as part of `go test` and let us know if the "Output:" magic comments become a lie. Pretty cool stuff! ([more info](https://go.dev/blog/examples))

Please nitpick the examples, since they might have a strong influence on how people write Dagger code.

Also adds a README. Note that this README will show up in the generated Godocs ([example](https://pkg.go.dev/github.com/moby/buildkit#section-readme)); suggestions welcome.