### PR TITLE
ci: Fix publish-sdk-rust GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish-sdk-rust.yml
+++ b/.github/workflows/publish-sdk-rust.yml
@@ -1,8 +1,8 @@
-name: "Publish Go SDK"
+name: "Publish Rust SDK"
 on:
   push:
     branches: ["main"]
-    tags: ["sdk/go/v**"]
+    tags: ["sdk/rust/v**"]
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'


### PR DESCRIPTION
Let's figure out privately the value for `CARGO_REGISTRY_TOKEN` @kjuulh.