### PR TITLE
ci: Fix lint-daggerized.yml error

### DIFF
--- a/.github/actions/experimental-setup-dagger/action.yml
+++ b/.github/actions/experimental-setup-dagger/action.yml
@@ -11,7 +11,7 @@ runs:
       shell: bash
       env:
         CGO_ENABLED: "0"
-    - run: echo "DAGGER_PROJECT=${{ github.repositoryUrl }}#${{ github.sha }}" >> $GITHUB_ENV
+    - run: echo "DAGGER_PROJECT=${{ github.repositoryUrl }}#${{ github.ref }}" >> $GITHUB_ENV
       shell: bash
     # This proves we are not reliant on the checkout
     - run: rm -rf * .git

--- a/.github/workflows/lint-daggerized.yml
+++ b/.github/workflows/lint-daggerized.yml
@@ -22,8 +22,9 @@ jobs:
   engine:
     runs-on: ubuntu-latest
     steps:
-      - uses: .github/actions/experimental-setup-dagger
-      - run: dagger do --debug --config ./ci ci sdk go lint
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/experimental-setup-dagger
+      - run: dagger do --debug --config ./ci ci:sdk:go:lint --repo ${{ github.server_url }}/${{ github.repository }} --branch ${{ github.ref }}
         env:
           _EXPERIMENTAL_DAGGER_JOURNAL: "/tmp/journal.log"
           _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"


### PR DESCRIPTION
Found from
https://github.com/dagger/dagger/actions/runs/5147441125. The `uses`
must have `./` to point to local action. And fixes 2 issues in the
workflow:

First, fix the daggerized job to use `${{ github.ref }}` instead of
`${{ github.sha }}` when setting `DAGGER_PROJECT` because when using
sha, the dagger didn't know the sha commit when sending a Pull Request
from another repo.

Second, fix the `dagger do` argument and passing `--repo` and `--branch`
to the project.