### PR TITLE
Python: Improve error messages

### DIFF
--- a/sdk/python/src/dagger/api/base.py
+++ b/sdk/python/src/dagger/api/base.py
@@ -13,6 +13,8 @@ from cattrs.preconf.json import make_converter
 from gql.client import AsyncClientSession, SyncClientSession
 from gql.dsl import DSLField, DSLQuery, DSLSchema, DSLSelectable, DSLType, dsl_gql
 
+from dagger.exceptions import DaggerException
+
 _T = TypeVar("_T")
 
 
@@ -146,7 +148,7 @@ class Root(Type):
         return self._ctx.schema._schema
 
 
-class ClientError(Exception):
+class ClientError(DaggerException):
     """Base class for client errors."""
 
 

--- a/sdk/python/src/dagger/connectors/docker.py
+++ b/sdk/python/src/dagger/connectors/docker.py
@@ -8,6 +8,7 @@ import anyio
 from attrs import Factory, define, field
 
 from dagger import Client
+from dagger.exceptions import DaggerException
 
 from .base import Config, register_connector
 from .http import HTTPConnector
@@ -189,5 +190,5 @@ class DockerConnector(HTTPConnector):
         self.engine.stop(exc_type)
 
 
-class ProvisionError(Exception):
+class ProvisionError(DaggerException):
     """Error while provisioning the Dagger engine."""

--- a/sdk/python/src/dagger/connectors/docker.py
+++ b/sdk/python/src/dagger/connectors/docker.py
@@ -75,6 +75,12 @@ class Engine:
                 "delete": False,
             }
             with tempfile.NamedTemporaryFile(**tempfile_args) as tmp_bin:
+
+                def cleanup():
+                    """Remove the tmp_bin on error."""
+                    tmp_bin.close()
+                    os.unlink(tmp_bin.name)
+
                 docker_run_args = [
                     "docker",
                     "run",
@@ -100,6 +106,13 @@ class Engine:
                     raise ProvisionError(
                         f"Failed to copy engine session binary: {e.stderr}"
                     ) from e
+                else:
+                    # Flake8 Ignores
+                    # F811 -- redefinition of (yet) unused function
+                    # E731 -- assigning a lambda.
+                    cleanup = lambda: None  # noqa: F811,E731
+                finally:
+                    cleanup()
 
                 tmp_bin_path = Path(tmp_bin.name)
                 tmp_bin_path.chmod(0o700)

--- a/sdk/python/src/dagger/connectors/docker.py
+++ b/sdk/python/src/dagger/connectors/docker.py
@@ -92,12 +92,14 @@ class Engine:
                         encoding="utf-8",
                         check=True,
                     )
-                except subprocess.CalledProcessError as e:
-                    tmp_bin.close()
-                    os.unlink(tmp_bin.name)
+                except FileNotFoundError as e:
                     raise ProvisionError(
-                        f"Failed to copy engine session binary: {e.stdout}"
-                    )
+                        f"Command '{docker_run_args[0]}' not found."
+                    ) from e
+                except subprocess.CalledProcessError as e:
+                    raise ProvisionError(
+                        f"Failed to copy engine session binary: {e.stderr}"
+                    ) from e
 
                 tmp_bin_path = Path(tmp_bin.name)
                 tmp_bin_path.chmod(0o700)

--- a/sdk/python/src/dagger/connectors/docker.py
+++ b/sdk/python/src/dagger/connectors/docker.py
@@ -127,12 +127,21 @@ class Engine:
             engine_session_args,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=self.cfg.log_output or subprocess.DEVNULL,
+            stderr=self.cfg.log_output or subprocess.PIPE,
             encoding="utf-8",
         )
 
-        # read port number from first line of stdout
-        port = int(self._proc.stdout.readline())
+        try:
+            # read port number from first line of stdout
+            port = int(self._proc.stdout.readline())
+        except ValueError as e:
+            # Check if the subprocess exited with an error.
+            return_value = self._proc.poll()
+            if return_value != 0 or return_value is not None:
+                raise DaggerException(self._proc.stderr.readline()) from e
+            # if the subprocess is OK raise the original error
+            else:
+                raise e
 
         # TODO: verify port number is valid
 

--- a/sdk/python/src/dagger/exceptions.py
+++ b/sdk/python/src/dagger/exceptions.py
@@ -1,0 +1,2 @@
+class DaggerException(Exception):
+    """Base exception for all Dagger exceptions."""


### PR DESCRIPTION
Improves error messages when dagger is not installed or not running.

Also creates the catch all (`DaggerExecption`) mentioned in #3805.

Discord thread: https://discord.com/channels/707636530424053791/1041044357345718282/1041044783155654766

# Message examples (Tracebacks removed)
## Docker not installed
### Before
```
FileNotFoundError: [Errno 2] No such file or directory: 'docker'
```
### After
```
dagger.connectors.docker.ProvisionError: Command 'docker' not found.
```

## Docker not running (Dagger Engine not cached)
### Before
```
dagger.connectors.docker.ProvisionError: Failed to copy engine session binary: None
```
### After 
```
dagger.connectors.docker.ProvisionError: Failed to copy engine session binary: docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?.
See 'docker run --help'.
```

## Docker not running (Dagger Engine cached)
### Before
```
ValueError: invalid literal for int() with base 10: ''
```
### After
```
dagger.exceptions.DaggerException: Error: failed to run container: docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?.
```