### PR TITLE
ci: Extract Node.js SDK lint & test in a standalone workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,12 +45,3 @@ jobs:
         with:
           go-version: 1.19
       - run: ./hack/make sdk:python:lint
-  sdk-nodejs:
-    name: sdk / nodejs
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version: 1.19
-      - run: ./hack/make sdk:nodejs:lint

--- a/.github/workflows/sdk-nodejs.yml
+++ b/.github/workflows/sdk-nodejs.yml
@@ -1,0 +1,38 @@
+name: Node.js SDK
+on:
+  push:
+    branches: [main]
+    paths:
+      - "sdk/nodejs/**.ts"
+      - "sdk/nodejs/**.js"
+      - "sdk/nodejs/**.json"
+      - "sdk/nodejs/.eslintrc.cjs"
+      - ".github/workflows/test-sdk-nodejs.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "sdk/nodejs/**.ts"
+      - "sdk/nodejs/**.js"
+      - "sdk/nodejs/**.json"
+      - "sdk/nodejs/.eslintrc.cjs"
+      - ".github/workflows/test-sdk-nodejs.yml"
+  # Enable manual trigger for easy ad-hoc debugging
+  # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs
+  workflow_dispatch:
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - run: ./hack/make sdk:nodejs:lint
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - run: ./hack/make sdk:nodejs:test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,6 @@ on:
       - "go.sum"
       - "**/go.mod"
       - "**/go.sum"
-      - "sdk/nodejs/**.js"
       - "sdk/python/**.py"
       - ".github/workflows/test.yml"
   pull_request:
@@ -19,7 +18,6 @@ on:
       - "go.sum"
       - "**/go.mod"
       - "**/go.sum"
-      - "sdk/nodejs/**.js"
       - "sdk/python/**.py"
       - ".github/workflows/test.yml"
   # Enable manual trigger for easy ad-hoc debugging
@@ -85,12 +83,3 @@ jobs:
         with:
           go-version: 1.19
       - run: ./hack/make sdk:python:test
-  sdk-nodejs:
-    name: sdk / nodejs
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version: 1.19
-      - run: ./hack/make sdk:nodejs:test


### PR DESCRIPTION
We do not want to run all the tests for everything at once. This makes the Node.js SDK tests run only when necessary.

This started with us realising that we were not running the tests when some important files would change.

We should probably do the same for the other SDKs & engine too.