### PR TITLE
Interactive TUI: better failure handling

### DIFF
--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -109,12 +109,14 @@ func interactiveTUI(
 		cbErr = fn(ctx, api)
 		return cbErr
 	})
+
+	tuiErr := <-tuiDone
+
 	if cbErr != nil {
 		// avoid unnecessary error wrapping
 		return cbErr
 	}
 
-	tuiErr := <-tuiDone
 	return errors.Join(tuiErr, engineErr)
 }
 

--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/dagger/dagger/engine"
+	"github.com/dagger/dagger/internal/tui"
 	"github.com/dagger/dagger/router"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
@@ -116,7 +117,7 @@ func run(ctx context.Context, args []string) error {
 			rec := progrock.RecorderFromContext(ctx)
 
 			cmdline := strings.Join(subCmd.Args, " ")
-			cmdVtx := rec.Vertex("cmd", cmdline)
+			cmdVtx := rec.Vertex(tui.RootVertex, cmdline)
 
 			if stdoutIsTTY {
 				subCmd.Stdout = cmdVtx.Stdout()

--- a/internal/tui/item.go
+++ b/internal/tui/item.go
@@ -405,6 +405,10 @@ func (g *Group) sort() {
 		ie := g.entries[i]
 		je := g.entries[j]
 		switch {
+		case g.isAncestor(ie, je):
+			return true
+		case g.isAncestor(je, ie):
+			return false
 		case ie.Started() == nil && je.Started() == nil:
 			// both pending
 			return false
@@ -421,6 +425,27 @@ func (g *Group) sort() {
 			return false
 		}
 	})
+}
+
+func (g *Group) isAncestor(i, j TreeEntry) bool {
+	if i == j {
+		return false
+	}
+
+	id := i.ID()
+
+	for _, d := range j.Inputs() {
+		if d == id {
+			return true
+		}
+
+		e, ok := g.entriesByID[string(d)]
+		if ok && g.isAncestor(i, e) {
+			return true
+		}
+	}
+
+	return false
 }
 
 type emptyGroup struct {

--- a/internal/tui/item.go
+++ b/internal/tui/item.go
@@ -241,7 +241,7 @@ type Group struct {
 
 func NewGroup(id, name string) *Group {
 	return &Group{
-		groupModel: &emptyGroup{}, // TODO remove
+		groupModel: &emptyGroup{},
 
 		id:          id,
 		name:        name,
@@ -302,7 +302,15 @@ func (g *Group) Open() tea.Cmd {
 	return openEditor(subDir)
 }
 
+const RootVertex = "<root>"
+
 func (g *Group) Add(e TreeEntry) {
+	if e.ID() == RootVertex {
+		g.name = e.Name()
+		g.groupModel = e
+		return
+	}
+
 	_, has := g.entriesByID[e.ID()]
 	if has {
 		return

--- a/internal/tui/item.go
+++ b/internal/tui/item.go
@@ -439,7 +439,7 @@ func (g *Group) isAncestor(i, j TreeEntry) bool {
 			return true
 		}
 
-		e, ok := g.entriesByID[string(d)]
+		e, ok := g.entriesByID[d]
 		if ok && g.isAncestor(i, e) {
 			return true
 		}

--- a/internal/tui/tree.go
+++ b/internal/tui/tree.go
@@ -315,6 +315,12 @@ func (m *Tree) Follow() {
 		return
 	}
 
+	if m.root.Completed() != nil {
+		// go back to the root node on completion
+		m.currentOffset = 0
+		return
+	}
+
 	current := m.Current()
 	if current == nil {
 		return


### PR DESCRIPTION
fixes #5191 

A grab bag of improvements for the interactive TUI:

* Don't exit the TUI on failure (simple regression)
* Move the command vertex back to the root of the tree
* Use vertex input ancestry to determine vertex order within a group
* In follow mode, switch to the command (i.e. root) on completion

To test:

```sh
env _EXPERIMENTAL_DAGGER_INTERACTIVE_TUI=1 dagger run sh -c 'echo hi; sleep 1; echo bye; exit 42'
```

(For a proper test with more vertices you'll need to run a failing Dagger pipeline, but I don't have one handy atm.)