### PR TITLE
docs: Add sidebar for Node.js SDK docs

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -47,6 +47,25 @@ module.exports = {
     },
     {
       type: "category",
+      label: "Node.js SDK",
+      collapsible: false,
+      collapsed: false,
+      items: [
+        {
+          type: "doc",
+          label: "Overview",
+          id: "current/sdk/nodejs/index",
+        },
+        "current/sdk/nodejs/install",
+        {
+          type: "doc",
+          label: "Get Started",
+          id: "current/sdk/nodejs/get-started",
+        },
+      ],
+    },
+    {
+      type: "category",
       label: "Python SDK",
       collapsible: false,
       collapsed: false,


### PR DESCRIPTION
This commit adds the Node.js SDK docs to the site navigation sidebar.

Relates to #3640 

Signed-off-by: Vikram Vaswani <vikram@dagger.io>