### PR TITLE
sdk: nodejs: format generated code

### DIFF
--- a/internal/mage/sdk/nodejs.go
+++ b/internal/mage/sdk/nodejs.go
@@ -35,15 +35,13 @@ func (t Nodejs) Lint(ctx context.Context) error {
 				ExperimentalPrivilegedNesting: true,
 			}).
 			ExitCode(ctx)
-		return err
+		if err != nil {
+			return err
+		}
+		return lintGeneratedCode(func() error {
+			return t.Generate(ctx)
+		}, nodejsGeneratedAPIPath)
 	})
-}
-
-// Generateandcheck checks generated code
-func (t Nodejs) Generateandcheck(ctx context.Context) error {
-	return lintGeneratedCode(func() error {
-		return t.Generate(ctx)
-	}, nodejsGeneratedAPIPath)
 }
 
 // Test tests the Node.js SDK
@@ -74,11 +72,18 @@ func (t Nodejs) Generate(ctx context.Context) error {
 	defer c.Close()
 
 	return util.WithDevEngine(ctx, c, func(ctx context.Context, c *dagger.Client) error {
-		generated, err := util.GoBase(c).
+		generated, err := nodeJsBase(c).
 			WithMountedFile("/usr/local/bin/cloak", util.DaggerBinary(c)).
 			Exec(dagger.ContainerExecOpts{
 				Args:                          []string{"cloak", "client-gen", "--lang", "nodejs", "-o", nodejsGeneratedAPIPath},
 				ExperimentalPrivilegedNesting: true,
+			}).
+			Exec(dagger.ContainerExecOpts{
+				Args: []string{
+					"yarn",
+					"fmt",
+					nodejsGeneratedAPIPath,
+				},
 			}).
 			File(nodejsGeneratedAPIPath).
 			Contents(ctx)

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -29,7 +29,7 @@
     "test": "mocha",
     "gen:typedoc": "yarn typedoc",
     "lint": "yarn eslint --max-warnings=0 .",
-    "fmt": "yarn eslint --fix ."
+    "fmt": "yarn eslint --fix"
   },
   "devDependencies": {
     "@types/mocha": "latest",


### PR DESCRIPTION
Temporary hack to manually format the generated code, until we generate
formatted code.

Without this, every time I call `sdk:all:generate`, I have explicitly to
cd into `sdk/nodejs` and run `yarn fmt` to fix it.

Signed-off-by: Andrea Luzzardi <al@dagger.io>
