### PR TITLE
core: Implicitly call `entrypoint` + `defaultArgs` when needed

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -996,6 +996,10 @@ func (container *Container) WithExec(ctx context.Context, gw bkgw.Client, defaul
 		args = append(cfg.Entrypoint, args...)
 	}
 
+	if len(args) == 0 {
+		return nil, errors.New("no command has been set")
+	}
+
 	runOpts := []llb.RunOption{
 		llb.Args(args),
 		container.Pipeline.LLBOpt(),

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3177,6 +3177,16 @@ func TestContainerNoExec(t *testing.T) {
 	stderr, err := c.Container().From("alpine:3.16.2").Stderr(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "", stderr)
+
+	_, err = c.Container().
+		From("alpine:3.16.2").
+		WithDefaultArgs(dagger.ContainerWithDefaultArgsOpts{
+			Args: nil,
+		}).
+		ExitCode(ctx)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no command has been set")
 }
 
 func TestContainerWithMountedFileOwner(t *testing.T) {

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -153,7 +153,7 @@ ENV FOO=bar
 CMD goenv
 `)
 
-		env, err := c.Container().Build(src).WithExec([]string{}).Stdout(ctx)
+		env, err := c.Container().Build(src).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, env, "FOO=bar\n")
 	})
@@ -172,7 +172,7 @@ CMD goenv
 
 		env, err := c.Container().Build(src, dagger.ContainerBuildOpts{
 			Dockerfile: "subdir/Dockerfile.whee",
-		}).WithExec([]string{}).Stdout(ctx)
+		}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, env, "FOO=bar\n")
 	})
@@ -191,7 +191,7 @@ CMD goenv
 
 		sub := c.Directory().WithDirectory("subcontext", src).Directory("subcontext")
 
-		env, err := c.Container().Build(sub).WithExec([]string{}).Stdout(ctx)
+		env, err := c.Container().Build(sub).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, env, "FOO=bar\n")
 	})
@@ -212,7 +212,7 @@ CMD goenv
 
 		env, err := c.Container().Build(sub, dagger.ContainerBuildOpts{
 			Dockerfile: "subdir/Dockerfile.whee",
-		}).WithExec([]string{}).Stdout(ctx)
+		}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, env, "FOO=bar\n")
 	})
@@ -230,11 +230,11 @@ ENV FOO=$FOOARG
 CMD goenv
 `)
 
-		env, err := c.Container().Build(src).WithExec([]string{}).Stdout(ctx)
+		env, err := c.Container().Build(src).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, env, "FOO=bar\n")
 
-		env, err = c.Container().Build(src, dagger.ContainerBuildOpts{BuildArgs: []dagger.BuildArg{{Name: "FOOARG", Value: "barbar"}}}).WithExec([]string{}).Stdout(ctx)
+		env, err = c.Container().Build(src, dagger.ContainerBuildOpts{BuildArgs: []dagger.BuildArg{{Name: "FOOARG", Value: "barbar"}}}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, env, "FOO=barbar\n")
 	})
@@ -252,11 +252,11 @@ FROM base AS stage2
 CMD echo "stage2"
 `)
 
-		output, err := c.Container().Build(src).WithExec([]string{}).Stdout(ctx)
+		output, err := c.Container().Build(src).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, output, "stage2\n")
 
-		output, err = c.Container().Build(src, dagger.ContainerBuildOpts{Target: "stage1"}).WithExec([]string{}).Stdout(ctx)
+		output, err = c.Container().Build(src, dagger.ContainerBuildOpts{Target: "stage1"}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, output, "stage1\n")
 		require.NotContains(t, output, "stage2\n")
@@ -277,7 +277,7 @@ CMD cat /secret
 
 		stdout, err := c.Container().Build(src, dagger.ContainerBuildOpts{
 			Secrets: []*dagger.Secret{sec},
-		}).WithExec([]string{}).Stdout(ctx)
+		}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, stdout, "***")
 	})
@@ -3162,21 +3162,21 @@ func TestContainerInsecureRootCapabilitesWithService(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("%s-from-outside\n%s-from-inside\n", randID, randID), out)
 }
 
-func TestContainerNoExecError(t *testing.T) {
+func TestContainerNoExec(t *testing.T) {
 	c, ctx := connect(t)
 	defer c.Close()
 
-	_, err := c.Container().From("alpine:3.16.2").ExitCode(ctx)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), core.ErrContainerNoExec.Error())
+	code, err := c.Container().From("alpine:3.16.2").ExitCode(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, code)
 
-	_, err = c.Container().From("alpine:3.16.2").Stdout(ctx)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), core.ErrContainerNoExec.Error())
+	stdout, err := c.Container().From("alpine:3.16.2").Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "", stdout)
 
-	_, err = c.Container().From("alpine:3.16.2").Stderr(ctx)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), core.ErrContainerNoExec.Error())
+	stderr, err := c.Container().From("alpine:3.16.2").Stderr(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "", stderr)
 }
 
 func TestContainerWithMountedFileOwner(t *testing.T) {

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -639,7 +639,7 @@ ENV FOO=bar
 CMD goenv
 `)
 
-		env, err := src.DockerBuild().WithExec([]string{}).Stdout(ctx)
+		env, err := src.DockerBuild().Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, env, "FOO=bar\n")
 	})
@@ -658,7 +658,7 @@ CMD goenv
 
 		env, err := src.DockerBuild(dagger.DirectoryDockerBuildOpts{
 			Dockerfile: "subdir/Dockerfile.whee",
-		}).WithExec([]string{}).Stdout(ctx)
+		}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, env, "FOO=bar\n")
 	})
@@ -677,7 +677,7 @@ CMD goenv
 
 		sub := c.Directory().WithDirectory("subcontext", src).Directory("subcontext")
 
-		env, err := sub.DockerBuild().WithExec([]string{}).Stdout(ctx)
+		env, err := sub.DockerBuild().Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, env, "FOO=bar\n")
 	})
@@ -698,7 +698,7 @@ CMD goenv
 
 		env, err := sub.DockerBuild(dagger.DirectoryDockerBuildOpts{
 			Dockerfile: "subdir/Dockerfile.whee",
-		}).WithExec([]string{}).Stdout(ctx)
+		}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, env, "FOO=bar\n")
 	})
@@ -716,11 +716,11 @@ ENV FOO=$FOOARG
 CMD goenv
 `)
 
-		env, err := src.DockerBuild().WithExec([]string{}).Stdout(ctx)
+		env, err := src.DockerBuild().Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, env, "FOO=bar\n")
 
-		env, err = src.DockerBuild(dagger.DirectoryDockerBuildOpts{BuildArgs: []dagger.BuildArg{{Name: "FOOARG", Value: "barbar"}}}).WithExec([]string{}).Stdout(ctx)
+		env, err = src.DockerBuild(dagger.DirectoryDockerBuildOpts{BuildArgs: []dagger.BuildArg{{Name: "FOOARG", Value: "barbar"}}}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, env, "FOO=barbar\n")
 	})
@@ -738,13 +738,13 @@ FROM base AS stage2
 CMD echo "stage2"
 `)
 
-		output, err := src.DockerBuild().WithExec([]string{}).Stdout(ctx)
+		output, err := src.DockerBuild().Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, output, "stage2\n")
 
 		output, err = src.DockerBuild(dagger.DirectoryDockerBuildOpts{
 			Target: "stage1",
-		}).WithExec([]string{}).Stdout(ctx)
+		}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, output, "stage1\n")
 		require.NotContains(t, output, "stage2\n")
@@ -762,7 +762,7 @@ RUN --mount=type=secret,id=my-secret cp /run/secrets/my-secret  /secret
 CMD cat /secret
 `)
 
-		stdout, err := src.DockerBuild(dagger.DirectoryDockerBuildOpts{Secrets: []*dagger.Secret{sec}}).WithExec([]string{}).Stdout(ctx)
+		stdout, err := src.DockerBuild(dagger.DirectoryDockerBuildOpts{Secrets: []*dagger.Secret{sec}}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, stdout, "***")
 	})

--- a/core/integration/remotecache_test.go
+++ b/core/integration/remotecache_test.go
@@ -49,8 +49,7 @@ func TestRemoteCacheRegistry(t *testing.T) {
 
 	registry := c.Pipeline("registry").Container().From("registry:2").
 		WithMountedCache("/var/lib/registry/", c.CacheVolume("remote-cache-registry-"+identity.NewID())).
-		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.Tcp}).
-		WithExec(nil)
+		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.Tcp})
 
 	cacheEnv := "type=registry,ref=registry:5000/test-cache,mode=max"
 

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -352,7 +352,7 @@ func TestContainerExecServicesError(t *testing.T) {
 	require.Contains(t, err.Error(), "start "+host+" (aliased as www): exited:")
 }
 
-func TestContainerServiceNoExecError(t *testing.T) {
+func TestContainerServiceNoExec(t *testing.T) {
 	t.Parallel()
 
 	checkNotDisabled(t, engine.ServicesDNSEnvName)
@@ -365,23 +365,6 @@ func TestContainerServiceNoExecError(t *testing.T) {
 		WithExposedPort(8080)
 
 	_, err := srv.Hostname(ctx)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), core.ErrContainerNoExec.Error())
-
-	client := c.Container().
-		From("alpine:3.16.2").
-		WithServiceBinding("www", srv).
-		WithExec([]string{"wget", "http://www:8080"})
-
-	_, err = client.ExitCode(ctx)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), core.ErrContainerNoExec.Error())
-
-	_, err = client.Stdout(ctx)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), core.ErrContainerNoExec.Error())
-
-	_, err = client.Stderr(ctx)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), core.ErrContainerNoExec.Error())
 }
@@ -556,7 +539,6 @@ CMD cat index.html
 		fileContent, err := c.Container().
 			WithServiceBinding("www", srv).
 			Build(src).
-			WithExec(nil).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, content, fileContent)
@@ -583,7 +565,6 @@ CMD cat index.html
 		fileContent, err := c.Container().
 			WithServiceBinding("www", srv).
 			Build(gitDir).
-			WithExec(nil).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, content, fileContent)
@@ -610,7 +591,6 @@ CMD cat index.html
 		fileContent, err := gitDir.
 			DockerBuild().
 			WithServiceBinding("www", srv).
-			WithExec(nil).
 			Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, content, fileContent)

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -121,8 +121,11 @@ func TestContainerHostnameEndpoint(t *testing.T) {
 
 		ep, err := srv.Endpoint(ctx)
 		require.NoError(t, err)
-
 		require.Equal(t, hn+":8000", ep)
+
+		exp, err := srv.WithExec(nil).Hostname(ctx)
+		require.NoError(t, err)
+		require.Equal(t, hn, exp)
 	})
 
 	t.Run("endpoint can specify arbitrary port", func(t *testing.T) {
@@ -386,10 +389,6 @@ func TestContainerServiceNoExec(t *testing.T) {
 
 	host, err := srv.Hostname(ctx)
 	require.NoError(t, err)
-
-	host2, err := srv.WithExec(nil).Hostname(ctx)
-	require.NoError(t, err)
-	require.Equal(t, host, host2)
 
 	client := c.Container().
 		From("alpine:3.16.2").

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -352,7 +352,7 @@ func TestContainerExecServicesError(t *testing.T) {
 	require.Contains(t, err.Error(), "start "+host+" (aliased as www): exited:")
 }
 
-func TestContainerServiceNoExec(t *testing.T) {
+func TestContainerServiceNoExecError(t *testing.T) {
 	t.Parallel()
 
 	checkNotDisabled(t, engine.ServicesDNSEnvName)

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -743,7 +743,7 @@ func (s *containerSchema) withServiceBinding(ctx *router.Context, parent *core.C
 		return nil, err
 	}
 
-	return parent.WithServiceBinding(svc, args.Alias)
+	return parent.WithServiceBinding(ctx, s.gw, svc, args.Alias)
 }
 
 type containerWithExposedPortArgs struct {

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -498,6 +498,8 @@ type Container {
   withExec(
     """
     Command to run instead of the container's default command (e.g., ["run", "main.go"]).
+
+    If empty, the container's default command is used.
     """
     args: [String!]!
 
@@ -572,19 +574,22 @@ type Container {
 
   """
   Exit code of the last executed command. Zero means success.
-  Errors if no command has been executed.
+
+  Will execute default command if none is set, or error if there's no default.
   """
   exitCode: Int!
 
   """
   The output stream of the last executed command.
-  Errors if no command has been executed.
+
+  Will execute default command if none is set, or error if there's no default.
   """
   stdout: String!
 
   """
   The error stream of the last executed command.
-  Errors if no command has been executed.
+
+  Will execute default command if none is set, or error if there's no default.
   """
   stderr: String!
 
@@ -719,7 +724,10 @@ type Container {
   exposedPorts: [Port!]!
 
   """
-  Establish a runtime dependency on a service. The service will be started automatically when needed and detached when it is no longer needed.
+  Establish a runtime dependency on a service.
+
+  The service will be started automatically when needed and detached when it is
+  no longer needed, executing the default command if none is set.
 
   The service will be reachable from the container via the provided hostname alias.
 

--- a/docs/current/guides/snippets/use-services/persist-service-state/index.ts
+++ b/docs/current/guides/snippets/use-services/persist-service-state/index.ts
@@ -7,8 +7,7 @@ connect(
       .from('redis')
       .withExposedPort(6379)
       .withMountedCache('/data', client.cacheVolume('my-redis'))
-      .withWorkdir('/data')
-      .withExec([]);
+      .withWorkdir('/data');
 
     // create Redis client container
     const redisCLI = client

--- a/docs/current/guides/snippets/use-services/persist-service-state/main.go
+++ b/docs/current/guides/snippets/use-services/persist-service-state/main.go
@@ -24,8 +24,7 @@ func main() {
 		From("redis").
 		WithExposedPort(6379).
 		WithMountedCache("/data", client.CacheVolume("my-redis")).
-		WithWorkdir("/data").
-		WithExec(nil)
+		WithWorkdir("/data")
 
 	// create Redis client container
 	redisCLI := client.Container().

--- a/docs/current/guides/snippets/use-services/persist-service-state/main.py
+++ b/docs/current/guides/snippets/use-services/persist-service-state/main.py
@@ -14,7 +14,6 @@ async def main():
             .with_exposed_port(6379)
             .with_mounted_cache("/data", client.cache_volume("my-redis"))
             .with_workdir("/data")
-            .with_exec([])
         )
 
         # create Redis client container

--- a/docs/current/guides/snippets/use-services/test-service-lifecycle-1/index.ts
+++ b/docs/current/guides/snippets/use-services/test-service-lifecycle-1/index.ts
@@ -7,8 +7,7 @@ connect(
     const redisSrv = client
       .container()
       .from('redis')
-      .withExposedPort(6379)
-      .withExec([]);
+      .withExposedPort(6379);
 
     // create Redis client container
     const redisCLI = client

--- a/docs/current/guides/snippets/use-services/test-service-lifecycle-1/main.go
+++ b/docs/current/guides/snippets/use-services/test-service-lifecycle-1/main.go
@@ -22,8 +22,7 @@ func main() {
 	// create Redis service container
 	redisSrv := client.Container().
 		From("redis").
-		WithExposedPort(6379).
-		WithExec(nil)
+		WithExposedPort(6379)
 
 	// create Redis client container
 	redisCLI := client.Container().

--- a/docs/current/guides/snippets/use-services/test-service-lifecycle-1/main.py
+++ b/docs/current/guides/snippets/use-services/test-service-lifecycle-1/main.py
@@ -9,7 +9,7 @@ async def main():
     async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
         # create Redis service container
         redis_srv = (
-            client.container().from_("redis").with_exposed_port(6379).with_exec([])
+            client.container().from_("redis").with_exposed_port(6379)
         )
 
         # create Redis client container

--- a/docs/current/guides/snippets/use-services/test-service-lifecycle-2/index.ts
+++ b/docs/current/guides/snippets/use-services/test-service-lifecycle-2/index.ts
@@ -6,8 +6,7 @@ connect(
     const redisSrv = client
       .container()
       .from('redis')
-      .withExposedPort(6379)
-      .withExec([]);
+      .withExposedPort(6379);
 
     // create Redis client container
     const redisCLI = client

--- a/docs/current/guides/snippets/use-services/test-service-lifecycle-2/main.go
+++ b/docs/current/guides/snippets/use-services/test-service-lifecycle-2/main.go
@@ -22,8 +22,7 @@ func main() {
 	// create Redis service container
 	redisSrv := client.Container().
 		From("redis").
-		WithExposedPort(6379).
-		WithExec(nil)
+		WithExposedPort(6379)
 
 	// create Redis client container
 	redisCLI := client.Container().

--- a/docs/current/guides/snippets/use-services/test-service-lifecycle-2/main.py
+++ b/docs/current/guides/snippets/use-services/test-service-lifecycle-2/main.py
@@ -9,7 +9,7 @@ async def main():
     async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
         # create Redis service container
         redis_srv = (
-            client.container().from_("redis").with_exposed_port(6379).with_exec([])
+            client.container().from_("redis").with_exposed_port(6379)
         )
 
         # create Redis client container

--- a/docs/current/guides/snippets/use-services/test-service-lifecycle-3/index.ts
+++ b/docs/current/guides/snippets/use-services/test-service-lifecycle-3/index.ts
@@ -6,8 +6,7 @@ connect(
     const redisSrv = client
       .container()
       .from('redis')
-      .withExposedPort(6379)
-      .withExec([]);
+      .withExposedPort(6379);
 
     // create Redis client container
     const redisCLI = client

--- a/docs/current/guides/snippets/use-services/test-service-lifecycle-3/main.go
+++ b/docs/current/guides/snippets/use-services/test-service-lifecycle-3/main.go
@@ -22,8 +22,7 @@ func main() {
 	// create Redis service container
 	redisSrv := client.Container().
 		From("redis").
-		WithExposedPort(6379).
-		WithExec(nil)
+		WithExposedPort(6379)
 
 	// create Redis client container
 	redisCLI := client.Container().

--- a/docs/current/guides/snippets/use-services/test-service-lifecycle-3/main.py
+++ b/docs/current/guides/snippets/use-services/test-service-lifecycle-3/main.py
@@ -9,7 +9,7 @@ async def main():
     async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
         # create Redis service container
         redis_srv = (
-            client.container().from_("redis").with_exposed_port(6379).with_exec([])
+            client.container().from_("redis").with_exposed_port(6379)
         )
 
         # create Redis client container

--- a/docs/current/guides/snippets/use-services/use-db-service/index.ts
+++ b/docs/current/guides/snippets/use-services/use-db-service/index.ts
@@ -11,8 +11,7 @@ connect(
       .withEnvVariable("MARIADB_PASSWORD", "password")
       .withEnvVariable("MARIADB_DATABASE", "drupal")
       .withEnvVariable("MARIADB_ROOT_PASSWORD", "root")
-      .withExposedPort(3306)
-      .withExec([]);
+      .withExposedPort(3306);
 
   	// get Drupal base image
   	// install additional dependencies

--- a/docs/current/guides/snippets/use-services/use-db-service/main.go
+++ b/docs/current/guides/snippets/use-services/use-db-service/main.go
@@ -26,8 +26,7 @@ func main() {
 		WithEnvVariable("MARIADB_PASSWORD", "password").
 		WithEnvVariable("MARIADB_DATABASE", "drupal").
 		WithEnvVariable("MARIADB_ROOT_PASSWORD", "root").
-		WithExposedPort(3306).
-		WithExec(nil)
+		WithExposedPort(3306)
 
 	// get Drupal base image
 	// install additional dependencies

--- a/docs/current/guides/snippets/use-services/use-db-service/main.py
+++ b/docs/current/guides/snippets/use-services/use-db-service/main.py
@@ -17,11 +17,10 @@ async def main():
             .with_env_variable("MARIADB_DATABASE", "drupal")
             .with_env_variable("MARIADB_ROOT_PASSWORD", "root")
             .with_exposed_port(3306)
-            .with_exec([])
         )
 
-      	# get Drupal base image
-      	# install additional dependencies
+        # get Drupal base image
+        # install additional dependencies
         drupal = (
             client
             .container()

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -349,7 +349,8 @@ func (r *Container) Exec(opts ...ContainerExecOpts) *Container {
 }
 
 // Exit code of the last executed command. Zero means success.
-// Errors if no command has been executed.
+//
+// Will execute default command if none is set, or error if there's no default.
 func (r *Container) ExitCode(ctx context.Context) (int, error) {
 	if r.exitCode != nil {
 		return *r.exitCode, nil
@@ -691,7 +692,8 @@ func (r *Container) Rootfs() *Directory {
 }
 
 // The error stream of the last executed command.
-// Errors if no command has been executed.
+//
+// Will execute default command if none is set, or error if there's no default.
 func (r *Container) Stderr(ctx context.Context) (string, error) {
 	if r.stderr != nil {
 		return *r.stderr, nil
@@ -705,7 +707,8 @@ func (r *Container) Stderr(ctx context.Context) (string, error) {
 }
 
 // The output stream of the last executed command.
-// Errors if no command has been executed.
+//
+// Will execute default command if none is set, or error if there's no default.
 func (r *Container) Stdout(ctx context.Context) (string, error) {
 	if r.stdout != nil {
 		return *r.stdout, nil
@@ -1236,7 +1239,10 @@ func (r *Container) WithSecretVariable(name string, secret *Secret) *Container {
 	}
 }
 
-// Establish a runtime dependency on a service. The service will be started automatically when needed and detached when it is no longer needed.
+// Establish a runtime dependency on a service.
+//
+// The service will be started automatically when needed and detached when it is
+// no longer needed, executing the default command if none is set.
 //
 // The service will be reachable from the container via the provided hostname alias.
 //

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -844,7 +844,8 @@ export class Container extends BaseClient {
 
   /**
    * Exit code of the last executed command. Zero means success.
-   * Errors if no command has been executed.
+   *
+   * Will execute default command if none is set, or error if there's no default.
    */
   async exitCode(): Promise<number> {
     const response: Awaited<number> = await computeQuery(
@@ -1170,7 +1171,8 @@ export class Container extends BaseClient {
 
   /**
    * The error stream of the last executed command.
-   * Errors if no command has been executed.
+   *
+   * Will execute default command if none is set, or error if there's no default.
    */
   async stderr(): Promise<string> {
     const response: Awaited<string> = await computeQuery(
@@ -1188,7 +1190,8 @@ export class Container extends BaseClient {
 
   /**
    * The output stream of the last executed command.
-   * Errors if no command has been executed.
+   *
+   * Will execute default command if none is set, or error if there's no default.
    */
   async stdout(): Promise<string> {
     const response: Awaited<string> = await computeQuery(
@@ -1309,6 +1312,8 @@ export class Container extends BaseClient {
   /**
    * Retrieves this container after executing the specified command inside it.
    * @param args Command to run instead of the container's default command (e.g., ["run", "main.go"]).
+   *
+   * If empty, the container's default command is used.
    * @param opts.skipEntrypoint If the container has an entrypoint, ignore it for args rather than using it to wrap them.
    * @param opts.stdin Content to write to the command's standard input before closing (e.g., "Hello world").
    * @param opts.redirectStdout Redirect the command's standard output to a file in the container (e.g., "/tmp/stdout").
@@ -1658,7 +1663,10 @@ export class Container extends BaseClient {
   }
 
   /**
-   * Establish a runtime dependency on a service. The service will be started automatically when needed and detached when it is no longer needed.
+   * Establish a runtime dependency on a service.
+   *
+   * The service will be started automatically when needed and detached when it is
+   * no longer needed, executing the default command if none is set.
    *
    * The service will be reachable from the container via the provided hostname alias.
    *

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -342,7 +342,9 @@ class Container(Type):
     @typecheck
     async def exit_code(self) -> int:
         """Exit code of the last executed command. Zero means success.
-        Errors if no command has been executed.
+
+        Will execute default command if none is set, or error if there's no
+        default.
 
         Returns
         -------
@@ -714,7 +716,9 @@ class Container(Type):
     @typecheck
     async def stderr(self) -> str:
         """The error stream of the last executed command.
-        Errors if no command has been executed.
+
+        Will execute default command if none is set, or error if there's no
+        default.
 
         Returns
         -------
@@ -737,7 +741,9 @@ class Container(Type):
     @typecheck
     async def stdout(self) -> str:
         """The output stream of the last executed command.
-        Errors if no command has been executed.
+
+        Will execute default command if none is set, or error if there's no
+        default.
 
         Returns
         -------
@@ -889,6 +895,7 @@ class Container(Type):
         args:
             Command to run instead of the container's default command (e.g.,
             ["run", "main.go"]).
+            If empty, the container's default command is used.
         skip_entrypoint:
             If the container has an entrypoint, ignore it for args rather than
             using it to wrap them.
@@ -1268,9 +1275,11 @@ class Container(Type):
 
     @typecheck
     def with_service_binding(self, alias: str, service: "Container") -> "Container":
-        """Establish a runtime dependency on a service. The service will be
-        started automatically when needed and detached when it is no longer
-        needed.
+        """Establish a runtime dependency on a service.
+
+        The service will be started automatically when needed and detached
+        when it is
+        no longer needed, executing the default command if none is set.
 
         The service will be reachable from the container via the provided
         hostname alias.

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -342,7 +342,9 @@ class Container(Type):
     @typecheck
     def exit_code(self) -> int:
         """Exit code of the last executed command. Zero means success.
-        Errors if no command has been executed.
+
+        Will execute default command if none is set, or error if there's no
+        default.
 
         Returns
         -------
@@ -714,7 +716,9 @@ class Container(Type):
     @typecheck
     def stderr(self) -> str:
         """The error stream of the last executed command.
-        Errors if no command has been executed.
+
+        Will execute default command if none is set, or error if there's no
+        default.
 
         Returns
         -------
@@ -737,7 +741,9 @@ class Container(Type):
     @typecheck
     def stdout(self) -> str:
         """The output stream of the last executed command.
-        Errors if no command has been executed.
+
+        Will execute default command if none is set, or error if there's no
+        default.
 
         Returns
         -------
@@ -889,6 +895,7 @@ class Container(Type):
         args:
             Command to run instead of the container's default command (e.g.,
             ["run", "main.go"]).
+            If empty, the container's default command is used.
         skip_entrypoint:
             If the container has an entrypoint, ignore it for args rather than
             using it to wrap them.
@@ -1268,9 +1275,11 @@ class Container(Type):
 
     @typecheck
     def with_service_binding(self, alias: str, service: "Container") -> "Container":
-        """Establish a runtime dependency on a service. The service will be
-        started automatically when needed and detached when it is no longer
-        needed.
+        """Establish a runtime dependency on a service.
+
+        The service will be started automatically when needed and detached
+        when it is
+        no longer needed, executing the default command if none is set.
 
         The service will be reachable from the container via the provided
         hostname alias.


### PR DESCRIPTION
Fixes #4833, DAG-282

## Before

You had to add an unintuitive `WithExec(nil)` to execute the *`entrypoint` + `defaultArgs`*, otherwise a *“no command has been executed”* error would be returned. This was confusing to some users.

```diff
_, err := client.Container().
    Build(src).
+   WithExec(nil).
    ExitCode(ctx)
```

```diff
db := client.Container().From("postgres").
     WithExposedPort(5432).
+    WithExec(nil)
ctr := app.WithServiceBinding("db", db)
```

## After

Using `ExitCode`, `Stdout`, `Stderr` and `WithServiceBinding` will now implicitly add the `WithExec(nil)` to run default command:

```go
// ✅ ExitCode → needs execution so use default exec
_, err := c.Container().From("alpine").ExitCode(ctx)
```

```go
// ✅ WithServiceBinding → needs execution so use default exec
db := client.Container().From("postgres").WithExposedPort(5432)
ctr := app.WithServiceBinding("db", db)
```

Signed-off-by: Helder Correia