### PR TITLE
support mounting host Unix sockets into containers

### DIFF
--- a/codegen/generator/go/templates/functions.go
+++ b/codegen/generator/go/templates/functions.go
@@ -90,6 +90,7 @@ func formatType(r *introspection.TypeRef, input bool) string {
 					"FileID":      "File",
 					"DirectoryID": "Directory",
 					"SecretID":    "Secret",
+					"SocketID":    "Socket",
 					"CacheID":     "CacheVolume",
 				}
 				if alias, ok := rewrite[ref.Name]; ok && input {

--- a/core/container.go
+++ b/core/container.go
@@ -512,6 +512,29 @@ func (container *Container) WithUnixSocket(ctx context.Context, target string, s
 	return &Container{ID: id}, nil
 }
 
+func (container *Container) WithoutUnixSocket(ctx context.Context, target string) (*Container, error) {
+	payload, err := container.ID.decode()
+	if err != nil {
+		return nil, err
+	}
+
+	target = absPath(payload.Config.WorkingDir, target)
+
+	for i, sock := range payload.Sockets {
+		if sock.UnixPath == target {
+			payload.Sockets = append(payload.Sockets[:i], payload.Sockets[i+1:]...)
+			break
+		}
+	}
+
+	id, err := payload.Encode()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Container{ID: id}, nil
+}
+
 func (container *Container) WithSecretVariable(ctx context.Context, name string, secret *Secret) (*Container, error) {
 	payload, err := container.ID.decode()
 	if err != nil {

--- a/core/container.go
+++ b/core/container.go
@@ -793,7 +793,7 @@ func (container *Container) Exec(ctx context.Context, gw bkgw.Client, defaultPla
 
 		runOpts = append(runOpts,
 			llb.AddSSHSocket(
-				llb.SSHID("socket:"+socket.Socket.String()),
+				llb.SSHID(socket.Socket.LLBID()),
 				llb.SSHSocketTarget(socket.UnixPath),
 			))
 	}

--- a/core/container.go
+++ b/core/container.go
@@ -499,10 +499,23 @@ func (container *Container) WithUnixSocket(ctx context.Context, target string, s
 
 	target = absPath(payload.Config.WorkingDir, target)
 
-	payload.Sockets = append(payload.Sockets, ContainerSocket{
+	newSocket := ContainerSocket{
 		Socket:   source.ID,
 		UnixPath: target,
-	})
+	}
+
+	var replaced bool
+	for i, sock := range payload.Sockets {
+		if sock.UnixPath == target {
+			payload.Sockets[i] = newSocket
+			replaced = true
+			break
+		}
+	}
+
+	if !replaced {
+		payload.Sockets = append(payload.Sockets, newSocket)
+	}
 
 	id, err := payload.Encode()
 	if err != nil {

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -2432,4 +2432,11 @@ func TestContainerWithUnixSocket(t *testing.T) {
 	stdout, err := ctr.Stdout(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "hello\n", stdout)
+
+	without := ctr.WithoutUnixSocket("/tmp/test.sock").
+		WithExec([]string{"ls", "/tmp"})
+
+	stdout, err = without.Stdout(ctx)
+	require.NoError(t, err)
+	require.Empty(t, stdout)
 }

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"io"
 	"net"
 	"os"
@@ -2397,13 +2398,17 @@ func TestContainerWithUnixSocket(t *testing.T) {
 		for {
 			c, err := l.Accept()
 			if err != nil {
-				t.Logf("accept: %s", err)
+				if !errors.Is(err, net.ErrClosed) {
+					t.Logf("accept: %s", err)
+					panic(err)
+				}
 				return
 			}
 
 			n, err := io.Copy(c, c)
 			if err != nil {
 				t.Logf("hello: %s", err)
+				panic(err)
 			}
 
 			t.Logf("copied %d bytes", n)
@@ -2411,6 +2416,7 @@ func TestContainerWithUnixSocket(t *testing.T) {
 			err = c.Close()
 			if err != nil {
 				t.Logf("close: %s", err)
+				panic(err)
 			}
 		}
 	}()

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -153,7 +153,10 @@ sleep infinity
 		for {
 			c, err := l.Accept()
 			if err != nil {
-				t.Logf("agent accept: %s", err)
+				if !errors.Is(err, net.ErrClosed) {
+					t.Logf("accept: %s", err)
+					panic(err)
+				}
 				break
 			}
 
@@ -162,8 +165,7 @@ sleep infinity
 			err = agent.ServeAgent(sshAgent, c)
 			if err != nil && !errors.Is(err, io.EOF) {
 				t.Logf("serve agent: %s", err)
-				t.Fail()
-				break
+				panic(err)
 			}
 		}
 	}()

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -2,11 +2,19 @@ package core
 
 import (
 	"context"
+	"errors"
+	"io"
+	"net"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"dagger.io/dagger"
 	"github.com/dagger/dagger/internal/testutil"
+	"github.com/moby/buildkit/identity"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
 )
 
 func TestGit(t *testing.T) {
@@ -53,6 +61,121 @@ func TestGit(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, res.Git.Branch.Tree.File.Contents, "Dagger")
 	require.Contains(t, res.Git.Commit.Tree.File.Contents, "Dagger")
+}
+
+func TestGitSSHAuthSock(t *testing.T) {
+	c, ctx := connect(t)
+	defer c.Close()
+
+	gitSSH := c.Container().
+		From("alpine:3.16.2").
+		WithExec([]string{"apk", "add", "git", "openssh"})
+
+	hostKeyGen := gitSSH.
+		WithExec([]string{
+			"ssh-keygen", "-t", "rsa", "-b", "4096", "-f", "/root/.ssh/host_key", "-N", "",
+		}).
+		WithExec([]string{
+			"ssh-keygen", "-t", "rsa", "-b", "4096", "-f", "/root/.ssh/id_rsa", "-N", "",
+		}).
+		WithExec([]string{
+			"cp", "/root/.ssh/id_rsa.pub", "/root/.ssh/authorized_keys",
+		})
+
+	hostPubKey, err := hostKeyGen.File("/root/.ssh/host_key.pub").Contents(ctx)
+	require.NoError(t, err)
+
+	userPrivateKey, err := hostKeyGen.File("/root/.ssh/id_rsa").Contents(ctx)
+	require.NoError(t, err)
+
+	setupScript := c.Directory().
+		WithNewFile("setup.sh", `#!/bin/sh
+
+set -e -u -x
+
+cd /root
+mkdir repo
+
+cd repo
+git init
+git branch -m main
+echo test >> README.md
+git add README.md
+git config --global user.email "root@localhost"
+git config --global user.name "Test User"
+git commit -m "init"
+
+chmod 0600 ~/.ssh/host_key
+$(which sshd) -h ~/.ssh/host_key -p 3486
+
+sleep infinity
+`).
+		File("setup.sh")
+
+	go func() {
+		_, err := hostKeyGen.
+			WithMountedFile("/root/start.sh", setupScript).
+			WithExec([]string{"sh", "/root/start.sh"}).
+			ExitCode(ctx)
+		if err != nil {
+			t.Logf("error running git + ssh: %v", err)
+		}
+	}()
+
+	// include a random ID so it runs every time (hack until we have no-cache or equivalent support)
+	randomID := identity.NewID()
+
+	t.Logf("polling for ssh server with id %s", randomID)
+
+	_, err = c.Container().
+		From("alpine:3.16.2").
+		WithEnvVariable("RANDOM", randomID).
+		WithExec([]string{"sh", "-c", "for i in $(seq 1 120); do nc -zv 127.0.0.1 3486 && exit 0; sleep 1; done; exit 1"}).
+		ExitCode(ctx)
+	require.NoError(t, err)
+
+	key, err := ssh.ParseRawPrivateKey([]byte(userPrivateKey))
+	require.NoError(t, err)
+
+	sshAgent := agent.NewKeyring()
+	err = sshAgent.Add(agent.AddedKey{
+		PrivateKey: key,
+	})
+	require.NoError(t, err)
+
+	tmp := t.TempDir()
+	sock := filepath.Join(tmp, "agent.sock")
+	l, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+	defer l.Close()
+
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				t.Logf("agent accept: %s", err)
+				break
+			}
+
+			t.Log("agent serving")
+
+			err = agent.ServeAgent(sshAgent, c)
+			if err != nil && !errors.Is(err, io.EOF) {
+				t.Logf("serve agent: %s", err)
+				t.Fail()
+				break
+			}
+		}
+	}()
+
+	entries, err := c.Git("ssh://root@127.0.0.1:3486/root/repo").
+		Branch("main").
+		Tree(dagger.GitRefTreeOpts{
+			SSHKnownHosts: "[127.0.0.1]:3486 " + strings.TrimSpace(hostPubKey),
+			SSHAuthSocket: c.Host().UnixSocket(sock),
+		}).Entries(ctx)
+	require.NoError(t, err)
+	require.Equal(t, []string{"README.md"}, entries)
 }
 
 func TestGitKeepGitDir(t *testing.T) {

--- a/core/integration/testdata/socket-echo.go
+++ b/core/integration/testdata/socket-echo.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintln(os.Stderr, "usage: %s <socket> <message>", os.Args[0])
+		os.Exit(1)
+		return
+	}
+
+	c, err := net.Dial("unix", os.Args[1])
+	if err != nil {
+		panic(err)
+	}
+
+	defer c.Close()
+
+	_, err = fmt.Fprintln(c, os.Args[2])
+	if err != nil {
+		panic(err)
+	}
+
+	var res string
+	n, err := fmt.Fscanln(c, &res)
+	if err != nil && n == 0 {
+		panic(err)
+	}
+
+	fmt.Println(res)
+}

--- a/core/schema/base.go
+++ b/core/schema/base.go
@@ -11,7 +11,6 @@ import (
 
 type InitializeArgs struct {
 	Router        *router.Router
-	SSHAuthSockID string
 	Workdir       string
 	Gateway       bkgw.Client
 	BKClient      *bkclient.Client
@@ -23,13 +22,12 @@ type InitializeArgs struct {
 
 func New(params InitializeArgs) (router.ExecutableSchema, error) {
 	base := &baseSchema{
-		router:        params.Router,
-		gw:            params.Gateway,
-		bkClient:      params.BKClient,
-		solveOpts:     params.SolveOpts,
-		solveCh:       params.SolveCh,
-		platform:      params.Platform,
-		sshAuthSockID: params.SSHAuthSockID,
+		router:    params.Router,
+		gw:        params.Gateway,
+		bkClient:  params.BKClient,
+		solveOpts: params.SolveOpts,
+		solveCh:   params.SolveCh,
+		platform:  params.Platform,
 	}
 	host := core.NewHost(params.Workdir, params.DisableHostRW)
 	return router.MergeExecutableSchemas("core",
@@ -51,11 +49,10 @@ func New(params InitializeArgs) (router.ExecutableSchema, error) {
 }
 
 type baseSchema struct {
-	router        *router.Router
-	gw            bkgw.Client
-	bkClient      *bkclient.Client
-	solveOpts     bkclient.SolveOpt
-	solveCh       chan *bkclient.SolveStatus
-	platform      specs.Platform
-	sshAuthSockID string
+	router    *router.Router
+	gw        bkgw.Client
+	bkClient  *bkclient.Client
+	solveOpts bkclient.SolveOpt
+	solveCh   chan *bkclient.SolveStatus
+	platform  specs.Platform
 }

--- a/core/schema/base.go
+++ b/core/schema/base.go
@@ -46,6 +46,7 @@ func New(params InitializeArgs) (router.ExecutableSchema, error) {
 		},
 		&httpSchema{base},
 		&platformSchema{base},
+		&socketSchema{base, host},
 	)
 }
 

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -61,6 +61,7 @@ func (s *containerSchema) Resolvers() router.Resolvers {
 			"withMountedCache":     router.ToResolver(s.withMountedCache),
 			"withMountedSecret":    router.ToResolver(s.withMountedSecret),
 			"withUnixSocket":       router.ToResolver(s.withUnixSocket),
+			"withoutUnixSocket":    router.ToResolver(s.withoutUnixSocket),
 			"withoutMount":         router.ToResolver(s.withoutMount),
 			"withExec":             router.ToResolver(s.withExec),
 			"exec":                 router.ToResolver(s.withExec), // deprecated
@@ -435,6 +436,14 @@ type containerWithUnixSocketArgs struct {
 
 func (s *containerSchema) withUnixSocket(ctx *router.Context, parent *core.Container, args containerWithUnixSocketArgs) (*core.Container, error) {
 	return parent.WithUnixSocket(ctx, args.Path, core.NewSocket(args.Source))
+}
+
+type containerWithoutUnixSocketArgs struct {
+	Path string
+}
+
+func (s *containerSchema) withoutUnixSocket(ctx *router.Context, parent *core.Container, args containerWithoutUnixSocketArgs) (*core.Container, error) {
+	return parent.WithoutUnixSocket(ctx, args.Path)
 }
 
 func (s *containerSchema) platform(ctx *router.Context, parent *core.Container, args any) (specs.Platform, error) {

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -60,6 +60,7 @@ func (s *containerSchema) Resolvers() router.Resolvers {
 			"withMountedTemp":      router.ToResolver(s.withMountedTemp),
 			"withMountedCache":     router.ToResolver(s.withMountedCache),
 			"withMountedSecret":    router.ToResolver(s.withMountedSecret),
+			"withUnixSocket":       router.ToResolver(s.withUnixSocket),
 			"withoutMount":         router.ToResolver(s.withoutMount),
 			"withExec":             router.ToResolver(s.withExec),
 			"exec":                 router.ToResolver(s.withExec), // deprecated
@@ -425,6 +426,15 @@ type containerWithMountedSecretArgs struct {
 
 func (s *containerSchema) withMountedSecret(ctx *router.Context, parent *core.Container, args containerWithMountedSecretArgs) (*core.Container, error) {
 	return parent.WithMountedSecret(ctx, args.Path, core.NewSecret(args.Source))
+}
+
+type containerWithUnixSocketArgs struct {
+	Path   string
+	Source core.SocketID
+}
+
+func (s *containerSchema) withUnixSocket(ctx *router.Context, parent *core.Container, args containerWithUnixSocketArgs) (*core.Container, error) {
+	return parent.WithUnixSocket(ctx, args.Path, core.NewSocket(args.Source))
 }
 
 func (s *containerSchema) platform(ctx *router.Context, parent *core.Container, args any) (specs.Platform, error) {

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -111,6 +111,9 @@ type Container {
   """
   withoutMount(path: String!): Container!
 
+  "This container plus a socket forwarded to the given Unix socket path"
+  withUnixSocket(path: String!, source: SocketID!): Container!
+
   "This container after executing the specified command inside it"
   withExec(
     "Command to run instead of the container's default command"

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -114,6 +114,9 @@ type Container {
   "This container plus a socket forwarded to the given Unix socket path"
   withUnixSocket(path: String!, source: SocketID!): Container!
 
+  "This container with a previously added Unix socket removed"
+  withoutUnixSocket(path: String!): Container!
+
   "This container after executing the specified command inside it"
   withExec(
     "Command to run instead of the container's default command"

--- a/core/schema/fs.go
+++ b/core/schema/fs.go
@@ -28,3 +28,6 @@ var Host string
 
 //go:embed platform.graphqls
 var Platform string
+
+//go:embed socket.graphqls
+var Socket string

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -107,13 +107,17 @@ func (s *gitSchema) digest(ctx *router.Context, parent any, args any) (any, erro
 	return nil, ErrNotImplementedYet
 }
 
-func (s *gitSchema) tree(ctx *router.Context, parent gitRef, args any) (*core.Directory, error) {
+type gitTreeArgs struct {
+	SshAuthSocket core.SocketID
+}
+
+func (s *gitSchema) tree(ctx *router.Context, parent gitRef, args gitTreeArgs) (*core.Directory, error) {
 	var opts []llb.GitOption
 	if parent.Repository.KeepGitDir {
 		opts = append(opts, llb.KeepGitDir())
 	}
-	if s.sshAuthSockID != "" {
-		opts = append(opts, llb.MountSSHSock(s.sshAuthSockID))
+	if args.SshAuthSocket != "" {
+		opts = append(opts, llb.MountSSHSock(args.SshAuthSocket.LLBID()))
 	}
 	st := llb.Git(parent.Repository.URL, parent.Name, opts...)
 	return core.NewDirectory(ctx, st, "", s.platform)

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -108,6 +108,7 @@ func (s *gitSchema) digest(ctx *router.Context, parent any, args any) (any, erro
 }
 
 type gitTreeArgs struct {
+	SSHKnownHosts string        `json:"sshKnownHosts"`
 	SSHAuthSocket core.SocketID `json:"sshAuthSocket"`
 }
 
@@ -115,6 +116,9 @@ func (s *gitSchema) tree(ctx *router.Context, parent gitRef, args gitTreeArgs) (
 	var opts []llb.GitOption
 	if parent.Repository.KeepGitDir {
 		opts = append(opts, llb.KeepGitDir())
+	}
+	if args.SSHKnownHosts != "" {
+		opts = append(opts, llb.KnownSSHHosts(args.SSHKnownHosts))
 	}
 	if args.SSHAuthSocket != "" {
 		opts = append(opts, llb.MountSSHSock(args.SSHAuthSocket.LLBID()))

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -108,7 +108,7 @@ func (s *gitSchema) digest(ctx *router.Context, parent any, args any) (any, erro
 }
 
 type gitTreeArgs struct {
-	SshAuthSocket core.SocketID
+	SSHAuthSocket core.SocketID `json:"sshAuthSocket"`
 }
 
 func (s *gitSchema) tree(ctx *router.Context, parent gitRef, args gitTreeArgs) (*core.Directory, error) {
@@ -116,8 +116,8 @@ func (s *gitSchema) tree(ctx *router.Context, parent gitRef, args gitTreeArgs) (
 	if parent.Repository.KeepGitDir {
 		opts = append(opts, llb.KeepGitDir())
 	}
-	if args.SshAuthSocket != "" {
-		opts = append(opts, llb.MountSSHSock(args.SshAuthSocket.LLBID()))
+	if args.SSHAuthSocket != "" {
+		opts = append(opts, llb.MountSSHSock(args.SSHAuthSocket.LLBID()))
 	}
 	st := llb.Git(parent.Repository.URL, parent.Name, opts...)
 	return core.NewDirectory(ctx, st, "", s.platform)

--- a/core/schema/git.graphqls
+++ b/core/schema/git.graphqls
@@ -22,5 +22,5 @@ type GitRef {
     "The digest of the current value of this ref"
     digest: String!
     "The filesystem tree at this ref"
-    tree: Directory!
+    tree(sshAuthSocket: SocketID): Directory!
 }

--- a/core/schema/git.graphqls
+++ b/core/schema/git.graphqls
@@ -22,5 +22,5 @@ type GitRef {
     "The digest of the current value of this ref"
     digest: String!
     "The filesystem tree at this ref"
-    tree(sshAuthSocket: SocketID): Directory!
+    tree(sshKnownHosts: String, sshAuthSocket: SocketID): Directory!
 }

--- a/core/schema/host.go
+++ b/core/schema/host.go
@@ -32,6 +32,7 @@ func (s *hostSchema) Resolvers() router.Resolvers {
 			"workdir":     router.ToResolver(s.workdir),
 			"directory":   router.ToResolver(s.directory),
 			"envVariable": router.ToResolver(s.envVariable),
+			"unixSocket":  router.ToResolver(s.socket),
 		},
 		"HostVariable": router.ObjectResolver{
 			"value":  router.ToResolver(s.envVariableValue),
@@ -78,4 +79,12 @@ type hostDirectoryArgs struct {
 
 func (s *hostSchema) directory(ctx *router.Context, parent any, args hostDirectoryArgs) (*core.Directory, error) {
 	return s.host.Directory(ctx, args.Path, s.platform, args.CopyFilter)
+}
+
+type hostSocketArgs struct {
+	Path string
+}
+
+func (s *hostSchema) socket(ctx *router.Context, parent any, args hostSocketArgs) (*core.Socket, error) {
+	return s.host.Socket(ctx, args.Path)
 }

--- a/core/schema/host.graphqls
+++ b/core/schema/host.graphqls
@@ -12,8 +12,11 @@ type Host {
   "Access a directory on the host"
   directory(path: String!, exclude: [String!], include: [String!]): Directory!
 
-  "Lookup the value of an environment variable. Null if the variable is not available."
+  "Access an environment variable on the host"
   envVariable(name: String!): HostVariable
+
+  "Access a Unix socket on the host"
+  unixSocket(path: String!): Socket!
 }
 
 "An environment variable on the host environment"

--- a/core/schema/project.go
+++ b/core/schema/project.go
@@ -113,7 +113,7 @@ func (s *projectSchema) schema(ctx *router.Context, parent *Project, args any) (
 	if !ok {
 		return "", fmt.Errorf("project %q not found", parent.Name)
 	}
-	return projectState.Schema(ctx, s.gw, s.platform, s.sshAuthSockID)
+	return projectState.Schema(ctx, s.gw, s.platform)
 }
 
 func (s *projectSchema) sdk(ctx *router.Context, parent *Project, args any) (string, error) {
@@ -130,7 +130,7 @@ func (s *projectSchema) extensions(ctx *router.Context, parent *Project, args an
 		return nil, fmt.Errorf("project %q not found", parent.Name)
 	}
 
-	dependencies, err := projectState.Extensions(ctx, s.projectStates, &s.mu, s.gw, s.platform, s.sshAuthSockID)
+	dependencies, err := projectState.Extensions(ctx, s.projectStates, &s.mu, s.gw, s.platform)
 	if err != nil {
 		return nil, err
 	}
@@ -170,12 +170,12 @@ func (s *projectSchema) getProjectState(name string) (*project.State, bool) {
 }
 
 func (s *projectSchema) projectToExecutableSchema(ctx context.Context, projectState *project.State) (router.ExecutableSchema, error) {
-	schema, err := projectState.Schema(ctx, s.gw, s.platform, s.sshAuthSockID)
+	schema, err := projectState.Schema(ctx, s.gw, s.platform)
 	if err != nil {
 		return nil, err
 	}
 
-	resolvers, err := projectState.Resolvers(ctx, s.gw, s.platform, s.sshAuthSockID)
+	resolvers, err := projectState.Resolvers(ctx, s.gw, s.platform)
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +186,7 @@ func (s *projectSchema) projectToExecutableSchema(ctx context.Context, projectSt
 		Resolvers: resolvers,
 	}
 
-	dependencies, err := projectState.Extensions(ctx, s.projectStates, &s.mu, s.gw, s.platform, s.sshAuthSockID)
+	dependencies, err := projectState.Extensions(ctx, s.projectStates, &s.mu, s.gw, s.platform)
 	if err != nil {
 		return nil, err
 	}

--- a/core/schema/socket.go
+++ b/core/schema/socket.go
@@ -1,0 +1,47 @@
+package schema
+
+import (
+	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/router"
+)
+
+type socketSchema struct {
+	*baseSchema
+
+	host *core.Host
+}
+
+var _ router.ExecutableSchema = &socketSchema{}
+
+func (s *socketSchema) Name() string {
+	return "socket"
+}
+
+func (s *socketSchema) Schema() string {
+	return Socket
+}
+
+var socketIDResolver = stringResolver(core.SocketID(""))
+
+func (s *socketSchema) Resolvers() router.Resolvers {
+	return router.Resolvers{
+		"SocketID": socketIDResolver,
+		"Query": router.ObjectResolver{
+			"socket": router.ToResolver(s.socket),
+		},
+		"Socket": router.ObjectResolver{},
+	}
+}
+
+func (s *socketSchema) Dependencies() []router.ExecutableSchema {
+	return nil
+}
+
+type socketArgs struct {
+	ID core.SocketID
+}
+
+// nolint: unparam
+func (s *socketSchema) socket(_ *router.Context, _ any, args socketArgs) (*core.Socket, error) {
+	return core.NewSocket(args.ID), nil
+}

--- a/core/schema/socket.graphqls
+++ b/core/schema/socket.graphqls
@@ -1,0 +1,12 @@
+extend type Query {
+  "Load a socket by ID"
+  socket(id: SocketID): Socket!
+}
+
+"A content-addressed socket identifier"
+scalar SocketID
+
+type Socket {
+  "The content-addressed identifier of the socket"
+  id: SocketID!
+}

--- a/core/secret.go
+++ b/core/secret.go
@@ -38,6 +38,8 @@ func NewSecretFromHostEnv(name string) (*Secret, error) {
 // SecretID is an opaque value representing a content-addressed secret.
 type SecretID string
 
+func (id SecretID) String() string { return string(id) }
+
 // secretIDPayload is the inner content of a SecretID.
 type secretIDPayload struct {
 	FromFile    FileID `json:"file,omitempty"`

--- a/core/socket.go
+++ b/core/socket.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 
@@ -15,6 +16,7 @@ type Socket struct {
 type SocketID string
 
 func (id SocketID) String() string { return string(id) }
+func (id SocketID) LLBID() string  { return fmt.Sprintf("socket:%s", id) }
 
 type socketIDPayload struct {
 	HostPath string `json:"host_path,omitempty"`

--- a/core/socket.go
+++ b/core/socket.go
@@ -1,0 +1,83 @@
+package core
+
+import (
+	"context"
+	"io"
+	"net"
+
+	"github.com/moby/buildkit/session/sshforward"
+)
+
+type Socket struct {
+	ID SocketID `json:"id"`
+}
+
+type SocketID string
+
+func (id SocketID) String() string { return string(id) }
+
+type socketIDPayload struct {
+	HostPath string `json:"host_path,omitempty"`
+}
+
+func (id SocketID) decode() (*socketIDPayload, error) {
+	var payload socketIDPayload
+	if err := decodeID(&payload, id); err != nil {
+		return nil, err
+	}
+
+	return &payload, nil
+}
+
+func (payload *socketIDPayload) ToSocket() (*Socket, error) {
+	id, err := encodeID(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewSocket(SocketID(id)), nil
+}
+
+func NewSocket(id SocketID) *Socket {
+	return &Socket{id}
+}
+
+func NewHostSocket(absPath string) (*Socket, error) {
+	payload := socketIDPayload{
+		HostPath: absPath,
+	}
+
+	return payload.ToSocket()
+}
+
+func (socket *Socket) Server() (sshforward.SSHServer, error) {
+	payload, err := socket.ID.decode()
+	if err != nil {
+		return nil, err
+	}
+
+	return &socketProxy{
+		dial: func() (io.ReadWriteCloser, error) {
+			return net.Dial("unix", payload.HostPath)
+		},
+	}, nil
+}
+
+type socketProxy struct {
+	dial func() (io.ReadWriteCloser, error)
+}
+
+var _ sshforward.SSHServer = &socketProxy{}
+
+func (p *socketProxy) CheckAgent(ctx context.Context, req *sshforward.CheckAgentRequest) (*sshforward.CheckAgentResponse, error) {
+	return &sshforward.CheckAgentResponse{}, nil
+}
+
+func (p *socketProxy) ForwardAgent(stream sshforward.SSH_ForwardAgentServer) error {
+	conn, err := p.dial()
+	if err != nil {
+		return err
+	}
+
+	return sshforward.Copy(context.TODO(), conn, stream, nil)
+}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -100,17 +100,6 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 		},
 	}
 
-	var sshAuthSockID string
-	if _, ok := os.LookupEnv(sshAuthSockEnv); ok {
-		sshAuthHandler, err := sshAuthSockHandler()
-		if err != nil {
-			return err
-		}
-		// using env key as the socket ID too for now
-		sshAuthSockID = sshAuthSockEnv
-		socketProviders.Named[sshAuthSockID] = sshAuthHandler
-	}
-
 	solveOpts := bkclient.SolveOpt{
 		Session: []session.Attachable{
 			secretsprovider.NewSecretProvider(secretStore),
@@ -154,7 +143,6 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 
 			coreAPI, err := schema.New(schema.InitializeArgs{
 				Router:        router,
-				SSHAuthSockID: sshAuthSockID,
 				Workdir:       startOpts.Workdir,
 				Gateway:       gw,
 				BKClient:      c,

--- a/engine/sshsock.go
+++ b/engine/sshsock.go
@@ -2,7 +2,9 @@ package engine
 
 import (
 	"context"
+	"strings"
 
+	"github.com/dagger/dagger/core"
 	"github.com/moby/buildkit/session/sshforward"
 	"github.com/moby/buildkit/session/sshforward/sshprovider"
 	"google.golang.org/grpc"
@@ -11,41 +13,62 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const (
-	sshAuthSockEnv = "SSH_AUTH_SOCK"
-)
-
 // Map of id -> handler for that id.
-type MergedSocketProviders map[string]sshforward.SSHServer
+type SocketProvider struct {
+	Named NamedSocketProviders
+}
 
-func (m MergedSocketProviders) Register(server *grpc.Server) {
+type NamedSocketProviders map[string]sshforward.SSHServer
+
+func (m SocketProvider) Register(server *grpc.Server) {
 	sshforward.RegisterSSHServer(server, m)
 }
 
-func (m MergedSocketProviders) CheckAgent(ctx context.Context, req *sshforward.CheckAgentRequest) (*sshforward.CheckAgentResponse, error) {
+func (m SocketProvider) CheckAgent(ctx context.Context, req *sshforward.CheckAgentRequest) (*sshforward.CheckAgentResponse, error) {
 	id := sshforward.DefaultID
 	if req.ID != "" {
 		id = req.ID
 	}
-	h, ok := m[id]
+	if strings.HasPrefix(id, "socket:") {
+		// always allow SocketIDs
+		return &sshforward.CheckAgentResponse{}, nil
+	}
+	h, ok := m.Named[id]
 	if !ok {
 		return nil, status.Errorf(codes.NotFound, "no ssh handler for id %s", id)
 	}
 	return h.CheckAgent(ctx, req)
 }
 
-func (m MergedSocketProviders) ForwardAgent(stream sshforward.SSH_ForwardAgentServer) error {
+func (m SocketProvider) ForwardAgent(stream sshforward.SSH_ForwardAgentServer) error {
 	id := sshforward.DefaultID
 	opts, _ := metadata.FromIncomingContext(stream.Context()) // if no metadata continue with empty object
 	if v, ok := opts[sshforward.KeySSHID]; ok && len(v) > 0 && v[0] != "" {
 		id = v[0]
 	}
-	h, ok := m[id]
-	if !ok {
-		return status.Errorf(codes.NotFound, "no ssh handler for id %s", id)
+
+	var h sshforward.SSHServer
+	if key, socketID, ok := strings.Cut(id, ":"); key == "socket" && ok {
+		socket := core.NewSocket(core.SocketID(socketID))
+
+		var err error
+		h, err = socket.Server()
+		if err != nil {
+			return err
+		}
+	} else {
+		h, ok = m.Named[id]
+		if !ok {
+			return status.Errorf(codes.NotFound, "no ssh handler for id %s", id)
+		}
 	}
+
 	return h.ForwardAgent(stream)
 }
+
+const (
+	sshAuthSockEnv = "SSH_AUTH_SOCK"
+)
 
 func sshAuthSockHandler() (sshforward.SSHServer, error) {
 	agentProvider, err := sshprovider.NewSSHAgentProvider([]sshprovider.AgentConfig{{ID: sshAuthSockEnv}})

--- a/engine/sshsock.go
+++ b/engine/sshsock.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/dagger/dagger/core"
 	"github.com/moby/buildkit/session/sshforward"
-	"github.com/moby/buildkit/session/sshforward/sshprovider"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -64,20 +63,4 @@ func (m SocketProvider) ForwardAgent(stream sshforward.SSH_ForwardAgentServer) e
 	}
 
 	return h.ForwardAgent(stream)
-}
-
-const (
-	sshAuthSockEnv = "SSH_AUTH_SOCK"
-)
-
-func sshAuthSockHandler() (sshforward.SSHServer, error) {
-	agentProvider, err := sshprovider.NewSSHAgentProvider([]sshprovider.AgentConfig{{ID: sshAuthSockEnv}})
-	if err != nil {
-		return nil, err
-	}
-	handler, ok := agentProvider.(sshforward.SSHServer)
-	if !ok {
-		return nil, status.Errorf(codes.Internal, "invalid agent provider type: %T", agentProvider)
-	}
-	return handler, nil
 }

--- a/project/llbutil.go
+++ b/project/llbutil.go
@@ -23,19 +23,6 @@ func withRunOpts(runOpts ...llb.RunOption) llb.RunOption {
 	})
 }
 
-func withSSHAuthSock(id, path string) llb.RunOption {
-	if id == "" {
-		return runOptionFunc(nil)
-	}
-	return withRunOpts(
-		llb.AddSSHSocket(
-			llb.SSHID(id),
-			llb.SSHSocketTarget(path),
-		),
-		llb.AddEnv("SSH_AUTH_SOCK", path),
-	)
-}
-
 func withGithubSSHKnownHosts() (llb.RunOption, error) {
 	knownHosts, err := sshutil.SSHKeyScan("github.com")
 	if err != nil {

--- a/project/pythonruntime.go
+++ b/project/pythonruntime.go
@@ -11,7 +11,7 @@ import (
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-func (p *State) pythonRuntime(ctx context.Context, subpath string, gw bkgw.Client, platform specs.Platform, sshAuthSockID string) (*core.Directory, error) {
+func (p *State) pythonRuntime(ctx context.Context, subpath string, gw bkgw.Client, platform specs.Platform) (*core.Directory, error) {
 	// TODO(vito): handle platform?
 	payload, err := p.workdir.ID.Decode()
 	if err != nil {
@@ -59,7 +59,6 @@ exec dagger-py "$@"
 					llb.Scratch(),
 					llb.AsPersistentCacheDir("pythonpipcache", llb.CacheMountShared),
 				),
-				withSSHAuthSock(sshAuthSockID, "/ssh-agent.sock"),
 				addSSHKnownHosts,
 			).
 			File(llb.Mkfile("/entrypoint", 0755, []byte(entrypointScript))),

--- a/project/sdk.go
+++ b/project/sdk.go
@@ -12,16 +12,16 @@ import (
 // TODO:(sipsma) SDKs should be pluggable extensions, not hardcoded LLB here. The implementation here is a temporary bridge from the previous hardcoded Dockerfiles to the sdk-as-extension model.
 
 // return the FS with the executable extension code, ready to be invoked by dagger
-func (p *State) Runtime(ctx context.Context, gw bkgw.Client, platform specs.Platform, sshAuthSockID string) (*core.Directory, error) {
+func (p *State) Runtime(ctx context.Context, gw bkgw.Client, platform specs.Platform) (*core.Directory, error) {
 	var runtimeFS *core.Directory
 	var err error
 	switch p.config.SDK {
 	case "go":
 		runtimeFS, err = p.goRuntime(ctx, "/", gw, platform)
 	case "ts":
-		runtimeFS, err = p.tsRuntime(ctx, "/", gw, platform, sshAuthSockID)
+		runtimeFS, err = p.tsRuntime(ctx, "/", gw, platform)
 	case "python":
-		runtimeFS, err = p.pythonRuntime(ctx, "/", gw, platform, sshAuthSockID)
+		runtimeFS, err = p.pythonRuntime(ctx, "/", gw, platform)
 	case "dockerfile":
 		runtimeFS, err = p.dockerfileRuntime(ctx, "/", gw, platform)
 	default:

--- a/project/tsruntime.go
+++ b/project/tsruntime.go
@@ -11,7 +11,7 @@ import (
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-func (p *State) tsRuntime(ctx context.Context, subpath string, gw bkgw.Client, platform specs.Platform, sshAuthSockID string) (*core.Directory, error) {
+func (p *State) tsRuntime(ctx context.Context, subpath string, gw bkgw.Client, platform specs.Platform) (*core.Directory, error) {
 	payload, err := p.workdir.ID.Decode()
 	if err != nil {
 		return nil, err
@@ -34,7 +34,6 @@ func (p *State) tsRuntime(ctx context.Context, subpath string, gw bkgw.Client, p
 			llb.Scratch(),
 			llb.AsPersistentCacheDir("yarn", llb.CacheMountLocked),
 		),
-		withSSHAuthSock(sshAuthSockID, "/ssh-agent.sock"),
 		addSSHKnownHosts,
 	)
 

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -625,6 +625,17 @@ func (r *Container) WithoutMount(path string) *Container {
 	}
 }
 
+// This container with a previously added Unix socket removed
+func (r *Container) WithoutUnixSocket(path string) *Container {
+	q := r.q.Select("withoutUnixSocket")
+	q = q.Arg("path", path)
+
+	return &Container{
+		q: q,
+		c: r.c,
+	}
+}
+
 // The working directory for all commands
 func (r *Container) Workdir(ctx context.Context) (string, error) {
 	q := r.q.Select("workdir")

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -935,12 +935,21 @@ func (r *GitRef) Digest(ctx context.Context) (string, error) {
 
 // GitRefTreeOpts contains options for GitRef.Tree
 type GitRefTreeOpts struct {
+	SSHKnownHosts string
+
 	SSHAuthSocket *Socket
 }
 
 // The filesystem tree at this ref
 func (r *GitRef) Tree(opts ...GitRefTreeOpts) *Directory {
 	q := r.q.Select("tree")
+	// `sshKnownHosts` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].SSHKnownHosts) {
+			q = q.Arg("sshKnownHosts", opts[i].SSHKnownHosts)
+			break
+		}
+	}
 	// `sshAuthSocket` optional argument
 	for i := len(opts) - 1; i >= 0; i-- {
 		if !querybuilder.IsZeroValue(opts[i].SSHAuthSocket) {

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -25,6 +25,9 @@ type Platform string
 // A unique identifier for a secret
 type SecretID string
 
+// A content-addressed socket identifier
+type SocketID string
+
 // A directory whose contents persist across runs
 type CacheVolume struct {
 	q *querybuilder.Selection
@@ -566,6 +569,18 @@ func (r *Container) WithSecretVariable(name string, secret *Secret) *Container {
 	}
 }
 
+// This container plus a socket forwarded to the given Unix socket path
+func (r *Container) WithUnixSocket(path string, source *Socket) *Container {
+	q := r.q.Select("withUnixSocket")
+	q = q.Arg("path", path)
+	q = q.Arg("source", source)
+
+	return &Container{
+		q: q,
+		c: r.c,
+	}
+}
+
 // This container but with a different command user
 func (r *Container) WithUser(name string) *Container {
 	q := r.q.Select("withUser")
@@ -1023,12 +1038,23 @@ func (r *Host) Directory(path string, opts ...HostDirectoryOpts) *Directory {
 	}
 }
 
-// Lookup the value of an environment variable. Null if the variable is not available.
+// Access an environment variable on the host
 func (r *Host) EnvVariable(name string) *HostVariable {
 	q := r.q.Select("envVariable")
 	q = q.Arg("name", name)
 
 	return &HostVariable{
+		q: q,
+		c: r.c,
+	}
+}
+
+// Access a Unix socket on the host
+func (r *Host) UnixSocket(path string) *Socket {
+	q := r.q.Select("unixSocket")
+	q = q.Arg("path", path)
+
+	return &Socket{
 		q: q,
 		c: r.c,
 	}
@@ -1310,6 +1336,28 @@ func (r *Query) Secret(id SecretID) *Secret {
 	}
 }
 
+// SocketOpts contains options for Query.Socket
+type SocketOpts struct {
+	ID SocketID
+}
+
+// Load a socket by ID
+func (r *Query) Socket(opts ...SocketOpts) *Socket {
+	q := r.q.Select("socket")
+	// `id` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].ID) {
+			q = q.Arg("id", opts[i].ID)
+			break
+		}
+	}
+
+	return &Socket{
+		q: q,
+		c: r.c,
+	}
+}
+
 // A reference to a secret value, which can be handled more safely than the value itself
 type Secret struct {
 	q *querybuilder.Selection
@@ -1346,4 +1394,32 @@ func (r *Secret) Plaintext(ctx context.Context) (string, error) {
 	var response string
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
+}
+
+type Socket struct {
+	q *querybuilder.Selection
+	c graphql.Client
+}
+
+// The content-addressed identifier of the socket
+func (r *Socket) ID(ctx context.Context) (SocketID, error) {
+	q := r.q.Select("id")
+
+	var response SocketID
+	q = q.Bind(&response)
+	return response, q.Execute(ctx, r.c)
+}
+
+// XXX_GraphQLType is an internal function. It returns the native GraphQL type name
+func (r *Socket) XXX_GraphQLType() string {
+	return "Socket"
+}
+
+// XXX_GraphQLID is an internal function. It returns the underlying type ID
+func (r *Socket) XXX_GraphQLID(ctx context.Context) (string, error) {
+	id, err := r.ID(ctx)
+	if err != nil {
+		return "", err
+	}
+	return string(id), nil
 }

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -933,9 +933,21 @@ func (r *GitRef) Digest(ctx context.Context) (string, error) {
 	return response, q.Execute(ctx, r.c)
 }
 
+// GitRefTreeOpts contains options for GitRef.Tree
+type GitRefTreeOpts struct {
+	SSHAuthSocket *Socket
+}
+
 // The filesystem tree at this ref
-func (r *GitRef) Tree() *Directory {
+func (r *GitRef) Tree(opts ...GitRefTreeOpts) *Directory {
 	q := r.q.Select("tree")
+	// `sshAuthSocket` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].SSHAuthSocket) {
+			q = q.Arg("sshAuthSocket", opts[i].SSHAuthSocket)
+			break
+		}
+	}
 
 	return &Directory{
 		q: q,

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -104,6 +104,12 @@ export type Platform = string
 export type SecretID = string
 
 /**
+ * A content-addressed socket identifier
+ * @hidden
+ */
+export type SocketID = string
+
+/**
  * A directory whose contents persist across runs
  */
 export class CacheVolume extends BaseClient {
@@ -682,6 +688,22 @@ export class Container extends BaseClient {
   }
 
   /**
+   * This container plus a socket forwarded to the given Unix socket path
+   */
+  withUnixSocket(path: string, source: SocketID): Container {
+    return new Container({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "withUnixSocket",
+          args: { path, source },
+        },
+      ],
+      host: this.clientHost,
+    })
+  }
+
+  /**
    * This container but with a different command user
    */
   withUser(name: string): Container {
@@ -1242,7 +1264,7 @@ export class Host extends BaseClient {
   }
 
   /**
-   * Lookup the value of an environment variable. Null if the variable is not available.
+   * Access an environment variable on the host
    */
   envVariable(name: string): HostVariable {
     return new HostVariable({
@@ -1251,6 +1273,22 @@ export class Host extends BaseClient {
         {
           operation: "envVariable",
           args: { name },
+        },
+      ],
+      host: this.clientHost,
+    })
+  }
+
+  /**
+   * Access a Unix socket on the host
+   */
+  unixSocket(path: string): Socket {
+    return new Socket({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "unixSocket",
+          args: { path },
         },
       ],
       host: this.clientHost,
@@ -1573,6 +1611,22 @@ export default class Client extends BaseClient {
       host: this.clientHost,
     })
   }
+
+  /**
+   * Load a socket by ID
+   */
+  socket(id?: SocketID): Socket {
+    return new Socket({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "socket",
+          args: { id },
+        },
+      ],
+      host: this.clientHost,
+    })
+  }
 }
 
 /**
@@ -1607,6 +1661,24 @@ export class Secret extends BaseClient {
     ]
 
     const response: Awaited<string> = await this._compute()
+
+    return response
+  }
+}
+
+export class Socket extends BaseClient {
+  /**
+   * The content-addressed identifier of the socket
+   */
+  async id(): Promise<SocketID> {
+    this._queryTree = [
+      ...this._queryTree,
+      {
+        operation: "id",
+      },
+    ]
+
+    const response: Awaited<SocketID> = await this._compute()
 
     return response
   }

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -1145,12 +1145,13 @@ export class GitRef extends BaseClient {
   /**
    * The filesystem tree at this ref
    */
-  tree(): Directory {
+  tree(sshAuthSocket?: SocketID): Directory {
     return new Directory({
       queryTree: [
         ...this._queryTree,
         {
           operation: "tree",
+          args: { sshAuthSocket },
         },
       ],
       host: this.clientHost,

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -1145,13 +1145,13 @@ export class GitRef extends BaseClient {
   /**
    * The filesystem tree at this ref
    */
-  tree(sshAuthSocket?: SocketID): Directory {
+  tree(sshKnownHosts?: string, sshAuthSocket?: SocketID): Directory {
     return new Directory({
       queryTree: [
         ...this._queryTree,
         {
           operation: "tree",
-          args: { sshAuthSocket },
+          args: { sshKnownHosts, sshAuthSocket },
         },
       ],
       host: this.clientHost,

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -768,6 +768,22 @@ export class Container extends BaseClient {
   }
 
   /**
+   * This container with a previously added Unix socket removed
+   */
+  withoutUnixSocket(path: string): Container {
+    return new Container({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "withoutUnixSocket",
+          args: { path },
+        },
+      ],
+      host: this.clientHost,
+    })
+  }
+
+  /**
    * The working directory for all commands
    */
   async workdir(): Promise<string> {

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -503,6 +503,14 @@ class Container(Type):
         _ctx = self._select("withoutMount", _args)
         return Container(_ctx)
 
+    def without_unix_socket(self, path: str) -> "Container":
+        """This container with a previously added Unix socket removed"""
+        _args = [
+            Arg("path", path),
+        ]
+        _ctx = self._select("withoutUnixSocket", _args)
+        return Container(_ctx)
+
     async def workdir(self) -> str | None:
         """The working directory for all commands
 

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -773,9 +773,14 @@ class GitRef(Type):
         _ctx = self._select("digest", _args)
         return await _ctx.execute(str)
 
-    def tree(self, ssh_auth_socket: "Socket | None" = None) -> "Directory":
+    def tree(
+        self,
+        ssh_known_hosts: str | None = None,
+        ssh_auth_socket: "Socket | None" = None,
+    ) -> "Directory":
         """The filesystem tree at this ref"""
         _args = [
+            Arg("sshKnownHosts", ssh_known_hosts, None),
             Arg("sshAuthSocket", ssh_auth_socket, None),
         ]
         _ctx = self._select("tree", _args)

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -773,9 +773,11 @@ class GitRef(Type):
         _ctx = self._select("digest", _args)
         return await _ctx.execute(str)
 
-    def tree(self) -> "Directory":
+    def tree(self, ssh_auth_socket: "Socket | None" = None) -> "Directory":
         """The filesystem tree at this ref"""
-        _args: list[Arg] = []
+        _args = [
+            Arg("sshAuthSocket", ssh_auth_socket, None),
+        ]
         _ctx = self._select("tree", _args)
         return Directory(_ctx)
 

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -24,6 +24,10 @@ SecretID = NewType("SecretID", str)
 """A unique identifier for a secret"""
 
 
+SocketID = NewType("SocketID", str)
+"""A content-addressed socket identifier"""
+
+
 class CacheVolume(Type):
     """A directory whose contents persist across runs"""
 
@@ -458,6 +462,15 @@ class Container(Type):
         _ctx = self._select("withSecretVariable", _args)
         return Container(_ctx)
 
+    def with_unix_socket(self, path: str, source: "Socket") -> "Container":
+        """This container plus a socket forwarded to the given Unix socket path"""
+        _args = [
+            Arg("path", path),
+            Arg("source", source),
+        ]
+        _ctx = self._select("withUnixSocket", _args)
+        return Container(_ctx)
+
     def with_user(self, name: str) -> "Container":
         """This container but with a different command user"""
         _args = [
@@ -842,14 +855,20 @@ class Host(Type):
         return Directory(_ctx)
 
     def env_variable(self, name: str) -> "HostVariable":
-        """Lookup the value of an environment variable. Null if the variable is
-        not available.
-        """
+        """Access an environment variable on the host"""
         _args = [
             Arg("name", name),
         ]
         _ctx = self._select("envVariable", _args)
         return HostVariable(_ctx)
+
+    def unix_socket(self, path: str) -> "Socket":
+        """Access a Unix socket on the host"""
+        _args = [
+            Arg("path", path),
+        ]
+        _ctx = self._select("unixSocket", _args)
+        return Socket(_ctx)
 
     def workdir(
         self, exclude: list[str] | None = None, include: list[str] | None = None
@@ -1051,6 +1070,14 @@ class Client(Root):
         _ctx = self._select("secret", _args)
         return Secret(_ctx)
 
+    def socket(self, id: "SocketID | Socket | None" = None) -> "Socket":
+        """Load a socket by ID"""
+        _args = [
+            Arg("id", id, None),
+        ]
+        _ctx = self._select("socket", _args)
+        return Socket(_ctx)
+
 
 class Secret(Type):
     """A reference to a secret value, which can be handled more safely
@@ -1087,6 +1114,24 @@ class Secret(Type):
         return await _ctx.execute(str)
 
 
+class Socket(Type):
+    async def id(self) -> SocketID:
+        """The content-addressed identifier of the socket
+
+        Note
+        ----
+        This is lazyly evaluated, no operation is actually run.
+
+        Returns
+        -------
+        SocketID
+            A content-addressed socket identifier
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("id", _args)
+        return await _ctx.execute(SocketID)
+
+
 __all__ = [
     "CacheID",
     "ContainerID",
@@ -1094,6 +1139,7 @@ __all__ = [
     "FileID",
     "Platform",
     "SecretID",
+    "SocketID",
     "CacheVolume",
     "Container",
     "Directory",
@@ -1106,4 +1152,5 @@ __all__ = [
     "Project",
     "Client",
     "Secret",
+    "Socket",
 ]

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -773,9 +773,11 @@ class GitRef(Type):
         _ctx = self._select("digest", _args)
         return _ctx.execute_sync(str)
 
-    def tree(self) -> "Directory":
+    def tree(self, ssh_auth_socket: "Socket | None" = None) -> "Directory":
         """The filesystem tree at this ref"""
-        _args: list[Arg] = []
+        _args = [
+            Arg("sshAuthSocket", ssh_auth_socket, None),
+        ]
         _ctx = self._select("tree", _args)
         return Directory(_ctx)
 

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -773,9 +773,14 @@ class GitRef(Type):
         _ctx = self._select("digest", _args)
         return _ctx.execute_sync(str)
 
-    def tree(self, ssh_auth_socket: "Socket | None" = None) -> "Directory":
+    def tree(
+        self,
+        ssh_known_hosts: str | None = None,
+        ssh_auth_socket: "Socket | None" = None,
+    ) -> "Directory":
         """The filesystem tree at this ref"""
         _args = [
+            Arg("sshKnownHosts", ssh_known_hosts, None),
             Arg("sshAuthSocket", ssh_auth_socket, None),
         ]
         _ctx = self._select("tree", _args)

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -503,6 +503,14 @@ class Container(Type):
         _ctx = self._select("withoutMount", _args)
         return Container(_ctx)
 
+    def without_unix_socket(self, path: str) -> "Container":
+        """This container with a previously added Unix socket removed"""
+        _args = [
+            Arg("path", path),
+        ]
+        _ctx = self._select("withoutUnixSocket", _args)
+        return Container(_ctx)
+
     def workdir(self) -> str | None:
         """The working directory for all commands
 

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -24,6 +24,10 @@ SecretID = NewType("SecretID", str)
 """A unique identifier for a secret"""
 
 
+SocketID = NewType("SocketID", str)
+"""A content-addressed socket identifier"""
+
+
 class CacheVolume(Type):
     """A directory whose contents persist across runs"""
 
@@ -458,6 +462,15 @@ class Container(Type):
         _ctx = self._select("withSecretVariable", _args)
         return Container(_ctx)
 
+    def with_unix_socket(self, path: str, source: "Socket") -> "Container":
+        """This container plus a socket forwarded to the given Unix socket path"""
+        _args = [
+            Arg("path", path),
+            Arg("source", source),
+        ]
+        _ctx = self._select("withUnixSocket", _args)
+        return Container(_ctx)
+
     def with_user(self, name: str) -> "Container":
         """This container but with a different command user"""
         _args = [
@@ -842,14 +855,20 @@ class Host(Type):
         return Directory(_ctx)
 
     def env_variable(self, name: str) -> "HostVariable":
-        """Lookup the value of an environment variable. Null if the variable is
-        not available.
-        """
+        """Access an environment variable on the host"""
         _args = [
             Arg("name", name),
         ]
         _ctx = self._select("envVariable", _args)
         return HostVariable(_ctx)
+
+    def unix_socket(self, path: str) -> "Socket":
+        """Access a Unix socket on the host"""
+        _args = [
+            Arg("path", path),
+        ]
+        _ctx = self._select("unixSocket", _args)
+        return Socket(_ctx)
 
     def workdir(
         self, exclude: list[str] | None = None, include: list[str] | None = None
@@ -1051,6 +1070,14 @@ class Client(Root):
         _ctx = self._select("secret", _args)
         return Secret(_ctx)
 
+    def socket(self, id: "SocketID | Socket | None" = None) -> "Socket":
+        """Load a socket by ID"""
+        _args = [
+            Arg("id", id, None),
+        ]
+        _ctx = self._select("socket", _args)
+        return Socket(_ctx)
+
 
 class Secret(Type):
     """A reference to a secret value, which can be handled more safely
@@ -1087,6 +1114,24 @@ class Secret(Type):
         return _ctx.execute_sync(str)
 
 
+class Socket(Type):
+    def id(self) -> SocketID:
+        """The content-addressed identifier of the socket
+
+        Note
+        ----
+        This is lazyly evaluated, no operation is actually run.
+
+        Returns
+        -------
+        SocketID
+            A content-addressed socket identifier
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("id", _args)
+        return _ctx.execute_sync(SocketID)
+
+
 __all__ = [
     "CacheID",
     "ContainerID",
@@ -1094,6 +1139,7 @@ __all__ = [
     "FileID",
     "Platform",
     "SecretID",
+    "SocketID",
     "CacheVolume",
     "Container",
     "Directory",
@@ -1106,4 +1152,5 @@ __all__ = [
     "Project",
     "Client",
     "Secret",
+    "Socket",
 ]

--- a/sdk/python/tests/api/test_codegen.py
+++ b/sdk/python/tests/api/test_codegen.py
@@ -29,7 +29,6 @@ def id_map():
         "CacheID": "CacheVolume",
         "FileID": "File",
         "SecretID": "Secret",
-        "SocketID": "Socket",
     }
 
 

--- a/sdk/python/tests/api/test_codegen.py
+++ b/sdk/python/tests/api/test_codegen.py
@@ -29,6 +29,7 @@ def id_map():
         "CacheID": "CacheVolume",
         "FileID": "File",
         "SecretID": "Secret",
+        "SocketID": "Socket",
     }
 
 


### PR DESCRIPTION
fixes #3850

Implements the following schema:

```graphql
extend type Query {
  "Load a socket by ID"
  socket(id: SocketID): Socket!
}

"A content-addressed socket identifier"
scalar SocketID

type Socket {
  "The content-addressed identifier of the socket"
  id: SocketID!
}

extend type Host {
  "Access a Unix socket on the host"
  unixSocket(path: String!): Socket!
}

extend type Container {
  "This container plus a socket forwarded to the given Unix socket path"
  withUnixSocket(path: String!, source: SocketID!): Container!

  "This container with a previously added Unix socket removed"
  withoutUnixSocket(path: String!): Container!
}
```

The current approach is to call `llb.SSHID` with the content-addressed `SocketID` prefixed by `socket:` to distinguish it from the current named sockets, making this backwards-compatible. The implementation is very similar to how the secret provider works (passing a FooID to the session.Attachable), but it's simpler for now since there's no container-to-network socket forwarding (yet?).