### PR TITLE
fix: update loggers to not display actions already done

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -248,7 +248,7 @@ func handleSolveEvents(startOpts *Config, ch chan *bkclient.SolveStatus) error {
 					}
 				}
 
-				if isAlreadyLogged == true {
+				if isAlreadyLogged {
 					continue
 				}
 


### PR DESCRIPTION
If this PR is merged, logs will no longer be duplicated on multi-stage export:

Example of output with changes applied

```logs
#1 resolve image config for docker.io/library/alpine:latest
#1 DONE 2.0s

#1 resolve image config for docker.io/library/alpine:latest
#1 DONE 2.1s

#2 
#2 DONE 0.0s

#3 from alpine
#3 resolve docker.io/library/alpine:latest 0.1s done
#3 sha256:af6eaf76a39c2d3e7e0b8a0420486e3df33c4027d696c076a99a3d0ac09026af 0B / 3.26MB 0.2s
#3 sha256:af6eaf76a39c2d3e7e0b8a0420486e3df33c4027d696c076a99a3d0ac09026af 3.26MB / 3.26MB 0.4s done
#3 extracting sha256:af6eaf76a39c2d3e7e0b8a0420486e3df33c4027d696c076a99a3d0ac09026af 0.1s done
#3 DONE 0.6s

#2 
#2 0.070 LOOK AT MEEEEEEEEEEEEEE now:1679099876 arch:aarch64 pid:15
#2 DONE 0.1s

#4 exporting to image
#4 exporting layers
#4 exporting layers 0.2s done
#4 exporting manifest sha256:73961352988f4dfd3c1dbdd59dbaff8829e016e4290fbdea7363ce50ac189e20 done
#4 exporting config sha256:90c11215ccef69deb8f652229a30bef7fbfd505a12e071d59b72afaec8ce13fc done
#4 pushing layers
#4 pushing layers 2.4s done
#4 pushing manifest for docker.io/the0only0vasek/test:latest@sha256:73961352988f4dfd3c1dbdd59dbaff8829e016e4290fbdea7363ce50ac189e20
#4 pushing manifest for docker.io/the0only0vasek/test:latest@sha256:73961352988f4dfd3c1dbdd59dbaff8829e016e4290fbdea7363ce50ac189e20 0.4s done
#4 DONE 3.0s
```

Resolves: #4605