### PR TITLE
Prevent GC of content pending export.

### DIFF
--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -713,7 +713,11 @@ func newController(ctx context.Context, c *cli.Context, cfg *config.Config) (*co
 	}
 
 	cacheExporterFunc, cacheImporterFunc, remoteCacheDoneCh, err := daggerremotecache.StartDaggerCache(ctx,
-		sessionManager, w.ContentStore(), resolverFn)
+		sessionManager,
+		w.ContentStore(),
+		w.LeaseManager(),
+		resolverFn,
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/engine/remotecache/cache.go
+++ b/engine/remotecache/cache.go
@@ -7,6 +7,7 @@ import (
 
 	"dagger.io/dagger"
 	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/dagger/dagger/internal/engine"
 	"github.com/moby/buildkit/cache/remotecache"
@@ -20,7 +21,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func StartDaggerCache(ctx context.Context, sm *session.Manager, cs content.Store, hosts docker.RegistryHosts) (remotecache.ResolveCacheExporterFunc, remotecache.ResolveCacheImporterFunc, <-chan struct{}, error) {
+func StartDaggerCache(ctx context.Context, sm *session.Manager, cs content.Store, lm leases.Manager, hosts docker.RegistryHosts) (remotecache.ResolveCacheExporterFunc, remotecache.ResolveCacheImporterFunc, <-chan struct{}, error) {
 	cacheType, attrs, err := cacheConfigFromEnv()
 	if err != nil {
 		return nil, nil, nil, err
@@ -29,7 +30,7 @@ func StartDaggerCache(ctx context.Context, sm *session.Manager, cs content.Store
 	doneCh := make(chan struct{}, 1)
 	var s3Manager *s3CacheManager
 	if cacheType == experimentalDaggerS3CacheType {
-		s3Manager, err = newS3CacheManager(ctx, attrs, doneCh)
+		s3Manager, err = newS3CacheManager(ctx, attrs, lm, doneCh)
 		if err != nil {
 			return nil, nil, nil, err
 		}


### PR DESCRIPTION
Before this if an async cache export tried to push content that was GC'd by buildkit since the export was requested, then an error could occur. Now we get a lease on the content for that time to prevent GC from deleting it until we no longer need it.

---

Fixes https://github.com/dagger/dagger/issues/4748

Testing this was not straightforward. I only managed to reproduce it reliably by overriding the engine GC config to be `{All: true, KeepBytes: 1}` and also adding a `time.Sleep(30*time.Second)` to the beginning of an export. Otherwise it was hard to even hit this. I can't actually automate that in our integ tests, so for now there's just manual verification of the fix by me running with those temp changes and verifying it no longer reproduced with this PR.

I think in the longer run if we A) add a way of easily configuring the GC at runtime (it's actually not straightforward to override the config file of the engine even when custom provisioning it) and B) have a set of load tests that get executed separately from our main integ tests, we will have better coverage of this.