### PR TITLE
chore: Rename WithDevEngine to AdvertiseDevEngine

### DIFF
--- a/internal/mage/sdk/nodejs.go
+++ b/internal/mage/sdk/nodejs.go
@@ -165,5 +165,5 @@ func nodeJsBase(c *dagger.Client) *dagger.Container {
 			WithDirectory("/workdir", workdir),
 	)
 
-	return util.WithDevEngine(c, src)
+	return util.AdvertiseDevEngine(c, src)
 }

--- a/internal/mage/sdk/python.go
+++ b/internal/mage/sdk/python.go
@@ -203,5 +203,5 @@ func pythonBase(c *dagger.Client, version string) *dagger.Container {
 		WithRootfs(deps.Rootfs().WithDirectory("/app", src)).
 		WithExec([]string{"poetry", "install", "--without", "docs"})
 
-	return util.WithDevEngine(c, deps)
+	return util.AdvertiseDevEngine(c, deps)
 }

--- a/internal/mage/util/util.go
+++ b/internal/mage/util/util.go
@@ -62,7 +62,7 @@ func RepositoryGoCodeOnly(c *dagger.Client) *dagger.Directory {
 	})
 }
 
-func WithDevEngine(c *dagger.Client, ctr *dagger.Container) *dagger.Container {
+func AdvertiseDevEngine(c *dagger.Client, ctr *dagger.Container) *dagger.Container {
 	// the cli bin is statically linked, can just mount it in anywhere
 	dockerCli := c.Container().From("docker:cli").File("/usr/local/bin/docker")
 
@@ -114,7 +114,7 @@ func goBase(c *dagger.Client) *dagger.Container {
 // NOTE: this function is a shared util ONLY because it's used both by the Engine
 // and the Go SDK. Other languages shouldn't have a common helper.
 func GoBase(c *dagger.Client) *dagger.Container {
-	return WithDevEngine(c, goBase(c))
+	return AdvertiseDevEngine(c, goBase(c))
 }
 
 func daggerBinary(c *dagger.Client, goos, goarch string) *dagger.File {


### PR DESCRIPTION
`WithDevEngine` implies that the wrapped container will use the dev engine. This is misleading and results in surprising behaviour, as described in https://github.com/dagger/dagger/pull/4300#issuecomment-1379391184

`AdvertiseDevEngine` is more accurate: the dev engine is being advertised for any component that is interested in using it, but nothing is enforced. As we discovered, some components will continue using the engine in which they already run (this used to be the stable engine). The link above goes into more detail - it includes screenshots & diagrams that explain the state better than text alone.

---

⚠️ This should be rebased on top of `main` & merged after https://github.com/dagger/dagger/pull/4371 is merged.