### PR TITLE
Lint sdk code before publishing.

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -2,8 +2,16 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/mitchellh/mapstructure v1.2.3 h1:f/MjBEBDLttYCGfRaKBbKSRVF5aV2O6fnBpzknuE3jU=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/vektah/gqlparser v1.1.2 h1:ZsyLGn7/7jDNI+y4SEhI4yAxRChlv15pUHMjijT+e68=
 golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 h1:kQgndtyPBW/JIYERgdxfwMYh3AVStj88WQTlNDi2a+o=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/mage/sdk/go.go
+++ b/internal/mage/sdk/go.go
@@ -92,6 +92,11 @@ func (t Go) Generate(ctx context.Context) error {
 
 // Publish publishes the Go SDK
 func (t Go) Publish(ctx context.Context, tag string) error {
+	// lint first to ensure generated apis are consistent w/ the engine
+	if err := t.Lint(ctx); err != nil {
+		return err
+	}
+
 	c, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
 	if err != nil {
 		return err

--- a/internal/mage/sdk/nodejs.go
+++ b/internal/mage/sdk/nodejs.go
@@ -83,6 +83,11 @@ func (t Nodejs) Generate(ctx context.Context) error {
 
 // Publish publishes the Node.js SDK
 func (t Nodejs) Publish(ctx context.Context, tag string) error {
+	// lint first to ensure generated apis are consistent w/ the engine
+	if err := t.Lint(ctx); err != nil {
+		return err
+	}
+
 	c, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
 	if err != nil {
 		return err

--- a/internal/mage/sdk/python.go
+++ b/internal/mage/sdk/python.go
@@ -118,6 +118,11 @@ func (t Python) Generate(ctx context.Context) error {
 
 // Publish publishes the Python SDK
 func (t Python) Publish(ctx context.Context, tag string) error {
+	// lint first to ensure generated apis are consistent w/ the engine
+	if err := t.Lint(ctx); err != nil {
+		return err
+	}
+
 	c, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
 	if err != nil {
 		return err


### PR DESCRIPTION
The main goal here is to ensure that the generated client-side APIs are matching the engine being published with. This requires that we use `./hack/make-prod` when calling publish in CI, which is currently the case already.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

PTAL @gerhard 

cc @slumbering @grouville goal here is to prevent future occurrences of the issue that happened today where the node sdk was published w/ unix socket APIs even though the released engine did not have them. 