### PR TITLE
docs: Add releasing instructions for Node.js SDK changelog

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -25,8 +25,13 @@ the various SDKs. **Merge it** as soon as the tests pass.
 
 ## Go SDK
 
-1. Ensure all tests in CI pass.
-2. Additionally, manually test provisioning by running the following commands on both Linux and MacOS hosts directly
+Ensure that all checks on the `main` branch are green. Pay special attention
+to `lint / sdk / go` & `test / sdk / go` checks. Ensure that these
+have passed for the commit that you are about to tag. If not, you may end up
+releasing a broken version.
+
+Additionally, manually test provisioning by running the following commands on
+both Linux and MacOS hosts directly
 
 ```console
 # ensure there's no existing container so we use the full provisioning code paths
@@ -41,7 +46,7 @@ go test -v -count=1 $(pwd)/core/integration # run the engine tests on your host,
 ### Release
 
 ```console
-export SDK_VERSION=v0.1.0
+export SDK_VERSION=v0.<MINOR>.<PATCH>
 git tag sdk/go/${SDK_VERSION}
 git push origin sdk/go/${SDK_VERSION}
 ```
@@ -49,13 +54,12 @@ git push origin sdk/go/${SDK_VERSION}
 ## Python SDK
 
 Ensure that all checks on the `main` branch are green. Pay special attention
-to `lint / sdk / python` & `test / sdk / python` checks. Since these checks
-only run when specific paths change (e.g. `sdk/python/**`), ensure that they
-have passed for the last commit that changed this path. If not, you may end up
+to `lint / sdk / python` & `test / sdk / python` checks. Ensure that these
+have passed for the commit that you are about to tag. If not, you may end up
 releasing a broken version.
 
-1. Ensure all tests in CI pass.
-2. Additionally, manually test provisioning by running the following commands on both Linux and MacOS hosts directly
+Additionally, manually test provisioning by running the following commands on
+both Linux and MacOS hosts directly
 
 ```console
 # ensure there's no existing container so we use the full provisioning code paths
@@ -72,7 +76,7 @@ poetry run poe test # to be run the `sdk/python` directory in our dagger repo
 When the above is looking good, you are ready to release:
 
 ```console
-export SDK_VERSION=v0.1.0
+export SDK_VERSION=v0.<MINOR>.<PATCH>
 git tag sdk/python/${SDK_VERSION}
 git push origin sdk/python/${SDK_VERSION}
 ```
@@ -80,41 +84,6 @@ git push origin sdk/python/${SDK_VERSION}
 This will trigger the [`Publish Python SDK`
 workflow](https://github.com/dagger/dagger/actions/workflows/publish-sdk-python.yml)
 which publishes [dagger-io to PyPI](https://pypi.org/project/dagger-io).
-
-## Node.js SDK
-
-Ensure that all checks on the `main` branch are green. Pay special attention
-to `lint / sdk / nodejs` & `test / sdk / nodejs` checks. Since these checks
-only run when specific paths change (e.g. `sdk/nodejs/**`), ensure that they
-have passed for the last commit that changed this path. If not, you may end up
-releasing a broken version.
-
-1. Ensure all tests in CI pass.
-2. Additionally, manually test provisioning by running the following commands on both Linux and MacOS hosts directly
-
-```console
-# ensure there's no existing container so we use the full provisioning code paths
-docker rm -fv $(docker ps --filter "name=^dagger-engine-*" -qa)
-docker volume prune -f
-docker system prune -f
-# ensure there's no existing local engine-session binaries for same reason as above
-rm -rf ~/.cache/dagger/*
-yarn test # to be run the `sdk/nodejs` directory in our dagger repo
-```
-
-### Release
-
-When the above is looking good, you are ready to release:
-
-```console
-export SDK_VERSION=v0.1.0
-git tag sdk/nodejs/${SDK_VERSION}
-git push origin sdk/nodejs/${SDK_VERSION}
-```
-
-This will trigger the [`Publish Node.js SDK`
-workflow](https://github.com/dagger/dagger/actions/workflows/publish-nodejs-python.yml)
-which publishes [@dagger.io/dagger to NPM.js](https://www.npmjs.com/package/@dagger.io/dagger).
 
 ### Changelog
 
@@ -125,7 +94,15 @@ And here are the steps on how that was created:
 
 #### 1/4. Generate a draft release
 
+To start the release notes, we need to have the [`gh`
+CLI](https://cli.github.com/) installed, e.g. `brew install gh`. Once that is
+installed, we can run our command:
+
 ```console
+# To find the previously released SDK version, go to:
+# https://github.com/dagger/dagger/releases?q=sdk%2Fpython&expanded=true
+export PREVIOUS_SDK_VERSION=v0.<MINOR>.<PATCH>
+
 gh release create sdk/python/${SDK_VERSION} --generate-notes --notes-start-tag sdk/python/${PREVIOUS_SDK_VERSION} --draft
 ```
 
@@ -145,8 +122,10 @@ gh release create sdk/python/${SDK_VERSION} --generate-notes --notes-start-tag s
 > SDK. Repeat until all pull requests under **What's Changed** are relevant to
 > this release.
 
-- Lastly, remove all **New Contributors** which do not have a pull request
+- Remove all **New Contributors** which do not have a pull request
   under the **What's Changed** section.
+- Lastly, remove **Full Changelog** since this will include changes across all
+  SDKs + Engine + docs, etc.
 
 #### 3/4. Publish release
 
@@ -162,6 +141,100 @@ post](https://dagger.io/blog/python-sdk).
 
 You may also want to link to this blog post from within the release notes, e.g.
 [sdk/python/v0.1.1](https://github.com/dagger/dagger/releases/tag/sdk%2Fpython%2Fv0.1.1).
+
+If there is a video in this blog post, you may want to add it to the release
+notes (see **3/4.**).
+
+## Node.js SDK
+
+Ensure that all checks on the `main` branch are green. Pay special attention
+to `lint / sdk / nodejs` & `test / sdk / nodejs` checks. Ensure that these
+have passed for the commit that you are about to tag. If not, you may end up
+releasing a broken version.
+
+Additionally, manually test provisioning by running the following commands on
+both Linux and MacOS hosts directly
+
+```console
+# ensure there's no existing container so we use the full provisioning code paths
+docker rm -fv $(docker ps --filter "name=^dagger-engine-*" -qa)
+docker volume prune -f
+docker system prune -f
+# ensure there's no existing local engine-session binaries for same reason as above
+rm -rf ~/.cache/dagger/*
+yarn test # to be run the `sdk/nodejs` directory in our dagger repo
+```
+
+### Release
+
+When the above is looking good, you are ready to release:
+
+```console
+export SDK_VERSION=v0.<MINOR>.<PATCH>
+git tag sdk/nodejs/${SDK_VERSION}
+git push origin sdk/nodejs/${SDK_VERSION}
+```
+
+This will trigger the [`Publish Node.js SDK`
+workflow](https://github.com/dagger/dagger/actions/workflows/publish-sdk-nodejs.yml)
+which publishes [@dagger.io/dagger to NPM.js](https://www.npmjs.com/package/@dagger.io/dagger).
+
+### Changelog
+
+After the release is out, we need to create a release from the tag. Here is an
+example of what we are aiming for
+[sdk/nodejs/v0.2.0](https://github.com/dagger/dagger/releases/tag/sdk%2Fnodejs%2Fv0.2.0).
+And here are the steps on how that was created:
+
+#### 1/4. Generate a draft release
+
+To start the release notes, we need to have the [`gh`
+CLI](https://cli.github.com/) installed, e.g. `brew install gh`. Once that is
+installed, we can run our command:
+
+```console
+# To find the previously released SDK version, go to:
+# https://github.com/dagger/dagger/releases?q=sdk%2Fnodejs&expanded=true
+export PREVIOUS_SDK_VERSION=v0.<MINOR>.<PATCH>
+
+gh release create sdk/nodejs/${SDK_VERSION} --generate-notes --notes-start-tag sdk/nodejs/${PREVIOUS_SDK_VERSION} --draft
+```
+
+#### 2/4. Clean up release notes
+
+- Add link to NPMJS, e.g. ⬡ https://www.npmjs.com/package/@dagger.io/dagger
+- If there is a blog post (see **4/4.**) add a link to it, e.g.
+  📝 https://dagger.io/blog/nodejs-sdk
+- If there is a video (see **4/4.**) add a link to it, e.g.
+  🎬 https://www.youtube.com/watch?v=cuqmq_aTNfY
+- Click through each pull request and remove all the ones that don't change any
+  Nodejs SDK files. Some pull requests are prefixed with `sdk: nodejs:`, which
+  makes this process quicker.
+
+> 💡 TIP: An approach that works is to open a dozen or so pull requests in new
+> tabs, click on **Preview** and remove all the ones that don't affect this
+> SDK. Repeat until all pull requests under **What's Changed** are relevant to
+> this release.
+
+- Remove all **New Contributors** which do not have a pull request
+  under the **What's Changed** section.
+- Lastly, remove **Full Changelog** since this will include changes across all
+  SDKs + Engine + docs, etc.
+
+#### 3/4. Publish release
+
+- ⚠️ De-select **Set as the latest release** (only used for Engine/CLI releases)
+- Click on **Publish release**
+
+#### 4/4. Update blog post
+
+This is an optional step. We sometimes publish a blog post when a new SDK
+release goes out. When that happens, we tend to include a link to the release
+notes. Here is an example for the [Node.js SDK v0.1.0 release blog
+post](https://dagger.io/blog/nodejs-sdk).
+
+You may also want to link to this blog post from within the release notes, e.g.
+[sdk/nodejs/v0.1.0](https://github.com/dagger/dagger/releases/tag/sdk%2Fnodejs%2Fv0.1.0).
 
 If there is a video in this blog post, you may want to add it to the release
 notes (see **3/4.**).


### PR DESCRIPTION
Used for creating:
- https://github.com/dagger/dagger/releases/tag/sdk%2Fnodejs%2Fv0.1.0
- https://github.com/dagger/dagger/releases/tag/sdk%2Fnodejs%2Fv0.1.1