### PR TITLE
Cache results for Container.Import and Container.Build

### DIFF
--- a/core/cachemap.go
+++ b/core/cachemap.go
@@ -5,85 +5,37 @@ import (
 )
 
 type cacheMap[K comparable, T any] struct {
-	cache map[K]*cacheInitializer[K, T]
 	l     sync.Mutex
+	calls map[K]*cache[T]
+}
+
+type cache[T any] struct {
+	wg  sync.WaitGroup
+	val T
+	err error
 }
 
 func newCacheMap[K comparable, T any]() *cacheMap[K, T] {
 	return &cacheMap[K, T]{
-		cache: make(map[K]*cacheInitializer[K, T]),
+		calls: map[K]*cache[T]{},
 	}
 }
 
-func (cache *cacheMap[K, T]) Get(key K) (T, bool) {
-	cache.l.Lock()
-	defer cache.l.Unlock()
-
-	init, found := cache.cache[key]
-	if found {
-		init.Wait()
-		return init.val, true
+func (m *cacheMap[K, T]) GetOrInitialize(key K, fn func() (T, error)) (T, error) {
+	m.l.Lock()
+	if c, ok := m.calls[key]; ok {
+		m.l.Unlock()
+		c.wg.Wait()
+		return c.val, c.err
 	}
 
-	var zero T
-	return zero, false
-}
+	c := &cache[T]{}
+	c.wg.Add(1)
+	m.calls[key] = c
+	m.l.Unlock()
 
-type Initializer[T any] interface {
-	// Put sets the value and wakes up any callers waiting for it.
-	Put(val T)
+	c.val, c.err = fn()
+	c.wg.Done()
 
-	// Release removes the initializer from the cache if it has not been
-	// initialized.
-	Release()
-}
-
-func (cache *cacheMap[K, T]) GetOrInitialize(key K) (T, Initializer[T], bool) {
-	cache.l.Lock()
-	defer cache.l.Unlock()
-
-	init, found := cache.cache[key]
-	if found {
-		init.Wait()
-		return init.val, nil, true
-	}
-
-	init = &cacheInitializer[K, T]{
-		wg:    new(sync.WaitGroup),
-		key:   key,
-		cache: cache,
-	}
-
-	init.wg.Add(1)
-
-	cache.cache[key] = init
-
-	var zero T
-	return zero, init, found
-}
-
-type cacheInitializer[K comparable, T any] struct {
-	wg    *sync.WaitGroup
-	key   K
-	val   T
-	cache *cacheMap[K, T]
-	done  bool
-}
-
-func (init *cacheInitializer[K, T]) Wait() {
-	init.wg.Wait()
-}
-
-func (init *cacheInitializer[K, T]) Put(val T) {
-	init.val = val
-	init.done = true
-	init.wg.Done()
-}
-
-func (init *cacheInitializer[K, T]) Release() {
-	if !init.done {
-		init.cache.l.Lock()
-		delete(init.cache.cache, init.key)
-		init.cache.l.Unlock()
-	}
+	return c.val, c.err
 }

--- a/core/cachemap.go
+++ b/core/cachemap.go
@@ -1,0 +1,77 @@
+package core
+
+import (
+	"sync"
+)
+
+type cacheMap[K comparable, T any] struct {
+	cache map[K]T
+	l     sync.Mutex
+}
+
+func newCacheMap[K comparable, T any]() *cacheMap[K, T] {
+	return &cacheMap[K, T]{
+		cache: make(map[K]T),
+	}
+}
+
+func (cache *cacheMap[K, T]) Get(key K) (T, bool) {
+	cache.l.Lock()
+	defer cache.l.Unlock()
+
+	val, found := cache.cache[key]
+	return val, found
+}
+
+type Initializer[T any] interface {
+	// Put sets the value and releases the lock on the cache.
+	Put(val T)
+
+	// Release will release the lock on the cache.
+	Release()
+}
+
+// TODO per-key locks
+func (cache *cacheMap[K, T]) GetOrInitialize(key K) (T, Initializer[T], bool) {
+	cache.l.Lock()
+
+	val, found := cache.cache[key]
+	if found {
+		cache.l.Unlock()
+		return val, nil, true
+	}
+
+	// leave l locked until initializer is released
+	//
+	// TODO: per-key locks
+
+	return val, &cacheInitializer[K, T]{
+		key:   key,
+		cache: cache,
+	}, found
+}
+
+func (cache *cacheMap[K, T]) Put(key K, val T) {
+	cache.l.Lock()
+	defer cache.l.Unlock()
+
+	cache.cache[key] = val
+}
+
+type cacheInitializer[K comparable, T any] struct {
+	key   K
+	cache *cacheMap[K, T]
+	done  bool
+}
+
+func (init *cacheInitializer[K, T]) Put(val T) {
+	init.cache.cache[init.key] = val
+	init.done = true
+	init.cache.l.Unlock()
+}
+
+func (init *cacheInitializer[K, T]) Release() {
+	if !init.done {
+		init.cache.l.Unlock()
+	}
+}

--- a/core/cachemap.go
+++ b/core/cachemap.go
@@ -37,5 +37,11 @@ func (m *cacheMap[K, T]) GetOrInitialize(key K, fn func() (T, error)) (T, error)
 	c.val, c.err = fn()
 	c.wg.Done()
 
+	if c.err != nil {
+		m.l.Lock()
+		delete(m.calls, key)
+		m.l.Unlock()
+	}
+
 	return c.val, c.err
 }

--- a/core/cachemap_test.go
+++ b/core/cachemap_test.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,4 +33,34 @@ func TestCacheMapConcurrent(t *testing.T) {
 
 	// only one of them should have initialized
 	require.Len(t, initialized, 1)
+}
+
+func TestCacheMapErrors(t *testing.T) {
+	c := newCacheMap[int, int]()
+
+	commonKey := 42
+
+	myErr := errors.New("nope")
+	_, err := c.GetOrInitialize(commonKey, func() (int, error) {
+		return 0, myErr
+	})
+	require.Equal(t, myErr, err)
+
+	otherErr := errors.New("nope 2")
+	_, err = c.GetOrInitialize(commonKey, func() (int, error) {
+		return 0, otherErr
+	})
+	require.Equal(t, otherErr, err)
+
+	res, err := c.GetOrInitialize(commonKey, func() (int, error) {
+		return 1, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, res)
+
+	res, err = c.GetOrInitialize(commonKey, func() (int, error) {
+		return 0, errors.New("ignored")
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, res)
 }

--- a/core/cachemap_test.go
+++ b/core/cachemap_test.go
@@ -1,0 +1,36 @@
+package core
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCacheMapConcurrent(t *testing.T) {
+	c := newCacheMap[int, int]()
+
+	commonKey := 42
+	initialized := map[int]bool{}
+
+	wg := new(sync.WaitGroup)
+	for i := 0; i < 100; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			val, initializer, found := c.GetOrInitialize(commonKey)
+			if found {
+				require.True(t, initialized[val])
+			} else {
+				initialized[i] = true
+				initializer.Put(i)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// only one of them should have initialized
+	require.Len(t, initialized, 1)
+}

--- a/core/cachemap_test.go
+++ b/core/cachemap_test.go
@@ -19,13 +19,12 @@ func TestCacheMapConcurrent(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			val, initializer, found := c.GetOrInitialize(commonKey)
-			if found {
-				require.True(t, initialized[val])
-			} else {
+			val, err := c.GetOrInitialize(commonKey, func() (int, error) {
 				initialized[i] = true
-				initializer.Put(i)
-			}
+				return i, nil
+			})
+			require.NoError(t, err)
+			require.True(t, initialized[val])
 		}()
 	}
 

--- a/core/container.go
+++ b/core/container.go
@@ -389,7 +389,7 @@ func (container *Container) Build(
 	target string,
 	secrets []SecretID,
 ) (*Container, error) {
-	cached, initializer, found := buildCache.GetOrInitialize(cacheKey(context, dockerfile, buildArgs, target, secrets))
+	cached, initializer, found := buildCache.GetOrInitialize(cacheKey(container, context, dockerfile, buildArgs, target, secrets))
 	if found {
 		return cached, nil
 	}
@@ -1512,7 +1512,7 @@ func (container *Container) Import(
 	tag string,
 	store content.Store,
 ) (*Container, error) {
-	cached, initializer, found := importCache.GetOrInitialize(cacheKey(source, tag))
+	cached, initializer, found := importCache.GetOrInitialize(cacheKey(container, source, tag))
 	if found {
 		return cached, nil
 	}

--- a/core/container.go
+++ b/core/container.go
@@ -367,6 +367,19 @@ func (container *Container) From(ctx context.Context, gw bkgw.Client, addr strin
 
 const defaultDockerfileName = "Dockerfile"
 
+var buildCache = newCacheMap[uint64, *Container]()
+
+func cacheKey(keys ...any) uint64 {
+	hash := xxh3.New()
+
+	enc := json.NewEncoder(hash)
+	for _, key := range keys {
+		enc.Encode(key)
+	}
+
+	return hash.Sum64()
+}
+
 func (container *Container) Build(
 	ctx context.Context,
 	gw bkgw.Client,
@@ -376,6 +389,13 @@ func (container *Container) Build(
 	target string,
 	secrets []SecretID,
 ) (*Container, error) {
+	cached, initializer, found := buildCache.GetOrInitialize(cacheKey(context, dockerfile, buildArgs, target, secrets))
+	if found {
+		return cached, nil
+	}
+
+	defer initializer.Release()
+
 	container = container.Clone()
 
 	container.Services.Merge(context.Services)
@@ -473,6 +493,8 @@ func (container *Container) Build(
 
 			container.Config = imgSpec.Config
 		}
+
+		initializer.Put(container)
 
 		return container, nil
 	})

--- a/core/container.go
+++ b/core/container.go
@@ -1502,7 +1502,7 @@ func (container *Container) Export(
 
 const OCIStoreName = "dagger-oci"
 
-var importCache = newCacheMap[FileID, *Container]()
+var importCache = newCacheMap[uint64, *Container]()
 
 func (container *Container) Import(
 	ctx context.Context,
@@ -1512,7 +1512,7 @@ func (container *Container) Import(
 	tag string,
 	store content.Store,
 ) (*Container, error) {
-	cached, initializer, found := importCache.GetOrInitialize(source)
+	cached, initializer, found := importCache.GetOrInitialize(cacheKey(source, tag))
 	if found {
 		return cached, nil
 	}

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -664,19 +664,7 @@ type containerImportArgs struct {
 }
 
 func (s *containerSchema) import_(ctx *router.Context, parent *core.Container, args containerImportArgs) (*core.Container, error) { // nolint:revive
-	file, err := args.Source.ToFile()
-	if err != nil {
-		return nil, err
-	}
-
-	src, err := file.Open(ctx, s.host, s.gw)
-	if err != nil {
-		return nil, err
-	}
-
-	defer src.Close()
-
-	return parent.Import(ctx, s.host, src, args.Tag, s.ociStore)
+	return parent.Import(ctx, s.gw, s.host, args.Source, args.Tag, s.ociStore)
 }
 
 type containerWithRegistryAuthArgs struct {


### PR DESCRIPTION
Builds on #5013 to use IDs as cache keys for expensive API requests.

This has by far the largest performance improvement for `dagger run ./bass/test -i src=./` because I use OCI archives for images everywhere. Without this, every single call to `Container.Import` imports the same file every time I run something, spending tens of seconds on redundant I/O that's invisible to the user.

I think it's important for these caches to live on the Dagger side because it frees the API consumer to structure their code however they want. I applied these same optimizations in Bass a couple of weeks ago for the same reason.