### PR TITLE
docs: Improved cache miss recipe for Python

### DIFF
--- a/docs/current/cookbook/snippets/cache-invalidation/main.py
+++ b/docs/current/cookbook/snippets/cache-invalidation/main.py
@@ -1,12 +1,12 @@
 import sys
 import anyio
-import datetime
+from datetime import datetime
 import dagger
 
 async def main():
 
     # create Dagger client
-    async with dagger.Connection(dagger.Config(log_output=sys.stderr, workdir=".")) as client:
+    async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
 
         # invalidate cache to force execution
         # of second with_exec() operation
@@ -15,7 +15,7 @@ async def main():
             container().
             from_("alpine").
             with_exec(["apk", "add", "curl"]).
-            with_env_variable("CACHEBUSTER", str(datetime.datetime.utcnow().timestamp())).
+            with_env_variable("CACHEBUSTER", str(datetime.now())).
             with_exec(["apk", "add", "zip"]).
             stdout()
         )


### PR DESCRIPTION
This commit improves the Python cache miss recipe first added in https://github.com/dagger/dagger/pull/5168.

Relates to DAG-1579