### PR TITLE
 docs(guide-go): copy embed directories to container (Go-SDK)

### DIFF
--- a/docs/current/sdk/go/275922-guides.md
+++ b/docs/current/sdk/go/275922-guides.md
@@ -6,3 +6,4 @@ slug: /sdk/go/275922/guides
 
 - [Work with the Host Filesystem](./guides/421437-work-with-host-filesystem.md)
 - [Understand Multi-Platform Support](./guides/406009-multiplatform-support.md)
+- [Copy Embedded Directories Into a Container](./guides/110632-embed-directories.md)

--- a/docs/current/sdk/go/guides/110632-embed-directories.md
+++ b/docs/current/sdk/go/guides/110632-embed-directories.md
@@ -1,0 +1,44 @@
+---
+slug: /110632/embed-directories
+displayed_sidebar: "current"
+---
+
+# Copy Embedded Directories into a Container
+
+Dagger does not expose the option to copy entire directories as a single step (yet), whether it is between containers or from an embedded directory to a container. It is, however, doable by traversing the directory tree.
+
+Assume that you have a Dagger CI tool containing the following code structure, which contains an example directory:
+
+```shell
+tree
+.
+├── go.mod
+├── go.sum
+├── main.go
+└── example
+    └── foo.go
+```
+
+The following example demonstrates how to copy an embedded directory:
+
+```go file=../snippets/embed-directories/main.go
+```
+
+Attempt to run the code and print the content of the `/embed` directory:
+
+```shell
+➜  go run .
+/embed/:
+total 4
+drwxr-xr-x    1 root     root          4096 Oct 31 16:49 example
+
+/embed/example:
+total 4
+-rw-r--r--    1 root     root            50 Oct 31 16:49 foo.go
+```
+
+In this case, the function succeeds in copying the embedded `example` directory.
+
+:::warning
+You may encounter errors if your directory contains +1000 files, due to the concatenation of the queries.
+:::

--- a/docs/current/sdk/go/snippets/embed-directories/example/foo.go
+++ b/docs/current/sdk/go/snippets/embed-directories/example/foo.go
@@ -1,0 +1,5 @@
+package test
+
+func Foo() string {
+	return "foo"
+}

--- a/docs/current/sdk/go/snippets/embed-directories/main.go
+++ b/docs/current/sdk/go/snippets/embed-directories/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"io/fs"
+
+	"dagger.io/dagger"
+)
+
+// create a copy of an embed directory
+func copyEmbedDir(e fs.FS, dir *dagger.Directory) (*dagger.Directory, error) {
+	err := fs.WalkDir(e, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		content, err := fs.ReadFile(e, path)
+		if err != nil {
+			return err
+		}
+
+		dir = dir.WithNewFile(path, dagger.DirectoryWithNewFileOpts{
+			Contents: string(content),
+		})
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return dir, nil
+}
+
+//go:embed example
+var e embed.FS
+
+func main() {
+	ctx := context.Background()
+
+	// Init Dagger client
+	client, err := dagger.Connect(ctx)
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	// Copy embed files to dir, a newly created directory.
+	dir := client.Directory()
+	dir, err = copyEmbedDir(e, dir)
+	if err != nil {
+		panic(err)
+	}
+
+	// Mount above directory ID and
+	container := client.Container().From("alpine:3.16.2").WithMountedDirectory("/embed", dir)
+
+	// List files
+	out, err := container.Exec(dagger.ContainerExecOpts{
+		Args: []string{"ls", "-lR", "/embed/"},
+	}).Stdout().Contents(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%s", out)
+}


### PR DESCRIPTION
Little docs following a question from Alvise on `help` channel:
- explains how to recusively copy a directory to container

With warning, until we implement the corresponding API call

!! Rebased on top of `git-login` branch !!
    