### PR TITLE
feat(rust): no-gen didn't work as intended

### DIFF
--- a/sdk/rust/crates/dagger-bootstrap/Cargo.toml
+++ b/sdk/rust/crates/dagger-bootstrap/Cargo.toml
@@ -13,9 +13,7 @@ publish = true
 
 [dependencies]
 dagger-codegen = { workspace = true, default-features = false }
-dagger-sdk = { workspace = true, default-features = false, features = [
-  "no-gen",
-] }
+dagger-sdk = { workspace = true, default-features = false }
 
 eyre = { workspace = true }
 color-eyre = { workspace = true }

--- a/sdk/rust/crates/dagger-codegen/Cargo.toml
+++ b/sdk/rust/crates/dagger-codegen/Cargo.toml
@@ -11,9 +11,7 @@ publish = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dagger-sdk = { workspace = true, features = [
-  "no-gen",
-], default-features = false }
+dagger-sdk = { workspace = true, default-features = false }
 
 eyre = { workspace = true }
 serde = { workspace = true }

--- a/sdk/rust/crates/dagger-sdk/Cargo.toml
+++ b/sdk/rust/crates/dagger-sdk/Cargo.toml
@@ -52,5 +52,4 @@ tracing-test = "0.2.4"
 [features]
 
 default = ["gen"]
-no-gen = []
 gen = []

--- a/sdk/rust/crates/dagger-sdk/src/lib.rs
+++ b/sdk/rust/crates/dagger-sdk/src/lib.rs
@@ -1,28 +1,16 @@
-#[cfg(not(feature = "no-gen"))]
-mod client;
-
-#[cfg(feature = "gen")]
-mod client;
-
 pub mod core;
 pub mod errors;
-
-#[cfg(not(feature = "no-gen"))]
-mod gen;
-
-#[cfg(feature = "gen")]
-mod gen;
 
 pub mod logging;
 mod querybuilder;
 
 pub use crate::core::config::Config;
 
-#[cfg(not(feature = "no-gen"))]
-pub use client::*;
+#[cfg(feature = "gen")]
+mod client;
 
-#[cfg(not(feature = "no-gen"))]
-pub use gen::*;
+#[cfg(feature = "gen")]
+mod gen;
 
 #[cfg(feature = "gen")]
 pub use client::*;


### PR DESCRIPTION
no-gen was intended to not provide generated code. However it caused trouble
with no features. As such it has been removed.

Instead --no-default-features and --feature gen are setup to work as it should.
