### PR TITLE
fix: Correct help output examples for dagger run

### DIFF
--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -30,8 +30,11 @@ DAGGER_SESSION_PORT and DAGGER_SESSION_TOKEN will be convieniently injected auto
 	Example: `  Run a Dagger pipeline written in Go:
     dagger run go run main.go
 
+  Run a Dagger pipeline written in Node.js:
+    dagger run node index.mjs
+
   Run a Dagger pipeline written in Python:
-    dagger run node pipeline.mjs
+    dagger run python pipeline.py
 
   Run a Dagger API request directly:
     jq -n '{query:"{container{id}}"}' | \

--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -34,7 +34,7 @@ DAGGER_SESSION_PORT and DAGGER_SESSION_TOKEN will be convieniently injected auto
     dagger run node index.mjs
 
   Run a Dagger pipeline written in Python:
-    dagger run python pipeline.py
+    dagger run python main.py
 
   Run a Dagger API request directly:
     jq -n '{query:"{container{id}}"}' | \


### PR DESCRIPTION
`dagger help run` after fix:

```
Examples:
  Run a Dagger pipeline written in Go:
    dagger run go run main.go

  Run a Dagger pipeline written in Node.js:
    dagger run node index.mjs

  Run a Dagger pipeline written in Python:
    dagger run python pipeline.py
    
. . .
    
```

Before fix:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/3187222/233795355-c6c4d900-9eef-4d73-a2e7-1a4a5f627c93.png">
