### PR TITLE
Add ability for clients to print which engine they are connected to.

### DIFF
--- a/cmd/engine/main_test.go
+++ b/cmd/engine/main_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"os"
 	"runtime"
 	"testing"
 
 	"github.com/moby/buildkit/cmd/buildkitd/config"
+	"github.com/moby/buildkit/session"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli"
 )
@@ -41,5 +43,91 @@ func TestParallelismFlag(t *testing.T) {
 	t.Run("invalid", func(t *testing.T) {
 		err := app.Run([]string{"buildkitd", "--oci-max-parallelism", "foo"})
 		require.Error(t, err)
+	})
+}
+
+func TestEngineNameLabel(t *testing.T) {
+	app := cli.NewApp()
+	app.Flags = append(app.Flags, appFlags...)
+
+	t.Run("default", func(t *testing.T) {
+		enableRunc := true
+		cfg := &config.Config{}
+		cfg.Root = t.TempDir()
+		cfg.Workers.OCI.Enabled = &enableRunc
+		cfg.Workers.OCI.Binary = "/proc/self/exe"
+		app.Action = func(c *cli.Context) error {
+			err := applyOCIFlags(c, cfg)
+			if err != nil {
+				return err
+			}
+			sessionManager, err := session.NewManager()
+			if err != nil {
+				return err
+			}
+
+			wc, err := newWorkerController(c, workerInitializerOpt{
+				config:         cfg,
+				sessionManager: sessionManager,
+			})
+			if err != nil {
+				return err
+			}
+			w, err := wc.GetDefault()
+			if err != nil {
+				return err
+			}
+			hostname, err := os.Hostname()
+			if err != nil {
+				return err
+			}
+			require.Equal(t, hostname, w.Labels()["engineName"])
+			return nil
+		}
+
+		err := app.Run([]string{"buildkitd"})
+		require.NoError(t, err)
+	})
+	t.Run("env", func(t *testing.T) {
+		existingEnv, ok := os.LookupEnv("_EXPERIMENTAL_DAGGER_ENGINE_NAME")
+		if ok {
+			defer os.Setenv("_EXPERIMENTAL_DAGGER_ENGINE_NAME", existingEnv)
+		} else {
+			defer os.Unsetenv("_EXPERIMENTAL_DAGGER_ENGINE_NAME")
+		}
+		engineName := "wacky-engine"
+		os.Setenv("_EXPERIMENTAL_DAGGER_ENGINE_NAME", engineName)
+		enableRunc := true
+		cfg := &config.Config{}
+		cfg.Root = t.TempDir()
+		cfg.Workers.OCI.Enabled = &enableRunc
+		cfg.Workers.OCI.Binary = "/proc/self/exe"
+		app.Action = func(c *cli.Context) error {
+			err := applyOCIFlags(c, cfg)
+			if err != nil {
+				return err
+			}
+			sessionManager, err := session.NewManager()
+			if err != nil {
+				return err
+			}
+
+			wc, err := newWorkerController(c, workerInitializerOpt{
+				config:         cfg,
+				sessionManager: sessionManager,
+			})
+			if err != nil {
+				return err
+			}
+			w, err := wc.GetDefault()
+			if err != nil {
+				return err
+			}
+			require.Equal(t, engineName, w.Labels()["engineName"])
+			return nil
+		}
+
+		err := app.Run([]string{"buildkitd"})
+		require.NoError(t, err)
 	})
 }

--- a/cmd/engine/operatorClient.go
+++ b/cmd/engine/operatorClient.go
@@ -85,7 +85,7 @@ func NewOperatorClient(ctx context.Context, c *bkclient.Client) (_ *dagger.Clien
 	go func() {
 		defer close(doneCh)
 		_, err = c.Build(solveCtx, solveOpts, "", func(ctx context.Context, gw bkgw.Client) (*bkgw.Result, error) {
-			go pipeline.LoadRootLabels(".")
+			go pipeline.LoadRootLabels(".", "")
 			router := router.New(sessionToken.String())
 			secretStore.SetGateway(gw)
 			gwClient := core.NewGatewayClient(gw, "", nil)

--- a/core/pipeline/label.go
+++ b/core/pipeline/label.go
@@ -36,15 +36,18 @@ func RootLabels() []Label {
 }
 
 // LoadRootLabels loads default Pipeline labels from a workdir.
-func LoadRootLabels(workdir string) {
+func LoadRootLabels(workdir string, engineName string) {
 	loadOnce.Do(func() {
 		defer close(loadDoneCh)
-		defaultLabels = loadRootLabels(workdir)
+		defaultLabels = loadRootLabels(workdir, engineName)
 	})
 }
 
-func loadRootLabels(workdir string) []Label {
-	labels := []Label{}
+func loadRootLabels(workdir, engineName string) []Label {
+	labels := []Label{{
+		Name:  "dagger.io/engine",
+		Value: engineName,
+	}}
 
 	if gitLabels, err := LoadGitLabels(workdir); err == nil {
 		labels = append(labels, gitLabels...)


### PR DESCRIPTION
When working with a lot of engine instances and clients that may end up connecting to any one of them it can be extremely useful to know which engine a given client connected to.

The engine can be configured w/ a name via a `_EXPERIMENTAL_DAGGER_ENGINE_NAME` env, otherwise it will just default to the hostname. Clients will now log that when they connect to it.

---

I updated the PR to have the client print the name of the engine it connects to while also including the engine name in the root labels for that pipeline so it can theoretically become part of the progress output too @aluzzardi @vito 