### PR TITLE
Add expand option when adding environment variables

### DIFF
--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -3,12 +3,12 @@ package schema
 import (
 	"fmt"
 	"path"
-	"strings"
 
 	"github.com/containerd/containerd/content"
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/pipeline"
 	"github.com/dagger/dagger/router"
+	"github.com/moby/buildkit/frontend/dockerfile/shell"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -311,17 +311,7 @@ func (s *containerSchema) withEnvVariable(ctx *router.Context, parent *core.Cont
 		// NB(vito): buildkit handles replacing properly when we do llb.AddEnv, but
 		// we want to replace it here anyway because someone might publish the image
 		// instead of running it. (there's a test covering this!)
-		newEnv := []string{}
-		prefix := args.Name + "="
-		for _, env := range cfg.Env {
-			if !strings.HasPrefix(env, prefix) {
-				newEnv = append(newEnv, env)
-			}
-		}
-
-		newEnv = append(newEnv, fmt.Sprintf("%s=%s", args.Name, args.Value))
-
-		cfg.Env = newEnv
+		cfg.Env = core.AddEnv(cfg.Env, args.Name, args.Value)
 
 		return cfg
 	})
@@ -333,15 +323,15 @@ type containerWithoutVariableArgs struct {
 
 func (s *containerSchema) withoutEnvVariable(ctx *router.Context, parent *core.Container, args containerWithoutVariableArgs) (*core.Container, error) {
 	return parent.UpdateImageConfig(ctx, func(cfg specs.ImageConfig) specs.ImageConfig {
-		removedEnv := []string{}
-		prefix := args.Name + "="
-		for _, env := range cfg.Env {
-			if !strings.HasPrefix(env, prefix) {
-				removedEnv = append(removedEnv, env)
-			}
-		}
+		newEnv := []string{}
 
-		cfg.Env = removedEnv
+		core.WalkEnv(cfg.Env, func(k, _, env string) {
+			if !shell.EqualEnvKeys(k, args.Name) {
+				newEnv = append(newEnv, env)
+			}
+		})
+
+		cfg.Env = newEnv
 
 		return cfg
 	})
@@ -359,15 +349,10 @@ func (s *containerSchema) envVariables(ctx *router.Context, parent *core.Contain
 	}
 
 	vars := make([]EnvVariable, 0, len(cfg.Env))
-	for _, v := range cfg.Env {
-		name, value, _ := strings.Cut(v, "=")
-		e := EnvVariable{
-			Name:  name,
-			Value: value,
-		}
 
-		vars = append(vars, e)
-	}
+	core.WalkEnv(cfg.Env, func(k, v, _ string) {
+		vars = append(vars, EnvVariable{Name: k, Value: v})
+	})
 
 	return vars, nil
 }
@@ -382,11 +367,8 @@ func (s *containerSchema) envVariable(ctx *router.Context, parent *core.Containe
 		return nil, err
 	}
 
-	for _, env := range cfg.Env {
-		name, val, ok := strings.Cut(env, "=")
-		if ok && name == args.Name {
-			return &val, nil
-		}
+	if val, ok := core.LookupEnv(cfg.Env, args.Name); ok {
+		return &val, nil
 	}
 
 	return nil, nil

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -168,6 +168,12 @@ type Container {
     The value of the environment variable. (e.g., "localhost").
     """
     value: String!
+
+    """
+    Replace ${VAR} or $VAR in the value according to the current environment
+    variables defined in the container (e.g., "/opt/bin:$PATH").
+    """
+    expand: Boolean
   ): Container!
 
   "Retrieves the list of labels passed to container."

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -857,11 +857,25 @@ func (r *Container) WithEntrypoint(args []string) *Container {
 	}
 }
 
+// ContainerWithEnvVariableOpts contains options for Container.WithEnvVariable
+type ContainerWithEnvVariableOpts struct {
+	// Replace ${VAR} or $VAR in the value according to the current environment
+	// variables defined in the container (e.g., "/opt/bin:$PATH").
+	Expand bool
+}
+
 // Retrieves this container plus the given environment variable.
-func (r *Container) WithEnvVariable(name string, value string) *Container {
+func (r *Container) WithEnvVariable(name string, value string, opts ...ContainerWithEnvVariableOpts) *Container {
 	q := r.q.Select("withEnvVariable")
 	q = q.Arg("name", name)
 	q = q.Arg("value", value)
+	// `expand` optional argument
+	for i := len(opts) - 1; i >= 0; i-- {
+		if !querybuilder.IsZeroValue(opts[i].Expand) {
+			q = q.Arg("expand", opts[i].Expand)
+			break
+		}
+	}
 
 	return &Container{
 		q: q,

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -238,6 +238,14 @@ export type ContainerWithDirectoryOpts = {
   owner?: string
 }
 
+export type ContainerWithEnvVariableOpts = {
+  /**
+   * Replace ${VAR} or $VAR in the value according to the current environment
+   * variables defined in the container (e.g., "/opt/bin:$PATH").
+   */
+  expand?: boolean
+}
+
 export type ContainerWithExecOpts = {
   /**
    * If the container has an entrypoint, ignore it for args rather than using it to wrap them.
@@ -1368,14 +1376,20 @@ export class Container extends BaseClient {
    * Retrieves this container plus the given environment variable.
    * @param name The name of the environment variable (e.g., "HOST").
    * @param value The value of the environment variable. (e.g., "localhost").
+   * @param opts.expand Replace ${VAR} or $VAR in the value according to the current environment
+   * variables defined in the container (e.g., "/opt/bin:$PATH").
    */
-  withEnvVariable(name: string, value: string): Container {
+  withEnvVariable(
+    name: string,
+    value: string,
+    opts?: ContainerWithEnvVariableOpts
+  ): Container {
     return new Container({
       queryTree: [
         ...this._queryTree,
         {
           operation: "withEnvVariable",
-          args: { name, value },
+          args: { name, value, ...opts },
         },
       ],
       host: this.clientHost,

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -924,7 +924,12 @@ class Container(Type):
         return Container(_ctx)
 
     @typecheck
-    def with_env_variable(self, name: str, value: str) -> "Container":
+    def with_env_variable(
+        self,
+        name: str,
+        value: str,
+        expand: Optional[bool] = None,
+    ) -> "Container":
         """Retrieves this container plus the given environment variable.
 
         Parameters
@@ -933,10 +938,15 @@ class Container(Type):
             The name of the environment variable (e.g., "HOST").
         value:
             The value of the environment variable. (e.g., "localhost").
+        expand:
+            Replace ${VAR} or $VAR in the value according to the current
+            environment
+            variables defined in the container (e.g., "/opt/bin:$PATH").
         """
         _args = [
             Arg("name", name),
             Arg("value", value),
+            Arg("expand", expand, None),
         ]
         _ctx = self._select("withEnvVariable", _args)
         return Container(_ctx)

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -921,7 +921,12 @@ class Container(Type):
         return Container(_ctx)
 
     @typecheck
-    def with_env_variable(self, name: str, value: str) -> "Container":
+    def with_env_variable(
+        self,
+        name: str,
+        value: str,
+        expand: Optional[bool] = None,
+    ) -> "Container":
         """Retrieves this container plus the given environment variable.
 
         Parameters
@@ -930,10 +935,15 @@ class Container(Type):
             The name of the environment variable (e.g., "HOST").
         value:
             The value of the environment variable. (e.g., "localhost").
+        expand:
+            Replace ${VAR} or $VAR in the value according to the current
+            environment
+            variables defined in the container (e.g., "/opt/bin:$PATH").
         """
         _args = [
             Arg("name", name),
             Arg("value", value),
+            Arg("expand", expand, None),
         ]
         _ctx = self._select("withEnvVariable", _args)
         return Container(_ctx)


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/5140

**Note:** This only applies to `withEnvVariable`.

Common example is to prepend to `$PATH`:
```go
WithEnvVariable("VIRTUAL_ENV", "/opt/venv").
WithEnvVariable(
	"PATH",
	"${VIRTUAL_ENV}/bin:$PATH",
	dagger.ContainerWithEnvVariableOpts{
		Expand: true,
	},
).
```

In Python:

```python
ctr
    .with_env_variable("VIRTUAL_ENV", "/opt/venv")
    .with_env_variable("PATH", "${VIRTUAL_ENV}/bin:$PATH", expand=True)
```