### PR TITLE
Switch session url to port

### DIFF
--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -19,13 +19,13 @@ var runCmd = &cobra.Command{
 	Use:                   "run [command]",
 	Aliases:               []string{"r"},
 	DisableFlagsInUseLine: true,
-	Long:                  "Runs the specified command in a Dagger session\n\nDAGGER_SESSION_URL and DAGGER_SESSION_TOKEN will be convieniently injected automatically.",
+	Long:                  "Runs the specified command in a Dagger session\n\nDAGGER_SESSION_PORT and DAGGER_SESSION_TOKEN will be convieniently injected automatically.",
 	Short:                 "Runs a command in a Dagger session",
 	Example: `
 dagger run -- sh -c 'curl \
 -u $DAGGER_SESSION_TOKEN: \
 -H "content-type:application/json" \
--d "{\"query\":\"{container{id}}\"}" $DAGGER_SESSION_URL'`,
+-d "{\"query\":\"{container{id}}\"}" http://127.0.0.1:$DAGGER_SESSION_PORT/query'`,
 	Run:  Run,
 	Args: cobra.MinimumNArgs(1),
 }
@@ -56,7 +56,7 @@ func Run(cmd *cobra.Command, args []string) {
 	}()
 
 	listenPort := <-listening
-	os.Setenv("DAGGER_SESSION_URL", fmt.Sprintf("http://127.0.0.1:%s/query", listenPort))
+	os.Setenv("DAGGER_SESSION_PORT", listenPort)
 	os.Setenv("DAGGER_SESSION_TOKEN", sessionToken.String())
 
 	c := exec.CommandContext(ctx, args[0], args[1:]...) // #nosec

--- a/cmd/dagger/session.go
+++ b/cmd/dagger/session.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strconv"
 	"syscall"
 	"time"
 
@@ -30,7 +29,7 @@ func sessionCmd() *cobra.Command {
 }
 
 type connectParams struct {
-	Host         string `json:"host"`
+	Port         int    `json:"port"`
 	SessionToken string `json:"session_token"`
 }
 
@@ -76,7 +75,7 @@ func EngineSession(cmd *cobra.Command, args []string) error {
 		}
 
 		paramBytes, err := json.Marshal(connectParams{
-			Host:         "127.0.0.1:" + strconv.Itoa(port),
+			Port:         port,
 			SessionToken: sessionToken.String(),
 		})
 		if err != nil {

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -318,7 +318,7 @@ func toggleNesting(ctx context.Context) ([]string, error) {
 				fmt.Printf("Error starting engine: %v\n", err)
 			}
 		}()
-		return []string{fmt.Sprintf("DAGGER_SESSION_URL=http://127.0.0.1:%d", l.Addr().(*net.TCPAddr).Port), fmt.Sprintf("DAGGER_SESSION_TOKEN=%s", sessionToken.String())}, nil
+		return []string{fmt.Sprintf("DAGGER_SESSION_PORT=%d", l.Addr().(*net.TCPAddr).Port), fmt.Sprintf("DAGGER_SESSION_TOKEN=%s", sessionToken.String())}, nil
 	}
 	return []string{}, nil
 }

--- a/core/integration/dind_test.go
+++ b/core/integration/dind_test.go
@@ -35,7 +35,7 @@ touch /root/1 /root/2
 curl \
 -u $DAGGER_SESSION_TOKEN: \
 -H "content-type:application/json" \
--d '{"query":"{host{directory(path:\"/root\"){entries}}}"}' $DAGGER_SESSION_URL/query
+-d '{"query":"{host{directory(path:\"/root\"){entries}}}"}' http://127.0.0.1:$DAGGER_SESSION_PORT/query
         """], experimentalPrivilegedNesting: true) {
           stdout
         }

--- a/docs/current/api/254103-build-custom-client.md
+++ b/docs/current/api/254103-build-custom-client.md
@@ -68,6 +68,7 @@ Once the client library is installed, create an API client as described below.
 Add the following code to `src/main.rs`:
 
 ```rust file=snippets/build-custom-client/step2/main.rs
+
 ```
 
 </TabItem>
@@ -76,6 +77,7 @@ Add the following code to `src/main.rs`:
 Create a new file named `client.php` and add the following code to it:
 
 ```php file=snippets/build-custom-client/step2/client.php
+
 ```
 
 </TabItem>
@@ -84,12 +86,12 @@ Create a new file named `client.php` and add the following code to it:
 This code listing initializes the client library and defines the Dagger pipeline to be executed as a GraphQL query. This query performs the following operations:
 
 - It requests the `from` field of Dagger's `Container` object type, passing it the address of a container image. To resolve this, Dagger will initialize a container using the specified image and return a `Container` object representing the `alpine:latest` container image.
-- Next, it requests the `withExec` field of the `Container` object from the previous step, passing  the `uname -a` command to the field as an array of arguments. To resolve this, Dagger will return a `Container` object containing the execution plan.
+- Next, it requests the `withExec` field of the `Container` object from the previous step, passing the `uname -a` command to the field as an array of arguments. To resolve this, Dagger will return a `Container` object containing the execution plan.
 - Finally, it requests the `stdout` field of the `Container` object returned in the previous step. To resolve this, Dagger will execute the command and return a `String` containing the results.
 - The result of the query is a JSON object, which is processed and printed to the output device.
 
 :::info
-The API endpoint and the HTTP authentication token for the GraphQL client are not statically defined, they must be retrieved at run-time from the special `DAGGER_SESSION_URL` and `DAGGER_SESSION_TOKEN` environment variables. This is explained in more detail in the next section.
+The API endpoint and the HTTP authentication token for the GraphQL client are not statically defined, they must be retrieved at run-time from the special `DAGGER_SESSION_PORT` and `DAGGER_SESSION_TOKEN` environment variables. This is explained in more detail in the next section.
 :::
 
 ## Step 3: Run the API client
@@ -97,7 +99,11 @@ The API endpoint and the HTTP authentication token for the GraphQL client are no
 To run the pipeline, the API client in the previous step needs to communicate with the Dagger Engine, which is responsible for accepting the query, executing it and returning the result. The `dagger run` command takes care of initializing a new local instance (or reusing a running instance) of the Dagger Engine on the host system and executing a specified command against it.
 
 :::info
-The Dagger Engine creates a unique local API endpoint for GraphQL queries for every Dagger session. This API endpoint is exposed in the `DAGGER_SESSION_URL` environment variable, and can be directly read from the environment in your client code. It additionally protects the exposed API with an HTTP Basic authentication token which can be retrieved from the `DAGGER_SESSION_TOKEN` variable.
+The Dagger Engine creates a unique local API endpoint for GraphQL queries for every Dagger session. This API endpoint is served over localhost at the port specified by the `DAGGER_SESSION_PORT` environment variable, and can be directly read from the environment in your client code.
+
+For example, if `DAGGER_SESSION_PORT` is set to `12345`, the API endpoint can be reached at `http://127.0.0.1:$DAGGER_SESSION_PORT/query`
+
+It additionally protects the exposed API with an HTTP Basic authentication token which can be retrieved from the `DAGGER_SESSION_TOKEN` variable.
 :::
 
 :::warning
@@ -116,7 +122,7 @@ dagger run cargo run
 This command:
 
 - initializes a new Dagger Engine session
-- sets the `DAGGER_SESSION_URL` and `DAGGER_SESSION_TOKEN` environment variables.
+- sets the `DAGGER_SESSION_PORT` and `DAGGER_SESSION_TOKEN` environment variables.
 - executes the `cargo run` command in that session
 
 </TabItem>
@@ -129,13 +135,13 @@ dagger run php client.php
 This command:
 
 - initializes a new Dagger Engine session
-- sets the `DAGGER_SESSION_URL` and `DAGGER_SESSION_TOKEN` environment variables.
+- sets the `DAGGER_SESSION_PORT` and `DAGGER_SESSION_TOKEN` environment variables.
 - executes the `php client.php` command in that session
 
 </TabItem>
 </Tabs>
 
-The specified command, in turn, invokes the custom API client, connects to the API endpoint specified in the `DAGGER_SESSION_URL` environment variable, sets an HTTP Basic authentication  token with `DAGGER_SESSION_TOKEN` and executes the GraphQL query. Here is an example of the output:
+The specified command, in turn, invokes the custom API client, connects to the API endpoint specified in the `DAGGER_SESSION_PORT` environment variable, sets an HTTP Basic authentication token with `DAGGER_SESSION_TOKEN` and executes the GraphQL query. Here is an example of the output:
 
 ```shell
 buildkitsandbox 5.15.0-53-generic unknown Linux

--- a/docs/current/api/snippets/build-custom-client/step2/client.php
+++ b/docs/current/api/snippets/build-custom-client/step2/client.php
@@ -7,11 +7,11 @@ use GraphQL\Client;
 try {
   // initialize client with
   // endpoint from environment
-  $sessionUrl = getenv('DAGGER_SESSION_URL') or throw new Exception("DAGGER_SESSION_URL doesn't exist");
+  $sessionPort = getenv('DAGGER_SESSION_PORT') or throw new Exception("DAGGER_SESSION_PORT doesn't exist");
   $sessionToken = getenv('DAGGER_SESSION_TOKEN') or throw new Exception("DAGGER_SESSION_TOKEN doesn't exist");
 
   $client = new Client(
-    $sessionUrl,
+    'http://127.0.0.1:' . $sessionPort . '/query',
     ['Authorization' => 'Basic ' . base64_encode($sessionToken . ':')]
   );
 

--- a/docs/current/api/snippets/build-custom-client/step2/main.rs
+++ b/docs/current/api/snippets/build-custom-client/step2/main.rs
@@ -6,7 +6,7 @@ use std::env;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let endpoint = env::var("DAGGER_SESSION_URL").expect("$DAGGER_SESSION_URL doesn't exist");
+    let port = env::var("DAGGER_SESSION_PORT").expect("$DAGGER_SESSION_PORT doesn't exist");
     let token = env::var("DAGGER_SESSION_TOKEN").expect("$DAGGER_SESSION_TOKEN doesn't exist");
     let query = r#"
     query {
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "authorization",
         format!("Basic {}", encode(format!("{}:", token))),
     );
-    let client = Client::new_with_headers(endpoint, headers);
+    let client = Client::new_with_headers(format!("http://127.0.0.1:{}/query", port), headers);
     let data = client.query_unwrap::<Value>(query).await.unwrap();
 
     println!(

--- a/docs/current/cli/979595-reference.md
+++ b/docs/current/cli/979595-reference.md
@@ -16,12 +16,12 @@ dagger [options] [command]
 
 The options below can be used with all CLI commands.
 
-| Option | Description |
-|---|---|
-| `--debug` | Show Buildkitd debug logs |
-| `-h`, `--help` | Show help text |
-| `--workdir` | Define the host working directory (default `.`) |
-|---|---|
+| Option         | Description                                     |
+| -------------- | ----------------------------------------------- |
+| `--debug`      | Show Buildkitd debug logs                       |
+| `-h`, `--help` | Show help text                                  |
+| `--workdir`    | Define the host working directory (default `.`) |
+| ---            | ---                                             |
 
 ## Commands
 
@@ -55,7 +55,7 @@ dagger completion bash > $(brew --prefix)/etc/bash_completion.d/dagger
 
 ## dagger run
 
-Executes the specified command in a Dagger session. `DAGGER_SESSION_URL` and `DAGGER_SESSION_TOKEN` will be injected automatically.
+Executes the specified command in a Dagger session. `DAGGER_SESSION_PORT` and `DAGGER_SESSION_TOKEN` will be injected automatically.
 
 ### Usage
 
@@ -72,7 +72,7 @@ dagger run -- sh -c 'curl \
   -u $DAGGER_SESSION_TOKEN: \
   -H "content-type:application/json" \
   -d "{\"query\":\"{container{id}}\"}" \
-  $DAGGER_SESSION_URL'
+  http://127.0.0.1:$DAGGER_SESSION_PORT/query'
 ```
 
 ## dagger help
@@ -105,12 +105,12 @@ dagger query [--doc file] [--var string] [--var-json string] [query]
 
 ### Options
 
-| Option | Description |
-|---|---|
-| `--doc` | Read query from file |
-| `--var` | Read query from string |
+| Option       | Description                 |
+| ------------ | --------------------------- |
+| `--doc`      | Read query from file        |
+| `--var`      | Read query from string      |
 | `--var-json` | Read query from JSON string |
-|---|---|
+| ---          | ---                         |
 
 ### Example
 

--- a/sdk/go/internal/engineconn/engineconn.go
+++ b/sdk/go/internal/engineconn/engineconn.go
@@ -2,6 +2,7 @@ package engineconn
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -23,7 +24,7 @@ type Config struct {
 }
 
 type ConnectParams struct {
-	Host         string `json:"host"`
+	Port         int    `json:"port"`
 	SessionToken string `json:"session_token"`
 }
 
@@ -60,7 +61,7 @@ func defaultHTTPClient(p *ConnectParams) *http.Client {
 			r.SetBasicAuth(p.SessionToken, "")
 			return (&http.Transport{
 				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-					return net.Dial("tcp", p.Host)
+					return net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", p.Port))
 				},
 			}).RoundTrip(r)
 		}),

--- a/sdk/go/internal/engineconn/engineconn.go
+++ b/sdk/go/internal/engineconn/engineconn.go
@@ -28,7 +28,7 @@ type ConnectParams struct {
 }
 
 func Get(ctx context.Context, cfg *Config) (EngineConn, error) {
-	// Prefer DAGGER_SESSION_URL if set
+	// Prefer DAGGER_SESSION_PORT if set
 	conn, ok, err := FromSessionEnv()
 	if err != nil {
 		return nil, err

--- a/sdk/go/internal/engineconn/env.go
+++ b/sdk/go/internal/engineconn/env.go
@@ -3,33 +3,33 @@ package engineconn
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
+	"strconv"
 )
 
 func FromSessionEnv() (EngineConn, bool, error) {
-	urlStr, ok := os.LookupEnv("DAGGER_SESSION_URL")
+	portStr, ok := os.LookupEnv("DAGGER_SESSION_PORT")
 	if !ok {
 		return nil, false, nil
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return nil, false, fmt.Errorf("invalid port in DAGGER_SESSION_PORT: %w", err)
 	}
 
 	sessionToken := os.Getenv("DAGGER_SESSION_TOKEN")
 	if sessionToken == "" {
-		return nil, false, fmt.Errorf("DAGGER_SESSION_TOKEN must be set when using DAGGER_SESSION_URL")
-	}
-	url, err := url.Parse(urlStr)
-	if err != nil {
-		return nil, false, fmt.Errorf("invalid DAGGER_SESSION_URL: %w", err)
+		return nil, false, fmt.Errorf("DAGGER_SESSION_TOKEN must be set when using DAGGER_SESSION_PORT")
 	}
 
 	httpClient := defaultHTTPClient(&ConnectParams{
-		Host:         url.Host,
+		Port:         port,
 		SessionToken: sessionToken,
 	})
 
 	return &sessionEnvConn{
 		Client: httpClient,
-		host:   url.Host,
+		host:   fmt.Sprintf("127.0.0.1:%d", port),
 	}, true, nil
 }
 

--- a/sdk/go/provision_test.go
+++ b/sdk/go/provision_test.go
@@ -40,12 +40,12 @@ func TestProvision(t *testing.T) {
 	xdg.Reload()
 	cacheDir := filepath.Join(tmpdir, "dagger")
 
-	// ignore DAGGER_SESSION_URL
-	origSessionURL, sessionURLSet := os.LookupEnv("DAGGER_SESSION_URL")
-	if sessionURLSet {
-		defer os.Setenv("DAGGER_SESSION_URL", origSessionURL)
+	// ignore DAGGER_SESSION_PORT
+	origSessionPort, sessionPortSet := os.LookupEnv("DAGGER_SESSION_PORT")
+	if sessionPortSet {
+		defer os.Setenv("DAGGER_SESSION_PORT", origSessionPort)
 	}
-	os.Unsetenv("DAGGER_SESSION_URL")
+	os.Unsetenv("DAGGER_SESSION_PORT")
 
 	if cliURL := os.Getenv("_INTERNAL_DAGGER_TEST_CLI_URL"); cliURL != "" {
 		// If explicitly requested to test against a certain URL, use that

--- a/sdk/nodejs/connect.ts
+++ b/sdk/nodejs/connect.ts
@@ -15,7 +15,7 @@ export interface ConnectOpts {
 export type CallbackFct = (client: Client) => Promise<void>
 
 export interface ConnectParams {
-  host: string
+  port: number
   session_token: string
 }
 

--- a/sdk/nodejs/connect.ts
+++ b/sdk/nodejs/connect.ts
@@ -39,17 +39,19 @@ export async function connect(
   let client
   let close: null | (() => void) = null
 
-  // Prefer DAGGER_SESSION_URL if set
-  const daggerSessionURL = process.env["DAGGER_SESSION_URL"]
-  if (daggerSessionURL) {
+  // Prefer DAGGER_SESSION_PORT if set
+  const daggerSessionPort = process.env["DAGGER_SESSION_PORT"]
+  if (daggerSessionPort) {
     const sessionToken = process.env["DAGGER_SESSION_TOKEN"]
     if (!sessionToken) {
       throw new Error(
-        "DAGGER_SESSION_TOKEN must be set when using DAGGER_SESSION_URL"
+        "DAGGER_SESSION_TOKEN must be set when using DAGGER_SESSION_PORT"
       )
     }
-    const url = new URL(daggerSessionURL)
-    client = new Client({ host: url.host, sessionToken: sessionToken })
+    client = new Client({
+      host: `http://127.0.0.1:${daggerSessionPort}/query`,
+      sessionToken: sessionToken,
+    })
   } else {
     // Otherwise, prefer _EXPERIMENTAL_DAGGER_CLI_BIN, with fallback behavior of
     // downloading the CLI and using that as the bin.

--- a/sdk/nodejs/provisioning/bin.ts
+++ b/sdk/nodejs/provisioning/bin.ts
@@ -155,7 +155,7 @@ export class Bin implements EngineConn {
     ])) as ConnectParams
 
     return new Client({
-      host: connectParams.host,
+      host: `127.0.0.1:${connectParams.port}`,
       sessionToken: connectParams.session_token,
     })
   }
@@ -166,7 +166,7 @@ export class Bin implements EngineConn {
     for await (const line of stdoutReader) {
       // parse the the line as json-encoded connect params
       const connectParams = JSON.parse(line) as ConnectParams
-      if (connectParams.host && connectParams.session_token) {
+      if (connectParams.port && connectParams.session_token) {
         return connectParams
       }
       throw new EngineSessionConnectParamsParseError(

--- a/sdk/nodejs/test/connect.spec.ts
+++ b/sdk/nodejs/test/connect.spec.ts
@@ -63,8 +63,8 @@ describe("NodeJS sdk Connect", function () {
     it("Should download and unpack the CLI binary automatically", async function () {
       this.timeout(30000)
 
-      // ignore DAGGER_SESSION_URL
-      delete process.env.DAGGER_SESSION_URL
+      // ignore DAGGER_SESSION_PORT
+      delete process.env.DAGGER_SESSION_PORT
 
       // If explicitly requested to test against a certain URL, use that
       const cliURL = process.env._INTERNAL_DAGGER_TEST_CLI_URL

--- a/sdk/python/src/dagger/engine/conn.py
+++ b/sdk/python/src/dagger/engine/conn.py
@@ -2,7 +2,6 @@ import logging
 import os
 
 import anyio
-import httpx
 
 from dagger.config import Config, ConnectParams
 from dagger.context import SyncResourceManager
@@ -22,20 +21,17 @@ class Engine(SyncResourceManager):
         self.cfg = cfg
 
     def from_env(self) -> ConnectParams | None:
-        if not (session_port := os.environ.get("DAGGER_SESSION_PORT")):
+        if not (port := os.environ.get("DAGGER_SESSION_PORT")):
             return None
-        session_url = f"http://127.0.0.1:{session_port}/query"
-        if not (session_token := os.environ.get("DAGGER_SESSION_TOKEN")):
+        if not (token := os.environ.get("DAGGER_SESSION_TOKEN")):
             raise ProvisionError(
                 "DAGGER_SESSION_TOKEN must be set when using DAGGER_SESSION_PORT"
             )
         try:
-            conn = ConnectParams(session_url, session_token)
-        except httpx.InvalidURL as e:
-            raise ProvisionError(f"Invalid DAGGER_SESSION_PORT: {session_port}") from e
-
-        logger.debug(f"Using '{conn.host}' from DAGGER_SESSION_PORT")
-        return conn
+            return ConnectParams(port, token)
+        except ValueError as e:
+            # only port is validated
+            raise ProvisionError(f"Invalid DAGGER_SESSION_PORT: {port}") from e
 
     def from_cli(self) -> ConnectParams:
         cli_bin = os.environ.get("_EXPERIMENTAL_DAGGER_CLI_BIN")

--- a/sdk/python/src/dagger/engine/conn.py
+++ b/sdk/python/src/dagger/engine/conn.py
@@ -22,18 +22,19 @@ class Engine(SyncResourceManager):
         self.cfg = cfg
 
     def from_env(self) -> ConnectParams | None:
-        if not (session_url := os.environ.get("DAGGER_SESSION_URL")):
+        if not (session_port := os.environ.get("DAGGER_SESSION_PORT")):
             return None
+        session_url = f"http://127.0.0.1:{session_port}/query"
         if not (session_token := os.environ.get("DAGGER_SESSION_TOKEN")):
             raise ProvisionError(
-                "DAGGER_SESSION_TOKEN must be set when using DAGGER_SESSION_URL"
+                "DAGGER_SESSION_TOKEN must be set when using DAGGER_SESSION_PORT"
             )
         try:
             conn = ConnectParams(session_url, session_token)
         except httpx.InvalidURL as e:
-            raise ProvisionError(f"Invalid DAGGER_SESSION_URL: {session_url}") from e
+            raise ProvisionError(f"Invalid DAGGER_SESSION_PORT: {session_port}") from e
 
-        logger.debug(f"Using '{conn.host}' from DAGGER_SESSION_URL")
+        logger.debug(f"Using '{conn.host}' from DAGGER_SESSION_PORT")
         return conn
 
     def from_cli(self) -> ConnectParams:

--- a/sdk/python/src/dagger/session.py
+++ b/sdk/python/src/dagger/session.py
@@ -35,7 +35,7 @@ class Session(ResourceManager, SyncResourceManager):
 
     def _make_transport(self, cls: type[_T]) -> _T:
         return cls(
-            self.conn.host.copy_with(path="/query"),
+            self.conn.url,
             timeout=self.cfg.execute_timeout,
             auth=(self.conn.session_token, ""),
         )

--- a/sdk/python/tests/engine/test_cli.py
+++ b/sdk/python/tests/engine/test_cli.py
@@ -12,10 +12,11 @@ from dagger.exceptions import ProvisionError
 def test_getting_connect_params(fp: FakeProcess):
     fp.register(
         ["dagger", "session"],
-        stdout=['{"host":"127.0.0.1:50004","session_token":"abc"}', ""],
+        stdout=['{"port":50004,"session_token":"abc"}', ""],
     )
     with cli.CLISession(dagger.Config(), "dagger") as conn:
-        assert conn.host == httpx.URL("http://127.0.0.1:50004")
+        assert conn.url == httpx.URL("http://127.0.0.1:50004/query")
+        assert conn.port == 50004
         assert conn.session_token == "abc"
 
 
@@ -29,6 +30,12 @@ def test_getting_connect_params(fp: FakeProcess):
             "returncode": 1,
         },
         {"stdout": []},
+        {"stdout": ['{"port":50004}', ""]},
+        {"stdout": ['{"port":"abc","session_token":"abc"}', ""]},
+        {"stdout": ['{"port":"","session_token":"abc"}', ""]},
+        {"stdout": ['{"port":0,"session_token":"abc"}', ""]},
+        {"stdout": ['{"session_token":"abc"}', ""]},
+        {"stdout": ["dagger devel", ""]},
         {"stdout": ["50004", ""]},
     ],
 )

--- a/sdk/python/tests/engine/test_download.py
+++ b/sdk/python/tests/engine/test_download.py
@@ -27,8 +27,8 @@ def cache_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 @pytest.mark.anyio
 @pytest.fixture(autouse=True)
 async def temporary_cli_server(monkeypatch: pytest.MonkeyPatch):
-    # ignore DAGGER_SESSION_URL
-    monkeypatch.delenv("DAGGER_SESSION_URL", raising=False)
+    # ignore DAGGER_SESSION_PORT
+    monkeypatch.delenv("DAGGER_SESSION_PORT", raising=False)
 
     # if explicitly requested to test against a certain URL, use that
     archive_url = os.environ.get("_INTERNAL_DAGGER_TEST_CLI_URL")


### PR DESCRIPTION
Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Related to: https://github.com/dagger/dagger/issues/3830 (see `DAGGER_SESSION_PORT or DAGGER_SESSION_URL?` section of issue description)

Slight tweak which results in our SDKs only ever being expected to connect over 127.0.0.1