### PR TITLE
Add SDK label to rust

### DIFF
--- a/sdk/rust/crates/dagger-sdk/src/core/cli_session.rs
+++ b/sdk/rust/crates/dagger-sdk/src/core/cli_session.rs
@@ -50,6 +50,12 @@ impl InnerCliSession {
             args.extend(["--project".into(), abs_path.to_string_lossy().to_string()])
         }
 
+        args.extend(["--label".into(), "dagger.io/sdk.name:rust".into()]);
+        args.extend([
+            "--label".into(),
+            format!("dagger.io/sdk.version:{}", env!("CARGO_PKG_VERSION")).into(),
+        ]);
+
         let proc = tokio::process::Command::new(
             cli_path
                 .to_str()


### PR DESCRIPTION
I found during reading SDK CONTRIBUTING.md. The rust SDK doesn't set label `dagger.io/sdk.name` and `dagger.io/sdk.version` to the `dagger session`. This changes start by adding the SDK name label to it.