### PR TITLE
fix Version handling

### DIFF
--- a/internal/engine/version.go
+++ b/internal/engine/version.go
@@ -21,6 +21,10 @@ func init() {
 	if Version == "" {
 		Version = DevelopmentVersion
 	}
+	// normalize Version to semver
+	if semver.IsValid("v" + Version) {
+		Version = "v" + Version
+	}
 }
 
 func ImageRef() string {
@@ -34,12 +38,12 @@ func ImageRef() string {
 	// If Version is set to something besides a semver tag, then it's a build off our main branch.
 	// For now, this also defaults to using the "main" tag, but in the future if we tag engine
 	// images with git sha then we could use that instead
-	if semver.IsValid(Version) {
+	if !semver.IsValid(Version) {
 		return fmt.Sprintf("%s:main", EngineImageRepo)
 	}
 
 	// Version is a semver tag, so use the engine image at that tag
-	return fmt.Sprintf("%s:v%s", EngineImageRepo, Version)
+	return fmt.Sprintf("%s:%s", EngineImageRepo, Version)
 }
 
 func RunnerHost() string {


### PR DESCRIPTION
A few things went wrong here:

* Homebrew sets [Version=v1.2.3](https://github.com/Homebrew/homebrew-core/blob/e7bbc68273847775d450f47a5d69da09c961c2cd/Formula/dagger.rb#L31)
* GoReleaser sets [Version=1.2.3](https://github.com/dagger/dagger/blob/7327f3381fe914f0acc754a024176dcc506a703f/.goreleaser.common.yml#L14)
* ImageRef had an accidentally inverted `if !semver.IsValid(Version) {`
* But it "worked" because when Version was `1.2.3` the condition would fail because it was missing the "v" prefix.

As a result, the Homebrew Dagger formula is actually using the `:main` tag, while our Goreleased binaries work fine, but for the wrong reasons.

I decided to normalize Version to semver format (with v prefix) rather than the other way around. We'll start getting `x-dagger-engine: v1.2.3` headers now. I'm guessing we were getting a mix before, between folks using Brew and folks using our GitHub released binaries.

This should be backwards compatible with the existing Homebrew formula. Seems reasonable to be defensive here.