### PR TITLE
Switch to short IDs kept in memory

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -34,6 +34,10 @@ import (
 	"github.com/zeebo/xxh3"
 )
 
+// containers stores an internal mapping from a content-derived hash to a real
+// container.
+var containers = newIDStore[ContainerID, *Container]()
+
 // Container is a content-addressed container.
 type Container struct {
 	// The container's root filesystem.
@@ -108,23 +112,17 @@ func (id ContainerID) String() string {
 }
 
 func (id ContainerID) ToContainer() (*Container, error) {
-	var container Container
-
 	if id == "" {
 		// scratch
-		return &container, nil
+		return &Container{}, nil
 	}
 
-	if err := decodeID(&container, id); err != nil {
-		return nil, err
-	}
-
-	return &container, nil
+	return containers.Get(id)
 }
 
 // ID marshals the container into a content-addressed ID.
 func (container *Container) ID() (ContainerID, error) {
-	return encodeID[ContainerID](container)
+	return containers.Put(container)
 }
 
 type HostAlias struct {

--- a/core/directory.go
+++ b/core/directory.go
@@ -20,6 +20,10 @@ import (
 	fstypes "github.com/tonistiigi/fsutil/types"
 )
 
+// containers stores an internal mapping from a content-derived hash to a real
+// container.
+var directories = newIDStore[DirectoryID, *Directory]()
+
 // Directory is a content-addressed directory.
 type Directory struct {
 	LLB      *pb.Definition `json:"llb"`
@@ -60,22 +64,16 @@ type DirectoryID string
 
 // ToDirectory converts the ID into a real Directory.
 func (id DirectoryID) ToDirectory() (*Directory, error) {
-	var dir Directory
-
 	if id == "" {
-		return &dir, nil
+		return &Directory{}, nil
 	}
 
-	if err := decodeID(&dir, id); err != nil {
-		return nil, err
-	}
-
-	return &dir, nil
+	return directories.Get(id)
 }
 
 // ID marshals the directory into a content-addressed ID.
 func (dir *Directory) ID() (DirectoryID, error) {
-	return encodeID[DirectoryID](dir)
+	return directories.Put(dir)
 }
 
 func (dir *Directory) State() (llb.State, error) {

--- a/core/file.go
+++ b/core/file.go
@@ -19,6 +19,8 @@ import (
 	fstypes "github.com/tonistiigi/fsutil/types"
 )
 
+var files = newIDStore[FileID, *File]()
+
 // File is a content-addressed file.
 type File struct {
 	LLB      *pb.Definition `json:"llb"`
@@ -59,16 +61,11 @@ type FileID string
 
 // ID marshals the file into a content-addressed ID.
 func (file *File) ID() (FileID, error) {
-	return encodeID[FileID](file)
+	return files.Put(file)
 }
 
 func (id FileID) ToFile() (*File, error) {
-	var file File
-	if err := decodeID(&file, id); err != nil {
-		return nil, err
-	}
-
-	return &file, nil
+	return files.Get(id)
 }
 
 func (file *File) State() (llb.State, error) {

--- a/core/idstore.go
+++ b/core/idstore.go
@@ -1,0 +1,50 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/zeebo/xxh3"
+)
+
+type idStore[K ~string, T any] struct {
+	cache map[K]T
+	l     sync.Mutex
+}
+
+func newIDStore[K ~string, T any]() *idStore[K, T] {
+	return &idStore[K, T]{
+		cache: make(map[K]T),
+	}
+}
+
+func (cache *idStore[K, T]) Get(key K) (T, error) {
+	cache.l.Lock()
+	defer cache.l.Unlock()
+
+	val, found := cache.cache[key]
+	if !found {
+		return val, fmt.Errorf("%T %v not found", key, key)
+	}
+
+	return val, nil
+}
+
+func (cache *idStore[K, T]) Put(val T) (K, error) {
+	cache.l.Lock()
+	defer cache.l.Unlock()
+
+	hasher := xxh3.New()
+
+	err := json.NewEncoder(hasher).Encode(val)
+	if err != nil {
+		return "", err
+	}
+
+	hash := K(b32(hasher.Sum64()))
+
+	cache.cache[hash] = val
+
+	return hash, nil
+}


### PR DESCRIPTION
Currently `ContainerID`, `FileID`, and `DirectoryID` are gigantic strings because they are self-contained values that store the instructions for creating them.

I noticed during testing that a these can be pretty expensive to deal with. Dagger was burning a ton of memory on my laptop and even caused my OS to crash. I think the root cause of this was really #5012 but either way I don't think we necessarily wanted these to be giant values forever.

This PR maintains their content-addressed quality by replacing them with a `digest.Digest` which maps to an internal cache from `digest.Digest` to `*Container`, `*Directory`, and `*File`.

New caveats to consider:

* IDs are no longer transferrable with zero-context as before. They're content-addressed, rather than being literally the content.
* The mapping from ID to concrete value grows without bounds, so if you have a long-lived session running containers over time you will eventually run out of memory. We could improve this with an LRU cache or something, but it raises some uncomfortable questions: what if someone finally calls back to use an ID that has been reaped?

I'm curious if that second point affects anyone. I don't think we're really focused on 'infinite sessions' right now so my hunch is nothing would break with this change, but it's worth picking apart a bit more.