### PR TITLE
Add a link to GitHub releases in the docs sidebar

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -152,6 +152,11 @@ module.exports = {
       type: "doc",
       id: "current/contributing",
     },
+    {
+      type: "link",
+      label: "Releases 🔗",
+      href: "https://github.com/dagger/dagger/releases",
+    },
   ],
   quickstart: [
     {


### PR DESCRIPTION
The Dagger public changelog is on GitHub; however, you can't easily find that fron docs.dagger.io. This change adds a new **Releases** item to the docs site sidebar. Clicking on this opens [https://github.com/dagger/dagger/releases](https://github.com/dagger/dagger/releases) as a new tab.

![](https://github.com/dagger/dagger/assets/1811126/6945c5e1-69e1-4205-bad6-677a2189c351)