### PR TITLE
Add support for pushing engine logs to cloud

### DIFF
--- a/cmd/engine/debug.go
+++ b/cmd/engine/debug.go
@@ -1,14 +1,26 @@
 package main
 
 import (
+	"context"
 	"expvar"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/pprof"
 	"runtime"
+	"strconv"
+	"time"
 
+	"github.com/mackerelio/go-osstat/cpu"
+	"github.com/mackerelio/go-osstat/loadavg"
+	"github.com/mackerelio/go-osstat/memory"
+	"github.com/mackerelio/go-osstat/uptime"
+	"github.com/moby/buildkit/util/bklog"
+	"github.com/prometheus/procfs"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/constraints"
 	"golang.org/x/net/trace"
+	"golang.org/x/sys/unix"
 )
 
 func setupDebugHandlers(addr string) error {
@@ -41,4 +53,123 @@ func setupDebugHandlers(addr string) error {
 	logrus.Debugf("debug handlers listening at %s", addr)
 	go http.Serve(l, m) // nolint:gosec
 	return nil
+}
+
+func logMetrics(ctx context.Context, engineStateRootDir string) {
+	for range time.Tick(60 * time.Second) {
+		l := bklog.G(ctx)
+
+		// system cpu stats
+		cpuStats, err := cpu.Get()
+		if err == nil {
+			l = withUnsignedIntField(l, "cpu-total", cpuStats.Total)
+			l = withUnsignedIntField(l, "cpu-user", cpuStats.User)
+			l = withUnsignedIntField(l, "cpu-nice", cpuStats.Nice)
+			l = withUnsignedIntField(l, "cpu-system", cpuStats.System)
+			l = withUnsignedIntField(l, "cpu-idle", cpuStats.Idle)
+			l = withUnsignedIntField(l, "cpu-iowait", cpuStats.Iowait)
+			l = withUnsignedIntField(l, "cpu-irq", cpuStats.Irq)
+			l = withUnsignedIntField(l, "cpu-softirq", cpuStats.Softirq)
+			l = withUnsignedIntField(l, "cpu-steal", cpuStats.Steal)
+			l = withSignedIntField(l, "cpu-count", cpuStats.CPUCount)
+		} else {
+			l = l.WithField("cpu-error", err.Error())
+		}
+
+		// system loadavg stats
+		loadAvgStats, err := loadavg.Get()
+		if err == nil {
+			l = withFloatField(l, "loadavg-1", loadAvgStats.Loadavg1)
+			l = withFloatField(l, "loadavg-5", loadAvgStats.Loadavg5)
+			l = withFloatField(l, "loadavg-15", loadAvgStats.Loadavg15)
+		} else {
+			l = l.WithField("loadavg-error", err.Error())
+		}
+
+		// system memory stats
+		memStats, err := memory.Get()
+		if err == nil {
+			l = withUnsignedIntField(l, "mem-total", memStats.Total)
+			l = withUnsignedIntField(l, "mem-free", memStats.Used)
+			l = withUnsignedIntField(l, "mem-available", memStats.Available)
+			l = withUnsignedIntField(l, "mem-buffers", memStats.Buffers)
+			l = withUnsignedIntField(l, "mem-cached", memStats.Cached)
+			l = withUnsignedIntField(l, "mem-active", memStats.Active)
+			l = withUnsignedIntField(l, "mem-inactive", memStats.Inactive)
+			l = withUnsignedIntField(l, "mem-swap-cached", memStats.SwapCached)
+			l = withUnsignedIntField(l, "mem-swap-total", memStats.SwapTotal)
+			l = withUnsignedIntField(l, "mem-swap-free", memStats.SwapFree)
+			l = withUnsignedIntField(l, "mem-mapped", memStats.Mapped)
+			l = withUnsignedIntField(l, "mem-shmem", memStats.Shmem)
+			l = withUnsignedIntField(l, "mem-slab", memStats.Slab)
+			l = withUnsignedIntField(l, "mem-page-tables", memStats.PageTables)
+			l = withUnsignedIntField(l, "mem-committed", memStats.Committed)
+			l = withUnsignedIntField(l, "mem-vmalloc-used", memStats.VmallocUsed)
+		} else {
+			l = l.WithField("mem-error", err.Error())
+		}
+
+		// system uptime
+		uptimeDuration, err := uptime.Get()
+		if err == nil {
+			l = withDurationField(l, "uptime", uptimeDuration)
+		} else {
+			l = l.WithField("uptime-error", err.Error())
+		}
+
+		// self stats
+		procSelf, err := procfs.Self()
+		if err == nil {
+			// self memory stats
+			smapsRollup, err := procSelf.ProcSMapsRollup()
+			if err == nil {
+				l = withUnsignedIntField(l, "proc-self-mem-rss", smapsRollup.Rss)
+				l = withUnsignedIntField(l, "proc-self-mem-pss", smapsRollup.Pss)
+				l = withUnsignedIntField(l, "proc-self-mem-shared-clean", smapsRollup.SharedClean)
+				l = withUnsignedIntField(l, "proc-self-mem-shared-dirty", smapsRollup.SharedDirty)
+				l = withUnsignedIntField(l, "proc-self-mem-private-clean", smapsRollup.PrivateClean)
+				l = withUnsignedIntField(l, "proc-self-mem-private-dirty", smapsRollup.PrivateDirty)
+				l = withUnsignedIntField(l, "proc-self-mem-referenced", smapsRollup.Referenced)
+				l = withUnsignedIntField(l, "proc-self-mem-anonymous", smapsRollup.Anonymous)
+				l = withUnsignedIntField(l, "proc-self-mem-swap", smapsRollup.Swap)
+				l = withUnsignedIntField(l, "proc-self-mem-swap-pss", smapsRollup.SwapPss)
+			} else {
+				l = l.WithField("proc-self-mem-error", err.Error())
+			}
+			// TODO: self cpu stats
+		} else {
+			l = l.WithField("proc-self-error", err.Error())
+		}
+
+		// disk usage stats
+		for _, dir := range []string{"/", engineStateRootDir} {
+			var statfs unix.Statfs_t
+			err := unix.Statfs(dir, &statfs)
+			if err == nil {
+				l = withUnsignedIntField(l, fmt.Sprintf("disk-size-%s", dir), statfs.Blocks*uint64(statfs.Bsize))
+				l = withUnsignedIntField(l, fmt.Sprintf("disk-free-%s", dir), statfs.Bfree*uint64(statfs.Bsize))
+				l = withUnsignedIntField(l, fmt.Sprintf("disk-available-%s", dir), statfs.Bavail*uint64(statfs.Bsize))
+			} else {
+				l = l.WithField(fmt.Sprintf("disk-error-%s", dir), err.Error())
+			}
+		}
+
+		l.Debug("engine metrics")
+	}
+}
+
+func withUnsignedIntField[T constraints.Unsigned](l *logrus.Entry, name string, value T) *logrus.Entry {
+	return l.WithField(name, strconv.FormatUint(uint64(value), 10))
+}
+
+func withSignedIntField[T constraints.Signed](l *logrus.Entry, name string, value T) *logrus.Entry {
+	return l.WithField(name, strconv.FormatInt(int64(value), 10))
+}
+
+func withFloatField[T constraints.Float](l *logrus.Entry, name string, value T) *logrus.Entry {
+	return l.WithField(name, strconv.FormatFloat(float64(value), 'f', -1, 64))
+}
+
+func withDurationField(l *logrus.Entry, name string, value time.Duration) *logrus.Entry {
+	return l.WithField(name, value.String())
 }

--- a/cmd/engine/logger.go
+++ b/cmd/engine/logger.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"os"
+
+	"github.com/dagger/dagger/telemetry"
+	"github.com/moby/buildkit/identity"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	engineName string
+	tel        *telemetry.Telemetry
+)
+
+func init() {
+	var ok bool
+	engineName, ok = os.LookupEnv("_EXPERIMENTAL_DAGGER_ENGINE_NAME")
+	if !ok {
+		// use the hostname
+		hostname, err := os.Hostname()
+		if err != nil {
+			engineName = "rand-" + identity.NewID() // random ID as a fallback
+		} else {
+			engineName = hostname
+		}
+	}
+
+	tel = telemetry.New(false)
+	tel.SetRunID("")
+
+	logrus.AddHook(&cloudHook{})
+}
+
+type cloudHook struct {
+}
+
+var _ logrus.Hook = (*cloudHook)(nil)
+
+func (h *cloudHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (h *cloudHook) Fire(entry *logrus.Entry) error {
+	payload := &engineLogPayload{
+		Engine: engineMetadata{
+			Name: engineName,
+		},
+		Message: entry.Message,
+		Level:   entry.Level.String(),
+		Fields:  entry.Data,
+	}
+
+	tel.Push(payload, entry.Time)
+	return nil
+}
+
+type engineLogPayload struct {
+	Engine  engineMetadata `json:"engine"`
+	Message string         `json:"message"`
+	Level   string         `json:"level"`
+	// NOTE: fields includes traceID and spanID, can we use that to correlate with clients?
+	Fields map[string]any `json:"fields"`
+}
+
+func (engineLogPayload) Type() telemetry.EventType {
+	return telemetry.EventType("engine_log")
+}
+
+type engineMetadata struct {
+	Name string `json:"name"`
+}

--- a/cmd/engine/logger.go
+++ b/cmd/engine/logger.go
@@ -27,7 +27,7 @@ func init() {
 	}
 
 	tel = telemetry.New(false)
-	tel.SetRunID("")
+	tel.SetRunID("00000000-0000-0000-0000-000000000000")
 
 	logrus.AddHook(&cloudHook{})
 }

--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -288,6 +288,8 @@ func main() { //nolint:gocyclo
 		}
 		cfg.Root = root
 
+		go logMetrics(context.Background(), cfg.Root)
+
 		if err := os.MkdirAll(root, 0700); err != nil {
 			return errors.Wrapf(err, "failed to create %s", root)
 		}

--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -397,6 +397,7 @@ func main() { //nolint:gocyclo
 	}
 
 	app.After = func(_ *cli.Context) error {
+		tel.Flush()
 		return detect.Shutdown(context.TODO())
 	}
 

--- a/cmd/engine/main_oci_worker.go
+++ b/cmd/engine/main_oci_worker.go
@@ -34,7 +34,6 @@ import (
 	"github.com/dagger/dagger/internal/engine"
 	"github.com/moby/buildkit/cmd/buildkitd/config"
 	"github.com/moby/buildkit/executor/oci"
-	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/entitlements"
@@ -289,17 +288,6 @@ func ociWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([]worker
 	cfg := common.config.Workers.OCI
 
 	// Add a name for this engine to the labels that clients can use to log who they are connected to
-	engineName, ok := os.LookupEnv("_EXPERIMENTAL_DAGGER_ENGINE_NAME")
-	if !ok {
-		// use the hostname
-		hostname, err := os.Hostname()
-		if err != nil {
-			bklog.G(context.Background()).WithError(err).Error("failed to get hostname")
-			engineName = identity.NewID() // random ID as a fallback
-		} else {
-			engineName = hostname
-		}
-	}
 	bklog.G(context.Background()).Debugf("engine name: %s", engineName)
 	cfg.Labels[engine.EngineNameLabel] = engineName
 

--- a/cmd/engine/main_test.go
+++ b/cmd/engine/main_test.go
@@ -88,46 +88,4 @@ func TestEngineNameLabel(t *testing.T) {
 		err := app.Run([]string{"buildkitd"})
 		require.NoError(t, err)
 	})
-	t.Run("env", func(t *testing.T) {
-		existingEnv, ok := os.LookupEnv("_EXPERIMENTAL_DAGGER_ENGINE_NAME")
-		if ok {
-			defer os.Setenv("_EXPERIMENTAL_DAGGER_ENGINE_NAME", existingEnv)
-		} else {
-			defer os.Unsetenv("_EXPERIMENTAL_DAGGER_ENGINE_NAME")
-		}
-		engineName := "wacky-engine"
-		os.Setenv("_EXPERIMENTAL_DAGGER_ENGINE_NAME", engineName)
-		enableRunc := true
-		cfg := &config.Config{}
-		cfg.Root = t.TempDir()
-		cfg.Workers.OCI.Enabled = &enableRunc
-		cfg.Workers.OCI.Binary = "/proc/self/exe"
-		app.Action = func(c *cli.Context) error {
-			err := applyOCIFlags(c, cfg)
-			if err != nil {
-				return err
-			}
-			sessionManager, err := session.NewManager()
-			if err != nil {
-				return err
-			}
-
-			wc, err := newWorkerController(c, workerInitializerOpt{
-				config:         cfg,
-				sessionManager: sessionManager,
-			})
-			if err != nil {
-				return err
-			}
-			w, err := wc.GetDefault()
-			if err != nil {
-				return err
-			}
-			require.Equal(t, engineName, w.Labels()["engineName"])
-			return nil
-		}
-
-		err := app.Run([]string{"buildkitd"})
-		require.NoError(t, err)
-	})
 }

--- a/cmd/upload-journal/main.go
+++ b/cmd/upload-journal/main.go
@@ -28,7 +28,7 @@ func main() {
 	}
 	journal := args[0]
 
-	t := telemetry.New()
+	t := telemetry.New(true)
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)

--- a/core/integration/engine_test.go
+++ b/core/integration/engine_test.go
@@ -84,10 +84,6 @@ func TestEngineSetsNameFromEnv(t *testing.T) {
 	c, ctx := connect(t)
 	defer c.Close()
 
-	// engine should shutdown with exit code 0 when receiving SIGTERM
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
 	engineName := "my-special-engine"
 	devEngine := devEngineContainer(c).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_ENGINE_NAME", engineName).

--- a/core/integration/engine_test.go
+++ b/core/integration/engine_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,6 +28,27 @@ func devEngineContainer(c *dagger.Client) *dagger.Container {
 	return c.Container().Import(devEngineTar).
 		WithEnvVariable("GOTRACEBACK", "all"). // if something goes wrong, dump all the goroutines
 		WithExposedPort(1234, dagger.ContainerWithExposedPortOpts{Protocol: dagger.Tcp})
+}
+
+func engineClientContainer(ctx context.Context, c *dagger.Client, devEngine *dagger.Container) (*dagger.Container, error) {
+	cliPath := os.Getenv("_EXPERIMENTAL_DAGGER_CLI_BIN")
+	if cliPath == "" {
+		return nil, fmt.Errorf("missing _EXPERIMENTAL_DAGGER_CLI_BIN")
+	}
+	parentDir := filepath.Dir(cliPath)
+	baseName := filepath.Base(cliPath)
+	daggerCli := c.Host().Directory(parentDir, dagger.HostDirectoryOpts{Include: []string{baseName}}).File(baseName)
+
+	cliBinPath := "/bin/dagger"
+	endpoint, err := devEngine.Endpoint(ctx, dagger.ContainerEndpointOpts{Port: 1234, Scheme: "tcp"})
+	if err != nil {
+		return nil, err
+	}
+	return c.Container().From("alpine:3.17").
+		WithServiceBinding("dev-engine", devEngine).
+		WithMountedFile(cliBinPath, daggerCli).
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint), nil
 }
 
 func TestEngineExitsZeroOnSignal(t *testing.T) {
@@ -56,4 +78,31 @@ exit $?
 		}).
 		ExitCode(ctx)
 	require.NoError(t, err)
+}
+
+func TestEngineSetsNameFromEnv(t *testing.T) {
+	c, ctx := connect(t)
+	defer c.Close()
+
+	// engine should shutdown with exit code 0 when receiving SIGTERM
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	engineName := "my-special-engine"
+	devEngine := devEngineContainer(c).
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_ENGINE_NAME", engineName).
+		WithExec([]string{"--addr", "tcp://0.0.0.0:1234"}, dagger.ContainerWithExecOpts{
+			InsecureRootCapabilities: true,
+		})
+
+	clientCtr, err := engineClientContainer(ctx, c, devEngine)
+	require.NoError(t, err)
+
+	out, err := clientCtr.
+		WithNewFile("/query.graphql", dagger.ContainerWithNewFileOpts{
+			Contents: `{ defaultPlatform }`}). // arbitrary valid query
+		WithExec([]string{"dagger", "query", "--debug", "--doc", "/query.graphql"}).
+		Stderr(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, "Connected to engine "+engineName)
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -389,7 +389,7 @@ func eventsMultiReader(ch chan *bkclient.SolveStatus, readers ...chan *bkclient.
 }
 
 func uploadTelemetry(ch chan *bkclient.SolveStatus) error {
-	t := telemetry.New()
+	t := telemetry.New(true)
 	defer t.Flush()
 
 	for ev := range ch {

--- a/go.mod
+++ b/go.mod
@@ -65,9 +65,11 @@ require (
 	github.com/go-git/go-git/v5 v5.5.2
 	github.com/google/go-github/v50 v50.1.0
 	github.com/jackpal/gateway v1.0.7
+	github.com/mackerelio/go-osstat v0.2.4
 	github.com/muesli/termenv v0.15.1
 	github.com/nxadm/tail v1.4.8
 	github.com/opencontainers/runc v1.1.6
+	github.com/prometheus/procfs v0.8.0
 	github.com/vito/vt100 v0.0.0-20230324203615-1b9f0c41442c
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 )
@@ -170,7 +172,6 @@ require (
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
-	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -954,6 +954,8 @@ github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQ
 github.com/logrusorgru/aurora/v3 v3.0.0/go.mod h1:vsR12bk5grlLvLXAYrBsb5Oc/N+LxAlxggSjiwMnCUc=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
+github.com/mackerelio/go-osstat v0.2.4 h1:qxGbdPkFo65PXOb/F/nhDKpF2nGmGaCFDLXoZjJTtUs=
+github.com/mackerelio/go-osstat v0.2.4/go.mod h1:Zy+qzGdZs3A9cuIqmgbJvwbmLQH9dJvtio5ZjJTbdlQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -303,6 +303,8 @@ func (t Engine) Dev(ctx context.Context) error {
 		// "--rm",
 		"-e", util.CacheConfigEnvName,
 		"-e", util.ServicesDNSEnvName,
+		"-e", "_EXPERIMENTAL_DAGGER_CLOUD_TOKEN",
+		"-e", "_EXPERIMENTAL_DAGGER_CLOUD_URL",
 		"-v", volumeName + ":" + util.EngineDefaultStateDir,
 		"--name", util.EngineContainerName,
 		"--privileged",

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -36,7 +36,7 @@ type Telemetry struct {
 	doneCh chan struct{}
 }
 
-func New() *Telemetry {
+func New(printURLMessage bool) *Telemetry {
 	t := &Telemetry{
 		runID:  uuid.NewString(),
 		url:    pushURL,
@@ -49,7 +49,9 @@ func New() *Telemetry {
 	if token := os.Getenv("_EXPERIMENTAL_DAGGER_CLOUD_TOKEN"); token != "" {
 		t.token = token
 		t.enable = true
-		fmt.Fprintf(os.Stderr, "Dagger Cloud URL: https://dagger.cloud/runs/%s\n\n", t.runID)
+		if printURLMessage {
+			fmt.Fprintf(os.Stderr, "Dagger Cloud URL: https://dagger.cloud/runs/%s\n\n", t.runID)
+		}
 
 		pts := strings.Split(token, ".")
 
@@ -65,7 +67,7 @@ func New() *Telemetry {
 			jwtClaims := map[string]interface{}{}
 			err = json.Unmarshal(jwtPayload, &jwtClaims)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "could not unmarsjal JWT payload: %v", err)
+				fmt.Fprintf(os.Stderr, "could not unmarshal JWT payload: %v", err)
 				t.enable = false
 			}
 			if v, ok := jwtClaims["id"].(string); ok {


### PR DESCRIPTION
Cloud endpoint is ready and did some load tests, they generated ~50k engine log events over ~30 mins (~28 events/sec) without any obvious performance issues.

Also added a separate commit for logging cpu/mem/disk metrics once a minute