### PR TITLE
Prepend truncated error output with notice

### DIFF
--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -196,6 +196,10 @@ func shim() int {
 			if seekFromEnd > core.MaxExecErrorOutputBytes {
 				// copy the last MaxExecErrorOutputBytes bytes only
 				seekFromEnd = core.MaxExecErrorOutputBytes
+                io.WriteString(os.Stdout, fmt.Sprintf(
+                    core.TruncationMessage,
+                    stdoutFileSize - seekFromEnd,
+                ))
 			}
 			_, err = stdoutFile.Seek(-int64(seekFromEnd), io.SeekEnd)
 			if err != nil {
@@ -219,6 +223,10 @@ func shim() int {
 			if seekFromEnd > core.MaxExecErrorOutputBytes {
 				// copy the last MaxExecErrorOutputBytes bytes only
 				seekFromEnd = core.MaxExecErrorOutputBytes
+                io.WriteString(os.Stderr, fmt.Sprintf(
+                    core.TruncationMessage,
+                    stderrFileSize - seekFromEnd,
+                ))
 			}
 			_, err = stderrFile.Seek(-int64(seekFromEnd), io.SeekEnd)
 			if err != nil {

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -2972,6 +2972,11 @@ func TestContainerExecError(t *testing.T) {
 		stderrStr := stderrBuf.String()
 		encodedErrMsg := base64.StdEncoding.EncodeToString(stderrBuf.Bytes())
 
+		truncMsg := fmt.Sprintf(
+			core.TruncationMessage,
+			core.MaxExecErrorOutputBytes,
+		)
+
 		_, err = c.Container().
 			From("alpine:3.16.2").
 			WithExec(
@@ -2981,9 +2986,9 @@ func TestContainerExecError(t *testing.T) {
 			).
 			Sync(ctx)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), stdoutStr[:core.MaxExecErrorOutputBytes])
+		require.Contains(t, err.Error(), truncMsg+stdoutStr[:core.MaxExecErrorOutputBytes])
 		require.NotContains(t, err.Error(), stdoutStr[:core.MaxExecErrorOutputBytes+1])
-		require.Contains(t, err.Error(), stderrStr[:core.MaxExecErrorOutputBytes])
+		require.Contains(t, err.Error(), truncMsg+stderrStr[:core.MaxExecErrorOutputBytes])
 		require.NotContains(t, err.Error(), stderrStr[:core.MaxExecErrorOutputBytes+1])
 	})
 }


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/5077
Related to https://github.com/dagger/dagger/issues/4979

Should show output in error like this:

<pre>
input:1: pipeline.pipeline.container.from.withExec.stdout process "sh -c echo xxxxxxx... && exit 1" did not complete successfully: exit code: 1
Stdout:
<b>[omitting 2412132 bytes]...</b>xxxxxxx....

Stderr:

Please visit https://dagger.io/help#go for troubleshooting guidance.
</pre>