### PR TITLE
DisableHostRW disables host socket access

### DIFF
--- a/core/socket.go
+++ b/core/socket.go
@@ -52,6 +52,15 @@ func NewHostSocket(absPath string) (*Socket, error) {
 	return payload.ToSocket()
 }
 
+func (socket *Socket) IsHost() (bool, error) {
+	payload, err := socket.ID.decode()
+	if err != nil {
+		return false, err
+	}
+
+	return payload.HostPath != "", nil
+}
+
 func (socket *Socket) Server() (sshforward.SSHServer, error) {
 	payload, err := socket.ID.decode()
 	if err != nil {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -98,6 +98,7 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 			core.RunnerProxySockName:     core.NewRunnerProxy(buildkitdHost),
 			project.SessionProxySockName: project.NewSessionProxy(router),
 		},
+		EnableHostNetworkAccess: !startOpts.DisableHostRW,
 	}
 
 	solveOpts := bkclient.SolveOpt{


### PR DESCRIPTION
Follow-up to #4025 

The `DisableHostRW` flag is already respected by the `Host { unixSocket }` API call, but there's nothing stopping someone from copy-pasting a `SocketID` from a host with it enabled.

This PR adds another check where the socket is actually used.