### PR TITLE
Python: Use platform dependent cache dirs

### DIFF
--- a/sdk/python/poetry.lock
+++ b/sdk/python/poetry.lock
@@ -783,7 +783,7 @@ files = [
 name = "platformdirs"
 version = "2.6.2"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1420,4 +1420,4 @@ server = ["strawberry-graphql"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "4a9d2d5e8e1c44e4942f172556bfca49a1ab71ba823bba543fff12e60405cd58"
+content-hash = "f12710aebb783d704b3dfa794f93a9035ac0b8de0c5f6f39c7b010ce376085c1"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -54,6 +54,7 @@ httpx = ">=0.23.1"
 strawberry-graphql = {version = ">=0.133.5", optional = true}
 typer = {version = ">=0.6.1", extras = ["all"]}
 beartype = ">=0.11.0"
+platformdirs = ">=2.6.2"
 
 [tool.poetry.extras]
 server = ["strawberry-graphql"]

--- a/sdk/python/src/dagger/engine/download.py
+++ b/sdk/python/src/dagger/engine/download.py
@@ -14,6 +14,7 @@ from pathlib import Path, PurePath
 from typing import IO, Iterator
 
 import httpx
+import platformdirs
 
 from dagger.context import SyncResourceManager
 
@@ -136,10 +137,12 @@ class Downloader:
 
     @functools.cached_property
     def cache_dir(self) -> Path:
-        # FIXME: should have platform dependent cache dirs
-        cache_dir = (
-            Path(os.environ.get("XDG_CACHE_HOME", "~/.cache")).expanduser() / "dagger"
-        )
+        # Use the XDG_CACHE_HOME environment variable in all platforms to follow
+        # https://github.com/adrg/xdg a bit more closely (used in the Go SDK).
+        # See https://github.com/dagger/dagger/issues/3963
+        env = os.environ.get("XDG_CACHE_HOME", "").strip()
+        path = Path(env).expanduser() if env else platformdirs.user_cache_path()
+        cache_dir = path / "dagger"
         cache_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
         return cache_dir
 


### PR DESCRIPTION
Fixes #4179

Uses [platformdirs](https://pypi.org/project/platformdirs/) to fallback to platform appropriate defaults if `XDG_CACHE_HOME` environment variable isn't set.

Examples:

| Platform | Fallback |
| -- | -- |
| Linux | `/home/acme/.cache/dagger` |
| macOS | `/Users/acme/Library/Caches/dagger` |
| Windows | `C:\\Users\\acme\\AppData\\Local\\dagger\\Cache` |