### PR TITLE
support dagger in dagger

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,15 +14,14 @@ jobs:
   engine:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19
-      - uses: actions/checkout@v3
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+      - uses: magefile/mage-action@v2
         with:
-          version: v1.48.0
-          args: --timeout=5m
+          version: latest
+          args: engine:lint
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,7 @@ on:
   # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs
   workflow_dispatch:
 jobs:
-  go:
-    name: go
+  engine:
     runs-on: ubuntu-22.04-16c-64g-600gb
     steps:
       - name: Set up QEMU
@@ -40,9 +39,9 @@ jobs:
           args: engine:build
       - run: cp ./bin/cloak /usr/local/bin
       - run: go test -v ./...
-  go-race:
-    needs: [go] # prioritize fast feedback + don't bother if tests fail
-    name: go with -race
+  engine-race:
+    needs: [engine] # prioritize fast feedback + don't bother if tests fail
+    name: engine with -race
     runs-on: ubuntu-22.04-16c-64g-600gb
     steps:
       - uses: actions/setup-go@v3
@@ -55,11 +54,14 @@ jobs:
     name: sdk / go
     runs-on: ubuntu-22.04-16c-64g-600gb
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19
-      - uses: actions/checkout@v3
-      - run: cd ./sdk/go && go test -v ./...
+      - uses: magefile/mage-action@v2
+        with:
+          version: latest
+          args: sdk:go:test
   sdk-nodejs:
     name: sdk / nodejs
     runs-on: ubuntu-22.04-16c-64g-600gb

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,16 +7,15 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
+    - exportloopref
     - goconst
     - gocritic
     - gocyclo
     - gofmt
     - goimports
-    - revive
     - goprintffuncname
     - gosec
     - gosimple
@@ -25,14 +24,13 @@ linters:
     - misspell
     - nakedret
     - prealloc
+    - revive
     - rowserrcheck
-    - exportloopref
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
+    - unused
     - whitespace

--- a/core/directory.go
+++ b/core/directory.go
@@ -34,6 +34,8 @@ type directoryIDPayload struct {
 //
 // NB(vito): Ideally this would not be exported, but it's currently needed for
 // the project/ package. I left the return type private as a compromise.
+//
+//nolint:revive
 func (id DirectoryID) Decode() (*directoryIDPayload, error) {
 	if id == "" {
 		return &directoryIDPayload{}, nil

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -114,6 +114,12 @@ type Container {
     redirectStdout: String
     "Redirect the command's standard error to a file in the container"
     redirectStderr: String
+    """
+    Provide dagger access to the executed command
+    Do not use this option unless you trust the command being executed
+    The command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM
+    """
+    experimentalPrivilegedNesting: Boolean
   ): Container!
 
   """

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/containerd/containerd/platforms"
+	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/schema"
 	"github.com/dagger/dagger/engine/filesync"
 	"github.com/dagger/dagger/internal/buildkitd"
@@ -81,7 +82,7 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 	secretStore := secret.NewStore()
 
 	socketProviders := MergedSocketProviders{
-		project.DaggerSockName: project.NewAPIProxy(router),
+		core.DaggerSockName: project.NewAPIProxy(router),
 	}
 	var sshAuthSockID string
 	if _, ok := os.LookupEnv(sshAuthSockEnv); ok {

--- a/internal/mage/docs.go
+++ b/internal/mage/docs.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"dagger.io/dagger"
+	"github.com/dagger/dagger/internal/mage/util"
 	"github.com/magefile/mage/mg"
 )
 
@@ -18,7 +19,7 @@ func (Docs) Lint(ctx context.Context) error {
 	}
 	defer c.Close()
 
-	workdir := c.Host().Workdir()
+	workdir := util.Repository(c)
 
 	_, err = c.Container().
 		From("tmknom/markdownlint:0.31.1").

--- a/internal/mage/util/util.go
+++ b/internal/mage/util/util.go
@@ -1,0 +1,71 @@
+package util
+
+import "dagger.io/dagger"
+
+// Repository with common set of exclude filters to speed up upload
+func Repository(c *dagger.Client) *dagger.Directory {
+	return c.Host().Workdir(dagger.HostWorkdirOpts{
+		Exclude: []string{
+			// node
+			"**/node_modules",
+
+			// python
+			"**/__pycache__",
+			"**/.venv",
+			"**/.mypy_cache",
+			"**/.pytest_cache",
+		},
+	})
+}
+
+// RepositoryGoCodeOnly is Repository, filtered to only contain Go code.
+//
+// NOTE: this function is a shared util ONLY because it's used both by the Engine
+// and the Go SDK. Other languages shouldn't have a common helper.
+func RepositoryGoCodeOnly(c *dagger.Client) *dagger.Directory {
+	return c.Directory().WithDirectory("/", Repository(c), dagger.DirectoryWithDirectoryOpts{
+		Include: []string{
+			// go source
+			"**/*.go",
+
+			// modules
+			"**/go.mod",
+			"**/go.sum",
+
+			// embedded files
+			"**/*.go.tmpl",
+			"**/*.graphqls",
+			"**/*.graphql",
+
+			// misc
+			".golangci.yml",
+		},
+	})
+}
+
+// GoBase is a standardized base image for running Go, cache optimized for the layout
+// of this repository
+//
+// NOTE: this function is a shared util ONLY because it's used both by the Engine
+// and the Go SDK. Other languages shouldn't have a common helper.
+func GoBase(c *dagger.Client) *dagger.Container {
+	repo := RepositoryGoCodeOnly(c)
+
+	// Create a directory containing only `go.{mod,sum}` files.
+	goMods := c.Directory()
+	for _, f := range []string{"go.mod", "go.sum", "sdk/go/go.mod", "sdk/go/go.sum"} {
+		goMods = goMods.WithFile(f, repo.File(f))
+	}
+
+	return c.Container().
+		From("golang:1.19-alpine").
+		WithEnvVariable("CGO_ENABLED", "0").
+		WithWorkdir("/app").
+		// run `go mod download` with only go.mod files (re-run only if mod files have changed)
+		WithMountedDirectory("/app", goMods).
+		Exec(dagger.ContainerExecOpts{
+			Args: []string{"go", "mod", "download"},
+		}).
+		// run `go build` with all source
+		WithMountedDirectory("/app", repo)
+}

--- a/project/project.go
+++ b/project/project.go
@@ -22,9 +22,6 @@ const (
 	schemaPath     = "/schema.graphql"
 	entrypointPath = "/entrypoint"
 
-	DaggerSockName = "dagger-sock"
-	daggerSockPath = "/dagger.sock"
-
 	fsMountPath  = "/mnt"
 	tmpMountPath = "/tmp"
 
@@ -323,8 +320,8 @@ func (p *State) resolver(runtimeFS *core.Directory, sdk string, gw bkgw.Client, 
 			llb.Args([]string{entrypointPath}),
 			llb.AddEnv("DAGGER_HOST", "unix:///dagger.sock"),
 			llb.AddSSHSocket(
-				llb.SSHID(DaggerSockName),
-				llb.SSHSocketTarget(daggerSockPath),
+				llb.SSHID(core.DaggerSockName),
+				llb.SSHSocketTarget(core.DaggerSockPath),
 			),
 			llb.AddMount(inputMountPath, input, llb.Readonly),
 			llb.AddMount(tmpMountPath, llb.Scratch(), llb.Tmpfs()),

--- a/project/proxy.go
+++ b/project/proxy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 
+	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/router"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/sshforward"
@@ -44,7 +45,7 @@ func (p *APIProxy) ForwardAgent(stream sshforward.SSH_ForwardAgentServer) error 
 	}
 	id := v[0]
 
-	if id != DaggerSockName {
+	if id != core.DaggerSockName {
 		return status.Errorf(codes.Internal, "no api connection for id %s", id)
 	}
 	serverConn, clientConn := net.Pipe()

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -132,10 +132,11 @@ func (r *Container) EnvVariables(ctx context.Context) ([]EnvVariable, error) {
 
 // ContainerExecOpts contains options for Container.Exec
 type ContainerExecOpts struct {
-	Args           []string
-	Stdin          string
-	RedirectStdout string
-	RedirectStderr string
+	Args                          []string
+	Stdin                         string
+	RedirectStdout                string
+	RedirectStderr                string
+	ExperimentalPrivilegedNesting bool
 }
 
 // This container after executing the specified command inside it
@@ -166,6 +167,13 @@ func (r *Container) Exec(opts ...ContainerExecOpts) *Container {
 	for i := len(opts) - 1; i >= 0; i-- {
 		if !querybuilder.IsZeroValue(opts[i].RedirectStderr) {
 			q = q.Arg("redirectStderr", opts[i].RedirectStderr)
+			break
+		}
+	}
+	// `experimentalPrivilegedNesting` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].ExperimentalPrivilegedNesting) {
+			q = q.Arg("experimentalPrivilegedNesting", opts[i].ExperimentalPrivilegedNesting)
 			break
 		}
 	}

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -128,7 +128,7 @@ func TestConnectOption(t *testing.T) {
 	}
 
 	for _, want := range wants {
-		require.Regexp(t, want, b.String())
+		require.Regexp(t, b.String(), want)
 	}
 }
 

--- a/sdk/go/examples_test.go
+++ b/sdk/go/examples_test.go
@@ -210,10 +210,9 @@ func ExampleHost_Workdir() {
 		panic(err)
 	}
 
-	lines := strings.Split(strings.TrimSpace(readme), "\n")
-	fmt.Println(lines[0])
+	fmt.Printf("%v\n", strings.Contains(readme, "Dagger"))
 
-	// Output: # Dagger Go SDK
+	// Output: true
 }
 
 // func ExampleHost_EnvVariable() {

--- a/sdk/go/internal/engineconn/unix/unix.go
+++ b/sdk/go/internal/engineconn/unix/unix.go
@@ -2,7 +2,6 @@ package unix
 
 import (
 	"context"
-	"errors"
 	"net"
 	"net/http"
 	"net/url"
@@ -27,15 +26,16 @@ func New(u *url.URL) (engineconn.EngineConn, error) {
 }
 
 func (c *Unix) Connect(ctx context.Context, cfg *engineconn.Config) (*http.Client, error) {
-	if cfg.Workdir != "" {
-		return nil, errors.New("workdir not supported on unix hosts")
-	}
-	if cfg.ConfigPath != "" {
-		return nil, errors.New("config path not supported on unix hosts")
-	}
-	if cfg.NoExtensions {
-		return nil, errors.New("no extensions is not supported on unix hosts")
-	}
+	// FIXME: These are necessary for dagger-in-dagger but do not work.
+	// if cfg.Workdir != "" {
+	// 	return nil, errors.New("workdir not supported on unix hosts")
+	// }
+	// if cfg.ConfigPath != "" {
+	// 	return nil, errors.New("config path not supported on unix hosts")
+	// }
+	// if cfg.NoExtensions {
+	// 	return nil, errors.New("no extensions is not supported on unix hosts")
+	// }
 	return &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {


### PR DESCRIPTION
Add the `ExperimentalPrivilegedNesting` flag to `Exec()` which sets a valid `DAGGER_HOST` inside the container, allowing to communicate back to the same engine instance.

In short, this means that it's possible to run a program that uses the Go SDK within Dagger itself -- `dagger.Connect()` will automagically work out of the box.

This PR also enables to to run dagger tests using dagger in our own CI.

/cc @helderco 