### PR TITLE
docs: Add guide for new host API

### DIFF
--- a/docs/current/sdk/go/275922-guides.md
+++ b/docs/current/sdk/go/275922-guides.md
@@ -1,0 +1,7 @@
+---
+slug: /sdk/go/275922/guides
+---
+
+# Guides
+
+- [Work with the Host Filesystem](./guides/421437-work-with-host-filesystem.md)

--- a/docs/current/sdk/go/guides/421437-work-with-host-filesystem.md
+++ b/docs/current/sdk/go/guides/421437-work-with-host-filesystem.md
@@ -1,0 +1,83 @@
+---
+slug: /421437/work-with-host-filesystem
+displayed_sidebar: 'current'
+---
+
+# Work with the Host Filesystem
+
+## Introduction
+
+This guide explains how to work with the host filesystem using the Dagger Go SDK. You will learn how to:
+
+- Set the working directory on the host
+- List host directory entries with include/exclude filters
+- Mount a host directory in a container
+- Export a directory from a container to the host
+
+## Requirements
+
+This guide assumes that:
+
+- You have a Go development environment with Go 1.15 or later. If not, [download and install Go](https://go.dev/doc/install).
+- You have Docker installed and running on the host system. If not, [install Docker](https://docs.docker.com/engine/install/).
+- You have a Go module with the Dagger Go SDK installed. If not, [install the Dagger Go SDK](../371491-install.md).
+
+## Set the host working directory
+
+The easiest way to set the working directory on the host for your Go CI pipeline is at the time of client instantiation, with the client's `WithWorkdir()` option.
+
+The following example shows how to set the host working directory:
+
+```go file=../snippets/work-with-host-filesystem/set-workdir/main.go
+```
+
+## List directory contents
+
+The `Host` type provides information about the host's execution environment. Its `Directory()` method accepts a path and returns a reference to the corresponding host directory as a `Directory` struct. There's also a shortcut `Workdir()` method, which returns a reference to the current working directory on the host. Entries in the directory can be obtained via the `Directory.Entries()` function.
+
+The following example shows how to list the contents of the host working directory:
+
+```go file=../snippets/work-with-host-filesystem/list-dir/main.go
+```
+
+## List directory contents with filters
+
+It's possible to restrict a `Directory` to a subset of directory entries, by specifying a list of filename patterns to include or exclude.
+
+The following example shows how to obtain a reference to the host working directory containing only `*.rar` files:
+
+```go file=../snippets/work-with-host-filesystem/list-dir-include/main.go
+```
+
+The following example shows how to obtain a reference to the host working directory containing all files except `*.txt` files:
+
+```go file=../snippets/work-with-host-filesystem/list-dir-exclude/main.go
+```
+
+:::note
+The `Exclude` pattern overrides the `Include` pattern, but not vice-versa.
+:::
+
+## Mount a host directory in a container
+
+A common operation when working with containers is to mount a host directory to a path in the container and then perform operations on it. This can be done using the `Container.WithMountedDirectory()` method, which accepts the mount point in the container and the `Directory` to be mounted as arguments.
+
+The following example shows how to mount a host directory in a container at the `/host` container path and then execute a command in the container referencing the mounted directory:
+
+```go file=../snippets/work-with-host-filesystem/mount-dir/main.go
+```
+
+## Export a directory from a container to the host
+
+A directory can be exported to a different path using the `Directory.Export()` method. The destination path is supplied to the method as an argument.
+
+The following example creates a file in a container's `/tmp` directory and then exports the contents of that directory to the host's temporary directory:
+
+```go file=../snippets/work-with-host-filesystem/export-dir/main.go
+```
+
+## Conclusion
+
+This guide introduced you to the functions available in the Dagger Go SDK to work with the host filesystem. It provided explanations and code samples demonstrating how to set the host working directory, read directory contents (with and without pathname filters), mount a host directory in a container and export a directory from a container to the host.
+
+Use the [SDK Reference](https://pkg.go.dev/dagger.io/dagger) to learn more about the Dagger Go SDK.

--- a/docs/current/sdk/go/snippets/work-with-host-filesystem/export-dir/main.go
+++ b/docs/current/sdk/go/snippets/work-with-host-filesystem/export-dir/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	hostdir := os.TempDir()
+
+	ctx := context.Background()
+
+	client, err := dagger.Connect(ctx)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	defer client.Close()
+
+	// highlight-start
+	_, err = client.Container().From("alpine:latest").
+		WithWorkdir("/tmp").
+		Exec(dagger.ContainerExecOpts{
+			Args: []string{"wget", "https://dagger.io"},
+		}).
+		Directory(".").
+		Export(ctx, hostdir)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	// highlight-end
+	contents, err := os.ReadFile(filepath.Join(hostdir, "index.html"))
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	fmt.Println(string(contents))
+}

--- a/docs/current/sdk/go/snippets/work-with-host-filesystem/list-dir-exclude/main.go
+++ b/docs/current/sdk/go/snippets/work-with-host-filesystem/list-dir-exclude/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	dir := os.TempDir()
+	os.WriteFile(filepath.Join(dir, "foo.txt"), []byte("1"), 0600)
+	os.WriteFile(filepath.Join(dir, "bar.txt"), []byte("2"), 0600)
+	os.WriteFile(filepath.Join(dir, "baz.rar"), []byte("3"), 0600)
+
+	ctx := context.Background()
+
+	client, err := dagger.Connect(ctx, dagger.WithWorkdir(dir))
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	defer client.Close()
+
+	// highlight-start
+	entries, err := client.Host().Workdir(dagger.HostWorkdirOpts{
+		Exclude: []string{"*.txt"},
+	}).Entries(ctx)
+	// highlight-end
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	fmt.Println(entries)
+}

--- a/docs/current/sdk/go/snippets/work-with-host-filesystem/list-dir-include/main.go
+++ b/docs/current/sdk/go/snippets/work-with-host-filesystem/list-dir-include/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	dir := os.TempDir()
+	os.WriteFile(filepath.Join(dir, "foo.txt"), []byte("1"), 0600)
+	os.WriteFile(filepath.Join(dir, "bar.txt"), []byte("2"), 0600)
+	os.WriteFile(filepath.Join(dir, "baz.rar"), []byte("3"), 0600)
+
+	ctx := context.Background()
+
+	client, err := dagger.Connect(ctx, dagger.WithWorkdir(dir))
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	defer client.Close()
+
+	// highlight-start
+	entries, err := client.Host().Workdir(dagger.HostWorkdirOpts{
+		Include: []string{"*.rar"},
+	}).Entries(ctx)
+	// highlight-end
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	fmt.Println(entries)
+}

--- a/docs/current/sdk/go/snippets/work-with-host-filesystem/list-dir/main.go
+++ b/docs/current/sdk/go/snippets/work-with-host-filesystem/list-dir/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	ctx := context.Background()
+
+	client, err := dagger.Connect(ctx, dagger.WithWorkdir("."))
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	defer client.Close()
+
+	// highlight-start
+	entries, err := client.Host().Workdir().Entries(ctx)
+	// highlight-end
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	fmt.Println(entries)
+}

--- a/docs/current/sdk/go/snippets/work-with-host-filesystem/mount-dir/main.go
+++ b/docs/current/sdk/go/snippets/work-with-host-filesystem/mount-dir/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	ctx := context.Background()
+
+	client, err := dagger.Connect(ctx, dagger.WithWorkdir("."))
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	defer client.Close()
+
+	// highlight-start
+	contents, err := client.Container().
+		From("alpine:latest").
+		WithMountedDirectory("/host", client.Host().Workdir()).
+		Exec(dagger.ContainerExecOpts{
+			Args: []string{"ls", "/host"},
+		}).Stdout().Contents(ctx)
+	// highlight-end
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	fmt.Println(contents)
+}

--- a/docs/current/sdk/go/snippets/work-with-host-filesystem/set-workdir/main.go
+++ b/docs/current/sdk/go/snippets/work-with-host-filesystem/set-workdir/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// highlight-start
+	client, err := dagger.Connect(ctx, dagger.WithWorkdir("."))
+	// highlight-end
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	defer client.Close()
+}

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -34,6 +34,11 @@ module.exports = {
           id: "current/sdk/go/get-started",
         },
         {
+          type: "doc",
+          label: "Guides",
+          id: "current/sdk/go/guides"
+        },
+        {
           type: "link",
           label: "Reference 🔗",
           href: "https://pkg.go.dev/dagger.io/dagger"


### PR DESCRIPTION
When applied, this commit adds a guide for the new host API.

It  also adds a sidebar node named "Guides" to the navigation tree and a guides index page.

Closes #3593

Signed-off-by: Vikram Vaswani <vikram@dagger.io>