### PR TITLE
Add support for loading OCI layout dirs

### DIFF
--- a/core/ocistore/layout.go
+++ b/core/ocistore/layout.go
@@ -1,0 +1,177 @@
+package ocistore
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path"
+	"time"
+
+	"github.com/containerd/containerd/content"
+	bkgw "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/opencontainers/go-digest"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type layoutStore struct {
+	unimplementedStore
+
+	ref        bkgw.Reference
+	sourcePath string
+}
+
+var _ content.Store = (*layoutStore)(nil)
+
+// NewLayoutStore returns a content store that uses the Buildkit gateway to
+// lazily fetch its content from the provided ref and source path.
+func NewLayoutStore(
+	ctx context.Context,
+	gw bkgw.Client,
+	def *pb.Definition,
+	sourcePath string, // optional path beneath the def's result
+) (content.Store, error) {
+	res, err := gw.Solve(ctx, bkgw.SolveRequest{
+		Definition: def,
+		Evaluate:   true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	ref, err := res.SingleRef()
+	if err != nil {
+		return nil, err
+	}
+
+	if ref == nil {
+		return nil, fmt.Errorf("no ref returned")
+	}
+
+	return &layoutStore{ref: ref, sourcePath: sourcePath}, nil
+}
+
+func (c *layoutStore) Info(ctx context.Context, dgst digest.Digest) (content.Info, error) {
+	stat, err := c.ref.StatFile(ctx, bkgw.StatRequest{
+		Path: c.blobPath(dgst),
+	})
+	if err != nil {
+		return content.Info{}, err
+	}
+
+	t := time.Unix(stat.ModTime/int64(time.Second), stat.ModTime%int64(time.Second))
+
+	return content.Info{
+		Digest:    dgst,
+		Size:      stat.Size_,
+		CreatedAt: t,
+		UpdatedAt: t,
+	}, nil
+}
+
+func (c *layoutStore) ReaderAt(ctx context.Context, desc ocispecs.Descriptor) (content.ReaderAt, error) {
+	blobPath := c.blobPath(desc.Digest)
+
+	stat, err := c.ref.StatFile(ctx, bkgw.StatRequest{
+		Path: blobPath,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &refReaderAt{
+		ctx:  ctx,
+		ref:  c.ref,
+		name: blobPath,
+		size: stat.Size_,
+	}, nil
+}
+
+func (c *layoutStore) Walk(ctx context.Context, fn content.WalkFunc, filters ...string) error {
+	algos, err := c.ref.ReadDir(ctx, bkgw.ReadDirRequest{
+		Path: c.path("blobs"),
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, algo := range algos {
+		if !algo.IsDir() {
+			continue
+		}
+
+		algoName := digest.Algorithm(algo.Path)
+
+		blobs, err := c.ref.ReadDir(ctx, bkgw.ReadDirRequest{
+			Path: c.path("blobs", algo.Path),
+		})
+		if err != nil {
+			return err
+		}
+
+		for _, blob := range blobs {
+			t := time.Unix(blob.ModTime/int64(time.Second), blob.ModTime%int64(time.Second))
+
+			err := fn(content.Info{
+				Digest:    digest.NewDigestFromEncoded(algoName, blob.Path),
+				Size:      blob.Size_,
+				CreatedAt: t,
+				UpdatedAt: t,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *layoutStore) path(parts ...string) string {
+	return path.Join(append([]string{c.sourcePath}, parts...)...)
+}
+
+func (c *layoutStore) blobPath(dgst digest.Digest) string {
+	return c.path("blobs", dgst.Algorithm().String(), dgst.Encoded())
+}
+
+type refReaderAt struct {
+	ctx  context.Context
+	ref  bkgw.Reference
+	name string
+	size int64
+}
+
+var _ content.ReaderAt = (*refReaderAt)(nil)
+
+func (f *refReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	if off >= f.size {
+		return 0, io.EOF
+	}
+
+	content, err := f.ref.ReadFile(f.ctx, bkgw.ReadRequest{
+		Filename: f.name,
+		Range: &bkgw.FileRange{
+			Offset: int(off),
+			Length: len(p),
+		},
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	n := copy(p, content)
+	if n < len(p) {
+		return n, fmt.Errorf("short read: %d < %d", n, len(p))
+	}
+
+	return n, nil
+}
+
+func (f *refReaderAt) Size() int64 {
+	return f.size
+}
+
+func (f *refReaderAt) Close() error {
+	return nil
+}

--- a/core/ocistore/unimplemented.go
+++ b/core/ocistore/unimplemented.go
@@ -1,0 +1,52 @@
+package ocistore
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/content"
+	"github.com/opencontainers/go-digest"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+// unimplementedStore is a content.Store intended to be embedded in a real
+// implementation that overrides its methods.
+type unimplementedStore struct{}
+
+var _ content.Store = unimplementedStore{}
+
+func (unimplementedStore) Info(ctx context.Context, dgst digest.Digest) (content.Info, error) {
+	return content.Info{}, errors.Errorf("contentstore.Info not implemented")
+}
+
+func (unimplementedStore) Update(ctx context.Context, info content.Info, fieldpaths ...string) (content.Info, error) {
+	return content.Info{}, errors.Errorf("contentstore.Update usage is forbidden")
+}
+
+func (unimplementedStore) Walk(ctx context.Context, fn content.WalkFunc, filters ...string) error {
+	return errors.Errorf("contentstore.Walk not implemented")
+}
+
+func (unimplementedStore) Delete(ctx context.Context, dgst digest.Digest) error {
+	return errors.Errorf("contentstore.Delete not implemented")
+}
+
+func (unimplementedStore) Status(ctx context.Context, ref string) (content.Status, error) {
+	return content.Status{}, errors.Errorf("contentstore.Status not implemented")
+}
+
+func (unimplementedStore) ListStatuses(ctx context.Context, filters ...string) ([]content.Status, error) {
+	return nil, errors.Errorf("contentstore.ListStatuses not implemented")
+}
+
+func (unimplementedStore) Abort(ctx context.Context, ref string) error {
+	return errors.Errorf("contentstore.Abort not implemented")
+}
+
+func (unimplementedStore) ReaderAt(ctx context.Context, desc ocispecs.Descriptor) (content.ReaderAt, error) {
+	return nil, errors.Errorf("contentstore.ReaderAt not implemented")
+}
+
+func (unimplementedStore) Writer(ctx context.Context, opts ...content.WriterOpt) (content.Writer, error) {
+	return nil, errors.Errorf("contentstore.Writer not implemented")
+}

--- a/core/ocistore/union.go
+++ b/core/ocistore/union.go
@@ -1,0 +1,59 @@
+package ocistore
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/containerd/containerd/content"
+	"github.com/opencontainers/go-digest"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// UnionStore is a content.Store that delegates to other content.Stores.
+type UnionStore struct {
+	stores  map[digest.Digest]content.Store
+	storesL sync.Mutex
+
+	unimplementedStore
+}
+
+// NewUnionStore constructs a new empty union store.
+func NewUnionStore() *UnionStore {
+	return &UnionStore{
+		stores: make(map[digest.Digest]content.Store),
+	}
+}
+
+var _ content.Store = (*UnionStore)(nil)
+
+// Info delegates to the content.Store that has the requested digest.
+func (c *UnionStore) Info(ctx context.Context, dgst digest.Digest) (content.Info, error) {
+	store, found := c.stores[dgst]
+	if !found {
+		return content.Info{}, fmt.Errorf("Info: digest not found: %s", dgst)
+	}
+
+	return store.Info(ctx, dgst)
+}
+
+// ReaderAt delegates to the content.Store that has the requested digest.
+func (c *UnionStore) ReaderAt(ctx context.Context, desc ocispecs.Descriptor) (content.ReaderAt, error) {
+	store, found := c.stores[desc.Digest]
+	if !found {
+		return nil, fmt.Errorf("ReaderAt: digest not found: %s", desc.Digest)
+	}
+
+	return store.ReaderAt(ctx, desc)
+}
+
+// Install walks over all blob digests available in store and maps them to the
+// store in the union.
+func (c *UnionStore) Install(ctx context.Context, store content.Store) error {
+	return store.Walk(ctx, func(info content.Info) error {
+		c.storesL.Lock()
+		c.stores[info.Digest] = store
+		c.storesL.Unlock()
+		return nil
+	})
+}

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -88,6 +88,7 @@ func (s *containerSchema) Resolvers() router.Resolvers {
 			"platform":             router.ToResolver(s.platform),
 			"export":               router.ToResolver(s.export),
 			"import":               router.ToResolver(s.import_),
+			"importDir":            router.ToResolver(s.importDir),
 			"withRegistryAuth":     router.ToResolver(s.withRegistryAuth),
 			"withoutRegistryAuth":  router.ToResolver(s.withoutRegistryAuth),
 			"imageRef":             router.ToResolver(s.imageRef),
@@ -671,7 +672,16 @@ type containerImportArgs struct {
 }
 
 func (s *containerSchema) import_(ctx *router.Context, parent *core.Container, args containerImportArgs) (*core.Container, error) { // nolint:revive
-	return parent.Import(ctx, s.gw, s.host, args.Source, args.Tag, s.ociStore)
+	return parent.ImportOCITarball(ctx, s.gw, s.host, args.Source, args.Tag, s.ociStore)
+}
+
+type containerImportDirArgs struct {
+	Source core.DirectoryID
+	Tag    string
+}
+
+func (s *containerSchema) importDir(ctx *router.Context, parent *core.Container, args containerImportDirArgs) (*core.Container, error) { // nolint:revive
+	return parent.ImportOCILayoutDir(ctx, s.gw, s.host, args.Source, args.Tag, s.ociStore)
 }
 
 type containerWithRegistryAuthArgs struct {

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -680,8 +680,22 @@ type Container {
     source: FileID!
 
     """
-    Identifies the tag to import from the archive, if the archive bundles
-    multiple tags.
+    Identifies the tag to import, if the image bundles multiple tags.
+    """
+    tag: String
+  ): Container!
+
+  """
+  Reads the container from an OCI layout directory.
+  """
+  importDir(
+    """
+    File to read the container from.
+    """
+    source: DirectoryID!
+
+    """
+    Identifies the tag to import, if the image bundles multiple tags.
     """
     tag: String
   ): Container!

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -177,7 +177,8 @@ func Start(ctx context.Context, startOpts Config, fn StartCallback) error {
 		},
 		AllowedEntitlements: allowedEntitlements,
 		OCIStores: map[string]content.Store{
-			core.OCIStoreName: ociStore,
+			core.LocalOCIStoreName: ociStore,
+			core.UnionOCIStoreName: core.UnionOCIStore,
 		},
 	}
 

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -524,8 +524,7 @@ func (r *Container) ImageRef(ctx context.Context) (string, error) {
 
 // ContainerImportOpts contains options for Container.Import
 type ContainerImportOpts struct {
-	// Identifies the tag to import from the archive, if the archive bundles
-	// multiple tags.
+	// Identifies the tag to import, if the image bundles multiple tags.
 	Tag string
 }
 
@@ -535,6 +534,29 @@ type ContainerImportOpts struct {
 // $XDG_CACHE_DIR/dagger/oci. This directory can be removed whenever you like.
 func (r *Container) Import(source *File, opts ...ContainerImportOpts) *Container {
 	q := r.q.Select("import")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `tag` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Tag) {
+			q = q.Arg("tag", opts[i].Tag)
+		}
+	}
+	q = q.Arg("source", source)
+
+	return &Container{
+		q: q,
+		c: r.c,
+	}
+}
+
+// ContainerImportDirOpts contains options for Container.ImportDir
+type ContainerImportDirOpts struct {
+	// Identifies the tag to import, if the image bundles multiple tags.
+	Tag string
+}
+
+// Reads the container from an OCI layout directory.
+func (r *Container) ImportDir(source *Directory, opts ...ContainerImportDirOpts) *Container {
+	q := r.q.Select("importDir")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `tag` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Tag) {

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -175,8 +175,14 @@ export type ContainerExportOpts = {
 
 export type ContainerImportOpts = {
   /**
-   * Identifies the tag to import from the archive, if the archive bundles
-   * multiple tags.
+   * Identifies the tag to import, if the image bundles multiple tags.
+   */
+  tag?: string
+}
+
+export type ContainerImportDirOpts = {
+  /**
+   * Identifies the tag to import, if the image bundles multiple tags.
    */
   tag?: string
 }
@@ -1090,8 +1096,7 @@ export class Container extends BaseClient {
    * NOTE: this involves unpacking the tarball to an OCI store on the host at
    * $XDG_CACHE_DIR/dagger/oci. This directory can be removed whenever you like.
    * @param source File to read the container from.
-   * @param opts.tag Identifies the tag to import from the archive, if the archive bundles
-   * multiple tags.
+   * @param opts.tag Identifies the tag to import, if the image bundles multiple tags.
    */
   import(source: File, opts?: ContainerImportOpts): Container {
     return new Container({
@@ -1099,6 +1104,25 @@ export class Container extends BaseClient {
         ...this._queryTree,
         {
           operation: "import",
+          args: { source, ...opts },
+        },
+      ],
+      host: this.clientHost,
+      sessionToken: this.sessionToken,
+    })
+  }
+
+  /**
+   * Reads the container from an OCI layout directory.
+   * @param source File to read the container from.
+   * @param opts.tag Identifies the tag to import, if the image bundles multiple tags.
+   */
+  importDir(source: Directory, opts?: ContainerImportDirOpts): Container {
+    return new Container({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "importDir",
           args: { source, ...opts },
         },
       ],

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -618,15 +618,35 @@ class Container(Type):
         source:
             File to read the container from.
         tag:
-            Identifies the tag to import from the archive, if the archive
-            bundles
-            multiple tags.
+            Identifies the tag to import, if the image bundles multiple tags.
         """
         _args = [
             Arg("source", source),
             Arg("tag", tag, None),
         ]
         _ctx = self._select("import", _args)
+        return Container(_ctx)
+
+    @typecheck
+    def import_dir(
+        self,
+        source: "Directory",
+        tag: Optional[str] = None,
+    ) -> "Container":
+        """Reads the container from an OCI layout directory.
+
+        Parameters
+        ----------
+        source:
+            File to read the container from.
+        tag:
+            Identifies the tag to import, if the image bundles multiple tags.
+        """
+        _args = [
+            Arg("source", source),
+            Arg("tag", tag, None),
+        ]
+        _ctx = self._select("importDir", _args)
         return Container(_ctx)
 
     @typecheck

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -618,15 +618,35 @@ class Container(Type):
         source:
             File to read the container from.
         tag:
-            Identifies the tag to import from the archive, if the archive
-            bundles
-            multiple tags.
+            Identifies the tag to import, if the image bundles multiple tags.
         """
         _args = [
             Arg("source", source),
             Arg("tag", tag, None),
         ]
         _ctx = self._select("import", _args)
+        return Container(_ctx)
+
+    @typecheck
+    def import_dir(
+        self,
+        source: "Directory",
+        tag: Optional[str] = None,
+    ) -> "Container":
+        """Reads the container from an OCI layout directory.
+
+        Parameters
+        ----------
+        source:
+            File to read the container from.
+        tag:
+            Identifies the tag to import, if the image bundles multiple tags.
+        """
+        _args = [
+            Arg("source", source),
+            Arg("tag", tag, None),
+        ]
+        _ctx = self._select("importDir", _args)
         return Container(_ctx)
 
     @typecheck


### PR DESCRIPTION
Adds a new API that is similar to `Container.Import` but loads from a `DirectoryID` containing an [OCI image layout](https://github.com/opencontainers/image-spec/blob/main/image-layout.md) instead of a `FileID` pointing to an OCI image tarball.

Using an OCI layout directory has major advantages:

1. It's a million times faster for cache hits. With an archive we have to stream the full content into the user's local OCI store, which is an expensive no-op on a cache hit. With a directory we can just fetch the index file using a Buildkit `gateway.Reference`; on a cache hit there's nothing else to do.
2. We don't need to unpack to a client-side OCI store. We still have to transfer data to the client and back in to Buildkit, but in the happy path where everything is cached already, the only thing that needs to be streamed is the tiny `index.json` file.

At this point I'm wondering if we should just deprecate `Container.Import`, but for now this PR adds a new API alongside it.

### TODO

* [ ] Tests

### API change

```graphql
extend type Container {
  importDir(source: DirectoryID!, tag: String): Container!
}
```

Note: I'm tempted to rename this to `fromOCILayout` or something. Now is a good time to bikeshed.

### How does it work?

The `core/ocistore/` package adds two new `content.Store` implementations:

1. `layoutStore` which essentially turns a `*core.Directory` into a read-only `content.Store`.
2. `UnionStore`, which is a glorified `map[digest.Digest]content.Store` representing the union of all digests we've seen and what `layoutStore` they came from.

There is a session-global `UnionStore` added to the Buildkit session's `OCIStores`. Calling `Container.ImportDir` will load up a `layoutStore` and install it into the global `UnionStore` and return an image refers the appropriate digest in the `UnionStore`.

### How much faster is it?

The difference is night and day:

* [Using OCI tarballs](https://asciinema.org/a/k0YwdT2c18guGoFcMo6hgH2kj) (`Container.Import`)
  * note the ~7s `import(...)` call on the second cached run
* [Using OCI layout dirs](https://asciinema.org/a/oKZhIhZLz2f0mh0078EK17kzq) (`Container.ImportDir` - maybe it should be `FromOCILayout`?)
  * import API call isn't even visible anymore, entire command finishes in < 1 second

In this example, using `Container.Import` added a 7-second penalty on every container that used the image.