### PR TITLE
Only runs test+lint on push to main branch.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,7 @@ name: lint
 
 on:
   push:
+    branches: ["main"]
   pull_request:
   # Enable manual trigger for easy debugging
   # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: test
 
 on:
   push:
+    branches: ["main"]
   pull_request:
   # Enable manual trigger for easy debugging
   # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs


### PR DESCRIPTION
Signed-off-by: Erik Sipsma <erik@sipsma.dev>

Should fix the problem mentioned in `2` [here](https://github.com/dagger/dagger/pull/4338#issuecomment-1376171223) that was noticed during the release. There were duplicated runs for test+lint, one for `pull_request` and one for `push` because we ran the checks against a push to any branch, which includes the branch that the engine bump PR is opened against (`bump-engine`)