### PR TITLE
Python: Fix type checking in object id resolution

### DIFF
--- a/sdk/python/tests/api/test_integration.py
+++ b/sdk/python/tests/api/test_integration.py
@@ -41,14 +41,17 @@ async def test_container_build():
         assert words[0] == "dagger"
 
 
-async def test_container_with_env_variable():
+@pytest.mark.parametrize("val", ["spam", ""])
+async def test_container_with_env_variable(val):
     async with dagger.Connection() as client:
-        container = (
-            client.container().from_("alpine:3.16.2").with_env_variable("FOO", "bar")
+        out = await (
+            client.container()
+            .from_("alpine:3.16.2")
+            .with_env_variable("FOO", val)
+            .with_exec(["sh", "-c", "echo -n $FOO"])
+            .stdout()
         )
-        out = await container.with_exec(["sh", "-c", "echo -n $FOO"]).stdout()
-
-        assert out == "bar"
+        assert out == val
 
 
 async def test_container_with_mounted_directory():


### PR DESCRIPTION
Fixes Python bug when using an empty string as an envirnoment variable: https://github.com/dagger/dagger/issues/4821#issuecomment-1491999494

Object to ID resolution had a bug in type checking if an input sequence needed to be resolved into IDs. As strings are also sequences, the `""` was being converted into `[]`, failing GraphQL validation in `withEnvVariable`, which expects a string as value.