### PR TITLE
chore: Rename test-dagger-engine to dagger-engine.dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - run: ./hack/make engine:test
       - name: "ALWAYS print engine logs - especialy useful on failure"
         if: always()
-        run: docker logs test-dagger-engine
+        run: docker logs dagger-engine.dev
       - name: "ALWAYS print kernel logs - especialy useful on failure"
         if: always()
         run: sudo dmesg
@@ -45,7 +45,7 @@ jobs:
       - run: ./hack/make engine:testrace
       - name: "ALWAYS print engine logs - especialy useful on failure"
         if: always()
-        run: docker logs test-dagger-engine
+        run: docker logs dagger-engine.dev
       - name: "ALWAYS print kernel logs - especialy useful on failure"
         if: always()
         run: sudo dmesg

--- a/hack/dev
+++ b/hack/dev
@@ -10,6 +10,6 @@ go run main.go -w $DAGGER_SRC_ROOT engine:dev
 popd
 
 export _EXPERIMENTAL_DAGGER_CLI_BIN=$DAGGER_SRC_ROOT/bin/dagger
-export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://test-dagger-engine
+export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev
 
 exec "$@"

--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -178,8 +178,8 @@ func (t Engine) Dev(ctx context.Context) error {
 		return err
 	}
 
-	volumeName := "test-dagger-engine"
-	imageName := "localhost/test-dagger-engine:latest"
+	volumeName := util.EngineContainerName
+	imageName := fmt.Sprintf("localhost/%s:latest", util.EngineContainerName)
 
 	// #nosec
 	loadCmd := exec.CommandContext(ctx, "docker", "load", "-i", tmpfile.Name())
@@ -204,7 +204,7 @@ func (t Engine) Dev(ctx context.Context) error {
 	if output, err := exec.CommandContext(ctx, "docker",
 		"rm",
 		"-fv",
-		util.TestContainerName,
+		util.EngineContainerName,
 	).CombinedOutput(); err != nil {
 		return fmt.Errorf("docker rm: %w: %s", err, output)
 	}
@@ -214,7 +214,7 @@ func (t Engine) Dev(ctx context.Context) error {
 		"-d",
 		"--rm",
 		"-v", volumeName+":"+engineDefaultStateDir,
-		"--name", util.TestContainerName,
+		"--name", util.EngineContainerName,
 		"--privileged",
 		imageName,
 		"--debug",
@@ -230,7 +230,7 @@ func (t Engine) Dev(ctx context.Context) error {
 	}
 
 	fmt.Println("export _EXPERIMENTAL_DAGGER_CLI_BIN=" + binDest)
-	fmt.Println("export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://" + util.TestContainerName)
+	fmt.Println("export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://" + util.EngineContainerName)
 	return nil
 }
 

--- a/internal/mage/util/util.go
+++ b/internal/mage/util/util.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	TestContainerName = "test-dagger-engine"
+	EngineContainerName = "dagger-engine.dev"
 )
 
 // Repository with common set of exclude filters to speed up upload
@@ -80,7 +80,7 @@ func WithDevEngine(c *dagger.Client, ctr *dagger.Container) *dagger.Container {
 		WithMountedFile(cliBinPath, DaggerBinary(c)).
 		// Point the SDKs to use the dev engine via these env vars
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", "docker-container://"+TestContainerName)
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", "docker-container://"+EngineContainerName)
 }
 
 func goBase(c *dagger.Client) *dagger.Container {


### PR DESCRIPTION
Because it is a dev dagger-engine that was built from the current source code.

My first instinct was to rename this to `dagger-engine-dev`, similar to `dagger-engine-<SHA>`, but there is garbage collection that uses the `dagger-engine-` prefix, and I didn't want to refactor that in this context. Yes, I was effectively side-stepping that problem since I didn't want to be pulling too much change at once. That is due a refactoring soon, so no point in digging into it now.

By the way, if you have an existing test-dagger-engine running, you will need to remove it manually. You will also need to prune the volume. I recommend:

    docker rm -f test-dagger-engine
    docker volume prune

---

This is related to a discussion we had with @sipsma in the context of https://github.com/dagger/dagger/pull/4300