### PR TITLE
docs: Clarified Python get started steps

### DIFF
--- a/docs/current/sdk/python/628797-get-started.md
+++ b/docs/current/sdk/python/628797-get-started.md
@@ -37,7 +37,7 @@ The code samples in this tutorial are based on the above FastAPI project. If usi
 The Dagger Python SDK requires [Python 3.10 or later](https://docs.python.org/3/using/index.html). 
 :::
 
-Create a [virtual environment](https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments) for your project (if you don't already have one):
+Create a [virtual environment](https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments) for your project (if you don't already have one). For example:
 
 ```shell
 python3 -m venv .venv && source .venv/bin/activate

--- a/docs/current/sdk/python/628797-get-started.md
+++ b/docs/current/sdk/python/628797-get-started.md
@@ -37,10 +37,12 @@ The code samples in this tutorial are based on the above FastAPI project. If usi
 The Dagger Python SDK requires [Python 3.10 or later](https://docs.python.org/3/using/index.html). 
 :::
 
-Create a [virtual environment](https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments) for your project (if you don't already have one). Example:
+Create a [virtual environment](https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments) for your project (if you don't already have one):
 
 ```shell
 python3 -m venv .venv && source .venv/bin/activate
+```
+
 Install the Dagger Python SDK in your project's virtual environment using `pip`:
 
 ```shell

--- a/docs/current/sdk/python/628797-get-started.md
+++ b/docs/current/sdk/python/628797-get-started.md
@@ -34,7 +34,7 @@ The code samples in this tutorial are based on the above FastAPI project. If usi
 ## Step 1: Install the Dagger Python SDK
 
 :::note
-The Dagger Python SDK requires [Python 3.10 or later](https://docs.python.org/3/using/index.html). 
+The Dagger Python SDK requires [Python 3.10 or later](https://docs.python.org/3/using/index.html).
 :::
 
 Create a [virtual environment](https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments) for your project (if you don't already have one). For example:

--- a/docs/current/sdk/python/628797-get-started.md
+++ b/docs/current/sdk/python/628797-get-started.md
@@ -37,6 +37,12 @@ The code samples in this tutorial are based on the above FastAPI project. If usi
 The Dagger Python SDK requires [Python 3.10 or later](https://docs.python.org/3/using/index.html). Using a [virtual environment](https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments) is recommended.
 :::
 
+Create a virtual environment for your project (if you don't already have one):
+
+```shell
+python3 -m venv .venv && source .venv/bin/activate
+```
+
 Install the Dagger Python SDK in your project's virtual environment using `pip`:
 
 ```shell

--- a/docs/current/sdk/python/628797-get-started.md
+++ b/docs/current/sdk/python/628797-get-started.md
@@ -34,15 +34,13 @@ The code samples in this tutorial are based on the above FastAPI project. If usi
 ## Step 1: Install the Dagger Python SDK
 
 :::note
-The Dagger Python SDK requires [Python 3.10 or later](https://docs.python.org/3/using/index.html). Using a [virtual environment](https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments) is recommended.
+The Dagger Python SDK requires [Python 3.10 or later](https://docs.python.org/3/using/index.html). 
 :::
 
-Create a virtual environment for your project (if you don't already have one):
+Create a [virtual environment](https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments) for your project (if you don't already have one). Example:
 
 ```shell
 python3 -m venv .venv && source .venv/bin/activate
-```
-
 Install the Dagger Python SDK in your project's virtual environment using `pip`:
 
 ```shell


### PR DESCRIPTION
This commit adds additional optional instructions for creating a Python virtual environment in the Python SDK get started guide.

Closes #5027 