### PR TITLE
docs: Made sidebar menu collapsible

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -34,8 +34,8 @@ module.exports = {
     {
       type: "category",
       label: "Go SDK",
-      collapsible: false,
-      collapsed: false,
+      collapsible: true,
+      collapsed: true,
       items: [
         {
           type: "doc",
@@ -58,8 +58,8 @@ module.exports = {
     {
       type: "category",
       label: "Node.js SDK",
-      collapsible: false,
-      collapsed: false,
+      collapsible: true,
+      collapsed: true,
       items: [
         {
           type: "doc",
@@ -82,8 +82,8 @@ module.exports = {
     {
       type: "category",
       label: "Python SDK",
-      collapsible: false,
-      collapsed: false,
+      collapsible: true,
+      collapsed: true,
       items: [
         {
           type: "doc",
@@ -106,8 +106,8 @@ module.exports = {
     {
       type: "category",
       label: "GraphQL API",
-      collapsible: false,
-      collapsed: false,
+      collapsible: true,
+      collapsed: true,
       items: [
         {
           type: "doc",
@@ -127,8 +127,8 @@ module.exports = {
     {
       type: "category",
       label: "CLI",
-      collapsible: false,
-      collapsed: false,
+      collapsible: true,
+      collapsed: true,
       items: [
         {
           type: "doc",

--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -609,6 +609,11 @@ button[class^="copyButton"] {
   background-color: transparent;
 }
 
+.menu__list-item-collapsible {
+  font-size: 1.2rem;
+  font-weight: bold;
+}
+
 li.theme-doc-sidebar-item-link-level-1,
 li.theme-doc-sidebar-item-link-level-1:active {
   font-size: 1.2rem;


### PR DESCRIPTION
This commit makes the left sidebar menu collapsible so that the entire menu is visible without scrolling.

Closes #4934
Closes DAG-917