### PR TITLE
Container: add `Run` helper

### DIFF
--- a/codegen/generator/go/templates/functions.go
+++ b/codegen/generator/go/templates/functions.go
@@ -137,7 +137,9 @@ func fieldFunction(f introspection.Field) string {
 	signature += "(" + strings.Join(args, ", ") + ")"
 
 	retType := ""
-	if f.TypeRef.IsScalar() || f.TypeRef.IsList() {
+	if f.TypeRef.IsVoid() {
+		retType = "error"
+	} else if f.TypeRef.IsScalar() || f.TypeRef.IsList() {
 		retType = fmt.Sprintf("(%s, error)", commonFunc.FormatOutputType(f.TypeRef))
 	} else {
 		retType = "*" + commonFunc.FormatOutputType(f.TypeRef)

--- a/codegen/generator/go/templates/functions.go
+++ b/codegen/generator/go/templates/functions.go
@@ -137,11 +137,12 @@ func fieldFunction(f introspection.Field) string {
 	signature += "(" + strings.Join(args, ", ") + ")"
 
 	retType := ""
-	if f.TypeRef.IsVoid() {
+	switch {
+	case f.TypeRef.IsVoid():
 		retType = "error"
-	} else if f.TypeRef.IsScalar() || f.TypeRef.IsList() {
+	case f.TypeRef.IsScalar() || f.TypeRef.IsList():
 		retType = fmt.Sprintf("(%s, error)", commonFunc.FormatOutputType(f.TypeRef))
-	} else {
+	default:
 		retType = "*" + commonFunc.FormatOutputType(f.TypeRef)
 	}
 	signature += " " + retType

--- a/codegen/generator/go/templates/src/object.go.tmpl
+++ b/codegen/generator/go/templates/src/object.go.tmpl
@@ -50,13 +50,15 @@ type {{ $field | FieldOptionsStructName }} struct {
 		c: r.c,
 	}
 	{{- else if or $field.TypeRef.IsScalar $field.TypeRef.IsList }}
-	var response {{ $field.TypeRef | FormatOutputType }}
-	q = q.Bind(&response)
 	{{- $typeName := $field.TypeRef | FormatOutputType }}
-	{{- if ne $typeName "Client" }}
-	return response, q.Execute(ctx, r.c)
-	{{- else }}
+	var response {{ $typeName }}
+	q = q.Bind(&response)
+  {{- if $field.TypeRef.IsVoid }}
+	return q.Execute(ctx, r.c)
+  {{- else if eq $typeName "Client" }}
 	return response, q.Execute(ctx, r.gql)
+	{{- else }}
+	return response, q.Execute(ctx, r.c)
 	{{- end }}
 	{{- end }}
 }

--- a/codegen/introspection/introspection.go
+++ b/codegen/introspection/introspection.go
@@ -147,6 +147,17 @@ func (r TypeRef) IsList() bool {
 	return false
 }
 
+func (r TypeRef) IsVoid() bool {
+	ref := r
+	if r.Kind == TypeKindNonNull {
+		ref = *ref.OfType
+	}
+	if ref.Kind != TypeKindScalar {
+		return false
+	}
+	return ref.Name == "Void"
+}
+
 type InputValues []InputValue
 
 func (i InputValues) HasOptionals() bool {

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -318,6 +318,34 @@ func TestContainerExecExitCode(t *testing.T) {
 	*/
 }
 
+func TestContainerRun(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := connect(t)
+	defer c.Close()
+
+	err := c.Container().
+		From("alpine:3.16.2").
+		WithExec([]string{"true"}).
+		Run(ctx)
+	require.NoError(t, err)
+
+	err = c.Container().
+		From("alpine:3.16.2").
+		WithExec([]string{"false"}).
+		Run(ctx)
+	require.Error(t, err)
+
+	err = c.Container().
+		From("alpine:3.16.2").
+		WithExec([]string{"sh", "-exc", "echo hello; echo goodbye >/dev/stderr; exit 42"}).
+		Run(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exit code: 42")
+	require.Contains(t, err.Error(), "hello")
+	require.Contains(t, err.Error(), "goodbye")
+}
+
 func TestContainerExecStdoutStderr(t *testing.T) {
 	t.Parallel()
 

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -77,6 +77,7 @@ func (s *containerSchema) Resolvers() router.Resolvers {
 			"exitCode":             router.ToResolver(s.exitCode),
 			"stdout":               router.ToResolver(s.stdout),
 			"stderr":               router.ToResolver(s.stderr),
+			"run":                  router.ToResolver(s.run),
 			"publish":              router.ToResolver(s.publish),
 			"platform":             router.ToResolver(s.platform),
 			"export":               router.ToResolver(s.export),
@@ -172,6 +173,10 @@ func (s *containerSchema) stdout(ctx *router.Context, parent *core.Container, ar
 
 func (s *containerSchema) stderr(ctx *router.Context, parent *core.Container, args any) (*string, error) {
 	return parent.MetaFileContents(ctx, s.gw, "stderr")
+}
+
+func (s *containerSchema) run(ctx *router.Context, parent *core.Container, args any) (core.Void, error) {
+	return "", parent.Evaluate(ctx, s.gw)
 }
 
 type containerWithEntrypointArgs struct {

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -12,6 +12,9 @@ extend type Query {
 "A unique container identifier. Null designates an empty container (scratch)."
 scalar ContainerID
 
+"Nothing. Used by SDK codegen to skip the return value."
+scalar Void
+
 """
 An OCI-compatible container, also known as a docker container.
 """
@@ -499,6 +502,12 @@ type Container {
   Null if no command has been executed.
   """
   stderr: String
+
+  """
+  Evaluates the command and returns an error if it exits with a nonzero exit
+  code.
+  """
+  run: Void!
 
   # FIXME: this is the last case of an actual "verb" that cannot cleanly go away.
   #    This may actually be a good candidate for a mutation. To be discussed.

--- a/core/schema/query.go
+++ b/core/schema/query.go
@@ -4,6 +4,7 @@ import (
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/pipeline"
 	"github.com/dagger/dagger/router"
+	"github.com/dagger/graphql/language/ast"
 )
 
 type querySchema struct {
@@ -24,6 +25,17 @@ func (s *querySchema) Resolvers() router.Resolvers {
 	return router.Resolvers{
 		"Query": router.ObjectResolver{
 			"pipeline": router.ToResolver(s.pipeline),
+		},
+		"Void": router.ScalarResolver{
+			Serialize: func(_ any) any {
+				return core.Void("")
+			},
+			ParseValue: func(_ any) any {
+				return core.Void("")
+			},
+			ParseLiteral: func(_ ast.Value) any {
+				return core.Void("")
+			},
 		},
 	}
 }

--- a/core/void.go
+++ b/core/void.go
@@ -1,0 +1,4 @@
+package core
+
+// Void is returned by schema queries that have no return value.
+type Void string

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -32,6 +32,9 @@ type SecretID string
 // A content-addressed socket identifier.
 type SocketID string
 
+// Nothing. Used by SDK codegen to skip the return value.
+type Void string
+
 // Key value object that represents a build argument.
 type BuildArg struct {
 	// The build argument name.
@@ -510,6 +513,16 @@ func (r *Container) Rootfs() *Directory {
 		q: q,
 		c: r.c,
 	}
+}
+
+// Evaluates the command and returns an error if it exits with a nonzero exit
+// code.
+func (r *Container) Run(ctx context.Context) error {
+	q := r.q.Select("run")
+
+	var response Void
+	q = q.Bind(&response)
+	return q.Execute(ctx, r.c)
 }
 
 // The error stream of the last executed command.

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -506,6 +506,11 @@ export type SecretID = string & { __SecretID: never }
  */
 export type SocketID = string & { __SocketID: never }
 
+/**
+ * Nothing. Used by SDK codegen to skip the return value.
+ */
+export type Void = string & { __Void: never }
+
 export type __TypeEnumValuesOpts = {
   includeDeprecated?: boolean
 }
@@ -1029,6 +1034,24 @@ export class Container extends BaseClient {
       host: this.clientHost,
       sessionToken: this.sessionToken,
     })
+  }
+
+  /**
+   * Evaluates the command and returns an error if it exits with a nonzero exit
+   * code.
+   */
+  async run(): Promise<Void> {
+    const response: Awaited<Void> = await computeQuery(
+      [
+        ...this._queryTree,
+        {
+          operation: "run",
+        },
+      ],
+      this.client
+    )
+
+    return response
   }
 
   /**

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -37,6 +37,10 @@ class SocketID(Scalar):
     """A content-addressed socket identifier."""
 
 
+class Void(Scalar):
+    """Nothing. Used by SDK codegen to skip the return value."""
+
+
 class CacheSharingMode(Enum):
     """Sharing mode of the cache volume."""
 
@@ -672,6 +676,28 @@ class Container(Type):
         _args: list[Arg] = []
         _ctx = self._select("rootfs", _args)
         return Directory(_ctx)
+
+    @typecheck
+    async def run(self) -> Void:
+        """Evaluates the command and returns an error if it exits with a nonzero
+        exit
+        code.
+
+        Returns
+        -------
+        Void
+            Nothing. Used by SDK codegen to skip the return value.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("run", _args)
+        return await _ctx.execute(Void)
 
     @typecheck
     async def stderr(self) -> Optional[str]:
@@ -2638,6 +2664,7 @@ __all__ = [
     "Platform",
     "SecretID",
     "SocketID",
+    "Void",
     "CacheSharingMode",
     "NetworkProtocol",
     "BuildArg",

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -37,6 +37,10 @@ class SocketID(Scalar):
     """A content-addressed socket identifier."""
 
 
+class Void(Scalar):
+    """Nothing. Used by SDK codegen to skip the return value."""
+
+
 class CacheSharingMode(Enum):
     """Sharing mode of the cache volume."""
 
@@ -672,6 +676,28 @@ class Container(Type):
         _args: list[Arg] = []
         _ctx = self._select("rootfs", _args)
         return Directory(_ctx)
+
+    @typecheck
+    def run(self) -> Void:
+        """Evaluates the command and returns an error if it exits with a nonzero
+        exit
+        code.
+
+        Returns
+        -------
+        Void
+            Nothing. Used by SDK codegen to skip the return value.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("run", _args)
+        return _ctx.execute_sync(Void)
 
     @typecheck
     def stderr(self) -> Optional[str]:
@@ -2638,6 +2664,7 @@ __all__ = [
     "Platform",
     "SecretID",
     "SocketID",
+    "Void",
     "CacheSharingMode",
     "NetworkProtocol",
     "BuildArg",


### PR DESCRIPTION
Adds this API:

```graphql
"Nothing. Used by SDK codegen to skip the return value."
scalar Void

extend type Container {
  """
  Evaluates the command and returns an error if it exits with a nonzero exit
  code.
  """
  run: Void!
}
```

This is a convenience to replace this pattern:

```go
code, err := container.ExitCode(ctx)
if err != nil {
  return err
}
if code != 0 {
  return fmt.Errorf("exit code: %d", code)
}
```

with this:

```go
err := container.Run(ctx)
if err != nil {
  return err
}
```

I expect this to be used in a _lot_ of pipelines that people write, so I biased towards what I think is a pretty ergonomic name ("run") even if it's a bit of a lie due to caching.

Right now this API is redundant because ExitCode returns an error when it encounters a nonzero exit code, ~~which is a bug (#3192). Anyone relying on that behavior and ignoring the exit code return value should switch to this new API instead to avoid silently dropping failures in the future~~. (edit: per https://github.com/dagger/dagger/issues/3192#issuecomment-1459212866 it'll keep erroring by default, so don't fear breakage in the future, but this API is still nice for when you don't actually care about the exit code.)

### implementation notes

I added a new `Void` scalar return type because the entire point of this API is to not have a return value and just raise an error if the container fails. I updated the Go SDK codegen to handle this but haven't updated the rest yet. Submitting PR early for API review.