### PR TITLE
avoid using HTML chars in doc string

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -352,7 +352,7 @@ func (container *Container) Build(ctx context.Context, gw bkgw.Client, context *
 		secPayload := secretID.decode()
 
 		payload.Secrets = append(payload.Secrets, ContainerSecret{
-			// Mounted at /run/secrets/<secret-id>
+			// Mounted at /run/secrets/<secret-name>
 			Secret:    secretID,
 			MountPath: fmt.Sprintf("/run/secrets/%s", secPayload.Name),
 		})

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -67,7 +67,7 @@ type Container {
     """
     Secrets to pass to the build.
 
-    They will be mounted at /run/secrets/<secret-id>.
+    They will be mounted at /run/secrets/[secret-name].
     """
     secrets: [SecretID!]
   ): Container!

--- a/core/schema/directory.graphqls
+++ b/core/schema/directory.graphqls
@@ -194,7 +194,7 @@ type Directory {
     """
     Secrets to pass to the build.
 
-    They will be mounted at /run/secrets/<secret-id>.
+    They will be mounted at /run/secrets/[secret-name].
     """
     secrets: [SecretID!]
   ): Container!

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -122,7 +122,7 @@ type ContainerBuildOpts struct {
 	Target string
 	// Secrets to pass to the build.
 	//
-	// They will be mounted at /run/secrets/<secret-id>.
+	// They will be mounted at /run/secrets/[secret-name].
 	Secrets []*Secret
 }
 
@@ -1325,7 +1325,7 @@ type DirectoryDockerBuildOpts struct {
 	Target string
 	// Secrets to pass to the build.
 	//
-	// They will be mounted at /run/secrets/<secret-id>.
+	// They will be mounted at /run/secrets/[secret-name].
 	Secrets []*Secret
 }
 

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -110,7 +110,7 @@ export type ContainerBuildOpts = {
   /**
    * Secrets to pass to the build.
    *
-   * They will be mounted at /run/secrets/<secret-id>.
+   * They will be mounted at /run/secrets/[secret-name].
    */
   secrets?: Secret[]
 }
@@ -339,7 +339,7 @@ export type DirectoryDockerBuildOpts = {
   /**
    * Secrets to pass to the build.
    *
-   * They will be mounted at /run/secrets/<secret-id>.
+   * They will be mounted at /run/secrets/[secret-name].
    */
   secrets?: Secret[]
 }
@@ -601,7 +601,7 @@ export class Container extends BaseClient {
    * @param opts.target Target build stage to build.
    * @param opts.secrets Secrets to pass to the build.
    *
-   * They will be mounted at /run/secrets/<secret-id>.
+   * They will be mounted at /run/secrets/[secret-name].
    */
   build(context: Directory, opts?: ContainerBuildOpts): Container {
     return new Container({
@@ -1811,7 +1811,7 @@ export class Directory extends BaseClient {
    * @param opts.target Target build stage to build.
    * @param opts.secrets Secrets to pass to the build.
    *
-   * They will be mounted at /run/secrets/<secret-id>.
+   * They will be mounted at /run/secrets/[secret-name].
    */
   dockerBuild(opts?: DirectoryDockerBuildOpts): Container {
     return new Container({

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -139,7 +139,7 @@ class Container(Type):
             Target build stage to build.
         secrets:
             Secrets to pass to the build.
-            They will be mounted at /run/secrets/<secret-id>.
+            They will be mounted at /run/secrets/[secret-name].
         """
         _args = [
             Arg("context", context),
@@ -1463,7 +1463,7 @@ class Directory(Type):
             Target build stage to build.
         secrets:
             Secrets to pass to the build.
-            They will be mounted at /run/secrets/<secret-id>.
+            They will be mounted at /run/secrets/[secret-name].
         """
         _args = [
             Arg("dockerfile", dockerfile, None),

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -139,7 +139,7 @@ class Container(Type):
             Target build stage to build.
         secrets:
             Secrets to pass to the build.
-            They will be mounted at /run/secrets/<secret-id>.
+            They will be mounted at /run/secrets/[secret-name].
         """
         _args = [
             Arg("context", context),
@@ -1463,7 +1463,7 @@ class Directory(Type):
             Target build stage to build.
         secrets:
             Secrets to pass to the build.
-            They will be mounted at /run/secrets/<secret-id>.
+            They will be mounted at /run/secrets/[secret-name].
         """
         _args = [
             Arg("dockerfile", dockerfile, None),


### PR DESCRIPTION
This is breaking the Netlify build. We should probably just HTML escape all these, but this is a quicker fix.