### PR TITLE
fix out-of-order event delivery

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/adrg/xdg"
@@ -378,21 +377,11 @@ func handleSolveEvents(startOpts *Config, upstreamCh chan *bkclient.SolveStatus)
 }
 
 func eventsMultiReader(ch chan *bkclient.SolveStatus, readers ...chan *bkclient.SolveStatus) {
-	wg := sync.WaitGroup{}
-
 	for ev := range ch {
 		for _, r := range readers {
-			r := r
-			ev := ev
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				r <- ev
-			}()
+			r <- ev
 		}
 	}
-
-	wg.Wait()
 
 	for _, w := range readers {
 		close(w)


### PR DESCRIPTION
This one's pretty straightforward. Previously we would concurrently write to all event readers, but that meant rapid writes to the same reader could be delivered out-of-order. This was especially likely to happen to vertexes that quickly start and finish.

It looks like the goal was to prevent one slow consumer from blocking all the rest, but I think we're fine; the TUI has an infinitely buffered pipe, and the telemetry is also pushed into a queue and sent in batches, so in practice it should be OK to just block.