### PR TITLE
nodesdk: added typesafe error names

### DIFF
--- a/sdk/nodejs/common/errors/DockerImageRefValidationError.ts
+++ b/sdk/nodejs/common/errors/DockerImageRefValidationError.ts
@@ -1,5 +1,5 @@
 import { DaggerSDKError, DaggerSDKErrorOptions } from "./DaggerSDKError.js"
-import { ERROR_CODES } from "./errors-codes.js"
+import { ERROR_CODES, ERROR_NAMES } from "./errors-codes.js"
 
 interface DockerImageRefValidationErrorOptions extends DaggerSDKErrorOptions {
   ref: string
@@ -10,8 +10,8 @@ interface DockerImageRefValidationErrorOptions extends DaggerSDKErrorOptions {
  *  DockerImage constructor.
  */
 export class DockerImageRefValidationError extends DaggerSDKError {
-  readonly name = "DockerImageRefValidationError"
-  readonly code = ERROR_CODES.DockerImageRefValidationError
+  name = ERROR_NAMES.DockerImageRefValidationError
+  code = ERROR_CODES.DockerImageRefValidationError
 
   /**
    *  The docker image reference, which caused the error.

--- a/sdk/nodejs/common/errors/EngineSessionConnectParamsParseError.ts
+++ b/sdk/nodejs/common/errors/EngineSessionConnectParamsParseError.ts
@@ -1,5 +1,5 @@
 import { DaggerSDKError, DaggerSDKErrorOptions } from "./DaggerSDKError.js"
-import { ERROR_CODES } from "./errors-codes.js"
+import { ERROR_CODES, ERROR_NAMES } from "./errors-codes.js"
 
 interface EngineSessionConnectParamsParseErrorOptions
   extends DaggerSDKErrorOptions {
@@ -10,8 +10,8 @@ interface EngineSessionConnectParamsParseErrorOptions
  * This error is thrown if the EngineSession does not manage to parse the required connection parameters from the session binary
  */
 export class EngineSessionConnectParamsParseError extends DaggerSDKError {
-  readonly name = "EngineSessionConnectParamsParseError"
-  readonly code = ERROR_CODES.EngineSessionConnectParamsParseError
+  name = ERROR_NAMES.EngineSessionConnectParamsParseError
+  code = ERROR_CODES.EngineSessionConnectParamsParseError
 
   /**
    *  the line, which caused the error during parsing, if the error was caused because of parsing.

--- a/sdk/nodejs/common/errors/EngineSessionConnectionTimeoutError.ts
+++ b/sdk/nodejs/common/errors/EngineSessionConnectionTimeoutError.ts
@@ -1,5 +1,5 @@
 import { DaggerSDKError, DaggerSDKErrorOptions } from "./DaggerSDKError.js"
-import { ERROR_CODES } from "./errors-codes.js"
+import { ERROR_CODES, ERROR_NAMES } from "./errors-codes.js"
 
 interface EngineSessionConnectionTimeoutErrorOptions
   extends DaggerSDKErrorOptions {
@@ -10,8 +10,8 @@ interface EngineSessionConnectionTimeoutErrorOptions
  * This error is thrown if the EngineSession does not manage to parse the required port successfully because the sessions connection timed out.
  */
 export class EngineSessionConnectionTimeoutError extends DaggerSDKError {
-  readonly name = "EngineSessionConnectionTimeoutError"
-  readonly code = ERROR_CODES.EngineSessionConnectionTimeoutError
+  name = ERROR_NAMES.EngineSessionConnectionTimeoutError
+  code = ERROR_CODES.EngineSessionConnectionTimeoutError
 
   /**
    * The duration until the timeout occurred in ms.

--- a/sdk/nodejs/common/errors/EngineSessionEOFErrorOptions.ts
+++ b/sdk/nodejs/common/errors/EngineSessionEOFErrorOptions.ts
@@ -1,5 +1,5 @@
 import { DaggerSDKError, DaggerSDKErrorOptions } from "./DaggerSDKError.js"
-import { ERROR_CODES } from "./errors-codes.js"
+import { ERROR_CODES, ERROR_NAMES } from "./errors-codes.js"
 
 type EngineSessionEOFErrorOptions = DaggerSDKErrorOptions
 
@@ -8,8 +8,8 @@ type EngineSessionEOFErrorOptions = DaggerSDKErrorOptions
  * This usually happens if no connection can be established.
  */
 export class EngineSessionEOFError extends DaggerSDKError {
-  readonly name = "EngineSessionEOFError"
-  readonly code = ERROR_CODES.EngineSessionEOFError
+  name = ERROR_NAMES.EngineSessionEOFError
+  code = ERROR_CODES.EngineSessionEOFError
 
   /**
    * @hidden

--- a/sdk/nodejs/common/errors/GraphQLRequestError.ts
+++ b/sdk/nodejs/common/errors/GraphQLRequestError.ts
@@ -4,7 +4,7 @@ import {
 } from "graphql-request/dist/types"
 
 import { DaggerSDKError, DaggerSDKErrorOptions } from "./DaggerSDKError.js"
-import { ERROR_CODES } from "./errors-codes.js"
+import { ERROR_CODES, ERROR_NAMES } from "./errors-codes.js"
 
 interface GraphQLRequestErrorOptions extends DaggerSDKErrorOptions {
   response: GraphQLResponse
@@ -15,8 +15,8 @@ interface GraphQLRequestErrorOptions extends DaggerSDKErrorOptions {
  *  This error originates from the dagger engine. It means that some error was thrown and sent back via GraphQL.
  */
 export class GraphQLRequestError extends DaggerSDKError {
-  readonly name = "GraphQLRequestError"
-  readonly code = ERROR_CODES.GraphQLRequestError
+  name = ERROR_NAMES.GraphQLRequestError
+  code = ERROR_CODES.GraphQLRequestError
 
   /**
    *  The query and variables, which caused the error.

--- a/sdk/nodejs/common/errors/InitEngineSessionBinaryError.ts
+++ b/sdk/nodejs/common/errors/InitEngineSessionBinaryError.ts
@@ -1,12 +1,12 @@
 import { DaggerSDKError, DaggerSDKErrorOptions } from "./DaggerSDKError.js"
-import { ERROR_CODES } from "./errors-codes.js"
+import { ERROR_CODES, ERROR_NAMES } from "./errors-codes.js"
 
 /**
  *  This error is thrown if the dagger binary cannot be copied from the dagger docker image and copied to the local host.
  */
 export class InitEngineSessionBinaryError extends DaggerSDKError {
-  readonly name = "InitEngineSessionBinaryError"
-  readonly code = ERROR_CODES.InitEngineSessionBinaryError
+  name = ERROR_NAMES.InitEngineSessionBinaryError
+  code = ERROR_CODES.InitEngineSessionBinaryError
 
   /**
    *  @hidden

--- a/sdk/nodejs/common/errors/TooManyNestedObjectsError.ts
+++ b/sdk/nodejs/common/errors/TooManyNestedObjectsError.ts
@@ -1,5 +1,5 @@
 import { DaggerSDKError, DaggerSDKErrorOptions } from "./DaggerSDKError.js"
-import { ERROR_CODES } from "./errors-codes.js"
+import { ERROR_CODES, ERROR_NAMES } from "./errors-codes.js"
 
 interface TooManyNestedObjectsErrorOptions extends DaggerSDKErrorOptions {
   response: unknown
@@ -9,8 +9,8 @@ interface TooManyNestedObjectsErrorOptions extends DaggerSDKErrorOptions {
  *  Dagger only expects one response value from the engine. If the engine returns more than one value this error is thrown.
  */
 export class TooManyNestedObjectsError extends DaggerSDKError {
-  readonly name = "TooManyNestedObjectsError"
-  readonly code = ERROR_CODES.TooManyNestedObjectsError
+  name = ERROR_NAMES.TooManyNestedObjectsError
+  code = ERROR_CODES.TooManyNestedObjectsError
 
   /**
    *  the response containing more than one value.

--- a/sdk/nodejs/common/errors/UnknownDaggerError.ts
+++ b/sdk/nodejs/common/errors/UnknownDaggerError.ts
@@ -1,12 +1,12 @@
 import { DaggerSDKError, DaggerSDKErrorOptions } from "./DaggerSDKError.js"
-import { ERROR_CODES } from "./errors-codes.js"
+import { ERROR_CODES, ERROR_NAMES } from "./errors-codes.js"
 
 /**
  *  This error is thrown if the dagger SDK does not identify the error and just wraps the cause.
  */
 export class UnknownDaggerError extends DaggerSDKError {
-  readonly name = "UnknownDaggerError"
-  readonly code = ERROR_CODES.UnknownDaggerError
+  name = ERROR_NAMES.UnknownDaggerError
+  code = ERROR_CODES.UnknownDaggerError
 
   /**
    * @hidden

--- a/sdk/nodejs/common/errors/errors-codes.ts
+++ b/sdk/nodejs/common/errors/errors-codes.ts
@@ -43,3 +43,11 @@ export const ERROR_CODES = {
 type ErrorCodesType = typeof ERROR_CODES
 export type ErrorNames = keyof ErrorCodesType
 export type ErrorCodes = ErrorCodesType[ErrorNames]
+
+type ErrorNamesMap = { readonly [Key in ErrorNames]: Key }
+export const ERROR_NAMES: ErrorNamesMap = (
+  Object.keys(ERROR_CODES) as Array<ErrorNames>
+).reduce<ErrorNamesMap>(
+  (obj, item) => ({ ...obj, [item]: item }),
+  {} as ErrorNamesMap
+)


### PR DESCRIPTION
Just some small improvement on errors by adding a const variable ERROR_NAMES holding all possible error names.