### PR TITLE
engine: Use MergeOp to optimize size of CombinedResult.

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -192,7 +192,7 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 
 			// Return a result that contains every reference that was solved in this session.
 			// If cache export is enabled server-side, all these references will be exported.
-			return gwClient.CombinedResult(), nil
+			return gwClient.CombinedResult(ctx)
 		}, solveCh)
 		return err
 	})


### PR DESCRIPTION
Before this, a session with a particularly enormous number of refs being solved could create a CombinedResult that would be greater than the grpc default message size of 16MB. This would cause builds to fail at the very end while trying to return the result to buildkit.

This was in part due to the fact that by just combining every individual ref from each vertex of the dag we were duplicating a ton of LLB.

The new approach instead uses MergeOp to combine all the solved refs together. A MergeOp result will be a cache hit for any individual input to it, so it serves the same purpose as before. But now when we call Marshal on the MergeOp the builtin deduplication of LLB kicks in which greatly reduces the size of what we are trying to send to Buildkit and thus makes it much harder to hit the size limitation.