### PR TITLE
Include output of failed exec in error message.

### DIFF
--- a/core/gateway.go
+++ b/core/gateway.go
@@ -1,0 +1,158 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/armon/circbuf"
+	bkgw "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/solver/errdefs"
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/pkg/errors"
+	fstypes "github.com/tonistiigi/fsutil/types"
+)
+
+const (
+	// Exec errors will only include the last this number of bytes of output.
+	maxExecErrorOutputBytes = 2 * 1024
+
+	// A magic env var that's interpreted by the shim, telling it to just output
+	// the stdout/stderr contents rather than actually execute anything.
+	DebugFailedExecEnv = "_DAGGER_SHIM_DEBUG_FAILED_EXEC"
+)
+
+// GatewayClient wraps the standard buildkit gateway client with errors that include the output
+// of execs when they fail.
+type GatewayClient struct {
+	bkgw.Client
+}
+
+func (g *GatewayClient) Solve(ctx context.Context, req bkgw.SolveRequest) (_ *bkgw.Result, rerr error) {
+	defer wrapSolveError(&rerr, g.Client)
+	res, err := g.Client.Solve(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if res.Ref != nil {
+		res.Ref = &ref{Reference: res.Ref, gw: g}
+	}
+	for k, r := range res.Refs {
+		res.Refs[k] = &ref{Reference: r, gw: g}
+	}
+	return res, nil
+}
+
+type ref struct {
+	bkgw.Reference
+	gw *GatewayClient
+}
+
+func (r *ref) ReadFile(ctx context.Context, req bkgw.ReadRequest) (_ []byte, rerr error) {
+	defer wrapSolveError(&rerr, r.gw.Client)
+	return r.Reference.ReadFile(ctx, req)
+}
+
+func (r *ref) StatFile(ctx context.Context, req bkgw.StatRequest) (_ *fstypes.Stat, rerr error) {
+	defer wrapSolveError(&rerr, r.gw.Client)
+	return r.Reference.StatFile(ctx, req)
+}
+
+func (r *ref) ReadDir(ctx context.Context, req bkgw.ReadDirRequest) (_ []*fstypes.Stat, rerr error) {
+	defer wrapSolveError(&rerr, r.gw.Client)
+	return r.Reference.ReadDir(ctx, req)
+}
+
+func wrapSolveError(inputErr *error, gw bkgw.Client) {
+	if inputErr == nil || *inputErr == nil {
+		return
+	}
+	returnErr := *inputErr
+
+	var se *errdefs.SolveError
+	if errors.As(returnErr, &se) {
+		// Ensure we don't get blocked trying to return an error by enforcing a timeout
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		op := se.Op
+		if op == nil || op.Op == nil {
+			return
+		}
+		execOp, ok := se.Op.Op.(*pb.Op_Exec)
+		if !ok {
+			return
+		}
+
+		// This was an exec error, we can retrieve the output still
+		// by starting a container w/ the mounts from the failed exec
+		// and having our shim output the file contents where the stdout
+		// and stderr were stored.
+		var mounts []bkgw.Mount
+		for i, mnt := range execOp.Exec.Mounts {
+			mnt := mnt
+			mounts = append(mounts, bkgw.Mount{
+				Selector:  mnt.Selector,
+				Dest:      mnt.Dest,
+				ResultID:  se.MountIDs[i],
+				Readonly:  mnt.Readonly,
+				MountType: mnt.MountType,
+				CacheOpt:  mnt.CacheOpt,
+				SecretOpt: mnt.SecretOpt,
+				SSHOpt:    mnt.SSHOpt,
+			})
+		}
+		ctr, err := gw.NewContainer(ctx, bkgw.NewContainerRequest{
+			Mounts:      mounts,
+			NetMode:     execOp.Exec.Network,
+			ExtraHosts:  execOp.Exec.Meta.ExtraHosts,
+			Platform:    op.Platform,
+			Constraints: op.Constraints,
+		})
+		if err != nil {
+			return
+		}
+		defer ctr.Release(ctx)
+		// Use a circular buffer to only save the last N bytes of output, which lets
+		// us prevent enormous error messages while retaining the output most likely
+		// to be of interest.
+		ctrOut, err := circbuf.NewBuffer(maxExecErrorOutputBytes)
+		if err != nil {
+			return
+		}
+		ctrErr, err := circbuf.NewBuffer(maxExecErrorOutputBytes)
+		if err != nil {
+			return
+		}
+		proc, err := ctr.Start(ctx, bkgw.StartRequest{
+			Args: execOp.Exec.Meta.Args,
+			// the magic env var is interpreted by the shim, telling it to just output
+			// the stdout/stderr contents rather than actually execute anything.
+			Env:    append(execOp.Exec.Meta.Env, DebugFailedExecEnv+"=1"),
+			User:   execOp.Exec.Meta.User,
+			Cwd:    execOp.Exec.Meta.Cwd,
+			Stdout: &nopCloser{ctrOut},
+			Stderr: &nopCloser{ctrErr},
+		})
+		if err != nil {
+			return
+		}
+		if err := proc.Wait(); err != nil {
+			return
+		}
+		stdout := strings.TrimSpace(ctrOut.String())
+		stderr := strings.TrimSpace(ctrErr.String())
+		returnErr = fmt.Errorf("%w\nStdout:\n%s\nStderr:\n%s", returnErr, stdout, stderr)
+	}
+	*inputErr = returnErr
+}
+
+type nopCloser struct {
+	io.Writer
+}
+
+func (n *nopCloser) Close() error {
+	return nil
+}

--- a/core/schema/base.go
+++ b/core/schema/base.go
@@ -23,7 +23,7 @@ type InitializeArgs struct {
 func New(params InitializeArgs) (router.ExecutableSchema, error) {
 	base := &baseSchema{
 		router:    params.Router,
-		gw:        params.Gateway,
+		gw:        &core.GatewayClient{Client: params.Gateway},
 		bkClient:  params.BKClient,
 		solveOpts: params.SolveOpts,
 		solveCh:   params.SolveCh,

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ replace cloud.google.com/go => cloud.google.com/go v0.100.2
 
 require (
 	dagger.io/dagger v0.4.1
+	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
 	github.com/containerd/containerd v1.6.10
 	github.com/dagger/graphql v0.0.0-20221102000338-24d5e47d3b72
 	github.com/dagger/graphql-go-tools v0.0.0-20221102001222-e68b44170936

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNg
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
+github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2 h1:7Ip0wMmLHLRJdrloDxZfhMm0xrLXZS8+COSu2bXmEQs=
+github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=


### PR DESCRIPTION
Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Fixes https://github.com/dagger/dagger/issues/3025

I looked a bit into the upcoming build history API in buildkit v0.11 but realized the way its implemented makes it very hard to use for this case (it's all the progress for the whole build, not just one exec), so I think the approach in this pr, while inherently ugly, to be the only viable way.

We use a secret feature of buildkit that lets you obtain the mounts of a failed exec and use them in `NewContainer` calls. We then create a NewContainer with the meta mount of the failed exec and tell our shim to just output the contents of it.

Example error message:
```
container.from.withExec.exitCode process "sh -c echo Z29vZGJ5ZSwgY3J1ZWwgd29ybGQ= | base64 -d >&2; exit 1" did not complete successfully: exit code: 1
        Stdout:
        
        Stderr:
        goodbye, cruel world
        
        Please visit https://dagger.io/help#go for troubleshooting guidance.
```

---

Important cleanups needed before merge:
- [x] Limit the size of the output we can include (i.e. so we don't try sending a 1MB error message)
- [x] Wrap all of all gateway method calls with this error check, not just file contents (though that covers exec stdout, stderr and exitcode)