### PR TITLE
Add build pipeline using goyek

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"runtime"
+
+	"dagger.io/dagger"
+	"github.com/goyek/goyek/v2"
+	"github.com/stretchr/testify/require"
+)
+
+var _ = goyek.Define(goyek.Task{
+	Name:  "build",
+	Usage: "Build builds the binary",
+	Action: func(tf *goyek.TF) {
+		ctx := tf.Context()
+		c := daggerClient(tf)
+		defer c.Close()
+
+		workdir := c.Host().Workdir()
+		builder := c.Container().
+			From("golang:1.19-alpine").
+			WithEnvVariable("CGO_ENABLED", "0").
+			WithEnvVariable("GOOS", runtime.GOOS).
+			WithEnvVariable("GOARCH", runtime.GOARCH).
+			WithWorkdir("/app")
+
+		// install dependencies
+		modules := c.Directory()
+		for _, f := range []string{"go.mod", "go.sum", "sdk/go/go.mod", "sdk/go/go.sum"} {
+			fileID, err := workdir.File(f).ID(ctx)
+			require.NoError(tf, err)
+
+			modules = modules.WithCopiedFile(f, fileID)
+		}
+		modID, err := modules.ID(ctx)
+		require.NoError(tf, err)
+		builder = builder.
+			WithMountedDirectory("/app", modID).
+			Exec(dagger.ContainerExecOpts{
+				Args: []string{"go", "mod", "download"},
+			})
+
+		src, err := workdir.ID(ctx)
+		require.NoError(tf, err)
+
+		builder = builder.
+			WithMountedDirectory("/app", src).WithWorkdir("/app").
+			Exec(dagger.ContainerExecOpts{
+				Args: []string{"go", "build", "-o", "./bin/cloak", "-ldflags", "-s -w", "/app/cmd/cloak"},
+			})
+
+		ok, err := builder.Directory("./bin").Export(ctx, "./bin")
+		require.NoError(tf, err)
+		require.True(tf, ok, "HostDirectoryWrite not ok")
+	},
+})

--- a/build/dagger.go
+++ b/build/dagger.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"dagger.io/dagger"
+	"github.com/goyek/goyek/v2"
+)
+
+func daggerClient(tf *goyek.TF) *dagger.Client {
+	tf.Helper()
+	c, err := dagger.Connect(tf.Context(), dagger.WithLogOutput(tf.Output()))
+	if err != nil {
+		tf.Fatal(err)
+	}
+	return c
+}

--- a/build/lint.go
+++ b/build/lint.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"dagger.io/dagger"
+	"github.com/dagger/dagger/codegen/generator"
+	"github.com/goyek/goyek/v2"
+	"github.com/stretchr/testify/require"
+)
+
+var _ = goyek.Define(goyek.Task{
+	Name:  "lint",
+	Usage: "All runs all lint targets",
+	Deps: goyek.Deps{
+		codegen,
+		markdown,
+	},
+})
+
+var markdown = goyek.Define(goyek.Task{
+	Name:  "lint:markdown",
+	Usage: "Markdown lints the markdown files",
+	Action: func(tf *goyek.TF) {
+		ctx := tf.Context()
+		c := daggerClient(tf)
+		defer c.Close()
+
+		workdir := c.Host().Workdir()
+
+		src, err := workdir.ID(ctx)
+		require.NoError(tf, err)
+
+		cfg, err := workdir.File(".markdownlint.yaml").ID(ctx)
+		require.NoError(tf, err)
+
+		_, err = c.Container().
+			From("tmknom/markdownlint:0.31.1").
+			WithMountedDirectory("/src", src).
+			WithMountedFile("/src/.markdownlint.yaml", cfg).
+			WithWorkdir("/src").
+			Exec(dagger.ContainerExecOpts{
+				Args: []string{
+					"-c",
+					".markdownlint.yaml",
+					"--",
+					"./docs",
+					"README.md",
+				},
+			}).ExitCode(ctx)
+		require.NoError(tf, err)
+	},
+})
+
+var codegen = goyek.Define(goyek.Task{
+	Name:  "lint:codegen",
+	Usage: "Codegen ensure the SDK code was re-generated",
+	Action: func(tf *goyek.TF) {
+		ctx := tf.Context()
+		c := daggerClient(tf)
+		defer c.Close()
+
+		generated, err := generator.IntrospectAndGenerate(ctx, c, generator.Config{
+			Package: "dagger",
+		})
+		require.NoError(tf, err)
+
+		// grab the file from the repo
+		src, err := c.
+			Host().
+			Workdir().
+			File("sdk/go/api.gen.go").
+			Contents(ctx)
+		require.NoError(tf, err)
+
+		// compare the two
+		require.Equal(tf, src, string(generated), "generated api mismatch. please run `go generate ./...")
+	},
+})

--- a/build/main.go
+++ b/build/main.go
@@ -1,0 +1,14 @@
+// Build demonstrates how dagger can by used together with goyek.
+package main
+
+import (
+	"os"
+
+	"github.com/goyek/goyek/v2"
+	"github.com/goyek/goyek/v2/middleware"
+)
+
+func main() {
+	goyek.Use(middleware.ReportStatus)
+	goyek.Main(os.Args[1:])
+}

--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,12 @@ require (
 	dagger.io/dagger v0.3.0-alpha.4
 	github.com/bhoriuchi/graphql-go-tools v1.0.0
 	github.com/containerd/containerd v1.6.9
-	github.com/docker/cli v20.10.17+incompatible
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/go-openapi/runtime v0.24.2
 	github.com/gofrs/flock v0.8.1
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/go-cmp v0.5.9
+	github.com/goyek/goyek/v2 v2.0.0-rc.8
 	github.com/graphql-go/graphql v0.8.0
 	github.com/graphql-go/handler v0.2.3
 	github.com/magefile/mage v1.14.0
@@ -52,6 +52,7 @@ require (
 	github.com/containerd/ttrpc v1.1.0 // indirect
 	github.com/containerd/typeurl v1.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/docker/cli v20.10.17+incompatible // indirect
 	github.com/docker/docker v20.10.17+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -408,6 +408,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/goyek/goyek/v2 v2.0.0-rc.8 h1:C+NKVE1Gg61tJdGmU4yhyPvZNbyCd6Y6EcEZrwEYojU=
+github.com/goyek/goyek/v2 v2.0.0-rc.8/go.mod h1:qtHlK7t/dYs1Dw7mLXjEVmgE3nccNa7mQW/RmasOoYg=
 github.com/graphql-go/graphql v0.8.0 h1:JHRQMeQjofwqVvGwYnr8JnPTY0AxgVy1HpHSGPLdH0I=
 github.com/graphql-go/graphql v0.8.0/go.mod h1:nKiHzRM0qopJEwCITUuIsxk9PlVlwIiiI8pnJEhordQ=
 github.com/graphql-go/handler v0.2.3 h1:CANh8WPnl5M9uA25c2GBhPqJhE53Fg0Iue/fRNla71E=

--- a/goyek.ps1
+++ b/goyek.ps1
@@ -1,0 +1,4 @@
+Push-Location "$PSScriptRoot\build" -ErrorAction Stop
+& go run . $args
+Pop-Location
+exit $global:LASTEXITCODE

--- a/goyek.sh
+++ b/goyek.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+cd "$DIR/build"
+go run . $@


### PR DESCRIPTION
## Why

Per https://github.com/dagger/dagger/discussions/3601#discussioncomment-4015779

I think that [goyek](https://github.com/goyek/goyek) perfectly aligns with dagger's ["Who is it for?"](https://github.com/dagger/dagger#who-is-it-for)

Even if you do not decide to take my contribution, any feedback is for me more than welcome (as I am the author of goyek).

## What

Add a build pipeline using https://github.com/goyek/goyek 

Usage examples:

```sh
$ ./goyek.sh 
no task provided
Tasks:
  build          Build builds the binary
  lint           All runs all lint targets (depends on: lint:codegen, lint:markdown)
task failed: build      0.023s
exit status 1
```

```sh
$ ./goyek.sh build
===== TASK  build
      build.go:16: exec: "docker": executable file not found in %PATH%
          Please visit https://dagger.io/help#go for troubleshooting guidance.
----- FAIL: build (0.02s)
task failed: build      0.021s
exit status 1
```

Instead of `./goyek.sh` you can also simply `cd build && go run .` or use `.\goyek.ps1`.


You may like that the API design is higly-inspired by `testing`. You can use `testify` and it even shows the correct line of code on failure (thanks to the usage of `Helper()`). You can also easily debug it (for Mage it is very complex: https://github.com/magefile/mage/issues/280).

I did a minimal PR so that you can compare `goyek` with `mage`. 