### PR TITLE
Python: Add convenience to await on an object that has `.sync()`

### DIFF
--- a/sdk/python/src/dagger/api/base.py
+++ b/sdk/python/src/dagger/api/base.py
@@ -92,7 +92,7 @@ class Context:
         return dsl_gql(DSLQuery(self.build()))
 
     @overload
-    async def execute(self, return_type: None) -> None:
+    async def execute(self, return_type: None = None) -> None:
         ...
 
     @overload

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -825,6 +825,9 @@ class Container(Type):
         await _ctx.execute()
         return self
 
+    def __await__(self):
+        return self.sync().__await__()
+
     @typecheck
     async def user(self) -> Optional[str]:
         """Retrieves the user to be set for all commands.

--- a/sdk/python/src/dagger/codegen.py
+++ b/sdk/python/src/dagger/codegen.py
@@ -429,6 +429,15 @@ class _ObjectField:
             indent(self.func_body()),
         )
 
+        # convenience to await any object that has a sync method
+        # without having to call it explicitly
+        if not self.ctx.sync and self.is_leaf and self.name == "sync":
+            yield from (
+                "",
+                "def __await__(self):",
+                indent("return self.sync().__await__()"),
+            )
+
     def func_signature(self) -> str:
         params = ", ".join(chain(("self",), (a.as_param() for a in self.args)))
         # arbitrary heuristic to force trailing comma in long signatures

--- a/sdk/python/tests/api/test_integration.py
+++ b/sdk/python/tests/api/test_integration.py
@@ -220,3 +220,16 @@ async def test_container_sync():
         # chaining
         out = await (await base.with_exec(["echo", "spam"]).sync()).stdout()
         assert out == "spam\n"
+
+
+async def test_container_awaitable():
+    async with dagger.Connection() as client:
+        base = client.container().from_("alpine:3.16.2")
+
+        # short cirtcut
+        with pytest.raises(dagger.QueryError, match="foobar"):
+            await base.with_exec(["foobar"])
+
+        # chaining
+        out = await (await base.with_exec(["echo", "spam"])).stdout()
+        assert out == "spam\n"


### PR DESCRIPTION
Follow up to https://github.com/dagger/dagger/pull/5071 and part of https://github.com/dagger/dagger/issues/5065

Adds a convenience to `await` on an object directly:

```python
await client.container().from_("alpine").with_exec(["true"])
``` 