### PR TITLE
engine: add cloud cache token env var

### DIFF
--- a/internal/engine/docker.go
+++ b/internal/engine/docker.go
@@ -19,7 +19,8 @@ const (
 	// NOTE: this needs to be consistent with engineDefaultStateDir in internal/mage/engine.go
 	DefaultStateDir = "/var/lib/dagger"
 
-	ServicesDNSEnvName = "_EXPERIMENTAL_DAGGER_SERVICES_DNS"
+	ServicesDNSEnvName    = "_EXPERIMENTAL_DAGGER_SERVICES_DNS"
+	DaggerCloudCacheToken = "_EXPERIMENTAL_DAGGER_CACHESERVICE_TOKEN"
 
 	// trim image digests to 16 characters to makeoutput more readable
 	hashLen             = 16
@@ -92,6 +93,7 @@ func dockerImageProvider(ctx context.Context, runnerHost *url.URL, userAgent str
 		"-d",
 		"--restart", "always",
 		"-e", ServicesDNSEnvName,
+		"-e", DaggerCloudCacheToken,
 		"-v", DefaultStateDir,
 		"--privileged",
 	}


### PR DESCRIPTION
this allows bootstrapping the engine with a cloud cache token if
present. We should eventually refactor this to enable a more dynamic
approach which would allow to change the cloud cache configuration at
runtime.

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
