### PR TITLE
Directory: consistent terminology for file/dir creation vs copying

### DIFF
--- a/core/directory.go
+++ b/core/directory.go
@@ -270,6 +270,30 @@ func (dir *Directory) WithDirectory(ctx context.Context, subdir string, src *Dir
 	return destPayload.ToDirectory()
 }
 
+func (dir *Directory) WithNewDirectory(ctx context.Context, gw bkgw.Client, dest string) (*Directory, error) {
+	payload, err := dir.ID.Decode()
+	if err != nil {
+		return nil, err
+	}
+
+	// be sure to create the file under the working directory
+	dest = path.Join(payload.Dir, dest)
+
+	st, err := payload.State()
+	if err != nil {
+		return nil, err
+	}
+
+	st = st.File(llb.Mkdir(dest, 0755, llb.WithParents(true)))
+
+	err = payload.SetState(ctx, st)
+	if err != nil {
+		return nil, err
+	}
+
+	return payload.ToDirectory()
+}
+
 func (dir *Directory) WithFile(ctx context.Context, subdir string, src *File) (*Directory, error) {
 	destPayload, err := dir.ID.Decode()
 	if err != nil {

--- a/core/directory.go
+++ b/core/directory.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path"
 	"reflect"
+	"strings"
 
 	bkclient "github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
@@ -274,6 +275,11 @@ func (dir *Directory) WithNewDirectory(ctx context.Context, gw bkgw.Client, dest
 	payload, err := dir.ID.Decode()
 	if err != nil {
 		return nil, err
+	}
+
+	dest = path.Clean(dest)
+	if strings.HasPrefix(dest, "../") {
+		return nil, fmt.Errorf("cannot create directory outside parent: %s", dest)
 	}
 
 	// be sure to create the file under the working directory

--- a/core/directory.go
+++ b/core/directory.go
@@ -270,7 +270,7 @@ func (dir *Directory) WithDirectory(ctx context.Context, subdir string, src *Dir
 	return destPayload.ToDirectory()
 }
 
-func (dir *Directory) WithCopiedFile(ctx context.Context, subdir string, src *File) (*Directory, error) {
+func (dir *Directory) WithFile(ctx context.Context, subdir string, src *File) (*Directory, error) {
 	destPayload, err := dir.ID.Decode()
 	if err != nil {
 		return nil, err

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -277,7 +277,7 @@ func TestDirectoryWithDirectoryIncludeExclude(t *testing.T) {
 	})
 }
 
-func TestDirectoryWithCopiedFile(t *testing.T) {
+func TestDirectoryWithFile(t *testing.T) {
 	var fileRes struct {
 		Directory struct {
 			WithNewFile struct {
@@ -303,7 +303,7 @@ func TestDirectoryWithCopiedFile(t *testing.T) {
 
 	var res struct {
 		Directory struct {
-			WithCopiedFile struct {
+			WithFile struct {
 				File struct {
 					ID       core.DirectoryID
 					Contents string
@@ -315,7 +315,7 @@ func TestDirectoryWithCopiedFile(t *testing.T) {
 	err = testutil.Query(
 		`query Test($src: FileID!) {
 			directory {
-				withCopiedFile(path: "target-file", source: $src) {
+				withFile(path: "target-file", source: $src) {
 					file(path: "target-file") {
 						id
 						contents
@@ -328,8 +328,8 @@ func TestDirectoryWithCopiedFile(t *testing.T) {
 			},
 		})
 	require.NoError(t, err)
-	require.NotEmpty(t, res.Directory.WithCopiedFile.File.ID)
-	require.Equal(t, "some-content", res.Directory.WithCopiedFile.File.Contents)
+	require.NotEmpty(t, res.Directory.WithFile.File.ID)
+	require.Equal(t, "some-content", res.Directory.WithFile.File.Contents)
 }
 
 func TestDirectoryWithoutDirectory(t *testing.T) {

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"testing"
 
 	"dagger.io/dagger"
@@ -275,6 +276,27 @@ func TestDirectoryWithDirectoryIncludeExclude(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, []string{"d.txt", "e.txt"}, entries)
 	})
+}
+
+func TestDirectoryWithNewDirectory(t *testing.T) {
+	ctx := context.Background()
+	c, err := dagger.Connect(ctx)
+	require.NoError(t, err)
+	defer c.Close()
+
+	dir := c.Directory().
+		WithNewDirectory("a").
+		WithNewDirectory("b/c")
+
+	entries, err := dir.Entries(ctx)
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b"}, entries)
+
+	entries, err = dir.Entries(ctx, dagger.DirectoryEntriesOpts{
+		Path: "b",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"c"}, entries)
 }
 
 func TestDirectoryWithFile(t *testing.T) {

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -297,6 +297,11 @@ func TestDirectoryWithNewDirectory(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, []string{"c"}, entries)
+
+	t.Run("does not permit creating directory outside of root", func(t *testing.T) {
+		_, err := dir.Directory("b").WithNewDirectory("../c").ID(ctx)
+		require.Error(t, err)
+	})
 }
 
 func TestDirectoryWithFile(t *testing.T) {

--- a/core/schema/README.md
+++ b/core/schema/README.md
@@ -40,7 +40,7 @@ Example:
 "An empty directory with a README copied to it"
 query readmeDir($readme: FileID!) {
   directory {
-    withCopiedFile(source: $readme, path: "README.md") {
+    withFile(source: $readme, path: "README.md") {
       id
     }
 }

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -32,11 +32,12 @@ func (s *directorySchema) Resolvers() router.Resolvers {
 		"Directory": router.ObjectResolver{
 			"entries":          router.ToResolver(s.entries),
 			"file":             router.ToResolver(s.file),
-			"withNewFile":      router.ToResolver(s.withNewFile),
 			"withFile":         router.ToResolver(s.withFile),
+			"withNewFile":      router.ToResolver(s.withNewFile),
 			"withoutFile":      router.ToResolver(s.withoutFile),
 			"directory":        router.ToResolver(s.subdirectory),
 			"withDirectory":    router.ToResolver(s.withDirectory),
+			"withNewDirectory": router.ToResolver(s.withNewDirectory),
 			"withoutDirectory": router.ToResolver(s.withoutDirectory),
 			"diff":             router.ToResolver(s.diff),
 			"export":           router.ToResolver(s.export),
@@ -64,6 +65,14 @@ type subdirectoryArgs struct {
 
 func (s *directorySchema) subdirectory(ctx *router.Context, parent *core.Directory, args subdirectoryArgs) (*core.Directory, error) {
 	return parent.Directory(ctx, args.Path)
+}
+
+type withNewDirectoryArgs struct {
+	Path string
+}
+
+func (s *directorySchema) withNewDirectory(ctx *router.Context, parent *core.Directory, args withNewDirectoryArgs) (*core.Directory, error) {
+	return parent.WithNewDirectory(ctx, s.gw, args.Path)
 }
 
 type withDirectoryArgs struct {

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -33,7 +33,7 @@ func (s *directorySchema) Resolvers() router.Resolvers {
 			"entries":          router.ToResolver(s.entries),
 			"file":             router.ToResolver(s.file),
 			"withNewFile":      router.ToResolver(s.withNewFile),
-			"withCopiedFile":   router.ToResolver(s.withCopiedFile),
+			"withFile":         router.ToResolver(s.withFile),
 			"withoutFile":      router.ToResolver(s.withoutFile),
 			"directory":        router.ToResolver(s.subdirectory),
 			"withDirectory":    router.ToResolver(s.withDirectory),
@@ -102,13 +102,13 @@ func (s *directorySchema) withNewFile(ctx *router.Context, parent *core.Director
 	return parent.WithNewFile(ctx, s.gw, args.Path, []byte(args.Contents))
 }
 
-type withCopiedFileArgs struct {
+type withFileArgs struct {
 	Path   string
 	Source core.FileID
 }
 
-func (s *directorySchema) withCopiedFile(ctx *router.Context, parent *core.Directory, args withCopiedFileArgs) (*core.Directory, error) {
-	return parent.WithCopiedFile(ctx, args.Path, &core.File{ID: args.Source})
+func (s *directorySchema) withFile(ctx *router.Context, parent *core.Directory, args withFileArgs) (*core.Directory, error) {
+	return parent.WithFile(ctx, args.Path, &core.File{ID: args.Source})
 }
 
 type withoutDirectoryArgs struct {

--- a/core/schema/directory.graphqls
+++ b/core/schema/directory.graphqls
@@ -17,11 +17,11 @@ type Directory {
   "Retrieve a file at the given path"
   file(path: String!): File!
 
-  "This directory plus a new file written at the given path"
-  withNewFile(path: String!, contents: String): Directory!
-
   "This directory plus the contents of the given file copied to the given path"
   withFile(path: String!, source: FileID!): Directory!
+
+  "This directory plus a new file written at the given path"
+  withNewFile(path: String!, contents: String): Directory!
 
   "This directory with the file at the given path removed"
   withoutFile(path: String!): Directory!
@@ -36,6 +36,9 @@ type Directory {
     exclude: [String!]
     include: [String!]
   ): Directory!
+
+  "This directory plus a new directory created at the given path"
+  withNewDirectory(path: String!): Directory!
 
   "This directory with the directory at the given path removed"
   withoutDirectory(path: String!): Directory!

--- a/core/schema/directory.graphqls
+++ b/core/schema/directory.graphqls
@@ -21,7 +21,7 @@ type Directory {
   withNewFile(path: String!, contents: String): Directory!
 
   "This directory plus the contents of the given file copied to the given path"
-  withCopiedFile(path: String!, source: FileID!): Directory!
+  withFile(path: String!, source: FileID!): Directory!
 
   "This directory with the file at the given path removed"
   withoutFile(path: String!): Directory!

--- a/magefile.go
+++ b/magefile.go
@@ -122,7 +122,7 @@ func Build(ctx context.Context) error {
 			return err
 		}
 
-		modules = modules.WithCopiedFile(f, fileID)
+		modules = modules.WithFile(f, fileID)
 	}
 	modID, err := modules.ID(ctx)
 	if err != nil {

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -724,6 +724,17 @@ func (r *Directory) WithFile(path string, source FileID) *Directory {
 	}
 }
 
+// This directory plus a new directory created at the given path
+func (r *Directory) WithNewDirectory(path string) *Directory {
+	q := r.q.Select("withNewDirectory")
+	q = q.Arg("path", path)
+
+	return &Directory{
+		q: q,
+		c: r.c,
+	}
+}
+
 // DirectoryWithNewFileOpts contains options for Directory.WithNewFile
 type DirectoryWithNewFileOpts struct {
 	Contents string

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -679,18 +679,6 @@ func (r *Directory) LoadProject(configPath string) *Project {
 	}
 }
 
-// This directory plus the contents of the given file copied to the given path
-func (r *Directory) WithCopiedFile(path string, source FileID) *Directory {
-	q := r.q.Select("withCopiedFile")
-	q = q.Arg("path", path)
-	q = q.Arg("source", source)
-
-	return &Directory{
-		q: q,
-		c: r.c,
-	}
-}
-
 // DirectoryWithDirectoryOpts contains options for Directory.WithDirectory
 type DirectoryWithDirectoryOpts struct {
 	Exclude []string
@@ -717,6 +705,18 @@ func (r *Directory) WithDirectory(directory DirectoryID, path string, opts ...Di
 		}
 	}
 	q = q.Arg("path", path)
+
+	return &Directory{
+		q: q,
+		c: r.c,
+	}
+}
+
+// This directory plus the contents of the given file copied to the given path
+func (r *Directory) WithFile(path string, source FileID) *Directory {
+	q := r.q.Select("withFile")
+	q = q.Arg("path", path)
+	q = q.Arg("source", source)
 
 	return &Directory{
 		q: q,


### PR DESCRIPTION
fixes #3588 
fixes #3567

* rename `withCopiedFile` to `withFile`, now consistent with `withDirectory`
* add `withNewDirectory` for the mkdir use case, consistent with `withNewFile`

via https://github.com/dagger/dagger/issues/3567#issuecomment-1294368392, here's the new convention:

> * `withDirectory`, `withFile`: copy a directory/file (source always required)
> * `withNewDirectory`, `withNewFile`: create a new directory/file