### PR TITLE
Ensure engine exits 0 when it receives SIGTERM/SIGINT.

### DIFF
--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -366,7 +366,11 @@ func main() { //nolint:gocyclo
 			err = serverErr
 			cancel()
 		case <-ctx.Done():
-			err = ctx.Err()
+			// context should only be cancelled when a signal is received, which
+			// isn't an error
+			if ctx.Err() != context.Canceled {
+				err = ctx.Err()
+			}
 		}
 
 		// TODO:(sipsma) make timeouts configurable

--- a/core/integration/engine_test.go
+++ b/core/integration/engine_test.go
@@ -1,0 +1,58 @@
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"dagger.io/dagger"
+	"github.com/moby/buildkit/identity"
+	"github.com/stretchr/testify/require"
+)
+
+func devEngineContainer(c *dagger.Client) *dagger.Container {
+	// This loads the engine.tar file from the host into the container, that was set up by
+	// internal/mage/engine.go:test or by ./hack/dev. This is used to spin up additional dev engines.
+	var tarPath string
+	if v, ok := os.LookupEnv("_DAGGER_TESTS_ENGINE_TAR"); ok {
+		tarPath = v
+	} else {
+		tarPath = "./bin/engine.tar"
+	}
+	parentDir := filepath.Dir(tarPath)
+	tarFileName := filepath.Base(tarPath)
+	devEngineTar := c.Host().Directory(parentDir, dagger.HostDirectoryOpts{Include: []string{tarFileName}}).File(tarFileName)
+	return c.Container().Import(devEngineTar).
+		WithExposedPort(1234, dagger.ContainerWithExposedPortOpts{Protocol: dagger.Tcp})
+}
+
+func TestEngineExitsZeroOnSignal(t *testing.T) {
+	c, ctx := connect(t)
+	defer c.Close()
+
+	// engine should shutdown with exit code 0 when receiving SIGTERM
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	_, err := devEngineContainer(c).
+		WithNewFile("/usr/local/bin/dagger-entrypoint.sh", dagger.ContainerWithNewFileOpts{
+			Contents: `#!/bin/sh
+env
+/usr/local/bin/dagger-engine --debug &
+engine_pid=$!
+
+sleep 5
+kill -TERM $engine_pid
+wait $engine_pid
+exit $?
+`,
+			Permissions: 0700,
+		}).
+		WithMountedCache("/var/lib/dagger", c.CacheVolume("dagger-dev-engine-state-"+identity.NewID())).
+		WithExec(nil, dagger.ContainerWithExecOpts{
+			InsecureRootCapabilities: true,
+		}).
+		ExitCode(ctx)
+	require.NoError(t, err)
+}

--- a/hack/dev
+++ b/hack/dev
@@ -11,5 +11,6 @@ popd
 
 export _EXPERIMENTAL_DAGGER_CLI_BIN=$DAGGER_SRC_ROOT/bin/dagger
 export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev
+export _DAGGER_TESTS_ENGINE_TAR=$DAGGER_SRC_ROOT/bin/engine.tar
 
 exec "$@"


### PR DESCRIPTION
Those signals were resulting in graceful shutdown before but the engine still exited non-zero because some errors were set to context canceled.

This also adds a test case and some associated plumbing so that the tests that spin up an additional engine work with ./hack/dev too.

---

cc @jlongtine was able to make good use of all the new setup from your recent refactorization here, also tweaked it to make the nested engine tests work with ./hack/dev