### PR TITLE
docs: add origin as embed domain

### DIFF
--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -86,12 +86,14 @@ from = "/683293/private-repositories"
 to = "/710884/private-repositories"
 status = 302
 
+# redirect to the playground's embed to maintain same origin
+# see https://github.com/dagger/dagger/pull/4753
 [[redirects]]
   from = "/embed/*"
   to = "https://play.dagger.cloud/embed/:splat"
   status = 200
 
-
+# redirect to the playground's Next.js build artifacts
 [[redirects]]
   from = "/_next/*"
   to = "https://play.dagger.cloud/_next/:splat"

--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -91,6 +91,12 @@ status = 302
   to = "https://play.dagger.cloud/embed/:splat"
   status = 200
 
+
+[[redirects]]
+  from = "/_next/*"
+  to = "https://play.dagger.cloud/_next/:splat"
+  status = 200
+
 [[headers]]
   for = "/*"
   [headers.values]

--- a/website/src/components/atoms/embed.js
+++ b/website/src/components/atoms/embed.js
@@ -16,7 +16,7 @@ const Embed = ({id, index}) => {
         onLoad={() => setLoading(false)}
         style={{display: loading ? "hidden" : "inherit"}}
         loading={(index === 0 || !index) ? "eager" : "lazy"}
-        src={`https://play.dagger.cloud/embed/${id}`}></iframe>
+        src={`${window.location.origin}/embed/${id}`}></iframe>
     </div>
   );
 };

--- a/website/src/components/atoms/embed.js
+++ b/website/src/components/atoms/embed.js
@@ -1,23 +1,32 @@
 import styles from "../../css/atoms/embed.module.scss";
 import React, {useState} from "react";
+import BrowserOnly from "@docusaurus/BrowserOnly";
 
 const Embed = ({id, index}) => {
   const [loading, setLoading] = useState(true);
 
   return (
-    <div className={styles.embedWrapper} id="embedWrapper">
-      {loading && (
-        <div className={styles.spinnerWrapper}>
-          <div className={styles.spinner}></div>
+    <BrowserOnly>
+      {() => (
+        <div className={styles.embedWrapper} id="embedWrapper">
+          {loading && (
+            <div className={styles.spinnerWrapper}>
+              <div className={styles.spinner}></div>
+            </div>
+          )}
+          <iframe
+            className={styles.embed}
+            onLoad={() => setLoading(false)}
+            style={{display: loading ? "hidden" : "inherit"}}
+            loading={index === 0 || !index ? "eager" : "lazy"}
+            src={`${
+              window.location.origin.includes("localhost")
+                ? "https://play.dagger.cloud"
+                : window.location.origin
+            }/embed/${id}`}></iframe>
         </div>
       )}
-      <iframe
-        className={styles.embed}
-        onLoad={() => setLoading(false)}
-        style={{display: loading ? "hidden" : "inherit"}}
-        loading={(index === 0 || !index) ? "eager" : "lazy"}
-        src={`${window.location.origin}/embed/${id}`}></iframe>
-    </div>
+    </BrowserOnly>
   );
 };
 


### PR DESCRIPTION
This will add a redirect in the `netlify.toml` to circumvent [this issue](#4640) related to third party cookies in Chrome browsers.
This error appears because Chrome does not allow an `iframe` with different domain to read `localstorage`. Currently, the iframes in the doc point to `play.dagger.cloud`.
Basically, we are changing to `docs.dagger.io` as the source of the iframe, and setting a rule in the `netlify.toml` for the `/embed` path to redirect to the real  `play.dagger.cloud`. This way, we maintain the same origin and the Chrome issue is gone.