### PR TITLE
Grab bag of minor logging+performance improvements in cache

### DIFF
--- a/engine/cache/manager.go
+++ b/engine/cache/manager.go
@@ -93,9 +93,11 @@ func NewManager(ctx context.Context, managerConfig ManagerConfig) (Manager, erro
 		cancelImport()
 	}()
 	go func() {
+		importTicker := time.NewTicker(config.ImportPeriod)
+		defer importTicker.Stop()
 		for {
 			select {
-			case <-time.After(config.ImportPeriod):
+			case <-importTicker.C:
 			case <-m.startCloseCh:
 				return
 			}
@@ -111,9 +113,11 @@ func NewManager(ctx context.Context, managerConfig ManagerConfig) (Manager, erro
 	go func() {
 		defer close(m.doneCh)
 		var shutdown bool
+		exportTicker := time.NewTicker(config.ExportPeriod)
+		defer exportTicker.Stop()
 		for {
 			select {
-			case <-time.After(config.ExportPeriod):
+			case <-exportTicker.C:
 			case <-m.startCloseCh:
 				shutdown = true
 				// always run a final export before shutdown


### PR DESCRIPTION
Was looking through some long-running test logs and noticed a few quick-fix improvements. The changes that are less self-obvious have detailed commit messages.

By eyeball alone I didn't notice any obvious performance improvements after these but they certainly don't hurt in that regard and help improve the logging in general anyway.