### PR TITLE
feat: pass secrets to Container.Build and Directory.Build

### DIFF
--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -261,6 +261,24 @@ CMD echo "stage2"
 		require.Contains(t, output, "stage1\n")
 		require.NotContains(t, output, "stage2\n")
 	})
+
+	t.Run("with build secrets", func(t *testing.T) {
+		sec := c.SetSecret("my-secret", "barbar")
+		require.NoError(t, err)
+
+		src := contextDir.
+			WithNewFile("Dockerfile",
+				`FROM golang:1.18.2-alpine
+WORKDIR /src
+RUN --mount=type=secret,id=my-secret test "$(cat /run/secrets/my-secret)" = "barbar"
+RUN --mount=type=secret,id=my-secret cp /run/secrets/my-secret  /secret
+CMD cat /secret
+`)
+
+		stdout, err := c.Container().Build(src, dagger.ContainerBuildOpts{Secrets: []*dagger.Secret{sec}}).WithExec([]string{}).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, stdout, "***")
+	})
 }
 
 func TestContainerWithRootFS(t *testing.T) {
@@ -3089,7 +3107,8 @@ func TestContainerInsecureRootCapabilitesWithService(t *testing.T) {
 		}).
 		WithMountedCache("/tmp", c.CacheVolume("share-tmp")).
 		WithExposedPort(2375).
-		WithExec([]string{"dockerd",
+		WithExec([]string{
+			"dockerd",
 			"--host=tcp://0.0.0.0:2375",
 			"--tls=false",
 		}, dagger.ContainerWithExecOpts{

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -134,10 +134,11 @@ type containerBuildArgs struct {
 	Dockerfile string
 	BuildArgs  []core.BuildArg
 	Target     string
+	Secrets    []core.SecretID
 }
 
 func (s *containerSchema) build(ctx *router.Context, parent *core.Container, args containerBuildArgs) (*core.Container, error) {
-	return parent.Build(ctx, s.gw, &core.Directory{ID: args.Context}, args.Dockerfile, args.BuildArgs, args.Target)
+	return parent.Build(ctx, s.gw, &core.Directory{ID: args.Context}, args.Dockerfile, args.BuildArgs, args.Target, args.Secrets)
 }
 
 func (s *containerSchema) withRootfs(ctx *router.Context, parent *core.Container, arg core.Directory) (*core.Container, error) {

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -64,7 +64,11 @@ type Container {
     "Target build stage to build."
     target: String
 
-    "Secrets to pass to the build."
+    """
+    Secrets to pass to the build.
+
+    They will be mounted at /run/secrets/<secret-id>.
+    """
     secrets: [SecretID!]
   ): Container!
 

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -63,6 +63,9 @@ type Container {
 
     "Target build stage to build."
     target: String
+
+    "Secrets to pass to the build."
+    secrets: [SecretID!]
   ): Container!
 
   "Retrieves this container's root filesystem. Mounts are not included."

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -196,6 +196,7 @@ type dirDockerBuildArgs struct {
 	Dockerfile string
 	BuildArgs  []core.BuildArg
 	Target     string
+	Secrets    []core.SecretID
 }
 
 func (s *directorySchema) dockerBuild(ctx *router.Context, parent *core.Directory, args dirDockerBuildArgs) (*core.Container, error) {
@@ -211,5 +212,5 @@ func (s *directorySchema) dockerBuild(ctx *router.Context, parent *core.Director
 	if err != nil {
 		return ctr, err
 	}
-	return ctr.Build(ctx, s.gw, parent, args.Dockerfile, args.BuildArgs, args.Target)
+	return ctr.Build(ctx, s.gw, parent, args.Dockerfile, args.BuildArgs, args.Target, args.Secrets)
 }

--- a/core/schema/directory.graphqls
+++ b/core/schema/directory.graphqls
@@ -190,6 +190,9 @@ type Directory {
 
     "Target build stage to build."
     target: String
+
+    "Secrets to pass to the build."
+    secrets: [SecretID!]
   ): Container!
 
   """

--- a/core/schema/directory.graphqls
+++ b/core/schema/directory.graphqls
@@ -191,7 +191,11 @@ type Directory {
     "Target build stage to build."
     target: String
 
-    "Secrets to pass to the build."
+    """
+    Secrets to pass to the build.
+
+    They will be mounted at /run/secrets/<secret-id>.
+    """
     secrets: [SecretID!]
   ): Container!
 

--- a/core/util.go
+++ b/core/util.go
@@ -29,7 +29,7 @@ func decodeID[T ~string](payload any, id T) error {
 	jsonBytes := make([]byte, base64.StdEncoding.DecodedLen(len(id)))
 	n, err := base64.StdEncoding.Decode(jsonBytes, []byte(id))
 	if err != nil {
-		return fmt.Errorf("failed to decode %T bytes: %v", payload, err)
+		return fmt.Errorf("failed to decode %T bytes: %v: %v", payload, err, payload)
 	}
 
 	jsonBytes = jsonBytes[:n]

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -120,6 +120,8 @@ type ContainerBuildOpts struct {
 	BuildArgs []BuildArg
 	// Target build stage to build.
 	Target string
+	// Secrets to pass to the build.
+	Secrets []*Secret
 }
 
 // Initializes this container from a Dockerfile build.
@@ -144,6 +146,13 @@ func (r *Container) Build(context *Directory, opts ...ContainerBuildOpts) *Conta
 	for i := len(opts) - 1; i >= 0; i-- {
 		if !querybuilder.IsZeroValue(opts[i].Target) {
 			q = q.Arg("target", opts[i].Target)
+			break
+		}
+	}
+	// `secrets` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].Secrets) {
+			q = q.Arg("secrets", opts[i].Secrets)
 			break
 		}
 	}
@@ -1312,6 +1321,8 @@ type DirectoryDockerBuildOpts struct {
 	BuildArgs []BuildArg
 	// Target build stage to build.
 	Target string
+	// Secrets to pass to the build.
+	Secrets []*Secret
 }
 
 // Builds a new Docker container from this directory.
@@ -1342,6 +1353,13 @@ func (r *Directory) DockerBuild(opts ...DirectoryDockerBuildOpts) *Container {
 	for i := len(opts) - 1; i >= 0; i-- {
 		if !querybuilder.IsZeroValue(opts[i].Target) {
 			q = q.Arg("target", opts[i].Target)
+			break
+		}
+	}
+	// `secrets` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].Secrets) {
+			q = q.Arg("secrets", opts[i].Secrets)
 			break
 		}
 	}

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -121,6 +121,8 @@ type ContainerBuildOpts struct {
 	// Target build stage to build.
 	Target string
 	// Secrets to pass to the build.
+	//
+	// They will be mounted at /run/secrets/<secret-id>.
 	Secrets []*Secret
 }
 
@@ -1322,6 +1324,8 @@ type DirectoryDockerBuildOpts struct {
 	// Target build stage to build.
 	Target string
 	// Secrets to pass to the build.
+	//
+	// They will be mounted at /run/secrets/<secret-id>.
 	Secrets []*Secret
 }
 

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -106,6 +106,11 @@ export type ContainerBuildOpts = {
    * Target build stage to build.
    */
   target?: string
+
+  /**
+   * Secrets to pass to the build.
+   */
+  secrets?: Secret[]
 }
 
 export type ContainerEndpointOpts = {
@@ -328,6 +333,11 @@ export type DirectoryDockerBuildOpts = {
    * Target build stage to build.
    */
   target?: string
+
+  /**
+   * Secrets to pass to the build.
+   */
+  secrets?: Secret[]
 }
 
 export type DirectoryEntriesOpts = {
@@ -585,6 +595,7 @@ export class Container extends BaseClient {
    * Default: './Dockerfile'.
    * @param opts.buildArgs Additional build arguments.
    * @param opts.target Target build stage to build.
+   * @param opts.secrets Secrets to pass to the build.
    */
   build(context: Directory, opts?: ContainerBuildOpts): Container {
     return new Container({
@@ -1792,6 +1803,7 @@ export class Directory extends BaseClient {
    * @param opts.platform The platform to build.
    * @param opts.buildArgs Build arguments to use in the build.
    * @param opts.target Target build stage to build.
+   * @param opts.secrets Secrets to pass to the build.
    */
   dockerBuild(opts?: DirectoryDockerBuildOpts): Container {
     return new Container({

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -109,6 +109,8 @@ export type ContainerBuildOpts = {
 
   /**
    * Secrets to pass to the build.
+   *
+   * They will be mounted at /run/secrets/<secret-id>.
    */
   secrets?: Secret[]
 }
@@ -336,6 +338,8 @@ export type DirectoryDockerBuildOpts = {
 
   /**
    * Secrets to pass to the build.
+   *
+   * They will be mounted at /run/secrets/<secret-id>.
    */
   secrets?: Secret[]
 }
@@ -596,6 +600,8 @@ export class Container extends BaseClient {
    * @param opts.buildArgs Additional build arguments.
    * @param opts.target Target build stage to build.
    * @param opts.secrets Secrets to pass to the build.
+   *
+   * They will be mounted at /run/secrets/<secret-id>.
    */
   build(context: Directory, opts?: ContainerBuildOpts): Container {
     return new Container({
@@ -1804,6 +1810,8 @@ export class Directory extends BaseClient {
    * @param opts.buildArgs Build arguments to use in the build.
    * @param opts.target Target build stage to build.
    * @param opts.secrets Secrets to pass to the build.
+   *
+   * They will be mounted at /run/secrets/<secret-id>.
    */
   dockerBuild(opts?: DirectoryDockerBuildOpts): Container {
     return new Container({

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -122,6 +122,7 @@ class Container(Type):
         dockerfile: Optional[str] = None,
         build_args: Optional[Sequence[BuildArg]] = None,
         target: Optional[str] = None,
+        secrets: Optional[Sequence["Secret"]] = None,
     ) -> "Container":
         """Initializes this container from a Dockerfile build.
 
@@ -136,12 +137,15 @@ class Container(Type):
             Additional build arguments.
         target:
             Target build stage to build.
+        secrets:
+            Secrets to pass to the build.
         """
         _args = [
             Arg("context", context),
             Arg("dockerfile", dockerfile, None),
             Arg("buildArgs", build_args, None),
             Arg("target", target, None),
+            Arg("secrets", secrets, None),
         ]
         _ctx = self._select("build", _args)
         return Container(_ctx)
@@ -1441,6 +1445,7 @@ class Directory(Type):
         platform: Optional[Platform] = None,
         build_args: Optional[Sequence[BuildArg]] = None,
         target: Optional[str] = None,
+        secrets: Optional[Sequence["Secret"]] = None,
     ) -> Container:
         """Builds a new Docker container from this directory.
 
@@ -1455,12 +1460,15 @@ class Directory(Type):
             Build arguments to use in the build.
         target:
             Target build stage to build.
+        secrets:
+            Secrets to pass to the build.
         """
         _args = [
             Arg("dockerfile", dockerfile, None),
             Arg("platform", platform, None),
             Arg("buildArgs", build_args, None),
             Arg("target", target, None),
+            Arg("secrets", secrets, None),
         ]
         _ctx = self._select("dockerBuild", _args)
         return Container(_ctx)

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -139,6 +139,7 @@ class Container(Type):
             Target build stage to build.
         secrets:
             Secrets to pass to the build.
+            They will be mounted at /run/secrets/<secret-id>.
         """
         _args = [
             Arg("context", context),
@@ -1462,6 +1463,7 @@ class Directory(Type):
             Target build stage to build.
         secrets:
             Secrets to pass to the build.
+            They will be mounted at /run/secrets/<secret-id>.
         """
         _args = [
             Arg("dockerfile", dockerfile, None),

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -122,6 +122,7 @@ class Container(Type):
         dockerfile: Optional[str] = None,
         build_args: Optional[Sequence[BuildArg]] = None,
         target: Optional[str] = None,
+        secrets: Optional[Sequence["Secret"]] = None,
     ) -> "Container":
         """Initializes this container from a Dockerfile build.
 
@@ -136,12 +137,15 @@ class Container(Type):
             Additional build arguments.
         target:
             Target build stage to build.
+        secrets:
+            Secrets to pass to the build.
         """
         _args = [
             Arg("context", context),
             Arg("dockerfile", dockerfile, None),
             Arg("buildArgs", build_args, None),
             Arg("target", target, None),
+            Arg("secrets", secrets, None),
         ]
         _ctx = self._select("build", _args)
         return Container(_ctx)
@@ -1441,6 +1445,7 @@ class Directory(Type):
         platform: Optional[Platform] = None,
         build_args: Optional[Sequence[BuildArg]] = None,
         target: Optional[str] = None,
+        secrets: Optional[Sequence["Secret"]] = None,
     ) -> Container:
         """Builds a new Docker container from this directory.
 
@@ -1455,12 +1460,15 @@ class Directory(Type):
             Build arguments to use in the build.
         target:
             Target build stage to build.
+        secrets:
+            Secrets to pass to the build.
         """
         _args = [
             Arg("dockerfile", dockerfile, None),
             Arg("platform", platform, None),
             Arg("buildArgs", build_args, None),
             Arg("target", target, None),
+            Arg("secrets", secrets, None),
         ]
         _ctx = self._select("dockerBuild", _args)
         return Container(_ctx)

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -139,6 +139,7 @@ class Container(Type):
             Target build stage to build.
         secrets:
             Secrets to pass to the build.
+            They will be mounted at /run/secrets/<secret-id>.
         """
         _args = [
             Arg("context", context),
@@ -1462,6 +1463,7 @@ class Directory(Type):
             Target build stage to build.
         secrets:
             Secrets to pass to the build.
+            They will be mounted at /run/secrets/<secret-id>.
         """
         _args = [
             Arg("dockerfile", dockerfile, None),


### PR DESCRIPTION
Now you can pass secrets to a Dockerfile build like in docker with

```Dockerfile
RUN --mount=type=secret,id=xxx,dst=/run/secrets/xxx
```

```
docker build --secret id=xxx,src=/my/file .
```

You can use


```graphql
type Container {
    build(dockerfile: [String], platform: [Platform], buildArgs: [BuildArg!], target: String, secrets: [SecretID!]): Container!
}

type Directory {
    dockerBuild(dockerfile: [String], platform: [Platform], buildArgs: [BuildArg!], target: String, secrets: [SecretID!]): Container!
}
```

## Limitations

It will mount in `/run/secrets/<secret-id>`, you cannot decide the target mount point with this current API.
It could be improved later on and discussed on how the API should look like.