### PR TITLE
Simplify shim setup by running shim outside of container

### DIFF
--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strings"
+	"sync"
 	"syscall"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -16,97 +18,24 @@ import (
 
 const (
 	metaMountPath = "/.dagger_meta_mount"
-	stdinPath     = metaMountPath + "/stdin"
-	exitCodePath  = metaMountPath + "/exitCode"
 	runcPath      = "/usr/bin/buildkit-runc"
-	shimPath      = "/_shim"
-)
-
-var (
-	stdoutPath = metaMountPath + "/stdout"
-	stderrPath = metaMountPath + "/stderr"
 )
 
 /*
-There are two "subcommands" of this binary:
- 1. The setupBundle command, which is invoked by buildkitd as the oci executor. It updates the
-    spec provided by buildkitd's executor to wrap the command in our shim (described below).
-    It then exec's to runc which will do the actual container setup+execution.
- 2. The shim, which is included in each Container.Exec and enables us to capture/redirect stdio,
-    capture the exit code, etc.
+This binary implements our shim, which enables each Container.Exec to
+capture/redirect stdio, capture the exit code, provide a dagger session,
+etc.
+
+It's implemented as a wrapper around runc and is invoked by buildkitd
+as the oci worker. Modeling the shim as an oci runtime allows us to
+customize containers with dagger specific logic+configuration without
+having to fork buildkitd or override custom executors in its codebase.
 */
 func main() {
-	if os.Args[0] == shimPath {
-		// If we're being executed as `/_shim`, then we're inside the container and should shim
-		// the user command.
-		os.Exit(shim())
-	} else {
-		// Otherwise, we're being invoked directly by buildkitd and should setup the bundle.
-		os.Exit(setupBundle())
-	}
+	os.Exit(run())
 }
 
-func shim() int {
-	if len(os.Args) < 2 {
-		fmt.Fprintf(os.Stderr, "usage: %s <path> [<args>]\n", os.Args[0])
-		return 1
-	}
-
-	name := os.Args[1]
-	args := []string{}
-	if len(os.Args) > 2 {
-		args = os.Args[2:]
-	}
-	cmd := exec.Command(name, args...)
-	cmd.Env = os.Environ()
-
-	if stdinFile, err := os.Open(stdinPath); err == nil {
-		defer stdinFile.Close()
-		cmd.Stdin = stdinFile
-	} else {
-		cmd.Stdin = nil
-	}
-
-	stdoutRedirect, found := internalEnv("_DAGGER_REDIRECT_STDOUT")
-	if found {
-		stdoutPath = stdoutRedirect
-	}
-
-	stdoutFile, err := os.Create(stdoutPath)
-	if err != nil {
-		panic(err)
-	}
-	defer stdoutFile.Close()
-	cmd.Stdout = io.MultiWriter(stdoutFile, os.Stdout)
-
-	stderrRedirect, found := internalEnv("_DAGGER_REDIRECT_STDERR")
-	if found {
-		stderrPath = stderrRedirect
-	}
-
-	stderrFile, err := os.Create(stderrPath)
-	if err != nil {
-		panic(err)
-	}
-	defer stderrFile.Close()
-	cmd.Stderr = io.MultiWriter(stderrFile, os.Stderr)
-
-	exitCode := 0
-	if err := cmd.Run(); err != nil {
-		exitCode = 1
-		if exiterr, ok := err.(*exec.ExitError); ok {
-			exitCode = exiterr.ExitCode()
-		}
-	}
-
-	if err := os.WriteFile(exitCodePath, []byte(fmt.Sprintf("%d", exitCode)), 0600); err != nil {
-		panic(err)
-	}
-
-	return exitCode
-}
-
-func setupBundle() int {
+func run() int {
 	// Figure out the path to the bundle dir, in which we can obtain the
 	// oci runtime config.json
 	var bundleDir string
@@ -137,38 +66,83 @@ func setupBundle() int {
 		return 1
 	}
 
-	// Check to see if this is a dagger exec, currently by using
-	// the presence of the dagger meta mount. If it is, set up the
-	// shim to be invoked as the init process. Otherwise, just
-	// pass through as is
-	var isDaggerExec bool
-	for _, mnt := range spec.Mounts {
+	// Check to see if this is a dagger exec by seeing if there is
+	// a dagger meta mount, which is where stdio and exit code files
+	// are written. This mount is part of buildkit's cache, so anything
+	// written to it will be cached alongside the actual container
+	// rootfs+mounts.
+	var metaMount *specs.Mount
+	for i, mnt := range spec.Mounts {
+		mnt := mnt
 		if mnt.Destination == metaMountPath {
-			isDaggerExec = true
+			if mnt.Type != "bind" {
+				// NOTE: we could handle others but this is simpler for now and
+				// it should currently always be a bind mount.
+				fmt.Printf("Error: dagger meta mount must be a bind mount")
+				return 1
+			}
+			// we found it, remove it from the actual container which
+			// doesn't need it mounted
+			metaMount = &mnt
+			spec.Mounts = append(spec.Mounts[:i], spec.Mounts[i+1:]...)
 			break
 		}
 	}
-	if isDaggerExec {
-		// mount this executable into the container so it can be invoked as the shim
-		selfPath, err := os.Executable()
-		if err != nil {
-			fmt.Printf("Error getting self path: %v\n", err)
-			return 1
-		}
-		selfPath, err = filepath.EvalSymlinks(selfPath)
-		if err != nil {
-			fmt.Printf("Error getting self path: %v\n", err)
-			return 1
-		}
-		spec.Mounts = append(spec.Mounts, specs.Mount{
-			Destination: shimPath,
-			Type:        "bind",
-			Source:      selfPath,
-			Options:     []string{"rbind", "ro"},
-		})
 
-		// update the args to specify the shim as the init process
-		spec.Process.Args = append([]string{shimPath}, spec.Process.Args...)
+	var stdin io.Reader = os.Stdin
+	var stdout io.Writer = os.Stdout
+	var stderr io.Writer = os.Stderr
+	if metaMount != nil {
+		metaPath := metaMount.Source
+
+		// If there's some stdin to provide, connect the file to the stdin of the process
+		stdinPath := filepath.Join(metaPath, "stdin")
+		if stdinFile, err := os.Open(stdinPath); err == nil {
+			defer stdinFile.Close()
+			stdin = stdinFile
+		}
+
+		// By default, stdout goes to both our output (and thus buildkit progress logs)
+		// and also to the default stdout file in the meta mount. But if the user setup
+		// a redirection, write to that instead of the meta mount.
+		//
+		// One slight complication: the redirect path is relative to the container's
+		// root and may be in a sub-mount, which doesn't exist yet. We could solve this
+		// with oci hooks but that is pretty complicated. Instead, we use the lazyOpenWriter
+		// implementation, which delays opening the path for writing until data is actually
+		// received (at which time the mount has been made).
+		redirectStdoutPath, newEnv, found := internalEnv("_DAGGER_REDIRECT_STDOUT", spec.Process.Env)
+		if found {
+			spec.Process.Env = newEnv
+			stdoutPath := filepath.Join(bundleDir, "rootfs", redirectStdoutPath)
+			stdout = io.MultiWriter(&lazyOpenWriter{path: stdoutPath}, os.Stdout)
+		} else {
+			stdoutPath := filepath.Join(metaPath, "stdout")
+			f, err := os.Create(stdoutPath)
+			if err != nil {
+				fmt.Printf("Error creating stdout file: %v\n", err)
+				return 1
+			}
+			defer f.Close()
+			stdout = io.MultiWriter(f, os.Stdout)
+		}
+
+		// Do the exact same thing as stdout for stderr
+		redirectStderrPath, newEnv, found := internalEnv("_DAGGER_REDIRECT_STDERR", spec.Process.Env)
+		if found {
+			spec.Process.Env = newEnv
+			stderrPath := filepath.Join(bundleDir, "rootfs", redirectStderrPath)
+			stderr = io.MultiWriter(&lazyOpenWriter{path: stderrPath}, os.Stderr)
+		} else {
+			stderrPath := filepath.Join(metaPath, "stderr")
+			f, err := os.Create(stderrPath)
+			if err != nil {
+				fmt.Printf("Error creating stderr file: %v\n", err)
+				return 1
+			}
+			defer f.Close()
+			stderr = io.MultiWriter(f, os.Stderr)
+		}
 
 		// write the updated config
 		configBytes, err = json.Marshal(spec)
@@ -183,14 +157,16 @@ func setupBundle() int {
 	}
 
 	// Run the actual runc binary as a child process with the (possibly updated) config
+	// #nosec G204
 	cmd := exec.Command(runcPath, os.Args[1:]...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Pdeathsig: syscall.SIGKILL,
 	}
 
+	// Forward any signals we receive to our runc child
 	sigCh := make(chan os.Signal, 32)
 	signal.Notify(sigCh)
 	if err := cmd.Start(); err != nil {
@@ -202,16 +178,34 @@ func setupBundle() int {
 			cmd.Process.Signal(sig)
 		}
 	}()
+
+	// capture the exit code so we can exit with it too
+	exitCode := 0
 	if err := cmd.Wait(); err != nil {
-		if exiterr, ok := err.(*exec.ExitError); ok {
-			if exitcode, ok := exiterr.Sys().(syscall.WaitStatus); ok {
-				return exitcode.ExitStatus()
-			}
+		exiterr, ok := err.(*exec.ExitError)
+		if !ok {
+			fmt.Printf("Error waiting for runc: %v", err)
+			return 1
 		}
-		fmt.Printf("Error waiting for runc: %v", err)
-		return 1
+		waitStatus, ok := exiterr.Sys().(syscall.WaitStatus)
+		if !ok {
+			fmt.Printf("Error getting exit status from runc: %v", err)
+			return 1
+		}
+		exitCode = waitStatus.ExitStatus()
 	}
-	return 0
+
+	// if we are running a dagger exec, also write the exit code to
+	// the meta mount
+	if metaMount != nil {
+		exitCodePath := filepath.Join(metaMount.Source, "exitCode")
+		if err := os.WriteFile(exitCodePath, []byte(fmt.Sprintf("%d", exitCode)), 0600); err != nil {
+			fmt.Printf("Error writing exit code: %v", err)
+			return 1
+		}
+	}
+
+	return exitCode
 }
 
 // nolint: unparam
@@ -225,13 +219,29 @@ func execRunc() int {
 	panic("congratulations: you've reached unreachable code, please report a bug!")
 }
 
-func internalEnv(name string) (string, bool) {
-	val, found := os.LookupEnv(name)
-	if !found {
-		return "", false
+func internalEnv(name string, env []string) (string, []string, bool) {
+	for i, e := range env {
+		if strings.HasPrefix(e, name+"=") {
+			return e[len(name)+1:], append(env[:i], env[i+1:]...), true
+		}
 	}
+	return "", env, false
+}
 
-	os.Unsetenv(name)
+// lazyOpenWriter is an io.Writer that delays opening the file at the given path
+// until data is actually received, after which it just writes to that file.
+type lazyOpenWriter struct {
+	path     string
+	openOnce sync.Once
+	file     *os.File
+}
 
-	return val, true
+func (w *lazyOpenWriter) Write(p []byte) (n int, err error) {
+	w.openOnce.Do(func() {
+		w.file, err = os.Create(w.path)
+	})
+	if err != nil {
+		return 0, err
+	}
+	return w.file.Write(p)
 }


### PR DESCRIPTION
This is a follow up to [the change yesterday](https://github.com/dagger/dagger/pull/3913) which simplifies the architecture significantly.

It also sets up cleaner integration with the [nested session change](https://github.com/dagger/dagger/pull/3787), which I'll do in another follow up to this PR (that should likely be the one that enables us to move dagger-in-dagger out of experimental mode).

## Before this change
```mermaid
graph LR;

subgraph outershim[oci wrapper]
  outershimNote["Update OCI runtime bundle to include dagger shim"]
end

subgraph innershim[dagger shim]
  innershimNote["Proxy stdio, write exit code, etc."]
end

buildkitd --> outershimNote --> runc --> innershimNote--> userexec["user executable"]
```

## After this change
```mermaid
graph LR;

subgraph shim[dagger shim]
  shimNote["Proxy stdio, write exit code, etc."]
end

buildkitd --> shimNote --> runc --> userexec["user executable"]
```

Basically, we now just have a single hook into the container startup process by combining the oci-wrapper and shim into one. The only slightly tricky part of this is that the shim runs outside the container, but that turned out to not be too bad to deal with. The code has comments explaining how we handle the stdio redirection now.

## Reason for the change
1. Significant simplification of the architecture
2. Fixes a long-standing minor problem induced by the shim where empty dirs and empty files at `/.dagger_meta_mount` and `/_shim` appeared in the layers created by user execs (and thus in exported directories)
   * Note that even though these are temporary mounts, empty dirs and files show up because buildkit needs to create the bind mount points for them.
3. Gives us more flexibility in the long run by allowing the shim to both run continuously and access resources both in the container and outside it.
   * For example, this will allow the shim to not necessarily be impacted by networking settings applied to the container (though it still can enter the network namespace easily if needed)
   * Also, some complication around the fact that the shim had things like the user/group of the container applied to it can likely be simplified now

## Next steps
The follow up to this PR will integrate all this with dagger-in-dagger by adding the ability to
1. Mount the engine-session binary into the exec container direct from the host
   * Note that this doesn't mean we go back to creating empty files in the exec layers. Due to the change in this PR we can easily clean up those temp mount points from the shim itself (whereas before that was difficult to impossible to do)
2. Update the process env to point to that binary with `DAGGER_HOST=bin://...`
3. Also bind mount `/var/run/buildkitd.sock` into the container (again, cleaning up the empty mount point) and set that to be `DAGGER_RUNNER_HOST`

There will be more longer term follow ups that can enhance that further, but that should get us to the point where dagger-in-dagger doesn't have to be experimental anymore.

I wanted to get this first change out since it seems like a better approach overall and I would rather base the dagger-in-dagger updates on it than try to retrofit this change on later. 

---

As a side note, what we have now is almost an *exact* mirror of containerd's architecture when using the default runc runtime, which is:
```mermaid
graph LR;

containerd --> shim[runtime shim] --> runc --> userexec["user executable"]
```

This makes me suspect that in the long run we should consider switching our engine image to use buildkit's containerd worker backend and model all this using an actual dagger containerd runtime, which might unlock more interesting long term possibilities. However, in the short term that adds a lot of overhead and not many immediate benefits, so not pursuing it now.