### PR TITLE
NodeJS SDK - Export Container type

### DIFF
--- a/sdk/nodejs/api/test/api.spec.ts
+++ b/sdk/nodejs/api/test/api.spec.ts
@@ -3,12 +3,12 @@ import { randomUUID } from "crypto"
 import fs from "fs"
 
 import { TooManyNestedObjectsError } from "../../common/errors/index.js"
-import { connect } from "../../index.js"
 import Client, {
+  connect,
   ClientContainerOpts,
   Container,
   Directory,
-} from "../client.gen.js"
+} from "../../index.js"
 import { queryFlatten, buildQuery } from "../utils.js"
 
 const querySanitizer = (query: string) => query.replace(/\s+/g, " ")

--- a/sdk/nodejs/api/test/api.spec.ts
+++ b/sdk/nodejs/api/test/api.spec.ts
@@ -3,8 +3,12 @@ import { randomUUID } from "crypto"
 import fs from "fs"
 
 import { TooManyNestedObjectsError } from "../../common/errors/index.js"
-import Client, { connect } from "../../index.js"
-import { ClientContainerOpts, Container, Directory } from "../client.gen.js"
+import { connect } from "../../index.js"
+import Client, {
+  ClientContainerOpts,
+  Container,
+  Directory,
+} from "../client.gen.js"
 import { queryFlatten, buildQuery } from "../utils.js"
 
 const querySanitizer = (query: string) => query.replace(/\s+/g, " ")

--- a/sdk/nodejs/index.ts
+++ b/sdk/nodejs/index.ts
@@ -1,4 +1,4 @@
-import Client from "./api/client.gen.js"
+import Client, { Container } from "./api/client.gen.js"
 
 export { gql } from "graphql-tag"
 export { GraphQLClient } from "graphql-request"
@@ -6,3 +6,4 @@ export { GraphQLClient } from "graphql-request"
 export { connect, ConnectOpts, CallbackFct } from "./connect.js"
 
 export default Client
+export { Container }

--- a/sdk/nodejs/index.ts
+++ b/sdk/nodejs/index.ts
@@ -1,9 +1,6 @@
-import Client, { Container } from "./api/client.gen.js"
+export * from "./api/client.gen.js"
 
 export { gql } from "graphql-tag"
 export { GraphQLClient } from "graphql-request"
 
 export { connect, ConnectOpts, CallbackFct } from "./connect.js"
-
-export default Client
-export { Container }

--- a/sdk/nodejs/index.ts
+++ b/sdk/nodejs/index.ts
@@ -1,6 +1,5 @@
 export * from "./api/client.gen.js"
-
+export { default } from "./api/client.gen.js"
 export { gql } from "graphql-tag"
 export { GraphQLClient } from "graphql-request"
-
 export { connect, ConnectOpts, CallbackFct } from "./connect.js"


### PR DESCRIPTION
To properly use typescript with the Node.js SDK, it should export more types.

In order to fix the cookbook PR #5139, this PR will only cover `Container` type.

Additional PRs will be developed subsequently to accommodate other types.