### PR TITLE
ci: Add release-dagger-cue GHA workflow to the main branch

### DIFF
--- a/.github/workflows/release-dagger-cue.yml
+++ b/.github/workflows/release-dagger-cue.yml
@@ -1,0 +1,74 @@
+name: "Release dagger-cue"
+
+# Only a single job with this concurrency can run at any given time
+concurrency: release-dagger-cue
+
+on:
+  # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs
+  #
+  # This workflow can only be triggered manually.
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: "E.g. 0.1.0"
+        required: true
+
+jobs:
+  tag-and-release:
+    # ⚠️ If this changes, remember to update the running-workflow-name property
+    name: "Tag & release"
+    runs-on: ubuntu-latest
+    # Only run this workflow from the cue-sdk branch
+    # We do not want to release dagger-cue from any other branch
+    if: ${{ github.ref_name == "cue-sdk" }}
+    steps:
+      - name: "Check out"
+        # https://github.com/actions/checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: "Ensure that all other checks have succeeded"
+        # https://github.com/lewagon/wait-on-check-action
+        uses: lewagon/wait-on-check-action@v1.0.0
+        with:
+          ref: ${{ github.ref }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10 # polls the GitHub API every 10 every seconds
+          running-workflow-name: "Tag & release"
+          allowed-conclusions: success
+
+      - name: "Create release tag"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X POST /repos/:owner/:repo/git/refs \
+            --field ref="refs/tags/sdk/cue/v${{ github.event.inputs.release_version }}" \
+            --field sha="$GITHUB_SHA"
+
+      - name: "Fetch new tag"
+        # https://github.com/actions/checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: "Install Go"
+        # https://github.com/actions/setup-go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+
+      - name: "Release"
+        # https://github.com/goreleaser/goreleaser-action
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          distribution: goreleaser-pro
+          args: release --rm-dist --debug
+        env:
+          GORELEASER_KEY: ${{ secrets.GORELEASER_PRO_LICENSE_KEY }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.RELEASE_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RELEASE_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.RELEASE_AWS_REGION }}
+          AWS_BUCKET: ${{ secrets.RELEASE_AWS_BUCKET }}
+          ARTEFACTS_FQDN: ${{ secrets.RELEASE_FQDN }}


### PR DESCRIPTION
Otherwise we will not be able to trigger it manually

Add a condition so that this workflow only runs from the `cue-sdk` branch. We do not want to release `dagger-cue` from any other branch.

This is a follow-up to:
- https://github.com/dagger/dagger/pull/3532

cc @shykes @aluzzardi @samalba @jpadams @mircubed 