### PR TITLE
sdk/go: Doc that ServeCommands is experimental.

### DIFF
--- a/sdk/go/server.go
+++ b/sdk/go/server.go
@@ -29,6 +29,8 @@ func (c *Context) Client() *Client {
 	return c.client
 }
 
+// EXPERIMENTAL: ServeCommands is not intended for production use yet.
+//
 //nolint:gocyclo
 func ServeCommands(entrypoints ...any) {
 	ctx := context.Background()


### PR DESCRIPTION
Couldn't find a way to hide it from pkg.go.dev other than marking it as deprecated, which doesn't feel right, so just updated the doc string.