### PR TITLE
sdk(elixir): fix id argument render incorrectly

### DIFF
--- a/sdk/elixir/lib/dagger/codegen/elixir/function.ex
+++ b/sdk/elixir/lib/dagger/codegen/elixir/function.ex
@@ -1,6 +1,19 @@
 defmodule Dagger.Codegen.Elixir.Function do
   @moduledoc false
 
+  @id_modules_map %{
+    "CacheID" => "cache_volume",
+    "ContainerID" => "container",
+    "DirectoryID" => "directory",
+    "FileID" => "file",
+    "ProjectCommandID" => "project_command",
+    "ProjectID" => "project",
+    "SecretID" => "secret",
+    "SocketID" => "socket"
+  }
+
+  def id_module_to_var_name(id_mod), do: Map.fetch!(@id_modules_map, id_mod)
+
   def format_var_name(name) when is_binary(name) do
     format_name(name)
   end

--- a/sdk/elixir/lib/dagger/codegen/elixir/module.ex
+++ b/sdk/elixir/lib/dagger/codegen/elixir/module.ex
@@ -1,6 +1,21 @@
 defmodule Dagger.Codegen.Elixir.Module do
   @moduledoc false
 
+  @id_modules_map %{
+    "CacheID" => "CacheVolume",
+    "ContainerID" => "Container",
+    "DirectoryID" => "Directory",
+    "FileID" => "File",
+    "ProjectCommandID" => "ProjectCommand",
+    "ProjectID" => "Project",
+    "SecretID" => "Secret",
+    "SocketID" => "Socket"
+  }
+
+  defmacro id_modules(), do: quote(do: Map.keys(@id_modules_map))
+
+  def id_module_to_module(id_mod), do: Map.fetch!(@id_modules_map, id_mod)
+
   def format_name(name) when is_binary(name) do
     name
     |> Macro.camelize()

--- a/sdk/elixir/lib/dagger/codegen/elixir/templates/scalar_tmpl.ex
+++ b/sdk/elixir/lib/dagger/codegen/elixir/templates/scalar_tmpl.ex
@@ -1,7 +1,6 @@
 defmodule Dagger.Codegen.Elixir.Templates.Scalar do
   @moduledoc false
 
-  alias Dagger.Codegen.Elixir.Function
   alias Dagger.Codegen.Elixir.Module, as: Mod
 
   @required_mods %{
@@ -19,28 +18,11 @@ defmodule Dagger.Codegen.Elixir.Templates.Scalar do
 
   def render(%{"name" => name, "description" => desc, "private" => %{mod_name: mod_name}})
       when name in @support_gen_fun do
-    required_name = @required_mods[name]
-
-    required_mod = Module.concat([Dagger, Mod.format_name(required_name)])
-
-    required_var =
-      required_name
-      |> Function.format_var_name()
-      |> Macro.var(__MODULE__)
-
-    doc = "Get ID from `#{Function.format_var_name(required_name)}`."
-
     quote do
       defmodule unquote(mod_name) do
         @moduledoc unquote(desc)
 
         @type t() :: String.t()
-
-        @doc unquote(doc)
-        def get_id(%unquote(required_mod){} = unquote(required_var)) do
-          unquote(required_var)
-          |> unquote(required_mod).id()
-        end
       end
     end
   end

--- a/sdk/elixir/lib/dagger/gen/cache_id.ex
+++ b/sdk/elixir/lib/dagger/gen/cache_id.ex
@@ -2,8 +2,4 @@
 defmodule Dagger.CacheID do
   @moduledoc "A global cache volume identifier."
   @type t() :: String.t()
-  @doc "Get ID from `cache_volume`."
-  def get_id(%Dagger.CacheVolume{} = cache_volume) do
-    cache_volume |> Dagger.CacheVolume.id()
-  end
 end

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -10,7 +10,7 @@ defmodule Dagger.Container do
     @spec build(t(), Dagger.Directory.t(), keyword()) :: Dagger.Container.t()
     def build(%__MODULE__{} = container, context, optional_args \\ []) do
       selection = select(container.selection, "build")
-      selection = arg(selection, "context", Dagger.DirectoryID.get_id(context))
+      selection = arg(selection, "context", Dagger.Directory.id(context))
 
       selection =
         if is_nil(optional_args[:dockerfile]) do
@@ -270,7 +270,7 @@ defmodule Dagger.Container do
     @spec import(t(), Dagger.File.t(), keyword()) :: Dagger.Container.t()
     def import(%__MODULE__{} = container, source, optional_args \\ []) do
       selection = select(container.selection, "import")
-      selection = arg(selection, "source", Dagger.FileID.get_id(source))
+      selection = arg(selection, "source", Dagger.File.id(source))
 
       selection =
         if is_nil(optional_args[:tag]) do
@@ -438,7 +438,7 @@ defmodule Dagger.Container do
     def with_directory(%__MODULE__{} = container, path, directory, optional_args \\ []) do
       selection = select(container.selection, "withDirectory")
       selection = arg(selection, "path", path)
-      selection = arg(selection, "directory", Dagger.DirectoryID.get_id(directory))
+      selection = arg(selection, "directory", Dagger.Directory.id(directory))
 
       selection =
         if is_nil(optional_args[:exclude]) do
@@ -580,9 +580,9 @@ defmodule Dagger.Container do
     @doc "Initializes this container from this DirectoryID.\n\n## Required Arguments\n\n* `id` -"
     @deprecated "Replaced by `withRootfs`"
     @spec with_fs(t(), Dagger.Directory.t()) :: Dagger.Container.t()
-    def with_fs(%__MODULE__{} = container, id) do
+    def with_fs(%__MODULE__{} = container, directory) do
       selection = select(container.selection, "withFS")
-      selection = arg(selection, "id", Dagger.DirectoryID.get_id(id))
+      selection = arg(selection, "id", Dagger.Directory.id(directory))
       %Dagger.Container{selection: selection, client: container.client}
     end
   )
@@ -593,7 +593,7 @@ defmodule Dagger.Container do
     def with_file(%__MODULE__{} = container, path, source, optional_args \\ []) do
       selection = select(container.selection, "withFile")
       selection = arg(selection, "path", path)
-      selection = arg(selection, "source", Dagger.FileID.get_id(source))
+      selection = arg(selection, "source", Dagger.File.id(source))
 
       selection =
         if is_nil(optional_args[:permissions]) do
@@ -630,7 +630,7 @@ defmodule Dagger.Container do
     def with_mounted_cache(%__MODULE__{} = container, path, cache, optional_args \\ []) do
       selection = select(container.selection, "withMountedCache")
       selection = arg(selection, "path", path)
-      selection = arg(selection, "cache", Dagger.CacheID.get_id(cache))
+      selection = arg(selection, "cache", Dagger.CacheVolume.id(cache))
 
       selection =
         if is_nil(optional_args[:source]) do
@@ -664,7 +664,7 @@ defmodule Dagger.Container do
     def with_mounted_directory(%__MODULE__{} = container, path, source, optional_args \\ []) do
       selection = select(container.selection, "withMountedDirectory")
       selection = arg(selection, "path", path)
-      selection = arg(selection, "source", Dagger.DirectoryID.get_id(source))
+      selection = arg(selection, "source", Dagger.Directory.id(source))
 
       selection =
         if is_nil(optional_args[:owner]) do
@@ -683,7 +683,7 @@ defmodule Dagger.Container do
     def with_mounted_file(%__MODULE__{} = container, path, source, optional_args \\ []) do
       selection = select(container.selection, "withMountedFile")
       selection = arg(selection, "path", path)
-      selection = arg(selection, "source", Dagger.FileID.get_id(source))
+      selection = arg(selection, "source", Dagger.File.id(source))
 
       selection =
         if is_nil(optional_args[:owner]) do
@@ -703,7 +703,7 @@ defmodule Dagger.Container do
     def with_mounted_secret(%__MODULE__{} = container, path, source, optional_args \\ []) do
       selection = select(container.selection, "withMountedSecret")
       selection = arg(selection, "path", path)
-      selection = arg(selection, "source", Dagger.SecretID.get_id(source))
+      selection = arg(selection, "source", Dagger.Secret.id(source))
 
       selection =
         if is_nil(optional_args[:owner]) do
@@ -766,7 +766,7 @@ defmodule Dagger.Container do
       selection = select(container.selection, "withRegistryAuth")
       selection = arg(selection, "address", address)
       selection = arg(selection, "username", username)
-      selection = arg(selection, "secret", Dagger.SecretID.get_id(secret))
+      selection = arg(selection, "secret", Dagger.Secret.id(secret))
       %Dagger.Container{selection: selection, client: container.client}
     end
   )
@@ -774,9 +774,9 @@ defmodule Dagger.Container do
   (
     @doc "Initializes this container from this DirectoryID.\n\n## Required Arguments\n\n* `id` -"
     @spec with_rootfs(t(), Dagger.Directory.t()) :: Dagger.Container.t()
-    def with_rootfs(%__MODULE__{} = container, id) do
+    def with_rootfs(%__MODULE__{} = container, directory) do
       selection = select(container.selection, "withRootfs")
-      selection = arg(selection, "id", Dagger.DirectoryID.get_id(id))
+      selection = arg(selection, "id", Dagger.Directory.id(directory))
       %Dagger.Container{selection: selection, client: container.client}
     end
   )
@@ -787,7 +787,7 @@ defmodule Dagger.Container do
     def with_secret_variable(%__MODULE__{} = container, name, secret) do
       selection = select(container.selection, "withSecretVariable")
       selection = arg(selection, "name", name)
-      selection = arg(selection, "secret", Dagger.SecretID.get_id(secret))
+      selection = arg(selection, "secret", Dagger.Secret.id(secret))
       %Dagger.Container{selection: selection, client: container.client}
     end
   )
@@ -798,7 +798,7 @@ defmodule Dagger.Container do
     def with_service_binding(%__MODULE__{} = container, alias, service) do
       selection = select(container.selection, "withServiceBinding")
       selection = arg(selection, "alias", alias)
-      selection = arg(selection, "service", Dagger.ContainerID.get_id(service))
+      selection = arg(selection, "service", Dagger.Container.id(service))
       %Dagger.Container{selection: selection, client: container.client}
     end
   )
@@ -809,7 +809,7 @@ defmodule Dagger.Container do
     def with_unix_socket(%__MODULE__{} = container, path, source, optional_args \\ []) do
       selection = select(container.selection, "withUnixSocket")
       selection = arg(selection, "path", path)
-      selection = arg(selection, "source", Dagger.SocketID.get_id(source))
+      selection = arg(selection, "source", Dagger.Socket.id(source))
 
       selection =
         if is_nil(optional_args[:owner]) do

--- a/sdk/elixir/lib/dagger/gen/container_id.ex
+++ b/sdk/elixir/lib/dagger/gen/container_id.ex
@@ -2,8 +2,4 @@
 defmodule Dagger.ContainerID do
   @moduledoc "A unique container identifier. Null designates an empty container (scratch)."
   @type t() :: String.t()
-  @doc "Get ID from `container`."
-  def get_id(%Dagger.Container{} = container) do
-    container |> Dagger.Container.id()
-  end
 end

--- a/sdk/elixir/lib/dagger/gen/directory.ex
+++ b/sdk/elixir/lib/dagger/gen/directory.ex
@@ -10,7 +10,7 @@ defmodule Dagger.Directory do
     @spec diff(t(), Dagger.Directory.t()) :: Dagger.Directory.t()
     def diff(%__MODULE__{} = directory, other) do
       selection = select(directory.selection, "diff")
-      selection = arg(selection, "other", Dagger.DirectoryID.get_id(other))
+      selection = arg(selection, "other", Dagger.Directory.id(other))
       %Dagger.Directory{selection: selection, client: directory.client}
     end
   )
@@ -147,7 +147,7 @@ defmodule Dagger.Directory do
     def with_directory(%__MODULE__{} = directory, path, directory, optional_args \\ []) do
       selection = select(directory.selection, "withDirectory")
       selection = arg(selection, "path", path)
-      selection = arg(selection, "directory", Dagger.DirectoryID.get_id(directory))
+      selection = arg(selection, "directory", Dagger.Directory.id(directory))
 
       selection =
         if is_nil(optional_args[:exclude]) do
@@ -173,7 +173,7 @@ defmodule Dagger.Directory do
     def with_file(%__MODULE__{} = directory, path, source, optional_args \\ []) do
       selection = select(directory.selection, "withFile")
       selection = arg(selection, "path", path)
-      selection = arg(selection, "source", Dagger.FileID.get_id(source))
+      selection = arg(selection, "source", Dagger.File.id(source))
 
       selection =
         if is_nil(optional_args[:permissions]) do

--- a/sdk/elixir/lib/dagger/gen/directory_id.ex
+++ b/sdk/elixir/lib/dagger/gen/directory_id.ex
@@ -2,8 +2,4 @@
 defmodule Dagger.DirectoryID do
   @moduledoc "A content-addressed directory identifier."
   @type t() :: String.t()
-  @doc "Get ID from `directory`."
-  def get_id(%Dagger.Directory{} = directory) do
-    directory |> Dagger.Directory.id()
-  end
 end

--- a/sdk/elixir/lib/dagger/gen/file_id.ex
+++ b/sdk/elixir/lib/dagger/gen/file_id.ex
@@ -2,8 +2,4 @@
 defmodule Dagger.FileID do
   @moduledoc "A file identifier."
   @type t() :: String.t()
-  @doc "Get ID from `file`."
-  def get_id(%Dagger.File{} = file) do
-    file |> Dagger.File.id()
-  end
 end

--- a/sdk/elixir/lib/dagger/gen/project.ex
+++ b/sdk/elixir/lib/dagger/gen/project.ex
@@ -28,7 +28,7 @@ defmodule Dagger.Project do
     @spec load(t(), Dagger.Directory.t(), String.t()) :: Dagger.Project.t()
     def load(%__MODULE__{} = project, source, config_path) do
       selection = select(project.selection, "load")
-      selection = arg(selection, "source", Dagger.DirectoryID.get_id(source))
+      selection = arg(selection, "source", Dagger.Directory.id(source))
       selection = arg(selection, "configPath", config_path)
       %Dagger.Project{selection: selection, client: project.client}
     end

--- a/sdk/elixir/lib/dagger/gen/project_command_id.ex
+++ b/sdk/elixir/lib/dagger/gen/project_command_id.ex
@@ -2,8 +2,4 @@
 defmodule Dagger.ProjectCommandID do
   @moduledoc "A unique project command identifier."
   @type t() :: String.t()
-  @doc "Get ID from `project_command`."
-  def get_id(%Dagger.ProjectCommand{} = project_command) do
-    project_command |> Dagger.ProjectCommand.id()
-  end
 end

--- a/sdk/elixir/lib/dagger/gen/project_id.ex
+++ b/sdk/elixir/lib/dagger/gen/project_id.ex
@@ -2,8 +2,4 @@
 defmodule Dagger.ProjectID do
   @moduledoc "A unique project identifier."
   @type t() :: String.t()
-  @doc "Get ID from `project`."
-  def get_id(%Dagger.Project{} = project) do
-    project |> Dagger.Project.id()
-  end
 end

--- a/sdk/elixir/lib/dagger/gen/query.ex
+++ b/sdk/elixir/lib/dagger/gen/query.ex
@@ -68,9 +68,9 @@ defmodule Dagger.Query do
   (
     @doc "Loads a file by ID.\n\n## Required Arguments\n\n* `id` -"
     @spec file(t(), Dagger.File.t()) :: Dagger.File.t()
-    def file(%__MODULE__{} = query, id) do
+    def file(%__MODULE__{} = query, file) do
       selection = select(query.selection, "file")
-      selection = arg(selection, "id", Dagger.FileID.get_id(id))
+      selection = arg(selection, "id", Dagger.File.id(file))
       execute(selection, query.client)
     end
   )
@@ -189,9 +189,9 @@ defmodule Dagger.Query do
   (
     @doc "Loads a secret from its ID.\n\n## Required Arguments\n\n* `id` -"
     @spec secret(t(), Dagger.Secret.t()) :: Dagger.Secret.t()
-    def secret(%__MODULE__{} = query, id) do
+    def secret(%__MODULE__{} = query, secret) do
       selection = select(query.selection, "secret")
-      selection = arg(selection, "id", Dagger.SecretID.get_id(id))
+      selection = arg(selection, "id", Dagger.Secret.id(secret))
       %Dagger.Secret{selection: selection, client: query.client}
     end
   )

--- a/sdk/elixir/lib/dagger/gen/secret_id.ex
+++ b/sdk/elixir/lib/dagger/gen/secret_id.ex
@@ -2,8 +2,4 @@
 defmodule Dagger.SecretID do
   @moduledoc "A unique identifier for a secret."
   @type t() :: String.t()
-  @doc "Get ID from `secret`."
-  def get_id(%Dagger.Secret{} = secret) do
-    secret |> Dagger.Secret.id()
-  end
 end

--- a/sdk/elixir/lib/dagger/gen/socket_id.ex
+++ b/sdk/elixir/lib/dagger/gen/socket_id.ex
@@ -2,8 +2,4 @@
 defmodule Dagger.SocketID do
   @moduledoc "A content-addressed socket identifier."
   @type t() :: String.t()
-  @doc "Get ID from `socket`."
-  def get_id(%Dagger.Socket{} = socket) do
-    socket |> Dagger.Socket.id()
-  end
 end


### PR DESCRIPTION
Uses name from type when found that name is `id` with type id. And remove `get_id` out of scalar modules. Code is now much simpler.

Fixes #5331