### PR TITLE
docs: fix external link icons

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -114,7 +114,7 @@ module.exports = {
         "current/api/build-custom-client",
         {
           type: "link",
-          label: "Reference",
+          label: "Reference 🔗",
           href: "https://docs.dagger.io/api/reference",
         },
       ],

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -114,7 +114,7 @@ module.exports = {
         "current/api/build-custom-client",
         {
           type: "link",
-          label: "Reference 🔗",
+          label: "Reference",
           href: "https://docs.dagger.io/api/reference",
         },
       ],

--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -797,3 +797,7 @@ img[alt="github-contribute"] {
 .markdown > #embedWrapper {
   margin-bottom: 20px;
 }
+
+a.menu__link[target="_blank"]::after {
+  display: none;
+}


### PR DESCRIPTION
There's a current issue where the external links in the menu are not rendered correctly.
Docusaurus adds an SVG at the end of these links, but they have an absolute position. This makes the SVG appear at the top of the sidebar (after scrolling up), as it's shown here.

![image](https://user-images.githubusercontent.com/70334844/226065798-eb69e23f-99b5-4202-8a5e-701849e3fc92.png)

This PR also adds a chain icon next to the `Reference` link for the GraphQL reference for consistency with the remaining references.