### PR TITLE
Add quickstart fixes

### DIFF
--- a/docs/current/quickstart/349011-quickstart-build.mdx
+++ b/docs/current/quickstart/349011-quickstart-build.mdx
@@ -25,6 +25,12 @@ So, let's update the previous pipeline and add a build step to it, by running `n
 - It obtains a reference to the `build/` directory in the container with the `Container.Directory()` method. This method returns a `Directory` object.
 - It writes the `build/` directory from the container to the host using the `Directory.Export()` method.
 
+Run the pipeline by executing the command below from the application directory:
+
+```shell
+go run ci/main.go
+```
+
 </TabItem>
 <TabItem value="Node.js">
 
@@ -36,6 +42,12 @@ This revised pipeline does everything described in the previous step, and then p
 - It obtains a reference to the `build/` directory in the container with the `Container.directory()` method. This method returns a `Directory` object.
 - It writes the `build/` directory from the container to the host using the `Directory.export()` method.
 
+Run the pipeline by executing the command below from the application directory:
+
+```shell
+node ci/index.mjs
+```
+
 </TabItem>
 <TabItem value="Python">
 
@@ -46,6 +58,12 @@ This revised pipeline does everything described in the previous step, and then p
 - It invokes the `Container.with_exec()` method again, this time to define the command `npm run build` in the container.
 - It obtains a reference to the `build/` directory in the container with the `Container.directory()` method. This method returns a `Directory` object.
 - It writes the `build/` directory from the container to the host using the `Directory.export()` method.
+
+Run the pipeline by executing the command below from the application directory:
+
+```shell
+python ci/main.py
+```
 
 </TabItem>
 </Tabs>

--- a/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
+++ b/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
@@ -31,6 +31,12 @@ Connect()`.
 - It uses the client's `Container().Build()` method to initialize a new container using a Dockerfile. This method defaults to using the Dockerfile located at `./Dockerfile` in the directory passed to it as argument and returns the built `Container` object.
 - It uses the `Container` object's `Publish()` method to publish the container to [ttl.sh](https://ttl.sh). As before, to prevent name collisions, the container image name is suffixed with a random number.
 
+Run the pipeline by executing the command below from the application directory:
+
+```shell
+go run ci/main.go
+```
+
 </TabItem>
 <TabItem value="Node.js">
 
@@ -42,6 +48,12 @@ This code listing does the following:
 - It uses the client's `host().directory()` method to obtain a reference to the source code directory on the host.
 - It uses the client's `container().build()` method to initialize a new container using a Dockerfile. This method defaults to using the Dockerfile located at `./Dockerfile` in the directory passed to it as argument and returns the built `Container` object.
 - It uses the `Container` object's `publish()` method to publish the container to [ttl.sh](https://ttl.sh). As before, to prevent name collisions, the container image name is suffixed with a random number.
+
+Run the pipeline by executing the command below from the application directory:
+
+```shell
+node ci/index.mjs
+```
 
 </TabItem>
 <TabItem value="Python">
@@ -55,6 +67,11 @@ This code listing does the following:
 - It uses the client's `container().build()` method to initialize a new container using a Dockerfile. This method defaults to using the Dockerfile located at `./Dockerfile` in the directory passed to it as argument and returns the built `Container` object.
 - It uses the `Container` object's `publish()` method to publish the container to [ttl.sh](https://ttl.sh). As before, to prevent name collisions, the container image name is suffixed with a random number.
 
+Run the pipeline by executing the command below from the application directory:
+
+```shell
+python ci/main.py
+```
 
 </TabItem>
 </Tabs>

--- a/docs/current/quickstart/472910-quickstart-build-multi.mdx
+++ b/docs/current/quickstart/472910-quickstart-build-multi.mdx
@@ -31,15 +31,33 @@ Let's now update our pipeline to use a multi-stage build, as described above.
 
 <iframe class="embed" src="https://play.dagger.cloud/embed/ho4ZF-6naKv"></iframe>
 
+Run the pipeline by executing the command below from the application directory:
+
+```shell
+go run ci/main.go
+```
+
 </TabItem>
 <TabItem value="Node.js">
 
 <iframe class="embed" src="https://play.dagger.cloud/embed/aPB-msb5UEn"></iframe>
 
+Run the pipeline by executing the command below from the application directory:
+
+```shell
+node ci/index.mjs
+```
+
 </TabItem>
 <TabItem value="Python">
 
 <iframe class="embed" src="https://play.dagger.cloud/embed/tqaPp2aVr_L"></iframe>
+
+Run the pipeline by executing the command below from the application directory:
+
+```shell
+python ci/main.py
+```
 
 </TabItem>
 </Tabs>

--- a/docs/current/quickstart/628381-quickstart-sdk.mdx
+++ b/docs/current/quickstart/628381-quickstart-sdk.mdx
@@ -21,7 +21,7 @@ The next step is to install the Dagger SDK for your preferred language. Select f
 The Dagger Go SDK requires [Go 1.15 or later](https://go.dev/doc/install).
 :::
 
-In the `ci` directory, create a new Go module and install the Dagger Go SDK using the commands below:
+Create a new Go module and install the Dagger Go SDK using the commands below:
 
 ```shell
 go mod init main
@@ -35,7 +35,7 @@ go get dagger.io/dagger@latest
 The Dagger Node.js SDK requires [Node.js 16.x or later](https://nodejs.org/en/download/).
 :::
 
-In the `ci` directory, install the Dagger Node.js SDK using `npm`:
+Install the Dagger Node.js SDK using `npm`:
 
 ```shell
 npm install @dagger.io/dagger@latest --save-dev
@@ -54,7 +54,7 @@ yarn add @dagger.io/dagger@latest --dev
 The Dagger Python SDK requires [Python 3.10 or later](https://docs.python.org/3/using/index.html). Using a [virtual environment](https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments) is recommended.
 :::
 
-In the `ci` directory, install the Dagger Python SDK using `pip`:
+Install the Dagger Python SDK using `pip`:
 
 ```shell
 pip install dagger-io

--- a/docs/current/quickstart/635927-quickstart-caching.mdx
+++ b/docs/current/quickstart/635927-quickstart-caching.mdx
@@ -29,6 +29,12 @@ This revised pipeline produces the same result as before, but now uses a cache f
 - It uses the `Container.WithMountedCache()` method to mount this cache volume at the `node_modules/` mount point in the container.
 - It uses the `Container.WithExec()` method to define the `npm install` command. When executed, this command downloads and installs dependencies in the `node_modules/` directory. Since this directory is defined as a cache volume, its contents will persist even after the pipeline terminates and can be reused on the next pipeline run.
 
+Run the pipeline by executing the command below from the application directory:
+
+```shell
+go run ci/main.go
+```
+
 </TabItem>
 <TabItem value="Node.js">
 
@@ -40,6 +46,12 @@ This revised pipeline produces the same result as before, but now uses a cache f
 - It uses the `Container.withMountedCache()` method to mount this cache volume at the `node_modules/` mount point in the container.
 - It uses the `Container.withExec()` method to define the `npm install` command. When executed, this command downloads and installs dependencies in the `node_modules/` directory. Since this directory is defined as a cache volume, its contents will persist even after the pipeline terminates and can be reused on the next pipeline run.
 
+Run the pipeline by executing the command below from the application directory:
+
+```shell
+node ci/index.mjs
+```
+
 </TabItem>
 <TabItem value="Python">
 
@@ -50,6 +62,12 @@ This revised pipeline produces the same result as before, but now uses a cache f
 - It uses the client's `cache_volume()` method to initialize a new cache volume.
 - It uses the `Container.with_mounted_cache()` method to mount this cache volume at the `node_modules/` mount point in the container.
 - It uses the `Container.with_exec()` method to define the `npm install` command. When executed, this command downloads and installs dependencies in the `node_modules/` directory. Since this directory is defined as a cache volume, its contents will persist even after the pipeline terminates and can be reused on the next pipeline run.
+
+Run the pipeline by executing the command below from the application directory:
+
+```shell
+python ci/main.py
+```
 
 </TabItem>
 </Tabs>

--- a/docs/current/quickstart/730264-quickstart-publish.mdx
+++ b/docs/current/quickstart/730264-quickstart-publish.mdx
@@ -21,15 +21,33 @@ Dagger SDKs have built-in support to publish container images. So, let's update 
 
 <iframe class="embed" src="https://play.dagger.cloud/embed/hGUZKAeot5K"></iframe>
 
+Run the pipeline by executing the command below from the application directory:
+
+```shell
+go run ci/main.go
+```
+
 </TabItem>
 <TabItem value="Node.js">
 
 <iframe class="embed" src="https://play.dagger.cloud/embed/xlXjwXsjvGt"></iframe>
 
+Run the pipeline by executing the command below from the application directory:
+
+```shell
+node ci/index.mjs
+```
+
 </TabItem>
 <TabItem value="Python">
 
 <iframe class="embed" src="https://play.dagger.cloud/embed/2r4dX0l8-zq"></iframe>
+
+Run the pipeline by executing the command below from the application directory:
+
+```shell
+python ci/main.py
+```
 
 </TabItem>
 </Tabs>

--- a/docs/current/quickstart/947391-quickstart-test.mdx
+++ b/docs/current/quickstart/947391-quickstart-test.mdx
@@ -2,7 +2,7 @@
 slug: /947391/quickstart-test
 displayed_sidebar: "quickstart"
 hide_table_of_contents: true
-title: "Run application tests"
+title: "Test the application"
 ---
 
 # Quickstart
@@ -10,7 +10,7 @@ title: "Run application tests"
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-## Run application tests
+## Test the application
 
 The pipeline in the previous example was illustrative - you wouldn't ever use it in the real world! So let's write a Dagger pipeline to do something more useful, like running an application's tests.
 

--- a/docs/current/quickstart/947391-quickstart-test.mdx
+++ b/docs/current/quickstart/947391-quickstart-test.mdx
@@ -16,6 +16,10 @@ The pipeline in the previous example was illustrative - you wouldn't ever use it
 
 The code listing below demonstrates a Dagger pipeline that runs tests for the example application, by executing the `npm run test` command.
 
+:::tip
+The `npm run test` command is appropriate for a React application, but other applications are likely to use different commands. Modify your Dagger pipeline accordingly.
+:::
+
 <Tabs groupId="language">
 <TabItem value="Go">
 
@@ -30,6 +34,12 @@ This code listing does the following:
 - It uses the `Container.WithExec()` method to define the commands to install dependencies and run tests in the container - in this case, the commands `npm install` and `npm test -- --watchAll=false`.
 - It uses the `Container.ExitCode()` method to execute the command and obtain the corresponding exit code. An exit code of `0` implies successful execution (all tests pass).
   - Failure, indicated by a non-zero exit code, will cause the pipeline to terminate.
+
+Run the pipeline by executing the command below from the application directory:
+
+```shell
+go run ci/main.go
+```
 
 </TabItem>
 <TabItem value="Node.js">
@@ -46,6 +56,12 @@ This code listing does the following:
 - It uses the `Container.exitCode()` method to execute the command and obtain the corresponding exit code. An exit code of `0` implies successful execution (all tests pass).
   - Failure, indicated by a non-zero exit code, will cause the pipeline to terminate.
 
+Run the pipeline by executing the command below from the application directory:
+
+```shell
+node ci/index.mjs
+```
+
 </TabItem>
 <TabItem value="Python">
 
@@ -60,6 +76,12 @@ This code listing does the following:
 - It uses the `Container.with_exec()` method to define the commands to install dependencies and run tests in the container - in this case, the commands `npm install` and `npm test -- --watchAll=false`.
 - It uses the `Container.exit_code()` method to execute the command and obtain the corresponding exit code. An exit code of `0` implies successful execution (all tests pass).
   - Failure, indicated by a non-zero exit code, will cause the pipeline to terminate.
+
+Run the pipeline by executing the command below from the application directory:
+
+```shell
+python ci/main.py
+```
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
- Remove step to cd into the `ci` directory since it's not required

cc @vikram-dagger @kpenfound 

We're removing this since it can be done from the repo root directory and could confuse users as they `cd` into the `ci` directory and then trying to run their pipelines will fail because they need to run it from the repo root.

LMKWYT.
