### PR TITLE
docs: search guides by content instead of tags

### DIFF
--- a/website/plugins/docusaurus-plugin-guides/index.js
+++ b/website/plugins/docusaurus-plugin-guides/index.js
@@ -38,10 +38,7 @@ module.exports = async function guidesPlugin(context, options) {
       guides.sort((a, b) => {
         return b.timestamp - a.timestamp;
       })
-      let allTags = new Set();
-      guides.forEach((guide) => guide.frontMatter.tags.forEach(tag => allTags.add(tag)));
-      allTags = [...allTags]
-      fs.writeFileSync(guidesJSONPath, JSON.stringify({guides, allTags}));
+      fs.writeFileSync(guidesJSONPath, JSON.stringify({guides}));
     },
   };
 };

--- a/website/src/components/atoms/tag.js
+++ b/website/src/components/atoms/tag.js
@@ -3,7 +3,7 @@ import styles from "@site/src/css/molecules/tag.module.scss";
 
 export default function Tag({label, onTagClick, onCloseClick, removable}) {
   return (
-    <div onClick={onTagClick} className={styles.tag} style={{cursor: removable ? "initial" : "pointer"}}>
+    <div onClick={onTagClick} className={styles.tag}>
       <span>{label}</span>
       {removable && (
         <div className={styles.close} onClick={onCloseClick}>

--- a/website/src/components/molecules/guideIndex.js
+++ b/website/src/components/molecules/guideIndex.js
@@ -1,81 +1,35 @@
-import React, {useEffect, useState} from "react";
+import React, { useEffect } from "react";
 import Link from "@docusaurus/Link";
 import styles from "@site/src/css/molecules/guideIndex.module.scss";
 import guidesJSON from "@site/static/guides.json";
 import Tag from "../atoms/tag";
+import { DocSearch } from '@docsearch/react';
 
 export default function GuidesIndex() {
   const guides = guidesJSON.guides;
-  const allTags = guidesJSON.allTags;
-  const [filteredGuides, setFilteredGuides] = useState(guides);
-  const [selectedTags, setSelectedTags] = useState([]);
 
+  const ref = React.useRef(null); 
   useEffect(() => {
-    if (selectedTags.length > 0) {
-      setFilteredGuides(
-        guides.filter((item) =>
-          selectedTags.every((tag) => item.frontMatter.tags.includes(tag)),
-        ),
-      );
-    } else {
-      setFilteredGuides(guides);
-    }
-  }, [selectedTags]);
-
-  useEffect(() => {
-    const tagURLParams = new URL(document.location).searchParams.getAll("tags");
-    tagURLParams && setSelectedTags([...tagURLParams]);
-  }, []);
-
-  const pushTag = (tag) => {
-    if (!selectedTags.some((x) => x === tag)) {
-      if ("URLSearchParams" in window) {
-        var searchParams = new URLSearchParams(window.location.search);
-        searchParams.append("tags", tag);
-        var newRelativePathQuery =
-          window.location.pathname + "?" + searchParams.toString();
-        history.pushState(null, "", newRelativePathQuery);
-      }
-      setSelectedTags([...selectedTags, tag]);
-    }
-  };
-
-  const popTag = (tag) => {
-    if ("URLSearchParams" in window) {
-      var searchParams = new URLSearchParams(window.location.search);
-      const path = window.location.pathname;
-      let allSearchParams = searchParams.getAll("tags");
-      if (allSearchParams.length === 1) {
-        searchParams.delete("tags");
-        let newRelativePathQuery = path;
-        history.pushState(null, "", newRelativePathQuery);
-      } else {
-        searchParams.delete("tags");
-        allSearchParams.forEach((x) =>
-          x != tag ? searchParams.append("tags", x) : null,
-        );
-        let newRelativePathQuery = path + "?" + searchParams.toString();
-        history.pushState(null, "", newRelativePathQuery);
-      }
-    }
-    setSelectedTags(selectedTags.filter((x) => x != tag));
-  };
-
+    console.log(ref.current)
+  }, [ref])
   return (
     <div className={styles.guideIndex}>
-      {/* <div className={styles.selectedTags}>
-        {selectedTags.map((x, i) => (
-          <Tag key={i} label={x} onCloseClick={() => popTag(x)} removable></Tag>
-        ))}
-      </div> */}
-      <GuideFilter
-        allTags={allTags}
-        selectedTags={selectedTags}
-        onCloseClick={popTag}
-        pushTag={pushTag}
-      />
+      <div className={styles.search}>
+        <label>
+          This searchbar is guide focused. Here you can search all the guides by content.
+        </label>
+        <DocSearch
+          forwardRef={ref}
+          apiKey="bffda1490c07dcce81a26a144115cc02"
+          appId="XEIYPBWGOI"
+          indexName="dagger"
+          placeholder="Search in all guides"
+          searchParameters={{ facetFilters: ["guide:true"] }}
+        ></DocSearch>
+      </div>
+      <div>
       <ul>
-        {filteredGuides.map((x, i) => (
+        {guides.map((x, i) => (
           <li key={i}>
             <GuideCard
               title={x.contentTitle}
@@ -83,16 +37,16 @@ export default function GuidesIndex() {
               tags={x.frontMatter.tags}
               authors={x.frontMatter.authors}
               timestamp={x.timestamp}
-              pushTag={pushTag}
             />
           </li>
         ))}
       </ul>
+      </div>
     </div>
   );
 }
 
-function GuideCard({title, url, tags, authors, timestamp, pushTag}) {
+function GuideCard({title, url, tags, authors, timestamp}) {
   const handleAuthors = () => {
     let authorsString = "";
     authors.forEach((x) => (authorsString += `, ${x}`));
@@ -114,72 +68,9 @@ function GuideCard({title, url, tags, authors, timestamp, pushTag}) {
       <div className={styles.tags}>
         {tags &&
           tags.map((x, i) => (
-            <Tag onTagClick={() => pushTag(x)} key={i} label={x} />
+            <Tag key={i} label={x} />
           ))}
       </div>
-    </div>
-  );
-}
-
-function GuideFilter({allTags, selectedTags, onCloseClick, pushTag}) {
-  const [filtering, setFiltering] = useState(false);
-  const [filteredTags, setFilteredTags] = useState(allTags);
-  const [query, setQuery] = useState("");
-
-  const handleChange = (e) => {
-    let newQuery = e.target.value.toLowerCase();
-    const results = allTags.filter((tag) => {
-      if (newQuery === "") return allTags;
-      return tag.toLowerCase().includes(e.target.value.toLowerCase());
-    });
-    setQuery(newQuery);
-    setFilteredTags(results);
-  };
-
-  const handlePushTag = (x) => {
-    pushTag(x)
-    setQuery("");
-    setFilteredTags(allTags);
-  };
-
-  return (
-    <div
-      className={styles.filterWrapper}
-      onMouseLeave={() => setFiltering(false)}>
-      <div className={styles.filter}>
-        <div className={styles.filterTags}>
-          {selectedTags.map((x, i) => (
-            <Tag
-              key={i}
-              label={x}
-              removable
-              onCloseClick={() => onCloseClick(x)}
-            />
-          ))}
-        </div>
-        <input
-          onClick={() => setFiltering(true)}
-          className={styles.filterInput}
-          placeholder="Filter guides by tag"
-          type="search"
-          value={query}
-          onChange={handleChange}></input>
-      </div>
-      {filtering && (
-        <div className={styles.filterDropdown}>
-          <ul>
-            {filteredTags.map((x, i) => (
-              <li
-                key={i}
-                onClick={() => {
-                  handlePushTag(x);
-                }}>
-                {x}
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
     </div>
   );
 }

--- a/website/src/components/molecules/guideIndex.js
+++ b/website/src/components/molecules/guideIndex.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import Link from "@docusaurus/Link";
 import styles from "@site/src/css/molecules/guideIndex.module.scss";
 import guidesJSON from "@site/static/guides.json";
@@ -8,10 +8,6 @@ import { DocSearch } from '@docsearch/react';
 export default function GuidesIndex() {
   const guides = guidesJSON.guides;
 
-  const ref = React.useRef(null); 
-  useEffect(() => {
-    console.log(ref.current)
-  }, [ref])
   return (
     <div className={styles.guideIndex}>
       <div className={styles.search}>
@@ -19,7 +15,6 @@ export default function GuidesIndex() {
           This searchbar is guide focused. Here you can search all the guides by content.
         </label>
         <DocSearch
-          forwardRef={ref}
           apiKey="bffda1490c07dcce81a26a144115cc02"
           appId="XEIYPBWGOI"
           indexName="dagger"

--- a/website/src/css/molecules/guideIndex.module.scss
+++ b/website/src/css/molecules/guideIndex.module.scss
@@ -28,95 +28,22 @@
   }
 }
 
-.selectedTags {
-  height: 50px;
-  display: flex;
-  gap: 5px;
-  flex-grow: inherit;
-  align-items: flex-start;
-}
-
-.filterWrapper {
+.search {
   position: relative;
-  margin-bottom: 1.5rem;
-  border: 1px solid var(--ifm-color-primary-darker);
-  min-width: 300px;
-  max-width: 600px;
-  width: 80%;
-    html[data-theme="dark"] & {
-    border: 1px solid var(--ifm-color-primary-light);
-  }
-}
+  margin: 20px 0px;
+  justify-content: start;
+  justify-content: flex-start;
 
-.filter {
-  display: flex;
-  flex-wrap: wrap;
-  padding: 1rem 1rem;
-  min-height: 50px;
-  gap: 10px;
-}
+  button {
+    position: relative;
+    left: 0;
+    top: 0;
+    margin: 20px 0px;
+    height: 3rem;
+    width: 100%;
 
-.filterTags {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 5px;
-}
-
-.filterInput {
-  border: none;
-
-  &:focus,
-  &:focus-visible {
-    outline: none;
-  }
-
-  html[data-theme="dark"] & {
-    color: var(--ifm-color-primary-light);
-    background: transparent;
-  }
-}
-
-.filterDropdown {
-  position: absolute;
-  left: -1px;
-  right: -1px;
-  border: 1px solid var(--ifm-color-primary-darker);
-  background-color: white;
-  max-height: 200px;
-  overflow-y: scroll;
-
-  html[data-theme="dark"] & {
-    border: 1px solid var(--ifm-color-primary-light);
-  }
-
-  ul {
-    padding: 0px;
-    margin: 0px;
-    gap: 0;
-  }
-
-  li {
-    font-size: 0.8rem;
-    margin: 0px;
-    padding: 0.5rem 0.5rem;
-    min-width: initial;
-    cursor: pointer;
-  }
-
-  li:last-of-type {
-    border-bottom: none;
-  }
-
-  li:hover {
-    background-color: lightgray;
-  }
-
-  html[data-theme="dark"] & {
-    color: var(--ifm-color-primary-light);
-    background: var(--ifm-color-primary-dark);
-    li:hover {
-      background-color: rgba(211, 211, 211, 0.118);
+    [class="DocSearch-Button-Keys"] {
+      display: none !important;
     }
   }
 }


### PR DESCRIPTION
This will replace the guides filter by tag for a content based search.

This makes it easier for the user to find what it's looking for, improving UX.

@vikram-dagger from the presentation side, I don't see a clash between the docs search and the guides search. 
The only downside of having two searchbars in the same page, is that CTRL+K may have an odd behavior. 
I don't think it's a blocker though, we can merge this IMO. I'll follow up with a fix for that.

Closes #4701 