### PR TITLE
Add `github.com/repo.full_name`, `github.com/repo.url` labels

### DIFF
--- a/core/pipeline/label.go
+++ b/core/pipeline/label.go
@@ -140,18 +140,35 @@ func loadGitHubLabels() ([]Label, error) {
 
 		var action *string
 		var pr *github.PullRequest
+		var repoURL, repoFullName string
 		switch x := event.(type) {
 		case *github.PushEvent:
 			action = x.Action
+			repoURL = x.GetRepo().GetHTMLURL()
+			repoFullName = x.GetRepo().GetFullName()
 		case *github.PullRequestEvent:
 			action = x.Action
 			pr = x.GetPullRequest()
+			repoURL = x.GetRepo().GetHTMLURL()
+			repoFullName = x.GetRepo().GetFullName()
 		}
 
 		if action != nil {
 			labels = append(labels, Label{
 				Name:  "github.com/event.action",
 				Value: *action,
+			})
+		}
+
+		if repoURL != "" && repoFullName != "" {
+			labels = append(labels, Label{
+				Name:  "github.com/repo.full_name",
+				Value: repoFullName,
+			})
+
+			labels = append(labels, Label{
+				Name:  "github.com/repo.url",
+				Value: repoURL,
 			})
 		}
 


### PR DESCRIPTION
These are useful since `dagger.io/git.remote` is a simplified string, normalized from SSH and HTTPS-like origin URIs, not meant to be a clickable URL. So if we want to actually link to the repo associated to a run, we need to pass the repo URL along.