### PR TITLE
Go SDK: include stderr in provisioning error.

### DIFF
--- a/internal/engine/docker.go
+++ b/internal/engine/docker.go
@@ -76,7 +76,9 @@ func dockerImageProvider(ctx context.Context, remote *url.URL) (string, error) {
 			if output, err := exec.CommandContext(ctx,
 				"docker", "rm", "-fv", line,
 			).CombinedOutput(); err != nil {
-				fmt.Fprintf(os.Stderr, "failed to remove old container %s: %s", line, output)
+				if !strings.Contains(string(output), fmt.Sprintf("removal of container %s is already in progress", line)) {
+					fmt.Fprintf(os.Stderr, "failed to remove old container %s: %s", line, output)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Previously unless you configured log output, no errors that occur in the engine-session binary would be visible to the end user, they would just get `EOF` as an error and nothing else, which is extremely confusing. This made it much harder to debug issue encountered in this PR for example: https://github.com/dagger/dagger/pull/3774

Now, even when log output is not set, the contents of stderr are temporarily buffered during provisioning and included in the error message if something goes wrong.

This should go well nicely with a similar change in the Python SDK: https://github.com/dagger/dagger/pull/3825/files