### PR TITLE
ts getting started: ignore node_modules

### DIFF
--- a/docs/current/sdk/nodejs/783645-get-started.md
+++ b/docs/current/sdk/nodejs/783645-get-started.md
@@ -102,7 +102,7 @@ Replace the `build.ts` file from the previous step with the version below (highl
 The revised code now does the following:
 
 - It creates a Dagger client with `connect()` as before.
-- It uses the client's `host().workdir().id()` method to obtain a reference to the current directory on the host. This reference is stored in the `source` variable.
+- It uses the client's `host().workdir(["node_modules/"]).id()` method to obtain a reference to the current directory on the host. This reference is stored in the `source` variable. It also will ignore the `node_modules` directory on the host since we passed that in as an excluded directory.
 - It uses the client's `container().from()` method to initialize a new container from a base image. This base image is the Node.js version to be tested against - the `node:16` image. This method returns a new `Container` object with the results.
 - It uses the `Container.withMountedDirectory()` method to mount the host directory into the container at the `/src` mount point, and the `Container.withWorkdir()` method to set the working directory in the container. The revised `Container` is stored in the `runner` constant.
 - It uses the `Container.exec()` method to define the command to run tests in the container - in this case, the command `npm test -- --watchAll=false`.

--- a/docs/current/sdk/nodejs/snippets/get-started/step4/build.ts
+++ b/docs/current/sdk/nodejs/snippets/get-started/step4/build.ts
@@ -5,7 +5,7 @@ connect(async (client: Client) => {
 
   // highlight-start
   // get reference to the local project
-  const source = await client.host().workdir().id();
+  const source = await client.host().workdir(["node_modules/"]).id();
 
   // get Node image
   const node = await client
@@ -18,6 +18,7 @@ connect(async (client: Client) => {
     .container(node.id)
     .withMountedDirectory("/src", source.id)
     .withWorkdir("/src")
+    .exec(["npm", "install"])
 
   // run tests
   await runner

--- a/docs/current/sdk/nodejs/snippets/get-started/step5/build.ts
+++ b/docs/current/sdk/nodejs/snippets/get-started/step5/build.ts
@@ -9,7 +9,7 @@ connect(async (client: Client) => {
   // highlight-end
 
   // get reference to the local project
-  const source = await client.host().workdir().id();
+  const source = await client.host().workdir(["node_modules/"]).id();
 
   // highlight-start
   // for each Node version
@@ -27,6 +27,7 @@ connect(async (client: Client) => {
       .container(node.id)
       .withMountedDirectory("/src", source.id)
       .withWorkdir("/src")
+      .exec(["npm", "install"])
 
     // run tests
     await runner


### PR DESCRIPTION
Signed-off-by: kpenfound <kyle@dagger.io>

This shows off `Directory(exclude=[])` to exclude the local node_modules from the test/build environment. As this is definitely a best practice, this is a great place to demonstrate this pattern