### PR TITLE
Write logs to stdout instead of stderr.

### DIFF
--- a/cmd/dagger/listen.go
+++ b/cmd/dagger/listen.go
@@ -42,7 +42,7 @@ func setupServer(ctx context.Context) error {
 	}
 
 	if debugLogs {
-		opts = append(opts, dagger.WithLogOutput(os.Stderr))
+		opts = append(opts, dagger.WithLogOutput(os.Stdout))
 	}
 
 	c, err := dagger.Connect(ctx, opts...)


### PR DESCRIPTION
Apparently anything written to stderr will show up in bright red messages in powershell, so it's probably safer right now to dump logs to stdout. I can't think of any downside to this on Linux or macos right now, so seems safe to make the change.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

cc @cdhunt 