### PR TITLE
feat: update `dagger/graphql` import commit to rely on extended `Int64` scalar

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/containerd/stargz-snapshotter v0.14.3
 	github.com/containernetworking/cni v1.1.2
 	github.com/coreos/go-systemd/v22 v22.5.0
-	github.com/dagger/graphql v0.0.0-20221102000338-24d5e47d3b72
+	github.com/dagger/graphql v0.0.0-20230601100125-137fc3a90735
 	github.com/dagger/graphql-go-tools v0.0.0-20230418214324-32c52f390881
 	github.com/docker/distribution v2.8.2+incompatible
 	github.com/google/go-containerregistry v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -457,8 +457,9 @@ github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1S
 github.com/d2g/dhcp4client v1.0.0/go.mod h1:j0hNfjhrt2SxUOw55nL0ATM/z4Yt3t2Kd1mW34z5W5s=
 github.com/d2g/dhcp4server v0.0.0-20181031114812-7d4a0a7f59a5/go.mod h1:Eo87+Kg/IX2hfWJfwxMzLyuSZyxSoAug2nGa1G2QAi8=
 github.com/d2g/hardwareaddr v0.0.0-20190221164911-e7d9fbe030e4/go.mod h1:bMl4RjIciD2oAxI7DmWRx6gbeqrkoLqv3MV0vzNad+I=
-github.com/dagger/graphql v0.0.0-20221102000338-24d5e47d3b72 h1:0I9Y9nsFVcP42k9eOpjYmcm+NMEIFxNuJFOHfQ8MKpo=
 github.com/dagger/graphql v0.0.0-20221102000338-24d5e47d3b72/go.mod h1:z9nYmunTkok2pE+Kdjpl1ICaqcCzlDxcVjwaFE0MJTc=
+github.com/dagger/graphql v0.0.0-20230601100125-137fc3a90735 h1:eZiRlRGdN726q4M1FRlO6Ti6KWPtMhOVzgZ9AQmq06g=
+github.com/dagger/graphql v0.0.0-20230601100125-137fc3a90735/go.mod h1:z9nYmunTkok2pE+Kdjpl1ICaqcCzlDxcVjwaFE0MJTc=
 github.com/dagger/graphql-go-tools v0.0.0-20230418214324-32c52f390881 h1:sy8EAAP1LrDQzuViMhHaW7HMiFGO32PXnEiU1AdWghc=
 github.com/dagger/graphql-go-tools v0.0.0-20230418214324-32c52f390881/go.mod h1:n/St2rWoBXCywBsC4Bw4Gj/Bs92X8fVd0Q8Y0aaNbH0=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -800,6 +801,8 @@ github.com/gostaticanalysis/analysisutil v0.0.0-20190318220348-4088753ea4d3/go.m
 github.com/gostaticanalysis/analysisutil v0.0.3/go.mod h1:eEOZF4jCKGi+aprrirO9e7WKB3beBRtWgqGunKl6pKE=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
+github.com/grouville/graphql v0.0.0-20230531125123-48a8b8506a4c h1:kV3FKS0UIMpJJRX3W1eeEc3QQThfZx2Dk1NWoYEgoNI=
+github.com/grouville/graphql v0.0.0-20230531125123-48a8b8506a4c/go.mod h1:z9nYmunTkok2pE+Kdjpl1ICaqcCzlDxcVjwaFE0MJTc=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.0/go.mod h1:mJzapYve32yjrKlk9GbyCZHuPgZsrbyIbyKhSzOpg6s=


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/4152

This PR intends to test the int64 scalar transition added by https://github.com/dagger/graphql/pull/2.

If:
1. it doesn't break the tests
2. we can indeed get size of file > [2.14gb](https://github.com/dagger/dagger/issues/4152)

Then we can merge the `dagger/graphql` PR and upgrade the commit hash on this PR


## Repro
It works perfectly:

```go
package main

import (
	"context"
	"fmt"
	"os"
	"time"

	"dagger.io/dagger"
)

func main() {
	// initialize Dagger client
	ctx := context.Background()
	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
	if err != nil {
		panic(err)
	}
	defer client.Close()

	container := client.Container().From("alpine:3.17")

	currentTime := time.Now()
	timeString := currentTime.Format("15:04:05")

	out, err := container.
		WithEnvVariable("toto", timeString).
		WithExec([]string{"dd", "if=/dev/zero", "of=./foo", "bs=1000", "count=9098199"}).File("./foo").Size(ctx)

	if err != nil {
		panic(err)
	}

	fmt.Println(out)
}
```

output:
```shell
go run .
Connected to engine 9db8b5648635
#1 resolve image config for docker.io/library/alpine:3.17
#1 DONE 0.5s

#2 from alpine:3.17
#2 resolve docker.io/library/alpine:3.17@sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126 0.0s done
#2 CACHED

#3 
#3 23.62 9098199+0 records in
#3 23.62 9098199+0 records out
#3 DONE 24.0s
9098199000
```

On larger numbers, we hit a runc issue (no space left on device)