### PR TITLE
remove YAML use case and add CUE warning

### DIFF
--- a/docs/current/543069-index.md
+++ b/docs/current/543069-index.md
@@ -80,6 +80,5 @@ To get started with Dagger, simply choose a SDK, then follow that SDK's getting 
 | waiting for your favorite language to be supported | [Let us know which one](https://blocklayer.typeform.com/to/a6m5gKSS), and we'll notify you when it is ready |
 | a GraphQL veteran | Use the [GraphQL API](api) |
 | a fan of shell scripts | Use the [CLI](cli) |
-| a fan of the [CUE](https://cuelang.org) language | Use the [CUE SDK](sdk/cue) |
-| enjoying the declarative nature of YAML, but wish it were more powerful | Take a look at the [CUE language](https://cuelang.org). If you like what you see, the [CUE SDK](sdk/cue) may be a good fit. |
+| a fan of the [CUE](https://cuelang.org) language, and don't mind using the old Dagger engine | Use the [CUE SDK](sdk/cue) |
 | Not sure which SDK to choose 🤷 | In doubt, try the [Go SDK](sdk/go). It does not require advanced Go knowledge, and what you learn will transpose well to future SDKs


### PR DESCRIPTION
remove YAML use case since we don't need to use cases pointing to CUE SKD and add CUE warning since it requires the old engine 

Signed-off-by: Miranda Carter <101831275+mircubed@users.noreply.github.com>