### PR TITLE
Apply Dagger engine config defaults at runtime, configure MTU that matches default interface

### DIFF
--- a/cmd/engine/config.go
+++ b/cmd/engine/config.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/dagger/dagger/network"
+	"github.com/jackpal/gateway"
+	"github.com/moby/buildkit/cmd/buildkitd/config"
+)
+
+// engineDefaultStateDir is the directory that we map to a volume by default.
+const engineDefaultStateDir = "/var/lib/dagger"
+
+// daggerConfigPath is the path containing Dagger-specific configuration, which
+// might be provided by the user.
+const daggerConfigPath = "/etc/dagger"
+
+// cniConfigPath is the path to Dagger's CNI configuration. It will be
+// generated if one isn't provided.
+var cniConfigPath = filepath.Join(daggerConfigPath, "cni.conflist")
+
+// servicesDNSEnvName is the feature flag for enabling the services network
+// stack.
+const servicesDNSEnvName = "_EXPERIMENTAL_DAGGER_SERVICES_DNS"
+
+func setDaggerDefaults(cfg *config.Config) error {
+	if cfg.Root == "" {
+		cfg.Root = engineDefaultStateDir
+	}
+
+	if os.Getenv(servicesDNSEnvName) != "" {
+		// check if CNI config already exists, just so we can respect a
+		// user-provided config
+		if _, err := os.Stat(cniConfigPath); os.IsNotExist(err) {
+			cni, err := cniConfig(network.Name, network.CIDR)
+			if err != nil {
+				return err
+			}
+
+			if err := os.MkdirAll(filepath.Dir(cniConfigPath), 0700); err != nil {
+				return err
+			}
+
+			if err := os.WriteFile(cniConfigPath, cni, 0600); err != nil {
+				return err
+			}
+		}
+
+		setNetworkDefaults(&cfg.Workers.OCI.NetworkConfig)
+
+		// we don't use containerd, but make it match anyway
+		setNetworkDefaults(&cfg.Workers.Containerd.NetworkConfig)
+	}
+
+	return nil
+}
+
+func setNetworkDefaults(cfg *config.NetworkConfig) {
+	if cfg.Mode == "" {
+		cfg.Mode = "cni"
+	}
+	if cfg.CNIConfigPath == "" {
+		cfg.CNIConfigPath = cniConfigPath
+	}
+	if cfg.CNIPoolSize == 0 {
+		cfg.CNIPoolSize = 16
+	}
+}
+
+func cniConfig(name, subnet string) ([]byte, error) {
+	ip, err := gateway.DiscoverInterface()
+	if err != nil {
+		return nil, err
+	}
+
+	networkIface, err := findIfaceWithIP(ip.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(map[string]any{
+		"cniVersion": "0.4.0",
+		"name":       name,
+		"plugins": []any{
+			map[string]any{
+				"type":             "bridge",
+				"bridge":           name + "0",
+				"isDefaultGateway": true,
+				"ipMasq":           true,
+				"hairpinMode":      true,
+				"mtu":              networkIface.MTU,
+				"ipam": map[string]any{
+					"type": "host-local",
+					"ranges": []any{
+						[]any{map[string]any{"subnet": subnet}},
+					},
+				},
+			},
+			map[string]any{
+				"type": "firewall",
+			},
+			map[string]any{
+				"type":       "dnsname",
+				"domainName": network.DNSDomain,
+				"capabilities": map[string]any{
+					"aliases": true,
+				},
+			},
+		},
+	})
+}
+
+func findIfaceWithIP(ip string) (net.Interface, error) {
+	networkIfaces, err := net.Interfaces()
+	if err != nil {
+		return net.Interface{}, err
+	}
+
+	for _, networkIface := range networkIfaces {
+		addrs, err := networkIface.Addrs()
+		if err != nil {
+			return net.Interface{}, err
+		}
+
+		for _, address := range addrs {
+			if strings.HasPrefix(address.String(), ip+"/") {
+				return networkIface, nil
+			}
+		}
+	}
+
+	return net.Interface{}, fmt.Errorf("no interface found for address %s", ip)
+}

--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -211,7 +211,12 @@ func main() {
 			return err
 		}
 
+		if err := setDaggerDefaults(&cfg); err != nil {
+			return err
+		}
+
 		setDefaultConfig(&cfg)
+
 		if err := applyMainFlags(c, &cfg); err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -121,6 +121,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.2 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
+	github.com/jackpal/gateway v1.0.7 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -845,6 +845,8 @@ github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7P
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ishidawataru/sctp v0.0.0-20191218070446-00ab2ac2db07/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
+github.com/jackpal/gateway v1.0.7 h1:7tIFeCGmpyrMx9qvT0EgYUi7cxVW48a0mMvnIL17bPM=
+github.com/jackpal/gateway v1.0.7/go.mod h1:aRcO0UFKt+MgIZmRmvOmnejdDT4Y1DNiNOsSd1AcIbA=
 github.com/jaguilar/vt100 v0.0.0-20150826170717-2703a27b14ea/go.mod h1:QMdK4dGB3YhEW2BmA1wgGpPYI3HZy/5gD705PXKUVSg=
 github.com/jarcoal/httpmock v1.0.5/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=

--- a/network/network.go
+++ b/network/network.go
@@ -1,7 +1,8 @@
 package network
 
 const (
-	DNSDomain = "dns.dagger"
+	Name      = "dagger"
+	DNSDomain = Name + ".local"
 	CIDR      = "10.87.0.0/16"
 	Bridge    = "10.87.0.1"
 )


### PR DESCRIPTION
* Follow-up to #4657
* Fixes #4652

Now we handle Buildkit config defaults in `cmd/engine/` on start. We'll load the user-provided config, apply our defaults on top, and then apply the Buildkit defaults.

It also detects the MTU of the default interface and sets the same value in the `bridge` plugin, which should fix #4652 