### PR TITLE
Node.js SDK: Nested queries

### DIFF
--- a/codegen/generator/nodejs/templates/src/header.ts.tmpl
+++ b/codegen/generator/nodejs/templates/src/header.ts.tmpl
@@ -4,8 +4,8 @@
  * Do not make direct changes to the file.
  */
 
-import { GraphQLClient, gql } from "graphql-request";
-import { queryBuilder, queryFlatten } from "./utils.js"
+import { GraphQLClient } from "graphql-request";
+import { queryBuilder } from "./utils.js"
 
 /**
  * @hidden
@@ -22,7 +22,7 @@ interface ClientConfig {
 
 class BaseClient {
   protected _queryTree:  QueryTree[]
-	private client: GraphQLClient;
+	protected client: GraphQLClient;
   /**
    * @defaultValue `127.0.0.1:8080`
    */
@@ -42,25 +42,6 @@ class BaseClient {
    */
   get queryTree() {
     return this._queryTree;
-  }
-
-  /**
-   * @hidden
-   */
-  protected async _compute<T>(): Promise<T> {
-    try {
-      // run the query and return the result.
-      const query = queryBuilder(this._queryTree)
-      const computeQuery: Awaited<T> = await this.client.request(
-        gql`
-          ${query}
-        `
-      )
-
-      return queryFlatten(computeQuery)
-    } catch (error) {
-      throw Error(`Error: ${JSON.stringify(error, undefined, 2)}`)
-    }
   }
 }
 {{- end }}

--- a/codegen/generator/nodejs/templates/src/method_solve.ts.tmpl
+++ b/codegen/generator/nodejs/templates/src/method_solve.ts.tmpl
@@ -12,7 +12,10 @@
       }
     ]
 
-    const response: Awaited<{{ .TypeRef | FormatOutputType }}> = await this._compute()
+    const response: Awaited<{{ .TypeRef | FormatOutputType }}> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }

--- a/codegen/generator/nodejs/templates/src/objects_test.go
+++ b/codegen/generator/nodejs/templates/src/objects_test.go
@@ -45,7 +45,10 @@ export class CacheVolume extends BaseClient {
       }
     ]
 
-    const response: Awaited<CacheID> = await this._compute()
+    const response: Awaited<CacheID> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }

--- a/docs/current/sdk/nodejs/783645-get-started.md
+++ b/docs/current/sdk/nodejs/783645-get-started.md
@@ -153,7 +153,7 @@ Replace the `build.js` file from the previous step with the version below (highl
 The revised code now does the following:
 
 - It creates a Dagger client with `connect()` as before.
-- It uses the client's `host().directory(".", ["node_modules/"]).id()` method to obtain a reference to the current directory on the host. This reference is stored in the `source` variable. It also will ignore the `node_modules` directory on the host since we passed that in as an excluded directory.
+- It uses the client's `host().directory(".", ["node_modules/"])` method to obtain a reference to the current directory on the host. This reference is stored in the `source` variable. It also will ignore the `node_modules` directory on the host since we passed that in as an excluded directory.
 - It uses the client's `container().from()` method to initialize a new container from a base image. This base image is the Node.js version to be tested against - the `node:16` image. This method returns a new `Container` object with the results.
 - It uses the `Container.withMountedDirectory()` method to mount the host directory into the container at the `/src` mount point, and the `Container.withWorkdir()` method to set the working directory in the container. The revised `Container` is stored in the `runner` constant.
 - It uses the `Container.withExec()` method to define the command to run tests in the container - in this case, the command `npm test -- --watchAll=false`.

--- a/docs/current/sdk/nodejs/snippets/get-started/step3/build.js
+++ b/docs/current/sdk/nodejs/snippets/get-started/step3/build.js
@@ -4,10 +4,10 @@ import { connect } from "@dagger.io/dagger"
 connect(async (client) => {
   // get Node image
   // get Node version
-  let node = client.container().from("node:16").withExec(["node", "-v"])
+  const node = client.container().from("node:16").withExec(["node", "-v"])
 
   // execute
-  let version = await node.stdout()
+  const version = await node.stdout()
 
   // print output
   console.log("Hello from Dagger and Node " + version)

--- a/docs/current/sdk/nodejs/snippets/get-started/step3/build.js
+++ b/docs/current/sdk/nodejs/snippets/get-started/step3/build.js
@@ -4,11 +4,11 @@ import { connect } from "@dagger.io/dagger"
 connect(async (client) => {
   // get Node image
   // get Node version
-  let node = await client.container().from("node:16").withExec(["node", "-v"])
+  let node = client.container().from("node:16").withExec(["node", "-v"])
 
   // execute
   let version = await node.stdout()
 
   // print output
-  console.log("Hello from Dagger and Node " + version.contents)
+  console.log("Hello from Dagger and Node " + version)
 })

--- a/docs/current/sdk/nodejs/snippets/get-started/step3/build.ts
+++ b/docs/current/sdk/nodejs/snippets/get-started/step3/build.ts
@@ -4,11 +4,11 @@ import Client, { connect } from "@dagger.io/dagger"
 connect(async (client: Client) => {
   // get Node image
   // get Node version
-  const node = await client.container().from("node:16").withExec(["node", "-v"])
+  const node = client.container().from("node:16").withExec(["node", "-v"])
 
   // execute
   const version = await node.stdout()
 
   // print output
-  console.log("Hello from Dagger and Node " + version.contents)
+  console.log("Hello from Dagger and Node " + version)
 })

--- a/docs/current/sdk/nodejs/snippets/get-started/step4/build.js
+++ b/docs/current/sdk/nodejs/snippets/get-started/step4/build.js
@@ -4,15 +4,15 @@ import { connect } from "@dagger.io/dagger"
 connect(async (client) => {
   // highlight-start
   // get reference to the local project
-  const source = await client.host().directory(".", ["node_modules/"]).id()
+  const source = client.host().directory(".", ["node_modules/"])
 
   // get Node image
-  const node = await client.container().from("node:16").id()
+  const node = client.container().from("node:16")
 
   // mount cloned repository into Node image
   const runner = client
-    .container(node.id)
-    .withMountedDirectory("/src", source.id)
+    .container(node)
+    .withMountedDirectory("/src", source)
     .withWorkdir("/src")
     .withExec(["npm", "install"])
 

--- a/docs/current/sdk/nodejs/snippets/get-started/step4/build.ts
+++ b/docs/current/sdk/nodejs/snippets/get-started/step4/build.ts
@@ -4,15 +4,15 @@ import Client, { connect } from "@dagger.io/dagger"
 connect(async (client: Client) => {
   // highlight-start
   // get reference to the local project
-  const source = await client.host().directory(".", ["node_modules/"]).id()
+  const source = client.host().directory(".", ["node_modules/"])
 
   // get Node image
-  const node = await client.container().from("node:16").id()
+  const node = client.container().from("node:16")
 
   // mount cloned repository into Node image
   const runner = client
-    .container(node.id)
-    .withMountedDirectory("/src", source.id)
+    .container(node)
+    .withMountedDirectory("/src", source)
     .withWorkdir("/src")
     .withExec(["npm", "install"])
 

--- a/docs/current/sdk/nodejs/snippets/get-started/step5/build.js
+++ b/docs/current/sdk/nodejs/snippets/get-started/step5/build.js
@@ -8,19 +8,19 @@ connect(async (client) => {
   // highlight-end
 
   // get reference to the local project
-  const source = await client.host().directory(".", ["node_modules/"]).id()
+  const source = client.host().directory(".", ["node_modules/"])
 
   // highlight-start
   // for each Node version
   for (const nodeVersion of nodeVersions) {
     // get Node image
-    const node = await client.container().from(`node:${nodeVersion}`).id()
+    const node = client.container().from(`node:${nodeVersion}`)
     // highlight-end
 
     // mount cloned repository into Node image
     const runner = client
-      .container(node.id)
-      .withMountedDirectory("/src", source.id)
+      .container(node)
+      .withMountedDirectory("/src", source)
       .withWorkdir("/src")
       .withExec(["npm", "install"])
 

--- a/docs/current/sdk/nodejs/snippets/get-started/step5/build.ts
+++ b/docs/current/sdk/nodejs/snippets/get-started/step5/build.ts
@@ -8,19 +8,19 @@ connect(async (client: Client) => {
   // highlight-end
 
   // get reference to the local project
-  const source = await client.host().directory(".", ["node_modules/"]).id()
+  const source = client.host().directory(".", ["node_modules/"])
 
   // highlight-start
   // for each Node version
   for (const nodeVersion of nodeVersions) {
     // get Node image
-    const node = await client.container().from(`node:${nodeVersion}`).id()
+    const node = client.container().from(`node:${nodeVersion}`)
     // highlight-end
 
     // mount cloned repository into Node image
     const runner = client
-      .container(node.id)
-      .withMountedDirectory("/src", source.id)
+      .container(node)
+      .withMountedDirectory("/src", source)
       .withWorkdir("/src")
       .withExec(["npm", "install"])
 

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -1803,7 +1803,10 @@ export class Socket extends BaseClient {
       },
     ]
 
-    const response: Awaited<SocketID> = await this._compute()
+    const response: Awaited<SocketID> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -3,8 +3,8 @@
  * Do not make direct changes to the file.
  */
 
-import { GraphQLClient, gql } from "graphql-request"
-import { queryBuilder, queryFlatten } from "./utils.js"
+import { GraphQLClient } from "graphql-request"
+import { queryBuilder } from "./utils.js"
 
 /**
  * @hidden
@@ -21,7 +21,7 @@ interface ClientConfig {
 
 class BaseClient {
   protected _queryTree: QueryTree[]
-  private client: GraphQLClient
+  protected client: GraphQLClient
   /**
    * @defaultValue `127.0.0.1:8080`
    */
@@ -41,25 +41,6 @@ class BaseClient {
    */
   get queryTree() {
     return this._queryTree
-  }
-
-  /**
-   * @hidden
-   */
-  protected async _compute<T>(): Promise<T> {
-    try {
-      // run the query and return the result.
-      const query = queryBuilder(this._queryTree)
-      const computeQuery: Awaited<T> = await this.client.request(
-        gql`
-          ${query}
-        `
-      )
-
-      return queryFlatten(computeQuery)
-    } catch (error) {
-      throw Error(`Error: ${JSON.stringify(error, undefined, 2)}`)
-    }
   }
 }
 
@@ -121,7 +102,10 @@ export class CacheVolume extends BaseClient {
       },
     ]
 
-    const response: Awaited<CacheID> = await this._compute()
+    const response: Awaited<CacheID> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -134,7 +118,7 @@ export class Container extends BaseClient {
   /**
    * Initialize this container from a Dockerfile build
    */
-  build(context: DirectoryID, dockerfile?: string): Container {
+  build(context: DirectoryID | Directory, dockerfile?: string): Container {
     return new Container({
       queryTree: [
         ...this._queryTree,
@@ -158,7 +142,10 @@ export class Container extends BaseClient {
       },
     ]
 
-    const response: Awaited<string[]> = await this._compute()
+    const response: Awaited<string[]> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -190,7 +177,10 @@ export class Container extends BaseClient {
       },
     ]
 
-    const response: Awaited<string[]> = await this._compute()
+    const response: Awaited<string[]> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -207,7 +197,10 @@ export class Container extends BaseClient {
       },
     ]
 
-    const response: Awaited<string> = await this._compute()
+    const response: Awaited<string> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -223,7 +216,10 @@ export class Container extends BaseClient {
       },
     ]
 
-    const response: Awaited<EnvVariable[]> = await this._compute()
+    const response: Awaited<EnvVariable[]> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -270,7 +266,10 @@ export class Container extends BaseClient {
       },
     ]
 
-    const response: Awaited<number> = await this._compute()
+    const response: Awaited<number> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -280,7 +279,7 @@ export class Container extends BaseClient {
    */
   async export(
     path: string,
-    platformVariants?: ContainerID[]
+    platformVariants?: ContainerID[] | Container[]
   ): Promise<boolean> {
     this._queryTree = [
       ...this._queryTree,
@@ -290,7 +289,10 @@ export class Container extends BaseClient {
       },
     ]
 
-    const response: Awaited<boolean> = await this._compute()
+    const response: Awaited<boolean> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -355,7 +357,10 @@ export class Container extends BaseClient {
       },
     ]
 
-    const response: Awaited<ContainerID> = await this._compute()
+    const response: Awaited<ContainerID> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -371,7 +376,10 @@ export class Container extends BaseClient {
       },
     ]
 
-    const response: Awaited<string[]> = await this._compute()
+    const response: Awaited<string[]> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -387,7 +395,10 @@ export class Container extends BaseClient {
       },
     ]
 
-    const response: Awaited<Platform> = await this._compute()
+    const response: Awaited<Platform> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -397,7 +408,7 @@ export class Container extends BaseClient {
    */
   async publish(
     address: string,
-    platformVariants?: ContainerID[]
+    platformVariants?: ContainerID[] | Container[]
   ): Promise<string> {
     this._queryTree = [
       ...this._queryTree,
@@ -407,7 +418,10 @@ export class Container extends BaseClient {
       },
     ]
 
-    const response: Awaited<string> = await this._compute()
+    const response: Awaited<string> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -439,7 +453,10 @@ export class Container extends BaseClient {
       },
     ]
 
-    const response: Awaited<string> = await this._compute()
+    const response: Awaited<string> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -456,7 +473,10 @@ export class Container extends BaseClient {
       },
     ]
 
-    const response: Awaited<string> = await this._compute()
+    const response: Awaited<string> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -472,7 +492,10 @@ export class Container extends BaseClient {
       },
     ]
 
-    const response: Awaited<string> = await this._compute()
+    const response: Awaited<string> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -558,7 +581,7 @@ export class Container extends BaseClient {
    *
    * @deprecated Replaced by withRootfs.
    */
-  withFS(id: DirectoryID): Container {
+  withFS(id: DirectoryID | Directory): Container {
     return new Container({
       queryTree: [
         ...this._queryTree,
@@ -576,8 +599,8 @@ export class Container extends BaseClient {
    */
   withMountedCache(
     path: string,
-    cache: CacheID,
-    source?: DirectoryID
+    cache: CacheID | CacheVolume,
+    source?: DirectoryID | Directory
   ): Container {
     return new Container({
       queryTree: [
@@ -594,7 +617,10 @@ export class Container extends BaseClient {
   /**
    * This container plus a directory mounted at the given path
    */
-  withMountedDirectory(path: string, source: DirectoryID): Container {
+  withMountedDirectory(
+    path: string,
+    source: DirectoryID | Directory
+  ): Container {
     return new Container({
       queryTree: [
         ...this._queryTree,
@@ -610,7 +636,7 @@ export class Container extends BaseClient {
   /**
    * This container plus a file mounted at the given path
    */
-  withMountedFile(path: string, source: FileID): Container {
+  withMountedFile(path: string, source: FileID | File): Container {
     return new Container({
       queryTree: [
         ...this._queryTree,
@@ -626,7 +652,7 @@ export class Container extends BaseClient {
   /**
    * This container plus a secret mounted into a file at the given path
    */
-  withMountedSecret(path: string, source: SecretID): Container {
+  withMountedSecret(path: string, source: SecretID | Secret): Container {
     return new Container({
       queryTree: [
         ...this._queryTree,
@@ -658,7 +684,7 @@ export class Container extends BaseClient {
   /**
    * Initialize this container from this DirectoryID
    */
-  withRootfs(id: DirectoryID): Container {
+  withRootfs(id: DirectoryID | Directory): Container {
     return new Container({
       queryTree: [
         ...this._queryTree,
@@ -674,7 +700,7 @@ export class Container extends BaseClient {
   /**
    * This container plus an env variable containing the given secret
    */
-  withSecretVariable(name: string, secret: SecretID): Container {
+  withSecretVariable(name: string, secret: SecretID | Secret): Container {
     return new Container({
       queryTree: [
         ...this._queryTree,
@@ -794,7 +820,10 @@ export class Container extends BaseClient {
       },
     ]
 
-    const response: Awaited<string> = await this._compute()
+    const response: Awaited<string> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -807,7 +836,7 @@ export class Directory extends BaseClient {
   /**
    * The difference between this directory and an another directory
    */
-  diff(other: DirectoryID): Directory {
+  diff(other: DirectoryID | Directory): Directory {
     return new Directory({
       queryTree: [
         ...this._queryTree,
@@ -864,7 +893,10 @@ export class Directory extends BaseClient {
       },
     ]
 
-    const response: Awaited<string[]> = await this._compute()
+    const response: Awaited<string[]> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -881,7 +913,10 @@ export class Directory extends BaseClient {
       },
     ]
 
-    const response: Awaited<boolean> = await this._compute()
+    const response: Awaited<boolean> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -913,7 +948,10 @@ export class Directory extends BaseClient {
       },
     ]
 
-    const response: Awaited<DirectoryID> = await this._compute()
+    const response: Awaited<DirectoryID> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -939,7 +977,7 @@ export class Directory extends BaseClient {
    */
   withDirectory(
     path: string,
-    directory: DirectoryID,
+    directory: DirectoryID | Directory,
     exclude?: string[],
     include?: string[]
   ): Directory {
@@ -958,7 +996,7 @@ export class Directory extends BaseClient {
   /**
    * This directory plus the contents of the given file copied to the given path
    */
-  withFile(path: string, source: FileID): Directory {
+  withFile(path: string, source: FileID | File): Directory {
     return new Directory({
       queryTree: [
         ...this._queryTree,
@@ -1051,7 +1089,10 @@ export class EnvVariable extends BaseClient {
       },
     ]
 
-    const response: Awaited<string> = await this._compute()
+    const response: Awaited<string> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -1067,7 +1108,10 @@ export class EnvVariable extends BaseClient {
       },
     ]
 
-    const response: Awaited<string> = await this._compute()
+    const response: Awaited<string> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -1088,7 +1132,10 @@ export class File extends BaseClient {
       },
     ]
 
-    const response: Awaited<string> = await this._compute()
+    const response: Awaited<string> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -1105,7 +1152,10 @@ export class File extends BaseClient {
       },
     ]
 
-    const response: Awaited<boolean> = await this._compute()
+    const response: Awaited<boolean> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -1121,7 +1171,10 @@ export class File extends BaseClient {
       },
     ]
 
-    const response: Awaited<FileID> = await this._compute()
+    const response: Awaited<FileID> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -1148,7 +1201,10 @@ export class File extends BaseClient {
       },
     ]
 
-    const response: Awaited<number> = await this._compute()
+    const response: Awaited<number> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -1169,7 +1225,10 @@ export class GitRef extends BaseClient {
       },
     ]
 
-    const response: Awaited<string> = await this._compute()
+    const response: Awaited<string> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -1222,7 +1281,10 @@ export class GitRepository extends BaseClient {
       },
     ]
 
-    const response: Awaited<string[]> = await this._compute()
+    const response: Awaited<string[]> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -1270,7 +1332,10 @@ export class GitRepository extends BaseClient {
       },
     ]
 
-    const response: Awaited<string[]> = await this._compute()
+    const response: Awaited<string[]> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -1377,7 +1442,10 @@ export class HostVariable extends BaseClient {
       },
     ]
 
-    const response: Awaited<string> = await this._compute()
+    const response: Awaited<string> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -1398,7 +1466,10 @@ export class Project extends BaseClient {
       },
     ]
 
-    const response: Awaited<Project[]> = await this._compute()
+    const response: Awaited<Project[]> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -1429,7 +1500,10 @@ export class Project extends BaseClient {
       },
     ]
 
-    const response: Awaited<boolean> = await this._compute()
+    const response: Awaited<boolean> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -1445,7 +1519,10 @@ export class Project extends BaseClient {
       },
     ]
 
-    const response: Awaited<string> = await this._compute()
+    const response: Awaited<string> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -1461,7 +1538,10 @@ export class Project extends BaseClient {
       },
     ]
 
-    const response: Awaited<string> = await this._compute()
+    const response: Awaited<string> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -1477,7 +1557,10 @@ export class Project extends BaseClient {
       },
     ]
 
-    const response: Awaited<string> = await this._compute()
+    const response: Awaited<string> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -1505,7 +1588,7 @@ export default class Client extends BaseClient {
    * Null ID returns an empty container (scratch).
    * Optional platform argument initializes new containers to execute and publish as that platform. Platform defaults to that of the builder's host.
    */
-  container(id?: ContainerID, platform?: Platform): Container {
+  container(id?: ContainerID | Container, platform?: Platform): Container {
     return new Container({
       queryTree: [
         ...this._queryTree,
@@ -1529,7 +1612,10 @@ export default class Client extends BaseClient {
       },
     ]
 
-    const response: Awaited<Platform> = await this._compute()
+    const response: Awaited<Platform> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -1537,7 +1623,7 @@ export default class Client extends BaseClient {
   /**
    * Load a directory by ID. No argument produces an empty directory.
    */
-  directory(id?: DirectoryID): Directory {
+  directory(id?: DirectoryID | Directory): Directory {
     return new Directory({
       queryTree: [
         ...this._queryTree,
@@ -1553,7 +1639,7 @@ export default class Client extends BaseClient {
   /**
    * Load a file by ID
    */
-  file(id: FileID): File {
+  file(id: FileID | File): File {
     return new File({
       queryTree: [
         ...this._queryTree,
@@ -1632,7 +1718,7 @@ export default class Client extends BaseClient {
   /**
    * Load a secret from its ID
    */
-  secret(id: SecretID): Secret {
+  secret(id: SecretID | Secret): Secret {
     return new Secret({
       queryTree: [
         ...this._queryTree,
@@ -1677,7 +1763,10 @@ export class Secret extends BaseClient {
       },
     ]
 
-    const response: Awaited<SecretID> = await this._compute()
+    const response: Awaited<SecretID> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }
@@ -1693,7 +1782,10 @@ export class Secret extends BaseClient {
       },
     ]
 
-    const response: Awaited<string> = await this._compute()
+    const response: Awaited<string> = await queryBuilder(
+      this._queryTree,
+      this.client
+    )
 
     return response
   }

--- a/sdk/nodejs/api/test/api.spec.ts
+++ b/sdk/nodejs/api/test/api.spec.ts
@@ -1,56 +1,104 @@
 import assert from "assert"
-import Client from "../client.gen.js"
-import { queryBuilder, queryFlatten } from "../utils.js"
+import Client, { connect } from "../../index.js"
+import { queryFlatten, buildQuery } from "../utils.js"
 
 const querySanitizer = (query: string) => query.replace(/\s+/g, " ")
 
 describe("NodeJS SDK api", function () {
-  it("Build correctly a query with one argument", async function () {
+  it("Build correctly a query with one argument", function () {
     const tree = new Client().container().from("alpine")
 
     assert.strictEqual(
-      querySanitizer(queryBuilder(tree.queryTree)),
+      querySanitizer(buildQuery(tree.queryTree)),
       `{ container { from (address: "alpine") } }`
     )
   })
 
-  it("Build one query with multiple arguments", async function () {
+  it("Build correctly a query with different args type", function () {
+    const tree = new Client().container().from("alpine")
+
+    assert.strictEqual(
+      querySanitizer(buildQuery(tree.queryTree)),
+      `{ container { from (address: "alpine") } }`
+    )
+
+    const tree2 = new Client().git("fake_url", true)
+
+    assert.strictEqual(
+      querySanitizer(buildQuery(tree2.queryTree)),
+      `{ git (url: "fake_url",keepGitDir: true) }`
+    )
+
+    const tree3 = [
+      {
+        operation: "test_types",
+        args: {
+          id: 1,
+          platform: ["string", "string2"],
+          boolean: true,
+          object: {},
+          undefined: undefined,
+        },
+      },
+    ]
+
+    assert.strictEqual(
+      querySanitizer(buildQuery(tree3)),
+      `{ test_types (id: 1,platform: ["string","string2"],boolean: true,object: {}) }`
+    )
+  })
+
+  it("Build one query with multiple arguments", function () {
     const tree = new Client()
       .container()
       .from("alpine")
       .withExec(["apk", "add", "curl"])
 
     assert.strictEqual(
-      querySanitizer(queryBuilder(tree.queryTree)),
+      querySanitizer(buildQuery(tree.queryTree)),
       `{ container { from (address: "alpine") { withExec (args: ["apk","add","curl"]) }} }`
     )
   })
 
-  it("Build a query by splitting it", async function () {
+  it("Build a query by splitting it", function () {
     const image = new Client().container().from("alpine")
-    const pkg = image.withExec(["apk", "add", "curl"])
+    const pkg = image.withExec(["echo", "foo bar"])
 
     assert.strictEqual(
-      querySanitizer(queryBuilder(pkg.queryTree)),
-      `{ container { from (address: "alpine") { withExec (args: ["apk","add","curl"]) }} }`
+      querySanitizer(buildQuery(pkg.queryTree)),
+      `{ container { from (address: "alpine") { withExec (args: ["echo","foo bar"]) }} }`
     )
   })
 
-  it("Test Field Immutability", async function () {
+  it("Pass a client with an implicit ID as a parameter", async function () {
+    connect(async (client: Client) => {
+      const image = await client
+        .container(
+          client.container().from("alpine").withExec(["apk", "add", "yarn"])
+        )
+        .withMountedCache("/root/.cache", client.cacheVolume("cache_key"))
+        .withExec(["echo", "foo bar"])
+        .stdout()
+
+      assert.strictEqual(image, `foo  bar`)
+    })
+  })
+
+  it("Test Field Immutability", function () {
     const image = new Client().container().from("alpine")
     const a = image.withExec(["echo", "hello", "world"])
     assert.strictEqual(
-      querySanitizer(queryBuilder(a.queryTree)),
+      querySanitizer(buildQuery(a.queryTree)),
       `{ container { from (address: "alpine") { withExec (args: ["echo","hello","world"]) }} }`
     )
     const b = image.withExec(["echo", "foo", "bar"])
     assert.strictEqual(
-      querySanitizer(queryBuilder(b.queryTree)),
+      querySanitizer(buildQuery(b.queryTree)),
       `{ container { from (address: "alpine") { withExec (args: ["echo","foo","bar"]) }} }`
     )
   })
 
-  it("Return a flatten Graphql response", async function () {
+  it("Return a flatten Graphql response", function () {
     const tree = {
       container: {
         from: {
@@ -68,7 +116,7 @@ describe("NodeJS SDK api", function () {
     )
   })
 
-  it("Return a error for Graphql object nested response", async function () {
+  it("Return a error for Graphql object nested response", function () {
     const tree = {
       container: {
         from: "from",

--- a/sdk/nodejs/api/utils.ts
+++ b/sdk/nodejs/api/utils.ts
@@ -1,34 +1,65 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { gql, GraphQLClient } from "graphql-request"
 import { QueryTree } from "./client.gen.js"
 
-export function queryBuilder(q: QueryTree[]) {
-  const args = (item: any) => {
-    const regex = /\{"[a-zA-Z]+"/gi
-
-    const entries = Object.entries(item.args)
-      .filter((value) => value[1] !== undefined)
-      .map((value) => {
-        if (typeof value[1] === "object") {
-          return `${value[0]}: ${JSON.stringify(value[1]).replace(
-            regex,
-            (str) => str.replace(/"/g, "")
-          )}`
-        }
-        if (typeof value[1] === "number") {
-          return `${value[0]}: ${value[1]}`
-        }
-        return `${value[0]}: "${value[1]}"`
-      })
-    if (entries.length === 0) {
-      return ""
-    }
-    return "(" + entries + ")"
+function buildArgs(item: any): string {
+  const entries = Object.entries(item.args)
+    .filter((value) => value[1] !== undefined)
+    .map((value) => {
+      return `${value[0]}: ${JSON.stringify(value[1]).replace(
+        /\{"[a-zA-Z]+"/gi,
+        (str) => str.replace(/"/g, "")
+      )}`
+    })
+  if (entries.length === 0) {
+    return ""
   }
+  return "(" + entries + ")"
+}
 
+/**
+ * Find querytree, convert them into GraphQl query
+ * then compute and return the result to the appropriate field
+ */
+async function computeNestedQuery(
+  query: QueryTree[],
+  client: GraphQLClient
+): Promise<void> {
+  /**
+   * Check if there is a nested queryTree to be executed
+   */
+  const isQueryTree = (value: any) =>
+    Object.keys(value).find((val) => val === "_queryTree")
+
+  for (const q of query) {
+    if (q.args !== undefined) {
+      await Promise.all(
+        Object.entries(q.args).map(async (val: any) => {
+          if (val[1] instanceof Object && isQueryTree(val[1])) {
+            // push an id that will be used by the container
+            val[1]["_queryTree"].push({ operation: "id" })
+            const getQueryTree = buildQuery(val[1]["_queryTree"])
+            const result = await compute(getQueryTree, client)
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            //@ts-ignore
+            q.args[val[0]] = result
+          }
+        })
+      )
+    }
+  }
+}
+
+/**
+ * Convert the queryTree into a GraphQL query
+ * @param q
+ * @returns
+ */
+export function buildQuery(q: QueryTree[]): string {
   let query = "{"
   q.forEach((item: QueryTree, index: number) => {
     query += `
-        ${item.operation} ${item.args ? `${args(item)}` : ""} ${
+        ${item.operation} ${item.args ? `${buildArgs(item)}` : ""} ${
       q.length - 1 !== index ? "{" : "}".repeat(q.length - 1)
     }
       `
@@ -39,7 +70,28 @@ export function queryBuilder(q: QueryTree[]) {
 }
 
 /**
+ * Convert querytree into a Graphql query then compute it
+ * @param q | QueryTree[]
+ * @param client | GraphQLClient
+ * @returns
+ */
+export async function queryBuilder<T>(
+  q: QueryTree[],
+  client: GraphQLClient
+): Promise<T> {
+  await computeNestedQuery(q, client)
+
+  const query = buildQuery(q)
+
+  const result: Awaited<T> = await compute(query, client)
+
+  return result
+}
+
+/**
  * Return a Graphql query result flattened
+ * @param response any
+ * @returns
  */
 export function queryFlatten<T>(response: any): T {
   // Recursion break condition
@@ -60,4 +112,22 @@ export function queryFlatten<T>(response: any): T {
   const nestedKey = keys[0]
 
   return queryFlatten(response[nestedKey])
+}
+
+/**
+ * Send a GraphQL document to the server
+ * return a flatten result
+ * @hidden
+ */
+export async function compute<T>(
+  query: string,
+  client: GraphQLClient
+): Promise<T> {
+  const computeQuery: Awaited<T> = await client.request(
+    gql`
+      ${query}
+    `
+  )
+
+  return queryFlatten(computeQuery)
 }

--- a/sdk/nodejs/yarn.lock
+++ b/sdk/nodejs/yarn.lock
@@ -198,6 +198,11 @@
     debug "^4.3.4"
     tsutils "^3.21.0"
 
+"@typescript-eslint/types@5.43.0":
+  version "5.43.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.43.0.tgz#e4ddd7846fcbc074325293515fa98e844d8d2578"
+  integrity sha512-jpsbcD0x6AUvV7tyOlyvon0aUsQpF8W+7TpJntfCUWU1qaIKu2K34pMwQKSzQH8ORgUrGYY6pVIh1Pi8TNeteg==
+
 "@typescript-eslint/types@5.44.0":
   version "5.44.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.44.0.tgz#f3f0b89aaff78f097a2927fe5688c07e786a0241"


### PR DESCRIPTION
Give the ability to pass the client as an argument without the needs of using its id.

Before
```ts
const cacheVolumeId = await client.cacheVolume("cache_key").id()

const image = await client 
        .container()
        .from("alpine")
        .withMountedCache("/root/.cache", cacheVolumeId)
        .withExec(["echo", "foo bar"])
        .stdout()

```

After
```ts
const image = await client 
        .container()
        .withMountedCache("/root/.cache", client.cacheVolume("cache_key"))
        .withExec(["echo", "foo bar"])
        .stdout()
```

Tasks list:
 - [X] Pass a method as an arg that return an id()
 - [x] Update docs and example to reflect api change
 - [x] Update Codegen (cc @dolanor)
 

Signed-off-by: jffarge <jf@dagger.io>