### PR TITLE
Support privileged executions.

### DIFF
--- a/cmd/engine/config.go
+++ b/cmd/engine/config.go
@@ -17,6 +17,9 @@ import (
 // engineDefaultStateDir is the directory that we map to a volume by default.
 const engineDefaultStateDir = "/var/lib/dagger"
 
+// engineDefaultShimBin is the path to the shim binary we use as our oci runtime.
+const engineDefaultShimBin = "/usr/local/bin/dagger-shim"
+
 // daggerConfigPath is the path containing Dagger-specific configuration, which
 // might be provided by the user.
 const daggerConfigPath = "/etc/dagger"
@@ -32,6 +35,10 @@ const servicesDNSEnvName = "_EXPERIMENTAL_DAGGER_SERVICES_DNS"
 func setDaggerDefaults(cfg *config.Config) error {
 	if cfg.Root == "" {
 		cfg.Root = engineDefaultStateDir
+	}
+
+	if cfg.Workers.OCI.Binary == "" {
+		cfg.Workers.OCI.Binary = engineDefaultShimBin
 	}
 
 	if os.Getenv(servicesDNSEnvName) != "0" {

--- a/cmd/engine/main_oci_worker.go
+++ b/cmd/engine/main_oci_worker.go
@@ -33,6 +33,7 @@ import (
 	"github.com/moby/buildkit/cmd/buildkitd/config"
 	"github.com/moby/buildkit/executor/oci"
 	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/util/entitlements"
 	"github.com/moby/buildkit/util/network/cniprovider"
 	"github.com/moby/buildkit/util/network/netproviders"
 	"github.com/moby/buildkit/util/resolver"
@@ -193,6 +194,14 @@ func applyOCIFlags(c *cli.Context, cfg *config.Config) error {
 	for k, v := range labels {
 		cfg.Workers.OCI.Labels[k] = v
 	}
+	for _, e := range cfg.Entitlements {
+		if e == string(entitlements.EntitlementSecurityInsecure) {
+			// this is a hacky way of allowing dagger clients to know whether their session
+			// should request the insecure entitlement.
+			cfg.Workers.OCI.Labels["privilegedEnabled"] = "true"
+		}
+	}
+
 	if c.GlobalIsSet("oci-worker-snapshotter") {
 		cfg.Workers.OCI.Snapshotter = c.GlobalString("oci-worker-snapshotter")
 	}

--- a/core/container.go
+++ b/core/container.go
@@ -1060,6 +1060,10 @@ func (container *Container) WithExec(ctx context.Context, gw bkgw.Client, defaul
 		runOpts = append(runOpts, llb.AddMount(mnt.Target, srcSt, mountOpts...))
 	}
 
+	if opts.InsecureRootCapabilities {
+		runOpts = append(runOpts, llb.Security(llb.SecurityModeInsecure))
+	}
+
 	// first, build without a hostname
 	execStNoHostname := fsSt.Run(runOpts...)
 
@@ -1608,6 +1612,9 @@ type ContainerExecOpts struct {
 	// Do not use this option unless you trust the command being executed.
 	// The command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM
 	ExperimentalPrivilegedNesting bool
+
+	// Grant the process all root capabilities
+	InsecureRootCapabilities bool
 }
 
 type BuildArg struct {

--- a/core/docs/d7yxc-operator_manual.md
+++ b/core/docs/d7yxc-operator_manual.md
@@ -120,6 +120,8 @@ The runner is distributed as a container image at `registry.dagger.io/engine`.
    - Otherwise runner execution may be extremely slow. This is due to the fact that it relies on overlayfs mounts for efficient operation, which isn't possible when `/var/lib/dagger` is itself an overlayfs.
    - For example, this can be provided to a `docker run` command as `-v dagger-engine:/var/lib/dagger`
 1. The container image comes with a default entrypoint which should be used to start the runner, no extra args are needed.
+1. The container image comes with a default config file at `/etc/dagger/engine.toml`
+   - The `insecure-entitlements = ["security.insecure"]` setting enables use of the `InsecureRootCapabilities` flag in `WithExec`. Removing that line will result in an error when trying to use that flag.
 
 ### Configuration
 
@@ -129,6 +131,8 @@ Currently supported is:
 
 1. Custom CA Certs - If you need any extra CA certs to be included in order to, e.g. push images to a private registry, they can be included under `/etc/ssl/certs` in the runner image.
    - This can be accomplished by building a custom engine image using ours as a base or by mounting them into a container created from our image at runtime.
+1. Disabling Privileged Execs - By default, the Dagger engine allows execs to run with root capabilities when the `InsecureRootCapabilities` field is set to true in the `WithExec` API. This can be disabled by overriding the default engine config at `/etc/dagger/engine.toml` to
+   1. Remove `insecure-entitlements = ["security.insecure"]`
 
 > **Warning**
 > The entrypoint currently invokes `buildkitd`, so there are numerous flags available there in addition to buildkit configuration files. However, this is just an implementation detail and it's highly likely the entrypoint may end up pointing to a different wrapper around `buildkitd` with a different interface in the near future, so any reliance on extra entrypoint flags or configuration files should be considered subject to breakage at any time.

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -440,6 +440,14 @@ type Container {
     The command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
     """
     experimentalPrivilegedNesting: Boolean
+
+    """
+    Execute the command with all root capabilities. This is similar to running a command
+    with "sudo" or executing `docker run` with the `--privileged` flag. Containerization
+    does not provide any security guarantees when using this option. It should only be used
+    when absolutely necessary and only with trusted commands.
+    """
+    insecureRootCapabilities: Boolean
   ): Container!
 
   """
@@ -577,9 +585,9 @@ type Container {
   """
   withExposedPort(
     "Port number to expose"
-    port: Int!,
+    port: Int!
     "Transport layer network protocol"
-    protocol: NetworkProtocol = TCP,
+    protocol: NetworkProtocol = TCP
     "Optional port description"
     description: String
   ): Container!
@@ -591,7 +599,7 @@ type Container {
   """
   withoutExposedPort(
     "Port number to unexpose"
-    port: Int!,
+    port: Int!
     "Port protocol to unexpose"
     protocol: NetworkProtocol = TCP
   ): Container!
@@ -614,7 +622,7 @@ type Container {
   """
   withServiceBinding(
     "A name that can be used to reach the service from the container"
-    alias: String!,
+    alias: String!
     "Identifier of the service container"
     service: ContainerID!
   ): Container!
@@ -637,7 +645,7 @@ type Container {
   """
   endpoint(
     "The exposed port number for the endpoint"
-    port: Int,
+    port: Int
     "Return a URL with the given scheme, eg. http for http://"
     scheme: String
   ): String!

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -25,6 +25,7 @@ import (
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/filesync"
 	"github.com/moby/buildkit/session/secrets/secretsprovider"
+	"github.com/moby/buildkit/util/entitlements"
 	"github.com/moby/buildkit/util/progress/progressui"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/tonistiigi/fsutil"
@@ -63,7 +64,7 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 	if err != nil {
 		return err
 	}
-	c, err := engine.Client(ctx, remote)
+	c, privilegedExecEnabled, err := engine.Client(ctx, remote)
 	if err != nil {
 		return err
 	}
@@ -108,6 +109,14 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 
 	registryAuth := auth.NewRegistryAuthProvider(config.LoadDefaultConfigFile(os.Stderr))
 
+	var allowedEntitlements []entitlements.Entitlement
+	if privilegedExecEnabled {
+		// NOTE: this just allows clients to set this if they want. It also needs
+		// to be set in the ExecOp LLB and enabled server-side in order for privileged
+		// execs to actually run.
+		allowedEntitlements = append(allowedEntitlements, entitlements.EntitlementSecurityInsecure)
+	}
+
 	solveOpts := bkclient.SolveOpt{
 		Session: []session.Attachable{
 			registryAuth,
@@ -123,6 +132,7 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 		CacheImports: []bkclient.CacheOptionsEntry{{
 			Type: "dagger",
 		}},
+		AllowedEntitlements: allowedEntitlements,
 	}
 
 	if !startOpts.DisableHostRW {

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -634,6 +634,11 @@ type ContainerWithExecOpts struct {
 	// Do not use this option unless you trust the command being executed.
 	// The command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
 	ExperimentalPrivilegedNesting bool
+	// Execute the command with all root capabilities. This is similar to running a command
+	// with "sudo" or executing `docker run` with the `--privileged` flag. Containerization
+	// does not provide any security guarantees when using this option. It should only be used
+	// when absolutely necessary and only with trusted commands.
+	InsecureRootCapabilities bool
 }
 
 // Retrieves this container after executing the specified command inside it.
@@ -665,6 +670,13 @@ func (r *Container) WithExec(args []string, opts ...ContainerWithExecOpts) *Cont
 	for i := len(opts) - 1; i >= 0; i-- {
 		if !querybuilder.IsZeroValue(opts[i].ExperimentalPrivilegedNesting) {
 			q = q.Arg("experimentalPrivilegedNesting", opts[i].ExperimentalPrivilegedNesting)
+			break
+		}
+	}
+	// `insecureRootCapabilities` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].InsecureRootCapabilities) {
+			q = q.Arg("insecureRootCapabilities", opts[i].InsecureRootCapabilities)
 			break
 		}
 	}

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -219,6 +219,14 @@ export type ContainerWithExecOpts = {
    * The command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
    */
   experimentalPrivilegedNesting?: boolean
+
+  /**
+   * Execute the command with all root capabilities. This is similar to running a command
+   * with "sudo" or executing `docker run` with the `--privileged` flag. Containerization
+   * does not provide any security guarantees when using this option. It should only be used
+   * when absolutely necessary and only with trusted commands.
+   */
+  insecureRootCapabilities?: boolean
 }
 
 export type ContainerWithExposedPortOpts = {
@@ -1166,6 +1174,10 @@ export class Container extends BaseClient {
    *
    * Do not use this option unless you trust the command being executed.
    * The command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
+   * @param opts.insecureRootCapabilities Execute the command with all root capabilities. This is similar to running a command
+   * with "sudo" or executing `docker run` with the `--privileged` flag. Containerization
+   * does not provide any security guarantees when using this option. It should only be used
+   * when absolutely necessary and only with trusted commands.
    */
   withExec(args: string[], opts?: ContainerWithExecOpts): Container {
     return new Container({

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -833,6 +833,7 @@ class Container(Type):
         redirect_stdout: Optional[str] = None,
         redirect_stderr: Optional[str] = None,
         experimental_privileged_nesting: Optional[bool] = None,
+        insecure_root_capabilities: Optional[bool] = None,
     ) -> "Container":
         """Retrieves this container after executing the specified command inside
         it.
@@ -857,6 +858,14 @@ class Container(Type):
             executed.
             The command being executed WILL BE GRANTED FULL ACCESS TO YOUR
             HOST FILESYSTEM.
+        insecure_root_capabilities:
+            Execute the command with all root capabilities. This is similar to
+            running a command
+            with "sudo" or executing `docker run` with the `--privileged`
+            flag. Containerization
+            does not provide any security guarantees when using this option.
+            It should only be used
+            when absolutely necessary and only with trusted commands.
         """
         _args = [
             Arg("args", args),
@@ -864,6 +873,7 @@ class Container(Type):
             Arg("redirectStdout", redirect_stdout, None),
             Arg("redirectStderr", redirect_stderr, None),
             Arg("experimentalPrivilegedNesting", experimental_privileged_nesting, None),
+            Arg("insecureRootCapabilities", insecure_root_capabilities, None),
         ]
         _ctx = self._select("withExec", _args)
         return Container(_ctx)

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -833,6 +833,7 @@ class Container(Type):
         redirect_stdout: Optional[str] = None,
         redirect_stderr: Optional[str] = None,
         experimental_privileged_nesting: Optional[bool] = None,
+        insecure_root_capabilities: Optional[bool] = None,
     ) -> "Container":
         """Retrieves this container after executing the specified command inside
         it.
@@ -857,6 +858,14 @@ class Container(Type):
             executed.
             The command being executed WILL BE GRANTED FULL ACCESS TO YOUR
             HOST FILESYSTEM.
+        insecure_root_capabilities:
+            Execute the command with all root capabilities. This is similar to
+            running a command
+            with "sudo" or executing `docker run` with the `--privileged`
+            flag. Containerization
+            does not provide any security guarantees when using this option.
+            It should only be used
+            when absolutely necessary and only with trusted commands.
         """
         _args = [
             Arg("args", args),
@@ -864,6 +873,7 @@ class Container(Type):
             Arg("redirectStdout", redirect_stdout, None),
             Arg("redirectStderr", redirect_stderr, None),
             Arg("experimentalPrivilegedNesting", experimental_privileged_nesting, None),
+            Arg("insecureRootCapabilities", insecure_root_capabilities, None),
         ]
         _ctx = self._select("withExec", _args)
         return Container(_ctx)


### PR DESCRIPTION
This adds a new bool flag called `InsecureRootCapabilities` to `WithExec` options that enables privileged execution of containers. [See discussion here](https://github.com/dagger/dagger/issues/3874#issuecomment-1452750360) for reasoning behind allowing this to be set in the engine (though the field itself defaults to `false`). The operator manual is also updated with instructions on disabling it if needed.

Went with the name `InsecureRootCapabilities` because it conveys that it's inherently insecure (security onus is on the user) and technically accurate in that it results in root capabilities being inherited by the process (whereas "privileged" is somewhat more ambiguous). Feel free to bikeshed away though.

In the longer run it would be great to give users fine grain settings for which capabilities should be inherited, but that can be added later in a backwards compatible way if needed.

Resolves #3874 