### PR TITLE
engine: enable full goroutine stack trace dump in trace logs.

### DIFF
--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -298,6 +298,9 @@ func main() { //nolint:gocyclo
 		cfg.Root = root
 
 		go logMetrics(context.Background(), cfg.Root)
+		if cfg.Trace {
+			go logTraceMetrics(context.Background())
+		}
 
 		if err := os.MkdirAll(root, 0700); err != nil {
 			return errors.Wrapf(err, "failed to create %s", root)


### PR DESCRIPTION
If trace logs are enabled, this can be very useful for identifying stuck or leaked goroutines.

I also tried using `debug.WriteHeapDump`, which would be even more powerful, but it was taking up more than 10GB to log and apparently includes raw memory contents of everything (including secrets), so not viable at this time... 