### PR TITLE
Invert services feature flag (opt-out, not opt-in)

### DIFF
--- a/cmd/engine/config.go
+++ b/cmd/engine/config.go
@@ -34,7 +34,7 @@ func setDaggerDefaults(cfg *config.Config) error {
 		cfg.Root = engineDefaultStateDir
 	}
 
-	if os.Getenv(servicesDNSEnvName) != "" {
+	if os.Getenv(servicesDNSEnvName) != "0" {
 		// check if CNI config already exists, just so we can respect a
 		// user-provided config
 		if _, err := os.Stat(cniConfigPath); os.IsNotExist(err) {

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -65,7 +65,7 @@ func TestGit(t *testing.T) {
 }
 
 func TestGitSSHAuthSock(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()

--- a/core/integration/http_test.go
+++ b/core/integration/http_test.go
@@ -21,7 +21,7 @@ func TestHTTP(t *testing.T) {
 }
 
 func TestHTTPService(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	t.Parallel()
 

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestServiceHostnamesAreStable(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -66,7 +66,7 @@ func TestServiceHostnamesAreStable(t *testing.T) {
 }
 
 func TestContainerHostnameEndpoint(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -130,7 +130,7 @@ func TestContainerHostnameEndpoint(t *testing.T) {
 }
 
 func TestContainerPortLifecycle(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -224,7 +224,7 @@ func TestContainerPortLifecycle(t *testing.T) {
 }
 
 func TestContainerExecServices(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -254,7 +254,7 @@ func TestContainerExecServices(t *testing.T) {
 }
 
 func TestContainerExecServicesError(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -281,7 +281,7 @@ func TestContainerExecServicesError(t *testing.T) {
 var udpSrc string
 
 func TestContainerExecUDPServices(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -313,7 +313,7 @@ func TestContainerExecUDPServices(t *testing.T) {
 }
 
 func TestContainerExecServiceAlias(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -343,7 +343,7 @@ func TestContainerExecServiceAlias(t *testing.T) {
 var pipeSrc string
 
 func TestContainerExecServicesDeduping(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -379,7 +379,7 @@ func TestContainerExecServicesDeduping(t *testing.T) {
 }
 
 func TestContainerExecServicesChained(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -417,7 +417,7 @@ func TestContainerExecServicesChained(t *testing.T) {
 }
 
 func TestContainerBuildService(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -499,7 +499,7 @@ CMD cat index.html
 }
 
 func TestContainerExportServices(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -519,7 +519,7 @@ func TestContainerExportServices(t *testing.T) {
 }
 
 func TestContainerMultiPlatformExportServices(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -546,7 +546,7 @@ func TestContainerMultiPlatformExportServices(t *testing.T) {
 }
 
 func TestServicesContainerPublish(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -571,7 +571,7 @@ func TestServicesContainerPublish(t *testing.T) {
 }
 
 func TestContainerRootFSServices(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -593,7 +593,7 @@ func TestContainerRootFSServices(t *testing.T) {
 }
 
 func TestContainerWithRootFSServices(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -627,7 +627,7 @@ func TestContainerWithRootFSServices(t *testing.T) {
 }
 
 func TestContainerDirectoryServices(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -673,7 +673,7 @@ func TestContainerDirectoryServices(t *testing.T) {
 }
 
 func TestContainerFileServices(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -693,7 +693,7 @@ func TestContainerFileServices(t *testing.T) {
 }
 
 func TestContainerWithServiceFileDirectory(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -741,7 +741,7 @@ func TestContainerWithServiceFileDirectory(t *testing.T) {
 }
 
 func TestDirectoryServiceEntries(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -759,7 +759,7 @@ func TestDirectoryServiceEntries(t *testing.T) {
 }
 
 func TestDirectoryServiceTimestamp(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -782,7 +782,7 @@ func TestDirectoryServiceTimestamp(t *testing.T) {
 }
 
 func TestDirectoryWithDirectoryFileServices(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -807,7 +807,7 @@ func TestDirectoryWithDirectoryFileServices(t *testing.T) {
 }
 
 func TestDirectoryServiceExport(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -831,7 +831,7 @@ func TestDirectoryServiceExport(t *testing.T) {
 }
 
 func TestFileServiceContents(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -850,7 +850,7 @@ func TestFileServiceContents(t *testing.T) {
 }
 
 func TestFileServiceExport(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -876,7 +876,7 @@ func TestFileServiceExport(t *testing.T) {
 }
 
 func TestFileServiceTimestamp(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()
@@ -898,7 +898,7 @@ func TestFileServiceTimestamp(t *testing.T) {
 }
 
 func TestFileServiceSecret(t *testing.T) {
-	checkEnabled(t, engine.ServicesDNSEnvName)
+	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)
 	defer c.Close()

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -268,8 +268,8 @@ func tarEntries(t *testing.T, path string) []string {
 	return entries
 }
 
-func checkEnabled(t *testing.T, env string) { //nolint:unparam
-	if os.Getenv(env) == "" {
-		t.Skipf("set $%s to enable", env)
+func checkNotDisabled(t *testing.T, env string) { //nolint:unparam
+	if os.Getenv(env) == "0" {
+		t.Skipf("disabled via %s=0", env)
 	}
 }

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -573,7 +573,7 @@ type Container {
     - For health checks and introspection, when running services
     - For setting the EXPOSE OCI field when publishing the container
 
-  Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
+  Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
   """
   withExposedPort(
     "Port number to expose"
@@ -587,7 +587,7 @@ type Container {
   """
   Unexpose a previously exposed port.
 
-  Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
+  Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
   """
   withoutExposedPort(
     "Port number to unexpose"
@@ -599,7 +599,7 @@ type Container {
   """
   Retrieves the list of exposed ports.
 
-  Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
+  Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
   """
   exposedPorts: [Port!]!
 
@@ -610,7 +610,7 @@ type Container {
 
   The service dependency will also convey to any files or directories produced by the container.
 
-  Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
+  Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
   """
   withServiceBinding(
     "A name that can be used to reach the service from the container"
@@ -622,7 +622,7 @@ type Container {
   """
   Retrieves a hostname which can be used by clients to reach this container.
 
-  Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
+  Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
   """
   hostname: String!
 
@@ -633,7 +633,7 @@ type Container {
 
   If a scheme is specified, a URL is returned. Otherwise, a host:port pair is returned.
 
-  Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
+  Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
   """
   endpoint(
     "The exposed port number for the endpoint"

--- a/core/schema/util.go
+++ b/core/schema/util.go
@@ -13,7 +13,7 @@ import (
 // yet.
 var ErrNotImplementedYet = errors.New("not implemented yet")
 
-var ErrServicesDisabled = fmt.Errorf("services are disabled; set %s to enable", engine.ServicesDNSEnvName)
+var ErrServicesDisabled = fmt.Errorf("services are disabled; unset %s to enable", engine.ServicesDNSEnvName)
 
 // stringResolver is used to generate a scalar resolver for a stringable type.
 func stringResolver[T ~string](sample T) router.ScalarResolver {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -155,7 +155,7 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 				Platform:       *platform,
 				DisableHostRW:  startOpts.DisableHostRW,
 				Auth:           registryAuth,
-				EnableServices: os.Getenv(engine.ServicesDNSEnvName) != "",
+				EnableServices: os.Getenv(engine.ServicesDNSEnvName) != "0",
 			})
 			if err != nil {
 				return nil, err

--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -58,7 +58,7 @@ if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
 		> /sys/fs/cgroup/cgroup.subtree_control
 fi
 
-if [ -n "$` + servicesDNSEnvName + `" ]; then
+if [ "$` + servicesDNSEnvName + `" != "0" ]; then
 	# relocate resolv.conf mount
 	touch /etc/resolv.conf.upstream
 	mount --bind /etc/resolv.conf /etc/resolv.conf.upstream

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -164,7 +164,7 @@ type ContainerEndpointOpts struct {
 //
 // If a scheme is specified, a URL is returned. Otherwise, a host:port pair is returned.
 //
-// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
+// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
 func (r *Container) Endpoint(ctx context.Context, opts ...ContainerEndpointOpts) (string, error) {
 	q := r.q.Select("endpoint")
 	// `port` optional argument
@@ -317,7 +317,7 @@ func (r *Container) Export(ctx context.Context, path string, opts ...ContainerEx
 
 // Retrieves the list of exposed ports.
 //
-// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
+// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
 func (r *Container) ExposedPorts(ctx context.Context) ([]Port, error) {
 	q := r.q.Select("exposedPorts")
 
@@ -364,7 +364,7 @@ func (r *Container) FS() *Directory {
 
 // Retrieves a hostname which can be used by clients to reach this container.
 //
-// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
+// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
 func (r *Container) Hostname(ctx context.Context) (string, error) {
 	q := r.q.Select("hostname")
 
@@ -689,7 +689,7 @@ type ContainerWithExposedPortOpts struct {
 //   - For health checks and introspection, when running services
 //   - For setting the EXPOSE OCI field when publishing the container
 //
-// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
+// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
 func (r *Container) WithExposedPort(port int, opts ...ContainerWithExposedPortOpts) *Container {
 	q := r.q.Select("withExposedPort")
 	q = q.Arg("port", port)
@@ -924,7 +924,7 @@ func (r *Container) WithSecretVariable(name string, secret *Secret) *Container {
 //
 // The service dependency will also convey to any files or directories produced by the container.
 //
-// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
+// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
 func (r *Container) WithServiceBinding(alias string, service *Container) *Container {
 	q := r.q.Select("withServiceBinding")
 	q = q.Arg("alias", alias)
@@ -989,7 +989,7 @@ type ContainerWithoutExposedPortOpts struct {
 
 // Unexpose a previously exposed port.
 //
-// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
+// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
 func (r *Container) WithoutExposedPort(port int, opts ...ContainerWithoutExposedPortOpts) *Container {
 	q := r.q.Select("withoutExposedPort")
 	q = q.Arg("port", port)

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -623,7 +623,7 @@ export class Container extends BaseClient {
    *
    * If a scheme is specified, a URL is returned. Otherwise, a host:port pair is returned.
    *
-   * Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
+   * Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
    * @param opts.port The exposed port number for the endpoint
    * @param opts.scheme Return a URL with the given scheme, eg. http for http://
    */
@@ -766,7 +766,7 @@ export class Container extends BaseClient {
   /**
    * Retrieves the list of exposed ports.
    *
-   * Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
+   * Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
    */
   async exposedPorts(): Promise<Port[]> {
     const response: Awaited<Port[]> = await computeQuery(
@@ -842,7 +842,7 @@ export class Container extends BaseClient {
   /**
    * Retrieves a hostname which can be used by clients to reach this container.
    *
-   * Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
+   * Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
    */
   async hostname(): Promise<string> {
     const response: Awaited<string> = await computeQuery(
@@ -1188,7 +1188,7 @@ export class Container extends BaseClient {
    *   - For health checks and introspection, when running services
    *   - For setting the EXPOSE OCI field when publishing the container
    *
-   * Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
+   * Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
    * @param port Port number to expose
    * @param opts.protocol Transport layer network protocol
    * @param opts.description Optional port description
@@ -1463,7 +1463,7 @@ export class Container extends BaseClient {
    *
    * The service dependency will also convey to any files or directories produced by the container.
    *
-   * Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
+   * Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
    * @param alias A name that can be used to reach the service from the container
    * @param service Identifier of the service container
    */
@@ -1557,7 +1557,7 @@ export class Container extends BaseClient {
   /**
    * Unexpose a previously exposed port.
    *
-   * Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to enable.
+   * Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
    * @param port Port number to unexpose
    * @param opts.protocol Port protocol to unexpose
    */

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -195,8 +195,8 @@ class Container(Type):
         If a scheme is specified, a URL is returned. Otherwise, a host:port
         pair is returned.
 
-        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to
-        enable.
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to
+        disable.
 
         Parameters
         ----------
@@ -397,8 +397,8 @@ class Container(Type):
     def exposed_ports(self) -> "Port":
         """Retrieves the list of exposed ports.
 
-        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to
-        enable.
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to
+        disable.
         """
         _args: list[Arg] = []
         _ctx = self._select("exposedPorts", _args)
@@ -454,8 +454,8 @@ class Container(Type):
         """Retrieves a hostname which can be used by clients to reach this
         container.
 
-        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to
-        enable.
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to
+        disable.
 
         Returns
         -------
@@ -881,8 +881,8 @@ class Container(Type):
           - For health checks and introspection, when running services
           - For setting the EXPOSE OCI field when publishing the container
 
-        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to
-        enable.
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to
+        disable.
 
         Parameters
         ----------
@@ -1159,8 +1159,8 @@ class Container(Type):
         The service dependency will also convey to any files or directories
         produced by the container.
 
-        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to
-        enable.
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to
+        disable.
 
         Parameters
         ----------
@@ -1248,8 +1248,8 @@ class Container(Type):
     ) -> "Container":
         """Unexpose a previously exposed port.
 
-        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to
-        enable.
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to
+        disable.
 
         Parameters
         ----------

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -195,8 +195,8 @@ class Container(Type):
         If a scheme is specified, a URL is returned. Otherwise, a host:port
         pair is returned.
 
-        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to
-        enable.
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to
+        disable.
 
         Parameters
         ----------
@@ -397,8 +397,8 @@ class Container(Type):
     def exposed_ports(self) -> "Port":
         """Retrieves the list of exposed ports.
 
-        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to
-        enable.
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to
+        disable.
         """
         _args: list[Arg] = []
         _ctx = self._select("exposedPorts", _args)
@@ -454,8 +454,8 @@ class Container(Type):
         """Retrieves a hostname which can be used by clients to reach this
         container.
 
-        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to
-        enable.
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to
+        disable.
 
         Returns
         -------
@@ -881,8 +881,8 @@ class Container(Type):
           - For health checks and introspection, when running services
           - For setting the EXPOSE OCI field when publishing the container
 
-        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to
-        enable.
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to
+        disable.
 
         Parameters
         ----------
@@ -1159,8 +1159,8 @@ class Container(Type):
         The service dependency will also convey to any files or directories
         produced by the container.
 
-        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to
-        enable.
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to
+        disable.
 
         Parameters
         ----------
@@ -1248,8 +1248,8 @@ class Container(Type):
     ) -> "Container":
         """Unexpose a previously exposed port.
 
-        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=1 to
-        enable.
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to
+        disable.
 
         Parameters
         ----------


### PR DESCRIPTION
Now that there are no known issues (#4652 is fixed) we can probably make services on by default, with opt-out still available.

I thought about just removing the feature flag, but we might as well give users the option to disable it for the first release or two while all the scaffolding is already in place, just in case something else comes up (as tends to happen with anything networking related).

We should include something like this in the services docs; cc @vikram-dagger:

> The new services feature changes Dagger's entire network stack. If something seems to have broken, you can disable it by setting the following environment variable prior to running the engine:
>
> ```sh
> export _EXPERIMENTAL_DAGGER_SERVICES_DNS=0
> ```
>
> Please report an issue if this is the case!