### PR TITLE
Return ExecError even without an ExitError

### DIFF
--- a/core/gateway.go
+++ b/core/gateway.go
@@ -237,17 +237,25 @@ func wrapSolveError(inputErr *error, gw bkgw.Client) {
 		if err != nil {
 			return
 		}
-		var exitErr *bkpb.ExitError
-		if err := proc.Wait(); !errors.As(err, &exitErr) {
+		if err := proc.Wait(); err != nil {
 			return
+		}
+
+		stdout := strings.TrimSpace(ctrOut.String())
+		stderr := strings.TrimSpace(ctrErr.String())
+
+		exitCode := -1
+		var exitErr *bkpb.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = int(exitErr.ExitCode)
 		}
 
 		returnErr = &ExecError{
 			original: returnErr,
 			Cmd:      execOp.Exec.Meta.Args,
-			ExitCode: int(exitErr.ExitCode),
-			Stdout:   strings.TrimSpace(ctrOut.String()),
-			Stderr:   strings.TrimSpace(ctrErr.String()),
+			ExitCode: exitCode,
+			Stdout:   stdout,
+			Stderr:   stderr,
 		}
 	}
 	*inputErr = returnErr


### PR DESCRIPTION
Follow up to #5184

Not sure when `proc.Wait` would succeed without returning a `*pb.ExitError`, but since it's only used for the exit code and at this point we have the stdout and stderr, they may be useful to debug.