### PR TITLE
Handle lists of scalars in codegen. 

### DIFF
--- a/codegen/generator/templates/functions.go
+++ b/codegen/generator/templates/functions.go
@@ -55,7 +55,8 @@ func formatType(r *introspection.TypeRef) string {
 				return representation
 			default:
 				// Custom scalar
-				return ref.Name
+				representation += ref.Name
+				return representation
 			}
 		case introspection.TypeKindObject:
 			representation += formatName(ref.Name)

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -1,4 +1,4 @@
-//go:generate dagger client-gen -o api.gen.go
+//go:generate cloak client-gen -o api.gen.go
 package dagger
 
 import (


### PR DESCRIPTION
Without this a field that accepted a list of custom scalars would never be generated as a slice in Go