### PR TITLE
Fix goroutine leak for CLI sessions in Go SDK

### DIFF
--- a/sdk/go/internal/engineconn/engineconn.go
+++ b/sdk/go/internal/engineconn/engineconn.go
@@ -56,14 +56,15 @@ func Get(ctx context.Context, cfg *Config) (EngineConn, error) {
 }
 
 func defaultHTTPClient(p *ConnectParams) *http.Client {
+	dialTransport := &http.Transport{
+		DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+			return net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", p.Port))
+		},
+	}
 	return &http.Client{
 		Transport: RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 			r.SetBasicAuth(p.SessionToken, "")
-			return (&http.Transport{
-				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-					return net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", p.Port))
-				},
-			}).RoundTrip(r)
+			return dialTransport.RoundTrip(r)
 		}),
 	}
 }


### PR DESCRIPTION
Fixes #4586 
This seems to be caused by multiple calls to `defaultHTTPClient` on every request.
`DisableKeepAlives` on the existing code also seemed to fixed the issue but I think it's better to avoid creating the transports over and over.

Test output with the fix:
```sh
% go test -run TestLeak -v
=== RUN   TestLeak
2023/04/14 05:11:00 goroutines: 2
2023/04/14 05:11:04 goroutines: 4
2023/04/14 05:11:04 goroutines: 5
2023/04/14 05:11:04 goroutines: 5
STATUS OK
2023/04/14 05:11:05 run: 1	ip: 10.87.0.113/16	elapsed: 1.444526s	goroutines: 7
STATUS OK
2023/04/14 05:11:06 run: 2	ip: 10.87.0.114/16	elapsed: 2.136249917s	goroutines: 7
STATUS OK
2023/04/14 05:11:07 run: 3	ip: 10.87.0.115/16	elapsed: 2.786011667s	goroutines: 7
STATUS OK
2023/04/14 05:11:07 run: 4	ip: 10.87.0.116/16	elapsed: 3.447061959s	goroutines: 7
STATUS OK
2023/04/14 05:11:08 run: 5	ip: 10.87.0.117/16	elapsed: 4.062645834s	goroutines: 7
STATUS OK
2023/04/14 05:11:09 run: 6	ip: 10.87.0.118/16	elapsed: 4.675820834s	goroutines: 7
STATUS OK
2023/04/14 05:11:09 run: 7	ip: 10.87.0.119/16	elapsed: 5.270860334s	goroutines: 7
STATUS OK
2023/04/14 05:11:10 run: 8	ip: 10.87.0.120/16	elapsed: 5.882883792s	goroutines: 7
STATUS OK
2023/04/14 05:11:10 run: 9	ip: 10.87.0.121/16	elapsed: 6.5250195s	goroutines: 7
```

Test output with original `main`:
```sh
% go test -run TestLeak -v
=== RUN   TestLeak
2023/04/14 05:11:47 goroutines: 2
2023/04/14 05:11:51 goroutines: 4
2023/04/14 05:11:51 goroutines: 5
2023/04/14 05:11:51 goroutines: 5
STATUS OK
2023/04/14 05:11:53 run: 1	ip: 10.87.0.122/16	elapsed: 1.486720709s	goroutines: 7
STATUS OK
2023/04/14 05:11:54 run: 2	ip: 10.87.0.123/16	elapsed: 2.133209542s	goroutines: 9
STATUS OK
2023/04/14 05:11:54 run: 3	ip: 10.87.0.124/16	elapsed: 2.766065375s	goroutines: 11
STATUS OK
2023/04/14 05:11:55 run: 4	ip: 10.87.0.125/16	elapsed: 3.397856084s	goroutines: 13
STATUS OK
2023/04/14 05:11:55 run: 5	ip: 10.87.0.126/16	elapsed: 4.017130417s	goroutines: 15
STATUS OK
2023/04/14 05:11:56 run: 6	ip: 10.87.0.127/16	elapsed: 4.637291209s	goroutines: 17
STATUS OK
2023/04/14 05:11:57 run: 7	ip: 10.87.0.128/16	elapsed: 5.286802834s	goroutines: 19
```