### PR TITLE
docs(python): port private registry docs to python

### DIFF
--- a/docs/current/partials/_private-git-repository_first.md
+++ b/docs/current/partials/_private-git-repository_first.md
@@ -1,0 +1,5 @@
+Dagger uses your host's SSH authentication agent to securely authenticate against private remote Git repositories.
+
+To clone private repositories, the only requirement is to run `ssh-add` on the Dagger host to add your SSH key to the authentication agent.
+
+Assume that you have a Dagger CI tool containing the following code, which references a private repository:

--- a/docs/current/partials/_private-git-repository_second.md
+++ b/docs/current/partials/_private-git-repository_second.md
@@ -1,0 +1,6 @@
+Now, first remove all the SSH keys from the authentication agent on the Dagger host:
+
+```shell
+➜  ssh-add -D
+All identities removed.
+```

--- a/docs/current/sdk/go/guides/710884-private-repositories.md
+++ b/docs/current/sdk/go/guides/710884-private-repositories.md
@@ -5,21 +5,12 @@ displayed_sidebar: 'current'
 
 # Use Dagger with Private Git Repositories
 
-Dagger uses your host's SSH authentication agent to securely authenticate against private remote Git repositories.
-
-To clone private repositories, the only requirement is to run `ssh-add` on the Dagger host to add your SSH key to the authentication agent.
-
-Assume that you have a Dagger CI tool containing the following code, which references a private repository:
+{@include: ../../../partials/_private-git-repository_first.md}
 
 ```go file=../snippets/private-repositories/main.go
 ```
 
-Now, first remove all the SSH keys from the authentication agent on the Dagger host:
-
-```shell
-➜  ssh-add -D
-All identities removed.
-```
+{@include: ../../../partials/_private-git-repository_second.md}
 
 Attempt to run the Go CI tool:
 

--- a/docs/current/sdk/python/234291-guides.md
+++ b/docs/current/sdk/python/234291-guides.md
@@ -5,3 +5,4 @@ slug: /sdk/python/234291/guides
 # Guides
 
 - [Create a Multi-Build CI Pipeline](./guides/648384-multi-builds.md)
+- [Use Dagger with Private Git Repositories](guides/683293-private-repositories.md)

--- a/docs/current/sdk/python/234291-guides.md
+++ b/docs/current/sdk/python/234291-guides.md
@@ -5,4 +5,4 @@ slug: /sdk/python/234291/guides
 # Guides
 
 - [Create a Multi-Build CI Pipeline](./guides/648384-multi-builds.md)
-- [Use Dagger with Private Git Repositories](guides/683293-private-repositories.md)
+- [Use Dagger with Private Git Repositories](./guides/683293-private-repositories.md)

--- a/docs/current/sdk/python/guides/683293-private-repositories.md
+++ b/docs/current/sdk/python/guides/683293-private-repositories.md
@@ -1,0 +1,42 @@
+---
+slug: /683293/private-repositories
+displayed_sidebar: "current"
+---
+
+# Use Dagger with Private Git Repositories
+
+Dagger uses your host's SSH authentication agent to securely authenticate against private remote Git repositories.
+
+To clone private repositories, the only requirement is to run `ssh-add` on the Dagger host to add your SSH key to the authentication agent.
+
+Assume that you have a Dagger CI tool containing the following code, which references a private repository:
+
+```python file=../snippets/private-repositories/clone.py
+```
+
+Now, first remove all the SSH keys from the authentication agent on the Dagger host:
+
+```shell
+➜  ssh-add -D
+All identities removed.
+```
+
+Attempt to run the Go CI tool:
+
+```shell
+➜  python clone.py
+{'message': 'failed to load cache key: failed to fetch remote https://xxxxx@private-repository.git: exit status 128', 'locations': [{'line': 6, 'column': 11}], 'path': ['git', 'branch', 'tree', 'file', 'contents']}
+```
+
+The CI tool fails, as it is unable to find the necessary authentication credentials to read the private repository in the SSH authentication agent.
+
+Now, add the SSH key to the authentication agent on the host and try again:
+
+```shell
+➜ ssh-add
+Identity added: xxxxx
+➜ python clone.py
+readme #
+```
+
+Finally, the CI tool succeeds in reading the private Git repository.

--- a/docs/current/sdk/python/guides/683293-private-repositories.md
+++ b/docs/current/sdk/python/guides/683293-private-repositories.md
@@ -5,23 +5,14 @@ displayed_sidebar: "current"
 
 # Use Dagger with Private Git Repositories
 
-Dagger uses your host's SSH authentication agent to securely authenticate against private remote Git repositories.
-
-To clone private repositories, the only requirement is to run `ssh-add` on the Dagger host to add your SSH key to the authentication agent.
-
-Assume that you have a Dagger CI tool containing the following code, which references a private repository:
+{@include: ../../../partials/_private-git-repository_first.md}
 
 ```python file=../snippets/private-repositories/clone.py
 ```
 
-Now, first remove all the SSH keys from the authentication agent on the Dagger host:
+{@include: ../../../partials/_private-git-repository_second.md}
 
-```shell
-➜  ssh-add -D
-All identities removed.
-```
-
-Attempt to run the Go CI tool:
+Attempt to run the Python CI tool:
 
 ```shell
 ➜  python clone.py

--- a/docs/current/sdk/python/snippets/private-repositories/clone.py
+++ b/docs/current/sdk/python/snippets/private-repositories/clone.py
@@ -1,0 +1,31 @@
+# """
+# Clone a Private Git Repository and print the content of the README.md file
+# """
+
+import anyio
+import dagger
+
+async def private_repo():
+    async with dagger.Connection() as client:
+
+        repo = (
+            client.
+            # Retrieve the repository
+            git("git@private-repository.git").
+            # Select the main branch, and the filesystem tree associated
+            branch("main").
+            tree().
+            # Select the README.md file
+            file("README.md")
+        )
+
+        # Retrieve the content of the README file
+        file = await repo.contents()
+
+        print(f"{file}")
+
+if __name__ == "__main__":
+    try:
+        anyio.run(private_repo)
+    except Exception as e:
+        print(e)

--- a/docs/current/sdk/python/snippets/private-repositories/clone.py
+++ b/docs/current/sdk/python/snippets/private-repositories/clone.py
@@ -1,6 +1,6 @@
-# """
-# Clone a Private Git Repository and print the content of the README.md file
-# """
+"""
+Clone a Private Git Repository and print the content of the README.md file
+"""
 
 import anyio
 import dagger
@@ -9,14 +9,14 @@ async def private_repo():
     async with dagger.Connection() as client:
 
         repo = (
-            client.
+            client
             # Retrieve the repository
-            git("git@private-repository.git").
+            .git("git@private-repository.git")
             # Select the main branch, and the filesystem tree associated
-            branch("main").
-            tree().
+            .branch("main")
+            .tree()
             # Select the README.md file
-            file("README.md")
+            .file("README.md")
         )
 
         # Retrieve the content of the README file

--- a/docs/current/sdk/python/snippets/private-repositories/clone.py
+++ b/docs/current/sdk/python/snippets/private-repositories/clone.py
@@ -2,12 +2,15 @@
 Clone a Private Git Repository and print the content of the README.md file
 """
 
+import sys
+
 import anyio
 import dagger
+from rich.console import Console
+
 
 async def private_repo():
     async with dagger.Connection() as client:
-
         repo = (
             client
             # Retrieve the repository
@@ -22,10 +25,14 @@ async def private_repo():
         # Retrieve the content of the README file
         file = await repo.contents()
 
-        print(f"{file}")
+        print(file)
+
 
 if __name__ == "__main__":
-    try:
-        anyio.run(private_repo)
-    except Exception as e:
-        print(e)
+    console = Console()
+    with console.status("Hold on..."):
+        try:
+            anyio.run(private_repo)
+        except Exception as e:
+            print(e, file=sys.stderr)
+            sys.exit(1)


### PR DESCRIPTION
- Port the private registry docs to python, to have a common basis
- Add it to guides list

It might be worth to have a better architecture other than copy-pasting ? I have several guides on-the-way that are worth being ported to python / go

cc @vikram-dagger 

Signed-off-by: Guillaume de Rouville