### PR TITLE
Add test for docker image provision. 

### DIFF
--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/iancoleman/strcase v0.2.0
 	github.com/opencontainers/go-digest v1.0.0
+	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.1
 	github.com/vektah/gqlparser/v2 v2.5.1

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/iancoleman/strcase v0.2.0
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.1
 	github.com/vektah/gqlparser/v2 v2.5.1
@@ -23,7 +22,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/sdk/go/go.sum
+++ b/sdk/go/go.sum
@@ -43,6 +43,8 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mitchellh/mapstructure v1.2.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799 h1:rc3tiVYb5z54aKaDfakKn0dDjIyPpTtszkjuMzyt7ec=
+github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/sdk/go/go.sum
+++ b/sdk/go/go.sum
@@ -21,8 +21,9 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
+github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -43,8 +44,6 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mitchellh/mapstructure v1.2.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
-github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799 h1:rc3tiVYb5z54aKaDfakKn0dDjIyPpTtszkjuMzyt7ec=
-github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/sdk/go/internal/engineconn/dockerprovision/dockerprovision.go
+++ b/sdk/go/internal/engineconn/dockerprovision/dockerprovision.go
@@ -33,27 +33,59 @@ const (
 )
 
 func startEngineSession(ctx context.Context, stderr io.Writer, cmd string, args ...string) (string, io.Closer, error) {
-	proc := exec.CommandContext(ctx, cmd, args...)
-	proc.Env = os.Environ()
-	proc.Stderr = stderr
-	setPlatformOpts(proc)
+	// Workaround https://github.com/golang/go/issues/22315
+	// Basically, if any other code in this process does fork/exec, it may
+	// temporarily have the tmpbin fd that we closed earlier open still, and it
+	// will be open for writing. Even though we rename the file, the
+	// underlying inode is the same and thus we can get a "text file busy"
+	// error when trying to exec it below.
+	//
+	// We workaround this the same way suggested in the issue, by sleeping
+	// and retrying the exec a few times. This is such an obscure case that
+	// this retry approach should be fine. It can only happen when a new
+	// engine-session binary needs to be created and even then only if many
+	// threads within this process are trying to provision it at the same time.
 
-	stdout, err := proc.StdoutPipe()
-	if err != nil {
-		return "", nil, err
+	var proc *exec.Cmd
+	var stdout io.ReadCloser
+	var childStdin io.WriteCloser
+	for i := 0; i < 10; i++ {
+		proc = exec.CommandContext(ctx, cmd, args...)
+		proc.Env = os.Environ()
+		proc.Stderr = stderr
+		setPlatformOpts(proc)
+
+		var err error
+		stdout, err = proc.StdoutPipe()
+		if err != nil {
+			return "", nil, err
+		}
+		defer stdout.Close() // don't need it after we read the port
+
+		// Open a stdin pipe with the child process. The engine-session shutsdown
+		// when it is closed. This is a platform-agnostic way of ensuring
+		// we don't leak child processes even if this process is SIGKILL'd.
+		childStdin, err = proc.StdinPipe()
+		if err != nil {
+			return "", nil, err
+		}
+
+		if err := proc.Start(); err != nil {
+			if strings.Contains(err.Error(), "text file busy") {
+				time.Sleep(100 * time.Millisecond)
+				proc = nil
+				stdout.Close()
+				stdout = nil
+				childStdin.Close()
+				childStdin = nil
+				continue
+			}
+			return "", nil, err
+		}
+		break
 	}
-	defer stdout.Close() // don't need it after we read the port
-
-	// Open a stdin pipe with the child process. The engine-session shutsdown
-	// when it is closed. This is a platform-agnostic way of ensuring
-	// we don't leak child processes even if this process is SIGKILL'd.
-	childStdin, err := proc.StdinPipe()
-	if err != nil {
-		return "", nil, err
-	}
-
-	if err := proc.Start(); err != nil {
-		return "", nil, err
+	if proc == nil {
+		return "", nil, fmt.Errorf("failed to start engine session")
 	}
 
 	// Read the port to connect to from the engine-session's stdout.
@@ -78,6 +110,7 @@ func startEngineSession(ctx context.Context, stderr io.Writer, cmd string, args 
 			return "", nil, portErr
 		}
 		portStr = strings.TrimSpace(portStr)
+		var err error
 		port, err = strconv.Atoi(portStr)
 		if err != nil {
 			return "", nil, err

--- a/sdk/go/internal/engineconn/dockerprovision/dockerprovision.go
+++ b/sdk/go/internal/engineconn/dockerprovision/dockerprovision.go
@@ -14,9 +14,14 @@ import (
 	exec "golang.org/x/sys/execabs"
 )
 
+const (
+	DockerImageConnName     = "docker-image"
+	DockerContainerConnName = "docker-container"
+)
+
 func init() {
-	engineconn.Register("docker-image", NewDockerImage)
-	engineconn.Register("docker-container", NewDockerContainer)
+	engineconn.Register(DockerImageConnName, NewDockerImage)
+	engineconn.Register(DockerContainerConnName, NewDockerContainer)
 }
 
 const (

--- a/sdk/go/provision_test.go
+++ b/sdk/go/provision_test.go
@@ -1,0 +1,101 @@
+package dagger
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"dagger.io/dagger/internal/engineconn/dockerprovision"
+	"github.com/adrg/xdg"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestImageProvision(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	daggerHost, ok := os.LookupEnv("DAGGER_HOST")
+	if ok {
+		if !strings.HasPrefix(daggerHost, dockerprovision.DockerImageConnName+"://") {
+			t.Skip("DAGGER_HOST is not set to docker-image://")
+		}
+	}
+
+	tmpdir := t.TempDir()
+	os.Setenv("XDG_CACHE_HOME", tmpdir)
+	defer os.Unsetenv("XDG_CACHE_HOME")
+	xdg.Reload()
+	cacheDir := filepath.Join(tmpdir, "dagger")
+
+	// create some garbage for the image provisioner to collect
+	err := os.MkdirAll(cacheDir, 0700)
+	require.NoError(t, err)
+	f, err := os.Create(filepath.Join(cacheDir, "dagger-engine-session-gcme"))
+	require.NoError(t, err)
+	f.Close()
+
+	tmpContainerName := "dagger-engine-gcme-" + strconv.Itoa(int(time.Now().UnixNano()))
+	if output, err := exec.CommandContext(ctx,
+		"docker", "run",
+		"--rm",
+		"--detach",
+		"--name", tmpContainerName,
+		"busybox",
+		"sleep", "120",
+	).CombinedOutput(); err != nil {
+		t.Fatalf("failed to create container: %s", output)
+	}
+
+	parallelism := 30
+	start := make(chan struct{})
+	var eg errgroup.Group
+	for i := 0; i < parallelism; i++ {
+		eg.Go(func() error {
+			<-start
+			c, err := Connect(ctx)
+			if err != nil {
+				return err
+			}
+			defer c.Close()
+			// do a trivial query to ensure the engine is actually there
+			_, err = c.Container().From("alpine:3.16").ID(ctx)
+			return err
+		})
+	}
+	close(start)
+	require.NoError(t, eg.Wait())
+
+	entries, err := os.ReadDir(cacheDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	entry := entries[0]
+	require.True(t, entry.Type().IsRegular())
+	require.True(t, strings.HasPrefix(entry.Name(), "dagger-engine-session-"))
+	shortSha := entry.Name()[len("dagger-engine-session-"):]
+	require.Len(t, shortSha, 16)
+
+	output, err := exec.CommandContext(ctx,
+		"docker", "ps",
+		"-a",
+		"--no-trunc",
+	).CombinedOutput()
+	require.NoError(t, err)
+	var found bool
+	for _, line := range strings.Split(string(output), "\n") {
+		if line == "" {
+			continue
+		}
+		require.NotContains(t, line, tmpContainerName)
+		if strings.Contains(line, shortSha) {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "container with sha %s not found in docker ps output: %s", shortSha, output)
+}


### PR DESCRIPTION
Main goal here is to automate provision testing. As part of that I found I was occasionally getting `text busy` errors trying to exec the `engine-session` binary.

After investigation this turned out to be incredibly obscure and highly specific to what the test case was doing. It could happen when:
1. The engine-session binary was not already provisioned
2. There are many fork/execs happening in parallel with the provisioning

It's actually a unsolved problem in Go and Linux in general apparently: https://github.com/golang/go/issues/22315

It's a bit annoying to workaround but worth it so we can have this test case if nothing else.