### PR TITLE
Fix mutating vertex name with LogOutput set

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -212,13 +212,19 @@ func handleSolveEvents(startOpts *Config, ch chan *bkclient.SolveStatus) error {
 		eg.Go(func() error {
 			defer close(cleanCh)
 			for ev := range ch {
-				for _, v := range ev.Vertexes {
+				cleaned := *ev
+				cleaned.Vertexes = make([]*bkclient.Vertex, len(ev.Vertexes))
+				for i, v := range ev.Vertexes {
 					customName := pipeline.CustomName{}
 					if json.Unmarshal([]byte(v.Name), &customName) == nil {
-						v.Name = customName.Name
+						cp := *v
+						cp.Name = customName.Name
+						cleaned.Vertexes[i] = &cp
+					} else {
+						cleaned.Vertexes[i] = v
 					}
 				}
-				cleanCh <- ev
+				cleanCh <- &cleaned
 			}
 			return nil
 		})


### PR DESCRIPTION
Previously if you had both the console output and journal file sinks enabled, the journal would end up containing vertices with their `Name` stripped down from the JSON CustomName encoding to just the "naked" name. This was happening because the console log consumer was mutating the `*Vertex`. Now we'll make a copy.