### PR TITLE
docs: Make first example give immediate feedback

### DIFF
--- a/docs/current/sdk/python/snippets/get-started/step1/test.py
+++ b/docs/current/sdk/python/snippets/get-started/step1/test.py
@@ -2,11 +2,14 @@
 Execute a command
 """
 
+import sys
 import anyio
 import dagger
 
 async def test():
-    async with dagger.Connection() as client:
+    config = dagger.Config(log_output=sys.stderr)
+
+    async with dagger.Connection(config) as client:
 
         python = (
             client.container()


### PR DESCRIPTION
Without this change:
```
python test.py #wait 10 to 30 seconds with no feedback

Hello from Dagger and Python 3.10.8
```

With this change:
```
python test.py #near immediate feedback

#1 resolve image config for docker.io/library/python:3.10-slim-buster
#1 DONE 1.7s

#2 mkfile /Dockerfile
#2 DONE 0.0s

#3 mkfile /main.go
#3 DONE 0.0s

#4 [internal] load metadata for docker.io/library/golang:1.18.2-alpine
#4 DONE 0.9s
...
#14 python -V
#0 0.077 Python 3.10.8
#14 DONE 0.1s
Hello from Dagger and Python 3.10.8
```

Instead could use the code in Step 3 of Getting Started right away:
```
async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
```

Could also add a comment to say this is optional:

```
# optional log output
log = dagger.Config(log_output=sys.stderr)
```

Signed-off-by: Jeremy Adams <jeremy@dagger.io>