### PR TITLE
api: Deprecate host.workdir

### DIFF
--- a/core/integration/examples_test.go
+++ b/core/integration/examples_test.go
@@ -68,7 +68,7 @@ func TestExtensionNetlify(t *testing.T) {
 			require.NoError(t, err)
 			defer c.Close()
 
-			dirID, err := c.Host().Workdir().ID(ctx)
+			dirID, err := c.Host().Directory(".").ID(ctx)
 			require.NoError(t, err)
 
 			secretID, err := c.Host().EnvVariable("NETLIFY_AUTH_TOKEN").Secret().ID(ctx)

--- a/core/integration/host_test.go
+++ b/core/integration/host_test.go
@@ -25,7 +25,7 @@ func TestHostWorkdir(t *testing.T) {
 	t.Run("contains the workdir's content", func(t *testing.T) {
 		contents, err := c.Container().
 			From("alpine:3.16.2").
-			WithMountedDirectory("/host", c.Host().Workdir()).
+			WithMountedDirectory("/host", c.Host().Directory(".")).
 			Exec(dagger.ContainerExecOpts{
 				Args: []string{"ls", "/host"},
 			}).Stdout().Contents(ctx)
@@ -39,7 +39,7 @@ func TestHostWorkdir(t *testing.T) {
 
 		contents, err := c.Container().
 			From("alpine:3.16.2").
-			WithMountedDirectory("/host", c.Host().Workdir()).
+			WithMountedDirectory("/host", c.Host().Directory(".")).
 			Exec(dagger.ContainerExecOpts{
 				Args: []string{"ls", "/host"},
 			}).Stdout().Contents(ctx)
@@ -62,7 +62,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 	defer c.Close()
 
 	t.Run("exclude", func(t *testing.T) {
-		wd := c.Host().Workdir(dagger.HostWorkdirOpts{
+		wd := c.Host().Directory(".", dagger.HostDirectoryOpts{
 			Exclude: []string{"*.rar"},
 		})
 
@@ -77,7 +77,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 	})
 
 	t.Run("include", func(t *testing.T) {
-		wd := c.Host().Workdir(dagger.HostWorkdirOpts{
+		wd := c.Host().Directory(".", dagger.HostDirectoryOpts{
 			Include: []string{"*.rar"},
 		})
 
@@ -92,7 +92,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 	})
 
 	t.Run("exclude overrides include", func(t *testing.T) {
-		wd := c.Host().Workdir(dagger.HostWorkdirOpts{
+		wd := c.Host().Directory(".", dagger.HostDirectoryOpts{
 			Include: []string{"*.txt"},
 			Exclude: []string{"b.txt"},
 		})
@@ -108,7 +108,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 	})
 
 	t.Run("include does not override exclude", func(t *testing.T) {
-		wd := c.Host().Workdir(dagger.HostWorkdirOpts{
+		wd := c.Host().Directory(".", dagger.HostDirectoryOpts{
 			Include: []string{"a.txt"},
 			Exclude: []string{"*.txt"},
 		})
@@ -139,7 +139,7 @@ func TestHostDirectoryRelative(t *testing.T) {
 		wdID1, err := c.Host().Directory(".").ID(ctx)
 		require.NoError(t, err)
 
-		wdID2, err := c.Host().Workdir().ID(ctx)
+		wdID2, err := c.Host().Directory(".").ID(ctx)
 		require.NoError(t, err)
 
 		require.Equal(t, wdID1, wdID2)

--- a/core/integration/platform_test.go
+++ b/core/integration/platform_test.go
@@ -101,7 +101,7 @@ func TestPlatformCrossCompile(t *testing.T) {
 				From("crazymax/goxx:latest").
 				WithMountedCache("/go/pkg/mod", c.CacheVolume("gomod")).
 				WithMountedCache("/root/.cache/go-build", c.CacheVolume("gobuild")).
-				WithMountedDirectory("/src", c.Host().Workdir()).
+				WithMountedDirectory("/src", c.Host().Directory(".")).
 				WithMountedDirectory("/out", c.Directory()).
 				WithWorkdir("/src").
 				WithEnvVariable("TARGETPLATFORM", string(platform)).

--- a/core/schema/host.graphqls
+++ b/core/schema/host.graphqls
@@ -7,6 +7,7 @@ extend type Query {
 type Host {
   "The current working directory on the host"
   workdir(exclude: [String!], include: [String!]): Directory!
+    @deprecated(reason: "Use `directory` with `path` set to . instead")
 
   "Access a directory on the host"
   directory(path: String!, exclude: [String!], include: [String!]): Directory!

--- a/core/schema/host.graphqls
+++ b/core/schema/host.graphqls
@@ -7,7 +7,7 @@ extend type Query {
 type Host {
   "The current working directory on the host"
   workdir(exclude: [String!], include: [String!]): Directory!
-    @deprecated(reason: "Use `directory` with `path` set to . instead")
+    @deprecated(reason: "Use `directory` with path set to '.' instead.")
 
   "Access a directory on the host"
   directory(path: String!, exclude: [String!], include: [String!]): Directory!

--- a/docs/current/sdk/go/959738-get-started.md
+++ b/docs/current/sdk/go/959738-get-started.md
@@ -76,7 +76,7 @@ Replace the `main.go` file from the previous step with the version below (highli
 The revised `build()` function is the main workhorse here, so let's step through it in detail.
 
 - It begins by creating a Dagger client with [`dagger.Connect()`](https://pkg.go.dev/dagger.io/dagger#Connect), as before.
-- It uses the client's [`Host().Workdir()`](https://pkg.go.dev/dagger.io/dagger#Host.Workdir) method to obtain a reference to the current directory on the host. This method returns a `Directory` struct. This reference is stored in the `src` variable.
+- It uses the client's [`Host().Directory()`](https://pkg.go.dev/dagger.io/dagger#Host.Directory) method to obtain a reference to the current directory on the host. This reference is stored in the `src` variable.
 - It initializes a new container from a base image with the [`Container().From()`](https://pkg.go.dev/dagger.io/dagger#Container.From) method and returns a new `Container` struct. In this case, the base image is the `golang:latest` image.
 - It mounts the filesystem of the repository branch in the container using the [`WithMountedDirectory()`](https://pkg.go.dev/dagger.io/dagger#Container.WithMountedDirectory) method of the `Container`.
   - The first argument is the target path in the container (here, `/src`).

--- a/docs/current/sdk/go/snippets/get-started/step4/main.go
+++ b/docs/current/sdk/go/snippets/get-started/step4/main.go
@@ -26,7 +26,7 @@ func build(ctx context.Context) error {
 	defer client.Close()
 
 	// get reference to the local project
-	src := client.Host().Workdir()
+	src := client.Host().Directory(".")
 
 	// get `golang` image
 	golang := client.Container().From("golang:latest")

--- a/docs/current/sdk/go/snippets/get-started/step5a/main.go
+++ b/docs/current/sdk/go/snippets/get-started/step5a/main.go
@@ -31,7 +31,7 @@ func build(ctx context.Context) error {
 	defer client.Close()
 
 	// get reference to the local project
-	src := client.Host().Workdir()
+	src := client.Host().Directory(".")
 
 	// highlight-start
 	// create empty directory to put build outputs

--- a/docs/current/sdk/go/snippets/get-started/step5b/main.go
+++ b/docs/current/sdk/go/snippets/get-started/step5b/main.go
@@ -32,7 +32,7 @@ func build(ctx context.Context) error {
 	defer client.Close()
 
 	// get reference to the local project
-	src := client.Host().Workdir()
+	src := client.Host().Directory(".")
 
 	// create empty directory to put build outputs
 	outputs := client.Directory()

--- a/docs/current/sdk/go/snippets/multistage-build/main.go
+++ b/docs/current/sdk/go/snippets/multistage-build/main.go
@@ -17,7 +17,7 @@ func main() {
 	}
 	defer client.Close()
 
-	project := client.Host().Workdir()
+	project := client.Host().Directory(".")
 
 	// Build our app
 	builder := client.Container().

--- a/docs/current/sdk/go/snippets/work-with-host-filesystem/list-dir-exclude/main.go
+++ b/docs/current/sdk/go/snippets/work-with-host-filesystem/list-dir-exclude/main.go
@@ -26,7 +26,7 @@ func main() {
 	defer client.Close()
 
 	// highlight-start
-	entries, err := client.Host().Workdir(dagger.HostWorkdirOpts{
+	entries, err := client.Host().Directory(".", dagger.HostDirectoryOpts{
 		Exclude: []string{"*.txt"},
 	}).Entries(ctx)
 	// highlight-end

--- a/docs/current/sdk/go/snippets/work-with-host-filesystem/list-dir-include/main.go
+++ b/docs/current/sdk/go/snippets/work-with-host-filesystem/list-dir-include/main.go
@@ -26,7 +26,7 @@ func main() {
 	defer client.Close()
 
 	// highlight-start
-	entries, err := client.Host().Workdir(dagger.HostWorkdirOpts{
+	entries, err := client.Host().Directory(".", dagger.HostDirectoryOpts{
 		Include: []string{"*.rar"},
 	}).Entries(ctx)
 	// highlight-end

--- a/docs/current/sdk/go/snippets/work-with-host-filesystem/list-dir/main.go
+++ b/docs/current/sdk/go/snippets/work-with-host-filesystem/list-dir/main.go
@@ -19,7 +19,7 @@ func main() {
 	defer client.Close()
 
 	// highlight-start
-	entries, err := client.Host().Workdir().Entries(ctx)
+	entries, err := client.Host().Directory(".").Entries(ctx)
 	// highlight-end
 	if err != nil {
 		log.Println(err)

--- a/docs/current/sdk/go/snippets/work-with-host-filesystem/mount-dir/main.go
+++ b/docs/current/sdk/go/snippets/work-with-host-filesystem/mount-dir/main.go
@@ -21,7 +21,7 @@ func main() {
 	// highlight-start
 	contents, err := client.Container().
 		From("alpine:latest").
-		WithMountedDirectory("/host", client.Host().Workdir()).
+		WithMountedDirectory("/host", client.Host().Directory(".")).
 		Exec(dagger.ContainerExecOpts{
 			Args: []string{"ls", "/host"},
 		}).Stdout().Contents(ctx)

--- a/docs/current/sdk/nodejs/783645-get-started.md
+++ b/docs/current/sdk/nodejs/783645-get-started.md
@@ -153,7 +153,7 @@ Replace the `build.js` file from the previous step with the version below (highl
 The revised code now does the following:
 
 - It creates a Dagger client with `connect()` as before.
-- It uses the client's `host().workdir(["node_modules/"]).id()` method to obtain a reference to the current directory on the host. This reference is stored in the `source` variable. It also will ignore the `node_modules` directory on the host since we passed that in as an excluded directory.
+- It uses the client's `host().directory(".", ["node_modules/"]).id()` method to obtain a reference to the current directory on the host. This reference is stored in the `source` variable. It also will ignore the `node_modules` directory on the host since we passed that in as an excluded directory.
 - It uses the client's `container().from()` method to initialize a new container from a base image. This base image is the Node.js version to be tested against - the `node:16` image. This method returns a new `Container` object with the results.
 - It uses the `Container.withMountedDirectory()` method to mount the host directory into the container at the `/src` mount point, and the `Container.withWorkdir()` method to set the working directory in the container. The revised `Container` is stored in the `runner` constant.
 - It uses the `Container.exec()` method to define the command to run tests in the container - in this case, the command `npm test -- --watchAll=false`.

--- a/docs/current/sdk/nodejs/snippets/get-started/step4/build.js
+++ b/docs/current/sdk/nodejs/snippets/get-started/step4/build.js
@@ -4,7 +4,7 @@ import { connect } from "@dagger.io/dagger"
 connect(async (client) => {
   // highlight-start
   // get reference to the local project
-  const source = await client.host().workdir(["node_modules/"]).id()
+  const source = await client.host().directory(".", ["node_modules/"]).id()
 
   // get Node image
   const node = await client.container().from("node:16").id()

--- a/docs/current/sdk/nodejs/snippets/get-started/step4/build.ts
+++ b/docs/current/sdk/nodejs/snippets/get-started/step4/build.ts
@@ -4,7 +4,7 @@ import Client, { connect } from "@dagger.io/dagger"
 connect(async (client: Client) => {
   // highlight-start
   // get reference to the local project
-  const source = await client.host().workdir(["node_modules/"]).id()
+  const source = await client.host().directory(".", ["node_modules/"]).id()
 
   // get Node image
   const node = await client.container().from("node:16").id()

--- a/docs/current/sdk/nodejs/snippets/get-started/step5/build.js
+++ b/docs/current/sdk/nodejs/snippets/get-started/step5/build.js
@@ -8,7 +8,7 @@ connect(async (client) => {
   // highlight-end
 
   // get reference to the local project
-  const source = await client.host().workdir(["node_modules/"]).id()
+  const source = await client.host().directory(".", ["node_modules/"]).id()
 
   // highlight-start
   // for each Node version

--- a/docs/current/sdk/nodejs/snippets/get-started/step5/build.ts
+++ b/docs/current/sdk/nodejs/snippets/get-started/step5/build.ts
@@ -8,7 +8,7 @@ connect(async (client: Client) => {
   // highlight-end
 
   // get reference to the local project
-  const source = await client.host().workdir(["node_modules/"]).id()
+  const source = await client.host().directory(".", ["node_modules/"]).id()
 
   // highlight-start
   // for each Node version

--- a/docs/current/sdk/python/628797-get-started.md
+++ b/docs/current/sdk/python/628797-get-started.md
@@ -81,7 +81,7 @@ Replace the `test.py` file from the previous step with the version below (highli
 The revised `test()` function now does the following:
 
 - It creates a Dagger client with `dagger.Connection()` as before.
-- It uses the client's `host().workdir().id()` method to obtain a reference to the current directory on the host. This reference is stored in the `src_id` variable.
+- It uses the client's `host().directory(".").id()` method to obtain a reference to the current directory on the host. This reference is stored in the `src_id` variable.
 - It uses the client's `container().from_()` method to initialize a new container from a base image. This base image is the Python version to be tested against - the `python:3.10-slim-buster` image. This method returns a new `Container` class with the results.
 - It uses the `Container.with_mounted_directory()` method to mount the host directory into the container at the `/src` mount point.
 - It uses the `Container.with_workdir()` method to set the working directory in the container.

--- a/docs/current/sdk/python/guides/648384-multi-builds.md
+++ b/docs/current/sdk/python/guides/648384-multi-builds.md
@@ -33,7 +33,7 @@ The `build()` function does the following:
 
 - It defines the build matrix, consisting of two OSs (`darwin` and `linux`) and two architectures (`amd64` and `arm64`).
 - It creates a Dagger client with `dagger.Connection()`.
-- It uses the client's `host().workdir().id()` method to obtain a reference to the current directory on the host. This reference is stored in the `src_id` variable.
+- It uses the client's `host().directory(".").id()` method to obtain a reference to the current directory on the host. This reference is stored in the `src_id` variable.
 - It uses the client's `container().from_()` method to initialize a new container from a base image. This base image contains all the tooling needed to build the application - in this case, the `golang:latest` image. This `from_()` method returns a new `Container` class with the results.
 - It uses the `Container.with_mounted_directory()` method to mount the host directory into the container at the `/src` mount point.
 - It uses the `Container.with_workdir()` method to set the working directory in the container.

--- a/docs/current/sdk/python/snippets/get-started/step3/test.py
+++ b/docs/current/sdk/python/snippets/get-started/step3/test.py
@@ -11,7 +11,7 @@ async def test():
 
         # highlight-start
         # get reference to the local project
-        src_id = await client.host().workdir().id()
+        src_id = await client.host().directory(".").id()
 
         python = (
             client.container()

--- a/docs/current/sdk/python/snippets/get-started/step4a/test.py
+++ b/docs/current/sdk/python/snippets/get-started/step4a/test.py
@@ -14,7 +14,7 @@ async def test():
     async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
 
         # get reference to the local project
-        src_id = await client.host().workdir().id()
+        src_id = await client.host().directory(".").id()
 
         # highlight-start
         for version in versions:

--- a/docs/current/sdk/python/snippets/get-started/step4b/test.py
+++ b/docs/current/sdk/python/snippets/get-started/step4b/test.py
@@ -12,7 +12,7 @@ async def test():
     async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
 
         # get reference to the local project
-        src_id = await client.host().workdir().id()
+        src_id = await client.host().directory(".").id()
 
         # highlight-start
         # when this block exits, all tasks will be awaited (i.e., executed)

--- a/docs/current/sdk/python/snippets/multi-builds/build.py
+++ b/docs/current/sdk/python/snippets/multi-builds/build.py
@@ -20,7 +20,7 @@ async def build():
     async with dagger.Connection() as client:
 
         # get reference to the local project
-        src_id = await client.host().workdir().id()
+        src_id = await client.host().directory(".").id()
 
         # create empty directory to put build outputs
         outputs = client.directory()

--- a/internal/mage/cli.go
+++ b/internal/mage/cli.go
@@ -19,7 +19,7 @@ func (cl Cli) Publish(ctx context.Context) error {
 	defer c.Close()
 
 	return util.WithDevEngine(ctx, c, func(ctx context.Context, c *dagger.Client) error {
-		wd := c.Host().Workdir()
+		wd := c.Host().Directory(".")
 		container := c.Container().
 			From("ghcr.io/goreleaser/goreleaser:v1.12.3").
 			WithEntrypoint([]string{}).

--- a/internal/mage/util/util.go
+++ b/internal/mage/util/util.go
@@ -14,7 +14,7 @@ import (
 
 // Repository with common set of exclude filters to speed up upload
 func Repository(c *dagger.Client) *dagger.Directory {
-	return c.Host().Workdir(dagger.HostWorkdirOpts{
+	return c.Host().Directory(".", dagger.HostDirectoryOpts{
 		Exclude: []string{
 			// node
 			"**/node_modules",

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -1000,6 +1000,8 @@ type HostWorkdirOpts struct {
 }
 
 // The current working directory on the host
+//
+// Deprecated: Use Directory with Path set to . instead
 func (r *Host) Workdir(opts ...HostWorkdirOpts) *Directory {
 	q := r.q.Select("workdir")
 	// `exclude` optional argument

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -1001,7 +1001,7 @@ type HostWorkdirOpts struct {
 
 // The current working directory on the host
 //
-// Deprecated: Use Directory with Path set to . instead
+// Deprecated: Use Directory with path set to '.' instead.
 func (r *Host) Workdir(opts ...HostWorkdirOpts) *Directory {
 	q := r.q.Select("workdir")
 	// `exclude` optional argument

--- a/sdk/go/examples_test.go
+++ b/sdk/go/examples_test.go
@@ -197,7 +197,7 @@ func ExampleDirectory() {
 	// Output: [goodbye.txt hello.txt]
 }
 
-func ExampleHost_Workdir() {
+func ExampleHost_Directory() {
 	ctx := context.Background()
 	client, err := dagger.Connect(ctx, dagger.WithWorkdir("."))
 	if err != nil {
@@ -205,7 +205,7 @@ func ExampleHost_Workdir() {
 	}
 	defer client.Close()
 
-	readme, err := client.Host().Workdir().File("README.md").Contents(ctx)
+	readme, err := client.Host().Directory(".").File("README.md").Contents(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -1231,7 +1231,7 @@ export class Host extends BaseClient {
   /**
    * The current working directory on the host
    *
-   * @deprecated Use directory with path set to . instead
+   * @deprecated Use directory with path set to "." instead
    */
   workdir(exclude?: string[], include?: string[]): Directory {
     return new Directory({

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -1230,6 +1230,8 @@ export class Host extends BaseClient {
 
   /**
    * The current working directory on the host
+   *
+   * @deprecated Use directory with path set to . instead
    */
   workdir(exclude?: string[], include?: string[]): Directory {
     return new Directory({

--- a/sdk/python/docs/conf.py
+++ b/sdk/python/docs/conf.py
@@ -23,11 +23,9 @@ extensions = [
 language = "en"
 locale_dirs = []
 
-templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 pygments_style = "sphinx"
 
 html_theme = "sphinx_rtd_theme"
-html_static_path = ["_static"]
 
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -204,7 +204,7 @@ class Container(Type):
         """This container's root filesystem. Mounts are not included.
 
         .. deprecated::
-            Replaced by `rootfs`.
+            Replaced by :py:meth:`rootfs`.
         """
         _args: list[Arg] = []
         _ctx = self._select("fs", _args)
@@ -333,7 +333,7 @@ class Container(Type):
         """Initialize this container from this DirectoryID
 
         .. deprecated::
-            Replaced by `withRootfs`.
+            Replaced by :py:meth:`with_rootfs`.
         """
         _args = [
             Arg("id", id),
@@ -801,7 +801,11 @@ class Host(Type):
     def workdir(
         self, exclude: list[str] | None = None, include: list[str] | None = None
     ) -> "Directory":
-        """The current working directory on the host"""
+        """The current working directory on the host
+
+        .. deprecated::
+            Use :py:meth:`directory` with path set to '.' instead.
+        """
         _args = [
             Arg("exclude", exclude, None),
             Arg("include", include, None),

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -204,7 +204,7 @@ class Container(Type):
         """This container's root filesystem. Mounts are not included.
 
         .. deprecated::
-            Replaced by `rootfs`.
+            Replaced by :py:meth:`rootfs`.
         """
         _args: list[Arg] = []
         _ctx = self._select("fs", _args)
@@ -333,7 +333,7 @@ class Container(Type):
         """Initialize this container from this DirectoryID
 
         .. deprecated::
-            Replaced by `withRootfs`.
+            Replaced by :py:meth:`with_rootfs`.
         """
         _args = [
             Arg("id", id),
@@ -801,7 +801,11 @@ class Host(Type):
     def workdir(
         self, exclude: list[str] | None = None, include: list[str] | None = None
     ) -> "Directory":
-        """The current working directory on the host"""
+        """The current working directory on the host
+
+        .. deprecated::
+            Use :py:meth:`directory` with path set to '.' instead.
+        """
         _args = [
             Arg("exclude", exclude, None),
             Arg("include", include, None),

--- a/sdk/python/tests/api/test_integration.py
+++ b/sdk/python/tests/api/test_integration.py
@@ -113,7 +113,7 @@ async def test_directory():
         assert entries == ["goodbye.txt", "hello.txt"]
 
 
-async def test_host_workdir():
+async def test_host_directory():
     async with dagger.Connection() as client:
-        readme = await client.host().workdir().file("README.md").contents()
+        readme = await client.host().directory(".").file("README.md").contents()
         assert "Dagger" in readme


### PR DESCRIPTION
Deprecated in favor of `host.directory(path: ".")`

Fixes #3828

@vikram-dagger: I updated the docs the best I could, please take a look

/cc @kpenfound @jpadams