### PR TITLE
Implement label API

### DIFF
--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -97,7 +97,7 @@ type Container {
   "Retrieves this container plus the given label."
   withLabel(name: String!, value: String!): Container!
 
-  "Retrieves this container minus the given environment variable."
+  "Retrieves this container minus the given environment label."
   withoutLabel(name: String!): Container!
 
   "Retrieves this container plus an env variable containing the given secret."

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -88,6 +88,18 @@ type Container {
   "Retrieves this container plus the given environment variable."
   withEnvVariable(name: String!, value: String!): Container!
 
+  "Retrieves the list of labels passed to container."
+  labels: [Label!]!
+
+  "Retrieves the value of the specified label."
+  label(name: String!): String
+
+  "Retrieves this container plus the given label."
+  withLabel(name: String!, value: String!): Container!
+
+  "Retrieves this container minus the given environment variable."
+  withoutLabel(name: String!): Container!
+
   "Retrieves this container plus an env variable containing the given secret."
   withSecretVariable(name: String!, secret: SecretID!): Container!
 
@@ -257,6 +269,15 @@ type EnvVariable {
   name: String!
 
   "The environment variable value."
+  value: String!
+}
+
+"A simple key value object that represents a label."
+type Label {
+  "The label name."
+  name: String!
+
+  "The label value."
   value: String!
 }
 

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -317,6 +317,25 @@ func (r *Container) XXX_GraphQLID(ctx context.Context) (string, error) {
 	return string(id), nil
 }
 
+// Retrieves the value of the specified label.
+func (r *Container) Label(ctx context.Context, name string) (string, error) {
+	q := r.q.Select("label")
+	q = q.Arg("name", name)
+
+	var response string
+	q = q.Bind(&response)
+	return response, q.Execute(ctx, r.c)
+}
+
+// Retrieves the list of labels passed to container.
+func (r *Container) Labels(ctx context.Context) ([]Label, error) {
+	q := r.q.Select("labels")
+
+	var response []Label
+	q = q.Bind(&response)
+	return response, q.Execute(ctx, r.c)
+}
+
 // Retrieves the list of paths where a directory is mounted.
 func (r *Container) Mounts(ctx context.Context) ([]string, error) {
 	q := r.q.Select("mounts")
@@ -589,6 +608,18 @@ func (r *Container) WithFile(path string, source *File, opts ...ContainerWithFil
 	}
 }
 
+// Retrieves this container plus the given label.
+func (r *Container) WithLabel(name string, value string) *Container {
+	q := r.q.Select("withLabel")
+	q = q.Arg("name", name)
+	q = q.Arg("value", value)
+
+	return &Container{
+		q: q,
+		c: r.c,
+	}
+}
+
 // ContainerWithMountedCacheOpts contains options for Container.WithMountedCache
 type ContainerWithMountedCacheOpts struct {
 	Source *Directory
@@ -752,6 +783,17 @@ func (r *Container) WithWorkdir(path string) *Container {
 // Retrieves this container minus the given environment variable.
 func (r *Container) WithoutEnvVariable(name string) *Container {
 	q := r.q.Select("withoutEnvVariable")
+	q = q.Arg("name", name)
+
+	return &Container{
+		q: q,
+		c: r.c,
+	}
+}
+
+// Retrieves this container minus the given environment label.
+func (r *Container) WithoutLabel(name string) *Container {
+	q := r.q.Select("withoutLabel")
 	q = q.Arg("name", name)
 
 	return &Container{
@@ -1425,6 +1467,30 @@ func (r *HostVariable) Secret() *Secret {
 
 // The value of this variable.
 func (r *HostVariable) Value(ctx context.Context) (string, error) {
+	q := r.q.Select("value")
+
+	var response string
+	q = q.Bind(&response)
+	return response, q.Execute(ctx, r.c)
+}
+
+// A simple key value object that represents a label.
+type Label struct {
+	q *querybuilder.Selection
+	c graphql.Client
+}
+
+// The label name.
+func (r *Label) Name(ctx context.Context) (string, error) {
+	q := r.q.Select("name")
+
+	var response string
+	q = q.Bind(&response)
+	return response, q.Execute(ctx, r.c)
+}
+
+// The label value.
+func (r *Label) Value(ctx context.Context) (string, error) {
 	q := r.q.Select("value")
 
 	var response string

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -585,6 +585,41 @@ Formatted as {host}/{user}/{repo}:{tag} (e.g. docker.io/dagger/dagger:main).
   }
 
   /**
+   * Retrieves the value of the specified label.
+   */
+  async label(name: string): Promise<string> {
+    const response: Awaited<string> = await computeQuery(
+      [
+        ...this._queryTree,
+        {
+          operation: "label",
+          args: { name },
+        },
+      ],
+      this.client
+    )
+
+    return response
+  }
+
+  /**
+   * Retrieves the list of labels passed to container.
+   */
+  async labels(): Promise<Label[]> {
+    const response: Awaited<Label[]> = await computeQuery(
+      [
+        ...this._queryTree,
+        {
+          operation: "labels",
+        },
+      ],
+      this.client
+    )
+
+    return response
+  }
+
+  /**
    * Retrieves the list of paths where a directory is mounted.
    */
   async mounts(): Promise<string[]> {
@@ -862,6 +897,23 @@ The command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
   }
 
   /**
+   * Retrieves this container plus the given label.
+   */
+  withLabel(name: string, value: string): Container {
+    return new Container({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "withLabel",
+          args: { name, value },
+        },
+      ],
+      host: this.clientHost,
+      sessionToken: this.sessionToken,
+    })
+  }
+
+  /**
    * Retrieves this container plus a cache volume mounted at the given path.
    */
   withMountedCache(
@@ -1061,6 +1113,23 @@ The command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
         ...this._queryTree,
         {
           operation: "withoutEnvVariable",
+          args: { name },
+        },
+      ],
+      host: this.clientHost,
+      sessionToken: this.sessionToken,
+    })
+  }
+
+  /**
+   * Retrieves this container minus the given environment label.
+   */
+  withoutLabel(name: string): Container {
+    return new Container({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "withoutLabel",
           args: { name },
         },
       ],
@@ -1795,6 +1864,45 @@ export class HostVariable extends BaseClient {
 
   /**
    * The value of this variable.
+   */
+  async value(): Promise<string> {
+    const response: Awaited<string> = await computeQuery(
+      [
+        ...this._queryTree,
+        {
+          operation: "value",
+        },
+      ],
+      this.client
+    )
+
+    return response
+  }
+}
+
+/**
+ * A simple key value object that represents a label.
+ */
+export class Label extends BaseClient {
+  /**
+   * The label name.
+   */
+  async name(): Promise<string> {
+    const response: Awaited<string> = await computeQuery(
+      [
+        ...this._queryTree,
+        {
+          operation: "name",
+        },
+      ],
+      this.client
+    )
+
+    return response
+  }
+
+  /**
+   * The label value.
    */
   async value(): Promise<string> {
     const response: Awaited<string> = await computeQuery(

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -307,6 +307,30 @@ class Container(Type):
         return await _ctx.execute(ContainerID)
 
     @typecheck
+    async def label(self, name: str) -> Optional[str]:
+        """Retrieves the value of the specified label.
+
+        Returns
+        -------
+        Optional[str]
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+        """
+        _args = [
+            Arg("name", name),
+        ]
+        _ctx = self._select("label", _args)
+        return await _ctx.execute(Optional[str])
+
+    @typecheck
+    def labels(self) -> "Label":
+        """Retrieves the list of labels passed to container."""
+        _args: list[Arg] = []
+        _ctx = self._select("labels", _args)
+        return Label(_ctx)
+
+    @typecheck
     async def mounts(self) -> list[str]:
         """Retrieves the list of paths where a directory is mounted.
 
@@ -547,6 +571,16 @@ class Container(Type):
         return Container(_ctx)
 
     @typecheck
+    def with_label(self, name: str, value: str) -> "Container":
+        """Retrieves this container plus the given label."""
+        _args = [
+            Arg("name", name),
+            Arg("value", value),
+        ]
+        _ctx = self._select("withLabel", _args)
+        return Container(_ctx)
+
+    @typecheck
     def with_mounted_cache(
         self, path: str, cache: CacheVolume, source: Optional["Directory"] = None
     ) -> "Container":
@@ -678,6 +712,15 @@ class Container(Type):
             Arg("name", name),
         ]
         _ctx = self._select("withoutEnvVariable", _args)
+        return Container(_ctx)
+
+    @typecheck
+    def without_label(self, name: str) -> "Container":
+        """Retrieves this container minus the given environment label."""
+        _args = [
+            Arg("name", name),
+        ]
+        _ctx = self._select("withoutLabel", _args)
         return Container(_ctx)
 
     @typecheck
@@ -1242,6 +1285,40 @@ class HostVariable(Type):
         return await _ctx.execute(str)
 
 
+class Label(Type):
+    """A simple key value object that represents a label."""
+
+    @typecheck
+    async def name(self) -> str:
+        """The label name.
+
+        Returns
+        -------
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("name", _args)
+        return await _ctx.execute(str)
+
+    @typecheck
+    async def value(self) -> str:
+        """The label value.
+
+        Returns
+        -------
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("value", _args)
+        return await _ctx.execute(str)
+
+
 class Project(Type):
     """A set of scripts and/or extensions"""
 
@@ -1525,6 +1602,7 @@ __all__ = [
     "GitRepository",
     "Host",
     "HostVariable",
+    "Label",
     "Project",
     "Client",
     "Secret",

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -307,6 +307,30 @@ class Container(Type):
         return _ctx.execute_sync(ContainerID)
 
     @typecheck
+    def label(self, name: str) -> Optional[str]:
+        """Retrieves the value of the specified label.
+
+        Returns
+        -------
+        Optional[str]
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+        """
+        _args = [
+            Arg("name", name),
+        ]
+        _ctx = self._select("label", _args)
+        return _ctx.execute_sync(Optional[str])
+
+    @typecheck
+    def labels(self) -> "Label":
+        """Retrieves the list of labels passed to container."""
+        _args: list[Arg] = []
+        _ctx = self._select("labels", _args)
+        return Label(_ctx)
+
+    @typecheck
     def mounts(self) -> list[str]:
         """Retrieves the list of paths where a directory is mounted.
 
@@ -547,6 +571,16 @@ class Container(Type):
         return Container(_ctx)
 
     @typecheck
+    def with_label(self, name: str, value: str) -> "Container":
+        """Retrieves this container plus the given label."""
+        _args = [
+            Arg("name", name),
+            Arg("value", value),
+        ]
+        _ctx = self._select("withLabel", _args)
+        return Container(_ctx)
+
+    @typecheck
     def with_mounted_cache(
         self, path: str, cache: CacheVolume, source: Optional["Directory"] = None
     ) -> "Container":
@@ -678,6 +712,15 @@ class Container(Type):
             Arg("name", name),
         ]
         _ctx = self._select("withoutEnvVariable", _args)
+        return Container(_ctx)
+
+    @typecheck
+    def without_label(self, name: str) -> "Container":
+        """Retrieves this container minus the given environment label."""
+        _args = [
+            Arg("name", name),
+        ]
+        _ctx = self._select("withoutLabel", _args)
         return Container(_ctx)
 
     @typecheck
@@ -1242,6 +1285,40 @@ class HostVariable(Type):
         return _ctx.execute_sync(str)
 
 
+class Label(Type):
+    """A simple key value object that represents a label."""
+
+    @typecheck
+    def name(self) -> str:
+        """The label name.
+
+        Returns
+        -------
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("name", _args)
+        return _ctx.execute_sync(str)
+
+    @typecheck
+    def value(self) -> str:
+        """The label value.
+
+        Returns
+        -------
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("value", _args)
+        return _ctx.execute_sync(str)
+
+
 class Project(Type):
     """A set of scripts and/or extensions"""
 
@@ -1525,6 +1602,7 @@ __all__ = [
     "GitRepository",
     "Host",
     "HostVariable",
+    "Label",
     "Project",
     "Client",
     "Secret",


### PR DESCRIPTION
Closes https://github.com/dagger/dagger/issues/4245
Closes https://github.com/dagger/dagger/issues/3887

Allows user to have the complete control over the labels of a given container:
- Add a label (`withLabel` API)
- Remove a label (`withoutLabel` API)
- Print the value of a single label (`label` API)
- Print all the labels of a container (`labels` API)

Adds corresponding graphQL tests, SDK codegen and graphQL docs.

The terminology is consistent with other APIs (cf. envVariable), and will help solving inherent docker issue https://github.com/moby/moby/issues/3465