### PR TITLE
project: also kebab flag names.

### DIFF
--- a/cmd/dagger/do.go
+++ b/cmd/dagger/do.go
@@ -191,7 +191,7 @@ func addCmd(ctx context.Context, cmdStack []*cobra.Command, projCmd dagger.Proje
 					if flagName == "help" {
 						continue
 					}
-					flagVal, err := cmd.Flags().GetString(flagName)
+					flagVal, err := cmd.Flags().GetString(strcase.ToKebab(flagName))
 					if err != nil {
 						return fmt.Errorf("failed to get flag %q: %w", flagName, err)
 					}
@@ -314,7 +314,7 @@ func addCmd(ctx context.Context, cmdStack []*cobra.Command, projCmd dagger.Proje
 		if err != nil {
 			return nil, fmt.Errorf("failed to get flag description: %w", err)
 		}
-		subcmd.Flags().String(flagName, "", flagDescription)
+		subcmd.Flags().String(strcase.ToKebab(flagName), "", flagDescription)
 		commandAnnotations(subcmd.Annotations).addCommandSpecificFlag(flagName)
 	}
 	returnCmds := []*cobra.Command{subcmd}

--- a/core/integration/project_test.go
+++ b/core/integration/project_test.go
@@ -247,7 +247,7 @@ func TestProjectHostExport(t *testing.T) {
 					ctr, err := CLITestContainer(ctx, t, c).
 						WithLoadedProject(projectDir, testGitProject).
 						WithTarget("test-file").
-						WithUserArg("prefix", prefix).
+						WithUserArg("file-prefix", prefix).
 						CallDo().
 						Sync(ctx)
 					if testGitProject {
@@ -266,7 +266,7 @@ func TestProjectHostExport(t *testing.T) {
 					ctr, err := CLITestContainer(ctx, t, c).
 						WithLoadedProject(projectDir, testGitProject).
 						WithTarget("test-dir").
-						WithUserArg("prefix", prefix).
+						WithUserArg("dir-prefix", prefix).
 						CallDo().
 						Sync(ctx)
 					if testGitProject {

--- a/core/integration/testdata/projects/go/basic/main.go
+++ b/core/integration/testdata/projects/go/basic/main.go
@@ -17,20 +17,20 @@ func main() {
 	)
 }
 
-func TestFile(ctx dagger.Context, prefix string) (*dagger.File, error) {
-	name := prefix + "foo.txt"
+func TestFile(ctx dagger.Context, filePrefix string) (*dagger.File, error) {
+	name := filePrefix + "foo.txt"
 	return ctx.Client().Directory().
 		WithNewFile(name, "foo\n").
 		File(name), nil
 }
 
-func TestDir(ctx dagger.Context, prefix string) (*dagger.Directory, error) {
+func TestDir(ctx dagger.Context, dirPrefix string) (*dagger.Directory, error) {
 	return ctx.Client().Directory().
-		WithNewDirectory(prefix+"subdir").
-		WithNewFile(prefix+"subdir/subbar1.txt", "subbar1\n").
-		WithNewFile(prefix+"subdir/subbar2.txt", "subbar2\n").
-		WithNewFile(prefix+"bar1.txt", "bar1\n").
-		WithNewFile(prefix+"bar2.txt", "bar2\n"), nil
+		WithNewDirectory(dirPrefix+"subdir").
+		WithNewFile(dirPrefix+"subdir/subbar1.txt", "subbar1\n").
+		WithNewFile(dirPrefix+"subdir/subbar2.txt", "subbar2\n").
+		WithNewFile(dirPrefix+"bar1.txt", "bar1\n").
+		WithNewFile(dirPrefix+"bar2.txt", "bar2\n"), nil
 }
 
 func TestImportedProjectDir(ctx dagger.Context) (string, error) {

--- a/core/integration/testdata/projects/python/basic/main.py
+++ b/core/integration/testdata/projects/python/basic/main.py
@@ -5,20 +5,20 @@ from dagger.server import command, commands
 
 
 @command
-def test_file(client: dagger.Client, prefix: str) -> dagger.File:
-    name = f"{prefix}foo.txt"
+def test_file(client: dagger.Client, file_prefix: str) -> dagger.File:
+    name = f"{file_prefix}foo.txt"
     return client.directory().with_new_file(name, "foo\n").file(name)
 
 
 @command
-def test_dir(client: dagger.Client, prefix: str) -> dagger.Directory:
+def test_dir(client: dagger.Client, dir_prefix: str) -> dagger.Directory:
     return (
         client.directory()
-        .with_new_directory(f"{prefix}subdir")
-        .with_new_file(f"{prefix}subdir/subbar1.txt", "subbar1\n")
-        .with_new_file(f"{prefix}subdir/subbar2.txt", "subbar2\n")
-        .with_new_file(f"{prefix}bar1.txt", "bar1\n")
-        .with_new_file(f"{prefix}bar2.txt", "bar2\n")
+        .with_new_directory(f"{dir_prefix}subdir")
+        .with_new_file(f"{dir_prefix}subdir/subbar1.txt", "subbar1\n")
+        .with_new_file(f"{dir_prefix}subdir/subbar2.txt", "subbar2\n")
+        .with_new_file(f"{dir_prefix}bar1.txt", "bar1\n")
+        .with_new_file(f"{dir_prefix}bar2.txt", "bar2\n")
     )
 
 


### PR DESCRIPTION
I noticed while working on user docs that my previous update to kebab command names missed that flags also need kebab-ing.