### PR TITLE
feat: add dynamic secret API

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -998,9 +998,6 @@ func (container *Container) WithExec(ctx context.Context, gw bkgw.Client, defaul
 
 	secretsToScrub := SecretToScrubInfo{}
 	for i, secret := range payload.Secrets {
-		// TODO use the digest, not the ID (because it leaks)
-		// TODO find a way to get the digest from the SecretID
-		// TODO maybe the ID can be name + digest concatenated. Use the secretPayload?
 		secretOpts := []llb.SecretOption{llb.SecretID(secret.Secret.String())}
 
 		var secretDest string

--- a/core/container.go
+++ b/core/container.go
@@ -998,6 +998,9 @@ func (container *Container) WithExec(ctx context.Context, gw bkgw.Client, defaul
 
 	secretsToScrub := SecretToScrubInfo{}
 	for i, secret := range payload.Secrets {
+		// TODO use the digest, not the ID (because it leaks)
+		// TODO find a way to get the digest from the SecretID
+		// TODO maybe the ID can be name + digest concatenated. Use the secretPayload?
 		secretOpts := []llb.SecretOption{llb.SecretID(secret.Secret.String())}
 
 		var secretDest string

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -2772,6 +2772,7 @@ func TestContainerWithRegistryAuth(t *testing.T) {
 		WithRegistryAuth(
 			privateRegistryHost,
 			"john",
+			//nolint:staticcheck // SA1019 We want to test this API while we support it.
 			c.Container().
 				WithNewFile("secret.txt", dagger.ContainerWithNewFileOpts{Contents: "xFlejaPdjrt25Dvr"}).
 				File("secret.txt").

--- a/core/integration/secret_test.go
+++ b/core/integration/secret_test.go
@@ -138,3 +138,18 @@ func TestSecretPlaintext(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "hi", plaintext)
 }
+
+func TestNewSecret(t *testing.T) {
+	ctx := context.Background()
+	c, err := dagger.Connect(ctx)
+	require.NoError(t, err)
+	defer c.Close()
+
+	secretValue := "very-secret-text"
+
+	s := c.SetSecret("aws_key", secretValue)
+
+	exitCode, err := c.Container().From("alpine").WithSecretVariable("AWS_KEY", s).WithExec([]string{"sh", "-c", "test \"$AWS_KEY\" = \"very-secret-text\""}).ExitCode(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+}

--- a/core/integration/secret_test.go
+++ b/core/integration/secret_test.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"testing"
-	"time"
 
 	"dagger.io/dagger"
 	"github.com/dagger/dagger/internal/testutil"
@@ -126,42 +125,6 @@ func TestSecretMountFromFileWithOverridingMount(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, res.Container.From.WithMountedSecret.WithMountedFile.Exec.ExitCode)
 	require.Contains(t, res.Container.From.WithMountedSecret.WithMountedFile.File.Contents, "some-content")
-}
-
-func TestSecretFromFileGoSDK(t *testing.T) {
-	ctx := context.Background()
-	c, err := dagger.Connect(ctx)
-	require.NoError(t, err)
-	defer c.Close()
-
-	//nolint:staticcheck // SA1019 We want to test this API while we support it.
-	file := c.Directory().
-		WithNewFile("TOP_SECRET", "hi Go SDK").File("TOP_SECRET")
-
-	cont := c.Container().From("alpine:3.17.2").
-		WithEnvVariable("CACHEBUSTER", time.Now().String()).
-		WithSecretVariable("TOP_SECRET_ENV", file.Secret()).
-		WithMountedFile("/myplaintext", file).
-		WithExec([]string{"sh", "-c", "echo \"$TOP_SECRET_ENV\" > echoenv"}).
-		WithExec([]string{"sh", "-c", "echo -e Why oh Why \"$TOP_SECRET_ENV\""})
-
-	out, err := cont.
-		Stdout(ctx)
-	require.NoError(t, err)
-
-	ok, err := cont.
-		File("/echoenv").
-		Export(ctx, "echoenv.host")
-	require.NoError(t, err)
-
-	ok, err = cont.
-		File("/myplaintext").
-		Export(ctx, "myplaintext.host")
-	require.NoError(t, err)
-
-	t.Log("ok:", ok)
-	t.Log("stdout:", out)
-	require.NoError(t, err)
 }
 
 func TestSecretPlaintext(t *testing.T) {

--- a/core/integration/secret_test.go
+++ b/core/integration/secret_test.go
@@ -133,6 +133,7 @@ func TestSecretPlaintext(t *testing.T) {
 	require.NoError(t, err)
 	defer c.Close()
 
+	//nolint:staticcheck // SA1019 We want to test this API while we support it.
 	plaintext, err := c.Directory().
 		WithNewFile("TOP_SECRET", "hi").File("TOP_SECRET").Secret().Plaintext(ctx)
 	require.NoError(t, err)

--- a/core/integration/secret_test.go
+++ b/core/integration/secret_test.go
@@ -150,7 +150,7 @@ func TestNewSecret(t *testing.T) {
 
 	s := c.SetSecret("aws_key", secretValue)
 
-	exitCode, err := c.Container().From("alpine").WithSecretVariable("AWS_KEY", s).WithExec([]string{"sh", "-c", "test \"$AWS_KEY\" = \"very-secret-text\""}).ExitCode(ctx)
+	exitCode, err := c.Container().From("alpine:3.16.2").WithSecretVariable("AWS_KEY", s).WithExec([]string{"sh", "-c", "test \"$AWS_KEY\" = \"very-secret-text\""}).ExitCode(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 0, exitCode)
 }

--- a/core/integration/secret_test.go
+++ b/core/integration/secret_test.go
@@ -141,9 +141,7 @@ func TestSecretPlaintext(t *testing.T) {
 }
 
 func TestNewSecret(t *testing.T) {
-	ctx := context.Background()
-	c, err := dagger.Connect(ctx)
-	require.NoError(t, err)
+	c, ctx := connect(t)
 	defer c.Close()
 
 	secretValue := "very-secret-text"

--- a/core/integration/secret_test.go
+++ b/core/integration/secret_test.go
@@ -148,7 +148,10 @@ func TestNewSecret(t *testing.T) {
 
 	s := c.SetSecret("aws_key", secretValue)
 
-	exitCode, err := c.Container().From("alpine:3.16.2").WithSecretVariable("AWS_KEY", s).WithExec([]string{"sh", "-c", "test \"$AWS_KEY\" = \"very-secret-text\""}).ExitCode(ctx)
+	exitCode, err := c.Container().From("alpine:3.16.2").
+		WithSecretVariable("AWS_KEY", s).
+		WithExec([]string{"sh", "-c", "test \"$AWS_KEY\" = \"very-secret-text\""}).
+		ExitCode(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 0, exitCode)
 }

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -940,6 +940,7 @@ func TestFileServiceSecret(t *testing.T) {
 
 	httpSrv, httpURL := httpService(ctx, t, c, content)
 
+	//nolint:staticcheck // SA1019 We want to test this API while we support it.
 	secret := c.HTTP(httpURL, dagger.HTTPOpts{
 		ExperimentalServiceHost: httpSrv,
 	}).Secret()

--- a/core/schema/base.go
+++ b/core/schema/base.go
@@ -5,6 +5,7 @@ import (
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/project"
 	"github.com/dagger/dagger/router"
+	"github.com/dagger/dagger/secret"
 	bkclient "github.com/moby/buildkit/client"
 	bkgw "github.com/moby/buildkit/frontend/gateway/client"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -20,6 +21,7 @@ type InitializeArgs struct {
 	Platform      specs.Platform
 	DisableHostRW bool
 	Auth          *auth.RegistryAuthProvider
+	Secrets       *secret.Store
 
 	// TODO(vito): remove when stable
 	EnableServices bool
@@ -34,6 +36,7 @@ func New(params InitializeArgs) (router.ExecutableSchema, error) {
 		solveCh:   params.SolveCh,
 		platform:  params.Platform,
 		auth:      params.Auth,
+		secrets:   params.Secrets,
 
 		// TODO(vito): remove when stable
 		servicesEnabled: params.EnableServices,
@@ -66,6 +69,7 @@ type baseSchema struct {
 	solveCh   chan *bkclient.SolveStatus
 	platform  specs.Platform
 	auth      *auth.RegistryAuthProvider
+	secrets   *secret.Store
 
 	// TODO(vito): remove when stable
 	servicesEnabled bool

--- a/core/schema/file.graphqls
+++ b/core/schema/file.graphqls
@@ -15,7 +15,7 @@ type File {
   contents: String!
 
   "Retrieves a secret referencing the contents of this file."
-  secret: Secret!
+  secret: Secret! @deprecated(reason: "insecure, leaves secret in cache")
 
   "Gets the size of the file, in bytes."
   size: Int!

--- a/core/schema/secret.go
+++ b/core/schema/secret.go
@@ -25,7 +25,8 @@ func (s *secretSchema) Resolvers() router.Resolvers {
 	return router.Resolvers{
 		"SecretID": secretIDResolver,
 		"Query": router.ObjectResolver{
-			"secret": router.ToResolver(s.secret),
+			"secret":    router.ToResolver(s.secret),
+			"setSecret": router.ToResolver(s.setSecret),
 		},
 		"Secret": router.ObjectResolver{
 			"plaintext": router.ToResolver(s.plaintext),
@@ -47,8 +48,25 @@ func (s *secretSchema) secret(ctx *router.Context, parent any, args secretArgs) 
 	}, nil
 }
 
+type setSecretArgs struct {
+	Name      string
+	Plaintext string
+}
+
+func (s *secretSchema) setSecret(ctx *router.Context, parent any, args setSecretArgs) (*core.Secret, error) {
+	secretID := s.secrets.AddSecret(ctx, args.Name, args.Plaintext)
+
+	return &core.Secret{
+		ID: secretID,
+	}, nil
+}
+
 func (s *secretSchema) plaintext(ctx *router.Context, parent core.Secret, args any) (string, error) {
-	bytes, err := parent.Plaintext(ctx, s.gw)
+	idStr := parent.ID.String()
+
+	// FIXME: remove
+	// bytes, err = parent.Plaintext(ctx, s.gw)
+	bytes, err := s.secrets.GetSecret(ctx, idStr)
 	if err != nil {
 		return "", err
 	}

--- a/core/schema/secret.go
+++ b/core/schema/secret.go
@@ -65,10 +65,14 @@ func (s *secretSchema) setSecret(ctx *router.Context, parent any, args setSecret
 }
 
 func (s *secretSchema) plaintext(ctx *router.Context, parent core.Secret, args any) (string, error) {
-	idStr := parent.ID.String()
+	digest, err := parent.ID.Digest()
+	// if it is the old format that doesn't use digests
+	if err != nil || digest == "" {
+		bytes, err := parent.Plaintext(ctx, s.gw)
+		return string(bytes), err
+	}
 
-	// FIXME: remove
-	// bytes, err = parent.Plaintext(ctx, s.gw)
+	idStr := parent.ID.String()
 	bytes, err := s.secrets.GetSecret(ctx, idStr)
 	if err != nil {
 		return "", err

--- a/core/schema/secret.go
+++ b/core/schema/secret.go
@@ -65,12 +65,12 @@ func (s *secretSchema) setSecret(ctx *router.Context, parent any, args setSecret
 }
 
 func (s *secretSchema) plaintext(ctx *router.Context, parent core.Secret, args any) (string, error) {
-	isOld, err := parent.ID.IsOldFormat()
+	isOldSecretIDFormat, err := parent.ID.IsOldFormat()
 	if err != nil {
 		return "", err
 	}
 
-	if isOld {
+	if isOldSecretIDFormat {
 		bytes, err := parent.Plaintext(ctx, s.gw)
 		return string(bytes), err
 	}

--- a/core/schema/secret.go
+++ b/core/schema/secret.go
@@ -54,7 +54,10 @@ type setSecretArgs struct {
 }
 
 func (s *secretSchema) setSecret(ctx *router.Context, parent any, args setSecretArgs) (*core.Secret, error) {
-	secretID := s.secrets.AddSecret(ctx, args.Name, args.Plaintext)
+	secretID, err := s.secrets.AddSecret(ctx, args.Name, args.Plaintext)
+	if err != nil {
+		return nil, err
+	}
 
 	return &core.Secret{
 		ID: secretID,

--- a/core/schema/secret.go
+++ b/core/schema/secret.go
@@ -65,9 +65,12 @@ func (s *secretSchema) setSecret(ctx *router.Context, parent any, args setSecret
 }
 
 func (s *secretSchema) plaintext(ctx *router.Context, parent core.Secret, args any) (string, error) {
-	digest, err := parent.ID.Digest()
-	// if it is the old format that doesn't use digests
-	if err != nil || digest == "" {
+	isOld, err := parent.ID.IsOldFormat()
+	if err != nil {
+		return "", err
+	}
+
+	if isOld {
 		bytes, err := parent.Plaintext(ctx, s.gw)
 		return string(bytes), err
 	}

--- a/core/schema/secret.graphqls
+++ b/core/schema/secret.graphqls
@@ -1,6 +1,22 @@
 extend type Query {
   "Loads a secret from its ID."
   secret(id: SecretID!): Secret!
+
+  """
+  Set a secret given a user defined name to its plaintext and returns the secret.
+  """
+  setSecret(
+
+  """
+  The user defined name for this secret
+  """
+  name: String!,
+
+  """
+  The plaintext of the secret
+  """
+  plaintext: String!
+  ): Secret!
 }
 
 "A unique identifier for a secret."

--- a/core/schema/secret.graphqls
+++ b/core/schema/secret.graphqls
@@ -3,7 +3,7 @@ extend type Query {
   secret(id: SecretID!): Secret!
 
   """
-  Set a secret given a user defined name to its plaintext and returns the secret.
+  Sets a secret given a user defined name to its plaintext and returns the secret.
   """
   setSecret(
 

--- a/core/schema/secret.graphqls
+++ b/core/schema/secret.graphqls
@@ -6,16 +6,15 @@ extend type Query {
   Sets a secret given a user defined name to its plaintext and returns the secret.
   """
   setSecret(
+    """
+    The user defined name for this secret
+    """
+    name: String!
 
-  """
-  The user defined name for this secret
-  """
-  name: String!,
-
-  """
-  The plaintext of the secret
-  """
-  plaintext: String!
+    """
+    The plaintext of the secret
+    """
+    plaintext: String!
   ): Secret!
 }
 

--- a/core/secret.go
+++ b/core/secret.go
@@ -2,15 +2,20 @@ package core
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	bkgw "github.com/moby/buildkit/frontend/gateway/client"
 )
 
 // Secret is a content-addressed secret.
 type Secret struct {
-	ID SecretID `json:"id"`
+	ID     SecretID `json:"id"`
+	Digest string   `json:"digest"`
 }
 
 func NewSecret(id SecretID) *Secret {
@@ -40,10 +45,37 @@ type SecretID string
 
 func (id SecretID) String() string { return string(id) }
 
+func (id SecretID) Digest() (string, error) {
+	b, err := base64.StdEncoding.DecodeString(string(id))
+	if err != nil {
+		return "", err
+	}
+
+	_, digest, ok := strings.Cut(string(b), "\x00")
+	if !ok {
+		// FIXME create a dedicated error
+		return "", errors.New("malformed secret ID")
+	}
+
+	return digest, nil
+}
+
+func NewSecretID(name, plaintext string) SecretID {
+	digestBytes := sha256.Sum256([]byte(plaintext))
+
+	idBytes := []byte(name + "\x00" + string(digestBytes[:]))
+
+	id := base64.StdEncoding.EncodeToString(idBytes)
+	return SecretID(id)
+}
+
 // secretIDPayload is the inner content of a SecretID.
 type secretIDPayload struct {
 	FromFile    FileID `json:"file,omitempty"`
 	FromHostEnv string `json:"host_env,omitempty"`
+
+	Name   string
+	Digest string
 }
 
 // Encode returns the opaque string ID representation of the secret.

--- a/core/secret.go
+++ b/core/secret.go
@@ -68,17 +68,28 @@ func NewSecretID(name, plaintext string) (SecretID, error) {
 
 	id, err := (&secretIDPayload{Name: name, Digest: string(digestBytes[:])}).Encode()
 	if err != nil {
-		return SecretID(""), err
+		return "", err
 	}
 	return id, nil
 }
 
 // secretIDPayload is the inner content of a SecretID.
 type secretIDPayload struct {
-	FromFile    FileID `json:"file,omitempty"`
+	// FromFile specifies the FileID it is based off.
+	//
+	// Deprecated: this shouldn't be used as it can leak secrets in the cache.
+	// Use the setSecret API instead.
+	FromFile FileID `json:"file,omitempty"`
+
+	// FromHostEnv specifies the FileID it is based off.
+	//
+	// Deprecated: use the setSecret API instead.
 	FromHostEnv string `json:"host_env,omitempty"`
 
-	Name   string `json:"name,omitempty"`
+	// Name specifies the arbitrary name/id of the secret.
+	Name string `json:"name,omitempty"`
+
+	// Digest represents a digest of the plaintext of the secret.
 	Digest string `json:"digest,omitempty"`
 }
 

--- a/core/secret.go
+++ b/core/secret.go
@@ -41,15 +41,6 @@ type SecretID string
 
 func (id SecretID) String() string { return string(id) }
 
-func (id SecretID) Digest() (string, error) {
-	secretIDPayload, err := id.decode()
-	if err != nil {
-		return "", err
-	}
-
-	return secretIDPayload.Digest, nil
-}
-
 func (id SecretID) IsOldFormat() (bool, error) {
 	payload, err := id.decode()
 	if err != nil {

--- a/core/secret.go
+++ b/core/secret.go
@@ -39,6 +39,16 @@ func NewSecretFromHostEnv(name string) (*Secret, error) {
 // SecretID is an opaque value representing a content-addressed secret.
 type SecretID string
 
+func NewSecretID(name, plaintext string) (SecretID, error) {
+	digestBytes := sha256.Sum256([]byte(plaintext))
+
+	id, err := (&secretIDPayload{Name: name, Digest: string(digestBytes[:])}).Encode()
+	if err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
 func (id SecretID) String() string { return string(id) }
 
 func (id SecretID) IsOldFormat() (bool, error) {
@@ -52,16 +62,6 @@ func (id SecretID) IsOldFormat() (bool, error) {
 	}
 
 	return true, nil
-}
-
-func NewSecretID(name, plaintext string) (SecretID, error) {
-	digestBytes := sha256.Sum256([]byte(plaintext))
-
-	id, err := (&secretIDPayload{Name: name, Digest: string(digestBytes[:])}).Encode()
-	if err != nil {
-		return "", err
-	}
-	return id, nil
 }
 
 // secretIDPayload is the inner content of a SecretID.

--- a/core/secret.go
+++ b/core/secret.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"log"
 	"os"
 
 	bkgw "github.com/moby/buildkit/frontend/gateway/client"
@@ -66,8 +65,8 @@ type secretIDPayload struct {
 	FromFile    FileID `json:"file,omitempty"`
 	FromHostEnv string `json:"host_env,omitempty"`
 
-	Name   string
-	Digest string
+	Name   string `json:"name,omitempty"`
+	Digest string `json:"digest,omitempty"`
 }
 
 // Encode returns the opaque string ID representation of the secret.
@@ -94,7 +93,6 @@ func (secret *Secret) Plaintext(ctx context.Context, gw bkgw.Client) ([]byte, er
 	if err != nil {
 		return nil, err
 	}
-	log.Println("DBGTHE: SECRET: PLAINTEXT:", payload)
 	if payload.FromFile != "" {
 		file := &File{ID: payload.FromFile}
 		return file.Contents(ctx, gw)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -160,8 +160,8 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 				Platform:       *platform,
 				DisableHostRW:  startOpts.DisableHostRW,
 				Auth:           registryAuth,
+				EnableServices: os.Getenv(engine.ServicesDNSEnvName) != "0",
 				Secrets:        secretStore,
-				EnableServices: os.Getenv(engine.ServicesDNSEnvName) != "",
 			})
 			if err != nil {
 				return nil, err

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -160,7 +160,8 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 				Platform:       *platform,
 				DisableHostRW:  startOpts.DisableHostRW,
 				Auth:           registryAuth,
-				EnableServices: os.Getenv(engine.ServicesDNSEnvName) != "0",
+				Secrets:        secretStore,
+				EnableServices: os.Getenv(engine.ServicesDNSEnvName) != "",
 			})
 			if err != nil {
 				return nil, err

--- a/engine/remotecache/mountsync.go
+++ b/engine/remotecache/mountsync.go
@@ -284,8 +284,8 @@ func execRclone(ctx context.Context, c *dagger.Client, args []string, cacheMount
 		if err != nil {
 			return err
 		}
-		// TODO:(sipsma) use dynamic secrets API for this once available
-		ctr = ctr.WithMountedSecret(v, c.Directory().WithNewFile("token", string(contents)).File("token").Secret())
+		secret := c.SetSecret("token", string(contents))
+		ctr = ctr.WithMountedSecret(v, secret)
 	}
 
 	_, err := ctr.WithExec(args).ExitCode(ctx)

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -2064,7 +2064,7 @@ func (r *Client) Secret(id SecretID) *Secret {
 	}
 }
 
-// Set a secret given a user defined name to its plaintext and returns the secret.
+// Sets a secret given a user defined name to its plaintext and returns the secret.
 func (r *Client) SetSecret(name string, plaintext string) *Secret {
 	q := r.q.Select("setSecret")
 	q = q.Arg("name", name)

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -1482,6 +1482,8 @@ func (r *File) XXX_GraphQLID(ctx context.Context) (string, error) {
 }
 
 // Retrieves a secret referencing the contents of this file.
+//
+// Deprecated: insecure, leaves secret in cache
 func (r *File) Secret() *Secret {
 	q := r.q.Select("secret")
 
@@ -2055,6 +2057,18 @@ func (r *Client) Project(name string) *Project {
 func (r *Client) Secret(id SecretID) *Secret {
 	q := r.q.Select("secret")
 	q = q.Arg("id", id)
+
+	return &Secret{
+		q: q,
+		c: r.c,
+	}
+}
+
+// Set a secret given a user defined name to its plaintext and returns the secret.
+func (r *Client) SetSecret(name string, plaintext string) *Secret {
+	q := r.q.Select("setSecret")
+	q = q.Arg("name", name)
+	q = q.Arg("plaintext", plaintext)
 
 	return &Secret{
 		q: q,

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -2188,6 +2188,7 @@ export class File extends BaseClient {
 
   /**
    * Retrieves a secret referencing the contents of this file.
+   * @deprecated insecure, leaves secret in cache
    */
   secret(): Secret {
     return new Secret({
@@ -3094,6 +3095,25 @@ export default class Client extends BaseClient {
         {
           operation: "secret",
           args: { id },
+        },
+      ],
+      host: this.clientHost,
+      sessionToken: this.sessionToken,
+    })
+  }
+
+  /**
+   * Set a secret given a user defined name to its plaintext and returns the secret.
+   * @param name The user defined name for this secret
+   * @param plaintext The plaintext of the secret
+   */
+  setSecret(name: string, plaintext: string): Secret {
+    return new Secret({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "setSecret",
+          args: { name, plaintext },
         },
       ],
       host: this.clientHost,

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -3103,7 +3103,7 @@ export default class Client extends BaseClient {
   }
 
   /**
-   * Set a secret given a user defined name to its plaintext and returns the secret.
+   * Sets a secret given a user defined name to its plaintext and returns the secret.
    * @param name The user defined name for this secret
    * @param plaintext The plaintext of the secret
    */

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -1843,7 +1843,11 @@ class File(Type):
 
     @typecheck
     def secret(self) -> "Secret":
-        """Retrieves a secret referencing the contents of this file."""
+        """Retrieves a secret referencing the contents of this file.
+
+        .. deprecated::
+            insecure, leaves secret in cache
+        """
         _args: list[Arg] = []
         _ctx = self._select("secret", _args)
         return Secret(_ctx)
@@ -2541,6 +2545,25 @@ class Client(Root):
             Arg("id", id),
         ]
         _ctx = self._select("secret", _args)
+        return Secret(_ctx)
+
+    @typecheck
+    def set_secret(self, name: str, plaintext: str) -> "Secret":
+        """Set a secret given a user defined name to its plaintext and returns
+        the secret.
+
+        Parameters
+        ----------
+        name:
+            The user defined name for this secret
+        plaintext:
+            The plaintext of the secret
+        """
+        _args = [
+            Arg("name", name),
+            Arg("plaintext", plaintext),
+        ]
+        _ctx = self._select("setSecret", _args)
         return Secret(_ctx)
 
     @typecheck

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -2549,7 +2549,7 @@ class Client(Root):
 
     @typecheck
     def set_secret(self, name: str, plaintext: str) -> "Secret":
-        """Set a secret given a user defined name to its plaintext and returns
+        """Sets a secret given a user defined name to its plaintext and returns
         the secret.
 
         Parameters

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -1843,7 +1843,11 @@ class File(Type):
 
     @typecheck
     def secret(self) -> "Secret":
-        """Retrieves a secret referencing the contents of this file."""
+        """Retrieves a secret referencing the contents of this file.
+
+        .. deprecated::
+            insecure, leaves secret in cache
+        """
         _args: list[Arg] = []
         _ctx = self._select("secret", _args)
         return Secret(_ctx)
@@ -2541,6 +2545,25 @@ class Client(Root):
             Arg("id", id),
         ]
         _ctx = self._select("secret", _args)
+        return Secret(_ctx)
+
+    @typecheck
+    def set_secret(self, name: str, plaintext: str) -> "Secret":
+        """Set a secret given a user defined name to its plaintext and returns
+        the secret.
+
+        Parameters
+        ----------
+        name:
+            The user defined name for this secret
+        plaintext:
+            The plaintext of the secret
+        """
+        _args = [
+            Arg("name", name),
+            Arg("plaintext", plaintext),
+        ]
+        _ctx = self._select("setSecret", _args)
         return Secret(_ctx)
 
     @typecheck

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -2549,7 +2549,7 @@ class Client(Root):
 
     @typecheck
     def set_secret(self, name: str, plaintext: str) -> "Secret":
-        """Set a secret given a user defined name to its plaintext and returns
+        """Sets a secret given a user defined name to its plaintext and returns
         the secret.
 
         Parameters

--- a/secret/store.go
+++ b/secret/store.go
@@ -2,6 +2,7 @@ package secret
 
 import (
 	"context"
+	"sync"
 
 	"github.com/dagger/dagger/core"
 	bkgw "github.com/moby/buildkit/frontend/gateway/client"
@@ -9,19 +10,56 @@ import (
 )
 
 func NewStore() *Store {
-	return &Store{}
+	return &Store{
+		nameToDigest:  map[string]string{},
+		idToPlaintext: map[core.SecretID]string{},
+	}
 }
 
 var _ secrets.SecretStore = &Store{}
 
 type Store struct {
 	gw bkgw.Client
+
+	mu            sync.Mutex
+	nameToDigest  map[string]string
+	idToPlaintext map[core.SecretID]string
 }
 
 func (store *Store) SetGateway(gw bkgw.Client) {
 	store.gw = gw
 }
 
+// AddSecret adds the secret identified by user defined name with its plaintext
+// value to the secret store.
+func (store *Store) AddSecret(_ context.Context, name, plaintext string) core.SecretID {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	id := core.NewSecretID(name, plaintext)
+
+	digest, err := id.Digest()
+	if err != nil {
+		// We shouldn't arrive here unless we messed up on our side.
+		// We should stop here to analyze what's wrong.
+		panic(err)
+	}
+
+	// add the digest to the map
+	store.nameToDigest[name] = digest
+
+	// add the plaintext to the map
+	store.idToPlaintext[id] = plaintext
+
+	return id
+}
+
+// GetSecret returns the plaintext from the id.
 func (store *Store) GetSecret(ctx context.Context, id string) ([]byte, error) {
-	return core.NewSecret(core.SecretID(id)).Plaintext(ctx, store.gw)
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	plaintext := []byte(store.idToPlaintext[core.SecretID(id)])
+
+	return plaintext, nil
 }

--- a/secret/store.go
+++ b/secret/store.go
@@ -32,11 +32,14 @@ func (store *Store) SetGateway(gw bkgw.Client) {
 
 // AddSecret adds the secret identified by user defined name with its plaintext
 // value to the secret store.
-func (store *Store) AddSecret(_ context.Context, name, plaintext string) core.SecretID {
+func (store *Store) AddSecret(_ context.Context, name, plaintext string) (core.SecretID, error) {
 	store.mu.Lock()
 	defer store.mu.Unlock()
 
-	id := core.NewSecretID(name, plaintext)
+	id, err := core.NewSecretID(name, plaintext)
+	if err != nil {
+		return id, err
+	}
 
 	digest, err := id.Digest()
 	if err != nil {
@@ -51,7 +54,7 @@ func (store *Store) AddSecret(_ context.Context, name, plaintext string) core.Se
 	// add the plaintext to the map
 	store.idToPlaintext[id] = plaintext
 
-	return id
+	return id, nil
 }
 
 // GetSecret returns the plaintext from the id.

--- a/secret/store.go
+++ b/secret/store.go
@@ -2,12 +2,16 @@ package secret
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/dagger/dagger/core"
 	bkgw "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/session/secrets"
 )
+
+// ErrNotFound indicates a secret can not be found.
+var ErrNotFound = errors.New("secret not found")
 
 func NewStore() *Store {
 	return &Store{
@@ -76,7 +80,10 @@ func (store *Store) GetSecret(ctx context.Context, id string) ([]byte, error) {
 	}
 
 	// we use the new SecretID format
-	plaintext := []byte(store.idToPlaintext[secretID])
+	plaintext, ok := store.idToPlaintext[secretID]
+	if !ok {
+		return nil, ErrNotFound
+	}
 
-	return plaintext, nil
+	return []byte(plaintext), nil
 }

--- a/secret/store.go
+++ b/secret/store.go
@@ -59,7 +59,16 @@ func (store *Store) GetSecret(ctx context.Context, id string) ([]byte, error) {
 	store.mu.Lock()
 	defer store.mu.Unlock()
 
-	plaintext := []byte(store.idToPlaintext[core.SecretID(id)])
+	secretID := core.SecretID(id)
+	// we check if it's the new SecretID format
+	_, err := secretID.Digest()
+	if err != nil {
+		// if not, we use the legacy SecretID format
+		return core.NewSecret(core.SecretID(id)).Plaintext(ctx, store.gw)
+	}
+
+	// if it is, we use it
+	plaintext := []byte(store.idToPlaintext[secretID])
 
 	return plaintext, nil
 }

--- a/secret/store.go
+++ b/secret/store.go
@@ -15,7 +15,6 @@ var ErrNotFound = errors.New("secret not found")
 
 func NewStore() *Store {
 	return &Store{
-		nameToDigest:  map[string]string{},
 		idToPlaintext: map[core.SecretID]string{},
 	}
 }
@@ -26,7 +25,6 @@ type Store struct {
 	gw bkgw.Client
 
 	mu            sync.Mutex
-	nameToDigest  map[string]string
 	idToPlaintext map[core.SecretID]string
 }
 
@@ -44,16 +42,6 @@ func (store *Store) AddSecret(_ context.Context, name, plaintext string) (core.S
 	if err != nil {
 		return id, err
 	}
-
-	digest, err := id.Digest()
-	if err != nil {
-		// We shouldn't arrive here unless we messed up on our side.
-		// We should stop here to analyze what's wrong.
-		panic(err)
-	}
-
-	// add the digest to the map
-	store.nameToDigest[name] = digest
 
 	// add the plaintext to the map
 	store.idToPlaintext[id] = plaintext

--- a/secret/store.go
+++ b/secret/store.go
@@ -64,8 +64,8 @@ func (store *Store) GetSecret(ctx context.Context, id string) ([]byte, error) {
 
 	secretID := core.SecretID(id)
 	// we check if it's the new SecretID format
-	_, err := secretID.Digest()
-	if err != nil {
+	digest, err := secretID.Digest()
+	if err != nil || digest == "" {
 		// if not, we use the legacy SecretID format
 		return core.NewSecret(core.SecretID(id)).Plaintext(ctx, store.gw)
 	}


### PR DESCRIPTION
This PR adds a top level query `setSecret(name: String!, plaintext: String!): Secret!` that will associate a user defined secret `name` to a `plaintext` value.


## Points to figure out

### `file.secret()` deprecation

At the same time, we deprecate `file.secret()` as it leaks secrets in the cache. It is not a breaking change, yet. But as it is insecure, I thought of actually breaking the `file.secret()` implementation (especially the one bringing the secret in) by always returning an error. We wouldn't want people to use it nonetheless and have important secrets leaked.

=> viewed with @jlongtine : we keep backwards compatibility, no breaking change

### secret id content

The only information going into the container information would be the secret id which is a base64 of the name of the secret and the sha256(plaintext). It should bust the cache if we change the plaintext. I think this is the behavior that we want. But it would be less secure than if we used a hash only derived from the secret name. In that case, nobody would know if the secret plaintext has been changed, and the cached version would be used. The user would have to bust their cache by themselves.

I'm open to discussion/experience sharing about this.