### PR TITLE
fix: don't trim all whitespace

### DIFF
--- a/sdk/nodejs/api/test/api.spec.ts
+++ b/sdk/nodejs/api/test/api.spec.ts
@@ -8,7 +8,7 @@ describe("NodeJS SDK api", function () {
 
     assert.strictEqual(
       queryBuilder(tree.queryTree),
-      `{container{from(address:"alpine")}}`
+      `{ container { from (address: "alpine") } }`
     )
   })
 
@@ -20,7 +20,7 @@ describe("NodeJS SDK api", function () {
 
     assert.strictEqual(
       queryBuilder(tree.queryTree),
-      `{container{from(address:"alpine"){withExec(args:["apk","add","curl"])}}}`
+      `{ container { from (address: "alpine") { withExec (args: ["apk","add","curl"]) }} }`
     )
   })
 
@@ -30,7 +30,7 @@ describe("NodeJS SDK api", function () {
 
     assert.strictEqual(
       queryBuilder(pkg.queryTree),
-      `{container{from(address:"alpine"){withExec(args:["apk","add","curl"])}}}`
+      `{ container { from (address: "alpine") { withExec (args: ["apk","add","curl"]) }} }`
     )
   })
 
@@ -39,12 +39,12 @@ describe("NodeJS SDK api", function () {
     const a = image.withExec(["echo", "hello", "world"])
     assert.strictEqual(
       queryBuilder(a.queryTree),
-      `{container{from(address:"alpine"){withExec(args:["echo","hello","world"])}}}`
+      `{ container { from (address: "alpine") { withExec (args: ["echo","hello","world"]) }} }`
     )
     const b = image.withExec(["echo", "foo", "bar"])
     assert.strictEqual(
       queryBuilder(b.queryTree),
-      `{container{from(address:"alpine"){withExec(args:["echo","foo","bar"])}}}`
+      `{ container { from (address: "alpine") { withExec (args: ["echo","foo","bar"]) }} }`
     )
   })
 

--- a/sdk/nodejs/api/test/api.spec.ts
+++ b/sdk/nodejs/api/test/api.spec.ts
@@ -2,12 +2,14 @@ import assert from "assert"
 import Client from "../client.gen.js"
 import { queryBuilder, queryFlatten } from "../utils.js"
 
+const querySanitizer = (query: string) => query.replace(/\s+/g, " ")
+
 describe("NodeJS SDK api", function () {
   it("Build correctly a query with one argument", async function () {
     const tree = new Client().container().from("alpine")
 
     assert.strictEqual(
-      queryBuilder(tree.queryTree),
+      querySanitizer(queryBuilder(tree.queryTree)),
       `{ container { from (address: "alpine") } }`
     )
   })
@@ -19,7 +21,7 @@ describe("NodeJS SDK api", function () {
       .withExec(["apk", "add", "curl"])
 
     assert.strictEqual(
-      queryBuilder(tree.queryTree),
+      querySanitizer(queryBuilder(tree.queryTree)),
       `{ container { from (address: "alpine") { withExec (args: ["apk","add","curl"]) }} }`
     )
   })
@@ -29,7 +31,7 @@ describe("NodeJS SDK api", function () {
     const pkg = image.withExec(["apk", "add", "curl"])
 
     assert.strictEqual(
-      queryBuilder(pkg.queryTree),
+      querySanitizer(queryBuilder(pkg.queryTree)),
       `{ container { from (address: "alpine") { withExec (args: ["apk","add","curl"]) }} }`
     )
   })
@@ -38,12 +40,12 @@ describe("NodeJS SDK api", function () {
     const image = new Client().container().from("alpine")
     const a = image.withExec(["echo", "hello", "world"])
     assert.strictEqual(
-      queryBuilder(a.queryTree),
+      querySanitizer(queryBuilder(a.queryTree)),
       `{ container { from (address: "alpine") { withExec (args: ["echo","hello","world"]) }} }`
     )
     const b = image.withExec(["echo", "foo", "bar"])
     assert.strictEqual(
-      queryBuilder(b.queryTree),
+      querySanitizer(queryBuilder(b.queryTree)),
       `{ container { from (address: "alpine") { withExec (args: ["echo","foo","bar"]) }} }`
     )
   })

--- a/sdk/nodejs/api/utils.ts
+++ b/sdk/nodejs/api/utils.ts
@@ -35,7 +35,7 @@ export function queryBuilder(q: QueryTree[]) {
   })
   query += "}"
 
-  return query.replace(/\s+/g, " ")
+  return query
 }
 
 /**

--- a/sdk/nodejs/api/utils.ts
+++ b/sdk/nodejs/api/utils.ts
@@ -35,7 +35,7 @@ export function queryBuilder(q: QueryTree[]) {
   })
   query += "}"
 
-  return query.trim()
+  return query.replace(/\s+/g, " ")
 }
 
 /**

--- a/sdk/nodejs/api/utils.ts
+++ b/sdk/nodejs/api/utils.ts
@@ -35,7 +35,7 @@ export function queryBuilder(q: QueryTree[]) {
   })
   query += "}"
 
-  return query.replace(/\s+/g, "")
+  return query.trim()
 }
 
 /**


### PR DESCRIPTION
When users pass strings for `client.directory().withNewFile()` or even to `container.withExec()`, this is removing all whitespace and breaking entrypoints, commands, and scripts.

fixes #3990