### PR TITLE
Spike: host-to-container networking

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -21,6 +21,9 @@ func init() {
 	// Disable logrus output, which only comes from the docker
 	// commandconn library that is used by buildkit's connhelper
 	// and prints unneeded warning logs.
+	//
+	// NB(vito): we now use Logrus in other places so it's a bit unfortunate to
+	// disable this, solution TBD
 	logrus.StandardLogger().SetOutput(io.Discard)
 
 	rootCmd.PersistentFlags().StringVar(&workdir, "workdir", ".", "The host workdir loaded into dagger")

--- a/cmd/shim/check.go
+++ b/cmd/shim/check.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/moby/buildkit/identity"
+)
+
+func check(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: check HOST PORT[/NETWORK] [PORT[/NETWORK] ...]")
+	}
+
+	logPrefix := fmt.Sprintf("[check %s]", identity.NewID())
+
+	host, ports := args[0], args[1:]
+
+	for _, port := range ports {
+		port, network, ok := strings.Cut(port, "/")
+		if !ok {
+			network = "tcp"
+		}
+
+		pollAddr := net.JoinHostPort(host, port)
+
+		fmt.Println(logPrefix, "polling for port", pollAddr)
+
+		reached, err := pollForPort(logPrefix, network, pollAddr)
+		if err != nil {
+			return fmt.Errorf("poll %s: %w", pollAddr, err)
+		}
+
+		fmt.Println(logPrefix, "port is up at", reached)
+	}
+
+	return nil
+}
+
+func pollForPort(logPrefix, network, addr string) (string, error) {
+	retry := backoff.NewExponentialBackOff()
+	retry.InitialInterval = 100 * time.Millisecond
+
+	dialer := net.Dialer{
+		Timeout: time.Second,
+	}
+
+	var reached string
+	err := backoff.Retry(func() error {
+		// NB(vito): it's a _little_ silly to dial a UDP network to see that it's
+		// up, since it'll be a false positive even if they're not listening yet,
+		// but it at least checks that we're able to resolve the container address.
+
+		conn, err := dialer.Dial(network, addr)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s port not ready: %s; elapsed: %s\n", logPrefix, err, retry.GetElapsedTime())
+			return err
+		}
+
+		reached = conn.RemoteAddr().String()
+
+		_ = conn.Close()
+
+		return nil
+	}, retry)
+	if err != nil {
+		return "", err
+	}
+
+	return reached, nil
+}

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -13,14 +13,11 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
-	"time"
 
-	"github.com/cenkalti/backoff/v4"
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/router"
 	"github.com/google/uuid"
-	"github.com/moby/buildkit/identity"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
 )
@@ -78,73 +75,16 @@ func internalCommand() int {
 			return 1
 		}
 		return 0
+	case "proxy":
+		if err := proxy(args); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		return 0
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", cmd)
 		return 1
 	}
-}
-
-func check(args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("usage: check <host> port/tcp [port/udp ...]")
-	}
-
-	logPrefix := fmt.Sprintf("[check %s]", identity.NewID())
-
-	host, ports := args[0], args[1:]
-
-	for _, port := range ports {
-		port, network, ok := strings.Cut(port, "/")
-		if !ok {
-			network = "tcp"
-		}
-
-		pollAddr := net.JoinHostPort(host, port)
-
-		fmt.Println(logPrefix, "polling for port", pollAddr)
-
-		reached, err := pollForPort(logPrefix, network, pollAddr)
-		if err != nil {
-			return fmt.Errorf("poll %s: %w", pollAddr, err)
-		}
-
-		fmt.Println(logPrefix, "port is up at", reached)
-	}
-
-	return nil
-}
-
-func pollForPort(logPrefix, network, addr string) (string, error) {
-	retry := backoff.NewExponentialBackOff()
-	retry.InitialInterval = 100 * time.Millisecond
-
-	dialer := net.Dialer{
-		Timeout: time.Second,
-	}
-
-	var reached string
-	err := backoff.Retry(func() error {
-		// NB(vito): it's a _little_ silly to dial a UDP network to see that it's
-		// up, since it'll be a false positive even if they're not listening yet,
-		// but it at least checks that we're able to resolve the container address.
-
-		conn, err := dialer.Dial(network, addr)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s port not ready: %s; elapsed: %s\n", logPrefix, err, retry.GetElapsedTime())
-			return err
-		}
-
-		reached = conn.RemoteAddr().String()
-
-		_ = conn.Close()
-
-		return nil
-	}, retry)
-	if err != nil {
-		return "", err
-	}
-
-	return reached, nil
 }
 
 func shim() int {

--- a/cmd/shim/proxy.go
+++ b/cmd/shim/proxy.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -33,6 +34,11 @@ func proxy(args []string) error {
 
 	eg.Go(func() error {
 		_, err := io.Copy(os.Stdout, conn)
+		if errors.Is(err, net.ErrClosed) {
+			// other side may have closed, either way we're done
+			return nil
+		}
+
 		return err
 	})
 

--- a/cmd/shim/proxy.go
+++ b/cmd/shim/proxy.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+
+	"golang.org/x/sync/errgroup"
+)
+
+func proxy(args []string) error {
+	if len(args) != 2 {
+		return fmt.Errorf("usage: proxy HOST PORT[/NETWORK]")
+	}
+
+	host, portNetwork := args[0], args[1]
+
+	port, network, ok := strings.Cut(portNetwork, "/")
+	if !ok {
+		network = "tcp"
+	}
+
+	addr := net.JoinHostPort(host, port)
+
+	conn, err := net.Dial(network, addr)
+	if err != nil {
+		return fmt.Errorf("dial %s: %w", addr, err)
+	}
+
+	eg := new(errgroup.Group)
+
+	eg.Go(func() error { _, err := io.Copy(os.Stdout, conn); return err })
+	eg.Go(func() error { _, err := io.Copy(conn, os.Stdin); return err })
+
+	return eg.Wait()
+}

--- a/codegen/generator/go/templates/functions.go
+++ b/codegen/generator/go/templates/functions.go
@@ -137,7 +137,9 @@ func fieldFunction(f introspection.Field) string {
 	signature += "(" + strings.Join(args, ", ") + ")"
 
 	retType := ""
-	if f.TypeRef.IsScalar() || f.TypeRef.IsList() {
+	if f.TypeRef.IsVoid() {
+		retType = "error"
+	} else if f.TypeRef.IsScalar() || f.TypeRef.IsList() {
 		retType = fmt.Sprintf("(%s, error)", commonFunc.FormatOutputType(f.TypeRef))
 	} else {
 		retType = "*" + commonFunc.FormatOutputType(f.TypeRef)

--- a/codegen/generator/go/templates/functions.go
+++ b/codegen/generator/go/templates/functions.go
@@ -137,11 +137,12 @@ func fieldFunction(f introspection.Field) string {
 	signature += "(" + strings.Join(args, ", ") + ")"
 
 	retType := ""
-	if f.TypeRef.IsVoid() {
+	switch {
+	case f.TypeRef.IsVoid():
 		retType = "error"
-	} else if f.TypeRef.IsScalar() || f.TypeRef.IsList() {
+	case f.TypeRef.IsScalar() || f.TypeRef.IsList():
 		retType = fmt.Sprintf("(%s, error)", commonFunc.FormatOutputType(f.TypeRef))
-	} else {
+	default:
 		retType = "*" + commonFunc.FormatOutputType(f.TypeRef)
 	}
 	signature += " " + retType

--- a/codegen/generator/go/templates/src/object.go.tmpl
+++ b/codegen/generator/go/templates/src/object.go.tmpl
@@ -50,13 +50,15 @@ type {{ $field | FieldOptionsStructName }} struct {
 		c: r.c,
 	}
 	{{- else if or $field.TypeRef.IsScalar $field.TypeRef.IsList }}
-	var response {{ $field.TypeRef | FormatOutputType }}
-	q = q.Bind(&response)
 	{{- $typeName := $field.TypeRef | FormatOutputType }}
-	{{- if ne $typeName "Client" }}
-	return response, q.Execute(ctx, r.c)
-	{{- else }}
+	var response {{ $typeName }}
+	q = q.Bind(&response)
+  {{- if $field.TypeRef.IsVoid }}
+	return q.Execute(ctx, r.c)
+  {{- else if eq $typeName "Client" }}
 	return response, q.Execute(ctx, r.gql)
+	{{- else }}
+	return response, q.Execute(ctx, r.c)
 	{{- end }}
 	{{- end }}
 }

--- a/codegen/introspection/introspection.go
+++ b/codegen/introspection/introspection.go
@@ -147,6 +147,17 @@ func (r TypeRef) IsList() bool {
 	return false
 }
 
+func (r TypeRef) IsVoid() bool {
+	ref := r
+	if r.Kind == TypeKindNonNull {
+		ref = *ref.OfType
+	}
+	if ref.Kind != TypeKindScalar {
+		return false
+	}
+	return ref.Name == "Void"
+}
+
 type InputValues []InputValue
 
 func (i InputValues) HasOptionals() bool {

--- a/core/container.go
+++ b/core/container.go
@@ -1682,6 +1682,7 @@ func publish(ctx context.Context, gw bkgw.Client, port ContainerPort, host strin
 				Ref:       scratchRes.Ref,
 			},
 		},
+		NetMode: pb.NetMode_HOST,
 	}
 
 	go func() {

--- a/core/container.go
+++ b/core/container.go
@@ -1705,7 +1705,7 @@ func proxyConn(ctx context.Context, gw bkgw.Client, containerReq bkgw.NewContain
 
 	proxyContainer, err := gw.NewContainer(ctx, containerReq)
 	if err != nil {
-		logrus.Warnf("create publish container for :%d: %s", publish, err)
+		logrus.Errorf("failed to create proxy container: %s", err)
 		return
 	}
 
@@ -1723,7 +1723,7 @@ func proxyConn(ctx context.Context, gw bkgw.Client, containerReq bkgw.NewContain
 		Stderr: os.Stderr, // TODO(vito)
 	})
 	if err != nil {
-		logrus.Warnf("published port :%d proxy error: ", publish, err)
+		logrus.Errorf("failed to start proxy process: %s", err)
 		return
 	}
 
@@ -1732,14 +1732,14 @@ func proxyConn(ctx context.Context, gw bkgw.Client, containerReq bkgw.NewContain
 
 		err := proc.Signal(cleanupCtx, syscall.SIGKILL)
 		if err != nil {
-			logrus.Warnf("published port :%d proxy kill error: ", publish, err)
+			logrus.Warnf("failed to kill proxy: %s", err)
 			return
 		}
 	}()
 
 	err = proc.Wait()
 	if err != nil {
-		logrus.Warn("published port :%d proxy exited with error: ", publish, err)
+		logrus.Warnf("proxy exited with error: %s", err)
 		return
 	}
 }

--- a/core/container.go
+++ b/core/container.go
@@ -1657,15 +1657,15 @@ func b32(n uint64) string {
 }
 
 func publish(ctx context.Context, gw bkgw.Client, port ContainerPort, host string) error {
-	publish := *port.Publish
+	publishedPort := *port.Publish
 
 	// NB: listen synchronously
-	l, err := net.Listen(port.Protocol.Network(), fmt.Sprintf(":%d", publish))
+	l, err := net.Listen(port.Protocol.Network(), fmt.Sprintf(":%d", publishedPort))
 	if err != nil {
 		return err
 	}
 
-	logrus.Debugf("listening on published port :%d => %s:%d", publish, host, port.Port)
+	logrus.Debugf("listening on published port :%d => %s:%d", publishedPort, host, port.Port)
 
 	args := []string{"proxy", host, fmt.Sprintf("%d/%s", port.Port, port.Protocol.Network())}
 
@@ -1689,7 +1689,7 @@ func publish(ctx context.Context, gw bkgw.Client, port ContainerPort, host strin
 		for {
 			conn, err := l.Accept()
 			if err != nil {
-				logrus.Warnf("published port :%d accept error: ", publish, err)
+				logrus.Warnf("published port :%d accept error: %s", publishedPort, err)
 				break
 			}
 

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -318,6 +318,34 @@ func TestContainerExecExitCode(t *testing.T) {
 	*/
 }
 
+func TestContainerRun(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := connect(t)
+	defer c.Close()
+
+	err := c.Container().
+		From("alpine:3.16.2").
+		WithExec([]string{"true"}).
+		Run(ctx)
+	require.NoError(t, err)
+
+	err = c.Container().
+		From("alpine:3.16.2").
+		WithExec([]string{"false"}).
+		Run(ctx)
+	require.Error(t, err)
+
+	err = c.Container().
+		From("alpine:3.16.2").
+		WithExec([]string{"sh", "-exc", "echo hello; echo goodbye >/dev/stderr; exit 42"}).
+		Run(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exit code: 42")
+	require.Contains(t, err.Error(), "hello")
+	require.Contains(t, err.Error(), "goodbye")
+}
+
 func TestContainerExecStdoutStderr(t *testing.T) {
 	t.Parallel()
 

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -77,6 +77,7 @@ func (s *containerSchema) Resolvers() router.Resolvers {
 			"exitCode":             router.ToResolver(s.exitCode),
 			"stdout":               router.ToResolver(s.stdout),
 			"stderr":               router.ToResolver(s.stderr),
+			"run":                  router.ToResolver(s.run),
 			"publish":              router.ToResolver(s.publish),
 			"platform":             router.ToResolver(s.platform),
 			"export":               router.ToResolver(s.export),
@@ -172,6 +173,10 @@ func (s *containerSchema) stdout(ctx *router.Context, parent *core.Container, ar
 
 func (s *containerSchema) stderr(ctx *router.Context, parent *core.Container, args any) (string, error) {
 	return parent.MetaFileContents(ctx, s.gw, "stderr")
+}
+
+func (s *containerSchema) run(ctx *router.Context, parent *core.Container, args any) (core.Void, error) {
+	return "", parent.Evaluate(ctx, s.gw)
 }
 
 type containerWithEntrypointArgs struct {

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -90,6 +90,7 @@ func (s *containerSchema) Resolvers() router.Resolvers {
 			"hostname":             router.ToResolver(s.hostname),
 			"endpoint":             router.ToResolver(s.endpoint),
 			"withServiceBinding":   router.ToResolver(s.withServiceBinding),
+			"socket":               router.ToResolver(s.socket),
 		},
 	}
 }
@@ -633,6 +634,19 @@ func (s *containerSchema) endpoint(ctx *router.Context, parent *core.Container, 
 	return parent.Endpoint(args.Port, args.Scheme)
 }
 
+type containerSocketArgs struct {
+	Port     int
+	Protocol core.NetworkProtocol
+}
+
+func (s *containerSchema) socket(ctx *router.Context, parent *core.Container, args containerSocketArgs) (*core.Socket, error) {
+	if !s.servicesEnabled {
+		return nil, ErrServicesDisabled
+	}
+
+	return parent.Socket(args.Port, args.Protocol)
+}
+
 type containerWithServiceDependencyArgs struct {
 	Service core.ContainerID
 	Alias   string
@@ -650,7 +664,6 @@ type containerWithExposedPortArgs struct {
 	Protocol    core.NetworkProtocol
 	Port        int
 	Description *string
-	Publish     *int
 }
 
 func (s *containerSchema) withExposedPort(ctx *router.Context, parent *core.Container, args containerWithExposedPortArgs) (*core.Container, error) {
@@ -662,7 +675,6 @@ func (s *containerSchema) withExposedPort(ctx *router.Context, parent *core.Cont
 		Protocol:    args.Protocol,
 		Port:        args.Port,
 		Description: args.Description,
-		Publish:     args.Publish,
 	})
 }
 

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -650,6 +650,7 @@ type containerWithExposedPortArgs struct {
 	Protocol    core.NetworkProtocol
 	Port        int
 	Description *string
+	Publish     *int
 }
 
 func (s *containerSchema) withExposedPort(ctx *router.Context, parent *core.Container, args containerWithExposedPortArgs) (*core.Container, error) {
@@ -661,6 +662,7 @@ func (s *containerSchema) withExposedPort(ctx *router.Context, parent *core.Cont
 		Protocol:    args.Protocol,
 		Port:        args.Port,
 		Description: args.Description,
+		Publish:     args.Publish,
 	})
 }
 

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -599,6 +599,8 @@ type Container {
     protocol: NetworkProtocol = TCP
     "Optional port description"
     description: String
+    "Make this port reachable via the given port on the host"
+    publish: Int
   ): Container!
 
   """

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -660,6 +660,22 @@ type Container {
     "Return a URL with the given scheme, eg. http for http://"
     scheme: String
   ): String!
+
+  """
+  Retrieves a socket connecting to a port in this container.
+
+  If no port is specified, the first exposed port is used. If none exist an error is returned.
+
+  If a scheme is specified, a URL is returned. Otherwise, a host:port pair is returned.
+
+  Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
+  """
+  socket(
+    "The port number for the socket to connect to"
+    port: Int
+    "The transport layer network protocol."
+    protocol: NetworkProtocol = TCP
+  ): Socket!
 }
 
 "A simple key value object that represents an environment variable."

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -12,6 +12,9 @@ extend type Query {
 "A unique container identifier. Null designates an empty container (scratch)."
 scalar ContainerID
 
+"Nothing. Used by SDK codegen to skip the return value."
+scalar Void
+
 """
 An OCI-compatible container, also known as a docker container.
 """
@@ -499,6 +502,12 @@ type Container {
   Errors if no command has been executed.
   """
   stderr: String!
+
+  """
+  Evaluates the command and returns an error if it exits with a nonzero exit
+  code.
+  """
+  run: Void!
 
   # FIXME: this is the last case of an actual "verb" that cannot cleanly go away.
   #    This may actually be a good candidate for a mutation. To be discussed.

--- a/core/schema/query.go
+++ b/core/schema/query.go
@@ -4,6 +4,7 @@ import (
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/pipeline"
 	"github.com/dagger/dagger/router"
+	"github.com/dagger/graphql/language/ast"
 )
 
 type querySchema struct {
@@ -24,6 +25,17 @@ func (s *querySchema) Resolvers() router.Resolvers {
 	return router.Resolvers{
 		"Query": router.ObjectResolver{
 			"pipeline": router.ToResolver(s.pipeline),
+		},
+		"Void": router.ScalarResolver{
+			Serialize: func(_ any) any {
+				return core.Void("")
+			},
+			ParseValue: func(_ any) any {
+				return core.Void("")
+			},
+			ParseLiteral: func(_ ast.Value) any {
+				return core.Void("")
+			},
 		},
 	}
 }

--- a/core/schema/socket.go
+++ b/core/schema/socket.go
@@ -29,7 +29,9 @@ func (s *socketSchema) Resolvers() router.Resolvers {
 		"Query": router.ObjectResolver{
 			"socket": router.ToResolver(s.socket),
 		},
-		"Socket": router.ObjectResolver{},
+		"Socket": router.ObjectResolver{
+			"bind": router.ToResolver(s.socketBind),
+		},
 	}
 }
 
@@ -44,4 +46,13 @@ type socketArgs struct {
 // nolint: unparam
 func (s *socketSchema) socket(_ *router.Context, _ any, args socketArgs) (*core.Socket, error) {
 	return core.NewSocket(args.ID), nil
+}
+
+type socketBindArgs struct {
+	Address string
+	Family  core.NetworkFamily
+}
+
+func (s *socketSchema) socketBind(ctx *router.Context, parent *core.Socket, args socketBindArgs) (core.Void, error) {
+	return core.Nothing, parent.Bind(ctx, s.gw, args.Address, args.Family)
 }

--- a/core/schema/socket.graphqls
+++ b/core/schema/socket.graphqls
@@ -9,4 +9,24 @@ scalar SocketID
 type Socket {
   "The content-addressed identifier of the socket."
   id: SocketID!
+
+  """
+  Bind the socket to the host namespace at the specified address.
+
+  If family is IP, the address can be either an IPv4 or IPv6 address and port.
+
+  If family is UNIX, the address is the path to the socket file.
+  """
+  bind(
+    address: String!
+    family: NetworkFamily = IP
+  ): Void!
+}
+
+"Network address family"
+enum NetworkFamily {
+  "IPv4 or IPv6"
+  IP
+  "Unix"
+  UNIX
 }

--- a/core/socket.go
+++ b/core/socket.go
@@ -5,8 +5,14 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
+	"syscall"
 
+	"github.com/moby/buildkit/client/llb"
+	bkgw "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/session/sshforward"
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/sirupsen/logrus"
 )
 
 type Socket struct {
@@ -19,7 +25,13 @@ func (id SocketID) String() string { return string(id) }
 func (id SocketID) LLBID() string  { return fmt.Sprintf("socket:%s", id) }
 
 type socketIDPayload struct {
+	// Unix socket on the host.
 	HostPath string `json:"host_path,omitempty"`
+
+	// IP socket in a container.
+	ContainerID       ContainerID     `json:"container_id,omitempty"`
+	ContainerProtocol NetworkProtocol `json:"container_protocol,omitempty"`
+	ContainerPort     int             `json:"container_port,omitempty"`
 }
 
 func (id SocketID) decode() (*socketIDPayload, error) {
@@ -52,6 +64,16 @@ func NewHostSocket(absPath string) (*Socket, error) {
 	return payload.ToSocket()
 }
 
+func NewContainerSocket(id ContainerID, port int, protocol NetworkProtocol) (*Socket, error) {
+	payload := socketIDPayload{
+		ContainerID:       id,
+		ContainerPort:     port,
+		ContainerProtocol: protocol,
+	}
+
+	return payload.ToSocket()
+}
+
 func (socket *Socket) IsHost() (bool, error) {
 	payload, err := socket.ID.decode()
 	if err != nil {
@@ -61,30 +83,194 @@ func (socket *Socket) IsHost() (bool, error) {
 	return payload.HostPath != "", nil
 }
 
-func (socket *Socket) Server() (sshforward.SSHServer, error) {
+func (socket *Socket) Dial(ctx context.Context, gw bkgw.Client) (net.Conn, error) {
 	payload, err := socket.ID.decode()
 	if err != nil {
 		return nil, err
 	}
 
-	return &socketProxy{
+	switch {
+	case payload.HostPath != "":
+		return (&net.Dialer{}).DialContext(ctx, "unix", payload.HostPath)
+	case payload.ContainerID != "":
+		r, w := net.Pipe()
+
+		containerPayload, err := payload.ContainerID.decode()
+		if err != nil {
+			return nil, err
+		}
+
+		scratchRes, err := result(ctx, gw, llb.Scratch())
+		if err != nil {
+			return nil, err
+		}
+
+		containerReq := bkgw.NewContainerRequest{
+			Mounts: []bkgw.Mount{
+				{
+					Dest:      "/",
+					MountType: pb.MountType_BIND,
+					Ref:       scratchRes.Ref,
+				},
+			},
+			NetMode: pb.NetMode_HOST,
+		}
+
+		go proxyConn(
+			ctx,
+			gw,
+			containerReq,
+			containerPayload.Hostname,
+			payload.ContainerPort,
+			payload.ContainerProtocol,
+			r,
+		)
+
+		return w, nil
+
+	default:
+		return nil, fmt.Errorf("unknown socket type! this is probably a bug")
+	}
+}
+
+func (socket *Socket) Bind(ctx context.Context, gw bkgw.Client, addr string, family NetworkFamily) error {
+	payload, err := socket.ID.decode()
+	if err != nil {
+		return err
+	}
+
+	if payload.HostPath != "" {
+		return fmt.Errorf("cannot bind to a host socket")
+	}
+
+	containerPayload, err := payload.ContainerID.decode()
+	if err != nil {
+		return err
+	}
+
+	scratchRes, err := result(ctx, gw, llb.Scratch())
+	if err != nil {
+		return err
+	}
+
+	containerReq := bkgw.NewContainerRequest{
+		Mounts: []bkgw.Mount{
+			{
+				Dest:      "/",
+				MountType: pb.MountType_BIND,
+				Ref:       scratchRes.Ref,
+			},
+		},
+		NetMode: pb.NetMode_HOST,
+	}
+
+	var l net.Listener
+	switch family {
+	case NetworkFamilyIP:
+		switch payload.ContainerProtocol {
+		case NetworkProtocolTCP:
+			l, err = net.Listen("tcp", addr)
+		// case NetworkProtocolUDP:
+		// 	l, err = net.ListenUDP("udp", addr)
+		default:
+			return fmt.Errorf("unknown network protocol: %s", payload.ContainerProtocol)
+		}
+	case NetworkFamilyUNIX:
+		l, err = net.Listen("unix", addr)
+	default:
+		return fmt.Errorf("unknown socket type! this is probably a bug")
+	}
+
+	if err != nil {
+		return err
+	}
+
+	// go func() {
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			logrus.Warnf("bind %s accept error: %s", addr, err)
+			break
+		}
+
+		go proxyConn(
+			ctx,
+			gw,
+			containerReq,
+			containerPayload.Hostname,
+			payload.ContainerPort,
+			payload.ContainerProtocol,
+			conn,
+		)
+	}
+	// }()
+
+	return nil
+}
+
+func proxyConn(ctx context.Context, gw bkgw.Client, containerReq bkgw.NewContainerRequest, host string, port int, proto NetworkProtocol, conn net.Conn) {
+	defer conn.Close()
+
+	proxyContainer, err := gw.NewContainer(ctx, containerReq)
+	if err != nil {
+		logrus.Errorf("failed to create proxy container: %s", err)
+		return
+	}
+
+	// NB: use a different ctx than the one that'll be interrupted for anything
+	// that needs to run as part of post-interruption cleanup
+	cleanupCtx := context.Background()
+
+	defer proxyContainer.Release(cleanupCtx)
+
+	proc, err := proxyContainer.Start(ctx, bkgw.StartRequest{
+		Args:   []string{"proxy", host, fmt.Sprintf("%d/%s", port, proto.Network())},
+		Env:    []string{"_DAGGER_INTERNAL_COMMAND="},
+		Stdin:  conn,
+		Stdout: conn,
+		Stderr: os.Stderr, // TODO(vito)
+	})
+	if err != nil {
+		logrus.Errorf("failed to start proxy process: %s", err)
+		return
+	}
+
+	go func() {
+		<-ctx.Done()
+
+		err := proc.Signal(cleanupCtx, syscall.SIGKILL)
+		if err != nil {
+			logrus.Warnf("failed to kill proxy: %s", err)
+			return
+		}
+	}()
+
+	err = proc.Wait()
+	if err != nil {
+		logrus.Warnf("proxy exited with error: %s", err)
+		return
+	}
+}
+
+func (socket *Socket) Server() (sshforward.SSHServer, error) {
+	return &socketSSHServer{
 		dial: func() (io.ReadWriteCloser, error) {
-			return net.Dial("unix", payload.HostPath)
+			return socket.Dial(context.TODO(), nil) // TODO(vito): no gateway
 		},
 	}, nil
 }
 
-type socketProxy struct {
+type socketSSHServer struct {
 	dial func() (io.ReadWriteCloser, error)
 }
 
-var _ sshforward.SSHServer = &socketProxy{}
+var _ sshforward.SSHServer = &socketSSHServer{}
 
-func (p *socketProxy) CheckAgent(ctx context.Context, req *sshforward.CheckAgentRequest) (*sshforward.CheckAgentResponse, error) {
+func (p *socketSSHServer) CheckAgent(ctx context.Context, req *sshforward.CheckAgentRequest) (*sshforward.CheckAgentResponse, error) {
 	return &sshforward.CheckAgentResponse{}, nil
 }
 
-func (p *socketProxy) ForwardAgent(stream sshforward.SSH_ForwardAgentServer) error {
+func (p *socketSSHServer) ForwardAgent(stream sshforward.SSH_ForwardAgentServer) error {
 	conn, err := p.dial()
 	if err != nil {
 		return err
@@ -92,3 +278,11 @@ func (p *socketProxy) ForwardAgent(stream sshforward.SSH_ForwardAgentServer) err
 
 	return sshforward.Copy(context.TODO(), conn, stream, nil)
 }
+
+// NetworkFamily is a string deriving from NetworkFamily enum
+type NetworkFamily string
+
+const (
+	NetworkFamilyIP   NetworkFamily = "IP"
+	NetworkFamilyUNIX NetworkFamily = "UNIX"
+)

--- a/core/void.go
+++ b/core/void.go
@@ -1,0 +1,4 @@
+package core
+
+// Void is returned by schema queries that have no return value.
+type Void string

--- a/core/void.go
+++ b/core/void.go
@@ -2,3 +2,6 @@ package core
 
 // Void is returned by schema queries that have no return value.
 type Void string
+
+// Nothing is a canonical name for Void("").
+var Nothing Void

--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -386,6 +386,8 @@ func devEngineContainer(c *dagger.Client, arches []string) []*dagger.Container {
 				"git", "openssh", "pigz", "xz",
 				// for CNI
 				"iptables", "ip6tables", "dnsmasq",
+				// for host->container networking
+				"socat",
 			}).
 			WithFile("/usr/local/bin/runc", runcBin(c, arch), dagger.ContainerWithFileOpts{
 				Permissions: 0700,

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -706,6 +706,8 @@ type ContainerWithExposedPortOpts struct {
 	Protocol NetworkProtocol
 	// Optional port description
 	Description string
+	// Make this port reachable via the given port on the host
+	Publish int
 }
 
 // Expose a network port.
@@ -729,6 +731,13 @@ func (r *Container) WithExposedPort(port int, opts ...ContainerWithExposedPortOp
 	for i := len(opts) - 1; i >= 0; i-- {
 		if !querybuilder.IsZeroValue(opts[i].Description) {
 			q = q.Arg("description", opts[i].Description)
+			break
+		}
+	}
+	// `publish` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].Publish) {
+			q = q.Arg("publish", opts[i].Publish)
 			break
 		}
 	}

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -32,6 +32,9 @@ type SecretID string
 // A content-addressed socket identifier.
 type SocketID string
 
+// Nothing. Used by SDK codegen to skip the return value.
+type Void string
+
 // Key value object that represents a build argument.
 type BuildArg struct {
 	// The build argument name.
@@ -510,6 +513,16 @@ func (r *Container) Rootfs() *Directory {
 		q: q,
 		c: r.c,
 	}
+}
+
+// Evaluates the command and returns an error if it exits with a nonzero exit
+// code.
+func (r *Container) Run(ctx context.Context) error {
+	q := r.q.Select("run")
+
+	var response Void
+	q = q.Bind(&response)
+	return q.Execute(ctx, r.c)
 }
 
 // The error stream of the last executed command.

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -506,6 +506,11 @@ export type SecretID = string & { __SecretID: never }
  */
 export type SocketID = string & { __SocketID: never }
 
+/**
+ * Nothing. Used by SDK codegen to skip the return value.
+ */
+export type Void = string & { __Void: never }
+
 export type __TypeEnumValuesOpts = {
   includeDeprecated?: boolean
 }
@@ -1029,6 +1034,24 @@ export class Container extends BaseClient {
       host: this.clientHost,
       sessionToken: this.sessionToken,
     })
+  }
+
+  /**
+   * Evaluates the command and returns an error if it exits with a nonzero exit
+   * code.
+   */
+  async run(): Promise<Void> {
+    const response: Awaited<Void> = await computeQuery(
+      [
+        ...this._queryTree,
+        {
+          operation: "run",
+        },
+      ],
+      this.client
+    )
+
+    return response
   }
 
   /**

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -239,6 +239,11 @@ export type ContainerWithExposedPortOpts = {
    * Optional port description
    */
   description?: string
+
+  /**
+   * Make this port reachable via the given port on the host
+   */
+  publish?: number
 }
 
 export type ContainerWithFileOpts = {
@@ -1227,6 +1232,7 @@ export class Container extends BaseClient {
    * @param port Port number to expose
    * @param opts.protocol Transport layer network protocol
    * @param opts.description Optional port description
+   * @param opts.publish Make this port reachable via the given port on the host
    */
   withExposedPort(
     port: number,

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -884,6 +884,7 @@ class Container(Type):
         port: int,
         protocol: Optional[NetworkProtocol] = None,
         description: Optional[str] = None,
+        publish: Optional[int] = None,
     ) -> "Container":
         """Expose a network port.
 
@@ -902,11 +903,14 @@ class Container(Type):
             Transport layer network protocol
         description:
             Optional port description
+        publish:
+            Make this port reachable via the given port on the host
         """
         _args = [
             Arg("port", port),
             Arg("protocol", protocol, None),
             Arg("description", description, None),
+            Arg("publish", publish, None),
         ]
         _ctx = self._select("withExposedPort", _args)
         return Container(_ctx)

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -37,6 +37,10 @@ class SocketID(Scalar):
     """A content-addressed socket identifier."""
 
 
+class Void(Scalar):
+    """Nothing. Used by SDK codegen to skip the return value."""
+
+
 class CacheSharingMode(Enum):
     """Sharing mode of the cache volume."""
 
@@ -50,6 +54,16 @@ class CacheSharingMode(Enum):
 
     SHARED = "SHARED"
     """Shares the cache volume amongst many build pipelines"""
+
+
+class NetworkFamily(Enum):
+    """Network address family"""
+
+    IP = "IP"
+    """IPv4 or IPv6"""
+
+    UNIX = "UNIX"
+    """Unix"""
 
 
 class NetworkProtocol(Enum):
@@ -672,6 +686,59 @@ class Container(Type):
         _args: list[Arg] = []
         _ctx = self._select("rootfs", _args)
         return Directory(_ctx)
+
+    @typecheck
+    async def run(self) -> Void:
+        """Evaluates the command and returns an error if it exits with a nonzero
+        exit
+        code.
+
+        Returns
+        -------
+        Void
+            Nothing. Used by SDK codegen to skip the return value.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("run", _args)
+        return await _ctx.execute(Void)
+
+    @typecheck
+    def socket(
+        self,
+        port: Optional[int] = None,
+        protocol: Optional[NetworkProtocol] = None,
+    ) -> "Socket":
+        """Retrieves a socket connecting to a port in this container.
+
+        If no port is specified, the first exposed port is used. If none exist
+        an error is returned.
+
+        If a scheme is specified, a URL is returned. Otherwise, a host:port
+        pair is returned.
+
+        Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to
+        disable.
+
+        Parameters
+        ----------
+        port:
+            The port number for the socket to connect to
+        protocol:
+            The transport layer network protocol.
+        """
+        _args = [
+            Arg("port", port, None),
+            Arg("protocol", protocol, None),
+        ]
+        _ctx = self._select("socket", _args)
+        return Socket(_ctx)
 
     @typecheck
     async def stderr(self) -> str:
@@ -2610,6 +2677,38 @@ class Secret(Type):
 
 class Socket(Type):
     @typecheck
+    async def bind(
+        self,
+        address: str,
+        family: Optional[NetworkFamily] = None,
+    ) -> Void:
+        """Bind the socket to the host namespace at the specified address.
+
+        If family is IP, the address can be either an IPv4 or IPv6 address and
+        port.
+
+        If family is UNIX, the address is the path to the socket file.
+
+        Returns
+        -------
+        Void
+            Nothing. Used by SDK codegen to skip the return value.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args = [
+            Arg("address", address),
+            Arg("family", family, None),
+        ]
+        _ctx = self._select("bind", _args)
+        return await _ctx.execute(Void)
+
+    @typecheck
     async def id(self) -> SocketID:
         """The content-addressed identifier of the socket.
 
@@ -2642,7 +2741,9 @@ __all__ = [
     "Platform",
     "SecretID",
     "SocketID",
+    "Void",
     "CacheSharingMode",
+    "NetworkFamily",
     "NetworkProtocol",
     "BuildArg",
     "PipelineLabel",

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -884,6 +884,7 @@ class Container(Type):
         port: int,
         protocol: Optional[NetworkProtocol] = None,
         description: Optional[str] = None,
+        publish: Optional[int] = None,
     ) -> "Container":
         """Expose a network port.
 
@@ -902,11 +903,14 @@ class Container(Type):
             Transport layer network protocol
         description:
             Optional port description
+        publish:
+            Make this port reachable via the given port on the host
         """
         _args = [
             Arg("port", port),
             Arg("protocol", protocol, None),
             Arg("description", description, None),
+            Arg("publish", publish, None),
         ]
         _ctx = self._select("withExposedPort", _args)
         return Container(_ctx)


### PR DESCRIPTION
Adds the following API:

```graphql
extend type Container {
  withExposedPort(
    # ...
    "Make this port reachable via the given port on the host"
    publish: Int
  )
}
```

Whenever a service runs, either via `run` (#4723) or `withServiceBinding`, the Dagger session will listen on any published ports and forward traffic to the container via the shim.

Note that this is a distinct behavior of `run` as opposed to `exitCode`/`stdout`/`stderr`.