### PR TITLE
docs: Fixed API Playground button CSS

### DIFF
--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -23,11 +23,6 @@ to = "https://api.amplitude.com"
 status = 200
 
 [[redirects]]
-from = "/api/reference"
-to = "/api/reference/"
-status = 200
-
-[[redirects]]
 from = "/reference"
 to = "/reference/alpine"
 status = 302

--- a/website/src/css/atoms/button.module.scss
+++ b/website/src/css/atoms/button.module.scss
@@ -48,6 +48,10 @@
 }
 
 .playground {
+  margin-bottom: 25px;
+  display: block;
+  width: fit-content;
+  text-decoration: none !important;
   background: #3D66FF;
   color: white !important;
   font-size: 1rem;


### PR DESCRIPTION
This fix will make the API Playground CTA in the docs render correctly. Based entirely on https://github.com/dagger/dagger/pull/4043

Signed-off-by: Vikram Vaswani <vikram@dagger.io>