### PR TITLE
Pull engine image from registry.dagger.io

### DIFF
--- a/core/docs/d7yxc-operator_manual.md
+++ b/core/docs/d7yxc-operator_manual.md
@@ -106,10 +106,10 @@ To ensure that an SDK will be used with a compatible CLI and runner:
 
 ### Distribution and Versioning
 
-The runner is distributed as a container image at `ghcr.io/dagger/engine`.
+The runner is distributed as a container image at `registry.dagger.io/engine`.
 
 - Tags are made for the version of each release.
-- For example, the [`v0.3.7` release](https://github.com/dagger/dagger/releases/tag/v0.3.7) has a corresponding image at `ghcr.io/dagger/engine:v0.3.7`
+- For example, the [`v0.3.7` release](https://github.com/dagger/dagger/releases/tag/v0.3.7) has a corresponding image at `registry.dagger.io/engine:v0.3.7`
 
 ### Execution Requirements
 

--- a/internal/engine/version.go
+++ b/internal/engine/version.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	EngineImageRepo = "ghcr.io/dagger/engine"
+	EngineImageRepo = "registry.dagger.io/engine"
 )
 
 var DevelopmentVersion = fmt.Sprintf("devel (%s)", vcsRevision())


### PR DESCRIPTION
This is a follow-up to https://github.com/dagger/registry-redirect/pull/1.

Merging this is a requirement for https://github.com/dagger/dagger.io/pull/1756 (private repo).