### PR TITLE
replace FS by RootFS

### DIFF
--- a/codegen/generator/go/templates/functions.go
+++ b/codegen/generator/go/templates/functions.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"text/template"
 
@@ -11,6 +12,7 @@ import (
 var (
 	funcMap = template.FuncMap{
 		"Comment":                comment,
+		"FormatDeprecation":      formatDeprecation,
 		"FormatInputType":        formatInputType,
 		"FormatOutputType":       formatOutputType,
 		"FormatName":             formatName,
@@ -30,6 +32,20 @@ func comment(s string) string {
 		lines[i] = "// " + l
 	}
 	return strings.Join(lines, "\n")
+}
+
+// format the deprecation reason
+// Example: `Replaced by @foo.` -> `// Replaced by Foo\n`
+func formatDeprecation(s string) string {
+	r := regexp.MustCompile("`[a-zA-Z0-9_]+`")
+	matches := r.FindAllString(s, -1)
+	for _, match := range matches {
+		replacement := strings.TrimPrefix(match, "`")
+		replacement = strings.TrimSuffix(replacement, "`")
+		replacement = formatName(replacement)
+		s = strings.ReplaceAll(s, match, replacement)
+	}
+	return comment("Deprecated: " + s)
 }
 
 // formatType formats a GraphQL type into Go

--- a/codegen/generator/go/templates/src/object.go.tmpl
+++ b/codegen/generator/go/templates/src/object.go.tmpl
@@ -24,7 +24,7 @@ type {{ $field | FieldOptionsStructName }} struct {
 {{ $field.Description | Comment }}
 {{- if $field.IsDeprecated }}
 //
-// Deprecated: {{ $field.DeprecationReason }}
+{{ $field.DeprecationReason | FormatDeprecation }}
 {{- end }}
 {{ $field | FieldFunction }} {
 	q := r.q.Select("{{ $field.Name }}")

--- a/codegen/generator/go/templates/src/object.go.tmpl
+++ b/codegen/generator/go/templates/src/object.go.tmpl
@@ -22,6 +22,10 @@ type {{ $field | FieldOptionsStructName }} struct {
 {{- end }}
 
 {{ $field.Description | Comment }}
+{{- if $field.IsDeprecated }}
+//
+// Deprecated: {{ $field.DeprecationReason }}
+{{- end }}
 {{ $field | FieldFunction }} {
 	q := r.q.Select("{{ $field.Name }}")
 	{{- range $arg := $field.Args }}

--- a/codegen/generator/nodejs/templates/functions.go
+++ b/codegen/generator/nodejs/templates/functions.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"regexp"
 	"strings"
 	"text/template"
 
@@ -11,16 +12,17 @@ import (
 
 var (
 	funcMap = template.FuncMap{
-		"CommentToLines":   commentToLines,
-		"FormatInputType":  formatInputType,
-		"FormatOutputType": formatOutputType,
-		"FormatName":       formatName,
-		"HasPrefix":        strings.HasPrefix,
-		"PascalCase":       pascalCase,
-		"IsArgOptional":    isArgOptional,
-		"IsCustomScalar":   isCustomScalar,
-		"Solve":            solve,
-		"Subtract":         subtract,
+		"CommentToLines":    commentToLines,
+		"FormatDeprecation": formatDeprecation,
+		"FormatInputType":   formatInputType,
+		"FormatOutputType":  formatOutputType,
+		"FormatName":        formatName,
+		"HasPrefix":         strings.HasPrefix,
+		"PascalCase":        pascalCase,
+		"IsArgOptional":     isArgOptional,
+		"IsCustomScalar":    isCustomScalar,
+		"Solve":             solve,
+		"Subtract":          subtract,
 	}
 )
 
@@ -46,6 +48,20 @@ func subtract(a, b int) int {
 func commentToLines(s string) []string {
 	split := strings.Split(s, "\n")
 	return split
+}
+
+// format the deprecation reason
+// Example: `Replaced by @foo.` -> `// Replaced by Foo\n`
+func formatDeprecation(s string) []string {
+	r := regexp.MustCompile("`[a-zA-Z0-9_]+`")
+	matches := r.FindAllString(s, -1)
+	for _, match := range matches {
+		replacement := strings.TrimPrefix(match, "`")
+		replacement = strings.TrimSuffix(replacement, "`")
+		replacement = formatName(replacement)
+		s = strings.ReplaceAll(s, match, replacement)
+	}
+	return commentToLines("@deprecated " + s)
 }
 
 // formatType formats a GraphQL type into Go

--- a/codegen/generator/nodejs/templates/src/method.ts.tmpl
+++ b/codegen/generator/nodejs/templates/src/method.ts.tmpl
@@ -1,5 +1,5 @@
 {{ define "method" }}
-{{- template "method_comment" .Description }}
+{{- template "method_comment" . }}
 {{- "" }}  {{ .Name -}}({{- template "args" .Args -}}){{ template "return" .TypeRef }} {
 		{{- if .TypeRef }}
     return new {{ .TypeRef | FormatOutputType }}({queryTree: [

--- a/codegen/generator/nodejs/templates/src/method_comment.ts.tmpl
+++ b/codegen/generator/nodejs/templates/src/method_comment.ts.tmpl
@@ -1,14 +1,21 @@
 {{ define "method_comment" }}
-	{{- if . -}}
-		{{- $commentLines := CommentToLines . }}
-		{{- /* we split the comment string into a string slice of one line per element */ -}}
+  {{- if .Description -}}
+    {{- $commentLines := CommentToLines .Description }}
+    {{- /* we split the comment string into a string slice of one line per element */ -}}
+    {{- $deprecationLines := FormatDeprecation .DeprecationReason }}
 {{""}}
 {{""}}
   /**
-		{{- range $commentLines }}
+  {{- range $commentLines }}
    * {{ . }}
-		{{- end }}
+  {{- end }}
+  {{- if .IsDeprecated }}
+   *
+  {{- range $deprecationLines }}
+   * {{ . }}
+  {{- end }}
+  {{- end }}
    */
 {{ "" -}}
-	{{- end }}
+  {{- end }}
 {{- end }}

--- a/codegen/generator/nodejs/templates/src/method_solve.ts.tmpl
+++ b/codegen/generator/nodejs/templates/src/method_solve.ts.tmpl
@@ -1,5 +1,5 @@
 {{ define "method_solve" }}
-{{- template "method_comment" .Description }}
+{{- template "method_comment" . }}
 {{- "" }}  async {{ .Name -}}({{- template "args" .Args -}}){{ template "return_solve" .TypeRef }} {
 		{{- if .TypeRef }}
     this._queryTree = [

--- a/codegen/generator/nodejs/templates/src/objects_test.go
+++ b/codegen/generator/nodejs/templates/src/objects_test.go
@@ -57,6 +57,7 @@ export class CacheVolume extends BaseClient {
 export class Host extends BaseClient {
 
 
+
   /**
    * Access a directory on the host
    */
@@ -70,6 +71,7 @@ export class Host extends BaseClient {
     ], host: this.clientHost})
   }
 
+
   /**
    * Lookup the value of an environment variable. Null if the variable is not available.
    */
@@ -82,6 +84,7 @@ export class Host extends BaseClient {
       }
     ], host: this.clientHost})
   }
+
 
   /**
    * The current working directory on the host

--- a/codegen/introspection/introspection.go
+++ b/codegen/introspection/introspection.go
@@ -90,10 +90,12 @@ func (t Types) Get(name string) *Type {
 }
 
 type Field struct {
-	Name        string      `json:"name"`
-	Description string      `json:"description"`
-	TypeRef     *TypeRef    `json:"type"`
-	Args        InputValues `json:"args"`
+	Name              string      `json:"name"`
+	Description       string      `json:"description"`
+	TypeRef           *TypeRef    `json:"type"`
+	Args              InputValues `json:"args"`
+	IsDeprecated      bool        `json:"isDeprecated"`
+	DeprecationReason string      `json:"deprecationReason"`
 
 	ParentObject *Type `json:"-"`
 }

--- a/core/container.go
+++ b/core/container.go
@@ -216,7 +216,7 @@ func (container *Container) From(ctx context.Context, gw bkgw.Client, addr strin
 		return nil, err
 	}
 
-	ctr, err := container.WithFS(ctx, dir)
+	ctr, err := container.WithRootFS(ctx, dir)
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +306,7 @@ func (container *Container) Build(ctx context.Context, gw bkgw.Client, context *
 	return &Container{ID: id}, nil
 }
 
-func (container *Container) FS(ctx context.Context) (*Directory, error) {
+func (container *Container) RootFS(ctx context.Context) (*Directory, error) {
 	payload, err := container.ID.decode()
 	if err != nil {
 		return nil, err
@@ -318,7 +318,7 @@ func (container *Container) FS(ctx context.Context) (*Directory, error) {
 	}).ToDirectory()
 }
 
-func (container *Container) WithFS(ctx context.Context, dir *Directory) (*Container, error) {
+func (container *Container) WithRootFS(ctx context.Context, dir *Directory) (*Container, error) {
 	payload, err := container.ID.decode()
 	if err != nil {
 		return nil, err

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -170,7 +170,7 @@ CMD goenv
 	})
 }
 
-func TestContainerWithFS(t *testing.T) {
+func TestContainerWithRootFS(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -184,8 +184,8 @@ func TestContainerWithFS(t *testing.T) {
 	require.NoError(t, err)
 
 	alpine316ReleaseStr = strings.TrimSpace(alpine316ReleaseStr)
-	dir := alpine316.FS()
-	exitCode, err := c.Container().WithEnvVariable("ALPINE_RELEASE", alpine316ReleaseStr).WithFS(dir).Exec(dagger.ContainerExecOpts{
+	dir := alpine316.Rootfs()
+	exitCode, err := c.Container().WithEnvVariable("ALPINE_RELEASE", alpine316ReleaseStr).WithRootfs(dir).Exec(dagger.ContainerExecOpts{
 		Args: []string{
 			"/bin/sh",
 			"-c",
@@ -206,7 +206,7 @@ func TestContainerWithFS(t *testing.T) {
 
 	require.Equal(t, varVal, varValResp)
 
-	alpine315ReplacedFS := alpine315WithVar.WithFS(dir)
+	alpine315ReplacedFS := alpine315WithVar.WithRootfs(dir)
 
 	varValResp, err = alpine315ReplacedFS.EnvVariable(ctx, "DAGGER_TEST")
 	require.NoError(t, err)
@@ -2387,7 +2387,7 @@ func TestContainerPublish(t *testing.T) {
 	require.Contains(t, pushedRef, "@sha256:")
 
 	contents, err := c.Container().
-		From(pushedRef).FS().File("/etc/alpine-release").Contents(ctx)
+		From(pushedRef).Rootfs().File("/etc/alpine-release").Contents(ctx)
 	require.NoError(t, err)
 	require.Equal(t, contents, "3.16.2\n")
 }

--- a/core/integration/platform_test.go
+++ b/core/integration/platform_test.go
@@ -121,7 +121,7 @@ func TestPlatformCrossCompile(t *testing.T) {
 			require.Equal(t, platformToUname[defaultPlatform], stdout)
 
 			out := ctr.Directory("/out")
-			variants[i] = c.Container(dagger.ContainerOpts{Platform: platform}).WithFS(out)
+			variants[i] = c.Container(dagger.ContainerOpts{Platform: platform}).WithRootfs(out)
 			return nil
 		})
 	}
@@ -154,7 +154,7 @@ func TestPlatformCrossCompile(t *testing.T) {
 	for platform, uname := range platformToFileArch {
 		pulledDir := c.Container(dagger.ContainerOpts{Platform: platform}).
 			From(testRef).
-			FS()
+			Rootfs()
 		ctr = ctr.WithMountedDirectory("/"+string(platform), pulledDir)
 		cmds = append(cmds, fmt.Sprintf(`file /%s/cloak | grep '%s'`, platform, uname))
 	}
@@ -243,7 +243,7 @@ func TestPlatformWindows(t *testing.T) {
 	// It's not possible to exec, but we can pull and read files
 	ents, err := c.Container(dagger.ContainerOpts{Platform: "windows/amd64"}).
 		From("mcr.microsoft.com/windows/nanoserver:ltsc2022").
-		FS().
+		Rootfs().
 		Entries(ctx)
 	require.NoError(t, err)
 	require.Equal(t, []string{"License.txt", "ProgramData", "Users", "Windows"}, ents)

--- a/core/integration/testdata/codetoschema/main.go
+++ b/core/integration/testdata/codetoschema/main.go
@@ -77,7 +77,7 @@ func (Test) ReturnDirectory(ctx context.Context, ref string) (*dagger.Directory,
 		return nil, err
 	}
 	defer client.Close()
-	return client.Container().From(ref).FS(), nil
+	return client.Container().From(ref).Rootfs(), nil
 }
 
 type AllTheTypes struct {

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -35,8 +35,10 @@ func (s *containerSchema) Resolvers() router.Resolvers {
 		"Container": router.ObjectResolver{
 			"from":                 router.ToResolver(s.from),
 			"build":                router.ToResolver(s.build),
-			"fs":                   router.ToResolver(s.fs),
-			"withFS":               router.ToResolver(s.withFS),
+			"rootfs":               router.ToResolver(s.rootfs),
+			"fs":                   router.ToResolver(s.rootfs), // deprecated
+			"withRootfs":           router.ToResolver(s.withRootfs),
+			"withFS":               router.ToResolver(s.withRootfs), // deprecated
 			"file":                 router.ToResolver(s.file),
 			"directory":            router.ToResolver(s.directory),
 			"user":                 router.ToResolver(s.user),
@@ -107,8 +109,8 @@ func (s *containerSchema) build(ctx *router.Context, parent *core.Container, arg
 	return parent.Build(ctx, s.gw, &core.Directory{ID: args.Context}, args.Dockerfile)
 }
 
-func (s *containerSchema) withFS(ctx *router.Context, parent *core.Container, arg core.Directory) (*core.Container, error) {
-	ctr, err := parent.WithFS(ctx, &arg)
+func (s *containerSchema) withRootfs(ctx *router.Context, parent *core.Container, arg core.Directory) (*core.Container, error) {
+	ctr, err := parent.WithRootFS(ctx, &arg)
 	if err != nil {
 		return nil, err
 	}
@@ -116,8 +118,8 @@ func (s *containerSchema) withFS(ctx *router.Context, parent *core.Container, ar
 	return ctr, nil
 }
 
-func (s *containerSchema) fs(ctx *router.Context, parent *core.Container, args any) (*core.Directory, error) {
-	return parent.FS(ctx)
+func (s *containerSchema) rootfs(ctx *router.Context, parent *core.Container, args any) (*core.Directory, error) {
+	return parent.RootFS(ctx)
 }
 
 type containerExecArgs struct {

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -30,14 +30,14 @@ type Container {
   rootfs: Directory!
 
   "This container's root filesystem. Mounts are not included."
-  fs: Directory! @deprecated(reason: "replaced by rootfs")
+  fs: Directory! @deprecated(reason: "Replaced by `rootfs`.")
 
   "Initialize this container from this DirectoryID"
   withRootfs(id: DirectoryID!): Container!
 
   "Initialize this container from this DirectoryID"
   withFS(id: DirectoryID!): Container!
-    @deprecated(reason: "replaced by withRootfs")
+    @deprecated(reason: "Replaced by `withRootfs`.")
 
   "Retrieve a directory at the given path. Mounts are included."
   directory(path: String!): Directory!

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -27,10 +27,17 @@ type Container {
   build(context: DirectoryID!, dockerfile: String): Container!
 
   "This container's root filesystem. Mounts are not included."
-  fs: Directory!
+  rootfs: Directory!
+
+  "This container's root filesystem. Mounts are not included."
+  fs: Directory! @deprecated(reason: "replaced by rootfs")
+
+  "Initialize this container from this DirectoryID"
+  withRootfs(id: DirectoryID!): Container!
 
   "Initialize this container from this DirectoryID"
   withFS(id: DirectoryID!): Container!
+    @deprecated(reason: "replaced by withRootfs")
 
   "Retrieve a directory at the given path. Mounts are included."
   directory(path: String!): Directory!

--- a/docs/current/sdk/go/snippets/multiplatform-support/build-images-cross-compilation/main.go
+++ b/docs/current/sdk/go/snippets/multiplatform-support/build-images-cross-compilation/main.go
@@ -83,7 +83,7 @@ func main() {
 		// with the platform
 		binaryCtr := client.
 			Container(dagger.ContainerOpts{Platform: platform}).
-			WithFS(outputDir)
+			WithRootfs(outputDir)
 		platformVariants = append(platformVariants, binaryCtr)
 	}
 

--- a/docs/current/sdk/go/snippets/multiplatform-support/build-images-emulation/main.go
+++ b/docs/current/sdk/go/snippets/multiplatform-support/build-images-emulation/main.go
@@ -65,7 +65,7 @@ func main() {
 		// with the same platform
 		binaryCtr := client.
 			Container(dagger.ContainerOpts{Platform: platform}).
-			WithFS(outputDir)
+			WithRootfs(outputDir)
 		platformVariants = append(platformVariants, binaryCtr)
 	}
 

--- a/docs/current/sdk/go/snippets/multiplatform-support/non-linux-support/main.go
+++ b/docs/current/sdk/go/snippets/multiplatform-support/non-linux-support/main.go
@@ -22,7 +22,7 @@ func main() {
 		From("mcr.microsoft.com/windows/nanoserver:ltsc2022")
 
 	// listing files works, no error should be returned
-	entries, err := ctr.FS().Entries(ctx)
+	entries, err := ctr.Rootfs().Entries(ctx)
 	if err != nil {
 		panic(err) // shouldn't happen
 	}

--- a/docs/current/sdk/go/snippets/multistage-build/main.go
+++ b/docs/current/sdk/go/snippets/multistage-build/main.go
@@ -33,8 +33,8 @@ func main() {
 	// Publish binary on Alpine base
 	prodImage := client.Container().
 		From("alpine")
-	prodImage = prodImage.WithFS(
-		prodImage.FS().WithFile("/bin/myapp",
+	prodImage = prodImage.WithRootfs(
+		prodImage.Rootfs().WithFile("/bin/myapp",
 			builder.File("/src/myapp"),
 		)).
 		WithEntrypoint([]string{"/bin/myapp"})

--- a/internal/mage/sdk/nodejs.go
+++ b/internal/mage/sdk/nodejs.go
@@ -153,9 +153,9 @@ func nodeJsBase(c *dagger.Client) *dagger.Container {
 		From("node:16-alpine").
 		WithWorkdir("/workdir")
 
-	deps := base.WithFS(
+	deps := base.WithRootfs(
 		base.
-			FS().
+			Rootfs().
 			WithFile("/workdir/package.json", workdir.File("package.json")).
 			WithFile("/workdir/yarn.lock", workdir.File("yarn.lock")),
 	).
@@ -163,9 +163,9 @@ func nodeJsBase(c *dagger.Client) *dagger.Container {
 			Args: []string{"yarn", "install"},
 		})
 
-	src := deps.WithFS(
+	src := deps.WithRootfs(
 		deps.
-			FS().
+			Rootfs().
 			WithDirectory("/workdir", workdir),
 	)
 

--- a/internal/mage/util/util.go
+++ b/internal/mage/util/util.go
@@ -116,6 +116,9 @@ func DevEngineContainer(c *dagger.Client, arches, oses []string) []*dagger.Conta
 						Args: []string{"go", "build", "-o", "./bin/" + engineSessionBin, "-ldflags", "-s -w", "/app/cmd/engine-session"},
 					}).
 					File("./bin/" + engineSessionBin)
+				// FIXME: the code below is part of "bootstrap" and using the LATEST
+				// released engine, which does not contain `WithRootfs`
+				//nolint
 				buildkitBase = buildkitBase.WithFS(
 					buildkitBase.FS().WithFile("/usr/bin/"+engineSessionBin+"-"+os+"-"+arch, builtBin),
 				)

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -246,6 +246,8 @@ func (r *Container) From(address string) *Container {
 }
 
 // This container's root filesystem. Mounts are not included.
+//
+// Deprecated: replaced by rootfs
 func (r *Container) FS() *Directory {
 	q := r.q.Select("fs")
 
@@ -316,6 +318,16 @@ func (r *Container) Publish(ctx context.Context, address string, opts ...Contain
 	var response string
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
+}
+
+// This container's root filesystem. Mounts are not included.
+func (r *Container) Rootfs() *Directory {
+	q := r.q.Select("rootfs")
+
+	return &Directory{
+		q: q,
+		c: r.c,
+	}
 }
 
 // The error stream of the last executed command.
@@ -395,6 +407,8 @@ func (r *Container) WithEnvVariable(name string, value string) *Container {
 }
 
 // Initialize this container from this DirectoryID
+//
+// Deprecated: replaced by withRootfs
 func (r *Container) WithFS(id *Directory) *Container {
 	q := r.q.Select("withFS")
 	q = q.Arg("id", id)
@@ -469,6 +483,17 @@ func (r *Container) WithMountedSecret(path string, source *Secret) *Container {
 func (r *Container) WithMountedTemp(path string) *Container {
 	q := r.q.Select("withMountedTemp")
 	q = q.Arg("path", path)
+
+	return &Container{
+		q: q,
+		c: r.c,
+	}
+}
+
+// Initialize this container from this DirectoryID
+func (r *Container) WithRootfs(id *Directory) *Container {
+	q := r.q.Select("withRootfs")
+	q = q.Arg("id", id)
 
 	return &Container{
 		q: q,

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -247,7 +247,7 @@ func (r *Container) From(address string) *Container {
 
 // This container's root filesystem. Mounts are not included.
 //
-// Deprecated: replaced by rootfs
+// Deprecated: Replaced by Rootfs.
 func (r *Container) FS() *Directory {
 	q := r.q.Select("fs")
 
@@ -408,7 +408,7 @@ func (r *Container) WithEnvVariable(name string, value string) *Container {
 
 // Initialize this container from this DirectoryID
 //
-// Deprecated: replaced by withRootfs
+// Deprecated: Replaced by WithRootfs.
 func (r *Container) WithFS(id *Directory) *Container {
 	q := r.q.Select("withFS")
 	q = q.Arg("id", id)

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -409,12 +409,15 @@ export class Container extends BaseClient {
    * This container's root filesystem. Mounts are not included.
    */
   rootfs(): Directory {
-    return new Directory({queryTree: [
-      ...this._queryTree,
-      {
-      operation: 'rootfs'
-      }
-    ], host: this.clientHost})
+    return new Directory({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "rootfs",
+        },
+      ],
+      host: this.clientHost,
+    })
   }
 
   /**
@@ -617,13 +620,16 @@ export class Container extends BaseClient {
    * Initialize this container from this DirectoryID
    */
   withRootfs(id: DirectoryID): Container {
-    return new Container({queryTree: [
-      ...this._queryTree,
-      {
-      operation: 'withRootfs',
-      args: {id}
-      }
-    ], host: this.clientHost})
+    return new Container({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "withRootfs",
+          args: { id },
+        },
+      ],
+      host: this.clientHost,
+    })
   }
 
   /**

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -324,6 +324,8 @@ export class Container extends BaseClient {
 
   /**
    * This container's root filesystem. Mounts are not included.
+   *
+   * @deprecated Replaced by rootfs.
    */
   fs(): Directory {
     return new Directory({
@@ -518,6 +520,8 @@ export class Container extends BaseClient {
 
   /**
    * Initialize this container from this DirectoryID
+   *
+   * @deprecated Replaced by withRootfs.
    */
   withFS(id: DirectoryID): Container {
     return new Container({

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -406,6 +406,18 @@ export class Container extends BaseClient {
   }
 
   /**
+   * This container's root filesystem. Mounts are not included.
+   */
+  rootfs(): Directory {
+    return new Directory({queryTree: [
+      ...this._queryTree,
+      {
+      operation: 'rootfs'
+      }
+    ], host: this.clientHost})
+  }
+
+  /**
    * The error stream of the last executed command.
    * Null if no command has been executed.
    */
@@ -599,6 +611,19 @@ export class Container extends BaseClient {
       ],
       host: this.clientHost,
     })
+  }
+
+  /**
+   * Initialize this container from this DirectoryID
+   */
+  withRootfs(id: DirectoryID): Container {
+    return new Container({queryTree: [
+      ...this._queryTree,
+      {
+      operation: 'withRootfs',
+      args: {id}
+      }
+    ], host: this.clientHost})
   }
 
   /**

--- a/sdk/python/docs/_ext/dagger_ext.py
+++ b/sdk/python/docs/_ext/dagger_ext.py
@@ -1,0 +1,29 @@
+from typing import TYPE_CHECKING
+
+from docutils import nodes
+from docutils.parsers.rst.directives import admonitions
+
+if TYPE_CHECKING:
+    from sphinx.application import Sphinx
+
+
+class Deprecated(admonitions.Warning):
+    """Deprecated admonition that looks like a warning and has
+    no version requirement."""
+
+    node_class = nodes.admonition
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.arguments = ["Deprecated"]
+        self.options["classes"] = ["warning"]
+
+
+def setup(app: "Sphinx"):
+    app.add_directive("deprecated", Deprecated, override=True)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/sdk/python/docs/conf.py
+++ b/sdk/python/docs/conf.py
@@ -3,18 +3,21 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import os
+import sys
+
+sys.path.append(os.path.abspath("./_ext"))
+
 project = "Dagger Python SDK"
 copyright = "2022, Dagger"
 author = "Dagger"
-
-# -- General configuration ---------------------------------------------------
-# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
     "sphinx.ext.intersphinx",
+    "dagger_ext",
 ]
 
 language = "en"

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -204,7 +204,7 @@ class Container(Type):
         """This container's root filesystem. Mounts are not included.
 
         .. deprecated::
-            replaced by rootfs
+            Replaced by `rootfs`.
         """
         _args: list[Arg] = []
         _ctx = self._select("fs", _args)
@@ -333,7 +333,7 @@ class Container(Type):
         """Initialize this container from this DirectoryID
 
         .. deprecated::
-            replaced by withRootfs
+            Replaced by `withRootfs`.
         """
         _args = [
             Arg("id", id),

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -262,6 +262,12 @@ class Container(Type):
         _ctx = self._select("publish", _args)
         return await _ctx.execute(str)
 
+    def rootfs(self) -> "Directory":
+        """This container's root filesystem. Mounts are not included."""
+        _args: list[Arg] = []
+        _ctx = self._select("rootfs", _args)
+        return Directory(_ctx)
+
     def stderr(self) -> "File":
         """The error stream of the last executed command.
 
@@ -372,6 +378,14 @@ class Container(Type):
             Arg("path", path),
         ]
         _ctx = self._select("withMountedTemp", _args)
+        return Container(_ctx)
+
+    def with_rootfs(self, id: "DirectoryID") -> "Container":
+        """Initialize this container from this DirectoryID"""
+        _args = [
+            Arg("id", id),
+        ]
+        _ctx = self._select("withRootfs", _args)
         return Container(_ctx)
 
     def with_secret_variable(self, name: str, secret: "Secret") -> "Container":

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -201,7 +201,11 @@ class Container(Type):
         return Container(_ctx)
 
     def fs(self) -> "Directory":
-        """This container's root filesystem. Mounts are not included."""
+        """This container's root filesystem. Mounts are not included.
+
+        .. deprecated::
+            replaced by rootfs
+        """
         _args: list[Arg] = []
         _ctx = self._select("fs", _args)
         return Directory(_ctx)
@@ -326,7 +330,11 @@ class Container(Type):
         return Container(_ctx)
 
     def with_fs(self, id: "DirectoryID") -> "Container":
-        """Initialize this container from this DirectoryID"""
+        """Initialize this container from this DirectoryID
+
+        .. deprecated::
+            replaced by withRootfs
+        """
         _args = [
             Arg("id", id),
         ]

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -204,7 +204,7 @@ class Container(Type):
         """This container's root filesystem. Mounts are not included.
 
         .. deprecated::
-            replaced by rootfs
+            Replaced by `rootfs`.
         """
         _args: list[Arg] = []
         _ctx = self._select("fs", _args)
@@ -333,7 +333,7 @@ class Container(Type):
         """Initialize this container from this DirectoryID
 
         .. deprecated::
-            replaced by withRootfs
+            Replaced by `withRootfs`.
         """
         _args = [
             Arg("id", id),

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -262,6 +262,12 @@ class Container(Type):
         _ctx = self._select("publish", _args)
         return _ctx.execute_sync(str)
 
+    def rootfs(self) -> "Directory":
+        """This container's root filesystem. Mounts are not included."""
+        _args: list[Arg] = []
+        _ctx = self._select("rootfs", _args)
+        return Directory(_ctx)
+
     def stderr(self) -> "File":
         """The error stream of the last executed command.
 
@@ -372,6 +378,14 @@ class Container(Type):
             Arg("path", path),
         ]
         _ctx = self._select("withMountedTemp", _args)
+        return Container(_ctx)
+
+    def with_rootfs(self, id: "DirectoryID") -> "Container":
+        """Initialize this container from this DirectoryID"""
+        _args = [
+            Arg("id", id),
+        ]
+        _ctx = self._select("withRootfs", _args)
         return Container(_ctx)
 
     def with_secret_variable(self, name: str, secret: "Secret") -> "Container":

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -201,7 +201,11 @@ class Container(Type):
         return Container(_ctx)
 
     def fs(self) -> "Directory":
-        """This container's root filesystem. Mounts are not included."""
+        """This container's root filesystem. Mounts are not included.
+
+        .. deprecated::
+            replaced by rootfs
+        """
         _args: list[Arg] = []
         _ctx = self._select("fs", _args)
         return Directory(_ctx)
@@ -326,7 +330,11 @@ class Container(Type):
         return Container(_ctx)
 
     def with_fs(self, id: "DirectoryID") -> "Container":
-        """Initialize this container from this DirectoryID"""
+        """Initialize this container from this DirectoryID
+
+        .. deprecated::
+            replaced by withRootfs
+        """
         _args = [
             Arg("id", id),
         ]

--- a/sdk/python/src/dagger/codegen.py
+++ b/sdk/python/src/dagger/codegen.py
@@ -352,6 +352,12 @@ class _ObjectField:
                 for line in self.description.split("\n"):
                     yield wrap(line)
 
+            if self.graphql.deprecation_reason:
+                yield chain(
+                    (".. deprecated::",),
+                    wrap_indent(self.graphql.deprecation_reason),
+                )
+
             if self.name == "id":
                 yield (
                     "Note",


### PR DESCRIPTION
- Add support for `@deprecated` GraphQL directive in the API
- Add support for handling `@deprecated` fields in the Go SDK codegen
- Renamed `fs` -> `rootfs` and `withFS` -> `withRootfs`
- Kept backward compat with deprecated `fs` / `withFS` fields

@helderco @slumbering @dolanor: The same `@deprecated` support needs to be added to Python and NodeJS as well. We're going to have a bunch like this.