### PR TITLE
docs: Add tech preview badge to API page

### DIFF
--- a/docs/current/api/990050-index.md
+++ b/docs/current/api/990050-index.md
@@ -4,6 +4,8 @@ slug: /api
 
 # Dagger GraphQL API
 
+<div class="status-badge">Technical Preview</div>
+
 ## What is the Dagger GraphQL API?
 
 The Dagger GraphQL API is a unified interface for programming the Dagger Engine using any standard GraphQL client. GraphQL serves as a low-level language-agnostic API framework for all Dagger operations.


### PR DESCRIPTION
This commit adds a "technical preview" badge to the API index page in the docs.

Signed-off-by: vikram-dagger <112123850+vikram-dagger@users.noreply.github.com>