### PR TITLE
project: update runtimes to use Dagger types.

### DIFF
--- a/core/directory.go
+++ b/core/directory.go
@@ -43,6 +43,14 @@ func NewDirectory(ctx context.Context, def *pb.Definition, dir string, pipeline 
 	}
 }
 
+func NewScratchDirectory(pipeline pipeline.Path, platform specs.Platform) *Directory {
+	return &Directory{
+		Dir:      "/",
+		Platform: platform,
+		Pipeline: pipeline.Copy(),
+	}
+}
+
 func NewDirectorySt(ctx context.Context, st llb.State, dir string, pipeline pipeline.Path, platform specs.Platform, services ServiceBindings) (*Directory, error) {
 	def, err := st.Marshal(ctx, llb.Platform(platform))
 	if err != nil {

--- a/core/goruntime.go
+++ b/core/goruntime.go
@@ -2,50 +2,63 @@ package core
 
 import (
 	"context"
-	"fmt"
-	"path/filepath"
+	"path"
 
 	"github.com/dagger/dagger/core/pipeline"
-	"github.com/moby/buildkit/client/llb"
 	bkgw "github.com/moby/buildkit/frontend/gateway/client"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-func (p *Project) goRuntime(ctx context.Context, subpath string, gw bkgw.Client, platform specs.Platform) (*Directory, error) {
-	contextState, err := p.Directory.State()
+func (p *Project) goRuntime(ctx context.Context, gw bkgw.Client, progSock *Socket, pipeline pipeline.Path) (*Container, error) {
+	ctr, err := NewContainer("", pipeline, p.Platform)
+	if err != nil {
+		return nil, err
+	}
+	ctr, err = ctr.From(ctx, gw, "golang:1.20-alpine")
 	if err != nil {
 		return nil, err
 	}
 
 	workdir := "/src"
-	return NewDirectorySt(ctx,
-		goBase(gw).Run(llb.Shlex(
-			fmt.Sprintf(
-				`go build -o /entrypoint -ldflags '-s -d -w' %s`,
-				filepath.ToSlash(filepath.Join(workdir, filepath.Dir(p.ConfigPath), subpath)),
-			)),
-			llb.AddEnv("CGO_ENABLED", "0"),
-			llb.AddMount(workdir, contextState, llb.SourcePath(p.Directory.Dir)),
-			llb.Dir(workdir),
-			llb.AddMount(
-				"/go/pkg/mod",
-				llb.Scratch(),
-				llb.AsPersistentCacheDir("gomodcache", llb.CacheMountShared),
-			),
-			llb.AddMount(
-				"/root/.cache/go-build",
-				llb.Scratch(),
-				llb.AsPersistentCacheDir("gobuildcache", llb.CacheMountShared),
-			),
-		).Root(),
-		"",
-		pipeline.Path{},
-		platform,
-		nil,
-	)
-}
+	ctr, err = ctr.UpdateImageConfig(ctx, func(cfg specs.ImageConfig) specs.ImageConfig {
+		cfg.WorkingDir = absPath(cfg.WorkingDir, workdir)
+		cfg.Cmd = nil
+		return cfg
+	})
+	if err != nil {
+		return nil, err
+	}
+	ctr, err = ctr.WithMountedDirectory(ctx, gw, workdir, p.Directory, "")
+	if err != nil {
+		return nil, err
+	}
 
-func goBase(gw bkgw.Client) llb.State {
-	return llb.Image("golang:1.20-alpine", llb.WithMetaResolver(gw)).
-		Run(llb.Shlex(`apk add --no-cache file git openssh-client`)).Root()
+	ctr, err = ctr.WithMountedCache(ctx, gw, "/go/pkg/mod", NewCache("gomodcache"), nil, CacheSharingModeShared, "")
+	if err != nil {
+		return nil, err
+	}
+	ctr, err = ctr.WithMountedCache(ctx, gw, "/root/.cache/go-build", NewCache("gobuildcache"), nil, CacheSharingModeShared, "")
+	if err != nil {
+		return nil, err
+	}
+
+	ctr, err = ctr.WithExec(ctx, gw, progSock, p.Platform, ContainerExecOpts{
+		Args: []string{
+			"go", "build", "-o", "/entrypoint", "-ldflags", "-s -d -w",
+			path.Join(workdir, path.Dir(p.ConfigPath)),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	ctr, err = ctr.UpdateImageConfig(ctx, func(cfg specs.ImageConfig) specs.ImageConfig {
+		cfg.Entrypoint = []string{"/entrypoint"}
+		return cfg
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return ctr, nil
 }

--- a/core/integration/project_test.go
+++ b/core/integration/project_test.go
@@ -193,8 +193,7 @@ func TestProjectCommandHierarchy(t *testing.T) {
 				CallDo().
 				Stderr(ctx)
 			require.NoError(t, err)
-			outputLines := strings.Split(output, "\n")
-			require.Contains(t, outputLines, "hello from foo")
+			require.Contains(t, output, "hello from foo")
 
 			output, err = CLITestContainer(ctx, t, c).
 				WithLoadedProject(projectDir, false).
@@ -202,8 +201,7 @@ func TestProjectCommandHierarchy(t *testing.T) {
 				CallDo().
 				Stderr(ctx)
 			require.NoError(t, err)
-			outputLines = strings.Split(output, "\n")
-			require.Contains(t, outputLines, "hello from bar")
+			require.Contains(t, output, "hello from bar")
 		})
 	}
 }
@@ -401,11 +399,10 @@ func TestProjectDirImported(t *testing.T) {
 					CallDo().
 					Stderr(ctx)
 				require.NoError(t, err)
-				outputLines := strings.Split(output, "\n")
-				require.Contains(t, outputLines, "README.md")
-				require.Contains(t, outputLines, projectDir)
-				require.Contains(t, outputLines, projectDir+"/dagger.json")
-				require.Contains(t, outputLines, projectDir+"/"+tc.expectedMainFile)
+				require.Contains(t, output, "README.md")
+				require.Contains(t, output, projectDir)
+				require.Contains(t, output, projectDir+"/dagger.json")
+				require.Contains(t, output, projectDir+"/"+tc.expectedMainFile)
 			})
 		}
 	}

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -367,7 +367,7 @@ func (ctr DaggerCLIContainer) WithNameArg(name string) *DaggerCLIContainer {
 }
 
 func (ctr DaggerCLIContainer) CallDo() *DaggerCLIContainer {
-	args := []string{testCLIBinPath, "--silent", "do"}
+	args := []string{testCLIBinPath, "do"}
 	if ctr.ProjectArg != "" {
 		args = append(args, "--project", ctr.ProjectArg)
 	}

--- a/core/schema/project.go
+++ b/core/schema/project.go
@@ -74,7 +74,7 @@ func (s *projectSchema) load(ctx *router.Context, parent *core.Project, args loa
 		return nil, err
 	}
 	progSock := &core.Socket{HostPath: s.progSock}
-	return parent.Load(ctx, s.gw, s.router, progSock, source, args.ConfigPath)
+	return parent.Load(ctx, s.gw, s.router, progSock, source.Pipeline, source, args.ConfigPath)
 }
 
 func (s *projectSchema) commands(ctx *router.Context, parent *core.Project, args any) ([]core.ProjectCommand, error) {


### PR DESCRIPTION
The project runtime code was leftover from ancient times where it still used raw llb and had its own codepaths separate from WithExec.

Now it's updated to use the Dagger API types and dogfood the Container implementation.

This gives it support for all the customization in WithExec (i.e. progrock sock setup) without needing to duplicate. It also benefits from the "stickiness" of Dagger mounts (relative to llb) such that runtimes can setup their own cache mounts and retain them during resolver execution.

---

Spinning this out from https://github.com/dagger/dagger/pull/5357, where I started going down this path as part of debugging stuff there.

@helderco this fixes the problem you mentioned previously w/ not being able to use cache mounts during resolver execution.

@TomChv this unfortunately will be slightly painful to rebase on if this is merged before your TS support PR, but hopefully it's clear how it results in better code for the TS runtime once converted over!