### PR TITLE
ci: Use alpine for golangci-lint image

### DIFF
--- a/ci/engine.go
+++ b/ci/engine.go
@@ -8,7 +8,7 @@ func (e EngineTargets) Lint(ctx dagger.Context) (string, error) {
 	c := ctx.Client().Pipeline("engine").Pipeline("lint")
 
 	out, err := c.Container().
-		From("golangci/golangci-lint:v1.51").
+		From("golangci/golangci-lint:v1.51-alpine").
 		WithMountedDirectory("/app", e.SrcDir).
 		WithWorkdir("/app").
 		WithExec([]string{"golangci-lint", "run", "-v", "--timeout", "5m"}).

--- a/ci/go.go
+++ b/ci/go.go
@@ -17,7 +17,7 @@ func (g GoTargets) Lint(ctx dagger.Context) (string, error) {
 	c := ctx.Client().Pipeline("sdk").Pipeline("go").Pipeline("lint")
 
 	out, err := c.Container().
-		From("golangci/golangci-lint:v1.51").
+		From("golangci/golangci-lint:v1.51-alpine").
 		WithMountedDirectory("/app", g.SrcDir).
 		WithWorkdir("/app/sdk/go").
 		WithExec([]string{"golangci-lint", "run", "-v", "--timeout", "5m"}).

--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -59,7 +59,7 @@ func (t Engine) Lint(ctx context.Context) error {
 	repo := util.RepositoryGoCodeOnly(c)
 
 	_, err = c.Container().
-		From("golangci/golangci-lint:v1.51").
+		From("golangci/golangci-lint:v1.51-alpine").
 		WithMountedDirectory("/app", repo).
 		WithWorkdir("/app").
 		WithExec([]string{"golangci-lint", "run", "-v", "--timeout", "5m"}).

--- a/internal/mage/sdk/go.go
+++ b/internal/mage/sdk/go.go
@@ -34,7 +34,7 @@ func (t Go) Lint(ctx context.Context) error {
 	c = c.Pipeline("sdk").Pipeline("go").Pipeline("lint")
 
 	_, err = c.Container().
-		From("golangci/golangci-lint:v1.51").
+		From("golangci/golangci-lint:v1.51-alpine").
 		WithMountedDirectory("/app", util.RepositoryGoCodeOnly(c)).
 		WithWorkdir("/app/sdk/go").
 		WithExec([]string{"golangci-lint", "run", "-v", "--timeout", "5m"}).


### PR DESCRIPTION
Provides a speed improvement when running the lint pipelines. About a 40 second improvement for the sdk/go lint run.

sdk/go:
Before(4m 22s):
https://github.com/KasonBraley/dagger/actions/runs/5251099871/jobs/9485711433

With this change(3m 40s):
https://github.com/KasonBraley/dagger/actions/runs/5251069261/jobs/9485647687