### PR TITLE
Directory+File: add `withTimestamps` for normalizing file/dir timestamps

### DIFF
--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -17,7 +17,7 @@ import (
 
 func connect(t *testing.T) (*dagger.Client, context.Context) {
 	ctx := context.Background()
-	client, err := dagger.Connect(ctx)
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
 	require.NoError(t, err)
 	return client, ctx
 }

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -38,6 +38,7 @@ func (s *directorySchema) Resolvers() router.Resolvers {
 			"withoutFile":      router.ToResolver(s.withoutFile),
 			"directory":        router.ToResolver(s.subdirectory),
 			"withDirectory":    router.ToResolver(s.withDirectory),
+			"withTimestamps":   router.ToResolver(s.withTimestamps),
 			"withNewDirectory": router.ToResolver(s.withNewDirectory),
 			"withoutDirectory": router.ToResolver(s.withoutDirectory),
 			"diff":             router.ToResolver(s.diff),
@@ -86,6 +87,14 @@ type withDirectoryArgs struct {
 
 func (s *directorySchema) withDirectory(ctx *router.Context, parent *core.Directory, args withDirectoryArgs) (*core.Directory, error) {
 	return parent.WithDirectory(ctx, args.Path, &core.Directory{ID: args.Directory}, args.CopyFilter)
+}
+
+type withTimestampsArgs struct {
+	Timestamp int
+}
+
+func (s *directorySchema) withTimestamps(ctx *router.Context, parent *core.Directory, args withTimestampsArgs) (*core.Directory, error) {
+	return parent.WithTimestamps(ctx, args.Timestamp)
 }
 
 type entriesArgs struct {

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -89,11 +89,11 @@ func (s *directorySchema) withDirectory(ctx *router.Context, parent *core.Direct
 	return parent.WithDirectory(ctx, args.Path, &core.Directory{ID: args.Directory}, args.CopyFilter)
 }
 
-type withTimestampsArgs struct {
+type dirWithTimestampsArgs struct {
 	Timestamp int
 }
 
-func (s *directorySchema) withTimestamps(ctx *router.Context, parent *core.Directory, args withTimestampsArgs) (*core.Directory, error) {
+func (s *directorySchema) withTimestamps(ctx *router.Context, parent *core.Directory, args dirWithTimestampsArgs) (*core.Directory, error) {
 	return parent.WithTimestamps(ctx, args.Timestamp)
 }
 

--- a/core/schema/directory.graphqls
+++ b/core/schema/directory.graphqls
@@ -51,4 +51,7 @@ type Directory {
 
   "Build a new Docker container from this directory"
   dockerBuild(dockerfile: String, platform: Platform): Container!
+
+  "This directory with all file/dir timestamps set to the given time, in seconds from the Unix epoch"
+  withTimestamps(timestamp: Int!): Directory!
 }

--- a/core/schema/file.go
+++ b/core/schema/file.go
@@ -30,10 +30,11 @@ func (s *fileSchema) Resolvers() router.Resolvers {
 			"file": router.ToResolver(s.file),
 		},
 		"File": router.ObjectResolver{
-			"contents": router.ToResolver(s.contents),
-			"secret":   router.ToResolver(s.secret),
-			"size":     router.ToResolver(s.size),
-			"export":   router.ToResolver(s.export),
+			"contents":       router.ToResolver(s.contents),
+			"secret":         router.ToResolver(s.secret),
+			"size":           router.ToResolver(s.size),
+			"export":         router.ToResolver(s.export),
+			"withTimestamps": router.ToResolver(s.withTimestamps),
 		},
 	}
 }
@@ -85,4 +86,12 @@ func (s *fileSchema) export(ctx *router.Context, parent *core.File, args fileExp
 	}
 
 	return true, nil
+}
+
+type fileWithTimestampsArgs struct {
+	Timestamp int
+}
+
+func (s *fileSchema) withTimestamps(ctx *router.Context, parent *core.File, args fileWithTimestampsArgs) (*core.File, error) {
+	return parent.WithTimestamps(ctx, args.Timestamp)
 }

--- a/core/schema/file.graphqls
+++ b/core/schema/file.graphqls
@@ -7,18 +7,21 @@ scalar FileID
 
 "A file"
 type File {
-    "The content-addressed identifier of the file"
-    id: FileID!
+  "The content-addressed identifier of the file"
+  id: FileID!
 
-    "The contents of the file"
-    contents: String!
+  "The contents of the file"
+  contents: String!
 
-    # "A secret referencing the contents of this file"
-    secret: Secret!
+  "A secret referencing the contents of this file"
+  secret: Secret!
 
-    "The size of the file, in bytes"
-    size: Int!
+  "The size of the file, in bytes"
+  size: Int!
 
-    "Write the file to a file path on the host"
-    export(path: String!): Boolean!
+  "Write the file to a file path on the host"
+  export(path: String!): Boolean!
+
+  "This file with its created/modified timestamps set to the given time, in seconds from the Unix epoch"
+  withTimestamps(timestamp: Int!): File!
 }

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -916,6 +916,17 @@ func (r *Directory) WithNewFile(path string, contents string) *Directory {
 	}
 }
 
+// This directory with all file/dir timestamps set to the given time, in seconds from the Unix epoch
+func (r *Directory) WithTimestamps(timestamp int) *Directory {
+	q := r.q.Select("withTimestamps")
+	q = q.Arg("timestamp", timestamp)
+
+	return &Directory{
+		q: q,
+		c: r.c,
+	}
+}
+
 // This directory with the directory at the given path removed
 func (r *Directory) WithoutDirectory(path string) *Directory {
 	q := r.q.Select("withoutDirectory")

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -1021,6 +1021,7 @@ func (r *File) XXX_GraphQLID(ctx context.Context) (string, error) {
 	return string(id), nil
 }
 
+// A secret referencing the contents of this file
 func (r *File) Secret() *Secret {
 	q := r.q.Select("secret")
 
@@ -1037,6 +1038,17 @@ func (r *File) Size(ctx context.Context) (int, error) {
 	var response int
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
+}
+
+// This file with its created/modified timestamps set to the given time, in seconds from the Unix epoch
+func (r *File) WithTimestamps(timestamp int) *File {
+	q := r.q.Select("withTimestamps")
+	q = q.Arg("timestamp", timestamp)
+
+	return &File{
+		q: q,
+		c: r.c,
+	}
 }
 
 // A git ref (tag or branch)

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -1194,6 +1194,10 @@ export class File extends BaseClient {
 
     return response
   }
+
+  /**
+   * A secret referencing the contents of this file
+   */
   secret(): Secret {
     return new Secret({
       queryTree: [
@@ -1221,6 +1225,22 @@ export class File extends BaseClient {
     )
 
     return response
+  }
+
+  /**
+   * This file with its created/modified timestamps set to the given time, in seconds from the Unix epoch
+   */
+  withTimestamps(timestamp: number): File {
+    return new File({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "withTimestamps",
+          args: { timestamp },
+        },
+      ],
+      host: this.clientHost,
+    })
   }
 }
 

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -1052,6 +1052,22 @@ export class Directory extends BaseClient {
   }
 
   /**
+   * This directory with all file/dir timestamps set to the given time, in seconds from the Unix epoch
+   */
+  withTimestamps(timestamp: number): Directory {
+    return new Directory({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "withTimestamps",
+          args: { timestamp },
+        },
+      ],
+      host: this.clientHost,
+    })
+  }
+
+  /**
    * This directory with the directory at the given path removed
    */
   withoutDirectory(path: string): Directory {

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -803,6 +803,7 @@ class File(Type):
         return await _ctx.execute(FileID)
 
     def secret(self) -> "Secret":
+        """A secret referencing the contents of this file"""
         _args: list[Arg] = []
         _ctx = self._select("secret", _args)
         return Secret(_ctx)
@@ -820,6 +821,16 @@ class File(Type):
         _args: list[Arg] = []
         _ctx = self._select("size", _args)
         return await _ctx.execute(int)
+
+    def with_timestamps(self, timestamp: int) -> "File":
+        """This file with its created/modified timestamps set to the given time,
+        in seconds from the Unix epoch
+        """
+        _args = [
+            Arg("timestamp", timestamp),
+        ]
+        _ctx = self._select("withTimestamps", _args)
+        return File(_ctx)
 
 
 class GitRef(Type):

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -700,6 +700,16 @@ class Directory(Type):
         _ctx = self._select("withNewFile", _args)
         return Directory(_ctx)
 
+    def with_timestamps(self, timestamp: int) -> "Directory":
+        """This directory with all file/dir timestamps set to the given time, in
+        seconds from the Unix epoch
+        """
+        _args = [
+            Arg("timestamp", timestamp),
+        ]
+        _ctx = self._select("withTimestamps", _args)
+        return Directory(_ctx)
+
     def without_directory(self, path: str) -> "Directory":
         """This directory with the directory at the given path removed"""
         _args = [

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -700,6 +700,16 @@ class Directory(Type):
         _ctx = self._select("withNewFile", _args)
         return Directory(_ctx)
 
+    def with_timestamps(self, timestamp: int) -> "Directory":
+        """This directory with all file/dir timestamps set to the given time, in
+        seconds from the Unix epoch
+        """
+        _args = [
+            Arg("timestamp", timestamp),
+        ]
+        _ctx = self._select("withTimestamps", _args)
+        return Directory(_ctx)
+
     def without_directory(self, path: str) -> "Directory":
         """This directory with the directory at the given path removed"""
         _args = [

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -803,6 +803,7 @@ class File(Type):
         return _ctx.execute_sync(FileID)
 
     def secret(self) -> "Secret":
+        """A secret referencing the contents of this file"""
         _args: list[Arg] = []
         _ctx = self._select("secret", _args)
         return Secret(_ctx)
@@ -820,6 +821,16 @@ class File(Type):
         _args: list[Arg] = []
         _ctx = self._select("size", _args)
         return _ctx.execute_sync(int)
+
+    def with_timestamps(self, timestamp: int) -> "File":
+        """This file with its created/modified timestamps set to the given time,
+        in seconds from the Unix epoch
+        """
+        _args = [
+            Arg("timestamp", timestamp),
+        ]
+        _ctx = self._select("withTimestamps", _args)
+        return File(_ctx)
 
 
 class GitRef(Type):


### PR DESCRIPTION
fixes #4104

Adds the following API:

```graphql
extend type Directory {
  "This directory with all file/dir timestamps set to the given time, in seconds from the Unix epoch"
  withTimestamps(timestamp: Int!): Directory!
}

extend type File {
  "This file with its created/modified timestamps set to the given time, in seconds from the Unix epoch"
  withTimestamps(timestamp: Int!): File!
}
```

Bikeshedding opportunities:

* `withTimestamps` name
* `timestamp` param name
* `timestamp` param type (should we have a `UnixSeconds` scalar? or just rename the param to `unixSeconds`?)

In hindsight there might be a less confusing name - we've got a plural `withTimestamps` yet a singular `timestamp` param. The name is plural because it modifies the contents recursively to a single timestamp.

One caveat: when mounting the `Directory` into a container the mountpoint itself won't have the desired timestamp. So if you do `tar -cf - -C /dir .` you'll still end up with an unstable `tar` archive because of the timestamp on `/dir`. I tried a few tricks with LLB but none of them worked. The workaround in this case is to just target the contents instead (`*` instead of `.`).