### PR TITLE
NodeJS Provisioning Follow ups 

### DIFF
--- a/sdk/nodejs/connect.ts
+++ b/sdk/nodejs/connect.ts
@@ -1,14 +1,14 @@
 import Client from "./api/client.gen.js"
 import { getProvisioner, DEFAULT_HOST } from "./provisioning/index.js"
+import { Writable } from "node:stream"
 
 /**
- * ConnectOpts defines option used to run cloak
- * in dev mode.
- * Options are based on `dagger cloak` CLI.
+ * ConnectOpts defines option used to connect to an engine.
  */
 export interface ConnectOpts {
   Workdir?: string
   ConfigPath?: string
+  LogOutput?: Writable
 }
 
 type CallbackFct = (client: Client) => Promise<void>
@@ -24,7 +24,7 @@ export async function connect(
 ): Promise<void> {
   // Create config with default values that may be overridden
   // by config if values are set.
-  const _config: Required<ConnectOpts> = {
+  const _config: ConnectOpts = {
     Workdir: process.env["DAGGER_WORKDIR"] || process.cwd(),
     ConfigPath: process.env["DAGGER_CONFIG"] || "./dagger.json",
     ...config,

--- a/sdk/nodejs/provisioning/docker-provision/image.ts
+++ b/sdk/nodejs/provisioning/docker-provision/image.ts
@@ -80,8 +80,8 @@ export class DockerImage implements EngineConn {
   /**
    * Generate a unix timestamp in nanosecond
    */
-  private getRandomId() {
-    return Math.floor(Date.now() * 1000000)
+  private getRandomId(): string {
+    return process.hrtime.bigint().toString()
   }
 
   Addr(): string {

--- a/sdk/nodejs/provisioning/docker-provision/image.ts
+++ b/sdk/nodejs/provisioning/docker-provision/image.ts
@@ -254,22 +254,25 @@ export class DockerImage implements EngineConn {
       input: this.subProcess.stdout!,
     })
 
-    // Set a timeout of 10 seconds by default
-    // Do not call the function if port is successfully retrieved.
-    const timeoutFct = setTimeout(
-      async () => this.Close(),
-      opts.Timeout || 10000
-    )
+    const port = await Promise.race([
+      this.readPort(stdoutReader),
+      new Promise((_, reject) => {
+        setTimeout(() => {
+          reject(new Error("timeout reading port from engine session"))
+        }, 300000).unref() // long timeout to account for extensions, though that should be optimized in future
+      }),
+    ])
 
+    return new Client({ host: `127.0.0.1:${port}` })
+  }
+
+  private async readPort(stdoutReader: readline.Interface): Promise<number> {
     for await (const line of stdoutReader) {
       // Read line as a port number
       const port = parseInt(line)
-
-      clearTimeout(timeoutFct)
-      return new Client({ host: `127.0.0.1:${port}` })
+      return port
     }
-
-    throw new Error("failed to connect to engine session")
+    throw new Error("failed to read port from engine session")
   }
 
   async Close(): Promise<void> {

--- a/sdk/nodejs/provisioning/docker-provision/image.ts
+++ b/sdk/nodejs/provisioning/docker-provision/image.ts
@@ -243,7 +243,7 @@ export class DockerImage implements EngineConn {
     }
 
     this.subProcess = execaCommand(engineSessionArgs.join(" "), {
-      stderr: opts.OutputLog || process.stderr,
+      stderr: opts.LogOutput || "ignore",
 
       // Kill the process if parent exit.
       cleanup: true,

--- a/sdk/nodejs/provisioning/engineconn.ts
+++ b/sdk/nodejs/provisioning/engineconn.ts
@@ -1,10 +1,10 @@
 import Client from "../api/client.gen.js"
-import { StdioOption } from "execa"
+import { Writable } from "node:stream"
 
 export interface ConnectOpts {
   Workdir?: string
   Project?: string
-  OutputLog?: StdioOption
+  LogOutput?: Writable
   Timeout?: number
 }
 


### PR DESCRIPTION
* Fixes: https://github.com/dagger/dagger/issues/3836
   * I noticed while working on this that the logging actually wasn't configurable at all outside of just the provisioning-related interface, so I went ahead and did that.
* Fixes: https://github.com/dagger/dagger/issues/3833
* I also noticed that the nanosecond timestamp was really just a second-timestamp, so I fixed that here too