### PR TITLE
dnsmasq: stability improvements + greater debuggability

### DIFF
--- a/cmd/dnsname/files.go
+++ b/cmd/dnsname/files.go
@@ -12,7 +12,7 @@ import (
 
 // appendToFile appends a new entry to the dnsmasqs hosts file
 func appendToFile(path, podname string, aliases []string, ips []*net.IPNet) error {
-	f, err := openFile(path)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}
@@ -26,8 +26,7 @@ func appendToFile(path, podname string, aliases []string, ips []*net.IPNet) erro
 		for _, alias := range aliases {
 			entry += fmt.Sprintf("\t%s", alias)
 		}
-		entry += "\n"
-		if _, err = f.WriteString(entry); err != nil {
+		if _, err = fmt.Fprintln(f, entry); err != nil {
 			return err
 		}
 		logrus.Debugf("appended %s: %s", path, entry)
@@ -36,84 +35,57 @@ func appendToFile(path, podname string, aliases []string, ips []*net.IPNet) erro
 }
 
 // removeLineFromFile removes a given entry from the dnsmasq host file
-func removeFromFile(path, podname string) error {
-	var (
-		keepers []string
-		found   bool
-	)
-	backup := fmt.Sprintf("%s.old", path)
-	if err := os.Rename(path, backup); err != nil {
-		return err
-	}
-	f, err := os.Open(backup)
-	if err != nil {
-		//	if the open fails here, we need to revert things
-		renameFile(backup, path)
-		return err
-	}
-	defer func() {
-		if err := f.Close(); err != nil {
-			logrus.Errorf("unable to close %q: %v", backup, err)
-		}
-	}()
+func removeFromFile(livePath, hostname string) error {
+	newFile := fmt.Sprintf("%s.new", livePath)
 
-	oldFile := bufio.NewScanner(f)
-	// Iterate the old file
-	for oldFile.Scan() {
-		fields := strings.Fields(oldFile.Text())
-		// if the IP of the entry and the given IP dont match, it should
-		// go into the new file
-		if len(fields) > 1 && fields[1] != podname {
-			keepers = append(keepers, fmt.Sprintf("%s\n", oldFile.Text()))
+	// clean up if things goes wrong; let it do a no-op if things go right
+	defer os.RemoveAll(newFile)
+
+	newF, err := os.Create(newFile)
+	if err != nil {
+		return fmt.Errorf("create new path: %w", err)
+	}
+	defer newF.Close()
+
+	oldF, err := os.Open(livePath)
+	if err != nil {
+		return fmt.Errorf("open live path: %w", err)
+	}
+	defer oldF.Close()
+
+	oldScan := bufio.NewScanner(oldF)
+
+	var found bool
+	for oldScan.Scan() {
+		fields := strings.Fields(oldScan.Text())
+
+		if len(fields) > 1 && fields[1] == hostname {
+			// found the hostname; filter it out
+			found = true
 			continue
 		}
-		found = true
+
+		_, err = fmt.Fprintln(newF, oldScan.Text())
+		if err != nil {
+			return fmt.Errorf("write to new file: %w", err)
+		}
 	}
+
 	if !found {
-		// We never found a matching record; non-fatal
-		logrus.Debugf("a record for %s was never found in %s", podname, path)
+		logrus.Debugf("a record for %s was never found in %s", hostname, livePath)
 	}
-	if _, err := writeFile(path, keepers); err != nil {
-		renameFile(backup, path)
-		return err
+
+	if err := oldF.Close(); err != nil {
+		return fmt.Errorf("close old file: %w", err)
 	}
-	if err := os.Remove(backup); err != nil {
-		logrus.Errorf("unable to delete '%s': %q", backup, err)
+
+	if err := newF.Close(); err != nil {
+		return fmt.Errorf("close new file: %w", err)
 	}
+
+	if err := os.Rename(newFile, livePath); err != nil {
+		return fmt.Errorf("rename new file: %w", err)
+	}
+
 	return nil
-}
-
-// renameFile renames a file to backup
-func renameFile(oldpath, newpath string) {
-	if renameError := os.Rename(oldpath, newpath); renameError != nil {
-		logrus.Errorf("unable to restore %q to %q: %v", oldpath, newpath, renameError)
-	}
-}
-
-// writeFile writes a []string to the given path and returns the number
-// of lines in the file
-func writeFile(path string, content []string) (int, error) {
-	var counter int
-	f, err := openFile(path)
-	if err != nil {
-		return 0, err
-	}
-	defer func() {
-		if err := f.Close(); err != nil {
-			logrus.Errorf("unable to close %q: %v", path, err)
-		}
-	}()
-
-	for _, line := range content {
-		if _, err := f.WriteString(line); err != nil {
-			return 0, err
-		}
-		counter++
-	}
-	return counter, nil
-}
-
-// openFile opens a file for reading
-func openFile(path string) (*os.File, error) {
-	return os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 }

--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -949,16 +949,6 @@ func setupNetwork(netName, netCIDR string) (string, error) {
 		return "", nil
 	}
 
-	err := network.InstallDnsmasq(netName)
-	if err != nil {
-		return "", fmt.Errorf("install dnsmasq: %w", err)
-	}
-
-	cniConfigPath, err := network.InstallCNIConfig(netName, netCIDR)
-	if err != nil {
-		return "", fmt.Errorf("install cni: %w", err)
-	}
-
 	bridge, err := network.BridgeFromCIDR(netCIDR)
 	if err != nil {
 		return "", fmt.Errorf("bridge from cidr: %w", err)
@@ -967,6 +957,16 @@ func setupNetwork(netName, netCIDR string) (string, error) {
 	err = network.InstallResolvconf(netName, bridge.String())
 	if err != nil {
 		return "", fmt.Errorf("install resolv.conf: %w", err)
+	}
+
+	err = network.InstallDnsmasq(netName)
+	if err != nil {
+		return "", fmt.Errorf("install dnsmasq: %w", err)
+	}
+
+	cniConfigPath, err := network.InstallCNIConfig(netName, netCIDR)
+	if err != nil {
+		return "", fmt.Errorf("install cni: %w", err)
 	}
 
 	return cniConfigPath, nil

--- a/network/dnsmasq.go
+++ b/network/dnsmasq.go
@@ -14,10 +14,12 @@ func InstallDnsmasq(name string) error {
 		return err
 	}
 
+	pidfile := pidfilePath(name)
+
 	config := dnsmasqConfig{
 		Domain:             name + ".local",
 		NetworkInterface:   name + "0",
-		PidFile:            pidfilePath(name),
+		PidFile:            pidfile,
 		AddnHostsFile:      hostsPath(name),
 		UpstreamResolvFile: upstreamResolvPath,
 	}
@@ -28,7 +30,14 @@ func InstallDnsmasq(name string) error {
 		return fmt.Errorf("write dnsmasq.conf: %w", err)
 	}
 
-	dnsmasq := exec.Command(dnsmasqPath, "--no-daemon", "--log-debug", "-u", "root", "--conf-file="+dnsmasqConfigFile)
+	dnsmasq := exec.Command(
+		dnsmasqPath,
+		"--keep-in-foreground",
+		"--log-facility=-",
+		"--log-debug",
+		"-u", "root",
+		"--conf-file="+dnsmasqConfigFile,
+	)
 
 	// forward dnsmasq logs to engine logs for debugging
 	dnsmasq.Stdout = os.Stdout

--- a/network/dnsmasq.go
+++ b/network/dnsmasq.go
@@ -14,13 +14,16 @@ func InstallDnsmasq(name string) error {
 		return err
 	}
 
-	pidfile := pidfilePath(name)
+	hostsFile := hostsPath(name)
+	if err := createIfNeeded(hostsFile); err != nil {
+		return err
+	}
 
 	config := dnsmasqConfig{
 		Domain:             name + ".local",
 		NetworkInterface:   name + "0",
-		PidFile:            pidfile,
-		AddnHostsFile:      hostsPath(name),
+		PidFile:            pidfilePath(name),
+		AddnHostsFile:      hostsFile,
 		UpstreamResolvFile: upstreamResolvPath,
 	}
 

--- a/network/dnsmasq.go
+++ b/network/dnsmasq.go
@@ -93,7 +93,6 @@ domain={{.Domain}}
 expand-hosts
 pid-file={{.PidFile}}
 except-interface=lo
-bind-dynamic
 no-hosts
 interface={{.NetworkInterface}}
 addn-hosts={{.AddnHostsFile}}


### PR DESCRIPTION
This fixes a couple of issues:

* Occasional `connection refused` errors, caused by configuring `bind-dynamic`
* Buggy atomic write implementation leading to missing/empty/partially-written `addnhosts` file
* Fixed up the setup sequence to avoid noisy red-herring error logs

It also changes `dnsmasq` to just run in the foreground and send its logs to the engine logs, rather than daemonizing.