### PR TITLE
sdk: python: Fix linter on poe task

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -91,12 +91,11 @@ default_item_type = "cmd"
 
 [tool.poe.tasks.fmt]
 sequence = [
-    "autoflake --in-place .",
-    "isort .",
-    "black .",
-    { ref = "lint"},
+    {cmd = "autoflake --in-place ."},
+    {cmd = "isort ."},
+    {cmd = "black ."},
+    {ref = "lint"},
 ]
-default_item_type = "cmd"
 
 [tool.poe.tasks.generate]
 sequence = [


### PR DESCRIPTION
Linter was complaining because of mixed types in list.

Signed-off-by: Helder Correia