### PR TITLE
Node.js GitHub + Google Cloud guide: remove awaited + fix the console.log

### DIFF
--- a/docs/current/sdk/nodejs/snippets/github-google-cloud/main.mjs
+++ b/docs/current/sdk/nodejs/snippets/github-google-cloud/main.mjs
@@ -8,14 +8,14 @@ const GCR_PUBLISH_ADDRESS = 'gcr.io/PROJECT/myapp'
 // initialize Dagger client
 connect(async (daggerClient) => {
   // get reference to the project directory
-  const source = await daggerClient.host().directory(".", { exclude: ["node_modules/", "ci/"] })
+  const source = daggerClient.host().directory(".", { exclude: ["node_modules/", "ci/"] })
 
   // get Node image
-  const node = await daggerClient.container().from("node:16")
+  const node = daggerClient.container().from("node:16")
 
   // mount cloned repository into Node image
   // install dependencies
-  const c = await node
+  const c = node
     .withMountedDirectory("/src", source)
     .withWorkdir("/src")
     .withExec(["cp", "-R", ".", "/home/node"])
@@ -28,7 +28,7 @@ connect(async (daggerClient) => {
     .publish(GCR_PUBLISH_ADDRESS)
 
   // print ref
-  console.log(`Published at: ${gcrContainerPublishResponse.publish}`)
+  console.log(`Published at: ${gcrContainerPublishResponse}`)
 
   // initialize Google Cloud Run client
   const gcrClient = new ServicesClient();

--- a/docs/current/sdk/nodejs/snippets/github-google-cloud/main.mjs
+++ b/docs/current/sdk/nodejs/snippets/github-google-cloud/main.mjs
@@ -31,7 +31,7 @@ connect(async (daggerClient) => {
   console.log(`Published at: ${gcrContainerPublishResponse}`)
 
   // initialize Google Cloud Run client
-  const gcrClient = new v2.ServicesClient();
+  const gcrClient = new ServicesClient();
 
   // define service request
   const gcrServiceUpdateRequest = {

--- a/docs/current/sdk/nodejs/snippets/github-google-cloud/main.mjs
+++ b/docs/current/sdk/nodejs/snippets/github-google-cloud/main.mjs
@@ -31,29 +31,31 @@ connect(async (daggerClient) => {
   console.log(`Published at: ${gcrContainerPublishResponse}`)
 
   // initialize Google Cloud Run client
-  const gcrClient = new ServicesClient();
+  const gcrClient = new v2.ServicesClient();
 
-  // define service
-  const gcrService = {
-    name: GCR_SERVICE_URL,
-    template: {
-      containers: [
-        {
-          image: gcrContainerPublishResponse,
-          ports: [
-            {
-              name: "http1",
-              containerPort: 3000
-            }
-          ]
-        }
-      ],
-    },
-   }
+  // define service request
+  const gcrServiceUpdateRequest = {
+    service: {
+      name: GCR_SERVICE_URL,
+      template: {
+        containers: [
+          {
+            image: gcrContainerPublishResponse,
+            ports: [
+              {
+                name: "http1",
+                containerPort: 3000
+              }
+            ]
+          }
+        ],
+      },
+     }
+  };
 
   // update service
-  const [gcrServiceUpdateRequest] = await gcrClient.updateService({gcrService});
-  const [gcrServiceUpdateResponse] = await gcrServiceUpdateRequest.promise();
+  const [gcrServiceUpdateOperation] = await gcrClient.updateService(gcrServiceUpdateRequest);
+  const [gcrServiceUpdateResponse] = await gcrServiceUpdateOperation.promise();
 
   // print ref
   console.log(`Deployment for image ${gcrContainerPublishResponse} now available at ${gcrServiceUpdateResponse.uri}`)

--- a/docs/current/sdk/nodejs/snippets/github-google-cloud/main.mjs
+++ b/docs/current/sdk/nodejs/snippets/github-google-cloud/main.mjs
@@ -39,7 +39,7 @@ connect(async (daggerClient) => {
     template: {
       containers: [
         {
-          image: `${gcr.publish}`,
+          image: gcrContainerPublishResponse,
           ports: [
             {
               name: "http1",

--- a/docs/current/sdk/nodejs/snippets/github-google-cloud/main.mjs
+++ b/docs/current/sdk/nodejs/snippets/github-google-cloud/main.mjs
@@ -56,6 +56,6 @@ connect(async (daggerClient) => {
   const [gcrServiceUpdateResponse] = await gcrServiceUpdateRequest.promise();
 
   // print ref
-  console.log(`Deployment for image ${gcrContainerPublishResponse.publish} now available at ${gcrServiceUpdateResponse.uri}`)
+  console.log(`Deployment for image ${gcrContainerPublishResponse} now available at ${gcrServiceUpdateResponse.uri}`)
 
 }, {LogOutput: process.stdout})


### PR DESCRIPTION
@vikram-dagger I've removed the awaited that are actually not running a Graphql query. 
The rule of thumb is to await a query that will execute a GraphQL query and return something. 
Maybe I'm wrong but the console.log seems to use the old syntax with `.publish`.

Signed-off-by: jffarge <jf@dagger.io>