### PR TITLE
telemetry: move run_id into event payload

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -409,6 +409,7 @@ func uploadTelemetry(ch chan *bkclient.SolveStatus) error {
 			}
 
 			payload := telemetry.OpPayload{
+				RunID:    t.RunID(),
 				OpID:     id,
 				OpName:   custom.Name,
 				Internal: custom.Internal,
@@ -430,6 +431,7 @@ func uploadTelemetry(ch chan *bkclient.SolveStatus) error {
 
 		for _, l := range ev.Logs {
 			t.Push(telemetry.LogPayload{
+				RunID:  t.RunID(),
 				OpID:   l.Vertex.String(),
 				Data:   string(l.Data),
 				Stream: l.Stream,

--- a/telemetry/event.go
+++ b/telemetry/event.go
@@ -6,13 +6,12 @@ import (
 	"github.com/dagger/dagger/core/pipeline"
 )
 
-const eventVersion = "2023-02-28.01"
+const eventVersion = "2023-05-01.01"
 
 type Event struct {
 	Version   string    `json:"v"`
 	Timestamp time.Time `json:"ts"`
 
-	RunID string `json:"run_id"`
 	OrgID string `json:"org_id"`
 
 	Type    EventType `json:"type"`
@@ -28,6 +27,7 @@ type Payload interface {
 var _ Payload = OpPayload{}
 
 type OpPayload struct {
+	RunID    string        `json:"run_id"`
 	OpID     string        `json:"op_id"`
 	OpName   string        `json:"op_name"`
 	Pipeline pipeline.Path `json:"pipeline"`
@@ -45,6 +45,7 @@ func (OpPayload) Type() EventType { return EventType("op") }
 var _ Payload = LogPayload{}
 
 type LogPayload struct {
+	RunID  string `json:"run_id"`
 	OpID   string `json:"op_id"`
 	Data   string `json:"data"`
 	Stream int    `json:"stream"`

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -109,7 +109,6 @@ func (t *Telemetry) Push(p Payload, ts time.Time) {
 	ev := &Event{
 		Version:   eventVersion,
 		Timestamp: ts,
-		RunID:     t.runID,
 		OrgID:     t.orgID,
 		Type:      p.Type(),
 		Payload:   p,


### PR DESCRIPTION
Alternative to #5066 -- this moves the `run_id` field into the event payload (e.g. not a top-level attribute anymore)