### PR TITLE
Fix session error handling

### DIFF
--- a/sdk/nodejs/common/errors/EngineSessionErrorOptions.ts
+++ b/sdk/nodejs/common/errors/EngineSessionErrorOptions.ts
@@ -1,20 +1,20 @@
 import { DaggerSDKError, DaggerSDKErrorOptions } from "./DaggerSDKError.js"
 import { ERROR_CODES, ERROR_NAMES } from "./errors-codes.js"
 
-type EngineSessionEOFErrorOptions = DaggerSDKErrorOptions
+type EngineSessionErrorOptions = DaggerSDKErrorOptions
 
 /**
  * This error is thrown if the EngineSession does not manage to parse the required port successfully because a EOF is read before any valid port.
  * This usually happens if no connection can be established.
  */
-export class EngineSessionEOFError extends DaggerSDKError {
-  name = ERROR_NAMES.EngineSessionEOFError
-  code = ERROR_CODES.EngineSessionEOFError
+export class EngineSessionError extends DaggerSDKError {
+  name = ERROR_NAMES.EngineSessionError
+  code = ERROR_CODES.EngineSessionError
 
   /**
    * @hidden
    */
-  constructor(message: string, options?: EngineSessionEOFErrorOptions) {
+  constructor(message: string, options?: EngineSessionErrorOptions) {
     super(message, options)
   }
 }

--- a/sdk/nodejs/common/errors/errors-codes.ts
+++ b/sdk/nodejs/common/errors/errors-codes.ts
@@ -25,9 +25,9 @@ export const ERROR_CODES = {
   EngineSessionConnectionTimeoutError: "D104",
 
   /**
-   * {@link EngineSessionEOFError}
+   * {@link EngineSessionError}
    */
-  EngineSessionEOFError: "D105",
+  EngineSessionError: "D105",
 
   /**
    * {@link InitEngineSessionBinaryError}

--- a/sdk/nodejs/common/errors/index.ts
+++ b/sdk/nodejs/common/errors/index.ts
@@ -5,6 +5,6 @@ export { EngineSessionConnectParamsParseError } from "./EngineSessionConnectPara
 export { GraphQLRequestError } from "./GraphQLRequestError.js"
 export { InitEngineSessionBinaryError } from "./InitEngineSessionBinaryError.js"
 export { TooManyNestedObjectsError } from "./TooManyNestedObjectsError.js"
-export { EngineSessionEOFError } from "./EngineSessionEOFErrorOptions.js"
+export { EngineSessionError } from "./EngineSessionErrorOptions.js"
 export { EngineSessionConnectionTimeoutError } from "./EngineSessionConnectionTimeoutError.js"
 export { ERROR_CODES } from "./errors-codes.js"

--- a/sdk/nodejs/provisioning/bin.ts
+++ b/sdk/nodejs/provisioning/bin.ts
@@ -188,6 +188,7 @@ export class Bin implements EngineConn {
       )
     }
 
+    // Need to find a better way to handle this part
     // At this stage something wrong happened, `for await` didn't return anything
     // await the subprocess to catch the error
     try {

--- a/sdk/nodejs/provisioning/bin.ts
+++ b/sdk/nodejs/provisioning/bin.ts
@@ -14,7 +14,7 @@ import Client from "../api/client.gen.js"
 import {
   EngineSessionConnectionTimeoutError,
   EngineSessionConnectParamsParseError,
-  EngineSessionEOFError,
+  EngineSessionError,
   InitEngineSessionBinaryError,
 } from "../common/errors/index.js"
 import { ConnectParams } from "../connect.js"
@@ -28,7 +28,7 @@ let OVERRIDE_CHECKSUMS_URL: string
  * Bin runs an engine session from a specified binary
  */
 export class Bin implements EngineConn {
-  private subProcess?: any
+  private subProcess?: ExecaChildProcess
 
   private binPath?: string
   private cliVersion?: string
@@ -188,11 +188,13 @@ export class Bin implements EngineConn {
       )
     }
 
+    // for await did return nothing
+    // await the subprocess to catch the buildkit error
     try {
       await this.subProcess
     } catch {
-      this.subProcess.catch((e: any) => {
-        throw new EngineSessionEOFError(e.stderr)
+      this.subProcess?.catch((e) => {
+        throw new EngineSessionError(e.stderr)
       })
     }
   }

--- a/sdk/nodejs/provisioning/bin.ts
+++ b/sdk/nodejs/provisioning/bin.ts
@@ -188,8 +188,8 @@ export class Bin implements EngineConn {
       )
     }
 
-    // for await did return nothing
-    // await the subprocess to catch the buildkit error
+    // At this stage something wrong happened, `for await` didn't return anything
+    // await the subprocess to catch the error
     try {
       await this.subProcess
     } catch {


### PR DESCRIPTION
Close to https://github.com/dagger/dagger/issues/4322
Buildkit sessions errors should be displayed with and without `LogOutput` config parameter
Signed-off-by: jffarge <jf@dagger.io>