### PR TITLE
Support the rest of the default buildkitd conns.

### DIFF
--- a/internal/engine/docker.go
+++ b/internal/engine/docker.go
@@ -15,8 +15,7 @@ import (
 )
 
 const (
-	DockerImageProvider     = "docker-image"
-	DockerContainerProvider = "docker-container"
+	DockerImageProvider = "docker-image"
 	// NOTE: this needs to be consistent with engineDefaultStateDir in internal/mage/engine.go
 	DefaultStateDir = "/var/lib/dagger"
 
@@ -104,11 +103,6 @@ func dockerImageProvider(ctx context.Context, runnerHost *url.URL) (string, erro
 		}
 	}
 	return "docker-container://" + containerName, nil
-}
-
-// Just connect to the container as provided, nothing fancy
-func dockerContainerProvider(ctx context.Context, remote *url.URL) (string, error) {
-	return "docker-container://" + remote.Host + remote.Path, nil
 }
 
 func isContainerAlreadyInUseOutput(output string) bool {


### PR DESCRIPTION
Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Part of https://github.com/dagger/dagger/issues/3830

Enables use of the rest the engine connection types we get from buildkit. This includes specific user requests such as `tcp://` support [here](https://github.com/dagger/dagger/issues/3830#issuecomment-1335783010).