### PR TITLE
Support configuring ownership (almost) everywhere

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,3 +34,10 @@ linters:
     - unused
     - unused
     - whitespace
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - dupl
+        - gosec

--- a/core/container.go
+++ b/core/container.go
@@ -124,18 +124,18 @@ type HostAlias struct {
 // ContainerSecret configures a secret to expose, either as an environment
 // variable or mounted to a file path.
 type ContainerSecret struct {
-	Secret    SecretID         `json:"secret"`
-	EnvName   string           `json:"env,omitempty"`
-	MountPath string           `json:"path,omitempty"`
-	Owner     *FilesystemOwner `json:"owner,omitempty"`
+	Secret    SecretID `json:"secret"`
+	EnvName   string   `json:"env,omitempty"`
+	MountPath string   `json:"path,omitempty"`
+	Owner     string   `json:"owner,omitempty"`
 }
 
 // ContainerSocket configures a socket to expose, currently as a Unix socket,
 // but potentially as a TCP or UDP address in the future.
 type ContainerSocket struct {
-	Socket   SocketID         `json:"socket"`
-	UnixPath string           `json:"unix_path,omitempty"`
-	Owner    *FilesystemOwner `json:"owner,omitempty"`
+	Socket   SocketID `json:"socket"`
+	UnixPath string   `json:"unix_path,omitempty"`
+	Owner    string   `json:"owner,omitempty"`
 }
 
 // ContainerPort configures a port to expose from the container.
@@ -209,7 +209,7 @@ type ContainerMount struct {
 	// A user:group to set for the mount and its contents.
 	//
 	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
-	Owner *FilesystemOwner `json:"owner,omitempty"`
+	Owner string `json:"owner,omitempty"`
 }
 
 // SourceState returns the state of the source of the mount.
@@ -481,7 +481,7 @@ func (container *Container) WithRootFS(ctx context.Context, dir *Directory) (*Co
 	return container.containerFromPayload(payload)
 }
 
-func (container *Container) WithDirectory(ctx context.Context, gw bkgw.Client, subdir string, src *Directory, filter CopyFilter, owner *FilesystemOwner) (*Container, error) {
+func (container *Container) WithDirectory(ctx context.Context, gw bkgw.Client, subdir string, src *Directory, filter CopyFilter, owner string) (*Container, error) {
 	return container.updateRootFS(ctx, subdir, func(dir *Directory) (*Directory, error) {
 		uid, gid, err := container.uidgid(ctx, gw, owner)
 		if err != nil {
@@ -492,7 +492,7 @@ func (container *Container) WithDirectory(ctx context.Context, gw bkgw.Client, s
 	})
 }
 
-func (container *Container) WithFile(ctx context.Context, gw bkgw.Client, subdir string, src *File, permissions fs.FileMode, owner *FilesystemOwner) (*Container, error) {
+func (container *Container) WithFile(ctx context.Context, gw bkgw.Client, subdir string, src *File, permissions fs.FileMode, owner string) (*Container, error) {
 	return container.updateRootFS(ctx, subdir, func(dir *Directory) (*Directory, error) {
 		uid, gid, err := container.uidgid(ctx, gw, owner)
 		if err != nil {
@@ -503,7 +503,7 @@ func (container *Container) WithFile(ctx context.Context, gw bkgw.Client, subdir
 	})
 }
 
-func (container *Container) WithNewFile(ctx context.Context, gw bkgw.Client, dest string, content []byte, permissions fs.FileMode, owner *FilesystemOwner) (*Container, error) {
+func (container *Container) WithNewFile(ctx context.Context, gw bkgw.Client, dest string, content []byte, permissions fs.FileMode, owner string) (*Container, error) {
 	dir, file := filepath.Split(dest)
 	return container.updateRootFS(ctx, dir, func(dir *Directory) (*Directory, error) {
 		uid, gid, err := container.uidgid(ctx, gw, owner)
@@ -515,7 +515,7 @@ func (container *Container) WithNewFile(ctx context.Context, gw bkgw.Client, des
 	})
 }
 
-func (container *Container) WithMountedDirectory(ctx context.Context, target string, source *Directory, owner *FilesystemOwner) (*Container, error) {
+func (container *Container) WithMountedDirectory(ctx context.Context, target string, source *Directory, owner string) (*Container, error) {
 	payload, err := source.ID.Decode()
 	if err != nil {
 		return nil, err
@@ -524,7 +524,7 @@ func (container *Container) WithMountedDirectory(ctx context.Context, target str
 	return container.withMounted(target, payload.LLB, payload.Dir, payload.Services, owner)
 }
 
-func (container *Container) WithMountedFile(ctx context.Context, target string, source *File, owner *FilesystemOwner) (*Container, error) {
+func (container *Container) WithMountedFile(ctx context.Context, target string, source *File, owner string) (*Container, error) {
 	payload, err := source.ID.decode()
 	if err != nil {
 		return nil, err
@@ -533,7 +533,7 @@ func (container *Container) WithMountedFile(ctx context.Context, target string, 
 	return container.withMounted(target, payload.LLB, payload.File, payload.Services, owner)
 }
 
-func (container *Container) WithMountedCache(ctx context.Context, target string, cache CacheID, source *Directory, concurrency CacheSharingMode, owner *FilesystemOwner) (*Container, error) {
+func (container *Container) WithMountedCache(ctx context.Context, target string, cache CacheID, source *Directory, concurrency CacheSharingMode, owner string) (*Container, error) {
 	payload, err := container.ID.decode()
 	if err != nil {
 		return nil, err
@@ -600,7 +600,7 @@ func (container *Container) WithMountedTemp(ctx context.Context, target string) 
 	return container.containerFromPayload(payload)
 }
 
-func (container *Container) WithMountedSecret(ctx context.Context, target string, source *Secret, owner *FilesystemOwner) (*Container, error) {
+func (container *Container) WithMountedSecret(ctx context.Context, target string, source *Secret, owner string) (*Container, error) {
 	payload, err := container.ID.decode()
 	if err != nil {
 		return nil, err
@@ -662,7 +662,7 @@ func (container *Container) Mounts(ctx context.Context) ([]string, error) {
 	return mounts, nil
 }
 
-func (container *Container) WithUnixSocket(ctx context.Context, target string, source *Socket, owner *FilesystemOwner) (*Container, error) {
+func (container *Container) WithUnixSocket(ctx context.Context, target string, source *Socket, owner string) (*Container, error) {
 	payload, err := container.ID.decode()
 	if err != nil {
 		return nil, err
@@ -841,7 +841,7 @@ func (container *Container) withMounted(
 	srcDef *pb.Definition,
 	srcPath string,
 	svcs ServiceBindings,
-	owner *FilesystemOwner,
+	owner string,
 ) (*Container, error) {
 	payload, err := container.ID.decode()
 	if err != nil {
@@ -901,7 +901,7 @@ func (container *Container) updateRootFS(ctx context.Context, subdir string, fn 
 		return nil, err
 	}
 
-	return container.withMounted(mount.Target, dirPayload.LLB, mount.SourcePath, nil, nil)
+	return container.withMounted(mount.Target, dirPayload.LLB, mount.SourcePath, nil, "")
 }
 
 func (container *Container) ImageConfig(ctx context.Context) (specs.ImageConfig, error) {
@@ -1050,8 +1050,8 @@ func (container *Container) WithExec(ctx context.Context, gw bkgw.Client, defaul
 		case secret.MountPath != "":
 			secretDest = secret.MountPath
 			secretsToScrub.Files = append(secretsToScrub.Files, secret.MountPath)
-			if secret.Owner != nil {
-				uid, gid, err := resolveUIDGID(ctx, fsSt, gw, platform, *secret.Owner)
+			if secret.Owner != "" {
+				uid, gid, err := resolveUIDGID(ctx, fsSt, gw, platform, secret.Owner)
 				if err != nil {
 					return nil, err
 				}
@@ -1086,8 +1086,8 @@ func (container *Container) WithExec(ctx context.Context, gw bkgw.Client, defaul
 			llb.SSHSocketTarget(socket.UnixPath),
 		}
 
-		if socket.Owner != nil {
-			uid, gid, err := resolveUIDGID(ctx, fsSt, gw, platform, *socket.Owner)
+		if socket.Owner != "" {
+			uid, gid, err := resolveUIDGID(ctx, fsSt, gw, platform, socket.Owner)
 			if err != nil {
 				return nil, err
 			}
@@ -1107,8 +1107,8 @@ func (container *Container) WithExec(ctx context.Context, gw bkgw.Client, defaul
 
 		mountOpts := []llb.MountOption{}
 
-		if mnt.Owner != nil {
-			uid, gid, err := resolveUIDGID(ctx, fsSt, gw, platform, *mnt.Owner)
+		if mnt.Owner != "" {
+			uid, gid, err := resolveUIDGID(ctx, fsSt, gw, platform, mnt.Owner)
 			if err != nil {
 				return nil, fmt.Errorf("mount %s: %w", mnt.Target, err)
 			}
@@ -1789,10 +1789,10 @@ func (container *Container) containerFromPayload(payload *containerIDPayload) (*
 	return &Container{ID: id}, nil
 }
 
-func (container *Container) uidgid(ctx context.Context, gw bkgw.Client, owner *FilesystemOwner) (int, int, error) {
-	if owner == nil {
-		// default to an invalid ID, which means don't set anything
-		return -1, -1, nil
+func (container *Container) uidgid(ctx context.Context, gw bkgw.Client, owner string) (int, int, error) {
+	if owner == "" {
+		// default to root
+		return 0, 0, nil
 	}
 
 	containerPayload, err := container.ID.decode()
@@ -1805,7 +1805,7 @@ func (container *Container) uidgid(ctx context.Context, gw bkgw.Client, owner *F
 		return -1, -1, err
 	}
 
-	return resolveUIDGID(ctx, fsSt, gw, containerPayload.Platform, *owner)
+	return resolveUIDGID(ctx, fsSt, gw, containerPayload.Platform, owner)
 }
 
 type ContainerExecOpts struct {
@@ -1922,16 +1922,4 @@ func overrideProgress(def *llb.Definition, pipeline pipeline.Path) {
 		metadata.ProgressGroup = pipeline.ProgressGroup()
 		def.Metadata[dgst] = metadata
 	}
-}
-
-type FilesystemOwner struct {
-	User  string `json:"user"`
-	Group string `json:"group"`
-}
-
-func (owner FilesystemOwner) String() string {
-	if owner.Group == "" {
-		return owner.User
-	}
-	return fmt.Sprintf("%s:%s", owner.User, owner.Group)
 }

--- a/core/container.go
+++ b/core/container.go
@@ -507,7 +507,17 @@ func (container *Container) WithRootFS(ctx context.Context, dir *Directory) (*Co
 		return nil, err
 	}
 
-	payload.FS = dirPayload.LLB
+	dirSt, err := dirPayload.StateWithSourcePath()
+	if err != nil {
+		return nil, err
+	}
+
+	def, err := dirSt.Marshal(ctx, llb.Platform(dirPayload.Platform))
+	if err != nil {
+		return nil, err
+	}
+
+	payload.FS = def.ToPB()
 
 	payload.Services.Merge(dirPayload.Services)
 

--- a/core/container.go
+++ b/core/container.go
@@ -121,6 +121,9 @@ type HostAlias struct {
 	Target string `json:"target"`
 }
 
+// Ownership contains a UID/GID pair resolved from a user/group name or ID pair
+// provided via the API. It primarily exists to distinguish an unspecified
+// ownership from UID/GID 0 (root) ownership.
 type Ownership struct {
 	UID int `json:"uid"`
 	GID int `json:"gid"`
@@ -941,7 +944,6 @@ func (container *Container) chown(
 		return nil, "", err
 	}
 
-	// "re-write" the mount to point to the chowned location
 	return def.ToPB(), filepath.Join("/chown", filepath.Base(srcPath)), nil
 }
 
@@ -1136,7 +1138,7 @@ func (container *Container) WithExec(ctx context.Context, gw bkgw.Client, defaul
 					secret.Owner.UID,
 					secret.Owner.GID,
 					0o400, // preserve default
-				)) // 0400 is default
+				))
 			}
 		default:
 			return nil, fmt.Errorf("malformed secret config at index %d", i)
@@ -1511,7 +1513,6 @@ const OCIStoreName = "dagger-oci"
 
 func (container *Container) Import(
 	ctx context.Context,
-	gw bkgw.Client,
 	host *Host,
 	source io.Reader,
 	tag string,

--- a/core/container.go
+++ b/core/container.go
@@ -124,18 +124,18 @@ type HostAlias struct {
 // ContainerSecret configures a secret to expose, either as an environment
 // variable or mounted to a file path.
 type ContainerSecret struct {
-	Secret    SecretID `json:"secret"`
-	EnvName   string   `json:"env,omitempty"`
-	MountPath string   `json:"path,omitempty"`
-	Owner     string   `json:"owner,omitempty"`
+	Secret    SecretID         `json:"secret"`
+	EnvName   string           `json:"env,omitempty"`
+	MountPath string           `json:"path,omitempty"`
+	Owner     *FilesystemOwner `json:"owner,omitempty"`
 }
 
 // ContainerSocket configures a socket to expose, currently as a Unix socket,
 // but potentially as a TCP or UDP address in the future.
 type ContainerSocket struct {
-	Socket   SocketID `json:"socket"`
-	UnixPath string   `json:"unix_path,omitempty"`
-	Owner    string   `json:"owner,omitempty"`
+	Socket   SocketID         `json:"socket"`
+	UnixPath string           `json:"unix_path,omitempty"`
+	Owner    *FilesystemOwner `json:"owner,omitempty"`
 }
 
 // ContainerPort configures a port to expose from the container.
@@ -209,7 +209,7 @@ type ContainerMount struct {
 	// A user:group to set for the mount and its contents.
 	//
 	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
-	Owner string `json:"owner,omitempty"`
+	Owner *FilesystemOwner `json:"owner,omitempty"`
 }
 
 // SourceState returns the state of the source of the mount.
@@ -481,7 +481,7 @@ func (container *Container) WithRootFS(ctx context.Context, dir *Directory) (*Co
 	return container.containerFromPayload(payload)
 }
 
-func (container *Container) WithDirectory(ctx context.Context, gw bkgw.Client, subdir string, src *Directory, filter CopyFilter, owner string) (*Container, error) {
+func (container *Container) WithDirectory(ctx context.Context, gw bkgw.Client, subdir string, src *Directory, filter CopyFilter, owner *FilesystemOwner) (*Container, error) {
 	return container.updateRootFS(ctx, subdir, func(dir *Directory) (*Directory, error) {
 		uid, gid, err := container.uidgid(ctx, gw, owner)
 		if err != nil {
@@ -492,7 +492,7 @@ func (container *Container) WithDirectory(ctx context.Context, gw bkgw.Client, s
 	})
 }
 
-func (container *Container) WithFile(ctx context.Context, gw bkgw.Client, subdir string, src *File, permissions fs.FileMode, owner string) (*Container, error) {
+func (container *Container) WithFile(ctx context.Context, gw bkgw.Client, subdir string, src *File, permissions fs.FileMode, owner *FilesystemOwner) (*Container, error) {
 	return container.updateRootFS(ctx, subdir, func(dir *Directory) (*Directory, error) {
 		uid, gid, err := container.uidgid(ctx, gw, owner)
 		if err != nil {
@@ -503,7 +503,7 @@ func (container *Container) WithFile(ctx context.Context, gw bkgw.Client, subdir
 	})
 }
 
-func (container *Container) WithNewFile(ctx context.Context, gw bkgw.Client, dest string, content []byte, permissions fs.FileMode, owner string) (*Container, error) {
+func (container *Container) WithNewFile(ctx context.Context, gw bkgw.Client, dest string, content []byte, permissions fs.FileMode, owner *FilesystemOwner) (*Container, error) {
 	dir, file := filepath.Split(dest)
 	return container.updateRootFS(ctx, dir, func(dir *Directory) (*Directory, error) {
 		uid, gid, err := container.uidgid(ctx, gw, owner)
@@ -515,7 +515,7 @@ func (container *Container) WithNewFile(ctx context.Context, gw bkgw.Client, des
 	})
 }
 
-func (container *Container) WithMountedDirectory(ctx context.Context, target string, source *Directory, owner string) (*Container, error) {
+func (container *Container) WithMountedDirectory(ctx context.Context, target string, source *Directory, owner *FilesystemOwner) (*Container, error) {
 	payload, err := source.ID.Decode()
 	if err != nil {
 		return nil, err
@@ -524,7 +524,7 @@ func (container *Container) WithMountedDirectory(ctx context.Context, target str
 	return container.withMounted(target, payload.LLB, payload.Dir, payload.Services, owner)
 }
 
-func (container *Container) WithMountedFile(ctx context.Context, target string, source *File, owner string) (*Container, error) {
+func (container *Container) WithMountedFile(ctx context.Context, target string, source *File, owner *FilesystemOwner) (*Container, error) {
 	payload, err := source.ID.decode()
 	if err != nil {
 		return nil, err
@@ -533,7 +533,7 @@ func (container *Container) WithMountedFile(ctx context.Context, target string, 
 	return container.withMounted(target, payload.LLB, payload.File, payload.Services, owner)
 }
 
-func (container *Container) WithMountedCache(ctx context.Context, target string, cache CacheID, source *Directory, concurrency CacheSharingMode, owner string) (*Container, error) {
+func (container *Container) WithMountedCache(ctx context.Context, target string, cache CacheID, source *Directory, concurrency CacheSharingMode, owner *FilesystemOwner) (*Container, error) {
 	payload, err := container.ID.decode()
 	if err != nil {
 		return nil, err
@@ -600,7 +600,7 @@ func (container *Container) WithMountedTemp(ctx context.Context, target string) 
 	return container.containerFromPayload(payload)
 }
 
-func (container *Container) WithMountedSecret(ctx context.Context, target string, source *Secret, owner string) (*Container, error) {
+func (container *Container) WithMountedSecret(ctx context.Context, target string, source *Secret, owner *FilesystemOwner) (*Container, error) {
 	payload, err := container.ID.decode()
 	if err != nil {
 		return nil, err
@@ -662,7 +662,7 @@ func (container *Container) Mounts(ctx context.Context) ([]string, error) {
 	return mounts, nil
 }
 
-func (container *Container) WithUnixSocket(ctx context.Context, target string, source *Socket, owner string) (*Container, error) {
+func (container *Container) WithUnixSocket(ctx context.Context, target string, source *Socket, owner *FilesystemOwner) (*Container, error) {
 	payload, err := container.ID.decode()
 	if err != nil {
 		return nil, err
@@ -841,7 +841,7 @@ func (container *Container) withMounted(
 	srcDef *pb.Definition,
 	srcPath string,
 	svcs ServiceBindings,
-	owner string,
+	owner *FilesystemOwner,
 ) (*Container, error) {
 	payload, err := container.ID.decode()
 	if err != nil {
@@ -901,7 +901,7 @@ func (container *Container) updateRootFS(ctx context.Context, subdir string, fn 
 		return nil, err
 	}
 
-	return container.withMounted(mount.Target, dirPayload.LLB, mount.SourcePath, nil, "")
+	return container.withMounted(mount.Target, dirPayload.LLB, mount.SourcePath, nil, nil)
 }
 
 func (container *Container) ImageConfig(ctx context.Context) (specs.ImageConfig, error) {
@@ -1050,8 +1050,8 @@ func (container *Container) WithExec(ctx context.Context, gw bkgw.Client, defaul
 		case secret.MountPath != "":
 			secretDest = secret.MountPath
 			secretsToScrub.Files = append(secretsToScrub.Files, secret.MountPath)
-			if secret.Owner != "" {
-				uid, gid, err := resolveUIDGID(ctx, fsSt, gw, platform, secret.Owner)
+			if secret.Owner != nil {
+				uid, gid, err := resolveUIDGID(ctx, fsSt, gw, platform, *secret.Owner)
 				if err != nil {
 					return nil, err
 				}
@@ -1086,8 +1086,8 @@ func (container *Container) WithExec(ctx context.Context, gw bkgw.Client, defaul
 			llb.SSHSocketTarget(socket.UnixPath),
 		}
 
-		if socket.Owner != "" {
-			uid, gid, err := resolveUIDGID(ctx, fsSt, gw, platform, socket.Owner)
+		if socket.Owner != nil {
+			uid, gid, err := resolveUIDGID(ctx, fsSt, gw, platform, *socket.Owner)
 			if err != nil {
 				return nil, err
 			}
@@ -1107,8 +1107,8 @@ func (container *Container) WithExec(ctx context.Context, gw bkgw.Client, defaul
 
 		mountOpts := []llb.MountOption{}
 
-		if mnt.Owner != "" {
-			uid, gid, err := resolveUIDGID(ctx, fsSt, gw, platform, mnt.Owner)
+		if mnt.Owner != nil {
+			uid, gid, err := resolveUIDGID(ctx, fsSt, gw, platform, *mnt.Owner)
 			if err != nil {
 				return nil, fmt.Errorf("mount %s: %w", mnt.Target, err)
 			}
@@ -1789,10 +1789,10 @@ func (container *Container) containerFromPayload(payload *containerIDPayload) (*
 	return &Container{ID: id}, nil
 }
 
-func (container *Container) uidgid(ctx context.Context, gw bkgw.Client, owner string) (int, int, error) {
-	if owner == "" {
-		// default to root
-		return 0, 0, nil
+func (container *Container) uidgid(ctx context.Context, gw bkgw.Client, owner *FilesystemOwner) (int, int, error) {
+	if owner == nil {
+		// default to an invalid ID, which means don't set anything
+		return -1, -1, nil
 	}
 
 	containerPayload, err := container.ID.decode()
@@ -1805,7 +1805,7 @@ func (container *Container) uidgid(ctx context.Context, gw bkgw.Client, owner st
 		return -1, -1, err
 	}
 
-	return resolveUIDGID(ctx, fsSt, gw, containerPayload.Platform, owner)
+	return resolveUIDGID(ctx, fsSt, gw, containerPayload.Platform, *owner)
 }
 
 type ContainerExecOpts struct {
@@ -1922,4 +1922,16 @@ func overrideProgress(def *llb.Definition, pipeline pipeline.Path) {
 		metadata.ProgressGroup = pipeline.ProgressGroup()
 		def.Metadata[dgst] = metadata
 	}
+}
+
+type FilesystemOwner struct {
+	User  string `json:"user"`
+	Group string `json:"group"`
+}
+
+func (owner FilesystemOwner) String() string {
+	if owner.Group == "" {
+		return owner.User
+	}
+	return fmt.Sprintf("%s:%s", owner.User, owner.Group)
 }

--- a/core/container.go
+++ b/core/container.go
@@ -1178,7 +1178,7 @@ func (container *Container) WithExec(ctx context.Context, gw bkgw.Client, defaul
 				llb.Mkdir("/chown", 0o700, llb.WithUIDGID(uid, gid)).
 					Copy(srcSt, mnt.SourcePath, "/chown", llb.WithUIDGID(uid, gid)),
 				pipeline.CustomName{
-					Name:     fmt.Sprintf("chown to %d:%d", uid, gid),
+					Name:     fmt.Sprintf("chown %s to %d:%d", mnt.Target, uid, gid),
 					Pipeline: payload.Pipeline,
 					Internal: true,
 				}.LLBOpt(),

--- a/core/container.go
+++ b/core/container.go
@@ -1171,7 +1171,11 @@ func (container *Container) WithExec(ctx context.Context, gw bkgw.Client, defaul
 			srcSt = llb.Scratch().File(
 				llb.Mkdir("/chown", 0o700, llb.WithUIDGID(uid, gid)).
 					Copy(srcSt, mnt.SourcePath, "/chown", llb.WithUIDGID(uid, gid)),
-				payload.Pipeline.LLBOpt(),
+				pipeline.CustomName{
+					Name:     fmt.Sprintf("chown to %d:%d", uid, gid),
+					Pipeline: payload.Pipeline,
+					Internal: true,
+				}.LLBOpt(),
 			)
 
 			// "re-write" the source path to point to the chowned location

--- a/core/container.go
+++ b/core/container.go
@@ -531,7 +531,7 @@ func (container *Container) WithMountedFile(ctx context.Context, target string, 
 	return container.withMounted(target, payload.LLB, payload.File, payload.Services, owner)
 }
 
-func (container *Container) WithMountedCache(ctx context.Context, target string, cache CacheID, source *Directory, concurrency CacheSharingMode) (*Container, error) {
+func (container *Container) WithMountedCache(ctx context.Context, target string, cache CacheID, source *Directory, concurrency CacheSharingMode, owner string) (*Container, error) {
 	payload, err := container.ID.decode()
 	if err != nil {
 		return nil, err
@@ -558,6 +558,7 @@ func (container *Container) WithMountedCache(ctx context.Context, target string,
 		Target:           target,
 		CacheID:          cachePayload.Sum(),
 		CacheSharingMode: cacheSharingMode,
+		Owner:            owner,
 	}
 
 	if source != nil {
@@ -1106,7 +1107,7 @@ func (container *Container) WithExec(ctx context.Context, gw bkgw.Client, defaul
 			mountOpts = append(mountOpts, llb.SourcePath(mnt.SourcePath))
 		}
 
-		if mnt.CacheSharingMode != "" {
+		if mnt.CacheID != "" {
 			var sharingMode llb.CacheMountSharingMode
 			switch mnt.CacheSharingMode {
 			case "shared":

--- a/core/directory.go
+++ b/core/directory.go
@@ -217,7 +217,7 @@ func (dir *Directory) Entries(ctx context.Context, gw bkgw.Client, src string) (
 	})
 }
 
-func (dir *Directory) WithNewFile(ctx context.Context, dest string, content []byte, permissions fs.FileMode, uid, gid int) (*Directory, error) {
+func (dir *Directory) WithNewFile(ctx context.Context, dest string, content []byte, permissions fs.FileMode, ownership *Ownership) (*Directory, error) {
 	err := validateFileName(dest)
 	if err != nil {
 		return nil, err
@@ -246,8 +246,8 @@ func (dir *Directory) WithNewFile(ctx context.Context, dest string, content []by
 	}
 
 	opts := []llb.MkfileOption{}
-	if uid != -1 && gid != -1 {
-		opts = append(opts, llb.WithUIDGID(uid, gid))
+	if ownership != nil {
+		opts = append(opts, ownership.Opt())
 	}
 
 	st = st.File(
@@ -293,7 +293,7 @@ func (dir *Directory) File(ctx context.Context, file string) (*File, error) {
 	}).ToFile()
 }
 
-func (dir *Directory) WithDirectory(ctx context.Context, subdir string, src *Directory, filter CopyFilter, uid, gid int) (*Directory, error) {
+func (dir *Directory) WithDirectory(ctx context.Context, subdir string, src *Directory, filter CopyFilter, owner *Ownership) (*Directory, error) {
 	destPayload, err := dir.ID.Decode()
 	if err != nil {
 		return nil, err
@@ -324,8 +324,8 @@ func (dir *Directory) WithDirectory(ctx context.Context, subdir string, src *Dir
 			AllowEmptyWildcard:  true,
 		},
 	}
-	if uid != -1 && gid != -1 {
-		opts = append(opts, llb.WithUIDGID(uid, gid))
+	if owner != nil {
+		opts = append(opts, owner.Opt())
 	}
 
 	st = st.File(
@@ -400,7 +400,7 @@ func (dir *Directory) WithNewDirectory(ctx context.Context, dest string, permiss
 	return payload.ToDirectory()
 }
 
-func (dir *Directory) WithFile(ctx context.Context, subdir string, src *File, permissions fs.FileMode, uid, gid int) (*Directory, error) {
+func (dir *Directory) WithFile(ctx context.Context, subdir string, src *File, permissions fs.FileMode, ownership *Ownership) (*Directory, error) {
 	destPayload, err := dir.ID.Decode()
 	if err != nil {
 		return nil, err
@@ -433,8 +433,8 @@ func (dir *Directory) WithFile(ctx context.Context, subdir string, src *File, pe
 		},
 	}
 
-	if uid != -1 && gid != -1 {
-		opts = append(opts, llb.WithUIDGID(uid, gid))
+	if ownership != nil {
+		opts = append(opts, ownership.Opt())
 	}
 
 	st = st.File(

--- a/core/directory.go
+++ b/core/directory.go
@@ -320,8 +320,6 @@ func (dir *Directory) WithDirectory(ctx context.Context, subdir string, src *Dir
 			CopyDirContentsOnly: true,
 			IncludePatterns:     filter.Include,
 			ExcludePatterns:     filter.Exclude,
-			AllowWildcard:       true,
-			AllowEmptyWildcard:  true,
 		},
 	}
 	if owner != nil {

--- a/core/directory.go
+++ b/core/directory.go
@@ -228,13 +228,15 @@ func (dir *Directory) WithNewFile(ctx context.Context, dest string, content []by
 		st = st.File(llb.Mkdir(parent, 0755, llb.WithParents(true)), payload.Pipeline.LLBOpt())
 	}
 
-	opts := []llb.MkfileOption{}
-
-	if uid != -1 && gid != -1 {
-		opts = append(opts, llb.WithUIDGID(uid, gid))
-	}
-
-	st = st.File(llb.Mkfile(dest, permissions, content, opts...), payload.Pipeline.LLBOpt())
+	st = st.File(
+		llb.Mkfile(
+			dest,
+			permissions,
+			content,
+			llb.WithUIDGID(uid, gid),
+		),
+		payload.Pipeline.LLBOpt(),
+	)
 
 	err = payload.SetState(ctx, st)
 	if err != nil {
@@ -295,25 +297,14 @@ func (dir *Directory) WithDirectory(ctx context.Context, subdir string, src *Dir
 		return nil, err
 	}
 
-	opts := []llb.CopyOption{
-		&llb.CopyInfo{
-			CreateDestPath:      true,
-			CopyDirContentsOnly: true,
-			IncludePatterns:     filter.Include,
-			ExcludePatterns:     filter.Exclude,
-		},
-	}
-
-	if uid != -1 && gid != -1 {
-		opts = append(opts, llb.WithUIDGID(uid, gid))
-	}
-
-	st = st.File(llb.Copy(
-		srcSt,
-		srcPayload.Dir,
-		path.Join(destPayload.Dir, subdir),
-		opts...,
-	), destPayload.Pipeline.LLBOpt())
+	st = st.File(llb.Copy(srcSt, srcPayload.Dir, path.Join(destPayload.Dir, subdir), &llb.CopyInfo{
+		CreateDestPath:      true,
+		CopyDirContentsOnly: true,
+		IncludePatterns:     filter.Include,
+		ExcludePatterns:     filter.Exclude,
+	}, llb.WithUIDGID(uid, gid)),
+		destPayload.Pipeline.LLBOpt(),
+	)
 
 	err = destPayload.SetState(ctx, st)
 	if err != nil {
@@ -409,23 +400,10 @@ func (dir *Directory) WithFile(ctx context.Context, subdir string, src *File, pe
 		perm = &permissions
 	}
 
-	opts := []llb.CopyOption{
-		&llb.CopyInfo{
-			CreateDestPath: true,
-			Mode:           perm,
-		},
-	}
-
-	if uid != -1 && gid != -1 {
-		opts = append(opts, llb.WithUIDGID(uid, gid))
-	}
-
-	st = st.File(llb.Copy(
-		srcSt,
-		srcPayload.File,
-		path.Join(destPayload.Dir, subdir),
-		opts...,
-	), destPayload.Pipeline.LLBOpt())
+	st = st.File(llb.Copy(srcSt, srcPayload.File, path.Join(destPayload.Dir, subdir), &llb.CopyInfo{
+		CreateDestPath: true,
+		Mode:           perm,
+	}, llb.WithUIDGID(uid, gid)), destPayload.Pipeline.LLBOpt())
 
 	err = destPayload.SetState(ctx, st)
 	if err != nil {

--- a/core/directory.go
+++ b/core/directory.go
@@ -72,7 +72,7 @@ func (payload *directoryIDPayload) StateWithSourcePath() (llb.State, error) {
 		return llb.State{}, err
 	}
 
-	if payload.Dir == "" {
+	if payload.Dir == "/" {
 		return dirSt, nil
 	}
 
@@ -104,9 +104,9 @@ func (payload *directoryIDPayload) ToDirectory() (*Directory, error) {
 	}, nil
 }
 
-func NewDirectory(ctx context.Context, st llb.State, cwd string, pipeline pipeline.Path, platform specs.Platform, services ServiceBindings) (*Directory, error) {
+func NewDirectory(ctx context.Context, st llb.State, dir string, pipeline pipeline.Path, platform specs.Platform, services ServiceBindings) (*Directory, error) {
 	payload := directoryIDPayload{
-		Dir:      cwd,
+		Dir:      dir,
 		Platform: platform,
 		Pipeline: pipeline.Copy(),
 		Services: services,
@@ -571,6 +571,18 @@ func (dir *Directory) Export(
 			})
 		})
 	})
+}
+
+// Root removes any relative path from the directory.
+func (dir *Directory) Root() (*Directory, error) {
+	payload, err := dir.ID.Decode()
+	if err != nil {
+		return nil, err
+	}
+
+	payload.Dir = "/"
+
+	return payload.ToDirectory()
 }
 
 func validateFileName(file string) error {

--- a/core/directory.go
+++ b/core/directory.go
@@ -66,6 +66,23 @@ func (payload *directoryIDPayload) State() (llb.State, error) {
 	return defToState(payload.LLB)
 }
 
+func (payload *directoryIDPayload) StateWithSourcePath() (llb.State, error) {
+	dirSt, err := payload.State()
+	if err != nil {
+		return llb.State{}, err
+	}
+
+	if payload.Dir == "" {
+		return dirSt, nil
+	}
+
+	return llb.Scratch().File(
+		llb.Copy(dirSt, payload.Dir, ".", &llb.CopyInfo{
+			CopyDirContentsOnly: true,
+		}),
+	), nil
+}
+
 func (payload *directoryIDPayload) SetState(ctx context.Context, st llb.State) error {
 	def, err := st.Marshal(ctx, llb.Platform(payload.Platform))
 	if err != nil {

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3457,74 +3457,47 @@ func TestContainerWithNewFileOwner(t *testing.T) {
 	c, ctx := connect(t)
 	defer c.Close()
 
-	tryAll := func(t *testing.T, file *dagger.File) {
-		output, err := c.Container().From("alpine:3.16.2").
-			WithExec([]string{"adduser", "-u", "1234", "-D", "auser"}).
-			WithExec([]string{"addgroup", "-g", "4321", "agroup"}).
-			WithWorkdir("/data").
-			WithExec([]string{"cat", "/etc/passwd"}).
-			WithNewFile("default.txt").
-			WithNewFile("userid.txt", dagger.ContainerWithNewFileOpts{
-				Owner: "1234",
-			}).
-			WithNewFile("userid-twice.txt", dagger.ContainerWithNewFileOpts{
-				Owner: "1234:1234",
-			}).
-			WithNewFile("username.txt", dagger.ContainerWithNewFileOpts{
-				Owner: "auser",
-			}).
-			WithNewFile("username-twice.txt", dagger.ContainerWithNewFileOpts{
-				Owner: "auser:auser",
-			}).
-			WithNewFile("ids.txt", dagger.ContainerWithNewFileOpts{
-				Owner: "1234:4321",
-			}).
-			WithNewFile("username-gid.txt", dagger.ContainerWithNewFileOpts{
-				Owner: "auser:4321",
-			}).
-			WithNewFile("uid-groupname.txt", dagger.ContainerWithNewFileOpts{
-				Owner: "1234:agroup",
-			}).
-			WithNewFile("names.txt", dagger.ContainerWithNewFileOpts{
-				Owner: "auser:agroup",
-			}).
-			WithExec([]string{"sh", "-c", "stat -c '%n %U %G' *"}).
-			Stdout(ctx)
-		require.NoError(t, err)
-		require.Contains(t, output, "default.txt root root")
-		require.Contains(t, output, "userid.txt auser auser")
-		require.Contains(t, output, "userid-twice.txt auser auser")
-		require.Contains(t, output, "username.txt auser auser")
-		require.Contains(t, output, "username-twice.txt auser auser")
-		require.Contains(t, output, "ids.txt auser agroup")
-		require.Contains(t, output, "username-gid.txt auser agroup")
-		require.Contains(t, output, "names.txt auser agroup")
-	}
-
-	t.Run("simple file", func(t *testing.T) {
-		tmp := t.TempDir()
-
-		err := os.WriteFile(filepath.Join(tmp, "message.txt"), []byte("hello world"), 0o600)
-		require.NoError(t, err)
-
-		msgFile := c.Host().Directory(tmp).File("message.txt")
-
-		tryAll(t, msgFile)
-	})
-
-	t.Run("file from subdirectory", func(t *testing.T) {
-		tmp := t.TempDir()
-
-		err := os.Mkdir(filepath.Join(tmp, "subdir"), 0755)
-		require.NoError(t, err)
-
-		err = os.WriteFile(filepath.Join(tmp, "subdir", "message.txt"), []byte("hello world"), 0o600)
-		require.NoError(t, err)
-
-		msgFile := c.Host().Directory(tmp).Directory("subdir").File("message.txt")
-
-		tryAll(t, msgFile)
-	})
+	output, err := c.Container().From("alpine:3.16.2").
+		WithExec([]string{"adduser", "-u", "1234", "-D", "auser"}).
+		WithExec([]string{"addgroup", "-g", "4321", "agroup"}).
+		WithWorkdir("/data").
+		WithExec([]string{"cat", "/etc/passwd"}).
+		WithNewFile("default.txt").
+		WithNewFile("userid.txt", dagger.ContainerWithNewFileOpts{
+			Owner: "1234",
+		}).
+		WithNewFile("userid-twice.txt", dagger.ContainerWithNewFileOpts{
+			Owner: "1234:1234",
+		}).
+		WithNewFile("username.txt", dagger.ContainerWithNewFileOpts{
+			Owner: "auser",
+		}).
+		WithNewFile("username-twice.txt", dagger.ContainerWithNewFileOpts{
+			Owner: "auser:auser",
+		}).
+		WithNewFile("ids.txt", dagger.ContainerWithNewFileOpts{
+			Owner: "1234:4321",
+		}).
+		WithNewFile("username-gid.txt", dagger.ContainerWithNewFileOpts{
+			Owner: "auser:4321",
+		}).
+		WithNewFile("uid-groupname.txt", dagger.ContainerWithNewFileOpts{
+			Owner: "1234:agroup",
+		}).
+		WithNewFile("names.txt", dagger.ContainerWithNewFileOpts{
+			Owner: "auser:agroup",
+		}).
+		WithExec([]string{"sh", "-c", "stat -c '%n %U %G' *"}).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Contains(t, output, "default.txt root root")
+	require.Contains(t, output, "userid.txt auser auser")
+	require.Contains(t, output, "userid-twice.txt auser auser")
+	require.Contains(t, output, "username.txt auser auser")
+	require.Contains(t, output, "username-twice.txt auser auser")
+	require.Contains(t, output, "ids.txt auser agroup")
+	require.Contains(t, output, "username-gid.txt auser agroup")
+	require.Contains(t, output, "names.txt auser agroup")
 }
 
 func TestContainerWithMountedCacheOwner(t *testing.T) {

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3447,7 +3447,7 @@ func testOwnership(
 		{name: "names", owner: "auser:agroup", output: "auser agroup"},
 
 		// NB: inheriting the user/group from the container was implemented, but we
-		// decided to back out for two reasons:
+		// decided to back out for a few reasons:
 		//
 		// 1. performance: right now chowning has to be a separate Copy operation,
 		//    which currently literally copies the relevant files even for a chown,

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3158,11 +3158,9 @@ func TestContainerWithMountedFileOwner(t *testing.T) {
 	defer c.Close()
 
 	tryAll := func(t *testing.T, file *dagger.File) {
-		output, err := c.Pipeline("test").
-			Container().
-			From("alpine").
-			WithExec([]string{"adduser", "-u", "1234", "-D", "vito"}).
-			WithExec([]string{"addgroup", "-g", "4321", "dagger"}).
+		output, err := c.Container().From("alpine:3.16.2").
+			WithExec([]string{"adduser", "-u", "1234", "-D", "auser"}).
+			WithExec([]string{"addgroup", "-g", "4321", "agroup"}).
 			WithWorkdir("/data").
 			WithMountedFile("default.txt", file).
 			WithMountedFile("userid.txt", file, dagger.ContainerWithMountedFileOpts{
@@ -3172,34 +3170,34 @@ func TestContainerWithMountedFileOwner(t *testing.T) {
 				Owner: "1234:1234",
 			}).
 			WithMountedFile("username.txt", file, dagger.ContainerWithMountedFileOpts{
-				Owner: "vito",
+				Owner: "auser",
 			}).
 			WithMountedFile("username-twice.txt", file, dagger.ContainerWithMountedFileOpts{
-				Owner: "vito:vito",
+				Owner: "auser:auser",
 			}).
 			WithMountedFile("ids.txt", file, dagger.ContainerWithMountedFileOpts{
 				Owner: "1234:4321",
 			}).
 			WithMountedFile("username-gid.txt", file, dagger.ContainerWithMountedFileOpts{
-				Owner: "vito:4321",
+				Owner: "auser:4321",
 			}).
 			WithMountedFile("uid-groupname.txt", file, dagger.ContainerWithMountedFileOpts{
-				Owner: "1234:dagger",
+				Owner: "1234:agroup",
 			}).
 			WithMountedFile("names.txt", file, dagger.ContainerWithMountedFileOpts{
-				Owner: "vito:dagger",
+				Owner: "auser:agroup",
 			}).
 			WithExec([]string{"sh", "-c", "stat -c '%n %U %G' *"}).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, output, "default.txt root root")
-		require.Contains(t, output, "userid.txt vito vito")
-		require.Contains(t, output, "userid-twice.txt vito vito")
-		require.Contains(t, output, "username.txt vito vito")
-		require.Contains(t, output, "username-twice.txt vito vito")
-		require.Contains(t, output, "ids.txt vito dagger")
-		require.Contains(t, output, "username-gid.txt vito dagger")
-		require.Contains(t, output, "names.txt vito dagger")
+		require.Contains(t, output, "userid.txt auser auser")
+		require.Contains(t, output, "userid-twice.txt auser auser")
+		require.Contains(t, output, "username.txt auser auser")
+		require.Contains(t, output, "username-twice.txt auser auser")
+		require.Contains(t, output, "ids.txt auser agroup")
+		require.Contains(t, output, "username-gid.txt auser agroup")
+		require.Contains(t, output, "names.txt auser agroup")
 	}
 
 	t.Run("simple file", func(t *testing.T) {
@@ -3233,11 +3231,9 @@ func TestContainerWithMountedDirectoryOwner(t *testing.T) {
 	defer c.Close()
 
 	tryAll := func(t *testing.T, dir *dagger.Directory) {
-		output, err := c.Pipeline("test").
-			Container().
-			From("alpine").
-			WithExec([]string{"adduser", "-u", "1234", "-D", "vito"}).
-			WithExec([]string{"addgroup", "-g", "4321", "dagger"}).
+		output, err := c.Container().From("alpine:3.16.2").
+			WithExec([]string{"adduser", "-u", "1234", "-D", "auser"}).
+			WithExec([]string{"addgroup", "-g", "4321", "agroup"}).
 			WithWorkdir("/data").
 			WithMountedDirectory("default", dir).
 			WithMountedDirectory("userid", dir, dagger.ContainerWithMountedDirectoryOpts{
@@ -3247,42 +3243,42 @@ func TestContainerWithMountedDirectoryOwner(t *testing.T) {
 				Owner: "1234:1234",
 			}).
 			WithMountedDirectory("username", dir, dagger.ContainerWithMountedDirectoryOpts{
-				Owner: "vito",
+				Owner: "auser",
 			}).
 			WithMountedDirectory("username-twice", dir, dagger.ContainerWithMountedDirectoryOpts{
-				Owner: "vito:vito",
+				Owner: "auser:auser",
 			}).
 			WithMountedDirectory("ids", dir, dagger.ContainerWithMountedDirectoryOpts{
 				Owner: "1234:4321",
 			}).
 			WithMountedDirectory("username-gid", dir, dagger.ContainerWithMountedDirectoryOpts{
-				Owner: "vito:4321",
+				Owner: "auser:4321",
 			}).
 			WithMountedDirectory("uid-groupname", dir, dagger.ContainerWithMountedDirectoryOpts{
-				Owner: "1234:dagger",
+				Owner: "1234:agroup",
 			}).
 			WithMountedDirectory("names", dir, dagger.ContainerWithMountedDirectoryOpts{
-				Owner: "vito:dagger",
+				Owner: "auser:agroup",
 			}).
 			WithExec([]string{"sh", "-c", "stat -c '%n %U %G' * */message.txt"}).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, output, "default root root")
-		require.Contains(t, output, "userid vito vito")
-		require.Contains(t, output, "userid-twice vito vito")
-		require.Contains(t, output, "username vito vito")
-		require.Contains(t, output, "username-twice vito vito")
-		require.Contains(t, output, "ids vito dagger")
-		require.Contains(t, output, "username-gid vito dagger")
-		require.Contains(t, output, "names vito dagger")
+		require.Contains(t, output, "userid auser auser")
+		require.Contains(t, output, "userid-twice auser auser")
+		require.Contains(t, output, "username auser auser")
+		require.Contains(t, output, "username-twice auser auser")
+		require.Contains(t, output, "ids auser agroup")
+		require.Contains(t, output, "username-gid auser agroup")
+		require.Contains(t, output, "names auser agroup")
 		require.Contains(t, output, "default/message.txt root root")
-		require.Contains(t, output, "userid/message.txt vito vito")
-		require.Contains(t, output, "userid-twice/message.txt vito vito")
-		require.Contains(t, output, "username/message.txt vito vito")
-		require.Contains(t, output, "username-twice/message.txt vito vito")
-		require.Contains(t, output, "ids/message.txt vito dagger")
-		require.Contains(t, output, "username-gid/message.txt vito dagger")
-		require.Contains(t, output, "names/message.txt vito dagger")
+		require.Contains(t, output, "userid/message.txt auser auser")
+		require.Contains(t, output, "userid-twice/message.txt auser auser")
+		require.Contains(t, output, "username/message.txt auser auser")
+		require.Contains(t, output, "username-twice/message.txt auser auser")
+		require.Contains(t, output, "ids/message.txt auser agroup")
+		require.Contains(t, output, "username-gid/message.txt auser agroup")
+		require.Contains(t, output, "names/message.txt auser agroup")
 	}
 
 	t.Run("simple directory", func(t *testing.T) {
@@ -3304,5 +3300,230 @@ func TestContainerWithMountedDirectoryOwner(t *testing.T) {
 		require.NoError(t, err)
 
 		tryAll(t, c.Host().Directory(tmp).Directory("subdir"))
+	})
+}
+
+func TestContainerWithFileOwner(t *testing.T) {
+	c, ctx := connect(t)
+	defer c.Close()
+
+	tryAll := func(t *testing.T, file *dagger.File) {
+		output, err := c.Container().From("alpine:3.16.2").
+			WithExec([]string{"adduser", "-u", "1234", "-D", "auser"}).
+			WithExec([]string{"addgroup", "-g", "4321", "agroup"}).
+			WithWorkdir("/data").
+			WithExec([]string{"cat", "/etc/passwd"}).
+			WithFile("default.txt", file).
+			WithFile("userid.txt", file, dagger.ContainerWithFileOpts{
+				Owner: "1234",
+			}).
+			WithFile("userid-twice.txt", file, dagger.ContainerWithFileOpts{
+				Owner: "1234:1234",
+			}).
+			WithFile("username.txt", file, dagger.ContainerWithFileOpts{
+				Owner: "auser",
+			}).
+			WithFile("username-twice.txt", file, dagger.ContainerWithFileOpts{
+				Owner: "auser:auser",
+			}).
+			WithFile("ids.txt", file, dagger.ContainerWithFileOpts{
+				Owner: "1234:4321",
+			}).
+			WithFile("username-gid.txt", file, dagger.ContainerWithFileOpts{
+				Owner: "auser:4321",
+			}).
+			WithFile("uid-groupname.txt", file, dagger.ContainerWithFileOpts{
+				Owner: "1234:agroup",
+			}).
+			WithFile("names.txt", file, dagger.ContainerWithFileOpts{
+				Owner: "auser:agroup",
+			}).
+			WithExec([]string{"sh", "-c", "stat -c '%n %U %G' *"}).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, output, "default.txt root root")
+		require.Contains(t, output, "userid.txt auser auser")
+		require.Contains(t, output, "userid-twice.txt auser auser")
+		require.Contains(t, output, "username.txt auser auser")
+		require.Contains(t, output, "username-twice.txt auser auser")
+		require.Contains(t, output, "ids.txt auser agroup")
+		require.Contains(t, output, "username-gid.txt auser agroup")
+		require.Contains(t, output, "names.txt auser agroup")
+	}
+
+	t.Run("simple file", func(t *testing.T) {
+		tmp := t.TempDir()
+
+		err := os.WriteFile(filepath.Join(tmp, "message.txt"), []byte("hello world"), 0644)
+		require.NoError(t, err)
+
+		msgFile := c.Host().Directory(tmp).File("message.txt")
+
+		tryAll(t, msgFile)
+	})
+
+	t.Run("file from subdirectory", func(t *testing.T) {
+		tmp := t.TempDir()
+
+		err := os.Mkdir(filepath.Join(tmp, "subdir"), 0755)
+		require.NoError(t, err)
+
+		err = os.WriteFile(filepath.Join(tmp, "subdir", "message.txt"), []byte("hello world"), 0644)
+		require.NoError(t, err)
+
+		msgFile := c.Host().Directory(tmp).Directory("subdir").File("message.txt")
+
+		tryAll(t, msgFile)
+	})
+}
+
+func TestContainerWithDirectoryOwner(t *testing.T) {
+	c, ctx := connect(t)
+	defer c.Close()
+
+	tryAll := func(t *testing.T, dir *dagger.Directory) {
+		output, err := c.Container().From("alpine:3.16.2").
+			WithExec([]string{"adduser", "-u", "1234", "-D", "auser"}).
+			WithExec([]string{"addgroup", "-g", "4321", "agroup"}).
+			WithWorkdir("/data").
+			WithDirectory("default", dir).
+			WithDirectory("userid", dir, dagger.ContainerWithDirectoryOpts{
+				Owner: "1234",
+			}).
+			WithDirectory("userid-twice", dir, dagger.ContainerWithDirectoryOpts{
+				Owner: "1234:1234",
+			}).
+			WithDirectory("username", dir, dagger.ContainerWithDirectoryOpts{
+				Owner: "auser",
+			}).
+			WithDirectory("username-twice", dir, dagger.ContainerWithDirectoryOpts{
+				Owner: "auser:auser",
+			}).
+			WithDirectory("ids", dir, dagger.ContainerWithDirectoryOpts{
+				Owner: "1234:4321",
+			}).
+			WithDirectory("username-gid", dir, dagger.ContainerWithDirectoryOpts{
+				Owner: "auser:4321",
+			}).
+			WithDirectory("uid-groupname", dir, dagger.ContainerWithDirectoryOpts{
+				Owner: "1234:agroup",
+			}).
+			WithDirectory("names", dir, dagger.ContainerWithDirectoryOpts{
+				Owner: "auser:agroup",
+			}).
+			WithExec([]string{"sh", "-c", "stat -c '%n %U %G' * */message.txt"}).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, output, "default root root")
+		require.Contains(t, output, "userid auser auser")
+		require.Contains(t, output, "userid-twice auser auser")
+		require.Contains(t, output, "username auser auser")
+		require.Contains(t, output, "username-twice auser auser")
+		require.Contains(t, output, "ids auser agroup")
+		require.Contains(t, output, "username-gid auser agroup")
+		require.Contains(t, output, "names auser agroup")
+		require.Contains(t, output, "default/message.txt root root")
+		require.Contains(t, output, "userid/message.txt auser auser")
+		require.Contains(t, output, "userid-twice/message.txt auser auser")
+		require.Contains(t, output, "username/message.txt auser auser")
+		require.Contains(t, output, "username-twice/message.txt auser auser")
+		require.Contains(t, output, "ids/message.txt auser agroup")
+		require.Contains(t, output, "username-gid/message.txt auser agroup")
+		require.Contains(t, output, "names/message.txt auser agroup")
+	}
+
+	t.Run("simple directory", func(t *testing.T) {
+		tmp := t.TempDir()
+
+		err := os.WriteFile(filepath.Join(tmp, "message.txt"), []byte("hello world"), 0644)
+		require.NoError(t, err)
+
+		tryAll(t, c.Host().Directory(tmp))
+	})
+
+	t.Run("file from subdirectory", func(t *testing.T) {
+		tmp := t.TempDir()
+
+		err := os.Mkdir(filepath.Join(tmp, "subdir"), 0755)
+		require.NoError(t, err)
+
+		err = os.WriteFile(filepath.Join(tmp, "subdir", "message.txt"), []byte("hello world"), 0644)
+		require.NoError(t, err)
+
+		tryAll(t, c.Host().Directory(tmp).Directory("subdir"))
+	})
+}
+
+func TestContainerWithNewFileOwner(t *testing.T) {
+	c, ctx := connect(t)
+	defer c.Close()
+
+	tryAll := func(t *testing.T, file *dagger.File) {
+		output, err := c.Container().From("alpine:3.16.2").
+			WithExec([]string{"adduser", "-u", "1234", "-D", "auser"}).
+			WithExec([]string{"addgroup", "-g", "4321", "agroup"}).
+			WithWorkdir("/data").
+			WithExec([]string{"cat", "/etc/passwd"}).
+			WithNewFile("default.txt").
+			WithNewFile("userid.txt", dagger.ContainerWithNewFileOpts{
+				Owner: "1234",
+			}).
+			WithNewFile("userid-twice.txt", dagger.ContainerWithNewFileOpts{
+				Owner: "1234:1234",
+			}).
+			WithNewFile("username.txt", dagger.ContainerWithNewFileOpts{
+				Owner: "auser",
+			}).
+			WithNewFile("username-twice.txt", dagger.ContainerWithNewFileOpts{
+				Owner: "auser:auser",
+			}).
+			WithNewFile("ids.txt", dagger.ContainerWithNewFileOpts{
+				Owner: "1234:4321",
+			}).
+			WithNewFile("username-gid.txt", dagger.ContainerWithNewFileOpts{
+				Owner: "auser:4321",
+			}).
+			WithNewFile("uid-groupname.txt", dagger.ContainerWithNewFileOpts{
+				Owner: "1234:agroup",
+			}).
+			WithNewFile("names.txt", dagger.ContainerWithNewFileOpts{
+				Owner: "auser:agroup",
+			}).
+			WithExec([]string{"sh", "-c", "stat -c '%n %U %G' *"}).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, output, "default.txt root root")
+		require.Contains(t, output, "userid.txt auser auser")
+		require.Contains(t, output, "userid-twice.txt auser auser")
+		require.Contains(t, output, "username.txt auser auser")
+		require.Contains(t, output, "username-twice.txt auser auser")
+		require.Contains(t, output, "ids.txt auser agroup")
+		require.Contains(t, output, "username-gid.txt auser agroup")
+		require.Contains(t, output, "names.txt auser agroup")
+	}
+
+	t.Run("simple file", func(t *testing.T) {
+		tmp := t.TempDir()
+
+		err := os.WriteFile(filepath.Join(tmp, "message.txt"), []byte("hello world"), 0644)
+		require.NoError(t, err)
+
+		msgFile := c.Host().Directory(tmp).File("message.txt")
+
+		tryAll(t, msgFile)
+	})
+
+	t.Run("file from subdirectory", func(t *testing.T) {
+		tmp := t.TempDir()
+
+		err := os.Mkdir(filepath.Join(tmp, "subdir"), 0755)
+		require.NoError(t, err)
+
+		err = os.WriteFile(filepath.Join(tmp, "subdir", "message.txt"), []byte("hello world"), 0644)
+		require.NoError(t, err)
+
+		msgFile := c.Host().Directory(tmp).Directory("subdir").File("message.txt")
+
+		tryAll(t, msgFile)
 	})
 }

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3202,7 +3202,7 @@ func TestContainerWithMountedFileOwner(t *testing.T) {
 	t.Run("simple file", func(t *testing.T) {
 		tmp := t.TempDir()
 
-		err := os.WriteFile(filepath.Join(tmp, "message.txt"), []byte("hello world"), 0644)
+		err := os.WriteFile(filepath.Join(tmp, "message.txt"), []byte("hello world"), 0o600)
 		require.NoError(t, err)
 
 		msgFile := c.Host().Directory(tmp).File("message.txt")
@@ -3216,7 +3216,7 @@ func TestContainerWithMountedFileOwner(t *testing.T) {
 		err := os.Mkdir(filepath.Join(tmp, "subdir"), 0755)
 		require.NoError(t, err)
 
-		err = os.WriteFile(filepath.Join(tmp, "subdir", "message.txt"), []byte("hello world"), 0644)
+		err = os.WriteFile(filepath.Join(tmp, "subdir", "message.txt"), []byte("hello world"), 0o600)
 		require.NoError(t, err)
 
 		msgFile := c.Host().Directory(tmp).Directory("subdir").File("message.txt")
@@ -3283,7 +3283,7 @@ func TestContainerWithMountedDirectoryOwner(t *testing.T) {
 	t.Run("simple directory", func(t *testing.T) {
 		tmp := t.TempDir()
 
-		err := os.WriteFile(filepath.Join(tmp, "message.txt"), []byte("hello world"), 0644)
+		err := os.WriteFile(filepath.Join(tmp, "message.txt"), []byte("hello world"), 0o600)
 		require.NoError(t, err)
 
 		tryAll(t, c.Host().Directory(tmp))
@@ -3295,7 +3295,7 @@ func TestContainerWithMountedDirectoryOwner(t *testing.T) {
 		err := os.Mkdir(filepath.Join(tmp, "subdir"), 0755)
 		require.NoError(t, err)
 
-		err = os.WriteFile(filepath.Join(tmp, "subdir", "message.txt"), []byte("hello world"), 0644)
+		err = os.WriteFile(filepath.Join(tmp, "subdir", "message.txt"), []byte("hello world"), 0o600)
 		require.NoError(t, err)
 
 		tryAll(t, c.Host().Directory(tmp).Directory("subdir"))
@@ -3353,7 +3353,7 @@ func TestContainerWithFileOwner(t *testing.T) {
 	t.Run("simple file", func(t *testing.T) {
 		tmp := t.TempDir()
 
-		err := os.WriteFile(filepath.Join(tmp, "message.txt"), []byte("hello world"), 0644)
+		err := os.WriteFile(filepath.Join(tmp, "message.txt"), []byte("hello world"), 0o600)
 		require.NoError(t, err)
 
 		msgFile := c.Host().Directory(tmp).File("message.txt")
@@ -3367,7 +3367,7 @@ func TestContainerWithFileOwner(t *testing.T) {
 		err := os.Mkdir(filepath.Join(tmp, "subdir"), 0755)
 		require.NoError(t, err)
 
-		err = os.WriteFile(filepath.Join(tmp, "subdir", "message.txt"), []byte("hello world"), 0644)
+		err = os.WriteFile(filepath.Join(tmp, "subdir", "message.txt"), []byte("hello world"), 0o600)
 		require.NoError(t, err)
 
 		msgFile := c.Host().Directory(tmp).Directory("subdir").File("message.txt")
@@ -3434,7 +3434,7 @@ func TestContainerWithDirectoryOwner(t *testing.T) {
 	t.Run("simple directory", func(t *testing.T) {
 		tmp := t.TempDir()
 
-		err := os.WriteFile(filepath.Join(tmp, "message.txt"), []byte("hello world"), 0644)
+		err := os.WriteFile(filepath.Join(tmp, "message.txt"), []byte("hello world"), 0o600)
 		require.NoError(t, err)
 
 		tryAll(t, c.Host().Directory(tmp))
@@ -3446,7 +3446,7 @@ func TestContainerWithDirectoryOwner(t *testing.T) {
 		err := os.Mkdir(filepath.Join(tmp, "subdir"), 0755)
 		require.NoError(t, err)
 
-		err = os.WriteFile(filepath.Join(tmp, "subdir", "message.txt"), []byte("hello world"), 0644)
+		err = os.WriteFile(filepath.Join(tmp, "subdir", "message.txt"), []byte("hello world"), 0o600)
 		require.NoError(t, err)
 
 		tryAll(t, c.Host().Directory(tmp).Directory("subdir"))
@@ -3504,7 +3504,7 @@ func TestContainerWithNewFileOwner(t *testing.T) {
 	t.Run("simple file", func(t *testing.T) {
 		tmp := t.TempDir()
 
-		err := os.WriteFile(filepath.Join(tmp, "message.txt"), []byte("hello world"), 0644)
+		err := os.WriteFile(filepath.Join(tmp, "message.txt"), []byte("hello world"), 0o600)
 		require.NoError(t, err)
 
 		msgFile := c.Host().Directory(tmp).File("message.txt")
@@ -3518,7 +3518,7 @@ func TestContainerWithNewFileOwner(t *testing.T) {
 		err := os.Mkdir(filepath.Join(tmp, "subdir"), 0755)
 		require.NoError(t, err)
 
-		err = os.WriteFile(filepath.Join(tmp, "subdir", "message.txt"), []byte("hello world"), 0644)
+		err = os.WriteFile(filepath.Join(tmp, "subdir", "message.txt"), []byte("hello world"), 0o600)
 		require.NoError(t, err)
 
 		msgFile := c.Host().Directory(tmp).Directory("subdir").File("message.txt")

--- a/core/integration/testdata/hello.go
+++ b/core/integration/testdata/hello.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, world!")
+}

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -229,7 +229,10 @@ type containerWithUserArgs struct {
 }
 
 func (s *containerSchema) withUser(ctx *router.Context, parent *core.Container, args containerWithUserArgs) (*core.Container, error) {
-	return parent.WithUser(ctx, s.gw, args.Name)
+	return parent.UpdateImageConfig(ctx, func(cfg specs.ImageConfig) specs.ImageConfig {
+		cfg.User = args.Name
+		return cfg
+	})
 }
 
 func (s *containerSchema) user(ctx *router.Context, parent *core.Container, args containerWithVariableArgs) (string, error) {
@@ -400,7 +403,7 @@ type containerWithMountedDirectoryArgs struct {
 }
 
 func (s *containerSchema) withMountedDirectory(ctx *router.Context, parent *core.Container, args containerWithMountedDirectoryArgs) (*core.Container, error) {
-	return parent.WithMountedDirectory(ctx, args.Path, &core.Directory{ID: args.Source}, args.Owner)
+	return parent.WithMountedDirectory(ctx, s.gw, args.Path, &core.Directory{ID: args.Source}, args.Owner)
 }
 
 type containerPublishArgs struct {
@@ -419,7 +422,7 @@ type containerWithMountedFileArgs struct {
 }
 
 func (s *containerSchema) withMountedFile(ctx *router.Context, parent *core.Container, args containerWithMountedFileArgs) (*core.Container, error) {
-	return parent.WithMountedFile(ctx, args.Path, &core.File{ID: args.Source}, args.Owner)
+	return parent.WithMountedFile(ctx, s.gw, args.Path, &core.File{ID: args.Source}, args.Owner)
 }
 
 type containerWithMountedCacheArgs struct {
@@ -436,7 +439,7 @@ func (s *containerSchema) withMountedCache(ctx *router.Context, parent *core.Con
 		dir = &core.Directory{ID: args.Source}
 	}
 
-	return parent.WithMountedCache(ctx, args.Path, args.Cache, dir, args.Concurrency, args.Owner)
+	return parent.WithMountedCache(ctx, s.gw, args.Path, args.Cache, dir, args.Concurrency, args.Owner)
 }
 
 type containerWithMountedTempArgs struct {

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -528,10 +528,11 @@ func (s *containerSchema) withSecretVariable(ctx *router.Context, parent *core.C
 type containerWithMountedSecretArgs struct {
 	Path   string
 	Source core.SecretID
+	Owner  string
 }
 
 func (s *containerSchema) withMountedSecret(ctx *router.Context, parent *core.Container, args containerWithMountedSecretArgs) (*core.Container, error) {
-	return parent.WithMountedSecret(ctx, args.Path, core.NewSecret(args.Source))
+	return parent.WithMountedSecret(ctx, args.Path, core.NewSecret(args.Source), args.Owner)
 }
 
 type containerWithDirectoryArgs struct {
@@ -564,10 +565,11 @@ func (s *containerSchema) withNewFile(ctx *router.Context, parent *core.Containe
 type containerWithUnixSocketArgs struct {
 	Path   string
 	Source core.SocketID
+	Owner  string
 }
 
 func (s *containerSchema) withUnixSocket(ctx *router.Context, parent *core.Container, args containerWithUnixSocketArgs) (*core.Container, error) {
-	return parent.WithUnixSocket(ctx, args.Path, core.NewSocket(args.Source))
+	return parent.WithUnixSocket(ctx, args.Path, core.NewSocket(args.Source), args.Owner)
 }
 
 type containerWithoutUnixSocketArgs struct {

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -426,10 +426,11 @@ func (s *containerSchema) withMountedFile(ctx *router.Context, parent *core.Cont
 }
 
 type containerWithMountedCacheArgs struct {
-	Path        string                `json:"path"`
-	Cache       core.CacheID          `json:"cache"`
-	Source      core.DirectoryID      `json:"source"`
-	Concurrency core.CacheSharingMode `json:"sharing"`
+	Path        string
+	Cache       core.CacheID
+	Source      core.DirectoryID
+	Concurrency core.CacheSharingMode
+	Owner       string
 }
 
 func (s *containerSchema) withMountedCache(ctx *router.Context, parent *core.Container, args containerWithMountedCacheArgs) (*core.Container, error) {
@@ -438,7 +439,7 @@ func (s *containerSchema) withMountedCache(ctx *router.Context, parent *core.Con
 		dir = &core.Directory{ID: args.Source}
 	}
 
-	return parent.WithMountedCache(ctx, args.Path, args.Cache, dir, args.Concurrency)
+	return parent.WithMountedCache(ctx, args.Path, args.Cache, dir, args.Concurrency, args.Owner)
 }
 
 type containerWithMountedTempArgs struct {

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -399,10 +399,11 @@ func (s *containerSchema) label(ctx *router.Context, parent *core.Container, arg
 type containerWithMountedDirectoryArgs struct {
 	Path   string
 	Source core.DirectoryID
+	Owner  string
 }
 
 func (s *containerSchema) withMountedDirectory(ctx *router.Context, parent *core.Container, args containerWithMountedDirectoryArgs) (*core.Container, error) {
-	return parent.WithMountedDirectory(ctx, args.Path, &core.Directory{ID: args.Source})
+	return parent.WithMountedDirectory(ctx, args.Path, &core.Directory{ID: args.Source}, args.Owner)
 }
 
 type containerPublishArgs struct {
@@ -417,10 +418,11 @@ func (s *containerSchema) publish(ctx *router.Context, parent *core.Container, a
 type containerWithMountedFileArgs struct {
 	Path   string
 	Source core.FileID
+	Owner  string
 }
 
 func (s *containerSchema) withMountedFile(ctx *router.Context, parent *core.Container, args containerWithMountedFileArgs) (*core.Container, error) {
-	return parent.WithMountedFile(ctx, args.Path, &core.File{ID: args.Source})
+	return parent.WithMountedFile(ctx, args.Path, &core.File{ID: args.Source}, args.Owner)
 }
 
 type containerWithMountedCacheArgs struct {

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -229,10 +229,7 @@ type containerWithUserArgs struct {
 }
 
 func (s *containerSchema) withUser(ctx *router.Context, parent *core.Container, args containerWithUserArgs) (*core.Container, error) {
-	return parent.UpdateImageConfig(ctx, func(cfg specs.ImageConfig) specs.ImageConfig {
-		cfg.User = args.Name
-		return cfg
-	})
+	return parent.WithUser(ctx, s.gw, args.Name)
 }
 
 func (s *containerSchema) user(ctx *router.Context, parent *core.Container, args containerWithVariableArgs) (string, error) {
@@ -612,7 +609,7 @@ func (s *containerSchema) import_(ctx *router.Context, parent *core.Container, a
 
 	defer src.Close()
 
-	return parent.Import(ctx, s.host, src, args.Tag, s.ociStore)
+	return parent.Import(ctx, s.gw, s.host, src, args.Tag, s.ociStore)
 }
 
 type containerWithRegistryAuthArgs struct {

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -9,7 +9,6 @@ import (
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/pipeline"
 	"github.com/dagger/dagger/router"
-	"github.com/dagger/graphql/language/ast"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -93,40 +92,6 @@ func (s *containerSchema) Resolvers() router.Resolvers {
 			"hostname":             router.ToResolver(s.hostname),
 			"endpoint":             router.ToResolver(s.endpoint),
 			"withServiceBinding":   router.ToResolver(s.withServiceBinding),
-		},
-		"FilesystemOwner": router.ScalarResolver{
-			Serialize: func(value any) any {
-				switch v := value.(type) {
-				case core.FilesystemOwner:
-					return v
-				default:
-					panic(fmt.Sprintf("unexpected filesystem owner scalar serialize type %T", v))
-				}
-			},
-			ParseValue: func(value any) any {
-				switch v := value.(type) {
-				case string:
-					var owner core.FilesystemOwner
-					owner.User, owner.Group, _ = strings.Cut(v, ":")
-					return owner
-				default:
-					panic(fmt.Sprintf("unexpected filesystem owner parse value type %T: %+v", v, v))
-				}
-			},
-			ParseLiteral: func(valueAST ast.Value) any {
-				switch valueAST := valueAST.(type) {
-				case *ast.StringValue:
-					var owner core.FilesystemOwner
-					owner.User, owner.Group, _ = strings.Cut(valueAST.Value, ":")
-					return owner
-				case *ast.IntValue:
-					var owner core.FilesystemOwner
-					owner.User = valueAST.Value
-					return owner
-				default:
-					panic(fmt.Sprintf("unexpected filesystem owner parse literal type: %T: %+v", valueAST, valueAST))
-				}
-			},
 		},
 	}
 }
@@ -434,7 +399,7 @@ func (s *containerSchema) label(ctx *router.Context, parent *core.Container, arg
 type containerWithMountedDirectoryArgs struct {
 	Path   string
 	Source core.DirectoryID
-	Owner  *core.FilesystemOwner
+	Owner  string
 }
 
 func (s *containerSchema) withMountedDirectory(ctx *router.Context, parent *core.Container, args containerWithMountedDirectoryArgs) (*core.Container, error) {
@@ -453,7 +418,7 @@ func (s *containerSchema) publish(ctx *router.Context, parent *core.Container, a
 type containerWithMountedFileArgs struct {
 	Path   string
 	Source core.FileID
-	Owner  *core.FilesystemOwner
+	Owner  string
 }
 
 func (s *containerSchema) withMountedFile(ctx *router.Context, parent *core.Container, args containerWithMountedFileArgs) (*core.Container, error) {
@@ -465,7 +430,7 @@ type containerWithMountedCacheArgs struct {
 	Cache       core.CacheID
 	Source      core.DirectoryID
 	Concurrency core.CacheSharingMode
-	Owner       *core.FilesystemOwner
+	Owner       string
 }
 
 func (s *containerSchema) withMountedCache(ctx *router.Context, parent *core.Container, args containerWithMountedCacheArgs) (*core.Container, error) {
@@ -563,7 +528,7 @@ func (s *containerSchema) withSecretVariable(ctx *router.Context, parent *core.C
 type containerWithMountedSecretArgs struct {
 	Path   string
 	Source core.SecretID
-	Owner  *core.FilesystemOwner
+	Owner  string
 }
 
 func (s *containerSchema) withMountedSecret(ctx *router.Context, parent *core.Container, args containerWithMountedSecretArgs) (*core.Container, error) {
@@ -572,7 +537,7 @@ func (s *containerSchema) withMountedSecret(ctx *router.Context, parent *core.Co
 
 type containerWithDirectoryArgs struct {
 	withDirectoryArgs
-	Owner *core.FilesystemOwner
+	Owner string
 }
 
 func (s *containerSchema) withDirectory(ctx *router.Context, parent *core.Container, args containerWithDirectoryArgs) (*core.Container, error) {
@@ -581,7 +546,7 @@ func (s *containerSchema) withDirectory(ctx *router.Context, parent *core.Contai
 
 type containerWithFileArgs struct {
 	withFileArgs
-	Owner *core.FilesystemOwner
+	Owner string
 }
 
 func (s *containerSchema) withFile(ctx *router.Context, parent *core.Container, args containerWithFileArgs) (*core.Container, error) {
@@ -590,7 +555,7 @@ func (s *containerSchema) withFile(ctx *router.Context, parent *core.Container, 
 
 type containerWithNewFileArgs struct {
 	withNewFileArgs
-	Owner *core.FilesystemOwner
+	Owner string
 }
 
 func (s *containerSchema) withNewFile(ctx *router.Context, parent *core.Container, args containerWithNewFileArgs) (*core.Container, error) {
@@ -600,7 +565,7 @@ func (s *containerSchema) withNewFile(ctx *router.Context, parent *core.Containe
 type containerWithUnixSocketArgs struct {
 	Path   string
 	Source core.SocketID
-	Owner  *core.FilesystemOwner
+	Owner  string
 }
 
 func (s *containerSchema) withUnixSocket(ctx *router.Context, parent *core.Container, args containerWithUnixSocketArgs) (*core.Container, error) {

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -612,7 +612,7 @@ func (s *containerSchema) import_(ctx *router.Context, parent *core.Container, a
 
 	defer src.Close()
 
-	return parent.Import(ctx, s.gw, s.host, src, args.Tag, s.ociStore)
+	return parent.Import(ctx, s.host, src, args.Tag, s.ociStore)
 }
 
 type containerWithRegistryAuthArgs struct {

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -532,7 +532,7 @@ type containerWithMountedSecretArgs struct {
 }
 
 func (s *containerSchema) withMountedSecret(ctx *router.Context, parent *core.Container, args containerWithMountedSecretArgs) (*core.Container, error) {
-	return parent.WithMountedSecret(ctx, args.Path, core.NewSecret(args.Source), args.Owner)
+	return parent.WithMountedSecret(ctx, s.gw, args.Path, core.NewSecret(args.Source), args.Owner)
 }
 
 type containerWithDirectoryArgs struct {
@@ -569,7 +569,7 @@ type containerWithUnixSocketArgs struct {
 }
 
 func (s *containerSchema) withUnixSocket(ctx *router.Context, parent *core.Container, args containerWithUnixSocketArgs) (*core.Container, error) {
-	return parent.WithUnixSocket(ctx, args.Path, core.NewSocket(args.Source), args.Owner)
+	return parent.WithUnixSocket(ctx, s.gw, args.Path, core.NewSocket(args.Source), args.Owner)
 }
 
 type containerWithoutUnixSocketArgs struct {

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -533,16 +533,31 @@ func (s *containerSchema) withMountedSecret(ctx *router.Context, parent *core.Co
 	return parent.WithMountedSecret(ctx, args.Path, core.NewSecret(args.Source))
 }
 
-func (s *containerSchema) withDirectory(ctx *router.Context, parent *core.Container, args withDirectoryArgs) (*core.Container, error) {
-	return parent.WithDirectory(ctx, s.gw, args.Path, &core.Directory{ID: args.Directory}, args.CopyFilter)
+type containerWithDirectoryArgs struct {
+	withDirectoryArgs
+	Owner string
 }
 
-func (s *containerSchema) withFile(ctx *router.Context, parent *core.Container, args withFileArgs) (*core.Container, error) {
-	return parent.WithFile(ctx, s.gw, args.Path, &core.File{ID: args.Source}, args.Permissions)
+func (s *containerSchema) withDirectory(ctx *router.Context, parent *core.Container, args containerWithDirectoryArgs) (*core.Container, error) {
+	return parent.WithDirectory(ctx, s.gw, args.Path, &core.Directory{ID: args.Directory}, args.CopyFilter, args.Owner)
 }
 
-func (s *containerSchema) withNewFile(ctx *router.Context, parent *core.Container, args withNewFileArgs) (*core.Container, error) {
-	return parent.WithNewFile(ctx, s.gw, args.Path, []byte(args.Contents), args.Permissions)
+type containerWithFileArgs struct {
+	withFileArgs
+	Owner string
+}
+
+func (s *containerSchema) withFile(ctx *router.Context, parent *core.Container, args containerWithFileArgs) (*core.Container, error) {
+	return parent.WithFile(ctx, s.gw, args.Path, &core.File{ID: args.Source}, args.Permissions, args.Owner)
+}
+
+type containerWithNewFileArgs struct {
+	withNewFileArgs
+	Owner string
+}
+
+func (s *containerSchema) withNewFile(ctx *router.Context, parent *core.Container, args containerWithNewFileArgs) (*core.Container, error) {
+	return parent.WithNewFile(ctx, s.gw, args.Path, []byte(args.Contents), args.Permissions, args.Owner)
 }
 
 type containerWithUnixSocketArgs struct {

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -323,6 +323,10 @@ type Container {
     """
     A user:group to set for the mounted cache directory.
 
+    Note that this changes the ownership of the specified mount along with the
+    initial filesystem provided by source (if any). It does not have any effect
+    if/when the cache has already been created.
+
     The user and group can either be an ID (1000:1000) or a name (foo:bar).
 
     If the group is omitted, it defaults to the same as the user.

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -267,7 +267,7 @@ type Container {
 
     If the group is omitted, it defaults to the same as the user.
     """
-    owner: String
+    owner: FilesystemOwner
   ): Container!
 
   """
@@ -289,7 +289,7 @@ type Container {
 
     If the group is omitted, it defaults to the same as the user.
     """
-    owner: String
+    owner: FilesystemOwner
   ): Container!
 
   """
@@ -327,7 +327,7 @@ type Container {
 
     If the group is omitted, it defaults to the same as the user.
     """
-    owner: String
+    owner: FilesystemOwner
   ): Container!
 
   """
@@ -349,7 +349,7 @@ type Container {
 
     If the group is omitted, it defaults to the same as the user.
     """
-    owner: String
+    owner: FilesystemOwner
   ): Container!
 
   """
@@ -388,7 +388,7 @@ type Container {
 
     If the group is omitted, it defaults to the same as the user.
     """
-    owner: String
+    owner: FilesystemOwner
   ): Container!
 
   """
@@ -419,7 +419,7 @@ type Container {
 
     If the group is omitted, it defaults to the same as the user.
     """
-    owner: String
+    owner: FilesystemOwner
   ): Container!
 
   """
@@ -451,7 +451,7 @@ type Container {
 
     If the group is omitted, it defaults to the same as the user.
     """
-    owner: String
+    owner: FilesystemOwner
   ): Container!
 
   """
@@ -475,7 +475,7 @@ type Container {
 
     If the group is omitted, it defaults to the same as the user.
     """
-    owner: String
+    owner: FilesystemOwner
   ): Container!
 
   """
@@ -806,3 +806,23 @@ enum NetworkProtocol {
   "UDP (User Datagram Protocol)"
   UDP
 }
+
+"""
+A user and group, as typically used to configure ownership of files and directories.
+
+The format is user[:group], where both user and group can either be IDs or
+names to be resolved to IDs using the container filesystem.
+
+If the group is omitted, it defaults to the same as the user.
+
+So, for a user 'foo' and group 'bar' with user ID and group ID 1111 and 2222
+respectively, the following are all valid:
+
+   foo      => 1111:1111
+   foo:bar  => 1111:2222
+   1111:bar => 1111:2222
+   foo:2222 => 1111:1111
+
+If the owner is unspecified, ownership will be left as-is.
+"""
+scalar FilesystemOwner

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -267,7 +267,7 @@ type Container {
 
     If the group is omitted, it defaults to the same as the user.
     """
-    owner: FilesystemOwner
+    owner: String
   ): Container!
 
   """
@@ -289,7 +289,7 @@ type Container {
 
     If the group is omitted, it defaults to the same as the user.
     """
-    owner: FilesystemOwner
+    owner: String
   ): Container!
 
   """
@@ -327,7 +327,7 @@ type Container {
 
     If the group is omitted, it defaults to the same as the user.
     """
-    owner: FilesystemOwner
+    owner: String
   ): Container!
 
   """
@@ -349,7 +349,7 @@ type Container {
 
     If the group is omitted, it defaults to the same as the user.
     """
-    owner: FilesystemOwner
+    owner: String
   ): Container!
 
   """
@@ -388,7 +388,7 @@ type Container {
 
     If the group is omitted, it defaults to the same as the user.
     """
-    owner: FilesystemOwner
+    owner: String
   ): Container!
 
   """
@@ -419,7 +419,7 @@ type Container {
 
     If the group is omitted, it defaults to the same as the user.
     """
-    owner: FilesystemOwner
+    owner: String
   ): Container!
 
   """
@@ -451,7 +451,7 @@ type Container {
 
     If the group is omitted, it defaults to the same as the user.
     """
-    owner: FilesystemOwner
+    owner: String
   ): Container!
 
   """
@@ -475,7 +475,7 @@ type Container {
 
     If the group is omitted, it defaults to the same as the user.
     """
-    owner: FilesystemOwner
+    owner: String
   ): Container!
 
   """
@@ -806,23 +806,3 @@ enum NetworkProtocol {
   "UDP (User Datagram Protocol)"
   UDP
 }
-
-"""
-A user and group, as typically used to configure ownership of files and directories.
-
-The format is user[:group], where both user and group can either be IDs or
-names to be resolved to IDs using the container filesystem.
-
-If the group is omitted, it defaults to the same as the user.
-
-So, for a user 'foo' and group 'bar' with user ID and group ID 1111 and 2222
-respectively, the following are all valid:
-
-   foo      => 1111:1111
-   foo:bar  => 1111:2222
-   1111:bar => 1111:2222
-   foo:2222 => 1111:1111
-
-If the owner is unspecified, ownership will be left as-is.
-"""
-scalar FilesystemOwner

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -259,6 +259,15 @@ type Container {
 
     "Identifier of the mounted directory."
     source: DirectoryID!
+
+    """
+    A user:group to set for the mounted directory and its contents.
+
+    The user and group can either be an ID (1000:1000) or a name (foo:bar).
+
+    If the group is omitted, it defaults to the same as the user.
+    """
+    owner: String
   ): Container!
 
   """
@@ -272,6 +281,15 @@ type Container {
 
     "Identifier of the mounted file."
     source: FileID!
+
+    """
+    A user or user:group to set for the mounted file.
+
+    The user and group can either be an ID (1000:1000) or a name (foo:bar).
+
+    If the group is omitted, it defaults to the same as the user.
+    """
+    owner: String
   ): Container!
 
   """
@@ -301,6 +319,15 @@ type Container {
 
     "Sharing mode of the cache volume."
     sharing: CacheSharingMode
+
+    """
+    A user:group to set for the mounted cache directory.
+
+    The user and group can either be an ID (1000:1000) or a name (foo:bar).
+
+    If the group is omitted, it defaults to the same as the user.
+    """
+    owner: String
   ): Container!
 
   """
@@ -314,6 +341,15 @@ type Container {
 
     "Identifier of the secret to mount."
     source: SecretID!
+
+    """
+    A user:group to set for the mounted secret.
+
+    The user and group can either be an ID (1000:1000) or a name (foo:bar).
+
+    If the group is omitted, it defaults to the same as the user.
+    """
+    owner: String
   ): Container!
 
   """
@@ -344,6 +380,15 @@ type Container {
     Default: 0644.
     """
     permissions: Int
+
+    """
+    A user:group to set for the file.
+
+    The user and group can either be an ID (1000:1000) or a name (foo:bar).
+
+    If the group is omitted, it defaults to the same as the user.
+    """
+    owner: String
   ): Container!
 
   """
@@ -366,6 +411,15 @@ type Container {
     Default: 0644.
     """
     permissions: Int
+
+    """
+    A user:group to set for the file.
+
+    The user and group can either be an ID (1000:1000) or a name (foo:bar).
+
+    If the group is omitted, it defaults to the same as the user.
+    """
+    owner: String
   ): Container!
 
   """
@@ -389,6 +443,15 @@ type Container {
     Patterns to include in the written directory (e.g., ["*.go", "go.mod", "go.sum"]).
     """
     include: [String!]
+
+    """
+    A user:group to set for the directory and its contents.
+
+    The user and group can either be an ID (1000:1000) or a name (foo:bar).
+
+    If the group is omitted, it defaults to the same as the user.
+    """
+    owner: String
   ): Container!
 
   """
@@ -404,6 +467,15 @@ type Container {
     Identifier of the socket to forward.
     """
     source: SocketID!
+
+    """
+    A user:group to set for the mounted socket.
+
+    The user and group can either be an ID (1000:1000) or a name (foo:bar).
+
+    If the group is omitted, it defaults to the same as the user.
+    """
+    owner: String
   ): Container!
 
   """

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -107,7 +107,7 @@ type withDirectoryArgs struct {
 }
 
 func (s *directorySchema) withDirectory(ctx *router.Context, parent *core.Directory, args withDirectoryArgs) (*core.Directory, error) {
-	return parent.WithDirectory(ctx, args.Path, &core.Directory{ID: args.Directory}, args.CopyFilter, 0, 0)
+	return parent.WithDirectory(ctx, args.Path, &core.Directory{ID: args.Directory}, args.CopyFilter, nil)
 }
 
 type dirWithTimestampsArgs struct {
@@ -141,7 +141,7 @@ type withNewFileArgs struct {
 }
 
 func (s *directorySchema) withNewFile(ctx *router.Context, parent *core.Directory, args withNewFileArgs) (*core.Directory, error) {
-	return parent.WithNewFile(ctx, args.Path, []byte(args.Contents), args.Permissions, 0, 0)
+	return parent.WithNewFile(ctx, args.Path, []byte(args.Contents), args.Permissions, nil)
 }
 
 type withFileArgs struct {
@@ -151,7 +151,7 @@ type withFileArgs struct {
 }
 
 func (s *directorySchema) withFile(ctx *router.Context, parent *core.Directory, args withFileArgs) (*core.Directory, error) {
-	return parent.WithFile(ctx, args.Path, &core.File{ID: args.Source}, args.Permissions, 0, 0)
+	return parent.WithFile(ctx, args.Path, &core.File{ID: args.Source}, args.Permissions, nil)
 }
 
 type withoutDirectoryArgs struct {

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -107,7 +107,7 @@ type withDirectoryArgs struct {
 }
 
 func (s *directorySchema) withDirectory(ctx *router.Context, parent *core.Directory, args withDirectoryArgs) (*core.Directory, error) {
-	return parent.WithDirectory(ctx, args.Path, &core.Directory{ID: args.Directory}, args.CopyFilter, 0, 0) // TODO: expose uid/gid
+	return parent.WithDirectory(ctx, args.Path, &core.Directory{ID: args.Directory}, args.CopyFilter, 0, 0)
 }
 
 type dirWithTimestampsArgs struct {
@@ -141,7 +141,7 @@ type withNewFileArgs struct {
 }
 
 func (s *directorySchema) withNewFile(ctx *router.Context, parent *core.Directory, args withNewFileArgs) (*core.Directory, error) {
-	return parent.WithNewFile(ctx, args.Path, []byte(args.Contents), args.Permissions, 0, 0) // TODO expose uid/gid
+	return parent.WithNewFile(ctx, args.Path, []byte(args.Contents), args.Permissions, 0, 0)
 }
 
 type withFileArgs struct {
@@ -151,7 +151,7 @@ type withFileArgs struct {
 }
 
 func (s *directorySchema) withFile(ctx *router.Context, parent *core.Directory, args withFileArgs) (*core.Directory, error) {
-	return parent.WithFile(ctx, args.Path, &core.File{ID: args.Source}, args.Permissions, 0, 0) // TODO expose uid/gid
+	return parent.WithFile(ctx, args.Path, &core.File{ID: args.Source}, args.Permissions, 0, 0)
 }
 
 type withoutDirectoryArgs struct {

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -107,7 +107,7 @@ type withDirectoryArgs struct {
 }
 
 func (s *directorySchema) withDirectory(ctx *router.Context, parent *core.Directory, args withDirectoryArgs) (*core.Directory, error) {
-	return parent.WithDirectory(ctx, args.Path, &core.Directory{ID: args.Directory}, args.CopyFilter)
+	return parent.WithDirectory(ctx, args.Path, &core.Directory{ID: args.Directory}, args.CopyFilter, 0, 0) // TODO: expose uid/gid
 }
 
 type dirWithTimestampsArgs struct {
@@ -141,7 +141,7 @@ type withNewFileArgs struct {
 }
 
 func (s *directorySchema) withNewFile(ctx *router.Context, parent *core.Directory, args withNewFileArgs) (*core.Directory, error) {
-	return parent.WithNewFile(ctx, args.Path, []byte(args.Contents), args.Permissions)
+	return parent.WithNewFile(ctx, args.Path, []byte(args.Contents), args.Permissions, 0, 0) // TODO expose uid/gid
 }
 
 type withFileArgs struct {
@@ -151,7 +151,7 @@ type withFileArgs struct {
 }
 
 func (s *directorySchema) withFile(ctx *router.Context, parent *core.Directory, args withFileArgs) (*core.Directory, error) {
-	return parent.WithFile(ctx, args.Path, &core.File{ID: args.Source}, args.Permissions)
+	return parent.WithFile(ctx, args.Path, &core.File{ID: args.Source}, args.Permissions, 0, 0) // TODO expose uid/gid
 }
 
 type withoutDirectoryArgs struct {

--- a/core/util.go
+++ b/core/util.go
@@ -100,11 +100,6 @@ func mirrorCh[T any](dest chan<- T) (chan T, *sync.WaitGroup) {
 }
 
 func resolveUIDGID(ctx context.Context, fsSt llb.State, gw bkgw.Client, platform specs.Platform, owner string) (*Ownership, error) {
-	if owner == "" || platform.OS != "linux" {
-		// default to root
-		return &Ownership{0, 0}, nil
-	}
-
 	uidOrName, gidOrName, hasGroup := strings.Cut(owner, ":")
 
 	var uid, gid int

--- a/core/util.go
+++ b/core/util.go
@@ -100,6 +100,11 @@ func mirrorCh[T any](dest chan<- T) (chan T, *sync.WaitGroup) {
 }
 
 func resolveUIDGID(ctx context.Context, fsSt llb.State, gw bkgw.Client, platform specs.Platform, owner string) (int, int, error) {
+	if owner == "" {
+		// default to root
+		return 0, 0, nil
+	}
+
 	uidOrName, gidOrName, hasGroup := strings.Cut(owner, ":")
 
 	var uid, gid int

--- a/core/util.go
+++ b/core/util.go
@@ -100,7 +100,7 @@ func mirrorCh[T any](dest chan<- T) (chan T, *sync.WaitGroup) {
 }
 
 func resolveUIDGID(ctx context.Context, fsSt llb.State, gw bkgw.Client, platform specs.Platform, owner string) (int, int, error) {
-	if owner == "" {
+	if owner == "" || platform.OS != "linux" {
 		// default to root
 		return 0, 0, nil
 	}

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -1011,6 +1011,10 @@ type ContainerWithMountedCacheOpts struct {
 	Sharing CacheSharingMode
 	// A user:group to set for the mounted cache directory.
 	//
+	// Note that this changes the ownership of the specified mount along with the
+	// initial filesystem provided by source (if any). It does not have any effect
+	// if/when the cache has already been created.
+	//
 	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
 	//
 	// If the group is omitted, it defaults to the same as the user.

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -21,6 +21,24 @@ type DirectoryID string
 // A file identifier.
 type FileID string
 
+// A user and group, as typically used to configure ownership of files and directories.
+//
+// The format is user[:group], where both user and group can either be IDs or
+// names to be resolved to IDs using the container filesystem.
+//
+// If the group is omitted, it defaults to the same as the user.
+//
+// So, for a user 'foo' and group 'bar' with user ID and group ID 1111 and 2222
+// respectively, the following are all valid:
+//
+//	foo      => 1111:1111
+//	foo:bar  => 1111:2222
+//	1111:bar => 1111:2222
+//	foo:2222 => 1111:1111
+//
+// If the owner is unspecified, ownership will be left as-is.
+type FilesystemOwner string
+
 // The platform config OS and architecture in a Container.
 //
 // The format is [os]/[platform]/[version] (e.g., "darwin/arm64/v7", "windows/amd64", "linux/arm64").
@@ -765,7 +783,7 @@ type ContainerWithDirectoryOpts struct {
 	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
 	//
 	// If the group is omitted, it defaults to the same as the user.
-	Owner string
+	Owner FilesystemOwner
 }
 
 // Retrieves this container plus a directory written at the given path.
@@ -962,7 +980,7 @@ type ContainerWithFileOpts struct {
 	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
 	//
 	// If the group is omitted, it defaults to the same as the user.
-	Owner string
+	Owner FilesystemOwner
 }
 
 // Retrieves this container plus the contents of the given file copied to the given path.
@@ -1014,7 +1032,7 @@ type ContainerWithMountedCacheOpts struct {
 	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
 	//
 	// If the group is omitted, it defaults to the same as the user.
-	Owner string
+	Owner FilesystemOwner
 }
 
 // Retrieves this container plus a cache volume mounted at the given path.
@@ -1057,7 +1075,7 @@ type ContainerWithMountedDirectoryOpts struct {
 	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
 	//
 	// If the group is omitted, it defaults to the same as the user.
-	Owner string
+	Owner FilesystemOwner
 }
 
 // Retrieves this container plus a directory mounted at the given path.
@@ -1086,7 +1104,7 @@ type ContainerWithMountedFileOpts struct {
 	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
 	//
 	// If the group is omitted, it defaults to the same as the user.
-	Owner string
+	Owner FilesystemOwner
 }
 
 // Retrieves this container plus a file mounted at the given path.
@@ -1115,7 +1133,7 @@ type ContainerWithMountedSecretOpts struct {
 	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
 	//
 	// If the group is omitted, it defaults to the same as the user.
-	Owner string
+	Owner FilesystemOwner
 }
 
 // Retrieves this container plus a secret mounted into a file at the given path.
@@ -1161,7 +1179,7 @@ type ContainerWithNewFileOpts struct {
 	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
 	//
 	// If the group is omitted, it defaults to the same as the user.
-	Owner string
+	Owner FilesystemOwner
 }
 
 // Retrieves this container plus a new file written at the given path.
@@ -1257,7 +1275,7 @@ type ContainerWithUnixSocketOpts struct {
 	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
 	//
 	// If the group is omitted, it defaults to the same as the user.
-	Owner string
+	Owner FilesystemOwner
 }
 
 // Retrieves this container plus a socket forwarded to the given Unix socket path.

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -21,24 +21,6 @@ type DirectoryID string
 // A file identifier.
 type FileID string
 
-// A user and group, as typically used to configure ownership of files and directories.
-//
-// The format is user[:group], where both user and group can either be IDs or
-// names to be resolved to IDs using the container filesystem.
-//
-// If the group is omitted, it defaults to the same as the user.
-//
-// So, for a user 'foo' and group 'bar' with user ID and group ID 1111 and 2222
-// respectively, the following are all valid:
-//
-//	foo      => 1111:1111
-//	foo:bar  => 1111:2222
-//	1111:bar => 1111:2222
-//	foo:2222 => 1111:1111
-//
-// If the owner is unspecified, ownership will be left as-is.
-type FilesystemOwner string
-
 // The platform config OS and architecture in a Container.
 //
 // The format is [os]/[platform]/[version] (e.g., "darwin/arm64/v7", "windows/amd64", "linux/arm64").
@@ -783,7 +765,7 @@ type ContainerWithDirectoryOpts struct {
 	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
 	//
 	// If the group is omitted, it defaults to the same as the user.
-	Owner FilesystemOwner
+	Owner string
 }
 
 // Retrieves this container plus a directory written at the given path.
@@ -980,7 +962,7 @@ type ContainerWithFileOpts struct {
 	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
 	//
 	// If the group is omitted, it defaults to the same as the user.
-	Owner FilesystemOwner
+	Owner string
 }
 
 // Retrieves this container plus the contents of the given file copied to the given path.
@@ -1032,7 +1014,7 @@ type ContainerWithMountedCacheOpts struct {
 	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
 	//
 	// If the group is omitted, it defaults to the same as the user.
-	Owner FilesystemOwner
+	Owner string
 }
 
 // Retrieves this container plus a cache volume mounted at the given path.
@@ -1075,7 +1057,7 @@ type ContainerWithMountedDirectoryOpts struct {
 	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
 	//
 	// If the group is omitted, it defaults to the same as the user.
-	Owner FilesystemOwner
+	Owner string
 }
 
 // Retrieves this container plus a directory mounted at the given path.
@@ -1104,7 +1086,7 @@ type ContainerWithMountedFileOpts struct {
 	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
 	//
 	// If the group is omitted, it defaults to the same as the user.
-	Owner FilesystemOwner
+	Owner string
 }
 
 // Retrieves this container plus a file mounted at the given path.
@@ -1133,7 +1115,7 @@ type ContainerWithMountedSecretOpts struct {
 	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
 	//
 	// If the group is omitted, it defaults to the same as the user.
-	Owner FilesystemOwner
+	Owner string
 }
 
 // Retrieves this container plus a secret mounted into a file at the given path.
@@ -1179,7 +1161,7 @@ type ContainerWithNewFileOpts struct {
 	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
 	//
 	// If the group is omitted, it defaults to the same as the user.
-	Owner FilesystemOwner
+	Owner string
 }
 
 // Retrieves this container plus a new file written at the given path.
@@ -1275,7 +1257,7 @@ type ContainerWithUnixSocketOpts struct {
 	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
 	//
 	// If the group is omitted, it defaults to the same as the user.
-	Owner FilesystemOwner
+	Owner string
 }
 
 // Retrieves this container plus a socket forwarded to the given Unix socket path.

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -760,6 +760,12 @@ type ContainerWithDirectoryOpts struct {
 	Exclude []string
 	// Patterns to include in the written directory (e.g., ["*.go", "go.mod", "go.sum"]).
 	Include []string
+	// A user:group to set for the directory and its contents.
+	//
+	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
+	//
+	// If the group is omitted, it defaults to the same as the user.
+	Owner string
 }
 
 // Retrieves this container plus a directory written at the given path.
@@ -778,6 +784,13 @@ func (r *Container) WithDirectory(path string, directory *Directory, opts ...Con
 	for i := len(opts) - 1; i >= 0; i-- {
 		if !querybuilder.IsZeroValue(opts[i].Include) {
 			q = q.Arg("include", opts[i].Include)
+			break
+		}
+	}
+	// `owner` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].Owner) {
+			q = q.Arg("owner", opts[i].Owner)
 			break
 		}
 	}
@@ -944,6 +957,12 @@ type ContainerWithFileOpts struct {
 	//
 	// Default: 0644.
 	Permissions int
+	// A user:group to set for the file.
+	//
+	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
+	//
+	// If the group is omitted, it defaults to the same as the user.
+	Owner string
 }
 
 // Retrieves this container plus the contents of the given file copied to the given path.
@@ -955,6 +974,13 @@ func (r *Container) WithFile(path string, source *File, opts ...ContainerWithFil
 	for i := len(opts) - 1; i >= 0; i-- {
 		if !querybuilder.IsZeroValue(opts[i].Permissions) {
 			q = q.Arg("permissions", opts[i].Permissions)
+			break
+		}
+	}
+	// `owner` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].Owner) {
+			q = q.Arg("owner", opts[i].Owner)
 			break
 		}
 	}
@@ -983,6 +1009,12 @@ type ContainerWithMountedCacheOpts struct {
 	Source *Directory
 	// Sharing mode of the cache volume.
 	Sharing CacheSharingMode
+	// A user:group to set for the mounted cache directory.
+	//
+	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
+	//
+	// If the group is omitted, it defaults to the same as the user.
+	Owner string
 }
 
 // Retrieves this container plus a cache volume mounted at the given path.
@@ -1004,30 +1036,71 @@ func (r *Container) WithMountedCache(path string, cache *CacheVolume, opts ...Co
 			break
 		}
 	}
+	// `owner` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].Owner) {
+			q = q.Arg("owner", opts[i].Owner)
+			break
+		}
+	}
 
 	return &Container{
 		q: q,
 		c: r.c,
 	}
+}
+
+// ContainerWithMountedDirectoryOpts contains options for Container.WithMountedDirectory
+type ContainerWithMountedDirectoryOpts struct {
+	// A user:group to set for the mounted directory and its contents.
+	//
+	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
+	//
+	// If the group is omitted, it defaults to the same as the user.
+	Owner string
 }
 
 // Retrieves this container plus a directory mounted at the given path.
-func (r *Container) WithMountedDirectory(path string, source *Directory) *Container {
+func (r *Container) WithMountedDirectory(path string, source *Directory, opts ...ContainerWithMountedDirectoryOpts) *Container {
 	q := r.q.Select("withMountedDirectory")
 	q = q.Arg("path", path)
 	q = q.Arg("source", source)
+	// `owner` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].Owner) {
+			q = q.Arg("owner", opts[i].Owner)
+			break
+		}
+	}
 
 	return &Container{
 		q: q,
 		c: r.c,
 	}
+}
+
+// ContainerWithMountedFileOpts contains options for Container.WithMountedFile
+type ContainerWithMountedFileOpts struct {
+	// A user or user:group to set for the mounted file.
+	//
+	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
+	//
+	// If the group is omitted, it defaults to the same as the user.
+	Owner string
 }
 
 // Retrieves this container plus a file mounted at the given path.
-func (r *Container) WithMountedFile(path string, source *File) *Container {
+func (r *Container) WithMountedFile(path string, source *File, opts ...ContainerWithMountedFileOpts) *Container {
 	q := r.q.Select("withMountedFile")
 	q = q.Arg("path", path)
 	q = q.Arg("source", source)
+	// `owner` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].Owner) {
+			q = q.Arg("owner", opts[i].Owner)
+			break
+		}
+	}
 
 	return &Container{
 		q: q,
@@ -1035,11 +1108,28 @@ func (r *Container) WithMountedFile(path string, source *File) *Container {
 	}
 }
 
+// ContainerWithMountedSecretOpts contains options for Container.WithMountedSecret
+type ContainerWithMountedSecretOpts struct {
+	// A user:group to set for the mounted secret.
+	//
+	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
+	//
+	// If the group is omitted, it defaults to the same as the user.
+	Owner string
+}
+
 // Retrieves this container plus a secret mounted into a file at the given path.
-func (r *Container) WithMountedSecret(path string, source *Secret) *Container {
+func (r *Container) WithMountedSecret(path string, source *Secret, opts ...ContainerWithMountedSecretOpts) *Container {
 	q := r.q.Select("withMountedSecret")
 	q = q.Arg("path", path)
 	q = q.Arg("source", source)
+	// `owner` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].Owner) {
+			q = q.Arg("owner", opts[i].Owner)
+			break
+		}
+	}
 
 	return &Container{
 		q: q,
@@ -1066,6 +1156,12 @@ type ContainerWithNewFileOpts struct {
 	//
 	// Default: 0644.
 	Permissions int
+	// A user:group to set for the file.
+	//
+	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
+	//
+	// If the group is omitted, it defaults to the same as the user.
+	Owner string
 }
 
 // Retrieves this container plus a new file written at the given path.
@@ -1083,6 +1179,13 @@ func (r *Container) WithNewFile(path string, opts ...ContainerWithNewFileOpts) *
 	for i := len(opts) - 1; i >= 0; i-- {
 		if !querybuilder.IsZeroValue(opts[i].Permissions) {
 			q = q.Arg("permissions", opts[i].Permissions)
+			break
+		}
+	}
+	// `owner` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].Owner) {
+			q = q.Arg("owner", opts[i].Owner)
 			break
 		}
 	}
@@ -1147,11 +1250,28 @@ func (r *Container) WithServiceBinding(alias string, service *Container) *Contai
 	}
 }
 
+// ContainerWithUnixSocketOpts contains options for Container.WithUnixSocket
+type ContainerWithUnixSocketOpts struct {
+	// A user:group to set for the mounted socket.
+	//
+	// The user and group can either be an ID (1000:1000) or a name (foo:bar).
+	//
+	// If the group is omitted, it defaults to the same as the user.
+	Owner string
+}
+
 // Retrieves this container plus a socket forwarded to the given Unix socket path.
-func (r *Container) WithUnixSocket(path string, source *Socket) *Container {
+func (r *Container) WithUnixSocket(path string, source *Socket, opts ...ContainerWithUnixSocketOpts) *Container {
 	q := r.q.Select("withUnixSocket")
 	q = q.Arg("path", path)
 	q = q.Arg("source", source)
+	// `owner` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].Owner) {
+			q = q.Arg("owner", opts[i].Owner)
+			break
+		}
+	}
 
 	return &Container{
 		q: q,

--- a/sdk/go/internal/querybuilder/marshal.go
+++ b/sdk/go/internal/querybuilder/marshal.go
@@ -26,7 +26,7 @@ var (
 	gqlMarshaller reflect.Type
 
 	// Taken from codegen/generator/functions.go
-	// Includes also Platform and Owner
+	// Includes also Platform
 	customScalar = map[string]struct{}{
 		"ContainerID": {},
 		"FileID":      {},
@@ -35,7 +35,6 @@ var (
 		"SocketID":    {},
 		"CacheID":     {},
 		"Platform":    {},
-		"Owner":       {},
 	}
 )
 

--- a/sdk/go/internal/querybuilder/marshal.go
+++ b/sdk/go/internal/querybuilder/marshal.go
@@ -26,7 +26,7 @@ var (
 	gqlMarshaller reflect.Type
 
 	// Taken from codegen/generator/functions.go
-	// Includes also Platform
+	// Includes also Platform and Owner
 	customScalar = map[string]struct{}{
 		"ContainerID": {},
 		"FileID":      {},
@@ -35,6 +35,7 @@ var (
 		"SocketID":    {},
 		"CacheID":     {},
 		"Platform":    {},
+		"Owner":       {},
 	}
 )
 

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -217,7 +217,7 @@ export type ContainerWithDirectoryOpts = {
    *
    * If the group is omitted, it defaults to the same as the user.
    */
-  owner?: FilesystemOwner
+  owner?: string
 }
 
 export type ContainerWithExecOpts = {
@@ -285,7 +285,7 @@ export type ContainerWithFileOpts = {
    *
    * If the group is omitted, it defaults to the same as the user.
    */
-  owner?: FilesystemOwner
+  owner?: string
 }
 
 export type ContainerWithMountedCacheOpts = {
@@ -306,7 +306,7 @@ export type ContainerWithMountedCacheOpts = {
    *
    * If the group is omitted, it defaults to the same as the user.
    */
-  owner?: FilesystemOwner
+  owner?: string
 }
 
 export type ContainerWithMountedDirectoryOpts = {
@@ -317,7 +317,7 @@ export type ContainerWithMountedDirectoryOpts = {
    *
    * If the group is omitted, it defaults to the same as the user.
    */
-  owner?: FilesystemOwner
+  owner?: string
 }
 
 export type ContainerWithMountedFileOpts = {
@@ -328,7 +328,7 @@ export type ContainerWithMountedFileOpts = {
    *
    * If the group is omitted, it defaults to the same as the user.
    */
-  owner?: FilesystemOwner
+  owner?: string
 }
 
 export type ContainerWithMountedSecretOpts = {
@@ -339,7 +339,7 @@ export type ContainerWithMountedSecretOpts = {
    *
    * If the group is omitted, it defaults to the same as the user.
    */
-  owner?: FilesystemOwner
+  owner?: string
 }
 
 export type ContainerWithNewFileOpts = {
@@ -362,7 +362,7 @@ export type ContainerWithNewFileOpts = {
    *
    * If the group is omitted, it defaults to the same as the user.
    */
-  owner?: FilesystemOwner
+  owner?: string
 }
 
 export type ContainerWithUnixSocketOpts = {
@@ -373,7 +373,7 @@ export type ContainerWithUnixSocketOpts = {
    *
    * If the group is omitted, it defaults to the same as the user.
    */
-  owner?: FilesystemOwner
+  owner?: string
 }
 
 export type ContainerWithoutExposedPortOpts = {
@@ -491,26 +491,6 @@ export type DirectoryID = string & { __DirectoryID: never }
  * A file identifier.
  */
 export type FileID = string & { __FileID: never }
-
-/**
- * A user and group, as typically used to configure ownership of files and directories.
- *
- * The format is user[:group], where both user and group can either be IDs or
- * names to be resolved to IDs using the container filesystem.
- *
- * If the group is omitted, it defaults to the same as the user.
- *
- * So, for a user 'foo' and group 'bar' with user ID and group ID 1111 and 2222
- * respectively, the following are all valid:
- *
- *    foo      => 1111:1111
- *    foo:bar  => 1111:2222
- *    1111:bar => 1111:2222
- *    foo:2222 => 1111:1111
- *
- * If the owner is unspecified, ownership will be left as-is.
- */
-export type FilesystemOwner = string & { __FilesystemOwner: never }
 
 export type GitRefTreeOpts = {
   sshKnownHosts?: string

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -217,7 +217,7 @@ export type ContainerWithDirectoryOpts = {
    *
    * If the group is omitted, it defaults to the same as the user.
    */
-  owner?: string
+  owner?: FilesystemOwner
 }
 
 export type ContainerWithExecOpts = {
@@ -285,7 +285,7 @@ export type ContainerWithFileOpts = {
    *
    * If the group is omitted, it defaults to the same as the user.
    */
-  owner?: string
+  owner?: FilesystemOwner
 }
 
 export type ContainerWithMountedCacheOpts = {
@@ -306,7 +306,7 @@ export type ContainerWithMountedCacheOpts = {
    *
    * If the group is omitted, it defaults to the same as the user.
    */
-  owner?: string
+  owner?: FilesystemOwner
 }
 
 export type ContainerWithMountedDirectoryOpts = {
@@ -317,7 +317,7 @@ export type ContainerWithMountedDirectoryOpts = {
    *
    * If the group is omitted, it defaults to the same as the user.
    */
-  owner?: string
+  owner?: FilesystemOwner
 }
 
 export type ContainerWithMountedFileOpts = {
@@ -328,7 +328,7 @@ export type ContainerWithMountedFileOpts = {
    *
    * If the group is omitted, it defaults to the same as the user.
    */
-  owner?: string
+  owner?: FilesystemOwner
 }
 
 export type ContainerWithMountedSecretOpts = {
@@ -339,7 +339,7 @@ export type ContainerWithMountedSecretOpts = {
    *
    * If the group is omitted, it defaults to the same as the user.
    */
-  owner?: string
+  owner?: FilesystemOwner
 }
 
 export type ContainerWithNewFileOpts = {
@@ -362,7 +362,7 @@ export type ContainerWithNewFileOpts = {
    *
    * If the group is omitted, it defaults to the same as the user.
    */
-  owner?: string
+  owner?: FilesystemOwner
 }
 
 export type ContainerWithUnixSocketOpts = {
@@ -373,7 +373,7 @@ export type ContainerWithUnixSocketOpts = {
    *
    * If the group is omitted, it defaults to the same as the user.
    */
-  owner?: string
+  owner?: FilesystemOwner
 }
 
 export type ContainerWithoutExposedPortOpts = {
@@ -491,6 +491,26 @@ export type DirectoryID = string & { __DirectoryID: never }
  * A file identifier.
  */
 export type FileID = string & { __FileID: never }
+
+/**
+ * A user and group, as typically used to configure ownership of files and directories.
+ *
+ * The format is user[:group], where both user and group can either be IDs or
+ * names to be resolved to IDs using the container filesystem.
+ *
+ * If the group is omitted, it defaults to the same as the user.
+ *
+ * So, for a user 'foo' and group 'bar' with user ID and group ID 1111 and 2222
+ * respectively, the following are all valid:
+ *
+ *    foo      => 1111:1111
+ *    foo:bar  => 1111:2222
+ *    1111:bar => 1111:2222
+ *    foo:2222 => 1111:1111
+ *
+ * If the owner is unspecified, ownership will be left as-is.
+ */
+export type FilesystemOwner = string & { __FilesystemOwner: never }
 
 export type GitRefTreeOpts = {
   sshKnownHosts?: string

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -209,6 +209,15 @@ export type ContainerWithDirectoryOpts = {
    * Patterns to include in the written directory (e.g., ["*.go", "go.mod", "go.sum"]).
    */
   include?: string[]
+
+  /**
+   * A user:group to set for the directory and its contents.
+   *
+   * The user and group can either be an ID (1000:1000) or a name (foo:bar).
+   *
+   * If the group is omitted, it defaults to the same as the user.
+   */
+  owner?: string
 }
 
 export type ContainerWithExecOpts = {
@@ -268,6 +277,15 @@ export type ContainerWithFileOpts = {
    * Default: 0644.
    */
   permissions?: number
+
+  /**
+   * A user:group to set for the file.
+   *
+   * The user and group can either be an ID (1000:1000) or a name (foo:bar).
+   *
+   * If the group is omitted, it defaults to the same as the user.
+   */
+  owner?: string
 }
 
 export type ContainerWithMountedCacheOpts = {
@@ -280,6 +298,48 @@ export type ContainerWithMountedCacheOpts = {
    * Sharing mode of the cache volume.
    */
   sharing?: CacheSharingMode
+
+  /**
+   * A user:group to set for the mounted cache directory.
+   *
+   * The user and group can either be an ID (1000:1000) or a name (foo:bar).
+   *
+   * If the group is omitted, it defaults to the same as the user.
+   */
+  owner?: string
+}
+
+export type ContainerWithMountedDirectoryOpts = {
+  /**
+   * A user:group to set for the mounted directory and its contents.
+   *
+   * The user and group can either be an ID (1000:1000) or a name (foo:bar).
+   *
+   * If the group is omitted, it defaults to the same as the user.
+   */
+  owner?: string
+}
+
+export type ContainerWithMountedFileOpts = {
+  /**
+   * A user or user:group to set for the mounted file.
+   *
+   * The user and group can either be an ID (1000:1000) or a name (foo:bar).
+   *
+   * If the group is omitted, it defaults to the same as the user.
+   */
+  owner?: string
+}
+
+export type ContainerWithMountedSecretOpts = {
+  /**
+   * A user:group to set for the mounted secret.
+   *
+   * The user and group can either be an ID (1000:1000) or a name (foo:bar).
+   *
+   * If the group is omitted, it defaults to the same as the user.
+   */
+  owner?: string
 }
 
 export type ContainerWithNewFileOpts = {
@@ -294,6 +354,26 @@ export type ContainerWithNewFileOpts = {
    * Default: 0644.
    */
   permissions?: number
+
+  /**
+   * A user:group to set for the file.
+   *
+   * The user and group can either be an ID (1000:1000) or a name (foo:bar).
+   *
+   * If the group is omitted, it defaults to the same as the user.
+   */
+  owner?: string
+}
+
+export type ContainerWithUnixSocketOpts = {
+  /**
+   * A user:group to set for the mounted socket.
+   *
+   * The user and group can either be an ID (1000:1000) or a name (foo:bar).
+   *
+   * If the group is omitted, it defaults to the same as the user.
+   */
+  owner?: string
 }
 
 export type ContainerWithoutExposedPortOpts = {
@@ -1161,6 +1241,11 @@ export class Container extends BaseClient {
    * @param directory Identifier of the directory to write
    * @param opts.exclude Patterns to exclude in the written directory (e.g., ["node_modules/**", ".gitignore", ".git/"]).
    * @param opts.include Patterns to include in the written directory (e.g., ["*.go", "go.mod", "go.sum"]).
+   * @param opts.owner A user:group to set for the directory and its contents.
+   *
+   * The user and group can either be an ID (1000:1000) or a name (foo:bar).
+   *
+   * If the group is omitted, it defaults to the same as the user.
    */
   withDirectory(
     path: string,
@@ -1301,6 +1386,11 @@ export class Container extends BaseClient {
    * @param opts.permissions Permission given to the copied file (e.g., 0600).
    *
    * Default: 0644.
+   * @param opts.owner A user:group to set for the file.
+   *
+   * The user and group can either be an ID (1000:1000) or a name (foo:bar).
+   *
+   * If the group is omitted, it defaults to the same as the user.
    */
   withFile(
     path: string,
@@ -1345,6 +1435,11 @@ export class Container extends BaseClient {
    * @param cache Identifier of the cache volume to mount.
    * @param opts.source Identifier of the directory to use as the cache volume's root.
    * @param opts.sharing Sharing mode of the cache volume.
+   * @param opts.owner A user:group to set for the mounted cache directory.
+   *
+   * The user and group can either be an ID (1000:1000) or a name (foo:bar).
+   *
+   * If the group is omitted, it defaults to the same as the user.
    */
   withMountedCache(
     path: string,
@@ -1368,14 +1463,23 @@ export class Container extends BaseClient {
    * Retrieves this container plus a directory mounted at the given path.
    * @param path Location of the mounted directory (e.g., "/mnt/directory").
    * @param source Identifier of the mounted directory.
+   * @param opts.owner A user:group to set for the mounted directory and its contents.
+   *
+   * The user and group can either be an ID (1000:1000) or a name (foo:bar).
+   *
+   * If the group is omitted, it defaults to the same as the user.
    */
-  withMountedDirectory(path: string, source: Directory): Container {
+  withMountedDirectory(
+    path: string,
+    source: Directory,
+    opts?: ContainerWithMountedDirectoryOpts
+  ): Container {
     return new Container({
       queryTree: [
         ...this._queryTree,
         {
           operation: "withMountedDirectory",
-          args: { path, source },
+          args: { path, source, ...opts },
         },
       ],
       host: this.clientHost,
@@ -1387,14 +1491,23 @@ export class Container extends BaseClient {
    * Retrieves this container plus a file mounted at the given path.
    * @param path Location of the mounted file (e.g., "/tmp/file.txt").
    * @param source Identifier of the mounted file.
+   * @param opts.owner A user or user:group to set for the mounted file.
+   *
+   * The user and group can either be an ID (1000:1000) or a name (foo:bar).
+   *
+   * If the group is omitted, it defaults to the same as the user.
    */
-  withMountedFile(path: string, source: File): Container {
+  withMountedFile(
+    path: string,
+    source: File,
+    opts?: ContainerWithMountedFileOpts
+  ): Container {
     return new Container({
       queryTree: [
         ...this._queryTree,
         {
           operation: "withMountedFile",
-          args: { path, source },
+          args: { path, source, ...opts },
         },
       ],
       host: this.clientHost,
@@ -1406,14 +1519,23 @@ export class Container extends BaseClient {
    * Retrieves this container plus a secret mounted into a file at the given path.
    * @param path Location of the secret file (e.g., "/tmp/secret.txt").
    * @param source Identifier of the secret to mount.
+   * @param opts.owner A user:group to set for the mounted secret.
+   *
+   * The user and group can either be an ID (1000:1000) or a name (foo:bar).
+   *
+   * If the group is omitted, it defaults to the same as the user.
    */
-  withMountedSecret(path: string, source: Secret): Container {
+  withMountedSecret(
+    path: string,
+    source: Secret,
+    opts?: ContainerWithMountedSecretOpts
+  ): Container {
     return new Container({
       queryTree: [
         ...this._queryTree,
         {
           operation: "withMountedSecret",
-          args: { path, source },
+          args: { path, source, ...opts },
         },
       ],
       host: this.clientHost,
@@ -1446,6 +1568,11 @@ export class Container extends BaseClient {
    * @param opts.permissions Permission given to the written file (e.g., 0600).
    *
    * Default: 0644.
+   * @param opts.owner A user:group to set for the file.
+   *
+   * The user and group can either be an ID (1000:1000) or a name (foo:bar).
+   *
+   * If the group is omitted, it defaults to the same as the user.
    */
   withNewFile(path: string, opts?: ContainerWithNewFileOpts): Container {
     return new Container({
@@ -1551,14 +1678,23 @@ export class Container extends BaseClient {
    * Retrieves this container plus a socket forwarded to the given Unix socket path.
    * @param path Location of the forwarded Unix socket (e.g., "/tmp/socket").
    * @param source Identifier of the socket to forward.
+   * @param opts.owner A user:group to set for the mounted socket.
+   *
+   * The user and group can either be an ID (1000:1000) or a name (foo:bar).
+   *
+   * If the group is omitted, it defaults to the same as the user.
    */
-  withUnixSocket(path: string, source: Socket): Container {
+  withUnixSocket(
+    path: string,
+    source: Socket,
+    opts?: ContainerWithUnixSocketOpts
+  ): Container {
     return new Container({
       queryTree: [
         ...this._queryTree,
         {
           operation: "withUnixSocket",
-          args: { path, source },
+          args: { path, source, ...opts },
         },
       ],
       host: this.clientHost,

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -302,6 +302,10 @@ export type ContainerWithMountedCacheOpts = {
   /**
    * A user:group to set for the mounted cache directory.
    *
+   * Note that this changes the ownership of the specified mount along with the
+   * initial filesystem provided by source (if any). It does not have any effect
+   * if/when the cache has already been created.
+   *
    * The user and group can either be an ID (1000:1000) or a name (foo:bar).
    *
    * If the group is omitted, it defaults to the same as the user.
@@ -1436,6 +1440,10 @@ export class Container extends BaseClient {
    * @param opts.source Identifier of the directory to use as the cache volume's root.
    * @param opts.sharing Sharing mode of the cache volume.
    * @param opts.owner A user:group to set for the mounted cache directory.
+   *
+   * Note that this changes the ownership of the specified mount along with the
+   * initial filesystem provided by source (if any). It does not have any effect
+   * if/when the cache has already been created.
    *
    * The user and group can either be an ID (1000:1000) or a name (foo:bar).
    *

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -1052,6 +1052,11 @@ class Container(Type):
             Sharing mode of the cache volume.
         owner:
             A user:group to set for the mounted cache directory.
+            Note that this changes the ownership of the specified mount along
+            with the
+            initial filesystem provided by source (if any). It does not have
+            any effect
+            if/when the cache has already been created.
             The user and group can either be an ID (1000:1000) or a name
             (foo:bar).
             If the group is omitted, it defaults to the same as the user.

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -25,18 +25,6 @@ class FileID(Scalar):
     """A file identifier."""
 
 
-class FilesystemOwner(Scalar):
-    """A user and group, as typically used to configure ownership of files
-    and directories.  The format is user[:group], where both user and
-    group can either be IDs or names to be resolved to IDs using the
-    container filesystem.  If the group is omitted, it defaults to the
-    same as the user.  So, for a user 'foo' and group 'bar' with user ID
-    and group ID 1111 and 2222 respectively, the following are all valid:
-    foo      => 1111:1111    foo:bar  => 1111:2222    1111:bar =>
-    1111:2222    foo:2222 => 1111:1111  If the owner is unspecified,
-    ownership will be left as-is."""
-
-
 class Platform(Scalar):
     """The platform config OS and architecture in a Container.  The format
     is [os]/[platform]/[version] (e.g., "darwin/arm64/v7",
@@ -817,7 +805,7 @@ class Container(Type):
         directory: "Directory",
         exclude: Optional[Sequence[str]] = None,
         include: Optional[Sequence[str]] = None,
-        owner: Optional[FilesystemOwner] = None,
+        owner: Optional[str] = None,
     ) -> "Container":
         """Retrieves this container plus a directory written at the given path.
 
@@ -992,7 +980,7 @@ class Container(Type):
         path: str,
         source: "File",
         permissions: Optional[int] = None,
-        owner: Optional[FilesystemOwner] = None,
+        owner: Optional[str] = None,
     ) -> "Container":
         """Retrieves this container plus the contents of the given file copied to
         the given path.
@@ -1047,7 +1035,7 @@ class Container(Type):
         cache: CacheVolume,
         source: Optional["Directory"] = None,
         sharing: Optional[CacheSharingMode] = None,
-        owner: Optional[FilesystemOwner] = None,
+        owner: Optional[str] = None,
     ) -> "Container":
         """Retrieves this container plus a cache volume mounted at the given
         path.
@@ -1083,7 +1071,7 @@ class Container(Type):
         self,
         path: str,
         source: "Directory",
-        owner: Optional[FilesystemOwner] = None,
+        owner: Optional[str] = None,
     ) -> "Container":
         """Retrieves this container plus a directory mounted at the given path.
 
@@ -1112,7 +1100,7 @@ class Container(Type):
         self,
         path: str,
         source: "File",
-        owner: Optional[FilesystemOwner] = None,
+        owner: Optional[str] = None,
     ) -> "Container":
         """Retrieves this container plus a file mounted at the given path.
 
@@ -1141,7 +1129,7 @@ class Container(Type):
         self,
         path: str,
         source: "Secret",
-        owner: Optional[FilesystemOwner] = None,
+        owner: Optional[str] = None,
     ) -> "Container":
         """Retrieves this container plus a secret mounted into a file at the
         given path.
@@ -1188,7 +1176,7 @@ class Container(Type):
         path: str,
         contents: Optional[str] = None,
         permissions: Optional[int] = None,
-        owner: Optional[FilesystemOwner] = None,
+        owner: Optional[str] = None,
     ) -> "Container":
         """Retrieves this container plus a new file written at the given path.
 
@@ -1307,7 +1295,7 @@ class Container(Type):
         self,
         path: str,
         source: "Socket",
-        owner: Optional[FilesystemOwner] = None,
+        owner: Optional[str] = None,
     ) -> "Container":
         """Retrieves this container plus a socket forwarded to the given Unix
         socket path.
@@ -2795,7 +2783,6 @@ __all__ = [
     "ContainerID",
     "DirectoryID",
     "FileID",
-    "FilesystemOwner",
     "Platform",
     "SecretID",
     "SocketID",

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -805,6 +805,7 @@ class Container(Type):
         directory: "Directory",
         exclude: Optional[Sequence[str]] = None,
         include: Optional[Sequence[str]] = None,
+        owner: Optional[str] = None,
     ) -> "Container":
         """Retrieves this container plus a directory written at the given path.
 
@@ -820,12 +821,18 @@ class Container(Type):
         include:
             Patterns to include in the written directory (e.g., ["*.go",
             "go.mod", "go.sum"]).
+        owner:
+            A user:group to set for the directory and its contents.
+            The user and group can either be an ID (1000:1000) or a name
+            (foo:bar).
+            If the group is omitted, it defaults to the same as the user.
         """
         _args = [
             Arg("path", path),
             Arg("directory", directory),
             Arg("exclude", exclude, None),
             Arg("include", include, None),
+            Arg("owner", owner, None),
         ]
         _ctx = self._select("withDirectory", _args)
         return Container(_ctx)
@@ -973,6 +980,7 @@ class Container(Type):
         path: str,
         source: "File",
         permissions: Optional[int] = None,
+        owner: Optional[str] = None,
     ) -> "Container":
         """Retrieves this container plus the contents of the given file copied to
         the given path.
@@ -986,11 +994,17 @@ class Container(Type):
         permissions:
             Permission given to the copied file (e.g., 0600).
             Default: 0644.
+        owner:
+            A user:group to set for the file.
+            The user and group can either be an ID (1000:1000) or a name
+            (foo:bar).
+            If the group is omitted, it defaults to the same as the user.
         """
         _args = [
             Arg("path", path),
             Arg("source", source),
             Arg("permissions", permissions, None),
+            Arg("owner", owner, None),
         ]
         _ctx = self._select("withFile", _args)
         return Container(_ctx)
@@ -1021,6 +1035,7 @@ class Container(Type):
         cache: CacheVolume,
         source: Optional["Directory"] = None,
         sharing: Optional[CacheSharingMode] = None,
+        owner: Optional[str] = None,
     ) -> "Container":
         """Retrieves this container plus a cache volume mounted at the given
         path.
@@ -1035,18 +1050,29 @@ class Container(Type):
             Identifier of the directory to use as the cache volume's root.
         sharing:
             Sharing mode of the cache volume.
+        owner:
+            A user:group to set for the mounted cache directory.
+            The user and group can either be an ID (1000:1000) or a name
+            (foo:bar).
+            If the group is omitted, it defaults to the same as the user.
         """
         _args = [
             Arg("path", path),
             Arg("cache", cache),
             Arg("source", source, None),
             Arg("sharing", sharing, None),
+            Arg("owner", owner, None),
         ]
         _ctx = self._select("withMountedCache", _args)
         return Container(_ctx)
 
     @typecheck
-    def with_mounted_directory(self, path: str, source: "Directory") -> "Container":
+    def with_mounted_directory(
+        self,
+        path: str,
+        source: "Directory",
+        owner: Optional[str] = None,
+    ) -> "Container":
         """Retrieves this container plus a directory mounted at the given path.
 
         Parameters
@@ -1055,16 +1081,27 @@ class Container(Type):
             Location of the mounted directory (e.g., "/mnt/directory").
         source:
             Identifier of the mounted directory.
+        owner:
+            A user:group to set for the mounted directory and its contents.
+            The user and group can either be an ID (1000:1000) or a name
+            (foo:bar).
+            If the group is omitted, it defaults to the same as the user.
         """
         _args = [
             Arg("path", path),
             Arg("source", source),
+            Arg("owner", owner, None),
         ]
         _ctx = self._select("withMountedDirectory", _args)
         return Container(_ctx)
 
     @typecheck
-    def with_mounted_file(self, path: str, source: "File") -> "Container":
+    def with_mounted_file(
+        self,
+        path: str,
+        source: "File",
+        owner: Optional[str] = None,
+    ) -> "Container":
         """Retrieves this container plus a file mounted at the given path.
 
         Parameters
@@ -1073,16 +1110,27 @@ class Container(Type):
             Location of the mounted file (e.g., "/tmp/file.txt").
         source:
             Identifier of the mounted file.
+        owner:
+            A user or user:group to set for the mounted file.
+            The user and group can either be an ID (1000:1000) or a name
+            (foo:bar).
+            If the group is omitted, it defaults to the same as the user.
         """
         _args = [
             Arg("path", path),
             Arg("source", source),
+            Arg("owner", owner, None),
         ]
         _ctx = self._select("withMountedFile", _args)
         return Container(_ctx)
 
     @typecheck
-    def with_mounted_secret(self, path: str, source: "Secret") -> "Container":
+    def with_mounted_secret(
+        self,
+        path: str,
+        source: "Secret",
+        owner: Optional[str] = None,
+    ) -> "Container":
         """Retrieves this container plus a secret mounted into a file at the
         given path.
 
@@ -1092,10 +1140,16 @@ class Container(Type):
             Location of the secret file (e.g., "/tmp/secret.txt").
         source:
             Identifier of the secret to mount.
+        owner:
+            A user:group to set for the mounted secret.
+            The user and group can either be an ID (1000:1000) or a name
+            (foo:bar).
+            If the group is omitted, it defaults to the same as the user.
         """
         _args = [
             Arg("path", path),
             Arg("source", source),
+            Arg("owner", owner, None),
         ]
         _ctx = self._select("withMountedSecret", _args)
         return Container(_ctx)
@@ -1122,6 +1176,7 @@ class Container(Type):
         path: str,
         contents: Optional[str] = None,
         permissions: Optional[int] = None,
+        owner: Optional[str] = None,
     ) -> "Container":
         """Retrieves this container plus a new file written at the given path.
 
@@ -1134,11 +1189,17 @@ class Container(Type):
         permissions:
             Permission given to the written file (e.g., 0600).
             Default: 0644.
+        owner:
+            A user:group to set for the file.
+            The user and group can either be an ID (1000:1000) or a name
+            (foo:bar).
+            If the group is omitted, it defaults to the same as the user.
         """
         _args = [
             Arg("path", path),
             Arg("contents", contents, None),
             Arg("permissions", permissions, None),
+            Arg("owner", owner, None),
         ]
         _ctx = self._select("withNewFile", _args)
         return Container(_ctx)
@@ -1230,7 +1291,12 @@ class Container(Type):
         return Container(_ctx)
 
     @typecheck
-    def with_unix_socket(self, path: str, source: "Socket") -> "Container":
+    def with_unix_socket(
+        self,
+        path: str,
+        source: "Socket",
+        owner: Optional[str] = None,
+    ) -> "Container":
         """Retrieves this container plus a socket forwarded to the given Unix
         socket path.
 
@@ -1240,10 +1306,16 @@ class Container(Type):
             Location of the forwarded Unix socket (e.g., "/tmp/socket").
         source:
             Identifier of the socket to forward.
+        owner:
+            A user:group to set for the mounted socket.
+            The user and group can either be an ID (1000:1000) or a name
+            (foo:bar).
+            If the group is omitted, it defaults to the same as the user.
         """
         _args = [
             Arg("path", path),
             Arg("source", source),
+            Arg("owner", owner, None),
         ]
         _ctx = self._select("withUnixSocket", _args)
         return Container(_ctx)

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -25,6 +25,18 @@ class FileID(Scalar):
     """A file identifier."""
 
 
+class FilesystemOwner(Scalar):
+    """A user and group, as typically used to configure ownership of files
+    and directories.  The format is user[:group], where both user and
+    group can either be IDs or names to be resolved to IDs using the
+    container filesystem.  If the group is omitted, it defaults to the
+    same as the user.  So, for a user 'foo' and group 'bar' with user ID
+    and group ID 1111 and 2222 respectively, the following are all valid:
+    foo      => 1111:1111    foo:bar  => 1111:2222    1111:bar =>
+    1111:2222    foo:2222 => 1111:1111  If the owner is unspecified,
+    ownership will be left as-is."""
+
+
 class Platform(Scalar):
     """The platform config OS and architecture in a Container.  The format
     is [os]/[platform]/[version] (e.g., "darwin/arm64/v7",
@@ -805,7 +817,7 @@ class Container(Type):
         directory: "Directory",
         exclude: Optional[Sequence[str]] = None,
         include: Optional[Sequence[str]] = None,
-        owner: Optional[str] = None,
+        owner: Optional[FilesystemOwner] = None,
     ) -> "Container":
         """Retrieves this container plus a directory written at the given path.
 
@@ -980,7 +992,7 @@ class Container(Type):
         path: str,
         source: "File",
         permissions: Optional[int] = None,
-        owner: Optional[str] = None,
+        owner: Optional[FilesystemOwner] = None,
     ) -> "Container":
         """Retrieves this container plus the contents of the given file copied to
         the given path.
@@ -1035,7 +1047,7 @@ class Container(Type):
         cache: CacheVolume,
         source: Optional["Directory"] = None,
         sharing: Optional[CacheSharingMode] = None,
-        owner: Optional[str] = None,
+        owner: Optional[FilesystemOwner] = None,
     ) -> "Container":
         """Retrieves this container plus a cache volume mounted at the given
         path.
@@ -1071,7 +1083,7 @@ class Container(Type):
         self,
         path: str,
         source: "Directory",
-        owner: Optional[str] = None,
+        owner: Optional[FilesystemOwner] = None,
     ) -> "Container":
         """Retrieves this container plus a directory mounted at the given path.
 
@@ -1100,7 +1112,7 @@ class Container(Type):
         self,
         path: str,
         source: "File",
-        owner: Optional[str] = None,
+        owner: Optional[FilesystemOwner] = None,
     ) -> "Container":
         """Retrieves this container plus a file mounted at the given path.
 
@@ -1129,7 +1141,7 @@ class Container(Type):
         self,
         path: str,
         source: "Secret",
-        owner: Optional[str] = None,
+        owner: Optional[FilesystemOwner] = None,
     ) -> "Container":
         """Retrieves this container plus a secret mounted into a file at the
         given path.
@@ -1176,7 +1188,7 @@ class Container(Type):
         path: str,
         contents: Optional[str] = None,
         permissions: Optional[int] = None,
-        owner: Optional[str] = None,
+        owner: Optional[FilesystemOwner] = None,
     ) -> "Container":
         """Retrieves this container plus a new file written at the given path.
 
@@ -1295,7 +1307,7 @@ class Container(Type):
         self,
         path: str,
         source: "Socket",
-        owner: Optional[str] = None,
+        owner: Optional[FilesystemOwner] = None,
     ) -> "Container":
         """Retrieves this container plus a socket forwarded to the given Unix
         socket path.
@@ -2783,6 +2795,7 @@ __all__ = [
     "ContainerID",
     "DirectoryID",
     "FileID",
+    "FilesystemOwner",
     "Platform",
     "SecretID",
     "SocketID",

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -1052,6 +1052,11 @@ class Container(Type):
             Sharing mode of the cache volume.
         owner:
             A user:group to set for the mounted cache directory.
+            Note that this changes the ownership of the specified mount along
+            with the
+            initial filesystem provided by source (if any). It does not have
+            any effect
+            if/when the cache has already been created.
             The user and group can either be an ID (1000:1000) or a name
             (foo:bar).
             If the group is omitted, it defaults to the same as the user.

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -25,18 +25,6 @@ class FileID(Scalar):
     """A file identifier."""
 
 
-class FilesystemOwner(Scalar):
-    """A user and group, as typically used to configure ownership of files
-    and directories.  The format is user[:group], where both user and
-    group can either be IDs or names to be resolved to IDs using the
-    container filesystem.  If the group is omitted, it defaults to the
-    same as the user.  So, for a user 'foo' and group 'bar' with user ID
-    and group ID 1111 and 2222 respectively, the following are all valid:
-    foo      => 1111:1111    foo:bar  => 1111:2222    1111:bar =>
-    1111:2222    foo:2222 => 1111:1111  If the owner is unspecified,
-    ownership will be left as-is."""
-
-
 class Platform(Scalar):
     """The platform config OS and architecture in a Container.  The format
     is [os]/[platform]/[version] (e.g., "darwin/arm64/v7",
@@ -817,7 +805,7 @@ class Container(Type):
         directory: "Directory",
         exclude: Optional[Sequence[str]] = None,
         include: Optional[Sequence[str]] = None,
-        owner: Optional[FilesystemOwner] = None,
+        owner: Optional[str] = None,
     ) -> "Container":
         """Retrieves this container plus a directory written at the given path.
 
@@ -992,7 +980,7 @@ class Container(Type):
         path: str,
         source: "File",
         permissions: Optional[int] = None,
-        owner: Optional[FilesystemOwner] = None,
+        owner: Optional[str] = None,
     ) -> "Container":
         """Retrieves this container plus the contents of the given file copied to
         the given path.
@@ -1047,7 +1035,7 @@ class Container(Type):
         cache: CacheVolume,
         source: Optional["Directory"] = None,
         sharing: Optional[CacheSharingMode] = None,
-        owner: Optional[FilesystemOwner] = None,
+        owner: Optional[str] = None,
     ) -> "Container":
         """Retrieves this container plus a cache volume mounted at the given
         path.
@@ -1083,7 +1071,7 @@ class Container(Type):
         self,
         path: str,
         source: "Directory",
-        owner: Optional[FilesystemOwner] = None,
+        owner: Optional[str] = None,
     ) -> "Container":
         """Retrieves this container plus a directory mounted at the given path.
 
@@ -1112,7 +1100,7 @@ class Container(Type):
         self,
         path: str,
         source: "File",
-        owner: Optional[FilesystemOwner] = None,
+        owner: Optional[str] = None,
     ) -> "Container":
         """Retrieves this container plus a file mounted at the given path.
 
@@ -1141,7 +1129,7 @@ class Container(Type):
         self,
         path: str,
         source: "Secret",
-        owner: Optional[FilesystemOwner] = None,
+        owner: Optional[str] = None,
     ) -> "Container":
         """Retrieves this container plus a secret mounted into a file at the
         given path.
@@ -1188,7 +1176,7 @@ class Container(Type):
         path: str,
         contents: Optional[str] = None,
         permissions: Optional[int] = None,
-        owner: Optional[FilesystemOwner] = None,
+        owner: Optional[str] = None,
     ) -> "Container":
         """Retrieves this container plus a new file written at the given path.
 
@@ -1307,7 +1295,7 @@ class Container(Type):
         self,
         path: str,
         source: "Socket",
-        owner: Optional[FilesystemOwner] = None,
+        owner: Optional[str] = None,
     ) -> "Container":
         """Retrieves this container plus a socket forwarded to the given Unix
         socket path.
@@ -2795,7 +2783,6 @@ __all__ = [
     "ContainerID",
     "DirectoryID",
     "FileID",
-    "FilesystemOwner",
     "Platform",
     "SecretID",
     "SocketID",

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -805,6 +805,7 @@ class Container(Type):
         directory: "Directory",
         exclude: Optional[Sequence[str]] = None,
         include: Optional[Sequence[str]] = None,
+        owner: Optional[str] = None,
     ) -> "Container":
         """Retrieves this container plus a directory written at the given path.
 
@@ -820,12 +821,18 @@ class Container(Type):
         include:
             Patterns to include in the written directory (e.g., ["*.go",
             "go.mod", "go.sum"]).
+        owner:
+            A user:group to set for the directory and its contents.
+            The user and group can either be an ID (1000:1000) or a name
+            (foo:bar).
+            If the group is omitted, it defaults to the same as the user.
         """
         _args = [
             Arg("path", path),
             Arg("directory", directory),
             Arg("exclude", exclude, None),
             Arg("include", include, None),
+            Arg("owner", owner, None),
         ]
         _ctx = self._select("withDirectory", _args)
         return Container(_ctx)
@@ -973,6 +980,7 @@ class Container(Type):
         path: str,
         source: "File",
         permissions: Optional[int] = None,
+        owner: Optional[str] = None,
     ) -> "Container":
         """Retrieves this container plus the contents of the given file copied to
         the given path.
@@ -986,11 +994,17 @@ class Container(Type):
         permissions:
             Permission given to the copied file (e.g., 0600).
             Default: 0644.
+        owner:
+            A user:group to set for the file.
+            The user and group can either be an ID (1000:1000) or a name
+            (foo:bar).
+            If the group is omitted, it defaults to the same as the user.
         """
         _args = [
             Arg("path", path),
             Arg("source", source),
             Arg("permissions", permissions, None),
+            Arg("owner", owner, None),
         ]
         _ctx = self._select("withFile", _args)
         return Container(_ctx)
@@ -1021,6 +1035,7 @@ class Container(Type):
         cache: CacheVolume,
         source: Optional["Directory"] = None,
         sharing: Optional[CacheSharingMode] = None,
+        owner: Optional[str] = None,
     ) -> "Container":
         """Retrieves this container plus a cache volume mounted at the given
         path.
@@ -1035,18 +1050,29 @@ class Container(Type):
             Identifier of the directory to use as the cache volume's root.
         sharing:
             Sharing mode of the cache volume.
+        owner:
+            A user:group to set for the mounted cache directory.
+            The user and group can either be an ID (1000:1000) or a name
+            (foo:bar).
+            If the group is omitted, it defaults to the same as the user.
         """
         _args = [
             Arg("path", path),
             Arg("cache", cache),
             Arg("source", source, None),
             Arg("sharing", sharing, None),
+            Arg("owner", owner, None),
         ]
         _ctx = self._select("withMountedCache", _args)
         return Container(_ctx)
 
     @typecheck
-    def with_mounted_directory(self, path: str, source: "Directory") -> "Container":
+    def with_mounted_directory(
+        self,
+        path: str,
+        source: "Directory",
+        owner: Optional[str] = None,
+    ) -> "Container":
         """Retrieves this container plus a directory mounted at the given path.
 
         Parameters
@@ -1055,16 +1081,27 @@ class Container(Type):
             Location of the mounted directory (e.g., "/mnt/directory").
         source:
             Identifier of the mounted directory.
+        owner:
+            A user:group to set for the mounted directory and its contents.
+            The user and group can either be an ID (1000:1000) or a name
+            (foo:bar).
+            If the group is omitted, it defaults to the same as the user.
         """
         _args = [
             Arg("path", path),
             Arg("source", source),
+            Arg("owner", owner, None),
         ]
         _ctx = self._select("withMountedDirectory", _args)
         return Container(_ctx)
 
     @typecheck
-    def with_mounted_file(self, path: str, source: "File") -> "Container":
+    def with_mounted_file(
+        self,
+        path: str,
+        source: "File",
+        owner: Optional[str] = None,
+    ) -> "Container":
         """Retrieves this container plus a file mounted at the given path.
 
         Parameters
@@ -1073,16 +1110,27 @@ class Container(Type):
             Location of the mounted file (e.g., "/tmp/file.txt").
         source:
             Identifier of the mounted file.
+        owner:
+            A user or user:group to set for the mounted file.
+            The user and group can either be an ID (1000:1000) or a name
+            (foo:bar).
+            If the group is omitted, it defaults to the same as the user.
         """
         _args = [
             Arg("path", path),
             Arg("source", source),
+            Arg("owner", owner, None),
         ]
         _ctx = self._select("withMountedFile", _args)
         return Container(_ctx)
 
     @typecheck
-    def with_mounted_secret(self, path: str, source: "Secret") -> "Container":
+    def with_mounted_secret(
+        self,
+        path: str,
+        source: "Secret",
+        owner: Optional[str] = None,
+    ) -> "Container":
         """Retrieves this container plus a secret mounted into a file at the
         given path.
 
@@ -1092,10 +1140,16 @@ class Container(Type):
             Location of the secret file (e.g., "/tmp/secret.txt").
         source:
             Identifier of the secret to mount.
+        owner:
+            A user:group to set for the mounted secret.
+            The user and group can either be an ID (1000:1000) or a name
+            (foo:bar).
+            If the group is omitted, it defaults to the same as the user.
         """
         _args = [
             Arg("path", path),
             Arg("source", source),
+            Arg("owner", owner, None),
         ]
         _ctx = self._select("withMountedSecret", _args)
         return Container(_ctx)
@@ -1122,6 +1176,7 @@ class Container(Type):
         path: str,
         contents: Optional[str] = None,
         permissions: Optional[int] = None,
+        owner: Optional[str] = None,
     ) -> "Container":
         """Retrieves this container plus a new file written at the given path.
 
@@ -1134,11 +1189,17 @@ class Container(Type):
         permissions:
             Permission given to the written file (e.g., 0600).
             Default: 0644.
+        owner:
+            A user:group to set for the file.
+            The user and group can either be an ID (1000:1000) or a name
+            (foo:bar).
+            If the group is omitted, it defaults to the same as the user.
         """
         _args = [
             Arg("path", path),
             Arg("contents", contents, None),
             Arg("permissions", permissions, None),
+            Arg("owner", owner, None),
         ]
         _ctx = self._select("withNewFile", _args)
         return Container(_ctx)
@@ -1230,7 +1291,12 @@ class Container(Type):
         return Container(_ctx)
 
     @typecheck
-    def with_unix_socket(self, path: str, source: "Socket") -> "Container":
+    def with_unix_socket(
+        self,
+        path: str,
+        source: "Socket",
+        owner: Optional[str] = None,
+    ) -> "Container":
         """Retrieves this container plus a socket forwarded to the given Unix
         socket path.
 
@@ -1240,10 +1306,16 @@ class Container(Type):
             Location of the forwarded Unix socket (e.g., "/tmp/socket").
         source:
             Identifier of the socket to forward.
+        owner:
+            A user:group to set for the mounted socket.
+            The user and group can either be an ID (1000:1000) or a name
+            (foo:bar).
+            If the group is omitted, it defaults to the same as the user.
         """
         _args = [
             Arg("path", path),
             Arg("source", source),
+            Arg("owner", owner, None),
         ]
         _ctx = self._select("withUnixSocket", _args)
         return Container(_ctx)

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -25,6 +25,18 @@ class FileID(Scalar):
     """A file identifier."""
 
 
+class FilesystemOwner(Scalar):
+    """A user and group, as typically used to configure ownership of files
+    and directories.  The format is user[:group], where both user and
+    group can either be IDs or names to be resolved to IDs using the
+    container filesystem.  If the group is omitted, it defaults to the
+    same as the user.  So, for a user 'foo' and group 'bar' with user ID
+    and group ID 1111 and 2222 respectively, the following are all valid:
+    foo      => 1111:1111    foo:bar  => 1111:2222    1111:bar =>
+    1111:2222    foo:2222 => 1111:1111  If the owner is unspecified,
+    ownership will be left as-is."""
+
+
 class Platform(Scalar):
     """The platform config OS and architecture in a Container.  The format
     is [os]/[platform]/[version] (e.g., "darwin/arm64/v7",
@@ -805,7 +817,7 @@ class Container(Type):
         directory: "Directory",
         exclude: Optional[Sequence[str]] = None,
         include: Optional[Sequence[str]] = None,
-        owner: Optional[str] = None,
+        owner: Optional[FilesystemOwner] = None,
     ) -> "Container":
         """Retrieves this container plus a directory written at the given path.
 
@@ -980,7 +992,7 @@ class Container(Type):
         path: str,
         source: "File",
         permissions: Optional[int] = None,
-        owner: Optional[str] = None,
+        owner: Optional[FilesystemOwner] = None,
     ) -> "Container":
         """Retrieves this container plus the contents of the given file copied to
         the given path.
@@ -1035,7 +1047,7 @@ class Container(Type):
         cache: CacheVolume,
         source: Optional["Directory"] = None,
         sharing: Optional[CacheSharingMode] = None,
-        owner: Optional[str] = None,
+        owner: Optional[FilesystemOwner] = None,
     ) -> "Container":
         """Retrieves this container plus a cache volume mounted at the given
         path.
@@ -1071,7 +1083,7 @@ class Container(Type):
         self,
         path: str,
         source: "Directory",
-        owner: Optional[str] = None,
+        owner: Optional[FilesystemOwner] = None,
     ) -> "Container":
         """Retrieves this container plus a directory mounted at the given path.
 
@@ -1100,7 +1112,7 @@ class Container(Type):
         self,
         path: str,
         source: "File",
-        owner: Optional[str] = None,
+        owner: Optional[FilesystemOwner] = None,
     ) -> "Container":
         """Retrieves this container plus a file mounted at the given path.
 
@@ -1129,7 +1141,7 @@ class Container(Type):
         self,
         path: str,
         source: "Secret",
-        owner: Optional[str] = None,
+        owner: Optional[FilesystemOwner] = None,
     ) -> "Container":
         """Retrieves this container plus a secret mounted into a file at the
         given path.
@@ -1176,7 +1188,7 @@ class Container(Type):
         path: str,
         contents: Optional[str] = None,
         permissions: Optional[int] = None,
-        owner: Optional[str] = None,
+        owner: Optional[FilesystemOwner] = None,
     ) -> "Container":
         """Retrieves this container plus a new file written at the given path.
 
@@ -1295,7 +1307,7 @@ class Container(Type):
         self,
         path: str,
         source: "Socket",
-        owner: Optional[str] = None,
+        owner: Optional[FilesystemOwner] = None,
     ) -> "Container":
         """Retrieves this container plus a socket forwarded to the given Unix
         socket path.
@@ -2783,6 +2795,7 @@ __all__ = [
     "ContainerID",
     "DirectoryID",
     "FileID",
+    "FilesystemOwner",
     "Platform",
     "SecretID",
     "SocketID",


### PR DESCRIPTION
fixes #4739

Adds `owner: String` to the following APIs:

```graphql
type Container {
  withMountedDirectory(..., owner: String): Container!
  withMountedFile(..., owner: String): Container!
  withDirectory(..., owner: String): Container!
  withFile(..., owner: String): Container!
  withNewFile(..., owner: String): Container!
  withMountedCache(..., owner: String): Container!
  withMountedSecret(..., owner: String): Container!
  withUnixSocket(..., owner: String): Container!
}
```

~The `String` type is a bit nebulous and might warrant its own scalar~ (edit: nevermind - https://github.com/dagger/dagger/pull/4932#issuecomment-1508494191). The following formats are supported:

```
user:group # set uid/gid by name
1234:4321  # set uid/gid
user       # same as user:user
1234       # same as 1234:1234
```

This was a little tricky to implement because only some parts of Buildkit support resolving names to IDs. Luckily we can use the gateway API to just fetch `/etc/passwd` and `/etc/group` ourselves, which this PR does so that everything supports names.

Note: we only change ownership if explicitly told to in the API; it will _not_ automatically chown to the container's "current user." See rationale in #4739 comments and in a comment for the test showing we don't inherit.