### PR TITLE
ci: Update release-dagger-cue GHA workflow from the main branch

### DIFF
--- a/.github/workflows/release-dagger-cue.yml
+++ b/.github/workflows/release-dagger-cue.yml
@@ -14,13 +14,17 @@ on:
         required: true
 
 jobs:
-  bump_version-tag-release:
+  tag-and-release:
     # ⚠️ If this changes, remember to update the running-workflow-name property
     name: "Tag & release"
     runs-on: ubuntu-latest
+    # Only run this workflow from the cue-sdk branch
+    # We do not want to release dagger-cue from any other branch
+    if: ${{ github.ref_name == "cue-sdk" }}
     steps:
       - name: "Check out"
-        uses: actions/checkout@v2
+        # https://github.com/actions/checkout
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -43,17 +47,20 @@ jobs:
             --field sha="$GITHUB_SHA"
 
       - name: "Fetch new tag"
-        uses: actions/checkout@v2
+        # https://github.com/actions/checkout
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: "Install Go"
-        uses: actions/setup-go@v2
+        # https://github.com/actions/setup-go
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
 
       - name: "Release"
-        uses: goreleaser/goreleaser-action@v2
+        # https://github.com/goreleaser/goreleaser-action
+        uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser-pro
           args: release --rm-dist --debug


### PR DESCRIPTION
This adds a few workflow improvements and makes them both the same.

Only the workflow from the `cue-sdk` branch is supposed to be run, as per the check.

This is a follow-up to:
- https://github.com/dagger/dagger/pull/3533