### PR TITLE
engine: Ensure that dnsmasq subprocess is killed

### DIFF
--- a/core/integration/engine_test.go
+++ b/core/integration/engine_test.go
@@ -25,6 +25,7 @@ func devEngineContainer(c *dagger.Client) *dagger.Container {
 	tarFileName := filepath.Base(tarPath)
 	devEngineTar := c.Host().Directory(parentDir, dagger.HostDirectoryOpts{Include: []string{tarFileName}}).File(tarFileName)
 	return c.Container().Import(devEngineTar).
+		WithEnvVariable("GOTRACEBACK", "all"). // if something goes wrong, dump all the goroutines
 		WithExposedPort(1234, dagger.ContainerWithExposedPortOpts{Protocol: dagger.Tcp})
 }
 
@@ -38,7 +39,7 @@ func TestEngineExitsZeroOnSignal(t *testing.T) {
 	_, err := devEngineContainer(c).
 		WithNewFile("/usr/local/bin/dagger-entrypoint.sh", dagger.ContainerWithNewFileOpts{
 			Contents: `#!/bin/sh
-env
+set -ex
 /usr/local/bin/dagger-engine --debug &
 engine_pid=$!
 

--- a/network/dnsmasq.go
+++ b/network/dnsmasq.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"fmt"
 	"html/template"
 	"os"
@@ -8,7 +9,7 @@ import (
 	"path/filepath"
 )
 
-func InstallDnsmasq(name string) error {
+func InstallDnsmasq(ctx context.Context, name string) error {
 	dnsmasqPath, err := exec.LookPath("dnsmasq")
 	if err != nil {
 		return err
@@ -33,7 +34,7 @@ func InstallDnsmasq(name string) error {
 		return fmt.Errorf("write dnsmasq.conf: %w", err)
 	}
 
-	dnsmasq := exec.Command(
+	dnsmasq := exec.CommandContext(ctx,
 		dnsmasqPath,
 		"--keep-in-foreground",
 		"--log-facility=-",


### PR DESCRIPTION
@vito the engine exit test caught something with the dnsmasq changes, just needed to update the child proc to use CommandContext