### PR TITLE
issue 3580: ref link to Dagger.Connect()

### DIFF
--- a/docs/current/sdk/go/959738-get-started.md
+++ b/docs/current/sdk/go/959738-get-started.md
@@ -79,7 +79,7 @@ This tool imports the Dagger SDK and defines two functions: `main()`, which prov
 
 The `main()` function accepts a git repo url as an argument. This is a Go repo that the tool will build in the following steps.
 
-The `build()` function currently just creates a dagger client with `dagger.Connect()`. In the next steps, this will provide the interface for executing commands against the Dagger engine.
+The `build()` function currently just creates a dagger client with [dagger.Connect()](https://pkg.go.dev/dagger.io/dagger#Connect). In the next steps, this will provide the interface for executing commands against the Dagger engine.
 
 1. Install the Dagger Go SDK
 


### PR DESCRIPTION
After this commit, the Go get started will display the reference on Dagger.Connect() to its package.
Closes [#3580](https://github.com/dagger/dagger/issues/3580)