### PR TITLE
Small fix / typo in Introduction

### DIFF
--- a/docs/current/543069-index.md
+++ b/docs/current/543069-index.md
@@ -73,10 +73,9 @@ To get started with Dagger, simply choose a SDK, then follow that SDK's getting 
 | -- | -- |
 | a Go developer | Use the [Go SDK](sdk/go) |
 | a Python developer | Use the [Python SDK](sdk/python) |
-| a TypeScript/JavaScript developer | Use the [Node.js SDK](sdk/nodejs) |
+| looking for an excuse to learn TypeScript/JavaScript | Use the [Node.js SDK](sdk/nodejs) |
 | looking for an excuse to learn Go | Use the [Go SDK](sdk/go) |
 | looking for an excuse to learn Python | Use the [Python SDK](sdk/python) |
-| looking for an excuse to learn TypeScript/JavaScript | Use the [Node.js SDK](sdk/nodejs) |
 | waiting for your favorite language to be supported | [Let us know which one](https://blocklayer.typeform.com/to/a6m5gKSS), and we'll notify you when it is ready
 | a fan of the [CUE](https://cuelang.org) language | Use the [Dagger CUE SDK](sdk/cue) |
 | enjoying the declarative nature of YAML, but wish it were more powerful | Take a look at the [CUE language](https://cuelang.org). If you like what you see, the [CUE SDK](sdk/cue) may be a good fit. |


### PR DESCRIPTION
NodeJS SDK is referred twice in the SDK list. Nothing serious, but better to remove this kind of small errors in a Get Started section.

Signed-off-by: Ryan Danion <49118858+ryandanion@users.noreply.github.com>