### PR TITLE
docs: Add API to Playground title

### DIFF
--- a/docs/current/api/282105-playground.md
+++ b/docs/current/api/282105-playground.md
@@ -2,7 +2,7 @@
 slug: /api/282105/playground
 ---
 
-# Playground
+# API Playground
 
 The API Playground is an in-browser tool for testing, running and sharing Dagger GraphQL API queries.
 


### PR DESCRIPTION
This commit changes the title of the Playground page.

Signed-off-by: Miranda Carter <101831275+mircubed@users.noreply.github.com>