### PR TITLE
Add text underline for docs reference links

### DIFF
--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -749,5 +749,6 @@ img[alt="github-contribute"] {
 
   a > code {
     font-weight: 400;
+    text-decoration: underline;
   }
 }


### PR DESCRIPTION
Close to the issue #4378 
Signed-off-by: jffarge <jf@dagger.io>