### PR TITLE
ci: Publish CLI & Engine at the same time

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,21 +1,8 @@
-name: publish-engine
+name: publish
 on:
   push:
-    branches:
-      - main
-    tags:
-      - "v*"
-    paths:
-      - "cmd/**"
-      - "codegen/**"
-      - "core/**"
-      - "engine/**"
-      - "internal/engine/**"
-      - "project/**"
-      - "router/**"
-      - "secret/**"
-      - "tracing/**"
-      - go.mod
+    branches: ["main"]
+    tags: ["v**"]
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -33,7 +20,18 @@ jobs:
           password: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}
       - run: ./hack/make-prod dagger:publish ${{ github.ref_name }}
 
-      - name: Bump SDK Engine Dependencies
+      - name: "Publish Engine & CLI"
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.RELEASE_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RELEASE_AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.RELEASE_AWS_REGION }}
+          AWS_BUCKET: ${{ secrets.RELEASE_AWS_BUCKET }}
+          ARTEFACTS_FQDN: ${{ secrets.RELEASE_FQDN }}
+          HOMEBREW_TAP_OWNER: ${{ secrets.RELEASE_HOMEBREW_TAP_OWNER }}
+        run: ./hack/make dagger:publish ${{ github.ref_name }}
+
+      - name: "Bump SDK Engine Dependencies"
         uses: peter-evans/create-pull-request@v3
         if: github.ref_name != 'main'
         with:
@@ -48,5 +46,3 @@ jobs:
             This PR was auto-generated.
           delete-branch: true
           branch: bump-engine
-
-      ## TODO add publish CLI workflow

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,7 @@ jobs:
       - name: "Publish Engine & CLI"
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}
+          DAGGER_ENGINE_IMAGE: ${{ secrets.RELEASE_DAGGER_ENGINE_IMAGE }}
           AWS_ACCESS_KEY_ID: ${{ secrets.RELEASE_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.RELEASE_AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.RELEASE_AWS_REGION }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -86,9 +86,7 @@ publishers:
 
 # https://goreleaser.com/customization/release/
 release:
-  prerelease: "true"
   footer: |
-    **Full Changelog**: https://github.com/dagger/dagger/compare/{{ .PreviousTag }}...{{ .Tag }}
     ## What to do next?
     - Read the [documentation](https://docs.dagger.io)
     - Join our [Discord server](https://discord.gg/dagger-io)

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,23 +59,22 @@ blobs:
     folder: "dagger/releases/{{ .Version }}"
 
 publishers:
-  # TODO: uncomment publishers below 👇 when we are finished publishing pre-releases.
-  # - name: publish-latest-version
-  #   cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://{{ .Env.AWS_BUCKET }}/dagger/latest_version"
-  #   env:
-  #     - PATH={{ .Env.PATH }}
-  #     - AWS_EC2_METADATA_DISABLED=true
-  #     - AWS_ACCESS_KEY_ID={{ .Env.AWS_ACCESS_KEY_ID }}
-  #     - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
-  #     - AWS_REGION={{ .Env.AWS_REGION }}
-  # - name: publish-latest
-  #   cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://{{ .Env.AWS_BUCKET }}/dagger/versions/latest"
-  #   env:
-  #     - PATH={{ .Env.PATH }}
-  #     - AWS_EC2_METADATA_DISABLED=true
-  #     - AWS_ACCESS_KEY_ID={{ .Env.AWS_ACCESS_KEY_ID }}
-  #     - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
-  #     - AWS_REGION={{ .Env.AWS_REGION }}
+  - name: publish-latest-version
+    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://{{ .Env.AWS_BUCKET }}/dagger/latest_version"
+    env:
+      - PATH={{ .Env.PATH }}
+      - AWS_EC2_METADATA_DISABLED=true
+      - AWS_ACCESS_KEY_ID={{ .Env.AWS_ACCESS_KEY_ID }}
+      - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
+      - AWS_REGION={{ .Env.AWS_REGION }}
+  - name: publish-latest
+    cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://{{ .Env.AWS_BUCKET }}/dagger/versions/latest"
+    env:
+      - PATH={{ .Env.PATH }}
+      - AWS_EC2_METADATA_DISABLED=true
+      - AWS_ACCESS_KEY_ID={{ .Env.AWS_ACCESS_KEY_ID }}
+      - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
+      - AWS_REGION={{ .Env.AWS_REGION }}
   - name: publish-latest-major-minor
     cmd: sh -c "echo {{ .Version }} | aws s3 cp - s3://{{ .Env.AWS_BUCKET }}/dagger/versions/{{ .Major }}.{{ .Minor }}"
     env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,7 +42,7 @@ brews:
   - tap:
       owner: "{{ .Env.HOMEBREW_TAP_OWNER }}"
       name: homebrew-tap
-    name: dagger@{{ .Major }}.{{ .Minor }}
+    name: dagger
     commit_author:
       name: dagger-bot
       email: noreply@dagger.io

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,6 @@ archives:
   - name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
     files:
       - LICENSE
-      - examples/**/*
     format_overrides:
       - goos: windows
         format: zip

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,27 +37,6 @@ checksum:
 snapshot:
   name_template: "{{ .Tag }}-next"
 
-changelog:
-  use: github
-  sort: asc
-  filters:
-    exclude:
-      - "^doc"
-      - "^test"
-      - "^ci"
-      - "^website"
-      - "^infra"
-      - "^chore"
-      - "^build"
-      - "^Merge"
-      - "^sdk"
-  groups:
-    - title: Breaking Changes
-      regexp: "^.*!:+.*$"
-      order: 0
-    - title: Changes
-      order: 999
-
 # https://goreleaser.com/customization/homebrew/
 brews:
   - tap:

--- a/internal/mage/cli.go
+++ b/internal/mage/cli.go
@@ -36,7 +36,7 @@ func (cl Cli) Publish(ctx context.Context) error {
 		WithSecretVariable("HOMEBREW_TAP_OWNER", util.WithSetHostVar(ctx, c.Host(), "HOMEBREW_TAP_OWNER").Secret())
 
 	_, err = container.
-		WithExec([]string{"release", "--rm-dist", "--debug"}).
+		WithExec([]string{"release", "--rm-dist", "--skip-validate", "--debug"}).
 		ExitCode(ctx)
 	return err
 }

--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -23,8 +23,6 @@ const (
 	shimBinName          = "dagger-shim"
 	buildkitRepo         = "github.com/moby/buildkit"
 	buildkitBranch       = "v0.10.5"
-
-	engineImage = "ghcr.io/dagger/engine"
 )
 
 func parseRef(tag string) error {
@@ -78,13 +76,17 @@ func (t Engine) Publish(ctx context.Context, version string) error {
 		return err
 	}
 
-	ref := fmt.Sprintf("%s:%s", engineImage, version)
-
 	c, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
 	if err != nil {
 		return err
 	}
 	defer c.Close()
+
+	engineImage, err := util.WithSetHostVar(ctx, c.Host(), "DAGGER_ENGINE_IMAGE").Value(ctx)
+	if err != nil {
+		return err
+	}
+	ref := fmt.Sprintf("%s:%s", engineImage, version)
 
 	arches := []string{"amd64", "arm64"}
 	oses := []string{"linux", "darwin", "windows"}

--- a/internal/mage/util/util.go
+++ b/internal/mage/util/util.go
@@ -132,8 +132,8 @@ func HostDockerDir(c *dagger.Client) *dagger.Directory {
 
 func WithSetHostVar(ctx context.Context, h *dagger.Host, varName string) *dagger.HostVariable {
 	hv := h.EnvVariable(varName)
-	if val, err := hv.Secret().Plaintext(ctx); err != nil || val == "" {
-		fmt.Fprintf(os.Stderr, "env var %s is empty", varName)
+	if val, _ := hv.Secret().Plaintext(ctx); val == "" {
+		fmt.Fprintf(os.Stderr, "env var %s must be set", varName)
 		os.Exit(1)
 	}
 	return hv


### PR DESCRIPTION
Closes https://github.com/dagger/dagger/issues/4002

- ci: Extend existing publish-engine workflow to include the CLI
- chore: Require DAGGER_ENGINE_IMAGE to be declared via env var
- chore: Skip GoReleaser validation
- chore: Remove examples/** from published CLI binaries
- chore: Disable changelog creation when publishing via GoReleaser
- chore: Publish unversioned brew tap
- chore: Make install.sh use the latest published CLI version

We captured all the interesting details in each commit, they will be visible in the final commit message, part of **Squash and merge**