### PR TITLE
raise an error for WithWorkdir + existing session

### DIFF
--- a/sdk/go/internal/engineconn/engineconn.go
+++ b/sdk/go/internal/engineconn/engineconn.go
@@ -35,6 +35,9 @@ func Get(ctx context.Context, cfg *Config) (EngineConn, error) {
 		return nil, err
 	}
 	if ok {
+		if cfg.Workdir != "" {
+			return nil, fmt.Errorf("cannot configure workdir for existing session (please use --workdir or host.directory with absolute paths instead)")
+		}
 		return conn, nil
 	}
 


### PR DESCRIPTION
This should make failures/weird behavior more obvious when using `dagger run`.

The problem is that all `dagger.Connect` configs are ignored when connecting to an existing session. Over time these options should all be removed, but for now we'll raise an error and try to tell the user what to do instead.

Status of all the config options, for posterity:

* `WithConfigPath`: already has `--project` (and no one should be using it anyway)
* `WithNoExtensions`: I don't think I've ever seen this used
* `WithLogOutput`: replaced by TUIs (or generally ways to process/redirect output in the CLI)
* `WithWorkdir`: replaced with `--workdir` and/or using absolute paths + `host.directory`

In practice `WithWorkdir` is the only one to worry about, since it breaks code. The rest are either unused or harmless no-ops.