### PR TITLE
Lower chance of failed cache export by increasing sdk waits.

### DIFF
--- a/sdk/go/internal/engineconn/session.go
+++ b/sdk/go/internal/engineconn/session.go
@@ -114,8 +114,9 @@ func startCLISession(ctx context.Context, binPath string, cfg *Config) (_ Engine
 		// chance to drain logs.
 		proc.Cancel = childStdin.Close
 
-		// Set a long timeout, just in case something get wedged.
-		proc.WaitDelay = 10 * time.Second
+		// Set a long timeout to give time for any cache exports to pack layers up
+		// which currently has to happen synchronously with the session.
+		proc.WaitDelay = 300 * time.Second // 5 mins
 
 		if err := proc.Start(); err != nil {
 			if strings.Contains(err.Error(), "text file busy") {

--- a/sdk/nodejs/provisioning/bin.ts
+++ b/sdk/nodejs/provisioning/bin.ts
@@ -203,7 +203,9 @@ export class Bin implements EngineConn {
   async Close(): Promise<void> {
     if (this.subProcess?.pid) {
       this.subProcess.kill("SIGTERM", {
-        forceKillAfterTimeout: 2000,
+        // Set a long timeout to give time for any cache exports to pack layers up
+        // which currently has to happen synchronously with the session.
+        forceKillAfterTimeout: 300000, // 5 mins
       })
     }
   }


### PR DESCRIPTION
Remote cache export currently still packs layers up synchronously. For particularly large number/size of layers, this can take quite a while (30s has been seen in relatively modest real world cases).

The problem is that this doesn't start until the session has begun to close (specifically, a result has been returned for the `Solve`) but if the client forcibly ends the session while it's happening it will fail (you will see context cancelled errors in the engine logs for the layer packing functions).

The Go and NodeJS SDKs had relatively small timeout settings for how long they would wait after sending SIGTERM/closing stdin before they would send SIGKILL, which meant that it was easy to cause cache exports to fail. The Python SDK however doesn't seem to have a timeout, it will just wait for the process to exit.

This change to simply increase that timeout to 5 minutes is not a great solution but it should hold us over for the actual solution of making the layer packing asynchronous to the client.

---

This change is also unfortunately hard to test in our current setup as it involves taking up tons of disk space (20GB+), which is not good for our current integ tests. We need a separate way of running load tests like this, but until then it's such a simple change that I think it's okay to verify manually.