### PR TITLE
Add docker image provisioner test.

### DIFF
--- a/sdk/python/tests/connectors/test_docker.py
+++ b/sdk/python/tests/connectors/test_docker.py
@@ -1,0 +1,40 @@
+import asyncio
+import os
+from pathlib import Path
+import tempfile
+
+import pytest
+
+import dagger
+
+pytestmark = [
+    pytest.mark.anyio,
+    pytest.mark.slow,
+]
+
+
+async def test_docker_image_provision():
+    # skip test if DAGGER_HOST is set and not prefixed with docker-image
+    dagger_host = os.environ.get("DAGGER_HOST")
+    if dagger_host and not dagger_host.startswith("docker-image:"):
+        pytest.skip("DAGGER_HOST is not docker-image")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_dir = Path(tmpdir) / "dagger"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+
+        # make some garbage for the image provisioner to collect
+        (cache_dir / "dagger-engine-session-gcme").touch()
+        # clean up of existing containers is handled in engine-session binary
+        # and is already tested in go, skipping coverage here
+
+        # run a bunch of provisions in parallel
+        async def connect_once():
+            async with dagger.Connection() as client:
+                assert await client.container().from_("alpine:3.16.2").id()
+        parallelism = 30
+        await asyncio.gather(*[connect_once() for _ in range(parallelism)])
+
+        # assert that there's only one engine-session binary in the cache
+        assert len(list(cache_dir.glob("*"))) == 1
+        assert list(cache_dir.glob("*"))[0].name.startswith("dagger-engine-session-")

--- a/sdk/python/tests/connectors/test_docker.py
+++ b/sdk/python/tests/connectors/test_docker.py
@@ -1,8 +1,6 @@
-import asyncio
-import os
 from pathlib import Path
-import tempfile
 
+import anyio
 import pytest
 
 import dagger
@@ -13,28 +11,33 @@ pytestmark = [
 ]
 
 
-async def test_docker_image_provision():
-    # skip test if DAGGER_HOST is set and not prefixed with docker-image
-    dagger_host = os.environ.get("DAGGER_HOST")
-    if dagger_host and not dagger_host.startswith("docker-image:"):
-        pytest.skip("DAGGER_HOST is not docker-image")
+@pytest.mark.skipif(
+    dagger.Config().host.scheme != "docker-image",
+    reason="DAGGER_HOST is not docker-image",
+)
+async def test_docker_image_provision(tmp_path: Path):
+    cache_dir = tmp_path / "dagger"
+    cache_dir.mkdir()
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        cache_dir = Path(tmpdir) / "dagger"
-        cache_dir.mkdir(parents=True, exist_ok=True)
+    # make some garbage for the image provisioner to collect
+    (cache_dir / "dagger-engine-session-gcme").touch()
 
-        # make some garbage for the image provisioner to collect
-        (cache_dir / "dagger-engine-session-gcme").touch()
-        # clean up of existing containers is handled in engine-session binary
-        # and is already tested in go, skipping coverage here
+    # clean up of existing containers is handled in engine-session binary
+    # and is already tested in go, skipping coverage here
 
-        # run a bunch of provisions in parallel
-        async def connect_once():
-            async with dagger.Connection() as client:
-                assert await client.container().from_("alpine:3.16.2").id()
-        parallelism = 30
-        await asyncio.gather(*[connect_once() for _ in range(parallelism)])
+    # run a bunch of provisions concurrently
+    async def connect_once():
+        async with dagger.Connection() as client:
+            assert await client.container().from_("alpine:3.16.2").id()
 
-        # assert that there's only one engine-session binary in the cache
-        assert len(list(cache_dir.glob("*"))) == 1
-        assert list(cache_dir.glob("*"))[0].name.startswith("dagger-engine-session-")
+    concurrency = 30
+    async with anyio.create_task_group() as tg:
+        for _ in range(concurrency):
+            tg.start_soon(connect_once)
+
+    # assert that there's only one engine-session binary in the cache
+    files = cache_dir.iterdir()
+    bin = next(files)
+    assert bin.name.startswith("dagger-engine-session-")
+    with pytest.raises(StopIteration):
+        next(files)


### PR DESCRIPTION
Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Same thing as for Go, but in Python now: https://github.com/dagger/dagger/pull/3761

---

NOTE: this test won't yet run in CI because when we use dagger-in-dagger DAGGER_HOST gets overridden, so right now this test is only useful for us when running manually directly on hosts. I'm gonna fix this for both go+python+future-sdks in a follow up so it can also run in CI.

---

Also note: the ETXTBSY issue hit in Go (https://github.com/golang/go/issues/22315) is not an issue here ***yet*** because our provisioner implementation is fully sync (and thus closes all file descriptors before they could end up in a forked process). However, that issue is a general Linux flaw and you can find people using pretty much any language hitting+complaining about it eventually across the internet, [python example here](https://github.com/pantsbuild/pants/issues/10507#issuecomment-674407120).

So I think we will hit it if we update the provisioner to use async code, in which case this test case will start flaking and we can apply a similar fix that we did in Go (afaict doing a few retries after etxtbsy is where most people land as a solution).