### PR TITLE
Scrub secret plaintext arg from progrock vertex.

### DIFF
--- a/core/schema/secret.go
+++ b/core/schema/secret.go
@@ -51,13 +51,20 @@ func (s *secretSchema) secret(ctx *router.Context, parent any, args secretArgs) 
 	return args.ID.ToSecret()
 }
 
+type SecretPlaintext string
+
+// This method ensures that the progrock vertex info does not display the plaintext.
+func (s SecretPlaintext) MarshalText() ([]byte, error) {
+	return []byte("***"), nil
+}
+
 type setSecretArgs struct {
 	Name      string
-	Plaintext string
+	Plaintext SecretPlaintext
 }
 
 func (s *secretSchema) setSecret(ctx *router.Context, parent any, args setSecretArgs) (*core.Secret, error) {
-	secretID, err := s.secrets.AddSecret(ctx, args.Name, args.Plaintext)
+	secretID, err := s.secrets.AddSecret(ctx, args.Name, string(args.Plaintext))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/5171

Problem before was that we'd serialize all the graphql args and values for every resolver, which included the secret plaintext value.

The fix here is an attempt to give a slightly more general+reusable solution than just putting in a hardcoded `if` in the progrock related code to check for this fieldname+argname pair. It makes the type of the plaintext in our code to be `type SecretPlaintext string` and gives that a `MarshalText` method so progrock shows that instead of the actual value.

--- 

I had a previous version of this that used reflection directly instead of doing another json marshal-unmarshal cycle, but it ended up being way more convoluted: https://github.com/sipsma/dagger/commit/e45690cda3d61a9a24fb329599c333acad79c7e6

So I just went with the extra cycle for now. I doubt that it matters in terms of performance at this time.

Will see if it's feasible to add an integ test too. Not incredibly straightforward to integ test TUI but it should be possible to create a new tty and then read from that.