### PR TITLE
ci: limit usage of large runners 

### DIFF
--- a/.github/workflows/release-v0.3.x.yml
+++ b/.github/workflows/release-v0.3.x.yml
@@ -9,17 +9,17 @@ on:
   # schedule:
   #   - cron: "6 17 * * 2"
   # TODO: ^^^^^^^^^^^^^^^^ we may run this on a schedule at some point - just manual for now - Oct. 13, 2022
-    # https://crontab.guru/#6_17_*_*_2
-    # Every Tuesday at 5:06pm UTC & 9:06am US West Coast.
-    # GitHub Actions defaults to UTC:
-    # There is high load on GitHub Actions at the top of the hour:
-    #
-    #     Note: The schedule event can be delayed during periods of high loads of
-    #     GitHub Actions workflow runs. High load times include the start of every
-    #     hour. To decrease the chance of delay, schedule your workflow to run at a
-    #     different time of the hour.
-    #
-    # So we run these at a special time, 9:06. Ask @gerhard about it.
+  # https://crontab.guru/#6_17_*_*_2
+  # Every Tuesday at 5:06pm UTC & 9:06am US West Coast.
+  # GitHub Actions defaults to UTC:
+  # There is high load on GitHub Actions at the top of the hour:
+  #
+  #     Note: The schedule event can be delayed during periods of high loads of
+  #     GitHub Actions workflow runs. High load times include the start of every
+  #     hour. To decrease the chance of delay, schedule your workflow to run at a
+  #     different time of the hour.
+  #
+  # So we run these at a special time, 9:06. Ask @gerhard about it.
 
   # And it also supports manual triggering:
   # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs
@@ -40,9 +40,7 @@ jobs:
   release:
     # ⚠️  If `name` changes, remember to update the `running-workflow-name` property too
     name: "Bump version, tag & release"
-    runs-on: ubuntu-22.04-16c-64g-600gb
-    # 🧰 comment the line above 👆 & uncomment the line below 👇 when debugging on a fork
-    # runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: "Check out"
         # https://github.com/actions/checkout
@@ -133,7 +131,7 @@ jobs:
       # - https://github.com/dagger/dagger/issues/2823#issuecomment-1190792261
       #
       # TODO: Uncomment this step AFTER we are producing final releases
-      # This will not be accepted by Homebrew maintainers otherwise: 
+      # This will not be accepted by Homebrew maintainers otherwise:
       # > Unstable versions (alpha, beta, development versions) are not acceptable for versioned (or unversioned) formulae.
       # > Excerpt from https://docs.brew.sh/Versions
       #

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
       - "**.go"
       - "go.mod"
       - "go.sum"
+      - "**/go.mod"
+      - "**/go.sum"
       - "sdk/nodejs/**.js"
       - "sdk/python/**.py"
       - ".github/workflows/test.yml"
@@ -35,7 +37,7 @@ jobs:
           go-version: 1.19
       - uses: actions/checkout@v3
       - run: ./hack/make engine:build
-      - run: cp ./bin/cloak /usr/local/bin
+      - run: echo `pwd`/bin >> $GITHUB_PATH
       - run: ./hack/make engine:test
       - name: Print Engine Logs
         if: always()
@@ -54,7 +56,8 @@ jobs:
         with:
           go-version: 1.19
       - uses: actions/checkout@v3
-      - run: go install $(pwd)/cmd/cloak/
+      - run: ./hack/make engine:build
+      - run: echo `pwd`/bin >> $GITHUB_PATH
       - run: ./hack/make engine:testrace
       - name: Print Engine Logs
         if: always()
@@ -66,7 +69,7 @@ jobs:
           sudo dmesg
   sdk-go:
     name: sdk / go
-    runs-on: ubuntu-22.04-16c-64g-600gb
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -75,7 +78,7 @@ jobs:
       - run: ./hack/make sdk:go:test
   sdk-python:
     name: sdk / python
-    runs-on: ubuntu-22.04-16c-64g-600gb
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -84,7 +87,7 @@ jobs:
       - run: ./hack/make sdk:python:test
   sdk-nodejs:
     name: sdk / nodejs
-    runs-on: ubuntu-22.04-16c-64g-600gb
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v3
         with:
@@ -93,7 +96,9 @@ jobs:
         with:
           # ⚠️  Keep this in sync with https://github.com/dagger/dagger/blob/main/package.json#L14
           node-version: 16
+      - run: npm install -g yarn
       - uses: actions/checkout@v3
-      - run: go install $(pwd)/cmd/cloak/
+      - run: ./hack/make engine:build
+      - run: echo `pwd`/bin >> $GITHUB_PATH
       - run: yarn install
       - run: yarn run test-sdk

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-latest
   tools:
     python: "3.10"
 

--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -117,7 +117,7 @@ func (t Engine) test(ctx context.Context, race bool) error {
 	}
 	defer c.Close()
 
-	args := []string{"go", "test", "-v", "-count=1"}
+	args := []string{"go", "test", "-p", "16", "-v", "-count=1"}
 	if race {
 		args = append(args, "-race", "-timeout=1h")
 	}

--- a/internal/mage/sdk/go.go
+++ b/internal/mage/sdk/go.go
@@ -58,7 +58,7 @@ func (t Go) Test(ctx context.Context) error {
 		_, err = util.GoBase(c).
 			WithWorkdir("sdk/go").
 			Exec(dagger.ContainerExecOpts{
-				Args:                          []string{"go", "test", "-v", "./..."},
+				Args:                          []string{"go", "test", "-p", "16", "-v", "./..."},
 				ExperimentalPrivilegedNesting: true,
 			}).
 			ExitCode(ctx)


### PR DESCRIPTION
/cc @gerhard @sipsma @vito 

Low urgency. Experimented with moving our CI to self-hosted to harness buildkit cache.