### PR TITLE
Merge exposed ports on From and Build

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -363,8 +363,6 @@ func (container *Container) From(ctx context.Context, gw bkgw.Client, addr strin
 	recordVertexes(subRecorder, container.FS)
 
 	container.Config = mergeImageConfig(container.Config, imgSpec.Config)
-	container = container.updatePortsFromConfig()
-
 	container.ImageRef = digested.String()
 
 	return container, nil
@@ -507,7 +505,6 @@ func (container *Container) buildUncached(
 			}
 
 			container.Config = mergeImageConfig(container.Config, imgSpec.Config)
-			container = container.updatePortsFromConfig()
 		}
 
 		return container, nil
@@ -1729,47 +1726,6 @@ func (container *Container) WithoutExposedPort(port int, protocol NetworkProtoco
 	container.Config.ExposedPorts = filteredOCI
 
 	return container, nil
-}
-
-func (container *Container) updatePortsFromConfig() *Container {
-	if container.Config.ExposedPorts == nil {
-		return container
-	}
-
-	container = container.Clone()
-
-	// convert to map to preserve the descriptions (not in the OCI spec)
-	existing := make(map[string]*ContainerPort, len(container.Ports))
-	for _, p := range container.Ports {
-		p := p
-		ociPort := fmt.Sprintf("%d/%s", p.Port, p.Protocol.Network())
-		existing[ociPort] = &p
-	}
-
-	ports := make([]ContainerPort, 0, len(container.Config.ExposedPorts))
-	for ociPort := range container.Config.ExposedPorts {
-		p, exists := existing[ociPort]
-		if !exists {
-			// ignore errors when parsing from OCI
-			port, proto, ok := strings.Cut(ociPort, "/")
-			if !ok {
-				continue
-			}
-			portNr, err := strconv.Atoi(port)
-			if err != nil {
-				continue
-			}
-			p = &ContainerPort{
-				Port:     portNr,
-				Protocol: NetworkProtocol(strings.ToUpper(proto)),
-			}
-		}
-		ports = append(ports, *p)
-	}
-
-	container.Ports = ports
-
-	return container
 }
 
 func (container *Container) WithServiceBinding(svc *Container, alias string) (*Container, error) {

--- a/core/container.go
+++ b/core/container.go
@@ -1687,7 +1687,20 @@ func (container *Container) Endpoint(port int, scheme string) (string, error) {
 func (container *Container) WithExposedPort(port ContainerPort) (*Container, error) {
 	container = container.Clone()
 
-	container.Ports = append(container.Ports, port)
+	// replace existing port to avoid duplicates
+	gotOne := false
+
+	for i, p := range container.Ports {
+		if p.Port == port.Port && p.Protocol == port.Protocol {
+			container.Ports[i] = port
+			gotOne = true
+			break
+		}
+	}
+
+	if !gotOne {
+		container.Ports = append(container.Ports, port)
+	}
 
 	if container.Config.ExposedPorts == nil {
 		container.Config.ExposedPorts = map[string]struct{}{}

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3265,8 +3265,7 @@ func TestContainerInsecureRootCapabilitesWithService(t *testing.T) {
 			Sharing: dagger.Private,
 		}).
 		WithMountedCache("/tmp", c.CacheVolume("share-tmp")).
-		WithoutExposedPort(2376).
-		WithExposedPort(2375). // not needed, just to be explicit
+		WithExposedPort(2375).
 		WithExec([]string{
 			"dockerd",
 			"--host=tcp://0.0.0.0:2375",
@@ -3860,14 +3859,14 @@ EXPOSE 8080
 	)
 	require.NoError(t, err)
 
-	// Random order due to updating container.Ports from
-	// ImageConfig.ExposedPorts which is a map.
+	// random order since ImageConfig.ExposedPorts is a map
 	for _, p := range res.Container.ExposedPorts {
 		require.Equal(t, core.NetworkProtocolTCP, p.Protocol)
 		switch p.Port {
 		case 8080:
 			require.Nil(t, p.Description)
 		case 5000:
+			require.NotNil(t, p.Description)
 			require.Equal(t, "five thousand", *p.Description)
 		default:
 			t.Fatalf("unexpected port %d", p.Port)

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3858,6 +3858,7 @@ EXPOSE 8080
 		},
 	)
 	require.NoError(t, err)
+	require.Len(t, res.Container.ExposedPorts, 2)
 
 	// random order since ImageConfig.ExposedPorts is a map
 	for _, p := range res.Container.ExposedPorts {

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3265,7 +3265,8 @@ func TestContainerInsecureRootCapabilitesWithService(t *testing.T) {
 			Sharing: dagger.Private,
 		}).
 		WithMountedCache("/tmp", c.CacheVolume("share-tmp")).
-		WithExposedPort(2375).
+		WithoutExposedPort(2376).
+		WithExposedPort(2375). // not needed, just to be explicit
 		WithExec([]string{
 			"dockerd",
 			"--host=tcp://0.0.0.0:2375",

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3794,14 +3794,11 @@ func TestContainerBuildMergesWithParent(t *testing.T) {
 	c, ctx := connect(t)
 
 	// Create a builder container
-	builderCtr := c.Directory().WithNewFile(
-		"Dockerfile",
-		`
-FROM node:alpine
-
+	builderCtr := c.Directory().WithNewFile("Dockerfile",
+		`FROM alpine:3.16.2
 ENV FOO=BAR
 LABEL "com.example.test-should-replace"="foo"
-RUN node --version
+EXPOSE 8080
 `,
 	)
 
@@ -3811,7 +3808,9 @@ RUN node --version
 		WithEnvVariable("FOO", "BAZ").
 		WithLabel("com.example.test-should-exist", "test").
 		WithLabel("com.example.test-should-replace", "bar").
-		WithExposedPort(5000).
+		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{
+			Description: "five thousand",
+		}).
 		Build(builderCtr)
 
 	envShouldExist, err := testCtr.EnvVariable(ctx, "BOOL")
@@ -3830,12 +3829,49 @@ RUN node --version
 	require.NoError(t, err)
 	require.Equal(t, "foo", labelShouldBeReplaced)
 
-	ports, err := testCtr.ExposedPorts(ctx)
+	// FIXME: Pretty clunky to work with lists of objects from the SDK
+	// so test the exposed ports with a query string for now.
+	cid, err := testCtr.ID(ctx)
 	require.NoError(t, err)
 
-	port, err := ports[0].Port(ctx)
+	res := struct {
+		Container struct {
+			ExposedPorts []core.ContainerPort
+		}
+	}{}
+
+	err = testutil.Query(`
+        query Test($id: ContainerID!) {
+            container(id: $id) {
+                exposedPorts {
+                    port
+                    protocol
+                    description
+                }
+            }
+        }`,
+		&res,
+		&testutil.QueryOptions{
+			Variables: map[string]interface{}{
+				"id": cid,
+			},
+		},
+	)
 	require.NoError(t, err)
-	require.Equal(t, 5000, port)
+
+	// Random order due to updating container.Ports from
+	// ImageConfig.ExposedPorts which is a map.
+	for _, p := range res.Container.ExposedPorts {
+		require.Equal(t, core.NetworkProtocolTCP, p.Protocol)
+		switch p.Port {
+		case 8080:
+			require.Nil(t, p.Description)
+		case 5000:
+			require.Equal(t, "five thousand", *p.Description)
+		default:
+			t.Fatalf("unexpected port %d", p.Port)
+		}
+	}
 }
 
 func TestContainerFromMergesWithParent(t *testing.T) {

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -203,15 +203,25 @@ func TestContainerPortLifecycle(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, res.Container.ExposedPorts, 3)
-	require.Equal(t, 8000, res.Container.ExposedPorts[0].Port)
-	require.Equal(t, dagger.Tcp, res.Container.ExposedPorts[0].Protocol)
-	require.Equal(t, "eight thousand tcp", *res.Container.ExposedPorts[0].Description)
-	require.Equal(t, 8000, res.Container.ExposedPorts[1].Port)
-	require.Equal(t, dagger.Udp, res.Container.ExposedPorts[1].Protocol)
-	require.Equal(t, "eight thousand udp", *res.Container.ExposedPorts[1].Description)
-	require.Equal(t, 5432, res.Container.ExposedPorts[2].Port)
-	require.Equal(t, dagger.Tcp, res.Container.ExposedPorts[2].Protocol)
-	require.Nil(t, res.Container.ExposedPorts[2].Description)
+
+	ports := map[string]*string{}
+	for _, p := range res.Container.ExposedPorts {
+		ports[fmt.Sprintf("%d/%s", p.Port, p.Protocol)] = p.Description
+	}
+
+	desc, ok := ports["8000/TCP"]
+	require.True(t, ok)
+	require.NotNil(t, desc)
+	require.Equal(t, "eight thousand tcp", *desc)
+
+	desc, ok = ports["8000/UDP"]
+	require.True(t, ok)
+	require.NotNil(t, desc)
+	require.Equal(t, "eight thousand udp", *desc)
+
+	desc, ok = ports["5432/TCP"]
+	require.True(t, ok)
+	require.Nil(t, desc)
 
 	withoutTCP := withPorts.WithoutExposedPort(8000)
 	cid, err = withoutTCP.ID(ctx)
@@ -223,12 +233,20 @@ func TestContainerPortLifecycle(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, res.Container.ExposedPorts, 2)
-	require.Equal(t, 8000, res.Container.ExposedPorts[0].Port)
-	require.Equal(t, dagger.Udp, res.Container.ExposedPorts[0].Protocol)
-	require.Equal(t, "eight thousand udp", *res.Container.ExposedPorts[0].Description)
-	require.Equal(t, 5432, res.Container.ExposedPorts[1].Port)
-	require.Equal(t, dagger.Tcp, res.Container.ExposedPorts[1].Protocol)
-	require.Nil(t, res.Container.ExposedPorts[1].Description)
+
+	ports = map[string]*string{}
+	for _, p := range res.Container.ExposedPorts {
+		ports[fmt.Sprintf("%d/%s", p.Port, p.Protocol)] = p.Description
+	}
+
+	desc, ok = ports["8000/UDP"]
+	require.True(t, ok)
+	require.NotNil(t, desc)
+	require.Equal(t, "eight thousand udp", *desc)
+
+	desc, ok = ports["5432/TCP"]
+	require.True(t, ok)
+	require.Nil(t, desc)
 
 	withoutUDP := withPorts.WithoutExposedPort(8000, dagger.ContainerWithoutExposedPortOpts{
 		Protocol: dagger.Udp,
@@ -242,12 +260,21 @@ func TestContainerPortLifecycle(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, res.Container.ExposedPorts, 2)
-	require.Equal(t, 8000, res.Container.ExposedPorts[0].Port)
-	require.Equal(t, dagger.Tcp, res.Container.ExposedPorts[0].Protocol)
-	require.Equal(t, "eight thousand tcp", *res.Container.ExposedPorts[0].Description)
-	require.Equal(t, 5432, res.Container.ExposedPorts[1].Port)
-	require.Equal(t, dagger.Tcp, res.Container.ExposedPorts[1].Protocol)
-	require.Nil(t, res.Container.ExposedPorts[1].Description)
+
+	ports = map[string]*string{}
+	for _, p := range res.Container.ExposedPorts {
+		ports[fmt.Sprintf("%d/%s", p.Port, p.Protocol)] = p.Description
+	}
+
+	desc, ok = ports["8000/TCP"]
+	require.True(t, ok)
+	require.NotNil(t, desc)
+	require.NotNil(t, desc)
+	require.Equal(t, "eight thousand tcp", *desc)
+
+	desc, ok = ports["5432/TCP"]
+	require.True(t, ok)
+	require.Nil(t, desc)
 }
 
 func TestContainerPortOCIConfig(t *testing.T) {

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -750,6 +750,9 @@ type Container {
   """
   Retrieves the list of exposed ports.
 
+  This includes ports already exposed by the image, even if not
+  explicitly added with dagger.
+
   Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
   """
   exposedPorts: [Port!]!

--- a/core/util.go
+++ b/core/util.go
@@ -278,7 +278,7 @@ func mergeEnv(dst, src []string) []string {
 
 // mergeMap adds or updates every key-value pair from the 'src' map
 // into the 'dst' map.
-func mergeMap(dst, src map[string]string) map[string]string {
+func mergeMap[T any](dst, src map[string]T) map[string]T {
 	if src == nil {
 		return dst
 	}
@@ -299,14 +299,12 @@ func mergeMap(dst, src map[string]string) map[string]string {
 // Only the configurations that have corresponding `WithXXX` and `WithoutXXX`
 // methods in `Container` are added or updated (i.e., `Env`, `Labels` and
 // `ExposedPorts`). Everything else is replaced.
-//
-// NOTE: there is an issue with merged ports for now.
-// See: https://github.com/dagger/dagger/pull/5052#issuecomment-1546814114
 func mergeImageConfig(dst, src specs.ImageConfig) specs.ImageConfig {
 	res := src
 
 	res.Env = mergeEnv(dst.Env, src.Env)
 	res.Labels = mergeMap(dst.Labels, src.Labels)
+	res.ExposedPorts = mergeMap(dst.ExposedPorts, src.ExposedPorts)
 
 	return res
 }

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -385,6 +385,9 @@ func (r *Container) Export(ctx context.Context, path string, opts ...ContainerEx
 
 // Retrieves the list of exposed ports.
 //
+// This includes ports already exposed by the image, even if not
+// explicitly added with dagger.
+//
 // Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
 func (r *Container) ExposedPorts(ctx context.Context) ([]Port, error) {
 	q := r.q.Select("exposedPorts")

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -947,6 +947,9 @@ export class Container extends BaseClient {
   /**
    * Retrieves the list of exposed ports.
    *
+   * This includes ports already exposed by the image, even if not
+   * explicitly added with dagger.
+   *
    * Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
    */
   async exposedPorts(): Promise<Port[]> {

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -446,6 +446,9 @@ class Container(Type):
     def exposed_ports(self) -> "Port":
         """Retrieves the list of exposed ports.
 
+        This includes ports already exposed by the image, even if not
+        explicitly added with dagger.
+
         Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to
         disable.
         """

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -446,6 +446,9 @@ class Container(Type):
     def exposed_ports(self) -> "Port":
         """Retrieves the list of exposed ports.
 
+        This includes ports already exposed by the image, even if not
+        explicitly added with dagger.
+
         Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to
         disable.
         """


### PR DESCRIPTION
Follow-up to https://github.com/dagger/dagger/issues/5052 to fix `ExposedPorts` support.

## What?

In https://github.com/dagger/dagger/issues/4588 we want to override an existing `Container`’s `Env`, `Labels` and `ExposedPorts` config when using `From` or `Build`. Everything else is completely replaced. The reasoning is that those fields have these corresponding CRUD methods:
| OCI                | Create/Update     | Delete               | List           | 
| ------------------ | ----------------- | -------------------- | -------------- |
| **`Env`**          | `WithEnvVariable` | `WithoutEnvVariable` | `EnvVariables` |
| **`Labels`**       | `WithLabel`       | `WithoutLabel`       | `Labels`       |
| **`ExposedPorts`** | `WithExposedPort` | `WithoutExposedPort` | `ExposedPorts` |

However, merging exposed ports wasn’t added in https://github.com/dagger/dagger/issues/5052:

https://github.com/dagger/dagger/blob/f525a276ff9ded404a630ba66c6b3eefa4b6c87d/core/util.go#L300-L301

This change fixes that.

## How?

It’s now possible to expose a port before `.From` or `.Build`:

```go
httpSrv := client.Container().
    WithExposedPort(8080).
    Build(src).
    WithExec([]string{"python", "-m", "http.server", "8080"})
```

The port will be preserved, just like environment variables and labels.

## Backwards compatibility

Listing with `exposedPorts` now includes ports that may not be used that were already exposed in the image config. This is to be consistent with other fields and reflects what will happen on `.Publish`.