### PR TITLE
collect `github.com/pr.head` label

### DIFF
--- a/core/pipeline/label.go
+++ b/core/pipeline/label.go
@@ -211,6 +211,11 @@ func LoadGitHubLabels() ([]Label, error) {
 				Name:  "github.com/pr.url",
 				Value: pr.GetHTMLURL(),
 			})
+
+			labels = append(labels, Label{
+				Name:  "github.com/pr.head",
+				Value: pr.GetHead().GetSHA(),
+			})
 		}
 	}
 

--- a/core/pipeline/label_test.go
+++ b/core/pipeline/label_test.go
@@ -105,6 +105,10 @@ func TestLoadGitHubLabels(t *testing.T) {
 					Name:  "github.com/pr.url",
 					Value: "https://github.com/dagger/testdata/pull/2018",
 				},
+				{
+					Name:  "github.com/pr.head",
+					Value: "81be07d3103b512159628bfa3aae2fbb5d255964",
+				},
 			},
 		},
 		{


### PR DESCRIPTION
This label is needed so we can distinguish from `dagger.io/git.ref` which points to a merge commit for PRs. This is the value that should be shown in the UI and tied to a commit status.