### PR TITLE
ci: Do not publish non semver CLI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}
-      - run: ./hack/make-prod dagger:publish ${{ github.ref_name }}
 
       - name: "Publish Engine & CLI"
         env:
@@ -30,7 +29,7 @@ jobs:
           AWS_BUCKET: ${{ secrets.RELEASE_AWS_BUCKET }}
           ARTEFACTS_FQDN: ${{ secrets.RELEASE_FQDN }}
           HOMEBREW_TAP_OWNER: ${{ secrets.RELEASE_HOMEBREW_TAP_OWNER }}
-        run: ./hack/make dagger:publish ${{ github.ref_name }}
+        run: ./hack/make-prod dagger:publish ${{ github.ref_name }}
 
       - name: "Bump SDK Engine Dependencies"
         uses: peter-evans/create-pull-request@v3

--- a/internal/mage/cli.go
+++ b/internal/mage/cli.go
@@ -16,7 +16,7 @@ type Cli mg.Namespace
 // Publish publishes dagger CLI using GoReleaser
 func (cl Cli) Publish(ctx context.Context, version string) error {
 	if !semver.IsValid(version) {
-		fmt.Printf("'%s' is not a semver version, skipping image bump in SDKs", version)
+		fmt.Printf("'%s' is not a semver version, skipping CLI publish", version)
 		return nil
 	}
 

--- a/internal/mage/cli.go
+++ b/internal/mage/cli.go
@@ -2,17 +2,24 @@ package mage
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"dagger.io/dagger"
 	"github.com/dagger/dagger/internal/mage/util"
 	"github.com/magefile/mage/mg" // mg contains helpful utility functions, like Deps
+	"golang.org/x/mod/semver"
 )
 
 type Cli mg.Namespace
 
 // Publish publishes dagger CLI using GoReleaser
-func (cl Cli) Publish(ctx context.Context) error {
+func (cl Cli) Publish(ctx context.Context, version string) error {
+	if !semver.IsValid(version) {
+		fmt.Printf("'%s' is not a semver version, skipping image bump in SDKs", version)
+		return nil
+	}
+
 	c, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
 	if err != nil {
 		return err

--- a/internal/mage/dagger.go
+++ b/internal/mage/dagger.go
@@ -15,7 +15,7 @@ func (Dagger) Publish(ctx context.Context, version string) error {
 		return err
 	}
 
-	err = Cli{}.Publish(ctx)
+	err = Cli{}.Publish(ctx, version)
 
 	if err != nil {
 		return err

--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -103,6 +103,8 @@ func (t Engine) Publish(ctx context.Context, version string) error {
 		if err := sdks.Bump(ctx, digest); err != nil {
 			return err
 		}
+	} else {
+		fmt.Printf("'%s' is not a semver version, skipping image bump in SDKs", version)
 	}
 
 	time.Sleep(3 * time.Second) // allow buildkit logs to flush, to minimize potential confusion with interleaving


### PR DESCRIPTION
Follow-up to:
- https://github.com/dagger/dagger/pull/4012

We trigger the `publish.yml` workflow on push to `main`. We do not want to publish a new CLI when that happens. This might change in the future when we might want to have an edge/dev version always built from `main`. Out of scope for now.

Adds:
- Fixes (my) bad refactor
- Mentions when & why we skip SDKs image bump