### PR TITLE
fix: session usage and double error prints

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/dagger/dagger/engine"
@@ -45,7 +44,6 @@ var rootCmd = &cobra.Command{
 func main() {
 	closer := tracing.Init()
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		closer.Close()
 		os.Exit(1)
 	}

--- a/cmd/dagger/session.go
+++ b/cmd/dagger/session.go
@@ -21,10 +21,11 @@ import (
 
 func sessionCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:    "session",
-		Long:   "WARNING: this is an internal-only command used by Dagger SDKs to communicate with the Dagger engine. It is not intended to be used by humans directly.",
-		Hidden: true,
-		RunE:   EngineSession,
+		Use:          "session",
+		Long:         "WARNING: this is an internal-only command used by Dagger SDKs to communicate with the Dagger engine. It is not intended to be used by humans directly.",
+		Hidden:       true,
+		RunE:         EngineSession,
+		SilenceUsage: true,
 	}
 }
 


### PR DESCRIPTION
SDKs will soon forward stderr from session binary (if not already). Current `dagger session` command had noise.

When trying to fix the printed errors on stopped engine container, we realized that:
- dagger session errors were double printed
- usage was being printed on stderr, whenever it exited with a code != 0

Context here: https://discord.com/channels/707636530424053791/1003718839739105300/1060253378816520252

As you were the one the `fmt.Fprintf(os.Stderr, "Error: %v\n", err)` line from the main dagger command @marcosnils, do you see any reason we shouldn't just pull our printing of the error?

PS: fixes blocker for  #4284 

cc @jlongtine @sipsma 
