### PR TITLE
collect `github.com/pr.branch` label

### DIFF
--- a/core/pipeline/label.go
+++ b/core/pipeline/label.go
@@ -236,6 +236,11 @@ func LoadGitHubLabels() ([]Label, error) {
 			})
 
 			labels = append(labels, Label{
+				Name:  "github.com/pr.label",
+				Value: pr.GetHead().GetLabel(),
+			})
+
+			labels = append(labels, Label{
 				Name:  "github.com/pr.head",
 				Value: pr.GetHead().GetSHA(),
 			})

--- a/core/pipeline/label.go
+++ b/core/pipeline/label.go
@@ -46,7 +46,7 @@ func LoadRootLabels(workdir string) {
 func loadRootLabels(workdir string) []Label {
 	labels := []Label{}
 
-	if gitLabels, err := loadGitLabels(workdir); err == nil {
+	if gitLabels, err := LoadGitLabels(workdir); err == nil {
 		labels = append(labels, gitLabels...)
 	} else {
 		logrus.Warnf("failed to collect git labels: %s", err)
@@ -64,7 +64,7 @@ func loadRootLabels(workdir string) []Label {
 // ServiceHostnameLabel is annotated on all services started by Dagger.
 const ServiceHostnameLabel = "dagger.io/service.hostname"
 
-func loadGitLabels(workdir string) ([]Label, error) {
+func LoadGitLabels(workdir string) ([]Label, error) {
 	repo, err := git.PlainOpenWithOptions(workdir, &git.PlainOpenOptions{
 		DetectDotGit: true,
 	})
@@ -103,14 +103,10 @@ func loadGitLabels(workdir string) ([]Label, error) {
 
 	title, _, _ := strings.Cut(commit.Message, "\n")
 
-	return []Label{
+	labels := []Label{
 		{
 			Name:  "dagger.io/git.remote",
 			Value: endpoint,
-		},
-		{
-			Name:  "dagger.io/git.branch",
-			Value: head.Name().Short(),
 		},
 		{
 			Name:  "dagger.io/git.ref",
@@ -136,7 +132,23 @@ func loadGitLabels(workdir string) ([]Label, error) {
 			Name:  "dagger.io/git.title",
 			Value: title, // first line from commit message
 		},
-	}, nil
+	}
+
+	if head.Name().IsTag() {
+		labels = append(labels, Label{
+			Name:  "dagger.io/git.tag",
+			Value: head.Name().Short(),
+		})
+	}
+
+	if head.Name().IsBranch() {
+		labels = append(labels, Label{
+			Name:  "dagger.io/git.branch",
+			Value: head.Name().Short(),
+		})
+	}
+
+	return labels, nil
 }
 
 func LoadGitHubLabels() ([]Label, error) {
@@ -219,6 +231,11 @@ func LoadGitHubLabels() ([]Label, error) {
 			})
 
 			labels = append(labels, Label{
+				Name:  "github.com/pr.branch",
+				Value: pr.GetHead().GetRef(),
+			})
+
+			labels = append(labels, Label{
 				Name:  "github.com/pr.head",
 				Value: pr.GetHead().GetSHA(),
 			})
@@ -290,7 +307,7 @@ func isCI() bool {
 }
 
 func (labels *Labels) AppendAnonymousGitLabels(workdir string) *Labels {
-	gitLabels, err := loadGitLabels(workdir)
+	gitLabels, err := LoadGitLabels(workdir)
 	if err != nil {
 		return labels
 	}

--- a/core/pipeline/label_test.go
+++ b/core/pipeline/label_test.go
@@ -207,12 +207,16 @@ func TestLoadGitHubLabels(t *testing.T) {
 					Value: "https://github.com/dagger/testdata/pull/2018",
 				},
 				{
+					Name:  "github.com/pr.head",
+					Value: "81be07d3103b512159628bfa3aae2fbb5d255964",
+				},
+				{
 					Name:  "github.com/pr.branch",
 					Value: "dump-env",
 				},
 				{
-					Name:  "github.com/pr.head",
-					Value: "81be07d3103b512159628bfa3aae2fbb5d255964",
+					Name:  "github.com/pr.label",
+					Value: "vito:dump-env",
 				},
 			},
 		},
@@ -263,7 +267,7 @@ func TestLoadGitHubLabels(t *testing.T) {
 
 			labels, err := pipeline.LoadGitHubLabels()
 			require.NoError(t, err)
-			require.Equal(t, example.Labels, labels)
+			require.ElementsMatch(t, example.Labels, labels)
 		})
 	}
 }

--- a/core/pipeline/label_test.go
+++ b/core/pipeline/label_test.go
@@ -2,12 +2,133 @@ package pipeline_test
 
 import (
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 
 	"github.com/dagger/dagger/core/pipeline"
 	"github.com/stretchr/testify/require"
 )
+
+func run(t *testing.T, exe string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command(exe, args...)
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	return strings.TrimSpace(string(out))
+}
+
+func setupRepo(t *testing.T) string {
+	repo := t.TempDir()
+	run(t, "git", "-C", repo, "init")
+	run(t, "git", "-C", repo, "config", "--local", "--add", "user.name", "Test User")
+	run(t, "git", "-C", repo, "config", "--local", "--add", "user.email", "test@example.com")
+	run(t, "git", "-C", repo, "remote", "add", "origin", "https://example.com")
+	run(t, "git", "-C", repo, "checkout", "-b", "main")
+	run(t, "git", "-C", repo, "commit", "--allow-empty", "-m", "init")
+	return repo
+}
+
+func TestLoadGitLabels(t *testing.T) {
+	normalRepo := setupRepo(t)
+	repoHead := run(t, "git", "-C", normalRepo, "rev-parse", "HEAD")
+
+	detachedRepo := setupRepo(t)
+	run(t, "git", "-C", detachedRepo, "commit", "--allow-empty", "-m", "second")
+	run(t, "git", "-C", detachedRepo, "commit", "--allow-empty", "-m", "third")
+	run(t, "git", "-C", detachedRepo, "checkout", "HEAD~2")
+	run(t, "git", "-C", detachedRepo, "merge", "main")
+	detachedHead := run(t, "git", "-C", detachedRepo, "rev-parse", "HEAD")
+
+	type Example struct {
+		Name   string
+		Repo   string
+		Labels []pipeline.Label
+	}
+
+	for _, example := range []Example{
+		{
+			Name: "normal branch state",
+			Repo: normalRepo,
+			Labels: []pipeline.Label{
+				{
+					Name:  "dagger.io/git.remote",
+					Value: "example.com",
+				},
+				{
+					Name:  "dagger.io/git.branch",
+					Value: "main",
+				},
+				{
+					Name:  "dagger.io/git.ref",
+					Value: repoHead,
+				},
+				{
+					Name:  "dagger.io/git.author.name",
+					Value: "Test User",
+				},
+				{
+					Name:  "dagger.io/git.author.email",
+					Value: "test@example.com",
+				},
+				{
+					Name:  "dagger.io/git.committer.name",
+					Value: "Test User",
+				},
+				{
+					Name:  "dagger.io/git.committer.email",
+					Value: "test@example.com",
+				},
+				{
+					Name:  "dagger.io/git.title",
+					Value: "init",
+				},
+			},
+		},
+		{
+			Name: "detached HEAD state",
+			Repo: detachedRepo,
+			Labels: []pipeline.Label{
+				{
+					Name:  "dagger.io/git.remote",
+					Value: "example.com",
+				},
+				{
+					Name:  "dagger.io/git.ref",
+					Value: detachedHead,
+				},
+				{
+					Name:  "dagger.io/git.author.name",
+					Value: "Test User",
+				},
+				{
+					Name:  "dagger.io/git.author.email",
+					Value: "test@example.com",
+				},
+				{
+					Name:  "dagger.io/git.committer.name",
+					Value: "Test User",
+				},
+				{
+					Name:  "dagger.io/git.committer.email",
+					Value: "test@example.com",
+				},
+				{
+					Name:  "dagger.io/git.title",
+					Value: "third",
+				},
+			},
+		},
+	} {
+		example := example
+		t.Run(example.Name, func(t *testing.T) {
+			labels, err := pipeline.LoadGitLabels(example.Repo)
+			require.NoError(t, err)
+			require.ElementsMatch(t, example.Labels, labels)
+		})
+	}
+}
 
 func TestLoadGitHubLabels(t *testing.T) {
 	type Example struct {
@@ -104,6 +225,10 @@ func TestLoadGitHubLabels(t *testing.T) {
 				{
 					Name:  "github.com/pr.url",
 					Value: "https://github.com/dagger/testdata/pull/2018",
+				},
+				{
+					Name:  "github.com/pr.branch",
+					Value: "dump-env",
 				},
 				{
 					Name:  "github.com/pr.head",

--- a/core/pipeline/label_test.go
+++ b/core/pipeline/label_test.go
@@ -10,26 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func run(t *testing.T, exe string, args ...string) string {
-	t.Helper()
-	cmd := exec.Command(exe, args...)
-	cmd.Stderr = os.Stderr
-	out, err := cmd.Output()
-	require.NoError(t, err)
-	return strings.TrimSpace(string(out))
-}
-
-func setupRepo(t *testing.T) string {
-	repo := t.TempDir()
-	run(t, "git", "-C", repo, "init")
-	run(t, "git", "-C", repo, "config", "--local", "--add", "user.name", "Test User")
-	run(t, "git", "-C", repo, "config", "--local", "--add", "user.email", "test@example.com")
-	run(t, "git", "-C", repo, "remote", "add", "origin", "https://example.com")
-	run(t, "git", "-C", repo, "checkout", "-b", "main")
-	run(t, "git", "-C", repo, "commit", "--allow-empty", "-m", "init")
-	return repo
-}
-
 func TestLoadGitLabels(t *testing.T) {
 	normalRepo := setupRepo(t)
 	repoHead := run(t, "git", "-C", normalRepo, "rev-parse", "HEAD")
@@ -286,4 +266,24 @@ func TestLoadGitHubLabels(t *testing.T) {
 			require.Equal(t, example.Labels, labels)
 		})
 	}
+}
+
+func run(t *testing.T, exe string, args ...string) string { // nolint: unparam
+	t.Helper()
+	cmd := exec.Command(exe, args...)
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	return strings.TrimSpace(string(out))
+}
+
+func setupRepo(t *testing.T) string {
+	repo := t.TempDir()
+	run(t, "git", "-C", repo, "init")
+	run(t, "git", "-C", repo, "config", "--local", "--add", "user.name", "Test User")
+	run(t, "git", "-C", repo, "config", "--local", "--add", "user.email", "test@example.com")
+	run(t, "git", "-C", repo, "remote", "add", "origin", "https://example.com")
+	run(t, "git", "-C", repo, "checkout", "-b", "main")
+	run(t, "git", "-C", repo, "commit", "--allow-empty", "-m", "init")
+	return repo
 }


### PR DESCRIPTION
Also: avoid putting a useless 'HEAD' value in `dagger.io/git.branch` when running on a detached HEAD.