### PR TITLE
Fix: Bumped copyright dates for licenses from 2022 to 2023

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2022 Dagger, Inc.
+   Copyright 2023 Dagger, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/sdk/go/LICENSE
+++ b/sdk/go/LICENSE
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2022 Dagger, Inc.
+   Copyright 2023 Dagger, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/sdk/nodejs/LICENSE
+++ b/sdk/nodejs/LICENSE
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2022 Dagger, Inc.
+   Copyright 2023 Dagger, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/sdk/python/LICENSE
+++ b/sdk/python/LICENSE
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2022 Dagger, Inc.
+   Copyright 2023 Dagger, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Signed-off-by: Jenn Allen <jenn.allen@gmail.com>

Fix for https://github.com/dagger/dagger/issues/4432