### PR TITLE
strip sourcemap from Dockerfile builds

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -413,6 +413,7 @@ func (container *Container) Build(ctx context.Context, gw bkgw.Client, context *
 		}))
 
 		container.FS = def.ToPB()
+		container.FS.Source = nil
 
 		cfgBytes, found := res.Metadata[exptypes.ExporterImageConfigKey]
 		if found {


### PR DESCRIPTION
A bug seems to be leading to a gigantic `pb.Definition` value which exceeds the gRPC message size. I ran into this when trying to run Bass's tests in Dagger:

```sh
cd bass/
dagger run ./bass/test -i src=./
```

It's really slow for other reasons; more PRs coming! But it should reliably trigger the bug.

I tried to investigate why this was happening, and attempted a fix in Buildkit (changed something from an `x.ys = append(x.ys, ys)` to just `x.ys = ys`), but my fix broke the tests, so I'm not sure if it's right.

Here's a gist for the gigantic `pb.Definition` and the "fixed" one: https://gist.github.com/vito/be84c33a40f243ad472e63b88cce5658

Basically Buildkit is repeatedly adding the same source information hundreds of times. I think this is partly caused by the fact that we propagate mounts from one container to the next, but my understanding of this is loose at best.

I don't think users have a way to interact with this value right now, so stripping it seems OK, but I may be missing some use case, and it would be better to get a fix upstream.