### PR TITLE
tooling: Reduce frequency of Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       - "kind/dependencies"
       - "area/engine"
       - "area/cli"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -15,6 +19,10 @@ updates:
     labels:
       - "kind/dependencies"
       - "area/tooling"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+
   - package-ecosystem: "npm"
     directory: "/sdk/nodejs"
     schedule:
@@ -22,6 +30,9 @@ updates:
     labels:
       - "kind/dependencies"
       - "sdk/nodejs"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   - package-ecosystem: "npm"
     directory: "/website"
@@ -30,6 +41,9 @@ updates:
     labels:
       - "kind/dependencies"
       - "area/docs"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   - package-ecosystem: "gomod"
     directory: "/sdk/go"
@@ -38,6 +52,9 @@ updates:
     labels:
       - "kind/dependencies"
       - "sdk/go"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   - package-ecosystem: "pip"
     directory: "/sdk/python"
@@ -46,3 +63,6 @@ updates:
     labels:
       - "kind/dependencies"
       - "sdk/python"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,17 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
 
+  - package-ecosystem: "gomod"
+    directory: "/internal/mage"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "kind/dependencies"
+      - "area/tooling"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+
   - package-ecosystem: "npm"
     directory: "/sdk/nodejs"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,19 +3,19 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     labels:
       - "kind/dependencies"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     labels:
       - "kind/dependencies"
   - package-ecosystem: "npm"
     directory: "/sdk/nodejs"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     labels:
       - "kind/dependencies"
       - "sdk/nodejs"
@@ -23,7 +23,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/website"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     labels:
       - "kind/dependencies"
       - "area/website"
@@ -31,7 +31,7 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/sdk/go"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     labels:
       - "kind/dependencies"
       - "sdk/go"
@@ -39,7 +39,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/sdk/python"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     labels:
       - "kind/dependencies"
       - "sdk/python"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,15 @@ updates:
       interval: "monthly"
     labels:
       - "kind/dependencies"
+      - "area/engine"
+      - "area/cli"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "monthly"
     labels:
       - "kind/dependencies"
+      - "area/tooling"
   - package-ecosystem: "npm"
     directory: "/sdk/nodejs"
     schedule:
@@ -26,7 +29,7 @@ updates:
       interval: "monthly"
     labels:
       - "kind/dependencies"
-      - "area/website"
+      - "area/docs"
 
   - package-ecosystem: "gomod"
     directory: "/sdk/go"


### PR DESCRIPTION
**Configure Dependabot to bump dependencies `monthly`** because `daily` results in too much noise. It makes it more difficult to spot "real" contributions vs. "noisy ones".

With a reduced frequency (monthly instead of daily), this gives us the chance to update the things that we care about ourselves. It is known for some updates to result in breakages further down the pipeline, e.g. https://github.com/dagger/dagger/pull/4850

FTR: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates

**Append extra labels to Dependabot PRs**. We were missing a few dependency update areas, e.g. `engine`, `cli`, `tooling`.

**Configure Dependabot to ignore patch updates**. FTR: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore

**Configure Dependabot to bump Go deps in /internal/mage**. Before this change, I could not find a single Dependabot update of `/internal/mage/go.mod`: https://github.com/dagger/dagger/commits/main/internal/mage/go.mod

---

🗣 Started as [(private) Discord thread](https://discord.com/channels/707636530424053791/1103659534167330946/1103659534167330946).
