### PR TITLE
sdk(elixir): fix api that return list of object not working

### DIFF
--- a/sdk/elixir/lib/dagger/codegen/compiler.ex
+++ b/sdk/elixir/lib/dagger/codegen/compiler.ex
@@ -22,7 +22,7 @@ defmodule Dagger.Codegen.Compiler do
       only_supported_kinds(type) and not_graphql_introspection_types(type)
     end)
     |> Enum.map(&Mutator.mutate/1)
-    |> Enum.map(&render/1)
+    |> Enum.map(&render(&1, types))
   end
 
   defp only_supported_kinds(%{"kind" => kind}) do
@@ -52,11 +52,11 @@ defmodule Dagger.Codegen.Compiler do
     ]
   end
 
-  defp render(%{"name" => name, "kind" => kind} = full_type) do
+  defp render(%{"name" => name, "kind" => kind} = full_type, types) do
     q =
       case kind do
         "OBJECT" ->
-          Object.render(full_type)
+          Object.render(full_type, types)
 
         "SCALAR" ->
           Scalar.render(full_type)

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -111,6 +111,7 @@ defmodule Dagger.Container do
     @spec env_variables(t()) :: [Dagger.EnvVariable.t()]
     def env_variables(%__MODULE__{} = container) do
       selection = select(container.selection, "envVariables")
+      selection = select(selection, "name value")
       execute(selection, container.client)
     end
   )
@@ -204,6 +205,7 @@ defmodule Dagger.Container do
     @spec exposed_ports(t()) :: [Dagger.Port.t()]
     def exposed_ports(%__MODULE__{} = container) do
       selection = select(container.selection, "exposedPorts")
+      selection = select(selection, "description port protocol")
       execute(selection, container.client)
     end
   )
@@ -298,6 +300,7 @@ defmodule Dagger.Container do
     @spec labels(t()) :: [Dagger.Label.t()]
     def labels(%__MODULE__{} = container) do
       selection = select(container.selection, "labels")
+      selection = select(selection, "name value")
       execute(selection, container.client)
     end
   )

--- a/sdk/elixir/lib/dagger/query_builder.ex
+++ b/sdk/elixir/lib/dagger/query_builder.ex
@@ -79,10 +79,23 @@ defmodule Dagger.QueryBuilder do
 
       {:ok, %{status: 200, body: %{"data" => data}}} ->
         # TODO: returns {:ok, response}.
-        get_in(data, Selection.path(selection))
+        select_data(data, Selection.path(selection) |> Enum.reverse())
 
       otherwise ->
         otherwise
+    end
+  end
+
+  defp select_data(data, [leaf | path]) do
+    case leaf |> String.split() do
+      children when is_list(children) ->
+        case get_in(data, Enum.reverse(path)) do
+          data when is_list(data) -> Enum.map(data, &Map.take(&1, children))
+          data when is_map(data) -> Map.take(data, children)
+        end
+
+      children when is_binary(children) ->
+        get_in(data, Enum.reverse([children | path]))
     end
   end
 

--- a/sdk/elixir/test/dagger/querybuilder_test.exs
+++ b/sdk/elixir/test/dagger/querybuilder_test.exs
@@ -29,6 +29,15 @@ defmodule Dagger.QueryBuilder.SelectionTest do
              "query{core{image(ref:\"alpine\"){foo:file(path:\"/etc/alpine-release\")}}}"
   end
 
+  test "select multi fields" do
+    root =
+      Selection.query()
+      |> Selection.select("core")
+      |> Selection.select("name value")
+
+    assert Selection.build(root) == "query{core{name value}}"
+  end
+
   test "args" do
     root =
       Selection.query()


### PR DESCRIPTION
This PR will select all children when the API return list of object. And fix execute/2 to select an object in the list.

## Testing

Run this code: 

```elixir
Mix.install([
  {:dagger, path: "."}
])

client = Dagger.connect!()

container =
  client
  |> Dagger.Query.container()
  |> Dagger.Container.from("nginx:alpine")

container
|> Dagger.Container.env_variables()
|> IO.inspect()

container
|> Dagger.Container.labels()
|> IO.inspect()

container
|> Dagger.Container.exposed_ports()
|> IO.inspect()
```

After run `elixir script.exs`, the result should be: 

```
[
  %{
    "name" => "PATH",
    "value" => "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
  },
  %{"name" => "NGINX_VERSION", "value" => "1.25.1"},
  %{"name" => "PKG_RELEASE", "value" => "1"},
  %{"name" => "NJS_VERSION", "value" => "0.7.12"}
]
[
  %{
    "name" => "maintainer",
    "value" => "NGINX Docker Maintainers <docker-maint@nginx.com>"
  }
]
[]
```

Fixes #5342