### PR TITLE
fix(secrets): remove 'r' from .with_registry_auth statement

### DIFF
--- a/docs/current/guides/snippets/use-secrets/sdk/main.py
+++ b/docs/current/guides/snippets/use-secrets/sdk/main.py
@@ -18,7 +18,7 @@ async def main():
         # use secret for registry authentication
         addr = await (
           ctr
-          .with_registry_auth("docker.io", "DOCKER-HUB-USERNAMEr", secret)
+          .with_registry_auth("docker.io", "DOCKER-HUB-USERNAME", secret)
           .publish("DOCKER-HUB-USERNAME/my-nginx")
         )
 


### PR DESCRIPTION
Remove the extra character from the `.with_registry_auth()` statement