### PR TITLE
Docs: tweak quickstart examples

### DIFF
--- a/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
+++ b/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
@@ -13,9 +13,9 @@ import QuickstartDoc from '@site/src/components/molecules/quickstartDoc.js'
 import Embed from '@site/src/components/atoms/embed.js'
 
 export const ids = {
-    Go: "nLOpYVtbMlV",
-    Node: "cXNoMjeG-2V",
-    Python: "k1Kvw2aFcIU"
+    Go: "IxHBXBhY82B",
+    Node: "blm0z0YQDmX",
+    Python: "TQbnFCp3R3R"
 }
 
 <QuickstartDoc embeds={ids}>
@@ -33,7 +33,7 @@ The example application repository includes a simple Dockerfile. Use it with a D
 <Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
-<Embed id="nLOpYVtbMlV"/>
+<Embed id="IxHBXBhY82B"/>
 
 This code listing does the following:
 
@@ -51,7 +51,7 @@ go run ci/main.go
 </TabItem>
 <TabItem value="Node">
 
-<Embed id="cXNoMjeG-2V"/>
+<Embed id="blm0z0YQDmX"/>
 
 This code listing does the following:
 
@@ -69,7 +69,7 @@ node ci/index.mjs
 </TabItem>
 <TabItem value="Python">
 
-<Embed id="k1Kvw2aFcIU"/>
+<Embed id="TQbnFCp3R3R"/>
 
 This code listing does the following:
 

--- a/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
+++ b/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
@@ -38,7 +38,7 @@ The example application repository includes a simple Dockerfile. Use it with a D
 This code listing does the following:
 Connect()`.
 - It uses the client's `Host().Directory()` method to obtain a reference to the source code directory on the host.
-- It uses the client's `Container().Build()` method to initialize a new container using a Dockerfile. This method defaults to using the Dockerfile located at `./Dockerfile` in the directory passed to it as argument and returns the built `Container` object.
+- It uses the `Directory` object's `DockerBuild()` method to build a new container using a Dockerfile. This method defaults to using the Dockerfile located at `./Dockerfile` in the directory passed to it as argument and returns the built `Container` object.
 - It uses the `Container` object's `Publish()` method to publish the container to [ttl.sh](https://ttl.sh). As before, to prevent name collisions, the container image name is suffixed with a random number.
 
 Run the pipeline by executing the command below from the application directory:
@@ -56,7 +56,7 @@ This code listing does the following:
 
 - It creates a Dagger client with `connect()`.
 - It uses the client's `host().directory()` method to obtain a reference to the source code directory on the host.
-- It uses the client's `container().build()` method to initialize a new container using a Dockerfile. This method defaults to using the Dockerfile located at `./Dockerfile` in the directory passed to it as argument and returns the built `Container` object.
+- It uses the `Directory` object's `dockerBuild()` method to build a new container using a Dockerfile. This method defaults to using the Dockerfile located at `./Dockerfile` in the directory passed to it as argument and returns the built `Container` object.
 - It uses the `Container` object's `publish()` method to publish the container to [ttl.sh](https://ttl.sh). As before, to prevent name collisions, the container image name is suffixed with a random number.
 
 Run the pipeline by executing the command below from the application directory:
@@ -74,7 +74,7 @@ This code listing does the following:
 
 - It creates a Dagger client with `with dagger.Connection()`.
 - It uses the client's `host().directory()` method to obtain a reference to the source code directory on the host.
-- It uses the client's `container().build()` method to initialize a new container using a Dockerfile. This method defaults to using the Dockerfile located at `./Dockerfile` in the directory passed to it as argument and returns the built `Container` object.
+- It uses the `Directory` object's `docker_build()` method to build a new container using a Dockerfile. This method defaults to using the Dockerfile located at `./Dockerfile` in the directory passed to it as argument and returns the built `Container` object.
 - It uses the `Container` object's `publish()` method to publish the container to [ttl.sh](https://ttl.sh). As before, to prevent name collisions, the container image name is suffixed with a random number.
 
 Run the pipeline by executing the command below from the application directory:

--- a/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
+++ b/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
@@ -13,9 +13,9 @@ import QuickstartDoc from '@site/src/components/molecules/quickstartDoc.js'
 import Embed from '@site/src/components/atoms/embed.js'
 
 export const ids = {
-    Go: "FkLP0dXMgIm",
-    Node: "IdHGiwvkn6E",
-    Python: "xCI5LKiZfGD"
+    Go: "nLOpYVtbMlV",
+    Node: "cXNoMjeG-2V",
+    Python: "k1Kvw2aFcIU"
 }
 
 <QuickstartDoc embeds={ids}>
@@ -33,10 +33,11 @@ The example application repository includes a simple Dockerfile. Use it with a D
 <Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
-<Embed id="FkLP0dXMgIm"/>
+<Embed id="nLOpYVtbMlV"/>
 
 This code listing does the following:
-Connect()`.
+
+- It creates a Dagger client with `Connect()`.
 - It uses the client's `Host().Directory()` method to obtain a reference to the source code directory on the host.
 - It uses the `Directory` object's `DockerBuild()` method to build a new container using a Dockerfile. This method defaults to using the Dockerfile located at `./Dockerfile` in the directory passed to it as argument and returns the built `Container` object.
 - It uses the `Container` object's `Publish()` method to publish the container to [ttl.sh](https://ttl.sh). As before, to prevent name collisions, the container image name is suffixed with a random number.
@@ -50,7 +51,7 @@ go run ci/main.go
 </TabItem>
 <TabItem value="Node">
 
-<Embed id="IdHGiwvkn6E"/>
+<Embed id="cXNoMjeG-2V"/>
 
 This code listing does the following:
 
@@ -68,7 +69,7 @@ node ci/index.mjs
 </TabItem>
 <TabItem value="Python">
 
-<Embed id="xCI5LKiZfGD"/>
+<Embed id="k1Kvw2aFcIU"/>
 
 This code listing does the following:
 

--- a/docs/current/quickstart/snippets/build-dockerfile/index.mjs
+++ b/docs/current/quickstart/snippets/build-dockerfile/index.mjs
@@ -7,8 +7,8 @@ connect(async (client) => {
 
   // build using Dockerfile
   // publish the resulting container to a registry
-  const imageRef = await client.container()
-    .build(contextDir)
+  const imageRef = await contextDir
+    .dockerBuild()
     .publish('ttl.sh/hello-dagger-' + Math.floor(Math.random() * 10000000))
   console.log(`Published image to: ${imageRef}`)
 

--- a/docs/current/quickstart/snippets/build-dockerfile/main.go
+++ b/docs/current/quickstart/snippets/build-dockerfile/main.go
@@ -22,8 +22,8 @@ func main() {
 
 	contextDir := client.Host().Directory(".")
 
-	ref, err := client.Container().
-		Build(contextDir).
+	ref, err := contextDir.
+		DockerBuild().
 		Publish(ctx, fmt.Sprintf("ttl.sh/hello-dagger-%.0f", math.Floor(rand.Float64()*10000000))) //#nosec
 	if err != nil {
 		panic(err)

--- a/docs/current/quickstart/snippets/build-dockerfile/main.py
+++ b/docs/current/quickstart/snippets/build-dockerfile/main.py
@@ -15,8 +15,7 @@ async def main():
         # build using Dockerfile
         # publish the resulting container to a registry
         image_ref = (
-            await client.container()
-            .build(context_dir)
+            await context_dir.docker_build()
             .publish(f"ttl.sh/hello-dagger-{random.randint(0, 10000000)}")
         )
 


### PR DESCRIPTION
Use `Directory { dockerBuild }` rather than `Container { build }`, following user feedback that the former is less confusing than the latter.