### PR TITLE
bump golangci-lint, fix lints

### DIFF
--- a/cmd/dagger/listen.go
+++ b/cmd/dagger/listen.go
@@ -27,7 +27,7 @@ func Listen(cmd *cobra.Command, args []string) {
 	ctx := context.Background()
 	if err := withEngine(ctx, "", func(ctx context.Context, r *router.Router) error {
 		fmt.Fprintf(os.Stderr, "==> server listening on http://%s/query\n", listenAddress)
-		return http.ListenAndServe(listenAddress, r)
+		return http.ListenAndServe(listenAddress, r) //nolint:gosec
 	}); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)

--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -3,12 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"net"
 	"net/http"
 	"os"
 	"os/exec"
-	"time"
 
 	"github.com/dagger/dagger/router"
 	"github.com/google/uuid"
@@ -31,7 +29,6 @@ dagger run -- sh -c 'curl \
 }
 
 func Run(cmd *cobra.Command, args []string) {
-	rand.Seed(time.Now().UnixNano())
 	ctx := context.Background()
 	sessionToken, err := uuid.NewRandom()
 	if err != nil {
@@ -49,7 +46,7 @@ func Run(cmd *cobra.Command, args []string) {
 		}
 		listening <- fmt.Sprintf("%d", l.Addr().(*net.TCPAddr).Port)
 		if err := withEngine(ctx, sessionToken.String(), func(ctx context.Context, r *router.Router) error {
-			return http.Serve(l, r)
+			return http.Serve(l, r) //nolint:gosec
 		}); err != nil {
 			panic(err)
 		}

--- a/cmd/engine/debug.go
+++ b/cmd/engine/debug.go
@@ -37,6 +37,6 @@ func setupDebugHandlers(addr string) error {
 		return err
 	}
 	logrus.Debugf("debug handlers listening at %s", addr)
-	go http.Serve(l, m)
+	go http.Serve(l, m) // nolint:gosec
 	return nil
 }

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -486,7 +486,7 @@ func toggleNesting(ctx context.Context) ([]string, error) {
 		}
 		go func() {
 			err := engine.Start(ctx, engineConf, func(ctx context.Context, r *router.Router) error {
-				return http.Serve(l, r)
+				return http.Serve(l, r) //nolint:gosec
 			})
 			if err != nil {
 				fmt.Printf("Error starting engine: %v\n", err)

--- a/core/directory.go
+++ b/core/directory.go
@@ -379,7 +379,7 @@ func (dir *Directory) WithFile(ctx context.Context, subdir string, src *File, pe
 		return nil, err
 	}
 
-	var perm *fs.FileMode = nil
+	var perm *fs.FileMode
 
 	if permissions != 0 {
 		perm = &permissions

--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -161,7 +161,7 @@ func (t Engine) Lint(ctx context.Context) error {
 	}
 
 	_, err = c.Container().
-		From("golangci/golangci-lint:v1.48").
+		From("golangci/golangci-lint:v1.51").
 		WithMountedDirectory("/app", repo).
 		WithWorkdir("/app").
 		WithExec([]string{"golangci-lint", "run", "-v", "--timeout", "5m"}).

--- a/internal/mage/sdk/go.go
+++ b/internal/mage/sdk/go.go
@@ -34,7 +34,7 @@ func (t Go) Lint(ctx context.Context) error {
 	c = c.Pipeline("sdk").Pipeline("go").Pipeline("lint")
 
 	_, err = c.Container().
-		From("golangci/golangci-lint:v1.48").
+		From("golangci/golangci-lint:v1.51").
 		WithMountedDirectory("/app", util.RepositoryGoCodeOnly(c)).
 		WithWorkdir("/app/sdk/go").
 		WithExec([]string{"golangci-lint", "run", "-v", "--timeout", "5m"}).

--- a/sdk/go/provision_test.go
+++ b/sdk/go/provision_test.go
@@ -82,7 +82,7 @@ func TestProvision(t *testing.T) {
 		checksumFileContents := fmt.Sprintf("%x  %s\n", checksum, archiveName)
 		checksumPath := path.Join(basePath, "checksums.txt")
 
-		go http.Serve(l, http.FileServer(http.FS(fstest.MapFS{
+		go http.Serve(l, http.FileServer(http.FS(fstest.MapFS{ //nolint:gosec
 			checksumPath: &fstest.MapFile{
 				Data:    []byte(checksumFileContents),
 				Mode:    0o644,


### PR DESCRIPTION
Decoupling this from #4615; I needed it for a brief period where I was using Go 1.20 features (`errors.Join`). Might as well get the bump out of the way for the future.

Most of these "fixes" are actually disabling `gosec` lints for various places that we spin up a HTTP server. I don't _think_ we're worried about those instances, but I was a bit rushed trying to get the linter happy for my other PR. We can give it more thought here.