### PR TITLE
docs: Fix Rust,PHP syntax highlight and API response in GraphQL docs

### DIFF
--- a/docs/current/api/254103-build-custom-client.md
+++ b/docs/current/api/254103-build-custom-client.md
@@ -68,7 +68,6 @@ Once the client library is installed, create an API client as described below.
 Add the following code to `src/main.rs`:
 
 ```rust file=snippets/build-custom-client/step2/main.rs
-
 ```
 
 </TabItem>
@@ -77,7 +76,6 @@ Add the following code to `src/main.rs`:
 Create a new file named `client.php` and add the following code to it:
 
 ```php file=snippets/build-custom-client/step2/client.php
-
 ```
 
 </TabItem>

--- a/docs/current/api/975146-concepts.md
+++ b/docs/current/api/975146-concepts.md
@@ -50,9 +50,7 @@ The query returns a list of the packages installed in the image:
   "container": {
    "from": {
     "withExec": {
-     "stdout": {
-      "contents": "alpine-baselayout-data\nmusl\nbusybox\nalpine-baselayout\nalpine-keys\nca-certificates-bundle\nlibcrypto1.1\nlibssl1.1\nssl_client\nzlib\napk-tools\nscanelf\nmusl-utils\nlibc-utils\n"
-     }
+     "stdout": "alpine-baselayout-data\nmusl\nbusybox\nalpine-baselayout\nalpine-keys\nca-certificates-bundle\nlibcrypto1.1\nlibssl1.1\nssl_client\nzlib\napk-tools\nscanelf\nmusl-utils\nlibc-utils\n"
     }
    }
   }

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -19,6 +19,7 @@ async function createConfig() {
       sidebarCollapsed: false,
       metadata: [{ name: 'og:image', content: '/img/favicon.png' }],
       prism: {
+        additionalLanguages: ["php", "rust"],
         theme: require("prism-react-renderer/themes/okaidia"),
       },
       navbar: {


### PR DESCRIPTION
Fix some things in GraphQL API docs

-  Enable syntax highlighting of PHP & Rust in docusaurus which is not enable by default (https://docusaurus.io/docs/markdown-features/code-blocks#supported-languages). The code blocks of these languages are here (https://docs.dagger.io/api/254103/build-custom-client#step-2-create-an-api-client).

- Fix schema of one of the GraphQL response

Signed-off-by: Rahul Modpur <rmodpur@gmail.com>