### PR TITLE
docs: Fix quickstart Node.js tabs

### DIFF
--- a/docs/current/quickstart/349011-quickstart-build.mdx
+++ b/docs/current/quickstart/349011-quickstart-build.mdx
@@ -14,7 +14,7 @@ import Embed from '@site/src/components/atoms/embed.js'
 
 export const ids = {
     Go: "guZd7rmOolE",
-    Node: "5mAEEtpy6mE",
+    "Node.js": "5mAEEtpy6mE",
     Python: "iOhSGUn7nFq"
 }
 

--- a/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
+++ b/docs/current/quickstart/429462-quickstart-build-dockerfile.mdx
@@ -14,7 +14,7 @@ import Embed from '@site/src/components/atoms/embed.js'
 
 export const ids = {
     Go: "j1-McCYMQiG",
-    Node: "AnwtJTV9Xj3",
+    "Node.js": "AnwtJTV9Xj3",
     Python: "EaSvAH9iPiG"
 }
 

--- a/docs/current/quickstart/472910-quickstart-build-multi.mdx
+++ b/docs/current/quickstart/472910-quickstart-build-multi.mdx
@@ -14,7 +14,7 @@ import Embed from '@site/src/components/atoms/embed.js'
 
 export const ids = {
     Go: "2ndfn2RcrVi",
-    Node: "IAe6sLfyUxi",
+    "Node.js": "IAe6sLfyUxi",
     Python: "LAC3B8Poada"
 }
 

--- a/docs/current/quickstart/593914-quickstart-hello.mdx
+++ b/docs/current/quickstart/593914-quickstart-hello.mdx
@@ -14,7 +14,7 @@ import Embed from '@site/src/components/atoms/embed.js'
 
 export const ids = {
     Go: "qRC42X7tgPx",
-    Node: "ANSxtgC136o",
+    "Node.js": "ANSxtgC136o",
     Python: "sLUm92wLwtw"
 }
 

--- a/docs/current/quickstart/635927-quickstart-caching.mdx
+++ b/docs/current/quickstart/635927-quickstart-caching.mdx
@@ -14,7 +14,7 @@ import Embed from "@site/src/components/atoms/embed.js"
 
 export const ids = {
     Go: "64jT5CYA_2W",
-    Node: "XRfLHVA3Li8",
+    "Node.js": "XRfLHVA3Li8",
     Python: "sNZQEeULT-M"
 }
 

--- a/docs/current/quickstart/730264-quickstart-publish.mdx
+++ b/docs/current/quickstart/730264-quickstart-publish.mdx
@@ -14,7 +14,7 @@ import Embed from "@site/src/components/atoms/embed.js"
 
 export const ids = {
     Go: "BnZUZFuzq9b",
-    Node: "I4sXINdejnV",
+    "Node.js": "I4sXINdejnV",
     Python: "TtfHpGFRukx"
 }
 

--- a/docs/current/quickstart/947391-quickstart-test.mdx
+++ b/docs/current/quickstart/947391-quickstart-test.mdx
@@ -14,7 +14,7 @@ import Embed from '@site/src/components/atoms/embed.js'
 
 export const ids = {
     Go: "E4jHp1gdczO",
-    Node: "PN7ayA3rjOB",
+    "Node.js": "PN7ayA3rjOB",
     Python: "2XgPeWiQsRX"
 }
 


### PR DESCRIPTION
After #5087 I realized the Node tabs in Quickstart weren't working. It was because of an incomplete change in:
- #5018.

Signed-off-by: Helder Correia