### PR TITLE
Create `with()` method to chain objects

### DIFF
--- a/codegen/generator/nodejs/templates/src/object.ts.tmpl
+++ b/codegen/generator/nodejs/templates/src/object.ts.tmpl
@@ -17,33 +17,33 @@ export class {{ .Name | FormatName }} extends BaseClient {
 						{{- template "method" $field }}
 					{{- end }}
 				{{- end }}
-				{{- if ne $name "Query" }}
+{{- if ne $name "Query" }}
 {{""}}
-					/**
-					* Chain objects together
-					* @example
-					* ```ts
-					*	function AddAFewMounts(c) {
-					*			return c
-					*			.withMountedDirectory("/foo", new Client().host().directory("/Users/slumbering/forks/dagger"))
-					*			.withMountedDirectory("/bar", new Client().host().directory("/Users/slumbering/forks/dagger/sdk/nodejs"))
-					*	}
-					*
-					* connect(async (client) => {
-					*		const tree = await client
-					*			.container()
-					*			.from("alpine")
-					*			.withWorkdir("/foo")
-					*			.with(AddAFewMounts)
-					*			.withExec(["ls", "-lh"])
-					*			.stdout()
-					* })
-					*```
-					*/
-					with(arg: (param: {{ .Name | FormatName }}) => {{ .Name | FormatName }}) {
-						return arg(this)
-					}
-				{{- end }}
+  /**
+  * Chain objects together
+  * @example
+  * ```ts
+  *	function AddAFewMounts(c) {
+  *			return c
+  *			.withMountedDirectory("/foo", new Client().host().directory("/Users/slumbering/forks/dagger"))
+  *			.withMountedDirectory("/bar", new Client().host().directory("/Users/slumbering/forks/dagger/sdk/nodejs"))
+  *	}
+  *
+  * connect(async (client) => {
+  *		const tree = await client
+  *			.container()
+  *			.from("alpine")
+  *			.withWorkdir("/foo")
+  *			.with(AddAFewMounts)
+  *			.withExec(["ls", "-lh"])
+  *			.stdout()
+  * })
+  *```
+  */
+  with(arg: (param: {{ .Name | FormatName }}) => {{ .Name | FormatName }}) {
+    return arg(this)
+  }
+{{- end }}
 }
 		{{- end }}
 	{{- end }}

--- a/codegen/generator/nodejs/templates/src/object.ts.tmpl
+++ b/codegen/generator/nodejs/templates/src/object.ts.tmpl
@@ -17,6 +17,33 @@ export class {{ .Name | FormatName }} extends BaseClient {
 						{{- template "method" $field }}
 					{{- end }}
 				{{- end }}
+				{{- if ne $name "Query" }}
+{{""}}
+					/**
+					* Chain objects together
+					* @example
+					* ```ts
+					*	function AddAFewMounts(c) {
+					*			return c
+					*			.withMountedDirectory("/foo", new Client().host().directory("/Users/slumbering/forks/dagger"))
+					*			.withMountedDirectory("/bar", new Client().host().directory("/Users/slumbering/forks/dagger/sdk/nodejs"))
+					*	}
+					*
+					* connect(async (client) => {
+					*		const tree = await client
+					*			.container()
+					*			.from("alpine")
+					*			.withWorkdir("/foo")
+					*			.with(AddAFewMounts)
+					*			.withExec(["ls", "-lh"])
+					*			.stdout()
+					* })
+					*```
+					*/
+					with(arg: (param: {{ .Name | FormatName }}) => {{ .Name | FormatName }}) {
+						return arg(this)
+					}
+				{{- end }}
 }
 		{{- end }}
 	{{- end }}

--- a/codegen/generator/nodejs/templates/src/testdata/object_test_want.ts
+++ b/codegen/generator/nodejs/templates/src/testdata/object_test_want.ts
@@ -14,4 +14,29 @@ export class Container extends BaseClient {
       sessionToken: this.sessionToken,
     })
   }
+
+  /**
+  * Chain objects together
+  * @example
+  * ```ts
+  *	function AddAFewMounts(c) {
+  *			return c
+  *			.withMountedDirectory("/foo", new Client().host().directory("/Users/slumbering/forks/dagger"))
+  *			.withMountedDirectory("/bar", new Client().host().directory("/Users/slumbering/forks/dagger/sdk/nodejs"))
+  *	}
+  *
+  * connect(async (client) => {
+  *		const tree = await client
+  *			.container()
+  *			.from("alpine")
+  *			.withWorkdir("/foo")
+  *			.with(AddAFewMounts)
+  *			.withExec(["ls", "-lh"])
+  *			.stdout()
+  * })
+  *```
+  */
+  with(arg: (param: Container) => Container) {
+    return arg(this)
+  }
 }

--- a/codegen/generator/nodejs/templates/src/testdata/objects_test_want.ts
+++ b/codegen/generator/nodejs/templates/src/testdata/objects_test_want.ts
@@ -17,6 +17,31 @@ export class CacheVolume extends BaseClient {
 
     return response
   }
+
+  /**
+  * Chain objects together
+  * @example
+  * ```ts
+  *	function AddAFewMounts(c) {
+  *			return c
+  *			.withMountedDirectory("/foo", new Client().host().directory("/Users/slumbering/forks/dagger"))
+  *			.withMountedDirectory("/bar", new Client().host().directory("/Users/slumbering/forks/dagger/sdk/nodejs"))
+  *	}
+  *
+  * connect(async (client) => {
+  *		const tree = await client
+  *			.container()
+  *			.from("alpine")
+  *			.withWorkdir("/foo")
+  *			.with(AddAFewMounts)
+  *			.withExec(["ls", "-lh"])
+  *			.stdout()
+  * })
+  *```
+  */
+  with(arg: (param: CacheVolume) => CacheVolume) {
+    return arg(this)
+  }
 }
 
 /**
@@ -74,5 +99,30 @@ export class Host extends BaseClient {
       host: this.clientHost,
       sessionToken: this.sessionToken,
     })
+  }
+
+  /**
+  * Chain objects together
+  * @example
+  * ```ts
+  *	function AddAFewMounts(c) {
+  *			return c
+  *			.withMountedDirectory("/foo", new Client().host().directory("/Users/slumbering/forks/dagger"))
+  *			.withMountedDirectory("/bar", new Client().host().directory("/Users/slumbering/forks/dagger/sdk/nodejs"))
+  *	}
+  *
+  * connect(async (client) => {
+  *		const tree = await client
+  *			.container()
+  *			.from("alpine")
+  *			.withWorkdir("/foo")
+  *			.with(AddAFewMounts)
+  *			.withExec(["ls", "-lh"])
+  *			.stdout()
+  * })
+  *```
+  */
+  with(arg: (param: Host) => Host) {
+    return arg(this)
   }
 }

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -362,6 +362,31 @@ export class CacheVolume extends BaseClient {
 
     return response
   }
+
+  /**
+   * Chain objects together
+   * @example
+   * ```ts
+   *	function AddAFewMounts(c) {
+   *			return c
+   *			.withMountedDirectory("/foo", new Client().host().directory("/Users/slumbering/forks/dagger"))
+   *			.withMountedDirectory("/bar", new Client().host().directory("/Users/slumbering/forks/dagger/sdk/nodejs"))
+   *	}
+   *
+   * connect(async (client) => {
+   *		const tree = await client
+   *			.container()
+   *			.from("alpine")
+   *			.withWorkdir("/foo")
+   *			.with(AddAFewMounts)
+   *			.withExec(["ls", "-lh"])
+   *			.stdout()
+   * })
+   *```
+   */
+  with(arg: (param: CacheVolume) => CacheVolume) {
+    return arg(this)
+  }
 }
 
 /**
@@ -787,10 +812,6 @@ Used for multi-platform image.
     )
 
     return response
-  }
-
-  with(arg: (param: Container) => Container) {
-    return arg(this)
   }
 
   /**
@@ -1268,6 +1289,31 @@ Formatted as [host]/[user]/[repo]:[tag] (e.g. docker.io/dagger/dagger:main).
 
     return response
   }
+
+  /**
+   * Chain objects together
+   * @example
+   * ```ts
+   *	function AddAFewMounts(c) {
+   *			return c
+   *			.withMountedDirectory("/foo", new Client().host().directory("/Users/slumbering/forks/dagger"))
+   *			.withMountedDirectory("/bar", new Client().host().directory("/Users/slumbering/forks/dagger/sdk/nodejs"))
+   *	}
+   *
+   * connect(async (client) => {
+   *		const tree = await client
+   *			.container()
+   *			.from("alpine")
+   *			.withWorkdir("/foo")
+   *			.with(AddAFewMounts)
+   *			.withExec(["ls", "-lh"])
+   *			.stdout()
+   * })
+   *```
+   */
+  with(arg: (param: Container) => Container) {
+    return arg(this)
+  }
 }
 
 /**
@@ -1571,6 +1617,31 @@ Defaults to './Dockerfile'.
       sessionToken: this.sessionToken,
     })
   }
+
+  /**
+   * Chain objects together
+   * @example
+   * ```ts
+   *	function AddAFewMounts(c) {
+   *			return c
+   *			.withMountedDirectory("/foo", new Client().host().directory("/Users/slumbering/forks/dagger"))
+   *			.withMountedDirectory("/bar", new Client().host().directory("/Users/slumbering/forks/dagger/sdk/nodejs"))
+   *	}
+   *
+   * connect(async (client) => {
+   *		const tree = await client
+   *			.container()
+   *			.from("alpine")
+   *			.withWorkdir("/foo")
+   *			.with(AddAFewMounts)
+   *			.withExec(["ls", "-lh"])
+   *			.stdout()
+   * })
+   *```
+   */
+  with(arg: (param: Directory) => Directory) {
+    return arg(this)
+  }
 }
 
 /**
@@ -1609,6 +1680,31 @@ export class EnvVariable extends BaseClient {
     )
 
     return response
+  }
+
+  /**
+   * Chain objects together
+   * @example
+   * ```ts
+   *	function AddAFewMounts(c) {
+   *			return c
+   *			.withMountedDirectory("/foo", new Client().host().directory("/Users/slumbering/forks/dagger"))
+   *			.withMountedDirectory("/bar", new Client().host().directory("/Users/slumbering/forks/dagger/sdk/nodejs"))
+   *	}
+   *
+   * connect(async (client) => {
+   *		const tree = await client
+   *			.container()
+   *			.from("alpine")
+   *			.withWorkdir("/foo")
+   *			.with(AddAFewMounts)
+   *			.withExec(["ls", "-lh"])
+   *			.stdout()
+   * })
+   *```
+   */
+  with(arg: (param: EnvVariable) => EnvVariable) {
+    return arg(this)
   }
 }
 
@@ -1717,6 +1813,31 @@ export class File extends BaseClient {
       sessionToken: this.sessionToken,
     })
   }
+
+  /**
+   * Chain objects together
+   * @example
+   * ```ts
+   *	function AddAFewMounts(c) {
+   *			return c
+   *			.withMountedDirectory("/foo", new Client().host().directory("/Users/slumbering/forks/dagger"))
+   *			.withMountedDirectory("/bar", new Client().host().directory("/Users/slumbering/forks/dagger/sdk/nodejs"))
+   *	}
+   *
+   * connect(async (client) => {
+   *		const tree = await client
+   *			.container()
+   *			.from("alpine")
+   *			.withWorkdir("/foo")
+   *			.with(AddAFewMounts)
+   *			.withExec(["ls", "-lh"])
+   *			.stdout()
+   * })
+   *```
+   */
+  with(arg: (param: File) => File) {
+    return arg(this)
+  }
 }
 
 /**
@@ -1755,6 +1876,31 @@ export class GitRef extends BaseClient {
       host: this.clientHost,
       sessionToken: this.sessionToken,
     })
+  }
+
+  /**
+   * Chain objects together
+   * @example
+   * ```ts
+   *	function AddAFewMounts(c) {
+   *			return c
+   *			.withMountedDirectory("/foo", new Client().host().directory("/Users/slumbering/forks/dagger"))
+   *			.withMountedDirectory("/bar", new Client().host().directory("/Users/slumbering/forks/dagger/sdk/nodejs"))
+   *	}
+   *
+   * connect(async (client) => {
+   *		const tree = await client
+   *			.container()
+   *			.from("alpine")
+   *			.withWorkdir("/foo")
+   *			.with(AddAFewMounts)
+   *			.withExec(["ls", "-lh"])
+   *			.stdout()
+   * })
+   *```
+   */
+  with(arg: (param: GitRef) => GitRef) {
+    return arg(this)
   }
 }
 
@@ -1846,6 +1992,31 @@ export class GitRepository extends BaseClient {
 
     return response
   }
+
+  /**
+   * Chain objects together
+   * @example
+   * ```ts
+   *	function AddAFewMounts(c) {
+   *			return c
+   *			.withMountedDirectory("/foo", new Client().host().directory("/Users/slumbering/forks/dagger"))
+   *			.withMountedDirectory("/bar", new Client().host().directory("/Users/slumbering/forks/dagger/sdk/nodejs"))
+   *	}
+   *
+   * connect(async (client) => {
+   *		const tree = await client
+   *			.container()
+   *			.from("alpine")
+   *			.withWorkdir("/foo")
+   *			.with(AddAFewMounts)
+   *			.withExec(["ls", "-lh"])
+   *			.stdout()
+   * })
+   *```
+   */
+  with(arg: (param: GitRepository) => GitRepository) {
+    return arg(this)
+  }
 }
 
 /**
@@ -1920,6 +2091,31 @@ export class Host extends BaseClient {
       sessionToken: this.sessionToken,
     })
   }
+
+  /**
+   * Chain objects together
+   * @example
+   * ```ts
+   *	function AddAFewMounts(c) {
+   *			return c
+   *			.withMountedDirectory("/foo", new Client().host().directory("/Users/slumbering/forks/dagger"))
+   *			.withMountedDirectory("/bar", new Client().host().directory("/Users/slumbering/forks/dagger/sdk/nodejs"))
+   *	}
+   *
+   * connect(async (client) => {
+   *		const tree = await client
+   *			.container()
+   *			.from("alpine")
+   *			.withWorkdir("/foo")
+   *			.with(AddAFewMounts)
+   *			.withExec(["ls", "-lh"])
+   *			.stdout()
+   * })
+   *```
+   */
+  with(arg: (param: Host) => Host) {
+    return arg(this)
+  }
 }
 
 /**
@@ -1957,6 +2153,31 @@ export class HostVariable extends BaseClient {
     )
 
     return response
+  }
+
+  /**
+   * Chain objects together
+   * @example
+   * ```ts
+   *	function AddAFewMounts(c) {
+   *			return c
+   *			.withMountedDirectory("/foo", new Client().host().directory("/Users/slumbering/forks/dagger"))
+   *			.withMountedDirectory("/bar", new Client().host().directory("/Users/slumbering/forks/dagger/sdk/nodejs"))
+   *	}
+   *
+   * connect(async (client) => {
+   *		const tree = await client
+   *			.container()
+   *			.from("alpine")
+   *			.withWorkdir("/foo")
+   *			.with(AddAFewMounts)
+   *			.withExec(["ls", "-lh"])
+   *			.stdout()
+   * })
+   *```
+   */
+  with(arg: (param: HostVariable) => HostVariable) {
+    return arg(this)
   }
 }
 
@@ -1996,6 +2217,31 @@ export class Label extends BaseClient {
     )
 
     return response
+  }
+
+  /**
+   * Chain objects together
+   * @example
+   * ```ts
+   *	function AddAFewMounts(c) {
+   *			return c
+   *			.withMountedDirectory("/foo", new Client().host().directory("/Users/slumbering/forks/dagger"))
+   *			.withMountedDirectory("/bar", new Client().host().directory("/Users/slumbering/forks/dagger/sdk/nodejs"))
+   *	}
+   *
+   * connect(async (client) => {
+   *		const tree = await client
+   *			.container()
+   *			.from("alpine")
+   *			.withWorkdir("/foo")
+   *			.with(AddAFewMounts)
+   *			.withExec(["ls", "-lh"])
+   *			.stdout()
+   * })
+   *```
+   */
+  with(arg: (param: Label) => Label) {
+    return arg(this)
   }
 }
 
@@ -2102,6 +2348,31 @@ export class Project extends BaseClient {
     )
 
     return response
+  }
+
+  /**
+   * Chain objects together
+   * @example
+   * ```ts
+   *	function AddAFewMounts(c) {
+   *			return c
+   *			.withMountedDirectory("/foo", new Client().host().directory("/Users/slumbering/forks/dagger"))
+   *			.withMountedDirectory("/bar", new Client().host().directory("/Users/slumbering/forks/dagger/sdk/nodejs"))
+   *	}
+   *
+   * connect(async (client) => {
+   *		const tree = await client
+   *			.container()
+   *			.from("alpine")
+   *			.withWorkdir("/foo")
+   *			.with(AddAFewMounts)
+   *			.withExec(["ls", "-lh"])
+   *			.stdout()
+   * })
+   *```
+   */
+  with(arg: (param: Project) => Project) {
+    return arg(this)
   }
 }
 
@@ -2350,6 +2621,31 @@ export class Secret extends BaseClient {
 
     return response
   }
+
+  /**
+   * Chain objects together
+   * @example
+   * ```ts
+   *	function AddAFewMounts(c) {
+   *			return c
+   *			.withMountedDirectory("/foo", new Client().host().directory("/Users/slumbering/forks/dagger"))
+   *			.withMountedDirectory("/bar", new Client().host().directory("/Users/slumbering/forks/dagger/sdk/nodejs"))
+   *	}
+   *
+   * connect(async (client) => {
+   *		const tree = await client
+   *			.container()
+   *			.from("alpine")
+   *			.withWorkdir("/foo")
+   *			.with(AddAFewMounts)
+   *			.withExec(["ls", "-lh"])
+   *			.stdout()
+   * })
+   *```
+   */
+  with(arg: (param: Secret) => Secret) {
+    return arg(this)
+  }
 }
 
 export class Socket extends BaseClient {
@@ -2368,5 +2664,30 @@ export class Socket extends BaseClient {
     )
 
     return response
+  }
+
+  /**
+   * Chain objects together
+   * @example
+   * ```ts
+   *	function AddAFewMounts(c) {
+   *			return c
+   *			.withMountedDirectory("/foo", new Client().host().directory("/Users/slumbering/forks/dagger"))
+   *			.withMountedDirectory("/bar", new Client().host().directory("/Users/slumbering/forks/dagger/sdk/nodejs"))
+   *	}
+   *
+   * connect(async (client) => {
+   *		const tree = await client
+   *			.container()
+   *			.from("alpine")
+   *			.withWorkdir("/foo")
+   *			.with(AddAFewMounts)
+   *			.withExec(["ls", "-lh"])
+   *			.stdout()
+   * })
+   *```
+   */
+  with(arg: (param: Socket) => Socket) {
+    return arg(this)
   }
 }

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -789,6 +789,10 @@ Used for multi-platform image.
     return response
   }
 
+  with(arg: (param: Container) => Container) {
+    return arg(this)
+  }
+
   /**
    * Configures default arguments for future commands.
    */

--- a/sdk/nodejs/api/test/api.spec.ts
+++ b/sdk/nodejs/api/test/api.spec.ts
@@ -2,6 +2,7 @@ import assert from "assert"
 
 import { TooManyNestedObjectsError } from "../../common/errors/index.js"
 import Client, { connect } from "../../index.js"
+import { Container } from "../client.gen.js"
 import { queryFlatten, buildQuery } from "../utils.js"
 
 const querySanitizer = (query: string) => query.replace(/\s+/g, " ")
@@ -211,5 +212,25 @@ describe("NodeJS SDK api", function () {
     }
 
     assert.throws(() => queryFlatten(tree), TooManyNestedObjectsError)
+  })
+
+  it("Support chainable utils via with()", function () {
+    function AddAFewMounts(c: Container): Container {
+      return c
+        .withMountedDirectory("/foo", new Client().host().directory("foo"))
+        .withMountedDirectory("/bar", new Client().host().directory("bar"))
+    }
+
+    const tree = new Client()
+      .container()
+      .from("alpine")
+      .withWorkdir("/foo")
+      .with(AddAFewMounts)
+      .withExec(["blah"])
+
+    assert.strictEqual(
+      querySanitizer(buildQuery(tree.queryTree)),
+      `{ container { from (address: "alpine") { withWorkdir (path: "/foo") { withMountedDirectory (path: "/foo",source: {"_queryTree":[{operation:"host"},{operation:"directory","args":{path:"foo"}}],"clientHost":"127.0.0.1:8080","sessionToken":"","client":{url:"http://127.0.0.1:8080/query","options":{headers:{Authorization:"Basic Og=="}}}}) { withMountedDirectory (path: "/bar",source: {"_queryTree":[{operation:"host"},{operation:"directory","args":{path:"bar"}}],"clientHost":"127.0.0.1:8080","sessionToken":"","client":{url:"http://127.0.0.1:8080/query","options":{headers:{Authorization:"Basic Og=="}}}}) { withExec (args: ["blah"]) }}}}} }`
+    )
   })
 })


### PR DESCRIPTION
Close to the issue: 
- https://github.com/dagger/dagger/issues/3885

This first iteration is using  the pattern proposed by @sipsma. 

```ts
func AddAFewMounts(c *dagger.Container) *dagger.Container {
  return c.
    WithMountedDirectory("/foo", c.Host().Directory("foo").
    WithMountedDirectory("/bar", c.Host().Directory("bar")
}

func main() {
 output, err := Container().
    From("alpine").
    WithWorkdir("/foo").
    With(AddAFewMounts).
    Exec("blah").Stdout().Contents()
...
}
```

@dolanor I know that you're doing some refactoring with the codegen so I'll leave you this part (talking about adding the `with()` method). You can directly push on this PR. Thanks

Signed-off-by: jffarge <jf@dagger.io>