### PR TITLE
docs: Fix tip content in quickstart test

### DIFF
--- a/docs/current/quickstart/947391-quickstart-test.mdx
+++ b/docs/current/quickstart/947391-quickstart-test.mdx
@@ -52,6 +52,10 @@ Run the pipeline by executing the command below from the application directory:
 go run ci/main.go
 ```
 
+:::tip
+The `From()`, `WithDirectory()`, `WithWorkdir()` and `WithExec()` methods all return a `Container`, making it easy to chain method calls together and create a pipeline that is intuitive to understand.
+:::
+
 </TabItem>
 <TabItem value="Node.js">
 
@@ -73,6 +77,10 @@ Run the pipeline by executing the command below from the application directory:
 node ci/index.mjs
 ```
 
+:::tip
+The `from()`, `withDirectory()`, `withWorkdir()` and `withExec()` methods all return a `Container`, making it easy to chain method calls together and create a pipeline that is intuitive to understand.
+:::
+
 </TabItem>
 <TabItem value="Python">
 
@@ -82,8 +90,8 @@ This code listing does the following:
 
 - It creates a Dagger client with `with dagger.Connection()` as before.
 - It uses the client's `container().from_()` method to initialize a new container from a base image - again, the `node:16-slim` image. This base image is the Node.js version to use for testing. The `from_()` method returns a new `Container` object with the result.
-- It uses the `Container.withdirectory()` method to mount the source code directory on the host at the `/src` mount point in the container, and the `Container.with_workdir()` method to set the working directory to that mount point.
-  - Notice that the `Container.withdirectory()` accepts additional options to exclude (or include) specific files from the mount. In this case, it excludes the `node_modules` (locally-installed dependencies) and `ci` (pipeline code) directories.
+- It uses the `Container.with_directory()` method to mount the source code directory on the host at the `/src` mount point in the container, and the `Container.with_workdir()` method to set the working directory to that mount point.
+  - Notice that the `Container.with_directory()` accepts additional options to exclude (or include) specific files from the mount. In this case, it excludes the `node_modules` (locally-installed dependencies) and `ci` (pipeline code) directories.
 - It uses the `Container.with_exec()` method to define the commands to install dependencies and run tests in the container - in this case, the commands `npm install` and `npm test -- --watchAll=false`.
 - It uses the `Container.stderr()` method to return the error stream of the last executed command. No error output implies successful execution (all tests pass).
   - Failure, indicated by error output, will cause the pipeline to terminate.
@@ -94,11 +102,11 @@ Run the pipeline by executing the command below from the application directory:
 python ci/main.py
 ```
 
+:::tip
+The `from_()`, `with_directory()`, `with_workdir()` and `with_exec()` methods all return a `Container`, making it easy to chain method calls together and create a pipeline that is intuitive to understand.
+:::
+
 </TabItem>
 </Tabs>
-
-:::tip
-The `from()`, `withDirectory()`, `withWorkdir()` and `withExec()` methods all return a `Container`, making it easy to chain method calls together and create a pipeline that is intuitive to understand.
-:::
 
 </QuickstartDoc>


### PR DESCRIPTION
There is only one version of the "tip" on the quickstart test page, but it should contain different method / function names for Go, Node.js, and Python. This PR places the tip in each tab with correct method names (as well as fixes one or two other typos on the page).