### PR TITLE
[GraphQL Reference] add ids and anchor tags to each field

### DIFF
--- a/website/docs-graphql/custom-theme/data/index.js
+++ b/website/docs-graphql/custom-theme/data/index.js
@@ -17,8 +17,6 @@ const chalk = require('chalk')
 
 const examplesPath = path.resolve(`${__dirname}/../../data/examples`);
 
-console.log("Test")
-
 function sortByName(a, b) {
   if (a.name > b.name) {
     return 1

--- a/website/docs-graphql/custom-theme/helpers/spanWrap.js
+++ b/website/docs-graphql/custom-theme/helpers/spanWrap.js
@@ -4,7 +4,8 @@
 //   clazz (String)
 module.exports = function (value, options) {
     if (options?.hash?.isField) {
-        return `<a class="${options?.hash?.className || ''}" id="${options?.hash?.id || ""}" href="#${options?.hash?.id}">${value}</a>`
+        let id = `${options?.hash?.prefix}-${options?.hash?.id || ""}`
+        return `<a class="${options?.hash?.className || ''}" id="${id}" href="#${id}">${value}</a>`
     } else {
         return `<span class="${options?.hash?.className || ''}">${value}</span>` 
     }

--- a/website/docs-graphql/custom-theme/helpers/spanWrap.js
+++ b/website/docs-graphql/custom-theme/helpers/spanWrap.js
@@ -1,0 +1,11 @@
+// Wraps a string in a span with a class
+//
+// Options:
+//   clazz (String)
+module.exports = function (value, options) {
+    if (options?.hash?.isField) {
+        return `<a class="${options?.hash?.className || ''}" id="${options?.hash?.id || ""}" href="#${options?.hash?.id}">${value}</a>`
+    } else {
+        return `<span class="${options?.hash?.className || ''}">${value}</span>` 
+    }
+  }

--- a/website/docs-graphql/custom-theme/views/partials/graphql/kinds/_fields.hbs
+++ b/website/docs-graphql/custom-theme/views/partials/graphql/kinds/_fields.hbs
@@ -1,0 +1,38 @@
+<table>
+  <thead>
+    <tr>
+      <th>Field Name</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    {{#each fields}}
+      <tr
+        {{#if (nempty args)}}class="row-has-field-arguments"{{/if}}
+      >
+        <td data-property-name="{{./htmlId}}"
+          {{! The Name column }}
+          {{#if (and isDeprecated (not @root.info.x-hideIsDeprecated)) }}class="definition-deprecated"{{/if}}
+        >
+          {{~> graphql/name-and-type . isField=true}}
+        </td>
+        <td>
+          {{! The Description column }}
+          {{#if description}}
+            {{md (interpolateReferences description) stripParagraph=true}}
+          {{/if}}
+          {{#if (and deprecationReason (not @root.info.x-hideDeprecationReason))}}
+            <span class="deprecation-reason">{{ md deprecationReason stripParagraph=true }}</span>
+          {{/if}}
+        </td>
+      </tr>
+      {{#if (nempty args)}}
+        <tr class="row-field-arguments">
+          <td colspan="2">
+            {{>graphql/field-arguments . }}
+          </td>
+        </tr>
+      {{/if}}
+    {{/each}}
+  </tbody>
+</table>

--- a/website/docs-graphql/custom-theme/views/partials/graphql/kinds/_fields.hbs
+++ b/website/docs-graphql/custom-theme/views/partials/graphql/kinds/_fields.hbs
@@ -14,7 +14,7 @@
           {{! The Name column }}
           {{#if (and isDeprecated (not @root.info.x-hideIsDeprecated)) }}class="definition-deprecated"{{/if}}
         >
-          {{~> graphql/name-and-type . isField=true}}
+          {{~> graphql/name-and-type . isField=true typeName=../name}}
         </td>
         <td>
           {{! The Description column }}

--- a/website/docs-graphql/custom-theme/views/partials/graphql/name-and-type.hbs
+++ b/website/docs-graphql/custom-theme/views/partials/graphql/name-and-type.hbs
@@ -1,0 +1,13 @@
+{{~md (
+  concat
+    (spanWrap (codify name) className="property-name" isField=isField id=name)
+    ' - '
+    (spanWrap (mdTypeLink . codify=true) className="property-type")
+    (ternary default
+      (spanWrap (concat " default = "  (codify default stringify=true)) className="property-default")
+      ""
+      undefOnly=true
+    )
+  )
+stripParagraph=true }}
+{{log isField}}

--- a/website/docs-graphql/custom-theme/views/partials/graphql/name-and-type.hbs
+++ b/website/docs-graphql/custom-theme/views/partials/graphql/name-and-type.hbs
@@ -10,4 +10,3 @@
     )
   )
 stripParagraph=true }}
-{{log isField}}

--- a/website/docs-graphql/custom-theme/views/partials/graphql/name-and-type.hbs
+++ b/website/docs-graphql/custom-theme/views/partials/graphql/name-and-type.hbs
@@ -1,6 +1,6 @@
 {{~md (
   concat
-    (spanWrap (codify name) className="property-name" isField=isField id=name)
+    (spanWrap (codify name) className="property-name" isField=isField prefix=typeName id=name)
     ' - '
     (spanWrap (mdTypeLink . codify=true) className="property-type")
     (ternary default


### PR DESCRIPTION
This will add an HTML id attribute to each field in each type, and wrap them in an anchor tag to make the fields clickable and shareable.

Closes #4305 

Signed-off-by: Julián Cruciani <julian@dagger.io>