### PR TITLE
Use HTTP basic auth for dagger session token.

### DIFF
--- a/cmd/dagger/listen.go
+++ b/cmd/dagger/listen.go
@@ -36,7 +36,7 @@ func Listen(cmd *cobra.Command, args []string) {
 	}
 }
 
-func setupServer(ctx context.Context, path string) error {
+func setupServer(ctx context.Context, sessionID string) error {
 	opts := []dagger.ClientOpt{
 		dagger.WithWorkdir(workdir),
 		dagger.WithConfigPath(configPath),
@@ -51,7 +51,14 @@ func setupServer(ctx context.Context, path string) error {
 		return err
 	}
 
-	http.HandleFunc("/"+path, func(rw http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
+		username, _, ok := r.BasicAuth()
+		if !ok || username != sessionID {
+			rw.Header().Set("WWW-Authenticate", `Basic realm="Access to the Dagger engine session"`)
+			rw.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
 		res := make(map[string]interface{})
 		resp := &dagger.Response{Data: &res}
 

--- a/cmd/dagger/listen.go
+++ b/cmd/dagger/listen.go
@@ -52,11 +52,13 @@ func setupServer(ctx context.Context, sessionID string) error {
 	}
 
 	http.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
-		username, _, ok := r.BasicAuth()
-		if !ok || username != sessionID {
-			rw.Header().Set("WWW-Authenticate", `Basic realm="Access to the Dagger engine session"`)
-			rw.WriteHeader(http.StatusUnauthorized)
-			return
+		if sessionID != "" {
+			username, _, ok := r.BasicAuth()
+			if !ok || username != sessionID {
+				rw.Header().Set("WWW-Authenticate", `Basic realm="Access to the Dagger engine session"`)
+				rw.WriteHeader(http.StatusUnauthorized)
+				return
+			}
 		}
 
 		res := make(map[string]interface{})

--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -18,10 +18,11 @@ var runCmd = &cobra.Command{
 	Use:                   "run [command]",
 	Aliases:               []string{"r"},
 	DisableFlagsInUseLine: true,
-	Long:                  "Runs the specified command in a Dagger session\n\nDAGGER_SESSION_URL will be convieniently injected automatically.",
+	Long:                  "Runs the specified command in a Dagger session\n\nDAGGER_SESSION_URL and DAGGER_SESSION_TOKEN will be convieniently injected automatically.",
 	Short:                 "Runs a command in a Dagger session",
 	Example: `
 dagger run -- sh -c 'curl \
+-u $DAGGER_SESSION_TOKEN \
 -H "content-type:application/json" \
 -d "{\"query\":\"{container{id}}\"}" $DAGGER_SESSION_URL'`,
 	Run:  Run,

--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -31,12 +31,12 @@ dagger run -- sh -c 'curl \
 func Run(cmd *cobra.Command, args []string) {
 	rand.Seed(time.Now().UnixNano())
 	ctx := context.Background()
-	randPath, err := uuid.NewRandom()
+	sessionID, err := uuid.NewRandom()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
-	if err := setupServer(ctx, randPath.String()); err != nil {
+	if err := setupServer(ctx, sessionID.String()); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
@@ -54,7 +54,8 @@ func Run(cmd *cobra.Command, args []string) {
 	}()
 
 	listenPort := <-listening
-	os.Setenv("DAGGER_SESSION_URL", fmt.Sprintf("http://localhost:%s/%s", listenPort, randPath))
+	os.Setenv("DAGGER_SESSION_URL", fmt.Sprintf("http://localhost:%s", listenPort))
+	os.Setenv("DAGGER_SESSION_TOKEN", sessionID.String())
 
 	c := exec.CommandContext(ctx, args[0], args[1:]...) // #nosec
 	c.Stdout = os.Stdout


### PR DESCRIPTION
Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Following the stripe approach of using the username: https://stripe.com/docs/api/authentication?lang=curl

---

Happy case:
```console
go run $(pwd)/cmd/dagger run -- sh -c 'curl -v \
-u $DAGGER_SESSION_TOKEN: \
-H "content-type:application/json" \
-d "{\"query\":\"{container{id}}\"}" $DAGGER_SESSION_URL'
*   Trying 127.0.0.1:32921...
* Connected to localhost (127.0.0.1) port 32921 (#0)
* Server auth using Basic with user '4501c97d-ba4d-437c-b089-1730179d1161'
> POST / HTTP/1.1
> Host: localhost:32921
> Authorization: Basic NDUwMWM5N2QtYmE0ZC00MzdjLWIwODktMTczMDE3OWQxMTYxOg==
> User-Agent: curl/7.85.0
> Accept: */*
> content-type:application/json
> Content-Length: 27
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Wed, 30 Nov 2022 03:50:32 GMT
< Content-Length: 124
< 
* Connection #0 to host localhost left intact
{"data":{"container":{"id":"eyJmcyI6bnVsbCwiY2ZnIjp7fSwicGxhdGZvcm0iOnsiYXJjaGl0ZWN0dXJlIjoiYXJtNjQiLCJvcyI6ImxpbnV4In19"}}}
```

Unauthorized case:
```console
go run $(pwd)/cmd/dagger run -- sh -c 'curl -v \
-H "content-type:application/json" \
-d "{\"query\":\"{container{id}}\"}" $DAGGER_SESSION_URL'
*   Trying 127.0.0.1:43973...
* Connected to localhost (127.0.0.1) port 43973 (#0)
> POST / HTTP/1.1
> Host: localhost:43973
> User-Agent: curl/7.85.0
> Accept: */*
> content-type:application/json
> Content-Length: 27
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 401 Unauthorized
< Www-Authenticate: Basic realm="Access to the Dagger engine session"
< Date: Wed, 30 Nov 2022 03:51:24 GMT
< Content-Length: 0
< 
* Connection #0 to host localhost left intact
```