### PR TITLE
Make services feature opt-in

### DIFF
--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"dagger.io/dagger"
+	"github.com/dagger/dagger/internal/engine"
 	"github.com/dagger/dagger/internal/testutil"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
@@ -64,6 +65,8 @@ func TestGit(t *testing.T) {
 }
 
 func TestGitSSHAuthSock(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 

--- a/core/integration/http_test.go
+++ b/core/integration/http_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"dagger.io/dagger"
+	"github.com/dagger/dagger/internal/engine"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,6 +21,8 @@ func TestHTTP(t *testing.T) {
 }
 
 func TestHTTPService(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	t.Parallel()
 
 	c, ctx := connect(t)

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"dagger.io/dagger"
+	"github.com/dagger/dagger/internal/engine"
 	"github.com/dagger/dagger/internal/testutil"
 	"github.com/moby/buildkit/identity"
 	"github.com/stretchr/testify/require"
@@ -30,6 +31,8 @@ import (
 )
 
 func TestServiceHostnamesAreStable(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -63,6 +66,8 @@ func TestServiceHostnamesAreStable(t *testing.T) {
 }
 
 func TestContainerHostnameEndpoint(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -125,6 +130,8 @@ func TestContainerHostnameEndpoint(t *testing.T) {
 }
 
 func TestContainerPortLifecycle(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -217,6 +224,8 @@ func TestContainerPortLifecycle(t *testing.T) {
 }
 
 func TestContainerExecServices(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -245,6 +254,8 @@ func TestContainerExecServices(t *testing.T) {
 }
 
 func TestContainerExecServicesError(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -270,6 +281,8 @@ func TestContainerExecServicesError(t *testing.T) {
 var udpSrc string
 
 func TestContainerExecUDPServices(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -300,6 +313,8 @@ func TestContainerExecUDPServices(t *testing.T) {
 }
 
 func TestContainerExecServiceAlias(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -328,6 +343,8 @@ func TestContainerExecServiceAlias(t *testing.T) {
 var pipeSrc string
 
 func TestContainerExecServicesDeduping(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -362,6 +379,8 @@ func TestContainerExecServicesDeduping(t *testing.T) {
 }
 
 func TestContainerExecServicesChained(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -398,6 +417,8 @@ func TestContainerExecServicesChained(t *testing.T) {
 }
 
 func TestContainerBuildService(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -478,6 +499,8 @@ CMD cat index.html
 }
 
 func TestContainerExportServices(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -496,6 +519,8 @@ func TestContainerExportServices(t *testing.T) {
 }
 
 func TestContainerMultiPlatformExportServices(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -521,6 +546,8 @@ func TestContainerMultiPlatformExportServices(t *testing.T) {
 }
 
 func TestServicesContainerPublish(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -544,6 +571,8 @@ func TestServicesContainerPublish(t *testing.T) {
 }
 
 func TestContainerRootFSServices(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -564,6 +593,8 @@ func TestContainerRootFSServices(t *testing.T) {
 }
 
 func TestContainerWithRootFSServices(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -596,6 +627,8 @@ func TestContainerWithRootFSServices(t *testing.T) {
 }
 
 func TestContainerDirectoryServices(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -640,6 +673,8 @@ func TestContainerDirectoryServices(t *testing.T) {
 }
 
 func TestContainerFileServices(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -658,6 +693,8 @@ func TestContainerFileServices(t *testing.T) {
 }
 
 func TestContainerWithServiceFileDirectory(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -704,6 +741,8 @@ func TestContainerWithServiceFileDirectory(t *testing.T) {
 }
 
 func TestDirectoryServiceEntries(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -720,6 +759,8 @@ func TestDirectoryServiceEntries(t *testing.T) {
 }
 
 func TestDirectoryServiceTimestamp(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -741,6 +782,8 @@ func TestDirectoryServiceTimestamp(t *testing.T) {
 }
 
 func TestDirectoryWithDirectoryFileServices(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -764,6 +807,8 @@ func TestDirectoryWithDirectoryFileServices(t *testing.T) {
 }
 
 func TestDirectoryServiceExport(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -786,6 +831,8 @@ func TestDirectoryServiceExport(t *testing.T) {
 }
 
 func TestFileServiceContents(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -803,6 +850,8 @@ func TestFileServiceContents(t *testing.T) {
 }
 
 func TestFileServiceExport(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -827,6 +876,8 @@ func TestFileServiceExport(t *testing.T) {
 }
 
 func TestFileServiceTimestamp(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -847,6 +898,8 @@ func TestFileServiceTimestamp(t *testing.T) {
 }
 
 func TestFileServiceSecret(t *testing.T) {
+	checkEnabled(t, engine.ServicesDNSEnvName)
+
 	c, ctx := connect(t)
 	defer c.Close()
 

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -267,3 +267,9 @@ func tarEntries(t *testing.T, path string) []string {
 
 	return entries
 }
+
+func checkEnabled(t *testing.T, env string) {
+	if os.Getenv(env) == "" {
+		t.Skipf("set $%s to enable", env)
+	}
+}

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -268,7 +268,7 @@ func tarEntries(t *testing.T, path string) []string {
 	return entries
 }
 
-func checkEnabled(t *testing.T, env string) {
+func checkEnabled(t *testing.T, env string) { //nolint:unparam
 	if os.Getenv(env) == "" {
 		t.Skipf("set $%s to enable", env)
 	}

--- a/core/schema/base.go
+++ b/core/schema/base.go
@@ -20,6 +20,9 @@ type InitializeArgs struct {
 	Platform      specs.Platform
 	DisableHostRW bool
 	Auth          *auth.RegistryAuthProvider
+
+	// TODO(vito): remove when stable
+	EnableServices bool
 }
 
 func New(params InitializeArgs) (router.ExecutableSchema, error) {
@@ -31,6 +34,9 @@ func New(params InitializeArgs) (router.ExecutableSchema, error) {
 		solveCh:   params.SolveCh,
 		platform:  params.Platform,
 		auth:      params.Auth,
+
+		// TODO(vito): remove when stable
+		servicesEnabled: params.EnableServices,
 	}
 	host := core.NewHost(params.Workdir, params.DisableHostRW)
 	return router.MergeExecutableSchemas("core",
@@ -60,4 +66,7 @@ type baseSchema struct {
 	solveCh   chan *bkclient.SolveStatus
 	platform  specs.Platform
 	auth      *auth.RegistryAuthProvider
+
+	// TODO(vito): remove when stable
+	servicesEnabled bool
 }

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -610,6 +610,10 @@ func (s *containerSchema) imageRef(ctx *router.Context, parent *core.Container, 
 }
 
 func (s *containerSchema) hostname(ctx *router.Context, parent *core.Container, args any) (string, error) {
+	if !s.servicesEnabled {
+		return "", ErrServicesDisabled
+	}
+
 	return parent.Hostname()
 }
 
@@ -619,6 +623,10 @@ type containerEndpointArgs struct {
 }
 
 func (s *containerSchema) endpoint(ctx *router.Context, parent *core.Container, args containerEndpointArgs) (string, error) {
+	if !s.servicesEnabled {
+		return "", ErrServicesDisabled
+	}
+
 	return parent.Endpoint(args.Port, args.Scheme)
 }
 
@@ -628,6 +636,10 @@ type containerWithServiceDependencyArgs struct {
 }
 
 func (s *containerSchema) withServiceBinding(ctx *router.Context, parent *core.Container, args containerWithServiceDependencyArgs) (*core.Container, error) {
+	if !s.servicesEnabled {
+		return nil, ErrServicesDisabled
+	}
+
 	return parent.WithServiceDependency(&core.Container{ID: args.Service}, args.Alias)
 }
 
@@ -638,6 +650,10 @@ type containerWithExposedPortArgs struct {
 }
 
 func (s *containerSchema) withExposedPort(ctx *router.Context, parent *core.Container, args containerWithExposedPortArgs) (*core.Container, error) {
+	if !s.servicesEnabled {
+		return nil, ErrServicesDisabled
+	}
+
 	return parent.WithExposedPort(core.ContainerPort{
 		Protocol:    args.Protocol,
 		Port:        args.Port,
@@ -651,6 +667,10 @@ type containerWithoutExposedPortArgs struct {
 }
 
 func (s *containerSchema) withoutExposedPort(ctx *router.Context, parent *core.Container, args containerWithoutExposedPortArgs) (*core.Container, error) {
+	if !s.servicesEnabled {
+		return nil, ErrServicesDisabled
+	}
+
 	return parent.WithoutExposedPort(args.Port, args.Protocol)
 }
 
@@ -663,6 +683,10 @@ type ExposedPort struct {
 }
 
 func (s *containerSchema) exposedPorts(ctx *router.Context, parent *core.Container, args any) ([]ExposedPort, error) {
+	if !s.servicesEnabled {
+		return nil, ErrServicesDisabled
+	}
+
 	ports, err := parent.ExposedPorts()
 	if err != nil {
 		return nil, err

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -563,9 +563,12 @@ type Container {
 
   """
   Expose a network port.
+
   Exposed ports serve two purposes:
     - For health checks and introspection, when running services
     - For setting the EXPOSE OCI field when publishing the container
+
+  Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
   """
   withExposedPort(
     "Port number to expose"
@@ -578,6 +581,8 @@ type Container {
 
   """
   Unexpose a previously exposed port.
+
+  Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
   """
   withoutExposedPort(
     "Port number to unexpose"
@@ -586,7 +591,11 @@ type Container {
     protocol: NetworkProtocol = TCP
   ): Container!
 
-  "Retrieves the list of exposed ports"
+  """
+  Retrieves the list of exposed ports.
+
+  Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
+  """
   exposedPorts: [Port!]!
 
   """
@@ -595,6 +604,8 @@ type Container {
   The service will be reachable from the container via the provided hostname alias.
 
   The service dependency will also convey to any files or directories produced by the container.
+
+  Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
   """
   withServiceBinding(
     "A name that can be used to reach the service from the container"
@@ -605,6 +616,8 @@ type Container {
 
   """
   Retrieves a hostname which can be used by clients to reach this container.
+
+  Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
   """
   hostname: String!
 
@@ -614,6 +627,8 @@ type Container {
   If no port is specified, the first exposed port is used. If none exist an error is returned.
 
   If a scheme is specified, a URL is returned. Otherwise, a host:port pair is returned.
+
+  Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
   """
   endpoint(
     "The exposed port number for the endpoint"

--- a/core/schema/util.go
+++ b/core/schema/util.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/dagger/dagger/internal/engine"
 	"github.com/dagger/dagger/router"
 	"github.com/dagger/graphql/language/ast"
 )
@@ -11,6 +12,8 @@ import (
 // ErrNotImplementedYet is used to stub out API fields that aren't implemented
 // yet.
 var ErrNotImplementedYet = errors.New("not implemented yet")
+
+var ErrServicesDisabled = fmt.Errorf("services are disabled; set %s to enable", engine.ServicesDNSEnvName)
 
 // stringResolver is used to generate a scalar resolver for a stringable type.
 func stringResolver[T ~string](sample T) router.ScalarResolver {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -137,15 +137,16 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 
 			gwClient := core.NewGatewayClient(gw)
 			coreAPI, err := schema.New(schema.InitializeArgs{
-				Router:        router,
-				Workdir:       startOpts.Workdir,
-				Gateway:       gwClient,
-				BKClient:      c,
-				SolveOpts:     solveOpts,
-				SolveCh:       solveCh,
-				Platform:      *platform,
-				DisableHostRW: startOpts.DisableHostRW,
-				Auth:          registryAuth,
+				Router:         router,
+				Workdir:        startOpts.Workdir,
+				Gateway:        gwClient,
+				BKClient:       c,
+				SolveOpts:      solveOpts,
+				SolveCh:        solveCh,
+				Platform:       *platform,
+				DisableHostRW:  startOpts.DisableHostRW,
+				Auth:           registryAuth,
+				EnableServices: os.Getenv(engine.ServicesDNSEnvName) != "",
 			})
 			if err != nil {
 				return nil, err

--- a/internal/engine/docker.go
+++ b/internal/engine/docker.go
@@ -20,6 +20,7 @@ const (
 	DefaultStateDir = "/var/lib/dagger"
 
 	CacheConfigEnvName = "_EXPERIMENTAL_DAGGER_CACHE_CONFIG"
+	ServicesDNSEnvName = "_EXPERIMENTAL_DAGGER_SERVICES_DNS"
 
 	// trim image digests to 16 characters to makeoutput more readable
 	hashLen             = 16
@@ -92,6 +93,7 @@ func dockerImageProvider(ctx context.Context, runnerHost *url.URL) (string, erro
 		"-d",
 		"--restart", "always",
 		"-e", CacheConfigEnvName,
+		"-e", ServicesDNSEnvName,
 		"-v", DefaultStateDir,
 		"--privileged",
 	}

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -154,6 +154,8 @@ type ContainerEndpointOpts struct {
 // If no port is specified, the first exposed port is used. If none exist an error is returned.
 //
 // If a scheme is specified, a URL is returned. Otherwise, a host:port pair is returned.
+//
+// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
 func (r *Container) Endpoint(ctx context.Context, opts ...ContainerEndpointOpts) (string, error) {
 	q := r.q.Select("endpoint")
 	// `port` optional argument
@@ -304,7 +306,9 @@ func (r *Container) Export(ctx context.Context, path string, opts ...ContainerEx
 	return response, q.Execute(ctx, r.c)
 }
 
-// Retrieves the list of exposed ports
+// Retrieves the list of exposed ports.
+//
+// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
 func (r *Container) ExposedPorts(ctx context.Context) ([]Port, error) {
 	q := r.q.Select("exposedPorts")
 
@@ -350,6 +354,8 @@ func (r *Container) FS() *Directory {
 }
 
 // Retrieves a hostname which can be used by clients to reach this container.
+//
+// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
 func (r *Container) Hostname(ctx context.Context) (string, error) {
 	q := r.q.Select("hostname")
 
@@ -659,9 +665,12 @@ type ContainerWithExposedPortOpts struct {
 }
 
 // Expose a network port.
+//
 // Exposed ports serve two purposes:
 //   - For health checks and introspection, when running services
 //   - For setting the EXPOSE OCI field when publishing the container
+//
+// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
 func (r *Container) WithExposedPort(port int, opts ...ContainerWithExposedPortOpts) *Container {
 	q := r.q.Select("withExposedPort")
 	q = q.Arg("port", port)
@@ -895,6 +904,8 @@ func (r *Container) WithSecretVariable(name string, secret *Secret) *Container {
 // The service will be reachable from the container via the provided hostname alias.
 //
 // The service dependency will also convey to any files or directories produced by the container.
+//
+// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
 func (r *Container) WithServiceBinding(alias string, service *Container) *Container {
 	q := r.q.Select("withServiceBinding")
 	q = q.Arg("alias", alias)
@@ -958,6 +969,8 @@ type ContainerWithoutExposedPortOpts struct {
 }
 
 // Unexpose a previously exposed port.
+//
+// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
 func (r *Container) WithoutExposedPort(port int, opts ...ContainerWithoutExposedPortOpts) *Container {
 	q := r.q.Select("withoutExposedPort")
 	q = q.Arg("port", port)

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -586,6 +586,8 @@ export class Container extends BaseClient {
    * If no port is specified, the first exposed port is used. If none exist an error is returned.
    *
    * If a scheme is specified, a URL is returned. Otherwise, a host:port pair is returned.
+   *
+   * Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
    * @param opts.port The exposed port number for the endpoint
    * @param opts.scheme Return a URL with the given scheme, eg. http for http://
    */
@@ -726,7 +728,9 @@ export class Container extends BaseClient {
   }
 
   /**
-   * Retrieves the list of exposed ports
+   * Retrieves the list of exposed ports.
+   *
+   * Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
    */
   async exposedPorts(): Promise<Port[]> {
     const response: Awaited<Port[]> = await computeQuery(
@@ -801,6 +805,8 @@ export class Container extends BaseClient {
 
   /**
    * Retrieves a hostname which can be used by clients to reach this container.
+   *
+   * Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
    */
   async hostname(): Promise<string> {
     const response: Awaited<string> = await computeQuery(
@@ -1138,9 +1144,12 @@ export class Container extends BaseClient {
 
   /**
    * Expose a network port.
+   *
    * Exposed ports serve two purposes:
    *   - For health checks and introspection, when running services
    *   - For setting the EXPOSE OCI field when publishing the container
+   *
+   * Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
    * @param port Port number to expose
    * @param opts.protocol Transport layer network protocol
    * @param opts.description Optional port description
@@ -1414,6 +1423,8 @@ export class Container extends BaseClient {
    * The service will be reachable from the container via the provided hostname alias.
    *
    * The service dependency will also convey to any files or directories produced by the container.
+   *
+   * Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
    * @param alias A name that can be used to reach the service from the container
    * @param service Identifier of the service container
    */
@@ -1506,6 +1517,8 @@ export class Container extends BaseClient {
 
   /**
    * Unexpose a previously exposed port.
+   *
+   * Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
    * @param port Port number to unexpose
    * @param opts.protocol Port protocol to unexpose
    */

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -185,6 +185,9 @@ class Container(Type):
         If a scheme is specified, a URL is returned. Otherwise, a host:port
         pair is returned.
 
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to
+        enable.
+
         Parameters
         ----------
         port:
@@ -382,7 +385,11 @@ class Container(Type):
 
     @typecheck
     def exposed_ports(self) -> "Port":
-        """Retrieves the list of exposed ports"""
+        """Retrieves the list of exposed ports.
+
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to
+        enable.
+        """
         _args: list[Arg] = []
         _ctx = self._select("exposedPorts", _args)
         return Port(_ctx)
@@ -436,6 +443,9 @@ class Container(Type):
     async def hostname(self) -> str:
         """Retrieves a hostname which can be used by clients to reach this
         container.
+
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to
+        enable.
 
         Returns
         -------
@@ -844,9 +854,13 @@ class Container(Type):
         description: Optional[str] = None,
     ) -> "Container":
         """Expose a network port.
+
         Exposed ports serve two purposes:
           - For health checks and introspection, when running services
           - For setting the EXPOSE OCI field when publishing the container
+
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to
+        enable.
 
         Parameters
         ----------
@@ -1123,6 +1137,9 @@ class Container(Type):
         The service dependency will also convey to any files or directories
         produced by the container.
 
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to
+        enable.
+
         Parameters
         ----------
         alias:
@@ -1208,6 +1225,9 @@ class Container(Type):
         protocol: Optional[NetworkProtocol] = None,
     ) -> "Container":
         """Unexpose a previously exposed port.
+
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to
+        enable.
 
         Parameters
         ----------

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -185,6 +185,9 @@ class Container(Type):
         If a scheme is specified, a URL is returned. Otherwise, a host:port
         pair is returned.
 
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to
+        enable.
+
         Parameters
         ----------
         port:
@@ -382,7 +385,11 @@ class Container(Type):
 
     @typecheck
     def exposed_ports(self) -> "Port":
-        """Retrieves the list of exposed ports"""
+        """Retrieves the list of exposed ports.
+
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to
+        enable.
+        """
         _args: list[Arg] = []
         _ctx = self._select("exposedPorts", _args)
         return Port(_ctx)
@@ -436,6 +443,9 @@ class Container(Type):
     def hostname(self) -> str:
         """Retrieves a hostname which can be used by clients to reach this
         container.
+
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to
+        enable.
 
         Returns
         -------
@@ -844,9 +854,13 @@ class Container(Type):
         description: Optional[str] = None,
     ) -> "Container":
         """Expose a network port.
+
         Exposed ports serve two purposes:
           - For health checks and introspection, when running services
           - For setting the EXPOSE OCI field when publishing the container
+
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to
+        enable.
 
         Parameters
         ----------
@@ -1123,6 +1137,9 @@ class Container(Type):
         The service dependency will also convey to any files or directories
         produced by the container.
 
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to
+        enable.
+
         Parameters
         ----------
         alias:
@@ -1208,6 +1225,9 @@ class Container(Type):
         protocol: Optional[NetworkProtocol] = None,
     ) -> "Container":
         """Unexpose a previously exposed port.
+
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to
+        enable.
 
         Parameters
         ----------


### PR DESCRIPTION
* Follow-up to #4505 
* Work around for #4652 until we can find a fix

To enable services you'll now need to `export _EXPERIMENTAL_DAGGER_SERVICES_DNS=1`, re-provision the engine, and keep that env var set anywhere you use the client.

Changes:

* only mess with `/etc/resolv.conf` if enabled
* only configure CNI + bridge networking if enabled
* all service related APIs return an error if not enabled

I suspect DNS is the issue (seems always a safe bet), but let's assume the worst and just disable the whole CNI stack so we don't need to do multiple releases.