### PR TITLE
Fix linktime override of Version var.

### DIFF
--- a/internal/engine/version.go
+++ b/internal/engine/version.go
@@ -15,7 +15,13 @@ const (
 var DevelopmentVersion = fmt.Sprintf("devel (%s)", vcsRevision())
 
 // Version holds the complete version number. Filled in at linking time.
-var Version = DevelopmentVersion
+var Version string
+
+func init() {
+	if Version == "" {
+		Version = DevelopmentVersion
+	}
+}
 
 func ImageRef() string {
 	// If "devel" is set, then this is a local build. Normally _EXPERIMENTAL_DAGGER_RUNNER_HOST


### PR DESCRIPTION
When using -X to override a variable at link time, this caveat is important:
> This is only effective if the variable is declared in the source
> code either uninitialized or initialized to a constant string
> expression. -X will not work if the initializer makes a function
> call or refers to other variables.

Now we set Version to DevelopmentVersion in an init func instead, which allows it to be uninitialized and thus usable w/ -X.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Test manually on my local machine (need a direct automated test too, but will save for follow up):
```
sipsma@dagger_dev:~/repo/github.com/sipsma/dagger$ go build -ldflags='-s -w -X github.com/dagger/dagger/internal/engine.Version=0.3.8
sipsma@dagger_dev:~/repo/github.com/sipsma/dagger$ ./dagger-test version
dagger 0.3.8 linux/arm64
```