### PR TITLE
docs: Revise CI guide titles

### DIFF
--- a/docs/current/sdk/go/guides/768421-go-ci.md
+++ b/docs/current/sdk/go/guides/768421-go-ci.md
@@ -3,7 +3,7 @@ slug: /768421/go-ci
 displayed_sidebar: "current"
 ---
 
-# Dagger Go SDK in CI
+# Use the Dagger Go SDK in CI
 
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';
 

--- a/docs/current/sdk/nodejs/guides/114934-nodejs-ci.md
+++ b/docs/current/sdk/nodejs/guides/114934-nodejs-ci.md
@@ -3,7 +3,7 @@ slug: /114934/nodejs-ci
 displayed_sidebar: "current"
 ---
 
-# Dagger Node.js SDK in CI
+# Use the Dagger Node.js SDK in CI
 
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';
 

--- a/docs/current/sdk/python/guides/454108-python-ci.md
+++ b/docs/current/sdk/python/guides/454108-python-ci.md
@@ -3,7 +3,7 @@ slug: /454108/python-ci
 displayed_sidebar: "current"
 ---
 
-# Dagger Python SDK in CI
+# Use the Dagger Python SDK in CI
 
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';
 


### PR DESCRIPTION
This commit updates the CI guide titles to match the titles shown on the guides index page. This title is also clearer when shown in  embedded link previews in social.

Relates to #3918 

Signed-off-by: Vikram Vaswani <vikram@dagger.io>