### PR TITLE
sdk: nodejs: make sure linting errors actually fail

### DIFF
--- a/sdk/nodejs/.eslintrc.cjs
+++ b/sdk/nodejs/.eslintrc.cjs
@@ -1,7 +1,13 @@
 module.exports = {
-  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
-  ignorePatterns: ["dist/**/*", "api/types.ts"],
-  parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint'],
+  extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  ignorePatterns: [
+    "dist/",
+
+    // FIXME: generated files should be linted
+    "api/client.gen.ts",
+    "api/types.ts",
+  ],
+  parser: "@typescript-eslint/parser",
+  plugins: ["@typescript-eslint"],
   root: true,
 };

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -28,7 +28,7 @@
     "build": "tsc",
     "test": "mocha",
     "gen:typedoc": "yarn typedoc",
-    "lint": "yarn eslint ."
+    "lint": "yarn eslint --max-warnings=0 ."
   },
   "devDependencies": {
     "@types/mocha": "latest",

--- a/sdk/nodejs/provisioning/http/http.ts
+++ b/sdk/nodejs/provisioning/http/http.ts
@@ -1,9 +1,4 @@
 import { ConnectOpts, EngineConn } from "../engineconn.js";
-import * as path from "path";
-import * as fs from "fs";
-import * as os from "os";
-import readline from "readline";
-import { execaCommandSync, execaCommand, ExecaChildProcess } from "execa";
 import Client from "../../api/client.gen.js";
 
 /**
@@ -21,6 +16,7 @@ export class HTTP implements EngineConn {
     return this.url.toString();
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async Connect(opts: ConnectOpts): Promise<Client> {
     return new Client({ host: this.url.host });
   }


### PR DESCRIPTION
Linter was not failing with warnings. Fixed a couple of issues.

Codegen code throws errors and was disabled, logged this: #3865