### PR TITLE
Raise error when using container has not been executed

### DIFF
--- a/core/errors.go
+++ b/core/errors.go
@@ -3,3 +3,5 @@ package core
 import "github.com/pkg/errors"
 
 var ErrHostRWDisabled = errors.New("host read/write is disabled")
+
+var ErrContainerNoExec = errors.New("no command has been executed")

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3005,3 +3005,20 @@ func TestContainerInsecureRootCapabilitesWithService(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, fmt.Sprintf("%s-from-outside\n%s-from-inside\n", randID, randID), out)
 }
+
+func TestContainerNoExecError(t *testing.T) {
+	c, ctx := connect(t)
+	defer c.Close()
+
+	_, err := c.Container().From("alpine:3.16.2").ExitCode(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), core.ErrContainerNoExec.Error())
+
+	_, err = c.Container().From("alpine:3.16.2").Stdout(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), core.ErrContainerNoExec.Error())
+
+	_, err = c.Container().From("alpine:3.16.2").Stderr(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), core.ErrContainerNoExec.Error())
+}

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -431,50 +431,13 @@ func TestContainerExecRedirectStdoutStderr(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "goodbye\n", stderr)
 
-	err = testutil.Query(
-		`{
-			container {
-				from(address: "alpine:3.16.2") {
-					exec(
-						args: ["sh", "-c", "echo hello; echo goodbye >/dev/stderr"],
-						redirectStdout: "out",
-						redirectStderr: "err"
-					) {
-						stdout
-						stderr
-					}
-				}
-			}
-		}`, &res, nil)
+	_, err = execWithMount.Stdout(ctx)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "stdout: no such file or directory")
+
+	_, err = execWithMount.Stderr(ctx)
+	require.Error(t, err)
 	require.Contains(t, err.Error(), "stderr: no such file or directory")
-}
-
-func TestContainerNullStdoutStderr(t *testing.T) {
-	t.Parallel()
-
-	res := struct {
-		Container struct {
-			From struct {
-				Stdout *string
-				Stderr *string
-			}
-		}
-	}{}
-
-	err := testutil.Query(
-		`{
-			container {
-				from(address: "alpine:3.16.2") {
-					stdout
-					stderr
-				}
-			}
-		}`, &res, nil)
-	require.NoError(t, err)
-	require.Nil(t, res.Container.From.Stdout)
-	require.Nil(t, res.Container.From.Stderr)
 }
 
 func TestContainerExecWithWorkdir(t *testing.T) {

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -162,15 +162,15 @@ func (s *containerSchema) withExec(ctx *router.Context, parent *core.Container, 
 	return parent.WithExec(ctx, s.gw, s.baseSchema.platform, args.ContainerExecOpts)
 }
 
-func (s *containerSchema) exitCode(ctx *router.Context, parent *core.Container, args any) (*int, error) {
+func (s *containerSchema) exitCode(ctx *router.Context, parent *core.Container, args any) (int, error) {
 	return parent.ExitCode(ctx, s.gw)
 }
 
-func (s *containerSchema) stdout(ctx *router.Context, parent *core.Container, args any) (*string, error) {
+func (s *containerSchema) stdout(ctx *router.Context, parent *core.Container, args any) (string, error) {
 	return parent.MetaFileContents(ctx, s.gw, "stdout")
 }
 
-func (s *containerSchema) stderr(ctx *router.Context, parent *core.Container, args any) (*string, error) {
+func (s *containerSchema) stderr(ctx *router.Context, parent *core.Container, args any) (string, error) {
 	return parent.MetaFileContents(ctx, s.gw, "stderr")
 }
 

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -484,21 +484,21 @@ type Container {
 
   """
   Exit code of the last executed command. Zero means success.
-  Null if no command has been executed.
+  Errors if no command has been executed.
   """
-  exitCode: Int
+  exitCode: Int!
 
   """
   The output stream of the last executed command.
-  Null if no command has been executed.
+  Errors if no command has been executed.
   """
-  stdout: String
+  stdout: String!
 
   """
   The error stream of the last executed command.
-  Null if no command has been executed.
+  Errors if no command has been executed.
   """
-  stderr: String
+  stderr: String!
 
   # FIXME: this is the last case of an actual "verb" that cannot cleanly go away.
   #    This may actually be a good candidate for a mutation. To be discussed.

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -279,7 +279,7 @@ func (r *Container) Exec(opts ...ContainerExecOpts) *Container {
 }
 
 // Exit code of the last executed command. Zero means success.
-// Null if no command has been executed.
+// Errors if no command has been executed.
 func (r *Container) ExitCode(ctx context.Context) (int, error) {
 	q := r.q.Select("exitCode")
 
@@ -513,7 +513,7 @@ func (r *Container) Rootfs() *Directory {
 }
 
 // The error stream of the last executed command.
-// Null if no command has been executed.
+// Errors if no command has been executed.
 func (r *Container) Stderr(ctx context.Context) (string, error) {
 	q := r.q.Select("stderr")
 
@@ -523,7 +523,7 @@ func (r *Container) Stderr(ctx context.Context) (string, error) {
 }
 
 // The output stream of the last executed command.
-// Null if no command has been executed.
+// Errors if no command has been executed.
 func (r *Container) Stdout(ctx context.Context) (string, error) {
 	q := r.q.Select("stdout")
 

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -730,7 +730,7 @@ export class Container extends BaseClient {
 
   /**
    * Exit code of the last executed command. Zero means success.
-   * Null if no command has been executed.
+   * Errors if no command has been executed.
    */
   async exitCode(): Promise<number> {
     const response: Awaited<number> = await computeQuery(
@@ -1033,7 +1033,7 @@ export class Container extends BaseClient {
 
   /**
    * The error stream of the last executed command.
-   * Null if no command has been executed.
+   * Errors if no command has been executed.
    */
   async stderr(): Promise<string> {
     const response: Awaited<string> = await computeQuery(
@@ -1051,7 +1051,7 @@ export class Container extends BaseClient {
 
   /**
    * The output stream of the last executed command.
-   * Null if no command has been executed.
+   * Errors if no command has been executed.
    */
   async stdout(): Promise<string> {
     const response: Awaited<string> = await computeQuery(

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -331,13 +331,13 @@ class Container(Type):
         return Container(_ctx)
 
     @typecheck
-    async def exit_code(self) -> Optional[int]:
+    async def exit_code(self) -> int:
         """Exit code of the last executed command. Zero means success.
-        Null if no command has been executed.
+        Errors if no command has been executed.
 
         Returns
         -------
-        Optional[int]
+        int
             The `Int` scalar type represents non-fractional signed whole
             numeric values. Int can represent values between -(2^31) and 2^31
             - 1.
@@ -351,7 +351,7 @@ class Container(Type):
         """
         _args: list[Arg] = []
         _ctx = self._select("exitCode", _args)
-        return await _ctx.execute(Optional[int])
+        return await _ctx.execute(int)
 
     @typecheck
     async def export(
@@ -674,13 +674,13 @@ class Container(Type):
         return Directory(_ctx)
 
     @typecheck
-    async def stderr(self) -> Optional[str]:
+    async def stderr(self) -> str:
         """The error stream of the last executed command.
-        Null if no command has been executed.
+        Errors if no command has been executed.
 
         Returns
         -------
-        Optional[str]
+        str
             The `String` scalar type represents textual data, represented as
             UTF-8 character sequences. The String type is most often used by
             GraphQL to represent free-form human-readable text.
@@ -694,16 +694,16 @@ class Container(Type):
         """
         _args: list[Arg] = []
         _ctx = self._select("stderr", _args)
-        return await _ctx.execute(Optional[str])
+        return await _ctx.execute(str)
 
     @typecheck
-    async def stdout(self) -> Optional[str]:
+    async def stdout(self) -> str:
         """The output stream of the last executed command.
-        Null if no command has been executed.
+        Errors if no command has been executed.
 
         Returns
         -------
-        Optional[str]
+        str
             The `String` scalar type represents textual data, represented as
             UTF-8 character sequences. The String type is most often used by
             GraphQL to represent free-form human-readable text.
@@ -717,7 +717,7 @@ class Container(Type):
         """
         _args: list[Arg] = []
         _ctx = self._select("stdout", _args)
-        return await _ctx.execute(Optional[str])
+        return await _ctx.execute(str)
 
     @typecheck
     async def user(self) -> Optional[str]:

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -331,13 +331,13 @@ class Container(Type):
         return Container(_ctx)
 
     @typecheck
-    def exit_code(self) -> Optional[int]:
+    def exit_code(self) -> int:
         """Exit code of the last executed command. Zero means success.
-        Null if no command has been executed.
+        Errors if no command has been executed.
 
         Returns
         -------
-        Optional[int]
+        int
             The `Int` scalar type represents non-fractional signed whole
             numeric values. Int can represent values between -(2^31) and 2^31
             - 1.
@@ -351,7 +351,7 @@ class Container(Type):
         """
         _args: list[Arg] = []
         _ctx = self._select("exitCode", _args)
-        return _ctx.execute_sync(Optional[int])
+        return _ctx.execute_sync(int)
 
     @typecheck
     def export(
@@ -674,13 +674,13 @@ class Container(Type):
         return Directory(_ctx)
 
     @typecheck
-    def stderr(self) -> Optional[str]:
+    def stderr(self) -> str:
         """The error stream of the last executed command.
-        Null if no command has been executed.
+        Errors if no command has been executed.
 
         Returns
         -------
-        Optional[str]
+        str
             The `String` scalar type represents textual data, represented as
             UTF-8 character sequences. The String type is most often used by
             GraphQL to represent free-form human-readable text.
@@ -694,16 +694,16 @@ class Container(Type):
         """
         _args: list[Arg] = []
         _ctx = self._select("stderr", _args)
-        return _ctx.execute_sync(Optional[str])
+        return _ctx.execute_sync(str)
 
     @typecheck
-    def stdout(self) -> Optional[str]:
+    def stdout(self) -> str:
         """The output stream of the last executed command.
-        Null if no command has been executed.
+        Errors if no command has been executed.
 
         Returns
         -------
-        Optional[str]
+        str
             The `String` scalar type represents textual data, represented as
             UTF-8 character sequences. The String type is most often used by
             GraphQL to represent free-form human-readable text.
@@ -717,7 +717,7 @@ class Container(Type):
         """
         _args: list[Arg] = []
         _ctx = self._select("stdout", _args)
-        return _ctx.execute_sync(Optional[str])
+        return _ctx.execute_sync(str)
 
     @typecheck
     def user(self) -> Optional[str]:


### PR DESCRIPTION
Previously `exitCode`, `stdout`, and `stderr` would simply return null if a container had not been executed yet, i.e. a container that's really just an image. Worse, this would actually get turned into the zero-value for each in the Go SDK (`0`, `""`) making it look like a successful exec.

Additionally, it was easy to accidentally use an un-exec'd container as a service, e.g. by running an off-the-shelf `redis` or `postgres` image without including `WithExec(nil)`. You'd get a weird error with an empty hostname.

Now in all cases we'll raise an error when trying to use a container that has never exec'd.

fixes #4668