### PR TITLE
cli: expose x-dagger-engine version with dagger listen

### DIFF
--- a/cmd/dagger/version.go
+++ b/cmd/dagger/version.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"runtime"
-	"runtime/debug"
 
 	"github.com/dagger/dagger/internal/engine"
 	"github.com/spf13/cobra"
@@ -21,24 +20,8 @@ var versionCmd = &cobra.Command{
 	},
 }
 
-// revision returns the VCS revision being used to build or empty string
-// if none.
-func revision() string {
-	bi, ok := debug.ReadBuildInfo()
-	if !ok {
-		return ""
-	}
-	for _, s := range bi.Settings {
-		if s.Key == "vcs.revision" {
-			return s.Value[:9]
-		}
-	}
-
-	return ""
-}
-
 func short() string {
-	return fmt.Sprintf("dagger %s (%s)", engine.Version, revision())
+	return fmt.Sprintf("dagger %s", engine.Version)
 }
 
 func long() string {

--- a/internal/engine/version.go
+++ b/internal/engine/version.go
@@ -3,14 +3,16 @@ package engine
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
 
 	"golang.org/x/mod/semver"
 )
 
 const (
-	DevelopmentVersion = "devel"
-	EngineImageRepo    = "ghcr.io/dagger/engine"
+	EngineImageRepo = "ghcr.io/dagger/engine"
 )
+
+var DevelopmentVersion = fmt.Sprintf("devel (%s)", vcsRevision())
 
 // Version holds the complete version number. Filled in at linking time.
 var Version = DevelopmentVersion
@@ -42,4 +44,20 @@ func RunnerHost() string {
 		runnerHost = "docker-image://" + ImageRef()
 	}
 	return runnerHost
+}
+
+// revision returns the VCS revision being used to build or empty string
+// if none.
+func vcsRevision() string {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	for _, s := range bi.Settings {
+		if s.Key == "vcs.revision" {
+			return s.Value[:9]
+		}
+	}
+
+	return ""
 }

--- a/router/router.go
+++ b/router/router.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dagger/dagger/internal/engine"
 	"github.com/dagger/dagger/router/internal/handler"
 	"github.com/dagger/graphql"
 	"github.com/dagger/graphql/gqlerrors"
@@ -133,6 +134,8 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	r.l.RLock()
 	h := r.h
 	r.l.RUnlock()
+
+	w.Header().Add("x-dagger-engine", engine.Version)
 
 	if r.sessionToken != "" {
 		username, _, ok := req.BasicAuth()


### PR DESCRIPTION
This allows to know which engine version is being used while serving
/query requests

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
