### PR TITLE
[Experimental] wasi/wasm32 platform support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,9 @@ jobs:
     name: go
     runs-on: ubuntu-22.04-16c-64g-600gb
     steps:
+      - name: Set up QEMU
+        run: |
+          docker run --rm --privileged tonistiigi/binfmt:latest --install all
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19

--- a/core/container.go
+++ b/core/container.go
@@ -28,6 +28,17 @@ type Container struct {
 	ID ContainerID `json:"id"`
 }
 
+func NewContainer(id ContainerID, platform specs.Platform) (*Container, error) {
+	if id == "" {
+		id, err := (&containerIDPayload{Platform: platform}).Encode()
+		if err != nil {
+			return nil, err
+		}
+		return &Container{ID: id}, nil
+	}
+	return &Container{ID: id}, nil
+}
+
 // ContainerID is an opaque value representing a content-addressed container.
 type ContainerID string
 
@@ -145,7 +156,13 @@ func (mnt ContainerMount) SourceState() (llb.State, error) {
 	return defToState(mnt.Source)
 }
 
-func (container *Container) From(ctx context.Context, gw bkgw.Client, addr string, platform specs.Platform) (*Container, error) {
+func (container *Container) From(ctx context.Context, gw bkgw.Client, addr string) (*Container, error) {
+	payload, err := container.ID.decode()
+	if err != nil {
+		return nil, err
+	}
+	platform := payload.Platform
+
 	refName, err := reference.ParseNormalizedNamed(addr)
 	if err != nil {
 		return nil, err
@@ -171,7 +188,7 @@ func (container *Container) From(ctx context.Context, gw bkgw.Client, addr strin
 		return nil, err
 	}
 
-	ctr, err := container.WithFS(ctx, dir, platform)
+	ctr, err := container.WithFS(ctx, dir)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +200,7 @@ func (container *Container) From(ctx context.Context, gw bkgw.Client, addr strin
 
 const defaultDockerfileName = "Dockerfile"
 
-func (container *Container) Build(ctx context.Context, gw bkgw.Client, context *Directory, dockerfile string, platform specs.Platform) (*Container, error) {
+func (container *Container) Build(ctx context.Context, gw bkgw.Client, context *Directory, dockerfile string) (*Container, error) {
 	payload, err := container.ID.decode()
 	if err != nil {
 		return nil, err
@@ -193,6 +210,8 @@ func (container *Container) Build(ctx context.Context, gw bkgw.Client, context *
 	if err != nil {
 		return nil, err
 	}
+
+	platform := payload.Platform
 
 	opts := map[string]string{
 		"platform":      platforms.Format(platform),
@@ -235,7 +254,6 @@ func (container *Container) Build(ctx context.Context, gw bkgw.Client, context *
 	}
 
 	payload.FS = def.ToPB()
-	payload.Platform = platform
 
 	cfgBytes, found := res.Metadata[exptypes.ExporterImageConfigKey]
 	if found {
@@ -267,7 +285,7 @@ func (container *Container) FS(ctx context.Context) (*Directory, error) {
 	}).ToDirectory()
 }
 
-func (container *Container) WithFS(ctx context.Context, dir *Directory, platform specs.Platform) (*Container, error) {
+func (container *Container) WithFS(ctx context.Context, dir *Directory) (*Container, error) {
 	payload, err := container.ID.decode()
 	if err != nil {
 		return nil, err
@@ -279,7 +297,6 @@ func (container *Container) WithFS(ctx context.Context, dir *Directory, platform
 	}
 
 	payload.FS = dirPayload.LLB
-	payload.Platform = platform
 
 	id, err := payload.Encode()
 	if err != nil {
@@ -814,36 +831,11 @@ func (container *Container) MetaFile(ctx context.Context, gw bkgw.Client, filePa
 func (container *Container) Publish(
 	ctx context.Context,
 	ref string,
+	platformVariants []ContainerID,
 	bkClient *bkclient.Client,
 	solveOpts bkclient.SolveOpt,
 	solveCh chan<- *bkclient.SolveStatus,
 ) (string, error) {
-	payload, err := container.ID.decode()
-	if err != nil {
-		return "", err
-	}
-
-	st, err := payload.FSState()
-	if err != nil {
-		return "", err
-	}
-
-	stDef, err := st.Marshal(ctx, llb.Platform(payload.Platform))
-	if err != nil {
-		return "", err
-	}
-
-	cfgBytes, err := json.Marshal(specs.Image{
-		Architecture: payload.Platform.Architecture,
-		OS:           payload.Platform.OS,
-		OSVersion:    payload.Platform.OSVersion,
-		OSFeatures:   payload.Platform.OSFeatures,
-		Config:       payload.Config,
-	})
-	if err != nil {
-		return "", err
-	}
-
 	// NOTE: be careful to not overwrite any values from original solveOpts (i.e. with append).
 	solveOpts.Exports = []bkclient.ExportEntry{
 		{
@@ -858,15 +850,85 @@ func (container *Container) Publish(
 	ch, wg := mirrorCh(solveCh)
 	defer wg.Wait()
 
+	var payloads []*containerIDPayload
+	if container.ID != "" {
+		payload, err := container.ID.decode()
+		if err != nil {
+			return "", err
+		}
+		if payload.FS != nil {
+			payloads = append(payloads, payload)
+		}
+	}
+	for _, id := range platformVariants {
+		payload, err := id.decode()
+		if err != nil {
+			return "", err
+		}
+		if payload.FS != nil {
+			payloads = append(payloads, payload)
+		}
+	}
+
+	if len(payloads) == 0 {
+		// Could also just ignore and do nothing, airing on side of error until proven otherwise.
+		return "", errors.New("no containers to publish")
+	}
+
 	res, err := bkClient.Build(ctx, solveOpts, "", func(ctx context.Context, gw bkgw.Client) (*bkgw.Result, error) {
-		res, err := gw.Solve(ctx, bkgw.SolveRequest{
-			Evaluate:   true,
-			Definition: stDef.ToPB(),
-		})
+		res := bkgw.NewResult()
+		expPlatforms := &exptypes.Platforms{
+			Platforms: make([]exptypes.Platform, len(payloads)),
+		}
+
+		for i, payload := range payloads {
+			st, err := payload.FSState()
+			if err != nil {
+				return nil, err
+			}
+
+			stDef, err := st.Marshal(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			r, err := gw.Solve(ctx, bkgw.SolveRequest{
+				Definition: stDef.ToPB(),
+			})
+			if err != nil {
+				return nil, err
+			}
+			ref, err := r.SingleRef()
+			if err != nil {
+				return nil, err
+			}
+
+			platformKey := platforms.Format(payload.Platform)
+			res.AddRef(platformKey, ref)
+			expPlatforms.Platforms[i] = exptypes.Platform{
+				ID:       platformKey,
+				Platform: payload.Platform,
+			}
+
+			cfgBytes, err := json.Marshal(specs.Image{
+				Architecture: payload.Platform.Architecture,
+				OS:           payload.Platform.OS,
+				OSVersion:    payload.Platform.OSVersion,
+				OSFeatures:   payload.Platform.OSFeatures,
+				Config:       payload.Config,
+			})
+			if err != nil {
+				return nil, err
+			}
+			res.AddMeta(fmt.Sprintf("%s/%s", exptypes.ExporterImageConfigKey, platformKey), cfgBytes)
+		}
+
+		platformBytes, err := json.Marshal(expPlatforms)
 		if err != nil {
 			return nil, err
 		}
-		res.AddMeta(exptypes.ExporterImageConfigKey, cfgBytes)
+		res.AddMeta(exptypes.ExporterPlatformsKey, platformBytes)
+
 		return res, nil
 	}, ch)
 	if err != nil {

--- a/core/container.go
+++ b/core/container.go
@@ -958,6 +958,14 @@ func (container *Container) Publish(
 	return ref, nil
 }
 
+func (container *Container) Platform() (specs.Platform, error) {
+	payload, err := container.ID.decode()
+	if err != nil {
+		return specs.Platform{}, err
+	}
+	return payload.Platform, nil
+}
+
 type ContainerExecOpts struct {
 	// Command to run instead of the container's default command
 	Args []string

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -35,7 +35,6 @@ func TestContainerScratch(t *testing.T) {
 			}
 		}`, &res, nil)
 	require.NoError(t, err)
-	require.Empty(t, res.Container.ID)
 	require.Empty(t, res.Container.Fs.Entries)
 }
 

--- a/core/integration/platform_test.go
+++ b/core/integration/platform_test.go
@@ -1,0 +1,132 @@
+package core
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"dagger.io/dagger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainerPlatformEmulatedExecAndPush(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
+	require.NoError(t, err)
+	defer c.Close()
+
+	startRegistry(ctx, c, t)
+
+	platformToUname := map[string]string{
+		"linux/amd64": "x86_64",
+		"linux/arm64": "aarch64",
+		"linux/s390x": "s390x",
+	}
+
+	variants := make([]dagger.ContainerID, 0, len(platformToUname))
+	for platform, uname := range platformToUname {
+		ctr := c.Container(dagger.ContainerOpts{Platform: platform}).
+			From("alpine:3.16.2").
+			Exec(dagger.ContainerExecOpts{
+				Args: []string{"uname", "-m"},
+			})
+		output, err := ctr.Stdout().Contents(ctx)
+		require.NoError(t, err)
+		output = strings.TrimSpace(output)
+		require.Equal(t, uname, output)
+
+		id, err := ctr.ID(ctx)
+		require.NoError(t, err)
+		variants = append(variants, id)
+	}
+
+	testRef := "127.0.0.1:5000/testmultiplatimagepush:latest"
+	_, err = c.Container().Publish(ctx, testRef, dagger.ContainerPublishOpts{
+		PlatformVariants: variants,
+	})
+	require.NoError(t, err)
+
+	for platform, uname := range platformToUname {
+		ctr := c.Container(dagger.ContainerOpts{Platform: platform}).
+			From(testRef).
+			Exec(dagger.ContainerExecOpts{
+				Args: []string{"uname", "-m"},
+			})
+		output, err := ctr.Stdout().Contents(ctx)
+		require.NoError(t, err)
+		output = strings.TrimSpace(output)
+		require.Equal(t, uname, output)
+	}
+}
+
+func TestContainerPlatformCrossCompile(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c, err := dagger.Connect(ctx,
+		dagger.WithWorkdir("../.."),
+		dagger.WithLogOutput(os.Stdout),
+	)
+	require.NoError(t, err)
+	defer c.Close()
+
+	startRegistry(ctx, c, t)
+
+	thisRepo, err := c.Host().Workdir().ID(ctx)
+	require.NoError(t, err)
+
+	platformToFileArch := map[string]string{
+		"linux/amd64": "x86-64",
+		"linux/arm64": "aarch64",
+		"linux/s390x": "IBM S/390",
+	}
+
+	variants := make([]dagger.ContainerID, 0, len(platformToFileArch))
+	for platform := range platformToFileArch {
+		dirID, err := c.Container().
+			From("crazymax/goxx:latest").
+			WithMountedDirectory("/src", thisRepo).
+			WithMountedDirectory("/out", "").
+			WithWorkdir("/src").
+			WithEnvVariable("TARGETPLATFORM", platform).
+			Exec(dagger.ContainerExecOpts{
+				Args: []string{"goxx-go", "build", "-o", "/out/cloak", "/src/cmd/cloak"},
+			}).
+			Directory("/out").
+			ID(ctx)
+		require.NoError(t, err)
+
+		id, err := c.Container(dagger.ContainerOpts{Platform: platform}).WithFS(dirID).ID(ctx)
+		require.NoError(t, err)
+		variants = append(variants, id)
+	}
+
+	testRef := "127.0.0.1:5000/testmultiplatimagepush:latest"
+	_, err = c.Container().Publish(ctx, testRef, dagger.ContainerPublishOpts{
+		PlatformVariants: variants,
+	})
+	require.NoError(t, err)
+
+	for platform, uname := range platformToFileArch {
+		pulledDirID, err := c.Container(dagger.ContainerOpts{Platform: platform}).
+			From(testRef).
+			FS().
+			ID(ctx)
+		require.NoError(t, err)
+
+		output, err := c.Container().From("alpine:3.16").
+			Exec(dagger.ContainerExecOpts{
+				Args: []string{"apk", "add", "file"},
+			}).
+			WithMountedDirectory("/mnt", pulledDirID).
+			Exec(dagger.ContainerExecOpts{
+				Args: []string{"file", "/mnt/cloak"},
+			}).
+			Stdout().Contents(ctx)
+		require.NoError(t, err)
+		require.Contains(t, output, uname)
+	}
+}

--- a/core/integration/platform_test.go
+++ b/core/integration/platform_test.go
@@ -10,6 +10,7 @@ import (
 	"dagger.io/dagger"
 	"github.com/moby/buildkit/identity"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 )
 
 var platformToUname = map[dagger.Platform]string{
@@ -75,7 +76,6 @@ func TestPlatformEmulatedExecAndPush(t *testing.T) {
 	}
 }
 
-// TODO: speed up test w/ parallelism
 func TestPlatformCrossCompile(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -101,40 +101,49 @@ func TestPlatformCrossCompile(t *testing.T) {
 	// cross compile the cloak binary for each platform
 	defaultPlatform, err := c.DefaultPlatform(ctx)
 	require.NoError(t, err)
-	variants := make([]dagger.ContainerID, 0, len(platformToFileArch))
+	variants := make([]dagger.ContainerID, len(platformToFileArch))
+	i := 0
+	var eg errgroup.Group
 	for platform := range platformToUname {
-		ctr := c.Container().
-			From("crazymax/goxx:latest").
-			WithMountedCache(gomodCache, "/go/pkg/mod").
-			WithMountedCache(gobuildCache, "/root/.cache/go-build").
-			WithMountedDirectory("/src", thisRepo).
-			WithMountedDirectory("/out", "").
-			WithWorkdir("/src").
-			WithEnvVariable("TARGETPLATFORM", string(platform)).
-			WithEnvVariable("CGO_ENABLED", "0").
-			Exec(dagger.ContainerExecOpts{
-				Args: []string{"sh", "-c", "uname -m && goxx-go build -o /out/cloak /src/cmd/cloak"},
-			})
+		i++
+		i := i - 1
+		platform := platform
+		eg.Go(func() error {
+			ctr := c.Container().
+				From("crazymax/goxx:latest").
+				WithMountedCache(gomodCache, "/go/pkg/mod").
+				WithMountedCache(gobuildCache, "/root/.cache/go-build").
+				WithMountedDirectory("/src", thisRepo).
+				WithMountedDirectory("/out", "").
+				WithWorkdir("/src").
+				WithEnvVariable("TARGETPLATFORM", string(platform)).
+				WithEnvVariable("CGO_ENABLED", "0").
+				Exec(dagger.ContainerExecOpts{
+					Args: []string{"sh", "-c", "uname -m && goxx-go build -o /out/cloak /src/cmd/cloak"},
+				})
 
-		// should be running as the default (buildkit host) platform
-		ctrPlatform, err := ctr.Platform(ctx)
-		require.NoError(t, err)
-		require.Equal(t, defaultPlatform, ctrPlatform)
+			// should be running as the default (buildkit host) platform
+			ctrPlatform, err := ctr.Platform(ctx)
+			require.NoError(t, err)
+			require.Equal(t, defaultPlatform, ctrPlatform)
 
-		stdout, err := ctr.Stdout().Contents(ctx)
-		require.NoError(t, err)
-		stdout = strings.TrimSpace(stdout)
-		require.Equal(t, platformToUname[defaultPlatform], stdout)
+			stdout, err := ctr.Stdout().Contents(ctx)
+			require.NoError(t, err)
+			stdout = strings.TrimSpace(stdout)
+			require.Equal(t, platformToUname[defaultPlatform], stdout)
 
-		dirID, err := ctr.
-			Directory("/out").
-			ID(ctx)
-		require.NoError(t, err)
+			dirID, err := ctr.
+				Directory("/out").
+				ID(ctx)
+			require.NoError(t, err)
 
-		id, err := c.Container(dagger.ContainerOpts{Platform: platform}).WithFS(dirID).ID(ctx)
-		require.NoError(t, err)
-		variants = append(variants, id)
+			id, err := c.Container(dagger.ContainerOpts{Platform: platform}).WithFS(dirID).ID(ctx)
+			require.NoError(t, err)
+			variants[i] = id
+			return nil
+		})
 	}
+	require.NoError(t, eg.Wait())
 
 	// make sure the binaries for each platform are executable via emulation now
 	for _, id := range variants {
@@ -178,21 +187,9 @@ func TestPlatformCrossCompile(t *testing.T) {
 	require.Equal(t, 0, exit)
 }
 
-func TestPlatformInvalid(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	c, err := dagger.Connect(ctx,
-		dagger.WithLogOutput(os.Stdout),
-	)
-	require.NoError(t, err)
-	defer c.Close()
-
-	_, err = c.Container(dagger.ContainerOpts{Platform: "windows98"}).ID(ctx)
-	require.ErrorContains(t, err, "unknown operating system or architecture")
-}
-
 func TestPlatformCacheMounts(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -236,5 +233,39 @@ func TestPlatformCacheMounts(t *testing.T) {
 	require.Equal(t, 0, exit)
 }
 
-// TODO: test that exec on darwin/windows fails reasonably
-// TODO: test you can cross-compile and local export darwin/windows binaries
+func TestPlatformInvalid(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c, err := dagger.Connect(ctx,
+		dagger.WithLogOutput(os.Stdout),
+	)
+	require.NoError(t, err)
+	defer c.Close()
+
+	_, err = c.Container(dagger.ContainerOpts{Platform: "windows98"}).ID(ctx)
+	require.ErrorContains(t, err, "unknown operating system or architecture")
+}
+
+func TestPlatformWindows(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c, err := dagger.Connect(ctx,
+		dagger.WithLogOutput(os.Stdout),
+	)
+	require.NoError(t, err)
+	defer c.Close()
+
+	// It's not possible to exec, but we can pull and read files
+	ents, err := c.Container(dagger.ContainerOpts{Platform: "windows/amd64"}).
+		From("mcr.microsoft.com/windows/nanoserver:ltsc2022").
+		FS().
+		Entries(ctx)
+	require.NoError(t, err)
+	require.Equal(t, []string{"License.txt", "ProgramData", "Users", "Windows"}, ents)
+}

--- a/core/integration/project_test.go
+++ b/core/integration/project_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"dagger.io/dagger"
@@ -14,6 +15,7 @@ func TestExtensionMount(t *testing.T) {
 		ctx,
 		dagger.WithWorkdir("../../"),
 		dagger.WithConfigPath("testdata/extension/dagger.json"),
+		dagger.WithLogOutput(os.Stdout),
 	)
 	require.NoError(t, err)
 	defer c.Close()
@@ -80,6 +82,7 @@ func TestCodeToSchema(t *testing.T) {
 		ctx,
 		dagger.WithWorkdir("../../"),
 		dagger.WithConfigPath("testdata/codetoschema/dagger.json"),
+		dagger.WithLogOutput(os.Stdout),
 	)
 	require.NoError(t, err)
 	defer c.Close()

--- a/core/schema/base.go
+++ b/core/schema/base.go
@@ -45,6 +45,7 @@ func New(params InitializeArgs) (router.ExecutableSchema, error) {
 			projectStates: make(map[string]*project.State),
 		},
 		&httpSchema{base},
+		&platformSchema{base},
 	)
 }
 

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -5,7 +5,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/containerd/containerd/platforms"
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/router"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -73,7 +72,7 @@ func (s *containerSchema) Dependencies() []router.ExecutableSchema {
 
 type containerArgs struct {
 	ID       core.ContainerID
-	Platform *string
+	Platform *specs.Platform
 }
 
 func (s *containerSchema) container(ctx *router.Context, parent any, args containerArgs) (*core.Container, error) {
@@ -82,11 +81,7 @@ func (s *containerSchema) container(ctx *router.Context, parent any, args contai
 		if args.ID != "" {
 			return nil, fmt.Errorf("cannot specify both existing container ID and platform")
 		}
-		var err error
-		platform, err = platforms.Parse(*args.Platform)
-		if err != nil {
-			return nil, err
-		}
+		platform = *args.Platform
 	}
 	return core.NewContainer(args.ID, platform)
 }

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -62,6 +62,7 @@ func (s *containerSchema) Resolvers() router.Resolvers {
 			"stdout":               router.ToResolver(s.stdout),
 			"stderr":               router.ToResolver(s.stderr),
 			"publish":              router.ToResolver(s.publish),
+			"platform":             router.ToResolver(s.platform),
 		},
 	}
 }
@@ -76,7 +77,7 @@ type containerArgs struct {
 }
 
 func (s *containerSchema) container(ctx *router.Context, parent any, args containerArgs) (*core.Container, error) {
-	platform := s.platform
+	platform := s.baseSchema.platform
 	if args.Platform != nil {
 		if args.ID != "" {
 			return nil, fmt.Errorf("cannot specify both existing container ID and platform")
@@ -418,4 +419,8 @@ type containerWithMountedSecretArgs struct {
 
 func (s *containerSchema) withMountedSecret(ctx *router.Context, parent *core.Container, args containerWithMountedSecretArgs) (*core.Container, error) {
 	return parent.WithMountedSecret(ctx, args.Path, core.NewSecret(args.Source))
+}
+
+func (s *containerSchema) platform(ctx *router.Context, parent *core.Container, args any) (specs.Platform, error) {
+	return parent.Platform()
 }

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -122,7 +122,7 @@ type containerExecArgs struct {
 }
 
 func (s *containerSchema) exec(ctx *router.Context, parent *core.Container, args containerExecArgs) (*core.Container, error) {
-	return parent.Exec(ctx, s.gw, args.ContainerExecOpts)
+	return parent.Exec(ctx, s.gw, args.ContainerExecOpts, s.baseSchema.platform)
 }
 
 func (s *containerSchema) exitCode(ctx *router.Context, parent *core.Container, args any) (*int, error) {

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -2,8 +2,9 @@ extend type Query {
   """
   Load a container from ID.
   Null ID returns an empty container (scratch).
+  Optional platform argument initializes new containers to execute and publish as that platform. Platform defaults to that of the builder's host.
   """
-  container(id: ContainerID, platform: String): Container!
+  container(id: ContainerID, platform: Platform): Container!
 }
 
 "A unique container identifier. Null designates an empty container (scratch)."

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -17,6 +17,9 @@ type Container {
   "A unique identifier for this container"
   id: ContainerID!
 
+  "The platform this container executes and publishes as"
+  platform: Platform!
+
   "Initialize this container from the base image published at the given address"
   from(address: String!): Container!
 

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -1,149 +1,152 @@
 extend type Query {
-    """
-    Load a container from ID.
-    Null ID returns an empty container (scratch).
-    """
-    container(id: ContainerID): Container!
+  """
+  Load a container from ID.
+  Null ID returns an empty container (scratch).
+  """
+  container(id: ContainerID, platform: String): Container!
 }
 
 "A unique container identifier. Null designates an empty container (scratch)."
 scalar ContainerID
 
-
 """
 An OCI-compatible container, also known as a docker container
 """
 type Container {
-    "A unique identifier for this container"
-    id: ContainerID!
+  "A unique identifier for this container"
+  id: ContainerID!
 
-    "Initialize this container from the base image published at the given address"
-    from(address: String!): Container!
+  "Initialize this container from the base image published at the given address"
+  from(address: String!): Container!
 
-    "Initialize this container from a Dockerfile build"
-    build(context: DirectoryID!, dockerfile: String): Container!
+  "Initialize this container from a Dockerfile build"
+  build(context: DirectoryID!, dockerfile: String): Container!
 
-    "This container's root filesystem. Mounts are not included."
-    fs: Directory!
+  "This container's root filesystem. Mounts are not included."
+  fs: Directory!
 
-   "Initialize this container from this DirectoryID"
-    withFS(id: DirectoryID!): Container!
+  "Initialize this container from this DirectoryID"
+  withFS(id: DirectoryID!): Container!
 
-    "Retrieve a directory at the given path. Mounts are included."
-    directory(path: String!): Directory!
+  "Retrieve a directory at the given path. Mounts are included."
+  directory(path: String!): Directory!
 
-    "Retrieve a file at the given path. Mounts are included."
-    file(path: String!): File!
+  "Retrieve a file at the given path. Mounts are included."
+  file(path: String!): File!
 
-    "The user to be set for all commands"
-    user: String
+  "The user to be set for all commands"
+  user: String
 
-    "This container but with a different command user"
-    withUser(name: String!): Container!
+  "This container but with a different command user"
+  withUser(name: String!): Container!
 
-    "The working directory for all commands"
-    workdir: String
+  "The working directory for all commands"
+  workdir: String
 
-    "This container but with a different working directory"
-    withWorkdir(path: String!): Container!
+  "This container but with a different working directory"
+  withWorkdir(path: String!): Container!
 
-    "A list of environment variables passed to commands"
-    envVariables: [EnvVariable!]!
+  "A list of environment variables passed to commands"
+  envVariables: [EnvVariable!]!
 
-    "The value of the specified environment variable"
-    envVariable(name: String!): String
+  "The value of the specified environment variable"
+  envVariable(name: String!): String
 
-    "This container plus the given environment variable"
-    withEnvVariable(name: String!, value: String!): Container!
+  "This container plus the given environment variable"
+  withEnvVariable(name: String!, value: String!): Container!
 
-    "This container plus an env variable containing the given secret"
-    withSecretVariable(name: String!, secret: SecretID!): Container!
+  "This container plus an env variable containing the given secret"
+  withSecretVariable(name: String!, secret: SecretID!): Container!
 
-    "This container minus the given environment variable"
-    withoutEnvVariable(name: String!): Container!
+  "This container minus the given environment variable"
+  withoutEnvVariable(name: String!): Container!
 
-    "Entrypoint to be prepended to the arguments of all commands"
-    entrypoint: [String!]
+  "Entrypoint to be prepended to the arguments of all commands"
+  entrypoint: [String!]
 
-    "This container but with a different command entrypoint"
-    withEntrypoint(args: [String!]!): Container!
+  "This container but with a different command entrypoint"
+  withEntrypoint(args: [String!]!): Container!
 
-    "Default arguments for future commands"
-    defaultArgs: [String!]
+  "Default arguments for future commands"
+  defaultArgs: [String!]
 
-    "Configures default arguments for future commands"
-    withDefaultArgs(args: [String!]): Container!
+  "Configures default arguments for future commands"
+  withDefaultArgs(args: [String!]): Container!
 
-    "List of paths where a directory is mounted"
-    mounts: [String!]!
+  "List of paths where a directory is mounted"
+  mounts: [String!]!
 
-    "This container plus a directory mounted at the given path"
-    withMountedDirectory(path: String!, source: DirectoryID!): Container!
+  "This container plus a directory mounted at the given path"
+  withMountedDirectory(path: String!, source: DirectoryID!): Container!
 
-    "This container plus a file mounted at the given path"
-    withMountedFile(path: String!, source: FileID!): Container!
+  "This container plus a file mounted at the given path"
+  withMountedFile(path: String!, source: FileID!): Container!
 
-    "This container plus a temporary directory mounted at the given path"
-    withMountedTemp(path: String!): Container!
+  "This container plus a temporary directory mounted at the given path"
+  withMountedTemp(path: String!): Container!
 
-    "This container plus a cache volume mounted at the given path"
-    withMountedCache(path: String!, cache: CacheID!, source: DirectoryID): Container!
+  "This container plus a cache volume mounted at the given path"
+  withMountedCache(
+    path: String!
+    cache: CacheID!
+    source: DirectoryID
+  ): Container!
 
-    "This container plus a secret mounted into a file at the given path"
-    withMountedSecret(path: String!, source: SecretID!): Container!
+  "This container plus a secret mounted into a file at the given path"
+  withMountedSecret(path: String!, source: SecretID!): Container!
 
-    """
-    This container after unmounting everything at the given path.
-    """
-    withoutMount(path: String!): Container!
+  """
+  This container after unmounting everything at the given path.
+  """
+  withoutMount(path: String!): Container!
 
-    "This container after executing the specified command inside it"
-    exec(
-      "Command to run instead of the container's default command"
-      args: [String!],
-      "Content to write to the command's standard input before closing"
-      stdin: String,
-      "Redirect the command's standard output to a file in the container"
-      redirectStdout: String,
-      "Redirect the command's standard error to a file in the container"
-      redirectStderr: String,
-    ): Container!
+  "This container after executing the specified command inside it"
+  exec(
+    "Command to run instead of the container's default command"
+    args: [String!]
+    "Content to write to the command's standard input before closing"
+    stdin: String
+    "Redirect the command's standard output to a file in the container"
+    redirectStdout: String
+    "Redirect the command's standard error to a file in the container"
+    redirectStderr: String
+  ): Container!
 
-    """
-    Exit code of the last executed command. Zero means success.
-    Null if no command has been executed.
-    """
-    exitCode: Int
+  """
+  Exit code of the last executed command. Zero means success.
+  Null if no command has been executed.
+  """
+  exitCode: Int
 
-    """
-    The output stream of the last executed command.
-    Null if no command has been executed.
-    """
-    stdout: File
+  """
+  The output stream of the last executed command.
+  Null if no command has been executed.
+  """
+  stdout: File
 
-    """
-    The error stream of the last executed command.
-    Null if no command has been executed.
-    """
-    stderr: File
+  """
+  The error stream of the last executed command.
+  Null if no command has been executed.
+  """
+  stderr: File
 
-    # FIXME: this is the last case of an actual "verb" that cannot cleanly go away.
-    #    This may actually be a good candidate for a mutation. To be discussed.
-    "Publish this container as a new image, returning a fully qualified ref"
-    publish(address: String!): String!
+  # FIXME: this is the last case of an actual "verb" that cannot cleanly go away.
+  #    This may actually be a good candidate for a mutation. To be discussed.
+  "Publish this container as a new image, returning a fully qualified ref"
+  publish(address: String!, platformVariants: [ContainerID!]): String!
 }
 
 """
 EnvVariable is a simple key value object that represents an environment variable.
 """
 type EnvVariable {
-    """
-    name is the environment variable name.
-    """
-    name: String!
+  """
+  name is the environment variable name.
+  """
+  name: String!
 
-    """
-    value is the environment variable value
-    """
-    value: String!
+  """
+  value is the environment variable value
+  """
+  value: String!
 }

--- a/core/schema/directory.graphqls
+++ b/core/schema/directory.graphqls
@@ -1,6 +1,6 @@
 extend type Query {
-    "Load a directory by ID. No argument produces an empty directory."
-    directory(id: DirectoryID): Directory!
+  "Load a directory by ID. No argument produces an empty directory."
+  directory(id: DirectoryID): Directory!
 }
 
 "A content-addressed directory identifier"
@@ -8,36 +8,41 @@ scalar DirectoryID
 
 "A directory"
 type Directory {
-    "The content-addressed identifier of the directory"
-    id: DirectoryID!
+  "The content-addressed identifier of the directory"
+  id: DirectoryID!
 
-    "Return a list of files and directories at the given path"
-    entries(path: String): [String!]!
+  "Return a list of files and directories at the given path"
+  entries(path: String): [String!]!
 
-    "Retrieve a file at the given path"
-    file(path: String!): File!
+  "Retrieve a file at the given path"
+  file(path: String!): File!
 
-    "This directory plus a new file written at the given path"
-    withNewFile(path: String!, contents: String): Directory!
+  "This directory plus a new file written at the given path"
+  withNewFile(path: String!, contents: String): Directory!
 
-    "This directory plus the contents of the given file copied to the given path"
-    withCopiedFile(path: String!, source: FileID!): Directory!
+  "This directory plus the contents of the given file copied to the given path"
+  withCopiedFile(path: String!, source: FileID!): Directory!
 
-    "This directory with the file at the given path removed"
-    withoutFile(path: String!): Directory!
+  "This directory with the file at the given path removed"
+  withoutFile(path: String!): Directory!
 
-    "Retrieve a directory at the given path"
-    directory(path: String!): Directory!
+  "Retrieve a directory at the given path"
+  directory(path: String!): Directory!
 
-    "This directory plus a directory written at the given path"
-    withDirectory(path: String!, directory: DirectoryID!, exclude: [String!], include: [String!]): Directory!
+  "This directory plus a directory written at the given path"
+  withDirectory(
+    path: String!
+    directory: DirectoryID!
+    exclude: [String!]
+    include: [String!]
+  ): Directory!
 
-    "This directory with the directory at the given path removed"
-    withoutDirectory(path: String!): Directory!
+  "This directory with the directory at the given path removed"
+  withoutDirectory(path: String!): Directory!
 
-    "The difference between this directory and an another directory"
-    diff(other: DirectoryID!): Directory!
+  "The difference between this directory and an another directory"
+  diff(other: DirectoryID!): Directory!
 
-    "Write the contents of the directory to a path on the host"
-    export(path: String!): Boolean!
+  "Write the contents of the directory to a path on the host"
+  export(path: String!): Boolean!
 }

--- a/core/schema/fs.go
+++ b/core/schema/fs.go
@@ -25,3 +25,6 @@ var Secret string
 
 //go:embed host.graphqls
 var Host string
+
+//go:embed platform.graphqls
+var Platform string

--- a/core/schema/platform.go
+++ b/core/schema/platform.go
@@ -1,0 +1,72 @@
+package schema
+
+import (
+	"fmt"
+
+	"github.com/containerd/containerd/platforms"
+	"github.com/dagger/dagger/router"
+	"github.com/graphql-go/graphql/language/ast"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type platformSchema struct {
+	*baseSchema
+}
+
+var _ router.ExecutableSchema = &platformSchema{}
+
+func (s *platformSchema) Name() string {
+	return "platform"
+}
+
+func (s *platformSchema) Schema() string {
+	return Platform
+}
+
+func (s *platformSchema) Resolvers() router.Resolvers {
+	return router.Resolvers{
+		"Platform": router.ScalarResolver{
+			Serialize: func(value any) any {
+				switch v := value.(type) {
+				case specs.Platform:
+					return platforms.Format(v)
+				case *specs.Platform:
+					if v == nil {
+						return ""
+					}
+					return platforms.Format(*v)
+				default:
+					panic(fmt.Sprintf("unexpected platform scalar serialize type %T", v))
+				}
+			},
+			ParseValue: func(value any) any {
+				switch v := value.(type) {
+				case string:
+					p, err := platforms.Parse(v)
+					if err != nil {
+						panic(router.InvalidInputError{Err: fmt.Errorf("platform parse value error: %w", err)})
+					}
+					return p
+				default:
+					panic(fmt.Sprintf("unexpected platform parse value type %T: %+v", v, v))
+				}
+			},
+			ParseLiteral: func(valueAST ast.Value) any {
+				switch valueAST := valueAST.(type) {
+				case *ast.StringValue:
+					p, err := platforms.Parse(valueAST.Value)
+					if err != nil {
+						panic(router.InvalidInputError{Err: fmt.Errorf("platform parse literal error: %w", err)})
+					}
+					return p
+				default:
+					panic(fmt.Sprintf("unexpected platform parse literal type: %T: %+v", valueAST, valueAST))
+				}
+			},
+		},
+	}
+}
+
+func (s *platformSchema) Dependencies() []router.ExecutableSchema {
+	return nil
+}

--- a/core/schema/platform.go
+++ b/core/schema/platform.go
@@ -25,6 +25,9 @@ func (s *platformSchema) Schema() string {
 
 func (s *platformSchema) Resolvers() router.Resolvers {
 	return router.Resolvers{
+		"Query": router.ObjectResolver{
+			"defaultPlatform": router.ToResolver(s.defaultPlatform),
+		},
 		"Platform": router.ScalarResolver{
 			Serialize: func(value any) any {
 				switch v := value.(type) {
@@ -69,4 +72,8 @@ func (s *platformSchema) Resolvers() router.Resolvers {
 
 func (s *platformSchema) Dependencies() []router.ExecutableSchema {
 	return nil
+}
+
+func (s *platformSchema) defaultPlatform(ctx *router.Context, parent, args any) (specs.Platform, error) {
+	return s.baseSchema.platform, nil
 }

--- a/core/schema/platform.graphqls
+++ b/core/schema/platform.graphqls
@@ -1,1 +1,8 @@
 scalar Platform
+
+extend type Query {
+  """
+  The default platform of the builder.
+  """
+  defaultPlatform: Platform!
+}

--- a/core/schema/platform.graphqls
+++ b/core/schema/platform.graphqls
@@ -1,0 +1,1 @@
+scalar Platform

--- a/core/shim/shim.go
+++ b/core/shim/shim.go
@@ -3,6 +3,7 @@ package shim
 import (
 	"context"
 	"embed"
+	"fmt"
 	"io/fs"
 	"path"
 	"sync"
@@ -24,6 +25,7 @@ var (
 )
 
 const Path = "/_shim"
+const WasmPath = "/_shim.wasm"
 
 func init() {
 	entries, err := fs.ReadDir(cmd, "cmd")
@@ -43,7 +45,8 @@ func init() {
 	}
 }
 
-func Build(ctx context.Context, gw bkgw.Client, p specs.Platform) (llb.State, error) {
+// TODO: includeWasm is clunky
+func Build(ctx context.Context, gw bkgw.Client, p specs.Platform, includeWasm bool) (llb.State, error) {
 	lock.Lock()
 	def, err := state.Marshal(ctx, llb.Platform(p))
 	lock.Unlock()
@@ -72,5 +75,86 @@ func Build(ctx context.Context, gw bkgw.Client, p specs.Platform) (llb.State, er
 		return llb.State{}, err
 	}
 
-	return bkref.ToState()
+	st, err := bkref.ToState()
+	if err != nil {
+		return llb.State{}, err
+	}
+
+	if includeWasm {
+		wasmSt, err := wasmShim(gw, p)
+		if err != nil {
+			return llb.State{}, err
+		}
+		st = llb.Merge([]llb.State{st, wasmSt})
+	}
+	return st, nil
 }
+
+func wasmShim(gw bkgw.Client, p specs.Platform) (llb.State, error) {
+	// TODO: more robust conversion matrix
+	var arch string
+	switch p.Architecture {
+	case "amd64":
+		arch = "x86_64"
+	case "arm64":
+		arch = "aarch64"
+	default:
+		return llb.State{}, fmt.Errorf("FIXME: compile wasmtime for this architecture %s", p.Architecture)
+	}
+
+	repo := llb.Git("https://github.com/bytecodealliance/wasmtime.git", "v2.0.1")
+
+	st := llb.Image("rust:1-alpine", llb.WithMetaResolver(gw)).Run(
+		llb.Shlex("apk add --no-cache musl-dev build-base"),
+	).Run(
+		llb.Shlex("rustup target add x86_64-unknown-linux-musl"),
+	).Run(
+		llb.Dir("/mnt"),
+		llb.AddMount("/usr/local/cargo/registry", llb.Scratch(), llb.AsPersistentCacheDir("cargoregistryshimcache", llb.CacheMountShared)),
+		llb.Shlex(fmt.Sprintf(
+			"cargo build --release --target %s-unknown-linux-musl",
+			arch,
+		)),
+	).AddMount("/mnt", repo)
+
+	st = llb.Scratch().File(llb.Copy(st, fmt.Sprintf(
+		"/target/%s-unknown-linux-musl/release/wasmtime",
+		arch,
+	), WasmPath))
+	return st, nil
+}
+
+/*
+// it's possible to embed wasmedge in go, but their instructions currently
+// require you have an .so around that's loaded by go, which is annoying, so
+// instead just building their CLI and having Exec handle calling that as
+// the shim.
+// https://wasmedge.org/book/en/sdk/go.html
+
+	repo := llb.Git("https://github.com/WasmEdge/WasmEdge.git", "0.11.1")
+
+	// https://wasmedge.org/book/en/contribute/build_from_src/linux.html
+	// https://wasmedge.org/book/en/contribute/build_from_src.html#cmake-building-options
+	src := llb.Image("ubuntu:20.04").Run(
+		llb.Args([]string{"sh", "-c", strings.Join([]string{
+			"apt-get update",
+			"DEBIAN_FRONTEND=noninteractive apt-get install -y git build-essential software-properties-common cmake libboost-all-dev llvm-12-dev liblld-12-dev clang-12",
+		}, " && ")}),
+	).Run(
+		llb.Dir("/src"),
+		llb.Args([]string{"sh", "-c", strings.Join([]string{
+			"apt install zlib1g-dev",
+			"mkdir -p build && cd build",
+			"cmake -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_LINK_TOOLS_STATIC=ON -DWASMEDGE_LINK_LLVM_STATIC=ON -DWASMEDGE_BUILD_STATIC_LIB=ON -DWASMEDGE_BUILD_SHARED_LIB=OFF -DWASMEDGE_FORCE_DISABLE_LTO=ON -DWASMEDGE_BUILD_PLUGINS=OFF .. && make -j",
+		}, " && ")}),
+	).AddMount("/src", repo)
+
+	st := llb.Image("ubuntu:20.04").Run(
+		llb.Shlex("ldd /src/build/tools/wasmedge/wasmedge"),
+		// llb.Shlex("tree /src/build"),
+		llb.AddMount("/src", src),
+	).Root()
+
+	// st := llb.Scratch().File(llb.Copy(src, "/build/tools/wasmedge/wasmedge", Path))
+	return st, nil
+*/

--- a/router/errors.go
+++ b/router/errors.go
@@ -1,0 +1,13 @@
+package router
+
+type InvalidInputError struct {
+	Err error
+}
+
+func (e InvalidInputError) Error() string {
+	return e.Err.Error()
+}
+
+func (e InvalidInputError) Unwrap() error {
+	return e.Err
+}

--- a/router/schema.go
+++ b/router/schema.go
@@ -3,6 +3,7 @@ package router
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/graphql-go/graphql"
 )
@@ -86,19 +87,19 @@ func ToResolver[P any, A any, R any](f func(*Context, P, A) (R, error)) graphql.
 		var args A
 		argBytes, err := json.Marshal(p.Args)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to marshal args: %w", err)
 		}
 		if err := json.Unmarshal(argBytes, &args); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to unmarshal args: %w", err)
 		}
 
 		var parent P
 		parentBytes, err := json.Marshal(p.Source)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to marshal parent: %w", err)
 		}
 		if err := json.Unmarshal(parentBytes, &parent); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to unmarshal parent: %w", err)
 		}
 
 		res, err := f(&ctx, parent, args)

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -1135,6 +1135,15 @@ func (r *Query) Container(opts ...ContainerOpts) *Container {
 	}
 }
 
+// The default platform of the builder.
+func (r *Query) DefaultPlatform(ctx context.Context) (Platform, error) {
+	q := r.q.Select("defaultPlatform")
+
+	var response Platform
+	q = q.Bind(&response)
+	return response, q.Execute(ctx, r.c)
+}
+
 // DirectoryOpts contains options for Query.Directory
 type DirectoryOpts struct {
 	ID DirectoryID

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -309,10 +309,22 @@ func (r *Container) Mounts(ctx context.Context) ([]string, error) {
 	return response, q.Execute(ctx, r.c)
 }
 
+// ContainerPublishOpts contains options for Container.Publish
+type ContainerPublishOpts struct {
+	PlatformVariants []ContainerID
+}
+
 // Publish this container as a new image, returning a fully qualified ref
-func (r *Container) Publish(ctx context.Context, address string) (string, error) {
+func (r *Container) Publish(ctx context.Context, address string, opts ...ContainerPublishOpts) (string, error) {
 	q := r.q.Select("publish")
 	q = q.Arg("address", address)
+	// `platformVariants` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].PlatformVariants) {
+			q = q.Arg("platformVariants", opts[i].PlatformVariants)
+			break
+		}
+	}
 
 	var response string
 	q = q.Bind(&response)
@@ -1072,6 +1084,8 @@ func (r *Query) CacheVolume(key string) *CacheVolume {
 // ContainerOpts contains options for Query.Container
 type ContainerOpts struct {
 	ID ContainerID
+
+	Platform string
 }
 
 // Load a container from ID.
@@ -1085,6 +1099,13 @@ func (r *Query) Container(opts ...ContainerOpts) *Container {
 			break
 		}
 	}
+	// `platform` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].Platform) {
+			q = q.Arg("platform", opts[i].Platform)
+			break
+		}
+	}
 
 	return &Container{
 		q: q,
@@ -1095,6 +1116,8 @@ func (r *Query) Container(opts ...ContainerOpts) *Container {
 // DirectoryOpts contains options for Query.Directory
 type DirectoryOpts struct {
 	ID DirectoryID
+
+	Platform string
 }
 
 // Load a directory by ID. No argument produces an empty directory.
@@ -1104,6 +1127,13 @@ func (r *Query) Directory(opts ...DirectoryOpts) *Directory {
 	for i := len(opts) - 1; i >= 0; i-- {
 		if !querybuilder.IsZeroValue(opts[i].ID) {
 			q = q.Arg("id", opts[i].ID)
+			break
+		}
+	}
+	// `platform` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].Platform) {
+			q = q.Arg("platform", opts[i].Platform)
 			break
 		}
 	}


### PR DESCRIPTION
Just a quick pass to see if we could get support for the `wasi/wasm32` platform on Dagger. Seems to be working and initial impression is that this could be cleaned up to the point of being mergeable; probably not a throwaway experiment.

Based on top of the [multiplatform PR](https://github.com/dagger/dagger/pull/3119).

## Usage
Example usage from included test case (pulling and running a test image I built that has a wasm binary and uses platform `wasi/wasm32`):
https://github.com/dagger/dagger/blob/ff64e543a317d70f3d1fe889cd2a8ac46f050ec8/core/integration/platform_test.go#L346-L351

In that example the Exec defaults to the Entrypoint of the container, but in general args just need to be set to point to a `.wasm` binary.

Example of building a wasm binary from rust code and then executing it:
https://github.com/dagger/dagger/blob/ff64e543a317d70f3d1fe889cd2a8ac46f050ec8/core/integration/platform_test.go#L285-L336

## Implementation

Quick hackish solution implemented in this PR:
* Build [wasmtime](https://github.com/bytecodealliance/wasmtime) as a static binary
* Include it alongside our shim binary
* When `wasi/wasm32` is being used, our shim invokes the wasmtime binary, which itself invokes the actual user's wasm binary 
* wasmtime is configured to setup mounts + env vars as configured in the container

Surprisingly that's it.

I started w/ a much more complicated path of using `wasmedge` and configuring buildkitd to use the containerd worker which is instrumented to use crun w/ wasmedge support (as described [here](https://wasmedge.org/book/en/use_cases/kubernetes/cri/containerd.html)), but I eventually realized all that did was result in [this very light wrapper](https://github.com/containers/crun/blob/b0d8d6e613037a3c86078ce41344037f140f7f83/src/libcrun/handlers/wasmedge.c#L70) being invoked from crun's codebase. 

However, we already have our own shim in dagger, so that's the much easier thing to use right now. It may be the right approach in the long run too? Not sure yet, haven't thought in depth.

## Current Caveats
1. There seems to be module incompatibilities between wasm binaries built by different tools and at different times, so some of the existing `wasi/wasm32` images I tried fail to load due to incompatible modules being required
   * AFAICT this is just an issue in the ecosystem, but I have not done anything w/ Wasm until today so I could easily be missing something. Need to research more.
   * For example, the [`michaelirwin244/wasm-example`](https://hub.docker.com/r/michaelirwin244/wasm-example) image fails to load w/ our wasmtime shim due to the errors listed [here](https://github.com/dagger/dagger/blob/ff64e543a317d70f3d1fe889cd2a8ac46f050ec8/core/integration/platform_test.go#L339-L344).
2. wasmtime lets you "mount" directories into the wasm sandbox but not individual files, so right now the silly workaround is that you can only include mounts which don't have a source path. Will need a better solution than this before merging though.
3. There's probably a lot of other features that don't translate perfectly to the wasm sandbox (i.e. I'm not sure you can set the current workding dir). We can decide if that's a dealbreaker or if it's okay to just have clean errors in those cases.
4. The shim build code statically compiles wasmtime from source, which takes a while (several minutes on my laptop). It's cached afterwards but still would be nice to avoid this as it slows down uncached CI builds a lot.