### PR TITLE
docs: Add deprecation note, update /install page

### DIFF
--- a/docs/current/729312-install.md
+++ b/docs/current/729312-install.md
@@ -1,0 +1,13 @@
+---
+slug: /install
+displayed_sidebar: 'current'
+---
+
+# Installation
+
+Dagger SDKs are available for multiple programming languages. Refer to the links below for installation instructions for your language of choice.
+
+- [Install the Dagger Go SDK](./sdk/go/371491-install.md)
+- [Install the Dagger Node.js SDK](./sdk/nodejs/835948-install.md)
+- [Install the Dagger Python SDK](./sdk/python/866944-install.md)
+- [Install the Dagger CUE SDK](./sdk/cue/getting-started/526369-install.mdx)

--- a/docs/partials/_caution-old-version.md
+++ b/docs/partials/_caution-old-version.md
@@ -1,0 +1,5 @@
+:::caution
+This documentation is for an older version of Dagger, which is no longer actively maintained.
+
+We encourage you to refer to the [documentation for the most current version](/).
+:::

--- a/docs/v0.1/0.1.md
+++ b/docs/v0.1/0.1.md
@@ -5,10 +5,10 @@ displayed_sidebar: '0.1'
 
 # Dagger 0.1
 
-This documentation is for dagger 0.1 which is no longer maintained.
+This documentation is for Dagger 0.1 which is no longer maintained.
 
-If you are still running dagger 0.1, we encourage you to upgrade to 0.2.
-These are the [current dagger 0.2 docs](/).
+If you are still running Dagger 0.1, we encourage you to upgrade.
+These are the [current Dagger docs](/).
 
 If you need help migrating your plan, we will be happy to assist you!
 Simply reply to [this thread](https://github.com/dagger/dagger/discussions/1772) with a description of your configuration.

--- a/docs/v0.1/1001-install.md
+++ b/docs/v0.1/1001-install.md
@@ -6,7 +6,7 @@ import CautionBanner from './\_caution-banner.md'
 
 # Install Dagger
 
-<CautionBanner old="0.1" new="0.2" />
+{@include: ../../partials/_caution-old-version.md}
 
 :::caution Requirement
 

--- a/docs/v0.1/administrator/1013-operator-manual.md
+++ b/docs/v0.1/administrator/1013-operator-manual.md
@@ -3,11 +3,9 @@ slug: /1013/operator-manual/
 displayed_sidebar: '0.1'
 ---
 
-import CautionBanner from '../\_caution-banner.md'
-
 # Dagger Operator Manual
 
-<CautionBanner old="0.1" new="0.2" />
+{@include: ../../partials/_caution-old-version.md}
 
 ## Custom buildkit setup
 

--- a/docs/v0.1/introduction/1000-what_is.md
+++ b/docs/v0.1/introduction/1000-what_is.md
@@ -2,11 +2,9 @@
 slug: /1000/what/
 ---
 
-import CautionBanner from '../\_caution-banner.md'
-
 # What is Dagger?
 
-<CautionBanner old="0.1" new="0.2" />
+{@include: ../../partials/_caution-old-version.md}
 
 Dagger is a portable devkit for CICD. It helps you develop powerful CICD pipelines that can run anywhere.
 

--- a/docs/v0.1/introduction/1002-vs_old.md
+++ b/docs/v0.1/introduction/1002-vs_old.md
@@ -3,11 +3,9 @@ slug: /1002/vs/
 ---
 
 
-import CautionBanner from '../\_caution-banner.md'
-
 # Dagger vs. Other Software
 
-<CautionBanner old="0.1" new="0.2" />
+{@include: ../../partials/_caution-old-version.md}
 
 ## Dagger vs. CI (GitHub Actions, GitLab, CircleCI, Jenkins, etc.)
 

--- a/docs/v0.1/learn/1003-get-started.md
+++ b/docs/v0.1/learn/1003-get-started.md
@@ -3,11 +3,9 @@ slug: /1003/get-started/
 ---
 
 
-import CautionBanner from '../\_caution-banner.md'
-
 # Get Started with Dagger
 
-<CautionBanner old="0.1" new="0.2" />
+{@include: ../../partials/_caution-old-version.md}
 
 <iframe width="800" height="450" style={{width: '100%', marginBottom: '2rem'}} src="https://www.youtube.com/embed/QvyB3m9Fti0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen"></iframe>
 

--- a/docs/v0.1/learn/1004-first-env.md
+++ b/docs/v0.1/learn/1004-first-env.md
@@ -2,11 +2,9 @@
 slug: /1004/dev-first-env/
 ---
 
-import CautionBanner from '../\_caution-banner.md'
-
 # Create your first Dagger environment
 
-<CautionBanner old="0.1" new="0.2" />
+{@include: ../../partials/_caution-old-version.md}
 
 ## Overview
 

--- a/docs/v0.1/learn/1005-what_is_cue.md
+++ b/docs/v0.1/learn/1005-what_is_cue.md
@@ -4,11 +4,9 @@ displayed_sidebar: "0.1"
 ---
 
 
-import CautionBanner from '../\_caution-banner.md'
-
 # What is Cue?
 
-<CautionBanner old="0.1" new="0.2" />
+{@include: ../../partials/_caution-old-version.md}
 
 CUE is a powerful configuration language created by Marcel van Lohuizen who co-created the Borg Configuration Language (BCL)&mdash;the [language used to deploy all applications at Google](https://storage.googleapis.com/pub-tools-public-publication-data/pdf/43438.pdf). CUE is the result of years of experience writing configuration languages at Google, and seeks to improve the developer experience while avoiding some nasty pitfalls. It is a superset of JSON, with additional features to make declarative, data-driven programming as pleasant and productive as regular imperative programming.
 

--- a/docs/v0.1/learn/1006-google-cloud-run.md
+++ b/docs/v0.1/learn/1006-google-cloud-run.md
@@ -2,11 +2,9 @@
 slug: /1006/google-cloud-run/
 ---
 
-import CautionBanner from '../\_caution-banner.md'
-
 # Deploy to Google Cloud Run with Dagger
 
-<CautionBanner old="0.1" new="0.2" />
+{@include: ../../partials/_caution-old-version.md}
 
 This tutorial illustrates how to use Dagger to build, push and deploy Docker images to Cloud Run.
 

--- a/docs/v0.1/learn/1007-kubernetes.md
+++ b/docs/v0.1/learn/1007-kubernetes.md
@@ -2,11 +2,9 @@
 slug: /1007/kubernetes/
 ---
 
-import CautionBanner from '../\_caution-banner.md'
-
 # Deploy to Kubernetes with Dagger
 
-<CautionBanner old="0.1" new="0.2" />
+{@include: ../../partials/_caution-old-version.md}
 
 This tutorial illustrates how to use Dagger to build, push and deploy Docker images to Kubernetes.
 

--- a/docs/v0.1/learn/1008-aws-cloudformation.md
+++ b/docs/v0.1/learn/1008-aws-cloudformation.md
@@ -2,11 +2,9 @@
 slug: /1008/aws-cloudformation/
 ---
 
-import CautionBanner from '../\_caution-banner.md'
-
 # Provision infrastructure with Dagger and AWS CloudFormation
 
-<CautionBanner old="0.1" new="0.2" />
+{@include: ../../partials/_caution-old-version.md}
 
 In this guide, you will learn how to automatically [provision infrastructure](https://dzone.com/articles/infrastructure-provisioning-–) on AWS by integrating [Amazon Cloudformation](https://aws.amazon.com/cloudformation/) in your Dagger environment.
 

--- a/docs/v0.1/learn/1009-github-actions.md
+++ b/docs/v0.1/learn/1009-github-actions.md
@@ -2,11 +2,9 @@
 slug: /1009/github-actions/
 ---
 
-import CautionBanner from '../\_caution-banner.md'
-
 # Integrate Dagger with GitHub Actions
 
-<CautionBanner old="0.1" new="0.2" />
+{@include: ../../partials/_caution-old-version.md}
 
 This tutorial illustrates how to use GitHub Actions and Dagger to build, push and deploy Docker images to Cloud Run.
 

--- a/docs/v0.1/learn/1010-dev-cue-package.md
+++ b/docs/v0.1/learn/1010-dev-cue-package.md
@@ -2,11 +2,9 @@
 slug: /1010/dev-cue-package/
 ---
 
-import CautionBanner from '../\_caution-banner.md'
-
 # Develop a new CUE package for Dagger
 
-<CautionBanner old="0.1" new="0.2" />
+{@include: ../../partials/_caution-old-version.md}
 
 This tutorial illustrates how to create new packages, manually distribute them among your applications and contribute to the Dagger stdlib packages.
 

--- a/docs/v0.1/learn/1011-package-manager.md
+++ b/docs/v0.1/learn/1011-package-manager.md
@@ -2,11 +2,9 @@
 slug: /1011/package-manager/
 ---
 
-import CautionBanner from '../\_caution-banner.md'
-
 # Manage packages using the package manager
 
-<CautionBanner old="0.1" new="0.2" />
+{@include: ../../partials/_caution-old-version.md}
 
 This tutorial illustrates how to install and upgrade packages using Dagger package manager.
 

--- a/docs/v0.1/use-cases/1012-ci.md
+++ b/docs/v0.1/use-cases/1012-ci.md
@@ -2,11 +2,9 @@
 slug: /1012/ci
 ---
 
-import CautionBanner from '../\_caution-banner.md'
-
 # Make your CI workflow portable
 
-<CautionBanner old="0.1" new="0.2" />
+{@include: ../../partials/_caution-old-version.md}
 
 ## Problems with existing CIs
 

--- a/docs/v0.2/core-concepts/1202-plan.md
+++ b/docs/v0.2/core-concepts/1202-plan.md
@@ -8,6 +8,8 @@ import {DaggerVersionLatestReleased} from '@site/src/components/DaggerVersionLat
 
 # A Dagger Plan orchestrates the Actions
 
+{@include: ../../partials/_caution-old-version.md}
+
 ## Plan structure
 
 A config declared in Dagger starts with a plan, specifically `dagger.#Plan`

--- a/docs/v0.2/core-concepts/1203-client.md
+++ b/docs/v0.2/core-concepts/1203-client.md
@@ -5,6 +5,8 @@ displayed_sidebar: '0.2'
 
 # Interacting with the client
 
+{@include: ../../partials/_caution-old-version.md}
+
 `dagger.#Plan` has a `client` field that allows interaction with the local machine where the `dagger` command line client is run. You can:
 
 - Read and write files and directories;

--- a/docs/v0.2/core-concepts/1204-secrets.md
+++ b/docs/v0.2/core-concepts/1204-secrets.md
@@ -5,6 +5,8 @@ displayed_sidebar: '0.2'
 
 # How to use secrets
 
+{@include: ../../partials/_caution-old-version.md}
+
 ## What are Secrets?
 
 Secrets support in Dagger allows you to utilize confidential information -- such as passwords, API keys, SSH keys, etc -- when running your Dagger Plans, _without_ exposing those secrets in plaintext logs, writing them into the filesystem of containers you're building, or inserting them into cache.
@@ -205,8 +207,8 @@ dagger.#Plan & {
 
 It is possible use Secrets in ways that can risk leaks. Be aware of the risks of these uses, and avoid them if possible.
 
-<!-- 
-TODO: Provide examples of these 
+<!--
+TODO: Provide examples of these
 - Baking secrets into a container, by copying them into a filesystem or container from a mount or environment variable
 -->
 

--- a/docs/v0.2/core-concepts/1206-packages.md
+++ b/docs/v0.2/core-concepts/1206-packages.md
@@ -4,3 +4,5 @@ displayed_sidebar: '0.2'
 ---
 
 # Create your own package
+
+{@include: ../../partials/_caution-old-version.md}

--- a/docs/v0.2/core-concepts/1207-caching.md
+++ b/docs/v0.2/core-concepts/1207-caching.md
@@ -4,3 +4,5 @@ displayed_sidebar: '0.2'
 ---
 
 # Make your builds fast
+
+{@include: ../../partials/_caution-old-version.md}

--- a/docs/v0.2/core-concepts/1213-dagger-cue.md
+++ b/docs/v0.2/core-concepts/1213-dagger-cue.md
@@ -5,6 +5,8 @@ displayed_sidebar: '0.2'
 
 # Dagger CUE API
 
+{@include: ../../partials/_caution-old-version.md}
+
 As of Dagger 0.2, the Dagger CUE API can be imported via `dagger.io/dagger` & `dagger.io/dagger/core`
 
 The Dagger CUE API is the set of CUE packages released alongside the Dagger engine.

--- a/docs/v0.2/core-concepts/1215-what-is-cue.md
+++ b/docs/v0.2/core-concepts/1215-what-is-cue.md
@@ -4,6 +4,8 @@ slug: /1215/what-is-cue/
 
 # What is CUE?
 
+{@include: ../../partials/_caution-old-version.md}
+
 CUE is a powerful configuration language created by Marcel van Lohuizen who co-created the Borg Configuration Language (BCL)&mdash;the [language used to deploy all applications at Google](https://storage.googleapis.com/pub-tools-public-publication-data/pdf/43438.pdf). CUE is the result of years of experience writing configuration languages at Google, and seeks to improve the developer experience while avoiding some nasty pitfalls. It is a superset of JSON, with additional features to make declarative, data-driven programming as pleasant and productive as regular imperative programming.
 
 ## The Need for a Configuration Language
@@ -211,7 +213,7 @@ Bob inherits the _default value_ but is now allowed to specify a different job.
 
 CUE allows the embedding of one definition into another, similar
 to [Golang Embedding](https://go.dev/doc/effective_go#embedding)
-or [object-oriented composition](https://en.wikipedia.org/wiki/Composition_over_inheritance).  
+or [object-oriented composition](https://en.wikipedia.org/wiki/Composition_over_inheritance).
 This avoids adding an extra level of depth to the definition
 
 ```cue
@@ -259,7 +261,7 @@ Bob:
   Domain: Backend
 ```
 
-Any definition that embed `#Engineer` will share its properties, and they will be accessible directly from the definition.  
+Any definition that embed `#Engineer` will share its properties, and they will be accessible directly from the definition.
 [Try it in the CUE Playground](https://cuelang.org/play/?id=iFcZKx72Bwm#cue@export@cue)
 
 ### Packages

--- a/docs/v0.2/core-concepts/1220-vs.md
+++ b/docs/v0.2/core-concepts/1220-vs.md
@@ -7,6 +7,8 @@ pagination_next: null
 
 # Dagger vs. Other Software
 
+{@include: ../../partials/_caution-old-version.md}
+
 ## What is Dagger?
 
 Dagger is a portable devkit for CI/CD.

--- a/docs/v0.2/core-concepts/1221-action.md
+++ b/docs/v0.2/core-concepts/1221-action.md
@@ -6,6 +6,8 @@ pagination_prev: v0.2/getting-started/how-it-works
 
 # Dagger Actions
 
+{@include: ../../partials/_caution-old-version.md}
+
 Actions are the basic building block of the Dagger platform.
 An action encapsulates an arbitrarily complex automation into a simple
 software component that can be safely shared, and repeatably executed by any Dagger engine.

--- a/docs/v0.2/core-concepts/1247-dagger-fs.md
+++ b/docs/v0.2/core-concepts/1247-dagger-fs.md
@@ -5,6 +5,8 @@ displayed_sidebar: "0.2"
 
 # Dagger filesystems: `#FS`
 
+{@include: ../../partials/_caution-old-version.md}
+
 Along with container images, filesystems are one of the building blocks of the Dagger platform. They are represented by the `dagger.#FS` type. An `#FS` is a reference to a filesystem tree: a directory storing files in a hierarchical/tree structure.
 
 ## Filesystems are everywhere

--- a/docs/v0.2/dgr18-overview.mdx
+++ b/docs/v0.2/dgr18-overview.mdx
@@ -14,6 +14,8 @@ import { useDocsSidebar } from "@docusaurus/theme-common";
 
 # Welcome!
 
+{@include: ../partials/_caution-old-version.md}
+
 Welcome to Dagger's documentation site!
 
 Dagger is a portable devkit for CI/CD pipelines that helps you build powerful CI/CD pipelines quickly, then run them anywhere.

--- a/docs/v0.2/getting-started/1242-install.mdx
+++ b/docs/v0.2/getting-started/1242-install.mdx
@@ -1,10 +1,11 @@
 ---
-id: install
-slug: /install
+slug: /1242/install
 displayed_sidebar: "0.2"
 ---
 
 # Install Dagger
+
+{@include: ../../partials/_caution-old-version.md}
 
 The first step to get started is to install dagger on your local machine.
 Once installed, we recommend [following our tutorial](/1200/local-dev) (or trying a template.)

--- a/docs/v0.2/getting-started/f44rm-how-it-works.mdx
+++ b/docs/v0.2/getting-started/f44rm-how-it-works.mdx
@@ -12,6 +12,8 @@ import styles from "@site/src/css/how-it-works.module.scss";
 
 # How It works
 
+{@include: ../../partials/_caution-old-version.md}
+
 Understanding how Dagger works is key for understanding the tool. If you understand Dagger, you can develop complex pipelines and experiment in ways that are not even documented yet with your preferred CI/CD tools.
 
 ## 💎 Core Concepts

--- a/docs/v0.2/getting-started/tutorial/1200-local-dev.md
+++ b/docs/v0.2/getting-started/tutorial/1200-local-dev.md
@@ -9,6 +9,8 @@ import BrowserOnly from '@docusaurus/BrowserOnly';
 
 # Build, run and test locally
 
+{@include: ../../../partials/_caution-old-version.md}
+
 Everyone should be able to develop, test and run their application using a local pipeline.
 Having to commit & push in order to test a change slows down iteration.
 This guide shows you the Dagger way.

--- a/docs/v0.2/getting-started/tutorial/1201-ci-environment.md
+++ b/docs/v0.2/getting-started/tutorial/1201-ci-environment.md
@@ -5,6 +5,8 @@ displayed_sidebar: "0.2"
 
 # Integrate with your CI environment
 
+{@include: ../../../partials/_caution-old-version.md}
+
 [Once you have Dagger running locally](/1200/local-dev), it's easy to use Dagger with any CI environment (no migration required) to run the same Dagger pipelines. Any CI environment with Docker pre-installed works with Dagger out of the box.
 
 We started with [CI environments that you told us you are using](https://github.com/dagger/dagger/discussions/1677).

--- a/docs/v0.2/guidelines/1226-coding-style.md
+++ b/docs/v0.2/guidelines/1226-coding-style.md
@@ -4,6 +4,8 @@ slug: /1226/coding-style
 
 # Package Coding Style
 
+{@include: ../../partials/_caution-old-version.md}
+
 Please follow these guidelines when contributing CUE packages to keep consistency,
 improve clarity and avoid issues.
 

--- a/docs/v0.2/guidelines/1227-contributing.md
+++ b/docs/v0.2/guidelines/1227-contributing.md
@@ -5,4 +5,6 @@ displayed_sidebar: '0.2'
 
 # Contributing to Dagger
 
+{@include: ../../partials/_caution-old-version.md}
+
 {@include: ../../partials/_contributing.md}

--- a/docs/v0.2/guides/actions/1228-handling-outputs.md
+++ b/docs/v0.2/guides/actions/1228-handling-outputs.md
@@ -7,6 +7,8 @@ import DaggerCloudCTA from '../../includes/\_dagger-cloud-cta.md';
 
 # Handling action outputs
 
+{@include: ../../../partials/_caution-old-version.md}
+
 Dagger tries to detect which fields are outputs in an action. Simple values like strings, numbers and booleans are printed directly to the console, as you can see when the [todo app example](/1200/local-dev) finishes:
 
 ```shell

--- a/docs/v0.2/guides/actions/1231-always-execute.md
+++ b/docs/v0.2/guides/actions/1231-always-execute.md
@@ -5,6 +5,8 @@ displayed_sidebar: '0.2'
 
 # How to always execute an action?
 
+{@include: ../../../partials/_caution-old-version.md}
+
 Dagger implemented a way to invalidate cache for a specific action.
 
 The `docker.#Run` and `core.#Exec` actions have an `always` field (which means "always run"):

--- a/docs/v0.2/guides/actions/1233-default-values-cue.md
+++ b/docs/v0.2/guides/actions/1233-default-values-cue.md
@@ -5,6 +5,8 @@ displayed_sidebar: '0.2'
 
 # Default values and optional fields
 
+{@include: ../../../partials/_caution-old-version.md}
+
 When writing a Cue config, you will sometimes want to set default values in your package.
 
 The most common way you'll encounter in our codebase is: `key: type | *value`:
@@ -27,7 +29,7 @@ To test the type of `defaultValue`, you can directly do such assertion:
 if defaultValue != "foo" | if defaultValue != false | if defaultValue != null {
     ...
 }
- 
+
 if defaultValue == "foo" | if defaultValue == false | if defaultValue == null {
     ...
 }
@@ -47,7 +49,7 @@ To check on a field's concreteness, use the bottom value `_|_`:
 if foo != _|_ { // if foo is not `undefined`
     ...
 }
- 
+
 if foo == _|_ { // if foo is `undefined`
     ...
 }

--- a/docs/v0.2/guides/actions/1239-making-reusable-package.md
+++ b/docs/v0.2/guides/actions/1239-making-reusable-package.md
@@ -5,6 +5,8 @@ displayed_sidebar: "0.2"
 
 # Making reusable packages
 
+{@include: ../../../partials/_caution-old-version.md}
+
 Whilst splitting your plan into several files is a good idea, you will sometimes need to create standalone packages aiming to be reusable and shared. Let's explore how to do that.
 
 ## Packages, modules, and Dagger projects

--- a/docs/v0.2/guides/actions/1240-core-source.md
+++ b/docs/v0.2/guides/actions/1240-core-source.md
@@ -5,6 +5,8 @@ displayed_sidebar: "0.2"
 
 # When to use `core.#Source`?
 
+{@include: ../../../partials/_caution-old-version.md}
+
 The [#Source core action](../../references/1222-core-actions-reference.md#core-actions-related-to-filesystem-trees) seems to do the same as `client: filesystem: ...: read: contents: dagger.#FS`, although there's important differences.
 
 ## Purpose

--- a/docs/v0.2/guides/actions/1241-field-shadowing.md
+++ b/docs/v0.2/guides/actions/1241-field-shadowing.md
@@ -5,6 +5,8 @@ displayed_sidebar: "0.2"
 
 # Understanding field shadowing and how to avoid it
 
+{@include: ../../../partials/_caution-old-version.md}
+
 Field shadowing is a common CUE error than can lead your plan to unexpected behavior really painful to debug.
 
 :::info
@@ -13,7 +15,7 @@ Before reading this page, we recommend you to read [CUE Guide](../../core-concep
 
 ## What is field shadowing ?
 
-It happens whenever you are using the same name as a key and value where this value is define at outer scope.  
+It happens whenever you are using the same name as a key and value where this value is define at outer scope.
 A concrete example is the best way to understand field shadowing
 
 ```cue
@@ -25,14 +27,14 @@ test: "hello world"
    test: string
 }
 
-// We concretise our definition and assign key test to value defined in 
+// We concretise our definition and assign key test to value defined in
 // outer key test
-// This will produce a shadowing 
+// This will produce a shadowing
 shadow: #Def & {
    test: test
 }
 
-// We concretise our definition and assign key test to value defined in 
+// We concretise our definition and assign key test to value defined in
 // outer key test but we resolve shadowing by encapsulate key with quote.
 concrete: #Def & {
   "test": test
@@ -91,7 +93,7 @@ If we execute this one, it will fail because `MESSAGE` has a conflict created
 from field shadowing.
 
 ```shell
-dagger do hello                   
+dagger do hello
 [✗] actions.hello.run                                                      0.0s
 [✔] actions.hello                                                          0.0s
 12:12PM FTL failed to execute plan: task failed: actions.hello.run._exec: actions.hello.run._exec.env.MESSAGE: non-concrete value (string|struct)

--- a/docs/v0.2/guides/buildkit/1223-custom-buildkit.md
+++ b/docs/v0.2/guides/buildkit/1223-custom-buildkit.md
@@ -4,6 +4,8 @@ slug: /1223/custom-buildkit/
 
 # Customizing your Buildkit installation
 
+{@include: ../../../partials/_caution-old-version.md}
+
 ## Using a custom buildkit daemon
 
 Dagger can be configured to use an existing buildkit daemon, running either locally or remotely. This can be done using the environment variable `BUILDKIT_HOST`.

--- a/docs/v0.2/guides/buildkit/1224-self-signed-certificates.md
+++ b/docs/v0.2/guides/buildkit/1224-self-signed-certificates.md
@@ -4,6 +4,8 @@ slug: /1224/self-signed-certificates/
 
 # Running Dagger with self-signed certificates
 
+{@include: ../../../partials/_caution-old-version.md}
+
 The connection to a container registry or to a remote docker daemon might require the need to add self-signed CA: `x509: certificate signed by unknown authority`.
 
 These operations are being run inside the buildkitd context and require you to mount your certificates inside your buildkit instance.

--- a/docs/v0.2/guides/buildkit/1229-empty-buildkit-cache.md
+++ b/docs/v0.2/guides/buildkit/1229-empty-buildkit-cache.md
@@ -5,6 +5,8 @@ displayed_sidebar: '0.2'
 
 # How to empty BuildKit's cache ?
 
+{@include: ../../../partials/_caution-old-version.md}
+
 There are two ways of emptying the BuildKit cache:
 
 - Run your action with the `--no-cache` option:

--- a/docs/v0.2/guides/buildkit/1237-persistent-cache.md
+++ b/docs/v0.2/guides/buildkit/1237-persistent-cache.md
@@ -5,6 +5,8 @@ displayed_sidebar: 0.2
 
 # Persistent cache
 
+{@include: ../../../partials/_caution-old-version.md}
+
 CI that takes an eternity is a real pain and can become a bottleneck when your
 infrastructure and process grow. But Dagger, working with a Buildkit daemon,
 has a powerful cache system that triggers actions only when it's necessary.

--- a/docs/v0.2/guides/concepts/1205-container-images.md
+++ b/docs/v0.2/guides/concepts/1205-container-images.md
@@ -5,6 +5,8 @@ displayed_sidebar: '0.2'
 
 # Building container images
 
+{@include: ../../../partials/_caution-old-version.md}
+
 You can use Dagger to build container images, either by executing a Dockerfile, or specifying the build steps natively in CUE. Which method to choose depends on the requirements of your project. You can mix and match builds from both methods in the same plan.
 
 :::tip

--- a/docs/v0.2/guides/concepts/1225-pushing-plan-dependencies.md
+++ b/docs/v0.2/guides/concepts/1225-pushing-plan-dependencies.md
@@ -4,6 +4,8 @@ slug: /1225/pushing-plan-dependencies/
 
 # Pushing your plan's dependencies
 
+{@include: ../../../partials/_caution-old-version.md}
+
 After completing your plan and setting up your GHA or Gitlab CI, you'll realize that a lot of `Cue` files are present in the `cue.mod/pkg` directory. These are the dependencies required by Dagger to run your actions :
 
 ```shell

--- a/docs/v0.2/guides/concepts/1232-chain-actions.md
+++ b/docs/v0.2/guides/concepts/1232-chain-actions.md
@@ -5,6 +5,8 @@ displayed_sidebar: '0.2'
 
 # How can I chain actions together ?
 
+{@include: ../../../partials/_caution-old-version.md}
+
 Dependencies are materialized at runtime, when your Cue files are parsed and the corresponding DAG gets generated:
 
 ```cue

--- a/docs/v0.2/guides/concepts/1238-project-file-organization.md
+++ b/docs/v0.2/guides/concepts/1238-project-file-organization.md
@@ -5,6 +5,8 @@ displayed_sidebar: "0.2"
 
 # Project file organization
 
+{@include: ../../../partials/_caution-old-version.md}
+
 When your Dagger configuration grows, you may feel the need to better organize your project by splitting it into multiple files.
 
 A simple way to accomplish this is to create and import packages within your project's module.

--- a/docs/v0.2/guides/concepts/1244-docker.md
+++ b/docs/v0.2/guides/concepts/1244-docker.md
@@ -5,6 +5,8 @@ displayed_sidebar: "0.2"
 
 # The docker package
 
+{@include: ../../../partials/_caution-old-version.md}
+
 The `universe.dagger.io` module is meant to provide higher level abstractions on top of [core actions](../../references/1222-core-actions-reference.md). Of these, the `universe.dagger.io/docker` package provides a general base for building and running docker images.
 
 Let's explore what you can do with this package.

--- a/docs/v0.2/guides/concepts/1246-go-ci.md
+++ b/docs/v0.2/guides/concepts/1246-go-ci.md
@@ -7,6 +7,8 @@ import DaggerCloudCTA from '../../includes/\_dagger-cloud-cta.md';
 
 # Testing and building a Go project
 
+{@include: ../../../partials/_caution-old-version.md}
+
 This guide explains how to run some tests and build a Go project with the `go` cue package.
 
 ## Plan

--- a/docs/v0.2/guides/concepts/4dhu9-api-customizable-image.md
+++ b/docs/v0.2/guides/concepts/4dhu9-api-customizable-image.md
@@ -5,6 +5,8 @@ displayed_sidebar: '0.2'
 
 # Packages with customizable images
 
+{@include: ../../../partials/_caution-old-version.md}
+
 You should move away from having a default image inside main actions: for example, actions such as [go](https://github.com/dagger/dagger/blob/d45b946f024c63bcb89d22bd843a011f18d64b69/pkg/universe.dagger.io/go/build.cue#L9-L83) are not as flexible and efficient as [golangci](https://github.com/dagger/dagger/blob/d45b946f024c63bcb89d22bd843a011f18d64b69/pkg/universe.dagger.io/alpha/go/golangci/lint.cue#L17-L48).
 
 Two reasons:

--- a/docs/v0.2/guides/docker/1216-docker-cli-load.md
+++ b/docs/v0.2/guides/docker/1216-docker-cli-load.md
@@ -5,6 +5,8 @@ displayed_sidebar: '0.2'
 
 # Loading an image into a docker engine
 
+{@include: ../../../partials/_caution-old-version.md}
+
 Dagger can build, run, push and pull docker images natively, without the need of a Docker engine.
 This feature is available in the package `universe.dagger.io/docker`.
 

--- a/docs/v0.2/guides/docker/1217-docker-cli-run.md
+++ b/docs/v0.2/guides/docker/1217-docker-cli-run.md
@@ -5,6 +5,8 @@ displayed_sidebar: '0.2'
 
 # Running commands with the docker binary (CLI)
 
+{@include: ../../../partials/_caution-old-version.md}
+
 There's a `universe.dagger.io/docker/cli` package that allows you to run docker commands against a local or remote docker engine. Here's a few examples.
 
 ## Local daemon

--- a/docs/v0.2/guides/logdebug/1230-better-logs.md
+++ b/docs/v0.2/guides/logdebug/1230-better-logs.md
@@ -7,6 +7,8 @@ import DaggerCloudCTA from '../../includes/\_dagger-cloud-cta.md';
 
 # How can I have better logs ?
 
+{@include: ../../../partials/_caution-old-version.md}
+
 Dagger exposes 2 logging format options:
 
 - `--log-format <auto|plain|tty|json>`

--- a/docs/v0.2/guides/logdebug/1243-dagger-cloud-debugging.md
+++ b/docs/v0.2/guides/logdebug/1243-dagger-cloud-debugging.md
@@ -5,6 +5,8 @@ displayed_sidebar: '0.2'
 
 # Debugging with Dagger Cloud
 
+{@include: ../../../partials/_caution-old-version.md}
+
 <p><a href="https://dagger.cloud/" target="_blank" rel="external"> Dagger Cloud </a> is under development, but we have just released the first telemetry feature!</p>
 
 :::tip

--- a/docs/v0.2/guides/system/1214-migrate-from-dagger-0.1.md
+++ b/docs/v0.2/guides/system/1214-migrate-from-dagger-0.1.md
@@ -5,6 +5,8 @@ displayed_sidebar: '0.2'
 
 # Migrate from Dagger 0.1
 
+{@include: ../../../partials/_caution-old-version.md}
+
 This is the documentation for dagger 0.2, codename Europa. This release has one focus: improve the developer experience. It features a redesigned CLI and powerful new APIs. The result is a completely new way to develop CI/CD pipelines: more productive, more portable… and way more fun!
 
 However, there is a downside: unfortunately, this release is not backwards compatible: plans written for dagger 0.1 will not run on version 0.2. Automatic migration is not supported, but manual migration is relatively straightforward.

--- a/docs/v0.2/guides/system/1218-cli-telemetry.md
+++ b/docs/v0.2/guides/system/1218-cli-telemetry.md
@@ -5,6 +5,8 @@ displayed_sidebar: '0.2'
 
 # Understanding CLI Telemetry
 
+{@include: ../../../partials/_caution-old-version.md}
+
 ## Overview
 
 By default, the dagger CLI sends anonymized telemetry to dagger.io. This allows us to improve Dagger by understanding how it is used.

--- a/docs/v0.2/references/1222-core-actions-reference.md
+++ b/docs/v0.2/references/1222-core-actions-reference.md
@@ -5,6 +5,8 @@ displayed_sidebar: '0.2'
 
 # Core Actions Reference
 
+{@include: ../../partials/_caution-old-version.md}
+
 Core Actions are primitives implemented by the Dagger Engine itself. They can be combined into higher-level composite actions. Their definitions can be imported in the `dagger.io/dagger/core` package.
 
 For more information about Dagger Actions, see [Dagger Actions](../core-concepts/1221-action.md).

--- a/docs/v0.2/references/1234-dagger-types-reference.md
+++ b/docs/v0.2/references/1234-dagger-types-reference.md
@@ -5,6 +5,8 @@ displayed_sidebar: "0.2"
 
 # Dagger Types Reference
 
+{@include: ../../partials/_caution-old-version.md}
+
 Dagger Types are primitives that hold internal references to values stored in the Dagger Engine. They extend the CUE type system and can be used in [Dagger Actions](../core-concepts/1221-action.md). Their definitions can be imported from the `dagger.io/dagger` package.
 
 The following types are available:

--- a/docs/v0.2/references/13ec8-dagger-env-reference.md
+++ b/docs/v0.2/references/13ec8-dagger-env-reference.md
@@ -5,6 +5,8 @@ displayed_sidebar: '0.2'
 
 # Dagger Environment Variables Reference
 
+{@include: ../../partials/_caution-old-version.md}
+
 Dagger supports a variety of environment variables.
 
 They have two purposes:

--- a/docs/v0.2/use-cases/1211-go-docker-swarm.md
+++ b/docs/v0.2/use-cases/1211-go-docker-swarm.md
@@ -5,6 +5,8 @@ displayed_sidebar: '0.2'
 
 # Go on Docker Swarm
 
+{@include: ../../partials/_caution-old-version.md}
+
 ![particubes.com](/img/use-cases/particubes.com.png)
 
 [Particubes](https://particubes.com) is a platform dedicated to voxel games, which are games made out of little cubes, like Minecraft.

--- a/docs/v0.2/use-cases/1219-go-docker-hub.md
+++ b/docs/v0.2/use-cases/1219-go-docker-hub.md
@@ -5,6 +5,8 @@ displayed_sidebar: '0.2'
 
 # Go on Docker Hub
 
+{@include: ../../partials/_caution-old-version.md}
+
 Dagger stands as a powerful CI/CD tool that works on any environment.
 
 For instance, you can use the [Dagger Go package](https://github.com/dagger/dagger/tree/main/pkg/universe.dagger.io/go)

--- a/docs/v0.2/use-cases/1245-node-ci.md
+++ b/docs/v0.2/use-cases/1245-node-ci.md
@@ -5,6 +5,8 @@ displayed_sidebar: '0.2'
 
 # Basic Node CI
 
+{@include: ../../partials/_caution-old-version.md}
+
 Dagger is incredibly useful for all kinds of complex deployment and building. In this use case we are going to focus on CI and using pre-built tools to check the code we have written. It will aim to give you a basic scaffolding on which to build more complex pipelines.
 
 ## Plan of Action

--- a/docs/v0.2/use-cases/1248-aws-sam.md
+++ b/docs/v0.2/use-cases/1248-aws-sam.md
@@ -5,6 +5,8 @@ displayed_sidebar: "0.2"
 
 # AWS SAM
 
+{@include: ../../partials/_caution-old-version.md}
+
 This is a [Dagger](https://dagger.io/) package to help you deploy serverless functions with ease.
 It is a superset of [AWS SAM](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html), which allows you to build and deploy Lambda function(s).
 The aim is to integrate the lambda deployment to your current [Dagger](https://dagger.io/) pipeline. This way, you can **build** and **deploy** with a single [Dagger environment](/1200/local-dev).


### PR DESCRIPTION
This commit adds a new deprecation notice to all documentation pages under /0.1 and /0.2.

The content of the deprecation notice is stored as a partial.

Since #3908 is related, this commit also creates a new page at the mutable /install endpoint with links to the SDK installation pages. The previous /install page is relocated to a new URL /1242/install. Links are adjusted in older navigation bars.

Relates to #3904 . Closes #3908 .

Signed-off-by: Vikram Vaswani <vikram@dagger.io>