### PR TITLE
docs: Fixed inconsistent Node.js tab labels

### DIFF
--- a/docs/current/quickstart/349011-quickstart-build.mdx
+++ b/docs/current/quickstart/349011-quickstart-build.mdx
@@ -46,7 +46,7 @@ go run ci/main.go
 ```
 
 </TabItem>
-<TabItem value="Node">
+<TabItem value="Node.js">
 
 <Embed id="HMeWQ18XgxM" />
 

--- a/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
+++ b/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
@@ -49,7 +49,7 @@ go run ci/main.go
 ```
 
 </TabItem>
-<TabItem value="Node">
+<TabItem value="Node.js">
 
 <Embed id="blm0z0YQDmX"/>
 

--- a/docs/current/quickstart/472910-quickstart-build-multi.mdx
+++ b/docs/current/quickstart/472910-quickstart-build-multi.mdx
@@ -48,7 +48,7 @@ go run ci/main.go
 ```
 
 </TabItem>
-<TabItem value="Node">
+<TabItem value="Node.js">
 
 <Embed id="ijTE41ISH95"/>
 

--- a/docs/current/quickstart/593914-quickstart-hello.mdx
+++ b/docs/current/quickstart/593914-quickstart-hello.mdx
@@ -53,7 +53,7 @@ Hello from Dagger and go version go1.19.5 linux/amd64
 ```
 
 </TabItem>
-<TabItem value="Node">
+<TabItem value="Node.js">
 
 In the `ci` directory, create a new file named `index.mjs` and add the following code to it.
 

--- a/docs/current/quickstart/635927-quickstart-caching.mdx
+++ b/docs/current/quickstart/635927-quickstart-caching.mdx
@@ -50,7 +50,7 @@ go run ci/main.go
 ```
 
 </TabItem>
-<TabItem value="Node">
+<TabItem value="Node.js">
 
 <Embed id="2DhNPJQ6pUU" />
 

--- a/docs/current/quickstart/730264-quickstart-publish.mdx
+++ b/docs/current/quickstart/730264-quickstart-publish.mdx
@@ -38,7 +38,7 @@ go run ci/main.go
 ```
 
 </TabItem>
-<TabItem value="Node">
+<TabItem value="Node.js">
 
 <Embed id="P8mz6yjC2lM"></Embed>
 

--- a/docs/current/quickstart/947391-quickstart-test.mdx
+++ b/docs/current/quickstart/947391-quickstart-test.mdx
@@ -53,7 +53,7 @@ go run ci/main.go
 ```
 
 </TabItem>
-<TabItem value="Node">
+<TabItem value="Node.js">
 
 <Embed id="XyDYQWN2edq" />
 


### PR DESCRIPTION
This commit fixes inconsistent tab labels in code snippets, from `Node` to `Node.js`.

Closes #4935