### PR TITLE
Cache mount import/export

### DIFF
--- a/cmd/engine/operatorClient.go
+++ b/cmd/engine/operatorClient.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"dagger.io/dagger"
+	"github.com/containerd/containerd/platforms"
+	"github.com/dagger/dagger/auth"
+	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/core/pipeline"
+	"github.com/dagger/dagger/core/schema"
+	"github.com/dagger/dagger/engine"
+	"github.com/dagger/dagger/router"
+	"github.com/dagger/dagger/secret"
+	"github.com/docker/cli/cli/config"
+	"github.com/google/uuid"
+	bkclient "github.com/moby/buildkit/client"
+	bkgw "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/secrets/secretsprovider"
+	"github.com/moby/buildkit/util/progress/progressui"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+)
+
+// NewOperatorClient is a dagger client used for querying+configuring engine-wide settings such
+// as cache mount import/export.
+func NewOperatorClient(ctx context.Context, c *bkclient.Client) (_ *dagger.Client, _ func() error, rerr error) {
+	platform, err := detectPlatform(ctx, c)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sessionToken, err := uuid.NewRandom()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// allocate the next available port
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, nil, err
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+
+	solveCh := make(chan *bkclient.SolveStatus)
+	go func() {
+		warn, err := progressui.DisplaySolveStatus(context.TODO(), nil, os.Stdout, solveCh)
+		for _, w := range warn {
+			fmt.Fprintf(os.Stdout, "=> %s\n", w.Short)
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "progress error: %v\n", err)
+		}
+	}()
+
+	secretStore := secret.NewStore()
+	registryAuth := auth.NewRegistryAuthProvider(config.LoadDefaultConfigFile(os.Stderr))
+	socketProviders := engine.SocketProvider{
+		EnableHostNetworkAccess: false,
+	}
+
+	solveOpts := bkclient.SolveOpt{
+		Session: []session.Attachable{
+			secretsprovider.NewSecretProvider(secretStore),
+			registryAuth,
+			socketProviders,
+		},
+	}
+
+	solveCtx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		if rerr != nil {
+			cancel()
+		}
+	}()
+	doneCh := make(chan error, 1)
+	go func() {
+		defer close(doneCh)
+		_, err = c.Build(solveCtx, solveOpts, "", func(ctx context.Context, gw bkgw.Client) (*bkgw.Result, error) {
+			go pipeline.LoadRootLabels(".")
+			router := router.New(sessionToken.String())
+			secretStore.SetGateway(gw)
+			gwClient := core.NewGatewayClient(gw)
+			coreAPI, err := schema.New(schema.InitializeArgs{
+				Router:         router,
+				Gateway:        gwClient,
+				BKClient:       c,
+				SolveOpts:      solveOpts,
+				SolveCh:        solveCh,
+				Platform:       *platform,
+				DisableHostRW:  true,
+				EnableServices: true,
+				Auth:           registryAuth,
+			})
+			if err != nil {
+				return nil, err
+			}
+			if err := router.Add(coreAPI); err != nil {
+				return nil, err
+			}
+			srv := http.Server{
+				Handler:           router,
+				ReadHeaderTimeout: 30 * time.Second,
+			}
+			err = srv.Serve(l)
+			if err != nil && !errors.Is(err, net.ErrClosed) {
+				return nil, err
+			}
+			return nil, nil
+		}, solveCh)
+		doneCh <- err
+	}()
+
+	os.Setenv("DAGGER_SESSION_PORT", strconv.Itoa(port))
+	defer os.Unsetenv("DAGGER_SESSION_PORT")
+	os.Setenv("DAGGER_SESSION_TOKEN", sessionToken.String())
+	defer os.Unsetenv("DAGGER_SESSION_TOKEN")
+	daggerClient, err := dagger.Connect(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return daggerClient, func() error {
+		cancel()
+		l.Close()
+		err := <-doneCh
+		c.Close()
+		daggerClient.Close()
+		return err
+	}, nil
+}
+
+func detectPlatform(ctx context.Context, c *bkclient.Client) (*specs.Platform, error) {
+	w, err := c.ListWorkers(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error detecting platform %w", err)
+	}
+
+	if len(w) > 0 && len(w[0].Platforms) > 0 {
+		dPlatform := w[0].Platforms[0]
+		return &dPlatform, nil
+	}
+	defaultPlatform := platforms.DefaultSpec()
+	return &defaultPlatform, nil
+}
+
+type inMemListener struct {
+	conns  chan net.Conn
+	closed chan struct{}
+}
+
+func newInMemListener(server *grpc.Server) *inMemListener {
+	l := &inMemListener{
+		conns:  make(chan net.Conn),
+		closed: make(chan struct{}),
+	}
+	go server.Serve(l)
+	return l
+}
+
+func (l *inMemListener) NewClient(ctx context.Context, opts ...bkclient.ClientOpt) (*bkclient.Client, error) {
+	return bkclient.New(ctx, "inmem", append(opts, bkclient.WithContextDialer(l.Dial))...)
+}
+
+func (l *inMemListener) Dial(ctx context.Context, _ string) (net.Conn, error) {
+	clientConn, serverConn := net.Pipe()
+	select {
+	case <-l.closed:
+		clientConn.Close()
+		serverConn.Close()
+		return nil, net.ErrClosed
+	case <-ctx.Done():
+		clientConn.Close()
+		serverConn.Close()
+		return nil, ctx.Err()
+	case l.conns <- serverConn:
+	}
+	return clientConn, nil
+}
+
+func (l *inMemListener) Accept() (net.Conn, error) {
+	select {
+	case <-l.closed:
+		return nil, net.ErrClosed
+	case conn := <-l.conns:
+		return conn, nil
+	}
+}
+
+func (l *inMemListener) Close() error {
+	close(l.closed)
+	return nil
+}
+
+func (l *inMemListener) Addr() net.Addr {
+	return &net.UnixAddr{Name: "inmem", Net: "unix"}
+}

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -110,6 +110,7 @@ func (s *containerSchema) container(ctx *router.Context, parent *core.Query, arg
 		}
 		platform = *args.Platform
 	}
+
 	ctr, err := core.NewContainer(args.ID, parent.PipelinePath(), platform)
 	if err != nil {
 		return nil, err

--- a/engine/remotecache/mountsync.go
+++ b/engine/remotecache/mountsync.go
@@ -1,0 +1,293 @@
+package remotecache
+
+import (
+	"context"
+	"os"
+	"path"
+	"strconv"
+	"time"
+
+	"dagger.io/dagger"
+	awsConfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/moby/buildkit/util/bklog"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+)
+
+func startS3CacheMountSync(ctx context.Context, attrs map[string]string, daggerClient *dagger.Client) (func(ctx context.Context) error, error) {
+	stop := func(ctx context.Context) error { return nil } // default to no-op
+	settings := settings(attrs)
+
+	if len(settings.synchronizedCacheMounts()) == 0 {
+		return stop, nil
+	}
+
+	bklog.G(ctx).Debugf("syncing cache mounts under prefix %q: %+v", settings.prefix(), settings.synchronizedCacheMounts())
+
+	cacheMountsExportPrefix := settings.prefix() + cacheMountsSubprefix + settings.name() + "/"
+
+	s3Client, _, err := getS3Client(ctx, settings)
+	if err != nil {
+		return nil, err
+	}
+
+	existingCacheMountKeys, err := getExistingCacheMountKeys(ctx, s3Client, settings)
+	if err != nil {
+		return nil, err
+	}
+
+	otherEngineNames, err := getOtherEngineNames(ctx, s3Client, settings)
+	if err != nil {
+		return nil, err
+	}
+
+	var eg errgroup.Group
+	for _, cacheMountName := range settings.synchronizedCacheMounts() {
+		cacheMountPrefix := settings.prefix() + cacheMountsSubprefix + settings.name() + "/" + cacheMountName + "/"
+		cacheMountName := cacheMountName
+		eg.Go(func() error {
+			if _, ok := existingCacheMountKeys[cacheMountName]; !ok {
+				// no existing cache mount backup to import from, check to see if there's any others we could use
+				for _, otherEngineName := range otherEngineNames {
+					otherEngineName := otherEngineName
+					otherCacheMountPrefix := settings.prefix() + cacheMountsSubprefix + otherEngineName + "/" + cacheMountName
+					// check if this prefix exists
+					resp, err := s3Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+						Bucket:  aws.String(settings.bucket()),
+						MaxKeys: 1, // only need to check if there's any objects in this prefix
+						Prefix:  aws.String(otherCacheMountPrefix),
+					})
+					if err != nil {
+						if !isS3NotFound(err) {
+							return errors.Wrapf(err, "error checking for existing cache mount backup")
+						}
+						continue
+					}
+					if len(resp.Contents) == 0 {
+						continue
+					}
+					// use the other engine's cache mount backup
+					cacheMountPrefix = otherCacheMountPrefix
+				}
+			}
+			bklog.G(ctx).Debugf("importing cache mount %q", cacheMountPrefix)
+			err := execRclone(ctx, daggerClient, rcloneDownloadArgs(cacheMountPrefix, settings), cacheMountName)
+			if err != nil {
+				bklog.G(ctx).Debugf("failed to sync cache mount locally %s: %v", cacheMountName, err)
+				return err
+			}
+			bklog.G(ctx).Debugf("synced cache mount locally %s", cacheMountName)
+			return nil
+		})
+	}
+	err = eg.Wait()
+	if err != nil {
+		return nil, err
+	}
+
+	stop = func(ctx context.Context) error {
+		var eg errgroup.Group
+		for _, cacheMountName := range settings.synchronizedCacheMounts() {
+			cacheMountName := cacheMountName
+			eg.Go(func() error {
+				bklog.G(ctx).Debugf("syncing cache mount remotely %s", cacheMountName)
+
+				cacheMountPrefix := cacheMountsExportPrefix + cacheMountName
+				err := execRclone(ctx, daggerClient, rcloneUploadArgs(cacheMountPrefix, settings), cacheMountName)
+				if err != nil {
+					bklog.G(ctx).Errorf("failed to sync cache mount remotely %s: %v", cacheMountName, err)
+					return err
+				}
+				bklog.G(ctx).Debugf("synced cache mount remotely %s", cacheMountName)
+				return nil
+			})
+		}
+		return eg.Wait()
+	}
+
+	return stop, nil
+}
+
+func getS3Client(ctx context.Context, s settings) (_ *s3.Client, bucket string, _ error) {
+	cfg, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion(s.region()))
+	if err != nil {
+		return nil, "", errors.Errorf("Unable to load AWS SDK config, %v", err)
+	}
+	s3Client := s3.NewFromConfig(cfg, func(options *s3.Options) {
+		if s.accessKey() != "" && s.secretKey() != "" {
+			options.Credentials = credentials.NewStaticCredentialsProvider(s.accessKey(), s.secretKey(), s.sessionToken())
+		}
+		if s.endpointURL() != "" {
+			options.UsePathStyle = s.usePathStyle()
+			options.EndpointResolver = s3.EndpointResolverFromURL(s.endpointURL())
+		}
+	})
+
+	return s3Client, s.bucket(), nil
+}
+
+func getExistingCacheMountKeys(ctx context.Context, s3Client *s3.Client, settings settings) (map[string]struct{}, error) {
+	existingCacheMountKeys := map[string]struct{}{}
+	listObjectsPages := s3.NewListObjectsV2Paginator(s3Client, &s3.ListObjectsV2Input{
+		Bucket:    aws.String(settings.bucket()),
+		Prefix:    aws.String(settings.prefix() + cacheMountsSubprefix + settings.name()),
+		Delimiter: aws.String("/"),
+	})
+	for listObjectsPages.HasMorePages() {
+		listResp, err := listObjectsPages.NextPage(ctx)
+		if err != nil {
+			if !isS3NotFound(err) {
+				return nil, errors.Wrapf(err, "error listing s3 objects")
+			}
+		}
+		for _, name := range listResp.CommonPrefixes {
+			existingCacheMountKeys[path.Base(*name.Prefix)] = struct{}{}
+		}
+	}
+	return existingCacheMountKeys, nil
+}
+
+func getOtherEngineNames(ctx context.Context, s3Client *s3.Client, settings settings) ([]string, error) {
+	var otherEngineNames []string
+	listEnginesPages := s3.NewListObjectsV2Paginator(s3Client, &s3.ListObjectsV2Input{
+		Bucket:    aws.String(settings.bucket()),
+		Prefix:    aws.String(settings.prefix() + cacheMountsSubprefix),
+		Delimiter: aws.String("/"),
+	})
+	for listEnginesPages.HasMorePages() {
+		listResp, err := listEnginesPages.NextPage(ctx)
+		if err != nil {
+			if !isS3NotFound(err) {
+				return nil, errors.Wrapf(err, "error listing s3 objects")
+			}
+		}
+		for _, obj := range listResp.CommonPrefixes {
+			otherEngineName := path.Base(*obj.Prefix)
+			if otherEngineName == settings.name() {
+				continue
+			}
+			otherEngineNames = append(otherEngineNames, otherEngineName)
+		}
+	}
+	return otherEngineNames, nil
+}
+
+func rcloneCommonArgs(s settings) []string {
+	// https://rclone.org/docs/
+	// https://rclone.org/s3/
+	commonArgs := []string{
+		"--s3-provider", s.serverImplementation(),
+		"--s3-region", s.region(),
+		"--s3-acl=private",
+		"--s3-no-check-bucket=true", // don't try to auto-create bucket
+		"--s3-env-auth=true",        // use AWS_* env vars for auth
+		"--metadata",                // preserve file metadata (note: this hurts performance a bit)
+		"-v",
+
+		// performance knobs
+		// "--s3-memory-pool-use-mmap=true",
+		// "--s3-upload-concurrency", strconv.Itoa(runtime.NumCPU()),
+		// --s3-list-chunk
+		// --s3-chunk-size
+		// --s3-copy-cutoff
+		// --s3-disable-checksum
+		// --s3-use-accelerate-endpoint
+		// --s3-no-head
+		// --s3-no-head-object
+		// --s3-encoding
+		// --s3-memory-pool-flush-time
+		// --size-only
+		// --checksum
+		// --update --use-server-modtime
+		// --buffer-size=SIZE
+		// --checkers=N
+		// --max-backlog=N
+		// --max-depth=N
+		// --multi-thread-cutoff
+		// --multi-thread-streams
+		// --track-renames
+		// --fast-list
+		// --transfers
+		// --use-mmap
+
+		// misc options
+		// --s3-leave-parts-on-error
+		// --retries
+		// --retries-sleep
+	}
+
+	if s.endpointURL() != "" {
+		commonArgs = append(commonArgs, "--s3-endpoint", s.endpointURL())
+	}
+	if s.usePathStyle() {
+		commonArgs = append(commonArgs, "--s3-force-path-style=true")
+	} else {
+		commonArgs = append(commonArgs, "--s3-force-path-style=false")
+	}
+
+	// TODO:(sipsma) use secrets instead, these currently are insecure anyways since they come from an env
+	// to the engine though and are only needed for our integ tests.
+	if s.accessKey() != "" {
+		commonArgs = append(commonArgs, "--s3-access-key-id", s.accessKey())
+	}
+	if s.secretKey() != "" {
+		commonArgs = append(commonArgs, "--s3-secret-access-key", s.secretKey())
+	}
+	if s.sessionToken() != "" {
+		commonArgs = append(commonArgs, "--s3-session-token", s.sessionToken())
+	}
+	return commonArgs
+}
+
+func rcloneDownloadArgs(cacheMountPrefix string, s settings) []string {
+	downloadArgs := []string{
+		"copy",
+		":s3:" + s.bucket() + "/" + cacheMountPrefix,
+		"/mnt",
+	}
+	return append(downloadArgs, rcloneCommonArgs(s)...)
+}
+
+func rcloneUploadArgs(cacheMountPrefix string, s settings) []string {
+	uploadArgs := []string{
+		"sync", // unlike copy, sync results in deletions taking place in remote
+		"/mnt",
+		":s3:" + s.bucket() + "/" + cacheMountPrefix,
+	}
+	return append(uploadArgs, rcloneCommonArgs(s)...)
+}
+
+func execRclone(ctx context.Context, c *dagger.Client, args []string, cacheMountName string) error {
+	ctr := c.Container().
+		From("rclone/rclone:1.61").
+		WithEnvVariable("CACHEBUST", strconv.Itoa(int(time.Now().UnixNano()))).
+		WithMountedCache("/mnt", c.CacheVolume(cacheMountName))
+
+	if v, ok := os.LookupEnv("AWS_STS_REGIONAL_ENDPOINTS"); ok {
+		ctr = ctr.WithEnvVariable("AWS_STS_REGIONAL_ENDPOINTS", v)
+	}
+	if v, ok := os.LookupEnv("AWS_DEFAULT_REGION"); ok {
+		ctr = ctr.WithEnvVariable("AWS_DEFAULT_REGION", v)
+	}
+	if v, ok := os.LookupEnv("AWS_REGION"); ok {
+		ctr = ctr.WithEnvVariable("AWS_REGION", v)
+	}
+	if v, ok := os.LookupEnv("AWS_ROLE_ARN"); ok {
+		ctr = ctr.WithEnvVariable("AWS_ROLE_ARN", v)
+	}
+	if v, ok := os.LookupEnv("AWS_WEB_IDENTITY_TOKEN_FILE"); ok {
+		ctr = ctr.WithEnvVariable("AWS_WEB_IDENTITY_TOKEN_FILE", v)
+		contents, err := os.ReadFile(v)
+		if err != nil {
+			return err
+		}
+		// TODO:(sipsma) use dynamic secrets API for this once available
+		ctr = ctr.WithMountedSecret(v, c.Directory().WithNewFile("token", string(contents)).File("token").Secret())
+	}
+
+	_, err := ctr.WithExec(args).ExitCode(ctx)
+	return err
+}

--- a/internal/engine/client.go
+++ b/internal/engine/client.go
@@ -76,10 +76,12 @@ func waitBuildkit(ctx context.Context, host string) ([]*bkclient.WorkerInfo, err
 	// FIXME Does output "failed to wait: signal: broken pipe"
 	defer c.Close()
 
-	// Try to connect every 100ms up to 100 times (10 seconds total)
+	// Try to connect every 100ms up to 1800 times (3 minutes total)
+	// NOTE: the long timeout accounts for startup time of the engine when
+	// it needs to synchronize cache state.
 	const (
 		retryPeriod   = 100 * time.Millisecond
-		retryAttempts = 100
+		retryAttempts = 1800
 	)
 
 	var workerInfo []*bkclient.WorkerInfo


### PR DESCRIPTION
Starting simple here:
1. When the engine starts, it checks its remote cache config for any
   cache mount names it should synchronize.
2. If there are any, it checks the s3 bucket (same used for remote layer
   caching) for any backups of the cache mount from this engine or any
   others in the pool. If it finds any, it synchronizes that locally to
   the cache mount.
3. At engine shutdown, it synchronizes the contents of these cache
   mounts back to s3, making it available to any other engines in the
   pool.

Current caveats:
1. Each engine uploads its backup of the cache mount under its own
   prefix in the pool. This prevents any problems with synchronizing the
   contents of the same cache mount from differents hosts. This however
   means that currently all of these files are persisted separately,
   even when many of them might be the same across engines.
2. The only pruning support currently is manual intervention by deleting
   contents from the S3 bucket.
3. Engine startup blocks on the initial synchronization of the cache
   mount contents; the engine won't be usable by clients until this sync
   is done. Use of locked cache mounts would be preferable but isn't
   possible due to the fact that it requires the user also specify a
   locked cache mount. Mixed use of a cache mount as both shared and
   locked appears to result in very ill-defined behavior in buildkit.
4. There's no performance tuning of the synchronization tool we use
   (rclone). We just use default settings, no compression, etc.
5. RClone runs in an exec by pulling the rclone docker image from
   dockerhub. This will cause problems for users whose engine can't
   reach dockerhub, so we will need to include rclone in our engine
   image in a future iteration (either the rclone binary or importing
   rclone as a library).

Misc notes:
1. To run rclone, we setup a dagger client with the engine using all in
   memory connections. This runs before the engine listens on the actual
   unix sockets served to clients so that the cache mount sync can
   happen before clients can try to use it.
   * The hope is that this will also serve as a base for the operator
     API that we eventually want to expose to users, which would include
     both core api and extra calls used to configure the engine.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>