### PR TITLE
dnsmasq: use AppArmor-compatible resolv.conf path

### DIFF
--- a/cmd/dnsname/config.go
+++ b/cmd/dnsname/config.go
@@ -30,7 +30,7 @@ bind-dynamic
 no-hosts
 interface={{.NetworkInterface}}
 addn-hosts={{.AddOnHostsFile}}
-resolv-file=/etc/resolv.conf.upstream
+resolv-file=/etc/dnsmasq-resolv.conf
 `
 
 var (

--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -60,8 +60,8 @@ fi
 
 if [ "$` + servicesDNSEnvName + `" != "0" ]; then
 	# relocate resolv.conf mount
-	touch /etc/resolv.conf.upstream
-	mount --bind /etc/resolv.conf /etc/resolv.conf.upstream
+	touch /etc/dnsmasq-resolv.conf
+	mount --bind /etc/resolv.conf /etc/dnsmasq-resolv.conf
 	umount /etc/resolv.conf
 
 	# add dnsmasq to resolver so buildkit can reach local services
@@ -69,8 +69,8 @@ if [ "$` + servicesDNSEnvName + `" != "0" ]; then
 	echo 'nameserver {{.Bridge}}' >> /etc/resolv.conf
 
 	# preserve DNS search/options config, but let dnsmasq delegate to
-	# /etc/resolv.conf.upstream for upstream nameservers
-	grep -v '^nameserver' /etc/resolv.conf.upstream || true >> /etc/resolv.conf
+	# /etc/dnsmasq-resolv.conf for upstream nameservers
+	grep -v '^nameserver' /etc/dnsmasq-resolv.conf || true >> /etc/resolv.conf
 fi
 
 exec {{.EngineBin}} --config {{.EngineConfig}} "$@"


### PR DESCRIPTION
AppArmor enforces that any executions of `/usr/sbin/dnsmasq`, regardless of namespace, can only read from a [handful of allowed paths](https://gitlab.com/apparmor/apparmor/-/blob/master/profiles/apparmor.d/usr.sbin.dnsmasq#L41-52). We could just rename the `dnsmasq` binary, but this filename is just as good as any, and I guess we'll get added AppArmor security for free.