### PR TITLE
chore(python): Revert reversion from outdated merge

### DIFF
--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -158,8 +158,6 @@ class Container(Type):
     def directory(self, path: str) -> "Directory":
         """Retrieves a directory at the given path.
 
-
-
         Mounts are included.
 
         Parameters
@@ -181,12 +179,8 @@ class Container(Type):
     ) -> str:
         """Retrieves an endpoint that clients can use to reach this container.
 
-
-
         If no port is specified, the first exposed port is used. If none exist
         an error is returned.
-
-
 
         If a scheme is specified, a URL is returned. Otherwise, a host:port
         pair is returned.
@@ -326,7 +320,6 @@ class Container(Type):
     @typecheck
     async def exit_code(self) -> Optional[int]:
         """Exit code of the last executed command. Zero means success.
-
         Null if no command has been executed.
 
         Returns
@@ -356,10 +349,7 @@ class Container(Type):
         """Writes the container as an OCI tarball to the destination file path on
         the host for the specified platform variants.
 
-
-
         Return true on success.
-
         It can also publishes platform variants.
 
         Parameters
@@ -400,8 +390,6 @@ class Container(Type):
     @typecheck
     def file(self, path: str) -> "File":
         """Retrieves a file at the given path.
-
-
 
         Mounts are included.
 
@@ -612,10 +600,7 @@ class Container(Type):
     ) -> str:
         """Publishes this container as a new image to the specified address.
 
-
-
         Publish returns a fully qualified ref.
-
         It can also publish platform variants.
 
         Parameters
@@ -659,7 +644,6 @@ class Container(Type):
     @typecheck
     async def stderr(self) -> Optional[str]:
         """The error stream of the last executed command.
-
         Null if no command has been executed.
 
         Returns
@@ -683,7 +667,6 @@ class Container(Type):
     @typecheck
     async def stdout(self) -> Optional[str]:
         """The output stream of the last executed command.
-
         Null if no command has been executed.
 
         Returns
@@ -861,11 +844,8 @@ class Container(Type):
         description: Optional[str] = None,
     ) -> "Container":
         """Expose a network port.
-
         Exposed ports serve two purposes:
-
           - For health checks and introspection, when running services
-
           - For setting the EXPOSE OCI field when publishing the container
 
         Parameters
@@ -1137,12 +1117,8 @@ class Container(Type):
         started automatically when needed and detached when it is no longer
         needed.
 
-
-
         The service will be reachable from the container via the provided
         hostname alias.
-
-
 
         The service dependency will also convey to any files or directories
         produced by the container.
@@ -2349,13 +2325,9 @@ class Client(Root):
     ) -> Container:
         """Loads a container from ID.
 
-
-
         Null ID returns an empty container (scratch).
-
         Optional platform argument initializes new containers to execute and
         publish as that platform.
-
         Platform defaults to that of the builder's host.
         """
         _args = [

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -158,8 +158,6 @@ class Container(Type):
     def directory(self, path: str) -> "Directory":
         """Retrieves a directory at the given path.
 
-
-
         Mounts are included.
 
         Parameters
@@ -181,12 +179,8 @@ class Container(Type):
     ) -> str:
         """Retrieves an endpoint that clients can use to reach this container.
 
-
-
         If no port is specified, the first exposed port is used. If none exist
         an error is returned.
-
-
 
         If a scheme is specified, a URL is returned. Otherwise, a host:port
         pair is returned.
@@ -326,7 +320,6 @@ class Container(Type):
     @typecheck
     def exit_code(self) -> Optional[int]:
         """Exit code of the last executed command. Zero means success.
-
         Null if no command has been executed.
 
         Returns
@@ -356,10 +349,7 @@ class Container(Type):
         """Writes the container as an OCI tarball to the destination file path on
         the host for the specified platform variants.
 
-
-
         Return true on success.
-
         It can also publishes platform variants.
 
         Parameters
@@ -400,8 +390,6 @@ class Container(Type):
     @typecheck
     def file(self, path: str) -> "File":
         """Retrieves a file at the given path.
-
-
 
         Mounts are included.
 
@@ -612,10 +600,7 @@ class Container(Type):
     ) -> str:
         """Publishes this container as a new image to the specified address.
 
-
-
         Publish returns a fully qualified ref.
-
         It can also publish platform variants.
 
         Parameters
@@ -659,7 +644,6 @@ class Container(Type):
     @typecheck
     def stderr(self) -> Optional[str]:
         """The error stream of the last executed command.
-
         Null if no command has been executed.
 
         Returns
@@ -683,7 +667,6 @@ class Container(Type):
     @typecheck
     def stdout(self) -> Optional[str]:
         """The output stream of the last executed command.
-
         Null if no command has been executed.
 
         Returns
@@ -861,11 +844,8 @@ class Container(Type):
         description: Optional[str] = None,
     ) -> "Container":
         """Expose a network port.
-
         Exposed ports serve two purposes:
-
           - For health checks and introspection, when running services
-
           - For setting the EXPOSE OCI field when publishing the container
 
         Parameters
@@ -1137,12 +1117,8 @@ class Container(Type):
         started automatically when needed and detached when it is no longer
         needed.
 
-
-
         The service will be reachable from the container via the provided
         hostname alias.
-
-
 
         The service dependency will also convey to any files or directories
         produced by the container.
@@ -2349,13 +2325,9 @@ class Client(Root):
     ) -> Container:
         """Loads a container from ID.
 
-
-
         Null ID returns an empty container (scratch).
-
         Optional platform argument initializes new containers to execute and
         publish as that platform.
-
         Platform defaults to that of the builder's host.
         """
         _args = [

--- a/sdk/python/src/dagger/codegen.py
+++ b/sdk/python/src/dagger/codegen.py
@@ -390,6 +390,7 @@ class _ObjectField:
             key=attrgetter("has_default"),
         )
         self.description = field.description
+
         self.is_leaf = is_output_leaf_type(field.type)
         self.is_custom_scalar = is_custom_scalar_type(field.type)
         self.type = format_output_type(field.type).replace("Query", "Client")
@@ -439,8 +440,7 @@ class _ObjectField:
     def func_doc(self) -> str:
         def _out():
             if self.description:
-                for line in self.description.split("\n"):
-                    yield wrap(line)
+                yield (textwrap.fill(line) for line in self.description.splitlines())
 
             if deprecated := self.deprecated():
                 yield chain(


### PR DESCRIPTION
#4505 reverted a `codegen.py` change due to an outdated merge in [aad86c7](https://github.com/dagger/dagger/pull/4505/commits/aad86c7cd0e471da4e7297679ba7dcaa4d5e5a40#diff-456e93caaf55f83fa963bff05f16413d26c0bfc01505ee73c7753b915ff22a55).

Signed-off-by: Helder Correia