### PR TITLE
docs: update private repo docs + add Node SDK example

### DIFF
--- a/docs/current/partials/_private-git-repository_first.md
+++ b/docs/current/partials/_private-git-repository_first.md
@@ -1,5 +1,5 @@
-Dagger uses your host's SSH authentication agent to securely authenticate against private remote Git repositories.
+Dagger recommends you to rely on your host's SSH authentication agent to securely authenticate against private remote Git repositories.
 
-To clone private repositories, the only requirement is to run `ssh-add` on the Dagger host to add your SSH key to the authentication agent.
+To clone private repositories, the only requirements are to run `ssh-add` on the Dagger host (to add your SSH key to the authentication agent), and mount its socket using the `SSHAuthSocket` parameter of the `(Dagger.GitRef).Tree` API.
 
 Assume that you have a Dagger CI tool containing the following code, which references a private repository:

--- a/docs/current/sdk/go/snippets/private-repositories/main.go
+++ b/docs/current/sdk/go/snippets/private-repositories/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"dagger.io/dagger"
 )
@@ -15,11 +16,18 @@ func main() {
 	}
 	defer client.Close()
 
+	// Retrieve path of authentication agent socket from host
+	sshAgentPath := os.Getenv("SSH_AUTH_SOCK")
+
 	// Private repository with a README.md file at the root.
 	readme, err := client.
 		Git("git@private-repository.git").
 		Branch("main").
-		Tree().
+		Tree(
+			dagger.GitRefTreeOpts{
+				SSHAuthSocket: client.Host().UnixSocket(sshAgentPath),
+			},
+		).
 		File("README.md").
 		Contents(ctx)
 

--- a/docs/current/sdk/nodejs/947203-guides.md
+++ b/docs/current/sdk/nodejs/947203-guides.md
@@ -6,3 +6,4 @@ slug: /sdk/nodejs/947203/guides
 
 - [Use the Dagger Node.js SDK in CI](./guides/114934-nodejs-ci.md)
 - [Use Dagger with GitHub Actions and Google Cloud](./guides/620941-github-google-cloud.md)
+- [Use Dagger with Private Git Repositories](./guides/560223-private-repositories.md)

--- a/docs/current/sdk/nodejs/guides/560223-private-repositories.md
+++ b/docs/current/sdk/nodejs/guides/560223-private-repositories.md
@@ -1,0 +1,33 @@
+---
+slug: /560223/private-repositories
+displayed_sidebar: "current"
+---
+
+# Use Dagger with Private Git Repositories
+
+{@include: ../../../partials/_private-git-repository_first.md}
+
+```typescript file=../snippets/private-repositories/clone.ts
+```
+
+{@include: ../../../partials/_private-git-repository_second.md}
+
+Attempt to run the Typescript CI tool:
+
+```shell
+➜  node --loader ts-node/esm clone.ts
+{'message': 'failed to load cache key: failed to fetch remote https://xxxxx@private-repository.git: exit status 128', 'locations': [{'line': 6, 'column': 11}], 'path': ['git', 'branch', 'tree', 'file', 'contents']}
+```
+
+The CI tool fails, as it is unable to find the necessary authentication credentials to read the private repository in the SSH authentication agent.
+
+Now, add the SSH key to the authentication agent on the host and try again:
+
+```shell
+➜ ssh-add
+Identity added: xxxxx
+➜ node --loader ts-node/esm clone.ts
+readme #
+```
+
+Finally, the CI tool succeeds in reading the private Git repository.

--- a/docs/current/sdk/nodejs/reference/modules.md
+++ b/docs/current/sdk/nodejs/reference/modules.md
@@ -11,4 +11,5 @@ displayed_sidebar: "current"
 ## Modules
 
 - [api/client.gen](modules/api_client_gen.md)
+- [common/errors](modules/common_errors.md)
 - [connect](modules/connect.md)

--- a/docs/current/sdk/nodejs/snippets/private-repositories/clone.ts
+++ b/docs/current/sdk/nodejs/snippets/private-repositories/clone.ts
@@ -1,0 +1,27 @@
+import Client, { connect } from "@dagger.io/dagger"
+import process from "process"
+
+// initialize Dagger client
+connect(async (client: Client) => {
+  // Collect value of SSH_AUTH_SOCK env var, to retrieve authentication socket path
+  const sshAuthSockPath = process.env.SSH_AUTH_SOCK?.toString() || ""
+
+  // Retrieve authentication socket ID from host
+  const sshAgentSocketID = await client.host().unixSocket(sshAuthSockPath).id()
+
+  const repo = client
+    // Retrieve the repository
+    .git("git@private-repository.git")
+    // Select the main branch, and the filesystem tree associated
+    .branch("main")
+    .tree({
+      sshAuthSocket: sshAgentSocketID,
+    })
+    // Select the README.md file
+    .file("README.md")
+
+  // Retrieve the content of the README file
+  const file = await repo.contents()
+
+  console.log(file)
+})

--- a/docs/current/sdk/python/snippets/private-repositories/clone.py
+++ b/docs/current/sdk/python/snippets/private-repositories/clone.py
@@ -2,6 +2,7 @@
 Clone a Private Git Repository and print the content of the README.md file
 """
 
+import os
 import sys
 
 import anyio
@@ -15,12 +16,18 @@ console = Console()
 async def private_repo():
     with console.status("Hold on..."):
         async with dagger.Connection() as client:
+            # Collect value of SSH_AUTH_SOCK env var, to retrieve auth socket path
+            ssh_auth_path = os.environ.get("SSH_AUTH_SOCK")
+
+            # Retrieve authentication socket from host
+            ssh_agent_socket = client.host().unix_socket(ssh_auth_path)
+
             repo = (
                 client
                 # Retrieve the repository
                 .git("git@private-repository.git")
                 # Select the main branch, and the filesystem tree associated
-                .branch("main").tree()
+                .branch("main").tree(None, ssh_agent_socket)
                 # Select the README.md file
                 .file("README.md")
             )


### PR DESCRIPTION
Unix socket implementation changed the behavior to connect to private repositories. This updates the docs accordingly + adds a Node example 😇 