### PR TITLE
go sdk: Wait on session child processes.

### DIFF
--- a/sdk/go/internal/engineconn/session.go
+++ b/sdk/go/internal/engineconn/session.go
@@ -114,6 +114,11 @@ func startCLISession(ctx context.Context, binPath string, cfg *Config) (_ Engine
 	if proc == nil {
 		return nil, fmt.Errorf("failed to start dagger session")
 	}
+	// Wait on the proc, this ensures it doesn't become a zombie in a long-running
+	// process and also ensures that GC won't collect any of its resources (e.g.
+	// pipe fds) until it has exited.
+	go proc.Wait()
+
 	defer func() {
 		if rerr != nil {
 			stderrContents := stderrBuf.String()


### PR DESCRIPTION
Without this the child proc became a zombie, which isn't good if lots of clients are being made in a long-running process.

Additionally, this may fix an issue where it seems that the Go GC is collecting the stdin pipe object for the child process before the process has closed.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

***Might*** fix https://github.com/dagger/dagger/issues/4538 (running tests locally to see if I can reproduce it still with this change, have not so far).

Either way though, we want to merge this change anyways since it stops zombies, so good to review right away.

Hypothesis: the problem in https://github.com/dagger/dagger/issues/4538 occurs when you have a pipeline like `c.Container().From(...).WithExec(...).ExitCode(ctx)` but you have no more references to `c` after that (not even a `defer c.Close()`). In that case, `c` becomes unreachable after the first call to `Container()` because we pass the [`graphql.Client` interface](https://github.com/sipsma/dagger/blob/e42fa37a879ee87addcfd626a5c7e151a18df689/sdk/go/client.go#L17-L17) along the query builder. This object is actually a struct with [the same embedded interface](https://github.com/sipsma/dagger/blob/e42fa37a879ee87addcfd626a5c7e151a18df689/sdk/go/client.go#L149-L149). That struct wrapper is what breaks things, it means that even though the underlying implementation of the interface is a struct that has references to the stdin pipe of the child process, it's no longer possible to access it ([example in go playground](https://go.dev/play/p/zNniDoDc5M1)).

That means after the first call to `Container()`, the stdin pipe object for the session child process is technically not reachable anymore, which means that a GC can collect it if it runs between that time and when the actual http request is made. `os.File` objects in Go have a gc finalizer that closes them, which means the pipe is closed and the child process exits early.

I was able to verify part of this by adding a bunch of println debugs and running a test case which doesn't close `c`; I could see that GC would run periodically and close a bunch of pipes and with extra information could see that included the child process that resulted in the EOF.

I think waiting on the process should fixes this as a side-effect because it keeps the `proc` object accessible to a running goroutine, which means that the pipe object should still be reachable and thus not available for GC.