### PR TITLE
Python: Show errors from session CLI

### DIFF
--- a/sdk/python/src/dagger/exceptions.py
+++ b/sdk/python/src/dagger/exceptions.py
@@ -6,6 +6,13 @@ class ProvisionError(DaggerError):
     """Error while provisioning the Dagger engine."""
 
 
+class SessionError(ProvisionError):
+    """Error while starting an engine session."""
+
+    def __str__(self) -> str:
+        return f"Dagger engine failed to start: {super().__str__()}"
+
+
 class ClientError(DaggerError):
     """Base class for client errors."""
 

--- a/sdk/python/tests/engine/test_cli.py
+++ b/sdk/python/tests/engine/test_cli.py
@@ -49,3 +49,17 @@ def test_cli_exec_errors(config_args: dict, call_kwargs: dict, fp: FakeProcess):
             ...
 
     assert "Dagger engine failed to start" in str(exc_info.value)
+
+
+def test_stderr(fp: FakeProcess):
+    fp.register(
+        ["dagger", "session"],
+        stderr=["Error: buildkit failed to respond", ""],
+        returncode=1,
+    )
+    with pytest.raises(ProvisionError) as exc_info, cli.CLISession(
+        dagger.Config(), "dagger"
+    ):
+        ...
+
+    assert "buildkit failed to respond" in str(exc_info.value)


### PR DESCRIPTION
Fixes #4321

## Before

`dagger.exceptions.ProvisionError: Dagger engine failed to start`

## After

`dagger.exceptions.SessionError: Dagger engine failed to start: Command '/Users/helder/Library/Caches/dagger/dagger-0.3.9 session' returned non-zero exit status 1. Error: failed to run container: docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?.`

Signed-off-by: Helder Correia