### PR TITLE
chore: Use expand PATH instead of string concatenation

### DIFF
--- a/internal/mage/sdk/python.go
+++ b/internal/mage/sdk/python.go
@@ -212,7 +212,9 @@ func pythonBase(c *dagger.Client, version string) *dagger.Container {
 		WithExec([]string{"pip", "install", "--user", "poetry==1.3.1", "poetry-dynamic-versioning"}).
 		WithExec([]string{"python", "-m", "venv", venv}).
 		WithEnvVariable("VIRTUAL_ENV", venv).
-		WithEnvVariable("PATH", fmt.Sprintf("%s/bin:%s", venv, path)).
+		WithEnvVariable("PATH", fmt.Sprintf("%s/bin:$PATH", venv), dagger.ContainerWithEnvVariableOpts{
+			Expand: true,
+		}).
 		WithEnvVariable("POETRY_VIRTUALENVS_CREATE", "false").
 		WithWorkdir(mountPath)
 


### PR DESCRIPTION
`PATH` variable use string concatenation. But since dagger 0.6, we have shell variable expansion. So I think we should use that instead to make sure PATH variable is up-to-date. 