### PR TITLE
show health-checks in progress UI

### DIFF
--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -22,7 +22,6 @@ import (
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/router"
 	"github.com/google/uuid"
-	"github.com/moby/buildkit/identity"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/vito/progrock"
 	"golang.org/x/sys/unix"
@@ -92,8 +91,6 @@ func check(args []string) error {
 		return fmt.Errorf("usage: check <host> port/tcp [port/udp ...]")
 	}
 
-	logPrefix := fmt.Sprintf("[check %s]", identity.NewID())
-
 	host, ports := args[0], args[1:]
 
 	for _, port := range ports {
@@ -104,20 +101,20 @@ func check(args []string) error {
 
 		pollAddr := net.JoinHostPort(host, port)
 
-		fmt.Println(logPrefix, "polling for port", pollAddr)
+		fmt.Println("polling for port", pollAddr)
 
-		reached, err := pollForPort(logPrefix, network, pollAddr)
+		reached, err := pollForPort(network, pollAddr)
 		if err != nil {
 			return fmt.Errorf("poll %s: %w", pollAddr, err)
 		}
 
-		fmt.Println(logPrefix, "port is up at", reached)
+		fmt.Println("port is up at", reached)
 	}
 
 	return nil
 }
 
-func pollForPort(logPrefix, network, addr string) (string, error) {
+func pollForPort(network, addr string) (string, error) {
 	retry := backoff.NewExponentialBackOff()
 	retry.InitialInterval = 100 * time.Millisecond
 
@@ -133,7 +130,7 @@ func pollForPort(logPrefix, network, addr string) (string, error) {
 
 		conn, err := dialer.Dial(network, addr)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s port not ready: %s; elapsed: %s\n", logPrefix, err, retry.GetElapsedTime())
+			fmt.Fprintf(os.Stderr, "port not ready: %s; elapsed: %s\n", err, retry.GetElapsedTime())
 			return err
 		}
 

--- a/core/container.go
+++ b/core/container.go
@@ -1379,7 +1379,7 @@ func (container *Container) Start(ctx context.Context, gw bkgw.Client) (*Service
 
 	checked := make(chan error, 1)
 	go func() {
-		checked <- health.Check(ctx)
+		checked <- health.Check(svcCtx)
 	}()
 
 	exited := make(chan error, 1)

--- a/core/gateway.go
+++ b/core/gateway.go
@@ -257,7 +257,7 @@ type nopCloser struct {
 	io.Writer
 }
 
-func (n *nopCloser) Close() error {
+func (n nopCloser) Close() error {
 	return nil
 }
 


### PR DESCRIPTION
Introduces a custom internal (`--debug`) vertex for displaying health-check logs, replacing the old-and-busted `_DAGGER_DEBUG_HEALTHCHECKS` hack which just dumped them straight to stderr (which is incompatible with TUIs).

The vertex is named after the internal command used to run the healthcheck: `check HOSTNAME 1234/tcp 5678/udp`.

![image](https://github.com/dagger/dagger/assets/1880/03388272-f9ac-49ad-a445-52b6e0778b36)
