### PR TITLE
Python: Include stderr in provisioning error when `log_output` is set

### DIFF
--- a/sdk/python/tests/engine/test_cli.py
+++ b/sdk/python/tests/engine/test_cli.py
@@ -53,14 +53,15 @@ def test_cli_exec_errors(config_args: dict, call_kwargs: dict, fp: FakeProcess):
     assert "Dagger engine failed to start" in str(exc_info.value)
 
 
-def test_stderr(fp: FakeProcess):
+@pytest.mark.parametrize("config_args", [{"log_output": sys.stderr}, {}])
+def test_stderr(config_args: dict, fp: FakeProcess):
     fp.register(
         ["dagger", "session"],
         stderr=["Error: buildkit failed to respond", ""],
         returncode=1,
     )
     with pytest.raises(ProvisionError) as exc_info, cli.CLISession(
-        dagger.Config(),
+        dagger.Config(**config_args),
         "dagger",
     ):
         ...


### PR DESCRIPTION
Fixes #3838

The error was only captured if `log_output` wasn’t set. For the common use case of setting it to `sys.stderr` though, it’s not really lost, but always reading in a thread and writing to multiple places ensures the exception message always has it.

Signed-off-by: Helder Correia