### PR TITLE
api: Deprecate Exec in favor of WithExec. Make args mandatory.

### DIFF
--- a/core/integration/host_test.go
+++ b/core/integration/host_test.go
@@ -26,9 +26,8 @@ func TestHostWorkdir(t *testing.T) {
 		contents, err := c.Container().
 			From("alpine:3.16.2").
 			WithMountedDirectory("/host", c.Host().Directory(".")).
-			Exec(dagger.ContainerExecOpts{
-				Args: []string{"ls", "/host"},
-			}).Stdout(ctx)
+			WithExec([]string{"ls", "/host"}).
+			Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "foo\n", contents)
 	})
@@ -40,9 +39,8 @@ func TestHostWorkdir(t *testing.T) {
 		contents, err := c.Container().
 			From("alpine:3.16.2").
 			WithMountedDirectory("/host", c.Host().Directory(".")).
-			Exec(dagger.ContainerExecOpts{
-				Args: []string{"ls", "/host"},
-			}).Stdout(ctx)
+			WithExec([]string{"ls", "/host"}).
+			Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "foo\n", contents)
 	})
@@ -69,9 +67,8 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 		contents, err := c.Container().
 			From("alpine:3.16.2").
 			WithMountedDirectory("/host", wd).
-			Exec(dagger.ContainerExecOpts{
-				Args: []string{"ls", "/host"},
-			}).Stdout(ctx)
+			WithExec([]string{"ls", "/host"}).
+			Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "a.txt\nb.txt\n", contents)
 	})
@@ -84,9 +81,8 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 		contents, err := c.Container().
 			From("alpine:3.16.2").
 			WithMountedDirectory("/host", wd).
-			Exec(dagger.ContainerExecOpts{
-				Args: []string{"ls", "/host"},
-			}).Stdout(ctx)
+			WithExec([]string{"ls", "/host"}).
+			Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "c.txt.rar\n", contents)
 	})
@@ -100,9 +96,8 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 		contents, err := c.Container().
 			From("alpine:3.16.2").
 			WithMountedDirectory("/host", wd).
-			Exec(dagger.ContainerExecOpts{
-				Args: []string{"ls", "/host"},
-			}).Stdout(ctx)
+			WithExec([]string{"ls", "/host"}).
+			Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "a.txt\n", contents)
 	})
@@ -116,9 +111,8 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 		contents, err := c.Container().
 			From("alpine:3.16.2").
 			WithMountedDirectory("/host", wd).
-			Exec(dagger.ContainerExecOpts{
-				Args: []string{"ls", "/host"},
-			}).Stdout(ctx)
+			WithExec([]string{"ls", "/host"}).
+			Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "", contents)
 	})
@@ -245,9 +239,8 @@ func TestHostVariable(t *testing.T) {
 	env, err := c.Container().
 		From("alpine:3.16.2").
 		WithSecretVariable("SECRET", secret.Secret()).
-		Exec(dagger.ContainerExecOpts{
-			Args: []string{"env"},
-		}).Stdout(ctx)
+		WithExec([]string{"env"}).
+		Stdout(ctx)
 	require.NoError(t, err)
 
 	require.Contains(t, env, "SECRET=hello")

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -144,7 +144,7 @@ func startRegistry(ctx context.Context, c *dagger.Client, t *testing.T) {
 		_, err := c.Container().
 			From("registry:2").
 			WithEnvVariable("RANDOM", randomID).
-			Exec().
+			WithExec([]string{}).
 			ExitCode(ctx)
 		if err != nil {
 			t.Logf("error running registry: %v", err)
@@ -154,9 +154,7 @@ func startRegistry(ctx context.Context, c *dagger.Client, t *testing.T) {
 	_, err := c.Container().
 		From("alpine:3.16.2").
 		WithEnvVariable("RANDOM", randomID).
-		Exec(dagger.ContainerExecOpts{
-			Args: []string{"sh", "-c", "for i in $(seq 1 60); do nc -zv 127.0.0.1 5000 && exit 0; sleep 1; done; exit 1"},
-		}).
+		WithExec([]string{"sh", "-c", "for i in $(seq 1 60); do nc -zv 127.0.0.1 5000 && exit 0; sleep 1; done; exit 1"}).
 		ExitCode(ctx)
 	require.NoError(t, err)
 }

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -61,7 +61,8 @@ func (s *containerSchema) Resolvers() router.Resolvers {
 			"withMountedCache":     router.ToResolver(s.withMountedCache),
 			"withMountedSecret":    router.ToResolver(s.withMountedSecret),
 			"withoutMount":         router.ToResolver(s.withoutMount),
-			"exec":                 router.ToResolver(s.exec),
+			"withExec":             router.ToResolver(s.withExec),
+			"exec":                 router.ToResolver(s.withExec), // deprecated
 			"exitCode":             router.ToResolver(s.exitCode),
 			"stdout":               router.ToResolver(s.stdout),
 			"stderr":               router.ToResolver(s.stderr),
@@ -126,7 +127,7 @@ type containerExecArgs struct {
 	core.ContainerExecOpts
 }
 
-func (s *containerSchema) exec(ctx *router.Context, parent *core.Container, args containerExecArgs) (*core.Container, error) {
+func (s *containerSchema) withExec(ctx *router.Context, parent *core.Container, args containerExecArgs) (*core.Container, error) {
 	return parent.Exec(ctx, s.gw, s.baseSchema.platform, args.ContainerExecOpts)
 }
 

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -112,6 +112,24 @@ type Container {
   withoutMount(path: String!): Container!
 
   "This container after executing the specified command inside it"
+  withExec(
+    "Command to run instead of the container's default command"
+    args: [String!]!
+    "Content to write to the command's standard input before closing"
+    stdin: String
+    "Redirect the command's standard output to a file in the container"
+    redirectStdout: String
+    "Redirect the command's standard error to a file in the container"
+    redirectStderr: String
+    """
+    Provide dagger access to the executed command
+    Do not use this option unless you trust the command being executed
+    The command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM
+    """
+    experimentalPrivilegedNesting: Boolean
+  ): Container!
+
+  "This container after executing the specified command inside it"
   exec(
     "Command to run instead of the container's default command"
     args: [String!]
@@ -127,7 +145,7 @@ type Container {
     The command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM
     """
     experimentalPrivilegedNesting: Boolean
-  ): Container!
+  ): Container! @deprecated(reason: "Replaced by `withExec`.")
 
   """
   Exit code of the last executed command. Zero means success.

--- a/docs/current/sdk/go/959738-get-started.md
+++ b/docs/current/sdk/go/959738-get-started.md
@@ -82,7 +82,7 @@ The revised `build()` function is the main workhorse here, so let's step through
   - The first argument is the target path in the container (here, `/src`).
   - The second argument is the directory to be mounted (here, the reference previously created in the `src` variable).
   It also changes the current working directory to the `/src` path of the container using the [`WithWorkdir()`](https://pkg.go.dev/dagger.io/dagger#Container.WithWorkdir) method and returns a revised `Container` with the results of these operations.
-- It uses the [`Exec()`](https://pkg.go.dev/dagger.io/dagger#Container.Exec) method to define the command to be executed in the container - in this case, the command `go build -o PATH`, where `PATH` refers to the `build/` directory in the container. The `Exec()` method returns a revised `Container` containing the results of command execution.
+- It uses the [`WithExec()`](https://pkg.go.dev/dagger.io/dagger#Container.WithExec) method to define the command to be executed in the container - in this case, the command `go build -o PATH`, where `PATH` refers to the `build/` directory in the container. The `WithExec()` method returns a revised `Container` containing the results of command execution.
 - It obtains a reference to the `build/` directory in the container with the [`Directory()`](https://pkg.go.dev/dagger.io/dagger#Directory) method.
 - It writes the `build/` directory from the container to the host using the `Directory.Export()` method.
 

--- a/docs/current/sdk/go/guides/406009-multiplatform-support.md
+++ b/docs/current/sdk/go/guides/406009-multiplatform-support.md
@@ -63,7 +63,7 @@ This example demonstrates how to pull images for multiple different architecture
 
 As illustrated above, you can optionally initialize a `Container` with a specific platform. That platform will be used to pull images and execute any commands.
 
-If the platform of the `Container` does not match that of the host, then emulation will be used for any commands specified in `Exec`.
+If the platform of the `Container` does not match that of the host, then emulation will be used for any commands specified in `WithExec`.
 
 If you don't specify a platform, the `Container` will be initialized with a platform matching that of the host.
 

--- a/docs/current/sdk/go/snippets/embed-directories/main.go
+++ b/docs/current/sdk/go/snippets/embed-directories/main.go
@@ -58,9 +58,7 @@ func main() {
 	container := client.Container().From("alpine:3.16.2").WithMountedDirectory("/embed", dir)
 
 	// List files
-	out, err := container.Exec(dagger.ContainerExecOpts{
-		Args: []string{"ls", "-lR", "/embed/"},
-	}).Stdout(ctx)
+	out, err := container.WithExec([]string{"ls", "-lR", "/embed/"}).Stdout(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/docs/current/sdk/go/snippets/get-started/step4/main.go
+++ b/docs/current/sdk/go/snippets/get-started/step4/main.go
@@ -36,9 +36,7 @@ func build(ctx context.Context) error {
 
 	// define the application build command
 	path := "build/"
-	golang = golang.Exec(dagger.ContainerExecOpts{
-		Args: []string{"go", "build", "-o", path},
-	})
+	golang = golang.WithExec([]string{"go", "build", "-o", path})
 
 	// get reference to build output directory in container
 	output := golang.Directory(path)

--- a/docs/current/sdk/go/snippets/get-started/step5a/main.go
+++ b/docs/current/sdk/go/snippets/get-started/step5a/main.go
@@ -55,9 +55,7 @@ func build(ctx context.Context) error {
 			build = build.WithEnvVariable("GOARCH", goarch)
 
 			// build application
-			build = build.Exec(dagger.ContainerExecOpts{
-				Args: []string{"go", "build", "-o", path},
-			})
+			build = build.WithExec([]string{"go", "build", "-o", path})
 
 			// get reference to build output directory in container
 			outputs = outputs.WithDirectory(path, build.Directory(path))

--- a/docs/current/sdk/go/snippets/get-started/step5b/main.go
+++ b/docs/current/sdk/go/snippets/get-started/step5b/main.go
@@ -57,9 +57,7 @@ func build(ctx context.Context) error {
 				build = build.WithEnvVariable("GOARCH", goarch)
 
 				// build application
-				build = build.Exec(dagger.ContainerExecOpts{
-					Args: []string{"go", "build", "-o", path},
-				})
+				build = build.WithExec([]string{"go", "build", "-o", path})
 
 				// get reference to build output directory in container
 				outputs = outputs.WithDirectory(path, build.Directory(path))

--- a/docs/current/sdk/go/snippets/multiplatform-support/build-images-cross-compilation/main.go
+++ b/docs/current/sdk/go/snippets/multiplatform-support/build-images-cross-compilation/main.go
@@ -68,14 +68,11 @@ func main() {
 		// build the binary and put the result at the mounted output
 		// directory
 		ctr = ctr.WithWorkdir("/src")
-		ctr = ctr.Exec(dagger.ContainerExecOpts{
-			Args: []string{
-				"go", "build",
-				"-o", "/output/dagger",
-				"/src/cmd/dagger",
-			},
+		ctr = ctr.WithExec([]string{
+			"go", "build",
+			"-o", "/output/dagger",
+			"/src/cmd/dagger",
 		})
-
 		// select the output directory
 		outputDir := ctr.Directory("/output")
 

--- a/docs/current/sdk/go/snippets/multiplatform-support/build-images-emulation/main.go
+++ b/docs/current/sdk/go/snippets/multiplatform-support/build-images-emulation/main.go
@@ -50,12 +50,10 @@ func main() {
 		// build the binary and put the result at the mounted output
 		// directory
 		ctr = ctr.WithWorkdir("/src")
-		ctr = ctr.Exec(dagger.ContainerExecOpts{
-			Args: []string{
-				"go", "build",
-				"-o", "/output/dagger",
-				"/src/cmd/dagger",
-			},
+		ctr = ctr.WithExec([]string{
+			"go", "build",
+			"-o", "/output/dagger",
+			"/src/cmd/dagger",
 		})
 
 		// select the output directory

--- a/docs/current/sdk/go/snippets/multiplatform-support/non-linux-support/main.go
+++ b/docs/current/sdk/go/snippets/multiplatform-support/non-linux-support/main.go
@@ -31,9 +31,7 @@ func main() {
 	}
 
 	// however, executing a command will fail
-	_, err = ctr.Exec(dagger.ContainerExecOpts{
-		Args: []string{"cmd.exe"},
-	}).Stdout(ctx)
+	_, err = ctr.WithExec([]string{"cmd.exe"}).Stdout(ctx)
 	if err != nil {
 		panic(err) // should happen
 	}

--- a/docs/current/sdk/go/snippets/multiplatform-support/pull-images/main.go
+++ b/docs/current/sdk/go/snippets/multiplatform-support/pull-images/main.go
@@ -35,9 +35,7 @@ func main() {
 		// execute `uname -m`, which prints the current CPU architecture
 		// being executed as
 		stdout, err := ctr.
-			Exec(dagger.ContainerExecOpts{
-				Args: []string{"uname", "-m"},
-			}).
+			WithExec([]string{"uname", "-m"}).
 			Stdout(ctx)
 		if err != nil {
 			panic(err)

--- a/docs/current/sdk/go/snippets/multistage-build/main.go
+++ b/docs/current/sdk/go/snippets/multistage-build/main.go
@@ -25,9 +25,7 @@ func main() {
 		WithMountedDirectory("/src", project).
 		WithWorkdir("/src").
 		WithEnvVariable("CGO_ENABLED", "0").
-		Exec(dagger.ContainerExecOpts{
-			Args: []string{"go", "build", "-o", "myapp"},
-		})
+		WithExec([]string{"go", "build", "-o", "myapp"})
 
 	// highlight-start
 	// Publish binary on Alpine base

--- a/docs/current/sdk/go/snippets/work-with-host-filesystem/export-dir/main.go
+++ b/docs/current/sdk/go/snippets/work-with-host-filesystem/export-dir/main.go
@@ -25,9 +25,7 @@ func main() {
 	// highlight-start
 	_, err = client.Container().From("alpine:latest").
 		WithWorkdir("/tmp").
-		Exec(dagger.ContainerExecOpts{
-			Args: []string{"wget", "https://dagger.io"},
-		}).
+		WithExec([]string{"wget", "https://dagger.io"}).
 		Directory(".").
 		Export(ctx, hostdir)
 	if err != nil {

--- a/docs/current/sdk/go/snippets/work-with-host-filesystem/mount-dir/main.go
+++ b/docs/current/sdk/go/snippets/work-with-host-filesystem/mount-dir/main.go
@@ -22,9 +22,8 @@ func main() {
 	contents, err := client.Container().
 		From("alpine:latest").
 		WithMountedDirectory("/host", client.Host().Directory(".")).
-		Exec(dagger.ContainerExecOpts{
-			Args: []string{"ls", "/host"},
-		}).Stdout(ctx)
+		WithExec([]string{"ls", "/host"}).
+		Stdout(ctx)
 	// highlight-end
 	if err != nil {
 		log.Println(err)

--- a/docs/current/sdk/nodejs/783645-get-started.md
+++ b/docs/current/sdk/nodejs/783645-get-started.md
@@ -99,7 +99,7 @@ This Node.js stub imports the Dagger SDK and defines an asynchronous function. T
 
 - It creates a Dagger client with `connect()`. This client provides an interface for executing commands against the Dagger engine.
 - It uses the client's `container().from()` method to initialize a new container from a base image. In this example, the base image is the `node:16` image. This method returns a `Container` representing an OCI-compatible container image.
-- It uses the `Container.exec()` method to define the command to be executed in the container - in this case, the command `node -v`, which returns the Node version string. The `exec()` method returns a revised `Container` with the results of command execution.
+- It uses the `Container.withExec()` method to define the command to be executed in the container - in this case, the command `node -v`, which returns the Node version string. The `withExec()` method returns a revised `Container` with the results of command execution.
 - It retrieves the output stream of the last executed with the `Container.stdout()` method and prints the result to the console.
 
 Run the Node.js CI tool by executing the command below from the project directory:
@@ -156,14 +156,14 @@ The revised code now does the following:
 - It uses the client's `host().directory(".", ["node_modules/"]).id()` method to obtain a reference to the current directory on the host. This reference is stored in the `source` variable. It also will ignore the `node_modules` directory on the host since we passed that in as an excluded directory.
 - It uses the client's `container().from()` method to initialize a new container from a base image. This base image is the Node.js version to be tested against - the `node:16` image. This method returns a new `Container` object with the results.
 - It uses the `Container.withMountedDirectory()` method to mount the host directory into the container at the `/src` mount point, and the `Container.withWorkdir()` method to set the working directory in the container. The revised `Container` is stored in the `runner` constant.
-- It uses the `Container.exec()` method to define the command to run tests in the container - in this case, the command `npm test -- --watchAll=false`.
+- It uses the `Container.withExec()` method to define the command to run tests in the container - in this case, the command `npm test -- --watchAll=false`.
 - It uses the `Container.exitCode()` method to execute the command and obtain the corresponding exit code. An exit code of `0` implies successful execution (all tests pass).
-- It invokes the `Container.exec()` method again, this time to define the build command `npm run build` in the container.
+- It invokes the `Container.withExec()` method again, this time to define the build command `npm run build` in the container.
 - It obtains a reference to the `build/` directory in the container with the `Container.directory()` method. This method returns a `Directory` object.
 - It writes the `build/` directory from the container to the host using the `Directory.export()` method.
 
 :::tip
-The `from()`, `withMountedDirectory()`, `withWorkdir()` and `exec()` methods all return a `Container`, making it easy to chain method calls together and create a pipeline that is intuitive to understand.
+The `from()`, `withMountedDirectory()`, `withWorkdir()` and `withExec()` methods all return a `Container`, making it easy to chain method calls together and create a pipeline that is intuitive to understand.
 :::
 
 Run the Node.js CI tool by executing the command below:

--- a/docs/current/sdk/nodejs/snippets/get-started/step3/build.js
+++ b/docs/current/sdk/nodejs/snippets/get-started/step3/build.js
@@ -4,7 +4,7 @@ import { connect } from "@dagger.io/dagger"
 connect(async (client) => {
   // get Node image
   // get Node version
-  let node = await client.container().from("node:16").exec(["node", "-v"])
+  let node = await client.container().from("node:16").withExec(["node", "-v"])
 
   // execute
   let version = await node.stdout()

--- a/docs/current/sdk/nodejs/snippets/get-started/step3/build.ts
+++ b/docs/current/sdk/nodejs/snippets/get-started/step3/build.ts
@@ -4,7 +4,7 @@ import Client, { connect } from "@dagger.io/dagger"
 connect(async (client: Client) => {
   // get Node image
   // get Node version
-  const node = await client.container().from("node:16").exec(["node", "-v"])
+  const node = await client.container().from("node:16").withExec(["node", "-v"])
 
   // execute
   const version = await node.stdout()

--- a/docs/current/sdk/nodejs/snippets/get-started/step4/build.js
+++ b/docs/current/sdk/nodejs/snippets/get-started/step4/build.js
@@ -14,15 +14,15 @@ connect(async (client) => {
     .container(node.id)
     .withMountedDirectory("/src", source.id)
     .withWorkdir("/src")
-    .exec(["npm", "install"])
+    .withExec(["npm", "install"])
 
   // run tests
-  await runner.exec(["npm", "test", "--", "--watchAll=false"]).exitCode()
+  await runner.withExec(["npm", "test", "--", "--watchAll=false"]).exitCode()
 
   // build application
   // write the build output to the host
   await runner
-    .exec(["npm", "run", "build"])
+    .withExec(["npm", "run", "build"])
     .directory("build/")
     .export("./build")
   // highlight-end

--- a/docs/current/sdk/nodejs/snippets/get-started/step4/build.ts
+++ b/docs/current/sdk/nodejs/snippets/get-started/step4/build.ts
@@ -14,15 +14,15 @@ connect(async (client: Client) => {
     .container(node.id)
     .withMountedDirectory("/src", source.id)
     .withWorkdir("/src")
-    .exec(["npm", "install"])
+    .withExec(["npm", "install"])
 
   // run tests
-  await runner.exec(["npm", "test", "--", "--watchAll=false"]).exitCode()
+  await runner.withExec(["npm", "test", "--", "--watchAll=false"]).exitCode()
 
   // build application
   // write the build output to the host
   await runner
-    .exec(["npm", "run", "build"])
+    .withExec(["npm", "run", "build"])
     .directory("build/")
     .export("./build")
   // highlight-end

--- a/docs/current/sdk/nodejs/snippets/get-started/step5/build.js
+++ b/docs/current/sdk/nodejs/snippets/get-started/step5/build.js
@@ -22,16 +22,16 @@ connect(async (client) => {
       .container(node.id)
       .withMountedDirectory("/src", source.id)
       .withWorkdir("/src")
-      .exec(["npm", "install"])
+      .withExec(["npm", "install"])
 
     // run tests
-    await runner.exec(["npm", "test", "--", "--watchAll=false"]).exitCode()
+    await runner.withExec(["npm", "test", "--", "--watchAll=false"]).exitCode()
 
     // highlight-start
     // build application using specified Node version
     // write the build output to the host
     await runner
-      .exec(["npm", "run", "build"])
+      .withExec(["npm", "run", "build"])
       .directory("build/")
       .export(`./build-node-${nodeVersion}`)
   }

--- a/docs/current/sdk/nodejs/snippets/get-started/step5/build.ts
+++ b/docs/current/sdk/nodejs/snippets/get-started/step5/build.ts
@@ -22,16 +22,16 @@ connect(async (client: Client) => {
       .container(node.id)
       .withMountedDirectory("/src", source.id)
       .withWorkdir("/src")
-      .exec(["npm", "install"])
+      .withExec(["npm", "install"])
 
     // run tests
-    await runner.exec(["npm", "test", "--", "--watchAll=false"]).exitCode()
+    await runner.withExec(["npm", "test", "--", "--watchAll=false"]).exitCode()
 
     // highlight-start
     // build application using specified Node version
     // write the build output to the host
     await runner
-      .exec(["npm", "run", "build"])
+      .withExec(["npm", "run", "build"])
       .directory("build/")
       .export(`./build-node-${nodeVersion}`)
   }

--- a/docs/current/sdk/python/628797-get-started.md
+++ b/docs/current/sdk/python/628797-get-started.md
@@ -54,7 +54,7 @@ This Python stub imports the Dagger SDK and defines an asynchronous function nam
 
 - It creates a Dagger client with `dagger.Connection()`. This client provides an interface for executing commands against the Dagger engine. The optional `dagger.Config(log_output=sys.stderr)` configuration displays the output from the Dagger engine.
 - It uses the client's `container().from_()` method to initialize a new container from a base image. In this example, the base image is the `python:3.10-slim-buster` image. This method returns a `Container` representing an OCI-compatible container image.
-- It uses the `Container.exec()` method to define the command to be executed in the container - in this case, the command `python -V`, which returns the Python version string. The `exec()` method returns a revised `Container` with the results of command execution.
+- It uses the `Container.with_exec()` method to define the command to be executed in the container - in this case, the command `python -V`, which returns the Python version string. The `with_exec()` method returns a revised `Container` with the results of command execution.
 - It retrieves the output stream of the last executed command with the `Container.stdout()` method and prints its contents.
 
 Run the Python CI tool by executing the command below from the project directory:
@@ -85,11 +85,11 @@ The revised `test()` function now does the following:
 - It uses the client's `container().from_()` method to initialize a new container from a base image. This base image is the Python version to be tested against - the `python:3.10-slim-buster` image. This method returns a new `Container` class with the results.
 - It uses the `Container.with_mounted_directory()` method to mount the host directory into the container at the `/src` mount point.
 - It uses the `Container.with_workdir()` method to set the working directory in the container.
-- It chains `Container.exec()` methods to install test dependencies and run tests in the container.
+- It chains `Container.with_exec()` methods to install test dependencies and run tests in the container.
 - It uses the `Container.exit_code()` method to obtain the exit code of the last executed command. An exit code of `0` implies successful execution.
 
 :::tip
-The `from_()`, `with_mounted_directory()`, `with_workdir()` and `exec()` methods all return a `Container`, making it easy to chain method calls together and create a pipeline that is easy and intuitive to understand.
+The `from_()`, `with_mounted_directory()`, `with_workdir()` and `with_exec()` methods all return a `Container`, making it easy to chain method calls together and create a pipeline that is easy and intuitive to understand.
 :::
 
 Run the Python CI tool by executing the command below:

--- a/docs/current/sdk/python/snippets/get-started/step1/test.py
+++ b/docs/current/sdk/python/snippets/get-started/step1/test.py
@@ -18,7 +18,7 @@ async def test():
             .from_("python:3.10-slim-buster")
 
             # get Python version
-            .exec(["python", "-V"])
+            .with_exec(["python", "-V"])
         )
 
         # execute

--- a/docs/current/sdk/python/snippets/get-started/step3/test.py
+++ b/docs/current/sdk/python/snippets/get-started/step3/test.py
@@ -24,10 +24,10 @@ async def test():
             .with_workdir("/src")
 
             # install test dependencies
-            .exec(["pip", "install", "-e", ".[test]"])
+            .with_exec(["pip", "install", "-e", ".[test]"])
 
             # run tests
-            .exec(["pytest", "tests"])
+            .with_exec(["pytest", "tests"])
         )
 
         # execute

--- a/docs/current/sdk/python/snippets/get-started/step4a/test.py
+++ b/docs/current/sdk/python/snippets/get-started/step4a/test.py
@@ -33,10 +33,10 @@ async def test():
                 .with_workdir("/src")
 
                 # install test dependencies
-                .exec(["pip", "install", "-e", ".[test]"])
+                .with_exec(["pip", "install", "-e", ".[test]"])
 
                 # run tests
-                .exec(["pytest", "tests"])
+                .with_exec(["pytest", "tests"])
             )
 
             # highlight-start

--- a/docs/current/sdk/python/snippets/get-started/step4b/test.py
+++ b/docs/current/sdk/python/snippets/get-started/step4b/test.py
@@ -36,10 +36,10 @@ async def test_version(version: str, src_id, client: dagger.Client):
         .with_workdir("/src")
 
         # install test dependencies
-        .exec(["pip", "install", "-e", ".[test]"])
+        .with_exec(["pip", "install", "-e", ".[test]"])
 
         # run tests
-        .exec(["pytest", "tests"])
+        .with_exec(["pytest", "tests"])
     )
 
     print(f"Starting tests for Python {version}")

--- a/docs/current/sdk/python/snippets/multi-builds/build.py
+++ b/docs/current/sdk/python/snippets/multi-builds/build.py
@@ -47,7 +47,7 @@ async def build():
                     .with_env_variable("GOARCH", goarch)
 
                     # build application
-                    .exec(["go", "build", "-o", path])
+                    .with_exec(["go", "build", "-o", path])
                 )
 
                 # get reference to build output directory in container

--- a/internal/mage/cli.go
+++ b/internal/mage/cli.go
@@ -23,7 +23,7 @@ func (cl Cli) Publish(ctx context.Context) error {
 		container := c.Container().
 			From("ghcr.io/goreleaser/goreleaser:v1.12.3").
 			WithEntrypoint([]string{}).
-			Exec(dagger.ContainerExecOpts{Args: []string{"apk", "add", "aws-cli"}}).
+			WithExec([]string{"apk", "add", "aws-cli"}).
 			WithEntrypoint([]string{"/sbin/tini", "--", "/entrypoint.sh"}).
 			WithWorkdir("/app").
 			WithMountedDirectory("/app", wd).
@@ -36,7 +36,7 @@ func (cl Cli) Publish(ctx context.Context) error {
 			WithSecretVariable("HOMEBREW_TAP_OWNER", c.Host().EnvVariable("HOMEBREW_TAP_OWNER").Secret())
 
 		_, err := container.
-			Exec(dagger.ContainerExecOpts{Args: []string{"release", "--rm-dist", "--debug"}}).
+			WithExec([]string{"release", "--rm-dist", "--debug"}).
 			ExitCode(ctx)
 		return err
 	})

--- a/internal/mage/docs.go
+++ b/internal/mage/docs.go
@@ -20,49 +20,47 @@ func (Docs) Lint(ctx context.Context) error {
 	}
 	defer c.Close()
 
-	workdir := util.Repository(c)
+	return util.WithDevEngine(ctx, c, func(ctx context.Context, c *dagger.Client) error {
+		workdir := util.Repository(c)
 
-	eg, gctx := errgroup.WithContext(ctx)
+		eg, gctx := errgroup.WithContext(ctx)
 
-	// Markdown
-	eg.Go(func() error {
-		_, err = c.Container().
-			From("tmknom/markdownlint:0.31.1").
-			WithMountedDirectory("/src", workdir).
-			WithMountedFile("/src/.markdownlint.yaml", workdir.File(".markdownlint.yaml")).
-			WithWorkdir("/src").
-			Exec(dagger.ContainerExecOpts{
-				Args: []string{
+		// Markdown
+		eg.Go(func() error {
+			_, err = c.Container().
+				From("tmknom/markdownlint:0.31.1").
+				WithMountedDirectory("/src", workdir).
+				WithMountedFile("/src/.markdownlint.yaml", workdir.File(".markdownlint.yaml")).
+				WithWorkdir("/src").
+				WithExec([]string{
 					"-c",
 					".markdownlint.yaml",
 					"--",
 					"./docs",
 					"README.md",
-				},
-			}).ExitCode(gctx)
-		return err
+				}).
+				ExitCode(gctx)
+			return err
+		})
+
+		// NodeJS
+		eg.Go(func() error {
+			nodeSnippets := c.Directory().
+				WithDirectory("/", workdir.Directory("docs/current/sdk/nodejs/snippets"))
+			_, err = c.Container().
+				From("node:16-alpine").
+				WithWorkdir("/src").
+				WithMountedDirectory("/src", nodeSnippets).
+				WithExec([]string{"yarn", "install"}).
+				WithExec([]string{"yarn", "lint"}).
+				ExitCode(gctx)
+			return err
+		})
+
+		// FIXME: Python
+
+		// Go is already linted by engine:lint
+
+		return eg.Wait()
 	})
-
-	// NodeJS
-	eg.Go(func() error {
-		nodeSnippets := c.Directory().
-			WithDirectory("/", workdir.Directory("docs/current/sdk/nodejs/snippets"))
-		_, err = c.Container().
-			From("node:16-alpine").
-			WithWorkdir("/src").
-			WithMountedDirectory("/src", nodeSnippets).
-			Exec(dagger.ContainerExecOpts{
-				Args: []string{"yarn", "install"},
-			}).
-			Exec(dagger.ContainerExecOpts{
-				Args: []string{"yarn", "lint"},
-			}).ExitCode(gctx)
-		return err
-	})
-
-	// FIXME: Python
-
-	// Go is already linted by engine:lint
-
-	return eg.Wait()
 }

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -147,6 +147,8 @@ type ContainerExecOpts struct {
 }
 
 // This container after executing the specified command inside it
+//
+// Deprecated: Replaced by WithExec.
 func (r *Container) Exec(opts ...ContainerExecOpts) *Container {
 	q := r.q.Select("exec")
 	// `args` optional argument
@@ -397,6 +399,59 @@ func (r *Container) WithEnvVariable(name string, value string) *Container {
 	q := r.q.Select("withEnvVariable")
 	q = q.Arg("name", name)
 	q = q.Arg("value", value)
+
+	return &Container{
+		q: q,
+		c: r.c,
+	}
+}
+
+// ContainerWithExecOpts contains options for Container.WithExec
+type ContainerWithExecOpts struct {
+	// Content to write to the command's standard input before closing
+	Stdin string
+	// Redirect the command's standard output to a file in the container
+	RedirectStdout string
+	// Redirect the command's standard error to a file in the container
+	RedirectStderr string
+	// Provide dagger access to the executed command
+	// Do not use this option unless you trust the command being executed
+	// The command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM
+	ExperimentalPrivilegedNesting bool
+}
+
+// This container after executing the specified command inside it
+func (r *Container) WithExec(args []string, opts ...ContainerWithExecOpts) *Container {
+	q := r.q.Select("withExec")
+	q = q.Arg("args", args)
+	// `stdin` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].Stdin) {
+			q = q.Arg("stdin", opts[i].Stdin)
+			break
+		}
+	}
+	// `redirectStdout` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].RedirectStdout) {
+			q = q.Arg("redirectStdout", opts[i].RedirectStdout)
+			break
+		}
+	}
+	// `redirectStderr` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].RedirectStderr) {
+			q = q.Arg("redirectStderr", opts[i].RedirectStderr)
+			break
+		}
+	}
+	// `experimentalPrivilegedNesting` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].ExperimentalPrivilegedNesting) {
+			q = q.Arg("experimentalPrivilegedNesting", opts[i].ExperimentalPrivilegedNesting)
+			break
+		}
+	}
 
 	return &Container{
 		q: q,

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -227,6 +227,8 @@ export class Container extends BaseClient {
 
   /**
    * This container after executing the specified command inside it
+   *
+   * @deprecated Replaced by withExec.
    */
   exec(
     args?: string[],
@@ -514,6 +516,34 @@ export class Container extends BaseClient {
         {
           operation: "withEnvVariable",
           args: { name, value },
+        },
+      ],
+      host: this.clientHost,
+    })
+  }
+
+  /**
+   * This container after executing the specified command inside it
+   */
+  withExec(
+    args: string[],
+    stdin?: string,
+    redirectStdout?: string,
+    redirectStderr?: string,
+    experimentalPrivilegedNesting?: boolean
+  ): Container {
+    return new Container({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "withExec",
+          args: {
+            args,
+            stdin,
+            redirectStdout,
+            redirectStderr,
+            experimentalPrivilegedNesting,
+          },
         },
       ],
       host: this.clientHost,

--- a/sdk/nodejs/api/test/api.spec.ts
+++ b/sdk/nodejs/api/test/api.spec.ts
@@ -16,35 +16,35 @@ describe("NodeJS SDK api", function () {
     const tree = new Client()
       .container()
       .from("alpine")
-      .exec(["apk", "add", "curl"])
+      .withExec(["apk", "add", "curl"])
 
     assert.strictEqual(
       queryBuilder(tree.queryTree),
-      `{container{from(address:"alpine"){exec(args:["apk","add","curl"])}}}`
+      `{container{from(address:"alpine"){withExec(args:["apk","add","curl"])}}}`
     )
   })
 
   it("Build a query by splitting it", async function () {
     const image = new Client().container().from("alpine")
-    const pkg = image.exec(["apk", "add", "curl"])
+    const pkg = image.withExec(["apk", "add", "curl"])
 
     assert.strictEqual(
       queryBuilder(pkg.queryTree),
-      `{container{from(address:"alpine"){exec(args:["apk","add","curl"])}}}`
+      `{container{from(address:"alpine"){withExec(args:["apk","add","curl"])}}}`
     )
   })
 
   it("Test Field Immutability", async function () {
     const image = new Client().container().from("alpine")
-    const a = image.exec(["echo", "hello", "world"])
+    const a = image.withExec(["echo", "hello", "world"])
     assert.strictEqual(
       queryBuilder(a.queryTree),
-      `{container{from(address:"alpine"){exec(args:["echo","hello","world"])}}}`
+      `{container{from(address:"alpine"){withExec(args:["echo","hello","world"])}}}`
     )
-    const b = image.exec(["echo", "foo", "bar"])
+    const b = image.withExec(["echo", "foo", "bar"])
     assert.strictEqual(
       queryBuilder(b.queryTree),
-      `{container{from(address:"alpine"){exec(args:["echo","foo","bar"])}}}`
+      `{container{from(address:"alpine"){withExec(args:["echo","foo","bar"])}}}`
     )
   })
 

--- a/sdk/nodejs/test/connect.spec.ts
+++ b/sdk/nodejs/test/connect.spec.ts
@@ -9,8 +9,8 @@ describe("NodeJS sdk", function () {
       const result = await client
         .container()
         .from("alpine")
-        .exec(["apk", "add", "curl"])
-        .exec(["curl", "https://dagger.io/"])
+        .withExec(["apk", "add", "curl"])
+        .withExec(["curl", "https://dagger.io/"])
         .stdout()
 
       assert.ok(result.stdout.length > 10000)

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -24,12 +24,12 @@ async def main(args: list[str]):
         ctr = (
             client.container()
             .from_("python:alpine")
-            .exec(["pip", "install", "cowsay"])
+            .with_exec(["pip", "install", "cowsay"])
             .with_entrypoint(["cowsay"])
         )
 
         # run cowsay with requested message
-        result = await ctr.exec(args).stdout()
+        result = await ctr.with_exec(args).stdout()
 
         print(result)
 

--- a/sdk/python/examples/client-simple/say.py
+++ b/sdk/python/examples/client-simple/say.py
@@ -12,12 +12,12 @@ async def main(args: list[str]):
         ctr = (
             client.container()
             .from_("python:alpine")
-            .exec(["pip", "install", "cowsay"])
+            .with_exec(["pip", "install", "cowsay"])
             .with_entrypoint(["cowsay"])
         )
 
         # run cowsay with requested message
-        result = await ctr.exec(args).stdout().contents()
+        result = await ctr.with_exec(args).stdout().contents()
 
         print(result)
 

--- a/sdk/python/examples/client-simple/say_sync.py
+++ b/sdk/python/examples/client-simple/say_sync.py
@@ -11,12 +11,12 @@ def main(args: list[str]):
         ctr = (
             client.container()
             .from_("python:alpine")
-            .exec(["pip", "install", "cowsay"])
+            .with_exec(["pip", "install", "cowsay"])
             .with_entrypoint(["cowsay"])
         )
 
         # run cowsay with requested message
-        result = ctr.exec(args).stdout().contents()
+        result = ctr.with_exec(args).stdout().contents()
 
         print(result)
 

--- a/sdk/python/experimental/hello/main.py
+++ b/sdk/python/experimental/hello/main.py
@@ -17,8 +17,8 @@ class Hello:
             return await (
                 client.container()
                 .from_("alpine")
-                .exec(["apk", "add", "curl"])
-                .exec(["curl", "https://dagger.io/"])
+                .with_exec(["apk", "add", "curl"])
+                .with_exec(["curl", "https://dagger.io/"])
                 .stdout()
             )
 

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -122,6 +122,9 @@ class Container(Type):
     ) -> "Container":
         """This container after executing the specified command inside it
 
+        .. deprecated::
+            Replaced by :py:meth:`with_exec`.
+
         Parameters
         ----------
         args:
@@ -341,6 +344,42 @@ class Container(Type):
             Arg("value", value),
         ]
         _ctx = self._select("withEnvVariable", _args)
+        return Container(_ctx)
+
+    def with_exec(
+        self,
+        args: list[str],
+        stdin: str | None = None,
+        redirect_stdout: str | None = None,
+        redirect_stderr: str | None = None,
+        experimental_privileged_nesting: bool | None = None,
+    ) -> "Container":
+        """This container after executing the specified command inside it
+
+        Parameters
+        ----------
+        args:
+            Command to run instead of the container's default command
+        stdin:
+            Content to write to the command's standard input before closing
+        redirect_stdout:
+            Redirect the command's standard output to a file in the container
+        redirect_stderr:
+            Redirect the command's standard error to a file in the container
+        experimental_privileged_nesting:
+            Provide dagger access to the executed command
+            Do not use this option unless you trust the command being executed
+            The command being executed WILL BE GRANTED FULL ACCESS TO YOUR
+            HOST FILESYSTEM
+        """
+        _args = [
+            Arg("args", args),
+            Arg("stdin", stdin, None),
+            Arg("redirectStdout", redirect_stdout, None),
+            Arg("redirectStderr", redirect_stderr, None),
+            Arg("experimentalPrivilegedNesting", experimental_privileged_nesting, None),
+        ]
+        _ctx = self._select("withExec", _args)
         return Container(_ctx)
 
     def with_fs(self, id: "DirectoryID") -> "Container":

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -122,6 +122,9 @@ class Container(Type):
     ) -> "Container":
         """This container after executing the specified command inside it
 
+        .. deprecated::
+            Replaced by :py:meth:`with_exec`.
+
         Parameters
         ----------
         args:
@@ -341,6 +344,42 @@ class Container(Type):
             Arg("value", value),
         ]
         _ctx = self._select("withEnvVariable", _args)
+        return Container(_ctx)
+
+    def with_exec(
+        self,
+        args: list[str],
+        stdin: str | None = None,
+        redirect_stdout: str | None = None,
+        redirect_stderr: str | None = None,
+        experimental_privileged_nesting: bool | None = None,
+    ) -> "Container":
+        """This container after executing the specified command inside it
+
+        Parameters
+        ----------
+        args:
+            Command to run instead of the container's default command
+        stdin:
+            Content to write to the command's standard input before closing
+        redirect_stdout:
+            Redirect the command's standard output to a file in the container
+        redirect_stderr:
+            Redirect the command's standard error to a file in the container
+        experimental_privileged_nesting:
+            Provide dagger access to the executed command
+            Do not use this option unless you trust the command being executed
+            The command being executed WILL BE GRANTED FULL ACCESS TO YOUR
+            HOST FILESYSTEM
+        """
+        _args = [
+            Arg("args", args),
+            Arg("stdin", stdin, None),
+            Arg("redirectStdout", redirect_stdout, None),
+            Arg("redirectStderr", redirect_stderr, None),
+            Arg("experimentalPrivilegedNesting", experimental_privileged_nesting, None),
+        ]
+        _ctx = self._select("withExec", _args)
         return Container(_ctx)
 
     def with_fs(self, id: "DirectoryID") -> "Container":

--- a/sdk/python/src/dagger/connection.py
+++ b/sdk/python/src/dagger/connection.py
@@ -24,7 +24,7 @@ class Connection:
 
             async with dagger.Connection(cfg) as client:
                 ctr = client.container().from_("python:3.10.8-alpine")
-                version = await ctr.exec(["python", "-V"]).stdout().contents()
+                version = await ctr.with_exec(["python", "-V"]).stdout().contents()
                 print(version)
 
                 # Output: Python 3.10.8

--- a/sdk/python/tests/api/test_integration.py
+++ b/sdk/python/tests/api/test_integration.py
@@ -14,7 +14,7 @@ pytestmark = [
 async def test_container():
     async with dagger.Connection() as client:
         alpine = client.container().from_("alpine:3.16.2")
-        version = await alpine.exec(["cat", "/etc/alpine-release"]).stdout()
+        version = await alpine.with_exec(["cat", "/etc/alpine-release"]).stdout()
 
         assert version == "3.16.2\n"
 
@@ -32,7 +32,7 @@ async def test_container_build():
         repo = client.git("https://github.com/dagger/dagger").tag("v0.3.0").tree()
         dagger_img = client.container().build(repo)
 
-        out = await dagger_img.exec(["version"]).stdout()
+        out = await dagger_img.with_exec(["version"]).stdout()
 
         words = out.strip().split(" ")
 
@@ -44,7 +44,7 @@ async def test_container_with_env_variable():
         container = (
             client.container().from_("alpine:3.16.2").with_env_variable("FOO", "bar")
         )
-        out = await container.exec(["sh", "-c", "echo -n $FOO"]).stdout()
+        out = await container.with_exec(["sh", "-c", "echo -n $FOO"]).stdout()
 
         assert out == "bar"
 
@@ -63,7 +63,7 @@ async def test_container_with_mounted_directory():
             .with_mounted_directory("/mnt", dir_)
         )
 
-        out = await container.exec(["ls", "/mnt"]).stdout()
+        out = await container.with_exec(["ls", "/mnt"]).stdout()
 
         assert out == dedent(
             """\
@@ -84,7 +84,7 @@ async def test_container_with_mounted_cache():
         )
 
         for i in range(5):
-            out = await container.exec(
+            out = await container.with_exec(
                 [
                     "sh",
                     "-c",

--- a/sdk/python/tests/api/test_integration_sync.py
+++ b/sdk/python/tests/api/test_integration_sync.py
@@ -15,7 +15,7 @@ def test_container_build():
         repo = client.git("https://github.com/dagger/dagger").tag("v0.3.0").tree()
         dagger_img = client.container().build(repo)
 
-        out = dagger_img.exec(["version"]).stdout()
+        out = dagger_img.with_exec(["version"]).stdout()
 
         words = out.strip().split(" ")
 
@@ -36,7 +36,7 @@ def test_container_with_mounted_directory():
             .with_mounted_directory("/mnt", dir_)
         )
 
-        out = container.exec(["ls", "/mnt"]).stdout()
+        out = container.with_exec(["ls", "/mnt"]).stdout()
 
         assert out == dedent(
             """\
@@ -57,7 +57,7 @@ def test_container_with_mounted_cache():
         )
 
         for i in range(5):
-            out = container.exec(
+            out = container.with_exec(
                 [
                     "sh",
                     "-c",


### PR DESCRIPTION
Before:

```go
ctr.Exec(dagger.ContainerExecOpts{
  Args: []string{"ls"},
})
```

After:

```go
ctr.WithExec([]string{"ls"})
```

/cc @vikram-dagger @kpenfound @helderco @dolanor