### PR TITLE
bump progrock for gRPC + resilient draining

### DIFF
--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -563,9 +563,8 @@ func runWithNesting(ctx context.Context, cmd *exec.Cmd) error {
 		RunnerHost:   "unix:///.runner.sock",
 	}
 
-	engineConf.LogOutput = os.Stderr
 	if _, err := os.Stat("/.progrock.sock"); err == nil {
-		progW, err := progrock.DialRPC("unix", "/.progrock.sock")
+		progW, err := progrock.DialRPC(ctx, "unix:/.progrock.sock")
 		if err != nil {
 			return fmt.Errorf("error connecting to progrock: %w", err)
 		}

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -588,5 +588,8 @@ func runWithNesting(ctx context.Context, cmd *exec.Cmd) error {
 		// propagate inner error with higher priority
 		return cmdErr
 	}
-	return engineErr
+	if engineErr != nil {
+		return fmt.Errorf("engine: %w", engineErr)
+	}
+	return nil
 }

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -564,7 +564,7 @@ func runWithNesting(ctx context.Context, cmd *exec.Cmd) error {
 	}
 
 	if _, err := os.Stat("/.progrock.sock"); err == nil {
-		progW, err := progrock.DialRPC(ctx, "unix:/.progrock.sock")
+		progW, err := progrock.DialRPC(ctx, "unix:///.progrock.sock")
 		if err != nil {
 			return fmt.Errorf("error connecting to progrock: %w", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ replace cloud.google.com/go => cloud.google.com/go v0.100.2
 
 require (
 	dagger.io/dagger v0.4.1
+	github.com/99designs/gqlgen v0.17.2 // indirect
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
 	github.com/aws/aws-sdk-go-v2/config v1.18.21 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.20 // indirect
@@ -25,7 +26,6 @@ require (
 	github.com/docker/distribution v2.8.2+incompatible
 	github.com/google/go-containerregistry v0.14.0
 	github.com/google/uuid v1.3.0
-	github.com/99designs/gqlgen v0.17.2
 	github.com/iancoleman/strcase v0.2.0
 	// https://github.com/moby/buildkit/commit/baffc1bda21be5dae54770fe828c03909b8547a6
 	github.com/moby/buildkit v0.11.0-rc3.0.20230529232739-baffc1bda21b
@@ -54,7 +54,7 @@ require (
 	golang.org/x/sync v0.2.0
 	golang.org/x/sys v0.8.0
 	golang.org/x/term v0.8.0
-	google.golang.org/grpc v1.54.0
+	google.golang.org/grpc v1.55.0
 	oss.terrastruct.com/d2 v0.4.0
 )
 
@@ -69,7 +69,7 @@ require (
 	github.com/nxadm/tail v1.4.8
 	github.com/opencontainers/runc v1.1.7
 	github.com/prometheus/procfs v0.9.0
-	github.com/vito/progrock v0.4.1
+	github.com/vito/progrock v0.5.0
 	github.com/vito/vt100 v0.1.1
 	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53
 )

--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/nxadm/tail v1.4.8
 	github.com/opencontainers/runc v1.1.7
 	github.com/prometheus/procfs v0.9.0
-	github.com/vito/progrock v0.5.0
+	github.com/vito/progrock v0.5.1
 	github.com/vito/vt100 v0.1.1
 	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53
 )

--- a/go.sum
+++ b/go.sum
@@ -1427,6 +1427,8 @@ github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmF
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vito/progrock v0.5.0 h1:jJHTXeHny7z5Jp/RBDr3LnUON0yHXUS2COGwoFBOMiY=
 github.com/vito/progrock v0.5.0/go.mod h1:leXc16rFSWTTb7Zviv/nEKD0MfN0ZXLGvtlwLt++cdw=
+github.com/vito/progrock v0.5.1 h1:0OcOCXe63kSRurW3TCr4kzGtEmugHmYcuZS+oryMGMk=
+github.com/vito/progrock v0.5.1/go.mod h1:leXc16rFSWTTb7Zviv/nEKD0MfN0ZXLGvtlwLt++cdw=
 github.com/vito/vt100 v0.1.1 h1:xaT02sjEjX6jbetczTmAxPnke3yATRY1SixzbYv6jxQ=
 github.com/vito/vt100 v0.1.1/go.mod h1:ByMBsZZEP04RrkT9q/UxvZOjECM8Xc/MRLZ7GLrAUXs=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=

--- a/go.sum
+++ b/go.sum
@@ -668,8 +668,8 @@ github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
+github.com/golang/glog v1.1.0 h1:/d3pCKDPWNnvIWe0vVUpNP32qc8U3PDVxySP/y360qE=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -1425,8 +1425,8 @@ github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
-github.com/vito/progrock v0.4.1 h1:mvpjln91biDcytJB7FwQ/vGnhUPoaORHk6DNNJDVQy0=
-github.com/vito/progrock v0.4.1/go.mod h1:aTY24XWrVdb2Uw2VaWKZdWIDXqaJYhp5h8GW1kXjsZI=
+github.com/vito/progrock v0.5.0 h1:jJHTXeHny7z5Jp/RBDr3LnUON0yHXUS2COGwoFBOMiY=
+github.com/vito/progrock v0.5.0/go.mod h1:leXc16rFSWTTb7Zviv/nEKD0MfN0ZXLGvtlwLt++cdw=
 github.com/vito/vt100 v0.1.1 h1:xaT02sjEjX6jbetczTmAxPnke3yATRY1SixzbYv6jxQ=
 github.com/vito/vt100 v0.1.1/go.mod h1:ByMBsZZEP04RrkT9q/UxvZOjECM8Xc/MRLZ7GLrAUXs=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
@@ -2028,8 +2028,8 @@ google.golang.org/grpc v1.44.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ5
 google.golang.org/grpc v1.45.0/go.mod h1:lN7owxKUQEqMfSyQikvvk5tf/6zMPsrK+ONuO11+0rQ=
 google.golang.org/grpc v1.46.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/grpc v1.47.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
-google.golang.org/grpc v1.54.0 h1:EhTqbhiYeixwWQtAEZAxmV9MGqcjEU2mFx52xCzNyag=
-google.golang.org/grpc v1.54.0/go.mod h1:PUSEXI6iWghWaB6lXM4knEgpJNu2qUcKfDtNci3EC2g=
+google.golang.org/grpc v1.55.0 h1:3Oj82/tFSCeUrRTg/5E/7d/W5A1tj6Ky1ABAuZuv5ag=
+google.golang.org/grpc v1.55.0/go.mod h1:iYEXKGkEBhg1PjZQvoYEVPTDkHo1/bjTnfwTeGONTY8=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=


### PR DESCRIPTION
Fixes root cause surfaced in https://github.com/dagger/dagger/pull/5224 (verified locally)

Previously the RPC flow required clients to explicitly send a Close RPC call, which wouldn't be sent for services because they are kill -9'd.

Now the RPC flow uses gRPC under the hood and simply uses a graceful shutdown to wait for any in-flight RPC requests to finish, which accomplishes the same thing while also allowing RPC clients to suddenly disappear.