### PR TITLE
Fix container use in nodejs get started guide.

### DIFF
--- a/docs/current/sdk/nodejs/snippets/get-started/step3/build.js
+++ b/docs/current/sdk/nodejs/snippets/get-started/step3/build.js
@@ -11,8 +11,7 @@
     const node = client.container().from("node:16")
 
     // mount cloned repository into Node image
-    const runner = client
-      .container({ id: node })
+    const runner = node
       .withMountedDirectory("/src", source)
       .withWorkdir("/src")
       .withExec(["npm", "install"])

--- a/docs/current/sdk/nodejs/snippets/get-started/step3/build.mjs
+++ b/docs/current/sdk/nodejs/snippets/get-started/step3/build.mjs
@@ -10,8 +10,7 @@ connect(async (client) => {
   const node = client.container().from("node:16")
 
   // mount cloned repository into Node image
-  const runner = client
-    .container({ id: node })
+  const runner = node
     .withMountedDirectory("/src", source)
     .withWorkdir("/src")
     .withExec(["npm", "install"])

--- a/docs/current/sdk/nodejs/snippets/get-started/step3/build.mts
+++ b/docs/current/sdk/nodejs/snippets/get-started/step3/build.mts
@@ -10,8 +10,7 @@ connect(async (client: Client) => {
   const node = client.container().from("node:16")
 
   // mount cloned repository into Node image
-  const runner = client
-    .container({ id: node })
+  const runner = node
     .withMountedDirectory("/src", source)
     .withWorkdir("/src")
     .withExec(["npm", "install"])

--- a/docs/current/sdk/nodejs/snippets/get-started/step4/build.js
+++ b/docs/current/sdk/nodejs/snippets/get-started/step4/build.js
@@ -19,8 +19,7 @@
       // highlight-end
 
       // mount cloned repository into Node image
-      const runner = client
-        .container({ id: node })
+      const runner = node
         .withMountedDirectory("/src", source)
         .withWorkdir("/src")
         .withExec(["npm", "install"])

--- a/docs/current/sdk/nodejs/snippets/get-started/step4/build.mjs
+++ b/docs/current/sdk/nodejs/snippets/get-started/step4/build.mjs
@@ -18,8 +18,7 @@ connect(async (client) => {
     // highlight-end
 
     // mount cloned repository into Node image
-    const runner = client
-      .container({ id: node })
+    const runner = node
       .withMountedDirectory("/src", source)
       .withWorkdir("/src")
       .withExec(["npm", "install"])

--- a/docs/current/sdk/nodejs/snippets/get-started/step4/build.mts
+++ b/docs/current/sdk/nodejs/snippets/get-started/step4/build.mts
@@ -18,8 +18,7 @@ connect(async (client: Client) => {
     // highlight-end
 
     // mount cloned repository into Node image
-    const runner = client
-      .container({ id: node })
+    const runner = node
       .withMountedDirectory("/src", source)
       .withWorkdir("/src")
       .withExec(["npm", "install"])


### PR DESCRIPTION
I ran through these quickly after a release and couldn't compile the typescript version due to the `node` var not being of type string when provided as the `id` of a `container`.

Fixing this by just not using IDs; you can just use `node` directly.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>