### PR TITLE
[Docs] Quickstart Layout

### DIFF
--- a/docs/current/543069-index.md
+++ b/docs/current/543069-index.md
@@ -65,9 +65,11 @@ lib -..-> engine -..-> oci -..-> A1 & B1 & C1
 
 ## Getting started
 
-To get started with Dagger, simply choose a SDK, then follow that SDK's getting started guide.
+To get started with Dagger, use our [quickstart](./quickstart/648215-quickstart-introduction.mdx), which walks you through the basics of creating and using a pipeline with our SDKs.
 
-### Which SDK should I use?
+Alternatively, choose an SDK and follow that SDK's getting started guide.
+
+## Which SDK should I use?
 
 | If you are... | then you should... |
 | -- | -- |

--- a/docs/current/543069-index.md
+++ b/docs/current/543069-index.md
@@ -1,5 +1,6 @@
 ---
 slug: /
+displayed_sidebar: "current"
 ---
 
 # Dagger Documentation

--- a/docs/current/quickstart/120918-quickstart-setup.mdx
+++ b/docs/current/quickstart/120918-quickstart-setup.mdx
@@ -1,10 +1,10 @@
 ---
 slug: /120918/quickstart-setup
-displayed_sidebar: "current"
+displayed_sidebar: "quickstart"
 hide_table_of_contents: true
 pagination_next: "current/quickstart/quickstart-sdk"
 pagination_prev: "current/quickstart/quickstart-basics"
-pagination_label: "Set up the example application"
+title: "Set up the example application"
 ---
 
 # Quickstart

--- a/docs/current/quickstart/120918-quickstart-setup.mdx
+++ b/docs/current/quickstart/120918-quickstart-setup.mdx
@@ -4,7 +4,7 @@ displayed_sidebar: "current"
 hide_table_of_contents: true
 pagination_next: "current/quickstart/quickstart-sdk"
 pagination_prev: "current/quickstart/quickstart-basics"
-pagination_label: "Setup"
+pagination_label: "Set up the example application"
 ---
 
 # Quickstart

--- a/docs/current/quickstart/120918-quickstart-setup.mdx
+++ b/docs/current/quickstart/120918-quickstart-setup.mdx
@@ -1,0 +1,31 @@
+---
+slug: /120918/quickstart-setup
+displayed_sidebar: "current"
+hide_table_of_contents: true
+---
+
+# Quickstart
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import Button from "@site/src/components/atoms/button.js";
+
+## Set up the example application
+
+The example application used in this tutorial is a simple React application.
+
+Let's begin by cloning the application repository into your local development environment:
+
+```shell
+git clone https://github.com/vikram-dagger/hello-dagger
+```
+
+Within the application directory, create a `ci` sub-directory. This sub-directory will hold the code you write in subsequent steps.
+
+```shell
+cd hello-dagger && mkdir ci
+```
+
+<Button label="Previous" docPath="319191/quickstart-basics" />
+
+<Button label="Next" docPath="628381/quickstart-sdk" />

--- a/docs/current/quickstart/120918-quickstart-setup.mdx
+++ b/docs/current/quickstart/120918-quickstart-setup.mdx
@@ -2,6 +2,9 @@
 slug: /120918/quickstart-setup
 displayed_sidebar: "current"
 hide_table_of_contents: true
+pagination_next: "current/quickstart/quickstart-sdk"
+pagination_prev: "current/quickstart/quickstart-basics"
+pagination_label: "Setup"
 ---
 
 # Quickstart
@@ -25,7 +28,3 @@ Within the application directory, create a `ci` sub-directory. This sub-director
 ```shell
 cd hello-dagger && mkdir ci
 ```
-
-<Button label="Previous" docPath="319191/quickstart-basics" />
-
-<Button label="Next" docPath="628381/quickstart-sdk" />

--- a/docs/current/quickstart/120918-quickstart-setup.mdx
+++ b/docs/current/quickstart/120918-quickstart-setup.mdx
@@ -11,7 +11,6 @@ pagination_label: "Set up the example application"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import Button from "@site/src/components/atoms/button.js";
 
 ## Set up the example application
 

--- a/docs/current/quickstart/319191-quickstart-basics.mdx
+++ b/docs/current/quickstart/319191-quickstart-basics.mdx
@@ -11,7 +11,6 @@ pagination_label: "Understand the basics of Dagger"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import Button from "@site/src/components/atoms/button.js";
 
 ## Understand the basics of Dagger
 

--- a/docs/current/quickstart/319191-quickstart-basics.mdx
+++ b/docs/current/quickstart/319191-quickstart-basics.mdx
@@ -2,6 +2,9 @@
 slug: /319191/quickstart-basics
 displayed_sidebar: "current"
 hide_table_of_contents: true
+pagination_next: "current/quickstart/quickstart-setup"
+pagination_prev: "current/quickstart/quickstart-introduction"
+pagination_label: "Basics"
 ---
 
 # Quickstart
@@ -58,7 +61,3 @@ lib -..-> engine -..-> oci -..-> A1 & B1 & C1
 4. When the engine receives an API request, it computes a [Directed Acyclic Graph (DAG)](https://en.wikipedia.org/wiki/Directed_acyclic_graph) of low-level operations required to compute the result, and starts processing operations concurrently.
 5. When all operations in the pipeline have been resolved, the engine sends the pipeline result back to your program.
 6. Your program may use the pipeline's result as input to new pipelines.
-
-<Button label="Previous" docPath="648215/quickstart" />
-
-<Button label="Next" docPath="120918/quickstart-setup" />

--- a/docs/current/quickstart/319191-quickstart-basics.mdx
+++ b/docs/current/quickstart/319191-quickstart-basics.mdx
@@ -1,10 +1,10 @@
 ---
 slug: /319191/quickstart-basics
-displayed_sidebar: "current"
+displayed_sidebar: "quickstart"
 hide_table_of_contents: true
 pagination_next: "current/quickstart/quickstart-setup"
 pagination_prev: "current/quickstart/quickstart-introduction"
-pagination_label: "Understand the basics of Dagger"
+title: "Understand the basics of Dagger"
 ---
 
 # Quickstart

--- a/docs/current/quickstart/319191-quickstart-basics.mdx
+++ b/docs/current/quickstart/319191-quickstart-basics.mdx
@@ -4,7 +4,7 @@ displayed_sidebar: "current"
 hide_table_of_contents: true
 pagination_next: "current/quickstart/quickstart-setup"
 pagination_prev: "current/quickstart/quickstart-introduction"
-pagination_label: "Basics"
+pagination_label: "Understand the basics"
 ---
 
 # Quickstart

--- a/docs/current/quickstart/319191-quickstart-basics.mdx
+++ b/docs/current/quickstart/319191-quickstart-basics.mdx
@@ -4,7 +4,7 @@ displayed_sidebar: "current"
 hide_table_of_contents: true
 pagination_next: "current/quickstart/quickstart-setup"
 pagination_prev: "current/quickstart/quickstart-introduction"
-pagination_label: "Understand the basics"
+pagination_label: "Understand the basics of Dagger"
 ---
 
 # Quickstart
@@ -13,7 +13,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import Button from "@site/src/components/atoms/button.js";
 
-## Understand the basics
+## Understand the basics of Dagger
 
 Before diving in to the code, here are some common questions about Dagger (and their answers).
 

--- a/docs/current/quickstart/319191-quickstart-basics.mdx
+++ b/docs/current/quickstart/319191-quickstart-basics.mdx
@@ -1,0 +1,64 @@
+---
+slug: /319191/quickstart-basics
+displayed_sidebar: "current"
+hide_table_of_contents: true
+---
+
+# Quickstart
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import Button from "@site/src/components/atoms/button.js";
+
+## Understand the basics
+
+Before diving in to the code, here are some common questions about Dagger (and their answers).
+
+### What is Dagger?
+
+Dagger is a programmable CI/CD engine that runs your pipelines in containers. It enables you to develop your CI/CD pipelines as code, in the same programming language as your application, and then executes those pipelines entirely as [standard OCI containers](https://opencontainers.org/).
+
+### Who is Dagger for?
+
+Dagger may be a good fit if you are...
+
+* A developer wishing your CI pipelines were code instead of YAML.
+* Your team's "designated devops person", hoping to replace a pile of artisanal scripts with something more powerful.
+* A platform engineer writing custom tooling, with the goal of unifying continuous delivery across organizational silos.
+* A cloud-native developer advocate or solutions engineer, looking to demonstrate a complex integration on short notice.
+
+### How does Dagger work?
+
+```mermaid
+graph LR;
+
+subgraph program["Your program"]
+  lib["Dagger SDK"]
+end
+
+engine["Dagger Engine"]
+
+oci["OCI container runtime"]
+subgraph A["your build pipeline"]
+  A1[" "] -.-> A2[" "] -.-> A3[" "]
+end
+subgraph B["your test pipeline"]
+  B1[" "] -.-> B2[" "] -.-> B3[" "] -.-> B4[" "]
+end
+subgraph C["your deploy pipeline"]
+  C1[" "] -.-> C2[" "] -.-> C3[" "] -.-> C4[" "]
+end
+
+lib -..-> engine -..-> oci -..-> A1 & B1 & C1
+```
+
+1. Your program imports the Dagger SDK in your language of choice.
+2. Using the SDK, your program opens a new session to a Dagger Engine: either by connecting to an existing engine, or by provisioning one on-the-fly.
+3. Using the SDK, your program prepares API requests describing pipelines to run, then sends them to the engine. The wire protocol used to communicate with the engine is private and not yet documented, but this will change in the future. For now, the SDK is the only documented API available to your program.
+4. When the engine receives an API request, it computes a [Directed Acyclic Graph (DAG)](https://en.wikipedia.org/wiki/Directed_acyclic_graph) of low-level operations required to compute the result, and starts processing operations concurrently.
+5. When all operations in the pipeline have been resolved, the engine sends the pipeline result back to your program.
+6. Your program may use the pipeline's result as input to new pipelines.
+
+<Button label="Previous" docPath="648215/quickstart" />
+
+<Button label="Next" docPath="120918/quickstart-setup" />

--- a/docs/current/quickstart/349011-quickstart-build.mdx
+++ b/docs/current/quickstart/349011-quickstart-build.mdx
@@ -2,6 +2,9 @@
 slug: /349011/quickstart-build
 displayed_sidebar: "current"
 hide_table_of_contents: true
+pagination_next: "current/quickstart/quickstart-publish"
+pagination_prev: "current/quickstart/quickstart-test"
+pagination_label: "Build"
 ---
 
 # Quickstart
@@ -78,7 +81,3 @@ build
     └── media
         └── logo.6ce24c58023cc2f8fd88fe9d219db6c6.svg
 ```
-
-<Button label="Back" docPath="947391/quickstart-test" />
-
-<Button label="Next" docPath="730264/quickstart-publish" />

--- a/docs/current/quickstart/349011-quickstart-build.mdx
+++ b/docs/current/quickstart/349011-quickstart-build.mdx
@@ -1,0 +1,76 @@
+---
+slug: /349011/quickstart-build
+displayed_sidebar: "current"
+hide_table_of_contents: true
+---
+
+# Quickstart
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import Button from "@site/src/components/atoms/button.js";
+
+## Build the application
+
+If your application passes all its tests, the typical next step is to build it.
+
+So, let's update the previous pipeline and add a build step to it, by running `npm run build`.
+
+<Tabs groupId="language">
+<TabItem value="Go">
+
+```go file=snippets/build/main.go
+```
+
+- It invokes the `Container.WithExec()` method again, this time to define the command `npm run build` in the container.
+- It obtains a reference to the `build/` directory in the container with the `Container.Directory()` method. This method returns a `Directory` object.
+- It writes the `build/` directory from the container to the host using the `Directory.Export()` method.
+
+</TabItem>
+<TabItem value="Node.js">
+
+
+```javascript file=snippets/build/index.mjs
+```
+
+This revised pipeline does everything described in the previous step, and then performs the following additional operations:
+
+- It invokes the `Container.withExec()` method again, this time to define the command `npm run build` in the container.
+- It obtains a reference to the `build/` directory in the container with the `Container.directory()` method. This method returns a `Directory` object.
+- It writes the `build/` directory from the container to the host using the `Directory.export()` method.
+
+</TabItem>
+<TabItem value="Python">
+TODO
+</TabItem>
+</Tabs>
+
+After Dagger resolves the pipeline, the built application is available in a new `build/` sub-directory of the application directory. Confirm this by executing the `tree` command in the application directory, as shown below:
+
+```shell
+tree build
+build
+├── asset-manifest.json
+├── favicon.ico
+├── index.html
+├── logo192.png
+├── logo512.png
+├── manifest.json
+├── robots.txt
+└── static
+    ├── css
+    │   ├── main.073c9b0a.css
+    │   └── main.073c9b0a.css.map
+    ├── js
+    │   ├── 787.305db8b6.chunk.js
+    │   ├── 787.305db8b6.chunk.js.map
+    │   ├── main.a03ce25e.js
+    │   ├── main.a03ce25e.js.LICENSE.txt
+    │   └── main.a03ce25e.js.map
+    └── media
+        └── logo.6ce24c58023cc2f8fd88fe9d219db6c6.svg
+```
+
+<Button label="Back" docPath="947391/quickstart-test" />
+
+<Button label="Next" docPath="730264/quickstart-publish" />

--- a/docs/current/quickstart/349011-quickstart-build.mdx
+++ b/docs/current/quickstart/349011-quickstart-build.mdx
@@ -40,7 +40,16 @@ This revised pipeline does everything described in the previous step, and then p
 
 </TabItem>
 <TabItem value="Python">
-TODO
+
+```python file=snippets/build/main.py
+```
+
+This revised pipeline does everything described in the previous step, and then performs the following additional operations:
+
+- It invokes the `Container.with_exec()` method again, this time to define the command `npm run build` in the container.
+- It obtains a reference to the `build/` directory in the container with the `Container.directory()` method. This method returns a `Directory` object.
+- It writes the `build/` directory from the container to the host using the `Directory.export()` method.
+
 </TabItem>
 </Tabs>
 

--- a/docs/current/quickstart/349011-quickstart-build.mdx
+++ b/docs/current/quickstart/349011-quickstart-build.mdx
@@ -43,8 +43,7 @@ This revised pipeline does everything described in the previous step, and then p
 </TabItem>
 <TabItem value="Python">
 
-```python file=snippets/build/main.py
-```
+<iframe class="embed" src="https://play.dagger.cloud/embed/kDR-sCOVDvG"></iframe>
 
 This revised pipeline does everything described in the previous step, and then performs the following additional operations:
 

--- a/docs/current/quickstart/349011-quickstart-build.mdx
+++ b/docs/current/quickstart/349011-quickstart-build.mdx
@@ -1,10 +1,10 @@
 ---
 slug: /349011/quickstart-build
-displayed_sidebar: "current"
+displayed_sidebar: "quickstart"
 hide_table_of_contents: true
 pagination_next: "current/quickstart/quickstart-publish"
 pagination_prev: "current/quickstart/quickstart-test"
-pagination_label: "Build the application"
+title: "Build the application"
 ---
 
 # Quickstart

--- a/docs/current/quickstart/349011-quickstart-build.mdx
+++ b/docs/current/quickstart/349011-quickstart-build.mdx
@@ -4,7 +4,7 @@ displayed_sidebar: "current"
 hide_table_of_contents: true
 pagination_next: "current/quickstart/quickstart-publish"
 pagination_prev: "current/quickstart/quickstart-test"
-pagination_label: "Build"
+pagination_label: "Build the application"
 ---
 
 # Quickstart

--- a/docs/current/quickstart/349011-quickstart-build.mdx
+++ b/docs/current/quickstart/349011-quickstart-build.mdx
@@ -30,9 +30,7 @@ So, let's update the previous pipeline and add a build step to it, by running `n
 </TabItem>
 <TabItem value="Node.js">
 
-
-```javascript file=snippets/build/index.mjs
-```
+<iframe class="embed" src="https://play.dagger.cloud/embed/WVNKVxYZ1zP"></iframe>
 
 This revised pipeline does everything described in the previous step, and then performs the following additional operations:
 

--- a/docs/current/quickstart/349011-quickstart-build.mdx
+++ b/docs/current/quickstart/349011-quickstart-build.mdx
@@ -19,8 +19,7 @@ So, let's update the previous pipeline and add a build step to it, by running `n
 <Tabs groupId="language">
 <TabItem value="Go">
 
-```go file=snippets/build/main.go
-```
+<iframe class="embed" src="https://play.dagger.cloud/embed/EPvbuzgZ-IH"></iframe>
 
 - It invokes the `Container.WithExec()` method again, this time to define the command `npm run build` in the container.
 - It obtains a reference to the `build/` directory in the container with the `Container.Directory()` method. This method returns a `Directory` object.

--- a/docs/current/quickstart/349011-quickstart-build.mdx
+++ b/docs/current/quickstart/349011-quickstart-build.mdx
@@ -11,7 +11,6 @@ pagination_label: "Build the application"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import Button from "@site/src/components/atoms/button.js";
 
 ## Build the application
 

--- a/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
+++ b/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
@@ -36,9 +36,7 @@ Connect()`.
 </TabItem>
 <TabItem value="Node.js">
 
-
-```javascript file=snippets/build-dockerfile/index.mjs
-```
+<iframe class="embed" src="https://play.dagger.cloud/embed/IdHGiwvkn6E"></iframe>
 
 This code listing does the following:
 

--- a/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
+++ b/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
@@ -47,7 +47,18 @@ This code listing does the following:
 
 </TabItem>
 <TabItem value="Python">
-TODO
+
+```python file=snippets/build-dockerfile/main.py
+```
+
+This code listing does the following:
+
+- It creates a Dagger client with `with dagger.Connection()`.
+- It uses the client's `host().directory()` method to obtain a reference to the source code directory on the host.
+- It uses the client's `container().build()` method to initialize a new container using a Dockerfile. This method defaults to using the Dockerfile located at `./Dockerfile` in the directory passed to it as argument and returns the built `Container` object.
+- It uses the `Container` object's `publish()` method to publish the container to [ttl.sh](https://ttl.sh). As before, to prevent name collisions, the container image name is suffixed with a random number.
+
+
 </TabItem>
 </Tabs>
 

--- a/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
+++ b/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
@@ -1,0 +1,59 @@
+---
+slug: /429462/quickstart-build-dockerfile
+displayed_sidebar: "current"
+hide_table_of_contents: true
+---
+
+# Quickstart
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import Button from "@site/src/components/atoms/button.js";
+
+## Transition at your own pace: Use Dockerfiles
+
+As you've seen over the last few pages, Dagger is a powerful tool. It lets you create CI pipelines using general purpose programming languages, giving you full access to native control structures like conditionals and loops. By allowing you to import and use existing language extensions or packages in your pipeline code, Dagger makes it easier to quickly add new functionality or integrate with third-party services. By the same token, Dagger pipelines also benefit from static typing and easier refactoring.
+
+However, rewriting your entire CI/CD system to use Dagger, all at once and without breaking compatibility, is not an easy task.
+
+The good news here is that Dagger can natively run Dockerfiles with full compatibility. This means that it's easy to wrap your existing Dockerfile in a Dagger pipeline, and gradually refactor it over time, without breaking your team's workflow.
+
+The example application repository includes a simple Dockerfile. Use it with a Dagger pipeline as shown below:
+
+<Tabs groupId="language">
+<TabItem value="Go">
+
+```go file=snippets/build-dockerfile/main.go
+```
+
+This code listing does the following:
+Connect()`.
+- It uses the client's `Host().Directory()` method to obtain a reference to the source code directory on the host.
+- It uses the client's `Container().Build()` method to initialize a new container using a Dockerfile. This method defaults to using the Dockerfile located at `./Dockerfile` in the directory passed to it as argument and returns the built `Container` object.
+- It uses the `Container` object's `Publish()` method to publish the container to [ttl.sh](https://ttl.sh). As before, to prevent name collisions, the container image name is suffixed with a random number.
+
+</TabItem>
+<TabItem value="Node.js">
+
+
+```javascript file=snippets/build-dockerfile/index.mjs
+```
+
+This code listing does the following:
+
+- It creates a Dagger client with `connect()`.
+- It uses the client's `host().directory()` method to obtain a reference to the source code directory on the host.
+- It uses the client's `container().build()` method to initialize a new container using a Dockerfile. This method defaults to using the Dockerfile located at `./Dockerfile` in the directory passed to it as argument and returns the built `Container` object.
+- It uses the `Container` object's `publish()` method to publish the container to [ttl.sh](https://ttl.sh). As before, to prevent name collisions, the container image name is suffixed with a random number.
+
+</TabItem>
+<TabItem value="Python">
+TODO
+</TabItem>
+</Tabs>
+
+After Dagger resolves the pipeline, the newly-built container image will be available in the [ttl.sh](https://ttl.sh) registry. Download and test it as described in the section on [publishing the application](./730264-quickstart-publish.mdx).
+
+<Button label="Back" docPath="635927/quickstart-caching" />
+
+<Button label="Next" docPath="481031/quickstart-conclusion" />

--- a/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
+++ b/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
@@ -23,8 +23,7 @@ The example application repository includes a simple Dockerfile. Use it with a D
 <Tabs groupId="language">
 <TabItem value="Go">
 
-```go file=snippets/build-dockerfile/main.go
-```
+<iframe class="embed" src="https://play.dagger.cloud/embed/FA1zGYpXHv2"></iframe>
 
 This code listing does the following:
 Connect()`.

--- a/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
+++ b/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
@@ -2,6 +2,9 @@
 slug: /429462/quickstart-build-dockerfile
 displayed_sidebar: "current"
 hide_table_of_contents: true
+pagination_next: "current/quickstart/quickstart-conclusion"
+pagination_prev: "current/quickstart/quickstart-build-multi"
+pagination_label: "Dockerfile"
 ---
 
 # Quickstart
@@ -63,7 +66,3 @@ This code listing does the following:
 </Tabs>
 
 After Dagger resolves the pipeline, the newly-built container image will be available in the [ttl.sh](https://ttl.sh) registry. Download and test it as described in the section on [publishing the application](./730264-quickstart-publish.mdx).
-
-<Button label="Back" docPath="635927/quickstart-caching" />
-
-<Button label="Next" docPath="481031/quickstart-conclusion" />

--- a/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
+++ b/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
@@ -4,7 +4,7 @@ displayed_sidebar: "current"
 hide_table_of_contents: true
 pagination_next: "current/quickstart/quickstart-conclusion"
 pagination_prev: "current/quickstart/quickstart-build-multi"
-pagination_label: "Dockerfile"
+pagination_label: "Wrap existing Dockerfiles with Dagger"
 ---
 
 # Quickstart
@@ -13,7 +13,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import Button from "@site/src/components/atoms/button.js";
 
-## Transition at your own pace: Use Dockerfiles
+## Wrap existing Dockerfiles with Dagger
 
 As you've seen over the last few pages, Dagger is a powerful tool. It lets you create CI pipelines using general purpose programming languages, giving you full access to native control structures like conditionals and loops. By allowing you to import and use existing language extensions or packages in your pipeline code, Dagger makes it easier to quickly add new functionality or integrate with third-party services. By the same token, Dagger pipelines also benefit from static typing and easier refactoring.
 

--- a/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
+++ b/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
@@ -26,7 +26,7 @@ The example application repository includes a simple Dockerfile. Use it with a D
 <Tabs groupId="language">
 <TabItem value="Go">
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/FA1zGYpXHv2"></iframe>
+<iframe class="embed" src="https://play.dagger.cloud/embed/FkLP0dXMgIm"></iframe>
 
 This code listing does the following:
 Connect()`.

--- a/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
+++ b/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
@@ -11,7 +11,6 @@ pagination_label: "Wrap existing Dockerfiles with Dagger"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import Button from "@site/src/components/atoms/button.js";
 
 ## Wrap existing Dockerfiles with Dagger
 

--- a/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
+++ b/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
@@ -50,8 +50,7 @@ This code listing does the following:
 </TabItem>
 <TabItem value="Python">
 
-```python file=snippets/build-dockerfile/main.py
-```
+<iframe class="embed" src="https://play.dagger.cloud/embed/xCI5LKiZfGD"></iframe>
 
 This code listing does the following:
 

--- a/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
+++ b/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
@@ -1,10 +1,10 @@
 ---
 slug: /429462/quickstart-build-dockerfile
-displayed_sidebar: "current"
+displayed_sidebar: "quickstart"
 hide_table_of_contents: true
 pagination_next: "current/quickstart/quickstart-conclusion"
 pagination_prev: "current/quickstart/quickstart-build-multi"
-pagination_label: "Wrap existing Dockerfiles with Dagger"
+title: "Wrap existing Dockerfiles with Dagger"
 ---
 
 # Quickstart

--- a/docs/current/quickstart/472910-quickstart-build-multi.mdx
+++ b/docs/current/quickstart/472910-quickstart-build-multi.mdx
@@ -29,8 +29,7 @@ Let's now update our pipeline to use a multi-stage build, as described above.
 <Tabs groupId="language">
 <TabItem value="Go">
 
-```go file=snippets/build-multi/main.go
-```
+<iframe class="embed" src="https://play.dagger.cloud/embed/q6Ieo7jNImX"></iframe>
 
 </TabItem>
 <TabItem value="Node.js">

--- a/docs/current/quickstart/472910-quickstart-build-multi.mdx
+++ b/docs/current/quickstart/472910-quickstart-build-multi.mdx
@@ -4,7 +4,7 @@ displayed_sidebar: "current"
 hide_table_of_contents: true
 pagination_next: "current/quickstart/quickstart-caching"
 pagination_prev: "current/quickstart/quickstart-publish"
-pagination_label: "Use a multi-stage build"
+pagination_label: "Perform a multi-stage build"
 ---
 
 # Quickstart
@@ -12,7 +12,7 @@ pagination_label: "Use a multi-stage build"
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-## Use a multi-stage build
+## Perform a multi-stage build
 
 Now that you have a working Dagger pipeline, let's refine and optimize it.
 
@@ -43,8 +43,7 @@ Let's now update our pipeline to use a multi-stage build, as described above.
 </TabItem>
 <TabItem value="Python">
 
-```python file=snippets/build-multi/main.py
-```
+<iframe class="embed" src="https://play.dagger.cloud/embed/tqaPp2aVr_L"></iframe>
 
 </TabItem>
 </Tabs>

--- a/docs/current/quickstart/472910-quickstart-build-multi.mdx
+++ b/docs/current/quickstart/472910-quickstart-build-multi.mdx
@@ -36,9 +36,7 @@ Let's now update our pipeline to use a multi-stage build, as described above.
 </TabItem>
 <TabItem value="Node.js">
 
-
-```javascript file=snippets/build-multi/index.mjs
-```
+<iframe class="embed" src="https://play.dagger.cloud/embed/aPB-msb5UEn"></iframe>
 
 </TabItem>
 <TabItem value="Python">

--- a/docs/current/quickstart/472910-quickstart-build-multi.mdx
+++ b/docs/current/quickstart/472910-quickstart-build-multi.mdx
@@ -11,7 +11,6 @@ pagination_label: "Use a multi-stage build"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import Button from "@site/src/components/atoms/button.js";
 
 ## Use a multi-stage build
 

--- a/docs/current/quickstart/472910-quickstart-build-multi.mdx
+++ b/docs/current/quickstart/472910-quickstart-build-multi.mdx
@@ -4,7 +4,7 @@ displayed_sidebar: "current"
 hide_table_of_contents: true
 pagination_next: "current/quickstart/quickstart-caching"
 pagination_prev: "current/quickstart/quickstart-publish"
-pagination_label: "Multi-stage build"
+pagination_label: "Use a multi-stage build"
 ---
 
 # Quickstart
@@ -13,7 +13,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import Button from "@site/src/components/atoms/button.js";
 
-## Be more efficient: Use a multi-stage build
+## Use a multi-stage build
 
 Now that you have a working Dagger pipeline, let's refine and optimize it.
 

--- a/docs/current/quickstart/472910-quickstart-build-multi.mdx
+++ b/docs/current/quickstart/472910-quickstart-build-multi.mdx
@@ -2,6 +2,9 @@
 slug: /472910/quickstart-build-multi
 displayed_sidebar: "current"
 hide_table_of_contents: true
+pagination_next: "current/quickstart/quickstart-caching"
+pagination_prev: "current/quickstart/quickstart-publish"
+pagination_label: "Multi-stage build"
 ---
 
 # Quickstart
@@ -51,7 +54,3 @@ This revised pipeline produces the same result as before, but using a two-stage 
 
 - In the first stage, the pipeline installs dependencies, runs tests and builds the application in the `node:16-slim` container. However, instead of exporting the `build/` directory to the host, it saves the corresponding `Directory` object as a constant. This object represents the filesystem state of the `build/` directory in the container after the build, and is portable to other Dagger pipelines.
 - In the second stage, the pipeline uses the saved `Directory` object as input, thereby transferring the filesystem state (the built React application) to the `nginx:alpine` container. It then publishes the result to a registry as previously described.
-
-<Button label="Back" docPath="730264/quickstart-publish" />
-
-<Button label="Next" docPath="635927/quickstart-caching" />

--- a/docs/current/quickstart/472910-quickstart-build-multi.mdx
+++ b/docs/current/quickstart/472910-quickstart-build-multi.mdx
@@ -32,7 +32,7 @@ Let's now update our pipeline to use a multi-stage build, as described above.
 <Tabs groupId="language">
 <TabItem value="Go">
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/q6Ieo7jNImX"></iframe>
+<iframe class="embed" src="https://play.dagger.cloud/embed/ho4ZF-6naKv"></iframe>
 
 </TabItem>
 <TabItem value="Node.js">

--- a/docs/current/quickstart/472910-quickstart-build-multi.mdx
+++ b/docs/current/quickstart/472910-quickstart-build-multi.mdx
@@ -1,0 +1,55 @@
+---
+slug: /472910/quickstart-build-multi
+displayed_sidebar: "current"
+hide_table_of_contents: true
+---
+
+# Quickstart
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import Button from "@site/src/components/atoms/button.js";
+
+## Be more efficient: Use a multi-stage build
+
+Now that you have a working Dagger pipeline, let's refine and optimize it.
+
+You may have noticed that the previous listing exported the build artifacts to a directory on the host, and then copied them to a directory in the destination container. While this works, a more efficient approach is to use a multi-stage build...something that Dagger, by virtue of its design, excels at.
+
+This is because Dagger SDK objects like `Container` and `Directory` can be thought of as collections of state. You can save this state and reference it elsewhere (even in a different Dagger pipeline or engine). You can also update the state from the point you left off, or use it an input to another operation.
+
+In the context of a multi-stage build, this means that you can use Dagger to:
+- Perform a build in a container.
+- Obtain and save a `Directory` object referencing the filesystem state of that container (including the build artifacts) after the build.
+- Pass the saved `Directory` object as a parameter to a different container or pipeline, thereby transferring the saved filesystem state (and build artifacts) to that container or pipeline.
+- Perform further container or pipeline operations as needed.
+
+Let's now update our pipeline to use a multi-stage build, as described above.
+
+<Tabs groupId="language">
+<TabItem value="Go">
+
+```go file=snippets/build-multi/main.go
+```
+
+</TabItem>
+<TabItem value="Node.js">
+
+
+```javascript file=snippets/build-multi/index.mjs
+```
+
+</TabItem>
+<TabItem value="Python">
+TODO
+</TabItem>
+</Tabs>
+
+This revised pipeline produces the same result as before, but using a two-stage process:
+
+- In the first stage, the pipeline installs dependencies, runs tests and builds the application in the `node:16-slim` container. However, instead of exporting the `build/` directory to the host, it saves the corresponding `Directory` object as a constant. This object represents the filesystem state of the `build/` directory in the container after the build, and is portable to other Dagger pipelines.
+- In the second stage, the pipeline uses the saved `Directory` object as input, thereby transferring the filesystem state (the built React application) to the `nginx:alpine` container. It then publishes the result to a registry as previously described.
+
+<Button label="Back" docPath="730264/quickstart-publish" />
+
+<Button label="Next" docPath="635927/quickstart-caching" />

--- a/docs/current/quickstart/472910-quickstart-build-multi.mdx
+++ b/docs/current/quickstart/472910-quickstart-build-multi.mdx
@@ -1,10 +1,10 @@
 ---
 slug: /472910/quickstart-build-multi
-displayed_sidebar: "current"
+displayed_sidebar: "quickstart"
 hide_table_of_contents: true
 pagination_next: "current/quickstart/quickstart-caching"
 pagination_prev: "current/quickstart/quickstart-publish"
-pagination_label: "Perform a multi-stage build"
+title: "Perform a multi-stage build"
 ---
 
 # Quickstart

--- a/docs/current/quickstart/472910-quickstart-build-multi.mdx
+++ b/docs/current/quickstart/472910-quickstart-build-multi.mdx
@@ -40,7 +40,10 @@ Let's now update our pipeline to use a multi-stage build, as described above.
 
 </TabItem>
 <TabItem value="Python">
-TODO
+
+```python file=snippets/build-multi/main.py
+```
+
 </TabItem>
 </Tabs>
 

--- a/docs/current/quickstart/481031-quickstart-conclusion.mdx
+++ b/docs/current/quickstart/481031-quickstart-conclusion.mdx
@@ -2,6 +2,8 @@
 slug: /481031/quickstart-conclusion
 displayed_sidebar: "current"
 hide_table_of_contents: true
+pagination_prev: "current/quickstart/quickstart-build-dockerfile"
+pagination_label: "Conclusion"
 ---
 
 # Quickstart
@@ -21,5 +23,3 @@ Contine your journey with Dagger by visiting the links below:
 - Reference documentation for the [Go](https://pkg.go.dev/dagger.io/dagger), [Node.js](../sdk/nodejs/reference/modules.md) and [Python](https://dagger-io.readthedocs.org/) SDKs
 - GraphQL [API Playground](../api/282105-playground.md)
 - [FAQ](../162770-faq.md)
-
-<Button label="Back" docPath="635927/quickstart-caching" />

--- a/docs/current/quickstart/481031-quickstart-conclusion.mdx
+++ b/docs/current/quickstart/481031-quickstart-conclusion.mdx
@@ -1,9 +1,9 @@
 ---
 slug: /481031/quickstart-conclusion
-displayed_sidebar: "current"
+displayed_sidebar: "quickstart"
 hide_table_of_contents: true
 pagination_prev: "current/quickstart/quickstart-build-dockerfile"
-pagination_label: "Conclusion"
+title: "Conclusion"
 ---
 
 # Quickstart

--- a/docs/current/quickstart/481031-quickstart-conclusion.mdx
+++ b/docs/current/quickstart/481031-quickstart-conclusion.mdx
@@ -1,0 +1,25 @@
+---
+slug: /481031/quickstart-conclusion
+displayed_sidebar: "current"
+hide_table_of_contents: true
+---
+
+# Quickstart
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import Button from "@site/src/components/atoms/button.js";
+
+## Conclusion
+
+Over the last few pages, this tutorial has walked you, step by step, through the process of creating and refining a CI pipeline to test, build and publish an example application with a Dagger SDK.
+
+Contine your journey with Dagger by visiting the links below:
+
+- GraphQL API [concepts](../api/975146-concepts.md) and [reference documentation](https://docs.dagger.io/api/reference)
+- Language-specific guides for [Go](../sdk/go/275922-guides.md), [Node.js](../sdk/nodejs/947203-guides.md) and [Python](../sdk/python/234291-guides.md)
+- Reference documentation for the [Go](https://pkg.go.dev/dagger.io/dagger), [Node.js](../sdk/nodejs/reference/modules.md) and [Python](https://dagger-io.readthedocs.org/) SDKs
+- GraphQL [API Playground](../api/282105-playground.md)
+- [FAQ](../162770-faq.md)
+
+<Button label="Back" docPath="635927/quickstart-caching" />

--- a/docs/current/quickstart/481031-quickstart-conclusion.mdx
+++ b/docs/current/quickstart/481031-quickstart-conclusion.mdx
@@ -10,7 +10,6 @@ pagination_label: "Conclusion"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import Button from "@site/src/components/atoms/button.js";
 
 ## Conclusion
 

--- a/docs/current/quickstart/593914-quickstart-hello.mdx
+++ b/docs/current/quickstart/593914-quickstart-hello.mdx
@@ -1,10 +1,10 @@
 ---
 slug: /593914/quickstart-hello
-displayed_sidebar: "current"
+displayed_sidebar: "quickstart"
 hide_table_of_contents: true
 pagination_next: "current/quickstart/quickstart-test"
 pagination_prev: "current/quickstart/quickstart-sdk"
-pagination_label: "Write your first Dagger pipeline"
+title: "Write your first Dagger pipeline"
 ---
 
 # Quickstart

--- a/docs/current/quickstart/593914-quickstart-hello.mdx
+++ b/docs/current/quickstart/593914-quickstart-hello.mdx
@@ -73,7 +73,31 @@ Hello from Dagger and Node v16.18.1
 
 </TabItem>
 <TabItem value="Python">
-TODO
+
+In the `ci` directory, create a new file named `main.py` and add the following code to it.
+
+```python file=snippets/hello/main.py
+```
+
+This Python script imports the Dagger SDK and defines an asynchronous function. This function performs the following operations:
+
+- It creates a Dagger client with `with dagger.Connection()`. This client provides an interface for executing commands against the Dagger engine.
+- It uses the client's `container().from_()` method to initialize a new container from a base image. In this example, the base image is the `python:3.11-slim` image. This method returns a `Container` representing an OCI-compatible container image.
+- It uses the `Container.with_exec()` method to define the command to be executed in the container - in this case, the command `python -V`, which returns the Python version string. The `with_exec()` method returns a revised `Container` with the results of command execution.
+- It retrieves the output stream of the last executed with the `Container.stdout()` method and prints the result to the console.
+
+Run the pipeline by executing the command below from the application directory:
+
+```shell
+python ci/main.py
+```
+
+Dagger resolves the pipeline and outputs a string similar to the one below.
+
+```shell
+Hello from Dagger and Python v3.11.1
+```
+
 </TabItem>
 </Tabs>
 

--- a/docs/current/quickstart/593914-quickstart-hello.mdx
+++ b/docs/current/quickstart/593914-quickstart-hello.mdx
@@ -45,8 +45,7 @@ Install the Dagger SDK
 
 In the `ci` directory, create a new file named `index.mjs` and add the following code to it.
 
-```javascript file=snippets/hello/index.mjs
-```
+<iframe class="embed" src="https://play.dagger.cloud/embed/USkiC0wbQ5k"></iframe>
 
 This Node.js script imports the Dagger SDK and defines an asynchronous function. This function performs the following operations:
 

--- a/docs/current/quickstart/593914-quickstart-hello.mdx
+++ b/docs/current/quickstart/593914-quickstart-hello.mdx
@@ -11,7 +11,6 @@ pagination_label: "Write your first Dagger pipeline"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import Button from "@site/src/components/atoms/button.js";
 
 ## Write your first Dagger pipeline
 

--- a/docs/current/quickstart/593914-quickstart-hello.mdx
+++ b/docs/current/quickstart/593914-quickstart-hello.mdx
@@ -28,7 +28,7 @@ In the `ci` directory, create a file named `main.go` and add the following code 
 This Go program imports the Dagger SDK and defines a `main()` function for the pipeline operations. This function performs the following operations:
 
 - It creates a Dagger client with `dagger.Connect()`. This client provides an interface for executing commands against the Dagger engine.
-- It uses the client's `Container().From()` method to initialize a new container from a base image. In this example, the base image is the `golang:1.19` image. This method returns a `Container` representing an OCI-compatible container image.
+- It uses the client's `Container().From()` method to initialize a new container from a base image. In this example, the base image is `golang:1.19`. This method returns a `Container` representing an OCI-compatible container image.
 - It uses the `Container.withExec()` method to define the command to be executed in the container - in this case, the command `go version`, which returns the Go version string. The `withExec()` method returns a revised `Container` with the results of command execution.
 - It retrieves the output stream of the last executed with the `Container.Stdout()` method and prints the result to the console.
 
@@ -51,7 +51,7 @@ In the `ci` directory, create a new file named `index.mjs` and add the following
 This Node.js script imports the Dagger SDK and defines an asynchronous function. This function performs the following operations:
 
 - It creates a Dagger client with `connect()`. This client provides an interface for executing commands against the Dagger engine.
-- It uses the client's `container().from()` method to initialize a new container from a base image. In this example, the base image is the `node:16-slim` image. This method returns a `Container` representing an OCI-compatible container image.
+- It uses the client's `container().from()` method to initialize a new container from a base image. In this example, the base image is `node:16-slim`. This method returns a `Container` representing an OCI-compatible container image.
 - It uses the `Container.withExec()` method to define the command to be executed in the container - in this case, the command `node -v`, which returns the Node version string. The `withExec()` method returns a revised `Container` with the results of command execution.
 - It retrieves the output stream of the last executed with the `Container.stdout()` method and prints the result to the console.
 
@@ -77,7 +77,7 @@ In the `ci` directory, create a new file named `main.py` and add the following c
 This Python script imports the Dagger SDK and defines an asynchronous function. This function performs the following operations:
 
 - It creates a Dagger client with `with dagger.Connection()`. This client provides an interface for executing commands against the Dagger engine.
-- It uses the client's `container().from_()` method to initialize a new container from a base image. In this example, the base image is the `python:3.11-slim` image. This method returns a `Container` representing an OCI-compatible container image.
+- It uses the client's `container().from_()` method to initialize a new container from a base image. In this example, the base image is `python:3.11-slim`. This method returns a `Container` representing an OCI-compatible container image.
 - It uses the `Container.with_exec()` method to define the command to be executed in the container - in this case, the command `python -V`, which returns the Python version string. The `with_exec()` method returns a revised `Container` with the results of command execution.
 - It retrieves the output stream of the last executed with the `Container.stdout()` method and prints the result to the console.
 

--- a/docs/current/quickstart/593914-quickstart-hello.mdx
+++ b/docs/current/quickstart/593914-quickstart-hello.mdx
@@ -2,7 +2,9 @@
 slug: /593914/quickstart-hello
 displayed_sidebar: "current"
 hide_table_of_contents: true
-wrappedClassName: juli-crack
+pagination_next: "current/quickstart/quickstart-test"
+pagination_prev: "current/quickstart/quickstart-sdk"
+pagination_label: "Hello"
 ---
 
 # Quickstart
@@ -102,7 +104,3 @@ Hello from Dagger and Python v3.11.1
 </Tabs>
 
 Well done! You've just successfully written and run your first Dagger pipeline!
-
-<Button label="Back" docPath="628381/quickstart-sdk" />
-
-<Button label="Next" docPath="947391/quickstart-test" />

--- a/docs/current/quickstart/593914-quickstart-hello.mdx
+++ b/docs/current/quickstart/593914-quickstart-hello.mdx
@@ -2,6 +2,7 @@
 slug: /593914/quickstart-hello
 displayed_sidebar: "current"
 hide_table_of_contents: true
+wrappedClassName: juli-crack
 ---
 
 # Quickstart
@@ -21,8 +22,8 @@ This first example is fairly simple: it creates a Dagger client using your chose
 
 In the `ci` directory, create a file named `main.go` and add the following code to it.
 
-```go file=snippets/hello/main.go
-```
+<iframe class="embed" src="https://play.dagger.cloud/embed/lGhP6fB2G2r"></iframe>
+
 
 This Go program imports the Dagger SDK and defines a `main()` function for the pipeline operations. This function performs the following operations:
 

--- a/docs/current/quickstart/593914-quickstart-hello.mdx
+++ b/docs/current/quickstart/593914-quickstart-hello.mdx
@@ -39,11 +39,7 @@ go run ci/main.go
 ```
 
 Dagger resolves the pipeline and outputs a string similar to the one below.
-
-```shell
-Hello from Dagger and go version go1.19.5 linux/amd64
-```
-
+Install the Dagger SDK
 </TabItem>
 <TabItem value="Node.js">
 
@@ -76,8 +72,7 @@ Hello from Dagger and Node v16.18.1
 
 In the `ci` directory, create a new file named `main.py` and add the following code to it.
 
-```python file=snippets/hello/main.py
-```
+<iframe class="embed" src="https://play.dagger.cloud/embed/FP6MBw_8qFm"></iframe>
 
 This Python script imports the Dagger SDK and defines an asynchronous function. This function performs the following operations:
 

--- a/docs/current/quickstart/593914-quickstart-hello.mdx
+++ b/docs/current/quickstart/593914-quickstart-hello.mdx
@@ -4,7 +4,7 @@ displayed_sidebar: "current"
 hide_table_of_contents: true
 pagination_next: "current/quickstart/quickstart-test"
 pagination_prev: "current/quickstart/quickstart-sdk"
-pagination_label: "Hello"
+pagination_label: "Write your first Dagger pipeline"
 ---
 
 # Quickstart
@@ -25,7 +25,6 @@ This first example is fairly simple: it creates a Dagger client using your chose
 In the `ci` directory, create a file named `main.go` and add the following code to it.
 
 <iframe class="embed" src="https://play.dagger.cloud/embed/lGhP6fB2G2r"></iframe>
-
 
 This Go program imports the Dagger SDK and defines a `main()` function for the pipeline operations. This function performs the following operations:
 

--- a/docs/current/quickstart/593914-quickstart-hello.mdx
+++ b/docs/current/quickstart/593914-quickstart-hello.mdx
@@ -1,0 +1,83 @@
+---
+slug: /593914/quickstart-hello
+displayed_sidebar: "current"
+hide_table_of_contents: true
+---
+
+# Quickstart
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import Button from "@site/src/components/atoms/button.js";
+
+## Write your first Dagger pipeline
+
+You're now ready to dive into Dagger and write your first pipeline!
+
+This first example is fairly simple: it creates a Dagger client using your chosen SDK, initializes a container, executes a command in that container and prints the output.
+
+<Tabs groupId="language">
+<TabItem value="Go">
+
+In the `ci` directory, create a file named `main.go` and add the following code to it.
+
+```go file=snippets/hello/main.go
+```
+
+This Go program imports the Dagger SDK and defines a `main()` function for the pipeline operations. This function performs the following operations:
+
+- It creates a Dagger client with `dagger.Connect()`. This client provides an interface for executing commands against the Dagger engine.
+- It uses the client's `Container().From()` method to initialize a new container from a base image. In this example, the base image is the `golang:1.19` image. This method returns a `Container` representing an OCI-compatible container image.
+- It uses the `Container.withExec()` method to define the command to be executed in the container - in this case, the command `go version`, which returns the Go version string. The `withExec()` method returns a revised `Container` with the results of command execution.
+- It retrieves the output stream of the last executed with the `Container.Stdout()` method and prints the result to the console.
+
+Run the pipeline by executing the command below from the application directory:
+
+```shell
+go run ci/main.go
+```
+
+Dagger resolves the pipeline and outputs a string similar to the one below.
+
+```shell
+Hello from Dagger and go version go1.19.5 linux/amd64
+```
+
+</TabItem>
+<TabItem value="Node.js">
+
+In the `ci` directory, create a new file named `index.mjs` and add the following code to it.
+
+```javascript file=snippets/hello/index.mjs
+```
+
+This Node.js script imports the Dagger SDK and defines an asynchronous function. This function performs the following operations:
+
+- It creates a Dagger client with `connect()`. This client provides an interface for executing commands against the Dagger engine.
+- It uses the client's `container().from()` method to initialize a new container from a base image. In this example, the base image is the `node:16-slim` image. This method returns a `Container` representing an OCI-compatible container image.
+- It uses the `Container.withExec()` method to define the command to be executed in the container - in this case, the command `node -v`, which returns the Node version string. The `withExec()` method returns a revised `Container` with the results of command execution.
+- It retrieves the output stream of the last executed with the `Container.stdout()` method and prints the result to the console.
+
+Run the pipeline by executing the command below from the application directory:
+
+```shell
+node ci/index.mjs
+```
+
+Dagger resolves the pipeline and outputs a string similar to the one below.
+
+```shell
+Hello from Dagger and Node v16.18.1
+```
+
+</TabItem>
+<TabItem value="Python">
+TODO
+</TabItem>
+</Tabs>
+
+Well done! You've just successfully written and run your first Dagger pipeline!
+
+<Button label="Back" docPath="628381/quickstart-sdk" />
+
+<Button label="Next" docPath="947391/quickstart-test" />

--- a/docs/current/quickstart/628381-quickstart-sdk.mdx
+++ b/docs/current/quickstart/628381-quickstart-sdk.mdx
@@ -50,7 +50,15 @@ yarn add @dagger.io/dagger --dev
 </TabItem>
 <TabItem value="Python">
 
-TODO
+:::note
+The Dagger Python SDK requires [Python 3.10 or later](https://docs.python.org/3/using/index.html). Using a [virtual environment](https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments) is recommended.
+:::
+
+In the `ci` directory, install the Dagger Python SDK using `pip`:
+
+```shell
+pip install dagger-io
+```
 
 </TabItem>
 </Tabs>

--- a/docs/current/quickstart/628381-quickstart-sdk.mdx
+++ b/docs/current/quickstart/628381-quickstart-sdk.mdx
@@ -4,7 +4,7 @@ displayed_sidebar: "current"
 hide_table_of_contents: true
 pagination_next: "current/quickstart/quickstart-hello"
 pagination_prev: "current/quickstart/quickstart-setup"
-pagination_label: "SDK"
+pagination_label: "Install the Dagger SDK"
 ---
 
 # Quickstart

--- a/docs/current/quickstart/628381-quickstart-sdk.mdx
+++ b/docs/current/quickstart/628381-quickstart-sdk.mdx
@@ -11,7 +11,6 @@ pagination_label: "Install the Dagger SDK"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import Button from "@site/src/components/atoms/button.js";
 
 ## Install the Dagger SDK
 

--- a/docs/current/quickstart/628381-quickstart-sdk.mdx
+++ b/docs/current/quickstart/628381-quickstart-sdk.mdx
@@ -1,0 +1,60 @@
+---
+slug: /628381/quickstart-sdk
+displayed_sidebar: "current"
+hide_table_of_contents: true
+---
+
+# Quickstart
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import Button from "@site/src/components/atoms/button.js";
+
+## Install the Dagger SDK
+
+The next step is to install the Dagger SDK for your preferred language. Select from the options below.
+
+<Tabs groupId="language">
+<TabItem value="Go">
+
+:::note
+The Dagger Go SDK requires [Go 1.15 or later](https://go.dev/doc/install).
+:::
+
+In the `ci` directory, create a new Go module and install the Dagger Go SDK using the commands below:
+
+```shell
+go mod init main
+go get dagger.io/dagger@latest
+```
+
+</TabItem>
+<TabItem value="Node.js">
+
+:::note
+The Dagger Node.js SDK requires [Node.js 16.x or later](https://nodejs.org/en/download/).
+:::
+
+In the `ci` directory, install the Dagger Node.js SDK using `npm`:
+
+```shell
+npm install @dagger.io/dagger@latest --save-dev
+```
+
+You can also install it using `yarn` if you prefer:
+
+```shell
+yarn add @dagger.io/dagger --dev
+```
+
+</TabItem>
+<TabItem value="Python">
+
+TODO
+
+</TabItem>
+</Tabs>
+
+<Button label="Back" docPath="120918/quickstart-setup" />
+
+<Button label="Next" docPath="593914/quickstart-hello" />

--- a/docs/current/quickstart/628381-quickstart-sdk.mdx
+++ b/docs/current/quickstart/628381-quickstart-sdk.mdx
@@ -1,10 +1,10 @@
 ---
 slug: /628381/quickstart-sdk
-displayed_sidebar: "current"
+displayed_sidebar: "quickstart"
 hide_table_of_contents: true
 pagination_next: "current/quickstart/quickstart-hello"
 pagination_prev: "current/quickstart/quickstart-setup"
-pagination_label: "Install the Dagger SDK"
+title: "Install the Dagger SDK"
 ---
 
 # Quickstart

--- a/docs/current/quickstart/628381-quickstart-sdk.mdx
+++ b/docs/current/quickstart/628381-quickstart-sdk.mdx
@@ -2,6 +2,9 @@
 slug: /628381/quickstart-sdk
 displayed_sidebar: "current"
 hide_table_of_contents: true
+pagination_next: "current/quickstart/quickstart-hello"
+pagination_prev: "current/quickstart/quickstart-setup"
+pagination_label: "SDK"
 ---
 
 # Quickstart
@@ -62,7 +65,3 @@ pip install dagger-io
 
 </TabItem>
 </Tabs>
-
-<Button label="Back" docPath="120918/quickstart-setup" />
-
-<Button label="Next" docPath="593914/quickstart-hello" />

--- a/docs/current/quickstart/628381-quickstart-sdk.mdx
+++ b/docs/current/quickstart/628381-quickstart-sdk.mdx
@@ -46,7 +46,7 @@ npm install @dagger.io/dagger@latest --save-dev
 You can also install it using `yarn` if you prefer:
 
 ```shell
-yarn add @dagger.io/dagger --dev
+yarn add @dagger.io/dagger@latest --dev
 ```
 
 </TabItem>

--- a/docs/current/quickstart/635927-quickstart-caching.mdx
+++ b/docs/current/quickstart/635927-quickstart-caching.mdx
@@ -4,7 +4,7 @@ displayed_sidebar: "current"
 hide_table_of_contents: true
 pagination_next: "current/quickstart/quickstart-build-dockerfile"
 pagination_prev: "current/quickstart/quickstart-build-multi"
-pagination_label: "Caching"
+pagination_label: "Use caching"
 ---
 
 # Quickstart
@@ -13,7 +13,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import Button from "@site/src/components/atoms/button.js";
 
-## Go faster: Use a cache
+## Use caching
 
 One of Dagger's most powerful features is its ability to cache data across pipeline runs. Dagger lets you define one or more directories as cache volume and persists their contents across runs. This enables you to reuse the contents of the cache every time the pipeline runs, and thereby speed up pipeline operations.
 
@@ -61,4 +61,3 @@ This revised pipeline produces the same result as before, but now uses a cache f
 </Tabs>
 
 Run the pipeline a few times. Notice that on the first run, the application dependencies are downloaded as usual. However, since the dependencies are cached, subsequent pipeline runs will skip the download operation and be significantly faster (assuming that there are no other changes to the application code).
-

--- a/docs/current/quickstart/635927-quickstart-caching.mdx
+++ b/docs/current/quickstart/635927-quickstart-caching.mdx
@@ -34,9 +34,7 @@ This revised pipeline produces the same result as before, but now uses a cache f
 </TabItem>
 <TabItem value="Node.js">
 
-
-```javascript file=snippets/caching/index.mjs
-```
+<iframe class="embed" src="https://play.dagger.cloud/embed/5L9pFphXK2l"></iframe>
 
 This revised pipeline produces the same result as before, but now uses a cache for the application dependencies.
 

--- a/docs/current/quickstart/635927-quickstart-caching.mdx
+++ b/docs/current/quickstart/635927-quickstart-caching.mdx
@@ -1,0 +1,56 @@
+---
+slug: /635927/quickstart-caching
+displayed_sidebar: "current"
+hide_table_of_contents: true
+---
+
+# Quickstart
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import Button from "@site/src/components/atoms/button.js";
+
+## Go faster: Use a cache
+
+One of Dagger's most powerful features is its ability to cache data across pipeline runs. Dagger lets you define one or more directories as cache volume and persists their contents across runs. This enables you to reuse the contents of the cache every time the pipeline runs, and thereby speed up pipeline operations.
+
+You may have noticed that the example pipeline executes the `npm install` command to download the application's dependencies every time the pipeline runs. Since these dependencies are usually locked to specific versions in the application's manifest, re-downloading them on every pipeline run is inefficient and time-consuming.
+
+This step is, therefore, a good candidate for a cache. Let's update the pipeline accordingly.
+
+<Tabs groupId="language">
+<TabItem value="Go">
+
+```go file=snippets/caching/main.go
+```
+
+This revised pipeline produces the same result as before, but now uses a cache for the application dependencies.
+
+- It uses the client's `CacheVolume()` method to initialize a new cache volume.
+- It uses the `Container.WithMountedCache()` method to mount this cache volume at the `node_modules/` mount point in the container.
+- It uses the `Container.WithExec()` method to define the `npm install` command. When executed, this command downloads and installs dependencies in the `node_modules/` directory. Since this directory is defined as a cache volume, its contents will persist even after the pipeline terminates and can be reused on the next pipeline run.
+
+</TabItem>
+<TabItem value="Node.js">
+
+
+```javascript file=snippets/caching/index.mjs
+```
+
+This revised pipeline produces the same result as before, but now uses a cache for the application dependencies.
+
+- It uses the client's `cacheVolume()` method to initialize a new cache volume.
+- It uses the `Container.withMountedCache()` method to mount this cache volume at the `node_modules/` mount point in the container.
+- It uses the `Container.withExec()` method to define the `npm install` command. When executed, this command downloads and installs dependencies in the `node_modules/` directory. Since this directory is defined as a cache volume, its contents will persist even after the pipeline terminates and can be reused on the next pipeline run.
+
+</TabItem>
+<TabItem value="Python">
+TODO
+</TabItem>
+</Tabs>
+
+Run the pipeline a few times. Notice that on the first run, the application dependencies are downloaded as usual. However, since the dependencies are cached, subsequent pipeline runs will skip the download operation and be significantly faster (assuming that there are no other changes to the application code).
+
+<Button label="Back" docPath="472910/quickstart-build-multi" />
+
+<Button label="Next" docPath="429462/quickstart-build-dockerfile" />

--- a/docs/current/quickstart/635927-quickstart-caching.mdx
+++ b/docs/current/quickstart/635927-quickstart-caching.mdx
@@ -1,10 +1,10 @@
 ---
 slug: /635927/quickstart-caching
-displayed_sidebar: "current"
+displayed_sidebar: "quickstart"
 hide_table_of_contents: true
 pagination_next: "current/quickstart/quickstart-build-dockerfile"
 pagination_prev: "current/quickstart/quickstart-build-multi"
-pagination_label: "Use caching"
+title: "Use caching"
 ---
 
 # Quickstart

--- a/docs/current/quickstart/635927-quickstart-caching.mdx
+++ b/docs/current/quickstart/635927-quickstart-caching.mdx
@@ -47,8 +47,7 @@ This revised pipeline produces the same result as before, but now uses a cache f
 </TabItem>
 <TabItem value="Python">
 
-```python file=snippets/caching/main.py
-```
+<iframe class="embed" src="https://play.dagger.cloud/embed/bnNET0xDiBl"></iframe>
 
 This revised pipeline produces the same result as before, but now uses a cache for the application dependencies.
 

--- a/docs/current/quickstart/635927-quickstart-caching.mdx
+++ b/docs/current/quickstart/635927-quickstart-caching.mdx
@@ -24,7 +24,7 @@ This step is, therefore, a good candidate for a cache. Let's update the pipeline
 <Tabs groupId="language">
 <TabItem value="Go">
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/q6Ieo7jNImX"></iframe>
+<iframe class="embed" src="https://play.dagger.cloud/embed/2va_6z_3JtB"></iframe>
 
 This revised pipeline produces the same result as before, but now uses a cache for the application dependencies.
 

--- a/docs/current/quickstart/635927-quickstart-caching.mdx
+++ b/docs/current/quickstart/635927-quickstart-caching.mdx
@@ -44,7 +44,16 @@ This revised pipeline produces the same result as before, but now uses a cache f
 
 </TabItem>
 <TabItem value="Python">
-TODO
+
+```python file=snippets/caching/main.py
+```
+
+This revised pipeline produces the same result as before, but now uses a cache for the application dependencies.
+
+- It uses the client's `cache_volume()` method to initialize a new cache volume.
+- It uses the `Container.with_mounted_cache()` method to mount this cache volume at the `node_modules/` mount point in the container.
+- It uses the `Container.with_exec()` method to define the `npm install` command. When executed, this command downloads and installs dependencies in the `node_modules/` directory. Since this directory is defined as a cache volume, its contents will persist even after the pipeline terminates and can be reused on the next pipeline run.
+
 </TabItem>
 </Tabs>
 

--- a/docs/current/quickstart/635927-quickstart-caching.mdx
+++ b/docs/current/quickstart/635927-quickstart-caching.mdx
@@ -2,6 +2,9 @@
 slug: /635927/quickstart-caching
 displayed_sidebar: "current"
 hide_table_of_contents: true
+pagination_next: "current/quickstart/quickstart-build-dockerfile"
+pagination_prev: "current/quickstart/quickstart-build-multi"
+pagination_label: "Caching"
 ---
 
 # Quickstart
@@ -59,6 +62,3 @@ This revised pipeline produces the same result as before, but now uses a cache f
 
 Run the pipeline a few times. Notice that on the first run, the application dependencies are downloaded as usual. However, since the dependencies are cached, subsequent pipeline runs will skip the download operation and be significantly faster (assuming that there are no other changes to the application code).
 
-<Button label="Back" docPath="472910/quickstart-build-multi" />
-
-<Button label="Next" docPath="429462/quickstart-build-dockerfile" />

--- a/docs/current/quickstart/635927-quickstart-caching.mdx
+++ b/docs/current/quickstart/635927-quickstart-caching.mdx
@@ -21,8 +21,7 @@ This step is, therefore, a good candidate for a cache. Let's update the pipeline
 <Tabs groupId="language">
 <TabItem value="Go">
 
-```go file=snippets/caching/main.go
-```
+<iframe class="embed" src="https://play.dagger.cloud/embed/q6Ieo7jNImX"></iframe>
 
 This revised pipeline produces the same result as before, but now uses a cache for the application dependencies.
 

--- a/docs/current/quickstart/635927-quickstart-caching.mdx
+++ b/docs/current/quickstart/635927-quickstart-caching.mdx
@@ -11,7 +11,6 @@ pagination_label: "Use caching"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import Button from "@site/src/components/atoms/button.js";
 
 ## Use caching
 

--- a/docs/current/quickstart/648215-quickstart-introduction.mdx
+++ b/docs/current/quickstart/648215-quickstart-introduction.mdx
@@ -2,7 +2,8 @@
 slug: /648215/quickstart
 hide_table_of_contents: true
 pagination_next: "current/quickstart/quickstart-basics"
-pagination_label: "Introduction"
+title: "Introduction"
+displayed_sidebar: "quickstart"
 ---
 
 # Quickstart

--- a/docs/current/quickstart/648215-quickstart-introduction.mdx
+++ b/docs/current/quickstart/648215-quickstart-introduction.mdx
@@ -1,0 +1,42 @@
+---
+slug: /648215/quickstart
+hide_table_of_contents: true
+---
+
+# Quickstart
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import Button from "@site/src/components/atoms/button.js";
+
+## Introduction
+
+Welcome to Dagger, a programmable CI/CD engine that runs your pipelines in containers.
+
+This tutorial introduces you to Dagger and the "Dagger way" of building portable CI pipelines.
+
+It walks you, step by step, through the process of creating and refining a CI pipeline to test, build and publish an example application with a Dagger SDK.
+
+## What you will learn
+
+In this tutorial, you will learn how to:
+
+- Install the Dagger SDK for your preferred language
+- Create a Dagger client using the SDK
+- Create a simple Dagger pipeline to understand the basics of Dagger
+- Create a more complex Dagger pipeline to test and build an application
+- Improve the Dagger pipeline to containerize and publish the application to a registry
+- Optimize the Dagger pipeline with caching and multi-stage builds
+- Use your existing Dockerfiles with Dagger
+
+## Requirements
+
+You can use this tutorial in two ways:
+
+- You can download the example application to your local development environment, and then copy and run the code snippets on your host system.
+  - This option requires [Docker](https://docs.docker.com/engine/install/) and [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) on your host system.
+
+- You can use our embedded API Playground to run the code snippets in your browser.
+  - The API Playground has the example application and SDKs pre-installed, so this option does not require any software to be downloaded or installed on your host system.
+
+<Button label="Next" docPath="319191/quickstart-basics" />

--- a/docs/current/quickstart/648215-quickstart-introduction.mdx
+++ b/docs/current/quickstart/648215-quickstart-introduction.mdx
@@ -42,5 +42,3 @@ You can use this tutorial in two ways:
   - The API Playground has the example application and SDKs pre-installed, so this option does not require any software to be downloaded or installed on your host system.
 
 <Button label="Next" docPath="319191/quickstart-basics" />
-
-<iframe src="https://play.dagger.cloud/embed/7g_LbYfUYG7" loading="eager"></iframe>

--- a/docs/current/quickstart/648215-quickstart-introduction.mdx
+++ b/docs/current/quickstart/648215-quickstart-introduction.mdx
@@ -40,3 +40,7 @@ You can use this tutorial in two ways:
 
 - You can use our embedded API Playground to run the code snippets in your browser.
   - The API Playground has the example application and SDKs pre-installed, so this option does not require any software to be downloaded or installed on your host system.
+
+<Button label="Next" docPath="319191/quickstart-basics" />
+
+<iframe src="https://play.dagger.cloud/embed/7g_LbYfUYG7" loading="eager"></iframe>

--- a/docs/current/quickstart/648215-quickstart-introduction.mdx
+++ b/docs/current/quickstart/648215-quickstart-introduction.mdx
@@ -1,6 +1,8 @@
 ---
 slug: /648215/quickstart
 hide_table_of_contents: true
+pagination_next: "current/quickstart/quickstart-basics"
+pagination_label: "Introduction"
 ---
 
 # Quickstart
@@ -39,4 +41,3 @@ You can use this tutorial in two ways:
 - You can use our embedded API Playground to run the code snippets in your browser.
   - The API Playground has the example application and SDKs pre-installed, so this option does not require any software to be downloaded or installed on your host system.
 
-<Button label="Next" docPath="319191/quickstart-basics" />

--- a/docs/current/quickstart/648215-quickstart-introduction.mdx
+++ b/docs/current/quickstart/648215-quickstart-introduction.mdx
@@ -9,7 +9,6 @@ pagination_label: "Introduction"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import Button from "@site/src/components/atoms/button.js";
 
 ## Introduction
 
@@ -40,4 +39,3 @@ You can use this tutorial in two ways:
 
 - You can use our embedded API Playground to run the code snippets in your browser.
   - The API Playground has the example application and SDKs pre-installed, so this option does not require any software to be downloaded or installed on your host system.
-

--- a/docs/current/quickstart/730264-quickstart-publish.mdx
+++ b/docs/current/quickstart/730264-quickstart-publish.mdx
@@ -1,10 +1,10 @@
 ---
 slug: /730264/quickstart-publish
-displayed_sidebar: "current"
+displayed_sidebar: "quickstart"
 hide_table_of_contents: true
 pagination_next: "current/quickstart/quickstart-build-multi"
 pagination_prev: "current/quickstart/quickstart-build"
-pagination_label: "Publish the application"
+title: "Publish the application"
 ---
 
 # Quickstart

--- a/docs/current/quickstart/730264-quickstart-publish.mdx
+++ b/docs/current/quickstart/730264-quickstart-publish.mdx
@@ -2,6 +2,9 @@
 slug: /730264/quickstart-publish
 displayed_sidebar: "current"
 hide_table_of_contents: true
+pagination_next: "current/quickstart/quickstart-build-multi"
+pagination_prev: "current/quickstart/quickstart-build"
+pagination_label: "Publish"
 ---
 
 # Quickstart
@@ -58,7 +61,3 @@ You may have noticed that the pipeline above is able to publish to the registry 
 
 Dagger SDKs rely on your existing Docker credentials for registry authentication. This means that you must execute `docker login` against your selected container registry on the Dagger host before attempting to publish an image to that registry.
 :::
-
-<Button label="Back" docPath="349011/quickstart-build" />
-
-<Button label="Next" docPath="472910/quickstart-build-multi" />

--- a/docs/current/quickstart/730264-quickstart-publish.mdx
+++ b/docs/current/quickstart/730264-quickstart-publish.mdx
@@ -19,8 +19,7 @@ Dagger SDKs can do this natively via their `publish()` method. So, let's update 
 <Tabs groupId="language">
 <TabItem value="Go">
 
-```go file=snippets/publish/main.go
-```
+<iframe class="embed" src="https://play.dagger.cloud/embed/464HvOQlZoK"></iframe>
 
 </TabItem>
 <TabItem value="Node.js">

--- a/docs/current/quickstart/730264-quickstart-publish.mdx
+++ b/docs/current/quickstart/730264-quickstart-publish.mdx
@@ -30,7 +30,10 @@ Dagger SDKs can do this natively via their `publish()` method. So, let's update 
 
 </TabItem>
 <TabItem value="Python">
-TODO
+
+```python file=snippets/publish/main.py
+```
+
 </TabItem>
 </Tabs>
 

--- a/docs/current/quickstart/730264-quickstart-publish.mdx
+++ b/docs/current/quickstart/730264-quickstart-publish.mdx
@@ -4,7 +4,7 @@ displayed_sidebar: "current"
 hide_table_of_contents: true
 pagination_next: "current/quickstart/quickstart-build-multi"
 pagination_prev: "current/quickstart/quickstart-build"
-pagination_label: "Publish"
+pagination_label: "Publish the application"
 ---
 
 # Quickstart
@@ -15,7 +15,7 @@ import Button from "@site/src/components/atoms/button.js";
 
 ## Publish the application
 
-At this point, your Dagger pipeline has tested, built and delivered the application to your local host. But why stop there? Why not also publish a container image of the application?
+At this point, your Dagger pipeline has tested, built and delivered the application to your local host. But why not also publish a container image of the application to a registry?
 
 Dagger SDKs can do this natively via their `publish()` method. So, let's update the pipeline to copy the built React application into an NGINX Web server container and deliver the result to a public registry.
 

--- a/docs/current/quickstart/730264-quickstart-publish.mdx
+++ b/docs/current/quickstart/730264-quickstart-publish.mdx
@@ -22,7 +22,7 @@ Dagger SDKs can do this natively via their `publish()` method. So, let's update 
 <Tabs groupId="language">
 <TabItem value="Go">
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/464HvOQlZoK"></iframe>
+<iframe class="embed" src="https://play.dagger.cloud/embed/hGUZKAeot5K"></iframe>
 
 </TabItem>
 <TabItem value="Node.js">

--- a/docs/current/quickstart/730264-quickstart-publish.mdx
+++ b/docs/current/quickstart/730264-quickstart-publish.mdx
@@ -16,7 +16,7 @@ import TabItem from "@theme/TabItem";
 
 At this point, your Dagger pipeline has tested, built and delivered the application to your local host. But why not also publish a container image of the application to a registry?
 
-Dagger SDKs can do this natively via their `publish()` method. So, let's update the pipeline to copy the built React application into an NGINX Web server container and deliver the result to a public registry.
+Dagger SDKs have built-in support to publish container images. So, let's update the pipeline to copy the built React application into an NGINX Web server container and deliver the result to a public registry. Depending on the SDK, you need either the `publish()` method (for Node.js and Python) or the `Publish()` method (for Go).
 
 <Tabs groupId="language">
 <TabItem value="Go">
@@ -26,9 +26,7 @@ Dagger SDKs can do this natively via their `publish()` method. So, let's update 
 </TabItem>
 <TabItem value="Node.js">
 
-
-```javascript file=snippets/publish/index.mjs
-```
+<iframe class="embed" src="https://play.dagger.cloud/embed/xlXjwXsjvGt"></iframe>
 
 </TabItem>
 <TabItem value="Python">

--- a/docs/current/quickstart/730264-quickstart-publish.mdx
+++ b/docs/current/quickstart/730264-quickstart-publish.mdx
@@ -11,7 +11,6 @@ pagination_label: "Publish the application"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import Button from "@site/src/components/atoms/button.js";
 
 ## Publish the application
 

--- a/docs/current/quickstart/730264-quickstart-publish.mdx
+++ b/docs/current/quickstart/730264-quickstart-publish.mdx
@@ -1,0 +1,62 @@
+---
+slug: /730264/quickstart-publish
+displayed_sidebar: "current"
+hide_table_of_contents: true
+---
+
+# Quickstart
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import Button from "@site/src/components/atoms/button.js";
+
+## Publish the application
+
+At this point, your Dagger pipeline has tested, built and delivered the application to your local host. But why stop there? Why not also publish a container image of the application?
+
+Dagger SDKs can do this natively via their `publish()` method. So, let's update the pipeline to copy the built React application into an NGINX Web server container and deliver the result to a public registry.
+
+<Tabs groupId="language">
+<TabItem value="Go">
+
+```go file=snippets/publish/main.go
+```
+
+</TabItem>
+<TabItem value="Node.js">
+
+
+```javascript file=snippets/publish/index.mjs
+```
+
+</TabItem>
+<TabItem value="Python">
+TODO
+</TabItem>
+</Tabs>
+
+This revised pipeline does everything described in the previous step, and then publishes the container to [ttl.sh](https://ttl.sh), an ephemeral Docker registry.
+
+To prevent name collisions, the container image name is suffixed with a random number, and printed to the console, as in the example output below:
+
+```shell
+Published image to: ttl.sh/hello-dagger-8724562@sha256:16b9344023b9bf1313fd111395a585e03bea13eff8a171616f202c0e9dbb219a
+```
+
+After Dagger resolves the pipeline, the newly-built container image will be available in the [ttl.sh](https://ttl.sh) registry. Download and test it using the command below (update the container image name as per the output of the pipeline):
+
+```shell
+docker run -p 8080:80 ttl.sh/hello-dagger-8724562@sha256:16b9344023b9bf1313fd111395a585e03bea13eff8a171616f202c0e9dbb219a
+```
+
+Browse to host port 8080. Confirm that you see the React application's welcome page.
+
+:::warning
+You may have noticed that the pipeline above is able to publish to the registry without requiring the user to enter any authentication credentials. This is only possible because the [ttl.sh](https://ttl.sh/) registry allows anonymous access. In reality, however, most popular registries require authentication before accepting images for publication.
+
+Dagger SDKs rely on your existing Docker credentials for registry authentication. This means that you must execute `docker login` against your selected container registry on the Dagger host before attempting to publish an image to that registry.
+:::
+
+<Button label="Back" docPath="349011/quickstart-build" />
+
+<Button label="Next" docPath="472910/quickstart-build-multi" />

--- a/docs/current/quickstart/730264-quickstart-publish.mdx
+++ b/docs/current/quickstart/730264-quickstart-publish.mdx
@@ -33,8 +33,7 @@ Dagger SDKs can do this natively via their `publish()` method. So, let's update 
 </TabItem>
 <TabItem value="Python">
 
-```python file=snippets/publish/main.py
-```
+<iframe class="embed" src="https://play.dagger.cloud/embed/2r4dX0l8-zq"></iframe>
 
 </TabItem>
 </Tabs>

--- a/docs/current/quickstart/947391-quickstart-test.mdx
+++ b/docs/current/quickstart/947391-quickstart-test.mdx
@@ -36,8 +36,7 @@ This code listing does the following:
 </TabItem>
 <TabItem value="Node.js">
 
-```javascript file=snippets/test/index.mjs
-```
+<iframe class="embed" src="https://play.dagger.cloud/embed/83Vv01LC5SN"></iframe>
 
 This code listing does the following:
 

--- a/docs/current/quickstart/947391-quickstart-test.mdx
+++ b/docs/current/quickstart/947391-quickstart-test.mdx
@@ -49,7 +49,20 @@ This code listing does the following:
 
 </TabItem>
 <TabItem value="Python">
-TODO
+
+```python file=snippets/test/main.py
+```
+
+This code listing does the following:
+
+- It creates a Dagger client with `with dagger.Connection()` as before.
+- It uses the client's `container().from_()` method to initialize a new container from a base image - again, the `node:16-slim` image. This base image is the Node.js version to use for testing. The `from_()` method returns a new `Container` object with the result.
+- It uses the `Container.with_mounted_directory()` method to mount the source code directory on the host at the `/src` mount point in the container, and the `Container.with_workdir()` method to set the working directory to that mount point.
+  - Notice that the `Container.with_mounted_directory()` accepts additional options to exclude (or include) specific files from the mount. In this case, it excludes the `node_modules` (locally-installed dependencies) and `ci` (pipeline code) directories.
+- It uses the `Container.with_exec()` method to define the commands to install dependencies and run tests in the container - in this case, the commands `npm install` and `npm test -- --watchAll=false`.
+- It uses the `Container.exit_code()` method to execute the command and obtain the corresponding exit code. An exit code of `0` implies successful execution (all tests pass).
+  - Failure, indicated by a non-zero exit code, will cause the pipeline to terminate.
+
 </TabItem>
 </Tabs>
 

--- a/docs/current/quickstart/947391-quickstart-test.mdx
+++ b/docs/current/quickstart/947391-quickstart-test.mdx
@@ -11,7 +11,6 @@ pagination_label: "Run application tests"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import Button from "@site/src/components/atoms/button.js";
 
 ## Run application tests
 

--- a/docs/current/quickstart/947391-quickstart-test.mdx
+++ b/docs/current/quickstart/947391-quickstart-test.mdx
@@ -4,7 +4,7 @@ displayed_sidebar: "current"
 hide_table_of_contents: true
 pagination_next: "current/quickstart/quickstart-build"
 pagination_prev: "current/quickstart/quickstart-hello"
-pagination_label: "Test"
+pagination_label: "Run application tests"
 ---
 
 # Quickstart

--- a/docs/current/quickstart/947391-quickstart-test.mdx
+++ b/docs/current/quickstart/947391-quickstart-test.mdx
@@ -1,10 +1,10 @@
 ---
 slug: /947391/quickstart-test
-displayed_sidebar: "current"
+displayed_sidebar: "quickstart"
 hide_table_of_contents: true
 pagination_next: "current/quickstart/quickstart-build"
 pagination_prev: "current/quickstart/quickstart-hello"
-pagination_label: "Run application tests"
+title: "Run application tests"
 ---
 
 # Quickstart

--- a/docs/current/quickstart/947391-quickstart-test.mdx
+++ b/docs/current/quickstart/947391-quickstart-test.mdx
@@ -2,6 +2,9 @@
 slug: /947391/quickstart-test
 displayed_sidebar: "current"
 hide_table_of_contents: true
+pagination_next: "current/quickstart/quickstart-build"
+pagination_prev: "current/quickstart/quickstart-hello"
+pagination_label: "Test"
 ---
 
 # Quickstart
@@ -69,7 +72,3 @@ This code listing does the following:
 :::tip
 The `from()`, `withMountedDirectory()`, `withWorkdir()` and `withExec()` methods all return a `Container`, making it easy to chain method calls together and create a pipeline that is intuitive to understand.
 :::
-
-<Button label="Back" docPath="593914/quickstart-hello" />
-
-<Button label="Next" docPath="349011/quickstart-build" />

--- a/docs/current/quickstart/947391-quickstart-test.mdx
+++ b/docs/current/quickstart/947391-quickstart-test.mdx
@@ -1,0 +1,63 @@
+---
+slug: /947391/quickstart-test
+displayed_sidebar: "current"
+hide_table_of_contents: true
+---
+
+# Quickstart
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import Button from "@site/src/components/atoms/button.js";
+
+## Run application tests
+
+The pipeline in the previous example was illustrative - you wouldn't ever use it in the real world! So let's write a Dagger pipeline to do something more useful, like running an application's tests.
+
+The code listing below demonstrates a Dagger pipeline that runs tests for the example application, by executing the `npm run test` command.
+
+<Tabs groupId="language">
+<TabItem value="Go">
+
+```go file=snippets/test/main.go
+```
+
+This code listing does the following:
+
+- It creates a Dagger client with `Connect()` as before.
+- It uses the client's `Container().From()` method to initialize a new container from a base image - again, the `node:16-slim` image. This base image is the Node.js version to use for testing. The `From()` method returns a new `Container` object with the result.
+- It uses the `Container.WithMountedDirectory()` method to mount the source code directory on the host at the `/src` mount point in the container, and the `Container.WithWorkdir()` method to set the working directory to that mount point.
+  - Notice that the `Container.WithMountedDirectory()` accepts additional options to exclude (or include) specific files from the mount. In this case, it excludes the `node_modules` (locally-installed dependencies) and `ci` (pipeline code) directories.
+- It uses the `Container.WithExec()` method to define the commands to install dependencies and run tests in the container - in this case, the commands `npm install` and `npm test -- --watchAll=false`.
+- It uses the `Container.ExitCode()` method to execute the command and obtain the corresponding exit code. An exit code of `0` implies successful execution (all tests pass).
+  - Failure, indicated by a non-zero exit code, will cause the pipeline to terminate.
+
+</TabItem>
+<TabItem value="Node.js">
+
+```javascript file=snippets/test/index.mjs
+```
+
+This code listing does the following:
+
+- It creates a Dagger client with `connect()` as before.
+- It uses the client's `container().from()` method to initialize a new container from a base image - again, the `node:16-slim` image. This base image is the Node.js version to use for testing. The `from()` method returns a new `Container` object with the result.
+- It uses the `Container.withMountedDirectory()` method to mount the source code directory on the host at the `/src` mount point in the container, and the `Container.withWorkdir()` method to set the working directory to that mount point.
+  - Notice that the `Container.withMountedDirectory()` accepts additional options to exclude (or include) specific files from the mount. In this case, it excludes the `node_modules` (locally-installed dependencies) and `ci` (pipeline code) directories.
+- It uses the `Container.withExec()` method to define the commands to install dependencies and run tests in the container - in this case, the commands `npm install` and `npm test -- --watchAll=false`.
+- It uses the `Container.exitCode()` method to execute the command and obtain the corresponding exit code. An exit code of `0` implies successful execution (all tests pass).
+  - Failure, indicated by a non-zero exit code, will cause the pipeline to terminate.
+
+</TabItem>
+<TabItem value="Python">
+TODO
+</TabItem>
+</Tabs>
+
+:::tip
+The `from()`, `withMountedDirectory()`, `withWorkdir()` and `withExec()` methods all return a `Container`, making it easy to chain method calls together and create a pipeline that is intuitive to understand.
+:::
+
+<Button label="Back" docPath="593914/quickstart-hello" />
+
+<Button label="Next" docPath="349011/quickstart-build" />

--- a/docs/current/quickstart/947391-quickstart-test.mdx
+++ b/docs/current/quickstart/947391-quickstart-test.mdx
@@ -52,8 +52,7 @@ This code listing does the following:
 </TabItem>
 <TabItem value="Python">
 
-```python file=snippets/test/main.py
-```
+<iframe class="embed" src="https://play.dagger.cloud/embed/7QfLUWG9CLE"></iframe>
 
 This code listing does the following:
 

--- a/docs/current/quickstart/947391-quickstart-test.mdx
+++ b/docs/current/quickstart/947391-quickstart-test.mdx
@@ -19,8 +19,7 @@ The code listing below demonstrates a Dagger pipeline that runs tests for the ex
 <Tabs groupId="language">
 <TabItem value="Go">
 
-```go file=snippets/test/main.go
-```
+<iframe class="embed" src="https://play.dagger.cloud/embed/PNNEJupDVW0"></iframe>
 
 This code listing does the following:
 

--- a/docs/current/quickstart/snippets/build-dockerfile/index.mjs
+++ b/docs/current/quickstart/snippets/build-dockerfile/index.mjs
@@ -1,0 +1,15 @@
+import { connect } from "@dagger.io/dagger"
+
+connect(async (client) => {
+
+  // set build context
+  const contextDir = client.host().directory(".")
+
+  // build using Dockerfile
+  // publish the resulting container to a registry
+  const imageRef = await client.container()
+    .build(contextDir)
+    .publish('ttl.sh/hello-dagger-' + Math.floor(Math.random() * 10000000))
+  console.log(`Published image to: ${imageRef}`)
+
+}, { LogOutput: process.stdout })

--- a/docs/current/quickstart/snippets/build-dockerfile/main.go
+++ b/docs/current/quickstart/snippets/build-dockerfile/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// initialize Dagger client
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	contextDir := client.Host().Directory(".")
+
+	ref, err := client.Container().
+		Build(contextDir).
+		Publish(ctx, fmt.Sprintf("ttl.sh/hello-dagger-%.0f", math.Floor(rand.Float64()*10000000)))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Published image to :%s\n", ref)
+}

--- a/docs/current/quickstart/snippets/build-dockerfile/main.go
+++ b/docs/current/quickstart/snippets/build-dockerfile/main.go
@@ -24,7 +24,7 @@ func main() {
 
 	ref, err := client.Container().
 		Build(contextDir).
-		Publish(ctx, fmt.Sprintf("ttl.sh/hello-dagger-%.0f", math.Floor(rand.Float64()*10000000)))
+		Publish(ctx, fmt.Sprintf("ttl.sh/hello-dagger-%.0f", math.Floor(rand.Float64()*10000000))) //#nosec
 	if err != nil {
 		panic(err)
 	}

--- a/docs/current/quickstart/snippets/build-dockerfile/main.py
+++ b/docs/current/quickstart/snippets/build-dockerfile/main.py
@@ -1,0 +1,26 @@
+import random
+import sys
+
+import anyio
+import dagger
+
+
+async def main():
+    config = dagger.Config(log_output=sys.stdout)
+
+    async with dagger.Connection(config) as client:
+        # set build context
+        context_dir = client.host().directory(".")
+
+        # build using Dockerfile
+        # publish the resulting container to a registry
+        image_ref = (
+            await client.container()
+            .build(context_dir)
+            .publish(f"ttl.sh/hello-dagger-{random.randint(0, 10000000)}")
+        )
+
+    print(f"Published image to: {image_ref}")
+
+
+anyio.run(main)

--- a/docs/current/quickstart/snippets/build-multi/index.mjs
+++ b/docs/current/quickstart/snippets/build-multi/index.mjs
@@ -1,0 +1,40 @@
+import { connect } from "@dagger.io/dagger"
+
+connect(async (client) => {
+
+  // use a node:16-slim container
+  // mount the source code directory on the host
+  // at /src in the container
+  const source = await client.container()
+    .from("node:16-slim")
+    .withMountedDirectory('/src', client.host().directory('.', { exclude: ["node_modules/", "ci/"] }))
+
+  // set the working directory in the container
+  // install application dependencies
+  const runner = source
+    .withWorkdir("/src")
+    .withExec(["npm", "install"])
+
+  // run application tests
+  const test = runner
+    .withExec(["npm", "test", "--", "--watchAll=false"])
+
+  // highlight-start
+  // first stage
+  // build application
+  const buildDir = test
+    .withExec(["npm", "run", "build"])
+    .directory("./build")
+
+  // second stage
+  // use an nginx:alpine container
+  // copy the build/ directory from the first stage
+  // publish the resulting container to a registry
+  const imageRef = await client.container()
+    .from("nginx:alpine")
+    .withDirectory('/usr/share/nginx/html', buildDir)
+    .publish('ttl.sh/hello-dagger-' + Math.floor(Math.random() * 10000000))
+  console.log(`Published image to: ${imageRef}`)
+  // highlight-end
+
+}, { LogOutput: process.stdout })

--- a/docs/current/quickstart/snippets/build-multi/index.mjs
+++ b/docs/current/quickstart/snippets/build-multi/index.mjs
@@ -5,7 +5,7 @@ connect(async (client) => {
   // use a node:16-slim container
   // mount the source code directory on the host
   // at /src in the container
-  const source = await client.container()
+  const source = client.container()
     .from("node:16-slim")
     .withMountedDirectory('/src', client.host().directory('.', { exclude: ["node_modules/", "ci/"] }))
 

--- a/docs/current/quickstart/snippets/build-multi/main.go
+++ b/docs/current/quickstart/snippets/build-multi/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// initialize Dagger client
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	hostSourceDir := client.Host().Directory(".", dagger.HostDirectoryOpts{
+		Exclude: []string{"node_modules/", "ci/"},
+	})
+
+	source := client.Container().
+		From("node:16").
+		WithMountedDirectory("/src", hostSourceDir)
+
+	runner := source.WithWorkdir("/src").
+		WithExec([]string{"npm", "install"})
+
+	test := runner.WithExec([]string{"npm", "test", "--", "--watchAll=false"})
+
+	buildDir := test.WithExec([]string{"npm", "run", "build"}).
+		Directory("./build")
+
+	ref, err := client.Container().
+		From("nginx").
+		WithDirectory("/usr/src/nginx", buildDir).
+		Publish(ctx, fmt.Sprintf("ttl.sh/hello-dagger-%.0f", math.Floor(rand.Float64()*10000000)))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Published image to :%s\n", ref)
+}

--- a/docs/current/quickstart/snippets/build-multi/main.go
+++ b/docs/current/quickstart/snippets/build-multi/main.go
@@ -39,7 +39,7 @@ func main() {
 	ref, err := client.Container().
 		From("nginx").
 		WithDirectory("/usr/src/nginx", buildDir).
-		Publish(ctx, fmt.Sprintf("ttl.sh/hello-dagger-%.0f", math.Floor(rand.Float64()*10000000)))
+		Publish(ctx, fmt.Sprintf("ttl.sh/hello-dagger-%.0f", math.Floor(rand.Float64()*10000000))) //#nosec
 	if err != nil {
 		panic(err)
 	}

--- a/docs/current/quickstart/snippets/build-multi/main.py
+++ b/docs/current/quickstart/snippets/build-multi/main.py
@@ -1,0 +1,51 @@
+import random
+import sys
+
+import anyio
+import dagger
+
+
+async def main():
+    config = dagger.Config(log_output=sys.stdout)
+
+    async with dagger.Connection(config) as client:
+        # use a node:16-slim container
+        # mount the source code directory on the host
+        # at /src in the container
+        source = (
+            client.container()
+            .from_("node:16-slim")
+            .with_mounted_directory(
+                "/src",
+                client.host().directory(".", exclude=["node_modules/", "ci/"]),
+            )
+        )
+
+        # set the working directory in the container
+        # install application dependencies
+        runner = source.with_workdir("/src").with_exec(["npm", "install"])
+
+        # run application tests
+        test = runner.with_exec(["npm", "test", "--", "--watchAll=false"])
+
+        # highlight-start
+        # first stage
+        # build application
+        build_dir = test.with_exec(["npm", "run", "build"]).directory("./build")
+
+        # second stage
+        # use an nginx:alpine container
+        # copy the build/ directory from the first stage
+        # publish the resulting container to a registry
+        image_ref = await (
+            client.container()
+            .from_("nginx:alpine")
+            .with_directory("/usr/share/nginx/html", build_dir)
+            .publish(f"ttl.sh/hello-dagger-{random.randint(0, 10000000)}")
+        )
+
+    print(f"Published image to: {image_ref}")
+    # highlight-end
+
+
+anyio.run(main)

--- a/docs/current/quickstart/snippets/build/index.mjs
+++ b/docs/current/quickstart/snippets/build/index.mjs
@@ -5,7 +5,7 @@ connect(async (client) => {
   // use a node:16-slim container
   // mount the source code directory on the host
   // at /src in the container
-  const source = await client.container()
+  const source = client.container()
     .from("node:16-slim")
     .withMountedDirectory('/src', client.host().directory('.', { exclude: ["node_modules/", "ci/"] }))
 

--- a/docs/current/quickstart/snippets/build/index.mjs
+++ b/docs/current/quickstart/snippets/build/index.mjs
@@ -1,0 +1,31 @@
+import { connect } from "@dagger.io/dagger"
+
+connect(async (client) => {
+
+  // use a node:16-slim container
+  // mount the source code directory on the host
+  // at /src in the container
+  const source = await client.container()
+    .from("node:16-slim")
+    .withMountedDirectory('/src', client.host().directory('.', { exclude: ["node_modules/", "ci/"] }))
+
+  // set the working directory in the container
+  // install application dependencies
+  const runner = source
+    .withWorkdir("/src")
+    .withExec(["npm", "install"])
+
+  // run application tests
+  const test = runner
+    .withExec(["npm", "test", "--", "--watchAll=false"])
+
+  // highlight-start
+  // build application
+  // write the build output to the host
+  await test
+    .withExec(["npm", "run", "build"])
+    .directory("./build")
+    .export("./build")
+  // highlight-end
+
+}, { LogOutput: process.stdout })

--- a/docs/current/quickstart/snippets/build/main.go
+++ b/docs/current/quickstart/snippets/build/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// initialize Dagger client
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	hostSourceDir := client.Host().Directory(".", dagger.HostDirectoryOpts{
+		Exclude: []string{"node_modules/", "ci/"},
+	})
+
+	source := client.Container().
+		From("node:16").
+		WithMountedDirectory("/src", hostSourceDir)
+
+	runner := source.WithWorkdir("/src").
+		WithExec([]string{"npm", "install"})
+
+	test := runner.WithExec([]string{"npm", "test", "--", "--watchAll=false"})
+
+	_, err = test.WithExec([]string{"npm", "run", "build"}).
+		Directory("./build").
+		Export(ctx, "./build")
+
+	if err != nil {
+		panic(err)
+	}
+}

--- a/docs/current/quickstart/snippets/build/main.py
+++ b/docs/current/quickstart/snippets/build/main.py
@@ -1,0 +1,41 @@
+import sys
+
+import anyio
+import dagger
+
+
+async def main():
+    config = dagger.Config(log_output=sys.stdout)
+
+    async with dagger.Connection(config) as client:
+        # use a node:16-slim container
+        # mount the source code directory on the host
+        # at /src in the container
+        source = (
+            client.container()
+            .from_("node:16-slim")
+            .with_mounted_directory(
+                "/src",
+                client.host().directory(".", exclude=["node_modules/", "ci/"]),
+            )
+        )
+
+        # set the working directory in the container
+        # install application dependencies
+        runner = source.with_workdir("/src").with_exec(["npm", "install"])
+
+        # run application tests
+        test = runner.with_exec(["npm", "test", "--", "--watchAll=false"])
+
+        # highlight-start
+        # build application
+        # writhe the build output to the host
+        await (
+            test.with_exec(["npm", "run", "build"])
+            .directory("./build")
+            .export("./build")
+        )
+        # highlight-end
+
+
+anyio.run(main)

--- a/docs/current/quickstart/snippets/caching/index.mjs
+++ b/docs/current/quickstart/snippets/caching/index.mjs
@@ -10,7 +10,7 @@ connect(async (client) => {
   // mount the source code directory on the host
   // at /src in the container
   // mount the cache volume to persist dependencies
-  const source = await client.container()
+  const source = client.container()
     .from("node:16-slim")
     .withMountedDirectory('/src', client.host().directory('.', { exclude: ["node_modules/", "ci/"] }))
     .withMountedCache("/src/node_modules", nodeCache)

--- a/docs/current/quickstart/snippets/caching/index.mjs
+++ b/docs/current/quickstart/snippets/caching/index.mjs
@@ -1,0 +1,45 @@
+import { connect } from "@dagger.io/dagger"
+
+connect(async (client) => {
+
+  // highlight-start
+  // create a cache volume
+  const nodeCache = client.cacheVolume("node")
+
+  // use a node:16-slim container
+  // mount the source code directory on the host
+  // at /src in the container
+  // mount the cache volume to persist dependencies
+  const source = await client.container()
+    .from("node:16-slim")
+    .withMountedDirectory('/src', client.host().directory('.', { exclude: ["node_modules/", "ci/"] }))
+    .withMountedCache("/src/node_modules", nodeCache)
+  // highlight-end
+
+  // set the working directory in the container
+  // install application dependencies
+  const runner = source
+    .withWorkdir("/src")
+    .withExec(["npm", "install"])
+
+  // run application tests
+  const test = runner
+    .withExec(["npm", "test", "--", "--watchAll=false"])
+
+  // first stage
+  // build application
+  const buildDir = test
+    .withExec(["npm", "run", "build"])
+    .directory("./build")
+
+  // second stage
+  // use an nginx:alpine container
+  // copy the build/ directory from the first stage
+  // publish the resulting container to a registry
+  const imageRef = await client.container()
+    .from("nginx:alpine")
+    .withDirectory('/usr/share/nginx/html', buildDir)
+    .publish('ttl.sh/hello-dagger-' + Math.floor(Math.random() * 10000000))
+  console.log(`Published image to: ${imageRef}`)
+
+}, { LogOutput: process.stdout })

--- a/docs/current/quickstart/snippets/caching/main.go
+++ b/docs/current/quickstart/snippets/caching/main.go
@@ -42,7 +42,7 @@ func main() {
 	ref, err := client.Container().
 		From("nginx").
 		WithDirectory("/usr/src/nginx", buildDir).
-		Publish(ctx, fmt.Sprintf("ttl.sh/hello-dagger-%.0f", math.Floor(rand.Float64()*10000000)))
+		Publish(ctx, fmt.Sprintf("ttl.sh/hello-dagger-%.0f", math.Floor(rand.Float64()*10000000))) //#nosec
 	if err != nil {
 		panic(err)
 	}

--- a/docs/current/quickstart/snippets/caching/main.go
+++ b/docs/current/quickstart/snippets/caching/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// initialize Dagger client
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	nodeCache := client.CacheVolume("node")
+
+	hostSourceDir := client.Host().Directory(".", dagger.HostDirectoryOpts{
+		Exclude: []string{"node_modules/", "ci/"},
+	})
+
+	source := client.Container().
+		From("node:16").
+		WithMountedDirectory("/src", hostSourceDir).
+		WithMountedCache("/src/node_modules", nodeCache)
+
+	runner := source.WithWorkdir("/src").
+		WithExec([]string{"npm", "install"})
+
+	test := runner.WithExec([]string{"npm", "test", "--", "--watchAll=false"})
+
+	buildDir := test.WithExec([]string{"npm", "run", "build"}).
+		Directory("./build")
+
+	ref, err := client.Container().
+		From("nginx").
+		WithDirectory("/usr/src/nginx", buildDir).
+		Publish(ctx, fmt.Sprintf("ttl.sh/hello-dagger-%.0f", math.Floor(rand.Float64()*10000000)))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Published image to :%s\n", ref)
+}

--- a/docs/current/quickstart/snippets/caching/main.py
+++ b/docs/current/quickstart/snippets/caching/main.py
@@ -1,0 +1,56 @@
+import random
+import sys
+
+import anyio
+import dagger
+
+
+async def main():
+    config = dagger.Config(log_output=sys.stdout)
+
+    async with dagger.Connection(config) as client:
+        # highlight-start
+        # create a cache volume
+        node_cache = client.cache_volume("node")
+
+        # use a node:16-slim container
+        # mount the source code directory on the host
+        # at /src in the container
+        # mount the cache volume to persist dependencies
+        source = (
+            client.container()
+            .from_("node:16-slim")
+            .with_mounted_directory(
+                "/src",
+                client.host().directory(".", exclude=["node_modules/", "ci/"]),
+            )
+            .with_mounted_cache("/src/node_modules", node_cache)
+        )
+        # highlight-end
+
+        # set the working directory in the container
+        # install application dependencies
+        runner = source.with_workdir("/src").with_exec(["npm", "install"])
+
+        # run application tests
+        test = runner.with_exec(["npm", "test", "--", "--watchAll=false"])
+
+        # first stage
+        # build application
+        build_dir = test.with_exec(["npm", "run", "build"]).directory("./build")
+
+        # second stage
+        # use an nginx:alpine container
+        # copy the build/ directory from the first stage
+        # publish the resulting container to a registry
+        image_ref = await (
+            client.container()
+            .from_("nginx:alpine")
+            .with_directory("/usr/share/nginx/html", build_dir)
+            .publish(f"ttl.sh/hello-dagger-{random.randint(0, 10000000)}")
+        )
+
+    print(f"Published image to: {image_ref}")
+
+
+anyio.run(main)

--- a/docs/current/quickstart/snippets/hello/index.mjs
+++ b/docs/current/quickstart/snippets/hello/index.mjs
@@ -1,0 +1,15 @@
+import { connect } from "@dagger.io/dagger"
+
+// initialize Dagger client
+connect(async (client) => {
+
+  // use a node:16-slim container
+  // get version
+  const node = client.container().from("node:16-slim").withExec(["node", "-v"])
+
+  // execute
+  const version = await node.stdout()
+
+  // print output
+  console.log("Hello from Dagger and Node " + version)
+}, { LogOutput: process.stdout })

--- a/docs/current/quickstart/snippets/hello/main.go
+++ b/docs/current/quickstart/snippets/hello/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// initialize Dagger client
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	golang := client.Container().From("golang:1.19").WithExec([]string{"go", "version"})
+
+	version, err := golang.Stdout(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Hello from Dagger and " + version)
+}

--- a/docs/current/quickstart/snippets/hello/main.py
+++ b/docs/current/quickstart/snippets/hello/main.py
@@ -1,0 +1,25 @@
+import sys
+
+import anyio
+import dagger
+
+
+async def main():
+    config = dagger.Config(log_output=sys.stdout)
+
+    # initialize Dagger client
+    async with dagger.Connection(config) as client:
+        # use a node:16-slim container
+        # get version
+        python = (
+            client.container().from_("python:3.11-slim").with_exec(["python", "-V"])
+        )
+
+        # execute
+        version = await python.stdout()
+
+    # print output
+    print(f"Hello from Dagger and {version}")
+
+
+anyio.run(main)

--- a/docs/current/quickstart/snippets/publish/index.mjs
+++ b/docs/current/quickstart/snippets/publish/index.mjs
@@ -1,0 +1,41 @@
+import { connect } from "@dagger.io/dagger"
+
+connect(async (client) => {
+
+  // use a node:16-slim container
+  // mount the source code directory on the host
+  // at /src in the container
+  const source = await client.container()
+    .from("node:16-slim")
+    .withMountedDirectory('/src', client.host().directory('.', { exclude: ["node_modules/", "ci/"] }))
+
+  // set the working directory in the container
+  // install application dependencies
+  const runner = source
+    .withWorkdir("/src")
+    .withExec(["npm", "install"])
+
+  // run application tests
+  const test = runner
+    .withExec(["npm", "test", "--", "--watchAll=false"])
+
+  // build application
+  // write the build output to the host
+  await test
+    .withExec(["npm", "run", "build"])
+    .directory("./build")
+    .export("./build")
+
+  // highlight-start
+  // use an nginx:alpine container
+  // copy the build/ directory into the container filesystem
+  // at the nginx server root
+  // publish the resulting container to a registry
+  const imageRef = await client.container()
+    .from("nginx:alpine")
+    .withDirectory('/usr/share/nginx/html', client.host().directory('./build'))
+    .publish('ttl.sh/hello-dagger-' + Math.floor(Math.random() * 10000000))
+  console.log(`Published image to: ${imageRef}`)
+  // highlight-end
+
+}, { LogOutput: process.stdout })

--- a/docs/current/quickstart/snippets/publish/index.mjs
+++ b/docs/current/quickstart/snippets/publish/index.mjs
@@ -5,7 +5,7 @@ connect(async (client) => {
   // use a node:16-slim container
   // mount the source code directory on the host
   // at /src in the container
-  const source = await client.container()
+  const source = client.container()
     .from("node:16-slim")
     .withMountedDirectory('/src', client.host().directory('.', { exclude: ["node_modules/", "ci/"] }))
 

--- a/docs/current/quickstart/snippets/publish/main.go
+++ b/docs/current/quickstart/snippets/publish/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// initialize Dagger client
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	hostSourceDir := client.Host().Directory(".", dagger.HostDirectoryOpts{
+		Exclude: []string{"node_modules/", "ci/"},
+	})
+
+	source := client.Container().
+		From("node:16").
+		WithMountedDirectory("/src", hostSourceDir)
+
+	runner := source.WithWorkdir("/src").
+		WithExec([]string{"npm", "install"})
+
+	test := runner.WithExec([]string{"npm", "test", "--", "--watchAll=false"})
+
+	_, err = test.WithExec([]string{"npm", "run", "build"}).
+		Directory("./build").
+		Export(ctx, "./build")
+
+	ref, err := client.Container().
+		From("nginx").
+		WithDirectory("/usr/src/nginx", client.Host().Directory("./build")).
+		Publish(ctx, fmt.Sprintf("ttl.sh/hello-dagger-%.0f", math.Floor(rand.Float64()*10000000)))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Published image to :%s\n", ref)
+}

--- a/docs/current/quickstart/snippets/publish/main.go
+++ b/docs/current/quickstart/snippets/publish/main.go
@@ -37,10 +37,14 @@ func main() {
 		Directory("./build").
 		Export(ctx, "./build")
 
+	if err != nil {
+		panic(err)
+	}
+
 	ref, err := client.Container().
 		From("nginx").
 		WithDirectory("/usr/src/nginx", client.Host().Directory("./build")).
-		Publish(ctx, fmt.Sprintf("ttl.sh/hello-dagger-%.0f", math.Floor(rand.Float64()*10000000)))
+		Publish(ctx, fmt.Sprintf("ttl.sh/hello-dagger-%.0f", math.Floor(rand.Float64()*10000000))) //#nosec
 	if err != nil {
 		panic(err)
 	}

--- a/docs/current/quickstart/snippets/publish/main.py
+++ b/docs/current/quickstart/snippets/publish/main.py
@@ -1,0 +1,55 @@
+import random
+import sys
+
+import anyio
+import dagger
+
+
+async def main():
+    config = dagger.Config(log_output=sys.stdout)
+
+    async with dagger.Connection(config) as client:
+        # use a node:16-slim container
+        # mount the source code directory on the host
+        # at /src in the container
+        source = (
+            client.container()
+            .from_("node:16-slim")
+            .with_mounted_directory(
+                "/src",
+                client.host().directory(".", exclude=["node_modules/", "ci/"]),
+            )
+        )
+
+        # set the working directory in the container
+        # install application dependencies
+        runner = source.with_workdir("/src").with_exec(["npm", "install"])
+
+        # run application tests
+        test = runner.with_exec(["npm", "test", "--", "--watchAll=false"])
+
+        # build application
+        # write the build output to the host
+        await (
+            test.with_exec(["npm", "run", "build"])
+            .directory("./build")
+            .export("./build")
+        )
+
+        # highlight-start
+        # use an nginx:alpine container
+        # copy the build/ directory into the container filesystem
+        # at the nginx server root
+        # publish the resulting container to a registry
+        image_ref = await (
+            client.container()
+            .from_("nginx:alpine")
+            .with_directory("/usr/share/nginx/html", client.host().directory("./build"))
+            .publish(f"ttl.sh/hello-dagger-{random.randint(0, 10000000)}")
+        )
+
+    print(f"Published image to: {image_ref}")
+    # highlight-end
+
+
+anyio.run(main)

--- a/docs/current/quickstart/snippets/test/index.mjs
+++ b/docs/current/quickstart/snippets/test/index.mjs
@@ -1,0 +1,23 @@
+import { connect } from "@dagger.io/dagger"
+
+connect(async (client) => {
+
+  // use a node:16-slim container
+  // mount the source code directory on the host
+  // at /src in the container
+  const source = await client.container()
+    .from("node:16-slim")
+    .withMountedDirectory('/src', client.host().directory('.', { exclude: ["node_modules/", "ci/"] }))
+
+  // set the working directory in the container
+  // install application dependencies
+  const runner = source
+    .withWorkdir("/src")
+    .withExec(["npm", "install"])
+
+  // run application tests
+  await runner
+    .withExec(["npm", "test", "--", "--watchAll=false"])
+    .exitCode()
+
+}, { LogOutput: process.stdout })

--- a/docs/current/quickstart/snippets/test/index.mjs
+++ b/docs/current/quickstart/snippets/test/index.mjs
@@ -5,7 +5,7 @@ connect(async (client) => {
   // use a node:16-slim container
   // mount the source code directory on the host
   // at /src in the container
-  const source = await client.container()
+  const source = client.container()
     .from("node:16-slim")
     .withMountedDirectory('/src', client.host().directory('.', { exclude: ["node_modules/", "ci/"] }))
 

--- a/docs/current/quickstart/snippets/test/main.go
+++ b/docs/current/quickstart/snippets/test/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// initialize Dagger client
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	hostSourceDir := client.Host().Directory(".", dagger.HostDirectoryOpts{
+		Exclude: []string{"node_modules/", "ci/"},
+	})
+
+	source := client.Container().
+		From("node:16").
+		WithMountedDirectory("/src", hostSourceDir)
+
+	runner := source.WithWorkdir("/src").
+		WithExec([]string{"npm", "install"})
+
+	_, err = runner.WithExec([]string{"npm", "test", "--", "--watchAll=false"}).
+		ExitCode(ctx)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/docs/current/quickstart/snippets/test/main.py
+++ b/docs/current/quickstart/snippets/test/main.py
@@ -1,0 +1,31 @@
+import sys
+
+import anyio
+import dagger
+
+
+async def main():
+    config = dagger.Config(log_output=sys.stdout)
+
+    async with dagger.Connection(config) as client:
+        # use a node:16-slim container
+        # mount the source code directory on the host
+        # at /src in the container
+        source = (
+            client.container()
+            .from_("node:16-slim")
+            .with_mounted_directory(
+                "/src",
+                client.host().directory(".", exclude=["node_modules/", "ci/"]),
+            )
+        )
+
+        # set the working directory in the container
+        # install application dependencies
+        runner = source.with_workdir("/src").with_exec(["npm", "install"])
+
+        # run application tests
+        await runner.with_exec(["npm", "test", "--", "--watchAll=false"]).exit_code()
+
+
+anyio.run(main)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -189,6 +189,33 @@ module.exports = {
       id: "current/contributing",
     },
   ],
+  quickstart: [
+    {
+      type: "doc",
+      id: "current/index",
+      label: "Home",
+    },
+    {
+      type: "category",
+      label: "Quickstart",
+      collapsible: false,
+      collapsed: false,
+      items: [
+        "current/quickstart/quickstart-introduction",
+        "current/quickstart/quickstart-basics",
+        "current/quickstart/quickstart-setup",
+        "current/quickstart/quickstart-sdk",
+        "current/quickstart/quickstart-hello",
+        "current/quickstart/quickstart-test",
+        "current/quickstart/quickstart-build",
+        "current/quickstart/quickstart-publish",
+        "current/quickstart/quickstart-build-multi",
+        "current/quickstart/quickstart-caching",
+        "current/quickstart/quickstart-build-dockerfile",
+        "current/quickstart/quickstart-conclusion",
+      ]
+    }
+  ],
   0.2: [
     {
       type: "category",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -17,6 +17,11 @@ module.exports = {
       label: "Introduction",
     },
     {
+      type: "doc",
+      id: "current/quickstart/quickstart-introduction",
+      label: "Quickstart",
+    },
+    {
       type: "category",
       label: "Go SDK",
       collapsible: false,

--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -734,3 +734,18 @@ img[alt="github-contribute"] {
 	height: 800px;
 
 }
+.docs-doc-id-current\/quickstart\/quickstart-setup,
+.docs-doc-id-current\/quickstart\/quickstart-introduction {
+  main .container {
+    margin: 0;
+    margin-right: 800px;
+
+    iframe {
+      position: fixed;
+      top: 96px;
+      right: 0;
+      width: 800px;
+      height: 100%;
+    }
+  }
+}

--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -106,6 +106,7 @@ html[data-theme="dark"] {
   --ifm-box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.5);
   --ifm-breadcrumb-item-background-active: var(--ifm-color-primary);
 }
+
 /* global */
 
 * {
@@ -139,28 +140,28 @@ code,
 }
 
 .markdown {
-  & > h1:first-child {
+  &>h1:first-child {
     font-size: 3.141rem;
     margin-bottom: 4rem;
     font-weight: 700;
     letter-spacing: -2px;
   }
 
-  & > h2 {
+  &>h2 {
     --ifm-h2-font-size: 2.344rem;
     --ifm-h2-vertical-rhythm-top: 3;
   }
 
-  & > h3 {
+  &>h3 {
     --ifm-h3-font-size: 1.762rem;
     --ifm-h3-vertical-rhythm-top: 2;
   }
 
-  & > h4 {
+  &>h4 {
     --ifm-h4-font-size: 1.36rem;
   }
 
-  & > h2 + h3 {
+  &>h2+h3 {
     --ifm-h3-vertical-rhythm-top: 2;
   }
 
@@ -399,7 +400,7 @@ h1[class^="h1Heading"] {
     }
   }
 
-  > span {
+  >span {
     margin-left: 10px;
     border-right: 1px solid white;
   }
@@ -441,8 +442,9 @@ h1[class^="h1Heading"] {
 
 /* color mode toggle button */
 
-.navbar__items--right > :last-child {
+.navbar__items--right> :last-child {
   margin: 0px 20px;
+
   button:hover {
     background: var(--ifm-color-primary);
   }
@@ -502,6 +504,7 @@ main[class^="docMainContainer"] {
 }
 
 html[data-theme="dark"] .table-of-contents__link {
+
   &--active,
   &:hover {
     color: var(--ifm-color-primary-light);
@@ -555,7 +558,7 @@ button[class^="copyButton"] {
   padding: 3rem 0.5rem 0.5rem !important;
 }
 
-.menu > .menu__list > .menu__list-item {
+.menu>.menu__list>.menu__list-item {
   padding-bottom: 1rem;
 }
 
@@ -648,6 +651,7 @@ li.theme-doc-sidebar-item-link-level-1:active {
 
 .DocSearch--active {
   html[data-theme="dark"] & {
+
     .DocSearch-Hit-source,
     .DocSearch-Cancel {
       color: rgb(190, 195, 201);
@@ -676,12 +680,12 @@ img[alt="github-contribute"] {
 }
 
 @mixin admonitionIcon($args...) {
-  @each $name, $path in meta.keywords($args) {
-    $bgColor: if(
-      $name==danger,
+
+  @each $name,
+  $path in meta.keywords($args) {
+    $bgColor: if($name==danger,
       var(--ifm-color-primary-light),
-      var(--ifm-color-primary-dark)
-    );
+      var(--ifm-color-primary-dark));
 
     .admonition-#{$name} .admonition-icon::before {
       mask: url($path);
@@ -694,8 +698,7 @@ img[alt="github-contribute"] {
   }
 }
 
-@include admonitionIcon(
-  $note: "/img/Dagger_Icons_Note.svg",
+@include admonitionIcon($note: "/img/Dagger_Icons_Note.svg",
   $tip: "/img/Dagger_Icons_Tip.svg",
   $info: "/img/Dagger_Icons_Info.svg",
   $caution: "/img/Dagger_Icons_Caution.svg",
@@ -730,25 +733,36 @@ img[alt="github-contribute"] {
 
 .embed {
 
-	width: 100%;
-	height: 800px;
+  width: 100%;
+  height: 800px;
 
 }
+
 .docs-doc-id-current\/quickstart\/quickstart-setup,
 .docs-doc-id-current\/quickstart\/quickstart-introduction {
   main .container {
     margin: 0;
-    margin-right: 800px;
+    margin-right: 40vw;
 
     iframe {
       position: fixed;
       top: 0;
       right: 0;
-      width: 800px;
+      width: 40vw;
       height: 100%;
       padding-top: 96px;
       box-shadow: 1px 1px 5px 2px black;
       background-color: rgb(14, 13, 28);
+    }
+  }
+}
+
+@include tablet {
+  main .container {
+    margin-right: inherit;
+
+    iframe {
+      visibility: hidden;
     }
   }
 }

--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -738,11 +738,20 @@ img[alt="github-contribute"] {
 
 }
 
-.docs-doc-id-current\/quickstart\/quickstart-setup,
-.docs-doc-id-current\/quickstart\/quickstart-introduction {
+.docs-doc-id-current\/quickstart\/quickstart-hello,
+.docs-doc-id-current\/quickstart\/quickstart-test,
+.docs-doc-id-current\/quickstart\/quickstart-build,
+.docs-doc-id-current\/quickstart\/quickstart-publish,
+.docs-doc-id-current\/quickstart\/quickstart-build-multi,
+.docs-doc-id-current\/quickstart\/quickstart-caching,
+.docs-doc-id-current\/quickstart\/quickstart-build-dockerfile {
   main .container {
     margin: 0;
-    margin-right: 40vw;
+    margin-right: 40vw !important;
+
+    .theme-code-block {
+      max-width: 35vw;
+    }
 
     iframe {
       position: fixed;
@@ -753,6 +762,7 @@ img[alt="github-contribute"] {
       padding-top: 96px;
       box-shadow: 1px 1px 5px 2px black;
       background-color: rgb(14, 13, 28);
+      z-index: 100;
     }
   }
 }

--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -727,3 +727,10 @@ img[alt="github-contribute"] {
     max-width: 1200px;
   }
 }
+
+.embed {
+
+	width: 100%;
+	height: 800px;
+
+}

--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -742,10 +742,13 @@ img[alt="github-contribute"] {
 
     iframe {
       position: fixed;
-      top: 96px;
+      top: 0;
       right: 0;
       width: 800px;
       height: 100%;
+      padding-top: 96px;
+      box-shadow: 1px 1px 5px 2px black;
+      background-color: rgb(14, 13, 28);
     }
   }
 }


### PR DESCRIPTION
This PR will change the layout of the docs in the Quickstart that contain an `<iframe>` by placing it into the right.

With this change, the user will not have to scroll to the editor while reading the documentation, as everything will be in the viewport.

TODO:
- [ ] Responsiveness
- [ ] Move tabs to the top of the editor
- [ ] Rebase on main once the Quickstart is merged