### PR TITLE
feat(codegen/nodejs): improve Socket SDK object reusability

### DIFF
--- a/codegen/generator/nodejs/templates/functions.go
+++ b/codegen/generator/nodejs/templates/functions.go
@@ -132,6 +132,7 @@ func formatType(r *introspection.TypeRef, input bool) (representation string) {
 					"FileID":      "File",
 					"DirectoryID": "Directory",
 					"SecretID":    "Secret",
+					"SocketID":    "Socket",
 					"CacheID":     "CacheVolume",
 				}
 				if alias, ok := rewrite[ref.Name]; ok && input {

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -196,7 +196,7 @@ export type FileID = string
 
 export type GitRefTreeOpts = {
   sshKnownHosts?: string
-  sshAuthSocket?: SocketID
+  sshAuthSocket?: SocketID | Socket
 }
 
 export type HostDirectoryOpts = {
@@ -230,7 +230,7 @@ export type ClientGitOpts = {
 }
 
 export type ClientSocketOpts = {
-  id?: SocketID
+  id?: SocketID | Socket
 }
 
 /**
@@ -911,7 +911,7 @@ The command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM
   /**
    * This container plus a socket forwarded to the given Unix socket path
    */
-  withUnixSocket(path: string, source: SocketID): Container {
+  withUnixSocket(path: string, source: SocketID | Socket): Container {
     return new Container({
       queryTree: [
         ...this._queryTree,


### PR DESCRIPTION
We forgot to add this in the NodeJS SDK when adding socket API.

It shows we really need to harmonize Go and NodeJS SDK to share more functionalities in the template functions. cf: #4032