### PR TITLE
sdk(elixir): fix sdk error when calling id function

### DIFF
--- a/sdk/elixir/lib/dagger/query_builder.ex
+++ b/sdk/elixir/lib/dagger/query_builder.ex
@@ -86,16 +86,16 @@ defmodule Dagger.QueryBuilder do
     end
   end
 
-  defp select_data(data, [leaf | path]) do
-    case leaf |> String.split() do
-      children when is_list(children) ->
-        case get_in(data, Enum.reverse(path)) do
-          data when is_list(data) -> Enum.map(data, &Map.take(&1, children))
-          data when is_map(data) -> Map.take(data, children)
-        end
+  defp select_data(data, [sub_selection | path]) do
+    case sub_selection |> String.split() do
+      [selection] ->
+        get_in(data, Enum.reverse([selection | path]))
 
-      children when is_binary(children) ->
-        get_in(data, Enum.reverse([children | path]))
+      selections ->
+        case get_in(data, Enum.reverse(path)) do
+          data when is_list(data) -> Enum.map(data, &Map.take(&1, selections))
+          data when is_map(data) -> Map.take(data, selections)
+        end
     end
   end
 


### PR DESCRIPTION
The bug was introduced in https://github.com/dagger/dagger/commit/165786187c91a8cd097645b645e22670e105b3f7. It makes any functions that expected to return scalar value returns map instead. Fixes by detecting selection on the last element and handle this.

Fixes #5342