### PR TITLE
Nodejs add callbackfct to doc

### DIFF
--- a/sdk/nodejs/connect.ts
+++ b/sdk/nodejs/connect.ts
@@ -11,7 +11,7 @@ export interface ConnectOpts {
   LogOutput?: Writable
 }
 
-type CallbackFct = (client: Client) => Promise<void>
+export type CallbackFct = (client: Client) => Promise<void>
 
 /**
  * connect runs GraphQL server and initializes a

--- a/sdk/nodejs/index.ts
+++ b/sdk/nodejs/index.ts
@@ -3,7 +3,7 @@ import Client from "./api/client.gen.js"
 export { gql } from "graphql-tag"
 export { GraphQLClient } from "graphql-request"
 
-export { connect, ConnectOpts } from "./connect.js"
+export { connect, ConnectOpts, CallbackFct } from "./connect.js"
 export { getProvisioner } from "./provisioning/index.js"
 
 export default Client


### PR DESCRIPTION
The `CallbackFct` was not exported by the nodejs sdk.
I exported it so we can have some minimal documentation in the reference doc.