### PR TITLE
keep 755 perms for cache with changed owner

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -868,7 +868,7 @@ func (container *Container) chown(
 	if srcDef == nil {
 		// e.g. empty cache mount
 		srcSt = llb.Scratch().File(
-			llb.Mkdir("/chown", 0o700, ownership.Opt()),
+			llb.Mkdir("/chown", 0o755, ownership.Opt()),
 		)
 
 		srcPath = "/chown"

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3381,6 +3381,50 @@ func TestContainerWithMountedCacheOwner(t *testing.T) {
 			Owner: owner,
 		})
 	})
+
+	t.Run("permissions (empty)", func(t *testing.T) {
+		ctr := c.Container().From("alpine:3.16.2").
+			WithExec([]string{"adduser", "-D", "inherituser"}).
+			WithExec([]string{"adduser", "-u", "1234", "-D", "auser"}).
+			WithExec([]string{"addgroup", "-g", "4321", "agroup"}).
+			WithUser("inherituser").
+			WithMountedCache("/data", cache, dagger.ContainerWithMountedCacheOpts{
+				Owner: "auser:agroup",
+			})
+
+		out, err := ctr.WithExec([]string{"stat", "-c", "%a:%U:%G", "/data"}).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "755:auser:agroup\n", out)
+	})
+
+	t.Run("permissions (source)", func(t *testing.T) {
+		dir := c.Directory().
+			WithNewDirectory("perms", dagger.DirectoryWithNewDirectoryOpts{
+				Permissions: 0745,
+			}).
+			WithNewFile("perms/foo", "whee", dagger.DirectoryWithNewFileOpts{
+				Permissions: 0645,
+			}).
+			Directory("perms")
+
+		ctr := c.Container().From("alpine:3.16.2").
+			WithExec([]string{"adduser", "-D", "inherituser"}).
+			WithExec([]string{"adduser", "-u", "1234", "-D", "auser"}).
+			WithExec([]string{"addgroup", "-g", "4321", "agroup"}).
+			WithUser("inherituser").
+			WithMountedCache("/data", cache, dagger.ContainerWithMountedCacheOpts{
+				Source: dir,
+				Owner:  "auser:agroup",
+			})
+
+		out, err := ctr.WithExec([]string{"stat", "-c", "%a:%U:%G", "/data"}).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "745:auser:agroup\n", out)
+
+		out, err = ctr.WithExec([]string{"stat", "-c", "%a:%U:%G", "/data/foo"}).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "645:auser:agroup\n", out)
+	})
 }
 
 func TestContainerWithMountedSecretOwner(t *testing.T) {


### PR DESCRIPTION
Empty caches have 755 permissions, so we should be consistent with that when changing ownership.

see https://github.com/dagger/dagger/pull/4932#discussion_r1174164399