### PR TITLE
Upgrade go releaser image to pick up go 1.20.

### DIFF
--- a/internal/mage/cli.go
+++ b/internal/mage/cli.go
@@ -26,7 +26,7 @@ func (cl Cli) Publish(ctx context.Context, version string) error {
 
 	wd := c.Host().Directory(".")
 	container := c.Container().
-		From("ghcr.io/goreleaser/goreleaser-pro:v1.12.3-pro").
+		From("ghcr.io/goreleaser/goreleaser-pro:v1.16.2-pro").
 		WithEntrypoint([]string{}).
 		WithExec([]string{"apk", "add", "aws-cli"}).
 		WithWorkdir("/app").


### PR DESCRIPTION
We were hitting some errors related to use of generics in a dependency due to the fact that the previous goreleaser image was still on go 1.19.

---

Error was encountered here: https://github.com/dagger/dagger/actions/runs/4598492189/jobs/8122598929#step:5:861