### PR TITLE
sdk(elixir): fix publish package issue

### DIFF
--- a/internal/mage/sdk/elixir.go
+++ b/internal/mage/sdk/elixir.go
@@ -169,7 +169,7 @@ func (Elixir) Publish(ctx context.Context, tag string) error {
 	}()
 
 	args := []string{"mix", "hex.publish", "--yes"}
-	if dryRun == "1" {
+	if dryRun == "1" || dryRun == "true" {
 		args = append(args, "--dry-run")
 	}
 

--- a/internal/mage/sdk/elixir.go
+++ b/internal/mage/sdk/elixir.go
@@ -169,7 +169,7 @@ func (Elixir) Publish(ctx context.Context, tag string) error {
 	}()
 
 	args := []string{"mix", "hex.publish", "--yes"}
-	if dryRun == "1" || dryRun == "true" {
+	if dryRun != "" {
 		args = append(args, "--dry-run")
 	}
 

--- a/sdk/elixir/mix.exs
+++ b/sdk/elixir/mix.exs
@@ -47,7 +47,17 @@ defmodule Dagger.MixProject do
       links: %{
         "GitHub" => @source_url,
         "Changelog" => "#{@source_url}/releases/tag/sdk%2Felixir%2Fv#{@version}"
-      }
+      },
+      files: [
+        "lib",
+        "priv",
+        ".formatter.exs",
+        "mix.exs",
+        "README*",
+        "LICENSE*",
+        "CHANGELOG*",
+        "VERSION"
+      ]
     }
   end
 


### PR DESCRIPTION
Make `HEX_DRY_RUN` to support `true` value and fix VERSION file not include when publishing package. Here is the example when publish with `HEX_API_KEY=abcd HEX_DRY_RUN=true ./hack/make sdk:elixir:publish sdk/elixir/v1.0.0`:


  ```
  +++ dirname ./hack/make
  ++ cd ./hack/..
  ++ pwd
  + DAGGER_SRC_ROOT=/Users/thanabodee/src/github.com/dagger/dagger
  + MAGEDIR=/Users/thanabodee/src/github.com/dagger/dagger/internal/mage
  + cd /Users/thanabodee/src/github.com/dagger/dagger/internal/mage
  + exec go run main.go -w /Users/thanabodee/src/github.com/dagger/dagger sdk:elixir:publish sdk/elixir/v1.0.0
  Connected to engine 93e4e6b5ead3
  #1 resolve image config for docker.io/hexpm/elixir:1.14.5-erlang-25.3-debian-buster-20230227-slim
  #1 DONE 0.8s
  
  #2 generate
  #2 DONE 0.0s
  
  #3 from hexpm/elixir:1.14.5-erlang-25.3-debian-buster-20230227-slim
  #3 resolve docker.io/hexpm/elixir:1.14.5-erlang-25.3-debian-buster-20230227-slim@sha256:5b6bc881a12a4eb0604f1376d653f1fc62a14f128f02b8cd99c97382782ae339 done
  #3 DONE 0.0s
  
  #4 host.directory /Users/thanabodee/src/github.com/dagger/dagger
  #4 transferring /Users/thanabodee/src/github.com/dagger/dagger: 326.45kB 0.1s
  #4 transferring /Users/thanabodee/src/github.com/dagger/dagger: 480.51kB 0.2s done
  #4 DONE 0.3s
  
  #3 from hexpm/elixir:1.14.5-erlang-25.3-debian-buster-20230227-slim
  #3 CACHED
  
  #2 generate
  #2 0.634 warning: failed to load system certificates. SSL peer verification will be skipped but downloads are still verified with a checksum
  #2 1.281 warning: failed to load system certificates. SSL peer verification will be skipped but downloads are still verified with a checksum
  #2 1.455 warning: failed to load system certificates. SSL peer verification will be skipped but downloads are still verified with a checksum
  #2 1.886 * creating /root/.mix/archives/hex-2.0.6
  #2 0.563 warning: failed to load system certificates. SSL peer verification will be skipped but downloads are still verified with a checksum
  #2 0.813 warning: failed to load system certificates. SSL peer verification will be skipped but downloads are still verified with a checksum
  #2 0.985 warning: failed to load system certificates. SSL peer verification will be skipped but downloads are still verified with a checksum
  #2 1.341 * creating /root/.mix/elixir/1-14/rebar3
  #2 2.074 Resolving Hex dependencies...
  #2 2.124 Resolution completed in 0.049s
  #2 2.132 Unchanged:
  #2 2.132   absinthe_client 0.1.0
  #2 2.132   bunt 0.2.1
  #2 2.132   castore 1.0.1
  #2 2.132   credo 1.7.0
  #2 2.132   earmark_parser 1.4.31
  #2 2.132   ex_doc 0.29.4
  #2 2.132   file_system 0.2.10
  #2 2.132   finch 0.15.0
  #2 2.132   hpax 0.1.2
  #2 2.132   jason 1.4.0
  #2 2.132   makeup 1.1.0
  #2 2.132   makeup_elixir 0.16.1
  #2 2.132   makeup_erlang 0.1.1
  #2 2.132   mime 2.0.3
  #2 2.132   mint 1.5.1
  #2 2.132   mint_web_socket 1.0.2
  #2 2.132   nimble_options 1.0.1
  #2 2.132   nimble_parsec 1.3.0
  #2 2.132   nimble_pool 0.2.6
  #2 2.132   req 0.3.6
  #2 2.132   slipstream 1.0.3
  #2 2.132   telemetry 1.2.1
  #2 2.139 * Getting req (Hex package)
  #2 2.493 * Getting absinthe_client (Hex package)
  #2 2.498 * Getting nimble_options (Hex package)
  #2 2.509 * Getting ex_doc (Hex package)
  #2 2.533 * Getting credo (Hex package)
  #2 2.709 * Getting bunt (Hex package)
  #2 2.713 * Getting file_system (Hex package)
  #2 2.718 * Getting jason (Hex package)
  #2 2.722 * Getting earmark_parser (Hex package)
  #2 2.751 * Getting makeup_elixir (Hex package)
  #2 2.769 * Getting makeup_erlang (Hex package)
  #2 2.774 * Getting makeup (Hex package)
  #2 2.784 * Getting nimble_parsec (Hex package)
  #2 2.789 * Getting castore (Hex package)
  #2 2.793 * Getting slipstream (Hex package)
  #2 2.810 * Getting mint_web_socket (Hex package)
  #2 2.826 * Getting telemetry (Hex package)
  #2 2.842 * Getting mint (Hex package)
  #2 2.850 * Getting hpax (Hex package)
  #2 2.854 * Getting finch (Hex package)
  #2 2.859 * Getting mime (Hex package)
  #2 2.862 * Getting nimble_pool (Hex package)
  #2 0.597 Building dagger 1.0.0
  #2 0.597   Dependencies:
  #2 0.597     req ~> 0.3 (app: req)
  #2 0.597     absinthe_client ~> 0.1 (app: absinthe_client)
  #2 0.597     nimble_options ~> 1.0 (app: nimble_options)
  #2 0.603   App: dagger
  #2 0.603   Name: dagger
  #2 0.603   Files:
  #2 0.603     lib
  #2 0.603     lib/mix
  #2 0.603     lib/mix/tasks
  #2 0.603     lib/mix/tasks/dagger.gen.ex
  #2 0.603     lib/dagger.ex
  #2 0.603     lib/dagger
  #2 0.603     lib/dagger/gen
  #2 0.603     lib/dagger/gen/query.ex
  #2 0.603     lib/dagger/gen/cache_id.ex
  #2 0.603     lib/dagger/gen/port.ex
  #2 0.603     lib/dagger/gen/network_protocol.ex
  #2 0.603     lib/dagger/gen/cache_volume.ex
  #2 0.603     lib/dagger/gen/secret.ex
  #2 0.603     lib/dagger/gen/file_id.ex
  #2 0.603     lib/dagger/gen/container.ex
  #2 0.603     lib/dagger/gen/socket.ex
  #2 0.603     lib/dagger/gen/host.ex
  #2 0.603     lib/dagger/gen/project_command.ex
  #2 0.603     lib/dagger/gen/label.ex
  #2 0.603     lib/dagger/gen/secret_id.ex
  #2 0.603     lib/dagger/gen/socket_id.ex
  #2 0.603     lib/dagger/gen/directory_id.ex
  #2 0.603     lib/dagger/gen/git_ref.ex
  #2 0.603     lib/dagger/gen/project.ex
  #2 0.603     lib/dagger/gen/file.ex
  #2 0.603     lib/dagger/gen/project_command_id.ex
  #2 0.603     lib/dagger/gen/container_id.ex
  #2 0.603     lib/dagger/gen/env_variable.ex
  #2 0.603     lib/dagger/gen/project_command_flag.ex
  #2 0.603     lib/dagger/gen/git_repository.ex
  #2 0.603     lib/dagger/gen/cache_sharing_mode.ex
  #2 0.603     lib/dagger/gen/image_layer_compression.ex
  #2 0.603     lib/dagger/gen/platform.ex
  #2 0.603     lib/dagger/gen/directory.ex
  #2 0.603     lib/dagger/gen/project_id.ex
  #2 0.603     lib/dagger/gen/host_variable.ex
  #2 0.603     lib/dagger/codegen
  #2 0.603     lib/dagger/codegen/generator.ex
  #2 0.603     lib/dagger/codegen/elixir
  #2 0.603     lib/dagger/codegen/elixir/templates
  #2 0.603     lib/dagger/codegen/elixir/templates/object_tmpl.ex
  #2 0.603     lib/dagger/codegen/elixir/templates/scalar_tmpl.ex
  #2 0.603     lib/dagger/codegen/elixir/templates/enum_tmpl.ex
  #2 0.603     lib/dagger/codegen/elixir/function.ex
  #2 0.603     lib/dagger/codegen/elixir/module.ex
  #2 0.603     lib/dagger/codegen/compiler
  #2 0.603     lib/dagger/codegen/compiler/mutator.ex
  #2 0.603     lib/dagger/codegen/compiler.ex
  #2 0.603     lib/dagger/codegen/introspection.ex
  #2 0.603     lib/dagger/query_builder.ex
  #2 0.603     lib/dagger/session.ex
  #2 0.603     lib/dagger/internal
  #2 0.603     lib/dagger/internal/client.ex
  #2 0.603     lib/dagger/internal/engine
  #2 0.603     lib/dagger/internal/engine/downloader.ex
  #2 0.603     lib/dagger/engine_conn.ex
  #2 0.603     priv
  #2 0.603     priv/introspection.graphql
  #2 0.603     .formatter.exs
  #2 0.603     mix.exs
  #2 0.603     README.md
  #2 0.603     LICENSE
  #2 0.603     CHANGELOG.md
  #2 0.603     VERSION
  #2 0.603   Version: 1.0.0
  #2 0.603   Build tools: mix
  #2 0.603   Description: Dagger SDK for Elixir
  #2 0.603   Licenses: Apache-2.0
  #2 0.603   Links: 
  #2 0.603     Changelog: https://github.com/dagger/dagger/releases/tag/sdk%2Felixir%2Fv1.0.0
  #2 0.603     GitHub: https://github.com/dagger/dagger
  #2 0.603   Elixir: ~> 1.14
  #2 0.607 Before publishing, please read the Code of Conduct: https://hex.pm/policies/codeofconduct
  #2 0.607 
  #2 0.607 Publishing package to public repository hexpm.
  #2 1.376 invalid API key
  #2 1.376 
  #2 1.376 Building docs...
  #2 1.435 ==> earmark_parser
  #2 1.435 Compiling 1 file (.yrl)
  #2 1.455 Compiling 2 files (.xrl)
  #2 1.486 Compiling 3 files (.erl)
  #2 1.572 Compiling 46 files (.ex)
  #2 2.145 Generated earmark_parser app
  #2 2.164 ==> file_system
  #2 2.164 Compiling 7 files (.ex)
  #2 2.262 Generated file_system app
  #2 2.276 ==> mime
  #2 2.276 Compiling 1 file (.ex)
  #2 2.335 Generated mime app
  #2 2.354 ==> nimble_options
  #2 2.354 Compiling 3 files (.ex)
  #2 2.566 Generated nimble_options app
  #2 2.584 ==> nimble_parsec
  #2 2.584 Compiling 4 files (.ex)
  #2 2.752 Generated nimble_parsec app
  #2 2.766 ==> bunt
  #2 2.766 Compiling 2 files (.ex)
  #2 2.997 Generated bunt app
  #2 3.392 ===> Analyzing applications...
  #2 3.420 ===> Compiling telemetry
  #2 3.781 ==> jason
  #2 3.781 Compiling 10 files (.ex)
  #2 4.476 Generated jason app
  #2 4.501 ==> hpax
  #2 4.501 Compiling 4 files (.ex)
  #2 4.735 Generated hpax app
  #2 4.763 ==> credo
  #2 4.763 Compiling 251 files (.ex)
  #2 7.699 Generated credo app
  #2 7.732 ==> makeup
  #2 7.732 Compiling 44 files (.ex)
  #2 8.141 Generated makeup app
  #2 8.164 ==> makeup_elixir
  #2 8.164 Compiling 6 files (.ex)
  #2 10.71 Generated makeup_elixir app
  #2 10.74 ==> makeup_erlang
  #2 10.74 Compiling 3 files (.ex)
  #2 10.75 warning: Application.get_env/3 is discouraged in the module body, use Application.compile_env/3 instead
  #2 10.75   lib/makeup/lexers/erlang_lexer.ex:250: Makeup.Lexers.ErlangLexer
  #2 10.75 
  #2 11.58 Generated makeup_erlang app
  #2 11.60 ==> ex_doc
  #2 11.60 Compiling 25 files (.ex)
  #2 12.11 Generated ex_doc app
  #2 12.13 ==> nimble_pool
  #2 12.13 Compiling 2 files (.ex)
  #2 12.27 Generated nimble_pool app
  #2 12.29 ==> castore
  #2 12.29 Compiling 1 file (.ex)
  #2 12.31 Generated castore app
  #2 12.34 ==> mint
  #2 12.34 Compiling 1 file (.erl)
  #2 12.38 Compiling 19 files (.ex)
  #2 12.88 Generated mint app
  #2 12.92 ==> mint_web_socket
  #2 12.92 Compiling 7 files (.ex)
  #2 13.11 Generated mint_web_socket app
  #2 13.16 ==> slipstream
  #2 13.16 Compiling 41 files (.ex)
  #2 13.57 Generated slipstream app
  #2 13.60 ==> finch
  #2 13.60 Compiling 13 files (.ex)
  #2 13.88 Generated finch app
  #2 13.91 ==> req
  #2 13.91 Compiling 5 files (.ex)
  #2 14.20 Generated req app
  #2 14.22 ==> absinthe_client
  #2 14.22 Compiling 7 files (.ex)
  #2 14.35 Generated absinthe_client app
  #2 14.37 ==> dagger
  #2 14.37 Compiling 45 files (.ex)
  #2 14.86 Generated dagger app
  #2 15.09 Generating docs...
  #2 15.22 View "html" docs at "doc/index.html"
  #2 15.32 View "epub" docs at "doc/dagger.epub"
  #2 15.32 Publishing package...
  #2 15.34 Publishing docs...
  #2 DONE 22.2s
  ```
Fixes #5326 