### PR TITLE
Fix `grep -v` in entrypoint causing early exit

### DIFF
--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -70,7 +70,7 @@ if [ "$` + servicesDNSEnvName + `" != "0" ]; then
 
 	# preserve DNS search/options config, but let dnsmasq delegate to
 	# /etc/resolv.conf.upstream for upstream nameservers
-	grep -v '^nameserver' /etc/resolv.conf.upstream >> /etc/resolv.conf
+	grep -v '^nameserver' /etc/resolv.conf.upstream || true >> /etc/resolv.conf
 fi
 
 exec {{.EngineBin}} --config {{.EngineConfig}} "$@"


### PR DESCRIPTION
This should fix the macOS publish build failures.

Note: no external impact since this is unreleased code, changed after v0.3.13.