### PR TITLE
Private registry support

### DIFF
--- a/cmd/engine-session/main.go
+++ b/cmd/engine-session/main.go
@@ -21,11 +21,13 @@ import (
 var (
 	configPath string
 	workdir    string
+	bindMounts []string
 	remote     string
 )
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&workdir, "workdir", "", "")
+	rootCmd.PersistentFlags().StringArrayVar(&bindMounts, "engine-bind-mount", []string{}, "")
 	rootCmd.PersistentFlags().StringVarP(&configPath, "project", "p", "", "")
 	rootCmd.PersistentFlags().StringVar(&remote, "remote", "", "")
 }
@@ -44,6 +46,7 @@ func EngineSession(cmd *cobra.Command, args []string) {
 	startOpts := &engine.Config{
 		Workdir:    workdir,
 		ConfigPath: configPath,
+		BindMounts: bindMounts,
 		LogOutput:  os.Stderr,
 		RemoteAddr: remote,
 	}
@@ -71,6 +74,7 @@ func EngineSession(cmd *cobra.Command, args []string) {
 	port := l.Addr().(*net.TCPAddr).Port
 
 	err = engine.Start(context.Background(), startOpts, func(ctx context.Context, r *router.Router) error {
+
 		srv := http.Server{
 			Handler:           r,
 			ReadHeaderTimeout: 30 * time.Second,

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -39,7 +39,7 @@ type Config struct {
 	LogOutput     io.Writer
 	DisableHostRW bool
 	RemoteAddr    string
-
+	BindMounts []string
 	// WARNING: this is currently exposed directly but will be removed or
 	// replaced with something incompatible in the future.
 	RawBuildkitStatus chan *bkclient.SolveStatus
@@ -61,7 +61,7 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 	if err != nil {
 		return err
 	}
-	c, err := engine.Client(ctx, remote)
+	c, err := engine.Client(ctx, remote, startOpts.BindMounts)
 	if err != nil {
 		return err
 	}
@@ -136,6 +136,7 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 			return err
 		})
 	}
+
 
 	eg.Go(func() error {
 		_, err := c.Build(ctx, solveOpts, "", func(ctx context.Context, gw bkgw.Client) (*bkgw.Result, error) {

--- a/internal/engine/docker.go
+++ b/internal/engine/docker.go
@@ -26,7 +26,7 @@ const (
 // previous executions of the engine at different versions (which
 // are identified by looking for containers with the prefix
 // "dagger-engine-").
-func dockerImageProvider(ctx context.Context, remote *url.URL) (string, error) {
+func dockerImageProvider(ctx context.Context, remote *url.URL, bindMounts []string) (string, error) {
 	imageRef := remote.Host + remote.Path
 
 	// NOTE: this isn't as robust as using the official docker parser, but
@@ -88,6 +88,6 @@ func dockerImageProvider(ctx context.Context, remote *url.URL) (string, error) {
 }
 
 // Just connect to the container as provided, nothing fancy
-func dockerContainerProvider(ctx context.Context, remote *url.URL) (string, error) {
+func dockerContainerProvider(ctx context.Context, remote *url.URL, bindMounts []string) (string, error) {
 	return "docker-container://" + remote.Host + remote.Path, nil
 }

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -45,6 +45,12 @@ func WithWorkdir(path string) ClientOpt {
 	})
 }
 
+func WithBindMounts(volumes []string) ClientOpt {
+	return clientOptFunc(func(cfg *engineconn.Config) {
+		cfg.BindMounts = volumes
+	}) 
+}
+
 // WithConfigPath sets the engine config path
 func WithConfigPath(path string) ClientOpt {
 	return clientOptFunc(func(cfg *engineconn.Config) {

--- a/sdk/go/internal/engineconn/dockerprovision/container.go
+++ b/sdk/go/internal/engineconn/dockerprovision/container.go
@@ -69,6 +69,14 @@ func (c *DockerContainer) Connect(ctx context.Context, cfg *engineconn.Config) (
 	args := []string{
 		"--remote", remote,
 	}
+
+
+	if len(cfg.BindMounts) > 0 {
+		for _, engineVolume := range cfg.BindMounts {
+			args = append(args, "--engine-bind-mount", engineVolume)
+		}
+	} 
+
 	if cfg.Workdir != "" {
 		args = append(args, "--workdir", cfg.Workdir)
 	}

--- a/sdk/go/internal/engineconn/engineconn.go
+++ b/sdk/go/internal/engineconn/engineconn.go
@@ -20,7 +20,7 @@ type EngineConn interface {
 
 func Get(host string) (EngineConn, error) {
 	u, err := url.Parse(host)
-	if err != nil {
+ 	if err != nil {
 		return nil, err
 	}
 
@@ -35,6 +35,7 @@ func Get(host string) (EngineConn, error) {
 type Config struct {
 	Workdir      string
 	ConfigPath   string
+	BindMounts []string
 	NoExtensions bool
 	LogOutput    io.Writer
 }


### PR DESCRIPTION
# Problem

Dagger used to support private registries via a custom buildkit instance. This made use of docker bind mounts. Here's an example:

```
docker run --net=host -d --restart always -v  /private/registry/cert.crt:/etc/ssl/certs/ca.crt --name dagger-buildkitd --privileged moby/buildkit:v0.10.5 --debug
```

However, from speaking to some of the maintainers on Discord, for various reasons it was removed. I'd like to get this brought back, even at the very least as an "official" escape hatch in the short term. 

To give some background as to why I need this: the company that I work for, Findmypast, uses a private registry for hosting all of our images. With no viable way for the engine to publish an image to a private registry, we would not be able to migrate from Usher, our in house task runner, to Dagger.  

## Options

[Please note that these implementations are a total fudge, only somewhat tested, and is just a draft. I'm happy to change the approach if need be or have it dumped in favour of something else. I'd just like to get something usable in the short-term that can unblock us]

I've put together two options: neither should require the user to start up their own instance of the engine.

### Option 1 - Engine reads an env var

The engine will read an env var that passes in one or more bind mounts like so: 

DAGGER_ENGINE_BIND_MOUNTS=/foo/bar.txt:/foo/bar.txt,/fiz/buzz.txt

When the engine is started by an SDK, it checks for this var and adds as many mounts as required via `-v` to the docker run command that's ran under the hood to start the engine. 

To test this locally I ran: 

```
DAGGER_ENGINE_BIND_MOUNTS=/whatever/cert.crt:/etc/ssl/certs/ca.crt,/var/run/docker.sock:/var/run/docker.sock go run ./cmd/engine-session/main.go 
apk add docker curl 
curl <registry>
docker login <registry>
```

You should see no more complaints about the certificate being signed by an unknown authority or that there was no such host.

### Option 2 - SDK 

This adds another parameter to the dagger engine: `--engine-bind-mount` so that under the hood the SDK would use this flag. It  would be set at the connect call: 

```
    client, err := dagger.Connect(ctx, 
        dagger.WithBindMounts([]string{"/private/registry/cert.crt:/etc/ssl/certs/ca.crt"}),
    )
```

For both options I used `--net host` so that the hosts file from the host was added to the engine container. I ran out of time to make that configurable.

I didn't manage to e2e test this as I could not figure out how to spin up a local instance of the engine. It looks like the Go SDK is set to pull a specific image down from the GitHub container registry or use the `DAGGER_HOST` env.

There's pros/cons to each, but if possible I'd like to focus on getting something usable in the short term.

### Related issues 

https://github.com/dagger/dagger/issues/2142
https://github.com/dagger/dagger/issues/3829

As a side, could this pull request also fix the issue :eyes: ? https://github.com/dagger/dagger/pull/3913