### PR TITLE
dagger run: support redirecting stdout/stderr

### DIFF
--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -18,13 +18,15 @@ import (
 )
 
 var silent bool
+var stdoutIsTTY = isatty.IsTerminal(os.Stdout.Fd())
+var stderrIsTTY = isatty.IsTerminal(os.Stderr.Fd())
 
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(
 		&silent,
 		"silent",
 		"s",
-		!isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsTerminal(os.Stderr.Fd()),
+		!stdoutIsTTY && !stderrIsTTY,
 		"disable terminal UI and progress output",
 	)
 }

--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -117,8 +117,18 @@ func run(ctx context.Context, args []string) error {
 
 			cmdline := strings.Join(subCmd.Args, " ")
 			cmdVtx := rec.Vertex("cmd", cmdline)
-			subCmd.Stdout = cmdVtx.Stdout()
-			subCmd.Stderr = cmdVtx.Stderr()
+
+			if stdoutIsTTY {
+				subCmd.Stdout = cmdVtx.Stdout()
+			} else {
+				subCmd.Stdout = os.Stdout
+			}
+
+			if stderrIsTTY {
+				subCmd.Stderr = cmdVtx.Stderr()
+			} else {
+				subCmd.Stderr = os.Stderr
+			}
 
 			cmdErr = subCmd.Run()
 			cmdVtx.Done(cmdErr)


### PR DESCRIPTION
fixes #5196 

Alternative to #5197. 

Tackles the same problem but with a different approach: if either stdout or stderr are redirected, respect the redirect rather than writing output to the TUI. I opted to not use a `MultiWriter` because that's how redirects normally work, but I don't feel too strongly about it; if someone has a good reason to also print the redirected content to the TUI I'm all ears.