### PR TITLE
fix Directory.WithTimestamps with subdir

### DIFF
--- a/core/directory.go
+++ b/core/directory.go
@@ -307,7 +307,10 @@ func (dir *Directory) WithTimestamps(ctx context.Context, unix int) (*Directory,
 	t := time.Unix(int64(unix), 0)
 
 	stamped := llb.Scratch().File(
-		llb.Copy(st, payload.Dir, ".", llb.WithCreatedTime(t)),
+		llb.Copy(st, payload.Dir, ".", &llb.CopyInfo{
+			CopyDirContentsOnly: true,
+			CreatedTime:         &t,
+		}),
 		payload.Pipeline.LLBOpt(),
 	)
 

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -396,9 +396,15 @@ func TestDirectoryWithTimestamps(t *testing.T) {
 
 	reallyImportantTime := time.Date(1985, 10, 26, 8, 15, 0, 0, time.UTC)
 
-	dir := c.Directory().
-		WithNewFile("some-file", "some-content").
-		WithNewFile("sub-dir/sub-file", "sub-content").
+	dir := c.Container().
+		From("alpine:3.16.2").
+		WithExec([]string{"sh", "-c", `
+		  mkdir output
+			touch output/some-file
+			mkdir output/sub-dir
+			touch output/sub-dir/sub-file
+		`}).
+		Directory("output").
 		WithTimestamps(int(reallyImportantTime.Unix()))
 
 	t.Run("changes file and directory timestamps recursively", func(t *testing.T) {
@@ -412,9 +418,6 @@ func TestDirectoryWithTimestamps(t *testing.T) {
 		require.Regexp(t, regexp.MustCompile(`-rw-r--r--\s+1 root\s+root\s+\d+ Oct 26  1985 some-file`), ls)
 		require.Regexp(t, regexp.MustCompile(`drwxr-xr-x\s+2 root\s+root\s+\d+ Oct 26  1985 sub-dir`), ls)
 		require.Regexp(t, regexp.MustCompile(`-rw-r--r--\s+1 root\s+root\s+\d+ Oct 26  1985 sub-file`), ls)
-		// require.Contains(t, ls, "-rw-r--r--    1 root     root            12 Oct 26  1985 some-file")
-		// require.Contains(t, ls, "drwxr-xr-x    2 root     root          4096 Oct 26  1985 sub-dir")
-		// require.Contains(t, ls, "-rw-r--r--    1 root     root            11 Oct 26  1985 sub-file")
 	})
 
 	t.Run("results in stable tar archiving", func(t *testing.T) {


### PR DESCRIPTION
This wasn't working with non-"root" directories, i.e. directories with a sub-dir, as they often are when coming from a container, which is often when you would want to tweak the timestamps.