### PR TITLE
Set HTTP source filename to be URL.

### DIFF
--- a/core/integration/http_test.go
+++ b/core/integration/http_test.go
@@ -14,8 +14,14 @@ func TestHTTP(t *testing.T) {
 	c, ctx := connect(t)
 	defer c.Close()
 
-	url := "https://raw.githubusercontent.com/dagger/dagger/main/README.md"
+	// do two in a row to ensure each gets downloaded correctly
+	url := "https://raw.githubusercontent.com/dagger/dagger/main/TESTING.md"
 	contents, err := c.HTTP(url).Contents(ctx)
+	require.NoError(t, err)
+	require.Contains(t, contents, "tests")
+
+	url = "https://raw.githubusercontent.com/dagger/dagger/main/README.md"
+	contents, err = c.HTTP(url).Contents(ctx)
 	require.NoError(t, err)
 	require.Contains(t, contents, "Dagger")
 }

--- a/core/schema/http.go
+++ b/core/schema/http.go
@@ -1,11 +1,10 @@
 package schema
 
 import (
-	"encoding/base64"
-
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/router"
 	"github.com/moby/buildkit/client/llb"
+	"github.com/opencontainers/go-digest"
 )
 
 var _ router.ExecutableSchema = &httpSchema{}
@@ -45,8 +44,8 @@ func (s *httpSchema) http(ctx *router.Context, parent *core.Query, args httpArgs
 	// Use a filename that is set to the URL. Buildkit internally stores some cache metadata of etags
 	// and http checksums using an id based on this name, so setting it to the URL maximizes our chances
 	// of following more optimized cache codepaths.
-	// Do a base64 encode to prevent conflicts with use of `/` in the URL.
-	filename := base64.URLEncoding.EncodeToString([]byte(args.URL))
+	// Do a hash encode to prevent conflicts with use of `/` in the URL while also not hitting max filename limits
+	filename := digest.FromString(args.URL).Encoded()
 	st := llb.HTTP(args.URL, llb.Filename(filename), pipeline.LLBOpt())
 
 	svcs := core.ServiceBindings{}


### PR DESCRIPTION
Buildkit internally stores some cache metadata of etags and http checksums using an id based on this name, so setting it to the URL maximizes our chances of following more optimized cache codepaths.

The codepaths in Buildkit are here:
1. A hash is used to lookup any possible etag/url-hash metadata from previous http sources: https://github.com/sipsma/buildkit/blob/cf2698c0e4b708127c3aa86c49d51532feee6b82/source/http/httpsource.go#L128-L134

2. That hash is based in part on this getFileName function: https://github.com/sipsma/buildkit/blob/cf2698c0e4b708127c3aa86c49d51532feee6b82/source/http/httpsource.go#L91

3. getFileName will default to just using the llb.Filename if explicitly set: https://github.com/sipsma/buildkit/blob/cf2698c0e4b708127c3aa86c49d51532feee6b82/source/http/httpsource.go#L419-L421

In theory this behavior should have just been unoptimal before this commit, the behavior was still correct. However, this did end up triggering a different buildkit bug where the GET request made after an unsuccessful attempt at matching based on previous etag metadata was accidentally not uncompressing gzip responses, fixed here: https://github.com/moby/buildkit/pull/3788