### PR TITLE
Node.js SDK - use XDG_CACHE_HOME env by default

### DIFF
--- a/sdk/nodejs/provisioning/bin.ts
+++ b/sdk/nodejs/provisioning/bin.ts
@@ -6,6 +6,7 @@ import * as fs from "fs"
 import fetch from "node-fetch"
 import * as os from "os"
 import * as path from "path"
+import * as process from "process"
 import readline from "readline"
 import * as tar from "tar"
 
@@ -32,7 +33,9 @@ export class Bin implements EngineConn {
   private binPath?: string
   private cliVersion?: string
 
-  private readonly cacheDir = envPaths("dagger", { suffix: "" }).cache
+  private readonly cacheDir = `${
+    process.env.XDG_CACHE_HOME?.trim() || envPaths("", { suffix: "" }).cache
+  }/dagger`
 
   private readonly DAGGER_CLI_BIN_PREFIX = "dagger"
 

--- a/sdk/nodejs/provisioning/bin.ts
+++ b/sdk/nodejs/provisioning/bin.ts
@@ -33,9 +33,11 @@ export class Bin implements EngineConn {
   private binPath?: string
   private cliVersion?: string
 
-  private readonly cacheDir = `${
-    process.env.XDG_CACHE_HOME?.trim() || envPaths("", { suffix: "" }).cache
-  }/dagger`
+  private readonly cacheDir = path.join(
+    `${
+      process.env.XDG_CACHE_HOME?.trim() || envPaths("", { suffix: "" }).cache
+    }/dagger`
+  )
 
   private readonly DAGGER_CLI_BIN_PREFIX = "dagger"
 


### PR DESCRIPTION
If XDG_CACHE_HOME not set fallback to the system default.

Close to 
- https://github.com/dagger/dagger/issues/3963

Signed-off-by: jffarge <jf@dagger.io>