### PR TITLE
ci: Do not bump SDK Engine Deps on push to main

### DIFF
--- a/.github/workflows/publish-engine.yml
+++ b/.github/workflows/publish-engine.yml
@@ -4,7 +4,18 @@ on:
     branches:
       - main
     tags:
-      - v*
+      - 'v*'
+    paths:
+      - 'cmd/**'
+      - 'codegen/**'
+      - 'core/**'
+      - 'engine/**'
+      - 'internal/engine/**'
+      - 'project/**'
+      - 'router/**'
+      - 'secret/**'
+      - 'tracing/**'
+      - go.mod
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-engine.yml
+++ b/.github/workflows/publish-engine.yml
@@ -10,17 +10,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19
+
       - uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}
       - run: ./hack/make engine:publish ${{ github.ref_name }}
+
       - name: Bump SDK Engine Dependencies
         uses: peter-evans/create-pull-request@v3
+        if: github.ref_name != 'main'
         with:
           add-paths: ./sdk/
           committer: Dagger CI <hello@dagger.io>


### PR DESCRIPTION
Follow-up to #3786

This should not have failed (or even be triggered) https://github.com/dagger/dagger/actions/runs/3447101778/jobs/5752758900#step:5:1127