### PR TITLE
Make archive names consistent with previous naming scheme.

### DIFF
--- a/.goreleaser.common.yml
+++ b/.goreleaser.common.yml
@@ -23,13 +23,5 @@ builds:
     goarm:
       - "7"
 
-archives:
-  - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
-    files:
-      - LICENSE
-    format_overrides:
-      - goos: windows
-        format: zip
-
 checksum:
   name_template: "checksums.txt"

--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -7,6 +7,14 @@ nightly:
   # https://goreleaser.com/customization/nightlies/#how-it-works
   name_template: "{{ .FullCommit }}"
 
+archives:
+  - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
+    files:
+      - LICENSE
+    format_overrides:
+      - goos: windows
+        format: zip
+
 blobs:
   - provider: s3
     region: "{{ .Env.AWS_REGION }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,14 @@ includes:
 snapshot:
   name_template: "{{ .Tag }}-next"
 
+archives:
+  - name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
+    files:
+      - LICENSE
+    format_overrides:
+      - goos: windows
+        format: zip
+
 # https://goreleaser.com/customization/homebrew/
 brews:
   - tap:

--- a/sdk/go/internal/engineconn/cli.go
+++ b/sdk/go/internal/engineconn/cli.go
@@ -233,7 +233,7 @@ func defaultCLIArchiveName() string {
 		return filepath.Base(url.Path)
 	}
 	// TODO:(sipsma) fix this for windows
-	return fmt.Sprintf("dagger_%s_%s_%s.tar.gz",
+	return fmt.Sprintf("dagger_v%s_%s_%s.tar.gz",
 		CLIVersion,
 		runtime.GOOS,
 		runtime.GOARCH,

--- a/sdk/nodejs/provisioning/bin.ts
+++ b/sdk/nodejs/provisioning/bin.ts
@@ -243,7 +243,7 @@ export class Bin implements EngineConn {
     if (OVERRIDE_CLI_URL) {
       return path.basename(new URL(OVERRIDE_CLI_URL).pathname)
     }
-    return `dagger_${
+    return `dagger_v${
       this.cliVersion
     }_${this.normalizedOS()}_${this.normalizedArch()}.tar.gz`
   }

--- a/sdk/python/src/dagger/engine/bin.py
+++ b/sdk/python/src/dagger/engine/bin.py
@@ -205,7 +205,7 @@ def cli_archive_name(cli_version: str):
     if OVERRIDE_CLI_ARCHIVE_URL:
         return Path(urllib.parse.urlparse(OVERRIDE_CLI_ARCHIVE_URL).path).name
     os_, arch = get_platform()
-    return f"dagger_{cli_version}_{os_}_{arch}.tar.gz"
+    return f"dagger_v{cli_version}_{os_}_{arch}.tar.gz"
 
 
 def cli_archive_url(cli_version: str):


### PR DESCRIPTION
Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Recent changes accidentally introduced a small change in how we name archives:
```
before: dagger/releases/0.3.7/dagger_v0.3.7_linux_arm64.tar.gz
after:  dagger/releases/0.3.7/dagger_0.3.7_linux_arm64.tar.gz
```

Noticed here: https://github.com/dagger/dagger/pull/4255#pullrequestreview-1229367604

I think the newer name scheme is nicer in that it's more consistent, however It's easier to just go back to the previous naming scheme than it is to try updating install.sh to be compatible with both schemes, so this just goes back to the previous one.

Goreleaser is a little annoying because we can't use `Tag` in nightly, so have to split that out into the separate configs, but should work.