### PR TITLE
chore: update `go.sum`

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -801,8 +801,6 @@ github.com/gostaticanalysis/analysisutil v0.0.0-20190318220348-4088753ea4d3/go.m
 github.com/gostaticanalysis/analysisutil v0.0.3/go.mod h1:eEOZF4jCKGi+aprrirO9e7WKB3beBRtWgqGunKl6pKE=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
-github.com/grouville/graphql v0.0.0-20230531125123-48a8b8506a4c h1:kV3FKS0UIMpJJRX3W1eeEc3QQThfZx2Dk1NWoYEgoNI=
-github.com/grouville/graphql v0.0.0-20230531125123-48a8b8506a4c/go.mod h1:z9nYmunTkok2pE+Kdjpl1ICaqcCzlDxcVjwaFE0MJTc=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.0/go.mod h1:mJzapYve32yjrKlk9GbyCZHuPgZsrbyIbyKhSzOpg6s=
@@ -1428,8 +1426,6 @@ github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
-github.com/vito/progrock v0.5.0 h1:jJHTXeHny7z5Jp/RBDr3LnUON0yHXUS2COGwoFBOMiY=
-github.com/vito/progrock v0.5.0/go.mod h1:leXc16rFSWTTb7Zviv/nEKD0MfN0ZXLGvtlwLt++cdw=
 github.com/vito/progrock v0.5.1 h1:0OcOCXe63kSRurW3TCr4kzGtEmugHmYcuZS+oryMGMk=
 github.com/vito/progrock v0.5.1/go.mod h1:leXc16rFSWTTb7Zviv/nEKD0MfN0ZXLGvtlwLt++cdw=
 github.com/vito/vt100 v0.1.1 h1:xaT02sjEjX6jbetczTmAxPnke3yATRY1SixzbYv6jxQ=


### PR DESCRIPTION
In latest PR https://github.com/dagger/dagger/pull/5227, @helderco  pointed out that I forgot to update the `go.sum` with `go mod tidy`. I merged it before he had the time to add a commit. This fixes it 🙏 