### PR TITLE
Container.Export: mkdir destination parent dir

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -1509,6 +1509,10 @@ func (container *Container) Export(
 		return err
 	}
 
+	if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
+		return err
+	}
+
 	out, err := os.Create(dest)
 	if err != nil {
 		return err

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -2719,6 +2719,17 @@ func TestContainerExport(t *testing.T) {
 		require.Contains(t, entries, "manifest.json")
 	})
 
+	t.Run("to subdir", func(t *testing.T) {
+		ok, err := ctr.Export(ctx, "./foo/image.tar")
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		entries := tarEntries(t, filepath.Join(wd, "foo", "image.tar"))
+		require.Contains(t, entries, "oci-layout")
+		require.Contains(t, entries, "index.json")
+		require.Contains(t, entries, "manifest.json")
+	})
+
 	t.Run("to outer dir", func(t *testing.T) {
 		ok, err := ctr.Export(ctx, "../")
 		require.Error(t, err)


### PR DESCRIPTION
fixes #5183 

For consistency with `File.Export` and `Directory.Export`, `Container.Export` should create the destination directory if it doesn't exist.