### PR TITLE
API: inbound and outbound tunnels for container networking

### DIFF
--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -17,6 +17,13 @@ type Container {
   "A unique identifier for this container"
   id: ContainerID!
 
+  """
+  Forward traffic from this container to the host
+    Frontend address is configurable but defaults to backend address
+    Example: withOutboundTunnel(protocol: UNIX, backend: "/var/run/docker.sock")
+  """
+  withOutboundTunnel(protocol: TunnelProtocol=TCP, backend: String!, frontend: String): Container!
+
   "The platform this container executes and publishes as"
   platform: Platform!
 

--- a/core/schema/service.graphqls
+++ b/core/schema/service.graphqls
@@ -1,0 +1,32 @@
+"Networking protocols which can be forwarded in a tunnel"
+enum TunnelProtocol {
+  TCP
+  UDP
+  UNIX
+}
+
+extend type Container {
+  """
+  Forward traffic from this container to the host
+    Frontend address is configurable but defaults to backend address
+    Example: withOutboundTunnel(protocol: UNIX, backend: "/var/run/docker.sock")
+  """
+  withOutboundTunnel(protocol: TunnelProtocol=TCP, backend: String!, frontend: String): Container!
+}
+
+
+extend type Service {
+  """
+  Forward traffic from the host to this service
+    Frontend address is configurable but defaults to backend address
+    Example: withInboundTunnel(backend: "localhost:80", frontend: "0.0.0.0:3000")
+  """
+  withInboundTunnel(protocol: TunnelProtocol=TCP, backend: String!, frontend: String): Service!
+
+"""
+  Forward traffic from this service to the host
+    Frontend address is configurable but defaults to backend address
+    Example: withOutboundTunnel(backend: "localhost:3306")
+  """
+  withOutboundTunnel(protocol: TunnelProtocol=TCP, backend: String!, frontend: String): Service!
+}


### PR DESCRIPTION
Draft API for container networking: c2h and h2c via explicit tunnels, inspired by SSH port forwarding.