### PR TITLE
engine: remove old cache config env from autoprovision.

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -39,6 +39,10 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+const (
+	cacheConfigEnvName = "_EXPERIMENTAL_DAGGER_CACHE_CONFIG"
+)
+
 type Config struct {
 	Workdir            string
 	JournalFile        string
@@ -327,7 +331,7 @@ func (AnyDirSource) LookupDir(name string) (filesync.SyncedDir, bool) {
 }
 
 func cacheConfigFromEnv() (string, map[string]string, error) {
-	envVal, ok := os.LookupEnv(engine.CacheConfigEnvName)
+	envVal, ok := os.LookupEnv(cacheConfigEnvName)
 	if !ok {
 		return "", nil, nil
 	}

--- a/internal/engine/docker.go
+++ b/internal/engine/docker.go
@@ -19,7 +19,6 @@ const (
 	// NOTE: this needs to be consistent with engineDefaultStateDir in internal/mage/engine.go
 	DefaultStateDir = "/var/lib/dagger"
 
-	CacheConfigEnvName = "_EXPERIMENTAL_DAGGER_CACHE_CONFIG"
 	ServicesDNSEnvName = "_EXPERIMENTAL_DAGGER_SERVICES_DNS"
 
 	// trim image digests to 16 characters to makeoutput more readable
@@ -92,7 +91,6 @@ func dockerImageProvider(ctx context.Context, runnerHost *url.URL, userAgent str
 		"--name", containerName,
 		"-d",
 		"--restart", "always",
-		"-e", CacheConfigEnvName,
 		"-e", ServicesDNSEnvName,
 		"-v", DefaultStateDir,
 		"--privileged",


### PR DESCRIPTION
The cache config env has not been interpreted by the engine container for a long time, it's only interpreted client-side.