### PR TITLE
ci: Do not publish Rust SDK on push to `main`

### DIFF
--- a/.github/workflows/publish-sdk-rust.yml
+++ b/.github/workflows/publish-sdk-rust.yml
@@ -1,7 +1,6 @@
 name: "Publish Rust SDK"
 on:
   push:
-    branches: ["main"]
     tags: ["sdk/rust/v**"]
 jobs:
   publish:


### PR DESCRIPTION
We do this just for the Go SDK so that we sync this repository with https://github.com/dagger/dagger-go-sdk, all other SDKs only trigger on tag.

Follow-up to:
- https://github.com/dagger/dagger/pull/5148