### PR TITLE
ci: Always run test & lint workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,14 +1,17 @@
 name: lint
+
 on:
   push:
   pull_request:
-  # Enable manual trigger for easy ad-hoc debugging
+  # Enable manual trigger for easy debugging
   # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs
   workflow_dispatch:
+
 permissions:
   contents: read
   # Optional: allow read access to pull request. Use with `only-new-issues` option.
   # pull-requests: read
+
 jobs:
   engine:
     runs-on: ubuntu-latest
@@ -18,6 +21,7 @@ jobs:
         with:
           go-version: 1.19
       - run: ./hack/make engine:lint
+
   docs:
     runs-on: ubuntu-latest
     steps:
@@ -26,8 +30,9 @@ jobs:
         with:
           go-version: 1.19
       - run: ./hack/make docs:lint
+
   sdk-go:
-    name: sdk / go
+    name: "sdk / go"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -35,8 +40,9 @@ jobs:
         with:
           go-version: 1.19
       - run: ./hack/make sdk:go:lint
+
   sdk-python:
-    name: sdk / python
+    name: "sdk / python"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -44,8 +50,9 @@ jobs:
         with:
           go-version: 1.19
       - run: ./hack/make sdk:python:lint
+
   sdk-nodejs:
-    name: sdk / nodejs
+    name: "sdk / nodejs"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,6 @@
 name: lint
 on:
   push:
-    branches: [main]
   pull_request:
   # Enable manual trigger for easy ad-hoc debugging
   # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs

--- a/.github/workflows/publish-sdk-go.yml
+++ b/.github/workflows/publish-sdk-go.yml
@@ -1,13 +1,7 @@
 name: publish-sdk-go
 on:
   push:
-    branches:
-      - main
-    tags:
-      - sdk/go/**
-    paths:
-      - "sdk/go/**"
-      - .github/workflows/publish-sdk-go.yml
+    tags: ["sdk/go/v**"]
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-sdk-nodejs.yml
+++ b/.github/workflows/publish-sdk-nodejs.yml
@@ -1,8 +1,7 @@
 name: "Publish NodeJS SDK"
 on:
   push:
-    tags:
-      - sdk/nodejs/v**
+    tags: ["sdk/nodejs/v**"]
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-sdk-python.yml
+++ b/.github/workflows/publish-sdk-python.yml
@@ -1,8 +1,7 @@
 name: "Publish Python SDK"
 on:
   push:
-    tags:
-      - sdk/python/v**
+    tags: ["sdk/python/v**"]
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,35 +1,17 @@
 name: test
+
 on:
   push:
-    branches: [main]
-    paths:
-      - "**.go"
-      - "go.mod"
-      - "go.sum"
-      - "**/go.mod"
-      - "**/go.sum"
-      - "sdk/nodejs/**.js"
-      - "sdk/python/**.py"
-      - ".github/workflows/test.yml"
   pull_request:
-    branches: [main]
-    paths:
-      - "**.go"
-      - "go.mod"
-      - "go.sum"
-      - "**/go.mod"
-      - "**/go.sum"
-      - "sdk/nodejs/**.js"
-      - "sdk/python/**.py"
-      - ".github/workflows/test.yml"
-  # Enable manual trigger for easy ad-hoc debugging
+  # Enable manual trigger for easy debugging
   # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs
   workflow_dispatch:
+
 jobs:
   engine:
     runs-on: ubuntu-22.04-16c-64g-600gb
     steps:
-      - name: Set up QEMU
+      - name: "Set up QEMU"
         run: |
           docker run --rm --privileged tonistiigi/binfmt:latest --install all
       - uses: actions/setup-go@v3
@@ -37,19 +19,20 @@ jobs:
           go-version: 1.19
       - uses: actions/checkout@v3
       - run: ./hack/make engine:build
-      - run: echo `pwd`/bin >> $GITHUB_PATH
+      - run: echo $PWD/bin >> $GITHUB_PATH
       - run: ./hack/make engine:test
-      - name: Print Engine Logs
+      - name: "ALWAYS print engine logs - especialy useful on failure"
         if: always()
-        run: |
-          docker logs test-dagger-engine
-      - name: Print Kernel Logs
+        run: docker logs test-dagger-engine
+      - name: "ALWAYS print kernel logs - especialy useful on failure"
         if: always()
-        run: |
-          sudo dmesg
-  engine-race:
-    needs: [engine] # prioritize fast feedback + don't bother if tests fail
-    name: engine with -race
+        run: sudo dmesg
+
+  # Run egine tests with race condition detection
+  # https://go.dev/blog/race-detector
+  #
+  # Run in parallel to the regular tests so that the entire pipeline finishes quicker
+  engine-race-detection:
     runs-on: ubuntu-22.04-16c-64g-600gb
     steps:
       - uses: actions/setup-go@v3
@@ -57,18 +40,17 @@ jobs:
           go-version: 1.19
       - uses: actions/checkout@v3
       - run: ./hack/make engine:build
-      - run: echo `pwd`/bin >> $GITHUB_PATH
+      - run: echo $PWD/bin >> $GITHUB_PATH
       - run: ./hack/make engine:testrace
-      - name: Print Engine Logs
+      - name: "ALWAYS print engine logs - especialy useful on failure"
         if: always()
-        run: |
-          docker logs test-dagger-engine
-      - name: Print Kernel Logs
+        run: docker logs test-dagger-engine
+      - name: "ALWAYS print kernel logs - especialy useful on failure"
         if: always()
-        run: |
-          sudo dmesg
+        run: sudo dmesg
+
   sdk-go:
-    name: sdk / go
+    name: "sdk / go"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -76,8 +58,9 @@ jobs:
         with:
           go-version: 1.19
       - run: ./hack/make sdk:go:test
+
   sdk-python:
-    name: sdk / python
+    name: "sdk / python"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -85,8 +68,9 @@ jobs:
         with:
           go-version: 1.19
       - run: ./hack/make sdk:python:test
+
   sdk-nodejs:
-    name: sdk / nodejs
+    name: "sdk / nodejs"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This is a follow-up to:
- https://github.com/dagger/dagger/pull/3897#issuecomment-1323917409

The TL;DR is that we want to keep as little logic in the GitHub Actions workflows as possible, and keep as much as we can in Dagger (especially the caching part).

The only other change that this introduces is running engine tests with race detection in parallel. We want to optimise for the entire test pipeline finishing as soon as possible, which means running everything in parallel. Before this change, regular tests would need to pass first before the tests with race detection would run. cc @vito 