### PR TITLE
fix flock usage for addnhosts

### DIFF
--- a/cmd/dnsname/config.go
+++ b/cmd/dnsname/config.go
@@ -19,6 +19,7 @@ type DNSNameConf struct {
 	DomainName    string   `json:"domainName"`
 	Hosts         string   `json:"hosts"`
 	Pidfile       string   `json:"pidfile"`
+	Lockfile      string   `json:"lockfile"`
 	RuntimeConfig struct { // The capability arg
 		Aliases map[string][]string `json:"aliases"`
 	} `json:"runtimeConfig,omitempty"`

--- a/cmd/dnsname/main.go
+++ b/cmd/dnsname/main.go
@@ -54,7 +54,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 
-	lock := flock.New(netConf.Hosts)
+	lock := flock.New(netConf.Lockfile)
 	if err := lock.Lock(); err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func cmdDel(args *skel.CmdArgs) error {
 		return nil
 	}
 
-	lock := flock.New(netConf.Hosts)
+	lock := flock.New(netConf.Lockfile)
 	if err := lock.Lock(); err != nil {
 		return err
 	}
@@ -134,7 +134,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 		return errors.Errorf("Required prevResult missing")
 	}
 
-	lock := flock.New(netConf.Hosts)
+	lock := flock.New(netConf.Lockfile)
 	if err := lock.Lock(); err != nil {
 		return err
 	}

--- a/network/cni.go
+++ b/network/cni.go
@@ -70,6 +70,7 @@ func cniConfig(name, subnet string) ([]byte, error) {
 				"domainName": name + ".local",
 				"pidfile":    pidfilePath(name),
 				"hosts":      hostsPath(name),
+				"lockfile":   lockfilePath(name),
 				"capabilities": map[string]any{
 					"aliases": true,
 				},

--- a/network/paths.go
+++ b/network/paths.go
@@ -48,3 +48,11 @@ func containerResolvPath(name string) string {
 func cniConfPath(name string) string {
 	return fmt.Sprintf("/var/run/containers/cni/dnsname/%s/cni.conflist", name)
 }
+
+// Location of the file used to synchronize dnsmasq config changes.
+//
+// NOTE: this is only placed beside the other paths for convenience; dnsmasq
+// doesn't try to read it.
+func lockfilePath(name string) string {
+	return fmt.Sprintf("/var/run/containers/cni/dnsname/%s/lock", name)
+}


### PR DESCRIPTION
Previously we would lock the addnhosts file itself, which in hindsight doesn't make a lot of sense because we also atomically write to it via renaming. This was causing service related tests to hang because concurrent updates weren't synchronizing properly.