### PR TITLE
Node.js SDK - Improve ref docs readability

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -13,7 +13,7 @@ async function createConfig() {
     organizationName: "Dagger",
     projectName: "Dagger",
     stylesheets: [
-      "https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400&display=swap",
+      "https://fonts.googleapis.com/css2?family=Montserrat:wght@500;700&family=Source+Code+Pro:wght@400&display=swap",
     ],
     customFields: {
       AMPLITUDE_ID: process.env.REACT_APP_AMPLITUDE_ID,
@@ -151,6 +151,7 @@ async function createConfig() {
             title: "Dagger NodeJS SDK"
           },
           hideMembersSymbol: true,
+          requiredToBeDocumented: ["Class"]
         },
       ]
     ],

--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -62,10 +62,10 @@ $desktop-xl-width: 1160px;
   --ifm-font-color-base: var(--ifm-color-primary-darker);
   --ifm-font-family-base: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-  --ifm-font-family-title: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  --ifm-font-family-title: "Montserrat", sans-serif;
   --ifm-font-family-monospace: "Source Code Pro", monospace;
   --ifm-h2-font-size: 2rem;
+  --ifm-heading-line-height: 1.2;
   --ifm-leading-desktop: 1;
   --ifm-link-color: var(--ifm-color-primary-dark);
   --ifm-link-hover-color: var(--ifm-color-primary);
@@ -106,7 +106,6 @@ html[data-theme="dark"] {
   --ifm-box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.5);
   --ifm-breadcrumb-item-background-active: var(--ifm-color-primary);
 }
-
 /* global */
 
 * {
@@ -704,7 +703,6 @@ img[alt="github-contribute"] {
   margin: 50px 0px;
 }
 
-
 /* release status badge */
 .status-badge {
   width: fit-content;
@@ -715,4 +713,41 @@ img[alt="github-contribute"] {
   border-radius: 5px;
   margin-bottom: 8px;
   font-size: 15px;
+}
+
+/* nodejs/reference page */
+
+[class*=" docs-doc-id-current\/sdk\/nodejs\/reference"] {
+  .container {
+    max-width: 1200px;
+  }
+
+  .markdown h1:first-child {
+    font-size: 3.157rem;
+    margin-bottom: 4rem;
+    font-weight: 700;
+    letter-spacing: -2px;
+  }
+  .markdown > h2 {
+    font-size: 2.369rem;
+    margin-bottom: 3rem;
+  }
+  .markdown > h3 {
+    font-size: 1.802rem;
+    margin-bottom: 2rem;
+  }
+
+  .markdown > h4 {
+    font-size: 1.2rem;
+  }
+
+  code,
+  .markdown a:not(.card) code {
+    background-color: rgba(19, 18, 38, 0.1);
+    color: var(--ifm-color-primary-dark);
+  }
+
+  a > code {
+    font-weight: 400;
+  }
 }


### PR DESCRIPTION
Update css only for node.js docs reference page. Use the latest Dagger UI Library 
- Bring back font family Montserrat only for Title
- Enhance title spacing
- Enhance code readability

Before:
![docs dagger io_current_sdk_nodejs_reference_modules_api_client_gen](https://user-images.githubusercontent.com/1186424/210258474-63b94933-8615-458f-ba4a-7683ca81b154.png)


After:
![deploy-preview-4275--devel-docs-dagger-io netlify app_current_sdk_nodejs_reference_modules_api_client_gen](https://user-images.githubusercontent.com/1186424/210258490-5868df1f-819e-44b4-976c-62c6c574e0a2.png)


Signed-off-by: jffarge <jf@dagger.io>