### PR TITLE
docs: Use /var/run/docker.sock base64

### DIFF
--- a/website/docs-graphql/data/examples/queries/socket/gql.md
+++ b/website/docs-graphql/data/examples/queries/socket/gql.md
@@ -1,6 +1,6 @@
 ```gql
 query {
-  socket(id: "eyJob3N0X3BhdGgiOiIvcnVuL2RvY2tlci5zb2NrIn0=") {
+  socket(id: "eyJob3N0X3BhdGgiOiIvdmFyL3J1bi9kb2NrZXIuc29jayJ9") {
     id
   }
 }


### PR DESCRIPTION
The current example uses `/run/docker.sock` which is fine for Linux, but other platforms like MacOS use `/var/run/docker.sock` which also works via symlinks on Linux, so we should use the more general example in case somebody uses this as-is.

old:
```
echo eyJob3N0X3BhdGgiOiIvcnVuL2RvY2tlci5zb2NrIn0= | base64 -D
{"host_path":"/run/docker.sock"}%
```

new:
```
echo -n eyJob3N0X3BhdGgiOiIvdmFyL3J1bi9kb2NrZXIuc29jayJ9 | base64 -D
{"host_path":"/var/run/docker.sock"}%
```

Signed-off-by: Jeremy Adams <jeremy@dagger.io>