### PR TITLE
Enable casting custom errors in Go

### DIFF
--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -145,6 +145,10 @@ type errorWrappedClient struct {
 func (c errorWrappedClient) MakeRequest(ctx context.Context, req *graphql.Request, resp *graphql.Response) error {
 	err := c.Client.MakeRequest(ctx, req, resp)
 	if err != nil {
+		// return custom error without wrapping to enable casting
+		if e := getCustomError(err); e != nil {
+			return e
+		}
 		return withErrorHelp(err)
 	}
 	return nil

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -225,6 +225,10 @@ func TestExecError(t *testing.T) {
 		require.Contains(t, exErr.Error(), errMsg)
 		require.NotContains(t, exErr.Message(), outMsg)
 		require.NotContains(t, exErr.Message(), errMsg)
+
+		if _, ok := err.(*ExecError); !ok {
+			t.Fatal("unable to cast error type, check potential wrapping")
+		}
 	})
 
 	t.Run("no output", func(t *testing.T) {

--- a/sdk/go/error.go
+++ b/sdk/go/error.go
@@ -12,22 +12,22 @@ const (
 )
 
 func withErrorHelp(err error) error {
-	err = parseGraphQLError(err)
 	return fmt.Errorf("%w\n%s", err, errorHelpBlurb)
 }
 
-func parseGraphQLError(err error) error {
+// getCustomError parses a GraphQL error into a more specific error type.
+func getCustomError(err error) error {
 	var gqlErr *gqlerror.Error
 
 	if !errors.As(err, &gqlErr) {
-		return err
+		return nil
 	}
 
 	ext := gqlErr.Extensions
 
 	typ, ok := ext["_type"].(string)
 	if !ok {
-		return err
+		return nil
 	}
 
 	if typ == "EXEC_ERROR" {
@@ -53,7 +53,7 @@ func parseGraphQLError(err error) error {
 		return e
 	}
 
-	return err
+	return nil
 }
 
 // ExecError is an API error from an exec operation.
@@ -68,7 +68,13 @@ type ExecError struct {
 func (e *ExecError) Error() string {
 	// As a default when just printing the error, include the stdout
 	// and stderr for visibility
-	return fmt.Sprintf("%s\nStdout:\n%s\nStderr:\n%s", e.Message(), e.Stdout, e.Stderr)
+	return fmt.Sprintf(
+		"%s\nStdout:\n%s\nStderr:\n%s\n%s",
+		e.Message(),
+		e.Stdout,
+		e.Stderr,
+		errorHelpBlurb,
+	)
 }
 
 func (e *ExecError) Message() string {


### PR DESCRIPTION
Follow up to #5184

Instead of having to unwrap a custom error:

```go
var e *dagger.ExecError
if errors.As(err, &e) {
    return e.ExitCode
}
```

This allows directly casting:

```go
if e, ok := err.(*dagger.ExecError); ok {
    return e.ExitCode
}
```
