### PR TITLE
add Dockerifle to build dagger-cue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# syntax = docker/dockerfile:1.2
+
+FROM golang:1.18.4-alpine AS build
+WORKDIR /src
+RUN apk add --no-cache file git
+ENV GOMODCACHE /root/.cache/gocache
+RUN --mount=target=. --mount=target=/root/.cache,type=cache \
+    CGO_ENABLED=0 go build -o /out/dagger-cue -ldflags '-s -d -w' ./cmd/dagger; \
+    file /out/dagger-cue | grep "statically linked"
+
+FROM scratch
+COPY --from=build /out/dagger-cue /bin/dagger-cue
+ENTRYPOINT ["/bin/dagger-cue"]
+


### PR DESCRIPTION
bringing this back since it's required by the dagger-for-github action

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
