### PR TITLE
Python: Add tests for improved Provisioning Error Messages

### DIFF
--- a/internal/mage/sdk/python.go
+++ b/internal/mage/sdk/python.go
@@ -83,7 +83,7 @@ func (t Python) Test(ctx context.Context) error {
 			eg.Go(func() error {
 				_, err := pythonBase(c, version).
 					WithMountedDirectory("/root/.docker", util.HostDockerDir(c)).
-					WithExec([]string{"poe", "test", "--exitfirst"}, dagger.ContainerWithExecOpts{
+					WithExec([]string{"poe", "test", "--exitfirst", "-m", "not provision"}, dagger.ContainerWithExecOpts{
 						ExperimentalPrivilegedNesting: true,
 					}).ExitCode(gctx)
 				return err

--- a/sdk/python/poetry.lock
+++ b/sdk/python/poetry.lock
@@ -570,6 +570,22 @@ pytest = ">=5.0"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
+name = "pytest-subprocess"
+version = "1.4.2"
+description = "A plugin to fake subprocess for pytest"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pytest = ">=4.0.0"
+
+[package.extras]
+dev = ["changelogd", "nox"]
+docs = ["changelogd", "furo", "sphinx", "sphinx-autodoc-typehints", "sphinxcontrib-napoleon"]
+test = ["Pygments (>=2.0)", "anyio", "coverage", "docutils (>=0.12)", "pytest (>=4.0)", "pytest-asyncio (>=0.15.1)", "pytest-rerunfailures"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -872,7 +888,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "722b31574e5045db73552081d8d5dbb89f1b25904aa901f57f8aca4ee4f504ec"
+content-hash = "cdaaf53a2216dc5c0151b67c1d724f1d625d39e0a112dbd0119b8dec44dba167"
 
 [metadata.files]
 aiohttp = [
@@ -1369,6 +1385,10 @@ pytest = [
 pytest-mock = [
     {file = "pytest-mock-3.10.0.tar.gz", hash = "sha256:fbbdb085ef7c252a326fd8cdcac0aa3b1333d8811f131bdcc701002e1be7ed4f"},
     {file = "pytest_mock-3.10.0-py3-none-any.whl", hash = "sha256:f4c973eeae0282963eb293eb173ce91b091a79c1334455acfac9ddee8a1c784b"},
+]
+pytest-subprocess = [
+    {file = "pytest-subprocess-1.4.2.tar.gz", hash = "sha256:3edccde14da6f65860d55891df37a1ec86fcf83db880512f856a77cfb521d1e1"},
+    {file = "pytest_subprocess-1.4.2-py3-none-any.whl", hash = "sha256:b072da330c64e238f25a14ed9410bf8882b276e64d823f651b33e91406899cee"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -130,6 +130,7 @@ addopts = [
 ]
 markers = [
     "slow: mark test as slow (integration)",
+    "provision: mark provisioning tests",
 ]
 
 [tool.mypy]

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -53,6 +53,7 @@ typer = {version = ">=0.6.1", extras = ["all"]}
 [tool.poetry.group.test.dependencies]
 pytest = ">=7.2.0"
 "pytest-mock" = ">=3.10.0"
+pytest-subprocess = "^1.4.2"
 
 [tool.poetry.group.lint.dependencies]
 autoflake = ">=1.3.1"

--- a/sdk/python/src/dagger/connectors/bin.py
+++ b/sdk/python/src/dagger/connectors/bin.py
@@ -34,7 +34,7 @@ class Engine:
             "DAGGER_RUNNER_HOST", default_dagger_runner_host
         )
         env = os.environ.copy()
-        if dagger_runner_host != "":
+        if dagger_runner_host:
             env["DAGGER_RUNNER_HOST"] = dagger_runner_host
 
         if self.cfg.workdir:

--- a/sdk/python/src/dagger/connectors/docker.py
+++ b/sdk/python/src/dagger/connectors/docker.py
@@ -58,7 +58,7 @@ class EngineFromImage(Engine):
 
         os_, arch = get_platform()
 
-        image = ImageRef(self.cfg.host.hostname + self.cfg.host.path)
+        image = ImageRef(self.cfg.host.netloc + self.cfg.host.path)
         engine_session_bin_path = (
             cache_dir / f"{ENGINE_SESSION_BINARY_PREFIX}{image.id}"
         )

--- a/sdk/python/tests/connectors/test_bin.py
+++ b/sdk/python/tests/connectors/test_bin.py
@@ -1,0 +1,34 @@
+import sys
+
+import pytest
+from pytest_subprocess.fake_process import FakeProcess
+
+import dagger
+from dagger.connectors.bin import Engine, ProvisionError
+
+
+def test_getting_port(fp: FakeProcess):
+    fp.register(["dagger-engine-session"], stdout=["50004", ""])
+
+    with Engine(dagger.Config(host="bin://")) as engine:
+        assert engine.cfg.host.geturl() == "http://localhost:50004"
+
+
+@pytest.mark.parametrize("config_args", [{"log_output": sys.stderr}, {}])
+def test_buildkit_not_running(config_args: dict, fp: FakeProcess):
+    """
+    When buildkit isn't running ensure that the `ValueError` is wrapped
+    in a `ProvisionError` and a more helpful error message is printed.
+    """
+
+    fp.register(
+        ["dagger-engine-session"],
+        stderr=["Error: buildkit failed to respond", ""],
+        returncode=1,
+    )
+
+    engine = Engine(dagger.Config(host="bin://", **config_args))
+    with pytest.raises(ProvisionError) as exc_info:
+        engine.start()
+
+    assert "Dagger engine failed to start" in str(exc_info.value)

--- a/sdk/python/tests/connectors/test_docker.py
+++ b/sdk/python/tests/connectors/test_docker.py
@@ -12,7 +12,7 @@ from dagger.connectors import docker
 from dagger.connectors.base import Config
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def cache_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Creates a temp cache_dir for testing & sets XDG_CACHE_HOME."""
     cache_dir = tmp_path / "dagger"
@@ -55,9 +55,7 @@ async def test_docker_image_provision(cache_dir: Path):
     assert not garbage_path.exists()
 
 
-def test_docker_cli_is_not_installed(
-    cache_dir: Path, monkeypatch: pytest.MonkeyPatch, fp: FakeProcess
-):
+def test_docker_cli_is_not_installed(monkeypatch: pytest.MonkeyPatch, fp: FakeProcess):
     """
     When the docker cli is not installed ensure that the `FileNotFoundError` returned by
     `subprocess.run` is wrapped by a `docker.ProvisionError` stating that
@@ -97,9 +95,7 @@ def test_tmp_files_are_removed_on_error(
     assert not [x for x in cache_dir.iterdir()]
 
 
-def test_docker_engine_is_not_running(
-    cache_dir: Path, fp: FakeProcess, monkeypatch: pytest.MonkeyPatch
-):
+def test_docker_engine_is_not_running(fp: FakeProcess, monkeypatch: pytest.MonkeyPatch):
     """
     When the docker image is not installed ensure that
     the `CalledProcessError` is wrapped in a `dagger.ProvisionError`
@@ -124,7 +120,6 @@ def test_docker_engine_is_not_running(
 @pytest.mark.anyio()
 async def test_docker_engine_is_not_running_cached_dagger_engine_exists(
     log_output: TextIO,
-    cache_dir: Path,
     monkeypatch: pytest.MonkeyPatch,
 ):
     """


### PR DESCRIPTION
Follow up to PR #3825 

The test names could probably use some work, let me know if there is a standard format you'd like to use and I'll fix them up. 
Maybe something like `test_raises_EXCEPTION_when_CONDITION`?

Also If I missed any test paths let me know!