### PR TITLE
docs: Improved cache invalidation recipe

### DIFF
--- a/docs/current/cookbook/snippets/cache-invalidation/index.mjs
+++ b/docs/current/cookbook/snippets/cache-invalidation/index.mjs
@@ -1,4 +1,5 @@
 import { connect } from "@dagger.io/dagger"
+import { v4 as uuidv4 } from 'uuid';
 
 // create Dagger client
 connect(async (client) => {
@@ -9,7 +10,7 @@ connect(async (client) => {
     container().
     from("alpine").
     withExec(["apk", "add", "curl"]).
-    withEnvVariable("CACHEBUSTER", Date.now().toString()).
+    withEnvVariable("CACHEBUSTER", uuidv4()).
     withExec(["apk", "add", "zip"]).
     stdout()
 

--- a/docs/current/cookbook/snippets/cache-invalidation/main.go
+++ b/docs/current/cookbook/snippets/cache-invalidation/main.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"dagger.io/dagger"
+	"github.com/google/uuid"
 )
 
 func main() {
@@ -24,7 +25,7 @@ func main() {
 		Container().
 		From("alpine").
 		WithExec([]string{"apk", "add", "curl"}).
-		WithEnvVariable("CACHEBUSTER", time.Now().String()).
+		WithEnvVariable("CACHEBUSTER", uuid.New().String()).
 		WithExec([]string{"apk", "add", "zip"}).
 		Stdout(ctx)
 	if err != nil {

--- a/docs/current/cookbook/snippets/cache-invalidation/main.py
+++ b/docs/current/cookbook/snippets/cache-invalidation/main.py
@@ -1,6 +1,6 @@
 import sys
 import anyio
-from datetime import datetime
+import uuid
 import dagger
 
 async def main():
@@ -15,7 +15,7 @@ async def main():
             container().
             from_("alpine").
             with_exec(["apk", "add", "curl"]).
-            with_env_variable("CACHEBUSTER", str(datetime.now())).
+            with_env_variable("CACHEBUSTER", str(uuid.uuid4())).
             with_exec(["apk", "add", "zip"]).
             stdout()
         )


### PR DESCRIPTION
This commit improves the cache invalidation recipe originally added in #5168 to use UUIDs. Refer https://github.com/dagger/dagger/pull/5168#discussion_r1202861315

Relates to DAG-1579