### PR TITLE
docs: add link to docs in api reference logo

### DIFF
--- a/website/docs-graphql/config.yml
+++ b/website/docs-graphql/config.yml
@@ -19,6 +19,7 @@ extensions:
 
 info:
   title: Dagger GraphQL API Reference
+  docs-url: https://docs.dagger.io 
   # x-introItems:
   #   - title: Welcome! 
   #     description: We are using a GraphQL server as the API to interact with our engine. This allows us to make interoperation between programming languages possible.

--- a/website/docs-graphql/custom-theme/views/partials/layout/page.hbs
+++ b/website/docs-graphql/custom-theme/views/partials/layout/page.hbs
@@ -1,0 +1,22 @@
+<div id="page" class="drawer-layout">
+  {{! DO THE NAVIGATION }}
+  <div id="sidebar">
+    <div class="sidebar-top-container">
+      <a href="{{info.docs-url}}" id="logo">
+        {{#if logo}}
+          <img src="images/{{logo}}" title="{{info.title}}" />
+        {{/if}}
+      </a>
+      <button class="close-button" aria-label="Close menu" type="button">
+        <span aria-hidden="true">×</span>
+      </button>
+    </div>
+    {{>layout/nav/main}}
+  </div>
+
+  <div id="docs">
+    {{>layout/nav/mobile-navbar}}
+    {{>layout/content/main}}
+    <div class="drawer-overlay"></div>
+  </div>
+</div>


### PR DESCRIPTION
This will make the GraphQL API Reference Dagger logo a link that takes you to `docs.dagger.io`.

Closes #4054

Signed-off-by: Julián Cruciani <julian@dagger.io>