### PR TITLE
fix: Go SDK: returned list of objects have same memory address

### DIFF
--- a/codegen/generator/go/templates/functions.go
+++ b/codegen/generator/go/templates/functions.go
@@ -123,7 +123,7 @@ func formatArrayField(fields []*introspection.Field) string {
 	result := []string{}
 
 	for _, f := range fields {
-		result = append(result, fmt.Sprintf("%s: &field.%s", f.Name, toUpperCase(f.Name)))
+		result = append(result, fmt.Sprintf("%s: &fields[i].%s", f.Name, toUpperCase(f.Name)))
 	}
 
 	return strings.Join(result, ", ")

--- a/codegen/generator/go/templates/src/object.go.tmpl
+++ b/codegen/generator/go/templates/src/object.go.tmpl
@@ -86,7 +86,7 @@ type {{ $field | FieldOptionsStructName }} struct {
     convert := func(fields []{{ $field.Name | ToLowerCase }}) {{ $field.TypeRef | FormatOutputType }} {
         out := {{ $field.TypeRef | FormatOutputType }}{}
 
-        for _, field := range fields {
+        for i := range fields {
             out = append(out, {{ $field.TypeRef | FormatOutputType | FormatArrayToSingleType }}{{"{"}}{{ $field | GetArrayField | FormatArrayField }}{{"}"}})
         }
 

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -267,8 +267,8 @@ func (r *Container) EnvVariables(ctx context.Context) ([]EnvVariable, error) {
 	convert := func(fields []envVariables) []EnvVariable {
 		out := []EnvVariable{}
 
-		for _, field := range fields {
-			out = append(out, EnvVariable{name: &field.Name, value: &field.Value})
+		for i := range fields {
+			out = append(out, EnvVariable{name: &fields[i].Name, value: &fields[i].Value})
 		}
 
 		return out
@@ -410,8 +410,8 @@ func (r *Container) ExposedPorts(ctx context.Context) ([]Port, error) {
 	convert := func(fields []exposedPorts) []Port {
 		out := []Port{}
 
-		for _, field := range fields {
-			out = append(out, Port{description: &field.Description, port: &field.Port, protocol: &field.Protocol})
+		for i := range fields {
+			out = append(out, Port{description: &fields[i].Description, port: &fields[i].Port, protocol: &fields[i].Protocol})
 		}
 
 		return out
@@ -575,8 +575,8 @@ func (r *Container) Labels(ctx context.Context) ([]Label, error) {
 	convert := func(fields []labels) []Label {
 		out := []Label{}
 
-		for _, field := range fields {
-			out = append(out, Label{name: &field.Name, value: &field.Value})
+		for i := range fields {
+			out = append(out, Label{name: &fields[i].Name, value: &fields[i].Value})
 		}
 
 		return out
@@ -2250,8 +2250,8 @@ func (r *Project) Extensions(ctx context.Context) ([]Project, error) {
 	convert := func(fields []extensions) []Project {
 		out := []Project{}
 
-		for _, field := range fields {
-			out = append(out, Project{install: &field.Install, name: &field.Name, schema: &field.Schema, sdk: &field.Sdk})
+		for i := range fields {
+			out = append(out, Project{install: &fields[i].Install, name: &fields[i].Name, schema: &fields[i].Schema, sdk: &fields[i].Sdk})
 		}
 
 		return out

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -161,16 +161,25 @@ func TestList(t *testing.T) {
 		Container().
 		From("alpine:3.16.2").
 		WithEnvVariable("FOO", "BAR").
+		WithEnvVariable("BAR", "BAZ").
 		EnvVariables(ctx)
 
 	require.NoError(t, err)
 
-	envName, err := envs[0].Name(ctx)
+	envName, err := envs[1].Name(ctx)
 	require.NoError(t, err)
 
-	envValue, err := envs[0].Value(ctx)
+	envValue, err := envs[1].Value(ctx)
 	require.NoError(t, err)
 
 	require.Equal(t, "FOO", envName)
 	require.Equal(t, "BAR", envValue)
+
+	envName, err = envs[2].Name(ctx)
+	require.NoError(t, err)
+
+	envValue, err = envs[2].Value(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "BAR", envName)
+	require.Equal(t, "BAZ", envValue)
 }


### PR DESCRIPTION
Refactor Go codegen to pass memory address of fields directly to Objects.
Otherwise, we would only return references to the values of the last object in the list

Example: 

Let's see the behavior of `EnvVariables()`:  it used to return n times the last env var encountered.

_Prior fix_
```shell
go run .
len: 5
{q:<nil> c:<nil> name:0x140001a01a0 value:0x140001a01b0}
var [tutu:titi]
{q:<nil> c:<nil> name:0x140001a01a0 value:0x140001a01b0}
var [tutu:titi]
{q:<nil> c:<nil> name:0x140001a01a0 value:0x140001a01b0}
var [tutu:titi]
{q:<nil> c:<nil> name:0x140001a01a0 value:0x140001a01b0}
var [tutu:titi]
{q:<nil> c:<nil> name:0x140001a01a0 value:0x140001a01b0}
var [tutu:titi]
```
We see that each object points to the same memory address

_After fix_
```shell
go run .
len:3, total: |[{q:<nil> c:<nil> name:0x14000222300 value:0x14000222310} {q:<nil> c:<nil> name:0x14000222320 value:0x14000222330} {q:<nil> c:<nil> name:0x14000222340 value:0x14000222350}]|
{q:<nil> c:<nil> name:0x14000222300 value:0x14000222310}
var [PATH:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin]
{q:<nil> c:<nil> name:0x14000222320 value:0x14000222330}
var [ok:da]
{q:<nil> c:<nil> name:0x14000222340 value:0x14000222350}
var [ti:ta]
```
Now, it points to the proper memory address of each env var

[Repro](https://gist.github.com/grouville/5416785cc9a24719f9f8f1904227768c)