### PR TITLE
feat: NodeSDK generate input from GQL schema.

### DIFF
--- a/codegen/generator/nodejs/templates/src/type.ts.tmpl
+++ b/codegen/generator/nodejs/templates/src/type.ts.tmpl
@@ -9,6 +9,7 @@
 export type {{ .Name }} = string;
 {{ "" }}
 	{{- end }}
+
 	{{- with .Fields }}
 		{{- range . -}}
 			{{- $optionals := GetOptionalArgs .Args }}
@@ -29,4 +30,24 @@ export type {{ $typeName }}{{ .Name | PascalCase }}Opts = {
 {{ "" }}		{{- end }}
 		{{- end }}
 	{{- end }}
+
+{{- /* Generate input GraphQL type */ -}}
+	{{- with .InputFields }}
+export type {{ $typeName }} = {
+    {{- range . -}}
+    {{- $opt := "" -}}
+    {{ if .TypeRef.IsOptional }}
+        {{- $opt = "?" -}}
+    {{- end }}
+    {{- if .Description }}
+{{ template "type_field_comment" .Description }}
+    {{- end }}
+  {{ .Name  }}{{ $opt }}: {{ .TypeRef | FormatInputType }};
+
+
+    {{- end }}
+};
+{{ "" }}
+	{{- end }}
+
 {{- end }}

--- a/codegen/generator/nodejs/templates/src/type_test.go
+++ b/codegen/generator/nodejs/templates/src/type_test.go
@@ -36,6 +36,64 @@ export type Container = string;
 		require.Equal(t, want, b.String())
 	})
 
+	t.Run("input", func(t *testing.T) {
+		var expectedInputType = `
+export type BuildArg = {
+  name: string;
+  value: string;
+};
+`
+
+		var fieldInputTypeJSON = `
+	{
+		"kind": "INPUT_OBJECT",
+		"name": "BuildArg",
+		"description": "foo",
+		"inputFields": [
+		  {
+		    "name": "name",
+		    "description": "",
+		    "defaultValue": null,
+		    "type": {
+		      "kind": "NON_NULL",
+		      "name": null,
+		      "ofType": {
+				"kind": "SCALAR",
+				"name": "String",
+				"ofType": null
+			  }
+		    }
+		  },
+		  {
+		    "name": "value",
+		    "description": "",
+		    "defaultValue": null,
+		    "type": {
+		      "kind": "NON_NULL",
+		      "name": null,
+		      "ofType": {
+				"kind": "SCALAR",
+				"name": "String",
+				"ofType": null
+			  }
+		    }
+		  }
+		]
+	}
+`
+		tmpl := templateHelper(t)
+
+		object := objectInit(t, fieldInputTypeJSON)
+
+		var b bytes.Buffer
+		err := tmpl.ExecuteTemplate(&b, "type", object)
+
+		want := expectedInputType
+
+		require.NoError(t, err)
+		require.Equal(t, want, b.String())
+	})
+
 	t.Run("args", func(t *testing.T) {
 		var expectedFieldArgsType = `
 export type ContainerExecOpts = {

--- a/codegen/generator/nodejs/templates/src/type_test.go
+++ b/codegen/generator/nodejs/templates/src/type_test.go
@@ -39,6 +39,10 @@ export type Container = string;
 	t.Run("input", func(t *testing.T) {
 		var expectedInputType = `
 export type BuildArg = {
+
+  /**
+   * Name description.
+   */
   name: string;
   value: string;
 };
@@ -52,7 +56,7 @@ export type BuildArg = {
 		"inputFields": [
 		  {
 		    "name": "name",
-		    "description": "",
+		    "description": "Name description.",
 		    "defaultValue": null,
 		    "type": {
 		      "kind": "NON_NULL",


### PR DESCRIPTION
type.ts.tpml now supports input types and
generates its Typescript representation.

Resolves: #4216
Signed-off-by: Tom Chauveau <tom.chauveau@epitech.eu>