### PR TITLE
Download runc binary instead of building it. 

### DIFF
--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -1,0 +1,20 @@
+name: Test Publish Engine
+on:
+  # only run this in PRs, it verifies that we can build all the images we publish
+  # once pushed to main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test-publish-engine:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.20"
+
+      - name: "Test Publish Engine"
+        run: |
+          ./hack/make engine:testpublish


### PR DESCRIPTION
Fixes the publish errors happening in main right now: https://github.com/dagger/dagger/actions/runs/4128172221/jobs/7133047657

There's a cross-compilation issue when building runc due to its use of CGO. Instead of setting up the cross compilation tool chains I opted to just download the official release as it's highly unlikely we will need to use anything besides an officially release runc binary.

This wasn't caught before merge because our PR workflows only built an engine image for the host platform, so I also added a quick extra workflow that verifies the engine builds for each platform too.