### PR TITLE
Update GraphQL playground template

### DIFF
--- a/router/internal/playground/playground.go
+++ b/router/internal/playground/playground.go
@@ -80,16 +80,14 @@ var page = template.Must(template.New("graphiql").Parse(`
 #
 #    Auto Complete:  Ctrl-Space (or just start typing)
 #
-# Here's a simple query to get you started, for more information visit
-# https:\/\/github.com/dagger/dagger/blob/cloak/docs/unxpq-introduction.md
+# Here's a simple query to get you started
 {
-  core {
-    image(ref: "alpine") {
-      exec(input: {args: ["apk", "add", "curl"]}){
-        fs {
-          exec(input: {args: ["curl", "https://dagger.io"]}) {
-            stdout(lines: 1)
-          }
+	container(id: "", platform: "linux"){
+  	from(address: "alpine") {
+      exec(args: ["echo", "hello dagger"]){
+        exitCode
+        stdout{
+          contents
         }
       }
     }


### PR DESCRIPTION
The GraphQL playground example is broken as a number of fields i.e core no longer exist. I've updated it to use a different example and removed a dead link referencing cloak.  