### PR TITLE
Support full isolated sessions w/ dagger-in-dagger. 

### DIFF
--- a/cmd/engine-session/main.go
+++ b/cmd/engine-session/main.go
@@ -47,7 +47,6 @@ func EngineSession(cmd *cobra.Command, args []string) {
 		LogOutput:  os.Stderr,
 		RemoteAddr: remote,
 	}
-
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, syscall.SIGINT, syscall.SIGTERM)
 

--- a/core/container.go
+++ b/core/container.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	DaggerSockName = "dagger-sock"
-	DaggerSockPath = "/dagger.sock"
+	RunnerProxySockName = "dagger-runner-sock"
+	RunnerProxySockPath = "/dagger-runner.sock"
 )
 
 // Container is a content-addressed container.
@@ -685,10 +685,13 @@ func (container *Container) Exec(ctx context.Context, gw bkgw.Client, defaultPla
 	// this allows executed containers to communicate back to this API
 	if opts.ExperimentalPrivilegedNesting {
 		runOpts = append(runOpts,
-			llb.AddEnv("DAGGER_HOST", "unix:///dagger.sock"),
+			// TODO: right now the user needs to explicitly set DAGGER_HOST,
+			// instead the default should be that the shim provides an engine
+			// session ala "dagger exec"
+			llb.AddEnv("DAGGER_RUNNER_HOST", "unix://"+RunnerProxySockPath),
 			llb.AddSSHSocket(
-				llb.SSHID(DaggerSockName),
-				llb.SSHSocketTarget(DaggerSockPath),
+				llb.SSHID(RunnerProxySockName),
+				llb.SSHSocketTarget(RunnerProxySockPath),
 			),
 		)
 	}

--- a/core/container.go
+++ b/core/container.go
@@ -685,9 +685,7 @@ func (container *Container) Exec(ctx context.Context, gw bkgw.Client, defaultPla
 	// this allows executed containers to communicate back to this API
 	if opts.ExperimentalPrivilegedNesting {
 		runOpts = append(runOpts,
-			// TODO: right now the user needs to explicitly set DAGGER_HOST,
-			// instead the default should be that the shim provides an engine
-			// session ala "dagger exec"
+			llb.AddEnv("DAGGER_HOST", "bin://"), // default to finding dagger-engine-session in $PATH
 			llb.AddEnv("DAGGER_RUNNER_HOST", "unix://"+RunnerProxySockPath),
 			llb.AddSSHSocket(
 				llb.SSHID(RunnerProxySockName),

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -2393,7 +2393,8 @@ func TestContainerPublish(t *testing.T) {
 }
 
 func TestExecFromScratch(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	c, err := dagger.Connect(ctx)
 	require.NoError(t, err)
 	defer c.Close()

--- a/core/integration/platform_test.go
+++ b/core/integration/platform_test.go
@@ -54,7 +54,7 @@ func TestPlatformEmulatedExecAndPush(t *testing.T) {
 		require.Equal(t, uname, output)
 	}
 
-	testRef := "127.0.0.1:5000/testmultiplatimagepush:latest"
+	testRef := "127.0.0.1:5000/testplatformemulatedexecandpush:latest"
 	_, err = c.Container().Publish(ctx, testRef, dagger.ContainerPublishOpts{
 		PlatformVariants: variants,
 	})
@@ -139,7 +139,7 @@ func TestPlatformCrossCompile(t *testing.T) {
 	}
 
 	// push a multiplatform image
-	testRef := "127.0.0.1:5000/testmultiplatimagepush:latest"
+	testRef := "127.0.0.1:5000/testplatformcrosscompile:latest"
 	_, err = c.Container().Publish(ctx, testRef, dagger.ContainerPublishOpts{
 		PlatformVariants: variants,
 	})
@@ -156,11 +156,11 @@ func TestPlatformCrossCompile(t *testing.T) {
 			From(testRef).
 			Rootfs()
 		ctr = ctr.WithMountedDirectory("/"+string(platform), pulledDir)
-		cmds = append(cmds, fmt.Sprintf(`file /%s/cloak | grep '%s'`, platform, uname))
+		cmds = append(cmds, fmt.Sprintf(`file /%s/cloak | tee /dev/stderr | grep -q '%s'`, platform, uname))
 	}
 	exit, err := ctr.
 		Exec(dagger.ContainerExecOpts{
-			Args: []string{"sh", "-c", strings.Join(cmds, " && ")},
+			Args: []string{"sh", "-x", "-e", "-c", strings.Join(cmds, "\n")},
 		}).
 		ExitCode(ctx)
 	require.NoError(t, err)

--- a/core/runnerproxy.go
+++ b/core/runnerproxy.go
@@ -1,0 +1,44 @@
+package core
+
+import (
+	"context"
+
+	"github.com/moby/buildkit/client/connhelper"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/sshforward"
+	"google.golang.org/grpc"
+)
+
+var _ session.Attachable = &RunnerProxy{}
+
+type RunnerProxy struct {
+	buildkitdHost string
+}
+
+func NewRunnerProxy(buildkitdHost string) *RunnerProxy {
+	return &RunnerProxy{
+		buildkitdHost: buildkitdHost,
+	}
+}
+
+func (p *RunnerProxy) Register(server *grpc.Server) {
+	sshforward.RegisterSSHServer(server, p)
+}
+
+func (p *RunnerProxy) CheckAgent(ctx context.Context, req *sshforward.CheckAgentRequest) (*sshforward.CheckAgentResponse, error) {
+	return &sshforward.CheckAgentResponse{}, nil
+}
+
+func (p *RunnerProxy) ForwardAgent(stream sshforward.SSH_ForwardAgentServer) error {
+	// TODO:(sipsma) also handle basic unix/tcp connections
+	ch, err := connhelper.GetConnectionHelper(p.buildkitdHost)
+	if err != nil {
+		return err
+	}
+
+	buildkitdConn, err := ch.ContextDialer(context.TODO(), p.buildkitdHost)
+	if err != nil {
+		return err
+	}
+	return sshforward.Copy(context.TODO(), buildkitdConn, stream, nil)
+}

--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -138,7 +138,6 @@ func (t Engine) test(ctx context.Context, race bool) error {
 			WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
 			WithMountedDirectory("/app", util.Repository(c)). // need all the source for extension tests
 			WithWorkdir("/app").
-			WithEnvVariable("DAGGER_HOST", "bin:///usr/bin/dagger-engine-session").
 			WithEnvVariable("CGO_ENABLED", cgoEnabledEnv).
 			WithMountedDirectory("/root/.docker", util.HostDockerDir(c)).
 			Exec(dagger.ContainerExecOpts{

--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -140,6 +140,7 @@ func (t Engine) test(ctx context.Context, race bool) error {
 			WithWorkdir("/app").
 			WithEnvVariable("DAGGER_HOST", "bin:///usr/bin/dagger-engine-session").
 			WithEnvVariable("CGO_ENABLED", cgoEnabledEnv).
+			WithMountedDirectory("/root/.docker", util.HostDockerDir(c)).
 			Exec(dagger.ContainerExecOpts{
 				Args:                          args,
 				ExperimentalPrivilegedNesting: true,

--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"runtime"
 	"time"
 
@@ -125,21 +124,32 @@ func (t Engine) test(ctx context.Context, race bool) error {
 	}
 	defer c.Close()
 
+	cgoEnabledEnv := "0"
 	args := []string{"go", "test", "-p", "16", "-v", "-count=1"}
 	if race {
 		args = append(args, "-race", "-timeout=1h")
+		cgoEnabledEnv = "1"
 	}
 	args = append(args, "./...")
 
-	fmt.Println("Running tests with args:", args)
-
-	// #nosec
 	return util.WithDevEngine(ctx, c, func(ctx context.Context, c *dagger.Client) error {
-		cmd := exec.CommandContext(ctx, args[0], args[1:]...)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		cmd.Env = os.Environ()
-		return cmd.Run()
+		output, err := util.GoBase(c).
+			WithMountedFile("/usr/bin/cloak", util.DaggerBinary(c)).
+			WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
+			WithMountedDirectory("/app", util.Repository(c)). // need all the source for extension tests
+			WithWorkdir("/app").
+			WithEnvVariable("DAGGER_HOST", "bin:///usr/bin/dagger-engine-session").
+			WithEnvVariable("CGO_ENABLED", cgoEnabledEnv).
+			Exec(dagger.ContainerExecOpts{
+				Args:                          args,
+				ExperimentalPrivilegedNesting: true,
+			}).
+			Stdout().Contents(ctx)
+		if err != nil {
+			return err
+		}
+		fmt.Println(output)
+		return nil
 	})
 }
 

--- a/internal/mage/sdk/go.go
+++ b/internal/mage/sdk/go.go
@@ -59,6 +59,7 @@ func (t Go) Test(ctx context.Context) error {
 			WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
 			WithWorkdir("sdk/go").
 			WithEnvVariable("DAGGER_HOST", "bin:///usr/bin/dagger-engine-session").
+			WithMountedDirectory("/root/.docker", util.HostDockerDir(c)).
 			Exec(dagger.ContainerExecOpts{
 				Args:                          []string{"go", "test", "-v", "./..."},
 				ExperimentalPrivilegedNesting: true,

--- a/internal/mage/sdk/go.go
+++ b/internal/mage/sdk/go.go
@@ -58,7 +58,6 @@ func (t Go) Test(ctx context.Context) error {
 		output, err := util.GoBase(c).
 			WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
 			WithWorkdir("sdk/go").
-			WithEnvVariable("DAGGER_HOST", "bin:///usr/bin/dagger-engine-session").
 			WithMountedDirectory("/root/.docker", util.HostDockerDir(c)).
 			Exec(dagger.ContainerExecOpts{
 				Args:                          []string{"go", "test", "-v", "./..."},
@@ -84,7 +83,6 @@ func (t Go) Generate(ctx context.Context) error {
 		generated, err := util.GoBase(c).
 			WithMountedFile("/usr/local/bin/cloak", util.DaggerBinary(c)).
 			WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
-			WithEnvVariable("DAGGER_HOST", "bin:///usr/bin/dagger-engine-session").
 			WithWorkdir("sdk/go").
 			Exec(dagger.ContainerExecOpts{
 				Args:                          []string{"go", "generate", "-v", "./..."},

--- a/internal/mage/sdk/go.go
+++ b/internal/mage/sdk/go.go
@@ -55,13 +55,18 @@ func (t Go) Test(ctx context.Context) error {
 	defer c.Close()
 
 	return util.WithDevEngine(ctx, c, func(ctx context.Context, c *dagger.Client) error {
-		_, err = util.GoBase(c).
+		output, err := util.GoBase(c).
+			WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
 			WithWorkdir("sdk/go").
+			WithEnvVariable("DAGGER_HOST", "bin:///usr/bin/dagger-engine-session").
 			Exec(dagger.ContainerExecOpts{
-				Args:                          []string{"go", "test", "-p", "16", "-v", "./..."},
+				Args:                          []string{"go", "test", "-v", "./..."},
 				ExperimentalPrivilegedNesting: true,
 			}).
-			ExitCode(ctx)
+			Stdout().Contents(ctx)
+		if err != nil {
+			err = fmt.Errorf("test failed: %w\n%s", err, output)
+		}
 		return err
 	})
 }
@@ -77,6 +82,8 @@ func (t Go) Generate(ctx context.Context) error {
 	return util.WithDevEngine(ctx, c, func(ctx context.Context, c *dagger.Client) error {
 		generated, err := util.GoBase(c).
 			WithMountedFile("/usr/local/bin/cloak", util.DaggerBinary(c)).
+			WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
+			WithEnvVariable("DAGGER_HOST", "bin:///usr/bin/dagger-engine-session").
 			WithWorkdir("sdk/go").
 			Exec(dagger.ContainerExecOpts{
 				Args:                          []string{"go", "generate", "-v", "./..."},

--- a/internal/mage/sdk/nodejs.go
+++ b/internal/mage/sdk/nodejs.go
@@ -30,6 +30,8 @@ func (t Nodejs) Lint(ctx context.Context) error {
 
 	return util.WithDevEngine(ctx, c, func(ctx context.Context, c *dagger.Client) error {
 		_, err = nodeJsBase(c).
+			WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
+			WithEnvVariable("DAGGER_HOST", "bin:///usr/bin/dagger-engine-session").
 			Exec(dagger.ContainerExecOpts{
 				Args:                          []string{"yarn", "lint"},
 				ExperimentalPrivilegedNesting: true,
@@ -56,6 +58,8 @@ func (t Nodejs) Test(ctx context.Context) error {
 
 	return util.WithDevEngine(ctx, c, func(ctx context.Context, c *dagger.Client) error {
 		_, err = nodeJsBase(c).
+			WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
+			WithEnvVariable("DAGGER_HOST", "bin:///usr/bin/dagger-engine-session").
 			Exec(dagger.ContainerExecOpts{
 				Args:                          []string{"yarn", "test"},
 				ExperimentalPrivilegedNesting: true,
@@ -76,6 +80,8 @@ func (t Nodejs) Generate(ctx context.Context) error {
 	return util.WithDevEngine(ctx, c, func(ctx context.Context, c *dagger.Client) error {
 		generated, err := util.GoBase(c).
 			WithMountedFile("/usr/local/bin/cloak", util.DaggerBinary(c)).
+			WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
+			WithEnvVariable("DAGGER_HOST", "bin:///usr/bin/dagger-engine-session").
 			Exec(dagger.ContainerExecOpts{
 				Args:                          []string{"cloak", "client-gen", "--lang", "nodejs", "-o", nodejsGeneratedAPIPath},
 				ExperimentalPrivilegedNesting: true,

--- a/internal/mage/sdk/nodejs.go
+++ b/internal/mage/sdk/nodejs.go
@@ -60,6 +60,7 @@ func (t Nodejs) Test(ctx context.Context) error {
 		_, err = nodeJsBase(c).
 			WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
 			WithEnvVariable("DAGGER_HOST", "bin:///usr/bin/dagger-engine-session").
+			WithMountedDirectory("/root/.docker", util.HostDockerDir(c)).
 			Exec(dagger.ContainerExecOpts{
 				Args:                          []string{"yarn", "test"},
 				ExperimentalPrivilegedNesting: true,

--- a/internal/mage/sdk/nodejs.go
+++ b/internal/mage/sdk/nodejs.go
@@ -31,7 +31,6 @@ func (t Nodejs) Lint(ctx context.Context) error {
 	return util.WithDevEngine(ctx, c, func(ctx context.Context, c *dagger.Client) error {
 		_, err = nodeJsBase(c).
 			WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
-			WithEnvVariable("DAGGER_HOST", "bin:///usr/bin/dagger-engine-session").
 			Exec(dagger.ContainerExecOpts{
 				Args:                          []string{"yarn", "lint"},
 				ExperimentalPrivilegedNesting: true,
@@ -59,7 +58,6 @@ func (t Nodejs) Test(ctx context.Context) error {
 	return util.WithDevEngine(ctx, c, func(ctx context.Context, c *dagger.Client) error {
 		_, err = nodeJsBase(c).
 			WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
-			WithEnvVariable("DAGGER_HOST", "bin:///usr/bin/dagger-engine-session").
 			WithMountedDirectory("/root/.docker", util.HostDockerDir(c)).
 			Exec(dagger.ContainerExecOpts{
 				Args:                          []string{"yarn", "test"},
@@ -82,7 +80,6 @@ func (t Nodejs) Generate(ctx context.Context) error {
 		generated, err := util.GoBase(c).
 			WithMountedFile("/usr/local/bin/cloak", util.DaggerBinary(c)).
 			WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
-			WithEnvVariable("DAGGER_HOST", "bin:///usr/bin/dagger-engine-session").
 			Exec(dagger.ContainerExecOpts{
 				Args:                          []string{"cloak", "client-gen", "--lang", "nodejs", "-o", nodejsGeneratedAPIPath},
 				ExperimentalPrivilegedNesting: true,

--- a/internal/mage/sdk/python.go
+++ b/internal/mage/sdk/python.go
@@ -63,6 +63,7 @@ func (t Python) Test(ctx context.Context) error {
 			test := pythonBase(c, version).
 				WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
 				WithEnvVariable("DAGGER_HOST", "bin:///usr/bin/dagger-engine-session").
+				WithMountedDirectory("/root/.docker", util.HostDockerDir(c)).
 				Exec(dagger.ContainerExecOpts{
 					Args:                          []string{"poe", "test"},
 					ExperimentalPrivilegedNesting: true,

--- a/internal/mage/sdk/python.go
+++ b/internal/mage/sdk/python.go
@@ -62,7 +62,6 @@ func (t Python) Test(ctx context.Context) error {
 		for _, version := range versions {
 			test := pythonBase(c, version).
 				WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
-				WithEnvVariable("DAGGER_HOST", "bin:///usr/bin/dagger-engine-session").
 				WithMountedDirectory("/root/.docker", util.HostDockerDir(c)).
 				Exec(dagger.ContainerExecOpts{
 					Args:                          []string{"poe", "test"},
@@ -89,7 +88,6 @@ func (t Python) Generate(ctx context.Context) error {
 	return util.WithDevEngine(ctx, c, func(ctx context.Context, c *dagger.Client) error {
 		generated := pythonBase(c, pythonDefaultVersion).
 			WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
-			WithEnvVariable("DAGGER_HOST", "bin:///usr/bin/dagger-engine-session").
 			Exec(dagger.ContainerExecOpts{
 				Args:                          []string{"poe", "generate"},
 				ExperimentalPrivilegedNesting: true,

--- a/internal/mage/sdk/python.go
+++ b/internal/mage/sdk/python.go
@@ -61,6 +61,8 @@ func (t Python) Test(ctx context.Context) error {
 
 		for _, version := range versions {
 			test := pythonBase(c, version).
+				WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
+				WithEnvVariable("DAGGER_HOST", "bin:///usr/bin/dagger-engine-session").
 				Exec(dagger.ContainerExecOpts{
 					Args:                          []string{"poe", "test"},
 					ExperimentalPrivilegedNesting: true,
@@ -85,6 +87,8 @@ func (t Python) Generate(ctx context.Context) error {
 
 	return util.WithDevEngine(ctx, c, func(ctx context.Context, c *dagger.Client) error {
 		generated := pythonBase(c, pythonDefaultVersion).
+			WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
+			WithEnvVariable("DAGGER_HOST", "bin:///usr/bin/dagger-engine-session").
 			Exec(dagger.ContainerExecOpts{
 				Args:                          []string{"poe", "generate"},
 				ExperimentalPrivilegedNesting: true,

--- a/internal/mage/util/util.go
+++ b/internal/mage/util/util.go
@@ -71,6 +71,10 @@ func GoBase(c *dagger.Client) *dagger.Container {
 
 	return c.Container().
 		From("golang:1.19-alpine").
+		Exec(dagger.ContainerExecOpts{
+			// gcc is needed to run go test -race https://github.com/golang/go/issues/9918 (???)
+			Args: []string{"apk", "add", "build-base"},
+		}).
 		WithEnvVariable("CGO_ENABLED", "0").
 		WithWorkdir("/app").
 		// run `go mod download` with only go.mod files (re-run only if mod files have changed)
@@ -89,6 +93,14 @@ func DaggerBinary(c *dagger.Client) *dagger.File {
 			Args: []string{"go", "build", "-o", "./bin/cloak", "-ldflags", "-s -w", "./cmd/cloak"},
 		}).
 		File("./bin/cloak")
+}
+
+func EngineSessionBinary(c *dagger.Client) *dagger.File {
+	return GoBase(c).
+		Exec(dagger.ContainerExecOpts{
+			Args: []string{"go", "build", "-o", "./bin/dagger-engine-session", "-ldflags", "-s -w", "./cmd/engine-session"},
+		}).
+		File("./bin/dagger-engine-session")
 }
 
 const (

--- a/internal/mage/util/util.go
+++ b/internal/mage/util/util.go
@@ -51,6 +51,7 @@ func RepositoryGoCodeOnly(c *dagger.Client) *dagger.Directory {
 			// misc
 			".golangci.yml",
 			"**/Dockerfile", // needed for shim TODO: just build shim directly
+			"**/README.md",  // needed for examples test
 		},
 	})
 }

--- a/internal/mage/util/util.go
+++ b/internal/mage/util/util.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -102,6 +103,19 @@ func EngineSessionBinary(c *dagger.Client) *dagger.File {
 			Args: []string{"go", "build", "-o", "./bin/dagger-engine-session", "-ldflags", "-s -w", "./cmd/engine-session"},
 		}).
 		File("./bin/dagger-engine-session")
+}
+
+// HostDockerCredentials returns the host's ~/.docker dir if it exists, otherwise just an empty dir
+func HostDockerDir(c *dagger.Client) *dagger.Directory {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return c.Directory()
+	}
+	path := filepath.Join(home, ".docker")
+	if _, err := os.Stat(path); err != nil {
+		return c.Directory()
+	}
+	return c.Host().Directory(path)
 }
 
 const (

--- a/project/project.go
+++ b/project/project.go
@@ -30,6 +30,9 @@ const (
 
 	outputMountPath = "/outputs"
 	outputFile      = "/dagger.json"
+
+	SessionProxySockName = "dagger-session"
+	sessionProxySockPath = "/dagger.sock"
 )
 
 type State struct {
@@ -318,17 +321,16 @@ func (p *State) resolver(runtimeFS *core.Directory, sdk string, gw bkgw.Client, 
 
 		st := fsState.Run(
 			llb.Args([]string{entrypointPath}),
-			llb.AddEnv("DAGGER_HOST", "unix:///dagger.sock"),
+			llb.AddEnv("DAGGER_HOST", "unix://"+sessionProxySockPath),
 			llb.AddSSHSocket(
-				llb.SSHID(core.DaggerSockName),
-				llb.SSHSocketTarget(core.DaggerSockPath),
+				llb.SSHID(SessionProxySockName),
+				llb.SSHSocketTarget(sessionProxySockPath),
 			),
 			llb.AddMount(inputMountPath, input, llb.Readonly),
 			llb.AddMount(tmpMountPath, llb.Scratch(), llb.Tmpfs()),
 			llb.ReadonlyRootFS(),
 		)
 
-		// TODO:
 		if sdk == "go" {
 			st.AddMount("/src", wdState, llb.Readonly) // TODO: not actually needed here, just makes go server code easier at moment
 		}

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -7,7 +7,8 @@ import (
 	"os"
 
 	"dagger.io/dagger/internal/engineconn"
-	_ "dagger.io/dagger/internal/engineconn/dockerprovision" // provision engine in docker
+	_ "dagger.io/dagger/internal/engineconn/bin"             // invoke engine-session binary
+	_ "dagger.io/dagger/internal/engineconn/dockerprovision" // provision engine-session from docker
 	_ "dagger.io/dagger/internal/engineconn/http"            // http connection
 	_ "dagger.io/dagger/internal/engineconn/unix"            // unix connection
 	"dagger.io/dagger/internal/querybuilder"

--- a/sdk/go/internal/engineconn/bin/bin.go
+++ b/sdk/go/internal/engineconn/bin/bin.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -26,21 +25,11 @@ func New(u *url.URL) (engineconn.EngineConn, error) {
 	path := u.Host + u.Path
 	var err error
 	if path == "" {
-		path, err = exec.LookPath("dagger-engine-session")
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		path, err = filepath.Abs(path)
-		if err != nil {
-			return nil, err
-		}
-		// check that it's executable
-		if stat, err := os.Stat(path); err != nil {
-			return nil, err
-		} else if stat.Mode()&0111 == 0 {
-			return nil, fmt.Errorf("%q is not executable", path)
-		}
+		path = "dagger-engine-session"
+	}
+	path, err = exec.LookPath(path)
+	if err != nil {
+		return nil, err
 	}
 
 	return &Bin{

--- a/sdk/go/internal/engineconn/bin/bin.go
+++ b/sdk/go/internal/engineconn/bin/bin.go
@@ -1,0 +1,179 @@
+package bin
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"dagger.io/dagger/internal/engineconn"
+)
+
+func init() {
+	engineconn.Register("bin", New)
+}
+
+func New(u *url.URL) (engineconn.EngineConn, error) {
+	path := u.Host + u.Path
+	var err error
+	if path == "" {
+		path, err = exec.LookPath("dagger-engine-session")
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		path, err = filepath.Abs(path)
+		if err != nil {
+			return nil, err
+		}
+		// check that it's executable
+		if stat, err := os.Stat(path); err != nil {
+			return nil, err
+		} else if stat.Mode()&0111 == 0 {
+			return nil, fmt.Errorf("%q is not executable", path)
+		}
+	}
+
+	return &Bin{
+		path: path,
+	}, nil
+}
+
+type Bin struct {
+	path       string
+	childStdin io.Closer
+}
+
+func (c *Bin) Connect(ctx context.Context, cfg *engineconn.Config) (*http.Client, error) {
+	args := []string{}
+	if cfg.Workdir != "" {
+		args = append(args, "--workdir", cfg.Workdir)
+	}
+	if cfg.ConfigPath != "" {
+		args = append(args, "--project", cfg.ConfigPath)
+	}
+
+	addr, childStdin, err := StartEngineSession(ctx, cfg.LogOutput, c.path, args...)
+	if err != nil {
+		return nil, err
+	}
+	c.childStdin = childStdin
+
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("tcp", addr)
+			},
+		},
+	}, nil
+}
+
+func (c *Bin) Addr() string {
+	return "http://dagger"
+}
+
+func (c *Bin) Close() error {
+	if c.childStdin != nil {
+		return c.childStdin.Close()
+	}
+	return nil
+}
+
+func StartEngineSession(ctx context.Context, stderr io.Writer, cmd string, args ...string) (string, io.Closer, error) {
+	// Workaround https://github.com/golang/go/issues/22315
+	// Basically, if any other code in this process does fork/exec, it may
+	// temporarily have the tmpbin fd that we closed earlier open still, and it
+	// will be open for writing. Even though we rename the file, the
+	// underlying inode is the same and thus we can get a "text file busy"
+	// error when trying to exec it below.
+	//
+	// We workaround this the same way suggested in the issue, by sleeping
+	// and retrying the exec a few times. This is such an obscure case that
+	// this retry approach should be fine. It can only happen when a new
+	// engine-session binary needs to be created and even then only if many
+	// threads within this process are trying to provision it at the same time.
+
+	var proc *exec.Cmd
+	var stdout io.ReadCloser
+	var childStdin io.WriteCloser
+	for i := 0; i < 10; i++ {
+		proc = exec.CommandContext(ctx, cmd, args...)
+		proc.Env = os.Environ()
+		proc.Stderr = stderr
+		setPlatformOpts(proc)
+
+		var err error
+		stdout, err = proc.StdoutPipe()
+		if err != nil {
+			return "", nil, err
+		}
+		defer stdout.Close() // don't need it after we read the port
+
+		// Open a stdin pipe with the child process. The engine-session shutsdown
+		// when it is closed. This is a platform-agnostic way of ensuring
+		// we don't leak child processes even if this process is SIGKILL'd.
+		childStdin, err = proc.StdinPipe()
+		if err != nil {
+			return "", nil, err
+		}
+
+		if err := proc.Start(); err != nil {
+			if strings.Contains(err.Error(), "text file busy") {
+				time.Sleep(100 * time.Millisecond)
+				proc = nil
+				stdout.Close()
+				stdout = nil
+				childStdin.Close()
+				childStdin = nil
+				continue
+			}
+			return "", nil, err
+		}
+		break
+	}
+	if proc == nil {
+		return "", nil, fmt.Errorf("failed to start engine session")
+	}
+
+	// Read the port to connect to from the engine-session's stdout.
+	portCh := make(chan string, 1)
+	var portErr error
+	go func() {
+		defer close(portCh)
+		portStr, err := bufio.NewReader(stdout).ReadString('\n')
+		if err != nil {
+			portErr = err
+			return
+		}
+		portCh <- portStr
+	}()
+
+	ctx, cancel := context.WithTimeout(ctx, 300*time.Second) // really long time to account for extensions that need to build, though that path should be optimized in future
+	defer cancel()
+	var port int
+	select {
+	case portStr := <-portCh:
+		if portErr != nil {
+			return "", nil, portErr
+		}
+		portStr = strings.TrimSpace(portStr)
+		var err error
+		port, err = strconv.Atoi(portStr)
+		if err != nil {
+			return "", nil, err
+		}
+	case <-ctx.Done():
+		return "", nil, ctx.Err()
+	}
+
+	return fmt.Sprintf("localhost:%d", port), childStdin, nil
+}

--- a/sdk/go/internal/engineconn/bin/bin_linux.go
+++ b/sdk/go/internal/engineconn/bin/bin_linux.go
@@ -1,6 +1,6 @@
 //go:build linux
 
-package dockerprovision
+package bin
 
 import (
 	"os/exec"

--- a/sdk/go/internal/engineconn/bin/bin_nolinux.go
+++ b/sdk/go/internal/engineconn/bin/bin_nolinux.go
@@ -1,6 +1,6 @@
 //go:build !linux
 
-package dockerprovision
+package bin
 
 import (
 	"os/exec"

--- a/sdk/go/internal/engineconn/dockerprovision/container.go
+++ b/sdk/go/internal/engineconn/dockerprovision/container.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 
 	"dagger.io/dagger/internal/engineconn"
+	"dagger.io/dagger/internal/engineconn/bin"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	exec "golang.org/x/sys/execabs"
@@ -76,7 +77,7 @@ func (c *DockerContainer) Connect(ctx context.Context, cfg *engineconn.Config) (
 		args = append(args, "--project", cfg.ConfigPath)
 	}
 
-	addr, childStdin, err := startEngineSession(ctx, cfg.LogOutput, tmpbin.Name(), args...)
+	addr, childStdin, err := bin.StartEngineSession(ctx, cfg.LogOutput, tmpbin.Name(), args...)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/internal/engineconn/dockerprovision/dockerprovision.go
+++ b/sdk/go/internal/engineconn/dockerprovision/dockerprovision.go
@@ -1,17 +1,7 @@
 package dockerprovision
 
 import (
-	"bufio"
-	"context"
-	"fmt"
-	"io"
-	"os"
-	"strconv"
-	"strings"
-	"time"
-
 	"dagger.io/dagger/internal/engineconn"
-	exec "golang.org/x/sys/execabs"
 )
 
 const (
@@ -31,93 +21,3 @@ const (
 	engineSessionBinPrefix          = "dagger-engine-session-"
 	containerEngineSessionBinPrefix = "/usr/bin/" + engineSessionBinPrefix
 )
-
-func startEngineSession(ctx context.Context, stderr io.Writer, cmd string, args ...string) (string, io.Closer, error) {
-	// Workaround https://github.com/golang/go/issues/22315
-	// Basically, if any other code in this process does fork/exec, it may
-	// temporarily have the tmpbin fd that we closed earlier open still, and it
-	// will be open for writing. Even though we rename the file, the
-	// underlying inode is the same and thus we can get a "text file busy"
-	// error when trying to exec it below.
-	//
-	// We workaround this the same way suggested in the issue, by sleeping
-	// and retrying the exec a few times. This is such an obscure case that
-	// this retry approach should be fine. It can only happen when a new
-	// engine-session binary needs to be created and even then only if many
-	// threads within this process are trying to provision it at the same time.
-
-	var proc *exec.Cmd
-	var stdout io.ReadCloser
-	var childStdin io.WriteCloser
-	for i := 0; i < 10; i++ {
-		proc = exec.CommandContext(ctx, cmd, args...)
-		proc.Env = os.Environ()
-		proc.Stderr = stderr
-		setPlatformOpts(proc)
-
-		var err error
-		stdout, err = proc.StdoutPipe()
-		if err != nil {
-			return "", nil, err
-		}
-		defer stdout.Close() // don't need it after we read the port
-
-		// Open a stdin pipe with the child process. The engine-session shutsdown
-		// when it is closed. This is a platform-agnostic way of ensuring
-		// we don't leak child processes even if this process is SIGKILL'd.
-		childStdin, err = proc.StdinPipe()
-		if err != nil {
-			return "", nil, err
-		}
-
-		if err := proc.Start(); err != nil {
-			if strings.Contains(err.Error(), "text file busy") {
-				time.Sleep(100 * time.Millisecond)
-				proc = nil
-				stdout.Close()
-				stdout = nil
-				childStdin.Close()
-				childStdin = nil
-				continue
-			}
-			return "", nil, err
-		}
-		break
-	}
-	if proc == nil {
-		return "", nil, fmt.Errorf("failed to start engine session")
-	}
-
-	// Read the port to connect to from the engine-session's stdout.
-	portCh := make(chan string, 1)
-	var portErr error
-	go func() {
-		defer close(portCh)
-		portStr, err := bufio.NewReader(stdout).ReadString('\n')
-		if err != nil {
-			portErr = err
-			return
-		}
-		portCh <- portStr
-	}()
-
-	ctx, cancel := context.WithTimeout(ctx, 300*time.Second) // really long time to account for extensions that need to build, though that path should be optimized in future
-	defer cancel()
-	var port int
-	select {
-	case portStr := <-portCh:
-		if portErr != nil {
-			return "", nil, portErr
-		}
-		portStr = strings.TrimSpace(portStr)
-		var err error
-		port, err = strconv.Atoi(portStr)
-		if err != nil {
-			return "", nil, err
-		}
-	case <-ctx.Done():
-		return "", nil, ctx.Err()
-	}
-
-	return fmt.Sprintf("localhost:%d", port), childStdin, nil
-}

--- a/sdk/go/internal/engineconn/dockerprovision/image.go
+++ b/sdk/go/internal/engineconn/dockerprovision/image.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"dagger.io/dagger/internal/engineconn"
+	"dagger.io/dagger/internal/engineconn/bin"
 	"github.com/adrg/xdg"
 	"github.com/opencontainers/go-digest"
 	exec "golang.org/x/sys/execabs"
@@ -132,7 +133,7 @@ func (c *DockerImage) Connect(ctx context.Context, cfg *engineconn.Config) (*htt
 		args = append(args, "--project", cfg.ConfigPath)
 	}
 
-	addr, childStdin, err := startEngineSession(ctx, cfg.LogOutput, engineSessionBinPath, args...)
+	addr, childStdin, err := bin.StartEngineSession(ctx, cfg.LogOutput, engineSessionBinPath, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/internal/engineconn/unix/unix.go
+++ b/sdk/go/internal/engineconn/unix/unix.go
@@ -16,12 +16,12 @@ func init() {
 var _ engineconn.EngineConn = &Unix{}
 
 type Unix struct {
-	path string
+	u *url.URL
 }
 
 func New(u *url.URL) (engineconn.EngineConn, error) {
 	return &Unix{
-		path: u.Path,
+		u: u,
 	}, nil
 }
 
@@ -30,20 +30,10 @@ func (c *Unix) Addr() string {
 }
 
 func (c *Unix) Connect(ctx context.Context, cfg *engineconn.Config) (*http.Client, error) {
-	// FIXME: These are necessary for dagger-in-dagger but do not work.
-	// if cfg.Workdir != "" {
-	// 	return nil, errors.New("workdir not supported on unix hosts")
-	// }
-	// if cfg.ConfigPath != "" {
-	// 	return nil, errors.New("config path not supported on unix hosts")
-	// }
-	// if cfg.NoExtensions {
-	// 	return nil, errors.New("no extensions is not supported on unix hosts")
-	// }
 	return &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-				return net.Dial("unix", c.path)
+				return net.Dial("unix", c.u.Host+c.u.Path)
 			},
 		},
 	}, nil

--- a/sdk/nodejs/provisioning/bin/bin.ts
+++ b/sdk/nodejs/provisioning/bin/bin.ts
@@ -1,0 +1,90 @@
+import { ConnectOpts, EngineConn } from "../engineconn.js"
+import readline from "readline"
+import { execaCommand, ExecaChildProcess } from "execa"
+import Client from "../../api/client.gen.js"
+
+/**
+ * Bin runs an engine session from a specified binary
+ */
+export class Bin implements EngineConn {
+  private subProcess?: ExecaChildProcess
+
+  private path: string
+
+  constructor(u: URL) {
+    this.path = u.host + u.pathname
+    if (this.path == "") {
+      // TODO: support finding in $PATH
+      // the "which" module looks good but is incompatible w/ our node version
+      // the "command-exists" module is compatible but implemented by shelling out... :-(
+      throw new Error("no engine session binary specified")
+    }
+  }
+
+  Addr(): string {
+    return "http://dagger"
+  }
+
+  async Connect(opts: ConnectOpts): Promise<Client> {
+    return this.runEngineSession(this.path, opts)
+  }
+
+  /**
+   * runEngineSession execute the engine binary and set up a GraphQL client that
+   * target this engine.
+   * TODO:(sipsma) dedupe this with equivalent code in image.ts
+   */
+  private async runEngineSession(
+    engineSessionBinPath: string,
+    opts: ConnectOpts
+  ): Promise<Client> {
+    const engineSessionArgs = [engineSessionBinPath]
+
+    if (opts.Workdir) {
+      engineSessionArgs.push("--workdir", opts.Workdir)
+    }
+    if (opts.Project) {
+      engineSessionArgs.push("--project", opts.Project)
+    }
+
+    this.subProcess = execaCommand(engineSessionArgs.join(" "), {
+      stderr: opts.LogOutput || "ignore",
+
+      // Kill the process if parent exit.
+      cleanup: true,
+    })
+
+    const stdoutReader = readline.createInterface({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      input: this.subProcess.stdout!,
+    })
+
+    const port = await Promise.race([
+      this.readPort(stdoutReader),
+      new Promise((_, reject) => {
+        setTimeout(() => {
+          reject(new Error("timeout reading port from engine session"))
+        }, 300000).unref() // long timeout to account for extensions, though that should be optimized in future
+      }),
+    ])
+
+    return new Client({ host: `127.0.0.1:${port}` })
+  }
+
+  private async readPort(stdoutReader: readline.Interface): Promise<number> {
+    for await (const line of stdoutReader) {
+      // Read line as a port number
+      const port = parseInt(line)
+      return port
+    }
+    throw new Error("failed to read port from engine session")
+  }
+
+  async Close(): Promise<void> {
+    if (this.subProcess?.pid) {
+      this.subProcess.kill("SIGTERM", {
+        forceKillAfterTimeout: 2000,
+      })
+    }
+  }
+}

--- a/sdk/nodejs/provisioning/bin/bin.ts
+++ b/sdk/nodejs/provisioning/bin/bin.ts
@@ -14,10 +14,8 @@ export class Bin implements EngineConn {
   constructor(u: URL) {
     this.path = u.host + u.pathname
     if (this.path == "") {
-      // TODO: support finding in $PATH
-      // the "which" module looks good but is incompatible w/ our node version
-      // the "command-exists" module is compatible but implemented by shelling out... :-(
-      throw new Error("no engine session binary specified")
+      // this results in execa looking for it in the $PATH
+      this.path = "dagger-engine-session"
     }
   }
 

--- a/sdk/nodejs/provisioning/bin/index.ts
+++ b/sdk/nodejs/provisioning/bin/index.ts
@@ -1,0 +1,1 @@
+export * from "./bin.js"

--- a/sdk/nodejs/provisioning/provisioner.ts
+++ b/sdk/nodejs/provisioning/provisioner.ts
@@ -1,12 +1,14 @@
 import { EngineConn } from "./engineconn.js"
 import { DockerImage } from "./docker-provision/image.js"
 import { HTTP } from "./http/http.js"
+import { Bin } from "./bin/bin.js"
 
 type ProvisionerFunc = (u: URL) => EngineConn
 
 const provisioners: Record<string, ProvisionerFunc> = {
   "docker-image": (u: URL) => new DockerImage(u),
   http: (u: URL) => new HTTP(u),
+  bin: (u: URL) => new Bin(u),
 }
 
 /**

--- a/sdk/python/src/dagger/cli.py
+++ b/sdk/python/src/dagger/cli.py
@@ -6,7 +6,8 @@ import typer
 
 from dagger import codegen
 from dagger.connectors import Config, get_connector
-from dagger.connectors.docker import Engine
+from dagger.connectors.bin import Engine
+from dagger.connectors.docker import EngineFromImage
 
 app = typer.Typer()
 
@@ -32,6 +33,9 @@ def generate(
     cfg = Config()
 
     if cfg.host.scheme == "docker-image":
+        with EngineFromImage(cfg) as engine:
+            code = generate_code(engine.cfg, sync)
+    elif cfg.host.scheme == "bin":
         with Engine(cfg) as engine:
             code = generate_code(engine.cfg, sync)
     else:

--- a/sdk/python/src/dagger/connectors/__init__.py
+++ b/sdk/python/src/dagger/connectors/__init__.py
@@ -1,4 +1,4 @@
-from . import docker, http  # noqa
+from . import bin, docker, http  # noqa
 from .base import Config, Connector, get_connector, register_connector
 
 __all__ = [

--- a/sdk/python/src/dagger/connectors/bin.py
+++ b/sdk/python/src/dagger/connectors/bin.py
@@ -1,0 +1,148 @@
+import logging
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import anyio
+from attrs import Factory, define, field
+
+from dagger import Client
+from dagger.exceptions import DaggerException
+
+from .base import Config, register_connector
+from .http import HTTPConnector
+
+logger = logging.getLogger(__name__)
+
+
+@define
+class Engine:
+    cfg: Config
+
+    _proc: subprocess.Popen | None = field(default=None, init=False)
+
+    def start(self) -> None:
+        hostname = self.cfg.host.hostname
+        if hostname is None:
+            hostname = ""
+        engine_session_bin_path = hostname + self.cfg.host.path
+        if engine_session_bin_path == "":
+            engine_session_bin_path = shutil.which("dagger-engine-session")
+
+        self._start([engine_session_bin_path])
+
+    def _start(self, base_args) -> None:
+        if self.cfg.workdir:
+            base_args.extend(["--workdir", str(Path(self.cfg.workdir).absolute())])
+        if self.cfg.config_path:
+            base_args.extend(["--project", str(Path(self.cfg.config_path).absolute())])
+
+        # Retry starting if "text file busy" error is hit. That error can happen
+        # due to a flaw in how Linux works: if any fork of this process happens
+        # while the temp binary file is open for writing, a child process can
+        # still have it open for writing before it calls exec.
+        # See this golang issue (which itself links to bug reports in other
+        # langs and the kernel): https://github.com/golang/go/issues/22315
+        # Unfortunately, this sort of retry loop is the best workaround. The
+        # case is obscure enough that it should not be hit very often at all.
+        for _ in range(10):
+            try:
+                self._proc = subprocess.Popen(
+                    base_args,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=self.cfg.log_output or subprocess.PIPE,
+                    encoding="utf-8",
+                )
+            except OSError as e:
+                # 26 is ETXTBSY
+                if e.errno == 26:
+                    time.sleep(0.1)
+                else:
+                    raise ProvisionError(f"Failed to start engine session: {e}") from e
+            except Exception as e:
+                raise ProvisionError(f"Failed to start engine session: {e}") from e
+            else:
+                break
+        else:
+            raise ProvisionError("Failed to start engine session after retries.")
+
+        try:
+            # read port number from first line of stdout
+            port = int(self._proc.stdout.readline())
+        except ValueError as e:
+            # Check if the subprocess exited with an error.
+            if not self._proc.poll():
+                raise e
+
+            # FIXME: Duplicate writes into a buffer until end of provisioning
+            # instead of reading directly from what the user may set in `log_output`
+            if self._proc.stderr is not None and self._proc.stderr.readable():
+                raise ProvisionError(
+                    f"Dagger engine failed to start: {self._proc.stderr.readline()}"
+                ) from e
+
+            raise ProvisionError(
+                "Dagger engine failed to start, is docker running?"
+            ) from e
+
+        # TODO: verify port number is valid
+        self.cfg.host = f"http://localhost:{port}"
+
+    def is_running(self) -> bool:
+        return self._proc is not None
+
+    def stop(self, exc_type) -> None:
+        if not self.is_running():
+            return
+        self._proc.__exit__(exc_type, None, None)
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, *args, **kwargs):
+        self.stop(exc_type)
+
+
+@register_connector("bin")
+@define
+class BinConnector(HTTPConnector):
+    """Start engine session from a specified binary"""
+
+    engine: Engine = Factory(lambda self: Engine(self.cfg), takes_self=True)
+
+    @property
+    def query_url(self) -> str:
+        return f"{self.cfg.host.geturl()}/query"
+
+    async def connect(self) -> Client:
+        # FIXME: Create proper async provisioning later.
+        # This is just to support sync faster.
+        await anyio.to_thread.run_sync(self.provision_sync)
+        return await super().connect()
+
+    async def close(self, exc_type) -> None:
+        # FIXME: need exit stack?
+        await super().close(exc_type)
+        if self.engine.is_running():
+            await anyio.to_thread.run_sync(self.engine.stop, exc_type)
+
+    def connect_sync(self) -> Client:
+        self.provision_sync()
+        return super().connect_sync()
+
+    def provision_sync(self) -> None:
+        # FIXME: handle cancellation, retries and timeout
+        # FIXME: handle errors during provisioning
+        self.engine.start()
+
+    def close_sync(self, exc_type) -> None:
+        # FIXME: need exit stack?
+        super().close_sync(exc_type)
+        self.engine.stop(exc_type)
+
+
+class ProvisionError(DaggerException):
+    """Error while provisioning the Dagger engine."""

--- a/sdk/python/src/dagger/connectors/bin.py
+++ b/sdk/python/src/dagger/connectors/bin.py
@@ -28,7 +28,10 @@ class Engine:
             hostname = ""
         engine_session_bin_path = hostname + self.cfg.host.path
         if engine_session_bin_path == "":
-            engine_session_bin_path = shutil.which("dagger-engine-session")
+            engine_session_bin_path = "dagger-engine-session"
+        engine_session_bin_path = shutil.which("dagger-engine-session")
+        if engine_session_bin_path is None:
+            raise DaggerException("Could not find dagger-engine-session executable")
 
         self._start([engine_session_bin_path])
 

--- a/sdk/python/src/dagger/connectors/docker.py
+++ b/sdk/python/src/dagger/connectors/docker.py
@@ -3,7 +3,6 @@ import os
 import platform
 import subprocess
 import tempfile
-import time
 from pathlib import Path
 
 from attrs import Factory, define, field
@@ -122,23 +121,9 @@ class EngineFromImage(Engine):
                 if bin != engine_session_bin_path:
                     bin.unlink()
 
-        remote = f"docker-image://{image.ref}"
-        self._start([engine_session_bin_path, "--remote", remote])
-
-    def is_running(self) -> bool:
-        return self._proc is not None
-
-    def stop(self, exc_type) -> None:
-        if not self.is_running():
-            return
-        self._proc.__exit__(exc_type, None, None)
-
-    def __enter__(self):
-        self.start()
-        return self
-
-    def __exit__(self, exc_type, *args, **kwargs):
-        self.stop(exc_type)
+        self._start(
+            [engine_session_bin_path, "--remote", f"docker-image://{image.ref}"]
+        )
 
 
 @register_connector("docker-image")

--- a/sdk/python/src/dagger/connectors/docker.py
+++ b/sdk/python/src/dagger/connectors/docker.py
@@ -6,14 +6,10 @@ import tempfile
 import time
 from pathlib import Path
 
-import anyio
 from attrs import Factory, define, field
 
-from dagger import Client
-from dagger.exceptions import DaggerException
-
 from .base import Config, register_connector
-from .http import HTTPConnector
+from .bin import BinConnector, Engine, ProvisionError
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +46,7 @@ class ImageRef:
 
 
 @define
-class Engine:
+class EngineFromImage(Engine):
     cfg: Config
 
     _proc: subprocess.Popen | None = field(default=None, init=False)
@@ -127,68 +123,7 @@ class Engine:
                     bin.unlink()
 
         remote = f"docker-image://{image.ref}"
-
-        engine_session_args = [engine_session_bin_path, "--remote", remote]
-        if self.cfg.workdir:
-            engine_session_args.extend(
-                ["--workdir", str(Path(self.cfg.workdir).absolute())]
-            )
-        if self.cfg.config_path:
-            engine_session_args.extend(
-                ["--project", str(Path(self.cfg.config_path).absolute())]
-            )
-
-        # Retry starting if "text file busy" error is hit. That error can happen
-        # due to a flaw in how Linux works: if any fork of this process happens
-        # while the temp binary file is open for writing, a child process can
-        # still have it open for writing before it calls exec.
-        # See this golang issue (which itself links to bug reports in other
-        # langs and the kernel): https://github.com/golang/go/issues/22315
-        # Unfortunately, this sort of retry loop is the best workaround. The
-        # case is obscure enough that it should not be hit very often at all.
-        for _ in range(10):
-            try:
-                self._proc = subprocess.Popen(
-                    engine_session_args,
-                    stdin=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    stderr=self.cfg.log_output or subprocess.PIPE,
-                    encoding="utf-8",
-                )
-            except OSError as e:
-                # 26 is ETXTBSY
-                if e.errno == 26:
-                    time.sleep(0.1)
-                else:
-                    raise ProvisionError(f"Failed to start engine session: {e}") from e
-            except Exception as e:
-                raise ProvisionError(f"Failed to start engine session: {e}") from e
-            else:
-                break
-        else:
-            raise ProvisionError("Failed to start engine session after retries.")
-
-        try:
-            # read port number from first line of stdout
-            port = int(self._proc.stdout.readline())
-        except ValueError as e:
-            # Check if the subprocess exited with an error.
-            if not self._proc.poll():
-                raise e
-
-            # FIXME: Duplicate writes into a buffer until end of provisioning
-            # instead of reading directly from what the user may set in `log_output`
-            if self._proc.stderr is not None and self._proc.stderr.readable():
-                raise ProvisionError(
-                    f"Dagger engine failed to start: {self._proc.stderr.readline()}"
-                ) from e
-
-            raise ProvisionError(
-                "Dagger engine failed to start, is docker running?"
-            ) from e
-
-        # TODO: verify port number is valid
-        self.cfg.host = f"http://localhost:{port}"
+        self._start([engine_session_bin_path, "--remote", remote])
 
     def is_running(self) -> bool:
         return self._proc is not None
@@ -208,41 +143,9 @@ class Engine:
 
 @register_connector("docker-image")
 @define
-class DockerConnector(HTTPConnector):
+class DockerConnector(BinConnector):
     """Provision dagger engine from an image with docker"""
 
-    engine: Engine = Factory(lambda self: Engine(self.cfg), takes_self=True)
-
-    @property
-    def query_url(self) -> str:
-        return f"{self.cfg.host.geturl()}/query"
-
-    async def connect(self) -> Client:
-        # FIXME: Create proper async provisioning later.
-        # This is just to support sync faster.
-        await anyio.to_thread.run_sync(self.provision_sync)
-        return await super().connect()
-
-    async def close(self, exc_type) -> None:
-        # FIXME: need exit stack?
-        await super().close(exc_type)
-        if self.engine.is_running():
-            await anyio.to_thread.run_sync(self.engine.stop, exc_type)
-
-    def connect_sync(self) -> Client:
-        self.provision_sync()
-        return super().connect_sync()
-
-    def provision_sync(self) -> None:
-        # FIXME: handle cancellation, retries and timeout
-        # FIXME: handle errors during provisioning
-        self.engine.start()
-
-    def close_sync(self, exc_type) -> None:
-        # FIXME: need exit stack?
-        super().close_sync(exc_type)
-        self.engine.stop(exc_type)
-
-
-class ProvisionError(DaggerException):
-    """Error while provisioning the Dagger engine."""
+    engine: EngineFromImage = Factory(
+        lambda self: EngineFromImage(self.cfg), takes_self=True
+    )


### PR DESCRIPTION
Signed-off-by: Erik Sipsma <erik@sipsma.dev>

## Goal
Get engine session nesting fully working, which enables tests of dagger-in-dagger that involve local dirs. Now, when running dagger-in-dagger a new engine session is started up (the same as when outside dagger) and local directories refer to directories local to the container (not the host).

**Pros:**
1. Dagger-in-dagger works fully, including localdir stuff.
3. Dagger-in-dagger is actually safe-ish now? It's no longer directly possible for an exec using dagger-in-dagger to access host resources
   * There are still roundabout ways that they might be able to do this due to the fact that buildkitd internally has a bunch of codepaths that will try "any connected session", however that's an independent issue we were always going to need to solve anyways; the previous problem of local dirs going back to the host is solved by this I think.
4. This gets rid of the need for the shim to setup localhost->unix proxying because we can just re-use `engine-session`'s ability to do that already.
   * I honestly wonder if `shim` and `engine-session` could become the same thing... but that might be too far
   * That could make sense though... every exec has a shim mounted in anyways, why not just make that be `engine-session` too? 
5. I *think* this might answer a **ton** of questions about extensions.
   * E.g. if extensions re-use this mechanism, then they might already have isolated schemas rather than a global one

**Cons**
1. Directly exposes buildkitd API
   * **However**, I actually don't think this is inherent at all. We wanted to wrap buildkitd anyways, so once we do that, we can just replace all occurrences of "buildkit" above with "dagger-runner" and no longer directly expose APIs we don't have direct control over.
1. Goes further down the path of reliance on a local engine-session bin
   * We're already kind of going down that path though

## Outline of solution

1. `ExperimentalPrivilegedNesting` now results in the exposed API socket providing the runner API (aka buildkit api for now) instead of an endpoint to the current session.
1. Dagger-in-dagger now requires the engine session binary be present. When present, it can be used by sdks via the new `bin://` engineconn, which can point to an existing binary (or if `bin://` is empty, $PATH will be searched for `dagger-engine-session`)
   * **Ugliness**: The engine-session binary is not provided out of the box when `ExperimentalPrivilegedNesting` is set.  It has to be provided by the user right now and put somewhere in the PATH.
      * I wanted to just have our code mount in the engine session binary from the engine image, but I realized that's much easier said than done right now. We need to solve that problem for a bunch of reasons, but I'm making a follow up issue for it, not practical for this PR.
   * **Ugliness**: When you provide `bin://` as the engineconn, the engine-session binary still needs to be told where the runner it should connect to is (default provisioner obviously doesn't work). This is done through a new env var `DAGGER_RUNNER_HOST` (which is essentially like `BUILDKIT_HOST` as of now)
      * This is *highly* specific to our test case needs. In the longer run, I suspect that we'll actually be able to just make the shim do the equivalent of `dagger exec` and wrap all the processes in the exec in a single session.
      * Our test cases however need to each run in separate sessions, in which case `bin://` will still need to be used and we will still need to be able to tell the invoked binary that it should find the runner api at `unix:///dagger-runner.sock`.
      * `DAGGER_RUNNER_HOST` may thus be a long-term feature, but it should *only* be needed for our test cases; users in general should not need to learn about it or use it.
1. I managed to get extensions to continue working too
   * **Ugliness**: they work by essentially just retaining the old behavior where `/dagger.sock` is just an endpoint to the current session.
   * There's thus two different socket session providers now: `RunnerProxy` is used for Execs w/ `ExperimentalPrivilegedNesting` enabled and `SessionProxy` is used when running extensions
   * The only reason for this is that updating extensions to have the `engine-session` binary automatically mounted in is too much work for this PR. Once that is possible, then extensions can just update to use the new SDKs and should be good to go.

### Path to cleaning up remaining ugliness
1. We should merge the engine session functionality into the shim and make the shim essentially just do the equivalent of `dagger exec` when nested dagger is enabled.
   * This will eliminate the requirement that `dagger-engine-session` binary be mounted into these execs by the user
2. If we also use the shim in extensions, we will fix the weirdness there and there can just be one `/dagger.sock` (RunnerProxy) rather than the current split where theres both `RunnerProxy` for execs and `SessionProxy` for extensions.

## Remaining TODOs for this PR
- [x] I've gotten a few ephemeral failures of `TestPlatformCrossCompile`. It's not clear whether/how this could be related to the changes here, but it's happened maybe 1-in-5 engine test runs, so it's too flaky to ignore. Need to look into it more