### PR TITLE
Recover app bootstrapping in Python entrypoints

### DIFF
--- a/demos/python-entrypoints/main.py
+++ b/demos/python-entrypoints/main.py
@@ -5,9 +5,6 @@ import strawberry
 import dagger
 from dagger.server import Server
 
-# TODO: probably not needed
-from dagger.server.cli import app
-
 
 @strawberry.type
 class Hello:
@@ -40,5 +37,3 @@ schema = strawberry.Schema(query=Query)
 
 server = Server(schema, debug=True)
 
-# TODO: probably not needed
-app(prog_name="dagger-server-py")

--- a/demos/python-entrypoints/requirements.txt
+++ b/demos/python-entrypoints/requirements.txt
@@ -1,1 +1,1 @@
-dagger-io[server]
+-e ../../sdk/python[server]

--- a/sdk/python/experimental/hello/requirements.txt
+++ b/sdk/python/experimental/hello/requirements.txt
@@ -1,1 +1,1 @@
-dagger-io
+dagger-io[server]

--- a/sdk/python/src/dagger/__main__.py
+++ b/sdk/python/src/dagger/__main__.py
@@ -1,3 +1,5 @@
+import sys
+
 from .cli import app
 
-app(prog_name="dagger-py")
+sys.exit(app(prog_name="dagger-py"))

--- a/sdk/python/src/dagger/server/__main__.py
+++ b/sdk/python/src/dagger/server/__main__.py
@@ -1,0 +1,5 @@
+import sys
+
+from .cli import app
+
+sys.exit(app(prog_name="dagger-server-py"))


### PR DESCRIPTION
Follow-up to https://github.com/dagger/dagger/pull/5060

Python had initial support for entrypoints but because of publishing to Conda, since we didn't publish the extensions code, it was easier to just remove the entrypoint executable from the SDK (in https://github.com/dagger/dagger/pull/4399, `sdk/python/pyproject.toml`):

```diff
- [tool.poetry.scripts]
- # FIXME: uncomment when extensions become available
- # dagger-server-py = "dagger.server.cli:app"
- dagger-py = "dagger.cli:app"
```

This PR recovers `__main__.py` to enable calling with `python -m`, without creating the `dagger-server-py` entrypoint. That executable did allow replacing the entrypoint shell wrapper in the runtime image, apart from needing `cd` to change the workdir when running the runtime entrypoint. But it also installed it in users venvs, that's why I've not recovered it.

I also simplified installing via `requirements.txt`. For now we can require it.

In the demo, I've changed the dependency to install SDK library from local dir. It'll require a release for `dagger-io[sever]` to have the `__main__.py` module, but it'll also allow iterating on the Python DX going forward.