### PR TITLE
docs: Updated quickstart for registry auth methods

### DIFF
--- a/docs/current/162770-faq.md
+++ b/docs/current/162770-faq.md
@@ -12,7 +12,7 @@ We currently offer technical previews of a [Go SDK](/sdk/go), a [Node.js SDK](/s
 
 There are two options available:
 
-1. Use the [withRegistryAuth()](https://docs.dagger.io/api/reference/#Container-withRegistryAuth) GraphQL API method. A native equivalent of this method is available in each Dagger SDK ([example](./guides/723462-use-secrets.md#use-secrets-with-dagger-sdk-methods)).
+1. Use the [`Container.withRegistryAuth()`](https://docs.dagger.io/api/reference/#Container-withRegistryAuth) GraphQL API method. A native equivalent of this method is available in each Dagger SDK ([example](./guides/723462-use-secrets.md#use-secrets-with-dagger-sdk-methods)).
 1. Dagger SDKs can use your existing Docker credentials without requiring separate authentication. Simply execute `docker login` against your container registry on the host where your Dagger pipelines are running.
 
 ### What API query language does Dagger use?

--- a/docs/current/quickstart/730264-quickstart-publish.mdx
+++ b/docs/current/quickstart/730264-quickstart-publish.mdx
@@ -81,7 +81,7 @@ Browse to host port 8080. Confirm that you see the React application's welcome p
 :::warning
 You may have noticed that the pipeline above is able to publish to the registry without requiring the user to enter any authentication credentials. This is only possible because the [ttl.sh](https://ttl.sh/) registry allows anonymous access. In reality, however, most popular registries require authentication before accepting images for publication.
 
-Dagger SDKs rely on your existing Docker credentials for registry authentication. This means that you must execute `docker login` against your selected container registry on the Dagger host before attempting to publish an image to that registry.
+Dagger SDKs rely on your existing Docker credentials for registry authentication. This means that you must either execute `docker login` on the Dagger host, or invoke the [`Container.withRegistryAuth()`](https://docs.dagger.io/api/reference/#Container-withRegistryAuth) API method in your Dagger pipeline, before attempting to publish an image to that registry.
 :::
 
 </QuickstartDoc>


### PR DESCRIPTION
This commit corrects a statement in the quickstart regarding registry authentication support in Dagger.