### PR TITLE
Restrict dagger listen localdir access by default.

### DIFF
--- a/cmd/dagger/do.go
+++ b/cmd/dagger/do.go
@@ -7,18 +7,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var doCmd = &cobra.Command{
-	Use:    "do",
-	Args:   cobra.NoArgs,
-	Hidden: true,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf(`############################################################################################
+func doCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    "do",
+		Args:   cobra.NoArgs,
+		Hidden: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf(`############################################################################################
 dagger do has been refactored into a new dagger-cue CLI.                                   #
 Please find the latest documentation in the following link: https://docs.dagger.io/sdk/cue #
 ############################################################################################
 		`)
-		os.Exit(1)
-	},
+			os.Exit(1)
+		},
+	}
 }
 
 // version holds the complete version number. Filled in at linking time.

--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -11,6 +11,7 @@ import (
 func withEngine(
 	ctx context.Context,
 	sessionToken string,
+	allowedLocalDirs []string,
 	cb engine.StartCallback,
 ) error {
 	var runnerHost string
@@ -21,10 +22,11 @@ func withEngine(
 	}
 
 	engineConf := &engine.Config{
-		Workdir:      workdir,
-		ConfigPath:   configPath,
-		SessionToken: sessionToken,
-		RunnerHost:   runnerHost,
+		Workdir:          workdir,
+		ConfigPath:       configPath,
+		SessionToken:     sessionToken,
+		RunnerHost:       runnerHost,
+		AllowedLocalDirs: allowedLocalDirs,
 	}
 	if debugLogs {
 		engineConf.LogOutput = os.Stderr

--- a/cmd/dagger/listen.go
+++ b/cmd/dagger/listen.go
@@ -10,7 +10,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var listenAddress string
+const outputPrefix = "==> server listening on "
+
+var (
+	listenAddress   string
+	listenLocalDirs []string
+)
 
 var listenCmd = &cobra.Command{
 	Use:     "listen",
@@ -22,15 +27,16 @@ var listenCmd = &cobra.Command{
 
 func Listen(cmd *cobra.Command, args []string) {
 	ctx := context.Background()
-	if err := withEngine(ctx, "", func(ctx context.Context, r *router.Router) error {
-		fmt.Fprintf(os.Stderr, "==> server listening on %s\n", listenAddress)
+	if err := withEngine(ctx, "", listenLocalDirs, func(ctx context.Context, r *router.Router) error {
+		fmt.Fprintf(cmd.OutOrStderr(), "%s %s\n", outputPrefix, listenAddress)
 		return http.ListenAndServe(listenAddress, r)
 	}); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
 		os.Exit(1)
 	}
 }
 
 func init() {
 	listenCmd.Flags().StringVarP(&listenAddress, "listen", "", ":8080", "Listen on network address ADDR")
+	listenCmd.Flags().StringSliceVar(&listenLocalDirs, "local-dirs", []string{}, "local directories to allow for syncing into containers")
 }

--- a/cmd/dagger/listen.go
+++ b/cmd/dagger/listen.go
@@ -18,12 +18,19 @@ var (
 	listenLocalDirs []string
 )
 
-var listenCmd = &cobra.Command{
-	Use:     "listen",
-	Aliases: []string{"l"},
-	Run:     Listen,
-	Hidden:  true,
-	Short:   "Starts the engine server",
+func listenCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "listen",
+		Aliases: []string{"l"},
+		Run:     Listen,
+		Hidden:  true,
+		Short:   "Starts the engine server",
+	}
+
+	cmd.Flags().StringVarP(&listenAddress, "listen", "", ":8080", "Listen on network address ADDR")
+	cmd.Flags().StringSliceVar(&listenLocalDirs, "local-dirs", []string{}, "local directories to allow for syncing into containers")
+
+	return cmd
 }
 
 func Listen(cmd *cobra.Command, args []string) {
@@ -42,9 +49,4 @@ func Listen(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
 		os.Exit(1)
 	}
-}
-
-func init() {
-	listenCmd.Flags().StringVarP(&listenAddress, "listen", "", ":8080", "Listen on network address ADDR")
-	listenCmd.Flags().StringSliceVar(&listenLocalDirs, "local-dirs", []string{}, "local directories to allow for syncing into containers")
 }

--- a/cmd/dagger/listen_test.go
+++ b/cmd/dagger/listen_test.go
@@ -25,7 +25,7 @@ func TestAllowedLocalDirs(t *testing.T) {
 	cmd := rootCmd
 	cmd.SetArgs([]string{
 		"listen",
-		"--listen", "localhost:12345",
+		"--listen", "localhost:0",
 		"--local-dirs", strings.Join([]string{allowedDir1, allowedDir2}, ","),
 		"--local-dirs", allowedDir3,
 	})

--- a/cmd/dagger/listen_test.go
+++ b/cmd/dagger/listen_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"dagger.io/dagger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllowedLocalDirs(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	allowedDir1 := t.TempDir()
+	allowedDir2 := t.TempDir()
+	allowedDir3 := t.TempDir()
+	notAllowedDir := t.TempDir()
+
+	cmd := rootCmd
+	cmd.SetArgs([]string{
+		"listen",
+		"--listen", "localhost:12345",
+		"--local-dirs", strings.Join([]string{allowedDir1, allowedDir2}, ","),
+		"--local-dirs", allowedDir3,
+	})
+
+	r, w := io.Pipe()
+	cmd.SetOut(w)
+
+	go func() {
+		if err := cmd.ExecuteContext(ctx); err != nil {
+			panic(err)
+		}
+	}()
+
+	outCh := make(chan string)
+	go func() {
+		defer close(outCh)
+		out, err := bufio.NewReader(r).ReadString('\n')
+		require.NoError(t, err)
+		outCh <- out
+	}()
+
+	var addr string
+	select {
+	case out := <-outCh:
+		var ok bool
+		_, addr, ok = strings.Cut(out, outputPrefix)
+		require.True(t, ok, "expected output to start with %q: %q", outputPrefix, out)
+		addr = strings.TrimSpace(addr)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for output")
+	}
+
+	origDaggerHost := os.Getenv("DAGGER_HOST")
+	os.Setenv("DAGGER_HOST", "http://"+addr)
+	defer os.Setenv("DAGGER_HOST", origDaggerHost)
+
+	c, err := dagger.Connect(ctx)
+	require.NoError(t, err)
+
+	for _, allowedDir := range []string{allowedDir1, allowedDir2, allowedDir3} {
+		_, err := c.Host().Directory(allowedDir).Entries(ctx)
+		require.NoError(t, err)
+	}
+
+	_, err = c.Host().Directory(notAllowedDir).Entries(ctx)
+	require.ErrorContains(t, err, "no access allowed")
+}

--- a/cmd/dagger/query.go
+++ b/cmd/dagger/query.go
@@ -19,13 +19,14 @@ var (
 	queryVarsJSONInput string
 )
 
-var queryCmd = &cobra.Command{
-	Use:                   "query [flags] [operation]",
-	Aliases:               []string{"q"},
-	DisableFlagsInUseLine: true,
-	Long:                  "Send API queries to a dagger engine\n\nWhen no document file, read query from standard input.",
-	Short:                 "Send API queries to a dagger engine",
-	Example: `
+func queryCmd() *cobra.Command {
+	queryCmd := &cobra.Command{
+		Use:                   "query [flags] [operation]",
+		Aliases:               []string{"q"},
+		DisableFlagsInUseLine: true,
+		Long:                  "Send API queries to a dagger engine\n\nWhen no document file, read query from standard input.",
+		Short:                 "Send API queries to a dagger engine",
+		Example: `
 dagger query <<EOF
 {
   container {
@@ -38,82 +39,10 @@ dagger query <<EOF
 }
 EOF
 `,
-	Run:  Query,
-	Args: cobra.MaximumNArgs(1), // operation can be specified
-}
-
-func Query(cmd *cobra.Command, args []string) {
-	ctx := context.Background()
-	var operation string
-	if len(args) > 0 {
-		operation = args[0]
+		Run:  Query,
+		Args: cobra.MaximumNArgs(1), // operation can be specified
 	}
 
-	vars := make(map[string]interface{})
-	if len(queryVarsJSONInput) > 0 {
-		if err := json.Unmarshal([]byte(queryVarsJSONInput), &vars); err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
-		}
-	} else {
-		vars = getKVInput(queryVarsInput)
-	}
-
-	// Use the provided query file if specified
-	// Otherwise, if stdin is a pipe or other non-tty thing, read from it.
-	// Finally, default to the operations returned by the loadExtension query
-	var operations string
-	if queryFile != "" {
-		inBytes, err := os.ReadFile(queryFile)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
-		}
-		operations = string(inBytes)
-	} else if !term.IsTerminal(int(os.Stdin.Fd())) {
-		inBytes, err := io.ReadAll(os.Stdin)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
-		}
-		operations = string(inBytes)
-	}
-
-	result, err := doQuery(ctx, operations, operation, vars)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
-	}
-
-	fmt.Printf("%s\n", result)
-}
-
-func doQuery(ctx context.Context, query, op string, vars map[string]interface{}) ([]byte, error) {
-	res := make(map[string]interface{})
-	err := withEngine(ctx, "", []string{"/"}, func(ctx context.Context, r *router.Router) error {
-		_, err := r.Do(ctx, query, op, vars, &res)
-		return err
-	})
-	if err != nil {
-		return nil, err
-	}
-	result, err := json.MarshalIndent(res, "", "    ")
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
-}
-
-func getKVInput(kvs []string) map[string]interface{} {
-	m := make(map[string]interface{})
-	for _, kv := range kvs {
-		split := strings.SplitN(kv, "=", 2)
-		m[split[0]] = split[1]
-	}
-	return m
-}
-
-func init() {
 	// changing usage template so examples are displayed below flags
 	queryCmd.SetUsageTemplate(`Usage:{{if .Runnable}}
   {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
@@ -148,4 +77,76 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 	queryCmd.Flags().StringVar(&queryFile, "doc", "", "document query file")
 	queryCmd.Flags().StringSliceVar(&queryVarsInput, "var", nil, "query variable")
 	queryCmd.Flags().StringVar(&queryVarsJSONInput, "var-json", "", "json query variables (overrides --var)")
+	return queryCmd
+}
+
+func Query(cmd *cobra.Command, args []string) {
+	ctx := context.Background()
+	var operation string
+	if len(args) > 0 {
+		operation = args[0]
+	}
+
+	vars := make(map[string]interface{})
+	if len(queryVarsJSONInput) > 0 {
+		if err := json.Unmarshal([]byte(queryVarsJSONInput), &vars); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		vars = getKVInput(queryVarsInput)
+	}
+
+	// Use the provided query file if specified
+	// Otherwise, if stdin is a pipe or other non-tty thing, read from it.
+	// Finally, default to the operations returned by the loadExtension query
+	var operations string
+	if queryFile != "" {
+		inBytes, err := os.ReadFile(queryFile)
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
+			os.Exit(1)
+		}
+		operations = string(inBytes)
+	} else if !term.IsTerminal(int(os.Stdin.Fd())) {
+		inBytes, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
+			os.Exit(1)
+		}
+		operations = string(inBytes)
+	}
+
+	result, err := doQuery(ctx, operations, operation, vars)
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "%s\n", result)
+}
+
+func doQuery(ctx context.Context, query, op string, vars map[string]interface{}) ([]byte, error) {
+	res := make(map[string]interface{})
+	err := withEngine(ctx, "", []string{"/"}, func(ctx context.Context, r *router.Router) error {
+		_, err := r.Do(ctx, query, op, vars, &res)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	result, err := json.MarshalIndent(res, "", "    ")
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func getKVInput(kvs []string) map[string]interface{} {
+	m := make(map[string]interface{})
+	for _, kv := range kvs {
+		split := strings.SplitN(kv, "=", 2)
+		m[split[0]] = split[1]
+	}
+	return m
 }

--- a/cmd/dagger/query.go
+++ b/cmd/dagger/query.go
@@ -90,7 +90,7 @@ func Query(cmd *cobra.Command, args []string) {
 
 func doQuery(ctx context.Context, query, op string, vars map[string]interface{}) ([]byte, error) {
 	res := make(map[string]interface{})
-	err := withEngine(ctx, "", func(ctx context.Context, r *router.Router) error {
+	err := withEngine(ctx, "", []string{"/"}, func(ctx context.Context, r *router.Router) error {
 		_, err := r.Do(ctx, query, op, vars, &res)
 		return err
 	})

--- a/cmd/dagger/query_test.go
+++ b/cmd/dagger/query_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQuery(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tmpdir := t.TempDir()
+	tmpfile := tmpdir + "/test.graphql"
+	err := os.WriteFile(tmpfile, []byte(`query Test{defaultPlatform}`), 0600)
+	require.NoError(t, err)
+
+	cmd := rootCmd()
+	cmd.SetArgs([]string{
+		"query",
+		"--doc", tmpfile,
+		"Test",
+	})
+
+	output := bytes.NewBuffer(nil)
+	cmd.SetOut(output)
+
+	err = cmd.ExecuteContext(ctx)
+	require.NoError(t, err)
+	require.Equal(t, fmt.Sprintf(`{
+    "defaultPlatform": "%s/%s"
+}
+`, runtime.GOOS, runtime.GOARCH), output.String())
+}

--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -15,19 +15,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var runCmd = &cobra.Command{
-	Use:                   "run [command]",
-	Aliases:               []string{"r"},
-	DisableFlagsInUseLine: true,
-	Long:                  "Runs the specified command in a Dagger session\n\nDAGGER_SESSION_URL and DAGGER_SESSION_TOKEN will be convieniently injected automatically.",
-	Short:                 "Runs a command in a Dagger session",
-	Example: `
+func runCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:                   "run [command]",
+		Aliases:               []string{"r"},
+		DisableFlagsInUseLine: true,
+		Long:                  "Runs the specified command in a Dagger session\n\nDAGGER_SESSION_URL and DAGGER_SESSION_TOKEN will be convieniently injected automatically.",
+		Short:                 "Runs a command in a Dagger session",
+		Example: `
 dagger run -- sh -c 'curl \
 -u $DAGGER_SESSION_TOKEN: \
 -H "content-type:application/json" \
 -d "{\"query\":\"{container{id}}\"}" $DAGGER_SESSION_URL'`,
-	Run:  Run,
-	Args: cobra.MinimumNArgs(1),
+		Run:  Run,
+		Args: cobra.MinimumNArgs(1),
+	}
 }
 
 func Run(cmd *cobra.Command, args []string) {
@@ -60,8 +62,8 @@ func Run(cmd *cobra.Command, args []string) {
 	os.Setenv("DAGGER_SESSION_TOKEN", sessionToken.String())
 
 	c := exec.CommandContext(ctx, args[0], args[1:]...) // #nosec
-	c.Stdout = os.Stdout
-	c.Stderr = os.Stderr
+	c.Stdout = cmd.OutOrStdout()
+	c.Stderr = cmd.ErrOrStderr()
 	c.Stdin = os.Stdin
 	c.Run()
 }

--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -48,7 +48,7 @@ func Run(cmd *cobra.Command, args []string) {
 			os.Exit(1)
 		}
 		listening <- fmt.Sprintf("%d", l.Addr().(*net.TCPAddr).Port)
-		if err := withEngine(ctx, sessionToken.String(), func(ctx context.Context, r *router.Router) error {
+		if err := withEngine(ctx, sessionToken.String(), []string{"/"}, func(ctx context.Context, r *router.Router) error {
 			return http.Serve(l, r)
 		}); err != nil {
 			panic(err)

--- a/cmd/dagger/run_test.go
+++ b/cmd/dagger/run_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRun(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := rootCmd()
+	cmd.SetArgs([]string{
+		"run",
+		"--",
+		"env",
+	})
+
+	output := bytes.NewBuffer(nil)
+	cmd.SetOut(output)
+
+	err := cmd.ExecuteContext(ctx)
+	require.NoError(t, err)
+
+	require.Regexp(t, `DAGGER_SESSION_URL=http://localhost:\d+/query\n`, output.String())
+	require.Regexp(t, `DAGGER_SESSION_TOKEN=[0-9a-f-]+\n`, output.String())
+}

--- a/cmd/dagger/version.go
+++ b/cmd/dagger/version.go
@@ -13,16 +13,18 @@ const (
 	engineImageRepo    = "ghcr.io/dagger/engine"
 )
 
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Print dagger version",
-	// Disable version hook here to avoid double version check
-	PersistentPreRun:  func(*cobra.Command, []string) {},
-	PersistentPostRun: func(*cobra.Command, []string) {},
-	Args:              cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(long())
-	},
+func versionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print dagger version",
+		// Disable version hook here to avoid double version check
+		PersistentPreRun:  func(*cobra.Command, []string) {},
+		PersistentPostRun: func(*cobra.Command, []string) {},
+		Args:              cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(long())
+		},
+	}
 }
 
 // version holds the complete version number. Filled in at linking time.

--- a/cmd/engine-session/main.go
+++ b/cmd/engine-session/main.go
@@ -19,8 +19,9 @@ import (
 )
 
 var (
-	configPath string
-	workdir    string
+	configPath       string
+	workdir          string
+	allowedLocalDirs []string
 )
 
 func init() {
@@ -40,10 +41,11 @@ var rootCmd = &cobra.Command{
 
 func EngineSession(cmd *cobra.Command, args []string) {
 	startOpts := &engine.Config{
-		Workdir:    workdir,
-		ConfigPath: configPath,
-		LogOutput:  os.Stderr,
-		RunnerHost: os.Getenv("_EXPERIMENTAL_DAGGER_RUNNER_HOST"),
+		Workdir:          workdir,
+		ConfigPath:       configPath,
+		LogOutput:        os.Stderr,
+		RunnerHost:       os.Getenv("_EXPERIMENTAL_DAGGER_RUNNER_HOST"),
+		AllowedLocalDirs: []string{"/"},
 	}
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, syscall.SIGINT, syscall.SIGTERM)

--- a/cmd/engine-session/main.go
+++ b/cmd/engine-session/main.go
@@ -19,9 +19,8 @@ import (
 )
 
 var (
-	configPath       string
-	workdir          string
-	allowedLocalDirs []string
+	configPath string
+	workdir    string
 )
 
 func init() {

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -67,6 +67,15 @@ func WithLogOutput(writer io.Writer) ClientOpt {
 	})
 }
 
+// WithAllowedLocalDirs sets the allowed local directories. If nil,
+// then all directories are allowed by default. If an empty non-nil slice,
+// no directories will be allowed.
+func WithAllowedLocalDirs(dirs []string) ClientOpt {
+	return clientOptFunc(func(cfg *engineconn.Config) {
+		cfg.AllowedLocalDirs = dirs
+	})
+}
+
 // Connect to a Dagger Engine
 func Connect(ctx context.Context, opts ...ClientOpt) (_ *Client, rerr error) {
 	defer func() {

--- a/sdk/go/internal/engineconn/bin/bin.go
+++ b/sdk/go/internal/engineconn/bin/bin.go
@@ -52,6 +52,9 @@ func (c *Bin) Connect(ctx context.Context, cfg *engineconn.Config) (*http.Client
 	if cfg.ConfigPath != "" {
 		args = append(args, "--project", cfg.ConfigPath)
 	}
+	if cfg.AllowedLocalDirs != nil {
+		args = append(args, "--allowed-local-dirs="+strings.Join(cfg.AllowedLocalDirs, ","))
+	}
 
 	addr, childStdin, err := StartEngineSession(ctx, cfg.LogOutput, "", c.path, args...)
 	if err != nil {

--- a/sdk/go/internal/engineconn/dockerprovision/container.go
+++ b/sdk/go/internal/engineconn/dockerprovision/container.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"runtime"
+	"strings"
 
 	"dagger.io/dagger/internal/engineconn"
 	"dagger.io/dagger/internal/engineconn/bin"
@@ -69,6 +70,9 @@ func (c *DockerContainer) Connect(ctx context.Context, cfg *engineconn.Config) (
 	}
 	if cfg.ConfigPath != "" {
 		args = append(args, "--project", cfg.ConfigPath)
+	}
+	if cfg.AllowedLocalDirs != nil {
+		args = append(args, "--allowed-local-dirs="+strings.Join(cfg.AllowedLocalDirs, ","))
 	}
 
 	defaultDaggerRunnerHost := "docker-container://" + c.containerName

--- a/sdk/go/internal/engineconn/dockerprovision/image.go
+++ b/sdk/go/internal/engineconn/dockerprovision/image.go
@@ -128,6 +128,9 @@ func (c *DockerImage) Connect(ctx context.Context, cfg *engineconn.Config) (*htt
 	if cfg.ConfigPath != "" {
 		args = append(args, "--project", cfg.ConfigPath)
 	}
+	if cfg.AllowedLocalDirs != nil {
+		args = append(args, "--allowed-local-dirs="+strings.Join(cfg.AllowedLocalDirs, ","))
+	}
 
 	defaultDaggerRunnerHost := "docker-image://" + c.imageRef
 	addr, childStdin, err := bin.StartEngineSession(ctx, cfg.LogOutput, defaultDaggerRunnerHost, engineSessionBinPath, args...)

--- a/sdk/go/internal/engineconn/engineconn.go
+++ b/sdk/go/internal/engineconn/engineconn.go
@@ -33,10 +33,11 @@ func Get(host string) (EngineConn, error) {
 }
 
 type Config struct {
-	Workdir      string
-	ConfigPath   string
-	NoExtensions bool
-	LogOutput    io.Writer
+	Workdir          string
+	ConfigPath       string
+	NoExtensions     bool
+	LogOutput        io.Writer
+	AllowedLocalDirs []string
 }
 
 // Register registers new connectionhelper for scheme


### PR DESCRIPTION
Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Running with this command: `./hack/dev go run $(pwd)/cmd/dagger listen --local-dirs /tmp`

And then trying to make this query that requests a not allowed dir:
```
curl \
  -H "content-type:application/json" \
  -d '{"query":"{host{directory(path:\"/home/sipsma\"){entries}}}"}' \
  http://127.0.0.1:8080/query
```

Now results in this error: `{"data":{},"errors":[{"message":"NotFound: no access allowed to dir \"/home/sipsma\"","path":["host","directory","entries"],"locations":[{"line":1,"column":38}]}]}`

TODO:
- [x] Add automated tests