### PR TITLE
ci: Improve how we handle cached vertices

### DIFF
--- a/cmd/otel-collector/traces.go
+++ b/cmd/otel-collector/traces.go
@@ -102,7 +102,7 @@ func (c *TraceExporter) sendVertex(v Vertex) {
 		otrace.WithLinks(links...),
 	)
 	c.contextByVertex[v.ID()] = vertexCtx
-	vertexSpan.SetAttributes(c.attributes(attribute.Bool("cached", v.Cached()))...)
+	vertexSpan.SetAttributes(c.attributes(attribute.Bool("cached", v.Cached()), attribute.String("digest", v.ID()))...)
 
 	if err := v.Error(); err != nil {
 		vertexSpan.RecordError(err)

--- a/hack/make
+++ b/hack/make
@@ -6,6 +6,5 @@ DAGGER_SRC_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 MAGEDIR="$DAGGER_SRC_ROOT/internal/mage"
 
 cd "$MAGEDIR"
-go run main.go -w "$DAGGER_SRC_ROOT" engine:dev
 
-exec go run main.go -w "$DAGGER_SRC_ROOT" "$@"
+exec go run main.go -w "$DAGGER_SRC_ROOT" engine:dev "$@"

--- a/internal/mage/util/util.go
+++ b/internal/mage/util/util.go
@@ -18,6 +18,9 @@ const (
 func Repository(c *dagger.Client) *dagger.Directory {
 	return c.Host().Directory(".", dagger.HostDirectoryOpts{
 		Exclude: []string{
+			".git",
+			"bin",
+
 			// node
 			"**/node_modules",
 


### PR DESCRIPTION
`./hack/make engine:dev` and `./hack/make engine:test` feeding data into the same `journal.log` resulted in spans that didn't make sense. Some spans would switch to a later group (i.e. `engine:test`), yet the started & completed timestamps would clearly belong to a former group (i.e. `engine:dev`).

When we did update the started & completed timestamps, we realised that we were overwriting previous vertices, the uncached ones, with cached timings, which also didn't make sense.

The easiest thing is to only track the first vertex, the uncached version, and ignore the cached ones. This means that once a vertex is solved in i.e. `engine:dev`, we don't show it again in `engine:test`, since it's cached and less significant timing-wise (it rounds down to 0 micros).

In order to do this better, we would need to use more than the vertex digest for the map. If we were to add the pipeline and/or the session token, then we would be able to track the first cached vertex too. Since it's not that much of a big win, it's OK to stop here for now, until we have something better than a trace to visualise a pipeline run.

<a href="https://daggerboard.grafana.net/d/SyaItlTVk/dagger-overview?from=1675280473239&to=1675280803129&var-detail=pipeline&var-micros=1000000&orgId=1"><img width="1728" alt="image" src="https://user-images.githubusercontent.com/3342/216149298-7d11a762-7e2e-43a1-88fe-e644c5b69a89.png"></a>

<a href="https://daggerboard.grafana.net/explore?orgId=1&left=%7B%22datasource%22:%22grafanacloud-traces%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22tempo%22,%22uid%22:%22grafanacloud-traces%22%7D,%22queryType%22:%22traceId%22,%22query%22:%220c5edaeb19ac9322f1bd8a58bd7e718e%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D"><img width="1727" alt="image" src="https://user-images.githubusercontent.com/3342/216149141-9a2c08d5-aa7e-4814-85c2-05b89c587213.png"></a>

---

This is a follow-up to:
- https://github.com/dagger/dagger/pull/4340