### PR TITLE
docs: Fix error in path of docs deprecation note

### DIFF
--- a/docs/v0.1/1001-install.md
+++ b/docs/v0.1/1001-install.md
@@ -2,11 +2,9 @@
 slug: /1001/install/
 ---
 
-import CautionBanner from './\_caution-banner.md'
-
 # Install Dagger
 
-{@include: ../../partials/_caution-old-version.md}
+{@include: ../partials/_caution-old-version.md}
 
 :::caution Requirement
 


### PR DESCRIPTION
This commit corrects an error in the file path for the docs deprecation notice on the 0.1 installation page: https://docs.dagger.io/1001/install/

Relates to #3904 and #3915.

Signed-off-by: Vikram Vaswani <vikram@dagger.io>