### PR TITLE
Collect more git labels, silence noisy log

### DIFF
--- a/core/pipeline/label.go
+++ b/core/pipeline/label.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/go-git/go-git/v5"
@@ -89,6 +90,13 @@ func loadGitLabels(workdir string) ([]Label, error) {
 		return nil, err
 	}
 
+	commit, err := repo.CommitObject(head.Hash())
+	if err != nil {
+		return nil, err
+	}
+
+	title, _, _ := strings.Cut(commit.Message, "\n")
+
 	return []Label{
 		{
 			Name:  "dagger.io/git.remote",
@@ -101,6 +109,26 @@ func loadGitLabels(workdir string) ([]Label, error) {
 		{
 			Name:  "dagger.io/git.ref",
 			Value: head.Hash().String(),
+		},
+		{
+			Name:  "dagger.io/git.author.name",
+			Value: commit.Author.Name,
+		},
+		{
+			Name:  "dagger.io/git.author.email",
+			Value: commit.Author.Email,
+		},
+		{
+			Name:  "dagger.io/git.committer.name",
+			Value: commit.Committer.Name,
+		},
+		{
+			Name:  "dagger.io/git.committer.email",
+			Value: commit.Committer.Email,
+		},
+		{
+			Name:  "dagger.io/git.title",
+			Value: title, // first line from commit message
 		},
 	}, nil
 }

--- a/core/pipeline/label.go
+++ b/core/pipeline/label.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -61,6 +62,10 @@ func loadGitLabels(workdir string) ([]Label, error) {
 		DetectDotGit: true,
 	})
 	if err != nil {
+		if errors.Is(err, git.ErrRepositoryNotExists) {
+			return nil, nil
+		}
+
 		return nil, err
 	}
 


### PR DESCRIPTION
Author/committer name and email are distinct labels, so in total there are four labels for author/committer:

* `dagger.io/git.author.name`
* `dagger.io/git.author.email`
* `dagger.io/git.committer.name`
* `dagger.io/git.committer.email`

Collects only the first line of the commit message, aka the "title" (verified that this name is accurate via [git docs](https://git-scm.com/docs/git-commit#_discussion)).

* `dagger.io/git.title`

Also silences the noisy default label collection log when not running in repo.