### PR TITLE
Scrub secrets

### DIFF
--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -217,7 +217,8 @@ func shim() int {
 		return 0
 	}
 
-	shimFS := os.DirFS("/")
+	currentDirPath := "/"
+	shimFS := os.DirFS(currentDirPath)
 
 	stdoutFile, err := os.Create(stdoutPath)
 	if err != nil {
@@ -226,7 +227,7 @@ func shim() int {
 	defer stdoutFile.Close()
 
 	outWriter := io.MultiWriter(stdoutFile, os.Stdout)
-	scrubOutWriter, err := NewSecretScrubWriter(outWriter, shimFS, cmd.Env, secretsToScrub)
+	scrubOutWriter, err := NewSecretScrubWriter(outWriter, currentDirPath, shimFS, cmd.Env, secretsToScrub)
 	if err != nil {
 		panic(err)
 	}
@@ -239,7 +240,7 @@ func shim() int {
 	defer stderrFile.Close()
 
 	errWriter := io.MultiWriter(stderrFile, os.Stderr)
-	scrubErrWriter, err := NewSecretScrubWriter(errWriter, shimFS, cmd.Env, secretsToScrub)
+	scrubErrWriter, err := NewSecretScrubWriter(errWriter, currentDirPath, shimFS, cmd.Env, secretsToScrub)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/shim/secret_scrub.go
+++ b/cmd/shim/secret_scrub.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"strings"
+	"sync"
+
+	"github.com/dagger/dagger/core"
+)
+
+type SecretScrubWriter struct {
+	mu            sync.Mutex
+	w             io.Writer
+	secretToScrub core.SecretToScrubInfo
+	secretValues  []string
+	fs            fs.FS
+}
+
+func (w *SecretScrubWriter) Write(b []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	s := string(b)
+	for _, secret := range w.secretValues {
+		// FIXME: I think we can do better
+		s = strings.ReplaceAll(s, secret, "***")
+	}
+
+	n, err := w.w.Write([]byte(s))
+	if err != nil {
+		return -1, err
+	}
+	if n != len(b) {
+		n = len(b)
+	}
+
+	return n, err
+}
+
+// NewSecretScrubWriter replaces known secrets by "***".
+// The value of the secrets referenced in secretsToScrub are loaded either
+// from env or from the fs.
+func NewSecretScrubWriter(w io.Writer, fsys fs.FS, env []string, secretsToScrub core.SecretToScrubInfo) (io.Writer, error) {
+	secrets := loadSecretsToScrubFromEnv(env, secretsToScrub.Envs)
+
+	fileSecrets, err := loadSecretsToScrubFromFiles(fsys, secretsToScrub.Files)
+	if err != nil {
+		return nil, fmt.Errorf("could not load secrets from file: %w", err)
+	}
+	secrets = append(secrets, fileSecrets...)
+
+	return &SecretScrubWriter{
+		fs:            fsys,
+		w:             w,
+		secretValues:  secrets,
+		secretToScrub: secretsToScrub,
+	}, nil
+}
+
+func loadSecretsToScrubFromEnv(env []string, secretsToScrub []string) []string {
+	secrets := []string{}
+
+	for _, envKV := range env {
+		envName, envValue, ok := strings.Cut(envKV, "=")
+		// no env value for this secret
+		if !ok {
+			continue
+		}
+
+		for _, envToScrub := range secretsToScrub {
+			if envName == envToScrub {
+				secrets = append(secrets, envValue)
+			}
+		}
+	}
+
+	return secrets
+}
+
+func loadSecretsToScrubFromFiles(fsys fs.FS, secretFilePathsToScrub []string) ([]string, error) {
+	secrets := make([]string, 0, len(secretFilePathsToScrub))
+
+	for _, fileToScrub := range secretFilePathsToScrub {
+		// we remove the first `/` from the fileToScrub to work with fs.ReadFile
+		secret, err := fs.ReadFile(fsys, fileToScrub[1:])
+		if err != nil {
+			return nil, fmt.Errorf("secret value not available for: %w", err)
+		}
+		secrets = append(secrets, string(secret))
+	}
+
+	return secrets, nil
+}

--- a/cmd/shim/secret_scrub.go
+++ b/cmd/shim/secret_scrub.go
@@ -31,15 +31,12 @@ func (w *SecretScrubWriter) Write(b []byte) (int, error) {
 		s = strings.ReplaceAll(s, secret, "***")
 	}
 
-	n, err := w.w.Write([]byte(s))
+	_, err := w.w.Write([]byte(s))
 	if err != nil {
 		return -1, err
 	}
-	if n != len(b) {
-		n = len(b)
-	}
 
-	return n, err
+	return len(b), err
 }
 
 // NewSecretScrubWriter replaces known secrets by "***".

--- a/cmd/shim/secret_scrub.go
+++ b/cmd/shim/secret_scrub.go
@@ -11,11 +11,10 @@ import (
 )
 
 type SecretScrubWriter struct {
-	mu            sync.Mutex
-	w             io.Writer
-	secretToScrub core.SecretToScrubInfo
-	secretValues  []string
-	fs            fs.FS
+	mu           sync.Mutex
+	w            io.Writer
+	secretValues []string
+	fs           fs.FS
 }
 
 func (w *SecretScrubWriter) Write(b []byte) (int, error) {
@@ -52,10 +51,9 @@ func NewSecretScrubWriter(w io.Writer, fsys fs.FS, env []string, secretsToScrub 
 	secrets = append(secrets, fileSecrets...)
 
 	return &SecretScrubWriter{
-		fs:            fsys,
-		w:             w,
-		secretValues:  secrets,
-		secretToScrub: secretsToScrub,
+		fs:           fsys,
+		w:            w,
+		secretValues: secrets,
 	}, nil
 }
 

--- a/cmd/shim/secret_scrub.go
+++ b/cmd/shim/secret_scrub.go
@@ -15,7 +15,6 @@ type SecretScrubWriter struct {
 	mu           sync.Mutex
 	w            io.Writer
 	secretValues []string
-	fs           fs.FS
 }
 
 func (w *SecretScrubWriter) Write(b []byte) (int, error) {
@@ -52,7 +51,6 @@ func NewSecretScrubWriter(w io.Writer, currentDirPath string, fsys fs.FS, env []
 	secrets = append(secrets, fileSecrets...)
 
 	return &SecretScrubWriter{
-		fs:           fsys,
 		w:            w,
 		secretValues: secrets,
 	}, nil

--- a/cmd/shim/secret_scrub.go
+++ b/cmd/shim/secret_scrub.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -81,8 +82,13 @@ func loadSecretsToScrubFromFiles(fsys fs.FS, secretFilePathsToScrub []string) ([
 	secrets := make([]string, 0, len(secretFilePathsToScrub))
 
 	for _, fileToScrub := range secretFilePathsToScrub {
-		// we remove the first `/` from the fileToScrub to work with fs.ReadFile
-		secret, err := fs.ReadFile(fsys, fileToScrub[1:])
+		absFileToScrub, err := filepath.Abs(fileToScrub)
+		if err != nil {
+			return secrets, err
+		}
+
+		// we remove the first `/` from the absolute path to  fileToScrub to work with fs.ReadFile
+		secret, err := fs.ReadFile(fsys, absFileToScrub[1:])
 		if err != nil {
 			return nil, fmt.Errorf("secret value not available for: %w", err)
 		}

--- a/cmd/shim/secret_scrub.go
+++ b/cmd/shim/secret_scrub.go
@@ -11,12 +11,15 @@ import (
 	"github.com/dagger/dagger/core"
 )
 
+// SecretScrubWriter is a writer that will scrub secretValues before writing to the underlying writer.
+// It is safe to write to it concurrently.
 type SecretScrubWriter struct {
 	mu           sync.Mutex
 	w            io.Writer
 	secretValues []string
 }
 
+// Write scrubs secret values from b and replace them with `***`.
 func (w *SecretScrubWriter) Write(b []byte) (int, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -40,7 +43,7 @@ func (w *SecretScrubWriter) Write(b []byte) (int, error) {
 
 // NewSecretScrubWriter replaces known secrets by "***".
 // The value of the secrets referenced in secretsToScrub are loaded either
-// from env or from the fs.
+// from env or from the fs accessed at currentDirPath.
 func NewSecretScrubWriter(w io.Writer, currentDirPath string, fsys fs.FS, env []string, secretsToScrub core.SecretToScrubInfo) (io.Writer, error) {
 	secrets := loadSecretsToScrubFromEnv(env, secretsToScrub.Envs)
 
@@ -56,6 +59,7 @@ func NewSecretScrubWriter(w io.Writer, currentDirPath string, fsys fs.FS, env []
 	}, nil
 }
 
+// loadSecretsToScrubFromEnv loads secrets value from env if they are in secretsToScrub.
 func loadSecretsToScrubFromEnv(env []string, secretsToScrub []string) []string {
 	secrets := []string{}
 

--- a/cmd/shim/secret_scrub.go
+++ b/cmd/shim/secret_scrub.go
@@ -24,6 +24,9 @@ func (w *SecretScrubWriter) Write(b []byte) (int, error) {
 
 	s := string(b)
 	for _, secret := range w.secretValues {
+		if secret == "" {
+			continue
+		}
 		// FIXME: I think we can do better
 		s = strings.ReplaceAll(s, secret, "***")
 	}

--- a/cmd/shim/secret_scrub_test.go
+++ b/cmd/shim/secret_scrub_test.go
@@ -36,7 +36,26 @@ func TestSecretScrubWriter_Write(t *testing.T) {
 		want := "I love to share *** to my close ones. But I keep *** to myself. As well as ***."
 		require.Equal(t, want, buf.String())
 	})
+	t.Run("do not scrub empty env", func(t *testing.T) {
+		env := append(env, "EMPTY_SECRET_ID=")
+		fsys := fstest.MapFS{
+			"emptysecret": &fstest.MapFile{
+				Data: []byte(""),
+			},
+		}
 
+		var buf bytes.Buffer
+		w, err := NewSecretScrubWriter(&buf, fsys, env, core.SecretToScrubInfo{
+			Envs:  []string{"EMPTY_SECRET_ID"},
+			Files: []string{"/emptysecret"},
+		})
+		require.NoError(t, err)
+
+		_, err = fmt.Fprintf(w, "I love to share my secret value to my close ones. But I keep my secret file to myself.")
+		require.NoError(t, err)
+		want := "I love to share my secret value to my close ones. But I keep my secret file to myself."
+		require.Equal(t, want, buf.String())
+	})
 }
 
 func TestFilterSecretToScrub(t *testing.T) {

--- a/cmd/shim/secret_scrub_test.go
+++ b/cmd/shim/secret_scrub_test.go
@@ -79,9 +79,8 @@ func TestLoadSecretsToScrubFromEnv(t *testing.T) {
 }
 
 func TestLoadSecretsToScrubFromFiles(t *testing.T) {
-
+	const currentDirPath = "/mnt"
 	t.Run("/mnt, fs relative, secret absolute", func(t *testing.T) {
-		currentDirPath := "/mnt"
 		fsys := fstest.MapFS{
 			"mysecret": &fstest.MapFile{
 				Data: []byte("my secret file"),
@@ -99,7 +98,6 @@ func TestLoadSecretsToScrubFromFiles(t *testing.T) {
 	})
 
 	t.Run("/mnt, fs relative, secret relative", func(t *testing.T) {
-		currentDirPath := "/mnt"
 		fsys := fstest.MapFS{
 			"mysecret": &fstest.MapFile{
 				Data: []byte("my secret file"),
@@ -117,7 +115,6 @@ func TestLoadSecretsToScrubFromFiles(t *testing.T) {
 	})
 
 	t.Run("/mnt, fs absolute, secret relative", func(t *testing.T) {
-		currentDirPath := "/mnt"
 		fsys := fstest.MapFS{
 			"mnt/mysecret": &fstest.MapFile{
 				Data: []byte("my secret file"),

--- a/cmd/shim/secret_scrub_test.go
+++ b/cmd/shim/secret_scrub_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"testing/fstest"
+
+	"github.com/dagger/dagger/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretScrubWriter_Write(t *testing.T) {
+	fsys := fstest.MapFS{
+		"mysecret": &fstest.MapFile{
+			Data: []byte("my secret file"),
+		},
+	}
+	env := []string{
+		"MY_SECRET_ID=my secret value",
+	}
+
+	var buf bytes.Buffer
+	w, err := NewSecretScrubWriter(&buf, fsys, env, core.SecretToScrubInfo{
+		Envs:  []string{"MY_SECRET_ID"},
+		Files: []string{"/mysecret"},
+	})
+	require.NoError(t, err)
+
+	_, err = fmt.Fprintf(w, "I love to share my secret value to my close ones. But I keep my secret file to myself.")
+	require.NoError(t, err)
+	want := "I love to share *** to my close ones. But I keep *** to myself."
+	require.Equal(t, want, buf.String())
+}
+
+func TestFilterSecretToScrub(t *testing.T) {
+	secretValue := "my secret value"
+	env := []string{
+		fmt.Sprintf("MY_SECRET_ID=%s", secretValue),
+		"PUBLIC_STUFF=so public",
+	}
+
+	secretToScrub := core.SecretToScrubInfo{
+		Envs: []string{
+			"MY_SECRET_ID",
+		},
+	}
+
+	secrets := loadSecretsToScrubFromEnv(env, secretToScrub.Envs)
+	require.NotContains(t, secrets, "PUBLIC_STUFF")
+	require.Contains(t, secrets, secretValue)
+}

--- a/core/container.go
+++ b/core/container.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -985,9 +986,19 @@ func (container *Container) WithExec(ctx context.Context, gw bkgw.Client, defaul
 			secretDest = secret.EnvName
 			secretOpts = append(secretOpts, llb.SecretAsEnv(true))
 			secretsToScrub.Envs = append(secretsToScrub.Envs, secret.EnvName)
+
+			// we sort to avoid non-deterministic order that would break caching
+			sort.SliceStable(secretsToScrub.Envs, func(i, j int) bool {
+				return secretsToScrub.Envs[i] < secretsToScrub.Envs[j]
+			})
 		case secret.MountPath != "":
 			secretDest = secret.MountPath
 			secretsToScrub.Files = append(secretsToScrub.Files, secret.MountPath)
+
+			// we sort to avoid non-deterministic order that would break caching
+			sort.SliceStable(secretsToScrub.Files, func(i, j int) bool {
+				return secretsToScrub.Files[i] < secretsToScrub.Files[j]
+			})
 		default:
 			return nil, fmt.Errorf("malformed secret config at index %d", i)
 		}

--- a/core/container.go
+++ b/core/container.go
@@ -986,19 +986,9 @@ func (container *Container) WithExec(ctx context.Context, gw bkgw.Client, defaul
 			secretDest = secret.EnvName
 			secretOpts = append(secretOpts, llb.SecretAsEnv(true))
 			secretsToScrub.Envs = append(secretsToScrub.Envs, secret.EnvName)
-
-			// we sort to avoid non-deterministic order that would break caching
-			sort.SliceStable(secretsToScrub.Envs, func(i, j int) bool {
-				return secretsToScrub.Envs[i] < secretsToScrub.Envs[j]
-			})
 		case secret.MountPath != "":
 			secretDest = secret.MountPath
 			secretsToScrub.Files = append(secretsToScrub.Files, secret.MountPath)
-
-			// we sort to avoid non-deterministic order that would break caching
-			sort.SliceStable(secretsToScrub.Files, func(i, j int) bool {
-				return secretsToScrub.Files[i] < secretsToScrub.Files[j]
-			})
 		default:
 			return nil, fmt.Errorf("malformed secret config at index %d", i)
 		}
@@ -1007,6 +997,10 @@ func (container *Container) WithExec(ctx context.Context, gw bkgw.Client, defaul
 	}
 
 	if len(secretsToScrub.Envs) != 0 || len(secretsToScrub.Files) != 0 {
+		// we sort to avoid non-deterministic order that would break caching
+		sort.Strings(secretsToScrub.Envs)
+		sort.Strings(secretsToScrub.Files)
+
 		secretsToScrubJSON, err := json.Marshal(secretsToScrub)
 		if err != nil {
 			return nil, fmt.Errorf("scrub secrets json: %w", err)

--- a/core/file.go
+++ b/core/file.go
@@ -187,6 +187,7 @@ func (file *File) Export(
 	})
 }
 
+// gwRef returns the buildkit reference from the solved def.
 func gwRef(ctx context.Context, gw bkgw.Client, def *pb.Definition) (bkgw.Reference, error) {
 	res, err := gw.Solve(ctx, bkgw.SolveRequest{
 		Definition: def,

--- a/core/integration/host_test.go
+++ b/core/integration/host_test.go
@@ -259,5 +259,5 @@ func TestHostVariable(t *testing.T) {
 		Stdout(ctx)
 	require.NoError(t, err)
 
-	require.Contains(t, env, "SECRET=hello")
+	require.Contains(t, env, "SECRET=***")
 }

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -859,23 +859,23 @@ func TestFileServiceSecret(t *testing.T) {
 	}).Secret()
 
 	t.Run("secret env", func(t *testing.T) {
-		stdout, err := c.Container().
+		exitCode, err := c.Container().
 			From("alpine:3.16.2").
 			WithSecretVariable("SEKRIT", secret).
-			WithExec([]string{"sh", "-c", "echo -n $SEKRIT"}).
-			Stdout(ctx)
+			WithExec([]string{"sh", "-c", fmt.Sprintf(`test "$SEKRIT" = "%s"`, content)}).
+			ExitCode(ctx)
 		require.NoError(t, err)
-		require.Equal(t, content, stdout)
+		require.Equal(t, 0, exitCode)
 	})
 
 	t.Run("secret mount", func(t *testing.T) {
-		stdout, err := c.Container().
+		exitCode, err := c.Container().
 			From("alpine:3.16.2").
 			WithMountedSecret("/sekrit", secret).
-			WithExec([]string{"cat", "/sekrit"}).
-			Stdout(ctx)
+			WithExec([]string{"sh", "-c", fmt.Sprintf(`test "$(cat /sekrit)" = "%s"`, content)}).
+			ExitCode(ctx)
 		require.NoError(t, err)
-		require.Equal(t, content, stdout)
+		require.Equal(t, 0, exitCode)
 	})
 }
 

--- a/core/secret_scrub.go
+++ b/core/secret_scrub.go
@@ -1,0 +1,10 @@
+package core
+
+// SecretToScrubInfo stores the info to access secrets and scrub them from outputs.
+type SecretToScrubInfo struct {
+	// Envs stores environment variable names that we need to scrub.
+	Envs []string `json:"envs,omitempty"`
+
+	// Files stores secret file paths that we need to scrub.
+	Files []string `json:"files,omitempty"`
+}


### PR DESCRIPTION
This PR provides a way to get the 0.2 feature that would scrub secrets from logs in case if it leaks.

For now, I only handle env var, and the scrub writer is heavily mocked. Also, the files need to be moved around, there will be a refactor later in the PR advancement.

I'll update this description along the implementation.