### PR TITLE
Increase truncation limit on error output

### DIFF
--- a/core/gateway.go
+++ b/core/gateway.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	// Exec errors will only include the last this number of bytes of output.
-	MaxExecErrorOutputBytes = 2 * 1024
+	MaxExecErrorOutputBytes = 100 * 1024
 
 	// MaxFileContentsChunkSize sets the maximum chunk size for ReadFile calls
 	// Equals around 95% of the max message size (16777216) in

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -2974,12 +2974,13 @@ func TestContainerExecError(t *testing.T) {
 
 		_, err = c.Container().
 			From("alpine:3.16.2").
-			WithExec(
-				[]string{"sh", "-c", fmt.Sprintf(
-					`echo %s | base64 -d >&1; echo %s | base64 -d >&2; exit 1`, encodedOutMsg, encodedErrMsg,
-				)},
+			WithDirectory("/", c.Directory().
+				WithNewFile("encout", encodedOutMsg).
+				WithNewFile("encerr", encodedErrMsg),
 			).
+			WithExec([]string{"sh", "-c", "base64 -d encout >&1; base64 -d encerr >&2; exit 1"}).
 			Sync(ctx)
+
 		require.Error(t, err)
 		require.Contains(t, err.Error(), stdoutStr[:core.MaxExecErrorOutputBytes])
 		require.NotContains(t, err.Error(), stdoutStr[:core.MaxExecErrorOutputBytes+1])


### PR DESCRIPTION
Related to https://github.com/dagger/dagger/issues/4979

Increasing the truncation limit hopefully makes it less necessary to add a flag for full output in an error.

\cc @aluzzardi 