### PR TITLE
`withExposedPort` also exposes port in OCI image config

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -1500,12 +1500,17 @@ func (container *Container) WithoutExposedPort(port int, protocol NetworkProtoco
 	}
 
 	filtered := []ContainerPort{}
+	filteredOCI := map[string]struct{}{}
 	for _, p := range payload.Ports {
 		if p.Port != port || p.Protocol != protocol {
 			filtered = append(filtered, p)
+			ociPort := fmt.Sprintf("%d/%s", p.Port, p.Protocol.Network())
+			filteredOCI[ociPort] = struct{}{}
 		}
 	}
+
 	payload.Ports = filtered
+	payload.Config.ExposedPorts = filteredOCI
 
 	id, err := payload.Encode()
 	if err != nil {

--- a/core/container.go
+++ b/core/container.go
@@ -1478,6 +1478,13 @@ func (container *Container) WithExposedPort(port ContainerPort) (*Container, err
 
 	payload.Ports = append(payload.Ports, port)
 
+	if payload.Config.ExposedPorts == nil {
+		payload.Config.ExposedPorts = map[string]struct{}{}
+	}
+
+	ociPort := fmt.Sprintf("%d/%s", port.Port, port.Protocol.Network())
+	payload.Config.ExposedPorts[ociPort] = struct{}{}
+
 	id, err := payload.Encode()
 	if err != nil {
 		return nil, fmt.Errorf("encode: %w", err)

--- a/core/service.go
+++ b/core/service.go
@@ -76,7 +76,8 @@ const (
 )
 
 // Network returns the value appropriate for the "network" argument to Go
-// net.Dial.
+// net.Dial, and for appending to the port number to form the key for the
+// ExposedPorts object in the OCI image config.
 func (p NetworkProtocol) Network() string {
 	return strings.ToLower(string(p))
 }


### PR DESCRIPTION
A small fix so that `withExposedPort` actually sets the `EXPOSE` equivalent config in the resulting container.