### PR TITLE
docs: Added database example to services guide

### DIFF
--- a/docs/current/guides/757394-use-service-containers.md
+++ b/docs/current/guides/757394-use-service-containers.md
@@ -355,7 +355,7 @@ The application used in this example is [Drupal](https://www.drupal.org/), a pop
 </TabItem>
 </Tabs>
 
-This example begins by creating a MariaDB service container and initializing a new MariaDB database. It then creates a PHP-FPM container and installs Drupal and related dependencies into it. Next it adds a binding for the MariaDB service (`db`) in the PHP-FPM container and sets a container environment variable (`SIMPLETEST_DB`) with the database DSN. Finally, it runs Drupal's kernel tests (which [require a database connection](https://www.drupal.org/docs/automated-testing/phpunit-in-drupal/running-phpunit-tests#non-unit-tests)) using PHPUnit and prints the test summary to the console.
+This example begins by creating a MariaDB service container and initializing a new MariaDB database. It then creates a PHP-FPM container and installs Drupal and related dependencies into it. Next, it adds a binding for the MariaDB service (`db`) in the PHP-FPM container and sets a container environment variable (`SIMPLETEST_DB`) with the database DSN. Finally, it runs Drupal's kernel tests (which [require a database connection](https://www.drupal.org/docs/automated-testing/phpunit-in-drupal/running-phpunit-tests#non-unit-tests)) using PHPUnit and prints the test summary to the console.
 
 ## Conclusion
 

--- a/docs/current/guides/757394-use-service-containers.md
+++ b/docs/current/guides/757394-use-service-containers.md
@@ -52,7 +52,7 @@ Service containers come with the following built-in features:
 - Service containers are health checked prior to running clients
 - Service containers are given an alias for the client container to use as its hostname
 
-## Using hostnames
+## Use hostnames
 
 Service containers run in a bridge network. Each container has its own IP address that other containers can reach. Here's a simple example:
 
@@ -118,7 +118,7 @@ To get a container's address, you wouldn't normally run the `hostname` command, 
 
 In practice, you are more likely to use aliases with service bindings or endpoints, which are covered in the next section.
 
-## Exposing ports
+## Expose ports
 
 Dagger offers two methods to work with service ports:
 
@@ -155,7 +155,7 @@ Here's an example:
 </TabItem>
 </Tabs>
 
-## Binding services
+## Bind services
 
 Dagger enables users to bind a service container to a client container with an alias (such as `redis`) that the client container can use as a hostname.
 
@@ -201,7 +201,7 @@ When a service is bound to a container, it also conveys to any outputs of that c
 </TabItem>
 </Tabs>
 
-## Understanding the service lifecycle
+## Understand the service lifecycle
 
 If you're not interested in what's happening in the background, you can skip this section and just trust that services are running when they need to be. If you're interested in the theory, keep reading.
 
@@ -261,7 +261,7 @@ Run-exactly-once semantics are very convenient. You don't have to come up with n
 If you need multiple instances of a service, just attach something unique to each one, such as an instance ID.
 :::
 
-Let's put all this together in a full client-server example of running commands against a Redis service:
+Here's a more detailed client-server example of running commands against a Redis service:
 
 <Tabs groupId="language" className="embeds">
 <TabItem value="Go">
@@ -305,7 +305,7 @@ Note that this example relies on the 10-second grace period, which you should tr
 Depending on the 10-second grace period is risky because there are many factors which could cause a 10-second delay between calls to Dagger, such as excessive CPU load, high network latency between the client and Dagger, or Dagger operations that require a variable amount of time to process.
 :::
 
-## Persisting service state
+## Persist service state
 
 Another way to avoid relying on the grace period is to use a cache volume to persist a service's data, as in the following example:
 
@@ -327,7 +327,35 @@ Another way to avoid relying on the grace period is to use a cache volume to per
 </TabItem>
 </Tabs>
 
-Note that this example uses Redis's `SAVE` command to ensure data is synced. By default, Redis flushes data to disk periodically.
+:::info
+This example uses Redis's `SAVE` command to ensure data is synced. By default, Redis flushes data to disk periodically.
+:::
+
+## Example: MariaDB database service for application tests
+
+The following example demonstrates service containers in action, by creating a MariaDB database service container for use in application unit/integration testing.
+
+The application used in this example is [Drupal](https://www.drupal.org/), a popular open-source PHP CMS. Drupal includes a large number of unit tests, including tests which require an active database connection. All Drupal 10.x tests are written and executed using the [PHPUnit](https://phpunit.de/) testing framework. Read more about [running PHPUnit tests in Drupal](https://www.drupal.org/docs/automated-testing/phpunit-in-drupal/running-phpunit-tests).
+
+<Tabs groupId="language" className="embeds">
+<TabItem value="Go">
+
+<Embed id="" />
+
+</TabItem>
+<TabItem value="Node.js">
+
+<Embed id="" />
+
+</TabItem>
+<TabItem value="Python">
+
+<Embed id="" />
+
+</TabItem>
+</Tabs>
+
+This example begins by creating a MariaDB service container and initializing a new MariaDB database. It then creates a PHP-FPM container and installs Drupal and related dependencies into it. Next it adds a binding for the MariaDB service (`db`) in the PHP-FPM container and sets a container environment variable (`SIMPLETEST_DB`) with the database DSN. Finally, it runs Drupal's kernel tests (which [require a database connection](https://www.drupal.org/docs/automated-testing/phpunit-in-drupal/running-phpunit-tests#non-unit-tests)) using PHPUnit and prints the test summary to the console.
 
 ## Conclusion
 

--- a/docs/current/guides/757394-use-service-containers.md
+++ b/docs/current/guides/757394-use-service-containers.md
@@ -358,7 +358,7 @@ The application used in this example is [Drupal](https://www.drupal.org/), a pop
 </TabItem>
 </Tabs>
 
-This example begins by creating a MariaDB service container and initializing a new MariaDB database. It then creates a PHP-FPM container and installs Drupal and related dependencies into it. Next, it adds a binding for the MariaDB service (`db`) in the PHP-FPM container and sets a container environment variable (`SIMPLETEST_DB`) with the database DSN. Finally, it runs Drupal's kernel tests (which [require a database connection](https://www.drupal.org/docs/automated-testing/phpunit-in-drupal/running-phpunit-tests#non-unit-tests)) using PHPUnit and prints the test summary to the console.
+This example begins by creating a MariaDB service container and initializing a new MariaDB database. It then creates a Drupal container and installs required dependencies into it. Next, it adds a binding for the MariaDB service (`db`) in the Drupal container and sets a container environment variable (`SIMPLETEST_DB`) with the database DSN. Finally, it runs Drupal's kernel tests (which [require a database connection](https://www.drupal.org/docs/automated-testing/phpunit-in-drupal/running-phpunit-tests#non-unit-tests)) using PHPUnit and prints the test summary to the console.
 
 ## Conclusion
 

--- a/docs/current/guides/757394-use-service-containers.md
+++ b/docs/current/guides/757394-use-service-containers.md
@@ -340,17 +340,20 @@ The application used in this example is [Drupal](https://www.drupal.org/), a pop
 <Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
-<Embed id="" />
+```go file=./snippets/use-services/use-db-service/main.go
+```
 
 </TabItem>
 <TabItem value="Node.js">
 
-<Embed id="" />
+```javascript file=./snippets/use-services/use-db-service/index.ts
+```
 
 </TabItem>
 <TabItem value="Python">
 
-<Embed id="" />
+```python file=./snippets/use-services/use-db-service/main.py
+```
 
 </TabItem>
 </Tabs>

--- a/docs/current/guides/snippets/use-services/use-db-service/index.ts
+++ b/docs/current/guides/snippets/use-services/use-db-service/index.ts
@@ -13,20 +13,11 @@ connect(
       .withEnvVariable("MARIADB_ROOT_PASSWORD", "root")
       .withExec([]);
 
-    // get PHP base image
-    // add Composer and install dependencies
-    // install PHP extensions for PDO and MySQL
-    const php = client
+  	// get Drupal base image
+  	// install additional dependencies
+    const drupal = client
       .container()
-      .from("php:8.1-fpm-alpine3.17")
-      .withExec(["apk", "add", "composer", "php81-dom", "php81-gd", "php81-pdo", "php81-tokenizer", "php81-session", "php81-simplexml", "php81-xmlwriter", "php81-xml"])
-      .withExec(["docker-php-ext-install", "mysqli", "pdo", "pdo_mysql"]);
-
-    // create new Drupal project
-    const drupal = php
-      .withWorkdir("/tmp")
-      .withExec(["composer", "create-project", "drupal/recommended-project", "my-project"])
-      .withWorkdir("/tmp/my-project")
+      .from("drupal:10.0.7-php8.2-fpm")
       .withExec(["composer", "require", "drupal/core-dev", "--dev", "--update-with-all-dependencies"]);
 
     // add service binding for MariaDB
@@ -35,7 +26,7 @@ connect(
       .withServiceBinding("db", mariadb)
       .withEnvVariable("SIMPLETEST_DB", "mysql://user:password@db/drupal")
       .withEnvVariable("SYMFONY_DEPRECATIONS_HELPER", "disabled")
-      .withWorkdir("/tmp/my-project/web/core")
+      .withWorkdir("/opt/drupal/web/core")
       .withExec(["../../vendor/bin/phpunit", "-v", "--group", "KernelTests"])
       .stdout();
 

--- a/docs/current/guides/snippets/use-services/use-db-service/index.ts
+++ b/docs/current/guides/snippets/use-services/use-db-service/index.ts
@@ -1,0 +1,46 @@
+import Client, { connect } from '@dagger.io/dagger';
+
+connect(
+  async (client: Client) => {
+
+    // get MariaDB base image
+    const mariadb = client
+      .container()
+      .from("mariadb:10.11.2")
+      .withEnvVariable("MARIADB_USER", "user")
+      .withEnvVariable("MARIADB_PASSWORD", "password")
+      .withEnvVariable("MARIADB_DATABASE", "drupal")
+      .withEnvVariable("MARIADB_ROOT_PASSWORD", "root")
+      .withExec([]);
+
+    // get PHP base image
+    // add Composer and install dependencies
+    // install PHP extensions for PDO and MySQL
+    const php = client
+      .container()
+      .from("php:8.1-fpm-alpine3.17")
+      .withExec(["apk", "add", "composer", "php81-dom", "php81-gd", "php81-pdo", "php81-tokenizer", "php81-session", "php81-simplexml", "php81-xmlwriter", "php81-xml"])
+      .withExec(["docker-php-ext-install", "mysqli", "pdo", "pdo_mysql"]);
+
+    // create new Drupal project
+    const drupal = php
+      .withWorkdir("/tmp")
+      .withExec(["composer", "create-project", "drupal/recommended-project", "my-project"])
+      .withWorkdir("/tmp/my-project")
+      .withExec(["composer", "require", "drupal/core-dev", "--dev", "--update-with-all-dependencies"]);
+
+    // add service binding for MariaDB
+    // run unit tests using PHPUnit
+    const test = await drupal
+      .withServiceBinding("db", mariadb)
+      .withEnvVariable("SIMPLETEST_DB", "mysql://user:password@db/drupal")
+      .withEnvVariable("SYMFONY_DEPRECATIONS_HELPER", "disabled")
+      .withWorkdir("/tmp/my-project/web/core")
+      .withExec(["../../vendor/bin/phpunit", "-v", "--group", "KernelTests"])
+      .stdout();
+
+    // print ref
+    console.log(test);
+
+  }, { LogOutput: process.stderr }
+);

--- a/docs/current/guides/snippets/use-services/use-db-service/main.go
+++ b/docs/current/guides/snippets/use-services/use-db-service/main.go
@@ -28,19 +28,10 @@ func main() {
 		WithEnvVariable("MARIADB_ROOT_PASSWORD", "root").
 		WithExec(nil)
 
-		// get PHP base image
-		// add Composer and install dependencies
-		// install PHP extensions for PDO and MySQL
-	php := client.Container().
-		From("php:8.1-fpm-alpine3.17").
-		WithExec([]string{"apk", "add", "composer", "php81-dom", "php81-gd", "php81-pdo", "php81-tokenizer", "php81-session", "php81-simplexml", "php81-xmlwriter", "php81-xml"}).
-		WithExec([]string{"docker-php-ext-install", "mysqli", "pdo", "pdo_mysql"})
-
-	// create new Drupal project
-	drupal := php.
-		WithWorkdir("/tmp").
-		WithExec([]string{"composer", "create-project", "drupal/recommended-project", "my-project"}).
-		WithWorkdir("/tmp/my-project").
+	// get Drupal base image
+	// install additional dependencies
+	drupal := client.Container().
+		From("drupal:10.0.7-php8.2-fpm").
 		WithExec([]string{"composer", "require", "drupal/core-dev", "--dev", "--update-with-all-dependencies"})
 
 	// add service binding for MariaDB
@@ -49,7 +40,7 @@ func main() {
 		WithServiceBinding("db", mariadb).
 		WithEnvVariable("SIMPLETEST_DB", "mysql://user:password@db/drupal").
 		WithEnvVariable("SYMFONY_DEPRECATIONS_HELPER", "disabled").
-		WithWorkdir("/tmp/my-project/web/core").
+		WithWorkdir("/opt/drupal/web/core").
 		WithExec([]string{"../../vendor/bin/phpunit", "-v", "--group", "KernelTests"}).
 		Stdout(ctx)
 

--- a/docs/current/guides/snippets/use-services/use-db-service/main.go
+++ b/docs/current/guides/snippets/use-services/use-db-service/main.go
@@ -19,22 +19,22 @@ func main() {
 	}
 	defer client.Close()
 
-    // get MariaDB base image
-		mariadb := client.Container().
-			From("mariadb:10.11.2").
-			WithEnvVariable("MARIADB_USER", "user").
-			WithEnvVariable("MARIADB_PASSWORD", "password").
-			WithEnvVariable("MARIADB_DATABASE", "drupal").
-			WithEnvVariable("MARIADB_ROOT_PASSWORD", "root").
-			WithExec(nil)
+	// get MariaDB base image
+	mariadb := client.Container().
+		From("mariadb:10.11.2").
+		WithEnvVariable("MARIADB_USER", "user").
+		WithEnvVariable("MARIADB_PASSWORD", "password").
+		WithEnvVariable("MARIADB_DATABASE", "drupal").
+		WithEnvVariable("MARIADB_ROOT_PASSWORD", "root").
+		WithExec(nil)
 
-    // get PHP base image
-    // add Composer and install dependencies
-    // install PHP extensions for PDO and MySQL
-		php := client.Container().
-			From("php:8.1-fpm-alpine3.17").
-			WithExec([]string{"apk", "add", "composer", "php81-dom", "php81-gd", "php81-pdo", "php81-tokenizer", "php81-session", "php81-simplexml", "php81-xmlwriter", "php81-xml"}).
-			WithExec([]string{"docker-php-ext-install", "mysqli", "pdo", "pdo_mysql"})
+		// get PHP base image
+		// add Composer and install dependencies
+		// install PHP extensions for PDO and MySQL
+	php := client.Container().
+		From("php:8.1-fpm-alpine3.17").
+		WithExec([]string{"apk", "add", "composer", "php81-dom", "php81-gd", "php81-pdo", "php81-tokenizer", "php81-session", "php81-simplexml", "php81-xmlwriter", "php81-xml"}).
+		WithExec([]string{"docker-php-ext-install", "mysqli", "pdo", "pdo_mysql"})
 
 	// create new Drupal project
 	drupal := php.

--- a/docs/current/guides/snippets/use-services/use-db-service/main.go
+++ b/docs/current/guides/snippets/use-services/use-db-service/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// create Dagger client
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
+
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+    // get MariaDB base image
+		mariadb := client.Container().
+			From("mariadb:10.11.2").
+			WithEnvVariable("MARIADB_USER", "user").
+			WithEnvVariable("MARIADB_PASSWORD", "password").
+			WithEnvVariable("MARIADB_DATABASE", "drupal").
+			WithEnvVariable("MARIADB_ROOT_PASSWORD", "root").
+			WithExec(nil)
+
+    // get PHP base image
+    // add Composer and install dependencies
+    // install PHP extensions for PDO and MySQL
+		php := client.Container().
+			From("php:8.1-fpm-alpine3.17").
+			WithExec([]string{"apk", "add", "composer", "php81-dom", "php81-gd", "php81-pdo", "php81-tokenizer", "php81-session", "php81-simplexml", "php81-xmlwriter", "php81-xml"}).
+			WithExec([]string{"docker-php-ext-install", "mysqli", "pdo", "pdo_mysql"})
+
+	// create new Drupal project
+	drupal := php.
+		WithWorkdir("/tmp").
+		WithExec([]string{"composer", "create-project", "drupal/recommended-project", "my-project"}).
+		WithWorkdir("/tmp/my-project").
+		WithExec([]string{"composer", "require", "drupal/core-dev", "--dev", "--update-with-all-dependencies"})
+
+	// add service binding for MariaDB
+	// run kernel tests using PHPUnit
+	test, err := drupal.
+		WithServiceBinding("db", mariadb).
+		WithEnvVariable("SIMPLETEST_DB", "mysql://user:password@db/drupal").
+		WithEnvVariable("SYMFONY_DEPRECATIONS_HELPER", "disabled").
+		WithWorkdir("/tmp/my-project/web/core").
+		WithExec([]string{"../../vendor/bin/phpunit", "-v", "--group", "KernelTests"}).
+		Stdout(ctx)
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(test)
+}

--- a/docs/current/guides/snippets/use-services/use-db-service/main.py
+++ b/docs/current/guides/snippets/use-services/use-db-service/main.py
@@ -1,0 +1,57 @@
+import sys
+
+import anyio
+import dagger
+
+async def main():
+    # create Dagger client
+    async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
+
+        # get MariaDB base image
+        mariadb = (
+            client
+            .container()
+            .from_("mariadb:10.11.2")
+            .with_env_variable("MARIADB_USER", "user")
+            .with_env_variable("MARIADB_PASSWORD", "password")
+            .with_env_variable("MARIADB_DATABASE", "drupal")
+            .with_env_variable("MARIADB_ROOT_PASSWORD", "root")
+            .with_exec([])
+        )
+
+        # get PHP base image
+        # add Composer and install dependencies
+        # install PHP extensions for PDO and MySQL
+        php = (
+            client
+            .container()
+            .from_("php:8.1-fpm-alpine3.17")
+            .with_exec(["apk", "add", "composer", "php81-dom", "php81-gd", "php81-pdo", "php81-tokenizer", "php81-session", "php81-simplexml", "php81-xmlwriter", "php81-xml"])
+            .with_exec(["docker-php-ext-install", "mysqli", "pdo", "pdo_mysql"])
+        )
+
+        # create new Drupal project
+        drupal = (
+            php
+            .with_workdir("/tmp")
+            .with_exec(["composer", "create-project", "drupal/recommended-project", "my-project"])
+            .with_workdir("/tmp/my-project")
+            .with_exec(["composer", "require", "drupal/core-dev", "--dev", "--update-with-all-dependencies"])
+        )
+
+        # add service binding for MariaDB
+        # run unit tests using PHPUnit
+        test = await (
+            drupal
+            .with_service_binding("db", mariadb)
+            .with_env_variable("SIMPLETEST_DB", "mysql://user:password@db/drupal")
+            .with_env_variable("SYMFONY_DEPRECATIONS_HELPER", "disabled")
+            .with_workdir("/tmp/my-project/web/core")
+            .with_exec(["../../vendor/bin/phpunit", "-v", "--group", "KernelTests"])
+            .stdout()
+        )
+
+    # print ref
+    print(test)
+
+anyio.run(main)

--- a/docs/current/guides/snippets/use-services/use-db-service/main.py
+++ b/docs/current/guides/snippets/use-services/use-db-service/main.py
@@ -19,23 +19,12 @@ async def main():
             .with_exec([])
         )
 
-        # get PHP base image
-        # add Composer and install dependencies
-        # install PHP extensions for PDO and MySQL
-        php = (
+      	# get Drupal base image
+      	# install additional dependencies
+        drupal = (
             client
             .container()
-            .from_("php:8.1-fpm-alpine3.17")
-            .with_exec(["apk", "add", "composer", "php81-dom", "php81-gd", "php81-pdo", "php81-tokenizer", "php81-session", "php81-simplexml", "php81-xmlwriter", "php81-xml"])
-            .with_exec(["docker-php-ext-install", "mysqli", "pdo", "pdo_mysql"])
-        )
-
-        # create new Drupal project
-        drupal = (
-            php
-            .with_workdir("/tmp")
-            .with_exec(["composer", "create-project", "drupal/recommended-project", "my-project"])
-            .with_workdir("/tmp/my-project")
+            .from_("drupal:10.0.7-php8.2-fpm")
             .with_exec(["composer", "require", "drupal/core-dev", "--dev", "--update-with-all-dependencies"])
         )
 
@@ -46,7 +35,7 @@ async def main():
             .with_service_binding("db", mariadb)
             .with_env_variable("SIMPLETEST_DB", "mysql://user:password@db/drupal")
             .with_env_variable("SYMFONY_DEPRECATIONS_HELPER", "disabled")
-            .with_workdir("/tmp/my-project/web/core")
+            .with_workdir("/opt/drupal/web/core")
             .with_exec(["../../vendor/bin/phpunit", "-v", "--group", "KernelTests"])
             .stdout()
         )


### PR DESCRIPTION
This commit adds an example of standing up a just-in-time database service for unit testing a PHP application to the service containers guide.

Closes #4866 