### PR TITLE
docs: withEnvVariables examples

### DIFF
--- a/docs/current/742989-cookbook.md
+++ b/docs/current/742989-cookbook.md
@@ -652,6 +652,31 @@ The following code listing uses a cache volume to persist a service's data acros
 
 [Learn more](./guides/757394-use-service-containers.md)
 
+### Add multiple environment variables to a container
+
+The following code listing demonstrates how to add multiple environment variables to a container.
+
+<Tabs groupId="language">
+<TabItem value="Go">
+
+```go file=./cookbook/snippets/environment-variables/main.go
+```
+
+</TabItem>
+<TabItem value="Node.js">
+
+```javascript file=./cookbook/snippets/environment-variables/index.ts
+```
+
+</TabItem>
+<TabItem value="Python">
+
+```python file=./cookbook/snippets/environment-variables/main.py
+```
+
+</TabItem>
+</Tabs>
+
 ## Integrations
 
 ### AWS Cloud Development Kit

--- a/docs/current/cookbook/snippets/environment-variables/index.ts
+++ b/docs/current/cookbook/snippets/environment-variables/index.ts
@@ -1,0 +1,30 @@
+import Client, { connect } from "@dagger.io/dagger"
+import { Container } from "@dagger.io/dagger/dist/api/client.gen"
+
+// create Dagger client
+connect(async (client) => {
+    // setup container and
+    // define environment variables
+    const ctr = client
+        .container()
+        .from("alpine")
+        .with(envVariables({
+            ENV_VAR_1: "VALUE 1",
+            ENV_VAR_2: "VALUE 2",
+            ENV_VAR_3: "VALUE 3",
+        }))
+        .withExec(["env"])
+
+    // print environment variables
+    console.log(await ctr.stdout())
+}, { LogOutput: process.stderr })
+
+
+function envVariables(envs: Record<string, string>) {
+    return (c: Container): Container => {
+        Object.entries(envs).forEach(([key, value]) => {
+            c = c.withEnvVariable(key, value)
+        })
+        return c
+    }
+}

--- a/docs/current/cookbook/snippets/environment-variables/index.ts
+++ b/docs/current/cookbook/snippets/environment-variables/index.ts
@@ -1,8 +1,7 @@
-import Client, { connect } from "@dagger.io/dagger"
-import { Container } from "@dagger.io/dagger/dist/api/client.gen"
+import Client, { connect, Container } from "@dagger.io/dagger"
 
 // create Dagger client
-connect(async (client) => {
+connect(async (client: Client) => {
     // setup container and
     // define environment variables
     const ctr = client

--- a/docs/current/cookbook/snippets/environment-variables/main.go
+++ b/docs/current/cookbook/snippets/environment-variables/main.go
@@ -22,7 +22,7 @@ func main() {
 	ctr := client.
 		Container().
 		From("alpine").
-		With(envVariables(map[string]string{
+		With(EnvVariables(map[string]string{
 			"ENV_VAR_1": "VALUE 1",
 			"ENV_VAR_2": "VALUE 2",
 			"ENV_VAR_3": "VALUE 3",
@@ -37,7 +37,7 @@ func main() {
 	fmt.Println(out)
 }
 
-func envVariables(envs map[string]string) dagger.WithContainerFunc {
+func EnvVariables(envs map[string]string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
 		for key, value := range envs {
 			c = c.WithEnvVariable(key, value)

--- a/docs/current/cookbook/snippets/environment-variables/main.go
+++ b/docs/current/cookbook/snippets/environment-variables/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	// create Dagger client
+	ctx := context.Background()
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	// setup container and
+	// define environment variables
+	ctr := client.
+		Container().
+		From("alpine").
+		With(envVariables(map[string]string{
+			"ENV_VAR_1": "VALUE 1",
+			"ENV_VAR_2": "VALUE 2",
+			"ENV_VAR_3": "VALUE 3",
+		})).
+		WithExec([]string{"env"})
+
+	// print environment variables
+	out, err := ctr.Stdout(ctx)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(out)
+}
+
+func envVariables(envs map[string]string) dagger.WithContainerFunc {
+	return func(c *dagger.Container) *dagger.Container {
+		for key, value := range envs {
+			c = c.WithEnvVariable(key, value)
+		}
+		return c
+	}
+}

--- a/docs/current/cookbook/snippets/environment-variables/main.py
+++ b/docs/current/cookbook/snippets/environment-variables/main.py
@@ -3,11 +3,10 @@ import sys
 import anyio
 import dagger
 
-async def main():
-    config = dagger.Config(log_output=sys.stderr)
 
+async def main():
     # create Dagger client
-    async with dagger.Connection(config) as client:
+    async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
         # setup container and
         # define environment variables
         ctr = (
@@ -25,7 +24,6 @@ async def main():
         # print environment variables
         print(await ctr.stdout())
 
-anyio.run(main)
 
 def env_variables(envs: dict[str, str]):
     def env_variables_inner(ctr: dagger.Container):
@@ -33,3 +31,7 @@ def env_variables(envs: dict[str, str]):
             ctr = ctr.with_env_variable(key, value)
         return ctr
     return env_variables_inner
+
+
+anyio.run(main)
+

--- a/docs/current/cookbook/snippets/environment-variables/main.py
+++ b/docs/current/cookbook/snippets/environment-variables/main.py
@@ -1,0 +1,35 @@
+import sys
+
+import anyio
+import dagger
+
+async def main():
+    config = dagger.Config(log_output=sys.stderr)
+
+    # create Dagger client
+    async with dagger.Connection(config) as client:
+        # setup container and
+        # define environment variables
+        ctr = (
+            client
+            .container()
+            .from_("alpine")
+            .with_(env_variables({
+                "ENV_VAR_1": "VALUE 1",
+                "ENV_VAR_2": "VALUE 2",
+                "ENV_VAR_3": "VALUE 3",
+            }))
+            .with_exec(["env"])
+        )
+
+        # print environment variables
+        print(await ctr.stdout())
+
+anyio.run(main)
+
+def env_variables(envs: dict[str, str]):
+    def env_variables_inner(ctr: dagger.Container):
+        for key, value in envs.items():
+            ctr = ctr.with_env_variable(key, value)
+        return ctr
+    return env_variables_inner


### PR DESCRIPTION
Fixes:
- https://github.com/dagger/dagger/issues/4835

This PR introduces a new utility function `env_variables` that can be used to set multiple environment variables. It relies on the `with()` helper that users can rely on to implement their own API wrapper.

