### PR TITLE
Additive caching support for S3 backend

### DIFF
--- a/core/integration/remotecache_test.go
+++ b/core/integration/remotecache_test.go
@@ -4,26 +4,28 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"sync"
 	"testing"
 	"time"
 
 	"dagger.io/dagger"
 	"github.com/moby/buildkit/identity"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 )
 
-func TestRemoteCache(t *testing.T) {
+func TestRemoteCacheRegistry(t *testing.T) {
 	// TODO: until this setting is configurable at runtime, just spawning separate engines w/ the config set
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	registryContainerName := runRegistryInDocker(ctx, t)
-
 	getClient := func() *dagger.Client {
 		return runSeparateEngine(ctx, t, map[string]string{
 			"_EXPERIMENTAL_DAGGER_CACHE_CONFIG": "type=registry,ref=127.0.0.1:5000/test-cache,mode=max",
 		}, "container:"+registryContainerName)
 	}
+
 	pipelineOutput := func(c *dagger.Client) string {
 		output, err := c.Container().From("alpine:3.17").WithExec([]string{
 			"sh", "-c", "head -c 128 /dev/random | sha256sum",
@@ -47,13 +49,131 @@ func TestRemoteCache(t *testing.T) {
 	require.Equal(t, outputA, outputB)
 }
 
-// TODO: dedupe this w/ the services PR
+func TestRemoteCacheS3(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	t.Run("buildkit s3 caching", func(t *testing.T) {
+		bucket := "dagger-test-remote-cache-s3-" + identity.NewID()
+		s3ContainerName := runS3InDocker(ctx, t, bucket)
+		getClient := func() *dagger.Client {
+			return runSeparateEngine(ctx, t, map[string]string{
+				"_EXPERIMENTAL_DAGGER_CACHE_CONFIG": "type=s3,mode=max,endpoint_url=http://localhost:9000,access_key_id=minioadmin,secret_access_key=minioadmin,region=mars,use_path_style=true,bucket=" + bucket,
+			}, "container:"+s3ContainerName)
+		}
+
+		pipelineOutput := func(c *dagger.Client) string {
+			output, err := c.Container().From("alpine:3.17").WithExec([]string{
+				"sh", "-c", "head -c 128 /dev/random | sha256sum",
+			}).Stdout(ctx)
+			require.NoError(t, err)
+			return output
+		}
+
+		/*
+			1. Start an s3 compatible server (minio) locally for storing the cache
+			2. Start two independent engines from empty cache that are configured to use s3 as remote cache backend
+			3. Run an exec w/ output from /dev/random in the first engine
+			4. Close the first engine's client, flushing the remote cache for the session
+			5. Run the same exec in the second engine, verify it imports the cache and output the same value as the first engine
+		*/
+		clientA := getClient()
+		clientB := getClient()
+		outputA := pipelineOutput(clientA)
+		require.NoError(t, clientA.Close())
+		outputB := pipelineOutput(clientB)
+		require.Equal(t, outputA, outputB)
+	})
+
+	t.Run("dagger s3 caching (with pooling)", func(t *testing.T) {
+		bucket := "dagger-test-remote-cache-s3-" + identity.NewID()
+		s3ContainerName := runS3InDocker(ctx, t, bucket)
+		getClient := func() *dagger.Client {
+			return runSeparateEngine(ctx, t, map[string]string{
+				"_EXPERIMENTAL_DAGGER_CACHE_CONFIG": "type=experimental_dagger_s3,mode=max,endpoint_url=http://localhost:9000,access_key_id=minioadmin,secret_access_key=minioadmin,region=mars,use_path_style=true,bucket=" + bucket + ",prefix=test-cache-pool/",
+			}, "container:"+s3ContainerName)
+		}
+
+		pipelineOutput := func(c *dagger.Client, id string) string {
+			output, err := c.Container().
+				From("alpine:3.17").
+				WithEnvVariable("ID", id).
+				WithExec([]string{
+					"sh", "-c", "head -c 128 /dev/random | sha256sum",
+				}).Stdout(ctx)
+			require.NoError(t, err)
+			return output
+		}
+
+		generatedOutputs := map[string]string{} // map of unique id set in exec -> output
+		var mu sync.Mutex
+		var eg errgroup.Group
+		for i := 0; i < 5; i++ {
+			eg.Go(func() error {
+				id := identity.NewID()
+				client := getClient()
+				mu.Lock()
+				defer mu.Unlock()
+				generatedOutputs[id] = pipelineOutput(client, id)
+				return client.Close()
+			})
+		}
+		require.NoError(t, eg.Wait())
+		require.Len(t, generatedOutputs, 5)
+		eg = errgroup.Group{}
+		client := getClient()
+		for id, cachedOutput := range generatedOutputs {
+			id, cachedOutput := id, cachedOutput
+			eg.Go(func() error {
+				require.Equal(t, cachedOutput, pipelineOutput(client, id))
+				return nil
+			})
+		}
+		require.NoError(t, eg.Wait())
+		require.NoError(t, client.Close())
+	})
+}
+
+func runS3InDocker(ctx context.Context, t *testing.T, bucket string) string {
+	t.Helper()
+	name := "dagger-test-remote-cache-s3-" + identity.NewID()
+	cmd := exec.Command("docker", "run", "--rm", "--name", name, "minio/minio", "server", "/data")
+	t.Cleanup(func() {
+		stopDockerRun(cmd, name)
+	})
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Start()
+	require.NoError(t, err)
+	// wait for the s3 to be ready
+	for i := 0; i < 100; i++ {
+		cmd := exec.CommandContext(ctx, "docker", "exec", name, "sh", "-c", "curl -s -o /dev/null -w '%{http_code}' http://localhost:9000/minio/health/live")
+		out, err := cmd.CombinedOutput()
+		if string(out) == "200" && err == nil {
+			break
+		}
+		if i == 99 {
+			t.Fatalf("minio s3 not ready: %v: %s", err, out)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// create the bucket
+	cmd = exec.Command("docker", "run", "--rm", "--network", "container:"+name, "--entrypoint", "sh", "minio/mc", "-c", "mc config host add minio http://localhost:9000 minioadmin minioadmin && mc mb minio/"+bucket) // #nosec G204
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	require.NoError(t, err)
+
+	return name
+}
+
 func runRegistryInDocker(ctx context.Context, t *testing.T) string {
 	t.Helper()
 	name := "dagger-test-remote-cache-registry-" + identity.NewID()
-	cmd := exec.CommandContext(ctx, "docker", "run", "--rm", "--name", name, "registry:2")
+	cmd := exec.Command("docker", "run", "--rm", "--name", name, "registry:2")
 	t.Cleanup(func() {
-		cmd.Process.Kill()
+		stopDockerRun(cmd, name)
 	})
 	err := cmd.Start()
 	require.NoError(t, err)
@@ -72,14 +192,21 @@ func runRegistryInDocker(ctx context.Context, t *testing.T) string {
 	return name
 }
 
+var connectLock sync.Mutex
+
 func runSeparateEngine(ctx context.Context, t *testing.T, env map[string]string, network string) *dagger.Client {
+	// Setting the RUNNER_HOST env var is global so while silly we need to lock here. This also seems to help with
+	// some race conditions setting up the engine network when they are all sharing one netns
+	connectLock.Lock()
+	defer connectLock.Unlock()
+
 	t.Helper()
 	name := "dagger-test-remote-cache-" + identity.NewID()
 
 	allArgs := []string{"run"}
 	dockerRunArgs := []string{
 		"--rm",
-		"-v", "/var/lib/dagger", // path is set in util/mage/engine.go
+		"-v", "/var/lib/dagger", // path is set in internal/mage/engine.go
 		"--privileged",
 		"--name", name,
 	}
@@ -91,18 +218,17 @@ func runSeparateEngine(ctx context.Context, t *testing.T, env map[string]string,
 	}
 	allArgs = append(allArgs, dockerRunArgs...)
 	allArgs = append(allArgs,
-		"localhost/dagger-engine.dev:latest", // set in util/mage/engine.go
+		"localhost/dagger-engine.dev:latest", // set in internal/mage/engine.go
 		"--debug",
 	)
 
-	cmd := exec.CommandContext(ctx, "docker", allArgs...)
+	cmd := exec.Command("docker", allArgs...)
 	t.Cleanup(func() {
-		cmd.Process.Kill()
+		stopDockerRun(cmd, name)
 	})
 	err := cmd.Start()
 	require.NoError(t, err)
 
-	// NOTE: this isn't thread safe, don't run in parallel w/ other tests
 	currentVal := os.Getenv("_EXPERIMENTAL_DAGGER_RUNNER_HOST")
 	os.Setenv("_EXPERIMENTAL_DAGGER_RUNNER_HOST", "docker-container://"+name)
 	defer os.Setenv("_EXPERIMENTAL_DAGGER_RUNNER_HOST", currentVal)
@@ -110,4 +236,9 @@ func runSeparateEngine(ctx context.Context, t *testing.T, env map[string]string,
 	c, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
 	require.NoError(t, err)
 	return c
+}
+
+func stopDockerRun(cmd *exec.Cmd, ctrName string) {
+	exec.Command("docker", "rm", "-fv", ctrName).Run()
+	cmd.Process.Kill()
 }

--- a/core/integration/remotecache_test.go
+++ b/core/integration/remotecache_test.go
@@ -21,7 +21,7 @@ func TestRemoteCache(t *testing.T) {
 
 	getClient := func() *dagger.Client {
 		return runSeparateEngine(ctx, t, map[string]string{
-			"_EXPERIMENTAL_DAGGER_CACHE_CONFIG": "type=registry,ref=127.0.0.1:5000/test-cache",
+			"_EXPERIMENTAL_DAGGER_CACHE_CONFIG": "type=registry,ref=127.0.0.1:5000/test-cache,mode=max",
 		}, "container:"+registryContainerName)
 	}
 	pipelineOutput := func(c *dagger.Client) string {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -107,6 +107,9 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 		},
 		CacheExports: []bkclient.CacheOptionsEntry{{
 			Type: "dagger",
+			Attrs: map[string]string{
+				"mode": "max",
+			},
 		}},
 		CacheImports: []bkclient.CacheOptionsEntry{{
 			Type: "dagger",

--- a/engine/remotecache/cache.go
+++ b/engine/remotecache/cache.go
@@ -12,7 +12,7 @@ import (
 	"github.com/moby/buildkit/cache/remotecache/azblob"
 	"github.com/moby/buildkit/cache/remotecache/gha"
 	registryremotecache "github.com/moby/buildkit/cache/remotecache/registry"
-	s3remotecache "github.com/moby/buildkit/cache/remotecache/s3"
+	"github.com/moby/buildkit/cache/remotecache/s3"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/util/bklog"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -32,7 +32,9 @@ func ResolveCacheExporterFunc(sm *session.Manager, resolverFn docker.RegistryHos
 		case "gha":
 			impl, err = gha.ResolveCacheExporterFunc()(ctx, g, attrs)
 		case "s3":
-			impl, err = s3remotecache.ResolveCacheExporterFunc()(ctx, g, attrs)
+			impl, err = s3.ResolveCacheExporterFunc()(ctx, g, attrs)
+		case "experimental_dagger_s3":
+			impl, err = s3Exporter(ctx, g, attrs)
 		case "azblob":
 			impl, err = azblob.ResolveCacheExporterFunc()(ctx, g, attrs)
 		default:
@@ -63,7 +65,9 @@ func ResolveCacheImporterFunc(sm *session.Manager, cs content.Store, hosts docke
 		case "gha":
 			impl, desc, err = gha.ResolveCacheImporterFunc()(ctx, g, attrs)
 		case "s3":
-			impl, desc, err = s3remotecache.ResolveCacheImporterFunc()(ctx, g, attrs)
+			impl, desc, err = s3.ResolveCacheImporterFunc()(ctx, g, attrs)
+		case "experimental_dagger_s3":
+			impl, desc, err = s3Importer(ctx, g, attrs)
 		case "azblob":
 			impl, desc, err = azblob.ResolveCacheImporterFunc()(ctx, g, attrs)
 		default:

--- a/engine/remotecache/cache.go
+++ b/engine/remotecache/cache.go
@@ -42,6 +42,9 @@ func ResolveCacheExporterFunc(sm *session.Manager, resolverFn docker.RegistryHos
 		if err != nil {
 			return nil, err
 		}
+		if userAttrs != nil {
+			userAttrs["mode"] = attrs["mode"]
+		}
 		return impl, nil
 	}
 }

--- a/engine/remotecache/combined.go
+++ b/engine/remotecache/combined.go
@@ -1,0 +1,29 @@
+package remotecache
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/moby/buildkit/cache/remotecache"
+	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/worker"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// TODO: not sure how well stacking importers like this scales,
+// in theory actually merging the manifests would be more efficient
+type combinedImporter struct {
+	importers []remotecache.Importer
+}
+
+func (i *combinedImporter) Resolve(ctx context.Context, desc ocispecs.Descriptor, id string, w worker.Worker) (solver.CacheManager, error) {
+	cacheManagers := make([]solver.CacheManager, len(i.importers))
+	for i, importer := range i.importers {
+		cm, err := importer.Resolve(ctx, desc, id+"-"+strconv.Itoa(i), w)
+		if err != nil {
+			return nil, err
+		}
+		cacheManagers[i] = cm
+	}
+	return solver.NewCombinedCacheManager(cacheManagers, nil), nil
+}

--- a/engine/remotecache/s3.go
+++ b/engine/remotecache/s3.go
@@ -1,0 +1,117 @@
+package remotecache
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"time"
+
+	awsConfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/moby/buildkit/cache/remotecache"
+	s3remotecache "github.com/moby/buildkit/cache/remotecache/s3"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/util/bklog"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+const (
+	bucketAttr       = "bucket"
+	regionAttr       = "region"
+	prefixAttr       = "prefix"
+	endpointURLAttr  = "endpoint_url"
+	usePathStyleAttr = "use_path_style"
+	accessKeyAttr    = "access_key_id"
+	secretKeyAttr    = "secret_access_key"
+	sessionTokenAttr = "session_token"
+
+	blobsSubprefix     = "blobs/"
+	manifestsSubprefix = "manifests/"
+)
+
+func s3Exporter(ctx context.Context, g session.Group, attrs map[string]string) (remotecache.Exporter, error) {
+	attrs["blob_prefix"] = blobsSubprefix
+	attrs["manifests_prefix"] = manifestsSubprefix
+	attrs["name"] = strconv.Itoa(int(time.Now().UnixNano())) + ".json"
+	attrs["ignore-error"] = "true"
+	return s3remotecache.ResolveCacheExporterFunc()(ctx, g, attrs)
+}
+
+func s3Importer(ctx context.Context, g session.Group, attrs map[string]string) (remotecache.Importer, ocispecs.Descriptor, error) {
+	prefix := attrs[prefixAttr]
+	bklog.G(ctx).Debugf("importing all manifests under prefix %q", prefix)
+
+	region := attrs[regionAttr]
+	if region == "" {
+		region = os.Getenv("AWS_REGION")
+	}
+	bucket := attrs[bucketAttr]
+	if bucket == "" {
+		bucket = os.Getenv("AWS_BUCKET")
+	}
+
+	accessKey := attrs[accessKeyAttr]
+	secretKey := attrs[secretKeyAttr]
+	sessionToken := attrs[sessionTokenAttr]
+	endpointURL := attrs[endpointURLAttr]
+	usePathStyle := attrs[usePathStyleAttr] == "true"
+
+	cfg, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion(region))
+	if err != nil {
+		return nil, ocispecs.Descriptor{}, errors.Errorf("Unable to load AWS SDK config, %v", err)
+	}
+	s3Client := s3.NewFromConfig(cfg, func(options *s3.Options) {
+		if accessKey != "" && secretKey != "" {
+			options.Credentials = credentials.NewStaticCredentialsProvider(accessKey, secretKey, sessionToken)
+		}
+		if endpointURL != "" {
+			options.UsePathStyle = usePathStyle
+			options.EndpointResolver = s3.EndpointResolverFromURL(endpointURL)
+		}
+	})
+
+	manifestsPrefix := prefix + manifestsSubprefix
+
+	listObjectsPages := s3.NewListObjectsV2Paginator(s3Client, &s3.ListObjectsV2Input{
+		Bucket: aws.String(bucket),
+		Prefix: aws.String(manifestsPrefix),
+	})
+	var manifestKeys []string
+	for listObjectsPages.HasMorePages() {
+		listResp, err := listObjectsPages.NextPage(ctx)
+		if err != nil {
+			// ignore not exists
+			// TODO: does this err check work? it's what copilot suggested
+			if awsErr, ok := err.(awserr.Error); !ok || awsErr.Code() != "NotFound" {
+				return nil, ocispecs.Descriptor{}, err
+			}
+			bklog.G(ctx).Debugf("not found error under prefix %s", prefix)
+		}
+		for _, obj := range listResp.Contents {
+			manifestKeys = append(manifestKeys, *obj.Key)
+		}
+	}
+	bklog.G(ctx).Debugf("found manifests under prefix %s: %+v", prefix, manifestKeys)
+
+	importers := make([]remotecache.Importer, len(manifestKeys))
+	for i, manifestKey := range manifestKeys {
+		theseAttrs := map[string]string{}
+		for k, v := range attrs {
+			theseAttrs[k] = v
+		}
+		theseAttrs["prefix"] = ""
+		theseAttrs["manifests_prefix"] = ""
+		theseAttrs["blobs_prefix"] = prefix + blobsSubprefix
+		theseAttrs["name"] = manifestKey
+		importer, _, err := s3remotecache.ResolveCacheImporterFunc()(ctx, g, theseAttrs)
+		if err != nil {
+			return nil, ocispecs.Descriptor{}, err
+		}
+		importers[i] = importer
+	}
+	return &combinedImporter{importers: importers}, ocispecs.Descriptor{}, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,10 @@ replace cloud.google.com/go => cloud.google.com/go v0.100.2
 require (
 	dagger.io/dagger v0.4.1
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
+	github.com/aws/aws-sdk-go v1.31.6
+	github.com/aws/aws-sdk-go-v2/config v1.15.5
+	github.com/aws/aws-sdk-go-v2/credentials v1.12.0
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.26.9
 	github.com/containerd/containerd v1.7.0-beta.4
 	github.com/containerd/fuse-overlayfs-snapshotter v1.0.2
 	github.com/containerd/stargz-snapshotter v0.14.1
@@ -68,8 +72,6 @@ require (
 	github.com/andybalholm/cascadia v1.3.1 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.16.3 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.1 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.15.5 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.12.0 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.4 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.10 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.10 // indirect
@@ -80,7 +82,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.4 // indirect
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.26.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.11.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.4 // indirect
 	github.com/aws/smithy-go v1.11.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,7 @@ github.com/aws/aws-sdk-go v1.20.6/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/aws/aws-sdk-go v1.25.11/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.27.1/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.31.6 h1:nKjQbpXhdImctBh1e0iLg9iQW/X297LPPuY/9f92R2k=
 github.com/aws/aws-sdk-go v1.31.6/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go-v2 v1.16.3 h1:0W1TSJ7O6OzwuEvIXAtJGvOeQ0SGAhcpxPN2/NK5EhM=
 github.com/aws/aws-sdk-go-v2 v1.16.3/go.mod h1:ytwTPBG6fXTZLxxeeCCWj2/EMYp/xDUgX+OET6TLNNU=


### PR DESCRIPTION
The code needs cleaning up, thrown together to enable testing of the idea, but it seems to work. Included an integ test that
1. spins up a local s3 implementation (minio)
2. spins up 5 dagger engines that each do cache exports to that s3 endpoint with different execs
3. and finally spins up another new engine that reruns each of the execs from the previous 5 engines and verifies they are cached

Crucially, all 6 of the engines have the exact same cache config settings, all the additive magic is taken care of by our dagger cache exporter.

There's two other commits with related fixes that ensure cache config settings propagate to buildkit correctly and that we don't run cache exports for "subsessions" used to export images.

cc @jlongtine if you want to give this a try. The "additive cache" integ test can be consulted for the right settings. The idea is basically to specify **just** `manifests_prefix` and not `name`. That kicks in our magic pooling behavior. Obviously need a more comprehensible interface but that was easiest to start.