### PR TITLE
Add GitHub workflow/job name to root pipeline labels

### DIFF
--- a/core/pipeline/label.go
+++ b/core/pipeline/label.go
@@ -94,6 +94,14 @@ func loadRootLabels(workdir string) ([]Label, error) {
 				Name:  "github.com/event.name",
 				Value: os.Getenv("GITHUB_EVENT_NAME"),
 			},
+			Label{
+				Name:  "github.com/workflow.name",
+				Value: os.Getenv("GITHUB_WORKFLOW"),
+			},
+			Label{
+				Name:  "github.com/workflow.job",
+				Value: os.Getenv("GITHUB_JOB"),
+			},
 		)
 
 		eventPath := os.Getenv("GITHUB_EVENT_PATH")


### PR DESCRIPTION
Adds two more labels when running in GHA:

* `github.com/workflow.name`: `$GITHUB_WORKFLOW`
* `github.com/workflow.job`: `$GITHUB_JOB`

Via the [docs](https://docs.github.com/en/actions/learn-github-actions/variables):

Variable | Description
-- | --
GITHUB_WORKFLOW | The name of the workflow. For example, My test workflow. If the workflow file doesn't specify a name, the value of this variable is the full path of the workflow file in the repository.
GITHUB_JOB	| The [job_id](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_id) of the current job. For example, greeting_job.