### PR TITLE
dagger run: don't attach stdin

### DIFF
--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -119,7 +119,6 @@ func run(ctx context.Context, args []string) error {
 	cmdline := strings.Join(args, " ")
 	model := tui.New(quit, journalR, cmdline)
 	program := tea.NewProgram(model, tea.WithAltScreen())
-	subCmd.Stdin = os.Stdin
 	subCmd.Stdout = progOutWriter{program}
 	subCmd.Stderr = progOutWriter{program}
 


### PR DESCRIPTION
Some applications (*cough* bass) detect the presence of a TTY on stdin/stdout/stderr and use that to determine whether to render a TUI of their own. In that case the application will likely just hang.

Also: this was never guaranteed to work as expected anyway, because both the Dagger TUI and the application will be competing for stdin's attention.