### PR TITLE
Use strings.Builder for querybuilder build method

### DIFF
--- a/sdk/go/internal/querybuilder/querybuilder.go
+++ b/sdk/go/internal/querybuilder/querybuilder.go
@@ -82,26 +82,38 @@ func (s *Selection) build(ctx context.Context) (string, error) {
 	if err := s.marshalArguments(ctx); err != nil {
 		return "", err
 	}
-	fields := []string{
-		"query",
-	}
+
+	var b strings.Builder
+	b.WriteString("query")
+
 	for _, sel := range s.path() {
-		q := sel.name
-		if len(sel.args) > 0 {
-			args := make([]string, 0, len(sel.args))
-			for name, arg := range sel.args {
-				args = append(args, fmt.Sprintf("%s:%s", name, arg.marshalled))
-			}
-			q += "(" + strings.Join(args, ", ") + ")"
-		}
+		b.WriteRune('{')
+
 		if sel.alias != "" {
-			q = sel.alias + ":" + q
+			b.WriteString(sel.alias)
+			b.WriteRune(':')
 		}
-		fields = append(fields, q)
+
+		b.WriteString(sel.name)
+
+		if len(sel.args) > 0 {
+			b.WriteRune('(')
+			i := 0
+			for name, arg := range sel.args {
+				if i > 0 {
+					b.WriteString(", ")
+				}
+				b.WriteString(name)
+				b.WriteRune(':')
+				b.WriteString(arg.marshalled)
+				i++
+			}
+			b.WriteRune(')')
+		}
 	}
 
-	q := strings.Join(fields, "{") + strings.Repeat("}", len(fields)-1)
-	return q, nil
+	b.WriteString(strings.Repeat("}", len(s.path())))
+	return b.String(), nil
 }
 
 func (s *Selection) unpack(data interface{}) error {

--- a/sdk/go/internal/querybuilder/querybuilder.go
+++ b/sdk/go/internal/querybuilder/querybuilder.go
@@ -86,7 +86,9 @@ func (s *Selection) build(ctx context.Context) (string, error) {
 	var b strings.Builder
 	b.WriteString("query")
 
-	for _, sel := range s.path() {
+	path := s.path()
+
+	for _, sel := range path {
 		b.WriteRune('{')
 
 		if sel.alias != "" {
@@ -112,7 +114,7 @@ func (s *Selection) build(ctx context.Context) (string, error) {
 		}
 	}
 
-	b.WriteString(strings.Repeat("}", len(s.path())))
+	b.WriteString(strings.Repeat("}", len(path)))
 	return b.String(), nil
 }
 


### PR DESCRIPTION
It's a minor improvement to `querybuilder` performance, given this benchmark:

```go
func BenchmarkBuilder(b *testing.B) {
	for i := 0; i < b.N; i++ {
		var contents string
		root := Query().
			Select("foo").
			Select("bar").Arg("hello", "world").
			Select("field").Arg("test", "test").Bind(&contents)
		root.build(context.Background())
		_, _ = Query().
			Select("a").Arg("arg", "one").
			Select("b").Arg("arg", "two").
			build(context.Background())
	}
}
```

`benchcmp` results:
```
% benchcmp old new 
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark                      old ns/op     new ns/op     delta
BenchmarkBuilder-8     11363         10839         -4.61%

benchmark                      old allocs     new allocs     delta
BenchmarkBuilder-8     88             76             -13.64%

benchmark                      old bytes     new bytes     delta
BenchmarkBuilder-8     3232          2849          -11.85%
```