### PR TITLE
Implement chunked reader for File.Contents

### DIFF
--- a/core/file.go
+++ b/core/file.go
@@ -18,14 +18,7 @@ import (
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	fstypes "github.com/tonistiigi/fsutil/types"
-)
-
-var (
-	// ErrFileContentsExceedsLimit is returned when a file that exceeds
-	// MaxFileContentsSize is passed to Contents method:
-	ErrFileContentsExceedsLimit = errors.New("file exceeds limit")
 )
 
 // File is a content-addressed file.
@@ -137,7 +130,8 @@ func (file *File) Contents(ctx context.Context, gw bkgw.Client) ([]byte, error) 
 		// Error on files that exceed MaxFileContentsSize:
 		fileSize := int(st.GetSize_())
 		if fileSize > MaxFileContentsSize {
-			return nil, ErrFileContentsExceedsLimit
+			// TODO: move to proper error structure
+			return nil, fmt.Errorf("file size %d exceeds limit %d", fileSize, MaxFileContentsSize)
 		}
 
 		// Allocate buffer with the given file size:

--- a/core/file.go
+++ b/core/file.go
@@ -113,6 +113,7 @@ func (file *File) State() (llb.State, error) {
 	return defToState(file.LLB)
 }
 
+// Contents handles file content retrieval
 func (file *File) Contents(ctx context.Context, gw bkgw.Client) ([]byte, error) {
 	return WithServices(ctx, gw, file.Services, func() ([]byte, error) {
 		ref, err := gwRef(ctx, gw, file.LLB)
@@ -120,9 +121,35 @@ func (file *File) Contents(ctx context.Context, gw bkgw.Client) ([]byte, error) 
 			return nil, err
 		}
 
-		return ref.ReadFile(ctx, bkgw.ReadRequest{
-			Filename: file.File,
-		})
+		// Stat the file and preallocate file contents buffer:
+		st, err := file.Stat(ctx, gw)
+		if err != nil {
+			return nil, err
+		}
+
+		fileSize := int(st.GetSize_())
+		contents := make([]byte, fileSize)
+
+		// Use a chunked reader to overcome issues when
+		// the input file exceeds MaxFileContentsChunkSize:
+		var offset int
+		for offset < fileSize {
+			chunk, err := ref.ReadFile(ctx, bkgw.ReadRequest{
+				Filename: file.File,
+				Range: &bkgw.FileRange{
+					Offset: offset,
+					Length: MaxFileContentsChunkSize,
+				},
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			// Copy the chunk and increment offset for subsequent reads:
+			copy(contents[offset:], chunk)
+			offset += len(chunk)
+		}
+		return contents, nil
 	})
 }
 

--- a/core/gateway.go
+++ b/core/gateway.go
@@ -24,6 +24,11 @@ const (
 	// Exec errors will only include the last this number of bytes of output.
 	MaxExecErrorOutputBytes = 2 * 1024
 
+	// MaxFileContentsChunkSize sets the maximum chunk size for ReadFile calls
+	// Equals around 95% of the max message size (16777216) in
+	// order to keep space for any Protocol Buffers overhead:
+	MaxFileContentsChunkSize = 15938355
+
 	// A magic env var that's interpreted by the shim, telling it to just output
 	// the stdout/stderr contents rather than actually execute anything.
 	DebugFailedExecEnv = "_DAGGER_SHIM_DEBUG_FAILED_EXEC"

--- a/core/gateway.go
+++ b/core/gateway.go
@@ -29,6 +29,10 @@ const (
 	// order to keep space for any Protocol Buffers overhead:
 	MaxFileContentsChunkSize = 15938355
 
+	// MaxFileContentsSize sets the limit of the maximum file size
+	// that can be retrieved using File.Contents, currently set to 128MB:
+	MaxFileContentsSize = 128 << 20
+
 	// A magic env var that's interpreted by the shim, telling it to just output
 	// the stdout/stderr contents rather than actually execute anything.
 	DebugFailedExecEnv = "_DAGGER_SHIM_DEBUG_FAILED_EXEC"

--- a/core/integration/file_test.go
+++ b/core/integration/file_test.go
@@ -209,6 +209,7 @@ func TestFileContents(t *testing.T) {
 		{size: core.MaxFileContentsChunkSize / 2},
 		{size: core.MaxFileContentsChunkSize},
 		{size: core.MaxFileContentsChunkSize * 2},
+		{size: core.MaxFileContentsSize + 1},
 	}
 	tempDir := t.TempDir()
 	for i, testFile := range testFiles {
@@ -233,6 +234,13 @@ func TestFileContents(t *testing.T) {
 	for i, testFile := range testFiles {
 		filename := strconv.Itoa(i)
 		contents, err := alpine.File(filename).Contents(ctx)
+
+		// Assert error on larger files:
+		if testFile.size > core.MaxFileContentsSize {
+			require.Error(t, err)
+			continue
+		}
+
 		require.NoError(t, err)
 		contentsHash := computeMD5FromReader(strings.NewReader(contents))
 		require.Equal(t, testFile.hash, contentsHash)

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"archive/tar"
 	"context"
+	"crypto/md5"
 	"errors"
 	"fmt"
 	"io"
@@ -196,4 +197,10 @@ func checkNotDisabled(t *testing.T, env string) { //nolint:unparam
 	if os.Getenv(env) == "0" {
 		t.Skipf("disabled via %s=0", env)
 	}
+}
+
+func computeMD5FromReader(reader io.Reader) string {
+	h := md5.New()
+	io.Copy(h, reader)
+	return fmt.Sprintf("%x", h.Sum(nil))
 }


### PR DESCRIPTION
This PR implements a chunked reader for the `File.Contents` method. A maximum chunk size constant is used to overcome the issue with default gRPC message size (`MaxFileContentsChunkSize`), this chunk size is fixed and currently set around 95% of the default gRPC message size (`0.95 * 16777221`) to leave some margin for any PB overhead (from a quick inspection seems this is pretty lightweight and there seems to be a single field in the message [here](https://github.com/moby/buildkit/blob/1e725ca8da95782188e6e5ae4dac3c07afaf4511/frontend/gateway/pb/gateway.proto#L185)). This can probably be optimized on a future iteration.

A `MaxFileContentsSize` constant is introduced so that we error on files that are too big (current magic number suggested by @sipsma is 128 MB).

I've added a two-step test that covers the following scenarios:
- Input file smaller than `MaxFileContentsChunkSize`.
- Input file equal to `MaxFileContentsChunkSize`.
- Input file larger than `MaxFileContentsChunkSize`.
- Input file larger than `MaxFileContentsSize` -which results in error-.

The first step initializes a temporary directory in the host, writes the test data and computes an MD5 hash of each test file.

The second step initializes the container and attempts to access the test data on the host directory through Dagger's `File.Content` method, if contents are successfully retrieved, an MD5 hash of the retrieved content is computed and compared with the initial hash to validate integrity. We also validate the failing scenario that's caused by using an input file larger than `MaxFileContentsSize`.