### PR TITLE
give services their own pipeline segment

### DIFF
--- a/core/pipeline/label.go
+++ b/core/pipeline/label.go
@@ -58,6 +58,9 @@ func loadRootLabels(workdir string) []Label {
 	return labels
 }
 
+// ServiceHostnameLabel is annotated on all services started by Dagger.
+const ServiceHostnameLabel = "dagger.io/service.hostname"
+
 func loadGitLabels(workdir string) ([]Label, error) {
 	repo, err := git.PlainOpenWithOptions(workdir, &git.PlainOpenOptions{
 		DetectDotGit: true,

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -639,7 +639,7 @@ func (s *containerSchema) withServiceBinding(ctx *router.Context, parent *core.C
 		return nil, ErrServicesDisabled
 	}
 
-	return parent.WithServiceDependency(&core.Container{ID: args.Service}, args.Alias)
+	return parent.WithServiceBinding(&core.Container{ID: args.Service}, args.Alias)
 }
 
 type containerWithExposedPortArgs struct {


### PR DESCRIPTION
Makes it possible for UIs to treat them differently, i.e. don't show them as errored when really they're just stopped.