### PR TITLE
Print engine name to it's own logs

### DIFF
--- a/cmd/engine/main_oci_worker.go
+++ b/cmd/engine/main_oci_worker.go
@@ -300,6 +300,7 @@ func ociWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([]worker
 			engineName = hostname
 		}
 	}
+	bklog.G(context.Background()).Debugf("engine name: %s", engineName)
 	cfg.Labels[engine.EngineNameLabel] = engineName
 
 	if (cfg.Enabled == nil && !validOCIBinary()) || (cfg.Enabled != nil && !*cfg.Enabled) {


### PR DESCRIPTION
@marcosnils pointed out this would be useful in the engine logs too