### PR TITLE
project: partial support for returning host dirs/files. 

### DIFF
--- a/ci/main.go
+++ b/ci/main.go
@@ -10,8 +10,12 @@ func main() {
 
 // Dagger CI targets
 func CI(ctx dagger.Context, repo, branch string) (CITargets, error) {
+	srcDir := ctx.Client().Host().Directory(".")
+	if repo != "" {
+		srcDir = ctx.Client().Git(repo).Branch(branch).Tree()
+	}
 	return CITargets{
-		SrcDir: ctx.Client().Git(repo).Branch(branch).Tree(),
+		SrcDir: srcDir,
 	}, nil
 }
 

--- a/core/integration/testdata/projects/go/basic/main.go
+++ b/core/integration/testdata/projects/go/basic/main.go
@@ -12,6 +12,7 @@ func main() {
 		TestFile,
 		TestDir,
 		TestImportedProjectDir,
+		TestExportLocalDir,
 		Level1,
 	)
 }
@@ -42,6 +43,10 @@ func TestImportedProjectDir(ctx dagger.Context) (string, error) {
 		return nil
 	})
 	return output, err
+}
+
+func TestExportLocalDir(ctx dagger.Context) (*dagger.Directory, error) {
+	return ctx.Client().Host().Directory("./core/integration/testdata/projects/go/basic"), nil
 }
 
 func Level1(ctx dagger.Context) (Level1Targets, error) {

--- a/core/integration/testdata/projects/python/basic/main.py
+++ b/core/integration/testdata/projects/python/basic/main.py
@@ -27,6 +27,11 @@ def test_imported_project_dir() -> str:
     return "\n".join(str(p) for p in Path().glob("**/*"))
 
 
+@command
+def test_export_local_dir(client: dagger.Client) -> dagger.Directory:
+    return client.host().directory("./core/integration/testdata/projects/python/basic")
+
+
 @commands
 class Level3:
     @command

--- a/core/schema/host.go
+++ b/core/schema/host.go
@@ -51,7 +51,7 @@ type hostWorkdirArgs struct {
 }
 
 func (s *hostSchema) workdir(ctx *router.Context, parent *core.Query, args hostWorkdirArgs) (*core.Directory, error) {
-	return s.host.Directory(ctx, ".", parent.PipelinePath(), "host.workdir", s.platform, args.CopyFilter)
+	return s.host.Directory(ctx, s.gw, ".", parent.PipelinePath(), "host.workdir", s.platform, args.CopyFilter)
 }
 
 type hostVariableArgs struct {
@@ -79,7 +79,7 @@ type hostDirectoryArgs struct {
 }
 
 func (s *hostSchema) directory(ctx *router.Context, parent *core.Query, args hostDirectoryArgs) (*core.Directory, error) {
-	return s.host.Directory(ctx, args.Path, parent.PipelinePath(), "host.directory", s.platform, args.CopyFilter)
+	return s.host.Directory(ctx, s.gw, args.Path, parent.PipelinePath(), "host.directory", s.platform, args.CopyFilter)
 }
 
 type hostSocketArgs struct {
@@ -95,5 +95,5 @@ type hostFileArgs struct {
 }
 
 func (s *hostSchema) file(ctx *router.Context, parent *core.Query, args hostFileArgs) (*core.File, error) {
-	return s.host.File(ctx, args.Path, parent.PipelinePath(), s.platform)
+	return s.host.File(ctx, s.gw, args.Path, parent.PipelinePath(), s.platform)
 }


### PR DESCRIPTION
This allows you to (usually) return a File or Directory from a command
that has a Local SourceOp somewhere in its LLB DAG. This is very
important as many projects will load source code from the project dir in
order to, e.g. build binaries/containers.

It works by using the session ID setting in local source ops, plus doing
a synchronous evaluate of the local op to ensure its cached.

Technically, it's still possible for the local ref to get pruned between
time of sync and time of use, but this solution is just meant to be
better than before, which always resulted in either an error or the
wrong dir getting loaded.

The long-term robust solution will come from better session sharing.

I considered an alternative solution of having the project API code
rewrite the LLB returned by projects to replace any local references
with the LLB for the project's exec op.

That approach has some nice advantages, but is such a headache-inducing
undertaking that I don't think it's worth it relative to the extremely
simple solution here. It feels likely that it would be better to invest
time in improving session sharing than go down that rabbit hole.

Signed-off-by: Erik Sipsma <erik@sipsma.dev>

cc @vito @helderco @shykes this is a "good-enough-for-now" solution to that problem we were talking about earlier today around the need to return files/directories that have a local ref somewhere in their DAG. It at least unblocks the dagger CI as a project dogfooding efforts, with a better long-term solution in the pipeline: https://linear.app/dagger/issue/DAG-1859/idea-session-as-a-frontend

---

TODO:
- [x] Currently based on CLI PR, rebase once that's merged https://github.com/dagger/dagger/pull/5308