### PR TITLE
ci: Only publish Python SDK when there is an sdk/python tag

### DIFF
--- a/.github/workflows/publish-sdk-python.yml
+++ b/.github/workflows/publish-sdk-python.yml
@@ -1,13 +1,8 @@
 name: publish-sdk-python
 on:
   push:
-    branches:
-      - main
     tags:
-      - sdk/python/**
-    paths:
-      - "sdk/python/**"
-      - .github/workflows/publish-sdk-python.yml
+      - sdk/python/v**
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This was triggered by a push to `main` which is not what we want: https://github.com/dagger/dagger/actions/runs/3428027315

Only tags starting with sdk/python/v tags should trigger this workflow