### PR TITLE
Disable logrus output only in CLI main.

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"io"
 	"os"
 
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/tracing"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -16,6 +18,11 @@ var (
 )
 
 func init() {
+	// Disable logrus output, which only comes from the docker
+	// commandconn library that is used by buildkit's connhelper
+	// and prints unneeded warning logs.
+	logrus.StandardLogger().SetOutput(io.Discard)
+
 	rootCmd.PersistentFlags().StringVar(&workdir, "workdir", ".", "The host workdir loaded into dagger")
 	rootCmd.PersistentFlags().BoolVar(&debugLogs, "debug", false, "show buildkit debug logs")
 

--- a/internal/engine/client.go
+++ b/internal/engine/client.go
@@ -3,27 +3,18 @@ package engine
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/url"
 	"strings"
 	"time"
 
 	bkclient "github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/util/tracing/detect"
-	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel"
 
 	_ "github.com/moby/buildkit/client/connhelper/dockercontainer" // import the docker connection driver
 	_ "github.com/moby/buildkit/client/connhelper/kubepod"         // import the kubernetes connection driver
 	_ "github.com/moby/buildkit/client/connhelper/podmancontainer" // import the podman connection driver
 )
-
-func init() {
-	// Disable logrus output, which only comes from the docker
-	// commandconn library that is used by buildkit's connhelper
-	// and prints unneeded warning logs.
-	logrus.StandardLogger().SetOutput(io.Discard)
-}
 
 func Client(ctx context.Context, remote *url.URL) (*bkclient.Client, error) {
 	buildkitdHost := remote.String()


### PR DESCRIPTION
This was causing problems because the init ended up in our new cmd/engine/main.go imports and thus disabled all logrus outputs for the daemon.

Fix is to just relocate the disabling of the log output to only exactly where we need it in our cli's main func.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>