### PR TITLE
Add temporary blurb about go get -u.

### DIFF
--- a/docs/current/partials/_install-sdk-go.md
+++ b/docs/current/partials/_install-sdk-go.md
@@ -13,6 +13,12 @@ go mod edit -replace github.com/docker/docker=github.com/docker/docker@v20.10.3-
 The `replace` statement is currently needed due to one of Dagger's dependencies using a `replace` statement in its Go module. Learn more in this [GitHub tracking issue](https://github.com/dagger/dagger/issues/3391).
 :::
 
+:::note
+Use of `go get -u` may currently result in a transitive dependency being upgraded to an incompatible version and errors like `filesync.go:112:20: cannot use dir.Map (variable of type func(string, *types.Stat) bool) as type fsutil.MapFunc in struct literal`.
+
+At this time, we recommend avoiding `-u` unless necessary to upgrade other unrelated dependencies. If you need to use it, you can patch the problem afterwards by running `go get github.com/tonistiigi/fsutil@v0.0.0-20220115021204-b19f7f9cb274`.
+:::
+
 Once you've added code to your module that imports `dagger.io/dagger` then you will need to run the following to update `go.sum`:
 
 ```shell


### PR DESCRIPTION
This may be fixed in the very near future by upgrading the version of buildkit we depend on but may as well include this blurb in the meantime.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>