### PR TITLE
docs: remove default tags pages

### DIFF
--- a/website/src/theme/DocTagDocListPage/index.js
+++ b/website/src/theme/DocTagDocListPage/index.js
@@ -1,0 +1,6 @@
+import React from "react";
+import NotFound from "@theme/NotFound";
+
+export default function DocTagDocListPage({tag}) {
+  return <NotFound></NotFound>;
+}

--- a/website/src/theme/DocTagsListPage/index.js
+++ b/website/src/theme/DocTagsListPage/index.js
@@ -1,0 +1,5 @@
+import React from "react";
+import NotFound from "@theme/NotFound";
+export default function DocTagsListPage({tags}) {
+  return <NotFound></NotFound>;
+}


### PR DESCRIPTION
With this PR, visiting the `docs.dagger.io/tags` & `docs.dagger.io/tags/{tag}` pages, will return the 404 Not Found default page, behaving the same as with other not found resources.

Closes #4761 