### PR TITLE
docs(python): Hide internal member from reference

### DIFF
--- a/sdk/python/docs/connection.rst
+++ b/sdk/python/docs/connection.rst
@@ -2,7 +2,7 @@ Connection
 ==========
 
 .. automodule:: dagger.config
-   :members:
+   :members: Config
 
 .. automodule:: dagger.connection
    :members:


### PR DESCRIPTION
Signed-off-by: Helder Correia