### PR TITLE
api: Return the contents directly in Container Stdout/Stderr

### DIFF
--- a/cmd/dagger/query.go
+++ b/cmd/dagger/query.go
@@ -31,9 +31,7 @@ dagger query <<EOF
   container {
     from(address:"hello-world") {
       exec(args:["/hello"]) {
-        stdout {
-          contents
-        }
+        stdout
       }
     }
   }

--- a/core/container.go
+++ b/core/container.go
@@ -835,7 +835,24 @@ func (container *Container) Exec(ctx context.Context, gw bkgw.Client, defaultPla
 }
 
 func (container *Container) ExitCode(ctx context.Context, gw bkgw.Client) (*int, error) {
-	file, err := container.MetaFile(ctx, gw, "exitCode")
+	content, err := container.MetaFileContents(ctx, gw, "exitCode")
+	if err != nil {
+		return nil, err
+	}
+	if content == nil {
+		return nil, nil
+	}
+
+	exitCode, err := strconv.Atoi(*content)
+	if err != nil {
+		return nil, err
+	}
+
+	return &exitCode, nil
+}
+
+func (container *Container) MetaFileContents(ctx context.Context, gw bkgw.Client, filePath string) (*string, error) {
+	file, err := container.MetaFile(ctx, gw, filePath)
 	if err != nil {
 		return nil, err
 	}
@@ -849,12 +866,12 @@ func (container *Container) ExitCode(ctx context.Context, gw bkgw.Client) (*int,
 		return nil, err
 	}
 
-	exitCode, err := strconv.Atoi(string(content))
+	strContent := string(content)
 	if err != nil {
 		return nil, err
 	}
 
-	return &exitCode, nil
+	return &strContent, nil
 }
 
 func (container *Container) MetaFile(ctx context.Context, gw bkgw.Client, filePath string) (*File, error) {

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -100,7 +100,7 @@ ENV FOO=bar
 CMD goenv
 `)
 
-		env, err := c.Container().Build(src).Exec().Stdout().Contents(ctx)
+		env, err := c.Container().Build(src).Exec().Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, env, "FOO=bar\n")
 	})
@@ -119,7 +119,7 @@ CMD goenv
 
 		env, err := c.Container().Build(src, dagger.ContainerBuildOpts{
 			Dockerfile: "subdir/Dockerfile.whee",
-		}).Exec().Stdout().Contents(ctx)
+		}).Exec().Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, env, "FOO=bar\n")
 	})
@@ -138,7 +138,7 @@ CMD goenv
 
 		sub := c.Directory().WithDirectory("subcontext", src).Directory("subcontext")
 
-		env, err := c.Container().Build(sub).Exec().Stdout().Contents(ctx)
+		env, err := c.Container().Build(sub).Exec().Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, env, "FOO=bar\n")
 	})
@@ -159,7 +159,7 @@ CMD goenv
 
 		env, err := c.Container().Build(sub, dagger.ContainerBuildOpts{
 			Dockerfile: "subdir/Dockerfile.whee",
-		}).Exec().Stdout().Contents(ctx)
+		}).Exec().Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, env, "FOO=bar\n")
 	})
@@ -276,9 +276,8 @@ func TestContainerExecStdoutStderr(t *testing.T) {
 		Container struct {
 			From struct {
 				Exec struct {
-					Stdout, Stderr struct {
-						Contents string
-					}
+					Stdout string
+					Stderr string
 				}
 			}
 		}
@@ -289,20 +288,15 @@ func TestContainerExecStdoutStderr(t *testing.T) {
 			container {
 				from(address: "alpine:3.16.2") {
 					exec(args: ["sh", "-c", "echo hello; echo goodbye >/dev/stderr"]) {
-						stdout {
-							contents
-						}
-
-						stderr {
-							contents
-						}
+						stdout
+						stderr
 					}
 				}
 			}
 		}`, &res, nil)
 	require.NoError(t, err)
-	require.Equal(t, res.Container.From.Exec.Stdout.Contents, "hello\n")
-	require.Equal(t, res.Container.From.Exec.Stderr.Contents, "goodbye\n")
+	require.Equal(t, res.Container.From.Exec.Stdout, "hello\n")
+	require.Equal(t, res.Container.From.Exec.Stderr, "goodbye\n")
 }
 
 func TestContainerExecStdin(t *testing.T) {
@@ -312,9 +306,7 @@ func TestContainerExecStdin(t *testing.T) {
 		Container struct {
 			From struct {
 				Exec struct {
-					Stdout struct {
-						Contents string
-					}
+					Stdout string
 				}
 			}
 		}
@@ -325,15 +317,13 @@ func TestContainerExecStdin(t *testing.T) {
 			container {
 				from(address: "alpine:3.16.2") {
 					exec(args: ["cat"], stdin: "hello") {
-						stdout {
-							contents
-						}
+						stdout
 					}
 				}
 			}
 		}`, &res, nil)
 	require.NoError(t, err)
-	require.Equal(t, res.Container.From.Exec.Stdout.Contents, "hello")
+	require.Equal(t, res.Container.From.Exec.Stdout, "hello")
 }
 
 func TestContainerExecRedirectStdoutStderr(t *testing.T) {
@@ -384,13 +374,8 @@ func TestContainerExecRedirectStdoutStderr(t *testing.T) {
 						redirectStdout: "out",
 						redirectStderr: "err"
 					) {
-						stdout {
-							contents
-						}
-
-						stderr {
-							contents
-						}
+						stdout
+						stderr
 					}
 				}
 			}
@@ -406,9 +391,8 @@ func TestContainerNullStdoutStderr(t *testing.T) {
 	res := struct {
 		Container struct {
 			From struct {
-				Stdout, Stderr *struct {
-					Contents string
-				}
+				Stdout *string
+				Stderr *string
 			}
 		}
 	}{}
@@ -417,13 +401,8 @@ func TestContainerNullStdoutStderr(t *testing.T) {
 		`{
 			container {
 				from(address: "alpine:3.16.2") {
-					stdout {
-						contents
-					}
-
-					stderr {
-						contents
-					}
+					stdout
+					stderr
 				}
 			}
 		}`, &res, nil)
@@ -440,9 +419,7 @@ func TestContainerExecWithWorkdir(t *testing.T) {
 			From struct {
 				WithWorkdir struct {
 					Exec struct {
-						Stdout struct {
-							Contents string
-						}
+						Stdout string
 					}
 				}
 			}
@@ -455,16 +432,14 @@ func TestContainerExecWithWorkdir(t *testing.T) {
 				from(address: "alpine:3.16.2") {
 					withWorkdir(path: "/usr") {
 						exec(args: ["pwd"]) {
-							stdout {
-								contents
-							}
+							stdout
 						}
 					}
 				}
 			}
 		}`, &res, nil)
 	require.NoError(t, err)
-	require.Equal(t, res.Container.From.WithWorkdir.Exec.Stdout.Contents, "/usr\n")
+	require.Equal(t, res.Container.From.WithWorkdir.Exec.Stdout, "/usr\n")
 }
 
 func TestContainerExecWithUser(t *testing.T) {
@@ -478,9 +453,7 @@ func TestContainerExecWithUser(t *testing.T) {
 				WithUser struct {
 					User string
 					Exec struct {
-						Stdout struct {
-							Contents string
-						}
+						Stdout string
 					}
 				}
 			}
@@ -496,9 +469,7 @@ func TestContainerExecWithUser(t *testing.T) {
 					withUser(name: "daemon") {
 						user
 						exec(args: ["whoami"]) {
-							stdout {
-								contents
-							}
+							stdout
 						}
 					}
 				}
@@ -507,7 +478,7 @@ func TestContainerExecWithUser(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "", res.Container.From.User)
 		require.Equal(t, "daemon", res.Container.From.WithUser.User)
-		require.Equal(t, "daemon\n", res.Container.From.WithUser.Exec.Stdout.Contents)
+		require.Equal(t, "daemon\n", res.Container.From.WithUser.Exec.Stdout)
 	})
 
 	t.Run("user and group name", func(t *testing.T) {
@@ -519,9 +490,7 @@ func TestContainerExecWithUser(t *testing.T) {
 					withUser(name: "daemon:floppy") {
 						user
 						exec(args: ["sh", "-c", "whoami; groups"]) {
-							stdout {
-								contents
-							}
+							stdout
 						}
 					}
 				}
@@ -530,7 +499,7 @@ func TestContainerExecWithUser(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "", res.Container.From.User)
 		require.Equal(t, "daemon:floppy", res.Container.From.WithUser.User)
-		require.Equal(t, "daemon\nfloppy\n", res.Container.From.WithUser.Exec.Stdout.Contents)
+		require.Equal(t, "daemon\nfloppy\n", res.Container.From.WithUser.Exec.Stdout)
 	})
 
 	t.Run("user ID", func(t *testing.T) {
@@ -542,9 +511,7 @@ func TestContainerExecWithUser(t *testing.T) {
 					withUser(name: "2") {
 						user
 						exec(args: ["whoami"]) {
-							stdout {
-								contents
-							}
+							stdout
 						}
 					}
 				}
@@ -553,7 +520,7 @@ func TestContainerExecWithUser(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "", res.Container.From.User)
 		require.Equal(t, "2", res.Container.From.WithUser.User)
-		require.Equal(t, "daemon\n", res.Container.From.WithUser.Exec.Stdout.Contents)
+		require.Equal(t, "daemon\n", res.Container.From.WithUser.Exec.Stdout)
 	})
 
 	t.Run("user and group ID", func(t *testing.T) {
@@ -565,9 +532,7 @@ func TestContainerExecWithUser(t *testing.T) {
 					withUser(name: "2:11") {
 						user
 						exec(args: ["sh", "-c", "whoami; groups"]) {
-							stdout {
-								contents
-							}
+							stdout
 						}
 					}
 				}
@@ -576,7 +541,7 @@ func TestContainerExecWithUser(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "", res.Container.From.User)
 		require.Equal(t, "2:11", res.Container.From.WithUser.User)
-		require.Equal(t, "daemon\nfloppy\n", res.Container.From.WithUser.Exec.Stdout.Contents)
+		require.Equal(t, "daemon\nfloppy\n", res.Container.From.WithUser.Exec.Stdout)
 	})
 }
 
@@ -590,9 +555,7 @@ func TestContainerExecWithEntrypoint(t *testing.T) {
 				WithEntrypoint struct {
 					Entrypoint []string
 					Exec       struct {
-						Stdout struct {
-							Contents string
-						}
+						Stdout string
 					}
 					WithEntrypoint struct {
 						Entrypoint []string
@@ -610,9 +573,7 @@ func TestContainerExecWithEntrypoint(t *testing.T) {
 					withEntrypoint(args: ["sh", "-c"]) {
 						entrypoint
 						exec(args: ["echo $HOME"]) {
-							stdout {
-								contents
-							}
+							stdout
 						}
 
 						withEntrypoint(args: []) {
@@ -625,7 +586,7 @@ func TestContainerExecWithEntrypoint(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, res.Container.From.Entrypoint)
 	require.Equal(t, []string{"sh", "-c"}, res.Container.From.WithEntrypoint.Entrypoint)
-	require.Equal(t, "/root\n", res.Container.From.WithEntrypoint.Exec.Stdout.Contents)
+	require.Equal(t, "/root\n", res.Container.From.WithEntrypoint.Exec.Stdout)
 	require.Empty(t, res.Container.From.WithEntrypoint.WithEntrypoint.Entrypoint)
 }
 
@@ -638,9 +599,7 @@ func TestContainerWithDefaultArgs(t *testing.T) {
 				Entrypoint  []string
 				DefaultArgs []string
 				Exec        struct {
-					Stdout struct {
-						Contents string
-					}
+					Stdout string
 				}
 				WithDefaultArgs struct {
 					Entrypoint  []string
@@ -650,17 +609,13 @@ func TestContainerWithDefaultArgs(t *testing.T) {
 					Entrypoint  []string
 					DefaultArgs []string
 					Exec        struct {
-						Stdout struct {
-							Contents string
-						}
+						Stdout string
 					}
 					WithDefaultArgs struct {
 						Entrypoint  []string
 						DefaultArgs []string
 						Exec        struct {
-							Stdout struct {
-								Contents string
-							}
+							Stdout string
 						}
 					}
 				}
@@ -684,9 +639,7 @@ func TestContainerWithDefaultArgs(t *testing.T) {
 						defaultArgs
 
 						exec(args: ["echo $HOME"]) {
-							stdout {
-								contents
-							}
+							stdout
 						}
 
 						withDefaultArgs(args: ["id"]) {
@@ -694,9 +647,7 @@ func TestContainerWithDefaultArgs(t *testing.T) {
 							defaultArgs
 
 							exec(args: []) {
-								stdout {
-									contents
-								}
+								stdout
 							}
 						}
 					}
@@ -720,14 +671,14 @@ func TestContainerWithDefaultArgs(t *testing.T) {
 	})
 
 	t.Run("with exec args", func(t *testing.T) {
-		require.Equal(t, "/root\n", res.Container.From.WithEntrypoint.Exec.Stdout.Contents)
+		require.Equal(t, "/root\n", res.Container.From.WithEntrypoint.Exec.Stdout)
 	})
 
 	t.Run("with default args set", func(t *testing.T) {
 		require.Equal(t, []string{"sh", "-c"}, res.Container.From.WithEntrypoint.WithDefaultArgs.Entrypoint)
 		require.Equal(t, []string{"id"}, res.Container.From.WithEntrypoint.WithDefaultArgs.DefaultArgs)
 
-		require.Equal(t, "uid=0(root) gid=0(root) groups=0(root),1(bin),2(daemon),3(sys),4(adm),6(disk),10(wheel),11(floppy),20(dialout),26(tape),27(video)\n", res.Container.From.WithEntrypoint.WithDefaultArgs.Exec.Stdout.Contents)
+		require.Equal(t, "uid=0(root) gid=0(root) groups=0(root),1(bin),2(daemon),3(sys),4(adm),6(disk),10(wheel),11(floppy),20(dialout),26(tape),27(video)\n", res.Container.From.WithEntrypoint.WithDefaultArgs.Exec.Stdout)
 	})
 }
 
@@ -739,9 +690,7 @@ func TestContainerExecWithEnvVariable(t *testing.T) {
 			From struct {
 				WithEnvVariable struct {
 					Exec struct {
-						Stdout struct {
-							Contents string
-						}
+						Stdout string
 					}
 				}
 			}
@@ -754,16 +703,14 @@ func TestContainerExecWithEnvVariable(t *testing.T) {
 				from(address: "alpine:3.16.2") {
 					withEnvVariable(name: "FOO", value: "bar") {
 						exec(args: ["env"]) {
-							stdout {
-								contents
-							}
+							stdout
 						}
 					}
 				}
 			}
 		}`, &res, nil)
 	require.NoError(t, err)
-	require.Contains(t, res.Container.From.WithEnvVariable.Exec.Stdout.Contents, "FOO=bar\n")
+	require.Contains(t, res.Container.From.WithEnvVariable.Exec.Stdout, "FOO=bar\n")
 }
 
 func TestContainerVariables(t *testing.T) {
@@ -774,9 +721,7 @@ func TestContainerVariables(t *testing.T) {
 			From struct {
 				EnvVariables []schema.EnvVariable
 				Exec         struct {
-					Stdout struct {
-						Contents string
-					}
+					Stdout string
 				}
 			}
 		}
@@ -791,9 +736,7 @@ func TestContainerVariables(t *testing.T) {
 						value
 					}
 					exec(args: ["env"]) {
-						stdout {
-							contents
-						}
+						stdout
 					}
 				}
 			}
@@ -804,7 +747,7 @@ func TestContainerVariables(t *testing.T) {
 		{Name: "GOLANG_VERSION", Value: "1.18.2"},
 		{Name: "GOPATH", Value: "/go"},
 	}, res.Container.From.EnvVariables)
-	require.Contains(t, res.Container.From.Exec.Stdout.Contents, "GOPATH=/go\n")
+	require.Contains(t, res.Container.From.Exec.Stdout, "GOPATH=/go\n")
 }
 
 func TestContainerVariable(t *testing.T) {
@@ -851,9 +794,7 @@ func TestContainerWithoutVariable(t *testing.T) {
 				WithoutEnvVariable struct {
 					EnvVariables []schema.EnvVariable
 					Exec         struct {
-						Stdout struct {
-							Contents string
-						}
+						Stdout string
 					}
 				}
 			}
@@ -870,9 +811,7 @@ func TestContainerWithoutVariable(t *testing.T) {
 							value
 						}
 						exec(args: ["env"]) {
-							stdout {
-								contents
-							}
+							stdout
 						}
 					}
 				}
@@ -883,7 +822,7 @@ func TestContainerWithoutVariable(t *testing.T) {
 		{Name: "PATH", Value: "/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
 		{Name: "GOPATH", Value: "/go"},
 	})
-	require.NotContains(t, res.Container.From.WithoutEnvVariable.Exec.Stdout.Contents, "GOLANG_VERSION")
+	require.NotContains(t, res.Container.From.WithoutEnvVariable.Exec.Stdout, "GOLANG_VERSION")
 }
 
 func TestContainerEnvVariablesReplace(t *testing.T) {
@@ -895,9 +834,7 @@ func TestContainerEnvVariablesReplace(t *testing.T) {
 				WithEnvVariable struct {
 					EnvVariables []schema.EnvVariable
 					Exec         struct {
-						Stdout struct {
-							Contents string
-						}
+						Stdout string
 					}
 				}
 			}
@@ -914,9 +851,7 @@ func TestContainerEnvVariablesReplace(t *testing.T) {
 							value
 						}
 						exec(args: ["env"]) {
-							stdout {
-								contents
-							}
+							stdout
 						}
 					}
 				}
@@ -928,7 +863,7 @@ func TestContainerEnvVariablesReplace(t *testing.T) {
 		{Name: "GOLANG_VERSION", Value: "1.18.2"},
 		{Name: "GOPATH", Value: "/gone"},
 	})
-	require.Contains(t, res.Container.From.WithEnvVariable.Exec.Stdout.Contents, "GOPATH=/gone\n")
+	require.Contains(t, res.Container.From.WithEnvVariable.Exec.Stdout, "GOPATH=/gone\n")
 }
 
 func TestContainerWorkdir(t *testing.T) {
@@ -939,9 +874,7 @@ func TestContainerWorkdir(t *testing.T) {
 			From struct {
 				Workdir string
 				Exec    struct {
-					Stdout struct {
-						Contents string
-					}
+					Stdout string
 				}
 			}
 		}
@@ -953,16 +886,14 @@ func TestContainerWorkdir(t *testing.T) {
 				from(address: "golang:1.18.2-alpine") {
 					workdir
 					exec(args: ["pwd"]) {
-						stdout {
-							contents
-						}
+						stdout
 					}
 				}
 			}
 		}`, &res, nil)
 	require.NoError(t, err)
 	require.Equal(t, res.Container.From.Workdir, "/go")
-	require.Equal(t, res.Container.From.Exec.Stdout.Contents, "/go\n")
+	require.Equal(t, res.Container.From.Exec.Stdout, "/go\n")
 }
 
 func TestContainerWithWorkdir(t *testing.T) {
@@ -974,9 +905,7 @@ func TestContainerWithWorkdir(t *testing.T) {
 				WithWorkdir struct {
 					Workdir string
 					Exec    struct {
-						Stdout struct {
-							Contents string
-						}
+						Stdout string
 					}
 				}
 			}
@@ -990,9 +919,7 @@ func TestContainerWithWorkdir(t *testing.T) {
 					withWorkdir(path: "/usr") {
 						workdir
 						exec(args: ["pwd"]) {
-							stdout {
-								contents
-							}
+							stdout
 						}
 					}
 				}
@@ -1000,7 +927,7 @@ func TestContainerWithWorkdir(t *testing.T) {
 		}`, &res, nil)
 	require.NoError(t, err)
 	require.Equal(t, res.Container.From.WithWorkdir.Workdir, "/usr")
-	require.Equal(t, res.Container.From.WithWorkdir.Exec.Stdout.Contents, "/usr\n")
+	require.Equal(t, res.Container.From.WithWorkdir.Exec.Stdout, "/usr\n")
 }
 
 func TestContainerWithMountedDirectory(t *testing.T) {
@@ -1035,14 +962,10 @@ func TestContainerWithMountedDirectory(t *testing.T) {
 			From struct {
 				WithMountedDirectory struct {
 					Exec struct {
-						Stdout struct {
-							Contents string
-						}
+						Stdout string
 
 						Exec struct {
-							Stdout struct {
-								Contents string
-							}
+							Stdout string
 						}
 					}
 				}
@@ -1055,14 +978,10 @@ func TestContainerWithMountedDirectory(t *testing.T) {
 				from(address: "alpine:3.16.2") {
 					withMountedDirectory(path: "/mnt", source: $id) {
 						exec(args: ["cat", "/mnt/some-file"]) {
-							stdout {
-								contents
-							}
+							stdout
 
 							exec(args: ["cat", "/mnt/some-dir/sub-file"]) {
-								stdout {
-									contents
-								}
+								stdout
 							}
 						}
 					}
@@ -1072,8 +991,8 @@ func TestContainerWithMountedDirectory(t *testing.T) {
 			"id": id,
 		}})
 	require.NoError(t, err)
-	require.Equal(t, "some-content", execRes.Container.From.WithMountedDirectory.Exec.Stdout.Contents)
-	require.Equal(t, "sub-content", execRes.Container.From.WithMountedDirectory.Exec.Exec.Stdout.Contents)
+	require.Equal(t, "some-content", execRes.Container.From.WithMountedDirectory.Exec.Stdout)
+	require.Equal(t, "sub-content", execRes.Container.From.WithMountedDirectory.Exec.Exec.Stdout)
 }
 
 func TestContainerWithMountedDirectorySourcePath(t *testing.T) {
@@ -1113,9 +1032,7 @@ func TestContainerWithMountedDirectorySourcePath(t *testing.T) {
 				WithMountedDirectory struct {
 					Exec struct {
 						Exec struct {
-							Stdout struct {
-								Contents string
-							}
+							Stdout string
 						}
 					}
 				}
@@ -1129,9 +1046,7 @@ func TestContainerWithMountedDirectorySourcePath(t *testing.T) {
 					withMountedDirectory(path: "/mnt", source: $id) {
 						exec(args: ["sh", "-c", "echo >> /mnt/sub-file; echo -n more-content >> /mnt/sub-file"]) {
 							exec(args: ["cat", "/mnt/sub-file"]) {
-								stdout {
-									contents
-								}
+								stdout
 							}
 						}
 					}
@@ -1141,7 +1056,7 @@ func TestContainerWithMountedDirectorySourcePath(t *testing.T) {
 			"id": id,
 		}})
 	require.NoError(t, err)
-	require.Equal(t, "sub-content\nmore-content", execRes.Container.From.WithMountedDirectory.Exec.Exec.Stdout.Contents)
+	require.Equal(t, "sub-content\nmore-content", execRes.Container.From.WithMountedDirectory.Exec.Exec.Stdout)
 }
 
 func TestContainerWithMountedDirectoryPropagation(t *testing.T) {
@@ -1172,23 +1087,15 @@ func TestContainerWithMountedDirectoryPropagation(t *testing.T) {
 			From struct {
 				WithMountedDirectory struct {
 					Exec struct {
-						Stdout struct {
-							Contents string
-						}
-						Exec struct {
+						Stdout string
+						Exec   struct {
 							Exec struct {
-								Stdout struct {
-									Contents string
-								}
+								Stdout               string
 								WithMountedDirectory struct {
 									Exec struct {
-										Stdout struct {
-											Contents string
-										}
-										Exec struct {
-											Stdout struct {
-												Contents string
-											}
+										Stdout string
+										Exec   struct {
+											Stdout string
 										}
 									}
 								}
@@ -1206,21 +1113,19 @@ func TestContainerWithMountedDirectoryPropagation(t *testing.T) {
 					withMountedDirectory(path: "/mnt", source: $id) {
 						exec(args: ["cat", "/mnt/some-file"]) {
 							# original content
-							stdout { contents }
-
+							stdout
 							exec(args: ["sh", "-c", "echo >> /mnt/some-file; echo -n more-content >> /mnt/some-file"]) {
 								exec(args: ["cat", "/mnt/some-file"]) {
 									# modified content should propagate
-									stdout { contents }
-
+									stdout
 									withMountedDirectory(path: "/mnt", source: $id) {
 										exec(args: ["cat", "/mnt/some-file"]) {
 											# should be back to the original content
-											stdout { contents }
+											stdout
 
 											exec(args: ["cat", "/mnt/some-file"]) {
 												# original content override should propagate
-												stdout { contents }
+												stdout
 											}
 										}
 									}
@@ -1237,19 +1142,19 @@ func TestContainerWithMountedDirectoryPropagation(t *testing.T) {
 
 	require.Equal(t,
 		"some-content",
-		execRes.Container.From.WithMountedDirectory.Exec.Stdout.Contents)
+		execRes.Container.From.WithMountedDirectory.Exec.Stdout)
 
 	require.Equal(t,
 		"some-content\nmore-content",
-		execRes.Container.From.WithMountedDirectory.Exec.Exec.Exec.Stdout.Contents)
+		execRes.Container.From.WithMountedDirectory.Exec.Exec.Exec.Stdout)
 
 	require.Equal(t,
 		"some-content",
-		execRes.Container.From.WithMountedDirectory.Exec.Exec.Exec.WithMountedDirectory.Exec.Stdout.Contents)
+		execRes.Container.From.WithMountedDirectory.Exec.Exec.Exec.WithMountedDirectory.Exec.Stdout)
 
 	require.Equal(t,
 		"some-content",
-		execRes.Container.From.WithMountedDirectory.Exec.Exec.Exec.WithMountedDirectory.Exec.Exec.Stdout.Contents)
+		execRes.Container.From.WithMountedDirectory.Exec.Exec.Exec.WithMountedDirectory.Exec.Exec.Stdout)
 }
 
 func TestContainerWithMountedFile(t *testing.T) {
@@ -1284,9 +1189,7 @@ func TestContainerWithMountedFile(t *testing.T) {
 			From struct {
 				WithMountedFile struct {
 					Exec struct {
-						Stdout struct {
-							Contents string
-						}
+						Stdout string
 					}
 				}
 			}
@@ -1298,9 +1201,7 @@ func TestContainerWithMountedFile(t *testing.T) {
 				from(address: "alpine:3.16.2") {
 					withMountedFile(path: "/mnt/file", source: $id) {
 						exec(args: ["cat", "/mnt/file"]) {
-							stdout {
-								contents
-							}
+							stdout
 						}
 					}
 				}
@@ -1309,7 +1210,7 @@ func TestContainerWithMountedFile(t *testing.T) {
 			"id": id,
 		}})
 	require.NoError(t, err)
-	require.Equal(t, "sub-content", execRes.Container.From.WithMountedFile.Exec.Stdout.Contents)
+	require.Equal(t, "sub-content", execRes.Container.From.WithMountedFile.Exec.Stdout)
 }
 
 func TestContainerWithMountedCache(t *testing.T) {
@@ -1323,9 +1224,7 @@ func TestContainerWithMountedCache(t *testing.T) {
 				WithEnvVariable struct {
 					WithMountedCache struct {
 						Exec struct {
-							Stdout struct {
-								Contents string
-							}
+							Stdout string
 						}
 					}
 				}
@@ -1339,9 +1238,7 @@ func TestContainerWithMountedCache(t *testing.T) {
 					withEnvVariable(name: "RAND", value: $rand) {
 						withMountedCache(path: "/mnt/cache", cache: $cache) {
 							exec(args: ["sh", "-c", "echo $RAND >> /mnt/cache/file; cat /mnt/cache/file"]) {
-								stdout {
-									contents
-								}
+								stdout
 							}
 						}
 					}
@@ -1355,7 +1252,7 @@ func TestContainerWithMountedCache(t *testing.T) {
 		"rand":  rand1,
 	}})
 	require.NoError(t, err)
-	require.Equal(t, rand1+"\n", execRes.Container.From.WithEnvVariable.WithMountedCache.Exec.Stdout.Contents)
+	require.Equal(t, rand1+"\n", execRes.Container.From.WithEnvVariable.WithMountedCache.Exec.Stdout)
 
 	rand2 := identity.NewID()
 	err = testutil.Query(query, &execRes, &testutil.QueryOptions{Variables: map[string]any{
@@ -1363,7 +1260,7 @@ func TestContainerWithMountedCache(t *testing.T) {
 		"rand":  rand2,
 	}})
 	require.NoError(t, err)
-	require.Equal(t, rand1+"\n"+rand2+"\n", execRes.Container.From.WithEnvVariable.WithMountedCache.Exec.Stdout.Contents)
+	require.Equal(t, rand1+"\n"+rand2+"\n", execRes.Container.From.WithEnvVariable.WithMountedCache.Exec.Stdout)
 }
 
 func TestContainerWithMountedCacheFromDirectory(t *testing.T) {
@@ -1401,9 +1298,7 @@ func TestContainerWithMountedCacheFromDirectory(t *testing.T) {
 				WithEnvVariable struct {
 					WithMountedCache struct {
 						Exec struct {
-							Stdout struct {
-								Contents string
-							}
+							Stdout string
 						}
 					}
 				}
@@ -1417,9 +1312,7 @@ func TestContainerWithMountedCacheFromDirectory(t *testing.T) {
 					withEnvVariable(name: "RAND", value: $rand) {
 						withMountedCache(path: "/mnt/cache", cache: $cache, source: $init) {
 							exec(args: ["sh", "-c", "echo $RAND >> /mnt/cache/sub-file; cat /mnt/cache/sub-file"]) {
-								stdout {
-									contents
-								}
+								stdout
 							}
 						}
 					}
@@ -1434,7 +1327,7 @@ func TestContainerWithMountedCacheFromDirectory(t *testing.T) {
 		"cache": cacheID,
 	}})
 	require.NoError(t, err)
-	require.Equal(t, "initial-content\n"+rand1+"\n", execRes.Container.From.WithEnvVariable.WithMountedCache.Exec.Stdout.Contents)
+	require.Equal(t, "initial-content\n"+rand1+"\n", execRes.Container.From.WithEnvVariable.WithMountedCache.Exec.Stdout)
 
 	rand2 := identity.NewID()
 	err = testutil.Query(query, &execRes, &testutil.QueryOptions{Variables: map[string]any{
@@ -1443,7 +1336,7 @@ func TestContainerWithMountedCacheFromDirectory(t *testing.T) {
 		"cache": cacheID,
 	}})
 	require.NoError(t, err)
-	require.Equal(t, "initial-content\n"+rand1+"\n"+rand2+"\n", execRes.Container.From.WithEnvVariable.WithMountedCache.Exec.Stdout.Contents)
+	require.Equal(t, "initial-content\n"+rand1+"\n"+rand2+"\n", execRes.Container.From.WithEnvVariable.WithMountedCache.Exec.Stdout)
 }
 
 func TestContainerWithMountedTemp(t *testing.T) {
@@ -1454,9 +1347,7 @@ func TestContainerWithMountedTemp(t *testing.T) {
 			From struct {
 				WithMountedTemp struct {
 					Exec struct {
-						Stdout struct {
-							Contents string
-						}
+						Stdout string
 					}
 				}
 			}
@@ -1468,16 +1359,14 @@ func TestContainerWithMountedTemp(t *testing.T) {
 				from(address: "alpine:3.16.2") {
 					withMountedTemp(path: "/mnt/tmp") {
 						exec(args: ["grep", "/mnt/tmp", "/proc/mounts"]) {
-							stdout {
-								contents
-							}
+							stdout
 						}
 					}
 				}
 			}
 		}`, &execRes, nil)
 	require.NoError(t, err)
-	require.Contains(t, execRes.Container.From.WithMountedTemp.Exec.Stdout.Contents, "tmpfs /mnt/tmp tmpfs")
+	require.Contains(t, execRes.Container.From.WithMountedTemp.Exec.Stdout, "tmpfs /mnt/tmp tmpfs")
 }
 
 func TestContainerMountsWithoutMount(t *testing.T) {
@@ -1515,15 +1404,11 @@ func TestContainerMountsWithoutMount(t *testing.T) {
 					WithMountedDirectory struct {
 						Mounts []string
 						Exec   struct {
-							Stdout struct {
-								Contents string
-							}
+							Stdout       string
 							WithoutMount struct {
 								Mounts []string
 								Exec   struct {
-									Stdout struct {
-										Contents string
-									}
+									Stdout string
 								}
 							}
 						}
@@ -1541,15 +1426,11 @@ func TestContainerMountsWithoutMount(t *testing.T) {
 						withMountedDirectory(path: "/mnt/dir", source: $id) {
 							mounts
 							exec(args: ["ls", "/mnt/dir"]) {
-								stdout {
-									contents
-								}
+								stdout
 								withoutMount(path: "/mnt/dir") {
 									mounts
 									exec(args: ["ls", "/mnt/dir"]) {
-										stdout {
-											contents
-										}
+										stdout
 									}
 								}
 							}
@@ -1563,8 +1444,8 @@ func TestContainerMountsWithoutMount(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"/mnt/tmp"}, execRes.Container.From.WithMountedTemp.Mounts)
 	require.Equal(t, []string{"/mnt/tmp", "/mnt/dir"}, execRes.Container.From.WithMountedTemp.WithMountedDirectory.Mounts)
-	require.Equal(t, "some-dir\nsome-file\n", execRes.Container.From.WithMountedTemp.WithMountedDirectory.Exec.Stdout.Contents)
-	require.Equal(t, "", execRes.Container.From.WithMountedTemp.WithMountedDirectory.Exec.WithoutMount.Exec.Stdout.Contents)
+	require.Equal(t, "some-dir\nsome-file\n", execRes.Container.From.WithMountedTemp.WithMountedDirectory.Exec.Stdout)
+	require.Equal(t, "", execRes.Container.From.WithMountedTemp.WithMountedDirectory.Exec.WithoutMount.Exec.Stdout)
 	require.Equal(t, []string{"/mnt/tmp"}, execRes.Container.From.WithMountedTemp.WithMountedDirectory.Exec.WithoutMount.Mounts)
 }
 
@@ -1589,7 +1470,7 @@ func TestContainerReplacedMounts(t *testing.T) {
 
 		out, err := ctr.Exec(dagger.ContainerExecOpts{
 			Args: []string{"cat", "/mnt/dir/some-file"},
-		}).Stdout().Contents(ctx)
+		}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "lower-content", out)
 	})
@@ -1603,7 +1484,7 @@ func TestContainerReplacedMounts(t *testing.T) {
 
 		out, err := replaced.Exec(dagger.ContainerExecOpts{
 			Args: []string{"cat", "/mnt/dir/some-file"},
-		}).Stdout().Contents(ctx)
+		}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "upper-content", out)
 	})
@@ -1625,7 +1506,7 @@ func TestContainerReplacedMounts(t *testing.T) {
 
 		out, err := clobbered.Exec(dagger.ContainerExecOpts{
 			Args: []string{"cat", "/mnt/some-file"},
-		}).Stdout().Contents(ctx)
+		}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "clobbered-content", out)
 	})
@@ -1640,7 +1521,7 @@ func TestContainerReplacedMounts(t *testing.T) {
 
 		out, err := clobberedSub.Exec(dagger.ContainerExecOpts{
 			Args: []string{"cat", "/mnt/dir/some-file"},
-		}).Stdout().Contents(ctx)
+		}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "clobbered-sub-content", out)
 	})
@@ -1715,9 +1596,7 @@ func TestContainerDirectory(t *testing.T) {
 			From struct {
 				WithMountedDirectory struct {
 					Exec struct {
-						Stdout struct {
-							Contents string
-						}
+						Stdout string
 					}
 				}
 			}
@@ -1729,9 +1608,7 @@ func TestContainerDirectory(t *testing.T) {
 				from(address: "alpine:3.16.2") {
 					withMountedDirectory(path: "/mnt/dir", source: $id) {
 						exec(args: ["cat", "/mnt/dir/another-file"]) {
-							stdout {
-								contents
-							}
+							stdout
 						}
 					}
 				}
@@ -1741,7 +1618,7 @@ func TestContainerDirectory(t *testing.T) {
 		}})
 	require.NoError(t, err)
 
-	require.Equal(t, "hello\n", execRes.Container.From.WithMountedDirectory.Exec.Stdout.Contents)
+	require.Equal(t, "hello\n", execRes.Container.From.WithMountedDirectory.Exec.Stdout)
 }
 
 func TestContainerDirectoryErrors(t *testing.T) {
@@ -1904,9 +1781,7 @@ func TestContainerDirectorySourcePath(t *testing.T) {
 			From struct {
 				WithMountedDirectory struct {
 					Exec struct {
-						Stdout struct {
-							Contents string
-						}
+						Stdout string
 					}
 				}
 			}
@@ -1918,9 +1793,7 @@ func TestContainerDirectorySourcePath(t *testing.T) {
 				from(address: "alpine:3.16.2") {
 					withMountedDirectory(path: "/mnt/dir", source: $id) {
 						exec(args: ["cat", "/mnt/dir/sub-file"]) {
-							stdout {
-								contents
-							}
+							stdout
 						}
 					}
 				}
@@ -1930,7 +1803,7 @@ func TestContainerDirectorySourcePath(t *testing.T) {
 		}})
 	require.NoError(t, err)
 
-	require.Equal(t, "sub-content\nmore-content\n", execRes.Container.From.WithMountedDirectory.Exec.Stdout.Contents)
+	require.Equal(t, "sub-content\nmore-content\n", execRes.Container.From.WithMountedDirectory.Exec.Stdout)
 }
 
 func TestContainerFile(t *testing.T) {
@@ -1980,9 +1853,7 @@ func TestContainerFile(t *testing.T) {
 			From struct {
 				WithMountedFile struct {
 					Exec struct {
-						Stdout struct {
-							Contents string
-						}
+						Stdout string
 					}
 				}
 			}
@@ -1994,9 +1865,7 @@ func TestContainerFile(t *testing.T) {
 				from(address: "alpine:3.16.2") {
 					withMountedFile(path: "/mnt/file", source: $id) {
 						exec(args: ["cat", "/mnt/file"]) {
-							stdout {
-								contents
-							}
+							stdout
 						}
 					}
 				}
@@ -2006,7 +1875,7 @@ func TestContainerFile(t *testing.T) {
 		}})
 	require.NoError(t, err)
 
-	require.Equal(t, "some-content-appended", execRes.Container.From.WithMountedFile.Exec.Stdout.Contents)
+	require.Equal(t, "some-content-appended", execRes.Container.From.WithMountedFile.Exec.Stdout)
 }
 
 func TestContainerFileErrors(t *testing.T) {
@@ -2131,9 +2000,7 @@ func TestContainerFSDirectory(t *testing.T) {
 			From struct {
 				WithMountedDirectory struct {
 					Exec struct {
-						Stdout struct {
-							Contents string
-						}
+						Stdout string
 					}
 				}
 			}
@@ -2145,9 +2012,7 @@ func TestContainerFSDirectory(t *testing.T) {
 				from(address: "alpine:3.16.2") {
 					withMountedDirectory(path: "/mnt/etc", source: $id) {
 						exec(args: ["cat", "/mnt/etc/alpine-release"]) {
-							stdout {
-								contents
-							}
+							stdout
 						}
 					}
 				}
@@ -2157,7 +2022,7 @@ func TestContainerFSDirectory(t *testing.T) {
 		}})
 	require.NoError(t, err)
 
-	require.Equal(t, "3.16.2\n", execRes.Container.From.WithMountedDirectory.Exec.Stdout.Contents)
+	require.Equal(t, "3.16.2\n", execRes.Container.From.WithMountedDirectory.Exec.Stdout)
 }
 
 func TestContainerRelativePaths(t *testing.T) {
@@ -2262,9 +2127,7 @@ func TestContainerRelativePaths(t *testing.T) {
 			From struct {
 				WithMountedDirectory struct {
 					Exec struct {
-						Stdout struct {
-							Contents string
-						}
+						Stdout string
 					}
 				}
 			}
@@ -2276,9 +2139,7 @@ func TestContainerRelativePaths(t *testing.T) {
 				from(address: "alpine:3.16.2") {
 					withMountedDirectory(path: "/mnt/dir", source: $id) {
 						exec(args: ["ls", "/mnt/dir"]) {
-							stdout {
-								contents
-							}
+							stdout
 						}
 					}
 				}
@@ -2288,7 +2149,7 @@ func TestContainerRelativePaths(t *testing.T) {
 		}})
 	require.NoError(t, err)
 
-	require.Equal(t, "another-file\nsome-file\n", execRes.Container.From.WithMountedDirectory.Exec.Stdout.Contents)
+	require.Equal(t, "another-file\nsome-file\n", execRes.Container.From.WithMountedDirectory.Exec.Stdout)
 }
 
 func TestContainerMultiFrom(t *testing.T) {
@@ -2318,9 +2179,7 @@ func TestContainerMultiFrom(t *testing.T) {
 						From struct {
 							Exec struct {
 								Exec struct {
-									Stdout struct {
-										Contents string
-									}
+									Stdout string
 								}
 							}
 						}
@@ -2338,9 +2197,7 @@ func TestContainerMultiFrom(t *testing.T) {
 							from(address: "golang:1.18.2-alpine") {
 								exec(args: ["sh", "-c", "go version >> /mnt/versions"]) {
 									exec(args: ["cat", "/mnt/versions"]) {
-										stdout {
-											contents
-										}
+										stdout
 									}
 								}
 							}
@@ -2352,8 +2209,8 @@ func TestContainerMultiFrom(t *testing.T) {
 			"id": id,
 		}})
 	require.NoError(t, err)
-	require.Contains(t, execRes.Container.From.WithMountedDirectory.Exec.From.Exec.Exec.Stdout.Contents, "v18.10.0\n")
-	require.Contains(t, execRes.Container.From.WithMountedDirectory.Exec.From.Exec.Exec.Stdout.Contents, "go version go1.18.2")
+	require.Contains(t, execRes.Container.From.WithMountedDirectory.Exec.From.Exec.Exec.Stdout, "v18.10.0\n")
+	require.Contains(t, execRes.Container.From.WithMountedDirectory.Exec.From.Exec.Exec.Stdout, "go version go1.18.2")
 }
 
 func TestContainerPublish(t *testing.T) {
@@ -2394,7 +2251,7 @@ func TestExecFromScratch(t *testing.T) {
 		WithMountedFile("/busybox", c.Container().From("busybox:musl").File("/bin/busybox")).
 		Exec(dagger.ContainerExecOpts{Args: []string{"/busybox"}})
 
-	_, err = execBusybox.Stdout().Contents(ctx)
+	_, err = execBusybox.Stdout(ctx)
 	require.NoError(t, err)
 	_, err = execBusybox.Publish(ctx, "127.0.0.1:5000/testexecfromscratch:latest")
 	require.NoError(t, err)
@@ -2426,7 +2283,7 @@ func TestContainerMultipleMounts(t *testing.T) {
 		Args: []string{"cat", "/example/one", "/example/two", "/example/three"},
 	})
 
-	out, err := build.Stdout().Contents(ctx)
+	out, err := build.Stdout(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "123", out)
 }

--- a/core/integration/examples_test.go
+++ b/core/integration/examples_test.go
@@ -25,9 +25,7 @@ func TestExtensionAlpine(t *testing.T) {
 		Alpine struct {
 			Build struct {
 				Exec struct {
-					Stdout struct {
-						Contents string
-					}
+					Stdout string
 				}
 			}
 		}
@@ -40,9 +38,7 @@ func TestExtensionAlpine(t *testing.T) {
 					alpine {
 						build(pkgs: ["curl"]) {
 							exec(args: ["curl", "--version"]) {
-								stdout {
-									contents
-								}
+								stdout
 							}
 						}
 					}
@@ -51,7 +47,7 @@ func TestExtensionAlpine(t *testing.T) {
 		resp,
 	)
 	require.NoError(t, err)
-	require.NotEmpty(t, data.Alpine.Build.Exec.Stdout.Contents)
+	require.NotEmpty(t, data.Alpine.Build.Exec.Stdout)
 }
 
 func TestExtensionNetlify(t *testing.T) {

--- a/core/integration/host_test.go
+++ b/core/integration/host_test.go
@@ -28,7 +28,7 @@ func TestHostWorkdir(t *testing.T) {
 			WithMountedDirectory("/host", c.Host().Directory(".")).
 			Exec(dagger.ContainerExecOpts{
 				Args: []string{"ls", "/host"},
-			}).Stdout().Contents(ctx)
+			}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "foo\n", contents)
 	})
@@ -42,7 +42,7 @@ func TestHostWorkdir(t *testing.T) {
 			WithMountedDirectory("/host", c.Host().Directory(".")).
 			Exec(dagger.ContainerExecOpts{
 				Args: []string{"ls", "/host"},
-			}).Stdout().Contents(ctx)
+			}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "foo\n", contents)
 	})
@@ -71,7 +71,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 			WithMountedDirectory("/host", wd).
 			Exec(dagger.ContainerExecOpts{
 				Args: []string{"ls", "/host"},
-			}).Stdout().Contents(ctx)
+			}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "a.txt\nb.txt\n", contents)
 	})
@@ -86,7 +86,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 			WithMountedDirectory("/host", wd).
 			Exec(dagger.ContainerExecOpts{
 				Args: []string{"ls", "/host"},
-			}).Stdout().Contents(ctx)
+			}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "c.txt.rar\n", contents)
 	})
@@ -102,7 +102,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 			WithMountedDirectory("/host", wd).
 			Exec(dagger.ContainerExecOpts{
 				Args: []string{"ls", "/host"},
-			}).Stdout().Contents(ctx)
+			}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "a.txt\n", contents)
 	})
@@ -118,7 +118,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 			WithMountedDirectory("/host", wd).
 			Exec(dagger.ContainerExecOpts{
 				Args: []string{"ls", "/host"},
-			}).Stdout().Contents(ctx)
+			}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "", contents)
 	})
@@ -247,7 +247,7 @@ func TestHostVariable(t *testing.T) {
 		WithSecretVariable("SECRET", secret.Secret()).
 		Exec(dagger.ContainerExecOpts{
 			Args: []string{"env"},
-		}).Stdout().Contents(ctx)
+		}).Stdout(ctx)
 	require.NoError(t, err)
 
 	require.Contains(t, env, "SECRET=hello")

--- a/core/integration/platform_test.go
+++ b/core/integration/platform_test.go
@@ -48,7 +48,7 @@ func TestPlatformEmulatedExecAndPush(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, platform, ctrPlatform)
 
-		output, err := ctr.Stdout().Contents(ctx)
+		output, err := ctr.Stdout(ctx)
 		require.NoError(t, err)
 		output = strings.TrimSpace(output)
 		require.Equal(t, uname, output)
@@ -66,7 +66,7 @@ func TestPlatformEmulatedExecAndPush(t *testing.T) {
 			Exec(dagger.ContainerExecOpts{
 				Args: []string{"uname", "-m"},
 			})
-		output, err := ctr.Stdout().Contents(ctx)
+		output, err := ctr.Stdout(ctx)
 		require.NoError(t, err)
 		output = strings.TrimSpace(output)
 		require.Equal(t, uname, output)
@@ -115,7 +115,7 @@ func TestPlatformCrossCompile(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, defaultPlatform, ctrPlatform)
 
-			stdout, err := ctr.Stdout().Contents(ctx)
+			stdout, err := ctr.Stdout(ctx)
 			require.NoError(t, err)
 			stdout = strings.TrimSpace(stdout)
 			require.Equal(t, platformToUname[defaultPlatform], stdout)

--- a/core/integration/secret_test.go
+++ b/core/integration/secret_test.go
@@ -19,7 +19,7 @@ func TestSecretEnvFromFile(t *testing.T) {
 			From struct {
 				WithSecretVariable struct {
 					Exec struct {
-						Stdout struct{ Contents string }
+						Stdout string
 					}
 				}
 			}
@@ -32,7 +32,7 @@ func TestSecretEnvFromFile(t *testing.T) {
 				from(address: "alpine:3.16.2") {
 					withSecretVariable(name: "SECRET", secret: $secret) {
 						exec(args: ["env"]) {
-							stdout { contents }
+							stdout
 						}
 					}
 				}
@@ -41,7 +41,7 @@ func TestSecretEnvFromFile(t *testing.T) {
 			"secret": secretID,
 		}})
 	require.NoError(t, err)
-	require.Contains(t, envRes.Container.From.WithSecretVariable.Exec.Stdout.Contents, "SECRET=some-content\n")
+	require.Contains(t, envRes.Container.From.WithSecretVariable.Exec.Stdout, "SECRET=some-content\n")
 }
 
 func TestSecretMountFromFile(t *testing.T) {
@@ -54,7 +54,7 @@ func TestSecretMountFromFile(t *testing.T) {
 			From struct {
 				WithMountedSecret struct {
 					Exec struct {
-						Stdout struct{ Contents string }
+						Stdout string
 					}
 				}
 			}
@@ -67,7 +67,7 @@ func TestSecretMountFromFile(t *testing.T) {
 				from(address: "alpine:3.16.2") {
 					withMountedSecret(path: "/sekret", source: $secret) {
 						exec(args: ["cat", "/sekret"]) {
-							stdout { contents }
+							stdout
 						}
 					}
 				}
@@ -76,7 +76,7 @@ func TestSecretMountFromFile(t *testing.T) {
 			"secret": secretID,
 		}})
 	require.NoError(t, err)
-	require.Contains(t, envRes.Container.From.WithMountedSecret.Exec.Stdout.Contents, "some-content")
+	require.Contains(t, envRes.Container.From.WithMountedSecret.Exec.Stdout, "some-content")
 }
 
 func TestSecretMountFromFileWithOverridingMount(t *testing.T) {
@@ -91,7 +91,7 @@ func TestSecretMountFromFileWithOverridingMount(t *testing.T) {
 				WithMountedSecret struct {
 					WithMountedFile struct {
 						Exec struct {
-							Stdout struct{ Contents string }
+							Stdout string
 						}
 						File struct {
 							Contents string
@@ -109,7 +109,7 @@ func TestSecretMountFromFileWithOverridingMount(t *testing.T) {
 					withMountedSecret(path: "/sekret", source: $secret) {
 						withMountedFile(path: "/sekret", source: $file) {
 							exec(args: ["cat", "/sekret"]) {
-								stdout { contents }
+								stdout
 							}
 							file(path: "/sekret") {
 								contents
@@ -123,7 +123,7 @@ func TestSecretMountFromFileWithOverridingMount(t *testing.T) {
 			"file":   fileID,
 		}})
 	require.NoError(t, err)
-	require.Contains(t, res.Container.From.WithMountedSecret.WithMountedFile.Exec.Stdout.Contents, "some-secret")
+	require.Contains(t, res.Container.From.WithMountedSecret.WithMountedFile.Exec.Stdout, "some-secret")
 	require.Contains(t, res.Container.From.WithMountedSecret.WithMountedFile.File.Contents, "some-content")
 }
 

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -134,12 +134,12 @@ func (s *containerSchema) exitCode(ctx *router.Context, parent *core.Container, 
 	return parent.ExitCode(ctx, s.gw)
 }
 
-func (s *containerSchema) stdout(ctx *router.Context, parent *core.Container, args any) (*core.File, error) {
-	return parent.MetaFile(ctx, s.gw, "stdout")
+func (s *containerSchema) stdout(ctx *router.Context, parent *core.Container, args any) (*string, error) {
+	return parent.MetaFileContents(ctx, s.gw, "stdout")
 }
 
-func (s *containerSchema) stderr(ctx *router.Context, parent *core.Container, args any) (*core.File, error) {
-	return parent.MetaFile(ctx, s.gw, "stderr")
+func (s *containerSchema) stderr(ctx *router.Context, parent *core.Container, args any) (*string, error) {
+	return parent.MetaFileContents(ctx, s.gw, "stderr")
 }
 
 type containerWithEntrypointArgs struct {

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -139,13 +139,13 @@ type Container {
   The output stream of the last executed command.
   Null if no command has been executed.
   """
-  stdout: File
+  stdout: String
 
   """
   The error stream of the last executed command.
   Null if no command has been executed.
   """
-  stderr: File
+  stderr: String
 
   # FIXME: this is the last case of an actual "verb" that cannot cleanly go away.
   #    This may actually be a good candidate for a mutation. To be discussed.

--- a/docs/current/sdk/go/snippets/embed-directories/main.go
+++ b/docs/current/sdk/go/snippets/embed-directories/main.go
@@ -60,7 +60,7 @@ func main() {
 	// List files
 	out, err := container.Exec(dagger.ContainerExecOpts{
 		Args: []string{"ls", "-lR", "/embed/"},
-	}).Stdout().Contents(ctx)
+	}).Stdout(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/docs/current/sdk/go/snippets/multiplatform-support/non-linux-support/main.go
+++ b/docs/current/sdk/go/snippets/multiplatform-support/non-linux-support/main.go
@@ -33,7 +33,7 @@ func main() {
 	// however, executing a command will fail
 	_, err = ctr.Exec(dagger.ContainerExecOpts{
 		Args: []string{"cmd.exe"},
-	}).Stdout().Contents(ctx)
+	}).Stdout(ctx)
 	if err != nil {
 		panic(err) // should happen
 	}

--- a/docs/current/sdk/go/snippets/multiplatform-support/pull-images/main.go
+++ b/docs/current/sdk/go/snippets/multiplatform-support/pull-images/main.go
@@ -38,7 +38,7 @@ func main() {
 			Exec(dagger.ContainerExecOpts{
 				Args: []string{"uname", "-m"},
 			}).
-			Stdout().Contents(ctx)
+			Stdout(ctx)
 		if err != nil {
 			panic(err)
 		}

--- a/docs/current/sdk/go/snippets/work-with-host-filesystem/mount-dir/main.go
+++ b/docs/current/sdk/go/snippets/work-with-host-filesystem/mount-dir/main.go
@@ -24,7 +24,7 @@ func main() {
 		WithMountedDirectory("/host", client.Host().Directory(".")).
 		Exec(dagger.ContainerExecOpts{
 			Args: []string{"ls", "/host"},
-		}).Stdout().Contents(ctx)
+		}).Stdout(ctx)
 	// highlight-end
 	if err != nil {
 		log.Println(err)

--- a/docs/current/sdk/nodejs/783645-get-started.md
+++ b/docs/current/sdk/nodejs/783645-get-started.md
@@ -100,7 +100,7 @@ This Node.js stub imports the Dagger SDK and defines an asynchronous function. T
 - It creates a Dagger client with `connect()`. This client provides an interface for executing commands against the Dagger engine.
 - It uses the client's `container().from()` method to initialize a new container from a base image. In this example, the base image is the `node:16` image. This method returns a `Container` representing an OCI-compatible container image.
 - It uses the `Container.exec()` method to define the command to be executed in the container - in this case, the command `node -v`, which returns the Node version string. The `exec()` method returns a revised `Container` with the results of command execution.
-- It retrieves the output stream of the last executed command as a `File` object with the `Container.stdout()` method and uses the `File.contents()` methods to print the result to the console.
+- It retrieves the output stream of the last executed with the `Container.stdout()` method and prints the result to the console.
 
 Run the Node.js CI tool by executing the command below from the project directory:
 

--- a/docs/current/sdk/nodejs/snippets/get-started/step3/build.js
+++ b/docs/current/sdk/nodejs/snippets/get-started/step3/build.js
@@ -7,7 +7,7 @@ connect(async (client) => {
   let node = await client.container().from("node:16").exec(["node", "-v"])
 
   // execute
-  let version = await node.stdout().contents()
+  let version = await node.stdout()
 
   // print output
   console.log("Hello from Dagger and Node " + version.contents)

--- a/docs/current/sdk/nodejs/snippets/get-started/step3/build.ts
+++ b/docs/current/sdk/nodejs/snippets/get-started/step3/build.ts
@@ -7,7 +7,7 @@ connect(async (client: Client) => {
   const node = await client.container().from("node:16").exec(["node", "-v"])
 
   // execute
-  const version = await node.stdout().contents()
+  const version = await node.stdout()
 
   // print output
   console.log("Hello from Dagger and Node " + version.contents)

--- a/docs/current/sdk/python/snippets/get-started/step1/test.py
+++ b/docs/current/sdk/python/snippets/get-started/step1/test.py
@@ -22,7 +22,7 @@ async def test():
         )
 
         # execute
-        version = await python.stdout().contents()
+        version = await python.stdout()
 
         print(f"Hello from Dagger and {version}")
 

--- a/examples/queries/docker_build.graphql
+++ b/examples/queries/docker_build.graphql
@@ -2,9 +2,7 @@
   git(remote: "github.com/dagger/dagger") {
     dockerbuild(dockerfile: "Dockerfile") {
       exec(args: ["dagger", "version"]) {
-        stdout {
-          contents
-        }
+        stdout
       }
     }
   }

--- a/examples/queries/multi.graphql
+++ b/examples/queries/multi.graphql
@@ -3,20 +3,12 @@
     from(address: "alpine") {
       exec(args: ["apk", "add", "curl"]) {
         dagger: exec(args: ["curl", "https://dagger.io/"]) {
-          stderr {
-            contents
-          }
-          stdout {
-            contents
-          }
+          stderr
+          stdout
         }
         github: exec(args: ["curl", "-L", "https://github.com/"]) {
-          stderr {
-            contents
-          }
-          stdout {
-            contents
-          }
+          stderr
+          stdout
         }
       }
     }

--- a/examples/queries/simple.graphql
+++ b/examples/queries/simple.graphql
@@ -3,9 +3,7 @@
     from(address: "alpine") {
       exec(args: ["apk", "add", "curl"]) {
         exec(args: ["curl", "https://dagger.io/"]) {
-          stdout {
-            contents
-          }
+          stdout
         }
       }
     }

--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -144,7 +144,7 @@ func (t Engine) test(ctx context.Context, race bool) error {
 				Args:                          args,
 				ExperimentalPrivilegedNesting: true,
 			}).
-			Stdout().Contents(ctx)
+			Stdout(ctx)
 		if err != nil {
 			return err
 		}

--- a/internal/mage/sdk/go.go
+++ b/internal/mage/sdk/go.go
@@ -63,7 +63,7 @@ func (t Go) Test(ctx context.Context) error {
 				Args:                          []string{"go", "test", "-v", "./..."},
 				ExperimentalPrivilegedNesting: true,
 			}).
-			Stdout().Contents(ctx)
+			Stdout(ctx)
 		if err != nil {
 			err = fmt.Errorf("test failed: %w\n%s", err, output)
 		}

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -332,24 +332,22 @@ func (r *Container) Rootfs() *Directory {
 
 // The error stream of the last executed command.
 // Null if no command has been executed.
-func (r *Container) Stderr() *File {
+func (r *Container) Stderr(ctx context.Context) (string, error) {
 	q := r.q.Select("stderr")
 
-	return &File{
-		q: q,
-		c: r.c,
-	}
+	var response string
+	q = q.Bind(&response)
+	return response, q.Execute(ctx, r.c)
 }
 
 // The output stream of the last executed command.
 // Null if no command has been executed.
-func (r *Container) Stdout() *File {
+func (r *Container) Stdout(ctx context.Context) (string, error) {
 	q := r.q.Select("stdout")
 
-	return &File{
-		q: q,
-		c: r.c,
-	}
+	var response string
+	q = q.Bind(&response)
+	return response, q.Execute(ctx, r.c)
 }
 
 // The user to be set for all commands

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -80,7 +80,7 @@ func TestContainer(t *testing.T) {
 
 	stdout, err := alpine.Exec(ContainerExecOpts{
 		Args: []string{"cat", "/etc/alpine-release"},
-	}).Stdout().Contents(ctx)
+	}).Stdout(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "3.16.2\n", stdout)
 

--- a/sdk/go/examples_test.go
+++ b/sdk/go/examples_test.go
@@ -22,7 +22,7 @@ func ExampleContainer() {
 
 	out, err := alpine.Exec(dagger.ContainerExecOpts{
 		Args: []string{"cat", "/etc/alpine-release"},
-	}).Stdout().Contents(ctx)
+	}).Stdout(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -69,7 +69,7 @@ func ExampleContainer_Build() {
 
 	out, err := daggerImg.Exec(dagger.ContainerExecOpts{
 		Args: []string{"version"},
-	}).Stdout().Contents(ctx)
+	}).Stdout(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -94,7 +94,7 @@ func ExampleContainer_WithEnvVariable() {
 
 	out, err := container.Exec(dagger.ContainerExecOpts{
 		Args: []string{"sh", "-c", "echo $FOO"},
-	}).Stdout().Contents(ctx)
+	}).Stdout(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -122,7 +122,7 @@ func ExampleContainer_WithMountedDirectory() {
 
 	out, err := container.Exec(dagger.ContainerExecOpts{
 		Args: []string{"ls", "/mnt"},
-	}).Stdout().Contents(ctx)
+	}).Stdout(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -156,7 +156,7 @@ func ExampleContainer_WithMountedCache() {
 				"echo $0 >> /cache/x.txt; cat /cache/x.txt",
 				strconv.Itoa(i),
 			},
-		}).Stdout().Contents(ctx)
+		}).Stdout(ctx)
 		if err != nil {
 			panic(err)
 		}
@@ -228,7 +228,7 @@ func ExampleHost_Directory() {
 // 		Exec(dagger.ContainerExecOpts{
 // 			Args: []string{"sh", "-c", "echo $PASSWORD"},
 // 		}).
-// 		Stdout().Contents(ctx)
+// 		Stdout(ctx)
 // 	if err != nil {
 // 		panic(err)
 // 	}

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -426,32 +426,34 @@ export class Container extends BaseClient {
    * The error stream of the last executed command.
    * Null if no command has been executed.
    */
-  stderr(): File {
-    return new File({
-      queryTree: [
-        ...this._queryTree,
-        {
-          operation: "stderr",
-        },
-      ],
-      host: this.clientHost,
-    })
+  async stderr(): Promise<Record<string, string>> {
+    this._queryTree = [
+      ...this._queryTree,
+      {
+        operation: "stderr",
+      },
+    ]
+
+    const response: Awaited<Record<string, string>> = await this._compute()
+
+    return response
   }
 
   /**
    * The output stream of the last executed command.
    * Null if no command has been executed.
    */
-  stdout(): File {
-    return new File({
-      queryTree: [
-        ...this._queryTree,
-        {
-          operation: "stdout",
-        },
-      ],
-      host: this.clientHost,
-    })
+  async stdout(): Promise<Record<string, string>> {
+    this._queryTree = [
+      ...this._queryTree,
+      {
+        operation: "stdout",
+      },
+    ]
+
+    const response: Awaited<Record<string, string>> = await this._compute()
+
+    return response
   }
 
   /**

--- a/sdk/nodejs/api/test/api.spec.ts
+++ b/sdk/nodejs/api/test/api.spec.ts
@@ -17,22 +17,20 @@ describe("NodeJS SDK api", function () {
       .container()
       .from("alpine")
       .exec(["apk", "add", "curl"])
-      .stdout()
 
     assert.strictEqual(
       queryBuilder(tree.queryTree),
-      `{container{from(address:"alpine"){exec(args:["apk","add","curl"]){stdout}}}}`
+      `{container{from(address:"alpine"){exec(args:["apk","add","curl"])}}}`
     )
   })
 
   it("Build a query by splitting it", async function () {
     const image = new Client().container().from("alpine")
     const pkg = image.exec(["apk", "add", "curl"])
-    const result = pkg.stdout()
 
     assert.strictEqual(
-      queryBuilder(result.queryTree),
-      `{container{from(address:"alpine"){exec(args:["apk","add","curl"]){stdout}}}}`
+      queryBuilder(pkg.queryTree),
+      `{container{from(address:"alpine"){exec(args:["apk","add","curl"])}}}`
     )
   })
 
@@ -55,17 +53,15 @@ describe("NodeJS SDK api", function () {
       container: {
         from: {
           exec: {
-            stdout: {
-              contents:
-                "fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/aarch64/APKINDEX.tar.gz",
-            },
+            stdout:
+              "fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/aarch64/APKINDEX.tar.gz",
           },
         },
       },
     }
 
     assert.deepStrictEqual(queryFlatten(tree), {
-      contents:
+      stdout:
         "fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/aarch64/APKINDEX.tar.gz",
     })
   })

--- a/sdk/nodejs/test/connect.spec.ts
+++ b/sdk/nodejs/test/connect.spec.ts
@@ -12,9 +12,8 @@ describe("NodeJS sdk", function () {
         .exec(["apk", "add", "curl"])
         .exec(["curl", "https://dagger.io/"])
         .stdout()
-        .size()
 
-      assert.ok(result.size > 10000)
+      assert.ok(result.stdout.length > 10000)
     })
   })
 })

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -29,7 +29,7 @@ async def main(args: list[str]):
         )
 
         # run cowsay with requested message
-        result = await ctr.exec(args).stdout().contents()
+        result = await ctr.exec(args).stdout()
 
         print(result)
 

--- a/sdk/python/experimental/hello/main.py
+++ b/sdk/python/experimental/hello/main.py
@@ -20,7 +20,6 @@ class Hello:
                 .exec(["apk", "add", "curl"])
                 .exec(["curl", "https://dagger.io/"])
                 .stdout()
-                .contents()
             )
 
 

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -272,23 +272,37 @@ class Container(Type):
         _ctx = self._select("rootfs", _args)
         return Directory(_ctx)
 
-    def stderr(self) -> "File":
+    async def stderr(self) -> str | None:
         """The error stream of the last executed command.
 
         Null if no command has been executed.
+
+        Returns
+        -------
+        str | None
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
         """
         _args: list[Arg] = []
         _ctx = self._select("stderr", _args)
-        return File(_ctx)
+        return await _ctx.execute(str | None)
 
-    def stdout(self) -> "File":
+    async def stdout(self) -> str | None:
         """The output stream of the last executed command.
 
         Null if no command has been executed.
+
+        Returns
+        -------
+        str | None
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
         """
         _args: list[Arg] = []
         _ctx = self._select("stdout", _args)
-        return File(_ctx)
+        return await _ctx.execute(str | None)
 
     async def user(self) -> str | None:
         """The user to be set for all commands

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -272,23 +272,37 @@ class Container(Type):
         _ctx = self._select("rootfs", _args)
         return Directory(_ctx)
 
-    def stderr(self) -> "File":
+    def stderr(self) -> str | None:
         """The error stream of the last executed command.
 
         Null if no command has been executed.
+
+        Returns
+        -------
+        str | None
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
         """
         _args: list[Arg] = []
         _ctx = self._select("stderr", _args)
-        return File(_ctx)
+        return _ctx.execute_sync(str | None)
 
-    def stdout(self) -> "File":
+    def stdout(self) -> str | None:
         """The output stream of the last executed command.
 
         Null if no command has been executed.
+
+        Returns
+        -------
+        str | None
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
         """
         _args: list[Arg] = []
         _ctx = self._select("stdout", _args)
-        return File(_ctx)
+        return _ctx.execute_sync(str | None)
 
     def user(self) -> str | None:
         """The user to be set for all commands

--- a/sdk/python/tests/api/test_integration.py
+++ b/sdk/python/tests/api/test_integration.py
@@ -14,7 +14,7 @@ pytestmark = [
 async def test_container():
     async with dagger.Connection() as client:
         alpine = client.container().from_("alpine:3.16.2")
-        version = await alpine.exec(["cat", "/etc/alpine-release"]).stdout().contents()
+        version = await alpine.exec(["cat", "/etc/alpine-release"]).stdout()
 
         assert version == "3.16.2\n"
 
@@ -32,7 +32,7 @@ async def test_container_build():
         repo = client.git("https://github.com/dagger/dagger").tag("v0.3.0").tree()
         dagger_img = client.container().build(repo)
 
-        out = await dagger_img.exec(["version"]).stdout().contents()
+        out = await dagger_img.exec(["version"]).stdout()
 
         words = out.strip().split(" ")
 
@@ -44,7 +44,7 @@ async def test_container_with_env_variable():
         container = (
             client.container().from_("alpine:3.16.2").with_env_variable("FOO", "bar")
         )
-        out = await container.exec(["sh", "-c", "echo -n $FOO"]).stdout().contents()
+        out = await container.exec(["sh", "-c", "echo -n $FOO"]).stdout()
 
         assert out == "bar"
 
@@ -63,7 +63,7 @@ async def test_container_with_mounted_directory():
             .with_mounted_directory("/mnt", dir_)
         )
 
-        out = await container.exec(["ls", "/mnt"]).stdout().contents()
+        out = await container.exec(["ls", "/mnt"]).stdout()
 
         assert out == dedent(
             """\
@@ -84,18 +84,14 @@ async def test_container_with_mounted_cache():
         )
 
         for i in range(5):
-            out = (
-                await container.exec(
-                    [
-                        "sh",
-                        "-c",
-                        "echo $0 >> /cache/x.txt; cat /cache/x.txt",
-                        str(i),
-                    ]
-                )
-                .stdout()
-                .contents()
-            )
+            out = await container.exec(
+                [
+                    "sh",
+                    "-c",
+                    "echo $0 >> /cache/x.txt; cat /cache/x.txt",
+                    str(i),
+                ]
+            ).stdout()
 
         assert out == "0\n1\n2\n3\n4\n"
 

--- a/sdk/python/tests/api/test_integration_sync.py
+++ b/sdk/python/tests/api/test_integration_sync.py
@@ -15,7 +15,7 @@ def test_container_build():
         repo = client.git("https://github.com/dagger/dagger").tag("v0.3.0").tree()
         dagger_img = client.container().build(repo)
 
-        out = dagger_img.exec(["version"]).stdout().contents()
+        out = dagger_img.exec(["version"]).stdout()
 
         words = out.strip().split(" ")
 
@@ -36,7 +36,7 @@ def test_container_with_mounted_directory():
             .with_mounted_directory("/mnt", dir_)
         )
 
-        out = container.exec(["ls", "/mnt"]).stdout().contents()
+        out = container.exec(["ls", "/mnt"]).stdout()
 
         assert out == dedent(
             """\
@@ -57,17 +57,13 @@ def test_container_with_mounted_cache():
         )
 
         for i in range(5):
-            out = (
-                container.exec(
-                    [
-                        "sh",
-                        "-c",
-                        "echo $0 >> /cache/x.txt; cat /cache/x.txt",
-                        str(i),
-                    ]
-                )
-                .stdout()
-                .contents()
-            )
+            out = container.exec(
+                [
+                    "sh",
+                    "-c",
+                    "echo $0 >> /cache/x.txt; cat /cache/x.txt",
+                    str(i),
+                ]
+            ).stdout()
 
         assert out == "0\n1\n2\n3\n4\n"


### PR DESCRIPTION
This change removes the indirection `stdout/stderr` -> `file` -> `contents`.

Before:

```
ctr.Stdout().Contents(ctx)
```

After:
```
ctr.Stdout(ctx)
```

/cc @sipsma @shykes @kpenfound @helderco @vikram-dagger 