### PR TITLE
collect `github.com/workflow.url` label

### DIFF
--- a/cmd/engine/operatorClient.go
+++ b/cmd/engine/operatorClient.go
@@ -85,7 +85,7 @@ func NewOperatorClient(ctx context.Context, c *bkclient.Client) (_ *dagger.Clien
 	go func() {
 		defer close(doneCh)
 		_, err = c.Build(solveCtx, solveOpts, "", func(ctx context.Context, gw bkgw.Client) (*bkgw.Result, error) {
-			go pipeline.LoadRootLabels(".")
+			go pipeline.LoadRootLabels(ctx, ".")
 			router := router.New(sessionToken.String())
 			secretStore.SetGateway(gw)
 			gwClient := core.NewGatewayClient(gw)

--- a/core/pipeline/label.go
+++ b/core/pipeline/label.go
@@ -259,6 +259,10 @@ func getGitHubJob(ctx context.Context, client *github.Client) (*github.WorkflowJ
 
 	jobs, err := allPages(func(github.ListOptions) ([]*github.WorkflowJob, *github.Response, error) {
 		res, resp, err := client.Actions.ListWorkflowJobs(ctx, owner, repo, int64(workflowID), nil)
+		if err != nil {
+			return nil, nil, err
+		}
+
 		return res.Jobs, resp, err
 	})
 	if err != nil {

--- a/core/pipeline/label.go
+++ b/core/pipeline/label.go
@@ -18,7 +18,13 @@ var (
 	loadOnce      sync.Once
 	loadDoneCh    = make(chan struct{})
 	defaultLabels []Label
+
+	log = logrus.New()
 )
+
+func init() {
+	log.SetOutput(os.Stderr)
+}
 
 type Label struct {
 	Name  string `json:"name"`
@@ -48,13 +54,13 @@ func loadRootLabels(ctx context.Context, workdir string) []Label {
 	if gitLabels, err := loadGitLabels(workdir); err == nil {
 		labels = append(labels, gitLabels...)
 	} else {
-		logrus.Warnf("failed to collect git labels: %s", err)
+		log.Warnf("failed to collect git labels: %s", err)
 	}
 
 	if githubLabels, err := loadGitHubLabels(ctx); err == nil {
 		labels = append(labels, githubLabels...)
 	} else {
-		logrus.Warnf("failed to collect GitHub labels: %s", err)
+		log.Warnf("failed to collect GitHub labels: %s", err)
 	}
 
 	return labels
@@ -165,7 +171,7 @@ func loadGitHubLabels(ctx context.Context) ([]Label, error) {
 
 	job, err := getGitHubJob(ctx, client)
 	if err != nil {
-		logrus.Warnf("failed to determine current job: %s", err)
+		log.Warnf("failed to determine current job: %s", err)
 	} else {
 		labels = append(labels, Label{
 			Name:  "github.com/workflow.url",

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -81,7 +81,7 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 	}
 
 	// Load default labels asynchronously in the background.
-	go pipeline.LoadRootLabels(startOpts.Workdir)
+	go pipeline.LoadRootLabels(ctx, startOpts.Workdir)
 
 	_, err = os.Stat(startOpts.ConfigPath)
 	switch {


### PR DESCRIPTION
This one's pretty annoying: the currently running job ID isn't exposed to Actions (https://github.com/orgs/community/discussions/8945), so we have to deduce it via the API.