### PR TITLE
Use 127.0.0.1 instead of localhost for sessions.

### DIFF
--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -42,7 +42,7 @@ func Run(cmd *cobra.Command, args []string) {
 	listening := make(chan string)
 	go func() {
 		// allocate the next available port
-		l, err := net.Listen("tcp", "localhost:0")
+		l, err := net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
@@ -56,7 +56,7 @@ func Run(cmd *cobra.Command, args []string) {
 	}()
 
 	listenPort := <-listening
-	os.Setenv("DAGGER_SESSION_URL", fmt.Sprintf("http://localhost:%s/query", listenPort))
+	os.Setenv("DAGGER_SESSION_URL", fmt.Sprintf("http://127.0.0.1:%s/query", listenPort))
 	os.Setenv("DAGGER_SESSION_TOKEN", sessionToken.String())
 
 	c := exec.CommandContext(ctx, args[0], args[1:]...) // #nosec

--- a/cmd/dagger/session.go
+++ b/cmd/dagger/session.go
@@ -50,7 +50,7 @@ func EngineSession(cmd *cobra.Command, args []string) error {
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, syscall.SIGINT, syscall.SIGTERM)
 
-	l, err := net.Listen("tcp", "localhost:0")
+	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return err
 	}
@@ -76,7 +76,7 @@ func EngineSession(cmd *cobra.Command, args []string) error {
 		}
 
 		paramBytes, err := json.Marshal(connectParams{
-			Host:         "localhost:" + strconv.Itoa(port),
+			Host:         "127.0.0.1:" + strconv.Itoa(port),
 			SessionToken: sessionToken.String(),
 		})
 		if err != nil {

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -266,7 +266,7 @@ checkenv:
 			if err != nil {
 				return specs.Spec{}, fmt.Errorf("error generating session token: %w", err)
 			}
-			l, err := net.Listen("tcp", "localhost:0")
+			l, err := net.Listen("tcp", "127.0.0.1:0")
 			if err != nil {
 				return specs.Spec{}, fmt.Errorf("error listening on session socket: %w", err)
 			}
@@ -284,7 +284,7 @@ checkenv:
 				}
 			}()
 
-			spec.Process.Env = append(spec.Process.Env, fmt.Sprintf("DAGGER_SESSION_URL=http://localhost:%d", l.Addr().(*net.TCPAddr).Port))
+			spec.Process.Env = append(spec.Process.Env, fmt.Sprintf("DAGGER_SESSION_URL=http://127.0.0.1:%d", l.Addr().(*net.TCPAddr).Port))
 			spec.Process.Env = append(spec.Process.Env, fmt.Sprintf("DAGGER_SESSION_TOKEN=%s", sessionToken.String()))
 
 			break checkenv


### PR DESCRIPTION
Localhost is often configured with entries for both ipv4 (127.0.0.1) and ipv6 entries (::1). Which one clients resolve to is inconsistent, so I found that sometimes nodejs would end up trying to connect to the ipv6 endpoint when the session was being listened to on ipv6.

Now we just consistently listen on 127.0.0.1. Technically it's possible for hosts to be ipv6 only or for a different loopback interface to be pointed to by /etc/hosts (e.g. 127.0.1.1), but these cases are extremely obscure to my knowledge so I think they can be dealt with later if needed.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>