### PR TITLE
Use zstd compression for s3 cached layers.

### DIFF
--- a/engine/remotecache/s3.go
+++ b/engine/remotecache/s3.go
@@ -448,8 +448,7 @@ func (e *s3CacheExporter) Name() string {
 
 func (e *s3CacheExporter) Config() remotecache.Config {
 	return remotecache.Config{
-		// TODO: support for faster compression types like zstd
-		Compression: compression.New(compression.Default),
+		Compression: compression.New(compression.Zstd),
 	}
 }
 


### PR DESCRIPTION
From some brief testing this seemed to reduce the time to prepare layers for remote cache export, with one case previously taking 5 seconds now taking 1 second. This isn't surprising given zstd is generally considered faster than zlib (what underlies gzip, the previous default) in almost all cases.