### PR TITLE
Bump buildkit for ExecProcessServer mutex fix

### DIFF
--- a/core/gateway.go
+++ b/core/gateway.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	// Exec errors will only include the last this number of bytes of output.
-	MaxExecErrorOutputBytes = 30 * 1024
+	MaxExecErrorOutputBytes = 100 * 1024
 
 	// TruncationMessage is the message that will be prepended to truncated output.
 	TruncationMessage = "[omitting %d bytes]..."

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.31.3 // indirect
 	github.com/charmbracelet/bubbles v0.16.1
 	github.com/charmbracelet/bubbletea v0.24.1
-	github.com/containerd/containerd v1.7.1
+	github.com/containerd/containerd v1.7.2
 	github.com/containerd/fuse-overlayfs-snapshotter v1.0.2
 	github.com/containerd/stargz-snapshotter v0.14.3
 	github.com/containernetworking/cni v1.1.2
@@ -27,8 +27,8 @@ require (
 	github.com/google/go-containerregistry v0.14.0
 	github.com/google/uuid v1.3.0
 	github.com/iancoleman/strcase v0.2.0
-	// https://github.com/moby/buildkit/commit/40c5efa4ae8ad0ffa9c293884ca8f600d5f89478
-	github.com/moby/buildkit v0.11.0-rc3.0.20230607083454-40c5efa4ae8a
+	// https://github.com/moby/buildkit/commit/8a28fe6bc051989cc1a5c2312a73d8da17d8a435
+	github.com/moby/buildkit v0.11.0-rc3.0.20230608232644-8a28fe6bc051
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc3
 	github.com/opencontainers/runtime-spec v1.1.0-rc.2

--- a/go.sum
+++ b/go.sum
@@ -358,6 +358,8 @@ github.com/containerd/containerd v1.5.0-beta.3/go.mod h1:/wr9AVtEM7x9c+n0+stptlo
 github.com/containerd/containerd v1.5.0-beta.4/go.mod h1:GmdgZd2zA2GYIBZ0w09ZvgqEq8EfBp/m3lcVZIvPHhI=
 github.com/containerd/containerd v1.7.1 h1:k8DbDkSOwt5rgxQ3uCI4WMKIJxIndSCBUaGm5oRn+Go=
 github.com/containerd/containerd v1.7.1/go.mod h1:gA+nJUADRBm98QS5j5RPROnt0POQSMK+r7P7EGMC/Qc=
+github.com/containerd/containerd v1.7.2 h1:UF2gdONnxO8I6byZXDi5sXWiWvlW3D/sci7dTQimEJo=
+github.com/containerd/containerd v1.7.2/go.mod h1:afcz74+K10M/+cjGHIVQrCt3RAQhUSCAjJ9iMYhhkuI=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20190815185530-f2a389ac0a02/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20191127005431-f65d91d395eb/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
@@ -1040,6 +1042,8 @@ github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQ
 github.com/moby/buildkit v0.8.1/go.mod h1:/kyU1hKy/aYCuP39GZA9MaKioovHku57N6cqlKZIaiQ=
 github.com/moby/buildkit v0.11.0-rc3.0.20230607083454-40c5efa4ae8a h1:TdEVgEWiKfuAAkd1FQkMNtryjXRbA5cwLcR33IpoVaM=
 github.com/moby/buildkit v0.11.0-rc3.0.20230607083454-40c5efa4ae8a/go.mod h1:rec100rKm3ASz5KZcmCG21kjjjk9zsnrlvDYeXFcXWE=
+github.com/moby/buildkit v0.11.0-rc3.0.20230608232644-8a28fe6bc051 h1:naT6gAUgWvig4xEeZNHa8WwYvO+838rNUKNGXb3WGJw=
+github.com/moby/buildkit v0.11.0-rc3.0.20230608232644-8a28fe6bc051/go.mod h1:4sM7BBBqXOQ+vV6LrVAOAMhZI9cVNYV5RhZCl906a64=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/patternmatcher v0.5.0 h1:YCZgJOeULcxLw1Q+sVR636pmS7sPEn1Qo2iAN6M7DBo=


### PR DESCRIPTION
Bumps `buildkit` version for this fix: https://github.com/moby/buildkit/pull/3940

`go get` also bumped `containerd` to 1.7.2.