### PR TITLE
NodeJS SDK required + optional types

### DIFF
--- a/codegen/generator/nodejs/templates/functions.go
+++ b/codegen/generator/nodejs/templates/functions.go
@@ -17,6 +17,8 @@ var (
 		"FormatInputType":   formatInputType,
 		"FormatOutputType":  formatOutputType,
 		"FormatName":        formatName,
+		"GetOptionalArgs":   getOptionalArgs,
+		"GetRequiredArgs":   getRequiredArgs,
 		"HasPrefix":         strings.HasPrefix,
 		"PascalCase":        pascalCase,
 		"IsArgOptional":     isArgOptional,
@@ -163,4 +165,24 @@ func isArgOptional(values introspection.InputValues) bool {
 		}
 	}
 	return true
+}
+
+func splitRequiredOptionalArgs(values introspection.InputValues) (required introspection.InputValues, optionals introspection.InputValues) {
+	for i, v := range values {
+		if v.TypeRef != nil && !v.TypeRef.IsOptional() {
+			continue
+		}
+		return values[:i], values[i:]
+	}
+	return values, nil
+}
+
+func getRequiredArgs(values introspection.InputValues) introspection.InputValues {
+	required, _ := splitRequiredOptionalArgs(values)
+	return required
+}
+
+func getOptionalArgs(values introspection.InputValues) introspection.InputValues {
+	_, optional := splitRequiredOptionalArgs(values)
+	return optional
 }

--- a/codegen/generator/nodejs/templates/functions_test.go
+++ b/codegen/generator/nodejs/templates/functions_test.go
@@ -1,0 +1,60 @@
+package templates
+
+import (
+	"context"
+	"testing"
+
+	"dagger.io/dagger"
+	"github.com/dagger/dagger/codegen/generator"
+	"github.com/dagger/dagger/codegen/introspection"
+	"github.com/stretchr/testify/require"
+)
+
+var currentSchema *introspection.Schema
+
+func init() {
+	ctx := context.Background()
+	client, err := dagger.Connect(ctx)
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	currentSchema, err = generator.Introspect(ctx, client)
+	if err != nil {
+		panic(err)
+	}
+	generator.SetSchemaParents(currentSchema)
+}
+
+func getField(t *introspection.Type, name string) *introspection.Field {
+	for _, v := range t.Fields {
+		if v.Name == name {
+			return v
+		}
+	}
+	return nil
+}
+
+func TestSplitRequiredOptionalArgs(t *testing.T) {
+	t.Run("container exec", func(t *testing.T) {
+		container := currentSchema.Types.Get("Container")
+		require.NotNil(t, container)
+		execField := getField(container, "exec")
+
+		t.Log(container)
+		required, optional := splitRequiredOptionalArgs(execField.Args)
+		require.Equal(t, execField.Args[:0], required)
+		require.Equal(t, execField.Args, optional)
+	})
+	t.Run("container export", func(t *testing.T) {
+		container := currentSchema.Types.Get("Container")
+		require.NotNil(t, container)
+		execField := getField(container, "export")
+
+		t.Log(container)
+		required, optional := splitRequiredOptionalArgs(execField.Args)
+		require.Equal(t, execField.Args[:1], required)
+		require.Equal(t, execField.Args[1:], optional)
+	})
+}

--- a/codegen/generator/nodejs/templates/src/args_test.go
+++ b/codegen/generator/nodejs/templates/src/args_test.go
@@ -30,10 +30,6 @@ func TestArgs(t *testing.T) {
 			err := json.Unmarshal([]byte(jsonData), &elems)
 			require.NoError(t, err)
 
-			for _, elem := range elems {
-				t.Log("optional:", elem.Name, ":", elem.TypeRef.IsOptional())
-			}
-
 			var b bytes.Buffer
 			err = tmpl.ExecuteTemplate(&b, "args", elems)
 

--- a/codegen/generator/nodejs/templates/src/method.ts.tmpl
+++ b/codegen/generator/nodejs/templates/src/method.ts.tmpl
@@ -1,13 +1,39 @@
 {{ define "method" }}
+	{{- $parentName := .ParentObject.Name }}
+	
+	{{- $required := GetRequiredArgs .Args }}
+	{{- $optionals := GetOptionalArgs .Args }}
+	{{- if $optionals }}
+		{{- if eq $parentName "Query" }}
+			{{- $parentName = "Client" }}
+		{{- end -}}
+	{{- end }}
+
 {{- template "method_comment" . }}
-{{- "" }}  {{ .Name -}}({{- template "args" .Args -}}){{ template "return" .TypeRef }} {
+{{- "" }}  {{ .Name -}}(
+{{- with $required }}
+	{{- template "args" $required }}
+{{- end }}
+{{- if $optionals }}
+	{{- if $required }}, {{ end }}
+	{{- "" }}opts?: {{ $parentName | PascalCase }}{{ .Name | PascalCase }}Opts
+{{- end }}
+{{- "" }}){{ template "return" .TypeRef }} {
 		{{- if .TypeRef }}
     return new {{ .TypeRef | FormatOutputType }}({queryTree: [
       ...this._queryTree,
       {
       operation: '{{ .Name}}'
-			{{- if .Args }},
-      args: { {{- template "call_args" .Args -}} }
+			{{- if or $required $optionals }},
+      args: { {{""}}
+      				{{- with $required }}
+					{{- template "call_args" $required }}
+				{{- end }}
+      				{{- with $optionals }}
+      					{{- if $required }}, {{ end -}}
+        ...opts
+				{{- end -}}
+{{""}} }
 			{{- end }}
       }
     ], host: this.clientHost})

--- a/codegen/generator/nodejs/templates/src/method_comment.ts.tmpl
+++ b/codegen/generator/nodejs/templates/src/method_comment.ts.tmpl
@@ -2,6 +2,8 @@
   {{- if .Description -}}
     {{- $commentLines := CommentToLines .Description }}
     {{- /* we split the comment string into a string slice of one line per element */ -}}
+    {{- $required := GetRequiredArgs .Args -}}
+    {{- $optionals := GetOptionalArgs .Args -}}
     {{- $deprecationLines := FormatDeprecation .DeprecationReason }}
 {{""}}
 {{""}}
@@ -10,6 +12,15 @@
    * {{ . }}
   {{- end }}
   {{- if .IsDeprecated }}
+   *
+  {{- range $required }}
+    {{- if .Description }}
+   * @param {{ .Description }}
+    {{- end }}
+  {{- end }}
+  {{- if $optionals }}
+   * @param opts optional params for {{ .Name | FormatName }}
+  {{- end }}
    *
   {{- range $deprecationLines }}
    * {{ . }}

--- a/codegen/generator/nodejs/templates/src/method_solve.ts.tmpl
+++ b/codegen/generator/nodejs/templates/src/method_solve.ts.tmpl
@@ -1,14 +1,40 @@
 {{ define "method_solve" }}
+	{{- $parentName := .ParentObject.Name }}
+	
+	{{- $required := GetRequiredArgs .Args }}
+	{{- $optionals := GetOptionalArgs .Args }}
+	{{- if $optionals }}
+		{{- if eq $parentName "Query" }}
+			{{- $parentName = "Client" }}
+		{{- end -}}
+	{{- end }}
+
 {{- template "method_comment" . }}
-{{- "" }}  async {{ .Name -}}({{- template "args" .Args -}}){{ template "return_solve" .TypeRef }} {
+{{- "" }}  async {{ .Name -}}(
+{{- with $required }}
+	{{- template "args" $required }}
+{{- end }}
+{{- if $optionals }}
+	{{- if $required }}, {{ end }}
+	{{- "" }}opts?: {{ $parentName | PascalCase }}{{ .Name | PascalCase }}Opts
+{{- end }}
+{{- "" }}){{ template "return_solve" .TypeRef }} {
 		{{- if .TypeRef }}
     const response: Awaited<{{ .TypeRef | FormatOutputType }}> = await queryBuilder(
       [
       ...this._queryTree,
       {
       operation: '{{ .Name }}'
-			{{- if .Args }},
-      args: { {{- template "call_args" .Args -}} }
+			{{- if or $required $optionals }},
+      args: { {{""}}
+      				{{- with $required }}
+					{{- template "call_args" $required }}
+				{{- end }}
+      				{{- with $optionals }}
+      					{{- if $required }}, {{ end -}}
+				...opts
+				{{- end -}}
+{{""}} }
 			{{- end }}
       }
     ],

--- a/codegen/generator/nodejs/templates/src/object_test.go
+++ b/codegen/generator/nodejs/templates/src/object_test.go
@@ -26,12 +26,12 @@ func TestObject(t *testing.T) {
 
 var wantTestObject = `
 export class Container extends BaseClient {
-  exec(args?: string[], stdin?: string, redirectStdout?: string, redirectStderr?: string): Container {
+  exec(opts?: ContainerExecOpts): Container {
     return new Container({queryTree: [
       ...this._queryTree,
       {
       operation: 'exec',
-      args: {args, stdin, redirectStdout, redirectStderr}
+      args: { ...opts }
       }
     ], host: this.clientHost})
   }

--- a/codegen/generator/nodejs/templates/src/objects_test.go
+++ b/codegen/generator/nodejs/templates/src/objects_test.go
@@ -62,12 +62,12 @@ export class Host extends BaseClient {
   /**
    * Access a directory on the host
    */
-  directory(path: string, exclude?: string[], include?: string[]): Directory {
+  directory(path: string, opts?: HostDirectoryOpts): Directory {
     return new Directory({queryTree: [
       ...this._queryTree,
       {
       operation: 'directory',
-      args: {path, exclude, include}
+      args: { path, ...opts }
       }
     ], host: this.clientHost})
   }
@@ -81,7 +81,7 @@ export class Host extends BaseClient {
       ...this._queryTree,
       {
       operation: 'envVariable',
-      args: {name}
+      args: { name }
       }
     ], host: this.clientHost})
   }
@@ -90,12 +90,12 @@ export class Host extends BaseClient {
   /**
    * The current working directory on the host
    */
-  workdir(exclude?: string[], include?: string[]): Directory {
+  workdir(opts?: HostWorkdirOpts): Directory {
     return new Directory({queryTree: [
       ...this._queryTree,
       {
       operation: 'workdir',
-      args: {exclude, include}
+      args: { ...opts }
       }
     ], host: this.clientHost})
   }

--- a/codegen/generator/nodejs/templates/src/type.ts.tmpl
+++ b/codegen/generator/nodejs/templates/src/type.ts.tmpl
@@ -1,7 +1,29 @@
 {{ define "type" -}}
+	{{- $typeName := .Name }}
+	{{- if  eq $typeName "Query" }}
+		{{- $typeName = "Client" -}}
+	{{- end -}}
+
 	{{- if IsCustomScalar . }}
 {{ template "object_comment" .Description }}
 export type {{ .Name }} = string;
 {{ "" }}
+	{{- end }}
+	{{- with .Fields }}
+		{{- range . -}}
+			{{- $optionals := GetOptionalArgs .Args }}
+			{{- $argsLen := len $optionals }}
+			{{- if gt $argsLen 0 }}
+export type {{ $typeName }}{{ .Name | PascalCase }}Opts = {
+				{{- range $optionals }}
+					{{- $opt := "" -}}
+					{{- if .TypeRef.IsOptional }}
+						{{- $opt = "?" -}}
+					{{- end }}
+  {{ .Name }}{{ $opt }}: {{ .TypeRef | FormatInputType }};
+				{{- end }}
+};
+{{ "" }}		{{- end }}
+		{{- end }}
 	{{- end }}
 {{- end }}

--- a/codegen/generator/nodejs/templates/src/type.ts.tmpl
+++ b/codegen/generator/nodejs/templates/src/type.ts.tmpl
@@ -20,6 +20,9 @@ export type {{ $typeName }}{{ .Name | PascalCase }}Opts = {
 					{{- if .TypeRef.IsOptional }}
 						{{- $opt = "?" -}}
 					{{- end }}
+					{{- if .Description }}
+{{ template "type_field_comment" .Description }}
+					{{- end }}
   {{ .Name }}{{ $opt }}: {{ .TypeRef | FormatInputType }};
 				{{- end }}
 };

--- a/codegen/generator/nodejs/templates/src/type_field_comment.ts.tmpl
+++ b/codegen/generator/nodejs/templates/src/type_field_comment.ts.tmpl
@@ -1,0 +1,11 @@
+{{ define "type_field_comment" -}}
+	{{- if . -}}
+		{{- /* we split the comment string into a string slice of one line per element */ -}}
+		{{- $commentLines := CommentToLines . }}
+  /**
+		{{- range $commentLines }}
+   * {{ . }}
+		{{- end }}
+   */
+	{{- end }}
+{{- end }}

--- a/codegen/generator/nodejs/templates/src/type_test.go
+++ b/codegen/generator/nodejs/templates/src/type_test.go
@@ -39,10 +39,32 @@ export type Container = string;
 	t.Run("args", func(t *testing.T) {
 		var expectedFieldArgsType = `
 export type ContainerExecOpts = {
+
+  /**
+   * Command to run instead of the container's default command
+   */
   args?: string[];
+
+  /**
+   * Content to write to the command's standard input before closing
+   */
   stdin?: string;
+
+  /**
+   * Redirect the command's standard output to a file in the container
+   */
   redirectStdout?: string;
+
+  /**
+   * Redirect the command's standard error to a file in the container
+   */
   redirectStderr?: string;
+
+  /**
+   * Provide dagger access to the executed command
+   * Do not use this option unless you trust the command being executed
+   * The command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM
+   */
   experimentalPrivilegedNesting?: boolean;
 };
 `

--- a/codegen/generator/nodejs/templates/src/type_test.go
+++ b/codegen/generator/nodejs/templates/src/type_test.go
@@ -8,30 +8,130 @@ import (
 )
 
 func TestType(t *testing.T) {
-	tmpl := templateHelper(t)
-
-	object := objectInit(t, fieldArgsTypeJSON)
-
-	var b bytes.Buffer
-	err := tmpl.ExecuteTemplate(&b, "type", object)
-
-	want := expectedFieldArgsType
-
-	require.NoError(t, err)
-	require.Equal(t, want, b.String())
-}
-
-var expectedFieldArgsType = `
+	t.Run("scalar", func(t *testing.T) {
+		var expectedFieldArgsType = `
 /**
  * Hola
  */
 export type Container = string;
 `
 
-var fieldArgsTypeJSON = `
+		var fieldArgsTypeJSON = `
       {
         "kind": "SCALAR",
         "name": "Container",
         "description": "Hola"
     }
 `
+		tmpl := templateHelper(t)
+
+		object := objectInit(t, fieldArgsTypeJSON)
+
+		var b bytes.Buffer
+		err := tmpl.ExecuteTemplate(&b, "type", object)
+
+		want := expectedFieldArgsType
+
+		require.NoError(t, err)
+		require.Equal(t, want, b.String())
+	})
+
+	t.Run("args", func(t *testing.T) {
+		var expectedFieldArgsType = `
+export type ContainerExecOpts = {
+  args?: string[];
+  stdin?: string;
+  redirectStdout?: string;
+  redirectStderr?: string;
+  experimentalPrivilegedNesting?: boolean;
+};
+`
+
+		var fieldArgsTypeJSON = `
+    {
+      "description": "An OCI-compatible container, also known as a docker container",
+      "fields": [
+	{
+          "args": [
+            {
+              "defaultValue": null,
+              "description": "Command to run instead of the container's default command",
+              "name": "args",
+              "type": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String"
+                  }
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "Content to write to the command's standard input before closing",
+              "name": "stdin",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "Redirect the command's standard output to a file in the container",
+              "name": "redirectStdout",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "Redirect the command's standard error to a file in the container",
+              "name": "redirectStderr",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String"
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "Provide dagger access to the executed command\nDo not use this option unless you trust the command being executed\nThe command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM",
+              "name": "experimentalPrivilegedNesting",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean"
+              }
+            }
+          ],
+          "deprecationReason": "",
+          "description": "This container after executing the specified command inside it",
+          "isDeprecated": false,
+          "name": "exec",
+          "type": {
+            "kind": "NON_NULL",
+            "ofType": {
+              "kind": "OBJECT",
+              "name": "Container"
+            }
+          }
+        }
+      ],
+      "kind": "OBJECT",
+      "name": "Container"
+    }
+`
+		tmpl := templateHelper(t)
+
+		object := objectInit(t, fieldArgsTypeJSON)
+
+		var b bytes.Buffer
+		err := tmpl.ExecuteTemplate(&b, "type", object)
+
+		want := expectedFieldArgsType
+
+		require.NoError(t, err)
+		require.Equal(t, want, b.String())
+	})
+}

--- a/codegen/generator/nodejs/templates/templates.go
+++ b/codegen/generator/nodejs/templates/templates.go
@@ -13,7 +13,7 @@ var srcs embed.FS
 func New() *template.Template {
 	topLevelTemplate := "api"
 	templateDeps := []string{
-		topLevelTemplate, "header", "objects", "object", "object_comment", "class_comment", "method", "method_solve", "call_args", "return", "return_solve", "method_comment", "types", "type", "args", "arg",
+		topLevelTemplate, "header", "objects", "object", "object_comment", "class_comment", "method", "method_solve", "call_args", "return", "return_solve", "method_comment", "types", "type", "type_field_comment", "args", "arg",
 	}
 
 	fileNames := make([]string, 0, len(templateDeps))

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -54,10 +54,31 @@ export type ContainerBuildOpts = {
 }
 
 export type ContainerExecOpts = {
+  /**
+   * Command to run instead of the container's default command
+   */
   args?: string[]
+
+  /**
+   * Content to write to the command's standard input before closing
+   */
   stdin?: string
+
+  /**
+   * Redirect the command's standard output to a file in the container
+   */
   redirectStdout?: string
+
+  /**
+   * Redirect the command's standard error to a file in the container
+   */
   redirectStderr?: string
+
+  /**
+   * Provide dagger access to the executed command
+   * Do not use this option unless you trust the command being executed
+   * The command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM
+   */
   experimentalPrivilegedNesting?: boolean
 }
 
@@ -79,9 +100,26 @@ export type ContainerWithDirectoryOpts = {
 }
 
 export type ContainerWithExecOpts = {
+  /**
+   * Content to write to the command's standard input before closing
+   */
   stdin?: string
+
+  /**
+   * Redirect the command's standard output to a file in the container
+   */
   redirectStdout?: string
+
+  /**
+   * Redirect the command's standard error to a file in the container
+   */
   redirectStderr?: string
+
+  /**
+   * Provide dagger access to the executed command
+   * Do not use this option unless you trust the command being executed
+   * The command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM
+   */
   experimentalPrivilegedNesting?: boolean
 }
 
@@ -311,6 +349,8 @@ export class Container extends BaseClient {
   /**
    * This container after executing the specified command inside it
    *
+   * @param opts optional params for exec
+   *
    * @deprecated Replaced by withExec.
    */
   exec(opts?: ContainerExecOpts): Container {
@@ -396,6 +436,7 @@ export class Container extends BaseClient {
 
   /**
    * This container's root filesystem. Mounts are not included.
+   *
    *
    * @deprecated Replaced by rootfs.
    */
@@ -634,6 +675,7 @@ export class Container extends BaseClient {
 
   /**
    * Initialize this container from this DirectoryID
+   *
    *
    * @deprecated Replaced by withRootfs.
    */
@@ -1456,6 +1498,8 @@ export class Host extends BaseClient {
 
   /**
    * The current working directory on the host
+   *
+   * @param opts optional params for workdir
    *
    * @deprecated Use directory with path set to '.' instead.
    */

--- a/sdk/nodejs/test/connect.spec.ts
+++ b/sdk/nodejs/test/connect.spec.ts
@@ -2,7 +2,7 @@ import { connect } from "../connect.js"
 import assert, { AssertionError } from "assert"
 import { GraphQLRequestError } from "../common/errors/index.js"
 
-describe("NodeJS sdk", function () {
+describe("NodeJS sdk Connect", function () {
   it("Connect to local engine and execute a simple query to make sure it does not fail", async function () {
     this.timeout(60000)
 


### PR DESCRIPTION
Now we can use best of both world:
- required params are available directly in the function params
- optional params are available through an object that lets you mix and match the options you want

```diff
- withExec(args: string[], stdin?: string, redirectStdout?: string, redirectStderr?: string, experimentalPrivilegedNesting?: boolean): Container {
-
+ export type ContainerWithExecOpts = {
+   stdin?: string
+   redirectStdout?: string
+   redirectStderr?: string
+   experimentalPrivilegedNesting?: boolean
+ }
+ withExec(args: string[], opts?: ContainerWithExecOpts): Container {
```
