### PR TITLE
sdk: python: Don’t timeout by default

### DIFF
--- a/sdk/python/src/dagger/config.py
+++ b/sdk/python/src/dagger/config.py
@@ -20,15 +20,16 @@ class Config:
     timeout:
         The maximum time in seconds for establishing a connection to the server.
     execute_timeout:
-        The maximum time in seconds for the execution of a request before a TimeoutError
-        is raised. Passing None results in waiting forever for a response.
+        The maximum time in seconds for the execution of a request before an
+        ExecuteTimeoutError is raised. Passing None results in waiting forever for a
+        response (default).
     """
 
     workdir: pathlib.Path | str = ""
     config_path: pathlib.Path | str = ""
     log_output: typing.TextIO | None = None
     timeout: int = 10
-    execute_timeout: int | float | None = 60 * 5
+    execute_timeout: int | float | None = None
 
 
 def _host_converter(value: str) -> httpx.URL:

--- a/sdk/python/src/dagger/exceptions.py
+++ b/sdk/python/src/dagger/exceptions.py
@@ -12,3 +12,7 @@ class ClientError(DaggerError):
 
 class InvalidQueryError(ClientError):
     """Misuse of the query builder."""
+
+
+class ExecuteTimeoutError(ClientError):
+    """Timeout while executing a query."""

--- a/sdk/python/src/dagger/session.py
+++ b/sdk/python/src/dagger/session.py
@@ -46,7 +46,13 @@ class Session(ResourceManager, SyncResourceManager):
         return GraphQLClient(
             transport=transport,
             fetch_schema_from_transport=True,
-            execute_timeout=self.cfg.execute_timeout,
+            # Don't timeout with the event loop. This setting is only for AsyncTransport
+            # and uses `asyncio.wait_for` which is not compatible with other event loops
+            # (e.g., Trio). Catching the TimeoutError would also be more complicated,
+            # unless *gql* adopts AnyIO in the future, but still only on *async*.
+            # Since we're using *httpx* as the transport for both *async* and *sync*, we
+            # can use that project's Timeout instead for both environments.
+            execute_timeout=None,
         )
 
     async def __aenter__(self) -> AsyncClientSession:


### PR DESCRIPTION
Fixes #4111

Dagger pipelines can take a long time to run. There’s no good default here so it’s better not to timeout unless the user says so.

Signed-off-by: Helder Correia