### PR TITLE
docs: change python variable names in snippets for service container guide 

### DIFF
--- a/docs/current/guides/snippets/use-services/bind-services-1/main.py
+++ b/docs/current/guides/snippets/use-services/bind-services-1/main.py
@@ -8,7 +8,7 @@ async def main():
     # create Dagger client
     async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
         # create HTTP service container with exposed port 8080
-        http_srv = (
+        httpSrv = (
             client.container()
             .from_("python")
             .with_directory(
@@ -25,7 +25,7 @@ async def main():
         val = await (
             client.container()
             .from_("alpine")
-            .with_service_binding("www", http_srv)
+            .with_service_binding("www", httpSrv)
             .with_exec(["wget", "-O-", "http://www:8080"])
             .stdout()
         )

--- a/docs/current/guides/snippets/use-services/bind-services-2/main.py
+++ b/docs/current/guides/snippets/use-services/bind-services-2/main.py
@@ -8,7 +8,7 @@ async def main():
     # create Dagger client
     async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
         # create HTTP service container with exposed port 8080
-        http_srv = (
+        httpSrv = (
             client.container()
             .from_("python")
             .with_directory(
@@ -25,7 +25,7 @@ async def main():
         val = await (
             client.container()
             .from_("alpine")
-            .with_service_binding("www", http_srv)
+            .with_service_binding("www", httpSrv)
             .with_exec(["wget", "http://www:8080"])
             .file("index.html")
             .contents()

--- a/docs/current/guides/snippets/use-services/expose-ports/main.py
+++ b/docs/current/guides/snippets/use-services/expose-ports/main.py
@@ -8,7 +8,7 @@ async def main():
     # create Dagger client
     async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
         # create HTTP service container with exposed port 8080
-        http_srv = (
+        httpSrv = (
             client.container()
             .from_("python")
             .with_directory(
@@ -21,10 +21,10 @@ async def main():
         )
 
         # get endpoint
-        val = await http_srv.endpoint()
+        val = await httpSrv.endpoint()
 
         # get HTTP endpoint
-        val_scheme = await http_srv.endpoint(scheme="http")
+        val_scheme = await httpSrv.endpoint(scheme="http")
 
     print(val)
     print(val_scheme)

--- a/docs/current/guides/snippets/use-services/persist-service-state/main.py
+++ b/docs/current/guides/snippets/use-services/persist-service-state/main.py
@@ -8,7 +8,7 @@ async def main():
     # create Dagger client
     async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
         # create Redis service container
-        redis_srv = (
+        redisSrv = (
             client.container()
             .from_("redis")
             .with_exposed_port(6379)
@@ -18,18 +18,18 @@ async def main():
         )
 
         # create Redis client container
-        redis_cli = (
+        redisCli = (
             client.container()
             .from_("redis")
-            .with_service_binding("redis-srv", redis_srv)
+            .with_service_binding("redis-srv", redisSrv)
             .with_entrypoint(["redis-cli", "-h", "redis-srv"])
         )
 
         # set and save value
-        await redis_cli.with_exec(["set", "foo", "abc"]).with_exec(["save"]).stdout()
+        await redisCli.with_exec(["set", "foo", "abc"]).with_exec(["save"]).stdout()
 
         # get value
-        val = await redis_cli.with_exec(["get", "foo"]).stdout()
+        val = await redisCli.with_exec(["get", "foo"]).stdout()
 
     print(val)
 

--- a/docs/current/guides/snippets/use-services/test-service-lifecycle-1/main.py
+++ b/docs/current/guides/snippets/use-services/test-service-lifecycle-1/main.py
@@ -8,20 +8,20 @@ async def main():
     # create Dagger client
     async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
         # create Redis service container
-        redis_srv = (
+        redisSrv = (
             client.container().from_("redis").with_exposed_port(6379).with_exec([])
         )
 
         # create Redis client container
-        redis_cli = (
+        redisCli = (
             client.container()
             .from_("redis")
-            .with_service_binding("redis-srv", redis_srv)
+            .with_service_binding("redis-srv", redisSrv)
             .with_entrypoint(["redis-cli", "-h", "redis-srv"])
         )
 
         # send ping from client to server
-        ping = await redis_cli.with_exec(["ping"]).stdout()
+        ping = await redisCli.with_exec(["ping"]).stdout()
 
     print(ping)
 

--- a/docs/current/guides/snippets/use-services/test-service-lifecycle-2/main.py
+++ b/docs/current/guides/snippets/use-services/test-service-lifecycle-2/main.py
@@ -8,23 +8,23 @@ async def main():
     # create Dagger client
     async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
         # create Redis service container
-        redis_srv = (
+        redisSrv = (
             client.container().from_("redis").with_exposed_port(6379).with_exec([])
         )
 
         # create Redis client container
-        redis_cli = (
+        redisCli = (
             client.container()
             .from_("redis")
-            .with_service_binding("redis-srv", redis_srv)
+            .with_service_binding("redis-srv", redisSrv)
             .with_entrypoint(["redis-cli", "-h", "redis-srv"])
         )
 
         # set value
-        setter = await redis_cli.with_exec(["set", "foo", "abc"]).stdout()
+        setter = await redisCli.with_exec(["set", "foo", "abc"]).stdout()
 
         # get value
-        getter = await redis_cli.with_exec(["get", "foo"]).stdout()
+        getter = await redisCli.with_exec(["get", "foo"]).stdout()
 
     print(setter)
     print(getter)

--- a/docs/current/guides/snippets/use-services/test-service-lifecycle-3/main.py
+++ b/docs/current/guides/snippets/use-services/test-service-lifecycle-3/main.py
@@ -8,21 +8,21 @@ async def main():
     # create Dagger client
     async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
         # create Redis service container
-        redis_srv = (
+        redisSrv = (
             client.container().from_("redis").with_exposed_port(6379).with_exec([])
         )
 
         # create Redis client container
-        redis_cli = (
+        redisCli = (
             client.container()
             .from_("redis")
-            .with_service_binding("redis-srv", redis_srv)
+            .with_service_binding("redis-srv", redisSrv)
             .with_entrypoint(["redis-cli", "-h", "redis-srv"])
         )
 
         # set and get value
         val = await (
-            redis_cli.with_exec(["set", "foo", "abc"])
+            redisCli.with_exec(["set", "foo", "abc"])
             .with_exec(["get", "foo"])
             .stdout()
         )


### PR DESCRIPTION
Namely `redis_srv` to `redisSrv` to be consistent with docs in the service containers