### PR TITLE
Truncate stdout/stderr from shim rather than session.

### DIFF
--- a/core/gateway.go
+++ b/core/gateway.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	// Exec errors will only include the last this number of bytes of output.
-	maxExecErrorOutputBytes = 2 * 1024
+	MaxExecErrorOutputBytes = 2 * 1024
 
 	// A magic env var that's interpreted by the shim, telling it to just output
 	// the stdout/stderr contents rather than actually execute anything.
@@ -186,11 +186,14 @@ func wrapSolveError(inputErr *error, gw bkgw.Client) {
 		// Use a circular buffer to only save the last N bytes of output, which lets
 		// us prevent enormous error messages while retaining the output most likely
 		// to be of interest.
-		ctrOut, err := circbuf.NewBuffer(maxExecErrorOutputBytes)
+		// NOTE: this is technically redundant with the output truncation done by
+		// the shim itself now, but still useful as a fallback in case something
+		// goes haywire there or if the session is talking to an older engine.
+		ctrOut, err := circbuf.NewBuffer(MaxExecErrorOutputBytes)
 		if err != nil {
 			return
 		}
-		ctrErr, err := circbuf.NewBuffer(maxExecErrorOutputBytes)
+		ctrErr, err := circbuf.NewBuffer(MaxExecErrorOutputBytes)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
This is primarily needed to workaround an issue in Buildkit where a series of bugs can result in container stdout/stderr resulting in runc getting blocked trying to write to its output pipes and never exit.

That needs an upstream fix but we can make it much rarer by reducing the amount of output our shim can send in the case where its printing stdout/stderr after an exec failure, which is the main place we hit the bug previously.

We were already truncating that output anyways, but we were doing it in the session. This updates the truncation to happen in the shim itself, which is slightly more complicated but avoids the bug and is technically more performant in general anyways.

---

Upstream issue: https://github.com/moby/buildkit/pull/3832

The actual error is flaky to reproduce and involves a pretty heavy load, so I have only manually verified this fixes it. I did update our automated tests to have coverage for the truncation though, which was missing previously.