### PR TITLE
Extend parallelization of integration tests

### DIFF
--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -317,6 +317,7 @@ func TestDirectoryWithDirectoryIncludeExclude(t *testing.T) {
 }
 
 func TestDirectoryWithNewDirectory(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	c, err := dagger.Connect(ctx)
 	require.NoError(t, err)
@@ -343,6 +344,7 @@ func TestDirectoryWithNewDirectory(t *testing.T) {
 }
 
 func TestDirectoryWithFile(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	c, err := dagger.Connect(ctx)
 	require.NoError(t, err)
@@ -389,6 +391,7 @@ func TestDirectoryWithFile(t *testing.T) {
 }
 
 func TestDirectoryWithTimestamps(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	c, err := dagger.Connect(ctx)
 	require.NoError(t, err)
@@ -611,6 +614,7 @@ func TestDirectoryExport(t *testing.T) {
 }
 
 func TestDirectoryDockerBuild(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	c, err := dagger.Connect(ctx)
 	require.NoError(t, err)

--- a/core/integration/file_test.go
+++ b/core/integration/file_test.go
@@ -175,6 +175,7 @@ func TestFileExport(t *testing.T) {
 }
 
 func TestFileWithTimestamps(t *testing.T) {
+	t.Parallel()
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -197,6 +198,7 @@ func TestFileWithTimestamps(t *testing.T) {
 }
 
 func TestFileContents(t *testing.T) {
+	t.Parallel()
 	c, ctx := connect(t)
 	defer c.Close()
 

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -65,6 +65,7 @@ func TestGit(t *testing.T) {
 }
 
 func TestGitSSHAuthSock(t *testing.T) {
+	t.Parallel()
 	checkNotDisabled(t, engine.ServicesDNSEnvName)
 
 	c, ctx := connect(t)

--- a/core/integration/host_test.go
+++ b/core/integration/host_test.go
@@ -135,6 +135,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 }
 
 func TestHostDirectoryRelative(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "some-file"), []byte("hello"), 0600))
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "some-dir"), 0755))
@@ -171,6 +172,7 @@ func TestHostDirectoryRelative(t *testing.T) {
 }
 
 func TestHostDirectoryAbsolute(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "some-file"), []byte("hello"), 0600))
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "some-dir"), 0755))

--- a/core/integration/secret_test.go
+++ b/core/integration/secret_test.go
@@ -128,6 +128,7 @@ func TestSecretMountFromFileWithOverridingMount(t *testing.T) {
 }
 
 func TestSecretPlaintext(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	c, err := dagger.Connect(ctx)
 	require.NoError(t, err)
@@ -141,6 +142,7 @@ func TestSecretPlaintext(t *testing.T) {
 }
 
 func TestNewSecret(t *testing.T) {
+	t.Parallel()
 	c, ctx := connect(t)
 	defer c.Close()
 
@@ -157,6 +159,7 @@ func TestNewSecret(t *testing.T) {
 }
 
 func TestWhitespaceSecretScrubbed(t *testing.T) {
+	t.Parallel()
 	c, ctx := connect(t)
 	defer c.Close()
 


### PR DESCRIPTION
- Minor improvement, adds `t.Parallel` to some tests that weren't using it.