### PR TITLE
sdk: python: Fix README.md example

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -11,15 +11,14 @@ The Dagger Python SDK contains everything you need to develop CI/CD pipelines in
 ```python
 # say.py
 import sys
-import anyio
 
+import anyio
 import dagger
 
 
 async def main(args: list[str]):
     async with dagger.Connection() as client:
         # build container with cowsay entrypoint
-        # note: this is reusable, no request is made to the server
         ctr = (
             client.container()
             .from_("python:alpine")
@@ -28,8 +27,6 @@ async def main(args: list[str]):
         )
 
         # run cowsay with requested message
-        # note: methods that return a coroutine with a Result need to
-        # await query execution
         result = await ctr.exec(args).stdout().contents()
 
         print(result)

--- a/sdk/python/examples/client-simple/say.py
+++ b/sdk/python/examples/client-simple/say.py
@@ -1,16 +1,14 @@
 import sys
 
 import anyio
+from rich.console import Console
 
 import dagger
 
 
 async def main(args: list[str]):
-    # Tip: If you want to see the output from the engine use
-    # `dagger.Connection(dagger.Config(log_output=sys.stderr))`
     async with dagger.Connection() as client:
         # build container with cowsay entrypoint
-        # note: this is reusable, no request is made to the server
         ctr = (
             client.container()
             .from_("python:alpine")
@@ -19,7 +17,6 @@ async def main(args: list[str]):
         )
 
         # run cowsay with requested message
-        # note: methods that return a coroutine need to await query execution
         result = await ctr.exec(args).stdout().contents()
 
         print(result)
@@ -29,4 +26,7 @@ if __name__ == "__main__":
     if not sys.argv[1:]:
         print("What do you want to say?", file=sys.stderr)
         sys.exit(1)
-    anyio.run(main, sys.argv[1:])
+
+    console = Console()
+    with console.status("Hold on..."):
+        anyio.run(main, sys.argv[1:])

--- a/sdk/python/examples/client-simple/say_sync.py
+++ b/sdk/python/examples/client-simple/say_sync.py
@@ -1,14 +1,13 @@
 import sys
 
+from rich.console import Console
+
 import dagger
 
 
 def main(args: list[str]):
-    # Tip: If you want to see the output from the engine use
-    # `dagger.Connection(dagger.Config(log_output=sys.stderr))`
     with dagger.Connection() as client:
         # build container with cowsay entrypoint
-        # note: this is reusable, no request is made to the server
         ctr = (
             client.container()
             .from_("python:alpine")
@@ -17,7 +16,6 @@ def main(args: list[str]):
         )
 
         # run cowsay with requested message
-        # note: methods that return a coroutine need to await query execution
         result = ctr.exec(args).stdout().contents()
 
         print(result)
@@ -27,4 +25,7 @@ if __name__ == "__main__":
     if not sys.argv[1:]:
         print("What do you want to say?", file=sys.stderr)
         sys.exit(1)
-    main(sys.argv[1:])
+
+    console = Console()
+    with console.status("Hold on..."):
+        main(sys.argv[1:])


### PR DESCRIPTION
Example had a wrong reference to the old `Result` wrapper.

Removed comments with `log_output` tip because it’s easy to miss and it’s covered in the getting started guide on the documentation site. Added progress status instead to keep terminal clean.

Kept the version in README.md as simple as possible. That’s just a carrot, the proper example is in the `examples` directory and in the docs.

Signed-off-by: Helder Correia