### PR TITLE
Better resolv.conf/dnsmasq setup

### DIFF
--- a/cmd/dnsname/config.go
+++ b/cmd/dnsname/config.go
@@ -29,7 +29,9 @@ except-interface=lo
 bind-dynamic
 no-hosts
 interface={{.NetworkInterface}}
-addn-hosts={{.AddOnHostsFile}}`
+addn-hosts={{.AddOnHostsFile}}
+resolv-file=/etc/resolv.conf.upstream
+`
 
 var (
 	// ErrBinaryNotFound means that the dnsmasq binary was not found


### PR DESCRIPTION
Previously we had a kind of wonky `dnsmasq` + `resolv.conf` setup that seemed to work in local testing but appears to cause problems in other environments. (#4652)

I haven't reproduced those issues, but a few potential weird things stuck out that this commit fixes:

* get rid of `search dns.dagger` - we always use qualified domains for container-to-container addresses, so this was unnecessary
* relocate original `resolv.conf` mount to `resolv.conf.upstream` so that updates can propagate without engine restart, rather than copying the contents once at boot
* point `dnsmasq` to `resolv.conf.upstream` instead of `resolv.conf` to avoid any weirdness with dnsmasq finding itself as an upstream server
* put _only_ `dnsmasq` in resolv.conf so we can be sure that it's the source of truth, but preserve any `search` and `options` configs from the upstream `resolv.conf` as I don't believe they would take effect otherwise