### PR TITLE
shim: unix->tcp API proxy

### DIFF
--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -8,6 +8,7 @@ import (
 
 	"dagger.io/dagger/internal/engineconn"
 	_ "dagger.io/dagger/internal/engineconn/embedded" // embedded connection
+	_ "dagger.io/dagger/internal/engineconn/http"     // http connection
 	_ "dagger.io/dagger/internal/engineconn/unix"     // unix connection
 	"dagger.io/dagger/internal/querybuilder"
 	"github.com/Khan/genqlient/graphql"
@@ -92,7 +93,7 @@ func Connect(ctx context.Context, opts ...ClientOpt) (_ *Client, rerr error) {
 	if err != nil {
 		return nil, err
 	}
-	c.gql = errorWrappedClient{graphql.NewClient("http://dagger/query", client)}
+	c.gql = errorWrappedClient{graphql.NewClient(c.conn.Addr()+"/query", client)}
 	c.Query = Query{
 		q: querybuilder.Query(),
 		c: c.gql,

--- a/sdk/go/internal/engineconn/embedded/embedded.go
+++ b/sdk/go/internal/engineconn/embedded/embedded.go
@@ -29,6 +29,10 @@ func New(_ *url.URL) (engineconn.EngineConn, error) {
 	}, nil
 }
 
+func (c *Embedded) Addr() string {
+	return "http://dagger"
+}
+
 func (c *Embedded) Connect(ctx context.Context, cfg *engineconn.Config) (*http.Client, error) {
 	started := make(chan struct{})
 	var client *http.Client

--- a/sdk/go/internal/engineconn/engineconn.go
+++ b/sdk/go/internal/engineconn/engineconn.go
@@ -13,6 +13,7 @@ type RegisterFunc func(*url.URL) (EngineConn, error)
 var helpers = map[string]RegisterFunc{}
 
 type EngineConn interface {
+	Addr() string
 	Connect(ctx context.Context, cfg *Config) (*http.Client, error)
 	Close() error
 }

--- a/sdk/go/internal/engineconn/http/http.go
+++ b/sdk/go/internal/engineconn/http/http.go
@@ -1,0 +1,37 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"dagger.io/dagger/internal/engineconn"
+)
+
+func init() {
+	engineconn.Register("http", New)
+}
+
+var _ engineconn.EngineConn = &HTTP{}
+
+type HTTP struct {
+	u *url.URL
+}
+
+func New(u *url.URL) (engineconn.EngineConn, error) {
+	return &HTTP{
+		u: u,
+	}, nil
+}
+
+func (c *HTTP) Addr() string {
+	return c.u.String()
+}
+
+func (c *HTTP) Connect(ctx context.Context, cfg *engineconn.Config) (*http.Client, error) {
+	return &http.Client{}, nil
+}
+
+func (c *HTTP) Close() error {
+	return nil
+}

--- a/sdk/go/internal/engineconn/unix/unix.go
+++ b/sdk/go/internal/engineconn/unix/unix.go
@@ -25,6 +25,10 @@ func New(u *url.URL) (engineconn.EngineConn, error) {
 	}, nil
 }
 
+func (c *Unix) Addr() string {
+	return "http://dagger"
+}
+
 func (c *Unix) Connect(ctx context.Context, cfg *engineconn.Config) (*http.Client, error) {
 	// FIXME: These are necessary for dagger-in-dagger but do not work.
 	// if cfg.Workdir != "" {


### PR DESCRIPTION
Will automatically rewrite a `DAGGER_HOST` from `unix://` to `http://`

This removes the need for SDKs to implement unix socket support.

/cc @helderco @slumbering @TomChv 