### PR TITLE
fix: sdk/nodejs: Handle empty strings and undefined/null args in buildArgs function

### DIFF
--- a/sdk/nodejs/api/test/api.spec.ts
+++ b/sdk/nodejs/api/test/api.spec.ts
@@ -287,6 +287,20 @@ describe("NodeJS SDK api", function () {
     )
   })
 
+  it("Compute empty string value", async function () {
+    this.timeout(60000)
+
+    await connect(async (client) => {
+      const alpine = client
+        .container()
+        .from("alpine:3.16.2")
+        .withEnvVariable("FOO", "")
+
+      const out = await alpine.withExec(["printenv", "FOO"]).stdout()
+      assert.strictEqual(out, "\n")
+    })
+  })
+
   it("Compute nested array of arguments", async function () {
     this.timeout(60000)
 

--- a/sdk/nodejs/api/utils.ts
+++ b/sdk/nodejs/api/utils.ts
@@ -19,9 +19,13 @@ function buildArgs(args: any): string {
       str.replace(/"/g, "")
     )
 
+  if (args === undefined || args === null) {
+    return ""
+  }
+
   const formattedArgs = Object.entries(args).reduce(
     (acc: any, [key, value]) => {
-      if (value) {
+      if (value !== undefined && value !== null) {
         acc.push(`${key}: ${formatValue(value as string)}`)
       }
 


### PR DESCRIPTION
Closes [#4821](https://github.com/dagger/dagger/issues/4821)

This PR addresses two issues found in the buildArgs function:

- **Empty string values were not processed**: The function was using the if (value) condition, which is falsy for empty strings, causing the code block to be skipped for empty string values. To fix this, the condition has been updated to explicitly check for undefined and null:
```javascript
if (value !== undefined && value !== null) {
  // ...
}
```
This change ensures that empty strings are processed correctly.

- **args parameter is undefined or null**: There was no check to handle the case when the args parameter is undefined or null, causing a TypeError when trying to use Object.entries(args). To fix this, a check has been added at the beginning of the function to return an empty string when args is undefined or null:
```javascript
if (args === undefined || args === null) {
  return ""
}
```
This change prevents the error and ensures the function returns an empty string for undefined or null args.

With these updates, the buildArgs function should now handle empty strings and undefined/null arguments correctly.

- **Corresponding test has also been added**