### PR TITLE
feat: implement dagger.WithEnvVariables()

### DIFF
--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -53,6 +53,7 @@ func (s *containerSchema) Resolvers() router.Resolvers {
 			"envVariables":         router.ToResolver(s.envVariables),
 			"envVariable":          router.ToResolver(s.envVariable),
 			"withEnvVariable":      router.ToResolver(s.withEnvVariable),
+			"withEnvVariables":     router.ToResolver(s.withEnvVariables),
 			"withSecretVariable":   router.ToResolver(s.withSecretVariable),
 			"withoutEnvVariable":   router.ToResolver(s.withoutEnvVariable),
 			"withLabel":            router.ToResolver(s.withLabel),
@@ -305,6 +306,26 @@ func (s *containerSchema) withEnvVariable(ctx *router.Context, parent *core.Cont
 
 		return cfg
 	})
+}
+
+type containerWithVariablesArgs struct {
+	Args []containerWithVariableArgs
+}
+
+func (s *containerSchema) withEnvVariables(ctx *router.Context, parent *core.Container, args containerWithVariablesArgs) (*core.Container, error) {
+	container := parent
+	for _, envVar := range args.Args {
+		if envVar.Name == "" || envVar.Value == "" {
+			return nil, fmt.Errorf("has to contain name and value arguments")
+		}
+
+		updatedContainer, err := s.withEnvVariable(ctx, container, envVar)
+		if err != nil {
+			return nil, err
+		}
+		container = updatedContainer
+	}
+	return container, nil
 }
 
 type containerWithoutVariableArgs struct {

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -163,6 +163,16 @@ type Container {
     value: String!
   ): Container!
 
+  """
+  Retrieves this container plus the given list of environment variables.
+  """
+  withEnvVariables(
+    """
+    List of environment variables to add.
+    """
+    args: [EnvVars!]!
+  ): Container!
+
   "Retrieves the list of labels passed to container."
   labels: [Label!]!
 

--- a/core/schema/query.graphqls
+++ b/core/schema/query.graphqls
@@ -24,3 +24,18 @@ input PipelineLabel {
   """
   value: String!
 }
+
+"""
+A simple key value object that represents an environment variable.
+"""
+input EnvVars {
+  """
+  The environment variable name.
+  """
+  name: String!
+
+  """
+  "The environment variable value."
+  """
+  value: String!
+}

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -41,6 +41,15 @@ type BuildArg struct {
 	Value string `json:"value"`
 }
 
+// A simple key value object that represents an environment variable.
+type EnvVars struct {
+	// The environment variable name.
+	Name string `json:"name"`
+
+	// "The environment variable value."
+	Value string `json:"value"`
+}
+
 // Key value object that represents a Pipeline label.
 type PipelineLabel struct {
 	// Label name.
@@ -817,6 +826,17 @@ func (r *Container) WithEnvVariable(name string, value string) *Container {
 	q := r.q.Select("withEnvVariable")
 	q = q.Arg("name", name)
 	q = q.Arg("value", value)
+
+	return &Container{
+		q: q,
+		c: r.c,
+	}
+}
+
+// Retrieves this container plus the given list of environment variables.
+func (r *Container) WithEnvVariables(args []EnvVars) *Container {
+	q := r.q.Select("withEnvVariables")
+	q = q.Arg("args", args)
 
 	return &Container{
 		q: q,


### PR DESCRIPTION
This PR proposes adding withEnvVariables to the Go SDK, as it's a strongly typed language with the most significant impact on developer experience. It aims to prevent unnecessary work on other SDK implementations.

⚠️ Please review the context [here](https://github.com/dagger/dagger/issues/4835#issuecomment-1521516640) before merging or closing. The current implementation follows Developer Experience Option 2.

If approved and completed, this PR will close #4835. We will follow up with Node and Python implementations after confirming this is the desired approach.

#### Example usage:

```go
package main

import (
	"context"
	"fmt"

	"dagger.io/dagger"
)

func main() {
	ctx := context.Background()
	client, err := dagger.Connect(ctx)
	if err != nil {
		panic(err)
	}
	defer client.Close()

	envs, err := client.Container().From("alpine").WithEnvVariable("ok", "da").WithEnvVariable("ti", "ta").
		WithEnvVariables(
			[]dagger.EnvVars{
			{Name: "toto", Value: "tata"},
			{Name: "toto", Value: "tata"},
			{Name: "toto", Value: "tata"},
			{Name: "tutu", Value: "titi"},
		}).
		EnvVariables(ctx)

	if err != nil {
		panic(err)
	}

	for _, env := range envs {
		n, _ := env.Name(ctx)
		v, _ := env.Value(ctx)
		fmt.Printf("var [%s:%s]\n", n, v)
	}
}
```

This PR adds a withEnvVariables method to the Go SDK for improved developer experience. Please review the context and ensure this is the desired approach before I proceed with Node and Python implementations.