### PR TITLE
docs: Add the Node SDK to the docs index page

### DIFF
--- a/docs/current/543069-index.md
+++ b/docs/current/543069-index.md
@@ -73,8 +73,10 @@ To get started with Dagger, simply choose a SDK, then follow that SDK's getting 
 | -- | -- |
 | a Go developer | Use the [Go SDK](sdk/go) |
 | a Python developer | Use the [Python SDK](sdk/python) |
+| a TypeScript/JavaScript developer | Use the [Node.js SDK](sdk/nodejs) |
 | looking for an excuse to learn Go | Use the [Go SDK](sdk/go) |
 | looking for an excuse to learn Python | Use the [Python SDK](sdk/python) |
+| looking for an excuse to learn TypeScript/JavaScript | Use the [Node.js SDK](sdk/nodejs) |
 | waiting for your favorite language to be supported | [Let us know which one](https://blocklayer.typeform.com/to/a6m5gKSS), and we'll notify you when it is ready
 | a fan of the [CUE](https://cuelang.org) language | Use the [Dagger CUE SDK](sdk/cue) |
 | enjoying the declarative nature of YAML, but wish it were more powerful | Take a look at the [CUE language](https://cuelang.org). If you like what you see, the [CUE SDK](sdk/cue) may be a good fit. |


### PR DESCRIPTION
This commit adds links to the Node.js SDK documentation in the usage grid on the index page.

Signed-off-by: Vikram Vaswani <vikram@dagger.io>