### PR TITLE
sdk: python: Check input types at runtime

### DIFF
--- a/sdk/python/poetry.lock
+++ b/sdk/python/poetry.lock
@@ -69,6 +69,21 @@ optional = false
 python-versions = ">=3.7,<4.0"
 
 [[package]]
+name = "beartype"
+version = "0.11.0"
+description = "Unbearably fast runtime type checking in pure Python."
+category = "main"
+optional = false
+python-versions = ">=3.7.0"
+
+[package.extras]
+all = ["typing-extensions (>=3.10.0.0)"]
+dev = ["coverage (>=5.5)", "mypy (>=0.800)", "numpy", "pytest (>=4.0.0)", "sphinx", "sphinx (>=4.1.0)", "tox (>=3.20.1)", "typing-extensions"]
+doc-rtd = ["sphinx (==4.1.0)", "sphinx-rtd-theme (==0.5.1)"]
+test-tox = ["mypy (>=0.800)", "numpy", "pytest (>=4.0.0)", "sphinx", "typing-extensions"]
+test-tox-coverage = ["coverage (>=5.5)"]
+
+[[package]]
 name = "black"
 version = "22.10.0"
 description = "The uncompromising code formatter."
@@ -554,6 +569,17 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
+name = "pytest-lazy-fixture"
+version = "0.6.3"
+description = "It helps to use fixtures in pytest.mark.parametrize"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pytest = ">=3.2.5"
+
+[[package]]
 name = "pytest-mock"
 version = "3.10.0"
 description = "Thin-wrapper around the mock package for easier use with pytest"
@@ -892,7 +918,7 @@ server = ["strawberry-graphql"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "7816efa32fe9013eaea911ea32fed3ed312520fb9e84142213b0d538e5c5d3a1"
+content-hash = "4a9d2d5e8e1c44e4942f172556bfca49a1ab71ba823bba543fff12e60405cd58"
 
 [metadata.files]
 alabaster = [
@@ -918,6 +944,10 @@ babel = [
 backoff = [
     {file = "backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8"},
     {file = "backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba"},
+]
+beartype = [
+    {file = "beartype-0.11.0-py3-none-any.whl", hash = "sha256:d1ed5f97edebe909385190fac95ef9af3daf233eb1a5cd08b88b0d8260708ad7"},
+    {file = "beartype-0.11.0.tar.gz", hash = "sha256:3854b50eaaa98bb89490be57e73c69c777a0f304574e7043ac7da98ac6a735a6"},
 ]
 black = [
     {file = "black-22.10.0-1fixedarch-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:5cc42ca67989e9c3cf859e84c2bf014f6633db63d1cbdf8fdb666dcd9e77e3fa"},
@@ -1224,6 +1254,10 @@ pyparsing = [
 pytest = [
     {file = "pytest-7.2.0-py3-none-any.whl", hash = "sha256:892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71"},
     {file = "pytest-7.2.0.tar.gz", hash = "sha256:c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59"},
+]
+pytest-lazy-fixture = [
+    {file = "pytest-lazy-fixture-0.6.3.tar.gz", hash = "sha256:0e7d0c7f74ba33e6e80905e9bfd81f9d15ef9a790de97993e34213deb5ad10ac"},
+    {file = "pytest_lazy_fixture-0.6.3-py3-none-any.whl", hash = "sha256:e0b379f38299ff27a653f03eaa69b08a6fd4484e46fd1c9907d984b9f9daeda6"},
 ]
 pytest-mock = [
     {file = "pytest-mock-3.10.0.tar.gz", hash = "sha256:fbbdb085ef7c252a326fd8cdcac0aa3b1333d8811f131bdcc701002e1be7ed4f"},

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -53,6 +53,7 @@ gql = ">=3.4.0"
 httpx = ">=0.23.1"
 strawberry-graphql = {version = ">=0.133.5", optional = true}
 typer = {version = ">=0.6.1", extras = ["all"]}
+beartype = ">=0.11.0"
 
 [tool.poetry.extras]
 server = ["strawberry-graphql"]
@@ -61,6 +62,7 @@ server = ["strawberry-graphql"]
 pytest = ">=7.2.0"
 pytest-mock = ">=3.10.0"
 pytest-subprocess = ">=1.4.2"
+pytest-lazy-fixture = "^0.6.3"
 
 [tool.poetry.group.lint.dependencies]
 autoflake = ">=1.3.1"

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -52,8 +52,8 @@ class Container(Type):
     def build(self, context: "Directory", dockerfile: str | None = None) -> "Container":
         """Initialize this container from a Dockerfile build"""
         _args = [
-            Arg("context", context),
-            Arg("dockerfile", dockerfile, None),
+            Arg("context", "context", context, Directory),
+            Arg("dockerfile", "dockerfile", dockerfile, str | None, None),
         ]
         _ctx = self._select("build", _args)
         return Container(_ctx)
@@ -75,7 +75,7 @@ class Container(Type):
     def directory(self, path: str) -> "Directory":
         """Retrieve a directory at the given path. Mounts are included."""
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("directory", _args)
         return Directory(_ctx)
@@ -105,7 +105,7 @@ class Container(Type):
             GraphQL to represent free-form human-readable text.
         """
         _args = [
-            Arg("name", name),
+            Arg("name", "name", name, str),
         ]
         _ctx = self._select("envVariable", _args)
         return await _ctx.execute(str | None)
@@ -146,11 +146,17 @@ class Container(Type):
             HOST FILESYSTEM
         """
         _args = [
-            Arg("args", args, None),
-            Arg("stdin", stdin, None),
-            Arg("redirectStdout", redirect_stdout, None),
-            Arg("redirectStderr", redirect_stderr, None),
-            Arg("experimentalPrivilegedNesting", experimental_privileged_nesting, None),
+            Arg("args", "args", args, list[str] | None, None),
+            Arg("stdin", "stdin", stdin, str | None, None),
+            Arg("redirect_stdout", "redirectStdout", redirect_stdout, str | None, None),
+            Arg("redirect_stderr", "redirectStderr", redirect_stderr, str | None, None),
+            Arg(
+                "experimental_privileged_nesting",
+                "experimentalPrivilegedNesting",
+                experimental_privileged_nesting,
+                bool | None,
+                None,
+            ),
         ]
         _ctx = self._select("exec", _args)
         return Container(_ctx)
@@ -183,8 +189,14 @@ class Container(Type):
             The `Boolean` scalar type represents `true` or `false`.
         """
         _args = [
-            Arg("path", path),
-            Arg("platformVariants", platform_variants, None),
+            Arg("path", "path", path, str),
+            Arg(
+                "platform_variants",
+                "platformVariants",
+                platform_variants,
+                list[Container] | None,
+                None,
+            ),
         ]
         _ctx = self._select("export", _args)
         return await _ctx.execute(bool)
@@ -192,7 +204,7 @@ class Container(Type):
     def file(self, path: str) -> "File":
         """Retrieve a file at the given path. Mounts are included."""
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("file", _args)
         return File(_ctx)
@@ -202,7 +214,7 @@ class Container(Type):
         address
         """
         _args = [
-            Arg("address", address),
+            Arg("address", "address", address, str),
         ]
         _ctx = self._select("from", _args)
         return Container(_ctx)
@@ -267,8 +279,14 @@ class Container(Type):
             GraphQL to represent free-form human-readable text.
         """
         _args = [
-            Arg("address", address),
-            Arg("platformVariants", platform_variants, None),
+            Arg("address", "address", address, str),
+            Arg(
+                "platform_variants",
+                "platformVariants",
+                platform_variants,
+                list[Container] | None,
+                None,
+            ),
         ]
         _ctx = self._select("publish", _args)
         return await _ctx.execute(str)
@@ -328,7 +346,7 @@ class Container(Type):
     def with_default_args(self, args: list[str] | None = None) -> "Container":
         """Configures default arguments for future commands"""
         _args = [
-            Arg("args", args, None),
+            Arg("args", "args", args, list[str] | None, None),
         ]
         _ctx = self._select("withDefaultArgs", _args)
         return Container(_ctx)
@@ -342,10 +360,10 @@ class Container(Type):
     ) -> "Container":
         """This container plus a directory written at the given path"""
         _args = [
-            Arg("path", path),
-            Arg("directory", directory),
-            Arg("exclude", exclude, None),
-            Arg("include", include, None),
+            Arg("path", "path", path, str),
+            Arg("directory", "directory", directory, Directory),
+            Arg("exclude", "exclude", exclude, list[str] | None, None),
+            Arg("include", "include", include, list[str] | None, None),
         ]
         _ctx = self._select("withDirectory", _args)
         return Container(_ctx)
@@ -353,7 +371,7 @@ class Container(Type):
     def with_entrypoint(self, args: list[str]) -> "Container":
         """This container but with a different command entrypoint"""
         _args = [
-            Arg("args", args),
+            Arg("args", "args", args, list[str]),
         ]
         _ctx = self._select("withEntrypoint", _args)
         return Container(_ctx)
@@ -361,8 +379,8 @@ class Container(Type):
     def with_env_variable(self, name: str, value: str) -> "Container":
         """This container plus the given environment variable"""
         _args = [
-            Arg("name", name),
-            Arg("value", value),
+            Arg("name", "name", name, str),
+            Arg("value", "value", value, str),
         ]
         _ctx = self._select("withEnvVariable", _args)
         return Container(_ctx)
@@ -394,11 +412,17 @@ class Container(Type):
             HOST FILESYSTEM
         """
         _args = [
-            Arg("args", args),
-            Arg("stdin", stdin, None),
-            Arg("redirectStdout", redirect_stdout, None),
-            Arg("redirectStderr", redirect_stderr, None),
-            Arg("experimentalPrivilegedNesting", experimental_privileged_nesting, None),
+            Arg("args", "args", args, list[str]),
+            Arg("stdin", "stdin", stdin, str | None, None),
+            Arg("redirect_stdout", "redirectStdout", redirect_stdout, str | None, None),
+            Arg("redirect_stderr", "redirectStderr", redirect_stderr, str | None, None),
+            Arg(
+                "experimental_privileged_nesting",
+                "experimentalPrivilegedNesting",
+                experimental_privileged_nesting,
+                bool | None,
+                None,
+            ),
         ]
         _ctx = self._select("withExec", _args)
         return Container(_ctx)
@@ -410,7 +434,7 @@ class Container(Type):
             Replaced by :py:meth:`with_rootfs`.
         """
         _args = [
-            Arg("id", id),
+            Arg("id", "id", id, DirectoryID | Directory),
         ]
         _ctx = self._select("withFS", _args)
         return Container(_ctx)
@@ -420,8 +444,8 @@ class Container(Type):
         path
         """
         _args = [
-            Arg("path", path),
-            Arg("source", source),
+            Arg("path", "path", path, str),
+            Arg("source", "source", source, File),
         ]
         _ctx = self._select("withFile", _args)
         return Container(_ctx)
@@ -431,9 +455,9 @@ class Container(Type):
     ) -> "Container":
         """This container plus a cache volume mounted at the given path"""
         _args = [
-            Arg("path", path),
-            Arg("cache", cache),
-            Arg("source", source, None),
+            Arg("path", "path", path, str),
+            Arg("cache", "cache", cache, CacheVolume),
+            Arg("source", "source", source, Directory | None, None),
         ]
         _ctx = self._select("withMountedCache", _args)
         return Container(_ctx)
@@ -441,8 +465,8 @@ class Container(Type):
     def with_mounted_directory(self, path: str, source: "Directory") -> "Container":
         """This container plus a directory mounted at the given path"""
         _args = [
-            Arg("path", path),
-            Arg("source", source),
+            Arg("path", "path", path, str),
+            Arg("source", "source", source, Directory),
         ]
         _ctx = self._select("withMountedDirectory", _args)
         return Container(_ctx)
@@ -450,8 +474,8 @@ class Container(Type):
     def with_mounted_file(self, path: str, source: "File") -> "Container":
         """This container plus a file mounted at the given path"""
         _args = [
-            Arg("path", path),
-            Arg("source", source),
+            Arg("path", "path", path, str),
+            Arg("source", "source", source, File),
         ]
         _ctx = self._select("withMountedFile", _args)
         return Container(_ctx)
@@ -459,8 +483,8 @@ class Container(Type):
     def with_mounted_secret(self, path: str, source: "Secret") -> "Container":
         """This container plus a secret mounted into a file at the given path"""
         _args = [
-            Arg("path", path),
-            Arg("source", source),
+            Arg("path", "path", path, str),
+            Arg("source", "source", source, Secret),
         ]
         _ctx = self._select("withMountedSecret", _args)
         return Container(_ctx)
@@ -468,7 +492,7 @@ class Container(Type):
     def with_mounted_temp(self, path: str) -> "Container":
         """This container plus a temporary directory mounted at the given path"""
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("withMountedTemp", _args)
         return Container(_ctx)
@@ -476,8 +500,8 @@ class Container(Type):
     def with_new_file(self, path: str, contents: str | None = None) -> "Container":
         """This container plus a new file written at the given path"""
         _args = [
-            Arg("path", path),
-            Arg("contents", contents, None),
+            Arg("path", "path", path, str),
+            Arg("contents", "contents", contents, str | None, None),
         ]
         _ctx = self._select("withNewFile", _args)
         return Container(_ctx)
@@ -485,7 +509,7 @@ class Container(Type):
     def with_rootfs(self, id: "DirectoryID | Directory") -> "Container":
         """Initialize this container from this DirectoryID"""
         _args = [
-            Arg("id", id),
+            Arg("id", "id", id, DirectoryID | Directory),
         ]
         _ctx = self._select("withRootfs", _args)
         return Container(_ctx)
@@ -493,8 +517,8 @@ class Container(Type):
     def with_secret_variable(self, name: str, secret: "Secret") -> "Container":
         """This container plus an env variable containing the given secret"""
         _args = [
-            Arg("name", name),
-            Arg("secret", secret),
+            Arg("name", "name", name, str),
+            Arg("secret", "secret", secret, Secret),
         ]
         _ctx = self._select("withSecretVariable", _args)
         return Container(_ctx)
@@ -502,8 +526,8 @@ class Container(Type):
     def with_unix_socket(self, path: str, source: "Socket") -> "Container":
         """This container plus a socket forwarded to the given Unix socket path"""
         _args = [
-            Arg("path", path),
-            Arg("source", source),
+            Arg("path", "path", path, str),
+            Arg("source", "source", source, Socket),
         ]
         _ctx = self._select("withUnixSocket", _args)
         return Container(_ctx)
@@ -511,7 +535,7 @@ class Container(Type):
     def with_user(self, name: str) -> "Container":
         """This container but with a different command user"""
         _args = [
-            Arg("name", name),
+            Arg("name", "name", name, str),
         ]
         _ctx = self._select("withUser", _args)
         return Container(_ctx)
@@ -519,7 +543,7 @@ class Container(Type):
     def with_workdir(self, path: str) -> "Container":
         """This container but with a different working directory"""
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("withWorkdir", _args)
         return Container(_ctx)
@@ -527,7 +551,7 @@ class Container(Type):
     def without_env_variable(self, name: str) -> "Container":
         """This container minus the given environment variable"""
         _args = [
-            Arg("name", name),
+            Arg("name", "name", name, str),
         ]
         _ctx = self._select("withoutEnvVariable", _args)
         return Container(_ctx)
@@ -535,7 +559,7 @@ class Container(Type):
     def without_mount(self, path: str) -> "Container":
         """This container after unmounting everything at the given path."""
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("withoutMount", _args)
         return Container(_ctx)
@@ -543,7 +567,7 @@ class Container(Type):
     def without_unix_socket(self, path: str) -> "Container":
         """This container with a previously added Unix socket removed"""
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("withoutUnixSocket", _args)
         return Container(_ctx)
@@ -569,7 +593,7 @@ class Directory(Type):
     def diff(self, other: "Directory") -> "Directory":
         """The difference between this directory and an another directory"""
         _args = [
-            Arg("other", other),
+            Arg("other", "other", other, Directory),
         ]
         _ctx = self._select("diff", _args)
         return Directory(_ctx)
@@ -577,7 +601,7 @@ class Directory(Type):
     def directory(self, path: str) -> "Directory":
         """Retrieve a directory at the given path"""
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("directory", _args)
         return Directory(_ctx)
@@ -587,8 +611,8 @@ class Directory(Type):
     ) -> "Container":
         """Build a new Docker container from this directory"""
         _args = [
-            Arg("dockerfile", dockerfile, None),
-            Arg("platform", platform, None),
+            Arg("dockerfile", "dockerfile", dockerfile, str | None, None),
+            Arg("platform", "platform", platform, Platform | None, None),
         ]
         _ctx = self._select("dockerBuild", _args)
         return Container(_ctx)
@@ -604,7 +628,7 @@ class Directory(Type):
             GraphQL to represent free-form human-readable text.
         """
         _args = [
-            Arg("path", path, None),
+            Arg("path", "path", path, str | None, None),
         ]
         _ctx = self._select("entries", _args)
         return await _ctx.execute(list[str])
@@ -618,7 +642,7 @@ class Directory(Type):
             The `Boolean` scalar type represents `true` or `false`.
         """
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("export", _args)
         return await _ctx.execute(bool)
@@ -626,7 +650,7 @@ class Directory(Type):
     def file(self, path: str) -> "File":
         """Retrieve a file at the given path"""
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("file", _args)
         return File(_ctx)
@@ -650,7 +674,7 @@ class Directory(Type):
     def load_project(self, config_path: str) -> "Project":
         """load a project's metadata"""
         _args = [
-            Arg("configPath", config_path),
+            Arg("config_path", "configPath", config_path, str),
         ]
         _ctx = self._select("loadProject", _args)
         return Project(_ctx)
@@ -664,10 +688,10 @@ class Directory(Type):
     ) -> "Directory":
         """This directory plus a directory written at the given path"""
         _args = [
-            Arg("path", path),
-            Arg("directory", directory),
-            Arg("exclude", exclude, None),
-            Arg("include", include, None),
+            Arg("path", "path", path, str),
+            Arg("directory", "directory", directory, Directory),
+            Arg("exclude", "exclude", exclude, list[str] | None, None),
+            Arg("include", "include", include, list[str] | None, None),
         ]
         _ctx = self._select("withDirectory", _args)
         return Directory(_ctx)
@@ -677,8 +701,8 @@ class Directory(Type):
         path
         """
         _args = [
-            Arg("path", path),
-            Arg("source", source),
+            Arg("path", "path", path, str),
+            Arg("source", "source", source, File),
         ]
         _ctx = self._select("withFile", _args)
         return Directory(_ctx)
@@ -686,7 +710,7 @@ class Directory(Type):
     def with_new_directory(self, path: str) -> "Directory":
         """This directory plus a new directory created at the given path"""
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("withNewDirectory", _args)
         return Directory(_ctx)
@@ -694,8 +718,8 @@ class Directory(Type):
     def with_new_file(self, path: str, contents: str) -> "Directory":
         """This directory plus a new file written at the given path"""
         _args = [
-            Arg("path", path),
-            Arg("contents", contents),
+            Arg("path", "path", path, str),
+            Arg("contents", "contents", contents, str),
         ]
         _ctx = self._select("withNewFile", _args)
         return Directory(_ctx)
@@ -705,7 +729,7 @@ class Directory(Type):
         seconds from the Unix epoch
         """
         _args = [
-            Arg("timestamp", timestamp),
+            Arg("timestamp", "timestamp", timestamp, int),
         ]
         _ctx = self._select("withTimestamps", _args)
         return Directory(_ctx)
@@ -713,7 +737,7 @@ class Directory(Type):
     def without_directory(self, path: str) -> "Directory":
         """This directory with the directory at the given path removed"""
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("withoutDirectory", _args)
         return Directory(_ctx)
@@ -721,7 +745,7 @@ class Directory(Type):
     def without_file(self, path: str) -> "Directory":
         """This directory with the file at the given path removed"""
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("withoutFile", _args)
         return Directory(_ctx)
@@ -786,7 +810,7 @@ class File(Type):
             The `Boolean` scalar type represents `true` or `false`.
         """
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("export", _args)
         return await _ctx.execute(bool)
@@ -827,7 +851,7 @@ class File(Type):
         in seconds from the Unix epoch
         """
         _args = [
-            Arg("timestamp", timestamp),
+            Arg("timestamp", "timestamp", timestamp, int),
         ]
         _ctx = self._select("withTimestamps", _args)
         return File(_ctx)
@@ -857,8 +881,10 @@ class GitRef(Type):
     ) -> "Directory":
         """The filesystem tree at this ref"""
         _args = [
-            Arg("sshKnownHosts", ssh_known_hosts, None),
-            Arg("sshAuthSocket", ssh_auth_socket, None),
+            Arg("ssh_known_hosts", "sshKnownHosts", ssh_known_hosts, str | None, None),
+            Arg(
+                "ssh_auth_socket", "sshAuthSocket", ssh_auth_socket, Socket | None, None
+            ),
         ]
         _ctx = self._select("tree", _args)
         return Directory(_ctx)
@@ -870,7 +896,7 @@ class GitRepository(Type):
     def branch(self, name: str) -> "GitRef":
         """Details on one branch"""
         _args = [
-            Arg("name", name),
+            Arg("name", "name", name, str),
         ]
         _ctx = self._select("branch", _args)
         return GitRef(_ctx)
@@ -892,7 +918,7 @@ class GitRepository(Type):
     def commit(self, id: str) -> "GitRef":
         """Details on one commit"""
         _args = [
-            Arg("id", id),
+            Arg("id", "id", id, str),
         ]
         _ctx = self._select("commit", _args)
         return GitRef(_ctx)
@@ -900,7 +926,7 @@ class GitRepository(Type):
     def tag(self, name: str) -> "GitRef":
         """Details on one tag"""
         _args = [
-            Arg("name", name),
+            Arg("name", "name", name, str),
         ]
         _ctx = self._select("tag", _args)
         return GitRef(_ctx)
@@ -931,9 +957,9 @@ class Host(Type):
     ) -> "Directory":
         """Access a directory on the host"""
         _args = [
-            Arg("path", path),
-            Arg("exclude", exclude, None),
-            Arg("include", include, None),
+            Arg("path", "path", path, str),
+            Arg("exclude", "exclude", exclude, list[str] | None, None),
+            Arg("include", "include", include, list[str] | None, None),
         ]
         _ctx = self._select("directory", _args)
         return Directory(_ctx)
@@ -941,7 +967,7 @@ class Host(Type):
     def env_variable(self, name: str) -> "HostVariable":
         """Access an environment variable on the host"""
         _args = [
-            Arg("name", name),
+            Arg("name", "name", name, str),
         ]
         _ctx = self._select("envVariable", _args)
         return HostVariable(_ctx)
@@ -949,7 +975,7 @@ class Host(Type):
     def unix_socket(self, path: str) -> "Socket":
         """Access a Unix socket on the host"""
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("unixSocket", _args)
         return Socket(_ctx)
@@ -963,8 +989,8 @@ class Host(Type):
             Use :py:meth:`directory` with path set to '.' instead.
         """
         _args = [
-            Arg("exclude", exclude, None),
-            Arg("include", include, None),
+            Arg("exclude", "exclude", exclude, list[str] | None, None),
+            Arg("include", "include", include, list[str] | None, None),
         ]
         _ctx = self._select("workdir", _args)
         return Directory(_ctx)
@@ -1068,7 +1094,7 @@ class Client(Root):
     def cache_volume(self, key: str) -> "CacheVolume":
         """Construct a cache volume for a given cache key"""
         _args = [
-            Arg("key", key),
+            Arg("key", "key", key, str),
         ]
         _ctx = self._select("cacheVolume", _args)
         return CacheVolume(_ctx)
@@ -1087,8 +1113,8 @@ class Client(Root):
         host.
         """
         _args = [
-            Arg("id", id, None),
-            Arg("platform", platform, None),
+            Arg("id", "id", id, ContainerID | Container | None, None),
+            Arg("platform", "platform", platform, Platform | None, None),
         ]
         _ctx = self._select("container", _args)
         return Container(_ctx)
@@ -1102,7 +1128,7 @@ class Client(Root):
     def directory(self, id: "DirectoryID | Directory | None" = None) -> "Directory":
         """Load a directory by ID. No argument produces an empty directory."""
         _args = [
-            Arg("id", id, None),
+            Arg("id", "id", id, DirectoryID | Directory | None, None),
         ]
         _ctx = self._select("directory", _args)
         return Directory(_ctx)
@@ -1110,7 +1136,7 @@ class Client(Root):
     def file(self, id: "FileID | File") -> "File":
         """Load a file by ID"""
         _args = [
-            Arg("id", id),
+            Arg("id", "id", id, FileID | File),
         ]
         _ctx = self._select("file", _args)
         return File(_ctx)
@@ -1118,8 +1144,8 @@ class Client(Root):
     def git(self, url: str, keep_git_dir: bool | None = None) -> "GitRepository":
         """Query a git repository"""
         _args = [
-            Arg("url", url),
-            Arg("keepGitDir", keep_git_dir, None),
+            Arg("url", "url", url, str),
+            Arg("keep_git_dir", "keepGitDir", keep_git_dir, bool | None, None),
         ]
         _ctx = self._select("git", _args)
         return GitRepository(_ctx)
@@ -1133,7 +1159,7 @@ class Client(Root):
     def http(self, url: str) -> "File":
         """An http remote"""
         _args = [
-            Arg("url", url),
+            Arg("url", "url", url, str),
         ]
         _ctx = self._select("http", _args)
         return File(_ctx)
@@ -1141,7 +1167,7 @@ class Client(Root):
     def project(self, name: str) -> "Project":
         """Look up a project by name"""
         _args = [
-            Arg("name", name),
+            Arg("name", "name", name, str),
         ]
         _ctx = self._select("project", _args)
         return Project(_ctx)
@@ -1149,7 +1175,7 @@ class Client(Root):
     def secret(self, id: "SecretID | Secret") -> "Secret":
         """Load a secret from its ID"""
         _args = [
-            Arg("id", id),
+            Arg("id", "id", id, SecretID | Secret),
         ]
         _ctx = self._select("secret", _args)
         return Secret(_ctx)
@@ -1157,7 +1183,7 @@ class Client(Root):
     def socket(self, id: "SocketID | Socket | None" = None) -> "Socket":
         """Load a socket by ID"""
         _args = [
-            Arg("id", id, None),
+            Arg("id", "id", id, SocketID | Socket | None, None),
         ]
         _ctx = self._select("socket", _args)
         return Socket(_ctx)

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -52,8 +52,8 @@ class Container(Type):
     def build(self, context: "Directory", dockerfile: str | None = None) -> "Container":
         """Initialize this container from a Dockerfile build"""
         _args = [
-            Arg("context", context),
-            Arg("dockerfile", dockerfile, None),
+            Arg("context", "context", context, Directory),
+            Arg("dockerfile", "dockerfile", dockerfile, str | None, None),
         ]
         _ctx = self._select("build", _args)
         return Container(_ctx)
@@ -75,7 +75,7 @@ class Container(Type):
     def directory(self, path: str) -> "Directory":
         """Retrieve a directory at the given path. Mounts are included."""
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("directory", _args)
         return Directory(_ctx)
@@ -105,7 +105,7 @@ class Container(Type):
             GraphQL to represent free-form human-readable text.
         """
         _args = [
-            Arg("name", name),
+            Arg("name", "name", name, str),
         ]
         _ctx = self._select("envVariable", _args)
         return _ctx.execute_sync(str | None)
@@ -146,11 +146,17 @@ class Container(Type):
             HOST FILESYSTEM
         """
         _args = [
-            Arg("args", args, None),
-            Arg("stdin", stdin, None),
-            Arg("redirectStdout", redirect_stdout, None),
-            Arg("redirectStderr", redirect_stderr, None),
-            Arg("experimentalPrivilegedNesting", experimental_privileged_nesting, None),
+            Arg("args", "args", args, list[str] | None, None),
+            Arg("stdin", "stdin", stdin, str | None, None),
+            Arg("redirect_stdout", "redirectStdout", redirect_stdout, str | None, None),
+            Arg("redirect_stderr", "redirectStderr", redirect_stderr, str | None, None),
+            Arg(
+                "experimental_privileged_nesting",
+                "experimentalPrivilegedNesting",
+                experimental_privileged_nesting,
+                bool | None,
+                None,
+            ),
         ]
         _ctx = self._select("exec", _args)
         return Container(_ctx)
@@ -183,8 +189,14 @@ class Container(Type):
             The `Boolean` scalar type represents `true` or `false`.
         """
         _args = [
-            Arg("path", path),
-            Arg("platformVariants", platform_variants, None),
+            Arg("path", "path", path, str),
+            Arg(
+                "platform_variants",
+                "platformVariants",
+                platform_variants,
+                list[Container] | None,
+                None,
+            ),
         ]
         _ctx = self._select("export", _args)
         return _ctx.execute_sync(bool)
@@ -192,7 +204,7 @@ class Container(Type):
     def file(self, path: str) -> "File":
         """Retrieve a file at the given path. Mounts are included."""
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("file", _args)
         return File(_ctx)
@@ -202,7 +214,7 @@ class Container(Type):
         address
         """
         _args = [
-            Arg("address", address),
+            Arg("address", "address", address, str),
         ]
         _ctx = self._select("from", _args)
         return Container(_ctx)
@@ -267,8 +279,14 @@ class Container(Type):
             GraphQL to represent free-form human-readable text.
         """
         _args = [
-            Arg("address", address),
-            Arg("platformVariants", platform_variants, None),
+            Arg("address", "address", address, str),
+            Arg(
+                "platform_variants",
+                "platformVariants",
+                platform_variants,
+                list[Container] | None,
+                None,
+            ),
         ]
         _ctx = self._select("publish", _args)
         return _ctx.execute_sync(str)
@@ -328,7 +346,7 @@ class Container(Type):
     def with_default_args(self, args: list[str] | None = None) -> "Container":
         """Configures default arguments for future commands"""
         _args = [
-            Arg("args", args, None),
+            Arg("args", "args", args, list[str] | None, None),
         ]
         _ctx = self._select("withDefaultArgs", _args)
         return Container(_ctx)
@@ -342,10 +360,10 @@ class Container(Type):
     ) -> "Container":
         """This container plus a directory written at the given path"""
         _args = [
-            Arg("path", path),
-            Arg("directory", directory),
-            Arg("exclude", exclude, None),
-            Arg("include", include, None),
+            Arg("path", "path", path, str),
+            Arg("directory", "directory", directory, Directory),
+            Arg("exclude", "exclude", exclude, list[str] | None, None),
+            Arg("include", "include", include, list[str] | None, None),
         ]
         _ctx = self._select("withDirectory", _args)
         return Container(_ctx)
@@ -353,7 +371,7 @@ class Container(Type):
     def with_entrypoint(self, args: list[str]) -> "Container":
         """This container but with a different command entrypoint"""
         _args = [
-            Arg("args", args),
+            Arg("args", "args", args, list[str]),
         ]
         _ctx = self._select("withEntrypoint", _args)
         return Container(_ctx)
@@ -361,8 +379,8 @@ class Container(Type):
     def with_env_variable(self, name: str, value: str) -> "Container":
         """This container plus the given environment variable"""
         _args = [
-            Arg("name", name),
-            Arg("value", value),
+            Arg("name", "name", name, str),
+            Arg("value", "value", value, str),
         ]
         _ctx = self._select("withEnvVariable", _args)
         return Container(_ctx)
@@ -394,11 +412,17 @@ class Container(Type):
             HOST FILESYSTEM
         """
         _args = [
-            Arg("args", args),
-            Arg("stdin", stdin, None),
-            Arg("redirectStdout", redirect_stdout, None),
-            Arg("redirectStderr", redirect_stderr, None),
-            Arg("experimentalPrivilegedNesting", experimental_privileged_nesting, None),
+            Arg("args", "args", args, list[str]),
+            Arg("stdin", "stdin", stdin, str | None, None),
+            Arg("redirect_stdout", "redirectStdout", redirect_stdout, str | None, None),
+            Arg("redirect_stderr", "redirectStderr", redirect_stderr, str | None, None),
+            Arg(
+                "experimental_privileged_nesting",
+                "experimentalPrivilegedNesting",
+                experimental_privileged_nesting,
+                bool | None,
+                None,
+            ),
         ]
         _ctx = self._select("withExec", _args)
         return Container(_ctx)
@@ -410,7 +434,7 @@ class Container(Type):
             Replaced by :py:meth:`with_rootfs`.
         """
         _args = [
-            Arg("id", id),
+            Arg("id", "id", id, DirectoryID | Directory),
         ]
         _ctx = self._select("withFS", _args)
         return Container(_ctx)
@@ -420,8 +444,8 @@ class Container(Type):
         path
         """
         _args = [
-            Arg("path", path),
-            Arg("source", source),
+            Arg("path", "path", path, str),
+            Arg("source", "source", source, File),
         ]
         _ctx = self._select("withFile", _args)
         return Container(_ctx)
@@ -431,9 +455,9 @@ class Container(Type):
     ) -> "Container":
         """This container plus a cache volume mounted at the given path"""
         _args = [
-            Arg("path", path),
-            Arg("cache", cache),
-            Arg("source", source, None),
+            Arg("path", "path", path, str),
+            Arg("cache", "cache", cache, CacheVolume),
+            Arg("source", "source", source, Directory | None, None),
         ]
         _ctx = self._select("withMountedCache", _args)
         return Container(_ctx)
@@ -441,8 +465,8 @@ class Container(Type):
     def with_mounted_directory(self, path: str, source: "Directory") -> "Container":
         """This container plus a directory mounted at the given path"""
         _args = [
-            Arg("path", path),
-            Arg("source", source),
+            Arg("path", "path", path, str),
+            Arg("source", "source", source, Directory),
         ]
         _ctx = self._select("withMountedDirectory", _args)
         return Container(_ctx)
@@ -450,8 +474,8 @@ class Container(Type):
     def with_mounted_file(self, path: str, source: "File") -> "Container":
         """This container plus a file mounted at the given path"""
         _args = [
-            Arg("path", path),
-            Arg("source", source),
+            Arg("path", "path", path, str),
+            Arg("source", "source", source, File),
         ]
         _ctx = self._select("withMountedFile", _args)
         return Container(_ctx)
@@ -459,8 +483,8 @@ class Container(Type):
     def with_mounted_secret(self, path: str, source: "Secret") -> "Container":
         """This container plus a secret mounted into a file at the given path"""
         _args = [
-            Arg("path", path),
-            Arg("source", source),
+            Arg("path", "path", path, str),
+            Arg("source", "source", source, Secret),
         ]
         _ctx = self._select("withMountedSecret", _args)
         return Container(_ctx)
@@ -468,7 +492,7 @@ class Container(Type):
     def with_mounted_temp(self, path: str) -> "Container":
         """This container plus a temporary directory mounted at the given path"""
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("withMountedTemp", _args)
         return Container(_ctx)
@@ -476,8 +500,8 @@ class Container(Type):
     def with_new_file(self, path: str, contents: str | None = None) -> "Container":
         """This container plus a new file written at the given path"""
         _args = [
-            Arg("path", path),
-            Arg("contents", contents, None),
+            Arg("path", "path", path, str),
+            Arg("contents", "contents", contents, str | None, None),
         ]
         _ctx = self._select("withNewFile", _args)
         return Container(_ctx)
@@ -485,7 +509,7 @@ class Container(Type):
     def with_rootfs(self, id: "DirectoryID | Directory") -> "Container":
         """Initialize this container from this DirectoryID"""
         _args = [
-            Arg("id", id),
+            Arg("id", "id", id, DirectoryID | Directory),
         ]
         _ctx = self._select("withRootfs", _args)
         return Container(_ctx)
@@ -493,8 +517,8 @@ class Container(Type):
     def with_secret_variable(self, name: str, secret: "Secret") -> "Container":
         """This container plus an env variable containing the given secret"""
         _args = [
-            Arg("name", name),
-            Arg("secret", secret),
+            Arg("name", "name", name, str),
+            Arg("secret", "secret", secret, Secret),
         ]
         _ctx = self._select("withSecretVariable", _args)
         return Container(_ctx)
@@ -502,8 +526,8 @@ class Container(Type):
     def with_unix_socket(self, path: str, source: "Socket") -> "Container":
         """This container plus a socket forwarded to the given Unix socket path"""
         _args = [
-            Arg("path", path),
-            Arg("source", source),
+            Arg("path", "path", path, str),
+            Arg("source", "source", source, Socket),
         ]
         _ctx = self._select("withUnixSocket", _args)
         return Container(_ctx)
@@ -511,7 +535,7 @@ class Container(Type):
     def with_user(self, name: str) -> "Container":
         """This container but with a different command user"""
         _args = [
-            Arg("name", name),
+            Arg("name", "name", name, str),
         ]
         _ctx = self._select("withUser", _args)
         return Container(_ctx)
@@ -519,7 +543,7 @@ class Container(Type):
     def with_workdir(self, path: str) -> "Container":
         """This container but with a different working directory"""
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("withWorkdir", _args)
         return Container(_ctx)
@@ -527,7 +551,7 @@ class Container(Type):
     def without_env_variable(self, name: str) -> "Container":
         """This container minus the given environment variable"""
         _args = [
-            Arg("name", name),
+            Arg("name", "name", name, str),
         ]
         _ctx = self._select("withoutEnvVariable", _args)
         return Container(_ctx)
@@ -535,7 +559,7 @@ class Container(Type):
     def without_mount(self, path: str) -> "Container":
         """This container after unmounting everything at the given path."""
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("withoutMount", _args)
         return Container(_ctx)
@@ -543,7 +567,7 @@ class Container(Type):
     def without_unix_socket(self, path: str) -> "Container":
         """This container with a previously added Unix socket removed"""
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("withoutUnixSocket", _args)
         return Container(_ctx)
@@ -569,7 +593,7 @@ class Directory(Type):
     def diff(self, other: "Directory") -> "Directory":
         """The difference between this directory and an another directory"""
         _args = [
-            Arg("other", other),
+            Arg("other", "other", other, Directory),
         ]
         _ctx = self._select("diff", _args)
         return Directory(_ctx)
@@ -577,7 +601,7 @@ class Directory(Type):
     def directory(self, path: str) -> "Directory":
         """Retrieve a directory at the given path"""
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("directory", _args)
         return Directory(_ctx)
@@ -587,8 +611,8 @@ class Directory(Type):
     ) -> "Container":
         """Build a new Docker container from this directory"""
         _args = [
-            Arg("dockerfile", dockerfile, None),
-            Arg("platform", platform, None),
+            Arg("dockerfile", "dockerfile", dockerfile, str | None, None),
+            Arg("platform", "platform", platform, Platform | None, None),
         ]
         _ctx = self._select("dockerBuild", _args)
         return Container(_ctx)
@@ -604,7 +628,7 @@ class Directory(Type):
             GraphQL to represent free-form human-readable text.
         """
         _args = [
-            Arg("path", path, None),
+            Arg("path", "path", path, str | None, None),
         ]
         _ctx = self._select("entries", _args)
         return _ctx.execute_sync(list[str])
@@ -618,7 +642,7 @@ class Directory(Type):
             The `Boolean` scalar type represents `true` or `false`.
         """
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("export", _args)
         return _ctx.execute_sync(bool)
@@ -626,7 +650,7 @@ class Directory(Type):
     def file(self, path: str) -> "File":
         """Retrieve a file at the given path"""
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("file", _args)
         return File(_ctx)
@@ -650,7 +674,7 @@ class Directory(Type):
     def load_project(self, config_path: str) -> "Project":
         """load a project's metadata"""
         _args = [
-            Arg("configPath", config_path),
+            Arg("config_path", "configPath", config_path, str),
         ]
         _ctx = self._select("loadProject", _args)
         return Project(_ctx)
@@ -664,10 +688,10 @@ class Directory(Type):
     ) -> "Directory":
         """This directory plus a directory written at the given path"""
         _args = [
-            Arg("path", path),
-            Arg("directory", directory),
-            Arg("exclude", exclude, None),
-            Arg("include", include, None),
+            Arg("path", "path", path, str),
+            Arg("directory", "directory", directory, Directory),
+            Arg("exclude", "exclude", exclude, list[str] | None, None),
+            Arg("include", "include", include, list[str] | None, None),
         ]
         _ctx = self._select("withDirectory", _args)
         return Directory(_ctx)
@@ -677,8 +701,8 @@ class Directory(Type):
         path
         """
         _args = [
-            Arg("path", path),
-            Arg("source", source),
+            Arg("path", "path", path, str),
+            Arg("source", "source", source, File),
         ]
         _ctx = self._select("withFile", _args)
         return Directory(_ctx)
@@ -686,7 +710,7 @@ class Directory(Type):
     def with_new_directory(self, path: str) -> "Directory":
         """This directory plus a new directory created at the given path"""
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("withNewDirectory", _args)
         return Directory(_ctx)
@@ -694,8 +718,8 @@ class Directory(Type):
     def with_new_file(self, path: str, contents: str) -> "Directory":
         """This directory plus a new file written at the given path"""
         _args = [
-            Arg("path", path),
-            Arg("contents", contents),
+            Arg("path", "path", path, str),
+            Arg("contents", "contents", contents, str),
         ]
         _ctx = self._select("withNewFile", _args)
         return Directory(_ctx)
@@ -705,7 +729,7 @@ class Directory(Type):
         seconds from the Unix epoch
         """
         _args = [
-            Arg("timestamp", timestamp),
+            Arg("timestamp", "timestamp", timestamp, int),
         ]
         _ctx = self._select("withTimestamps", _args)
         return Directory(_ctx)
@@ -713,7 +737,7 @@ class Directory(Type):
     def without_directory(self, path: str) -> "Directory":
         """This directory with the directory at the given path removed"""
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("withoutDirectory", _args)
         return Directory(_ctx)
@@ -721,7 +745,7 @@ class Directory(Type):
     def without_file(self, path: str) -> "Directory":
         """This directory with the file at the given path removed"""
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("withoutFile", _args)
         return Directory(_ctx)
@@ -786,7 +810,7 @@ class File(Type):
             The `Boolean` scalar type represents `true` or `false`.
         """
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("export", _args)
         return _ctx.execute_sync(bool)
@@ -827,7 +851,7 @@ class File(Type):
         in seconds from the Unix epoch
         """
         _args = [
-            Arg("timestamp", timestamp),
+            Arg("timestamp", "timestamp", timestamp, int),
         ]
         _ctx = self._select("withTimestamps", _args)
         return File(_ctx)
@@ -857,8 +881,10 @@ class GitRef(Type):
     ) -> "Directory":
         """The filesystem tree at this ref"""
         _args = [
-            Arg("sshKnownHosts", ssh_known_hosts, None),
-            Arg("sshAuthSocket", ssh_auth_socket, None),
+            Arg("ssh_known_hosts", "sshKnownHosts", ssh_known_hosts, str | None, None),
+            Arg(
+                "ssh_auth_socket", "sshAuthSocket", ssh_auth_socket, Socket | None, None
+            ),
         ]
         _ctx = self._select("tree", _args)
         return Directory(_ctx)
@@ -870,7 +896,7 @@ class GitRepository(Type):
     def branch(self, name: str) -> "GitRef":
         """Details on one branch"""
         _args = [
-            Arg("name", name),
+            Arg("name", "name", name, str),
         ]
         _ctx = self._select("branch", _args)
         return GitRef(_ctx)
@@ -892,7 +918,7 @@ class GitRepository(Type):
     def commit(self, id: str) -> "GitRef":
         """Details on one commit"""
         _args = [
-            Arg("id", id),
+            Arg("id", "id", id, str),
         ]
         _ctx = self._select("commit", _args)
         return GitRef(_ctx)
@@ -900,7 +926,7 @@ class GitRepository(Type):
     def tag(self, name: str) -> "GitRef":
         """Details on one tag"""
         _args = [
-            Arg("name", name),
+            Arg("name", "name", name, str),
         ]
         _ctx = self._select("tag", _args)
         return GitRef(_ctx)
@@ -931,9 +957,9 @@ class Host(Type):
     ) -> "Directory":
         """Access a directory on the host"""
         _args = [
-            Arg("path", path),
-            Arg("exclude", exclude, None),
-            Arg("include", include, None),
+            Arg("path", "path", path, str),
+            Arg("exclude", "exclude", exclude, list[str] | None, None),
+            Arg("include", "include", include, list[str] | None, None),
         ]
         _ctx = self._select("directory", _args)
         return Directory(_ctx)
@@ -941,7 +967,7 @@ class Host(Type):
     def env_variable(self, name: str) -> "HostVariable":
         """Access an environment variable on the host"""
         _args = [
-            Arg("name", name),
+            Arg("name", "name", name, str),
         ]
         _ctx = self._select("envVariable", _args)
         return HostVariable(_ctx)
@@ -949,7 +975,7 @@ class Host(Type):
     def unix_socket(self, path: str) -> "Socket":
         """Access a Unix socket on the host"""
         _args = [
-            Arg("path", path),
+            Arg("path", "path", path, str),
         ]
         _ctx = self._select("unixSocket", _args)
         return Socket(_ctx)
@@ -963,8 +989,8 @@ class Host(Type):
             Use :py:meth:`directory` with path set to '.' instead.
         """
         _args = [
-            Arg("exclude", exclude, None),
-            Arg("include", include, None),
+            Arg("exclude", "exclude", exclude, list[str] | None, None),
+            Arg("include", "include", include, list[str] | None, None),
         ]
         _ctx = self._select("workdir", _args)
         return Directory(_ctx)
@@ -1068,7 +1094,7 @@ class Client(Root):
     def cache_volume(self, key: str) -> "CacheVolume":
         """Construct a cache volume for a given cache key"""
         _args = [
-            Arg("key", key),
+            Arg("key", "key", key, str),
         ]
         _ctx = self._select("cacheVolume", _args)
         return CacheVolume(_ctx)
@@ -1087,8 +1113,8 @@ class Client(Root):
         host.
         """
         _args = [
-            Arg("id", id, None),
-            Arg("platform", platform, None),
+            Arg("id", "id", id, ContainerID | Container | None, None),
+            Arg("platform", "platform", platform, Platform | None, None),
         ]
         _ctx = self._select("container", _args)
         return Container(_ctx)
@@ -1102,7 +1128,7 @@ class Client(Root):
     def directory(self, id: "DirectoryID | Directory | None" = None) -> "Directory":
         """Load a directory by ID. No argument produces an empty directory."""
         _args = [
-            Arg("id", id, None),
+            Arg("id", "id", id, DirectoryID | Directory | None, None),
         ]
         _ctx = self._select("directory", _args)
         return Directory(_ctx)
@@ -1110,7 +1136,7 @@ class Client(Root):
     def file(self, id: "FileID | File") -> "File":
         """Load a file by ID"""
         _args = [
-            Arg("id", id),
+            Arg("id", "id", id, FileID | File),
         ]
         _ctx = self._select("file", _args)
         return File(_ctx)
@@ -1118,8 +1144,8 @@ class Client(Root):
     def git(self, url: str, keep_git_dir: bool | None = None) -> "GitRepository":
         """Query a git repository"""
         _args = [
-            Arg("url", url),
-            Arg("keepGitDir", keep_git_dir, None),
+            Arg("url", "url", url, str),
+            Arg("keep_git_dir", "keepGitDir", keep_git_dir, bool | None, None),
         ]
         _ctx = self._select("git", _args)
         return GitRepository(_ctx)
@@ -1133,7 +1159,7 @@ class Client(Root):
     def http(self, url: str) -> "File":
         """An http remote"""
         _args = [
-            Arg("url", url),
+            Arg("url", "url", url, str),
         ]
         _ctx = self._select("http", _args)
         return File(_ctx)
@@ -1141,7 +1167,7 @@ class Client(Root):
     def project(self, name: str) -> "Project":
         """Look up a project by name"""
         _args = [
-            Arg("name", name),
+            Arg("name", "name", name, str),
         ]
         _ctx = self._select("project", _args)
         return Project(_ctx)
@@ -1149,7 +1175,7 @@ class Client(Root):
     def secret(self, id: "SecretID | Secret") -> "Secret":
         """Load a secret from its ID"""
         _args = [
-            Arg("id", id),
+            Arg("id", "id", id, SecretID | Secret),
         ]
         _ctx = self._select("secret", _args)
         return Secret(_ctx)
@@ -1157,7 +1183,7 @@ class Client(Root):
     def socket(self, id: "SocketID | Socket | None" = None) -> "Socket":
         """Load a socket by ID"""
         _args = [
-            Arg("id", id, None),
+            Arg("id", "id", id, SocketID | Socket | None, None),
         ]
         _ctx = self._select("socket", _args)
         return Socket(_ctx)

--- a/sdk/python/src/dagger/codegen.py
+++ b/sdk/python/src/dagger/codegen.py
@@ -290,7 +290,7 @@ class _InputField:
 
     def as_arg(self) -> str:
         """As a Arg object for the query builder."""
-        params = [f"'{self.graphql_name}'", self.name]
+        params = [f"'{self.name}', '{self.graphql_name}'", self.name, self.type]
         if self.has_default:
             params.append(repr(self.default_value))
         return f"Arg({', '.join(params)}),"

--- a/sdk/python/tests/api/test_codegen.py
+++ b/sdk/python/tests/api/test_codegen.py
@@ -121,14 +121,30 @@ def test_input_field_param(cls, name, args, expected, id_map):
 @pytest.mark.parametrize(
     "name, args, expected",
     [
-        ("context", (NonNull(Scalar("DirectoryID")),), "Arg('context', context),"),
-        ("secret", (Scalar("SecretID"),), "Arg('secret', secret, None),"),
-        ("lines", (Int, 1), "Arg('lines', lines, 1),"),
-        ("from", (String, None), "Arg('from', from_, None),"),
+        (
+            "context",
+            (NonNull(Scalar("DirectoryID")),),
+            "Arg('context', 'context', context, DirectoryID),",
+        ),
+        (
+            "secret",
+            (Scalar("SecretID"),),
+            "Arg('secret', 'secret', secret, Secret | None, None),",
+        ),
+        (
+            "lines",
+            (Int, 1),
+            "Arg('lines', 'lines', lines, int | None, 1),",
+        ),
+        (
+            "from",
+            (String, None),
+            "Arg('from_', 'from', from_, str | None, None),",
+        ),
         (
             "configPath",
             (NonNull(String), "/dagger.json"),
-            "Arg('configPath', config_path, '/dagger.json'),",
+            "Arg('config_path', 'configPath', config_path, str, '/dagger.json'),",
         ),
     ],
 )

--- a/sdk/python/tests/api/test_inputs.py
+++ b/sdk/python/tests/api/test_inputs.py
@@ -1,0 +1,76 @@
+from typing import NewType
+
+import pytest
+from pytest_lazyfixture import lazy_fixture
+
+from dagger.api.base import Arg, Type
+
+
+class Directory(Type):
+    ...
+
+
+class File(Type):
+    ...
+
+
+FileID = NewType("FileID", str)
+
+
+@pytest.fixture
+def directory(mocker):
+    return Directory(mocker.MagicMock())
+
+
+@pytest.fixture
+def file(mocker):
+    return File(mocker.MagicMock())
+
+
+@pytest.fixture
+def file_list(file):
+    return [file]
+
+
+@pytest.mark.parametrize(
+    "value, type_",
+    [
+        ("abc", str),
+        ("abc", str | None),
+        (None, str | None),
+        (None, bool | None),
+        (True, bool | None),
+        (False, bool | None),
+        (None, None),
+        (lazy_fixture("file"), File),
+        (lazy_fixture("file_list"), list[File]),
+        (None, list[File] | None),
+        (["a", "b", "c"], list[str] | None),
+        (None, list[str] | None),
+        (None, list[str | None] | None),
+        ([None], list[str | None] | None),
+        ("abc", FileID),
+        (FileID("abc"), FileID),
+        ("abc", FileID | File),
+        (None, FileID | File | None),
+        (lazy_fixture("file"), FileID | File),
+    ],
+)
+def test_right_type(directory: Directory, value, type_):
+    directory._convert_args([Arg("egg", "egg", value, type_)])
+
+
+@pytest.mark.parametrize(
+    "value, type_",
+    [
+        ("abc", int),
+        ("abc", int | None),
+        ("abc", File),
+        (FileID("abc"), File),
+        (lazy_fixture("directory"), File),
+        ([None], list[int]),
+    ],
+)
+def test_wrong_type(directory: Directory, value, type_):
+    with pytest.raises(TypeError, match=r"Wrong type .* Expected .* instead"):
+        directory._convert_args([Arg("egg", "egg", value, type_)])


### PR DESCRIPTION
Fixes #3772

## Overview

This helps detect some typos or mistakes during runtime.

Since type checking is optional, it's possible that the IDE doesn't complain in some cases and Python won't fail to execute in any case. So if you had the wrong type in a parameter, you'd get an _AST_ conversion error and only during query execution, which is harder to debug.

With this change, you'll get an earlier error (during query building) with a more useful error message.


## Example

Let's say you still use an ID value:

```python
repo_id = await client.git(repo_url).branch("master").tree().id()
...
ctr.with_mounted_directory("/src", repo_id)
```

This will show the following error **in Python 3.11**:

```console
File "/Users/helder/Projects/dagger-examples/test_simple.py", line 24, in test
    .with_mounted_directory("/src", repo_id)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/helder/Projects/dagger/sdk/python/src/dagger/api/gen.py", line 471, in with_mounted_directory
    _ctx = self._select("withMountedDirectory", _args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/helder/Projects/dagger/sdk/python/src/dagger/api/base.py", line 156, in _select
    self._convert_args(args),
    ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/helder/Projects/dagger/sdk/python/src/dagger/api/base.py", line 170, in _convert_args
    raise TypeError(
TypeError: Wrong type for 'source' parameter. Expected a 'Directory' instead.
```

In Python 3.10 there's no carets below the source code lines.

## Breaking change

This is a breaking change if there was a reliance on converting types. For example providing a `set` instead of a `list`, or an `int` instead of a `str`.

It was also possible to pass an _ID_ instead of an object (e.g., `DirectoryID` vs `Directory`) even if the type hint doesn't allow it. It would still work because of how it's implemented but now it'll fail.

## What comes next?

I want to improve printing tracebacks by annotating exactly to the parameter that is failing since right now it's pointing to the whole method. This can be done also for versions prior to Python 3.11.

It should look like this:

```console
File "/Users/helder/Projects/dagger-examples/test_simple.py", line 24, in test
    .with_mounted_directory("/src", repo_id)
                                    ^^^^^^^
```

Signed-off-by: Helder Correia