### PR TITLE
Container: add `withFocus`, `withoutFocus`

### DIFF
--- a/ci/engine.go
+++ b/ci/engine.go
@@ -11,9 +11,8 @@ func (e EngineTargets) Lint(ctx dagger.Context) (string, error) {
 		From("golangci/golangci-lint:v1.51-alpine").
 		WithMountedDirectory("/app", e.SrcDir).
 		WithWorkdir("/app").
-		WithExec([]string{"golangci-lint", "run", "-v", "--timeout", "5m"}, dagger.ContainerWithExecOpts{
-			Focus: true,
-		}).
+		WithFocus().
+		WithExec([]string{"golangci-lint", "run", "-v", "--timeout", "5m"}).
 		Stdout(ctx)
 	return out, err
 }

--- a/ci/engine.go
+++ b/ci/engine.go
@@ -11,7 +11,9 @@ func (e EngineTargets) Lint(ctx dagger.Context) (string, error) {
 		From("golangci/golangci-lint:v1.51-alpine").
 		WithMountedDirectory("/app", e.SrcDir).
 		WithWorkdir("/app").
-		WithExec([]string{"golangci-lint", "run", "-v", "--timeout", "5m"}).
+		WithExec([]string{"golangci-lint", "run", "-v", "--timeout", "5m"}, dagger.ContainerWithExecOpts{
+			Focus: true,
+		}).
 		Stdout(ctx)
 	return out, err
 }

--- a/cmd/dagger/do.go
+++ b/cmd/dagger/do.go
@@ -30,6 +30,7 @@ const (
 
 func init() {
 	doCmd.PersistentFlags().StringVarP(&outputPath, "output", "o", "", "If the command returns a file or directory, it will be written to this path. If --output is not specified, the file or directory will be written to the project's root directory when using a project loaded from a local dir.")
+	doCmd.PersistentFlags().BoolVar(&focus, "focus", true, "Only show output for focused commands.")
 }
 
 // project flags (--project) for do command are setup in project.go

--- a/cmd/dagger/do.go
+++ b/cmd/dagger/do.go
@@ -22,6 +22,7 @@ import (
 
 var (
 	outputPath string
+	doFocus    bool
 )
 
 const (
@@ -30,7 +31,7 @@ const (
 
 func init() {
 	doCmd.PersistentFlags().StringVarP(&outputPath, "output", "o", "", "If the command returns a file or directory, it will be written to this path. If --output is not specified, the file or directory will be written to the project's root directory when using a project loaded from a local dir.")
-	doCmd.PersistentFlags().BoolVar(&focus, "focus", true, "Only show output for focused commands.")
+	doCmd.PersistentFlags().BoolVar(&doFocus, "focus", true, "Only show output for focused commands.")
 }
 
 // project flags (--project) for do command are setup in project.go
@@ -49,6 +50,8 @@ var doCmd = &cobra.Command{
 			return fmt.Errorf("failed to parse top-level flags: %w", err)
 		}
 		dynamicCmdArgs := flags.Args()
+
+		focus = doFocus
 
 		return withEngineAndTUI(cmd.Context(), engine.Config{}, func(ctx context.Context, r *router.Router) (err error) {
 			rec := progrock.RecorderFromContext(ctx)

--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -43,6 +43,9 @@ func init() {
 	)
 }
 
+// show only focused vertices. enabled by default for dagger do.
+var focus bool
+
 var interactive = os.Getenv("_EXPERIMENTAL_DAGGER_INTERACTIVE_TUI") != ""
 
 func withEngineAndTUI(
@@ -146,9 +149,8 @@ func inlineTUI(
 	fn engine.StartCallback,
 ) error {
 	tape := progrock.NewTape()
-	if debug {
-		tape.ShowInternal(true)
-	}
+	tape.ShowInternal(debug)
+	tape.Focus(focus)
 
 	progW, engineErr := progrockTee(tape)
 	if engineErr != nil {

--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -49,6 +49,7 @@ DAGGER_SESSION_PORT and DAGGER_SESSION_TOKEN will be convieniently injected auto
 }
 
 var waitDelay time.Duration
+var runFocus bool
 
 func init() {
 	// don't require -- to disambiguate subcommand flags
@@ -60,6 +61,8 @@ func init() {
 		10*time.Second,
 		"max duration to wait between SIGTERM and SIGKILL on interrupt",
 	)
+
+	runCmd.Flags().BoolVar(&runFocus, "focus", false, "Only show output for focused commands.")
 }
 
 func Run(cmd *cobra.Command, args []string) {
@@ -86,6 +89,8 @@ func run(ctx context.Context, args []string) error {
 	}
 
 	sessionToken := u.String()
+
+	focus = runFocus
 
 	return withEngineAndTUI(ctx, engine.Config{
 		SessionToken: sessionToken,

--- a/core/bk2progrock.go
+++ b/core/bk2progrock.go
@@ -1,0 +1,87 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	bkclient "github.com/moby/buildkit/client"
+	"github.com/vito/progrock"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const focusPrefix = "[focus] "
+const internalPrefix = "[internal] "
+
+func RecordBuildkitStatus(rec *progrock.Recorder, solveCh <-chan *bkclient.SolveStatus) error {
+	for ev := range solveCh {
+		if err := rec.Record(bk2progrock(ev)); err != nil {
+			return fmt.Errorf("record: %w", err)
+		}
+	}
+	return nil
+}
+
+func bk2progrock(event *bkclient.SolveStatus) *progrock.StatusUpdate {
+	var status progrock.StatusUpdate
+	for _, v := range event.Vertexes {
+		vtx := &progrock.Vertex{
+			Id:     v.Digest.String(),
+			Name:   v.Name,
+			Cached: v.Cached,
+		}
+		if strings.HasPrefix(v.Name, internalPrefix) {
+			vtx.Internal = true
+			vtx.Name = strings.TrimPrefix(v.Name, internalPrefix)
+		}
+		if strings.HasPrefix(v.Name, focusPrefix) {
+			vtx.Focused = true
+			vtx.Name = strings.TrimPrefix(v.Name, focusPrefix)
+		}
+		for _, input := range v.Inputs {
+			vtx.Inputs = append(vtx.Inputs, input.String())
+		}
+		if v.Started != nil {
+			vtx.Started = timestamppb.New(*v.Started)
+		}
+		if v.Completed != nil {
+			vtx.Completed = timestamppb.New(*v.Completed)
+		}
+		if v.Error != "" {
+			if strings.HasSuffix(v.Error, context.Canceled.Error()) {
+				vtx.Canceled = true
+			} else {
+				msg := v.Error
+				vtx.Error = &msg
+			}
+		}
+		status.Vertexes = append(status.Vertexes, vtx)
+	}
+
+	for _, s := range event.Statuses {
+		task := &progrock.VertexTask{
+			Vertex:  s.Vertex.String(),
+			Name:    s.ID, // remap
+			Total:   s.Total,
+			Current: s.Current,
+		}
+		if s.Started != nil {
+			task.Started = timestamppb.New(*s.Started)
+		}
+		if s.Completed != nil {
+			task.Completed = timestamppb.New(*s.Completed)
+		}
+		status.Tasks = append(status.Tasks, task)
+	}
+
+	for _, s := range event.Logs {
+		status.Logs = append(status.Logs, &progrock.VertexLog{
+			Vertex:    s.Vertex.String(),
+			Stream:    progrock.LogStream(s.Stream),
+			Data:      s.Data,
+			Timestamp: timestamppb.New(s.Timestamp),
+		})
+	}
+
+	return &status
+}

--- a/core/container.go
+++ b/core/container.go
@@ -74,6 +74,10 @@ type Container struct {
 	// Services to start before running the container.
 	Services    ServiceBindings `json:"services,omitempty"`
 	HostAliases []HostAlias     `json:"host_aliases,omitempty"`
+
+	// Focused indicates whether subsequent operations will be
+	// focused, i.e. shown more prominently in the UI.
+	Focused bool `json:"focused"`
 }
 
 func NewContainer(id ContainerID, pipeline pipeline.Path, platform specs.Platform) (*Container, error) {
@@ -1047,7 +1051,7 @@ func (container *Container) WithExec(ctx context.Context, gw bkgw.Client, progSo
 	}
 
 	var namef string
-	if opts.Focus {
+	if container.Focused {
 		namef = focusPrefix + "exec %s"
 	} else {
 		namef = "exec %s"
@@ -1875,10 +1879,6 @@ func (container *Container) ownership(ctx context.Context, gw bkgw.Client, owner
 type ContainerExecOpts struct {
 	// Command to run instead of the container's default command
 	Args []string
-
-	// Focus indicates that the command is the primary focus of the pipeline
-	// being run.
-	Focus bool
 
 	// If the container has an entrypoint, ignore it for this exec rather than
 	// calling it with args.

--- a/core/container.go
+++ b/core/container.go
@@ -1046,9 +1046,16 @@ func (container *Container) WithExec(ctx context.Context, gw bkgw.Client, progSo
 		return nil, errors.New("no command has been set")
 	}
 
+	var namef string
+	if opts.Focus {
+		namef = focusPrefix + "exec %s"
+	} else {
+		namef = "exec %s"
+	}
+
 	runOpts := []llb.RunOption{
 		llb.Args(args),
-		llb.WithCustomNamef("exec %s", strings.Join(args, " ")),
+		llb.WithCustomNamef(namef, strings.Join(args, " ")),
 	}
 
 	// this allows executed containers to communicate back to this API
@@ -1079,7 +1086,7 @@ func (container *Container) WithExec(ctx context.Context, gw bkgw.Client, progSo
 	// create /dagger mount point for the shim to write to
 	runOpts = append(runOpts,
 		llb.AddMount(metaMountDestPath,
-			llb.Scratch().File(meta, llb.WithCustomName("[internal] creating dagger metadata")),
+			llb.Scratch().File(meta, llb.WithCustomName(internalPrefix+"creating dagger metadata")),
 			llb.SourcePath(metaSourcePath)))
 
 	if opts.RedirectStdout != "" {
@@ -1868,6 +1875,10 @@ func (container *Container) ownership(ctx context.Context, gw bkgw.Client, owner
 type ContainerExecOpts struct {
 	// Command to run instead of the container's default command
 	Args []string
+
+	// Focus indicates that the command is the primary focus of the pipeline
+	// being run.
+	Focus bool
 
 	// If the container has an entrypoint, ignore it for this exec rather than
 	// calling it with args.

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -97,6 +97,8 @@ func (s *containerSchema) Resolvers() router.Resolvers {
 			"hostname":             router.ToResolver(s.hostname),
 			"endpoint":             router.ToResolver(s.endpoint),
 			"withServiceBinding":   router.ToResolver(s.withServiceBinding),
+			"focus":                router.ToResolver(s.focus),
+			"unfocus":              router.ToResolver(s.unfocus),
 		},
 	}
 }
@@ -840,4 +842,16 @@ func (s *containerSchema) exposedPorts(ctx *router.Context, parent *core.Contain
 	}
 
 	return exposedPorts, nil
+}
+
+func (s *containerSchema) focus(ctx *router.Context, parent *core.Container, args any) (*core.Container, error) {
+	child := parent.Clone()
+	child.Focused = true
+	return child, nil
+}
+
+func (s *containerSchema) unfocus(ctx *router.Context, parent *core.Container, args any) (*core.Container, error) {
+	child := parent.Clone()
+	child.Focused = false
+	return child, nil
 }

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -97,8 +97,8 @@ func (s *containerSchema) Resolvers() router.Resolvers {
 			"hostname":             router.ToResolver(s.hostname),
 			"endpoint":             router.ToResolver(s.endpoint),
 			"withServiceBinding":   router.ToResolver(s.withServiceBinding),
-			"focus":                router.ToResolver(s.focus),
-			"unfocus":              router.ToResolver(s.unfocus),
+			"withFocus":            router.ToResolver(s.withFocus),
+			"withoutFocus":         router.ToResolver(s.withoutFocus),
 		},
 	}
 }
@@ -844,13 +844,13 @@ func (s *containerSchema) exposedPorts(ctx *router.Context, parent *core.Contain
 	return exposedPorts, nil
 }
 
-func (s *containerSchema) focus(ctx *router.Context, parent *core.Container, args any) (*core.Container, error) {
+func (s *containerSchema) withFocus(ctx *router.Context, parent *core.Container, args any) (*core.Container, error) {
 	child := parent.Clone()
 	child.Focused = true
 	return child, nil
 }
 
-func (s *containerSchema) unfocus(ctx *router.Context, parent *core.Container, args any) (*core.Container, error) {
+func (s *containerSchema) withoutFocus(ctx *router.Context, parent *core.Container, args any) (*core.Container, error) {
 	child := parent.Clone()
 	child.Focused = false
 	return child, nil

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -517,6 +517,12 @@ type Container {
     args: [String!]!
 
     """
+    Indicate that this command is a primary focus of the pipeline being run so
+    that it will be featured more prominently in the UI.
+    """
+    focus: Boolean
+
+    """
     If the container has an entrypoint, ignore it for args rather than using it to wrap them.
     """
     skipEntrypoint: Boolean

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -509,7 +509,7 @@ type Container {
   Indicate that subsequent commands should be featured more
   prominently in the UI.
   """
-  focus: Container!
+  withFocus: Container!
 
   """
   Indicate that subsequent commands should not be featured
@@ -517,7 +517,7 @@ type Container {
 
   This is the initial state of all containers.
   """
-  unfocus: Container!
+  withoutFocus: Container!
 
   """
   Retrieves this container after executing the specified command inside it.

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -506,14 +506,14 @@ type Container {
   ): Container!
 
   """
-  Indicate that subsequent commands should be featured more
-  prominently in the UI.
+  Indicate that subsequent operations should be featured more prominently in
+  the UI.
   """
   withFocus: Container!
 
   """
-  Indicate that subsequent commands should not be featured
-  more prominently in the UI.
+  Indicate that subsequent operations should not be featured more prominently
+  in the UI.
 
   This is the initial state of all containers.
   """

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -506,6 +506,20 @@ type Container {
   ): Container!
 
   """
+  Indicate that subsequent commands should be featured more
+  prominently in the UI.
+  """
+  focus: Container!
+
+  """
+  Indicate that subsequent commands should not be featured
+  more prominently in the UI.
+
+  This is the initial state of all containers.
+  """
+  unfocus: Container!
+
+  """
   Retrieves this container after executing the specified command inside it.
   """
   withExec(
@@ -515,12 +529,6 @@ type Container {
     If empty, the container's default command is used.
     """
     args: [String!]!
-
-    """
-    Indicate that this command is a primary focus of the pipeline being run so
-    that it will be featured more prominently in the UI.
-    """
-    focus: Boolean
 
     """
     If the container has an entrypoint, ignore it for args rather than using it to wrap them.

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -36,7 +36,6 @@ import (
 	fstypes "github.com/tonistiigi/fsutil/types"
 	"github.com/vito/progrock"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -207,12 +206,7 @@ func Start(ctx context.Context, startOpts Config, fn StartCallback) error {
 	eg, groupCtx := errgroup.WithContext(ctx)
 	solveCh := make(chan *bkclient.SolveStatus)
 	eg.Go(func() error {
-		for ev := range solveCh {
-			if err := recorder.Record(bk2progrock(ev)); err != nil {
-				return fmt.Errorf("record: %w", err)
-			}
-		}
-		return nil
+		return core.RecordBuildkitStatus(recorder, solveCh)
 	})
 
 	eg.Go(func() error {
@@ -355,66 +349,6 @@ func cacheConfigFromEnv() (string, map[string]string, error) {
 	}
 	delete(attrs, "type")
 	return typeVal, attrs, nil
-}
-
-func bk2progrock(event *bkclient.SolveStatus) *progrock.StatusUpdate {
-	var status progrock.StatusUpdate
-	for _, v := range event.Vertexes {
-		vtx := &progrock.Vertex{
-			Id:     v.Digest.String(),
-			Name:   v.Name,
-			Cached: v.Cached,
-		}
-		if strings.HasPrefix(v.Name, "[internal] ") {
-			vtx.Internal = true
-			vtx.Name = strings.TrimPrefix(v.Name, "[internal] ")
-		}
-		for _, input := range v.Inputs {
-			vtx.Inputs = append(vtx.Inputs, input.String())
-		}
-		if v.Started != nil {
-			vtx.Started = timestamppb.New(*v.Started)
-		}
-		if v.Completed != nil {
-			vtx.Completed = timestamppb.New(*v.Completed)
-		}
-		if v.Error != "" {
-			if strings.HasSuffix(v.Error, context.Canceled.Error()) {
-				vtx.Canceled = true
-			} else {
-				msg := v.Error
-				vtx.Error = &msg
-			}
-		}
-		status.Vertexes = append(status.Vertexes, vtx)
-	}
-
-	for _, s := range event.Statuses {
-		task := &progrock.VertexTask{
-			Vertex:  s.Vertex.String(),
-			Name:    s.ID, // remap
-			Total:   s.Total,
-			Current: s.Current,
-		}
-		if s.Started != nil {
-			task.Started = timestamppb.New(*s.Started)
-		}
-		if s.Completed != nil {
-			task.Completed = timestamppb.New(*s.Completed)
-		}
-		status.Tasks = append(status.Tasks, task)
-	}
-
-	for _, s := range event.Logs {
-		status.Logs = append(status.Logs, &progrock.VertexLog{
-			Vertex:    s.Vertex.String(),
-			Stream:    progrock.LogStream(s.Stream),
-			Data:      s.Data,
-			Timestamp: timestamppb.New(s.Timestamp),
-		})
-	}
-
-	return &status
 }
 
 func progrockForwarder(w progrock.Writer) (string, progrock.Writer, func() error, error) {

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/prometheus/procfs v0.11.0
 	github.com/rs/zerolog v1.29.1
 	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29
-	github.com/vito/progrock v0.7.0
+	github.com/vito/progrock v0.7.1-0.20230628234355-c8ce2c2e3c24
 	github.com/vito/vt100 v0.1.2
 	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53
 	golang.org/x/oauth2 v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -1410,6 +1410,8 @@ github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmF
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vito/progrock v0.7.0 h1:NJ6pOV6igmgFAi23JhEw9nwRGNtid/sqgMJ37hlknbo=
 github.com/vito/progrock v0.7.0/go.mod h1:UVw9s+ns8pVpHBIoLMfE8bMzFxXefnSejksNUiqSBvw=
+github.com/vito/progrock v0.7.1-0.20230628234355-c8ce2c2e3c24 h1:E6NeGFp8/YGYHnWtwzP5lrphxXLmoKsoAvdwuIkUTOk=
+github.com/vito/progrock v0.7.1-0.20230628234355-c8ce2c2e3c24/go.mod h1:YjiMvY2X47zc9H5je8w4V59cTSrV2d0vQPwJOB5TLH8=
 github.com/vito/vt100 v0.1.2 h1:gRhKJ/shHTRfMHg+Wc5ExHJzV6HHZqyQIAL52x4EUmA=
 github.com/vito/vt100 v0.1.2/go.mod h1:ByMBsZZEP04RrkT9q/UxvZOjECM8Xc/MRLZ7GLrAUXs=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -990,8 +990,8 @@ func (r *Container) WithFile(path string, source *File, opts ...ContainerWithFil
 	}
 }
 
-// Indicate that subsequent commands should be featured more
-// prominently in the UI.
+// Indicate that subsequent operations should be featured more prominently in
+// the UI.
 func (r *Container) WithFocus() *Container {
 	q := r.q.Select("withFocus")
 
@@ -1336,8 +1336,8 @@ func (r *Container) WithoutExposedPort(port int, opts ...ContainerWithoutExposed
 	}
 }
 
-// Indicate that subsequent commands should not be featured
-// more prominently in the UI.
+// Indicate that subsequent operations should not be featured more prominently
+// in the UI.
 //
 // This is the initial state of all containers.
 func (r *Container) WithoutFocus() *Container {

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -849,6 +849,9 @@ func (r *Container) WithEnvVariable(name string, value string, opts ...Container
 
 // ContainerWithExecOpts contains options for Container.WithExec
 type ContainerWithExecOpts struct {
+	// Indicate that this command is a primary focus of the pipeline being run so
+	// that it will be featured more prominently in the UI.
+	Focus bool
 	// If the container has an entrypoint, ignore it for args rather than using it to wrap them.
 	SkipEntrypoint bool
 	// Content to write to the command's standard input before closing (e.g., "Hello world").
@@ -873,6 +876,10 @@ type ContainerWithExecOpts struct {
 func (r *Container) WithExec(args []string, opts ...ContainerWithExecOpts) *Container {
 	q := r.q.Select("withExec")
 	for i := len(opts) - 1; i >= 0; i-- {
+		// `focus` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Focus) {
+			q = q.Arg("focus", opts[i].Focus)
+		}
 		// `skipEntrypoint` optional argument
 		if !querybuilder.IsZeroValue(opts[i].SkipEntrypoint) {
 			q = q.Arg("skipEntrypoint", opts[i].SkipEntrypoint)

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -439,6 +439,17 @@ func (r *Container) File(path string) *File {
 	}
 }
 
+// Indicate that subsequent commands should be featured more
+// prominently in the UI.
+func (r *Container) Focus() *Container {
+	q := r.q.Select("focus")
+
+	return &Container{
+		q: q,
+		c: r.c,
+	}
+}
+
 // Initializes this container from a pulled base image.
 func (r *Container) From(address string) *Container {
 	q := r.q.Select("from")
@@ -736,6 +747,19 @@ func (r *Container) Sync(ctx context.Context) (*Container, error) {
 	return r, q.Execute(ctx, r.c)
 }
 
+// Indicate that subsequent commands should not be featured
+// more prominently in the UI.
+//
+// This is the initial state of all containers.
+func (r *Container) Unfocus() *Container {
+	q := r.q.Select("unfocus")
+
+	return &Container{
+		q: q,
+		c: r.c,
+	}
+}
+
 // Retrieves the user to be set for all commands.
 func (r *Container) User(ctx context.Context) (string, error) {
 	if r.user != nil {
@@ -849,9 +873,6 @@ func (r *Container) WithEnvVariable(name string, value string, opts ...Container
 
 // ContainerWithExecOpts contains options for Container.WithExec
 type ContainerWithExecOpts struct {
-	// Indicate that this command is a primary focus of the pipeline being run so
-	// that it will be featured more prominently in the UI.
-	Focus bool
 	// If the container has an entrypoint, ignore it for args rather than using it to wrap them.
 	SkipEntrypoint bool
 	// Content to write to the command's standard input before closing (e.g., "Hello world").
@@ -876,10 +897,6 @@ type ContainerWithExecOpts struct {
 func (r *Container) WithExec(args []string, opts ...ContainerWithExecOpts) *Container {
 	q := r.q.Select("withExec")
 	for i := len(opts) - 1; i >= 0; i-- {
-		// `focus` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Focus) {
-			q = q.Arg("focus", opts[i].Focus)
-		}
 		// `skipEntrypoint` optional argument
 		if !querybuilder.IsZeroValue(opts[i].SkipEntrypoint) {
 			q = q.Arg("skipEntrypoint", opts[i].SkipEntrypoint)

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -439,17 +439,6 @@ func (r *Container) File(path string) *File {
 	}
 }
 
-// Indicate that subsequent commands should be featured more
-// prominently in the UI.
-func (r *Container) Focus() *Container {
-	q := r.q.Select("focus")
-
-	return &Container{
-		q: q,
-		c: r.c,
-	}
-}
-
 // Initializes this container from a pulled base image.
 func (r *Container) From(address string) *Container {
 	q := r.q.Select("from")
@@ -747,19 +736,6 @@ func (r *Container) Sync(ctx context.Context) (*Container, error) {
 	return r, q.Execute(ctx, r.c)
 }
 
-// Indicate that subsequent commands should not be featured
-// more prominently in the UI.
-//
-// This is the initial state of all containers.
-func (r *Container) Unfocus() *Container {
-	q := r.q.Select("unfocus")
-
-	return &Container{
-		q: q,
-		c: r.c,
-	}
-}
-
 // Retrieves the user to be set for all commands.
 func (r *Container) User(ctx context.Context) (string, error) {
 	if r.user != nil {
@@ -1007,6 +983,17 @@ func (r *Container) WithFile(path string, source *File, opts ...ContainerWithFil
 	}
 	q = q.Arg("path", path)
 	q = q.Arg("source", source)
+
+	return &Container{
+		q: q,
+		c: r.c,
+	}
+}
+
+// Indicate that subsequent commands should be featured more
+// prominently in the UI.
+func (r *Container) WithFocus() *Container {
+	q := r.q.Select("withFocus")
 
 	return &Container{
 		q: q,
@@ -1342,6 +1329,19 @@ func (r *Container) WithoutExposedPort(port int, opts ...ContainerWithoutExposed
 		}
 	}
 	q = q.Arg("port", port)
+
+	return &Container{
+		q: q,
+		c: r.c,
+	}
+}
+
+// Indicate that subsequent commands should not be featured
+// more prominently in the UI.
+//
+// This is the initial state of all containers.
+func (r *Container) WithoutFocus() *Container {
+	q := r.q.Select("withoutFocus")
 
 	return &Container{
 		q: q,

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -248,12 +248,6 @@ export type ContainerWithEnvVariableOpts = {
 
 export type ContainerWithExecOpts = {
   /**
-   * Indicate that this command is a primary focus of the pipeline being run so
-   * that it will be featured more prominently in the UI.
-   */
-  focus?: boolean
-
-  /**
    * If the container has an entrypoint, ignore it for args rather than using it to wrap them.
    */
   skipEntrypoint?: boolean
@@ -1001,6 +995,23 @@ export class Container extends BaseClient {
   }
 
   /**
+   * Indicate that subsequent commands should be featured more
+   * prominently in the UI.
+   */
+  focus(): Container {
+    return new Container({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "focus",
+        },
+      ],
+      host: this.clientHost,
+      sessionToken: this.sessionToken,
+    })
+  }
+
+  /**
    * Initializes this container from a pulled base image.
    * @param address Image's address from its registry.
    *
@@ -1307,6 +1318,25 @@ export class Container extends BaseClient {
   }
 
   /**
+   * Indicate that subsequent commands should not be featured
+   * more prominently in the UI.
+   *
+   * This is the initial state of all containers.
+   */
+  unfocus(): Container {
+    return new Container({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "unfocus",
+        },
+      ],
+      host: this.clientHost,
+      sessionToken: this.sessionToken,
+    })
+  }
+
+  /**
    * Retrieves the user to be set for all commands.
    */
   async user(): Promise<string> {
@@ -1419,8 +1449,6 @@ export class Container extends BaseClient {
    * @param args Command to run instead of the container's default command (e.g., ["run", "main.go"]).
    *
    * If empty, the container's default command is used.
-   * @param opts.focus Indicate that this command is a primary focus of the pipeline being run so
-   * that it will be featured more prominently in the UI.
    * @param opts.skipEntrypoint If the container has an entrypoint, ignore it for args rather than using it to wrap them.
    * @param opts.stdin Content to write to the command's standard input before closing (e.g., "Hello world").
    * @param opts.redirectStdout Redirect the command's standard output to a file in the container (e.g., "/tmp/stdout").

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -248,6 +248,12 @@ export type ContainerWithEnvVariableOpts = {
 
 export type ContainerWithExecOpts = {
   /**
+   * Indicate that this command is a primary focus of the pipeline being run so
+   * that it will be featured more prominently in the UI.
+   */
+  focus?: boolean
+
+  /**
    * If the container has an entrypoint, ignore it for args rather than using it to wrap them.
    */
   skipEntrypoint?: boolean
@@ -1413,6 +1419,8 @@ export class Container extends BaseClient {
    * @param args Command to run instead of the container's default command (e.g., ["run", "main.go"]).
    *
    * If empty, the container's default command is used.
+   * @param opts.focus Indicate that this command is a primary focus of the pipeline being run so
+   * that it will be featured more prominently in the UI.
    * @param opts.skipEntrypoint If the container has an entrypoint, ignore it for args rather than using it to wrap them.
    * @param opts.stdin Content to write to the command's standard input before closing (e.g., "Hello world").
    * @param opts.redirectStdout Redirect the command's standard output to a file in the container (e.g., "/tmp/stdout").

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -1519,8 +1519,8 @@ export class Container extends BaseClient {
   }
 
   /**
-   * Indicate that subsequent commands should be featured more
-   * prominently in the UI.
+   * Indicate that subsequent operations should be featured more prominently in
+   * the UI.
    */
   withFocus(): Container {
     return new Container({
@@ -1913,8 +1913,8 @@ export class Container extends BaseClient {
   }
 
   /**
-   * Indicate that subsequent commands should not be featured
-   * more prominently in the UI.
+   * Indicate that subsequent operations should not be featured more prominently
+   * in the UI.
    *
    * This is the initial state of all containers.
    */

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -995,23 +995,6 @@ export class Container extends BaseClient {
   }
 
   /**
-   * Indicate that subsequent commands should be featured more
-   * prominently in the UI.
-   */
-  focus(): Container {
-    return new Container({
-      queryTree: [
-        ...this._queryTree,
-        {
-          operation: "focus",
-        },
-      ],
-      host: this.clientHost,
-      sessionToken: this.sessionToken,
-    })
-  }
-
-  /**
    * Initializes this container from a pulled base image.
    * @param address Image's address from its registry.
    *
@@ -1318,25 +1301,6 @@ export class Container extends BaseClient {
   }
 
   /**
-   * Indicate that subsequent commands should not be featured
-   * more prominently in the UI.
-   *
-   * This is the initial state of all containers.
-   */
-  unfocus(): Container {
-    return new Container({
-      queryTree: [
-        ...this._queryTree,
-        {
-          operation: "unfocus",
-        },
-      ],
-      host: this.clientHost,
-      sessionToken: this.sessionToken,
-    })
-  }
-
-  /**
    * Retrieves the user to be set for all commands.
    */
   async user(): Promise<string> {
@@ -1547,6 +1511,23 @@ export class Container extends BaseClient {
         {
           operation: "withFile",
           args: { path, source, ...opts },
+        },
+      ],
+      host: this.clientHost,
+      sessionToken: this.sessionToken,
+    })
+  }
+
+  /**
+   * Indicate that subsequent commands should be featured more
+   * prominently in the UI.
+   */
+  withFocus(): Container {
+    return new Container({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "withFocus",
         },
       ],
       host: this.clientHost,
@@ -1924,6 +1905,25 @@ export class Container extends BaseClient {
         {
           operation: "withoutExposedPort",
           args: { port, ...opts },
+        },
+      ],
+      host: this.clientHost,
+      sessionToken: this.sessionToken,
+    })
+  }
+
+  /**
+   * Indicate that subsequent commands should not be featured
+   * more prominently in the UI.
+   *
+   * This is the initial state of all containers.
+   */
+  withoutFocus(): Container {
+    return new Container({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "withoutFocus",
         },
       ],
       host: this.clientHost,

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -486,6 +486,15 @@ class Container(Type):
         return File(_ctx)
 
     @typecheck
+    def focus(self) -> "Container":
+        """Indicate that subsequent commands should be featured more
+        prominently in the UI.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("focus", _args)
+        return Container(_ctx)
+
+    @typecheck
     def from_(self, address: str) -> "Container":
         """Initializes this container from a pulled base image.
 
@@ -868,6 +877,17 @@ class Container(Type):
         return self.sync().__await__()
 
     @typecheck
+    def unfocus(self) -> "Container":
+        """Indicate that subsequent commands should not be featured
+        more prominently in the UI.
+
+        This is the initial state of all containers.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("unfocus", _args)
+        return Container(_ctx)
+
+    @typecheck
     async def user(self) -> Optional[str]:
         """Retrieves the user to be set for all commands.
 
@@ -994,7 +1014,6 @@ class Container(Type):
     def with_exec(
         self,
         args: Sequence[str],
-        focus: Optional[bool] = None,
         skip_entrypoint: Optional[bool] = None,
         stdin: Optional[str] = None,
         redirect_stdout: Optional[str] = None,
@@ -1011,10 +1030,6 @@ class Container(Type):
             Command to run instead of the container's default command (e.g.,
             ["run", "main.go"]).
             If empty, the container's default command is used.
-        focus:
-            Indicate that this command is a primary focus of the pipeline
-            being run so
-            that it will be featured more prominently in the UI.
         skip_entrypoint:
             If the container has an entrypoint, ignore it for args rather than
             using it to wrap them.
@@ -1044,7 +1059,6 @@ class Container(Type):
         """
         _args = [
             Arg("args", args),
-            Arg("focus", focus, None),
             Arg("skipEntrypoint", skip_entrypoint, None),
             Arg("stdin", stdin, None),
             Arg("redirectStdout", redirect_stdout, None),

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -486,15 +486,6 @@ class Container(Type):
         return File(_ctx)
 
     @typecheck
-    def focus(self) -> "Container":
-        """Indicate that subsequent commands should be featured more
-        prominently in the UI.
-        """
-        _args: list[Arg] = []
-        _ctx = self._select("focus", _args)
-        return Container(_ctx)
-
-    @typecheck
     def from_(self, address: str) -> "Container":
         """Initializes this container from a pulled base image.
 
@@ -877,17 +868,6 @@ class Container(Type):
         return self.sync().__await__()
 
     @typecheck
-    def unfocus(self) -> "Container":
-        """Indicate that subsequent commands should not be featured
-        more prominently in the UI.
-
-        This is the initial state of all containers.
-        """
-        _args: list[Arg] = []
-        _ctx = self._select("unfocus", _args)
-        return Container(_ctx)
-
-    @typecheck
     async def user(self) -> Optional[str]:
         """Retrieves the user to be set for all commands.
 
@@ -1153,6 +1133,15 @@ class Container(Type):
             Arg("owner", owner, None),
         ]
         _ctx = self._select("withFile", _args)
+        return Container(_ctx)
+
+    @typecheck
+    def with_focus(self) -> "Container":
+        """Indicate that subsequent commands should be featured more
+        prominently in the UI.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("withFocus", _args)
         return Container(_ctx)
 
     @typecheck
@@ -1541,6 +1530,17 @@ class Container(Type):
             Arg("protocol", protocol, None),
         ]
         _ctx = self._select("withoutExposedPort", _args)
+        return Container(_ctx)
+
+    @typecheck
+    def without_focus(self) -> "Container":
+        """Indicate that subsequent commands should not be featured
+        more prominently in the UI.
+
+        This is the initial state of all containers.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("withoutFocus", _args)
         return Container(_ctx)
 
     @typecheck

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -994,6 +994,7 @@ class Container(Type):
     def with_exec(
         self,
         args: Sequence[str],
+        focus: Optional[bool] = None,
         skip_entrypoint: Optional[bool] = None,
         stdin: Optional[str] = None,
         redirect_stdout: Optional[str] = None,
@@ -1010,6 +1011,10 @@ class Container(Type):
             Command to run instead of the container's default command (e.g.,
             ["run", "main.go"]).
             If empty, the container's default command is used.
+        focus:
+            Indicate that this command is a primary focus of the pipeline
+            being run so
+            that it will be featured more prominently in the UI.
         skip_entrypoint:
             If the container has an entrypoint, ignore it for args rather than
             using it to wrap them.
@@ -1039,6 +1044,7 @@ class Container(Type):
         """
         _args = [
             Arg("args", args),
+            Arg("focus", focus, None),
             Arg("skipEntrypoint", skip_entrypoint, None),
             Arg("stdin", stdin, None),
             Arg("redirectStdout", redirect_stdout, None),

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -1137,8 +1137,9 @@ class Container(Type):
 
     @typecheck
     def with_focus(self) -> "Container":
-        """Indicate that subsequent commands should be featured more
-        prominently in the UI.
+        """Indicate that subsequent operations should be featured more
+        prominently in
+        the UI.
         """
         _args: list[Arg] = []
         _ctx = self._select("withFocus", _args)
@@ -1534,8 +1535,9 @@ class Container(Type):
 
     @typecheck
     def without_focus(self) -> "Container":
-        """Indicate that subsequent commands should not be featured
-        more prominently in the UI.
+        """Indicate that subsequent operations should not be featured more
+        prominently
+        in the UI.
 
         This is the initial state of all containers.
         """

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -486,6 +486,15 @@ class Container(Type):
         return File(_ctx)
 
     @typecheck
+    def focus(self) -> "Container":
+        """Indicate that subsequent commands should be featured more
+        prominently in the UI.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("focus", _args)
+        return Container(_ctx)
+
+    @typecheck
     def from_(self, address: str) -> "Container":
         """Initializes this container from a pulled base image.
 
@@ -865,6 +874,17 @@ class Container(Type):
         return Container(_ctx)
 
     @typecheck
+    def unfocus(self) -> "Container":
+        """Indicate that subsequent commands should not be featured
+        more prominently in the UI.
+
+        This is the initial state of all containers.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("unfocus", _args)
+        return Container(_ctx)
+
+    @typecheck
     def user(self) -> Optional[str]:
         """Retrieves the user to be set for all commands.
 
@@ -991,7 +1011,6 @@ class Container(Type):
     def with_exec(
         self,
         args: Sequence[str],
-        focus: Optional[bool] = None,
         skip_entrypoint: Optional[bool] = None,
         stdin: Optional[str] = None,
         redirect_stdout: Optional[str] = None,
@@ -1008,10 +1027,6 @@ class Container(Type):
             Command to run instead of the container's default command (e.g.,
             ["run", "main.go"]).
             If empty, the container's default command is used.
-        focus:
-            Indicate that this command is a primary focus of the pipeline
-            being run so
-            that it will be featured more prominently in the UI.
         skip_entrypoint:
             If the container has an entrypoint, ignore it for args rather than
             using it to wrap them.
@@ -1041,7 +1056,6 @@ class Container(Type):
         """
         _args = [
             Arg("args", args),
-            Arg("focus", focus, None),
             Arg("skipEntrypoint", skip_entrypoint, None),
             Arg("stdin", stdin, None),
             Arg("redirectStdout", redirect_stdout, None),

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -991,6 +991,7 @@ class Container(Type):
     def with_exec(
         self,
         args: Sequence[str],
+        focus: Optional[bool] = None,
         skip_entrypoint: Optional[bool] = None,
         stdin: Optional[str] = None,
         redirect_stdout: Optional[str] = None,
@@ -1007,6 +1008,10 @@ class Container(Type):
             Command to run instead of the container's default command (e.g.,
             ["run", "main.go"]).
             If empty, the container's default command is used.
+        focus:
+            Indicate that this command is a primary focus of the pipeline
+            being run so
+            that it will be featured more prominently in the UI.
         skip_entrypoint:
             If the container has an entrypoint, ignore it for args rather than
             using it to wrap them.
@@ -1036,6 +1041,7 @@ class Container(Type):
         """
         _args = [
             Arg("args", args),
+            Arg("focus", focus, None),
             Arg("skipEntrypoint", skip_entrypoint, None),
             Arg("stdin", stdin, None),
             Arg("redirectStdout", redirect_stdout, None),

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -1134,8 +1134,9 @@ class Container(Type):
 
     @typecheck
     def with_focus(self) -> "Container":
-        """Indicate that subsequent commands should be featured more
-        prominently in the UI.
+        """Indicate that subsequent operations should be featured more
+        prominently in
+        the UI.
         """
         _args: list[Arg] = []
         _ctx = self._select("withFocus", _args)
@@ -1531,8 +1532,9 @@ class Container(Type):
 
     @typecheck
     def without_focus(self) -> "Container":
-        """Indicate that subsequent commands should not be featured
-        more prominently in the UI.
+        """Indicate that subsequent operations should not be featured more
+        prominently
+        in the UI.
 
         This is the initial state of all containers.
         """

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -486,15 +486,6 @@ class Container(Type):
         return File(_ctx)
 
     @typecheck
-    def focus(self) -> "Container":
-        """Indicate that subsequent commands should be featured more
-        prominently in the UI.
-        """
-        _args: list[Arg] = []
-        _ctx = self._select("focus", _args)
-        return Container(_ctx)
-
-    @typecheck
     def from_(self, address: str) -> "Container":
         """Initializes this container from a pulled base image.
 
@@ -874,17 +865,6 @@ class Container(Type):
         return Container(_ctx)
 
     @typecheck
-    def unfocus(self) -> "Container":
-        """Indicate that subsequent commands should not be featured
-        more prominently in the UI.
-
-        This is the initial state of all containers.
-        """
-        _args: list[Arg] = []
-        _ctx = self._select("unfocus", _args)
-        return Container(_ctx)
-
-    @typecheck
     def user(self) -> Optional[str]:
         """Retrieves the user to be set for all commands.
 
@@ -1150,6 +1130,15 @@ class Container(Type):
             Arg("owner", owner, None),
         ]
         _ctx = self._select("withFile", _args)
+        return Container(_ctx)
+
+    @typecheck
+    def with_focus(self) -> "Container":
+        """Indicate that subsequent commands should be featured more
+        prominently in the UI.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("withFocus", _args)
         return Container(_ctx)
 
     @typecheck
@@ -1538,6 +1527,17 @@ class Container(Type):
             Arg("protocol", protocol, None),
         ]
         _ctx = self._select("withoutExposedPort", _args)
+        return Container(_ctx)
+
+    @typecheck
+    def without_focus(self) -> "Container":
+        """Indicate that subsequent commands should not be featured
+        more prominently in the UI.
+
+        This is the initial state of all containers.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("withoutFocus", _args)
         return Container(_ctx)
 
     @typecheck


### PR DESCRIPTION
fixes #5156 

```graphql
extend type Container {
  """
  Indicate that subsequent commands should be featured more
  prominently in the UI.
  """
  withFocus: Container!

  """
  Indicate that subsequent commands should not be featured
  more prominently in the UI.
  This is the initial state of all containers.
  """
  withoutFocus: Container!
}
```

You would typically use this to mark the command that accomplishes the primary goal of the pipeline, such as the command that runs your tests. You can also just splice it into a call chain for troubleshooting.

```go
func GoGenerate(
	ctx dagger.Context,
	base *dagger.Container,
	src *dagger.Directory,
) *dagger.Directory {
	return base.
		With(GoCache(ctx)).
		With(Cd("/src", src)).
		WithFocus().
		WithExec([]string{"go", "generate", "./..."}).
		Directory("/src")
}
```

Depends on vito/progrock#8

Here's how it looks in its current form:

[![asciicast](https://asciinema.org/a/k0YwdT2c18guGoFcMo6hgH2kj.svg)](https://asciinema.org/a/k0YwdT2c18guGoFcMo6hgH2kj)