### PR TITLE
feat: improve Go SDK to fetch list of objects

### DIFF
--- a/codegen/generator/functions.go
+++ b/codegen/generator/functions.go
@@ -1,6 +1,8 @@
 package generator
 
-import "github.com/dagger/dagger/codegen/introspection"
+import (
+	"github.com/dagger/dagger/codegen/introspection"
+)
 
 const (
 	QueryStructName       = "Query"

--- a/codegen/generator/go/generator.go
+++ b/codegen/generator/go/generator.go
@@ -17,6 +17,8 @@ type GoGenerator struct {
 }
 
 func (g *GoGenerator) Generate(_ context.Context, schema *introspection.Schema) ([]byte, error) {
+	generator.SetSchema(schema)
+
 	headerData := struct {
 		Package string
 		Schema  *introspection.Schema

--- a/codegen/generator/go/templates/functions.go
+++ b/codegen/generator/go/templates/functions.go
@@ -120,7 +120,7 @@ func getArrayField(f *introspection.Field) []*introspection.Field {
 }
 
 func formatArrayField(fields []*introspection.Field) string {
-	var result []string
+	result := []string{}
 
 	for _, f := range fields {
 		result = append(result, fmt.Sprintf("%s: &field.%s", f.Name, toUpperCase(f.Name)))

--- a/codegen/generator/go/templates/src/object.go.tmpl
+++ b/codegen/generator/go/templates/src/object.go.tmpl
@@ -3,6 +3,12 @@
 type {{ .Name | FormatName }} struct {
 	q *querybuilder.Selection
 	c graphql.Client
+
+    {{ range $field := .Fields }}
+        {{- if $field.TypeRef.IsScalar }}
+        {{ $field.Name }} *{{ $field.TypeRef | FormatOutputType }}
+        {{- end }}
+	{{- end }}
 }
 {{- end }}
 {{ range $field := .Fields }}
@@ -29,7 +35,13 @@ type {{ $field | FieldOptionsStructName }} struct {
 {{ $field.DeprecationReason | FormatDeprecation }}
 {{- end }}
 {{ $field | FieldFunction }} {
+    {{- if and ($field.TypeRef.IsScalar) (ne $field.ParentObject.Name "Query") }}
+    if r.{{ $field.Name }} != nil {
+        return *r.{{ $field.Name }}, nil
+    }
+    {{- end }}
 	q := r.q.Select("{{ $field.Name }}")
+
 	{{- range $arg := $field.Args }}
 	{{- if $arg.TypeRef.IsOptional }}
 	// `{{ $arg.Name }}` optional argument
@@ -49,12 +61,50 @@ type {{ $field | FieldOptionsStructName }} struct {
 		q: q,
 		c: r.c,
 	}
+
 	{{- else if or $field.TypeRef.IsScalar $field.TypeRef.IsList }}
+		{{- if and $field.TypeRef.IsList (IsListOfObject $field.TypeRef) }}
+    q = q.Select("{{ range $v := $field | GetArrayField }}{{ $v.Name }} {{ end }}")
+
+    type {{ $field.Name | ToLowerCase }} struct {
+            {{ range $v := $field | GetArrayField }}
+      {{ $v.Name | ToUpperCase }} {{ $v.TypeRef | FormatOutputType }}
+            {{- end }}
+    }
+
+    convert := func(fields []{{ $field.Name | ToLowerCase }}) {{ $field.TypeRef | FormatOutputType }} {
+        out := {{ $field.TypeRef | FormatOutputType }}{}
+
+        for _, field := range fields {
+            out = append(out, {{ $field.TypeRef | FormatOutputType | FormatArrayToSingleType }}{{"{"}}{{ $field | GetArrayField | FormatArrayField }}{{"}"}})
+        }
+
+        return out
+    }
+
+        {{- end }}
+
+
+    {{- if and $field.TypeRef.IsList (IsListOfObject $field.TypeRef) }}
+	var response []{{ $field.Name | ToLowerCase }}
+	{{- else }}
 	var response {{ $field.TypeRef | FormatOutputType }}
+	{{- end  }}
+
 	q = q.Bind(&response)
 	{{- $typeName := $field.TypeRef | FormatOutputType }}
 	{{- if ne $typeName "Client" }}
+	    {{- if and $field.TypeRef.IsList (IsListOfObject $field.TypeRef) }}
+
+	err := q.Execute(ctx, r.c)
+	if err != nil {
+	    return nil, err
+	}
+
+	return convert(response), nil
+	    {{- else }}
 	return response, q.Execute(ctx, r.c)
+	    {{- end }}
 	{{- else }}
 	return response, q.Execute(ctx, r.gql)
 	{{- end }}

--- a/codegen/generator/go/templates/src/object.go.tmpl
+++ b/codegen/generator/go/templates/src/object.go.tmpl
@@ -64,7 +64,7 @@ type {{ $field | FieldOptionsStructName }} struct {
 
 	{{- else if or $field.TypeRef.IsScalar $field.TypeRef.IsList }}
 		{{- if and $field.TypeRef.IsList (IsListOfObject $field.TypeRef) }}
-    q = q.Select("{{ range $v := $field | GetArrayField }}{{ $v.Name }} {{ end }}")
+    q = q.Select("{{ range $i, $v := $field | GetArrayField }}{{ if $i }} {{ end }}{{ $v.Name }}{{ end }}")
 
     type {{ $field.Name | ToLowerCase }} struct {
             {{ range $v := $field | GetArrayField }}

--- a/codegen/generator/schema.go
+++ b/codegen/generator/schema.go
@@ -1,0 +1,13 @@
+package generator
+
+import "github.com/dagger/dagger/codegen/introspection"
+
+var _schema *introspection.Schema
+
+func SetSchema(schema *introspection.Schema) {
+	_schema = schema
+}
+
+func GetSchema() *introspection.Schema {
+	return _schema
+}

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -54,12 +54,18 @@ type PipelineLabel struct {
 type CacheVolume struct {
 	q *querybuilder.Selection
 	c graphql.Client
+
+	id *CacheID
 }
 
 func (r *CacheVolume) ID(ctx context.Context) (CacheID, error) {
+	if r.id != nil {
+		return *r.id, nil
+	}
 	q := r.q.Select("id")
 
 	var response CacheID
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -82,6 +88,21 @@ func (r *CacheVolume) XXX_GraphQLID(ctx context.Context) (string, error) {
 type Container struct {
 	q *querybuilder.Selection
 	c graphql.Client
+
+	endpoint    *string
+	envVariable *string
+	exitCode    *int
+	export      *bool
+	hostname    *string
+	id          *ContainerID
+	imageRef    *string
+	label       *string
+	platform    *Platform
+	publish     *string
+	stderr      *string
+	stdout      *string
+	user        *string
+	workdir     *string
 }
 
 // ContainerBuildOpts contains options for Container.Build
@@ -133,6 +154,7 @@ func (r *Container) DefaultArgs(ctx context.Context) ([]string, error) {
 	q := r.q.Select("defaultArgs")
 
 	var response []string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -166,6 +188,9 @@ type ContainerEndpointOpts struct {
 //
 // Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
 func (r *Container) Endpoint(ctx context.Context, opts ...ContainerEndpointOpts) (string, error) {
+	if r.endpoint != nil {
+		return *r.endpoint, nil
+	}
 	q := r.q.Select("endpoint")
 	// `port` optional argument
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -183,6 +208,7 @@ func (r *Container) Endpoint(ctx context.Context, opts ...ContainerEndpointOpts)
 	}
 
 	var response string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -192,16 +218,21 @@ func (r *Container) Entrypoint(ctx context.Context) ([]string, error) {
 	q := r.q.Select("entrypoint")
 
 	var response []string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
 
 // Retrieves the value of the specified environment variable.
 func (r *Container) EnvVariable(ctx context.Context, name string) (string, error) {
+	if r.envVariable != nil {
+		return *r.envVariable, nil
+	}
 	q := r.q.Select("envVariable")
 	q = q.Arg("name", name)
 
 	var response string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -210,9 +241,32 @@ func (r *Container) EnvVariable(ctx context.Context, name string) (string, error
 func (r *Container) EnvVariables(ctx context.Context) ([]EnvVariable, error) {
 	q := r.q.Select("envVariables")
 
-	var response []EnvVariable
+	q = q.Select("name value ")
+
+	type envVariables struct {
+		Name  string
+		Value string
+	}
+
+	convert := func(fields []envVariables) []EnvVariable {
+		out := []EnvVariable{}
+
+		for _, field := range fields {
+			out = append(out, EnvVariable{name: &field.Name, value: &field.Value})
+		}
+
+		return out
+	}
+	var response []envVariables
+
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.c)
+
+	err := q.Execute(ctx, r.c)
+	if err != nil {
+		return nil, err
+	}
+
+	return convert(response), nil
 }
 
 // ContainerExecOpts contains options for Container.Exec
@@ -281,9 +335,13 @@ func (r *Container) Exec(opts ...ContainerExecOpts) *Container {
 // Exit code of the last executed command. Zero means success.
 // Errors if no command has been executed.
 func (r *Container) ExitCode(ctx context.Context) (int, error) {
+	if r.exitCode != nil {
+		return *r.exitCode, nil
+	}
 	q := r.q.Select("exitCode")
 
 	var response int
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -300,6 +358,9 @@ type ContainerExportOpts struct {
 // Return true on success.
 // It can also publishes platform variants.
 func (r *Container) Export(ctx context.Context, path string, opts ...ContainerExportOpts) (bool, error) {
+	if r.export != nil {
+		return *r.export, nil
+	}
 	q := r.q.Select("export")
 	q = q.Arg("path", path)
 	// `platformVariants` optional argument
@@ -311,6 +372,7 @@ func (r *Container) Export(ctx context.Context, path string, opts ...ContainerEx
 	}
 
 	var response bool
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -321,9 +383,33 @@ func (r *Container) Export(ctx context.Context, path string, opts ...ContainerEx
 func (r *Container) ExposedPorts(ctx context.Context) ([]Port, error) {
 	q := r.q.Select("exposedPorts")
 
-	var response []Port
+	q = q.Select("description port protocol ")
+
+	type exposedPorts struct {
+		Description string
+		Port        int
+		Protocol    NetworkProtocol
+	}
+
+	convert := func(fields []exposedPorts) []Port {
+		out := []Port{}
+
+		for _, field := range fields {
+			out = append(out, Port{description: &field.Description, port: &field.Port, protocol: &field.Protocol})
+		}
+
+		return out
+	}
+	var response []exposedPorts
+
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.c)
+
+	err := q.Execute(ctx, r.c)
+	if err != nil {
+		return nil, err
+	}
+
+	return convert(response), nil
 }
 
 // Retrieves a file at the given path.
@@ -366,18 +452,26 @@ func (r *Container) FS() *Directory {
 //
 // Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
 func (r *Container) Hostname(ctx context.Context) (string, error) {
+	if r.hostname != nil {
+		return *r.hostname, nil
+	}
 	q := r.q.Select("hostname")
 
 	var response string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
 
 // A unique identifier for this container.
 func (r *Container) ID(ctx context.Context) (ContainerID, error) {
+	if r.id != nil {
+		return *r.id, nil
+	}
 	q := r.q.Select("id")
 
 	var response ContainerID
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -398,19 +492,27 @@ func (r *Container) XXX_GraphQLID(ctx context.Context) (string, error) {
 
 // The unique image reference which can only be retrieved immediately after the 'Container.From' call.
 func (r *Container) ImageRef(ctx context.Context) (string, error) {
+	if r.imageRef != nil {
+		return *r.imageRef, nil
+	}
 	q := r.q.Select("imageRef")
 
 	var response string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
 
 // Retrieves the value of the specified label.
 func (r *Container) Label(ctx context.Context, name string) (string, error) {
+	if r.label != nil {
+		return *r.label, nil
+	}
 	q := r.q.Select("label")
 	q = q.Arg("name", name)
 
 	var response string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -419,9 +521,32 @@ func (r *Container) Label(ctx context.Context, name string) (string, error) {
 func (r *Container) Labels(ctx context.Context) ([]Label, error) {
 	q := r.q.Select("labels")
 
-	var response []Label
+	q = q.Select("name value ")
+
+	type labels struct {
+		Name  string
+		Value string
+	}
+
+	convert := func(fields []labels) []Label {
+		out := []Label{}
+
+		for _, field := range fields {
+			out = append(out, Label{name: &field.Name, value: &field.Value})
+		}
+
+		return out
+	}
+	var response []labels
+
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.c)
+
+	err := q.Execute(ctx, r.c)
+	if err != nil {
+		return nil, err
+	}
+
+	return convert(response), nil
 }
 
 // Retrieves the list of paths where a directory is mounted.
@@ -429,6 +554,7 @@ func (r *Container) Mounts(ctx context.Context) ([]string, error) {
 	q := r.q.Select("mounts")
 
 	var response []string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -468,9 +594,13 @@ func (r *Container) Pipeline(name string, opts ...ContainerPipelineOpts) *Contai
 
 // The platform this container executes and publishes as.
 func (r *Container) Platform(ctx context.Context) (Platform, error) {
+	if r.platform != nil {
+		return *r.platform, nil
+	}
 	q := r.q.Select("platform")
 
 	var response Platform
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -487,6 +617,9 @@ type ContainerPublishOpts struct {
 // Publish returns a fully qualified ref.
 // It can also publish platform variants.
 func (r *Container) Publish(ctx context.Context, address string, opts ...ContainerPublishOpts) (string, error) {
+	if r.publish != nil {
+		return *r.publish, nil
+	}
 	q := r.q.Select("publish")
 	q = q.Arg("address", address)
 	// `platformVariants` optional argument
@@ -498,6 +631,7 @@ func (r *Container) Publish(ctx context.Context, address string, opts ...Contain
 	}
 
 	var response string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -515,9 +649,13 @@ func (r *Container) Rootfs() *Directory {
 // The error stream of the last executed command.
 // Errors if no command has been executed.
 func (r *Container) Stderr(ctx context.Context) (string, error) {
+	if r.stderr != nil {
+		return *r.stderr, nil
+	}
 	q := r.q.Select("stderr")
 
 	var response string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -525,18 +663,26 @@ func (r *Container) Stderr(ctx context.Context) (string, error) {
 // The output stream of the last executed command.
 // Errors if no command has been executed.
 func (r *Container) Stdout(ctx context.Context) (string, error) {
+	if r.stdout != nil {
+		return *r.stdout, nil
+	}
 	q := r.q.Select("stdout")
 
 	var response string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
 
 // Retrieves the user to be set for all commands.
 func (r *Container) User(ctx context.Context) (string, error) {
+	if r.user != nil {
+		return *r.user, nil
+	}
 	q := r.q.Select("user")
 
 	var response string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -1065,9 +1211,13 @@ func (r *Container) WithoutUnixSocket(path string) *Container {
 
 // Retrieves the working directory for all commands.
 func (r *Container) Workdir(ctx context.Context) (string, error) {
+	if r.workdir != nil {
+		return *r.workdir, nil
+	}
 	q := r.q.Select("workdir")
 
 	var response string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -1076,6 +1226,9 @@ func (r *Container) Workdir(ctx context.Context) (string, error) {
 type Directory struct {
 	q *querybuilder.Selection
 	c graphql.Client
+
+	export *bool
+	id     *DirectoryID
 }
 
 // Gets the difference between this directory and an another directory.
@@ -1170,16 +1323,21 @@ func (r *Directory) Entries(ctx context.Context, opts ...DirectoryEntriesOpts) (
 	}
 
 	var response []string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
 
 // Writes the contents of the directory to a path on the host.
 func (r *Directory) Export(ctx context.Context, path string) (bool, error) {
+	if r.export != nil {
+		return *r.export, nil
+	}
 	q := r.q.Select("export")
 	q = q.Arg("path", path)
 
 	var response bool
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -1197,9 +1355,13 @@ func (r *Directory) File(path string) *File {
 
 // The content-addressed identifier of the directory.
 func (r *Directory) ID(ctx context.Context) (DirectoryID, error) {
+	if r.id != nil {
+		return *r.id, nil
+	}
 	q := r.q.Select("id")
 
 	var response DirectoryID
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -1413,22 +1575,33 @@ func (r *Directory) WithoutFile(path string) *Directory {
 type EnvVariable struct {
 	q *querybuilder.Selection
 	c graphql.Client
+
+	name  *string
+	value *string
 }
 
 // The environment variable name.
 func (r *EnvVariable) Name(ctx context.Context) (string, error) {
+	if r.name != nil {
+		return *r.name, nil
+	}
 	q := r.q.Select("name")
 
 	var response string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
 
 // The environment variable value.
 func (r *EnvVariable) Value(ctx context.Context) (string, error) {
+	if r.value != nil {
+		return *r.value, nil
+	}
 	q := r.q.Select("value")
 
 	var response string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -1437,32 +1610,49 @@ func (r *EnvVariable) Value(ctx context.Context) (string, error) {
 type File struct {
 	q *querybuilder.Selection
 	c graphql.Client
+
+	contents *string
+	export   *bool
+	id       *FileID
+	size     *int
 }
 
 // Retrieves the contents of the file.
 func (r *File) Contents(ctx context.Context) (string, error) {
+	if r.contents != nil {
+		return *r.contents, nil
+	}
 	q := r.q.Select("contents")
 
 	var response string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
 
 // Writes the file to a file path on the host.
 func (r *File) Export(ctx context.Context, path string) (bool, error) {
+	if r.export != nil {
+		return *r.export, nil
+	}
 	q := r.q.Select("export")
 	q = q.Arg("path", path)
 
 	var response bool
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
 
 // Retrieves the content-addressed identifier of the file.
 func (r *File) ID(ctx context.Context) (FileID, error) {
+	if r.id != nil {
+		return *r.id, nil
+	}
 	q := r.q.Select("id")
 
 	var response FileID
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -1495,9 +1685,13 @@ func (r *File) Secret() *Secret {
 
 // Gets the size of the file, in bytes.
 func (r *File) Size(ctx context.Context) (int, error) {
+	if r.size != nil {
+		return *r.size, nil
+	}
 	q := r.q.Select("size")
 
 	var response int
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -1517,13 +1711,19 @@ func (r *File) WithTimestamps(timestamp int) *File {
 type GitRef struct {
 	q *querybuilder.Selection
 	c graphql.Client
+
+	digest *string
 }
 
 // The digest of the current value of this ref.
 func (r *GitRef) Digest(ctx context.Context) (string, error) {
+	if r.digest != nil {
+		return *r.digest, nil
+	}
 	q := r.q.Select("digest")
 
 	var response string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -1581,6 +1781,7 @@ func (r *GitRepository) Branches(ctx context.Context) ([]string, error) {
 	q := r.q.Select("branches")
 
 	var response []string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -1612,6 +1813,7 @@ func (r *GitRepository) Tags(ctx context.Context) ([]string, error) {
 	q := r.q.Select("tags")
 
 	var response []string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -1715,6 +1917,8 @@ func (r *Host) Workdir(opts ...HostWorkdirOpts) *Directory {
 type HostVariable struct {
 	q *querybuilder.Selection
 	c graphql.Client
+
+	value *string
 }
 
 // A secret referencing the value of this variable.
@@ -1729,9 +1933,13 @@ func (r *HostVariable) Secret() *Secret {
 
 // The value of this variable.
 func (r *HostVariable) Value(ctx context.Context) (string, error) {
+	if r.value != nil {
+		return *r.value, nil
+	}
 	q := r.q.Select("value")
 
 	var response string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -1740,22 +1948,33 @@ func (r *HostVariable) Value(ctx context.Context) (string, error) {
 type Label struct {
 	q *querybuilder.Selection
 	c graphql.Client
+
+	name  *string
+	value *string
 }
 
 // The label name.
 func (r *Label) Name(ctx context.Context) (string, error) {
+	if r.name != nil {
+		return *r.name, nil
+	}
 	q := r.q.Select("name")
 
 	var response string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
 
 // The label value.
 func (r *Label) Value(ctx context.Context) (string, error) {
+	if r.value != nil {
+		return *r.value, nil
+	}
 	q := r.q.Select("value")
 
 	var response string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -1764,31 +1983,47 @@ func (r *Label) Value(ctx context.Context) (string, error) {
 type Port struct {
 	q *querybuilder.Selection
 	c graphql.Client
+
+	description *string
+	port        *int
+	protocol    *NetworkProtocol
 }
 
 // The port description.
 func (r *Port) Description(ctx context.Context) (string, error) {
+	if r.description != nil {
+		return *r.description, nil
+	}
 	q := r.q.Select("description")
 
 	var response string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
 
 // The port number.
 func (r *Port) Port(ctx context.Context) (int, error) {
+	if r.port != nil {
+		return *r.port, nil
+	}
 	q := r.q.Select("port")
 
 	var response int
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
 
 // The transport layer network protocol.
 func (r *Port) Protocol(ctx context.Context) (NetworkProtocol, error) {
+	if r.protocol != nil {
+		return *r.protocol, nil
+	}
 	q := r.q.Select("protocol")
 
 	var response NetworkProtocol
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -1797,15 +2032,45 @@ func (r *Port) Protocol(ctx context.Context) (NetworkProtocol, error) {
 type Project struct {
 	q *querybuilder.Selection
 	c graphql.Client
+
+	install *bool
+	name    *string
+	schema  *string
+	sdk     *string
 }
 
 // extensions in this project
 func (r *Project) Extensions(ctx context.Context) ([]Project, error) {
 	q := r.q.Select("extensions")
 
-	var response []Project
+	q = q.Select("install name schema sdk ")
+
+	type extensions struct {
+		Install bool
+		Name    string
+		Schema  string
+		Sdk     string
+	}
+
+	convert := func(fields []extensions) []Project {
+		out := []Project{}
+
+		for _, field := range fields {
+			out = append(out, Project{install: &field.Install, name: &field.Name, schema: &field.Schema, sdk: &field.Sdk})
+		}
+
+		return out
+	}
+	var response []extensions
+
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.c)
+
+	err := q.Execute(ctx, r.c)
+	if err != nil {
+		return nil, err
+	}
+
+	return convert(response), nil
 }
 
 // Code files generated by the SDKs in the project
@@ -1820,36 +2085,52 @@ func (r *Project) GeneratedCode() *Directory {
 
 // install the project's schema
 func (r *Project) Install(ctx context.Context) (bool, error) {
+	if r.install != nil {
+		return *r.install, nil
+	}
 	q := r.q.Select("install")
 
 	var response bool
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
 
 // name of the project
 func (r *Project) Name(ctx context.Context) (string, error) {
+	if r.name != nil {
+		return *r.name, nil
+	}
 	q := r.q.Select("name")
 
 	var response string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
 
 // schema provided by the project
 func (r *Project) Schema(ctx context.Context) (string, error) {
+	if r.schema != nil {
+		return *r.schema, nil
+	}
 	q := r.q.Select("schema")
 
 	var response string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
 
 // sdk used to generate code for and/or execute this project
 func (r *Project) SDK(ctx context.Context) (string, error) {
+	if r.sdk != nil {
+		return *r.sdk, nil
+	}
 	q := r.q.Select("sdk")
 
 	var response string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -1905,6 +2186,7 @@ func (r *Client) DefaultPlatform(ctx context.Context) (Platform, error) {
 	q := r.q.Select("defaultPlatform")
 
 	var response Platform
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -2102,13 +2384,20 @@ func (r *Client) Socket(opts ...SocketOpts) *Socket {
 type Secret struct {
 	q *querybuilder.Selection
 	c graphql.Client
+
+	id        *SecretID
+	plaintext *string
 }
 
 // The identifier for this secret.
 func (r *Secret) ID(ctx context.Context) (SecretID, error) {
+	if r.id != nil {
+		return *r.id, nil
+	}
 	q := r.q.Select("id")
 
 	var response SecretID
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -2129,9 +2418,13 @@ func (r *Secret) XXX_GraphQLID(ctx context.Context) (string, error) {
 
 // The value of this secret.
 func (r *Secret) Plaintext(ctx context.Context) (string, error) {
+	if r.plaintext != nil {
+		return *r.plaintext, nil
+	}
 	q := r.q.Select("plaintext")
 
 	var response string
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
@@ -2139,13 +2432,19 @@ func (r *Secret) Plaintext(ctx context.Context) (string, error) {
 type Socket struct {
 	q *querybuilder.Selection
 	c graphql.Client
+
+	id *SocketID
 }
 
 // The content-addressed identifier of the socket.
 func (r *Socket) ID(ctx context.Context) (SocketID, error) {
+	if r.id != nil {
+		return *r.id, nil
+	}
 	q := r.q.Select("id")
 
 	var response SocketID
+
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -241,7 +241,7 @@ func (r *Container) EnvVariable(ctx context.Context, name string) (string, error
 func (r *Container) EnvVariables(ctx context.Context) ([]EnvVariable, error) {
 	q := r.q.Select("envVariables")
 
-	q = q.Select("name value ")
+	q = q.Select("name value")
 
 	type envVariables struct {
 		Name  string
@@ -383,7 +383,7 @@ func (r *Container) Export(ctx context.Context, path string, opts ...ContainerEx
 func (r *Container) ExposedPorts(ctx context.Context) ([]Port, error) {
 	q := r.q.Select("exposedPorts")
 
-	q = q.Select("description port protocol ")
+	q = q.Select("description port protocol")
 
 	type exposedPorts struct {
 		Description string
@@ -521,7 +521,7 @@ func (r *Container) Label(ctx context.Context, name string) (string, error) {
 func (r *Container) Labels(ctx context.Context) ([]Label, error) {
 	q := r.q.Select("labels")
 
-	q = q.Select("name value ")
+	q = q.Select("name value")
 
 	type labels struct {
 		Name  string
@@ -2043,7 +2043,7 @@ type Project struct {
 func (r *Project) Extensions(ctx context.Context) ([]Project, error) {
 	q := r.q.Select("extensions")
 
-	q = q.Select("install name schema sdk ")
+	q = q.Select("install name schema sdk")
 
 	type extensions struct {
 		Install bool

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -3,6 +3,7 @@ package dagger
 import (
 	"context"
 	"io"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -145,4 +146,31 @@ func TestErrorMessage(t *testing.T) {
 	_, err = c.Container().From("fake.invalid:latest").ID(ctx)
 	require.Error(t, err)
 	require.ErrorContains(t, err, errorHelpBlurb)
+}
+
+func TestList(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	c, err := Connect(ctx, WithLogOutput(os.Stdout))
+	require.NoError(t, err)
+
+	defer c.Close()
+
+	envs, err := c.
+		Container().
+		From("alpine:3.16.2").
+		WithEnvVariable("FOO", "BAR").
+		EnvVariables(ctx)
+
+	require.NoError(t, err)
+
+	envName, err := envs[0].Name(ctx)
+	require.NoError(t, err)
+
+	envValue, err := envs[0].Value(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, "FOO", envName)
+	require.Equal(t, "BAR", envValue)
 }

--- a/sdk/go/internal/querybuilder/querybuilder.go
+++ b/sdk/go/internal/querybuilder/querybuilder.go
@@ -110,7 +110,16 @@ func (s *Selection) unpack(data interface{}) error {
 		if i.alias != "" {
 			k = i.alias
 		}
-		data = data.(map[string]interface{})[k]
+
+		// Try to asert type of the value
+		switch f := data.(type) {
+		case map[string]interface{}:
+			data = data.(map[string]interface{})[k]
+		case []interface{}:
+			data = data.([]interface{})
+		default:
+			fmt.Printf("type not found %s\n", f)
+		}
 
 		if i.bind != nil {
 			marshalled, err := json.Marshal(data)

--- a/sdk/go/internal/querybuilder/querybuilder.go
+++ b/sdk/go/internal/querybuilder/querybuilder.go
@@ -111,12 +111,12 @@ func (s *Selection) unpack(data interface{}) error {
 			k = i.alias
 		}
 
-		// Try to asert type of the value
+		// Try to assert type of the value
 		switch f := data.(type) {
 		case map[string]interface{}:
-			data = data.(map[string]interface{})[k]
+			data = f[k]
 		case []interface{}:
-			data = data.([]interface{})
+			data = f
 		default:
 			fmt.Printf("type not found %s\n", f)
 		}


### PR DESCRIPTION
### Changes

Extends Go template capabilities.
Store scalar type private field to return it if it's set by a list execution.
Add test on list of objects.
Add Schema setter and getter to fetch global GQL
types.
Add utility functions to the Go template.
Improve query builder to also parse a list of objects.

### Approach

This feature has a simple concept but is actually really hard to implement.
The purpose is to make possible to fetch list of objects.
For the whole context: See #3457.

That implies multiple constraints:

1. How build the GQL query?

Our current way of building GQL query is simple, each method called adds a level of depth.
For instance: `container.ID(ctx)` will build the query `{ query { container { id } } }`.

But it's different for array: you cannot do `container.EnvVariables(ctx).Name(ctx)`.
For 2 reasons:
- You may want to retrieve more than just on the property of the object at the same time so how do you chain those calls?.
- Most important, the value returned by `EnvVariable` is an array so no method can be called on it.

**As a workaround**, the GQL query built on call to array includes all possible scalar fields in it.
For instance: `container.EnvVariables(ctx)` build: `{ query { container { envVariables { name value } } } }`.

---

:bulb: See last section of this comment for a possible workaround.

---

2. Each type already has public methods exposed to retrieve its values. Let's take for example `EnvVariable`.

```go
// A simple key value object that represents an environment variable.
type EnvVariable struct {...}

// The environment variable name.
func (r *EnvVariable) Name(ctx context.Context) (string, error) {...}

// The environment variable value.
func (r *EnvVariable) Value(ctx context.Context) (string, error) {...}
```

This type is designed to be used as a single value that will directly update the GQL query and execute it.
To fix that, each type stores as privates members its scalar types.

For instance:

```go
type EnvVariable struct {
  name string
  value string
}
```

And on call to array methods, those private fields will be set so they can be returned instead of executing a GQL query (see usage for more details).
Those private fields are set thanks a temporary data structure with the public field of those values, so it can be `Unmarshalled` by the query response.

3. The Go Generation

This was the most challenging part, the Go generator (and probably the Typescript one too) had no way to access the whole GQL schema. 

I'm not sure if it is a design problem but I created special methods so I can access any part of the GQL schema in resolvers so I can introspect a high level type from another.
For instance `Container` can returns `EnvVariable` but  `EnvVariable` is a whole type too defined at the same level as `Container` so I could not access its field without going through the whole schema.

I think generators need a complete refactor, as much about Go text templates as the Go code to make that kind of feature naturally possible in the code.

### Usage & Result

[Test](https://github.com/dagger/dagger/pull/4683/files#diff-3bab379acb41abd86e1ed861f5a3b851da0d48f0bbd453755046e933ac82123cR151) already shows an example of usage and expected result.

I think the DX is acceptable but could be better.
However, it's quite straightforward and the experience is simple:

```go
// Setup container
alpine, err := c.
  Container().
  From("alpine:3.16.2").
  WithEnvVariable("FOO", "BAR").

// Call array method
envs, err := alpine.EnvVariables(ctx)
if err != nil { ... }

for _, env := range envs {
   name, err := env.Name(ctx) // I wish we could suppress the returns of the error + ctx usage since they are useless here
   if err != nil { ... }

   value, err := env.Value(ctx) // I wish we could suppress the returns of the error + ctx usage since they are useless here
   if err != nil { ... }

   fmt.Println(name, value)
}
```

### Limitation

Current changes only support the fetching of Scalar types like `String`, `Boolean`, or `Int`.
As a consequence, it is not possible to fetch data in recursivity.

For instance, you can call `project.Extensions()` but each returned project will have `extensions` stored
in the list.

### An idea that may improve the DX.

Create a special class or wrapper around arrays to still take benefits of GraphQL by allowing the fetch of only 
selected fields, removing the `error` returns and context usage.

I'm not sure about the design for now but we shall think about it.

Resolves: #3457 