### PR TITLE
cache: Support extra headers for pre-signed URLs

### DIFF
--- a/engine/cache/manager.go
+++ b/engine/cache/manager.go
@@ -263,6 +263,9 @@ func (m *manager) pushLayer(ctx context.Context, layerDesc ocispecs.Descriptor, 
 	}
 	defer req.Body.Close()
 	req.ContentLength = readerAt.Size()
+	for k, v := range getURLResp.Headers {
+		req.Header.Set(k, v)
+	}
 
 	resp, err := m.httpClient.Do(req)
 	if err != nil {

--- a/engine/cache/mountsync.go
+++ b/engine/cache/mountsync.go
@@ -165,17 +165,15 @@ func (m *manager) StartCacheMountSynchronization(ctx context.Context) error {
 						return fmt.Errorf("failed to create http request: %w", err)
 					}
 					httpReq.ContentLength = contentLength // set it here, go stdlib will ignore if set on Header (??!!)
+					for k, v := range getURLResp.Headers {
+						httpReq.Header.Set(k, v)
+					}
 					resp, err := m.httpClient.Do(httpReq)
 					if err != nil {
 						return fmt.Errorf("failed to upload cache mount: %w", err)
 					}
 					defer resp.Body.Close()
 					if resp.StatusCode != http.StatusOK {
-						// get the error message from the body
-						body, err := io.ReadAll(resp.Body)
-						if err == nil {
-							return fmt.Errorf("failed to upload cache mount: %s, %s", resp.Status, body)
-						}
 						return fmt.Errorf("failed to upload cache mount: %s", resp.Status)
 					}
 

--- a/engine/cache/service.go
+++ b/engine/cache/service.go
@@ -178,7 +178,8 @@ type GetLayerUploadURLRequest struct {
 }
 
 type GetLayerUploadURLResponse struct {
-	URL string
+	URL     string
+	Headers map[string]string
 }
 
 type GetCacheMountConfigRequest struct {
@@ -203,7 +204,8 @@ type GetCacheMountUploadURLRequest struct {
 }
 
 type GetCacheMountUploadURLResponse struct {
-	URL string
+	URL     string
+	Headers map[string]string
 }
 
 type client struct {


### PR DESCRIPTION
For certain settings, S3 pre-signed URLs will sign the URL with the setting name and value, but doesn't include it in the URL as a query string. It's expected that the user of the URL include it as a header with the same value when actually making the request.

Previously, this was just Content-Length, which we handled as a special case but it turns out another such header is `x-amz-acl`, which we currently need to use in order to ensure that uploading to a cross-account bucket will work. This only due to the fact that the cache service still runs on-prem; once it's in the cloud then the generator of the pre-signed URL will always be the owner of the bucket. But until that time, this is required.

Implemented this by having the cache service just give the engine a set of extra headers to include with its upload requests. This keeps the engine code S3-agnostic.