### PR TITLE
Update client-gen to use engine.Start directly.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,7 @@ builds:
     binary: dagger
     ldflags:
       - -s -w
-      - -X main.version={{.Version}}
+      - -X github.com/dagger/dagger/internal/engine.Version={{.Version}}
     goos:
       - linux
       - windows

--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/dagger/dagger/engine"
+	internalengine "github.com/dagger/dagger/internal/engine"
 	"github.com/dagger/dagger/router"
 )
 
@@ -13,18 +14,11 @@ func withEngine(
 	sessionToken string,
 	cb engine.StartCallback,
 ) error {
-	var runnerHost string
-	if v, ok := os.LookupEnv("_EXPERIMENTAL_DAGGER_RUNNER_HOST"); ok {
-		runnerHost = v
-	} else {
-		runnerHost = "docker-image://" + engineImageRef()
-	}
-
 	engineConf := &engine.Config{
 		Workdir:      workdir,
 		ConfigPath:   configPath,
 		SessionToken: sessionToken,
-		RunnerHost:   runnerHost,
+		RunnerHost:   internalengine.RunnerHost(),
 	}
 	if debugLogs {
 		engineConf.LogOutput = os.Stderr

--- a/cmd/dagger/version.go
+++ b/cmd/dagger/version.go
@@ -5,12 +5,8 @@ import (
 	"runtime"
 	"runtime/debug"
 
+	"github.com/dagger/dagger/internal/engine"
 	"github.com/spf13/cobra"
-)
-
-const (
-	developmentVersion = "devel"
-	engineImageRepo    = "ghcr.io/dagger/engine"
 )
 
 var versionCmd = &cobra.Command{
@@ -24,9 +20,6 @@ var versionCmd = &cobra.Command{
 		fmt.Println(long())
 	},
 }
-
-// version holds the complete version number. Filled in at linking time.
-var version = developmentVersion
 
 // revision returns the VCS revision being used to build or empty string
 // if none.
@@ -45,18 +38,9 @@ func revision() string {
 }
 
 func short() string {
-	return fmt.Sprintf("dagger %s (%s)", version, revision())
+	return fmt.Sprintf("dagger %s (%s)", engine.Version, revision())
 }
 
 func long() string {
 	return fmt.Sprintf("%s %s/%s", short(), runtime.GOOS, runtime.GOARCH)
-}
-
-func engineImageRef() string {
-	// if this is a release, use the release image
-	if version != developmentVersion {
-		return fmt.Sprintf("%s:v%s", engineImageRepo, version)
-	}
-	// fallback to using the latest image from main
-	return fmt.Sprintf("%s:main", engineImageRepo)
 }

--- a/cmd/engine-session/main.go
+++ b/cmd/engine-session/main.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/dagger/dagger/engine"
+	internalengine "github.com/dagger/dagger/internal/engine"
 	"github.com/dagger/dagger/router"
 	"github.com/dagger/dagger/tracing"
 	"github.com/spf13/cobra"
@@ -43,7 +44,7 @@ func EngineSession(cmd *cobra.Command, args []string) {
 		Workdir:    workdir,
 		ConfigPath: configPath,
 		LogOutput:  os.Stderr,
-		RunnerHost: os.Getenv("_EXPERIMENTAL_DAGGER_RUNNER_HOST"),
+		RunnerHost: internalengine.RunnerHost(),
 	}
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, syscall.SIGINT, syscall.SIGTERM)

--- a/codegen/generator/generator.go
+++ b/codegen/generator/generator.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 
-	"dagger.io/dagger"
 	"github.com/dagger/dagger/codegen/introspection"
+	"github.com/dagger/dagger/router"
 )
 
 var ErrUnknownSDKLang = errors.New("unknown sdk language")
@@ -39,24 +39,19 @@ func SetSchemaParents(schema *introspection.Schema) {
 	}
 }
 
-// Introspect get the Dagger Schema with the client c.
-func Introspect(ctx context.Context, c *dagger.Client) (*introspection.Schema, error) {
+// Introspect get the Dagger Schema with the router r.
+func Introspect(ctx context.Context, r *router.Router) (*introspection.Schema, error) {
 	var response introspection.Response
-	err := c.Do(ctx,
-		&dagger.Request{
-			Query: introspection.Query,
-		},
-		&dagger.Response{Data: &response},
-	)
+	_, err := r.Do(ctx, introspection.Query, "", nil, &response)
 	if err != nil {
 		return nil, fmt.Errorf("error querying the API: %w", err)
 	}
 	return response.Schema, nil
 }
 
-// IntrospectAndGenerate generate the Dagger API with the client c.
-func IntrospectAndGenerate(ctx context.Context, c *dagger.Client, generator Generator) ([]byte, error) {
-	schema, err := Introspect(ctx, c)
+// IntrospectAndGenerate generate the Dagger API with the router r.
+func IntrospectAndGenerate(ctx context.Context, r *router.Router, generator Generator) ([]byte, error) {
+	schema, err := Introspect(ctx, r)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/engine/version.go
+++ b/internal/engine/version.go
@@ -1,0 +1,33 @@
+package engine
+
+import (
+	"fmt"
+	"os"
+)
+
+const (
+	DevelopmentVersion = "devel"
+	EngineImageRepo    = "ghcr.io/dagger/engine"
+)
+
+// Version holds the complete version number. Filled in at linking time.
+var Version = DevelopmentVersion
+
+func ImageRef() string {
+	// if this is a release, use the release image
+	if Version != DevelopmentVersion {
+		return fmt.Sprintf("%s:v%s", EngineImageRepo, Version)
+	}
+	// fallback to using the latest image from main
+	return fmt.Sprintf("%s:main", EngineImageRepo)
+}
+
+func RunnerHost() string {
+	var runnerHost string
+	if v, ok := os.LookupEnv("_EXPERIMENTAL_DAGGER_RUNNER_HOST"); ok {
+		runnerHost = v
+	} else {
+		runnerHost = "docker-image://" + ImageRef()
+	}
+	return runnerHost
+}


### PR DESCRIPTION
Fixes #4131

Same update as made to the dagger cli, but now to client-gen. Required moving the engine version stamp to a shared internal package so it could be reuse by both dagger and client-gen.