### PR TITLE
ci: mage -> ./hack/make

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,10 +18,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19
-      - uses: magefile/mage-action@v2
-        with:
-          version: latest
-          args: engine:lint
+      - run: ./hack/make engine:lint
   docs:
     runs-on: ubuntu-latest
     steps:
@@ -29,10 +26,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19
-      - uses: magefile/mage-action@v2
-        with:
-          version: latest
-          args: docs:lint
+      - run: ./hack/make docs:lint
   sdk-go:
     name: sdk / go
     runs-on: ubuntu-latest
@@ -41,10 +35,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19
-      - uses: magefile/mage-action@v2
-        with:
-          version: latest
-          args: sdk:go:lint
+      - run: ./hack/make sdk:go:lint
   sdk-python:
     name: sdk / python
     runs-on: ubuntu-latest
@@ -53,7 +44,4 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19
-      - uses: magefile/mage-action@v2
-        with:
-          version: latest
-          args: sdk:python:lint
+      - run: ./hack/make sdk:python:lint

--- a/.github/workflows/publish-sdk-go.yml
+++ b/.github/workflows/publish-sdk-go.yml
@@ -16,11 +16,6 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19
-        # https://github.com/magefile/mage-action
-      - uses: magefile/mage-action@v2
-        with:
-          # ⚠️ This must match our go.mod version
-          version: v1.14.0
-          args: sdk:go:publish ${{ github.ref_name }}
+      - run: ./hack/make sdk:go:publish ${{ github.ref_name }}
         env:
           GITHUB_PAT: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}

--- a/.github/workflows/publish-sdk-python.yml
+++ b/.github/workflows/publish-sdk-python.yml
@@ -11,12 +11,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19
-        # https://github.com/magefile/mage-action
-      - uses: magefile/mage-action@v2
-        with:
-          # ⚠️ This must match our go.mod version
-          version: v1.14.0
-          args: sdk:python:publish ${{ github.ref_name }}
+      - run: ./hack/make sdk:python:publish ${{ github.ref_name }}
         env:
           PYPI_REPO: ${{ secrets.RELEASE_PYPI_REPO }}
           PYPI_TOKEN: ${{ secrets.RELEASE_PYPI_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,17 +34,9 @@ jobs:
         with:
           go-version: 1.19
       - uses: actions/checkout@v3
-      - name: build
-        uses: magefile/mage-action@v2
-        with:
-          version: latest
-          args: engine:build
+      - run: ./hack/make engine:build
       - run: cp ./bin/cloak /usr/local/bin
-      - name: test
-        uses: magefile/mage-action@v2
-        with:
-          version: latest
-          args: engine:test
+      - run: ./hack/make engine:test
       - name: Print Engine Logs
         if: always()
         run: |
@@ -59,11 +51,7 @@ jobs:
           go-version: 1.19
       - uses: actions/checkout@v3
       - run: go install $(pwd)/cmd/cloak/
-      - name: test
-        uses: magefile/mage-action@v2
-        with:
-          version: latest
-          args: engine:testrace
+      - run: ./hack/make engine:testrace
       - name: Print Engine Logs
         if: always()
         run: |
@@ -76,10 +64,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19
-      - uses: magefile/mage-action@v2
-        with:
-          version: latest
-          args: sdk:go:test
+      - run: ./hack/make sdk:go:test
   sdk-python:
     name: sdk / python
     runs-on: ubuntu-22.04-16c-64g-600gb
@@ -88,10 +73,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19
-      - uses: magefile/mage-action@v2
-        with:
-          version: latest
-          args: sdk:python:test
+      - run: ./hack/make sdk:python:test
   sdk-nodejs:
     name: sdk / nodejs
     runs-on: ubuntu-22.04-16c-64g-600gb

--- a/hack/make
+++ b/hack/make
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+ROOTDIR="$(dirname "${BASH_SOURCE[0]}")/.."
+
+cd "$ROOTDIR"
+go run internal/mage/main.go $@

--- a/internal/mage/main.go
+++ b/internal/mage/main.go
@@ -1,0 +1,12 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+	"os"
+
+	"github.com/magefile/mage/mage"
+)
+
+func main() { os.Exit(mage.Main()) }


### PR DESCRIPTION
- Run `./hack/make X` instead of `mage X`
- Use vendored version of mage instead of binary

/cc @gerhard @sipsma @vito 