### PR TITLE
Set secret store in engine internal session.

### DIFF
--- a/cmd/engine/operatorClient.go
+++ b/cmd/engine/operatorClient.go
@@ -99,6 +99,7 @@ func NewOperatorClient(ctx context.Context, c *bkclient.Client) (_ *dagger.Clien
 				DisableHostRW:  true,
 				EnableServices: true,
 				Auth:           registryAuth,
+				Secrets:        secretStore,
 			})
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Without this you can get a nil pointer exception when trying to use a secret w/ the cache mount synchronization code paths (currently only when running in k8s w/ `AWS_WEB_IDENTITY_TOKEN_FILE` set)

---

I'll also send out a followup that refactors the code so session initialization is shared between `engine/engine.go` and `cmd/engine/operatorClient.go` which will prevent future problems w/ trying to make sure they are both updated equivalently, but this change is a quick fix in the meantime.