### PR TITLE
docs: Fix minor spelling issue in Python build quickstart docs

### DIFF
--- a/docs/current/quickstart/snippets/build/main.py
+++ b/docs/current/quickstart/snippets/build/main.py
@@ -28,7 +28,7 @@ async def main():
         test = runner.with_exec(["npm", "test", "--", "--watchAll=false"])
 
         # build application
-        # writhe the build output to the host
+        # write the build output to the host
         build_dir = (
             test.with_exec(["npm", "run", "build"])
             .directory("./build")


### PR DESCRIPTION
Fix minor spelling issue in Python build quickstart docs