### PR TITLE
fix mount propagation causing repeated runs

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -148,20 +148,21 @@ func (mnt ContainerMount) SourceState() (llb.State, error) {
 type ContainerMounts []ContainerMount
 
 func (mnts ContainerMounts) With(newMnt ContainerMount) ContainerMounts {
-	mntsCp := make(ContainerMounts, len(mnts))
-	copy(mntsCp, mnts)
+	mntsCp := make(ContainerMounts, 0, len(mnts))
 
-	var replaced bool
-	for i, mnt := range mntsCp {
-		if mnt.Target == newMnt.Target {
-			mntsCp[i] = newMnt
-			replaced = true
+	// NB: this / might need to change on Windows, but I'm not even sure how
+	// mounts work on Windows, so...
+	parent := newMnt.Target + "/"
+
+	for _, mnt := range mnts {
+		if mnt.Target == newMnt.Target || strings.HasPrefix(mnt.Target, parent) {
+			continue
 		}
+
+		mntsCp = append(mntsCp, mnt)
 	}
 
-	if !replaced {
-		mntsCp = append(mntsCp, newMnt)
-	}
+	mntsCp = append(mntsCp, newMnt)
 
 	return mntsCp
 }

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -1586,7 +1586,7 @@ func TestContainerMountsWithoutMount(t *testing.T) {
 	require.Equal(t, []string{"/mnt/tmp"}, execRes.Container.From.WithMountedTemp.WithMountedDirectory.Exec.WithoutMount.Mounts)
 }
 
-func TestContainerStackedMounts(t *testing.T) {
+func TestContainerReplacedMounts(t *testing.T) {
 	t.Parallel()
 
 	dirRes := struct {
@@ -1636,11 +1636,6 @@ func TestContainerStackedMounts(t *testing.T) {
 								}
 								WithoutMount struct {
 									Mounts []string
-									Exec   struct {
-										Stdout struct {
-											Contents string
-										}
-									}
 								}
 							}
 						}
@@ -1667,11 +1662,6 @@ func TestContainerStackedMounts(t *testing.T) {
 									}
 									withoutMount(path: "/mnt/dir") {
 										mounts
-										exec(args: ["cat", "/mnt/dir/some-file"]) {
-											stdout {
-												contents
-											}
-										}
 									}
 								}
 							}
@@ -1686,10 +1676,9 @@ func TestContainerStackedMounts(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"/mnt/dir"}, execRes.Container.From.WithMountedDirectory.Mounts)
 	require.Equal(t, "lower-content", execRes.Container.From.WithMountedDirectory.Exec.Stdout.Contents)
-	require.Equal(t, []string{"/mnt/dir", "/mnt/dir"}, execRes.Container.From.WithMountedDirectory.Exec.WithMountedDirectory.Mounts)
+	require.Equal(t, []string{"/mnt/dir"}, execRes.Container.From.WithMountedDirectory.Exec.WithMountedDirectory.Mounts)
 	require.Equal(t, "upper-content", execRes.Container.From.WithMountedDirectory.Exec.WithMountedDirectory.Exec.Stdout.Contents)
-	require.Equal(t, []string{"/mnt/dir"}, execRes.Container.From.WithMountedDirectory.Exec.WithMountedDirectory.Exec.WithoutMount.Mounts)
-	require.Equal(t, "lower-content", execRes.Container.From.WithMountedDirectory.Exec.WithMountedDirectory.Exec.WithoutMount.Exec.Stdout.Contents)
+	require.Equal(t, []string{}, execRes.Container.From.WithMountedDirectory.Exec.WithMountedDirectory.Exec.WithoutMount.Mounts)
 }
 
 func TestContainerDirectory(t *testing.T) {


### PR DESCRIPTION
fixes #3551

* propagate mounts from the result of running the command with every mount, rather than one at a time as we iterate, which meant each mount technically had a different llb state.
* remove stacking semantics as Buildkit currently assumes mount targets are unique (see second commit message)