### PR TITLE
docs: Add first draft of style guide

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -31,3 +31,7 @@ GIT_USER=<Your GitHub username> USE_SSH=true yarn deploy
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+
+## New content
+
+Refer to the [documentation style guide](./STYLE_GUIDE.md).

--- a/website/STYLE_GUIDE.md
+++ b/website/STYLE_GUIDE.md
@@ -20,5 +20,6 @@ Code
 
 Text
 - Avoid using `you`, `we`, `our` and other personal pronouns. Alternatives are (e.g. instead of `this is where you will deploy the application`):
-  - Rewrite the sentence using passive voice e.g. `this is where the application will be deployed`   - Rewrite the sentence to personify the subject e.g. `the application will be deployed here`
+  - Rewrite the sentence using passive voice e.g. `this is where the application will be deployed`   
+  - Rewrite the sentence to personify the subject e.g. `the application will be deployed here`
   - Rewrite the sentence using active voice and a verb e.g. `deploy the application to...`

--- a/website/STYLE_GUIDE.md
+++ b/website/STYLE_GUIDE.md
@@ -1,0 +1,24 @@
+# Documentation Style Guide
+
+Files
+- Filenames should be prefixed with random 6-digit identifier generated via `new.sh` script
+- URLs for SDK-specific pages should be in the form `/sdk/[language]/[number]/[label]`
+- URLs for API- or CLI-specific pages should be in the form `/[api|cli]/[number]/[label]`
+- URLs for non-SDK pages should be in the form `/[number]/[label]`
+
+Page titles
+- Page titles should be in Word Case
+- For guides and tutorials, start each title with a verb e.g. `Create Pipeline...`, `Deploy App...`
+
+Page sections
+- Section headings should be in Sentence case
+
+Code
+- SDK example code should be stored in `sdk/snippets` subdirectory
+  - Subdirectory name = docs filename that embeds its snippets
+  - Separate each code snippet further into its own subdirectory if required so it can be run standalone
+
+Text
+- Avoid using `you`, `we`, `our` and other personal pronouns. Alternatives are (e.g. instead of `this is where you will deploy the application`):
+  - Rewrite the sentence using passive voice e.g. `this is where the application will be deployed`   - Rewrite the sentence to personify the subject e.g. `the application will be deployed here`
+  - Rewrite the sentence using active voice and a verb e.g. `deploy the application to...`


### PR DESCRIPTION
This commit adds the first draft of a style guide for documentation authors. The purpose is to help content authors produce more consistent documentation.

Closes #3641.

Signed-off-by: Vikram Vaswani <vikram@dagger.io>