### PR TITLE
use TUI for `dagger do`, `dagger query`, `dagger listen`

### DIFF
--- a/cmd/dagger/do.go
+++ b/cmd/dagger/do.go
@@ -13,7 +13,6 @@ import (
 	"dagger.io/dagger"
 	"github.com/dagger/dagger/engine"
 	internalengine "github.com/dagger/dagger/internal/engine"
-	"github.com/dagger/dagger/internal/engine/journal"
 	"github.com/dagger/dagger/router"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -52,9 +51,8 @@ var doCmd = &cobra.Command{
 		dynamicCmdArgs := flags.Args()
 
 		engineConf := engine.Config{
-			Workdir:       workdir,
-			RunnerHost:    internalengine.RunnerHost(),
-			JournalWriter: journal.Discard{},
+			Workdir:    workdir,
+			RunnerHost: internalengine.RunnerHost(),
 		}
 		if debugLogs {
 			engineConf.LogOutput = os.Stderr

--- a/cmd/dagger/do.go
+++ b/cmd/dagger/do.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 
 	"dagger.io/dagger"
-	"github.com/dagger/dagger/engine"
-	internalengine "github.com/dagger/dagger/internal/engine"
 	"github.com/dagger/dagger/router"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -50,16 +48,8 @@ var doCmd = &cobra.Command{
 		}
 		dynamicCmdArgs := flags.Args()
 
-		engineConf := engine.Config{
-			Workdir:    workdir,
-			RunnerHost: internalengine.RunnerHost(),
-		}
-		if debugLogs {
-			engineConf.LogOutput = os.Stderr
-		}
-
-		cmd.Println("Loading+installing project (use --debug to track progress)...")
-		return engine.Start(cmd.Context(), engineConf, func(ctx context.Context, r *router.Router) error {
+		// cmd.Println("Loading+installing project (use --debug to track progress)...")
+		return withEngineAndTUI(cmd.Context(), func(ctx context.Context, r *router.Router, sessionToken string) error {
 			opts := []dagger.ClientOpt{
 				dagger.WithConn(router.EngineConn(r)),
 			}

--- a/cmd/dagger/do.go
+++ b/cmd/dagger/do.go
@@ -11,11 +11,13 @@ import (
 	"strings"
 
 	"dagger.io/dagger"
+	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/router"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/vektah/gqlparser/v2/ast"
 	"github.com/vektah/gqlparser/v2/formatter"
+	"github.com/vito/progrock"
 )
 
 var (
@@ -48,13 +50,17 @@ var doCmd = &cobra.Command{
 		}
 		dynamicCmdArgs := flags.Args()
 
-		// cmd.Println("Loading+installing project (use --debug to track progress)...")
-		return withEngineAndTUI(cmd.Context(), func(ctx context.Context, r *router.Router, sessionToken string) error {
+		return withEngineAndTUI(cmd.Context(), engine.Config{}, func(ctx context.Context, r *router.Router) (err error) {
+			rec := progrock.RecorderFromContext(ctx)
+			vtx := rec.Vertex("do", strings.Join(os.Args, " "))
+			cmd.SetOut(vtx.Stdout())
+			cmd.SetErr(vtx.Stderr())
+			defer func() { vtx.Done(err) }()
+
+			cmd.Println("Loading+installing project...")
+
 			opts := []dagger.ClientOpt{
 				dagger.WithConn(router.EngineConn(r)),
-			}
-			if debugLogs {
-				opts = append(opts, dagger.WithLogOutput(os.Stderr))
 			}
 			c, err := dagger.Connect(ctx, opts...)
 			if err != nil {

--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -113,7 +113,6 @@ func inlineTUI(
 	fn engine.StartCallback,
 ) error {
 	tape := progrock.NewTape()
-	tape.ShowAllOutput(true)
 	if debugLogs {
 		tape.ShowInternal(true)
 	}

--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -114,6 +114,7 @@ func inlineTUI(
 ) error {
 	tape := progrock.NewTape()
 	if debugLogs {
+		tape.ShowAllOutput(true)
 		tape.ShowInternal(true)
 	}
 

--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -2,31 +2,188 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/dagger/dagger/engine"
 	internalengine "github.com/dagger/dagger/internal/engine"
-	"github.com/dagger/dagger/internal/engine/journal"
+	"github.com/dagger/dagger/internal/tui"
+	"github.com/dagger/dagger/router"
+	"github.com/google/uuid"
+	"github.com/vito/progrock"
 )
 
-func withEngine(
+var useShinyNewTUI = os.Getenv("_EXPERIMENTAL_DAGGER_TUI") != ""
+var interactive bool
+
+func init() {
+	rootCmd.Flags().BoolVarP(
+		&interactive,
+		"interactive",
+		"i",
+		false,
+		"use interactive tree-style TUI",
+	)
+}
+
+type EngineTUIFunc func(
 	ctx context.Context,
+	api *router.Router,
 	sessionToken string,
-	journalW journal.Writer,
-	logsW io.Writer,
-	cb engine.StartCallback,
+) error
+
+func withEngineAndTUI(
+	ctx context.Context,
+	fn EngineTUIFunc,
 ) error {
+	sessionToken, err := uuid.NewRandom()
+	if err != nil {
+		return fmt.Errorf("generate uuid: %w", err)
+	}
+
 	engineConf := engine.Config{
 		Workdir:       workdir,
-		SessionToken:  sessionToken,
+		SessionToken:  sessionToken.String(),
 		RunnerHost:    internalengine.RunnerHost(),
 		DisableHostRW: disableHostRW,
 		JournalFile:   os.Getenv("_EXPERIMENTAL_DAGGER_JOURNAL"),
-		JournalWriter: journalW,
 	}
+
+	if !useShinyNewTUI {
+		return engine.Start(ctx, engineConf, func(ctx context.Context, api *router.Router) error {
+			return fn(ctx, api, engineConf.SessionToken)
+		})
+	}
+
+	if interactive {
+		return interactiveTUI(ctx, engineConf, fn)
+	}
+
+	return inlineTUI(ctx, engineConf, fn)
+}
+
+func progrockTee(progW progrock.Writer) (progrock.Writer, error) {
+	if log := os.Getenv("_EXPERIMENTAL_DAGGER_PROGROCK_JOURNAL"); log != "" {
+		fileW, err := newProgrockWriter(log)
+		if err != nil {
+			return nil, fmt.Errorf("open progrock log: %w", err)
+		}
+
+		return progrock.MultiWriter{progW, fileW}, nil
+	}
+
+	return progW, nil
+}
+
+func interactiveTUI(
+	ctx context.Context,
+	engineConf engine.Config,
+	fn EngineTUIFunc,
+) error {
+	progR, progW := progrock.Pipe()
+	progW, err := progrockTee(progW)
+	if err != nil {
+		return err
+	}
+
+	engineConf.ProgrockWriter = progW
+
+	ctx, quit := context.WithCancel(ctx)
+	defer quit()
+
+	program := tea.NewProgram(tui.New(quit, progR), tea.WithAltScreen())
+
+	tuiDone := make(chan error, 1)
+	go func() {
+		_, err := program.Run()
+		tuiDone <- err
+	}()
+
+	var cbErr error
+	engineErr := engine.Start(ctx, engineConf, func(ctx context.Context, api *router.Router) error {
+		cbErr = fn(ctx, api, engineConf.SessionToken)
+		return cbErr
+	})
+	if cbErr != nil {
+		// avoid unnecessary error wrapping
+		return cbErr
+	}
+
+	tuiErr := <-tuiDone
+	return errors.Join(tuiErr, engineErr)
+}
+
+func inlineTUI(
+	ctx context.Context,
+	engineConf engine.Config,
+	fn EngineTUIFunc,
+) error {
+	tape := progrock.NewTape()
 	if debugLogs {
-		engineConf.LogOutput = logsW
+		tape.ShowInternal(true)
 	}
-	return engine.Start(ctx, engineConf, cb)
+
+	progW, engineErr := progrockTee(tape)
+	if engineErr != nil {
+		return engineErr
+	}
+
+	engineConf.ProgrockWriter = progW
+
+	ctx, quit := context.WithCancel(ctx)
+	defer quit()
+
+	stop := progrock.DefaultUI().RenderLoop(quit, tape, os.Stderr, true)
+	defer stop()
+
+	var cbErr error
+	engineErr = engine.Start(ctx, engineConf, func(ctx context.Context, api *router.Router) error {
+		cbErr = fn(ctx, api, engineConf.SessionToken)
+		return cbErr
+	})
+	if cbErr != nil {
+		return cbErr
+	}
+
+	return engineErr
+}
+
+type progOutWriter struct {
+	prog *tea.Program
+}
+
+func (w progOutWriter) Write(p []byte) (int, error) {
+	w.prog.Send(tui.CommandOutMsg{Output: p})
+	return len(p), nil
+}
+
+func newProgrockWriter(dest string) (progrock.Writer, error) {
+	f, err := os.Create(dest)
+	if err != nil {
+		return nil, err
+	}
+
+	return progrockFileWriter{
+		enc: json.NewEncoder(f),
+		c:   f,
+	}, nil
+}
+
+type progrockFileWriter struct {
+	enc *json.Encoder
+	c   io.Closer
+}
+
+var _ progrock.Writer = progrockFileWriter{}
+
+func (p progrockFileWriter) WriteStatus(update *progrock.StatusUpdate) error {
+	return p.enc.Encode(update)
+}
+
+func (p progrockFileWriter) Close() error {
+	return p.c.Close()
 }

--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -22,7 +22,7 @@ func withEngine(
 		SessionToken:  sessionToken,
 		RunnerHost:    internalengine.RunnerHost(),
 		DisableHostRW: disableHostRW,
-		JournalURI:    os.Getenv("_EXPERIMENTAL_DAGGER_JOURNAL"),
+		JournalFile:   os.Getenv("_EXPERIMENTAL_DAGGER_JOURNAL"),
 		JournalWriter: journalW,
 	}
 	if debugLogs {

--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -143,15 +143,6 @@ func inlineTUI(
 	return engineErr
 }
 
-type progOutWriter struct {
-	prog *tea.Program
-}
-
-func (w progOutWriter) Write(p []byte) (int, error) {
-	w.prog.Send(tui.CommandOutMsg{Output: p})
-	return len(p), nil
-}
-
 func newProgrockWriter(dest string) (progrock.Writer, error) {
 	f, err := os.Create(dest)
 	if err != nil {

--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -114,7 +114,6 @@ func inlineTUI(
 ) error {
 	tape := progrock.NewTape()
 	if debugLogs {
-		tape.ShowAllOutput(true)
 		tape.ShowInternal(true)
 	}
 

--- a/cmd/dagger/listen.go
+++ b/cmd/dagger/listen.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/dagger/dagger/internal/engine/journal"
 	"github.com/dagger/dagger/router"
 	"github.com/spf13/cobra"
 )
@@ -24,18 +23,18 @@ var listenCmd = &cobra.Command{
 	Short:   "Starts the engine server",
 }
 
+func init() {
+	listenCmd.Flags().StringVarP(&listenAddress, "listen", "", "127.0.0.1:8080", "Listen on network address ADDR")
+	listenCmd.Flags().BoolVar(&disableHostRW, "disable-host-read-write", false, "disable host read/write access")
+}
+
 func Listen(cmd *cobra.Command, args []string) {
 	ctx := context.Background()
-	if err := withEngine(ctx, "", journal.Discard{}, os.Stderr, func(ctx context.Context, r *router.Router) error {
+	if err := withEngineAndTUI(ctx, func(ctx context.Context, r *router.Router, sessionToken string) error {
 		fmt.Fprintf(os.Stderr, "==> server listening on http://%s/query\n", listenAddress)
 		return http.ListenAndServe(listenAddress, r) //nolint:gosec
 	}); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
-}
-
-func init() {
-	listenCmd.Flags().StringVarP(&listenAddress, "listen", "", "127.0.0.1:8080", "Listen on network address ADDR")
-	listenCmd.Flags().BoolVar(&disableHostRW, "disable-host-read-write", false, "disable host read/write access")
 }

--- a/cmd/dagger/listen.go
+++ b/cmd/dagger/listen.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/router"
 	"github.com/spf13/cobra"
 )
@@ -30,7 +31,7 @@ func init() {
 
 func Listen(cmd *cobra.Command, args []string) {
 	ctx := context.Background()
-	if err := withEngineAndTUI(ctx, func(ctx context.Context, r *router.Router, sessionToken string) error {
+	if err := withEngineAndTUI(ctx, engine.Config{}, func(ctx context.Context, r *router.Router) error {
 		fmt.Fprintf(os.Stderr, "==> server listening on http://%s/query\n", listenAddress)
 		return http.ListenAndServe(listenAddress, r) //nolint:gosec
 	}); err != nil {

--- a/cmd/dagger/query.go
+++ b/cmd/dagger/query.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/router"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -90,7 +91,7 @@ func Query(cmd *cobra.Command, args []string) {
 
 func doQuery(ctx context.Context, query, op string, vars map[string]interface{}) ([]byte, error) {
 	res := make(map[string]interface{})
-	err := withEngineAndTUI(ctx, func(ctx context.Context, r *router.Router, sessionToken string) error {
+	err := withEngineAndTUI(ctx, engine.Config{}, func(ctx context.Context, r *router.Router) error {
 		_, err := r.Do(ctx, query, op, vars, &res)
 		return err
 	})

--- a/cmd/dagger/query.go
+++ b/cmd/dagger/query.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/dagger/dagger/internal/engine/journal"
 	"github.com/dagger/dagger/router"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -91,7 +90,7 @@ func Query(cmd *cobra.Command, args []string) {
 
 func doQuery(ctx context.Context, query, op string, vars map[string]interface{}) ([]byte, error) {
 	res := make(map[string]interface{})
-	err := withEngine(ctx, "", journal.Discard{}, os.Stderr, func(ctx context.Context, r *router.Router) error {
+	err := withEngineAndTUI(ctx, func(ctx context.Context, r *router.Router, sessionToken string) error {
 		_, err := r.Do(ctx, query, op, vars, &res)
 		return err
 	})

--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -11,7 +11,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/router"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"github.com/vito/progrock"
 )
@@ -77,7 +79,16 @@ func Run(cmd *cobra.Command, args []string) {
 }
 
 func run(ctx context.Context, args []string) error {
-	return withEngineAndTUI(ctx, func(ctx context.Context, api *router.Router, sessionToken string) error {
+	u, err := uuid.NewRandom()
+	if err != nil {
+		return fmt.Errorf("generate uuid: %w", err)
+	}
+
+	sessionToken := u.String()
+
+	return withEngineAndTUI(ctx, engine.Config{
+		SessionToken: sessionToken,
+	}, func(ctx context.Context, api *router.Router) error {
 		sessionL, err := net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {
 			return fmt.Errorf("session listen: %w", err)

--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -112,7 +112,7 @@ func run(ctx context.Context, args []string) error {
 		go http.Serve(sessionL, api) // nolint:gosec
 
 		var cmdErr error
-		if useShinyNewTUI {
+		if useTUI {
 			rec := progrock.RecorderFromContext(ctx)
 
 			cmdline := strings.Join(subCmd.Args, " ")

--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -213,7 +213,7 @@ func inlineTUI(
 		SessionToken:   sessionToken.String(),
 		RunnerHost:     internalengine.RunnerHost(),
 		DisableHostRW:  disableHostRW,
-		JournalURI:     os.Getenv("_EXPERIMENTAL_DAGGER_JOURNAL"),
+		JournalFile:    os.Getenv("_EXPERIMENTAL_DAGGER_JOURNAL"),
 		ProgrockWriter: mw,
 	}
 

--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"os"
@@ -13,12 +11,7 @@ import (
 	"strings"
 	"time"
 
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/dagger/dagger/engine"
-	internalengine "github.com/dagger/dagger/internal/engine"
-	"github.com/dagger/dagger/internal/tui"
 	"github.com/dagger/dagger/router"
-	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"github.com/vito/progrock"
 )
@@ -53,8 +46,6 @@ DAGGER_SESSION_PORT and DAGGER_SESSION_TOKEN will be convieniently injected auto
 }
 
 var waitDelay time.Duration
-var useShinyNewTUI = os.Getenv("_EXPERIMENTAL_DAGGER_TUI") != ""
-var interactive bool
 
 func init() {
 	// don't require -- to disambiguate subcommand flags
@@ -65,14 +56,6 @@ func init() {
 		"cleanup-timeout",
 		10*time.Second,
 		"max duration to wait between SIGTERM and SIGKILL on interrupt",
-	)
-
-	runCmd.Flags().BoolVarP(
-		&interactive,
-		"interactive",
-		"i",
-		false,
-		"use interactive tree-style TUI",
 	)
 }
 
@@ -134,166 +117,6 @@ func run(ctx context.Context, args []string) error {
 			cmdErr = subCmd.Run()
 		}
 
-		go http.Serve(sessionL, api) // nolint:gosec
-
 		return cmdErr
 	})
-}
-
-func progrockTee(progW progrock.Writer) (progrock.Writer, error) {
-	if log := os.Getenv("_EXPERIMENTAL_DAGGER_PROGROCK_JOURNAL"); log != "" {
-		fileW, err := newProgrockWriter(log)
-		if err != nil {
-			return nil, fmt.Errorf("open progrock log: %w", err)
-		}
-
-		return progrock.MultiWriter{progW, fileW}, nil
-	}
-
-	return progW, nil
-}
-
-func interactiveTUI(
-	ctx context.Context,
-	engineConf engine.Config,
-	fn EngineTUIFunc,
-) error {
-	progR, progW := progrock.Pipe()
-	progW, err := progrockTee(progW)
-	if err != nil {
-		return err
-	}
-
-	engineConf.ProgrockWriter = progW
-
-	ctx, quit := context.WithCancel(ctx)
-	defer quit()
-
-	program := tea.NewProgram(tui.New(quit, progR), tea.WithAltScreen())
-
-	tuiDone := make(chan error, 1)
-	go func() {
-		_, err := program.Run()
-		tuiDone <- err
-	}()
-
-	var cbErr error
-	engineErr := engine.Start(ctx, engineConf, func(ctx context.Context, api *router.Router) error {
-		cbErr = fn(ctx, api, engineConf.SessionToken)
-		return cbErr
-	})
-	if cbErr != nil {
-		// avoid unnecessary error wrapping
-		return cbErr
-	}
-
-	tuiErr := <-tuiDone
-	return errors.Join(tuiErr, engineErr)
-}
-
-func inlineTUI(
-	ctx context.Context,
-	engineConf engine.Config,
-	fn EngineTUIFunc,
-) error {
-	tape := progrock.NewTape()
-	if debugLogs {
-		tape.ShowInternal(true)
-	}
-
-	progW, engineErr := progrockTee(tape)
-	if engineErr != nil {
-		return engineErr
-	}
-
-	engineConf.ProgrockWriter = progW
-
-	ctx, quit := context.WithCancel(ctx)
-	defer quit()
-
-	stop := progrock.DefaultUI().RenderLoop(quit, tape, os.Stderr, true)
-	defer stop()
-
-	var cbErr error
-	engineErr = engine.Start(ctx, engineConf, func(ctx context.Context, api *router.Router) error {
-		cbErr = fn(ctx, api, engineConf.SessionToken)
-		return cbErr
-	})
-	if cbErr != nil {
-		return cbErr
-	}
-
-	return engineErr
-}
-
-type progOutWriter struct {
-	prog *tea.Program
-}
-
-func (w progOutWriter) Write(p []byte) (int, error) {
-	w.prog.Send(tui.CommandOutMsg{Output: p})
-	return len(p), nil
-}
-
-func newProgrockWriter(dest string) (progrock.Writer, error) {
-	f, err := os.Create(dest)
-	if err != nil {
-		return nil, err
-	}
-
-	return progrockFileWriter{
-		enc: json.NewEncoder(f),
-		c:   f,
-	}, nil
-}
-
-type progrockFileWriter struct {
-	enc *json.Encoder
-	c   io.Closer
-}
-
-var _ progrock.Writer = progrockFileWriter{}
-
-func (p progrockFileWriter) WriteStatus(update *progrock.StatusUpdate) error {
-	return p.enc.Encode(update)
-}
-
-func (p progrockFileWriter) Close() error {
-	return p.c.Close()
-}
-
-type EngineTUIFunc func(
-	ctx context.Context,
-	api *router.Router,
-	sessionToken string,
-) error
-
-func withEngineAndTUI(
-	ctx context.Context,
-	fn EngineTUIFunc,
-) error {
-	sessionToken, err := uuid.NewRandom()
-	if err != nil {
-		return fmt.Errorf("generate uuid: %w", err)
-	}
-
-	engineConf := engine.Config{
-		Workdir:       workdir,
-		SessionToken:  sessionToken.String(),
-		RunnerHost:    internalengine.RunnerHost(),
-		DisableHostRW: disableHostRW,
-		JournalFile:   os.Getenv("_EXPERIMENTAL_DAGGER_JOURNAL"),
-	}
-
-	if !useShinyNewTUI {
-		return engine.Start(ctx, engineConf, func(ctx context.Context, api *router.Router) error {
-			return fn(ctx, api, engineConf.SessionToken)
-		})
-	}
-
-	if interactive {
-		return interactiveTUI(ctx, engineConf, fn)
-	}
-
-	return inlineTUI(ctx, engineConf, fn)
 }

--- a/cmd/dagger/session.go
+++ b/cmd/dagger/session.go
@@ -56,7 +56,7 @@ func EngineSession(cmd *cobra.Command, args []string) error {
 		LogOutput:    os.Stderr,
 		RunnerHost:   internalengine.RunnerHost(),
 		SessionToken: sessionToken.String(),
-		JournalURI:   os.Getenv("_EXPERIMENTAL_DAGGER_JOURNAL"),
+		JournalFile:  os.Getenv("_EXPERIMENTAL_DAGGER_JOURNAL"),
 		UserAgent:    labels.AppendCILabel().AppendAnonymousGitLabels(workdir).String(),
 	}
 

--- a/core/schema/base.go
+++ b/core/schema/base.go
@@ -12,17 +12,18 @@ import (
 )
 
 type InitializeArgs struct {
-	Router        *router.Router
-	Workdir       string
-	Gateway       *core.GatewayClient
-	BKClient      *bkclient.Client
-	SolveOpts     bkclient.SolveOpt
-	SolveCh       chan *bkclient.SolveStatus
-	OCIStore      content.Store
-	Platform      specs.Platform
-	DisableHostRW bool
-	Auth          *auth.RegistryAuthProvider
-	Secrets       *secret.Store
+	Router         *router.Router
+	Workdir        string
+	Gateway        *core.GatewayClient
+	BKClient       *bkclient.Client
+	SolveOpts      bkclient.SolveOpt
+	SolveCh        chan *bkclient.SolveStatus
+	OCIStore       content.Store
+	Platform       specs.Platform
+	DisableHostRW  bool
+	Auth           *auth.RegistryAuthProvider
+	Secrets        *secret.Store
+	ProgrockSocket string
 
 	// TODO(vito): remove when stable
 	EnableServices bool
@@ -41,6 +42,8 @@ func New(params InitializeArgs) (router.ExecutableSchema, error) {
 
 		// TODO(vito): remove when stable
 		servicesEnabled: params.EnableServices,
+
+		progSock: params.ProgrockSocket,
 	}
 	host := core.NewHost(params.Workdir, params.DisableHostRW)
 	return router.MergeExecutableSchemas("core",
@@ -71,4 +74,7 @@ type baseSchema struct {
 
 	// TODO(vito): remove when stable
 	servicesEnabled bool
+
+	// path to Progrock forwarding socket
+	progSock string
 }

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -181,7 +181,8 @@ type containerExecArgs struct {
 }
 
 func (s *containerSchema) withExec(ctx *router.Context, parent *core.Container, args containerExecArgs) (*core.Container, error) {
-	return parent.WithExec(ctx, s.gw, s.baseSchema.platform, args.ContainerExecOpts)
+	progSock := &core.Socket{HostPath: s.progSock}
+	return parent.WithExec(ctx, s.gw, progSock, s.baseSchema.platform, args.ContainerExecOpts)
 }
 
 func (s *containerSchema) withDefaultExec(ctx *router.Context, parent *core.Container) (*core.Container, error) {
@@ -192,15 +193,18 @@ func (s *containerSchema) withDefaultExec(ctx *router.Context, parent *core.Cont
 }
 
 func (s *containerSchema) exitCode(ctx *router.Context, parent *core.Container, args any) (int, error) {
-	return parent.ExitCode(ctx, s.gw)
+	progSock := &core.Socket{HostPath: s.progSock}
+	return parent.ExitCode(ctx, s.gw, progSock)
 }
 
 func (s *containerSchema) stdout(ctx *router.Context, parent *core.Container, args any) (string, error) {
-	return parent.MetaFileContents(ctx, s.gw, "stdout")
+	progSock := &core.Socket{HostPath: s.progSock}
+	return parent.MetaFileContents(ctx, s.gw, progSock, "stdout")
 }
 
 func (s *containerSchema) stderr(ctx *router.Context, parent *core.Container, args any) (string, error) {
-	return parent.MetaFileContents(ctx, s.gw, "stderr")
+	progSock := &core.Socket{HostPath: s.progSock}
+	return parent.MetaFileContents(ctx, s.gw, progSock, "stderr")
 }
 
 type containerWithEntrypointArgs struct {

--- a/core/schema/project.go
+++ b/core/schema/project.go
@@ -73,7 +73,8 @@ func (s *projectSchema) load(ctx *router.Context, parent *core.Project, args loa
 	if err != nil {
 		return nil, err
 	}
-	return parent.Load(ctx, s.gw, s.router, source, args.ConfigPath)
+	progSock := &core.Socket{HostPath: s.progSock}
+	return parent.Load(ctx, s.gw, s.router, progSock, source, args.ConfigPath)
 }
 
 func (s *projectSchema) commands(ctx *router.Context, parent *core.Project, args any) ([]core.ProjectCommand, error) {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -569,7 +569,7 @@ func bk2progrock(event *bkclient.SolveStatus) *progrock.StatusUpdate {
 
 func progrockForwarder(w progrock.Writer) (string, progrock.Writer, func() error, error) {
 	progSock := filepath.Join(
-		xdg.CacheHome,
+		xdg.RuntimeDir,
 		"dagger",
 		fmt.Sprintf("progrock-%d.sock", time.Now().UnixNano()),
 	)

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/nxadm/tail v1.4.8
 	github.com/opencontainers/runc v1.1.6
 	github.com/prometheus/procfs v0.9.0
-	github.com/vito/progrock v0.2.0
+	github.com/vito/progrock v0.3.0
 	github.com/vito/vt100 v0.0.0-20230429034200-0ebbfae52df4
 	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53
 )

--- a/go.sum
+++ b/go.sum
@@ -1423,6 +1423,10 @@ github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmF
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vito/progrock v0.2.0 h1:DXZkJysDmTQ3xv+rz0w4WqsYcw6L/1mVRsSwCABem3k=
 github.com/vito/progrock v0.2.0/go.mod h1:rCnvnxqE6ugs4WjS/DTLlhbDR8ANb7pgwtIHDuFr5ac=
+github.com/vito/progrock v0.2.1-0.20230518185953-c005e3ac3d7f h1:Z4GeXtSoqDkOdXrlhAAtw3btjnSoXRarKErrndT/c+o=
+github.com/vito/progrock v0.2.1-0.20230518185953-c005e3ac3d7f/go.mod h1:rCnvnxqE6ugs4WjS/DTLlhbDR8ANb7pgwtIHDuFr5ac=
+github.com/vito/progrock v0.3.0 h1:2ScNW313zncpwBUUS7zYzSBm56sOPTA0MnshRQhnv/8=
+github.com/vito/progrock v0.3.0/go.mod h1:rCnvnxqE6ugs4WjS/DTLlhbDR8ANb7pgwtIHDuFr5ac=
 github.com/vito/vt100 v0.0.0-20230429034200-0ebbfae52df4 h1:MX+b1wthWS36Xo9xcnQzxMJVY5pjv/o+1EiORdbJsgk=
 github.com/vito/vt100 v0.0.0-20230429034200-0ebbfae52df4/go.mod h1:qfoJd8OdENFcCg3MFm//aH0ah6b88mqNAYthSr14FuI=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=

--- a/internal/tui/item.go
+++ b/internal/tui/item.go
@@ -442,33 +442,3 @@ func (g emptyGroup) View() string {
 func (g emptyGroup) Save(dir string) (string, error) {
 	return "", nil
 }
-
-type logsPrinter struct {
-	*Vterm
-
-	name string
-}
-
-func (lp logsPrinter) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	m, cmd := lp.Vterm.Update(msg)
-	lp.Vterm = m.(*Vterm)
-	return lp, cmd
-}
-
-func (lp logsPrinter) Save(dir string) (string, error) {
-	filePath := filepath.Join(dir, sanitizeFilename(lp.name))
-	f, err := os.Create(filePath)
-	if err != nil {
-		return "", err
-	}
-
-	if err := lp.Print(f); err != nil {
-		return "", err
-	}
-
-	if err := f.Close(); err != nil {
-		return "", err
-	}
-
-	return filePath, nil
-}

--- a/internal/tui/item.go
+++ b/internal/tui/item.go
@@ -68,7 +68,7 @@ func (i *Item) Error() *string {
 }
 
 func (i *Item) Save(dir string) (string, error) {
-	filePath := filepath.Join(dir, sanitizeFilename(i.Name()))
+	filePath := filepath.Join(dir, sanitizeFilename(i.Name())) + ".log"
 	f, err := os.Create(filePath)
 	if err != nil {
 		return "", fmt.Errorf("save item to %s as %s: %w", dir, filePath, err)

--- a/internal/tui/item.go
+++ b/internal/tui/item.go
@@ -2,8 +2,6 @@ package tui
 
 import (
 	"bytes"
-	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path"
@@ -17,94 +15,57 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/dagger/dagger/core/pipeline"
-	bkclient "github.com/moby/buildkit/client"
-	"github.com/opencontainers/go-digest"
 	"github.com/tonistiigi/units"
+	"github.com/vito/progrock"
 )
 
-func NewItem(v *bkclient.Vertex, width int) *Item {
-	var name pipeline.CustomName
-	if json.Unmarshal([]byte(v.Name), &name) != nil {
-		name.Name = v.Name
-		if pg := v.ProgressGroup.GetId(); pg != "" {
-			if err := json.Unmarshal([]byte(pg), &name.Pipeline); err != nil {
-				panic("unmarshal pipeline: " + err.Error())
-			}
-		}
-	}
-
-	group := []string{}
-	var isService bool
-	for i, p := range name.Pipeline {
-		if i == 0 && p.Name == "" {
-			// skip root pipeline; we show the command logs instead
-			continue
-		}
-
-		group = append(group, p.Name)
-
-		for _, l := range p.Labels {
-			if l.Name == pipeline.ServiceHostnameLabel {
-				isService = true
-			}
-		}
-	}
-
-	saneName := strings.Join(strings.Fields(name.Name), " ")
+func NewItem(v *progrock.Vertex, width int) *Item {
+	saneName := strings.Join(strings.Fields(v.Name), " ")
 
 	return &Item{
-		id:            v.Digest,
-		inputs:        v.Inputs,
-		name:          saneName,
-		group:         group,
-		logs:          &bytes.Buffer{},
-		logsModel:     NewVterm(width),
-		statusesModel: viewport.New(width, 1),
-		spinner:       newSpinner(),
-		width:         width,
-		isService:     isService,
+		id:         v.Id,
+		inputs:     v.Inputs,
+		name:       saneName,
+		logs:       &bytes.Buffer{},
+		logsModel:  NewVterm(width),
+		tasksModel: viewport.New(width, 1),
+		spinner:    newSpinner(),
+		width:      width,
 	}
 }
 
 var _ TreeEntry = &Item{}
 
 type Item struct {
-	id            digest.Digest
-	inputs        []digest.Digest
-	name          string
-	group         []string
-	started       *time.Time
-	completed     *time.Time
-	cached        bool
-	error         string
-	logs          *bytes.Buffer
-	logsModel     *Vterm
-	statuses      []*bkclient.VertexStatus
-	statusesModel viewport.Model
-	internal      bool
-	spinner       spinner.Model
-	width         int
-	isService     bool
+	id         string
+	inputs     []string
+	name       string
+	group      []string
+	started    *time.Time
+	completed  *time.Time
+	cached     bool
+	error      *string
+	logs       *bytes.Buffer
+	logsModel  *Vterm
+	tasks      []*progrock.VertexTask
+	tasksModel viewport.Model
+	internal   bool
+	spinner    spinner.Model
+	width      int
+	isInfinite bool
 }
 
-func (i *Item) ID() digest.Digest       { return i.id }
-func (i *Item) Inputs() []digest.Digest { return i.inputs }
-func (i *Item) Name() string            { return i.name }
-func (i *Item) Internal() bool          { return i.internal }
-func (i *Item) Entries() []TreeEntry    { return nil }
-func (i *Item) Started() *time.Time     { return i.started }
-func (i *Item) Completed() *time.Time   { return i.completed }
-func (i *Item) Cached() bool            { return i.cached }
-func (i *Item) Service() bool           { return i.isService }
+func (i *Item) ID() string            { return i.id }
+func (i *Item) Inputs() []string      { return i.inputs }
+func (i *Item) Name() string          { return i.name }
+func (i *Item) Internal() bool        { return i.internal }
+func (i *Item) Entries() []TreeEntry  { return nil }
+func (i *Item) Started() *time.Time   { return i.started }
+func (i *Item) Completed() *time.Time { return i.completed }
+func (i *Item) Cached() bool          { return i.cached }
+func (i *Item) Infinite() bool        { return i.isInfinite }
 
-func (i *Item) Error() string {
-	if i.Service() && strings.Contains(i.error, context.Canceled.Error()) {
-		// ignore services "errors" from simply being interrupted when no longer
-		// needed
-		return ""
-	}
-
+func (i *Item) Error() *string {
 	return i.error
 }
 
@@ -144,34 +105,38 @@ func (i *Item) Open() tea.Cmd {
 	return openEditor(filePath)
 }
 
-func (i *Item) UpdateVertex(v *bkclient.Vertex) {
+func (i *Item) UpdateVertex(v *progrock.Vertex) {
 	// Started clock might reset for each layer when pulling images.
 	// We want to keep the original started time and only updated the completed time.
 	if i.started == nil && v.Started != nil {
-		i.started = v.Started
+		t := v.Started.AsTime()
+		i.started = &t
 	}
-	i.completed = v.Completed
+	if v.Completed != nil {
+		t := v.Completed.AsTime()
+		i.completed = &t
+	}
 	i.cached = v.Cached
 	i.error = v.Error
 }
 
-func (i *Item) UpdateLog(log *bkclient.VertexLog) {
+func (i *Item) UpdateLog(log *progrock.VertexLog) {
 	i.logsModel.Write(log.Data)
 }
 
-func (i *Item) UpdateStatus(status *bkclient.VertexStatus) {
-	var current *bkclient.VertexStatus
-	for _, s := range i.statuses {
-		if s.ID == status.ID {
-			current = s
+func (i *Item) UpdateStatus(task *progrock.VertexTask) {
+	var current int = -1
+	for i, s := range i.tasks {
+		if s.Name == task.Name {
+			current = i
 			break
 		}
 	}
 
-	if current == nil {
-		i.statuses = append(i.statuses, status)
+	if current == -1 {
+		i.tasks = append(i.tasks, task)
 	} else {
-		*current = *status
+		i.tasks[current] = task
 	}
 }
 
@@ -189,9 +154,9 @@ func (i *Item) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		i.spinner = spinnerM
 		return i, cmd
 	default:
-		if len(i.statuses) > 0 {
-			statusM, cmd := i.statusesModel.Update(msg)
-			i.statusesModel = statusM
+		if len(i.tasks) > 0 {
+			statusM, cmd := i.tasksModel.Update(msg)
+			i.tasksModel = statusM
 			return i, cmd
 		}
 		vtermM, cmd := i.logsModel.Update(msg)
@@ -201,9 +166,9 @@ func (i *Item) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (i *Item) View() string {
-	if len(i.statuses) > 0 {
-		i.statusesModel.SetContent(i.statusView())
-		return i.statusesModel.View()
+	if len(i.tasks) > 0 {
+		i.tasksModel.SetContent(i.tasksView())
+		return i.tasksModel.View()
 	}
 
 	return i.logsModel.View()
@@ -211,50 +176,50 @@ func (i *Item) View() string {
 
 func (i *Item) SetHeight(height int) {
 	i.logsModel.SetHeight(height)
-	i.statusesModel.Height = height
+	i.tasksModel.Height = height
 }
 
 func (i *Item) SetWidth(width int) {
 	i.width = width
 	i.logsModel.SetWidth(width)
-	i.statusesModel.Width = width
+	i.tasksModel.Width = width
 }
 
 func (i *Item) ScrollPercent() float64 {
-	if len(i.statuses) > 0 {
-		return i.statusesModel.ScrollPercent()
+	if len(i.tasks) > 0 {
+		return i.tasksModel.ScrollPercent()
 	}
 	return i.logsModel.ScrollPercent()
 }
 
-func (i *Item) statusView() string {
-	statuses := []string{}
+func (i *Item) tasksView() string {
+	tasks := []string{}
 
 	bar := progress.New(progress.WithSolidFill("2"))
 	bar.Width = i.width / 4
 
-	for _, s := range i.statuses {
+	for _, t := range i.tasks {
 		status := completedStatus.String() + " "
-		if s.Completed == nil {
+		if t.Completed == nil {
 			status = i.spinner.View() + " "
 		}
 
-		name := s.ID
+		name := t.Name
 
 		progress := ""
-		if s.Total != 0 {
-			progress = fmt.Sprintf("%.2f / %.2f", units.Bytes(s.Current), units.Bytes(s.Total))
-			progress += " " + bar.ViewAs(float64(s.Current)/float64(s.Total))
-		} else if s.Current != 0 {
-			progress = fmt.Sprintf("%.2f", units.Bytes(s.Current))
+		if t.Total != 0 {
+			progress = fmt.Sprintf("%.2f / %.2f", units.Bytes(t.Current), units.Bytes(t.Total))
+			progress += " " + bar.ViewAs(float64(t.Current)/float64(t.Total))
+		} else if t.Current != 0 {
+			progress = fmt.Sprintf("%.2f", units.Bytes(t.Current))
 		}
 
 		pad := strings.Repeat(" ", max(0, i.width-lipgloss.Width(status)-lipgloss.Width(name)-lipgloss.Width(progress)))
 		view := status + name + pad + progress
-		statuses = append(statuses, view)
+		tasks = append(tasks, view)
 	}
 
-	return strings.Join(statuses, "\n")
+	return strings.Join(tasks, "\n")
 }
 
 type groupModel interface {
@@ -289,11 +254,11 @@ func NewGroup(id, name string, logs groupModel) *Group {
 
 var _ TreeEntry = &Group{}
 
-func (g *Group) ID() digest.Digest {
-	return digest.Digest(g.id)
+func (g *Group) ID() string {
+	return g.id
 }
 
-func (g *Group) Inputs() []digest.Digest {
+func (g *Group) Inputs() []string {
 	return nil
 }
 
@@ -371,16 +336,16 @@ func (g *Group) Cached() bool {
 	return true
 }
 
-func (g *Group) Error() string {
+func (g *Group) Error() *string {
 	for _, e := range g.entries {
-		if e.Error() != "" {
+		if e.Error() != nil {
 			return e.Error()
 		}
 	}
-	return ""
+	return nil
 }
 
-func (g *Group) Service() bool {
+func (g *Group) Infinite() bool {
 	return false
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -87,7 +87,7 @@ func (m Model) adjustLocalTime(t *timestamppb.Timestamp) *timestamppb.Timestamp 
 
 	adjusted := t.AsTime().Add(m.localTimeDiff)
 	cp := proto.Clone(t).(*timestamppb.Timestamp)
-	cp.Seconds = int64(adjusted.Unix())
+	cp.Seconds = adjusted.Unix()
 	cp.Nanos = int32(adjusted.Nanosecond())
 	return cp
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -400,9 +400,9 @@ func (m Model) errorsView() string {
 		return ""
 	}
 
-	var errs []string
-	for _, err := range m.errors {
-		errs = append(errs, errorStyle.Render(err.Error()))
+	errs := make([]string, len(m.errors))
+	for i, err := range m.errors {
+		errs[i] = errorStyle.Render(err.Error())
 	}
 
 	return lipgloss.JoinVertical(lipgloss.Left, errs...)

--- a/internal/tui/style.go
+++ b/internal/tui/style.go
@@ -75,7 +75,7 @@ var (
 
 	selectedStyleBlur = lipgloss.NewStyle().
 				Inline(true).
-				Background(colorForeground).
+				Background(colorFaint).
 				Foreground(colorBackground)
 
 	completedStatus = lipgloss.NewStyle().

--- a/internal/tui/tree.go
+++ b/internal/tui/tree.go
@@ -388,6 +388,9 @@ func (m *Tree) nth(entry TreeEntry, n int) TreeEntry {
 	if n == 0 {
 		return entry
 	}
+	if m.collapsed[entry] {
+		return nil
+	}
 	skipped := 1
 	for _, child := range entry.Entries() {
 		if found := m.nth(child, n-skipped); found != nil {

--- a/internal/tui/tree.go
+++ b/internal/tui/tree.go
@@ -95,7 +95,7 @@ func (m *Tree) Open() tea.Cmd {
 
 func (m *Tree) View() string {
 	if m.root == nil {
-		return "no root"
+		return ""
 	}
 
 	offset := m.currentOffset

--- a/internal/tui/tree.go
+++ b/internal/tui/tree.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -94,12 +95,13 @@ func (m *Tree) Open() tea.Cmd {
 
 func (m *Tree) View() string {
 	if m.root == nil {
-		return ""
+		return "no root"
 	}
 
 	offset := m.currentOffset(m.root)
 
 	views := m.itemView(m.root, []bool{})
+	log.Println("views", len(views))
 
 	m.viewport.SetContent(strings.Join(views, "\n"))
 

--- a/internal/tui/tree.go
+++ b/internal/tui/tree.go
@@ -288,14 +288,6 @@ func (m *Tree) PageDown() {
 	}
 }
 
-func lastEntry(entry TreeEntry) TreeEntry {
-	entries := entry.Entries()
-	if len(entries) == 0 {
-		return entry
-	}
-	return lastEntry(entries[len(entries)-1])
-}
-
 func (m *Tree) Collapse(entry TreeEntry, recursive bool) {
 	m.setCollapsed(entry, true, recursive)
 }

--- a/internal/tui/tree.go
+++ b/internal/tui/tree.go
@@ -9,24 +9,24 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/opencontainers/go-digest"
 )
 
 type TreeEntry interface {
 	tea.Model
 
-	ID() digest.Digest
-	Inputs() []digest.Digest
+	ID() string
+	Inputs() []string
 
 	Name() string
 
 	Entries() []TreeEntry
 
+	Infinite() bool
+
 	Started() *time.Time
 	Completed() *time.Time
 	Cached() bool
-	Error() string
-	Service() bool
+	Error() *string
 
 	SetWidth(int)
 	SetHeight(int)
@@ -137,7 +137,7 @@ func (m *Tree) statusView(item TreeEntry) string {
 	if item.Cached() {
 		return cachedStatus.String()
 	}
-	if item.Error() != "" {
+	if item.Error() != nil {
 		return failedStatus.String()
 	}
 	if item.Started() != nil {
@@ -464,7 +464,7 @@ func findOldestIncompleteEntry(entry TreeEntry) TreeEntry {
 		cached := e.Cached()
 		entries := e.Entries()
 
-		if e.Service() {
+		if e.Infinite() {
 			// avoid following services, since they run forever
 			return
 		}

--- a/internal/tui/util.go
+++ b/internal/tui/util.go
@@ -37,5 +37,5 @@ func sanitizeFilename(name string) string {
 			return r
 		}
 	}, name)
-	return strings.Join(strings.Fields(sanitized), " ") + ".log"
+	return strings.Join(strings.Fields(sanitized), " ")
 }


### PR DESCRIPTION
This PR extracts the TUI setup from `dagger run` and implements it for all other commands that start an engine.

It also does a few other things:

* The inline TUI is now on by default, and the  `_EXPERIMENTAL_DAGGER_TUI` env has been removed.
* The interactive tree TUI is now behind a `_EXPERIMENTAL_DAGGER_INTERACTIVE_TUI` env.
* The interactive tree TUI has been converted to read from a Progrock event stream instead of Buildkit.
* When stdout and stderr are both a non-TTY, the Buildkit console output format will be used instead. This should be replaced with a Progrock equivalent in the future, but this is a cheap stopgap in the meantime.
  * `--debug` is no longer required to see console output. It seems a little odd to me to be completely silent by default when there's no TTY, but maybe there was a good reason for this?