### PR TITLE
tests: fix slowness by disabling unnecessary session nesting.

### DIFF
--- a/core/integration/remotecache_test.go
+++ b/core/integration/remotecache_test.go
@@ -34,8 +34,7 @@ func getDevEngineForRemoteCache(ctx context.Context, c *dagger.Client, cache *da
 		WithEnvVariable("ENGINE_ID", id).
 		WithMountedCache("/var/lib/dagger", c.CacheVolume("dagger-dev-engine-state-"+identity.NewID())).
 		WithExec(nil, dagger.ContainerWithExecOpts{
-			InsecureRootCapabilities:      true,
-			ExperimentalPrivilegedNesting: true,
+			InsecureRootCapabilities: true,
 		})
 
 	endpoint, err = devEngine.Endpoint(ctx, dagger.ContainerEndpointOpts{Port: 1234, Scheme: "tcp"})

--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -189,8 +189,7 @@ func (t Engine) test(ctx context.Context, race bool) error {
 		WithExposedPort(1234, dagger.ContainerWithExposedPortOpts{Protocol: dagger.Tcp}).
 		WithMountedCache("/var/lib/dagger", c.CacheVolume("dagger-dev-engine-test-state")).
 		WithExec(nil, dagger.ContainerWithExecOpts{
-			InsecureRootCapabilities:      true,
-			ExperimentalPrivilegedNesting: true,
+			InsecureRootCapabilities: true,
 		})
 
 	endpoint, err := devEngine.Endpoint(ctx, dagger.ContainerEndpointOpts{Port: 1234, Scheme: "tcp"})


### PR DESCRIPTION
I was wondering why the tests were taking so long as of late, noticed that the remote cache tests had a huge jump in execution time on [this commit](https://github.com/dagger/dagger/commit/f5f76fcbda4b772a54aecc43812bd03e51c0d62c):
* [Before](https://github.com/dagger/dagger/actions/runs/5017303368/jobs/8995255666#step:5:12833)
* [After](https://github.com/dagger/dagger/actions/runs/5025704148/jobs/9013022074#step:5:12781)

The only possible connection point I could see was nested sessions, so tried this and found it worked ([here's the new time from this PR's run](https://github.com/dagger/dagger/actions/runs/5126725502/jobs/9221586856?pr=5224#step:5:12613)), but have not debugged why the new progress forwarding would have this sort of impact @vito 