### PR TITLE
docs: Quickstart improvements

### DIFF
--- a/docs/current/543069-index.md
+++ b/docs/current/543069-index.md
@@ -34,35 +34,7 @@ Dagger may be a good fit if you are...
 
 ## How does it work?
 
-```mermaid
-graph LR;
-
-subgraph program["Your program"]
-  lib["Dagger SDK"]
-end
-
-engine["Dagger Engine"]
-
-oci["OCI container runtime"]
-subgraph A["your build pipeline"]
-  A1[" "] -.-> A2[" "] -.-> A3[" "]
-end
-subgraph B["your test pipeline"]
-  B1[" "] -.-> B2[" "] -.-> B3[" "] -.-> B4[" "]
-end
-subgraph C["your deploy pipeline"]
-  C1[" "] -.-> C2[" "] -.-> C3[" "] -.-> C4[" "]
-end
-
-lib -..-> engine -..-> oci -..-> A1 & B1 & C1
-```
-
-1. Your program imports the Dagger SDK in your language of choice.
-2. Using the SDK, your program opens a new session to a Dagger Engine: either by connecting to an existing engine, or by provisioning one on-the-fly.
-3. Using the SDK, your program prepares API requests describing pipelines to run, then sends them to the engine. The wire protocol used to communicate with the engine is private and not yet documented, but this will change in the future. For now, the SDK is the only documented API available to your program.
-4. When the engine receives an API request, it computes a [Directed Acyclic Graph (DAG)](https://en.wikipedia.org/wiki/Directed_acyclic_graph) of low-level operations required to compute the result, and starts processing operations concurrently.
-5. When all operations in the pipeline have been resolved, the engine sends the pipeline result back to your program.
-6. Your program may use the pipeline's result as input to new pipelines.
+{@include: ../../partials/_how_does_dagger_work.md}
 
 ## Getting started
 

--- a/docs/current/cli/698277-index.md
+++ b/docs/current/cli/698277-index.md
@@ -27,9 +27,8 @@ subgraph program["Your program"]
   lib["Dagger CLI"]
 end
 
-engine["Dagger Engine"]
+engine["Dagger Engine - OCI container runtime"]
 
-oci["OCI container runtime"]
 subgraph A["your build pipeline"]
   A1[" "] -.-> A2[" "] -.-> A3[" "]
 end
@@ -40,7 +39,7 @@ subgraph C["your deployment pipeline"]
   C1[" "] -.-> C2[" "] -.-> C3[" "] -.-> C4[" "]
 end
 
-lib -..-> engine -..-> oci -..-> A1 & B1 & C1
+lib -..-> engine -..-> A1 & B1 & C1
 ```
 
 1. Using the Dagger CLI, your program (typically a shell script) opens a new session to a Dagger Engine: either by connecting to an existing engine, or by provisioning one on-the-fly.

--- a/docs/current/partials/_how_does_dagger_work.md
+++ b/docs/current/partials/_how_does_dagger_work.md
@@ -1,0 +1,28 @@
+```mermaid
+graph LR;
+
+subgraph program["Your program"]
+  lib["Dagger SDK"]
+end
+
+engine["Dagger Engine - OCI container runtime"]
+
+subgraph A["your build pipeline"]
+  A1[" "] -.-> A2[" "] -.-> A3[" "]
+end
+subgraph B["your test pipeline"]
+  B1[" "] -.-> B2[" "] -.-> B3[" "] -.-> B4[" "]
+end
+subgraph C["your deploy pipeline"]
+  C1[" "] -.-> C2[" "] -.-> C3[" "] -.-> C4[" "]
+end
+
+lib -..-> engine -..-> A1 & B1 & C1
+```
+
+1. Your program imports the Dagger SDK in your language of choice.
+2. Using the SDK, your program opens a new session to a Dagger Engine: either by connecting to an existing engine, or by provisioning one on-the-fly.
+3. Using the SDK, your program prepares API requests describing pipelines to run, then sends them to the engine. The wire protocol used to communicate with the engine is private and not yet documented, but this will change in the future. For now, the SDK is the only documented API available to your program.
+4. When the engine receives an API request, it computes a [Directed Acyclic Graph (DAG)](https://en.wikipedia.org/wiki/Directed_acyclic_graph) of low-level operations required to compute the result, and starts processing operations concurrently.
+5. When all operations in the pipeline have been resolved, the engine sends the pipeline result back to your program.
+6. Your program may use the pipeline's result as input to new pipelines.

--- a/docs/current/quickstart/120918-quickstart-setup.mdx
+++ b/docs/current/quickstart/120918-quickstart-setup.mdx
@@ -20,7 +20,7 @@ Let's begin by cloning the application repository into your local development en
 git clone https://github.com/dagger/hello-dagger.git
 ```
 
-Within the application directory, create a `ci` sub-directory. This sub-directory will hold the code you write in subsequent steps.
+Within the application directory, create a `ci` sub-directory. This sub-directory will hold the code that you will write in subsequent steps.
 
 ```shell
 cd hello-dagger && mkdir ci

--- a/docs/current/quickstart/319191-quickstart-basics.mdx
+++ b/docs/current/quickstart/319191-quickstart-basics.mdx
@@ -12,7 +12,7 @@ import TabItem from "@theme/TabItem";
 
 ## Understand the basics of Dagger
 
-Before diving into the code, let us address some common questions about Dagger:
+Before diving into the code, let's address some common questions about Dagger:
 
 ### What is Dagger?
 

--- a/docs/current/quickstart/319191-quickstart-basics.mdx
+++ b/docs/current/quickstart/319191-quickstart-basics.mdx
@@ -29,31 +29,4 @@ Dagger may be a good fit if you are...
 
 ### How does Dagger work?
 
-```mermaid
-graph LR;
-
-subgraph program["Your program"]
-  lib["Dagger SDK"]
-end
-
-engine["Dagger Engine - OCI container runtime"]
-
-subgraph A["your build pipeline"]
-  A1[" "] -.-> A2[" "] -.-> A3[" "]
-end
-subgraph B["your test pipeline"]
-  B1[" "] -.-> B2[" "] -.-> B3[" "] -.-> B4[" "]
-end
-subgraph C["your deploy pipeline"]
-  C1[" "] -.-> C2[" "] -.-> C3[" "] -.-> C4[" "]
-end
-
-lib -..-> engine -..-> A1 & B1 & C1
-```
-
-1. Your program imports the Dagger SDK in your language of choice.
-2. Using the SDK, your program opens a new session to a Dagger Engine: either by connecting to an existing engine, or by provisioning one on-the-fly.
-3. Using the SDK, your program prepares API requests describing pipelines to run, then sends them to the engine. The wire protocol used to communicate with the engine is private and not yet documented, but this will change in the future. For now, the SDK is the only documented API available to your program.
-4. When the engine receives an API request, it computes a [Directed Acyclic Graph (DAG)](https://en.wikipedia.org/wiki/Directed_acyclic_graph) of low-level operations required to compute the result, and starts processing operations concurrently.
-5. When all operations in the pipeline have been resolved, the engine sends the pipeline result back to your program.
-6. Your program may use the pipeline's result as input to new pipelines.
+{@include: ../../partials/_how_does_dagger_work.md}

--- a/docs/current/quickstart/319191-quickstart-basics.mdx
+++ b/docs/current/quickstart/319191-quickstart-basics.mdx
@@ -36,9 +36,8 @@ subgraph program["Your program"]
   lib["Dagger SDK"]
 end
 
-engine["Dagger Engine"]
+engine["Dagger Engine - OCI container runtime"]
 
-oci["OCI container runtime"]
 subgraph A["your build pipeline"]
   A1[" "] -.-> A2[" "] -.-> A3[" "]
 end
@@ -49,7 +48,7 @@ subgraph C["your deploy pipeline"]
   C1[" "] -.-> C2[" "] -.-> C3[" "] -.-> C4[" "]
 end
 
-lib -..-> engine -..-> oci -..-> A1 & B1 & C1
+lib -..-> engine -..-> A1 & B1 & C1
 ```
 
 1. Your program imports the Dagger SDK in your language of choice.

--- a/docs/current/quickstart/319191-quickstart-basics.mdx
+++ b/docs/current/quickstart/319191-quickstart-basics.mdx
@@ -12,7 +12,7 @@ import TabItem from "@theme/TabItem";
 
 ## Understand the basics of Dagger
 
-Before diving in to the code, here are some common questions about Dagger (and their answers).
+Before diving into the code, let us address some common questions about Dagger:
 
 ### What is Dagger?
 

--- a/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
+++ b/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
@@ -2,7 +2,7 @@
 slug: /429462/quickstart-build-dockerfile
 displayed_sidebar: "quickstart"
 hide_table_of_contents: true
-title: "Wrap existing Dockerfiles with Dagger"
+title: "Reuse existing Dockerfiles"
 ---
 
 # Quickstart
@@ -20,7 +20,7 @@ export const ids = {
 
 <QuickstartDoc embeds={ids}>
 
-## Wrap existing Dockerfiles with Dagger
+## Reuse existing Dockerfiles
 
 As you've seen over the last few pages, Dagger is a powerful tool. It lets you create CI pipelines using general purpose programming languages, giving you full access to native control structures like conditionals and loops. By allowing you to import and use existing language extensions or packages in your pipeline code, Dagger makes it easier to quickly add new functionality or integrate with third-party services. By the same token, Dagger pipelines also benefit from static typing and easier refactoring.
 

--- a/docs/current/quickstart/481031-quickstart-conclusion.mdx
+++ b/docs/current/quickstart/481031-quickstart-conclusion.mdx
@@ -14,7 +14,7 @@ import TabItem from "@theme/TabItem";
 
 Over the last few pages, this tutorial has walked you, step by step, through the process of creating and refining a CI pipeline to test, build and publish an example application with a Dagger SDK.
 
-Contine your journey with Dagger by visiting the links below:
+Continue your journey with Dagger by visiting the links below:
 
 - GraphQL API [concepts](../api/975146-concepts.mdx) and [reference documentation](https://docs.dagger.io/api/reference)
 - Task-focused [guides and walkthroughs](../278912-guides.mdx)

--- a/docs/current/quickstart/593914-quickstart-hello.mdx
+++ b/docs/current/quickstart/593914-quickstart-hello.mdx
@@ -35,7 +35,7 @@ In the `ci` directory, create a file named `main.go` and add the following code 
 
 This Go program imports the Dagger SDK and defines a `main()` function for the pipeline operations. This function performs the following operations:
 
-- It creates a Dagger client with `dagger.Connect()`. This client provides an interface for executing commands against the Dagger engine.
+- It creates a Dagger client with `dagger.Connect()`. This client provides an interface for executing commands against the Dagger Engine.
 - It uses the client's `Container().From()` method to initialize a new container from a base image. In this example, the base image is `golang:1.19`. This method returns a `Container` representing an OCI-compatible container image.
 - It uses the `Container.withExec()` method to define the command to be executed in the container - in this case, the command `go version`, which returns the Go version string. The `withExec()` method returns a revised `Container` with the results of command execution.
 - It retrieves the output stream of the last executed with the `Container.Stdout()` method and prints the result to the console.
@@ -61,7 +61,7 @@ In the `ci` directory, create a new file named `index.mjs` and add the following
 
 This Node.js script imports the Dagger SDK and defines an asynchronous function. This function performs the following operations:
 
-- It creates a Dagger client with `connect()`. This client provides an interface for executing commands against the Dagger engine.
+- It creates a Dagger client with `connect()`. This client provides an interface for executing commands against the Dagger Engine.
 - It uses the client's `container().from()` method to initialize a new container from a base image. In this example, the base image is `node:16-slim`. This method returns a `Container` representing an OCI-compatible container image.
 - It uses the `Container.withExec()` method to define the command to be executed in the container - in this case, the command `node -v`, which returns the Node version string. The `withExec()` method returns a revised `Container` with the results of command execution.
 - It retrieves the output stream of the last executed with the `Container.stdout()` method and prints the result to the console.
@@ -87,7 +87,7 @@ In the `ci` directory, create a new file named `main.py` and add the following c
 
 This Python script imports the Dagger SDK and defines an asynchronous function. This function performs the following operations:
 
-- It creates a Dagger client with `with dagger.Connection()`. This client provides an interface for executing commands against the Dagger engine.
+- It creates a Dagger client with `with dagger.Connection()`. This client provides an interface for executing commands against the Dagger Engine.
 - It uses the client's `container().from_()` method to initialize a new container from a base image. In this example, the base image is `python:3.11-slim`. This method returns a `Container` representing an OCI-compatible container image.
 - It uses the `Container.with_exec()` method to define the command to be executed in the container - in this case, the command `python -V`, which returns the Python version string. The `with_exec()` method returns a revised `Container` with the results of command execution.
 - It retrieves the output stream of the last executed with the `Container.stdout()` method and prints the result to the console.

--- a/docs/current/quickstart/628381-quickstart-sdk.mdx
+++ b/docs/current/quickstart/628381-quickstart-sdk.mdx
@@ -25,7 +25,7 @@ Create a new Go module and install the Dagger Go SDK using the commands below:
 
 ```shell
 go mod init main
-go get dagger.io/dagger@latest
+go get dagger.io/dagger
 ```
 
 </TabItem>
@@ -38,13 +38,13 @@ The Dagger Node.js SDK requires [Node.js 16.x or later](https://nodejs.org/en/do
 Install the Dagger Node.js SDK using `npm`:
 
 ```shell
-npm install @dagger.io/dagger@latest --save-dev
+npm install @dagger.io/dagger --save-dev
 ```
 
 You can also install it using `yarn` if you prefer:
 
 ```shell
-yarn add @dagger.io/dagger@latest --dev
+yarn add @dagger.io/dagger --dev
 ```
 
 </TabItem>

--- a/docs/current/quickstart/730264-quickstart-publish.mdx
+++ b/docs/current/quickstart/730264-quickstart-publish.mdx
@@ -24,7 +24,7 @@ export const ids = {
 
 At this point, your Dagger pipeline has tested, built and delivered the application to your local host. But why not also publish a container image of the application to a registry?
 
-Dagger SDKs have built-in support to publish container images. So, let's update the pipeline to copy the built React application into an NGINX Web server container and deliver the result to a public registry. Depending on the SDK, you need either the `publish()` method (for Node.js and Python) or the `Publish()` method (for Go).
+Dagger SDKs have built-in support to publish container images. So, let's update the pipeline to copy the built React application into an NGINX web server container and deliver the result to a public registry. Depending on the SDK, you need either the `publish()` method (for Node.js and Python) or the `Publish()` method (for Go).
 
 <Tabs groupId="language" className="embeds">
 <TabItem value="Go">

--- a/docs/current/sdk/go/440319-index.md
+++ b/docs/current/sdk/go/440319-index.md
@@ -45,9 +45,8 @@ subgraph program["Your Go program"]
   lib["Go library"]
 end
 
-engine["Dagger Engine"]
+engine["Dagger Engine - OCI container runtime"]
 
-oci["OCI container runtime"]
 subgraph A["your build pipeline"]
   A1[" "] -.-> A2[" "] -.-> A3[" "]
 end
@@ -58,7 +57,7 @@ subgraph C["your deployment pipeline"]
   C1[" "] -.-> C2[" "] -.-> C3[" "] -.-> C4[" "]
 end
 
-lib -..-> engine -..-> oci -..-> A1 & B1 & C1
+lib -..-> engine -..-> A1 & B1 & C1
 ```
 
 1. Your Go program imports the Dagger Go library.

--- a/docs/current/sdk/nodejs/722802-index.md
+++ b/docs/current/sdk/nodejs/722802-index.md
@@ -39,9 +39,8 @@ subgraph program["Your Node.js program"]
   lib["Node.js package"]
 end
 
-engine["Dagger Engine"]
+engine["Dagger Engine - OCI container runtime"]
 
-oci["OCI container runtime"]
 subgraph A["your build pipeline"]
   A1[" "] -.-> A2[" "] -.-> A3[" "]
 end
@@ -52,7 +51,7 @@ subgraph C["your deployment pipeline"]
   C1[" "] -.-> C2[" "] -.-> C3[" "] -.-> C4[" "]
 end
 
-lib -..-> engine -..-> oci -..-> A1 & B1 & C1
+lib -..-> engine -..-> A1 & B1 & C1
 ```
 
 1. Your Node.js program imports the Dagger Node.js package.

--- a/docs/current/sdk/python/459708-index.md
+++ b/docs/current/sdk/python/459708-index.md
@@ -40,9 +40,8 @@ subgraph program["Your Python program"]
   lib["Python package"]
 end
 
-engine["Dagger Engine"]
+engine["Dagger Engine - OCI container runtime"]
 
-oci["OCI container runtime"]
 subgraph A["your build pipeline"]
   A1[" "] -.-> A2[" "] -.-> A3[" "]
 end
@@ -53,7 +52,7 @@ subgraph C["your deployment pipeline"]
   C1[" "] -.-> C2[" "] -.-> C3[" "] -.-> C4[" "]
 end
 
-lib -..-> engine -..-> oci -..-> A1 & B1 & C1
+lib -..-> engine -..-> A1 & B1 & C1
 ```
 
 1. Your Python program imports the Dagger Python package.


### PR DESCRIPTION
- docs: Reword a few things in the Quickstart
  - might be subjective, feel free to reject anything that doesn't stick
- docs: Fix typo
- docs: Make diagram accurate
  - the Dagger Engine **is** the OCI container runtime. All pipeline ops run inside the Dagger Engine.
- docs: Drop @latest from the package
  - In the case of Go, this will default to the latest published package version, which is what we want. Versioned is unlikely to break in the future, while `latest` is a moving target. In this context, moving targets usually lead to unexpected breakages. I never regretted pinning my dependencies. I consider it good advice at this point, but feel free to drop this commit if you think otherwise.
