### PR TITLE
docs: Added tsc instruction to Node get started

### DIFF
--- a/docs/current/sdk/nodejs/783645-get-started.md
+++ b/docs/current/sdk/nodejs/783645-get-started.md
@@ -58,6 +58,12 @@ Install the TypeScript engine (if not already present):
 npm install ts-node
 ```
 
+Create a TypeScript configuration file (if not already present):
+
+```shell
+tsc --init --module esnext --moduleResolution nodenext
+```
+
 In your project directory, create a new file named `build.mts` and add the following code to it.
 
 ```typescript file=snippets/get-started/step2/build.mts


### PR DESCRIPTION
This commit adds an instruction for how to create a `tsconfig.json` file for TypeScript users.

Closes #4865 