### PR TITLE
Add `WithAllowWildcard` to `(dir *Directory) Without()`

### DIFF
--- a/core/directory.go
+++ b/core/directory.go
@@ -409,7 +409,7 @@ func (dir *Directory) Without(ctx context.Context, path string) (*Directory, err
 		return nil, err
 	}
 
-	err = payload.SetState(ctx, st.File(llb.Rm(path)))
+	err = payload.SetState(ctx, st.File(llb.Rm(path, llb.WithAllowWildcard(true))))
 	if err != nil {
 		return nil, err
 	}

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -325,7 +325,7 @@ func TestDirectoryWithFile(t *testing.T) {
 }
 
 func TestDirectoryWithoutDirectoryWithoutFile(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	ctx := context.Background()
 	c, err := dagger.Connect(ctx)
 	require.NoError(t, err)

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -68,37 +68,6 @@ func newDirWithFile(t *testing.T, path, contents string) core.DirectoryID {
 	return dirRes.Directory.WithNewFile.ID
 }
 
-func newDirWithFiles(t *testing.T, path, contents, path2, contents2 string) core.DirectoryID {
-	dirRes := struct {
-		Directory struct {
-			WithNewFile struct {
-				WithNewFile struct {
-					ID core.DirectoryID
-				}
-			}
-		}
-	}{}
-
-	err := testutil.Query(
-		`query Test($path: String!, $contents: String!, $path2: String!, $contents2: String!) {
-			directory {
-				withNewFile(path: $path, contents: $contents) {
-					withNewFile(path: $path2, contents: $contents2) {
-						id
-					}
-				}
-			}
-		}`, &dirRes, &testutil.QueryOptions{Variables: map[string]any{
-			"path":      path,
-			"contents":  contents,
-			"path2":     path2,
-			"contents2": contents2,
-		}})
-	require.NoError(t, err)
-
-	return dirRes.Directory.WithNewFile.WithNewFile.ID
-}
-
 func newSecret(t *testing.T, content string) core.SecretID {
 	var secretRes struct {
 		Directory struct {


### PR DESCRIPTION
Allow a user to specify wildcards in their paths for `(dir *Directory) Without()`. 

I need _at least_ this for `dagger-cue`. Even better would be the ability to turn it on/off, but that would require an API change. 

If we are up for that, I'd suggest this as the new API.

```
type Directory {
  withoutDirectory(path: String!, disableWildcards: bool): Directory!
}
```

I can make that change, if we're cool with it. 

Another possibility is adding this API:

```
type Directory {
  without(pattern: String!): Directory!
}
```

Signed-off-by: Joel Longtine <joel@dagger.io>