### PR TITLE
use common image version

### DIFF
--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -8,6 +8,7 @@ import (
 
 	"dagger.io/dagger"
 	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/internal/image"
 	"github.com/dagger/dagger/internal/testutil"
 	"github.com/moby/buildkit/identity"
 	"github.com/stretchr/testify/require"
@@ -225,7 +226,7 @@ func TestDirectoryWithDirectory(t *testing.T) {
 			WithNewFile("some-file", "some content", dagger.DirectoryWithNewFileOpts{Permissions: 0444}).
 			WithNewDirectory("some-dir", dagger.DirectoryWithNewDirectoryOpts{Permissions: 0444}).
 			WithNewFile("some-dir/sub-file", "sub-content", dagger.DirectoryWithNewFileOpts{Permissions: 0444})
-		ctr := c.Container().From("alpine").WithDirectory("/permissions-test", dir)
+		ctr := c.Container().From(image.Alpine).WithDirectory("/permissions-test", dir)
 
 		stdout, err := ctr.WithExec([]string{"ls", "-ld", "/permissions-test"}).Stdout(ctx)
 
@@ -371,7 +372,7 @@ func TestDirectoryWithFile(t *testing.T) {
 				"this should have rwxrwxrwx permissions",
 				dagger.DirectoryWithNewFileOpts{Permissions: 0777})
 
-		ctr := c.Container().From("alpine").WithDirectory("/permissions-test", dir)
+		ctr := c.Container().From(image.Alpine).WithDirectory("/permissions-test", dir)
 
 		stdout, err := ctr.WithExec([]string{"ls", "-l", "/permissions-test/file-with-permissions"}).Stdout(ctx)
 		require.NoError(t, err)
@@ -381,7 +382,7 @@ func TestDirectoryWithFile(t *testing.T) {
 			WithNewFile(
 				"file-with-permissions",
 				"this should have rw-r--r-- permissions")
-		ctr2 := c.Container().From("alpine").WithDirectory("/permissions-test", dir2)
+		ctr2 := c.Container().From(image.Alpine).WithDirectory("/permissions-test", dir2)
 		stdout2, err := ctr2.WithExec([]string{"ls", "-l", "/permissions-test/file-with-permissions"}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, stdout2, "rw-r--r--")
@@ -397,7 +398,7 @@ func TestDirectoryWithTimestamps(t *testing.T) {
 	reallyImportantTime := time.Date(1985, 10, 26, 8, 15, 0, 0, time.UTC)
 
 	dir := c.Container().
-		From("alpine:3.16.2").
+		From(image.Alpine).
 		WithExec([]string{"sh", "-c", `
 		  mkdir output
 			touch output/some-file
@@ -409,7 +410,7 @@ func TestDirectoryWithTimestamps(t *testing.T) {
 
 	t.Run("changes file and directory timestamps recursively", func(t *testing.T) {
 		ls, err := c.Container().
-			From("alpine:3.16.2").
+			From(image.Alpine).
 			WithMountedDirectory("/dir", dir).
 			WithEnvVariable("RANDOM", identity.NewID()).
 			WithExec([]string{"sh", "-c", "ls -al /dir && ls -al /dir/sub-dir"}).
@@ -422,7 +423,7 @@ func TestDirectoryWithTimestamps(t *testing.T) {
 
 	t.Run("results in stable tar archiving", func(t *testing.T) {
 		content, err := c.Container().
-			From("alpine:3.16.2").
+			From(image.Alpine).
 			WithMountedDirectory("/dir", dir).
 			WithEnvVariable("RANDOM", identity.NewID()).
 			// NB: there's a gotcha here: we need to tar * and not . because the
@@ -581,7 +582,7 @@ func TestDirectoryExport(t *testing.T) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	dir := c.Container().From("alpine:3.16.2").Directory("/etc/profile.d")
+	dir := c.Container().From(image.Alpine).Directory("/etc/profile.d")
 
 	t.Run("to absolute dir", func(t *testing.T) {
 		ok, err := dir.Export(ctx, dest)

--- a/core/integration/file_test.go
+++ b/core/integration/file_test.go
@@ -9,6 +9,7 @@ import (
 
 	"dagger.io/dagger"
 	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/internal/image"
 	"github.com/dagger/dagger/internal/testutil"
 	"github.com/moby/buildkit/identity"
 	"github.com/stretchr/testify/require"
@@ -120,7 +121,7 @@ func TestFileExport(t *testing.T) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	file := c.Container().From("alpine:3.16.2").File("/etc/alpine-release")
+	file := c.Container().From(image.Alpine).File("/etc/alpine-release")
 
 	t.Run("to absolute path", func(t *testing.T) {
 		dest := filepath.Join(targetDir, "some-file")
@@ -131,7 +132,7 @@ func TestFileExport(t *testing.T) {
 
 		contents, err := os.ReadFile(dest)
 		require.NoError(t, err)
-		require.Equal(t, "3.16.2\n", string(contents))
+		require.Equal(t, "3.17.2\n", string(contents))
 
 		entries, err := ls(targetDir)
 		require.NoError(t, err)
@@ -145,7 +146,7 @@ func TestFileExport(t *testing.T) {
 
 		contents, err := os.ReadFile(filepath.Join(wd, "some-file"))
 		require.NoError(t, err)
-		require.Equal(t, "3.16.2\n", string(contents))
+		require.Equal(t, "3.17.2\n", string(contents))
 
 		entries, err := ls(wd)
 		require.NoError(t, err)
@@ -183,7 +184,7 @@ func TestFileWithTimestamps(t *testing.T) {
 		WithTimestamps(int(reallyImportantTime.Unix()))
 
 	ls, err := c.Container().
-		From("alpine:3.16.2").
+		From(image.Alpine).
 		WithMountedFile("/file", file).
 		WithEnvVariable("RANDOM", identity.NewID()).
 		WithExec([]string{"stat", "/file"}).

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -12,6 +12,7 @@ import (
 
 	"dagger.io/dagger"
 	"github.com/dagger/dagger/internal/engine"
+	"github.com/dagger/dagger/internal/image"
 	"github.com/dagger/dagger/internal/testutil"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
@@ -71,7 +72,7 @@ func TestGitSSHAuthSock(t *testing.T) {
 	defer c.Close()
 
 	gitSSH := c.Container().
-		From("alpine:3.16.2").
+		From(image.Alpine).
 		WithExec([]string{"apk", "add", "git", "openssh"})
 
 	hostKeyGen := gitSSH.

--- a/core/integration/host_test.go
+++ b/core/integration/host_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"dagger.io/dagger"
+	"github.com/dagger/dagger/internal/image"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,7 +25,7 @@ func TestHostWorkdir(t *testing.T) {
 
 	t.Run("contains the workdir's content", func(t *testing.T) {
 		contents, err := c.Container().
-			From("alpine:3.16.2").
+			From(image.Alpine).
 			WithMountedDirectory("/host", c.Host().Directory(".")).
 			WithExec([]string{"ls", "/host"}).
 			Stdout(ctx)
@@ -37,7 +38,7 @@ func TestHostWorkdir(t *testing.T) {
 		require.NoError(t, err)
 
 		contents, err := c.Container().
-			From("alpine:3.16.2").
+			From(image.Alpine).
 			WithMountedDirectory("/host", c.Host().Directory(".")).
 			WithExec([]string{"ls", "/host"}).
 			Stdout(ctx)
@@ -67,7 +68,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 		})
 
 		contents, err := c.Container().
-			From("alpine:3.16.2").
+			From(image.Alpine).
 			WithMountedDirectory("/host", wd).
 			WithExec([]string{"ls", "/host"}).
 			Stdout(ctx)
@@ -81,7 +82,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 		})
 
 		contents, err := c.Container().
-			From("alpine:3.16.2").
+			From(image.Alpine).
 			WithMountedDirectory("/host", wd).
 			WithExec([]string{"ls", "/host"}).
 			Stdout(ctx)
@@ -95,7 +96,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 		})
 
 		contents, err := c.Container().
-			From("alpine:3.16.2").
+			From(image.Alpine).
 			WithMountedDirectory("/host", wd).
 			WithExec([]string{"ls", "/host"}).
 			Stdout(ctx)
@@ -110,7 +111,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 		})
 
 		contents, err := c.Container().
-			From("alpine:3.16.2").
+			From(image.Alpine).
 			WithMountedDirectory("/host", wd).
 			WithExec([]string{"ls", "/host"}).
 			Stdout(ctx)
@@ -125,7 +126,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 		})
 
 		contents, err := c.Container().
-			From("alpine:3.16.2").
+			From(image.Alpine).
 			WithMountedDirectory("/host", wd).
 			WithExec([]string{"ls", "/host"}).
 			Stdout(ctx)
@@ -253,7 +254,7 @@ func TestHostVariable(t *testing.T) {
 	require.Equal(t, "hello", varValue)
 
 	env, err := c.Container().
-		From("alpine:3.16.2").
+		From(image.Alpine).
 		WithSecretVariable("SECRET", secret.Secret()).
 		WithExec([]string{"env"}).
 		Stdout(ctx)

--- a/core/integration/pipeline_test.go
+++ b/core/integration/pipeline_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"dagger.io/dagger"
+	"github.com/dagger/dagger/internal/image"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,7 +48,7 @@ func TestPipeline(t *testing.T) {
 		_, err = c.
 			Container().
 			Pipeline("container pipeline").
-			From("alpine:3.16.2").
+			From(image.Alpine).
 			WithExec([]string{"echo", cacheBuster}).
 			ExitCode(ctx)
 

--- a/core/integration/platform_test.go
+++ b/core/integration/platform_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"dagger.io/dagger"
+	"github.com/dagger/dagger/internal/image"
 	"github.com/moby/buildkit/identity"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -36,7 +37,7 @@ func TestPlatformEmulatedExecAndPush(t *testing.T) {
 	variants := make([]*dagger.Container, 0, len(platformToUname))
 	for platform, uname := range platformToUname {
 		ctr := c.Container(dagger.ContainerOpts{Platform: platform}).
-			From("alpine:3.16.2").
+			From(image.Alpine).
 			WithExec([]string{"uname", "-m"})
 		variants = append(variants, ctr)
 
@@ -134,7 +135,7 @@ func TestPlatformCrossCompile(t *testing.T) {
 	require.NoError(t, err)
 
 	// pull the images, mount them all into a container and ensure the binaries are the right platform
-	ctr := c.Container().From("alpine:3.16").WithExec([]string{"apk", "add", "file"})
+	ctr := c.Container().From(image.Alpine).WithExec([]string{"apk", "add", "file"})
 
 	cmds := make([]string, 0, len(platformToFileArch))
 	for platform, uname := range platformToFileArch {
@@ -171,7 +172,7 @@ func TestPlatformCacheMounts(t *testing.T) {
 	cmds := make([]string, 0, len(platformToUname))
 	for platform := range platformToUname {
 		exit, err := c.Container(dagger.ContainerOpts{Platform: platform}).
-			From("alpine:3.16").
+			From(image.Alpine).
 			WithMountedCache("/cache", cache).
 			WithExec([]string{"sh", "-x", "-c", strings.Join([]string{
 				"mkdir -p /cache/" + randomID + string(platform),
@@ -184,7 +185,7 @@ func TestPlatformCacheMounts(t *testing.T) {
 	}
 
 	exit, err := c.Container().
-		From("alpine:3.16").
+		From(image.Alpine).
 		WithMountedCache("/cache", cache).
 		WithExec([]string{"sh", "-x", "-c", strings.Join(cmds, " && ")}).
 		ExitCode(ctx)

--- a/core/integration/remotecache_test.go
+++ b/core/integration/remotecache_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"dagger.io/dagger"
+	"github.com/dagger/dagger/internal/image"
 	"github.com/moby/buildkit/identity"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -30,7 +31,7 @@ func TestRemoteCacheRegistry(t *testing.T) {
 	}
 
 	pipelineOutput := func(c *dagger.Client) string {
-		output, err := c.Container().From("alpine:3.17").WithExec([]string{
+		output, err := c.Container().From(image.Alpine).WithExec([]string{
 			"sh", "-c", "head -c 128 /dev/random | sha256sum",
 		}).Stdout(ctx)
 		require.NoError(t, err)
@@ -67,7 +68,7 @@ func TestRemoteCacheS3(t *testing.T) {
 		}
 
 		pipelineOutput := func(c *dagger.Client) string {
-			output, err := c.Container().From("alpine:3.17").WithExec([]string{
+			output, err := c.Container().From(image.Alpine).WithExec([]string{
 				"sh", "-c", "head -c 128 /dev/random | sha256sum",
 			}).Stdout(ctx)
 			require.NoError(t, err)
@@ -105,7 +106,7 @@ func TestRemoteCacheS3(t *testing.T) {
 
 		pipelineOutput := func(c *dagger.Client, id string) string {
 			output, err := c.Container().
-				From("alpine:3.17").
+				From(image.Alpine).
 				WithEnvVariable("ID", id).
 				WithExec([]string{
 					"sh", "-c", "head -c 128 /dev/random | sha256sum",
@@ -160,7 +161,7 @@ func TestRemoteCacheS3(t *testing.T) {
 
 		pipelineOutput := func(c *dagger.Client, id string) string {
 			output, err := c.Container().
-				From("alpine:3.17").
+				From(image.Alpine).
 				WithMountedCache("/cache", c.CacheVolume("test-cache-mount")).
 				WithExec([]string{
 					"sh", "-c", "if [ ! -f /cache/test.txt ]; then echo '" + id + "' > /cache/test.txt; fi; cat /cache/test.txt",

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -1,0 +1,9 @@
+package image
+
+const (
+	GoAlpine     = "golang:1.20.2-alpine3.17"
+	GoAlpineHash = "golang@sha256-405962195c7fd525604cb74ab86cb7c88fcfc30af0e31a5b3c0636a7c4e9e567"
+
+	Alpine     = "alpine:3.17.2"
+	AlpineHash = "alpine@sha256-e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e177002501"
+)

--- a/internal/mage/util/util.go
+++ b/internal/mage/util/util.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 
 	"dagger.io/dagger"
+	"github.com/dagger/dagger/internal/image"
 )
 
 const (
@@ -96,7 +97,7 @@ func goBase(c *dagger.Client) *dagger.Container {
 	}
 
 	return c.Container().
-		From("golang:1.20.0-alpine").
+		From(image.GoAlpine).
 		// gcc is needed to run go test -race https://github.com/golang/go/issues/9918 (???)
 		Exec(dagger.ContainerExecOpts{Args: []string{"apk", "add", "build-base"}}).
 		WithEnvVariable("CGO_ENABLED", "0").

--- a/project/goruntime.go
+++ b/project/goruntime.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/pipeline"
+	"github.com/dagger/dagger/internal/image"
 	"github.com/moby/buildkit/client/llb"
 	bkgw "github.com/moby/buildkit/frontend/gateway/client"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -44,7 +45,7 @@ func (p *State) goRuntime(ctx context.Context, subpath string, gw bkgw.Client, p
 }
 
 func goBase(gw bkgw.Client) llb.State {
-	return llb.Image("golang:1.20.0-alpine", llb.WithMetaResolver(gw)).
+	return llb.Image(image.GoAlpine, llb.WithMetaResolver(gw)).
 		Run(llb.Shlex(`apk add --no-cache file git openssh-client`)).Root()
 }
 

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/dagger/dagger/internal/image"
 	"github.com/stretchr/testify/require"
 )
 
@@ -69,7 +70,7 @@ func TestContainer(t *testing.T) {
 
 	alpine := c.
 		Container().
-		From("alpine:3.16.2")
+		From(image.Alpine)
 
 	contents, err := alpine.
 		FS().
@@ -108,7 +109,7 @@ func TestConnectOption(t *testing.T) {
 
 	_, err = c.
 		Container().
-		From("alpine:3.16.1").
+		From(image.Alpine).
 		FS().
 		File("/etc/alpine-release").
 		Contents(ctx)

--- a/sdk/go/examples_test.go
+++ b/sdk/go/examples_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"dagger.io/dagger"
+	"github.com/dagger/dagger/internal/image"
 )
 
 func ExampleContainer() {
@@ -18,7 +19,7 @@ func ExampleContainer() {
 	}
 	defer client.Close()
 
-	alpine := client.Container().From("alpine:3.16.2")
+	alpine := client.Container().From(image.Alpine)
 
 	out, err := alpine.Exec(dagger.ContainerExecOpts{
 		Args: []string{"cat", "/etc/alpine-release"},
@@ -88,7 +89,7 @@ func ExampleContainer_WithEnvVariable() {
 	}
 	defer client.Close()
 
-	container := client.Container().From("alpine:3.16.2")
+	container := client.Container().From(image.Alpine)
 
 	container = container.WithEnvVariable("FOO", "bar")
 
@@ -116,7 +117,7 @@ func ExampleContainer_WithMountedDirectory() {
 		WithNewFile("hello.txt", "Hello, world!").
 		WithNewFile("goodbye.txt", "Goodbye, world!")
 
-	container := client.Container().From("alpine:3.16.2")
+	container := client.Container().From(image.Alpine)
 
 	container = container.WithMountedDirectory("/mnt", dir)
 
@@ -144,7 +145,7 @@ func ExampleContainer_WithMountedCache() {
 
 	cache := client.CacheVolume(cacheKey)
 
-	container := client.Container().From("alpine:3.16.2")
+	container := client.Container().From(image.Alpine)
 
 	container = container.WithMountedCache("/cache", cache)
 


### PR DESCRIPTION
To avoid using/pulling too many version of some images, I suggest we use a common definition that we can update in one place. It would avoid pulling different images version when running test and reduce test time.

## Limits

A bunch of images are part of documentation snippets, they are not run during test (I think), so they don't affect the test duration. We couldn't use our common definition as it would render them less copy-pastable.
But it would be good to have some automated script to update them all at the same time as well.
I guess, some script in the CI to check for that?