### PR TITLE
forwarding host TCP/UDP addresses to container

### DIFF
--- a/core/host.go
+++ b/core/host.go
@@ -84,7 +84,7 @@ func (host *Host) Directory(ctx context.Context, dirPath string, platform specs.
 	return NewDirectory(ctx, st, "", platform)
 }
 
-func (host *Host) Socket(ctx context.Context, sockPath string) (*Socket, error) {
+func (host *Host) UnixSocket(ctx context.Context, sockPath string) (*Socket, error) {
 	if host.DisableRW {
 		return nil, ErrHostRWDisabled
 	}
@@ -106,7 +106,15 @@ func (host *Host) Socket(ctx context.Context, sockPath string) (*Socket, error) 
 		return nil, fmt.Errorf("eval symlinks: %w", err)
 	}
 
-	return NewHostSocket(absPath)
+	return NewHostSocket("unix", absPath)
+}
+
+func (host *Host) PortSocket(ctx context.Context, network, addr string) (*Socket, error) {
+	if host.DisableRW {
+		return nil, ErrHostRWDisabled
+	}
+
+	return NewHostSocket(network, addr)
 }
 
 func (host *Host) Export(

--- a/core/integration/testdata/socket-echo.go
+++ b/core/integration/testdata/socket-echo.go
@@ -7,20 +7,20 @@ import (
 )
 
 func main() {
-	if len(os.Args) != 3 {
-		fmt.Fprintln(os.Stderr, "usage: %s <socket> <message>", os.Args[0])
+	if len(os.Args) != 4 {
+		fmt.Fprintln(os.Stderr, "usage: %s <network> <addr> <message>", os.Args[0])
 		os.Exit(1)
 		return
 	}
 
-	c, err := net.Dial("unix", os.Args[1])
+	c, err := net.Dial(os.Args[1], os.Args[2])
 	if err != nil {
 		panic(err)
 	}
 
 	defer c.Close()
 
-	_, err = fmt.Fprintln(c, os.Args[2])
+	_, err = fmt.Fprintln(c, os.Args[3])
 	if err != nil {
 		panic(err)
 	}

--- a/core/schema/host.go
+++ b/core/schema/host.go
@@ -32,7 +32,9 @@ func (s *hostSchema) Resolvers() router.Resolvers {
 			"workdir":     router.ToResolver(s.workdir),
 			"directory":   router.ToResolver(s.directory),
 			"envVariable": router.ToResolver(s.envVariable),
-			"unixSocket":  router.ToResolver(s.socket),
+			"unixSocket":  router.ToResolver(s.unixSocket),
+			"tcpSocket":   router.ToResolver(s.tcpSocket),
+			"udpSocket":   router.ToResolver(s.udpSocket),
 		},
 		"HostVariable": router.ObjectResolver{
 			"value":  router.ToResolver(s.envVariableValue),
@@ -81,10 +83,26 @@ func (s *hostSchema) directory(ctx *router.Context, parent any, args hostDirecto
 	return s.host.Directory(ctx, args.Path, s.platform, args.CopyFilter)
 }
 
-type hostSocketArgs struct {
+type hostUnixSocketArgs struct {
 	Path string
 }
 
-func (s *hostSchema) socket(ctx *router.Context, parent any, args hostSocketArgs) (*core.Socket, error) {
-	return s.host.Socket(ctx, args.Path)
+func (s *hostSchema) unixSocket(ctx *router.Context, parent any, args hostUnixSocketArgs) (*core.Socket, error) {
+	return s.host.UnixSocket(ctx, args.Path)
+}
+
+type hostTCPSocketArgs struct {
+	Address string
+}
+
+func (s *hostSchema) tcpSocket(ctx *router.Context, parent any, args hostTCPSocketArgs) (*core.Socket, error) {
+	return s.host.PortSocket(ctx, "tcp", args.Address)
+}
+
+type hostUDPSocketArgs struct {
+	Address string
+}
+
+func (s *hostSchema) udpSocket(ctx *router.Context, parent any, args hostUDPSocketArgs) (*core.Socket, error) {
+	return s.host.PortSocket(ctx, "udp", args.Address)
 }

--- a/core/schema/host.graphqls
+++ b/core/schema/host.graphqls
@@ -17,6 +17,12 @@ type Host {
 
   "Access a Unix socket on the host"
   unixSocket(path: String!): Socket!
+
+  "Access a TCP host:port address via the host network"
+  tcpSocket(address: String!): Socket!
+
+  "Access a UDP host:port address via the host network"
+  udpSocket(address: String!): Socket!
 }
 
 "An environment variable on the host environment"

--- a/core/socket.go
+++ b/core/socket.go
@@ -19,7 +19,8 @@ func (id SocketID) String() string { return string(id) }
 func (id SocketID) LLBID() string  { return fmt.Sprintf("socket:%s", id) }
 
 type socketIDPayload struct {
-	HostPath string `json:"host_path,omitempty"`
+	HostNetwork string `json:"host_network,omitempty"`
+	HostAddr    string `json:"host_addr,omitempty"`
 }
 
 func (id SocketID) decode() (*socketIDPayload, error) {
@@ -44,9 +45,10 @@ func NewSocket(id SocketID) *Socket {
 	return &Socket{id}
 }
 
-func NewHostSocket(absPath string) (*Socket, error) {
+func NewHostSocket(network, addr string) (*Socket, error) {
 	payload := socketIDPayload{
-		HostPath: absPath,
+		HostNetwork: network,
+		HostAddr:    addr,
 	}
 
 	return payload.ToSocket()
@@ -58,7 +60,7 @@ func (socket *Socket) IsHost() (bool, error) {
 		return false, err
 	}
 
-	return payload.HostPath != "", nil
+	return payload.HostNetwork != "", nil
 }
 
 func (socket *Socket) Server() (sshforward.SSHServer, error) {
@@ -69,7 +71,7 @@ func (socket *Socket) Server() (sshforward.SSHServer, error) {
 
 	return &socketProxy{
 		dial: func() (io.ReadWriteCloser, error) {
-			return net.Dial("unix", payload.HostPath)
+			return net.Dial(payload.HostNetwork, payload.HostAddr)
 		},
 	}, nil
 }

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -1180,6 +1180,28 @@ func (r *Host) EnvVariable(name string) *HostVariable {
 	}
 }
 
+// Access a TCP host:port address via the host network
+func (r *Host) TCPSocket(address string) *Socket {
+	q := r.q.Select("tcpSocket")
+	q = q.Arg("address", address)
+
+	return &Socket{
+		q: q,
+		c: r.c,
+	}
+}
+
+// Access a UDP host:port address via the host network
+func (r *Host) UDPSocket(address string) *Socket {
+	q := r.q.Select("udpSocket")
+	q = q.Arg("address", address)
+
+	return &Socket{
+		q: q,
+		c: r.c,
+	}
+}
+
 // Access a Unix socket on the host
 func (r *Host) UnixSocket(path string) *Socket {
 	q := r.q.Select("unixSocket")

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -1424,6 +1424,38 @@ export class Host extends BaseClient {
   }
 
   /**
+   * Access a TCP host:port address via the host network
+   */
+  tcpSocket(address: string): Socket {
+    return new Socket({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "tcpSocket",
+          args: { address },
+        },
+      ],
+      host: this.clientHost,
+    })
+  }
+
+  /**
+   * Access a UDP host:port address via the host network
+   */
+  udpSocket(address: string): Socket {
+    return new Socket({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "udpSocket",
+          args: { address },
+        },
+      ],
+      host: this.clientHost,
+    })
+  }
+
+  /**
    * Access a Unix socket on the host
    */
   unixSocket(path: string): Socket {

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -925,6 +925,22 @@ class Host(Type):
         _ctx = self._select("envVariable", _args)
         return HostVariable(_ctx)
 
+    def tcp_socket(self, address: str) -> "Socket":
+        """Access a TCP host:port address via the host network"""
+        _args = [
+            Arg("address", address),
+        ]
+        _ctx = self._select("tcpSocket", _args)
+        return Socket(_ctx)
+
+    def udp_socket(self, address: str) -> "Socket":
+        """Access a UDP host:port address via the host network"""
+        _args = [
+            Arg("address", address),
+        ]
+        _ctx = self._select("udpSocket", _args)
+        return Socket(_ctx)
+
     def unix_socket(self, path: str) -> "Socket":
         """Access a Unix socket on the host"""
         _args = [

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -925,6 +925,22 @@ class Host(Type):
         _ctx = self._select("envVariable", _args)
         return HostVariable(_ctx)
 
+    def tcp_socket(self, address: str) -> "Socket":
+        """Access a TCP host:port address via the host network"""
+        _args = [
+            Arg("address", address),
+        ]
+        _ctx = self._select("tcpSocket", _args)
+        return Socket(_ctx)
+
+    def udp_socket(self, address: str) -> "Socket":
+        """Access a UDP host:port address via the host network"""
+        _args = [
+            Arg("address", address),
+        ]
+        _ctx = self._select("udpSocket", _args)
+        return Socket(_ctx)
+
     def unix_socket(self, path: str) -> "Socket":
         """Access a Unix socket on the host"""
         _args = [


### PR DESCRIPTION
A pretty straightforward tweak to #4025 to support forwarding TCP/UDP addresses into the container in addition to Unix socket paths.

Schema changes:

```graphql
extend type Host {
  "Access a TCP host:port address via the host network"
  tcpSocket(address: String!): Socket!

  "Access a UDP host:port address via the host network"
  udpSocket(address: String!): Socket!
}
```

This is similar to the proposal in https://github.com/dagger/dagger/pull/3691#issuecomment-1311145961 except it allows full specification of `host:port` rather than being restricted to a port the host's loopback. It's a trivial implementation difference that could allow for some interesting use cases, like forwarding a private network into the container (imagining containers are normally isolated from it, anyway).

Note that we still only support forwarding to Unix sockets into the container. Forwarding to TCP/UDP in the container will require an orthogonal change to the shim as mentioned in the previously linked proposal (shim listens on loopback TCP/UDP and just forwards to a local obfuscated Unix socket).

Bikeshedding encouraged!