### PR TITLE
Remove import dependency of CLI on containerd packages. 

### DIFF
--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -1,7 +1,7 @@
-name: Test Publish Engine
+name: Test Publish Engine & CLI
 on:
-  # only run this in PRs, it verifies that we can build all the images we publish
-  # once pushed to main
+  # only run this in PRs, it verifies that we can build all the images
+  # and binaries we publish once pushed to main
   pull_request:
   workflow_dispatch:
 
@@ -18,3 +18,16 @@ jobs:
       - name: "Test Publish Engine"
         run: |
           ./hack/make engine:testpublish
+
+  test-publish-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.20"
+
+      - name: "Test Publish CLI"
+        run: |
+          ./hack/make cli:testpublish

--- a/engine/remotecache/cache.go
+++ b/engine/remotecache/cache.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/remotes/docker"
+	"github.com/dagger/dagger/internal/engine"
 	"github.com/moby/buildkit/cache/remotecache"
 	"github.com/moby/buildkit/cache/remotecache/azblob"
 	"github.com/moby/buildkit/cache/remotecache/gha"
@@ -19,8 +20,7 @@ import (
 )
 
 const (
-	exporterName       = "dagger-exporter"
-	CacheConfigEnvName = "_EXPERIMENTAL_DAGGER_CACHE_CONFIG"
+	exporterName = "dagger-exporter"
 )
 
 func ResolveCacheExporterFunc(sm *session.Manager, resolverFn docker.RegistryHosts) remotecache.ResolveCacheExporterFunc {
@@ -81,7 +81,7 @@ func ResolveCacheImporterFunc(sm *session.Manager, cs content.Store, hosts docke
 }
 
 func cacheConfigFromEnv() (string, map[string]string, error) {
-	envVal, ok := os.LookupEnv(CacheConfigEnvName)
+	envVal, ok := os.LookupEnv(engine.CacheConfigEnvName)
 	if !ok {
 		return "", nil, nil
 	}

--- a/internal/engine/docker.go
+++ b/internal/engine/docker.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/dagger/dagger/engine/remotecache"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -19,6 +18,8 @@ const (
 	DockerImageProvider = "docker-image"
 	// NOTE: this needs to be consistent with engineDefaultStateDir in internal/mage/engine.go
 	DefaultStateDir = "/var/lib/dagger"
+
+	CacheConfigEnvName = "_EXPERIMENTAL_DAGGER_CACHE_CONFIG"
 
 	// trim image digests to 16 characters to makeoutput more readable
 	hashLen             = 16
@@ -90,7 +91,7 @@ func dockerImageProvider(ctx context.Context, runnerHost *url.URL) (string, erro
 		"--name", containerName,
 		"-d",
 		"--restart", "always",
-		"-e", remotecache.CacheConfigEnvName,
+		"-e", CacheConfigEnvName,
 		"-v", DefaultStateDir,
 		"--privileged",
 		imageRef,

--- a/internal/mage/util/util.go
+++ b/internal/mage/util/util.go
@@ -122,13 +122,16 @@ func GoBase(c *dagger.Client) *dagger.Container {
 	return AdvertiseDevEngine(c, goBase(c))
 }
 
-func daggerBinary(c *dagger.Client, goos, goarch string) *dagger.File {
+func PlatformDaggerBinary(c *dagger.Client, goos, goarch, goarm string) *dagger.File {
 	base := goBase(c)
 	if goos != "" {
 		base = base.WithEnvVariable("GOOS", goos)
 	}
 	if goarch != "" {
 		base = base.WithEnvVariable("GOARCH", goarch)
+	}
+	if goarm != "" {
+		base = base.WithEnvVariable("GOARM", goarm)
 	}
 	return base.
 		WithExec([]string{"go", "build", "-o", "./bin/dagger", "-ldflags", "-s -w", "./cmd/dagger"}).
@@ -137,12 +140,16 @@ func daggerBinary(c *dagger.Client, goos, goarch string) *dagger.File {
 
 // DaggerBinary returns a compiled dagger binary
 func DaggerBinary(c *dagger.Client) *dagger.File {
-	return daggerBinary(c, "", "")
+	return PlatformDaggerBinary(c, "", "", "")
 }
 
 // HostDaggerBinary returns a dagger binary compiled to target the host's OS+arch
 func HostDaggerBinary(c *dagger.Client) *dagger.File {
-	return daggerBinary(c, runtime.GOOS, runtime.GOARCH)
+	var goarm string
+	if runtime.GOARCH == "arm" {
+		goarm = "7" // not always correct but not sure of better way right now
+	}
+	return PlatformDaggerBinary(c, runtime.GOOS, runtime.GOARCH, goarm)
 }
 
 // ClientGenBinary returns a compiled dagger binary


### PR DESCRIPTION
Code imported by the CLI was importing a constant from the new
remotecache package in dagger, but that created a transitive dependency
on some containerd packages which only build for Linux. This was causing
builds of the CLI for darwin to fail.

This works around that issue by reversing the import dependency so that
the remotecache package imports from `internal/engine` instead.

---

Also adding a workflow so we catch this in PRs going forward. This wasn't caught before because PRs only ever built the CLI for their own host platform. Now we test each one that we want to release for.