### PR TITLE
cli: fix incorrect subcommand being called.

### DIFF
--- a/cmd/dagger/do.go
+++ b/cmd/dagger/do.go
@@ -168,6 +168,8 @@ func addCmd(ctx context.Context, cmdStack []*cobra.Command, projCmd dagger.Proje
 		cmdName = getCommandName(parentCmd) + commandSeparator + projCmdName
 	}
 
+	// make a copy of cmdStack
+	cmdStack = append([]*cobra.Command{}, cmdStack...)
 	subcmd := &cobra.Command{
 		Use:         cmdName,
 		Short:       description,
@@ -300,6 +302,7 @@ func addCmd(ctx context.Context, cmdStack []*cobra.Command, projCmd dagger.Proje
 			return nil
 		},
 	}
+	cmdStack = append(cmdStack, subcmd)
 
 	if parentCmd != nil {
 		subcmd.Flags().AddFlagSet(parentCmd.Flags())
@@ -317,7 +320,6 @@ func addCmd(ctx context.Context, cmdStack []*cobra.Command, projCmd dagger.Proje
 		commandAnnotations(subcmd.Annotations).addCommandSpecificFlag(flagName)
 	}
 	returnCmds := []*cobra.Command{subcmd}
-	cmdStack = append(cmdStack, subcmd)
 	for _, subProjCmd := range projSubcommands {
 		subCmds, err := addCmd(ctx, cmdStack, subProjCmd, c, r)
 		if err != nil {

--- a/core/integration/project_test.go
+++ b/core/integration/project_test.go
@@ -176,6 +176,32 @@ func TestProjectCmdInit(t *testing.T) {
 	})
 }
 
+func TestProjectCommandHierarchy(t *testing.T) {
+	t.Parallel()
+	projectDir := "core/integration/testdata/projects/go/basic"
+
+	c, ctx := connect(t)
+	defer c.Close()
+
+	output, err := CLITestContainer(ctx, t, c).
+		WithLoadedProject(projectDir, false).
+		WithTarget("level1:level2:level3:foo").
+		CallDo().
+		Stderr(ctx)
+	require.NoError(t, err)
+	outputLines := strings.Split(output, "\n")
+	require.Contains(t, outputLines, "hello from foo")
+
+	output, err = CLITestContainer(ctx, t, c).
+		WithLoadedProject(projectDir, false).
+		WithTarget("level1:level2:level3:bar").
+		CallDo().
+		Stderr(ctx)
+	require.NoError(t, err)
+	outputLines = strings.Split(output, "\n")
+	require.Contains(t, outputLines, "hello from bar")
+}
+
 func TestProjectHostExport(t *testing.T) {
 	t.Parallel()
 

--- a/core/integration/project_test.go
+++ b/core/integration/project_test.go
@@ -178,28 +178,33 @@ func TestProjectCmdInit(t *testing.T) {
 
 func TestProjectCommandHierarchy(t *testing.T) {
 	t.Parallel()
-	projectDir := "core/integration/testdata/projects/go/basic"
 
-	c, ctx := connect(t)
-	defer c.Close()
+	for _, sdk := range []string{"go", "python"} {
+		projectDir := fmt.Sprintf("core/integration/testdata/projects/%s/basic", sdk)
 
-	output, err := CLITestContainer(ctx, t, c).
-		WithLoadedProject(projectDir, false).
-		WithTarget("level1:level2:level3:foo").
-		CallDo().
-		Stderr(ctx)
-	require.NoError(t, err)
-	outputLines := strings.Split(output, "\n")
-	require.Contains(t, outputLines, "hello from foo")
+		t.Run(projectDir, func(t *testing.T) {
+			c, ctx := connect(t)
+			defer c.Close()
 
-	output, err = CLITestContainer(ctx, t, c).
-		WithLoadedProject(projectDir, false).
-		WithTarget("level1:level2:level3:bar").
-		CallDo().
-		Stderr(ctx)
-	require.NoError(t, err)
-	outputLines = strings.Split(output, "\n")
-	require.Contains(t, outputLines, "hello from bar")
+			output, err := CLITestContainer(ctx, t, c).
+				WithLoadedProject(projectDir, false).
+				WithTarget("level1:level2:level3:foo").
+				CallDo().
+				Stderr(ctx)
+			require.NoError(t, err)
+			outputLines := strings.Split(output, "\n")
+			require.Contains(t, outputLines, "hello from foo")
+
+			output, err = CLITestContainer(ctx, t, c).
+				WithLoadedProject(projectDir, false).
+				WithTarget("level1:level2:level3:bar").
+				CallDo().
+				Stderr(ctx)
+			require.NoError(t, err)
+			outputLines = strings.Split(output, "\n")
+			require.Contains(t, outputLines, "hello from bar")
+		})
+	}
 }
 
 func TestProjectHostExport(t *testing.T) {

--- a/core/integration/testdata/projects/go/basic/main.go
+++ b/core/integration/testdata/projects/go/basic/main.go
@@ -12,6 +12,7 @@ func main() {
 		TestFile,
 		TestDir,
 		TestImportedProjectDir,
+		Level1,
 	)
 }
 
@@ -41,4 +42,33 @@ func TestImportedProjectDir(ctx dagger.Context) (string, error) {
 		return nil
 	})
 	return output, err
+}
+
+func Level1(ctx dagger.Context) (Level1Targets, error) {
+	return Level1Targets{}, nil
+}
+
+type Level1Targets struct {
+}
+
+func (l Level1Targets) Level2(ctx dagger.Context) (Level2Targets, error) {
+	return Level2Targets{}, nil
+}
+
+type Level2Targets struct {
+}
+
+func (l Level2Targets) Level3(ctx dagger.Context) (Level3Targets, error) {
+	return Level3Targets{}, nil
+}
+
+type Level3Targets struct {
+}
+
+func (l Level3Targets) Foo(ctx dagger.Context) (string, error) {
+	return "hello from foo", nil
+}
+
+func (l Level3Targets) Bar(ctx dagger.Context) (string, error) {
+	return "hello from bar", nil
 }

--- a/core/integration/testdata/projects/python/basic/main.py
+++ b/core/integration/testdata/projects/python/basic/main.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import dagger
-from dagger.server import command
+from dagger.server import command, commands
 
 
 @command
@@ -25,3 +25,33 @@ def test_dir(client: dagger.Client, prefix: str) -> dagger.Directory:
 @command
 def test_imported_project_dir() -> str:
     return "\n".join(str(p) for p in Path().glob("**/*"))
+
+
+@commands
+class Level3:
+    @command
+    def foo(self) -> str:
+        return "hello from foo"
+
+    @command
+    def bar(self) -> str:
+        return "hello from bar"
+
+
+@commands
+class Level2:
+    @command
+    def level3(self) -> Level3:
+        return Level3()
+
+
+@commands
+class Level1:
+    @command
+    def level2(self) -> Level2:
+        return Level2()
+
+
+@command
+def level1() -> Level1:
+    return Level1()


### PR DESCRIPTION
We were mutating a common slice across different call branches, which resulted in different call branches overwriting objects in the array underlying the slice and the wrong command sometimes being used.

---

Found by @helderco, thanks!