### PR TITLE
Proposal: dynamic secret via helpers

### DIFF
--- a/core/schema/file.graphqls
+++ b/core/schema/file.graphqls
@@ -16,6 +16,7 @@ type File {
 
   "Retrieves a secret referencing the contents of this file."
   secret: Secret!
+    @deprecated(reason: "This operation is considered unsafe. See https://github.com/dagger/dagger/issues/4403")
 
   "Gets the size of the file, in bytes."
   size: Int!

--- a/core/schema/secret.graphqls
+++ b/core/schema/secret.graphqls
@@ -1,6 +1,12 @@
 extend type Query {
-  "Loads a secret from its ID."
-  secret(id: SecretID!): Secret!
+  """
+  Lookup a secret by its key.
+
+  Secret store is configurable by the end user.
+  Default store looks up environment variables in the host,
+  first with exact capitalization, then all uppercase.
+  """
+  secret(key: String!): Secret!
 }
 
 "A unique identifier for a secret."
@@ -11,6 +17,6 @@ type Secret {
   "The identifier for this secret."
   id: SecretID!
 
-  "The value of this secret."
+  "The plaintext value of this secret"
   plaintext: String!
 }


### PR DESCRIPTION
This is a proposal for a new API that adds supports for #4426, by calling external helpers.

Highlights:

* Secrets are looked up by an abstract key, for example "netlify_token"
* Secret value is retrieved just-in-time when a pipeline needs it. Under the hood this is powered by buildkit "session attachables".
* By default, secret value is retrieved by looking up the corresponding env variable
* Custom secret retrieval logic can be injected by the operator, by adding an executable helper in the `$PATH` of the client machine.
* This is similar to how [Earthly](https://earthly.dev) supports secrets. Note [this undocumented PR](https://github.com/earthly/earthly/pull/1822) for the use of helpers.
* Pre-existing `File { secret }` method is deprecated, [because it is unsafe](#4403).

Relevant discussions:

* #3442 
* #2377 
* #3323