### PR TITLE
Container: add `withExec(skipEntrypoint: Boolean)`

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -917,7 +917,7 @@ func (container *Container) WithExec(ctx context.Context, gw bkgw.Client, defaul
 		args = cfg.Cmd
 	}
 
-	if len(cfg.Entrypoint) > 0 {
+	if len(cfg.Entrypoint) > 0 && !opts.SkipEntrypoint {
 		args = append(cfg.Entrypoint, args...)
 	}
 
@@ -1701,6 +1701,10 @@ func (container *Container) containerFromPayload(payload *containerIDPayload) (*
 type ContainerExecOpts struct {
 	// Command to run instead of the container's default command
 	Args []string
+
+	// If the container has an entrypoint, ignore it for this exec rather than
+	// calling it with args.
+	SkipEntrypoint bool
 
 	// Content to write to the command's standard input before closing
 	Stdin string

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -419,6 +419,11 @@ type Container {
     args: [String!]!
 
     """
+    If the container has an entrypoint, ignore it for args rather than using it to wrap them.
+    """
+    skipEntrypoint: Boolean
+
+    """
     Content to write to the command's standard input before closing (e.g., "Hello world").
     """
     stdin: String

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -797,6 +797,8 @@ func (r *Container) WithEnvVariable(name string, value string) *Container {
 
 // ContainerWithExecOpts contains options for Container.WithExec
 type ContainerWithExecOpts struct {
+	// If the container has an entrypoint, ignore it for args rather than using it to wrap them.
+	SkipEntrypoint bool
 	// Content to write to the command's standard input before closing (e.g., "Hello world").
 	Stdin string
 	// Redirect the command's standard output to a file in the container (e.g., "/tmp/stdout").
@@ -819,6 +821,13 @@ type ContainerWithExecOpts struct {
 func (r *Container) WithExec(args []string, opts ...ContainerWithExecOpts) *Container {
 	q := r.q.Select("withExec")
 	q = q.Arg("args", args)
+	// `skipEntrypoint` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].SkipEntrypoint) {
+			q = q.Arg("skipEntrypoint", opts[i].SkipEntrypoint)
+			break
+		}
+	}
 	// `stdin` optional argument
 	for i := len(opts) - 1; i >= 0; i-- {
 		if !querybuilder.IsZeroValue(opts[i].Stdin) {

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -206,6 +206,11 @@ export type ContainerWithDirectoryOpts = {
 
 export type ContainerWithExecOpts = {
   /**
+   * If the container has an entrypoint, ignore it for args rather than using it to wrap them.
+   */
+  skipEntrypoint?: boolean
+
+  /**
    * Content to write to the command's standard input before closing (e.g., "Hello world").
    */
   stdin?: string
@@ -1198,6 +1203,7 @@ export class Container extends BaseClient {
   /**
    * Retrieves this container after executing the specified command inside it.
    * @param args Command to run instead of the container's default command (e.g., ["run", "main.go"]).
+   * @param opts.skipEntrypoint If the container has an entrypoint, ignore it for args rather than using it to wrap them.
    * @param opts.stdin Content to write to the command's standard input before closing (e.g., "Hello world").
    * @param opts.redirectStdout Redirect the command's standard output to a file in the container (e.g., "/tmp/stdout").
    * @param opts.redirectStderr Redirect the command's standard error to a file in the container (e.g., "/tmp/stderr").

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -862,6 +862,7 @@ class Container(Type):
     def with_exec(
         self,
         args: Sequence[str],
+        skip_entrypoint: Optional[bool] = None,
         stdin: Optional[str] = None,
         redirect_stdout: Optional[str] = None,
         redirect_stderr: Optional[str] = None,
@@ -876,6 +877,9 @@ class Container(Type):
         args:
             Command to run instead of the container's default command (e.g.,
             ["run", "main.go"]).
+        skip_entrypoint:
+            If the container has an entrypoint, ignore it for args rather than
+            using it to wrap them.
         stdin:
             Content to write to the command's standard input before closing
             (e.g., "Hello world").
@@ -902,6 +906,7 @@ class Container(Type):
         """
         _args = [
             Arg("args", args),
+            Arg("skipEntrypoint", skip_entrypoint, None),
             Arg("stdin", stdin, None),
             Arg("redirectStdout", redirect_stdout, None),
             Arg("redirectStderr", redirect_stderr, None),

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -862,6 +862,7 @@ class Container(Type):
     def with_exec(
         self,
         args: Sequence[str],
+        skip_entrypoint: Optional[bool] = None,
         stdin: Optional[str] = None,
         redirect_stdout: Optional[str] = None,
         redirect_stderr: Optional[str] = None,
@@ -876,6 +877,9 @@ class Container(Type):
         args:
             Command to run instead of the container's default command (e.g.,
             ["run", "main.go"]).
+        skip_entrypoint:
+            If the container has an entrypoint, ignore it for args rather than
+            using it to wrap them.
         stdin:
             Content to write to the command's standard input before closing
             (e.g., "Hello world").
@@ -902,6 +906,7 @@ class Container(Type):
         """
         _args = [
             Arg("args", args),
+            Arg("skipEntrypoint", skip_entrypoint, None),
             Arg("stdin", stdin, None),
             Arg("redirectStdout", redirect_stdout, None),
             Arg("redirectStderr", redirect_stderr, None),


### PR DESCRIPTION
Allows an exec to skip the entrypoint. This allows folks to implement Dockerfile semantics (e.g. `RUN`, which skips entrypoint) without having to collect the current value, remove it, and add it back afterwards.

[Example use case](https://github.com/vito/bass/blob/0888230999825a59b110f9de2ad9a152519111ad/pkg/runtimes/dagger.go#L342-L364)