### PR TITLE
Prevent concurrent/leaked mutation in a couple of spots

### DIFF
--- a/core/cache.go
+++ b/core/cache.go
@@ -20,7 +20,7 @@ func NewCache(keys ...string) *CacheVolume {
 
 func (cache *CacheVolume) Clone() *CacheVolume {
 	cp := *cache
-	cp.Keys = clone(cp.Keys)
+	cp.Keys = cloneSlice(cp.Keys)
 	return &cp
 }
 

--- a/core/container.go
+++ b/core/container.go
@@ -486,7 +486,7 @@ func (container *Container) buildUncached(
 
 		// associate vertexes to the 'docker build' sub-pipeline
 		recordVertexes(subRecorder, def.ToPB())
-		overrideProgress(def, subPipeline)
+		def = overrideProgress(def, subPipeline)
 
 		container.FS = def.ToPB()
 		container.FS.Source = nil
@@ -1327,7 +1327,7 @@ func (container *Container) Evaluate(ctx context.Context, gw bkgw.Client, pipeli
 
 		if pipelineOverride != nil {
 			recordVertexes(progrock.RecorderFromContext(ctx), def.ToPB())
-			overrideProgress(def, *pipelineOverride)
+			def = overrideProgress(def, *pipelineOverride)
 		}
 
 		return gw.Solve(ctx, bkgw.SolveRequest{

--- a/core/container.go
+++ b/core/container.go
@@ -92,13 +92,19 @@ func NewContainer(id ContainerID, pipeline pipeline.Path, platform specs.Platfor
 // WithXXX method.
 func (container *Container) Clone() *Container {
 	cp := *container
-	cp.Mounts = clone(cp.Mounts)
-	cp.Secrets = clone(cp.Secrets)
-	cp.Sockets = clone(cp.Sockets)
-	cp.Ports = clone(cp.Ports)
+	cp.Config.ExposedPorts = cloneMap(cp.Config.ExposedPorts)
+	cp.Config.Env = cloneSlice(cp.Config.Env)
+	cp.Config.Entrypoint = cloneSlice(cp.Config.Entrypoint)
+	cp.Config.Cmd = cloneSlice(cp.Config.Cmd)
+	cp.Config.Volumes = cloneMap(cp.Config.Volumes)
+	cp.Config.Labels = cloneMap(cp.Config.Labels)
+	cp.Mounts = cloneSlice(cp.Mounts)
+	cp.Secrets = cloneSlice(cp.Secrets)
+	cp.Sockets = cloneSlice(cp.Sockets)
+	cp.Ports = cloneSlice(cp.Ports)
 	cp.Services = cloneMap(cp.Services)
-	cp.HostAliases = clone(cp.HostAliases)
-	cp.Pipeline = clone(cp.Pipeline)
+	cp.HostAliases = cloneSlice(cp.HostAliases)
+	cp.Pipeline = cloneSlice(cp.Pipeline)
 	return &cp
 }
 

--- a/core/directory.go
+++ b/core/directory.go
@@ -56,7 +56,7 @@ func NewDirectorySt(ctx context.Context, st llb.State, dir string, pipeline pipe
 // WithXXX method.
 func (dir *Directory) Clone() *Directory {
 	cp := *dir
-	cp.Pipeline = clone(cp.Pipeline)
+	cp.Pipeline = cloneSlice(cp.Pipeline)
 	cp.Services = cloneMap(cp.Services)
 	return &cp
 }

--- a/core/file.go
+++ b/core/file.go
@@ -55,7 +55,7 @@ func NewFileSt(ctx context.Context, st llb.State, dir string, pipeline pipeline.
 // WithXXX method.
 func (file *File) Clone() *File {
 	cp := *file
-	cp.Pipeline = clone(cp.Pipeline)
+	cp.Pipeline = cloneSlice(cp.Pipeline)
 	cp.Services = cloneMap(cp.Services)
 	return &cp
 }

--- a/core/progress.go
+++ b/core/progress.go
@@ -10,12 +10,18 @@ import (
 // FIXME: this can't be done in a normal way because Buildkit doesn't currently
 // allow overriding the metadata of DefinitionOp. See this PR and comment:
 // https://github.com/moby/buildkit/pull/2819
-func overrideProgress(def *llb.Definition, pipeline pipeline.Path) {
+func overrideProgress(def *llb.Definition, pipeline pipeline.Path) *llb.Definition {
+	progressGroup := pipeline.ProgressGroup()
+
+	cp := *def
+	cp.Metadata = cloneMap(def.Metadata)
 	for dgst, metadata := range def.Metadata {
 		// FIXME: this clobbers any existing progress groups, e.g. image pulls and
 		// Dockerfile builds. We can't just check for != nil either because the
 		// goal of this is sometimes to nest beneath it.
-		metadata.ProgressGroup = pipeline.ProgressGroup()
-		def.Metadata[dgst] = metadata
+		metadata.ProgressGroup = progressGroup
+		cp.Metadata[dgst] = metadata
 	}
+
+	return &cp
 }

--- a/core/util.go
+++ b/core/util.go
@@ -199,13 +199,16 @@ func parseUID(str string) (int, error) {
 	return int(uid), nil
 }
 
-func clone[T any](src []T) []T {
+func cloneSlice[T any](src []T) []T {
 	dst := make([]T, len(src))
 	copy(dst, src)
 	return dst
 }
 
 func cloneMap[K comparable, T any](src map[K]T) map[K]T {
+	if src == nil {
+		return src
+	}
 	dst := make(map[K]T, len(src))
 	for k, v := range src {
 		dst[k] = v


### PR DESCRIPTION
Attempts to address https://github.com/airbytehq/airbyte/issues/26863 though the fixes here are purely theoretical; there's no smoking gun for where the concurrent write actually happened.

Two areas fixed: `overrideProgress` and `Container.Clone`.

#### `overrideProgress`

This function gets called when starting a service, and previously was directly mutating the `Metadata` map that's present in container's underlying `*pb.Definition` because the map is [carried directly over](https://github.com/moby/buildkit/blob/80b91c55a47feb52a66e143a3929e614dd5c7adc/client/llb/definition.go#L99) when converting it to a `llb.State` (!).

We don't really want to mutate in this scenario anyway; it's purely a runtime concern, and should not affect the original Container, so now this helper returns a copy.

Ultimately this whole function can go away once we're fully switched to Progrock.

#### `Container.Clone`

We weren't cloning the image config's inner slices and maps. This is mostly defensive; it's unlikely for there to be concurrent reads and writes to a container config, unlike `overrideProgress` which could happen in parallel to reads when starting a service.

The worst that could probably happen is accidentally sharing the changes in a "parallel" GraphQL query that assigns to multiple fields, similar to what's being tested [here](https://github.com/dagger/dagger/blob/2dd8717ee0c09230dbc2d9bee5d3f6343e8ccd36/core/integration/container_test.go#L3677).