### PR TITLE
docs: fix API Playground button style

### DIFF
--- a/website/src/css/atoms/button.module.scss
+++ b/website/src/css/atoms/button.module.scss
@@ -48,6 +48,10 @@
 }
 
 .playground {
+  margin-bottom: 25px;
+  display: block;
+  width: fit-content;
+  text-decoration: none !important;
   background: #3D66FF;
   color: white !important;
   font-size: 1rem;


### PR DESCRIPTION
This fix will make the API Playground CTA in the docs render correctly.

Signed-off-by: Julián Cruciani <julian@dagger.io>