### PR TITLE
docs: add new layout to quickstart

### DIFF
--- a/docs/_README.md
+++ b/docs/_README.md
@@ -43,6 +43,35 @@ We prefer to keep the organisation of doc pages, and writing them separate.
 For the time being - 2022 Q1 - the focus is on writing self-contained doc content.
 Don't worry about where to fit this content, it's enough to keep this in mind: [Writing effective documentation](https://www.youtube.com/watch?v=R6zeikbTgVc&t=19s).
 
+
+### Adding or editing a Quickstart page
+
+> **Note**
+> "Step", "`.mdx` file" and "doc" are used interchangeably.
+> **Note**
+>The new format of the step only affects the steps that have an embedded Playground instance. If no embed is present in the step (no `<QuickstartDoc>` component is present in the `.mdx` file), the default Docusarus theme is used.  
+
+The new layout is based on two columns for wide screens. The embed is placed as `sticky` on the right. This allows the user to scroll through the doc content and keep the editor visible.  
+To add or edit a step, be sure to:  
+
+- Create an object with the SDK name as properties and their Playground ID as their value, then pass it to the `<QuickstartDoc>` component as an "embeds" prop.
+
+```jsx
+export const ids = {
+    Go: "ho4ZF-6naKv",
+    Node: "aPB-msb5UEn",
+    Python: "tqaPp2aVr_L"
+}
+
+<QuickstartDoc embeds={ids}>
+```
+
+- Encapsulate the whole quickstart content inside the `<QuickstartDoc>` component. This will pass all the content as children. This component will take care of rendering each column accordingly.
+- Use the `<Embed>` component instead of the native `<iframe>` element. This component makes sure to add a spinner while the `<iframe>` is loading, besides taking care of some custom styling.  
+- Make sure the `<TabItem>` `value` prop has the same values as the `ids` object property names. Use `value=Node` instead of value="Node.js" on the prop, as property names cannot contain dots in JS.
+
+See [children](https://beta.reactjs.org/reference/react/Children) and [tabs](https://docusaurus.io/docs/markdown-features/tabs) for implementation context.
+
 ## Debugging
 
 A [debug plugin](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-debug) is available at `http://localhost:3000/__docusaurus/debug`.  

--- a/docs/_README.md
+++ b/docs/_README.md
@@ -43,7 +43,6 @@ We prefer to keep the organisation of doc pages, and writing them separate.
 For the time being - 2022 Q1 - the focus is on writing self-contained doc content.
 Don't worry about where to fit this content, it's enough to keep this in mind: [Writing effective documentation](https://www.youtube.com/watch?v=R6zeikbTgVc&t=19s).
 
-
 ### Adding or editing a Quickstart page
 
 > **Note**

--- a/docs/current/quickstart/349011-quickstart-build.mdx
+++ b/docs/current/quickstart/349011-quickstart-build.mdx
@@ -9,6 +9,16 @@ title: "Build the application"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
+import QuickstartDoc from '@site/src/components/molecules/quickstartDoc.js'
+import Embed from '@site/src/components/atoms/embed.js'
+
+export const ids = {
+    Go: "1H9zPpWRtDi",
+    Node: "HMeWQ18XgxM",
+    Python: "Hh2ra08H6lu"
+}
+
+<QuickstartDoc embeds={ids}>
 
 ## Build the application
 
@@ -20,10 +30,10 @@ So, let's update the previous pipeline and add a build step to it, by running `n
 The `npm run build` command is appropriate for a React application, but other applications are likely to use different commands. Modify your Dagger pipeline accordingly.
 :::
 
-<Tabs groupId="language">
+<Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/1H9zPpWRtDi"></iframe>
+<Embed id="1H9zPpWRtDi" />
 
 - It invokes the `Container.WithExec()` method again, this time to define the command `npm run build` in the container.
 - It obtains a reference to the `build/` directory in the container with the `Container.Directory()` method. This method returns a `Directory` object.
@@ -36,9 +46,9 @@ go run ci/main.go
 ```
 
 </TabItem>
-<TabItem value="Node.js">
+<TabItem value="Node">
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/HMeWQ18XgxM"></iframe>
+<Embed id="HMeWQ18XgxM" />
 
 This revised pipeline does everything described in the previous step, and then performs the following additional operations:
 
@@ -55,7 +65,7 @@ node ci/index.mjs
 </TabItem>
 <TabItem value="Python">
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/Hh2ra08H6lu"></iframe>
+<Embed id="Hh2ra08H6lu" />
 
 This revised pipeline does everything described in the previous step, and then performs the following additional operations:
 
@@ -97,3 +107,5 @@ build
     └── media
         └── logo.6ce24c58023cc2f8fd88fe9d219db6c6.svg
 ```
+
+</QuickstartDoc>

--- a/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
+++ b/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
@@ -9,6 +9,16 @@ title: "Wrap existing Dockerfiles with Dagger"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
+import QuickstartDoc from '@site/src/components/molecules/quickstartDoc.js'
+import Embed from '@site/src/components/atoms/embed.js'
+
+export const ids = {
+    Go: "FkLP0dXMgIm",
+    Node: "IdHGiwvkn6E",
+    Python: "xCI5LKiZfGD"
+}
+
+<QuickstartDoc embeds={ids}>
 
 ## Wrap existing Dockerfiles with Dagger
 
@@ -20,10 +30,10 @@ The good news here is that Dagger can natively run Dockerfiles with full compati
 
 The example application repository includes a simple Dockerfile. Use it with a Dagger pipeline as shown below:
 
-<Tabs groupId="language">
+<Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/FkLP0dXMgIm"></iframe>
+<Embed id="FkLP0dXMgIm"/>
 
 This code listing does the following:
 Connect()`.
@@ -38,9 +48,9 @@ go run ci/main.go
 ```
 
 </TabItem>
-<TabItem value="Node.js">
+<TabItem value="Node">
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/IdHGiwvkn6E"></iframe>
+<Embed id="IdHGiwvkn6E"/>
 
 This code listing does the following:
 
@@ -58,7 +68,7 @@ node ci/index.mjs
 </TabItem>
 <TabItem value="Python">
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/xCI5LKiZfGD"></iframe>
+<Embed id="xCI5LKiZfGD"/>
 
 This code listing does the following:
 
@@ -77,3 +87,5 @@ python ci/main.py
 </Tabs>
 
 After Dagger resolves the pipeline, the newly-built container image will be available in the [ttl.sh](https://ttl.sh) registry. Download and test it as described in the section on [publishing the application](./730264-quickstart-publish.mdx).
+
+</QuickstartDoc>

--- a/docs/current/quickstart/472910-quickstart-build-multi.mdx
+++ b/docs/current/quickstart/472910-quickstart-build-multi.mdx
@@ -9,6 +9,16 @@ title: "Perform a multi-stage build"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
+import QuickstartDoc from '@site/src/components/molecules/quickstartDoc.js'
+import Embed from '@site/src/components/atoms/embed.js'
+
+export const ids = {
+    Go: "m1TsqrqYvgE",
+    Node: "ijTE41ISH95",
+    Python: "rgVdmi0ssZq"
+}
+
+<QuickstartDoc embeds={ids}>
 
 ## Perform a multi-stage build
 
@@ -26,10 +36,10 @@ In the context of a multi-stage build, this means that you can use Dagger to:
 
 Let's now update our pipeline to use a multi-stage build, as described above.
 
-<Tabs groupId="language">
+<Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/m1TsqrqYvgE"></iframe>
+<Embed id="m1TsqrqYvgE"/>
 
 Run the pipeline by executing the command below from the application directory:
 
@@ -38,9 +48,9 @@ go run ci/main.go
 ```
 
 </TabItem>
-<TabItem value="Node.js">
+<TabItem value="Node">
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/ijTE41ISH95"></iframe>
+<Embed id="ijTE41ISH95"/>
 
 Run the pipeline by executing the command below from the application directory:
 
@@ -51,7 +61,7 @@ node ci/index.mjs
 </TabItem>
 <TabItem value="Python">
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/rgVdmi0ssZq"></iframe>
+<Embed id="rgVdmi0ssZq"/>
 
 Run the pipeline by executing the command below from the application directory:
 
@@ -66,3 +76,5 @@ This revised pipeline produces the same result as before, but using a two-stage 
 
 - In the first stage, the pipeline installs dependencies, runs tests and builds the application in the `node:16-slim` container. However, instead of exporting the `build/` directory to the host, it saves the corresponding `Directory` object as a constant. This object represents the filesystem state of the `build/` directory in the container after the build, and is portable to other Dagger pipelines.
 - In the second stage, the pipeline uses the saved `Directory` object as input, thereby transferring the filesystem state (the built React application) to the `nginx:alpine` container. It then publishes the result to a registry as previously described.
+
+</QuickstartDoc>

--- a/docs/current/quickstart/593914-quickstart-hello.mdx
+++ b/docs/current/quickstart/593914-quickstart-hello.mdx
@@ -9,6 +9,16 @@ title: "Write your first Dagger pipeline"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
+import QuickstartDoc from '@site/src/components/molecules/quickstartDoc.js'
+import Embed from '@site/src/components/atoms/embed.js'
+
+export const ids = {
+    Go: "i0bfOBUBkn8",
+    Node: "oMQiF1h-W1O",
+    Python: "UjXJ6KJrFqZ"
+}
+
+<QuickstartDoc embeds={ids}>
 
 ## Write your first Dagger pipeline
 
@@ -16,12 +26,12 @@ You're now ready to dive into Dagger and write your first pipeline!
 
 This first example is fairly simple: it creates a Dagger client using your chosen SDK, initializes a container, executes a command in that container and prints the output.
 
-<Tabs groupId="language">
+<Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
 In the `ci` directory, create a file named `main.go` and add the following code to it.
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/i0bfOBUBkn8"></iframe>
+<Embed id= "i0bfOBUBkn8"/>
 
 This Go program imports the Dagger SDK and defines a `main()` function for the pipeline operations. This function performs the following operations:
 
@@ -43,11 +53,11 @@ Hello from Dagger and go version go1.19.5 linux/amd64
 ```
 
 </TabItem>
-<TabItem value="Node.js">
+<TabItem value="Node">
 
 In the `ci` directory, create a new file named `index.mjs` and add the following code to it.
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/oMQiF1h-W1O"></iframe>
+<Embed id= "oMQiF1h-W1O"/>
 
 This Node.js script imports the Dagger SDK and defines an asynchronous function. This function performs the following operations:
 
@@ -73,7 +83,7 @@ Hello from Dagger and Node v16.18.1
 
 In the `ci` directory, create a new file named `main.py` and add the following code to it.
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/UjXJ6KJrFqZ"></iframe>
+<Embed id= "UjXJ6KJrFqZ"/>
 
 This Python script imports the Dagger SDK and defines an asynchronous function. This function performs the following operations:
 
@@ -98,3 +108,5 @@ Hello from Dagger and Python v3.11.1
 </Tabs>
 
 Well done! You've just successfully written and run your first Dagger pipeline!
+
+</QuickstartDoc>

--- a/docs/current/quickstart/635927-quickstart-caching.mdx
+++ b/docs/current/quickstart/635927-quickstart-caching.mdx
@@ -10,11 +10,12 @@ title: "Use caching"
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import QuickstartDoc from "@site/src/components/molecules/quickstartDoc.js"
+import Embed from "@site/src/components/atoms/embed.js"
 
 export const ids = {
-    Go: "hGUZKAeot5K",
-    Node: "xlXjwXsjvGt",
-    Python: "2r4dX0l8-zq"
+    Go: "faz9rMJNQca",
+    Node: "2DhNPJQ6pUU",
+    Python: "ZxqkCRsSlGU"
 }
 
 <QuickstartDoc embeds={ids}>
@@ -34,7 +35,7 @@ The `npm install` command is appropriate for a React application, but other appl
 <Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/faz9rMJNQca"></iframe>
+<Embed id="faz9rMJNQca" />
 
 This revised pipeline now uses a cache for the application dependencies.
 
@@ -51,7 +52,7 @@ go run ci/main.go
 </TabItem>
 <TabItem value="Node">
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/2DhNPJQ6pUU"></iframe>
+<Embed id="2DhNPJQ6pUU" />
 
 This revised pipeline now uses a cache for the application dependencies.
 
@@ -68,7 +69,7 @@ node ci/index.mjs
 </TabItem>
 <TabItem value="Python">
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/ZxqkCRsSlGU"></iframe>
+<Embed id="ZxqkCRsSlGU" />
 
 This revised pipeline now uses a cache for the application dependencies.
 

--- a/docs/current/quickstart/635927-quickstart-caching.mdx
+++ b/docs/current/quickstart/635927-quickstart-caching.mdx
@@ -9,6 +9,15 @@ title: "Use caching"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
+import QuickstartDoc from "@site/src/components/molecules/quickstartDoc.js"
+
+export const ids = {
+    Go: "hGUZKAeot5K",
+    Node: "xlXjwXsjvGt",
+    Python: "2r4dX0l8-zq"
+}
+
+<QuickstartDoc embeds={ids}>
 
 ## Use caching
 
@@ -22,7 +31,7 @@ This step is, therefore, a good candidate for a cache. Let's update the pipeline
 The `npm install` command is appropriate for a React application, but other applications are likely to use different commands. Modify your Dagger pipeline accordingly.
 :::
 
-<Tabs groupId="language">
+<Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
 <iframe class="embed" src="https://play.dagger.cloud/embed/faz9rMJNQca"></iframe>
@@ -40,7 +49,7 @@ go run ci/main.go
 ```
 
 </TabItem>
-<TabItem value="Node.js">
+<TabItem value="Node">
 
 <iframe class="embed" src="https://play.dagger.cloud/embed/2DhNPJQ6pUU"></iframe>
 
@@ -79,3 +88,5 @@ python ci/main.py
 This revised pipeline produces the same result as before.
 
 Run the pipeline a few times. Notice that on the first run, the application dependencies are downloaded as usual. However, since the dependencies are cached, subsequent pipeline runs will skip the download operation and be significantly faster (assuming that there are no other changes to the application code).
+
+</QuickstartDoc>

--- a/docs/current/quickstart/730264-quickstart-publish.mdx
+++ b/docs/current/quickstart/730264-quickstart-publish.mdx
@@ -9,6 +9,15 @@ title: "Publish the application"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
+import QuickstartDoc from "@site/src/components/molecules/quickstartDoc.js"
+
+export const ids = {
+    Go: "hGUZKAeot5K",
+    Node: "xlXjwXsjvGt",
+    Python: "2r4dX0l8-zq"
+}
+
+<QuickstartDoc embeds={ids}>
 
 ## Publish the application
 
@@ -16,7 +25,7 @@ At this point, your Dagger pipeline has tested, built and delivered the applicat
 
 Dagger SDKs have built-in support to publish container images. So, let's update the pipeline to copy the built React application into an NGINX Web server container and deliver the result to a public registry. Depending on the SDK, you need either the `publish()` method (for Node.js and Python) or the `Publish()` method (for Go).
 
-<Tabs groupId="language">
+<Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
 <iframe class="embed" src="https://play.dagger.cloud/embed/SYJ885fBPOy"></iframe>
@@ -28,7 +37,7 @@ go run ci/main.go
 ```
 
 </TabItem>
-<TabItem value="Node.js">
+<TabItem value="Node">
 
 <iframe class="embed" src="https://play.dagger.cloud/embed/P8mz6yjC2lM"></iframe>
 
@@ -73,3 +82,5 @@ You may have noticed that the pipeline above is able to publish to the registry 
 
 Dagger SDKs rely on your existing Docker credentials for registry authentication. This means that you must execute `docker login` against your selected container registry on the Dagger host before attempting to publish an image to that registry.
 :::
+
+</QuickstartDoc>

--- a/docs/current/quickstart/730264-quickstart-publish.mdx
+++ b/docs/current/quickstart/730264-quickstart-publish.mdx
@@ -10,11 +10,12 @@ title: "Publish the application"
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import QuickstartDoc from "@site/src/components/molecules/quickstartDoc.js"
+import Embed from "@site/src/components/atoms/embed.js"
 
 export const ids = {
-    Go: "hGUZKAeot5K",
-    Node: "xlXjwXsjvGt",
-    Python: "2r4dX0l8-zq"
+    Go: "SYJ885fBPOy",
+    Node: "P8mz6yjC2lM",
+    Python: "Vz6OJ6gIDaP"
 }
 
 <QuickstartDoc embeds={ids}>
@@ -28,7 +29,7 @@ Dagger SDKs have built-in support to publish container images. So, let's update 
 <Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/SYJ885fBPOy"></iframe>
+<Embed id={"SYJ885fBPOy"}></Embed>
 
 Run the pipeline by executing the command below from the application directory:
 
@@ -39,7 +40,7 @@ go run ci/main.go
 </TabItem>
 <TabItem value="Node">
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/P8mz6yjC2lM"></iframe>
+<Embed id="P8mz6yjC2lM"></Embed>
 
 Run the pipeline by executing the command below from the application directory:
 
@@ -50,7 +51,7 @@ node ci/index.mjs
 </TabItem>
 <TabItem value="Python">
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/Vz6OJ6gIDaP"></iframe>
+<Embed id="Vz6OJ6gIDaP"></Embed>
 
 Run the pipeline by executing the command below from the application directory:
 

--- a/docs/current/quickstart/730264-quickstart-publish.mdx
+++ b/docs/current/quickstart/730264-quickstart-publish.mdx
@@ -29,7 +29,7 @@ Dagger SDKs have built-in support to publish container images. So, let's update 
 <Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
-<Embed id={"SYJ885fBPOy"}></Embed>
+<Embed id="SYJ885fBPOy"></Embed>
 
 Run the pipeline by executing the command below from the application directory:
 

--- a/docs/current/quickstart/947391-quickstart-test.mdx
+++ b/docs/current/quickstart/947391-quickstart-test.mdx
@@ -9,6 +9,16 @@ title: "Test the application"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
+import QuickstartDoc from '@site/src/components/molecules/quickstartDoc.js'
+import Embed from '@site/src/components/atoms/embed.js'
+
+export const ids = {
+    Go: "M8NHUR0WTWT",
+    Node: "XyDYQWN2edq",
+    Python: "SF9BGtA_py3"
+}
+
+<QuickstartDoc embeds={ids}>
 
 ## Test the application
 
@@ -20,10 +30,11 @@ The code listing below demonstrates a Dagger pipeline that runs tests for the ex
 The `npm run test` command is appropriate for a React application, but other applications are likely to use different commands. Modify your Dagger pipeline accordingly.
 :::
 
-<Tabs groupId="language">
+
+<Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/M8NHUR0WTWT"></iframe>
+<Embed id="M8NHUR0WTWT" />
 
 This code listing does the following:
 
@@ -42,9 +53,9 @@ go run ci/main.go
 ```
 
 </TabItem>
-<TabItem value="Node.js">
+<TabItem value="Node">
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/XyDYQWN2edq"></iframe>
+<Embed id="XyDYQWN2edq" />
 
 This code listing does the following:
 
@@ -65,7 +76,7 @@ node ci/index.mjs
 </TabItem>
 <TabItem value="Python">
 
-<iframe class="embed" src="https://play.dagger.cloud/embed/SF9BGtA_py3"></iframe>
+<Embed id="SF9BGtA_py3" />
 
 This code listing does the following:
 
@@ -89,3 +100,5 @@ python ci/main.py
 :::tip
 The `from()`, `withMountedDirectory()`, `withWorkdir()` and `withExec()` methods all return a `Container`, making it easy to chain method calls together and create a pipeline that is intuitive to understand.
 :::
+
+</QuickstartDoc>

--- a/website/src/components/atoms/embed.js
+++ b/website/src/components/atoms/embed.js
@@ -1,0 +1,24 @@
+import styles from "../../css/atoms/embed.module.scss";
+import React, {useState} from "react";
+
+const Embed = ({id, index}) => {
+  const [loading, setLoading] = useState(true);
+
+  return (
+    <div className={styles.embedWrapper} id="embedWrapper">
+      {loading && (
+        <div className={styles.spinnerWrapper}>
+          <div className={styles.spinner}></div>
+        </div>
+      )}
+      <iframe
+        className={styles.embed}
+        onLoad={() => setLoading(false)}
+        style={{display: loading ? "hidden" : "inherit"}}
+        loading={(index === 0 || !index) ? "eager" : "lazy"}
+        src={`https://play.dagger.cloud/embed/${id}`}></iframe>
+    </div>
+  );
+};
+
+export default Embed;

--- a/website/src/components/molecules/quickstartDoc.js
+++ b/website/src/components/molecules/quickstartDoc.js
@@ -1,14 +1,10 @@
 import styles from "../../css/molecules/quickstartDoc.module.scss";
-import React, {useEffect, useState} from "react";
+import React from "react";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
+import Embed from "../atoms/embed";
 
 const QuickstartDoc = ({children, embeds}) => {
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    console.log(loading);
-  }, [loading]);
 
   return (
     <>
@@ -19,16 +15,7 @@ const QuickstartDoc = ({children, embeds}) => {
             {Object.keys(embeds).map((x, index) => {
               return (
                 <TabItem key={x} value={x}>
-                  {loading ? (
-                    <div className={styles.spinnerWrapper}>
-                      <div className={styles.spinner}></div>
-                    </div>
-                  ) : null}
-                  <iframe
-                    onLoad={() => setLoading(false)}
-                    style={{display: loading ? "hidden" : "inherit"}}
-                    loading={index === 0 ? "eager" : "lazy"}
-                    src={`https://play.dagger.cloud/embed/${embeds[x]}`}></iframe>
+                  <Embed id={embeds[x]} index={index}/>
                 </TabItem>
               );
             })}

--- a/website/src/components/molecules/quickstartDoc.js
+++ b/website/src/components/molecules/quickstartDoc.js
@@ -1,0 +1,29 @@
+import styles from "../../css/molecules/quickstartDoc.module.scss";
+import React from "react";
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+const QuickstartDoc = ({children, embeds}) => {
+  return (
+    <>
+      <div className={styles.quickstartDoc}>
+        <div className={styles.stepContent}>{children}</div>
+        <div className={styles.stepEmbed}>
+          <Tabs groupId="language">
+            {Object.keys(embeds).map((x, index) => {
+              return (
+                <TabItem key={x} value={x}>
+                  <iframe
+                    loading={index === 0 ? "eager" : "lazy"}
+                    src={`https://play.dagger.cloud/embed/${embeds[x]}`}></iframe>
+                </TabItem>
+              );
+            })}
+          </Tabs>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default QuickstartDoc;

--- a/website/src/components/molecules/quickstartDoc.js
+++ b/website/src/components/molecules/quickstartDoc.js
@@ -1,9 +1,15 @@
 import styles from "../../css/molecules/quickstartDoc.module.scss";
-import React from "react";
+import React, {useEffect, useState} from "react";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
 const QuickstartDoc = ({children, embeds}) => {
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    console.log(loading);
+  }, [loading]);
+
   return (
     <>
       <div className={styles.quickstartDoc}>
@@ -13,7 +19,14 @@ const QuickstartDoc = ({children, embeds}) => {
             {Object.keys(embeds).map((x, index) => {
               return (
                 <TabItem key={x} value={x}>
+                  {loading ? (
+                    <div className={styles.spinnerWrapper}>
+                      <div className={styles.spinner}></div>
+                    </div>
+                  ) : null}
                   <iframe
+                    onLoad={() => setLoading(false)}
+                    style={{display: loading ? "hidden" : "inherit"}}
                     loading={index === 0 ? "eager" : "lazy"}
                     src={`https://play.dagger.cloud/embed/${embeds[x]}`}></iframe>
                 </TabItem>

--- a/website/src/css/atoms/embed.module.scss
+++ b/website/src/css/atoms/embed.module.scss
@@ -1,0 +1,41 @@
+.embedWrapper {
+    position: relative;
+}
+
+.embed {
+	width: 100%;
+	height: 800px;
+}
+
+.spinnerWrapper {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    align-content: center;
+    position: absolute;
+    padding-bottom: 300px;
+    background-color: var(--ifm-background-color);
+  }
+  
+  .spinner {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    display: inline-block;
+    border-top: 3px solid var(--ifm-code-color);
+    border-right: 3px solid transparent;
+    box-sizing: border-box;
+    animation: rotation 0.8s linear infinite;
+  }
+  
+  @keyframes rotation {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+  

--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -730,8 +730,27 @@ img[alt="github-contribute"] {
 }
 
 .embed {
-
 	width: 100%;
 	height: 800px;
+}
 
+
+.docs-doc-id-current\/quickstart\/quickstart-hello,
+.docs-doc-id-current\/quickstart\/quickstart-test,
+.docs-doc-id-current\/quickstart\/quickstart-build,
+.docs-doc-id-current\/quickstart\/quickstart-publish,
+.docs-doc-id-current\/quickstart\/quickstart-build-multi,
+.docs-doc-id-current\/quickstart\/quickstart-caching,
+.docs-doc-id-current\/quickstart\/quickstart-build-dockerfile {
+  main {
+    padding-right: 0px !important;
+  }
+  main .container {
+    margin: 0;
+    max-width: unset !important;
+  }
+
+  .container > .row .col {
+    padding-right: 20px !important;
+  }
 }

--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -729,11 +729,6 @@ img[alt="github-contribute"] {
   }
 }
 
-.embed {
-	width: 100%;
-	height: 800px;
-}
-
 
 .docs-doc-id-current\/quickstart\/quickstart-hello,
 .docs-doc-id-current\/quickstart\/quickstart-test,

--- a/website/src/css/molecules/quickstartDoc.module.scss
+++ b/website/src/css/molecules/quickstartDoc.module.scss
@@ -31,8 +31,8 @@ iframe {
   }
 
   .stepContent :global(.embeds),
-  .stepContent iframe {
-    display: none;
+  .stepContent :global(#embedWrapper) {
+    display: none !important;
   }
 }
 
@@ -64,34 +64,3 @@ iframe {
   @include show-embed-in-column;
 }
 
-.spinnerWrapper {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  align-content: center;
-  position: absolute;
-  padding-bottom: 300px;
-  background-color: var(--ifm-background-color);
-}
-
-.spinner {
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
-  display: inline-block;
-  border-top: 3px solid var(--ifm-code-color);
-  border-right: 3px solid transparent;
-  box-sizing: border-box;
-  animation: rotation 0.8s linear infinite;
-}
-
-@keyframes rotation {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-}

--- a/website/src/css/molecules/quickstartDoc.module.scss
+++ b/website/src/css/molecules/quickstartDoc.module.scss
@@ -53,3 +53,35 @@
     display: none;
   }
 }
+
+.spinnerWrapper {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  align-content: center;
+  position: absolute;
+  padding-bottom: 300px;
+  background-color: var(--ifm-background-color);
+}
+
+.spinner {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  display: inline-block;
+  border-top: 3px solid var(--ifm-code-color);
+  border-right: 3px solid transparent;
+  box-sizing: border-box;
+  animation: rotation 0.8s linear infinite;
+}
+
+@keyframes rotation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/website/src/css/molecules/quickstartDoc.module.scss
+++ b/website/src/css/molecules/quickstartDoc.module.scss
@@ -1,0 +1,55 @@
+@use "../custom.scss";
+
+.quickstartDoc {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 30px;
+}
+
+.stepContent {
+  width: 40%;
+}
+
+.stepEmbed {
+  position: sticky;
+  top: 120px;
+  width: 60%;
+  right: 20px;
+  height: 100%;
+
+  & .tabs {
+    background-color: var(--ifm-navbar-background-color) !important;
+  }
+
+  iframe {
+    width: 100%;
+    min-height: 50vh;
+    height: 100%;
+    height: calc(100vh - 230px);
+
+    border-radius: var(--ifm-alert-border-radius);
+  }
+}
+
+.stepContent :global(.embeds),
+.stepContent iframe {
+  display: none;
+}
+
+@include custom.mobile {
+  .stepContent {
+    width: 100%;
+
+    iframe {
+      display: inherit;
+    }
+  }
+
+  .stepContent :global(.embeds) {
+    display: inherit;
+  }
+
+  .stepEmbed {
+    display: none;
+  }
+}

--- a/website/src/css/molecules/quickstartDoc.module.scss
+++ b/website/src/css/molecules/quickstartDoc.module.scss
@@ -7,41 +7,43 @@
 }
 
 .stepContent {
-  width: 40%;
+  width: 45%;
 }
 
-.stepEmbed {
-  position: sticky;
-  top: 120px;
-  width: 60%;
-  right: 20px;
-  height: 100%;
+iframe {
+  border-radius: var(--ifm-alert-border-radius);
+}
 
-  & .tabs {
-    background-color: var(--ifm-navbar-background-color) !important;
-  }
-
-  iframe {
-    width: 100%;
-    min-height: 50vh;
+@mixin show-embed-in-column {
+  .stepEmbed {
+    position: sticky;
+    top: 120px;
+    width: 55%;
+    right: 20px;
     height: 100%;
-    height: calc(100vh - 230px);
 
-    border-radius: var(--ifm-alert-border-radius);
+    iframe {
+      width: 100%;
+      min-height: 50vh;
+      height: 100%;
+      height: calc(100vh - 230px);
+    }
+  }
+
+  .stepContent :global(.embeds),
+  .stepContent iframe {
+    display: none;
   }
 }
 
-.stepContent :global(.embeds),
-.stepContent iframe {
-  display: none;
-}
-
-@include custom.mobile {
+@mixin show-embed-in-content {
   .stepContent {
     width: 100%;
+    max-width: var(--ifm-container-width-xl);
 
     iframe {
       display: inherit;
+      margin-bottom: 20px;
     }
   }
 
@@ -52,6 +54,14 @@
   .stepEmbed {
     display: none;
   }
+}
+
+@media screen and (max-width: 1199px) {
+  @include show-embed-in-content;
+}
+
+@media screen and (min-width: 1200px) {
+  @include show-embed-in-column;
 }
 
 .spinnerWrapper {


### PR DESCRIPTION
This will add a new layout to the Quickstart as previously thought on #4419.
The idea behind it is to improve the UX by allowing the user to scroll while maintaining the content and the editor in the same viewport.
Before making this change, we must modify every `.mdx` file in the quickstart, as the PoC is only implemented in the `quickstart-publish.mdx` file.

BTW took my time to ship this one as I wanted to maintain the current sidebar + avoid breaking the current structure of the `.mdx` files as having the ability of writing the docs in markdown is key.

Signed-off-by: Julián Cruciani <julian@dagger.io>