### PR TITLE
Disable logrus to prevent library spam.

### DIFF
--- a/internal/buildkitd/buildkitd.go
+++ b/internal/buildkitd/buildkitd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,6 +18,7 @@ import (
 	bkclient "github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/util/tracing/detect"
 	"github.com/rs/zerolog/log"
+	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel"
 
 	_ "github.com/moby/buildkit/client/connhelper/dockercontainer" // import the docker connection driver
@@ -34,6 +36,13 @@ const (
 	// buildkitd while not blocking for infinity
 	lockTimeout = 10 * time.Minute
 )
+
+func init() {
+	// Disable logrus output, which only comes from the docker
+	// commandconn library that is used by buildkit's connhelper
+	// and prints unneeded warning logs.
+	logrus.StandardLogger().SetOutput(io.Discard)
+}
 
 // NB: normally we take the version of Buildkit from our go.mod, e.g. v0.10.5,
 // and use the same version for the moby/buildkit Docker tag.


### PR DESCRIPTION
Signed-off-by: Erik Sipsma <erik@sipsma.dev>

fixes https://github.com/dagger/dagger/issues/3723

Note: this will affect the whole process, so it prevents us from using logrus and it means anyone importing engine will be impacted. However, we don't expect engine to be imported a lot anymore since it's no longer imported by the sdk (https://github.com/dagger/dagger/pull/3724) so I think this is okay.

The alternatives would be:
1. Fix upstream - this is not a buildkit library but a docker/cli one, so it may be easier said than done to both get a fix merged and to actually get that fix into our dependency tree
2. Write our own connhelper that is the same as buildkit's but without any logrus usage. Essentially requires forking a little bit of buildkit code and the commandconn implementation from docker/cli