### PR TITLE
Fix redirect of stdio to non root mount.

### DIFF
--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -183,6 +183,7 @@ func setupBundle() int {
 	}
 
 	// Run the actual runc binary as a child process with the (possibly updated) config
+	// #nosec G204
 	cmd := exec.Command(runcPath, os.Args[1:]...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
Realized that [this commit](https://github.com/dagger/dagger/commit/dfee9e47f9a33b30f8bda249ffe758c46eea5868) partially broke redirecting of stdout/stderr, specifically in the case where the redirect points to a non-root mount. Was missed because we didn't have a test case covering that (added one now).

This is fixable without having to revert that change, but the fix will involve some complexity (the cleanest fix is probably to use a containerd worker backend instead of runc) and we want to do a release tomorrow, so I'm just going to revert that change for now.

The reverted change's only benefit was simpler internal architecture, so it's not a huge loss to temporarily revert it. We still retain all the benefits of the oci runtime wrapper without it.