### PR TITLE
Go SDK: Pass objects by reference instead of ID

### DIFF
--- a/codegen/generator/templates/src/header.go.tmpl
+++ b/codegen/generator/templates/src/header.go.tmpl
@@ -8,11 +8,3 @@ import (
 	"github.com/Khan/genqlient/graphql"
 	"dagger.io/dagger/internal/querybuilder"
 )
-
-// graphqlMarshaller is an interface for marshalling an object into GraphQL.
-type graphqlMarshaller interface {
-	// GraphQLType returns the native GraphQL type name
-	graphqlType() string
-	// GraphQLMarshal serializes the structure into GraphQL
-	graphqlMarshal(ctx context.Context) (any, error)
-}

--- a/codegen/generator/templates/src/input.go.tmpl
+++ b/codegen/generator/templates/src/input.go.tmpl
@@ -2,6 +2,6 @@
 type {{ .Name | FormatName }} struct {
 {{- range $field := .InputFields }}
 {{ $field.Description | Comment }}
-{{ $field.Name | FormatName }} {{ $field.TypeRef | FormatType }} `json:"{{ $field.Name }}"`
+{{ $field.Name | FormatName }} {{ $field.TypeRef | FormatInputType }} `json:"{{ $field.Name }}"`
 {{ end }}
 }

--- a/codegen/generator/templates/src/object.go.tmpl
+++ b/codegen/generator/templates/src/object.go.tmpl
@@ -8,8 +8,12 @@ type {{ .Name | FormatName }} struct {
 // {{ $field | FieldOptionsStructName }} contains options for {{ $.Name | FormatName }}.{{ $field.Name | FormatName }}
 type {{ $field | FieldOptionsStructName }} struct {
 	{{- range $arg := $field.Args }}
-	{{ if $arg.TypeRef.IsOptional }}
-	{{ $arg.Name | FormatName }} {{ $arg.TypeRef | FormatType }}
+	{{- if $arg.TypeRef.IsOptional }}
+	{{- if and (eq $arg.Name "id") (eq $.Name "Query") }}
+	{{ $arg.Name | FormatName }} {{ $arg.TypeRef | FormatOutputType }}
+	{{- else }}
+	{{ $arg.Name | FormatName }} {{ $arg.TypeRef | FormatInputType }}
+	{{- end }}
 	{{- end }}
 	{{- end }}
 }
@@ -33,30 +37,30 @@ type {{ $field | FieldOptionsStructName }} struct {
 	{{- end }}
 	{{- end }}
 	{{ if $field.TypeRef.IsObject }}
-	return &{{ $field.TypeRef | FormatType }} {
+	return &{{ $field.TypeRef | FormatOutputType }} {
 		q: q,
 		c: r.c,
 	}
 	{{- else if or $field.TypeRef.IsScalar $field.TypeRef.IsList }}
-	var response {{ $field.TypeRef | FormatType }}
+	var response {{ $field.TypeRef | FormatOutputType }}
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 	{{- end }}
 }
 
 {{ if eq $field.Name "id" }}
-// graphqlType returns the native GraphQL type name
-func (r *{{ $.Name | FormatName }}) graphqlType() string {
+// XXX_GraphQLType is an internal function. It returns the native GraphQL type name
+func (r *{{ $.Name | FormatName }}) XXX_GraphQLType() string {
 	return "{{ $.Name }}"
 }
 
-// graphqlMarshal serializes the structure into GraphQL
-func (r *{{ $.Name | FormatName }}) graphqlMarshal(ctx context.Context) (any, error) {
+// XXX_GraphQLID is an internal function. It returns the underlying type ID
+func (r *{{ $.Name | FormatName }}) XXX_GraphQLID(ctx context.Context) (string, error) {
     id, err := r.ID(ctx)
     if err != nil {
-        return nil, err
+        return "", err
     }
-    return map[string]any{"id": id}, nil
+	return string(id), nil
 }
 {{ end }}
 {{ end -}}

--- a/codegen/generator/templates/src/scalar.go.tmpl
+++ b/codegen/generator/templates/src/scalar.go.tmpl
@@ -1,12 +1,2 @@
 {{ .Description | Comment }}
 type {{ .Name | FormatName }} string
-
-// graphqlType returns the native GraphQL type name
-func (s {{ .Name | FormatName }}) graphqlType() string {
-	return "{{ .Name }}"
-}
-
-// graphqlMarshal serializes the structure into GraphQL
-func (s {{ .Name | FormatName }}) graphqlMarshal(ctx context.Context) (any, error) {
-    return string(s), nil
-}

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -186,30 +186,29 @@ func TestDirectoryWithDirectory(t *testing.T) {
 	c, ctx := connect(t)
 	defer c.Close()
 
-	dirID, err := c.Directory().
+	dir := c.Directory().
 		WithNewFile("some-file", dagger.DirectoryWithNewFileOpts{
 			Contents: "some-content",
 		}).
 		WithNewFile("some-dir/sub-file", dagger.DirectoryWithNewFileOpts{
 			Contents: "sub-content",
 		}).
-		Directory("some-dir").ID(ctx)
-	require.NoError(t, err)
+		Directory("some-dir")
 
-	entries, err := c.Directory().WithDirectory(dirID, "with-dir").Entries(ctx, dagger.DirectoryEntriesOpts{
+	entries, err := c.Directory().WithDirectory(dir, "with-dir").Entries(ctx, dagger.DirectoryEntriesOpts{
 		Path: "with-dir",
 	})
 	require.NoError(t, err)
 	require.Equal(t, []string{"sub-file"}, entries)
 
-	entries, err = c.Directory().WithDirectory(dirID, "sub-dir/sub-sub-dir/with-dir").Entries(ctx, dagger.DirectoryEntriesOpts{
+	entries, err = c.Directory().WithDirectory(dir, "sub-dir/sub-sub-dir/with-dir").Entries(ctx, dagger.DirectoryEntriesOpts{
 		Path: "sub-dir/sub-sub-dir/with-dir",
 	})
 	require.NoError(t, err)
 	require.Equal(t, []string{"sub-file"}, entries)
 
 	t.Run("copies directory contents to .", func(t *testing.T) {
-		entries, err := c.Directory().WithDirectory(dirID, ".").Entries(ctx)
+		entries, err := c.Directory().WithDirectory(dir, ".").Entries(ctx)
 		require.NoError(t, err)
 		require.Equal(t, []string{"sub-file"}, entries)
 	})
@@ -229,11 +228,8 @@ func TestDirectoryWithDirectoryIncludeExclude(t *testing.T) {
 		WithNewFile("subdir/e.txt").
 		WithNewFile("subdir/f.txt.rar")
 
-	dirID, err := dir.ID(ctx)
-	require.NoError(t, err)
-
 	t.Run("exclude", func(t *testing.T) {
-		entries, err := c.Directory().WithDirectory(dirID, ".", dagger.DirectoryWithDirectoryOpts{
+		entries, err := c.Directory().WithDirectory(dir, ".", dagger.DirectoryWithDirectoryOpts{
 			Exclude: []string{"*.rar"},
 		}).Entries(ctx)
 		require.NoError(t, err)
@@ -241,7 +237,7 @@ func TestDirectoryWithDirectoryIncludeExclude(t *testing.T) {
 	})
 
 	t.Run("include", func(t *testing.T) {
-		entries, err := c.Directory().WithDirectory(dirID, ".", dagger.DirectoryWithDirectoryOpts{
+		entries, err := c.Directory().WithDirectory(dir, ".", dagger.DirectoryWithDirectoryOpts{
 			Include: []string{"*.rar"},
 		}).Entries(ctx)
 		require.NoError(t, err)
@@ -249,7 +245,7 @@ func TestDirectoryWithDirectoryIncludeExclude(t *testing.T) {
 	})
 
 	t.Run("exclude overrides include", func(t *testing.T) {
-		entries, err := c.Directory().WithDirectory(dirID, ".", dagger.DirectoryWithDirectoryOpts{
+		entries, err := c.Directory().WithDirectory(dir, ".", dagger.DirectoryWithDirectoryOpts{
 			Include: []string{"*.txt"},
 			Exclude: []string{"b.txt"},
 		}).Entries(ctx)
@@ -258,7 +254,7 @@ func TestDirectoryWithDirectoryIncludeExclude(t *testing.T) {
 	})
 
 	t.Run("include does not override exclude", func(t *testing.T) {
-		entries, err := c.Directory().WithDirectory(dirID, ".", dagger.DirectoryWithDirectoryOpts{
+		entries, err := c.Directory().WithDirectory(dir, ".", dagger.DirectoryWithDirectoryOpts{
 			Include: []string{"a.txt"},
 			Exclude: []string{"*.txt"},
 		}).Entries(ctx)
@@ -266,11 +262,10 @@ func TestDirectoryWithDirectoryIncludeExclude(t *testing.T) {
 		require.Equal(t, []string{}, entries)
 	})
 
-	subdirID, err := dir.Directory("subdir").ID(ctx)
-	require.NoError(t, err)
+	subdir := dir.Directory("subdir")
 
 	t.Run("exclude respects subdir", func(t *testing.T) {
-		entries, err := c.Directory().WithDirectory(subdirID, ".", dagger.DirectoryWithDirectoryOpts{
+		entries, err := c.Directory().WithDirectory(subdir, ".", dagger.DirectoryWithDirectoryOpts{
 			Exclude: []string{"*.rar"},
 		}).Entries(ctx)
 		require.NoError(t, err)
@@ -310,21 +305,20 @@ func TestDirectoryWithFile(t *testing.T) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	fileID, err := c.Directory().
+	file := c.Directory().
 		WithNewFile("some-file", dagger.DirectoryWithNewFileOpts{
 			Contents: "some-content",
 		}).
-		File("some-file").ID(ctx)
-	require.NoError(t, err)
+		File("some-file")
 
 	content, err := c.Directory().
-		WithFile("target-file", fileID).
+		WithFile("target-file", file).
 		File("target-file").Contents(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "some-content", content)
 
 	content, err = c.Directory().
-		WithFile("sub-dir/target-file", fileID).
+		WithFile("sub-dir/target-file", file).
 		File("sub-dir/target-file").Contents(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "some-content", content)

--- a/magefile.go
+++ b/magefile.go
@@ -37,20 +37,10 @@ func (Lint) Markdown(ctx context.Context) error {
 
 	workdir := c.Host().Workdir()
 
-	src, err := workdir.ID(ctx)
-	if err != nil {
-		return err
-	}
-
-	cfg, err := workdir.File(".markdownlint.yaml").ID(ctx)
-	if err != nil {
-		return err
-	}
-
 	_, err = c.Container().
 		From("tmknom/markdownlint:0.31.1").
-		WithMountedDirectory("/src", src).
-		WithMountedFile("/src/.markdownlint.yaml", cfg).
+		WithMountedDirectory("/src", workdir).
+		WithMountedFile("/src/.markdownlint.yaml", workdir.File(".markdownlint.yaml")).
 		WithWorkdir("/src").
 		Exec(dagger.ContainerExecOpts{
 			Args: []string{
@@ -106,46 +96,32 @@ func Build(ctx context.Context) error {
 	}
 	defer c.Close()
 
-	workdir := c.Host().Workdir()
-	builder := c.Container().
+	src := c.Host().Workdir()
+
+	// Create a directory containing only `go.{mod,sum}` files.
+	goMods := c.Directory()
+	for _, f := range []string{"go.mod", "go.sum", "sdk/go/go.mod", "sdk/go/go.sum"} {
+		goMods = goMods.WithFile(f, src.File(f))
+	}
+
+	build := c.Container().
 		From("golang:1.19-alpine").
 		WithEnvVariable("CGO_ENABLED", "0").
 		WithEnvVariable("GOOS", runtime.GOOS).
 		WithEnvVariable("GOARCH", runtime.GOARCH).
-		WithWorkdir("/app")
-
-	// install dependencies
-	modules := c.Directory()
-	for _, f := range []string{"go.mod", "go.sum", "sdk/go/go.mod", "sdk/go/go.sum"} {
-		fileID, err := workdir.File(f).ID(ctx)
-		if err != nil {
-			return err
-		}
-
-		modules = modules.WithFile(f, fileID)
-	}
-	modID, err := modules.ID(ctx)
-	if err != nil {
-		return err
-	}
-	builder = builder.
-		WithMountedDirectory("/app", modID).
+		WithWorkdir("/app").
+		// run `go mod download` with only go.mod files (re-run only if mod files have changed)
+		WithMountedDirectory("/app", goMods).
 		Exec(dagger.ContainerExecOpts{
 			Args: []string{"go", "mod", "download"},
-		})
-
-	src, err := workdir.ID(ctx)
-	if err != nil {
-		return err
-	}
-
-	builder = builder.
-		WithMountedDirectory("/app", src).WithWorkdir("/app").
+		}).
+		// run `go build` with all source
+		WithMountedDirectory("/app", src).
 		Exec(dagger.ContainerExecOpts{
 			Args: []string{"go", "build", "-o", "./bin/cloak", "-ldflags", "-s -w", "/app/cmd/cloak"},
 		})
 
-	ok, err := builder.Directory("./bin").Export(ctx, "./bin")
+	ok, err := build.Directory("./bin").Export(ctx, "./bin")
 	if err != nil {
 		return err
 	}

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -1,4 +1,4 @@
-//go:generate cloak client-gen -o api.gen.go
+//go:generate cloak client-gen -o api.gen.go --package dagger
 package dagger
 
 import (

--- a/sdk/go/examples_test.go
+++ b/sdk/go/examples_test.go
@@ -61,14 +61,11 @@ func ExampleContainer_Build() {
 	}
 	defer client.Close()
 
-	repoID, err := client.Git("https://github.com/dagger/dagger").
+	repo := client.Git("https://github.com/dagger/dagger").
 		Tag("v0.3.0").
-		Tree().ID(ctx)
-	if err != nil {
-		panic(err)
-	}
+		Tree()
 
-	daggerImg := client.Container().Build(repoID)
+	daggerImg := client.Container().Build(repo)
 
 	out, err := daggerImg.Exec(dagger.ContainerExecOpts{
 		Args: []string{"version"},
@@ -123,14 +120,9 @@ func ExampleContainer_WithMountedDirectory() {
 			Contents: "Goodbye, world!",
 		})
 
-	dirID, err := dir.ID(ctx)
-	if err != nil {
-		panic(err)
-	}
-
 	container := client.Container().From("alpine:3.16.2")
 
-	container = container.WithMountedDirectory("/mnt", dirID)
+	container = container.WithMountedDirectory("/mnt", dir)
 
 	out, err := container.Exec(dagger.ContainerExecOpts{
 		Args: []string{"ls", "/mnt"},
@@ -154,14 +146,11 @@ func ExampleContainer_WithMountedCache() {
 
 	cacheKey := "example-" + time.Now().Format(time.RFC3339)
 
-	cacheID, err := client.CacheVolume(cacheKey).ID(ctx)
-	if err != nil {
-		panic(err)
-	}
+	cache := client.CacheVolume(cacheKey)
 
 	container := client.Container().From("alpine:3.16.2")
 
-	container = container.WithMountedCache(cacheID, "/cache")
+	container = container.WithMountedCache(cache, "/cache")
 
 	var out string
 	for i := 0; i < 5; i++ {

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/iancoleman/strcase v0.2.0
 	github.com/stretchr/testify v1.8.1
 	github.com/vektah/gqlparser/v2 v2.5.1
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 )
 
 require (
@@ -74,7 +75,6 @@ require (
 	go.opentelemetry.io/proto/otlp v0.18.0 // indirect
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
 	golang.org/x/net v0.0.0-20220811182439-13a9a731de15 // indirect
-	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
 	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9 // indirect

--- a/sdk/go/internal/querybuilder/marshal.go
+++ b/sdk/go/internal/querybuilder/marshal.go
@@ -1,61 +1,118 @@
 package querybuilder
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
+
+	"golang.org/x/sync/errgroup"
 )
 
-func MarshalGQL(v any) string {
-	return marshalGQL(reflect.ValueOf(v))
+// GraphQLMarshaller is an internal interface for marshalling an object into GraphQL.
+type GraphQLMarshaller interface {
+	// XXX_GraphQLType is an internal function. It returns the native GraphQL type name
+	XXX_GraphQLType() string
+	// XXX_GraphqlID is an internal function. It returns the underlying type ID
+	XXX_GraphQLID(ctx context.Context) (string, error)
 }
 
-func marshalGQL(v reflect.Value) string {
+const (
+	GraphQLMarshallerType = "XXX_GraphQLType"
+	GraphQLMarshallerID   = "XXX_GraphQLID"
+)
+
+var gqlMarshaller reflect.Type
+
+func init() {
+	gqlMarshaller = reflect.TypeOf((*GraphQLMarshaller)(nil)).Elem()
+}
+
+func MarshalGQL(ctx context.Context, v any) (string, error) {
+	return marshalValue(ctx, reflect.ValueOf(v))
+}
+
+func marshalValue(ctx context.Context, v reflect.Value) (string, error) {
 	t := v.Type()
+
+	if t.Implements(gqlMarshaller) {
+		return marshalCustom(ctx, v)
+	}
 
 	switch t.Kind() {
 	case reflect.Bool:
-		return fmt.Sprintf("%t", v.Bool())
+		return fmt.Sprintf("%t", v.Bool()), nil
 	case reflect.Int:
-		return fmt.Sprintf("%d", v.Int())
+		return fmt.Sprintf("%d", v.Int()), nil
 	case reflect.String:
-		return fmt.Sprintf("%q", v.String())
+		return fmt.Sprintf("%q", v.String()), nil
 	case reflect.Pointer:
 		if v.IsNil() {
-			return "null"
+			return "null", nil
 		}
-		return marshalGQL(v.Elem())
+		return marshalValue(ctx, v.Elem())
 	case reflect.Slice:
-		encoded := "["
 		n := v.Len()
+		elems := make([]string, n)
+		eg, gctx := errgroup.WithContext(ctx)
 		for i := 0; i < n; i++ {
-			if i > 0 {
-				encoded += ","
-			}
-			encoded += marshalGQL(v.Index(i))
+			i := i
+			eg.Go(func() error {
+				m, err := marshalValue(gctx, v.Index(i))
+				if err != nil {
+					return err
+				}
+				elems[i] = m
+				return nil
+			})
 		}
-		encoded += "]"
-		return encoded
+		if err := eg.Wait(); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("[%s]", strings.Join(elems, ",")), nil
 	case reflect.Struct:
-		encoded := "{"
-		for i := 0; i < v.NumField(); i++ {
-			if i > 0 {
-				encoded += ","
-			}
-
-			f := t.Field(i)
-			name := f.Name
-			tag := strings.SplitN(f.Tag.Get("json"), ",", 2)[0]
-			if tag != "" {
-				name = tag
-			}
-			encoded += fmt.Sprintf("%s:%s", name, marshalGQL(v.Field(i)))
+		n := v.NumField()
+		elems := make([]string, n)
+		eg, gctx := errgroup.WithContext(ctx)
+		for i := 0; i < n; i++ {
+			i := i
+			eg.Go(func() error {
+				f := t.Field(i)
+				name := f.Name
+				tag := strings.SplitN(f.Tag.Get("json"), ",", 2)[0]
+				if tag != "" {
+					name = tag
+				}
+				m, err := marshalValue(gctx, v.Field(i))
+				if err != nil {
+					return err
+				}
+				elems[i] = fmt.Sprintf("%s:%s", name, m)
+				return nil
+			})
 		}
-		encoded += "}"
-		return encoded
+		if err := eg.Wait(); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("{%s}", strings.Join(elems, ",")), nil
 	default:
 		panic(fmt.Errorf("unsupported argument of kind %s", t.Kind()))
 	}
+}
+
+func marshalCustom(ctx context.Context, v reflect.Value) (string, error) {
+	result := v.MethodByName(GraphQLMarshallerID).Call([]reflect.Value{
+		reflect.ValueOf(ctx),
+	})
+	if len(result) != 2 {
+		panic(result)
+	}
+	err := result[1].Interface()
+	if err != nil {
+		return "", err.(error)
+	}
+
+	return fmt.Sprintf("%q", result[0].String()), nil
 }
 
 func IsZeroValue(value any) bool {

--- a/sdk/go/internal/querybuilder/querybuilder_test.go
+++ b/sdk/go/internal/querybuilder/querybuilder_test.go
@@ -1,6 +1,7 @@
 package querybuilder
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -13,7 +14,8 @@ func TestQuery(t *testing.T) {
 		Select("image").Arg("ref", "alpine").
 		Select("file").Arg("path", "/etc/alpine-release")
 
-	q := root.Build()
+	q, err := root.build(context.Background())
+	require.NoError(t, err)
 	require.Equal(t, `query{core{image(ref:"alpine"){file(path:"/etc/alpine-release")}}}`, q)
 }
 
@@ -23,15 +25,18 @@ func TestAlias(t *testing.T) {
 		Select("image").Arg("ref", "alpine").
 		SelectWithAlias("foo", "file").Arg("path", "/etc/alpine-release")
 
-	q := root.Build()
+	q, err := root.build(context.Background())
+	require.NoError(t, err)
 	require.Equal(t, `query{core{image(ref:"alpine"){foo:file(path:"/etc/alpine-release")}}}`, q)
 }
 
 func TestArgsCollision(t *testing.T) {
-	q := Query().
+	q, err := Query().
 		Select("a").Arg("arg", "one").
 		Select("b").Arg("arg", "two").
-		Build()
+		build(context.Background())
+
+	require.NoError(t, err)
 	require.Equal(t, `query{a(arg:"one"){b(arg:"two")}}`, q)
 }
 
@@ -65,7 +70,8 @@ func TestNullableArgs(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		q := Query().Select("a").Arg("arg", test.arg).Build()
+		q, err := Query().Select("a").Arg("arg", test.arg).build(context.Background())
+		require.NoError(t, err)
 		require.Equal(t, test.expect, q)
 	}
 }
@@ -74,11 +80,13 @@ func TestFieldImmutability(t *testing.T) {
 	root := Query().
 		Select("test")
 
-	a := root.Select("a").Build()
+	a, err := root.Select("a").build(context.Background())
+	require.NoError(t, err)
 	require.Equal(t, `query{test{a}}`, a)
 
 	// Make sure this is not `test{a,b}` (e.g. the previous select didn't modify `root` in-place)
-	b := root.Select("b").Build()
+	b, err := root.Select("b").build(context.Background())
+	require.NoError(t, err)
 	require.Equal(t, `query{test{b}}`, b)
 }
 
@@ -86,11 +94,13 @@ func TestArgImmutability(t *testing.T) {
 	root := Query().
 		Select("test")
 
-	a := root.Arg("foo", "bar").Build()
+	a, err := root.Arg("foo", "bar").build(context.Background())
+	require.NoError(t, err)
 	require.Equal(t, `query{test(foo:"bar")}`, a)
 
 	// Make sure this does not contain `hello` (e.g. the previous select didn't modify `root` in-place)
-	b := root.Arg("hello", "world").Build()
+	b, err := root.Arg("hello", "world").build(context.Background())
+	require.NoError(t, err)
 	require.Equal(t, `query{test(hello:"world")}`, b)
 }
 
@@ -112,6 +122,6 @@ func TestUnpack(t *testing.T) {
 		}
 	`), &response)
 	require.NoError(t, err)
-	require.NoError(t, root.Unpack(response))
+	require.NoError(t, root.unpack(response))
 	require.Equal(t, "TEST", contents)
 }


### PR DESCRIPTION
Partial implementation of #3558. Example:

**Before**:
```go
modules := c.Directory()
for _, f := range []string{"go.mod", "go.sum", "sdk/go/go.mod", "sdk/go/go.sum"} {
	fileID, err := workdir.File(f).ID(ctx)
	if err != nil {
		return err
	}

	modules = modules.WithCopiedFile(f, fileID)
}
```

**After**:
```go
modules := c.Directory()
for _, f := range []string{"go.mod", "go.sum", "sdk/go/go.mod", "sdk/go/go.sum"} {
	modules = modules.WithCopiedFile(f, workdir.File(f))
}
```

See our changes to `magefile.go` and various tests for other examples.

**Caveats**

- Some arguments are named `id` in the API (e.g. `id FileID`), but they're not IDs in the SDK (e.g. `id *File`)
- Currently it doesn't work on optional fields, because they're structures. I don't know yet how to get around that without recursive reflection (blargh)
- With everything is generic and would work with any ID, however I've had to hardcode a few things to work around these limitations:
  - Top-level selectors (e.g. `File(id FileID)`) become weird (`File(id *File)`) -- if you already have the file, what's the point of having a function to look it up? I've kept them as `File(id FileID)`
  - I don't have a good heuristic to go from `DirectoryID` to `Directory` (stripping the `ID` is not enough, for instance it's `CacheID` -> `CacheVolume`), so the conversion map is hardcoded
  - We could potentially analyze the schema and look for objects that have an `id` field pointing to a scalar -- and recording that as scalar->object conversion