### PR TITLE
Adds t.Parallel to auth, core and router tests

### DIFF
--- a/auth/registry_test.go
+++ b/auth/registry_test.go
@@ -16,6 +16,7 @@ const (
 )
 
 func TestParseAuthAddress(t *testing.T) {
+	t.Parallel()
 	type TestCase struct {
 		InputAddress string
 		Expected     string
@@ -113,6 +114,7 @@ func TestParseAuthAddress(t *testing.T) {
 }
 
 func TestRegistryAuthProvider(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	cfg := configfile.ConfigFile{}
 	registry := NewRegistryAuthProvider(&cfg)

--- a/core/cachemap_test.go
+++ b/core/cachemap_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestCacheMapConcurrent(t *testing.T) {
+	t.Parallel()
 	c := newCacheMap[int, int]()
 
 	commonKey := 42
@@ -36,6 +37,7 @@ func TestCacheMapConcurrent(t *testing.T) {
 }
 
 func TestCacheMapErrors(t *testing.T) {
+	t.Parallel()
 	c := newCacheMap[int, int]()
 
 	commonKey := 42

--- a/router/merge_test.go
+++ b/router/merge_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestMergeObjects(t *testing.T) {
+	t.Parallel()
 	merged, err := MergeExecutableSchemas("",
 		StaticSchema(StaticSchemaParams{
 			Schema: `
@@ -52,6 +53,7 @@ func TestMergeObjects(t *testing.T) {
 }
 
 func TestMergeFieldExtend(t *testing.T) {
+	t.Parallel()
 	merged, err := MergeExecutableSchemas("",
 		StaticSchema(StaticSchemaParams{
 			Schema: `
@@ -89,6 +91,7 @@ func TestMergeFieldExtend(t *testing.T) {
 }
 
 func TestMergeFieldConflict(t *testing.T) {
+	t.Parallel()
 	_, err := MergeExecutableSchemas("",
 		StaticSchema(StaticSchemaParams{
 			Schema: `
@@ -147,6 +150,7 @@ func TestMergeTypeConflict(t *testing.T) {
 }
 
 func TestMergeScalars(t *testing.T) {
+	t.Parallel()
 	merged, err := MergeExecutableSchemas("",
 		StaticSchema(StaticSchemaParams{
 			Schema: `
@@ -176,6 +180,7 @@ func TestMergeScalars(t *testing.T) {
 }
 
 func TestMergeScalarConflict(t *testing.T) {
+	t.Parallel()
 	_, err := MergeExecutableSchemas("",
 		StaticSchema(StaticSchemaParams{
 			Schema: `scalar TypeA`,


### PR DESCRIPTION
Like #5134, a minor improvement for tests in `auth`, `core` and `router` subpackages.