### PR TITLE
sdk: nodejs: consistent label name

### DIFF
--- a/sdk/nodejs/provisioning/bin.ts
+++ b/sdk/nodejs/provisioning/bin.ts
@@ -164,7 +164,7 @@ export class Bin implements EngineConn {
     const flagsAndValues = [
       { flag: "--workdir", value: opts.Workdir },
       { flag: "--project", value: opts.Project },
-      { flag: "--label", value: "dagger.io/sdk.name:node" },
+      { flag: "--label", value: "dagger.io/sdk.name:nodejs" },
       { flag: "--label", value: `dagger.io/sdk.version:${sdkVersion}` },
     ]
 


### PR DESCRIPTION
To keep consistency with all SDK labels name, use nodejs as label instead of node.

Following request from @gerhard https://github.com/dagger/dagger.io/pull/2145