### PR TITLE
docs: fix guides rendering

### DIFF
--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -754,7 +754,7 @@ img[alt="github-contribute"] {
   height: 800px;
 }
 
-[class*=" docs-doc-id-current\/guides"] {
+[class~="docs-doc-id-current\/guides"] {
   .container {
     max-width: initial;
     width: 100%;


### PR DESCRIPTION
This will fix guides rendering, as right now the Table of Contents is being shifted to the bottom of the page because of flex properties.