### PR TITLE
Use more obscure name for shim meta mount.

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -94,7 +94,7 @@ func (payload *containerIDPayload) FSState() (llb.State, error) {
 }
 
 // metaMount is the special path that the shim writes metadata to.
-const metaMount = "/dagger"
+const metaMount = "/.dagger_meta_mount"
 
 // metaSourcePath is a world-writable directory created and mounted to /dagger.
 const metaSourcePath = "meta"

--- a/core/shim/cmd/main.go
+++ b/core/shim/cmd/main.go
@@ -8,13 +8,13 @@ import (
 )
 
 const (
-	stdinPath    = "/dagger/stdin"
-	exitCodePath = "/dagger/exitCode"
+	stdinPath    = "/.dagger_meta_mount/stdin"
+	exitCodePath = "/.dagger_meta_mount/exitCode"
 )
 
 var (
-	stdoutPath = "/dagger/stdout"
-	stderrPath = "/dagger/stderr"
+	stdoutPath = "/.dagger_meta_mount/stdout"
+	stderrPath = "/.dagger_meta_mount/stderr"
 )
 
 func run() int {


### PR DESCRIPTION
Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Fixes https://github.com/dagger/dagger/issues/3407

Could also add verification in the code that users don't mount over this I suppose, but the name is obscure enough now that I don't think anyone would do it accidentally, so probably not worth it IMO.