### PR TITLE
feat: improve error message on `dagger session` connection failures

### DIFF
--- a/internal/engine/client.go
+++ b/internal/engine/client.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"strings"
 	"time"
 
 	bkclient "github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/util/tracing/detect"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel"
 
@@ -83,5 +83,7 @@ func waitBuildkit(ctx context.Context, host string) error {
 		}
 		time.Sleep(retryPeriod)
 	}
-	return errors.New("buildkit failed to respond")
+
+	listWorkerError := strings.ReplaceAll(err.Error(), "\\n", "")
+	return fmt.Errorf("buildkit failed to respond: %s", listWorkerError)
 }


### PR DESCRIPTION
Each SDK handles error messages differently: some of them are unclear, especially the connection errors from `dagger session`.

> Rebased on top of #4303, which removed usage + duplicates output.

1. Followed @sipsma's recommendations.
We now just output the last error sent by Buildkit, which gives enough context to hint users on the way to fix their issue.

This is what it will look like, once the PR gets merged:
<img width="1328" alt="image" src="https://user-images.githubusercontent.com/31691250/210795116-10558d7e-8ca8-4046-a6bf-812bb9fba519.png">

2. ⚠️ Only Go SDK is currently impacted by this change, as both Python SDK and Node SDK do not forward stderr for now.

_Next step:_ Creating follow-up PRs, so that SDK owners can add it to their milestones (following discussion with @helderco yesterday)