### PR TITLE
ci: update add-issues-to-backlog workflow

### DIFF
--- a/.github/workflows/add-issues-to-backlog.yml
+++ b/.github/workflows/add-issues-to-backlog.yml
@@ -10,7 +10,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.0.3
+      - uses: actions/add-to-project@v0.3.0
         with:
           project-url: https://github.com/orgs/dagger/projects/2
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
GitHub deprecated an API, breaking the action version we were using.

This change bumps it to the latest version.
