### PR TITLE
cache: return error if cacheservice scheme is not supported

### DIFF
--- a/engine/cache/service.go
+++ b/engine/cache/service.go
@@ -182,8 +182,7 @@ type GetLayerUploadURLResponse struct {
 	Headers map[string]string
 }
 
-type GetCacheMountConfigRequest struct {
-}
+type GetCacheMountConfigRequest struct{}
 
 type GetCacheMountConfigResponse struct {
 	SyncedCacheMounts []SyncedCacheMountConfig
@@ -210,7 +209,7 @@ type GetCacheMountUploadURLResponse struct {
 
 type client struct {
 	httpClient *http.Client
-	host       string
+	baseURL    string
 }
 
 var _ Service = &client{}
@@ -225,10 +224,10 @@ func newClient(urlString string) (Service, error) {
 
 	switch u.Scheme {
 	case "tcp":
-		c.host = u.Host
+		c.baseURL = "http://" + u.Host
 		c.httpClient = &http.Client{}
 	case "unix":
-		c.host = "local"
+		c.baseURL = "http://local"
 		c.httpClient = &http.Client{
 			Transport: &http.Transport{
 				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
@@ -236,6 +235,9 @@ func newClient(urlString string) (Service, error) {
 				},
 			},
 		}
+	default:
+		c.baseURL = urlString
+		c.httpClient = &http.Client{}
 	}
 
 	return c, nil
@@ -252,7 +254,7 @@ func (c *client) GetConfig(ctx context.Context, req GetConfigRequest) (*Config, 
 		}
 	}()
 
-	httpReq, err := http.NewRequestWithContext(ctx, "GET", "http://"+c.host+"/config", bodyR)
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/config", bodyR)
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +290,7 @@ func (c *client) UpdateCacheRecords(
 		}
 	}()
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", "http://"+c.host+"/records", bodyR)
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/records", bodyR)
 	if err != nil {
 		return nil, err
 	}
@@ -324,7 +326,7 @@ func (c *client) UpdateCacheLayers(
 		}
 	}()
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", "http://"+c.host+"/layers", bodyR)
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/layers", bodyR)
 	if err != nil {
 		return err
 	}
@@ -344,7 +346,7 @@ func (c *client) UpdateCacheLayers(
 
 //nolint:dupl
 func (c *client) ImportCache(ctx context.Context) (*remotecache.CacheConfig, error) {
-	httpReq, err := http.NewRequestWithContext(ctx, "GET", "http://"+c.host+"/import", nil)
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/import", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -376,7 +378,7 @@ func (c *client) GetLayerDownloadURL(ctx context.Context, req GetLayerDownloadUR
 		}
 	}()
 
-	httpReq, err := http.NewRequestWithContext(ctx, "GET", "http://"+c.host+"/layerDownloadURL", bodyR)
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/layerDownloadURL", bodyR)
 	if err != nil {
 		return nil, err
 	}
@@ -409,7 +411,7 @@ func (c *client) GetLayerUploadURL(ctx context.Context, req GetLayerUploadURLReq
 		}
 	}()
 
-	httpReq, err := http.NewRequestWithContext(ctx, "GET", "http://"+c.host+"/layerUploadURL", bodyR)
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/layerUploadURL", bodyR)
 	if err != nil {
 		return nil, err
 	}
@@ -442,7 +444,7 @@ func (c *client) GetCacheMountConfig(ctx context.Context, req GetCacheMountConfi
 		}
 	}()
 
-	httpReq, err := http.NewRequestWithContext(ctx, "GET", "http://"+c.host+"/cacheMountConfig", bodyR)
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/cacheMountConfig", bodyR)
 	if err != nil {
 		return nil, err
 	}
@@ -475,7 +477,7 @@ func (c *client) GetCacheMountUploadURL(ctx context.Context, req GetCacheMountUp
 		}
 	}()
 
-	httpReq, err := http.NewRequestWithContext(ctx, "GET", "http://"+c.host+"/cacheMountUploadURL", bodyR)
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/cacheMountUploadURL", bodyR)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
otherwise we get a nasty nil pointer exception: 

```
time="2023-05-26T17:05:16Z" level=debug msg="using cache service at localhost:8020/magicache"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x6e0fd4]

goroutine 1 [running]:
net/http.(*Client).deadline(0xc000665520?)
        /usr/local/go/src/net/http/client.go:189 +0x14
net/http.(*Client).do(0x0, 0xc00064e700)
        /usr/local/go/src/net/http/client.go:600 +0x225
net/http.(*Client).Do(...)
        /usr/local/go/src/net/http/client.go:582
github.com/dagger/dagger/engine/cache.(*client).GetConfig(0xc000109ab8, {0x1ca7af8?, 0xc0000b6a00}, {{0xc0002b2fe0?, 0x1cb2780?}})
        /app/engine/cache/service.go:261 +0x3f3
github.com/dagger/dagger/engine/cache.NewManager({0x1ca7af8?, 0xc0000b6a00}, {{0x1cb2780, 0xc000012520}, {0x1ca8930, 0xc000012530}, {0x1cb5c00, 0xc000618160}, 0xc000312a40, {0xc000046026, ...}, ...})
        /app/engine/cache/manager.go:73 +0x351
```

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
