### PR TITLE
Automatically mount in engine-session binary from host when dagger-in-dagger enabled.

### DIFF
--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -137,7 +137,6 @@ func (t Engine) test(ctx context.Context, race bool) error {
 
 	return util.WithDevEngine(ctx, c, func(ctx context.Context, c *dagger.Client) error {
 		output, err := util.GoBase(c).
-			WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
 			WithMountedDirectory("/app", util.Repository(c)). // need all the source for extension tests
 			WithWorkdir("/app").
 			WithEnvVariable("CGO_ENABLED", cgoEnabledEnv).

--- a/internal/mage/sdk/go.go
+++ b/internal/mage/sdk/go.go
@@ -57,7 +57,6 @@ func (t Go) Test(ctx context.Context) error {
 
 	return util.WithDevEngine(ctx, c, func(ctx context.Context, c *dagger.Client) error {
 		output, err := util.GoBase(c).
-			WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
 			WithWorkdir("sdk/go").
 			WithMountedDirectory("/root/.docker", util.HostDockerDir(c)).
 			WithExec([]string{"go", "test", "-v", "./..."}, dagger.ContainerWithExecOpts{
@@ -83,7 +82,6 @@ func (t Go) Generate(ctx context.Context) error {
 		generated, err := util.GoBase(c).
 			WithMountedFile("/usr/local/bin/dagger", util.DaggerBinary(c)).
 			WithMountedFile("/usr/local/bin/client-gen", util.ClientGenBinary(c)).
-			WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
 			WithWorkdir("sdk/go").
 			WithExec([]string{"go", "generate", "-v", "./..."}, dagger.ContainerWithExecOpts{
 				ExperimentalPrivilegedNesting: true,

--- a/internal/mage/sdk/nodejs.go
+++ b/internal/mage/sdk/nodejs.go
@@ -28,7 +28,6 @@ func (t Nodejs) Lint(ctx context.Context) error {
 
 	return util.WithDevEngine(ctx, c, func(ctx context.Context, c *dagger.Client) error {
 		_, err = nodeJsBase(c).
-			WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
 			WithExec([]string{"yarn", "lint"}, dagger.ContainerWithExecOpts{
 				ExperimentalPrivilegedNesting: true,
 			}).
@@ -52,7 +51,6 @@ func (t Nodejs) Test(ctx context.Context) error {
 
 	return util.WithDevEngine(ctx, c, func(ctx context.Context, c *dagger.Client) error {
 		_, err = nodeJsBase(c).
-			WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
 			WithMountedDirectory("/root/.docker", util.HostDockerDir(c)).
 			WithExec([]string{"yarn", "test"}, dagger.ContainerWithExecOpts{
 				ExperimentalPrivilegedNesting: true,
@@ -73,7 +71,6 @@ func (t Nodejs) Generate(ctx context.Context) error {
 	return util.WithDevEngine(ctx, c, func(ctx context.Context, c *dagger.Client) error {
 		generated, err := nodeJsBase(c).
 			WithMountedFile("/usr/local/bin/client-gen", util.ClientGenBinary(c)).
-			WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
 			WithExec([]string{"client-gen", "--lang", "nodejs", "-o", nodejsGeneratedAPIPath}, dagger.ContainerWithExecOpts{
 				ExperimentalPrivilegedNesting: true,
 			}).

--- a/internal/mage/sdk/python.go
+++ b/internal/mage/sdk/python.go
@@ -82,7 +82,6 @@ func (t Python) Test(ctx context.Context) error {
 			version := version
 			eg.Go(func() error {
 				_, err := pythonBase(c, version).
-					WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
 					WithMountedDirectory("/root/.docker", util.HostDockerDir(c)).
 					WithExec([]string{"poe", "test", "--exitfirst"}, dagger.ContainerWithExecOpts{
 						ExperimentalPrivilegedNesting: true,
@@ -105,7 +104,6 @@ func (t Python) Generate(ctx context.Context) error {
 
 	return util.WithDevEngine(ctx, c, func(ctx context.Context, c *dagger.Client) error {
 		generated := pythonBase(c, pythonDefaultVersion).
-			WithMountedFile("/usr/bin/dagger-engine-session", util.EngineSessionBinary(c)).
 			WithExec([]string{"poe", "generate"}, dagger.ContainerWithExecOpts{
 				ExperimentalPrivilegedNesting: true,
 			})


### PR DESCRIPTION
Originally was planning on making dagger-in-dagger the default with this PR, but we decided to wait for other still-moving architecture pieces to settle before doing that, just so we can minimize the occurrence of any breaking changes.

So now I reduced the scope of this and it just updates the `ExperimentalPrivilegedNesting` flag to result in the engine-session binary automatically being mounted in from the engine image rather than requiring the user to provide it.

The remaining steps needed before enabling dagger-in-dagger by default:
1. Make the "single-session-per-connect" behavior the default for dagger-in-dagger execs (this commit results in the "separate session" behavior being the default.
   * Requires merging the engine-session functionality into the shim, fairly straightforward
2. Getting rid of the `ExperimentalPrivilegedNesting`flag and replacing it with a bool flag that can optionally disable the nesting functionality 