### PR TITLE
add `--pprof` flag for serving net/http/pprof handlers

### DIFF
--- a/cmd/dagger/debug.go
+++ b/cmd/dagger/debug.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"expvar"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	"os"
+	"runtime"
+
+	"golang.org/x/net/trace"
+)
+
+func setupDebugHandlers(addr string) error {
+	m := http.NewServeMux()
+	m.Handle("/debug/vars", expvar.Handler())
+	m.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
+	m.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
+	m.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
+	m.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
+	m.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
+	m.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+	m.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+	m.Handle("/debug/requests", http.HandlerFunc(trace.Traces))
+	m.Handle("/debug/events", http.HandlerFunc(trace.Events))
+
+	m.Handle("/debug/gc", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		runtime.GC()
+		fmt.Fprintln(os.Stderr, "triggered GC from debug endpoint")
+	}))
+
+	// setting debugaddr is opt-in. permission is defined by listener address
+	trace.AuthRequest = func(_ *http.Request) (bool, bool) {
+		return true, true
+	}
+
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stderr, "debug handlers listening at", addr)
+	go http.Serve(l, m) // nolint:gosec
+	return nil
+}

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -18,6 +18,7 @@ var (
 	workdir    string
 
 	cpuprofile string
+	pprofAddr  string
 	debugLogs  bool
 )
 
@@ -30,6 +31,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&workdir, "workdir", ".", "The host workdir loaded into dagger")
 	rootCmd.PersistentFlags().BoolVar(&debugLogs, "debug", false, "show buildkit debug logs")
 	rootCmd.PersistentFlags().StringVar(&cpuprofile, "cpuprofile", "", "collect CPU profile to path, and trace at path.trace")
+	rootCmd.PersistentFlags().StringVar(&pprofAddr, "pprof", "", "serve HTTP pprof at this address")
 
 	rootCmd.PersistentFlags().StringVarP(&configPath, "project", "p", "", "")
 	rootCmd.PersistentFlags().MarkHidden("project")
@@ -64,6 +66,12 @@ var rootCmd = &cobra.Command{
 
 			if err := trace.Start(traceF); err != nil {
 				return fmt.Errorf("start trace: %w", err)
+			}
+		}
+
+		if pprofAddr != "" {
+			if err := setupDebugHandlers(pprofAddr); err != nil {
+				return fmt.Errorf("start pprof: %w", err)
 			}
 		}
 


### PR DESCRIPTION
This is lifted straight from `cmd/engine/main.go`. Needed it because I was trying to profile a process that was running out of memory and churning CPU, but profiles weren't being saved because I had to kill the process.