### PR TITLE
Continue using engine image ref digests for now.

### DIFF
--- a/internal/engine/docker.go
+++ b/internal/engine/docker.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
 
@@ -32,9 +33,12 @@ func dockerImageProvider(ctx context.Context, remote *url.URL) (string, error) {
 	// our other SDKs don't have access to that, so this is simpler to
 	// replicate and keep consistent.
 	var id string
-	_, dgst, ok := strings.Cut(imageRef, ":")
+	_, dgst, ok := strings.Cut(imageRef, "@sha256:")
 	if !ok {
 		return "", errors.Errorf("invalid image reference %q", imageRef)
+	}
+	if err := digest.Digest("sha256:" + dgst).Validate(); err != nil {
+		return "", errors.Wrap(err, "invalid digest")
 	}
 	id = dgst
 	id = id[:hashLen]

--- a/sdk/go/internal/engineconn/dockerprovision/image.go
+++ b/sdk/go/internal/engineconn/dockerprovision/image.go
@@ -15,6 +15,7 @@ import (
 	"dagger.io/dagger/internal/engineconn"
 	"dagger.io/dagger/internal/engineconn/bin"
 	"github.com/adrg/xdg"
+	"github.com/opencontainers/go-digest"
 	exec "golang.org/x/sys/execabs"
 )
 
@@ -42,9 +43,12 @@ func (c *DockerImage) Connect(ctx context.Context, cfg *engineconn.Config) (*htt
 	// our other SDKs don't have access to that, so this is simpler to
 	// replicate and keep consistent.
 	var id string
-	_, dgst, ok := strings.Cut(c.imageRef, ":")
+	_, dgst, ok := strings.Cut(c.imageRef, "@sha256:")
 	if !ok {
 		return nil, fmt.Errorf("invalid image reference %q", c.imageRef)
+	}
+	if err := digest.Digest("sha256:" + dgst).Validate(); err != nil {
+		return nil, fmt.Errorf("invalid digest: %w", err)
 	}
 	id = dgst
 	id = id[:hashLen]


### PR DESCRIPTION
This is a partial revert of 18458978b8a94a5d09a2b78066ce8ecffb4c1158.

The SDKs will for now continue to use image digests instead of git commits. The CLI will also temporarily just continue using the Go SDK and thus pick up this same change.

In the longer term, SDKs will switch to obtaining the CLI/engine-session bin from S3 rather than from the engine image. Additionally, the CLI will no longer use the Go SDK and instead just call engine.Start directly. It will then obtain the engine image based on the burned in vcs information (at least git tag, maybe git commit too).

Signed-off-by: Erik Sipsma <erik@sipsma.dev>