### PR TITLE
Change buildkit config+state to be dagger specific.

### DIFF
--- a/internal/engine/docker.go
+++ b/internal/engine/docker.go
@@ -17,6 +17,8 @@ import (
 const (
 	DockerImageProvider     = "docker-image"
 	DockerContainerProvider = "docker-container"
+	// NOTE: this needs to be consistent with engineDefaultStateDir in internal/mage/engine.go
+	DefaultStateDir = "/var/lib/dagger"
 
 	// trim image digests to 16 characters to makeoutput more readable
 	hashLen             = 16
@@ -63,6 +65,7 @@ func dockerImageProvider(ctx context.Context, runnerHost *url.URL) (string, erro
 		"--name", containerName,
 		"-d",
 		"--restart", "always",
+		"-v", DefaultStateDir,
 		"--privileged",
 		imageRef,
 		"--debug",

--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -22,7 +22,13 @@ const (
 	shimBinName      = "dagger-shim"
 	buildkitRepo     = "github.com/moby/buildkit"
 	buildkitBranch   = "v0.11.0-rc3"
+
+	engineTomlPath = "/etc/dagger/engine.toml"
+	// NOTE: this needs to be consistent with DefaultStateDir in internal/engine/docker.go
+	engineDefaultStateDir = "/var/lib/dagger"
 )
+
+var engineToml = fmt.Sprintf("root = %q\n", engineDefaultStateDir)
 
 func parseRef(tag string) error {
 	if tag == "main" {
@@ -207,7 +213,7 @@ func (t Engine) Dev(ctx context.Context) error {
 		"run",
 		"-d",
 		"--rm",
-		"-v", volumeName+":/var/lib/buildkit",
+		"-v", volumeName+":"+engineDefaultStateDir,
 		"--name", util.TestContainerName,
 		"--privileged",
 		imageName,
@@ -248,14 +254,17 @@ func devEngineContainer(c *dagger.Client, arches []string) []*dagger.Container {
 				"/app/cmd/shim",
 			}).
 			File("./bin/" + shimBinName)
-		//nolint
 		buildkitBase = buildkitBase.WithRootfs(
-			buildkitBase.Rootfs().WithFile("/usr/bin/"+shimBinName, shimBin),
+			buildkitBase.Rootfs().
+				WithFile("/usr/bin/"+shimBinName, shimBin).
+				WithNewFile(engineTomlPath, engineToml).
+				WithNewDirectory(engineDefaultStateDir),
 		)
 
 		// setup entrypoint
 		buildkitBase = buildkitBase.WithEntrypoint([]string{
 			"buildkitd",
+			"--config", engineTomlPath,
 			"--oci-worker-binary", "/usr/bin/" + shimBinName,
 		})
 


### PR DESCRIPTION
Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Related to the docs updates here: https://github.com/dagger/dagger/pull/4232/files#diff-0c99ecf7ccd8b4b55d5e0f38e908be1c2aee1ecf9cad1199170e7b6990b70668R119

Allows us to be dagger specific, not tied to external defaults we don't control.