### PR TITLE
telemetry: make run_id optional

### DIFF
--- a/cmd/engine/logger.go
+++ b/cmd/engine/logger.go
@@ -27,7 +27,6 @@ func init() {
 	}
 
 	tel = telemetry.New(false)
-	tel.SetRunID("00000000-0000-0000-0000-000000000000")
 
 	logrus.AddHook(&cloudHook{})
 }
@@ -65,6 +64,10 @@ type engineLogPayload struct {
 
 func (engineLogPayload) Type() telemetry.EventType {
 	return telemetry.EventType("engine_log")
+}
+
+func (engineLogPayload) Scope() telemetry.EventScope {
+	return telemetry.EventScopeSystem
 }
 
 type engineMetadata struct {

--- a/telemetry/event.go
+++ b/telemetry/event.go
@@ -12,8 +12,8 @@ type Event struct {
 	Version   string    `json:"v"`
 	Timestamp time.Time `json:"ts"`
 
-	RunID string `json:"run_id"`
 	OrgID string `json:"org_id"`
+	RunID string `json:"run_id,omitempty"`
 
 	Type    EventType `json:"type"`
 	Payload Payload   `json:"payload"`
@@ -21,8 +21,16 @@ type Event struct {
 
 type EventType string
 
+type EventScope string
+
+const (
+	EventScopeSystem = EventScope("system")
+	EventScopeRun    = EventScope("run")
+)
+
 type Payload interface {
 	Type() EventType
+	Scope() EventScope
 }
 
 var _ Payload = OpPayload{}
@@ -40,7 +48,8 @@ type OpPayload struct {
 	Error     string     `json:"error"`
 }
 
-func (OpPayload) Type() EventType { return EventType("op") }
+func (OpPayload) Type() EventType   { return EventType("op") }
+func (OpPayload) Scope() EventScope { return EventScopeRun }
 
 var _ Payload = LogPayload{}
 
@@ -50,4 +59,5 @@ type LogPayload struct {
 	Stream int    `json:"stream"`
 }
 
-func (LogPayload) Type() EventType { return EventType("log") }
+func (LogPayload) Type() EventType   { return EventType("log") }
+func (LogPayload) Scope() EventScope { return EventScopeRun }

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -109,10 +109,13 @@ func (t *Telemetry) Push(p Payload, ts time.Time) {
 	ev := &Event{
 		Version:   eventVersion,
 		Timestamp: ts,
-		RunID:     t.runID,
 		OrgID:     t.orgID,
 		Type:      p.Type(),
 		Payload:   p,
+	}
+
+	if p.Scope() == EventScopeRun {
+		ev.RunID = t.runID
 	}
 
 	t.mu.Lock()


### PR DESCRIPTION
[not to be merged before making API changes]

This makes the `run_id` event field optional.