### PR TITLE
Remove scoop & choco until `dagger-cue` pkgs exist

### DIFF
--- a/docs/current/sdk/cue/getting-started/526369-install.mdx
+++ b/docs/current/sdk/cue/getting-started/526369-install.mdx
@@ -88,7 +88,7 @@ dagger-cue 0.2.19 (GIT_SHA) linux/amd64
 
 <TabItem value="windows">
 
-`dagger-cue` can be installed in Windows via an installation powershell script, [Chocolatey](https://community.chocolatey.org/packages/dagger-cue) or [Scoop](https://scoop.sh/#/apps?q=dagger-cue).
+`dagger-cue` can be installed in Windows via an installation powershell script.
 
 If you want to use the installation script, powershell 7.0 or newer is required. From powershell, run:
 
@@ -120,20 +120,6 @@ Check that `dagger-cue` is installed correctly by opening a `Command Prompt` ter
 where dagger-cue
 C:\<your home folder>\dagger\dagger-cue.exe
 ```
-
-If you have Chocolatey installed, just open a terminal and run:
-
-```shell
-choco install dagger-cue
-```
-
-If you have Scoop installed, just open a terminal and run:
-
-```shell
-scoop bucket add main # If you don't have the main bucket added yet
-scoop install dagger-cue
-```
-
 </TabItem>
 
 </Tabs>


### PR DESCRIPTION
Today there are `dagger` install pkgs in Scoop and Chocolatey. There are not yet `dagger-cue` pkgs. This PR removes instructions for install via Scoop and Choco from `current` docs for now until we have `dagger-cue` pkgs. The `v0.2.x` version of docs is still correct for users of `dagger`. 
https://github.com/dagger/dagger/issues/3484#issuecomment-1290649686
