### PR TITLE
SDK - Node.js - Pipe SIGINT to child process

### DIFF
--- a/sdk/nodejs/provisioning/bin.ts
+++ b/sdk/nodejs/provisioning/bin.ts
@@ -175,12 +175,17 @@ export class Bin implements EngineConn {
     })
 
     this.subProcess = execaCommand(args.join(" "), {
-      stderr: opts.LogOutput || "pipe",
+      stdio: "pipe",
       reject: true,
 
       // Kill the process if parent exit.
       cleanup: true,
     })
+
+    // Log the output if the user wants to.
+    if (opts.LogOutput) {
+      this.subProcess.stderr?.pipe(opts.LogOutput)
+    }
 
     const stdoutReader = readline.createInterface({
       input: this.subProcess?.stdout as NodeJS.ReadableStream,


### PR DESCRIPTION
Close to the issue: #4823 

After starting to run a pipeline and when users hit ctrl+c early, the child process is killed as it should.

However, as long as the pipeline start to pull an image for instance, the SIGINT is not handle correctly.

The PR should fix that by updating the configuration for the pipes that are established between the parent and child process