### PR TITLE
engine: fix Export on Windows (workdir verification)

### DIFF
--- a/core/host.go
+++ b/core/host.go
@@ -167,7 +167,9 @@ func (host *Host) NormalizeDest(dest string) (string, error) {
 		return dest, nil
 	}
 
-	if !strings.HasPrefix(dest, wd+"/") {
+	// filepath.ToSlash is needed for Windows
+	// filepath.Clean transforms / to \ on Windows
+	if !strings.HasPrefix(filepath.ToSlash(dest), filepath.ToSlash(wd+"/")) {
 		// writing outside of workdir
 		return "", fmt.Errorf("destination %q escapes workdir", dest)
 	}


### PR DESCRIPTION
Closes #4458

### Context
When using `.Export()`, workdir scope is checked using `strings.HasPrefix()`.

However, on Windows:
`workdir` and `dest` have different separators, making this comparison break.

We now rely on `filepath.ToSlash` to make sure `dest` and `wd + "/"` are resolving to the comparable path

### Repro

Given this repro, on Windows:
```go
package main

import (
        "context"
        "fmt"
        "os"

        "dagger.io/dagger"
)

func main() {
        ctx := context.Background()

        client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
        if err != nil {
                fmt.Printf("Error connecting to Dagger Engine: %s\n", err)
                os.Exit(1)
        }
        defer client.Close()

        // src := client.Host().Directory(".")

        golang := client.Container().From("golang:latest")
        // golang = golang.WithMountedDirectory("/src", src).WithWorkdir("/src")

        // path := "build/"
        path := "/tmp"
        // golang = golang.WithExec([]string{"go", "build", "-o", path})

        output := golang.Directory(path)
        hostPath := "tmp"
        _, err = output.Export(ctx, hostPath)
        if err != nil {
                fmt.Printf("Error on export: %s", err)
        }
}
```

We had this error, on Windows (with some path debug):
```powershell
Error on export: input:1: container.from.directory.export destination "\\\\tsclient\\tmp-shared-rdp\\repro-export\\tmp" escapes workdir (debug "\\\\tsclient\\tmp-shared-rdp\\repro-export/")

Please visit https://dagger.io/help#go for troubleshooting guidance.
```
In above example:
- dest == `\\\\tsclient\\tmp-shared-rdp\\repro-export\\tmp`
- wd == `"\\\\tsclient\\tmp-shared-rdp\\repro-export/"`

### Solution

This PR solves this by uniforming the check with Slashes, whatever the platform.

Works now:
<img width="753" alt="image" src="https://user-images.githubusercontent.com/31691250/215610825-53d763e7-d8cd-43ef-b0fd-1fb98ed67216.png">

cc @Ekyazed

Signed-off-by: grouville