### PR TITLE
docs: Updated embeds to use correct repo

### DIFF
--- a/docs/create_embed_qs.sh
+++ b/docs/create_embed_qs.sh
@@ -18,7 +18,7 @@ query='
   container {
     from(address: "golang") {
       withExec(
-        args: ["sh", "-c", "git clone https://github.com/vikram-dagger/hello-dagger /usr/src/app/hello-dagger"]
+        args: ["sh", "-c", "git clone https://github.com/dagger/hello-dagger /usr/src/app/hello-dagger"]
       ) {
         withWorkdir(path: "/usr/src/app/hello-dagger") {
           withExec(
@@ -46,7 +46,7 @@ query='
   container {
     from(address: "python:3") {
       withExec(
-        args: ["sh", "-c", "git clone https://github.com/vikram-dagger/hello-dagger /usr/src/app/hello-dagger"]
+        args: ["sh", "-c", "git clone https://github.com/dagger/hello-dagger /usr/src/app/hello-dagger"]
       ) {
         withWorkdir(path: "/usr/src/app/hello-dagger") {
           withExec(args: ["sh", "-c", "mkdir ci && pip install dagger-io"]) {
@@ -72,7 +72,7 @@ query='
   container {
     from(address: "node") {
       withExec(
-        args: ["sh", "-c", "git clone --depth=1 https://github.com/vikram-dagger/hello-dagger /usr/src/app/hello-dagger"]
+        args: ["sh", "-c", "git clone --depth=1 https://github.com/dagger/hello-dagger /usr/src/app/hello-dagger"]
       ) {
         withWorkdir(path: "/usr/src/app/hello-dagger") {
           withExec(args: ["sh", "-c", "mkdir ci && npm install @dagger.io/dagger --save-dev && npm pkg set type=module"]) {
@@ -98,7 +98,7 @@ query='
   container {
     from(address: "node") {
       withExec(
-        args: ["sh", "-c", "git clone --depth=1 https://github.com/vikram-dagger/hello-dagger /usr/src/app/hello-dagger"]
+        args: ["sh", "-c", "git clone --depth=1 https://github.com/dagger/hello-dagger /usr/src/app/hello-dagger"]
       ) {
         withWorkdir(path: "/usr/src/app/hello-dagger") {
           withExec(args: ["sh", "-c", "mkdir ci && npm install @dagger.io/dagger --save-dev && npm pkg set type=module"]) {

--- a/docs/current/quickstart/349011-quickstart-build.mdx
+++ b/docs/current/quickstart/349011-quickstart-build.mdx
@@ -13,9 +13,9 @@ import QuickstartDoc from '@site/src/components/molecules/quickstartDoc.js'
 import Embed from '@site/src/components/atoms/embed.js'
 
 export const ids = {
-    Go: "1H9zPpWRtDi",
-    Node: "HMeWQ18XgxM",
-    Python: "Hh2ra08H6lu"
+    Go: "guZd7rmOolE",
+    Node: "5mAEEtpy6mE",
+    Python: "iOhSGUn7nFq"
 }
 
 <QuickstartDoc embeds={ids}>
@@ -33,7 +33,7 @@ The `npm run build` command is appropriate for a React application, but other ap
 <Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
-<Embed id="1H9zPpWRtDi" />
+<Embed id="guZd7rmOolE" />
 
 - It invokes the `Container.WithExec()` method again, this time to define the command `npm run build` in the container.
 - It obtains a reference to the `build/` directory in the container with the `Container.Directory()` method. This method returns a `Directory` object.
@@ -48,7 +48,7 @@ go run ci/main.go
 </TabItem>
 <TabItem value="Node.js">
 
-<Embed id="HMeWQ18XgxM" />
+<Embed id="5mAEEtpy6mE" />
 
 This revised pipeline does everything described in the previous step, and then performs the following additional operations:
 
@@ -65,7 +65,7 @@ node ci/index.mjs
 </TabItem>
 <TabItem value="Python">
 
-<Embed id="Hh2ra08H6lu" />
+<Embed id="iOhSGUn7nFq" />
 
 This revised pipeline does everything described in the previous step, and then performs the following additional operations:
 

--- a/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
+++ b/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
@@ -13,9 +13,9 @@ import QuickstartDoc from '@site/src/components/molecules/quickstartDoc.js'
 import Embed from '@site/src/components/atoms/embed.js'
 
 export const ids = {
-    Go: "IxHBXBhY82B",
-    Node: "blm0z0YQDmX",
-    Python: "TQbnFCp3R3R"
+    Go: "j1-McCYMQiG",
+    Node: "AnwtJTV9Xj3",
+    Python: "EaSvAH9iPiG"
 }
 
 <QuickstartDoc embeds={ids}>
@@ -33,7 +33,7 @@ The example application repository includes a simple Dockerfile. Use it with a D
 <Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
-<Embed id="IxHBXBhY82B"/>
+<Embed id="j1-McCYMQiG"/>
 
 This code listing does the following:
 
@@ -51,7 +51,7 @@ go run ci/main.go
 </TabItem>
 <TabItem value="Node.js">
 
-<Embed id="blm0z0YQDmX"/>
+<Embed id="AnwtJTV9Xj3"/>
 
 This code listing does the following:
 
@@ -69,7 +69,7 @@ node ci/index.mjs
 </TabItem>
 <TabItem value="Python">
 
-<Embed id="TQbnFCp3R3R"/>
+<Embed id="EaSvAH9iPiG"/>
 
 This code listing does the following:
 

--- a/docs/current/quickstart/472910-quickstart-build-multi.mdx
+++ b/docs/current/quickstart/472910-quickstart-build-multi.mdx
@@ -13,9 +13,9 @@ import QuickstartDoc from '@site/src/components/molecules/quickstartDoc.js'
 import Embed from '@site/src/components/atoms/embed.js'
 
 export const ids = {
-    Go: "m1TsqrqYvgE",
-    Node: "ijTE41ISH95",
-    Python: "rgVdmi0ssZq"
+    Go: "2ndfn2RcrVi",
+    Node: "IAe6sLfyUxi",
+    Python: "LAC3B8Poada"
 }
 
 <QuickstartDoc embeds={ids}>
@@ -39,7 +39,7 @@ Let's now update our pipeline to use a multi-stage build, as described above.
 <Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
-<Embed id="m1TsqrqYvgE"/>
+<Embed id="2ndfn2RcrVi"/>
 
 Run the pipeline by executing the command below from the application directory:
 
@@ -50,7 +50,7 @@ go run ci/main.go
 </TabItem>
 <TabItem value="Node.js">
 
-<Embed id="ijTE41ISH95"/>
+<Embed id="IAe6sLfyUxi"/>
 
 Run the pipeline by executing the command below from the application directory:
 
@@ -61,7 +61,7 @@ node ci/index.mjs
 </TabItem>
 <TabItem value="Python">
 
-<Embed id="rgVdmi0ssZq"/>
+<Embed id="LAC3B8Poada"/>
 
 Run the pipeline by executing the command below from the application directory:
 

--- a/docs/current/quickstart/593914-quickstart-hello.mdx
+++ b/docs/current/quickstart/593914-quickstart-hello.mdx
@@ -13,9 +13,9 @@ import QuickstartDoc from '@site/src/components/molecules/quickstartDoc.js'
 import Embed from '@site/src/components/atoms/embed.js'
 
 export const ids = {
-    Go: "rgaPq2gzM_2",
-    Node: "oMQiF1h-W1O",
-    Python: "EDa1xwZ-hll"
+    Go: "qRC42X7tgPx",
+    Node: "ANSxtgC136o",
+    Python: "sLUm92wLwtw"
 }
 
 <QuickstartDoc embeds={ids}>
@@ -31,7 +31,7 @@ This first example is fairly simple: it creates a Dagger client using your chose
 
 In the `ci` directory, create a file named `main.go` and add the following code to it.
 
-<Embed id= "rgaPq2gzM_2"/>
+<Embed id="qRC42X7tgPx"/>
 
 This Go program imports the Dagger SDK and defines a `main()` function for the pipeline operations. This function performs the following operations:
 
@@ -57,7 +57,7 @@ Hello from Dagger and go version go1.19.5 linux/amd64
 
 In the `ci` directory, create a new file named `index.mjs` and add the following code to it.
 
-<Embed id= "oMQiF1h-W1O"/>
+<Embed id="ANSxtgC136o"/>
 
 This Node.js script imports the Dagger SDK and defines an asynchronous function. This function performs the following operations:
 
@@ -83,7 +83,7 @@ Hello from Dagger and Node v16.18.1
 
 In the `ci` directory, create a new file named `main.py` and add the following code to it.
 
-<Embed id= "EDa1xwZ-hll"/>
+<Embed id="sLUm92wLwtw"/>
 
 This Python script imports the Dagger SDK and defines an asynchronous function. This function performs the following operations:
 

--- a/docs/current/quickstart/635927-quickstart-caching.mdx
+++ b/docs/current/quickstart/635927-quickstart-caching.mdx
@@ -13,9 +13,9 @@ import QuickstartDoc from "@site/src/components/molecules/quickstartDoc.js"
 import Embed from "@site/src/components/atoms/embed.js"
 
 export const ids = {
-    Go: "faz9rMJNQca",
-    Node: "2DhNPJQ6pUU",
-    Python: "ZxqkCRsSlGU"
+    Go: "64jT5CYA_2W",
+    Node: "XRfLHVA3Li8",
+    Python: "-9shfjyoTbn"
 }
 
 <QuickstartDoc embeds={ids}>
@@ -35,7 +35,7 @@ The `npm install` command is appropriate for a React application, but other appl
 <Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
-<Embed id="faz9rMJNQca" />
+<Embed id="64jT5CYA_2W" />
 
 This revised pipeline now uses a cache for the application dependencies.
 
@@ -52,7 +52,7 @@ go run ci/main.go
 </TabItem>
 <TabItem value="Node.js">
 
-<Embed id="2DhNPJQ6pUU" />
+<Embed id="XRfLHVA3Li8" />
 
 This revised pipeline now uses a cache for the application dependencies.
 
@@ -69,7 +69,7 @@ node ci/index.mjs
 </TabItem>
 <TabItem value="Python">
 
-<Embed id="ZxqkCRsSlGU" />
+<Embed id="-9shfjyoTbn" />
 
 This revised pipeline now uses a cache for the application dependencies.
 

--- a/docs/current/quickstart/730264-quickstart-publish.mdx
+++ b/docs/current/quickstart/730264-quickstart-publish.mdx
@@ -13,9 +13,9 @@ import QuickstartDoc from "@site/src/components/molecules/quickstartDoc.js"
 import Embed from "@site/src/components/atoms/embed.js"
 
 export const ids = {
-    Go: "SYJ885fBPOy",
-    Node: "P8mz6yjC2lM",
-    Python: "Vz6OJ6gIDaP"
+    Go: "",
+    Node: "I4sXINdejnV",
+    Python: "TtfHpGFRukx"
 }
 
 <QuickstartDoc embeds={ids}>
@@ -29,7 +29,7 @@ Dagger SDKs have built-in support to publish container images. So, let's update 
 <Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
-<Embed id="SYJ885fBPOy"></Embed>
+<Embed id=""></Embed>
 
 Run the pipeline by executing the command below from the application directory:
 
@@ -40,7 +40,7 @@ go run ci/main.go
 </TabItem>
 <TabItem value="Node.js">
 
-<Embed id="P8mz6yjC2lM"></Embed>
+<Embed id="I4sXINdejnV"></Embed>
 
 Run the pipeline by executing the command below from the application directory:
 
@@ -51,7 +51,7 @@ node ci/index.mjs
 </TabItem>
 <TabItem value="Python">
 
-<Embed id="Vz6OJ6gIDaP"></Embed>
+<Embed id="TtfHpGFRukx"></Embed>
 
 Run the pipeline by executing the command below from the application directory:
 

--- a/docs/current/quickstart/730264-quickstart-publish.mdx
+++ b/docs/current/quickstart/730264-quickstart-publish.mdx
@@ -13,7 +13,7 @@ import QuickstartDoc from "@site/src/components/molecules/quickstartDoc.js"
 import Embed from "@site/src/components/atoms/embed.js"
 
 export const ids = {
-    Go: "",
+    Go: "BnZUZFuzq9b",
     Node: "I4sXINdejnV",
     Python: "TtfHpGFRukx"
 }
@@ -29,7 +29,7 @@ Dagger SDKs have built-in support to publish container images. So, let's update 
 <Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
-<Embed id=""></Embed>
+<Embed id="BnZUZFuzq9b"></Embed>
 
 Run the pipeline by executing the command below from the application directory:
 

--- a/docs/current/quickstart/947391-quickstart-test.mdx
+++ b/docs/current/quickstart/947391-quickstart-test.mdx
@@ -13,9 +13,9 @@ import QuickstartDoc from '@site/src/components/molecules/quickstartDoc.js'
 import Embed from '@site/src/components/atoms/embed.js'
 
 export const ids = {
-    Go: "M8NHUR0WTWT",
-    Node: "XyDYQWN2edq",
-    Python: "SF9BGtA_py3"
+    Go: "E4jHp1gdczO",
+    Node: "PN7ayA3rjOB",
+    Python: "2XgPeWiQsRX"
 }
 
 <QuickstartDoc embeds={ids}>
@@ -34,7 +34,7 @@ The `npm run test` command is appropriate for a React application, but other app
 <Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
-<Embed id="M8NHUR0WTWT" />
+<Embed id="E4jHp1gdczO" />
 
 This code listing does the following:
 
@@ -55,7 +55,7 @@ go run ci/main.go
 </TabItem>
 <TabItem value="Node.js">
 
-<Embed id="XyDYQWN2edq" />
+<Embed id="PN7ayA3rjOB" />
 
 This code listing does the following:
 
@@ -76,7 +76,7 @@ node ci/index.mjs
 </TabItem>
 <TabItem value="Python">
 
-<Embed id="SF9BGtA_py3" />
+<Embed id="2XgPeWiQsRX" />
 
 This code listing does the following:
 

--- a/docs/current/quickstart/snippets/publish/main.go
+++ b/docs/current/quickstart/snippets/publish/main.go
@@ -43,7 +43,7 @@ func main() {
 	ref, err := client.Container().
 		From("nginx:1.23-alpine").
 		WithDirectory("/usr/share/nginx/html", client.Host().Directory("./build")).
-		Publish(ctx, fmt.Sprintf("ttl.sh/hello-dagger-%.0f", math.Floor(rand.Float64()*10000000)))
+		Publish(ctx, fmt.Sprintf("ttl.sh/hello-dagger-%.0f", math.Floor(rand.Float64()*10000000)))//nosec
 	if err != nil {
 		panic(err)
 	}

--- a/docs/current/quickstart/snippets/publish/main.go
+++ b/docs/current/quickstart/snippets/publish/main.go
@@ -43,7 +43,7 @@ func main() {
 	ref, err := client.Container().
 		From("nginx:1.23-alpine").
 		WithDirectory("/usr/share/nginx/html", client.Host().Directory("./build")).
-		Publish(ctx, fmt.Sprintf("ttl.sh/hello-dagger-%.0f", math.Floor(rand.Float64()*10000000))) // nosec
+		Publish(ctx, fmt.Sprintf("ttl.sh/hello-dagger-%.0f", math.Floor(rand.Float64()*10000000))) //#nosec
 	if err != nil {
 		panic(err)
 	}

--- a/docs/current/quickstart/snippets/publish/main.go
+++ b/docs/current/quickstart/snippets/publish/main.go
@@ -43,7 +43,7 @@ func main() {
 	ref, err := client.Container().
 		From("nginx:1.23-alpine").
 		WithDirectory("/usr/share/nginx/html", client.Host().Directory("./build")).
-		Publish(ctx, fmt.Sprintf("ttl.sh/hello-dagger-%.0f", math.Floor(rand.Float64()*10000000)))//nosec
+		Publish(ctx, fmt.Sprintf("ttl.sh/hello-dagger-%.0f", math.Floor(rand.Float64()*10000000))) // nosec
 	if err != nil {
 		panic(err)
 	}

--- a/docs/current/quickstart/snippets/publish/main.go
+++ b/docs/current/quickstart/snippets/publish/main.go
@@ -43,7 +43,7 @@ func main() {
 	ref, err := client.Container().
 		From("nginx:1.23-alpine").
 		WithDirectory("/usr/share/nginx/html", client.Host().Directory("./build")).
-		Publish(ctx, fmt.Sprintf("ttl.sh/hello-dagger-%.0f", math.Floor(rand.Float64()*10000000))) //#nosec
+		Publish(ctx, fmt.Sprintf("ttl.sh/hello-dagger-%.0f", math.Floor(rand.Float64()*10000000)))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This commit updates the quickstart embed creation script to use the repo at github.com/dagger/hello-dagger as source and also updates the embeds and their IDs.

Closes DAG-921