### PR TITLE
Fix flakiness in TestContainerExecError test

### DIFF
--- a/core/gateway.go
+++ b/core/gateway.go
@@ -237,15 +237,28 @@ func wrapSolveError(inputErr *error, gw bkgw.Client) {
 		if err != nil {
 			return
 		}
-		var exitErr *bkpb.ExitError
-		if err := proc.Wait(); !errors.As(err, &exitErr) {
-			return
+
+		err = proc.Wait()
+
+		exitCode := -1 // -1 indicates failure to get exit code
+		if err != nil {
+			var exitErr *bkpb.ExitError
+			if errors.As(err, &exitErr) {
+				exitCode = int(exitErr.ExitCode)
+			} else {
+				// This can happen for example if debugging the failed exec
+				// takes longer than the timeout in this context, but since
+				// we know the exec op failed, try to return what we have
+				// at this point with the ExecError. The exit code will be -1
+				// and stdout/stderr output may not be complete.
+				returnErr = fmt.Errorf("[%w]: %w", err, returnErr)
+			}
 		}
 
 		returnErr = &ExecError{
 			original: returnErr,
 			Cmd:      execOp.Exec.Meta.Args,
-			ExitCode: int(exitErr.ExitCode),
+			ExitCode: exitCode,
 			Stdout:   strings.TrimSpace(ctrOut.String()),
 			Stderr:   strings.TrimSpace(ctrErr.String()),
 		}

--- a/core/gateway.go
+++ b/core/gateway.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	// Exec errors will only include the last this number of bytes of output.
-	MaxExecErrorOutputBytes = 50 * 1024
+	MaxExecErrorOutputBytes = 30 * 1024
 
 	// TruncationMessage is the message that will be prepended to truncated output.
 	TruncationMessage = "[omitting %d bytes]..."

--- a/core/gateway.go
+++ b/core/gateway.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	// Exec errors will only include the last this number of bytes of output.
-	MaxExecErrorOutputBytes = 100 * 1024
+	MaxExecErrorOutputBytes = 50 * 1024
 
 	// TruncationMessage is the message that will be prepended to truncated output.
 	TruncationMessage = "[omitting %d bytes]..."


### PR DESCRIPTION
This change attempts to solve one aspect of the flakiness in `TestContainerExecError` of late:

```
#11 230.3 === NAME  TestContainerExecError/truncates_output_past_a_maximum_size
#11 230.3     container_test.go:3032: 
#11 230.3         	Error Trace:	/app/core/integration/container_test.go:3032
#11 230.3         	Error:      	Should be in error chain:
#11 230.3         	            	expected: %!q(**dagger.ExecError=0xc001439718)
#11 230.3         	            	in chain: "input:1: container.from.withDirectory.withExec.sync failed to solve: process \"sh -c base64 -d encout >&1; base64 -d encerr >&2; exit 1\" did not complete successfully: exit code: 1\n\nPlease visit https://dagger.io/help#go for troubleshooting guidance."
#11 230.3         	            		"input:1: container.from.withDirectory.withExec.sync failed to solve: process \"sh -c base64 -d encout >&1; base64 -d encerr >&2; exit 1\" did not complete successfully: exit code: 1\n"
#11 230.3         	Test:       	TestContainerExecError/truncates_output_past_a_maximum_size
#11 230.3 --- FAIL: TestContainerExecError (33.28s)
#11 230.3     --- PASS: TestContainerExecError/includes_output_of_failed_exec_in_error (0.91s)
#11 230.3     --- PASS: TestContainerExecError/includes_output_of_failed_exec_in_error_when_redirects_are_enabled (0.97s)
#11 230.3     --- FAIL: TestContainerExecError/truncates_output_past_a_maximum_size (30.83s)
```

There's a deeper problem where trying to get the output of a failed exec can get canceled by exceeding the timeout of 30s. At least this change avoids failing the test by ensuring we always return an `ExecError` if we can.