### PR TITLE
Fix engine state path in operator manual.

### DIFF
--- a/core/docs/d7yxc-operator_manual.md
+++ b/core/docs/d7yxc-operator_manual.md
@@ -116,8 +116,9 @@ The runner is distributed as a container image at `ghcr.io/dagger/engine`.
 1. The runner container currently needs root capabilities, including among others `CAP_SYS_ADMIN`, in order to execute pipelines.
    - For example, this will be granted when using the `--privileged` flag of `docker run`.
    - There is an issue for [supporting rootless execution](https://github.com/dagger/dagger/issues/1287).
-1. The runner container should be given a volume at `/var/lib/buildkit`.
-   - Otherwise runner execution may be extremely slow. This is due to the fact that it relies on overlayfs mounts for efficient operation, which isn't possible when `/var/lib/buildkit` is itself an overlayfs.
+1. The runner container should be given a volume at `/var/lib/dagger`.
+   - Otherwise runner execution may be extremely slow. This is due to the fact that it relies on overlayfs mounts for efficient operation, which isn't possible when `/var/lib/dagger` is itself an overlayfs.
+   - For example, this can be provided to a `docker run` command as `-v dagger-engine:/var/lib/dagger`
 1. The container image comes with a default entrypoint which should be used to start the runner, no extra args are needed.
 
 ### Configuration


### PR DESCRIPTION
Signed-off-by: Erik Sipsma <erik@sipsma.dev>

The state path changed recently, this catches up the doc with it. Hit by user here: https://discord.com/channels/707636530424053791/1065955877678501919/1066073015307223101