### PR TITLE
docs: Updated service containers guide reg. ports

### DIFF
--- a/docs/current/guides/757394-use-service-containers.md
+++ b/docs/current/guides/757394-use-service-containers.md
@@ -360,6 +360,10 @@ The application used in this example is [Drupal](https://www.drupal.org/), a pop
 
 This example begins by creating a MariaDB service container and initializing a new MariaDB database. It then creates a Drupal container and installs required dependencies into it. Next, it adds a binding for the MariaDB service (`db`) in the Drupal container and sets a container environment variable (`SIMPLETEST_DB`) with the database DSN. Finally, it runs Drupal's kernel tests (which [require a database connection](https://www.drupal.org/docs/automated-testing/phpunit-in-drupal/running-phpunit-tests#non-unit-tests)) using PHPUnit and prints the test summary to the console.
 
+:::tip
+Explicitly specifying the service container port with `WithExposedPort()` (Go), `withExposedPort()` (Node.js) or `with_exposed_port()` (Python) is particularly important here. Without it, Dagger will start the service container and immediately allow access to service clients. With it, Dagger will wait for the service to be listening first.
+:::
+
 ## Conclusion
 
 This tutorial walked you through the basics of using service containers with Dagger. It explained how container-to-container networking and the service lifecycle is implemented in Dagger. It also provided examples of exposing service ports, binding services and persisting service state using Dagger.

--- a/docs/current/guides/snippets/use-services/use-db-service/index.ts
+++ b/docs/current/guides/snippets/use-services/use-db-service/index.ts
@@ -11,6 +11,7 @@ connect(
       .withEnvVariable("MARIADB_PASSWORD", "password")
       .withEnvVariable("MARIADB_DATABASE", "drupal")
       .withEnvVariable("MARIADB_ROOT_PASSWORD", "root")
+      .withExposedPort(3306)
       .withExec([]);
 
   	// get Drupal base image

--- a/docs/current/guides/snippets/use-services/use-db-service/main.go
+++ b/docs/current/guides/snippets/use-services/use-db-service/main.go
@@ -26,6 +26,7 @@ func main() {
 		WithEnvVariable("MARIADB_PASSWORD", "password").
 		WithEnvVariable("MARIADB_DATABASE", "drupal").
 		WithEnvVariable("MARIADB_ROOT_PASSWORD", "root").
+		WithExposedPort(3306).
 		WithExec(nil)
 
 	// get Drupal base image

--- a/docs/current/guides/snippets/use-services/use-db-service/main.py
+++ b/docs/current/guides/snippets/use-services/use-db-service/main.py
@@ -16,6 +16,7 @@ async def main():
             .with_env_variable("MARIADB_PASSWORD", "password")
             .with_env_variable("MARIADB_DATABASE", "drupal")
             .with_env_variable("MARIADB_ROOT_PASSWORD", "root")
+            .with_exposed_port(3306)
             .with_exec([])
         )
 


### PR DESCRIPTION
This commit adds an important note to the service containers guide regarding ports. It is related to the example in https://github.com/dagger/dagger.io/issues/1769.