### PR TITLE
docs: Fixed error in quickstart caching embed (py)

### DIFF
--- a/docs/current/quickstart/635927-quickstart-caching.mdx
+++ b/docs/current/quickstart/635927-quickstart-caching.mdx
@@ -15,7 +15,7 @@ import Embed from "@site/src/components/atoms/embed.js"
 export const ids = {
     Go: "64jT5CYA_2W",
     Node: "XRfLHVA3Li8",
-    Python: "-9shfjyoTbn"
+    Python: "sNZQEeULT-M"
 }
 
 <QuickstartDoc embeds={ids}>
@@ -69,7 +69,7 @@ node ci/index.mjs
 </TabItem>
 <TabItem value="Python">
 
-<Embed id="-9shfjyoTbn" />
+<Embed id="sNZQEeULT-M" />
 
 This revised pipeline now uses a cache for the application dependencies.
 

--- a/docs/current/quickstart/snippets/caching/main.py
+++ b/docs/current/quickstart/snippets/caching/main.py
@@ -18,10 +18,10 @@ async def main():
         source = (
             client.container()
             .from_("node:16-slim")
-            .with_mounted_directory(
+            .with_directory(
                 "/src",
                 client.host().directory("."),
-                exclude=["node_modules/", "ci/"],
+                ["node_modules/", "ci/"],
             )
             .with_mounted_cache("/src/node_modules", node_cache)
         )


### PR DESCRIPTION
This commit fixes an error in the code snippet for the quickstart Python caching example, to match the other caching examples.