### PR TITLE
ci: use mounted cache for go modules download

### DIFF
--- a/internal/mage/util/util.go
+++ b/internal/mage/util/util.go
@@ -85,6 +85,7 @@ func goBase(c *dagger.Client) *dagger.Container {
 		WithWorkdir("/app").
 		// run `go mod download` with only go.mod files (re-run only if mod files have changed)
 		WithMountedDirectory("/app", goMods).
+		WithMountedCache("/go/pkg/mod", c.CacheVolume("go-mod")).
 		WithExec([]string{"go", "mod", "download"}).
 		// run `go build` with all source
 		WithMountedDirectory("/app", repo).


### PR DESCRIPTION
Until now, we didn't use a cache for Go modules download in our CI, resulting in a lot of wasteful downloads.

Now, it's loaded directly from the cache.