### PR TITLE
WIP: attempt to use a generic query builder

### DIFF
--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -208,11 +208,16 @@ func (r *Container) EnvVariable(ctx context.Context, name string) (string, error
 
 // Retrieves the list of environment variables passed to commands.
 func (r *Container) EnvVariables(ctx context.Context) ([]EnvVariable, error) {
-	q := r.q.Select("envVariables")
+	return query[[]EnvVariable](ctx, r.c, r.q, "envVariables")
+}
 
-	var response []EnvVariable
+func query[T any](ctx context.Context, c graphql.Client, q *querybuilder.Selection, name string) (T, error){
+	q = q.Select(name)
+
+	var response T
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.c)
+	return response, q.Execute(ctx, c)
+
 }
 
 // ContainerExecOpts contains options for Container.Exec
@@ -423,6 +428,7 @@ func (r *Container) Labels(ctx context.Context) ([]Label, error) {
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, r.c)
 }
+
 
 // Retrieves the list of paths where a directory is mounted.
 func (r *Container) Mounts(ctx context.Context) ([]string, error) {

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -208,12 +208,14 @@ func (r *Container) EnvVariable(ctx context.Context, name string) (string, error
 
 // Retrieves the list of environment variables passed to commands.
 func (r *Container) EnvVariables(ctx context.Context) ([]EnvVariable, error) {
-	return query[[]EnvVariable](ctx, r.c, r.q, "envVariables")
+	return query[[]EnvVariable, any](ctx, r.c, r.q, "envVariables")
 }
 
-func query[T any](ctx context.Context, c graphql.Client, q *querybuilder.Selection, name string) (T, error){
+func query[T, TOpts any](ctx context.Context, c graphql.Client, q *querybuilder.Selection, name string, opts ...TOpts) (T, error){
 	q = q.Select(name)
 
+	for i := 0; i < len(opts); i++ {
+	}
 	var response T
 	q = q.Bind(&response)
 	return response, q.Execute(ctx, c)


### PR DESCRIPTION
Following https://github.com/dagger/dagger/pull/4683 I had a clearer idea in my head to use some generics to help for the SDK query builder.

For now, it would reduced generated boilerplate. But I bet we could even fix the field subselection in the same kind of use.

Complete WIP for now as I lack time to work on it but didn't want to forget about it.