### PR TITLE
Make dagger-cue compatible with existing dagger packages

### DIFF
--- a/pkg/pkg.go
+++ b/pkg/pkg.go
@@ -31,8 +31,8 @@ var (
 	// ModuleRequirements specifies the MINIMUM version of the module dagger requires in order to work.
 	// This must be updated whenever we make breaking changes so users are prompt to upgrade the packages.
 	ModuleRequirements = map[string]*gv.Version{
-		DaggerModule:   gv.Must(gv.NewVersion("0.1.0")),
-		UniverseModule: gv.Must(gv.NewVersion("0.1.0")),
+		DaggerModule:   gv.Must(gv.NewVersion("0.2.11")),
+		UniverseModule: gv.Must(gv.NewVersion("0.2.9")),
 	}
 
 	DaggerPackage     = fmt.Sprintf("%s/dagger", DaggerModule)


### PR DESCRIPTION
This is a follow-up to:
- https://github.com/dagger/dagger/pull/3506
- https://github.com/dagger/dagger/pull/3486

We are reverting the dagger & universe modules checks back in preparation for publishing `v0.2.232`

Once we merge this PR and publish `v0.2.232`, this should work:

```
dagger-cue do hello
1:04AM ERROR system | failed to load plan: this plan requires dagger 0.2.36 or newer. Run `dagger version --check` to check for latest version
this plan requires dagger 0.2.36 or newer. Run `dagger version --check` to check for latest version
```

Thank you @jpadams for reporting this. cc @shykes @aluzzardi for being part of the conversation 🐴

---

[Why `.232`?](https://www.youtube.com/watch?v=099cHWSbAL8)