### PR TITLE
add include/exclude support 

### DIFF
--- a/core/directory.go
+++ b/core/directory.go
@@ -258,6 +258,7 @@ func (dir *Directory) WithDirectory(ctx context.Context, subdir string, src *Dir
 	st = st.File(llb.Copy(srcSt, srcPayload.Dir, path.Join(destPayload.Dir, subdir), &llb.CopyInfo{
 		CreateDestPath:      true,
 		CopyDirContentsOnly: true,
+		AllowWildcard:       true,
 		IncludePatterns:     filter.Include,
 		ExcludePatterns:     filter.Exclude,
 	}))

--- a/core/directory.go
+++ b/core/directory.go
@@ -234,7 +234,7 @@ func (dir *Directory) File(ctx context.Context, file string) (*File, error) {
 	}).ToFile()
 }
 
-func (dir *Directory) WithDirectory(ctx context.Context, subdir string, src *Directory) (*Directory, error) {
+func (dir *Directory) WithDirectory(ctx context.Context, subdir string, src *Directory, filter CopyFilter) (*Directory, error) {
 	destPayload, err := dir.ID.Decode()
 	if err != nil {
 		return nil, err
@@ -256,7 +256,9 @@ func (dir *Directory) WithDirectory(ctx context.Context, subdir string, src *Dir
 	}
 
 	st = st.File(llb.Copy(srcSt, srcPayload.Dir, path.Join(destPayload.Dir, subdir), &llb.CopyInfo{
-		CreateDestPath: true,
+		CreateDestPath:  true,
+		IncludePatterns: filter.Include,
+		ExcludePatterns: filter.Exclude,
 	}))
 
 	err = destPayload.SetState(ctx, st)

--- a/core/directory.go
+++ b/core/directory.go
@@ -256,9 +256,10 @@ func (dir *Directory) WithDirectory(ctx context.Context, subdir string, src *Dir
 	}
 
 	st = st.File(llb.Copy(srcSt, srcPayload.Dir, path.Join(destPayload.Dir, subdir), &llb.CopyInfo{
-		CreateDestPath:  true,
-		IncludePatterns: filter.Include,
-		ExcludePatterns: filter.Exclude,
+		CreateDestPath:      true,
+		CopyDirContentsOnly: true,
+		IncludePatterns:     filter.Include,
+		ExcludePatterns:     filter.Exclude,
 	}))
 
 	err = destPayload.SetState(ctx, st)

--- a/core/directory.go
+++ b/core/directory.go
@@ -258,7 +258,6 @@ func (dir *Directory) WithDirectory(ctx context.Context, subdir string, src *Dir
 	st = st.File(llb.Copy(srcSt, srcPayload.Dir, path.Join(destPayload.Dir, subdir), &llb.CopyInfo{
 		CreateDestPath:      true,
 		CopyDirContentsOnly: true,
-		AllowWildcard:       true,
 		IncludePatterns:     filter.Include,
 		ExcludePatterns:     filter.Exclude,
 	}))

--- a/core/host.go
+++ b/core/host.go
@@ -28,12 +28,12 @@ type HostVariable struct {
 	Name string `json:"name"`
 }
 
-type FilterOpts struct {
+type CopyFilter struct {
 	Exclude []string
 	Include []string
 }
 
-func (host *Host) Directory(ctx context.Context, dirPath string, platform specs.Platform, filter FilterOpts) (*Directory, error) {
+func (host *Host) Directory(ctx context.Context, dirPath string, platform specs.Platform, filter CopyFilter) (*Directory, error) {
 	if host.DisableRW {
 		return nil, ErrHostRWDisabled
 	}

--- a/core/host.go
+++ b/core/host.go
@@ -28,7 +28,12 @@ type HostVariable struct {
 	Name string `json:"name"`
 }
 
-func (host *Host) Directory(ctx context.Context, dirPath string, platform specs.Platform) (*Directory, error) {
+type FilterOpts struct {
+	Exclude []string
+	Include []string
+}
+
+func (host *Host) Directory(ctx context.Context, dirPath string, platform specs.Platform, filter FilterOpts) (*Directory, error) {
 	if host.DisableRW {
 		return nil, ErrHostRWDisabled
 	}
@@ -50,17 +55,31 @@ func (host *Host) Directory(ctx context.Context, dirPath string, platform specs.
 		return nil, fmt.Errorf("eval symlinks: %w", err)
 	}
 
+	localID := fmt.Sprintf("host:%s", absPath)
+
+	localOpts := []llb.LocalOption{
+		// synchronize concurrent filesyncs for the same path
+		llb.SharedKeyHint(localID),
+
+		// make the LLB stable so we can test invariants like:
+		//
+		//   workdir == directory(".")
+		llb.LocalUniqueID(localID),
+	}
+
+	if len(filter.Exclude) > 0 {
+		localOpts = append(localOpts, llb.ExcludePatterns(filter.Exclude))
+	}
+
+	if len(filter.Include) > 0 {
+		localOpts = append(localOpts, llb.IncludePatterns(filter.Include))
+	}
+
 	// copy to scratch to avoid making buildkit's snapshot of the local dir immutable,
 	// which makes it unable to reused, which in turn creates cache invalidations
 	// TODO: this should be optional, the above issue can also be avoided w/ readonly
 	// mount when possible
-	st := llb.Scratch().File(llb.Copy(llb.Local(
-		absPath, // TODO: is there a better thing to set here? ...seems ok?
-		llb.SharedKeyHint(absPath),
-		llb.LocalUniqueID(absPath),
-		// FIXME: should not be hardcoded
-		llb.ExcludePatterns([]string{"**/node_modules"}),
-	), "/", "/"))
+	st := llb.Scratch().File(llb.Copy(llb.Local(absPath, localOpts...), "/", "/"))
 
 	return NewDirectory(ctx, st, "", platform)
 }

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"testing"
 
+	"dagger.io/dagger"
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/internal/testutil"
 	"github.com/stretchr/testify/require"
@@ -181,69 +182,78 @@ func TestDirectoryDirectoryWithNewFile(t *testing.T) {
 func TestDirectoryWithDirectory(t *testing.T) {
 	t.Parallel()
 
-	var res struct {
-		Directory struct {
-			WithNewFile struct {
-				WithNewFile struct {
-					Directory struct {
-						ID core.DirectoryID
-					}
-				}
-			}
-		}
-	}
+	c, ctx := connect(t)
+	defer c.Close()
 
-	err := testutil.Query(
-		`{
-			directory {
-				withNewFile(path: "some-file", contents: "some-content") {
-					withNewFile(path: "some-dir/sub-file", contents: "some-content") {
-						directory(path: "some-dir") {
-							id
-						}
-					}
-				}
-			}
-		}`, &res, nil)
+	dirID, err := c.Directory().
+		WithNewFile("some-file", dagger.DirectoryWithNewFileOpts{
+			Contents: "some-content",
+		}).
+		WithNewFile("some-dir/sub-file", dagger.DirectoryWithNewFileOpts{
+			Contents: "sub-content",
+		}).
+		Directory("some-dir").ID(ctx)
 	require.NoError(t, err)
 
-	var res2 struct {
-		Directory struct {
-			WithDirectory struct {
-				Entries []string
-			}
-		}
-	}
-
-	err = testutil.Query(
-		`query Test($src: DirectoryID!) {
-			directory {
-				withDirectory(path: "with-dir", directory: $src) {
-					entries(path: "with-dir")
-				}
-			}
-		}`, &res2, &testutil.QueryOptions{
-			Variables: map[string]any{
-				"src": res.Directory.WithNewFile.WithNewFile.Directory.ID,
-			},
-		})
+	entries, err := c.Directory().WithDirectory(dirID, "with-dir").Entries(ctx, dagger.DirectoryEntriesOpts{
+		Path: "with-dir",
+	})
 	require.NoError(t, err)
-	require.Equal(t, []string{"sub-file"}, res2.Directory.WithDirectory.Entries)
+	require.Equal(t, []string{"sub-file"}, entries)
 
-	err = testutil.Query(
-		`query Test($src: DirectoryID!) {
-			directory {
-				withDirectory(path: "sub-dir/sub-sub-dir/with-dir", directory: $src) {
-					entries(path: "sub-dir/sub-sub-dir/with-dir")
-				}
-			}
-		}`, &res2, &testutil.QueryOptions{
-			Variables: map[string]any{
-				"src": res.Directory.WithNewFile.WithNewFile.Directory.ID,
-			},
-		})
+	entries, err = c.Directory().WithDirectory(dirID, "sub-dir/sub-sub-dir/with-dir").Entries(ctx, dagger.DirectoryEntriesOpts{
+		Path: "sub-dir/sub-sub-dir/with-dir",
+	})
 	require.NoError(t, err)
-	require.Equal(t, []string{"sub-file"}, res2.Directory.WithDirectory.Entries)
+	require.Equal(t, []string{"sub-file"}, entries)
+}
+
+func TestDirectoryWithDirectoryIncludeExclude(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := connect(t)
+	defer c.Close()
+
+	dirID, err := c.Directory().
+		WithNewFile("a.txt").
+		WithNewFile("b.txt").
+		WithNewFile("c.txt.rar").
+		ID(ctx)
+	require.NoError(t, err)
+
+	t.Run("exclude", func(t *testing.T) {
+		entries, err := c.Directory().WithDirectory(dirID, ".", dagger.DirectoryWithDirectoryOpts{
+			Exclude: []string{"*.rar"},
+		}).Entries(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{"a.txt", "b.txt"}, entries)
+	})
+
+	t.Run("include", func(t *testing.T) {
+		entries, err := c.Directory().WithDirectory(dirID, ".", dagger.DirectoryWithDirectoryOpts{
+			Include: []string{"*.rar"},
+		}).Entries(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{"c.txt.rar"}, entries)
+	})
+
+	t.Run("exclude overrides include", func(t *testing.T) {
+		entries, err := c.Directory().WithDirectory(dirID, ".", dagger.DirectoryWithDirectoryOpts{
+			Include: []string{"*.txt"},
+			Exclude: []string{"b.txt"},
+		}).Entries(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{"a.txt"}, entries)
+	})
+
+	t.Run("include does not override exclude", func(t *testing.T) {
+		entries, err := c.Directory().WithDirectory(dirID, ".", dagger.DirectoryWithDirectoryOpts{
+			Include: []string{"a.txt"},
+			Exclude: []string{"*.txt"},
+		}).Entries(ctx)
+		require.NoError(t, err)
+		require.Equal(t, []string{}, entries)
+	})
 }
 
 func TestDirectoryWithCopiedFile(t *testing.T) {

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -277,29 +277,6 @@ func TestDirectoryWithDirectoryIncludeExclude(t *testing.T) {
 	})
 }
 
-func TestDirectoryWithDirectoryWildcard(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
-	defer c.Close()
-
-	dir := c.Directory().
-		WithNewFile("ayy/bee/cee/dee/ee/eff.txt").
-		WithNewFile("ayy/bee/cee/dee/ee/gee.txt")
-
-	dirID, err := dir.Directory("*/b*/c*").ID(ctx)
-	require.NoError(t, err)
-	entries, err := c.Directory().WithDirectory(dirID, ".").Entries(ctx)
-	require.NoError(t, err)
-	require.Equal(t, []string{"dee"}, entries)
-
-	dirID, err = dir.Directory("ayy/bee/cee/dee/*").ID(ctx)
-	require.NoError(t, err)
-	entries, err = c.Directory().WithDirectory(dirID, ".").Entries(ctx)
-	require.NoError(t, err)
-	require.Equal(t, []string{"eff.txt", "gee.txt"}, entries)
-}
-
 func TestDirectoryWithCopiedFile(t *testing.T) {
 	var fileRes struct {
 		Directory struct {

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -277,6 +277,29 @@ func TestDirectoryWithDirectoryIncludeExclude(t *testing.T) {
 	})
 }
 
+func TestDirectoryWithDirectoryWildcard(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := connect(t)
+	defer c.Close()
+
+	dir := c.Directory().
+		WithNewFile("ayy/bee/cee/dee/ee/eff.txt").
+		WithNewFile("ayy/bee/cee/dee/ee/gee.txt")
+
+	dirID, err := dir.Directory("*/b*/c*").ID(ctx)
+	require.NoError(t, err)
+	entries, err := c.Directory().WithDirectory(dirID, ".").Entries(ctx)
+	require.NoError(t, err)
+	require.Equal(t, []string{"dee"}, entries)
+
+	dirID, err = dir.Directory("ayy/bee/cee/dee/*").ID(ctx)
+	require.NoError(t, err)
+	entries, err = c.Directory().WithDirectory(dirID, ".").Entries(ctx)
+	require.NoError(t, err)
+	require.Equal(t, []string{"eff.txt", "gee.txt"}, entries)
+}
+
 func TestDirectoryWithCopiedFile(t *testing.T) {
 	var fileRes struct {
 		Directory struct {

--- a/core/integration/host_test.go
+++ b/core/integration/host_test.go
@@ -3,7 +3,7 @@ package core
 import (
 	"context"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"dagger.io/dagger"
@@ -14,7 +14,7 @@ func TestHostWorkdir(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	err := os.WriteFile(path.Join(dir, "foo"), []byte("bar"), 0600)
+	err := os.WriteFile(filepath.Join(dir, "foo"), []byte("bar"), 0600)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -37,7 +37,7 @@ func TestHostWorkdir(t *testing.T) {
 	})
 
 	t.Run("does NOT re-sync on each call", func(t *testing.T) {
-		err := os.WriteFile(path.Join(dir, "fizz"), []byte("buzz"), 0600)
+		err := os.WriteFile(filepath.Join(dir, "fizz"), []byte("buzz"), 0600)
 		require.NoError(t, err)
 
 		contents, err := c.Container().
@@ -51,11 +51,91 @@ func TestHostWorkdir(t *testing.T) {
 	})
 }
 
+func TestHostWorkdirExcludeInclude(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("1"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.txt"), []byte("2"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "c.txt.rar"), []byte("3"), 0600))
+
+	ctx := context.Background()
+	c, err := dagger.Connect(ctx, dagger.WithWorkdir(dir))
+	require.NoError(t, err)
+	defer c.Close()
+
+	t.Run("exclude", func(t *testing.T) {
+		wdID, err := c.Host().Workdir(dagger.HostWorkdirOpts{
+			Exclude: []string{"*.rar"},
+		}).ID(ctx)
+		require.NoError(t, err)
+
+		contents, err := c.Container().
+			From("alpine:3.16.2").
+			WithMountedDirectory("/host", wdID).
+			Exec(dagger.ContainerExecOpts{
+				Args: []string{"ls", "/host"},
+			}).Stdout().Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "a.txt\nb.txt\n", contents)
+	})
+
+	t.Run("include", func(t *testing.T) {
+		wdID, err := c.Host().Workdir(dagger.HostWorkdirOpts{
+			Include: []string{"*.rar"},
+		}).ID(ctx)
+		require.NoError(t, err)
+
+		contents, err := c.Container().
+			From("alpine:3.16.2").
+			WithMountedDirectory("/host", wdID).
+			Exec(dagger.ContainerExecOpts{
+				Args: []string{"ls", "/host"},
+			}).Stdout().Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "c.txt.rar\n", contents)
+	})
+
+	t.Run("exclude overrides include", func(t *testing.T) {
+		wdID, err := c.Host().Workdir(dagger.HostWorkdirOpts{
+			Include: []string{"*.txt"},
+			Exclude: []string{"b.txt"},
+		}).ID(ctx)
+		require.NoError(t, err)
+
+		contents, err := c.Container().
+			From("alpine:3.16.2").
+			WithMountedDirectory("/host", wdID).
+			Exec(dagger.ContainerExecOpts{
+				Args: []string{"ls", "/host"},
+			}).Stdout().Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "a.txt\n", contents)
+	})
+
+	t.Run("include does not override exclude", func(t *testing.T) {
+		wdID, err := c.Host().Workdir(dagger.HostWorkdirOpts{
+			Include: []string{"a.txt"},
+			Exclude: []string{"*.txt"},
+		}).ID(ctx)
+		require.NoError(t, err)
+
+		contents, err := c.Container().
+			From("alpine:3.16.2").
+			WithMountedDirectory("/host", wdID).
+			Exec(dagger.ContainerExecOpts{
+				Args: []string{"ls", "/host"},
+			}).Stdout().Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "", contents)
+	})
+}
+
 func TestHostDirectoryRelative(t *testing.T) {
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(path.Join(dir, "some-file"), []byte("hello"), 0600))
-	require.NoError(t, os.MkdirAll(path.Join(dir, "some-dir"), 0755))
-	require.NoError(t, os.WriteFile(path.Join(dir, "some-dir", "sub-file"), []byte("goodbye"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "some-file"), []byte("hello"), 0600))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "some-dir"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "some-dir", "sub-file"), []byte("goodbye"), 0600))
 
 	ctx := context.Background()
 	c, err := dagger.Connect(ctx, dagger.WithWorkdir(dir))
@@ -87,11 +167,107 @@ func TestHostDirectoryRelative(t *testing.T) {
 	})
 }
 
+func TestHostDirectoryAbsolute(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "some-file"), []byte("hello"), 0600))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "some-dir"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "some-dir", "sub-file"), []byte("goodbye"), 0600))
+
+	ctx := context.Background()
+	c, err := dagger.Connect(ctx, dagger.WithWorkdir(dir))
+	require.NoError(t, err)
+	defer c.Close()
+
+	entries, err := c.Host().Directory(filepath.Join(dir, "some-dir")).Entries(ctx)
+	require.NoError(t, err)
+	require.Equal(t, []string{"sub-file"}, entries)
+}
+
+func TestHostDirectoryExcludeInclude(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("1"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.txt"), []byte("2"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "c.txt.rar"), []byte("3"), 0600))
+
+	ctx := context.Background()
+	c, err := dagger.Connect(ctx)
+	require.NoError(t, err)
+	defer c.Close()
+
+	t.Run("exclude", func(t *testing.T) {
+		wdID, err := c.Host().Directory(dir, dagger.HostDirectoryOpts{
+			Exclude: []string{"*.rar"},
+		}).ID(ctx)
+		require.NoError(t, err)
+
+		contents, err := c.Container().
+			From("alpine:3.16.2").
+			WithMountedDirectory("/host", wdID).
+			Exec(dagger.ContainerExecOpts{
+				Args: []string{"ls", "/host"},
+			}).Stdout().Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "a.txt\nb.txt\n", contents)
+	})
+
+	t.Run("include", func(t *testing.T) {
+		wdID, err := c.Host().Directory(dir, dagger.HostDirectoryOpts{
+			Include: []string{"*.rar"},
+		}).ID(ctx)
+		require.NoError(t, err)
+
+		contents, err := c.Container().
+			From("alpine:3.16.2").
+			WithMountedDirectory("/host", wdID).
+			Exec(dagger.ContainerExecOpts{
+				Args: []string{"ls", "/host"},
+			}).Stdout().Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "c.txt.rar\n", contents)
+	})
+
+	t.Run("exclude overrides include", func(t *testing.T) {
+		wdID, err := c.Host().Directory(dir, dagger.HostDirectoryOpts{
+			Include: []string{"*.txt"},
+			Exclude: []string{"b.txt"},
+		}).ID(ctx)
+		require.NoError(t, err)
+
+		contents, err := c.Container().
+			From("alpine:3.16.2").
+			WithMountedDirectory("/host", wdID).
+			Exec(dagger.ContainerExecOpts{
+				Args: []string{"ls", "/host"},
+			}).Stdout().Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "a.txt\n", contents)
+	})
+
+	t.Run("include does not override exclude", func(t *testing.T) {
+		wdID, err := c.Host().Directory(dir, dagger.HostDirectoryOpts{
+			Include: []string{"a.txt"},
+			Exclude: []string{"*.txt"},
+		}).ID(ctx)
+		require.NoError(t, err)
+
+		contents, err := c.Container().
+			From("alpine:3.16.2").
+			WithMountedDirectory("/host", wdID).
+			Exec(dagger.ContainerExecOpts{
+				Args: []string{"ls", "/host"},
+			}).Stdout().Contents(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "", contents)
+	})
+}
+
 func TestHostDirectoryReadWrite(t *testing.T) {
 	t.Parallel()
 
 	dir1 := t.TempDir()
-	err := os.WriteFile(path.Join(dir1, "foo"), []byte("bar"), 0600)
+	err := os.WriteFile(filepath.Join(dir1, "foo"), []byte("bar"), 0600)
 	require.NoError(t, err)
 
 	dir2 := t.TempDir()
@@ -108,7 +284,7 @@ func TestHostDirectoryReadWrite(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, exported)
 
-	content, err := os.ReadFile(path.Join(dir2, "foo"))
+	content, err := os.ReadFile(filepath.Join(dir2, "foo"))
 	require.NoError(t, err)
 	require.Equal(t, "bar", string(content))
 }

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -1,13 +1,22 @@
 package core
 
 import (
+	"context"
 	"testing"
 
+	"dagger.io/dagger"
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/internal/testutil"
 	"github.com/moby/buildkit/identity"
 	"github.com/stretchr/testify/require"
 )
+
+func connect(t *testing.T) (*dagger.Client, context.Context) {
+	ctx := context.Background()
+	client, err := dagger.Connect(ctx)
+	require.NoError(t, err)
+	return client, ctx
+}
 
 func newCache(t *testing.T) core.CacheID {
 	var res struct {

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -69,10 +69,12 @@ func (s *directorySchema) subdirectory(ctx *router.Context, parent *core.Directo
 type withDirectoryArgs struct {
 	Path      string
 	Directory core.DirectoryID
+
+	core.CopyFilter
 }
 
 func (s *directorySchema) withDirectory(ctx *router.Context, parent *core.Directory, args withDirectoryArgs) (*core.Directory, error) {
-	return parent.WithDirectory(ctx, args.Path, &core.Directory{ID: args.Directory})
+	return parent.WithDirectory(ctx, args.Path, &core.Directory{ID: args.Directory}, args.CopyFilter)
 }
 
 type entriesArgs struct {

--- a/core/schema/directory.graphqls
+++ b/core/schema/directory.graphqls
@@ -30,7 +30,7 @@ type Directory {
     directory(path: String!): Directory!
 
     "This directory plus a directory written at the given path"
-    withDirectory(path: String!, directory: DirectoryID!): Directory!
+    withDirectory(path: String!, directory: DirectoryID!, exclude: [String!], include: [String!]): Directory!
 
     "This directory with the directory at the given path removed"
     withoutDirectory(path: String!): Directory!

--- a/core/schema/host.go
+++ b/core/schema/host.go
@@ -44,8 +44,12 @@ func (s *hostSchema) Dependencies() []router.ExecutableSchema {
 	return nil
 }
 
-func (s *hostSchema) workdir(ctx *router.Context, parent any, args any) (*core.Directory, error) {
-	return s.host.Directory(ctx, ".", s.platform)
+type hostWorkdirArgs struct {
+	core.FilterOpts
+}
+
+func (s *hostSchema) workdir(ctx *router.Context, parent any, args hostWorkdirArgs) (*core.Directory, error) {
+	return s.host.Directory(ctx, ".", s.platform, args.FilterOpts)
 }
 
 type hostVariableArgs struct {
@@ -68,8 +72,10 @@ func (s *hostSchema) envVariableSecret(ctx *router.Context, parent *core.HostVar
 
 type hostDirectoryArgs struct {
 	Path string
+
+	core.FilterOpts
 }
 
 func (s *hostSchema) directory(ctx *router.Context, parent any, args hostDirectoryArgs) (*core.Directory, error) {
-	return s.host.Directory(ctx, args.Path, s.platform)
+	return s.host.Directory(ctx, args.Path, s.platform, args.FilterOpts)
 }

--- a/core/schema/host.go
+++ b/core/schema/host.go
@@ -45,11 +45,11 @@ func (s *hostSchema) Dependencies() []router.ExecutableSchema {
 }
 
 type hostWorkdirArgs struct {
-	core.FilterOpts
+	core.CopyFilter
 }
 
 func (s *hostSchema) workdir(ctx *router.Context, parent any, args hostWorkdirArgs) (*core.Directory, error) {
-	return s.host.Directory(ctx, ".", s.platform, args.FilterOpts)
+	return s.host.Directory(ctx, ".", s.platform, args.CopyFilter)
 }
 
 type hostVariableArgs struct {
@@ -73,9 +73,9 @@ func (s *hostSchema) envVariableSecret(ctx *router.Context, parent *core.HostVar
 type hostDirectoryArgs struct {
 	Path string
 
-	core.FilterOpts
+	core.CopyFilter
 }
 
 func (s *hostSchema) directory(ctx *router.Context, parent any, args hostDirectoryArgs) (*core.Directory, error) {
-	return s.host.Directory(ctx, args.Path, s.platform, args.FilterOpts)
+	return s.host.Directory(ctx, args.Path, s.platform, args.CopyFilter)
 }

--- a/core/schema/host.graphqls
+++ b/core/schema/host.graphqls
@@ -6,10 +6,10 @@ extend type Query {
 "Information about the host execution environment"
 type Host {
   "The current working directory on the host"
-  workdir: Directory!
+  workdir(exclude: [String!], include: [String!]): Directory!
 
   "Access a directory on the host"
-  directory(path: String!): Directory!
+  directory(path: String!, exclude: [String!], include: [String!]): Directory!
 
   "Lookup the value of an environment variable. Null if the variable is not available."
   envVariable(name: String!): HostVariable

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -658,10 +658,31 @@ func (r *Directory) WithCopiedFile(path string, source FileID) *Directory {
 	}
 }
 
+// DirectoryWithDirectoryOpts contains options for Directory.WithDirectory
+type DirectoryWithDirectoryOpts struct {
+	Exclude []string
+
+	Include []string
+}
+
 // This directory plus a directory written at the given path
-func (r *Directory) WithDirectory(directory DirectoryID, path string) *Directory {
+func (r *Directory) WithDirectory(directory DirectoryID, path string, opts ...DirectoryWithDirectoryOpts) *Directory {
 	q := r.q.Select("withDirectory")
 	q = q.Arg("directory", directory)
+	// `exclude` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].Exclude) {
+			q = q.Arg("exclude", opts[i].Exclude)
+			break
+		}
+	}
+	// `include` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].Include) {
+			q = q.Arg("include", opts[i].Include)
+			break
+		}
+	}
 	q = q.Arg("path", path)
 
 	return &Directory{
@@ -872,9 +893,30 @@ type Host struct {
 	c graphql.Client
 }
 
+// HostDirectoryOpts contains options for Host.Directory
+type HostDirectoryOpts struct {
+	Exclude []string
+
+	Include []string
+}
+
 // Access a directory on the host
-func (r *Host) Directory(path string) *Directory {
+func (r *Host) Directory(path string, opts ...HostDirectoryOpts) *Directory {
 	q := r.q.Select("directory")
+	// `exclude` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].Exclude) {
+			q = q.Arg("exclude", opts[i].Exclude)
+			break
+		}
+	}
+	// `include` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].Include) {
+			q = q.Arg("include", opts[i].Include)
+			break
+		}
+	}
 	q = q.Arg("path", path)
 
 	return &Directory{
@@ -894,9 +936,30 @@ func (r *Host) EnvVariable(name string) *HostVariable {
 	}
 }
 
+// HostWorkdirOpts contains options for Host.Workdir
+type HostWorkdirOpts struct {
+	Exclude []string
+
+	Include []string
+}
+
 // The current working directory on the host
-func (r *Host) Workdir() *Directory {
+func (r *Host) Workdir(opts ...HostWorkdirOpts) *Directory {
 	q := r.q.Select("workdir")
+	// `exclude` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].Exclude) {
+			q = q.Arg("exclude", opts[i].Exclude)
+			break
+		}
+	}
+	// `include` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].Include) {
+			q = q.Arg("include", opts[i].Include)
+			break
+		}
+	}
 
 	return &Directory{
 		q: q,


### PR DESCRIPTION
Adds `include`/`exclude` filters to the following APIs:

```graphql
type Directory {
  withDirectory(path: String!, directory: DirectoryID!, exclude: [String!], include: [String!]): Directory!
}

type Host {
  workdir(exclude: [String!], include: [String!]): Directory!
  directory(path: String!, exclude: [String!], include: [String!]): Directory!
}
```