### PR TITLE
sdk(elixir): returns {:ok, result} instead of just result

### DIFF
--- a/sdk/elixir/lib/dagger/query_builder.ex
+++ b/sdk/elixir/lib/dagger/query_builder.ex
@@ -78,8 +78,7 @@ defmodule Dagger.QueryBuilder do
         {:error, %Dagger.QueryError{errors: errors}}
 
       {:ok, %{status: 200, body: %{"data" => data}}} ->
-        # TODO: returns {:ok, response}.
-        select_data(data, Selection.path(selection) |> Enum.reverse())
+        {:ok, select_data(data, Selection.path(selection) |> Enum.reverse())}
 
       otherwise ->
         otherwise


### PR DESCRIPTION
Make any api that perform graphql request return in pattern of `{:ok, result} | {:error, reason}` pattern. Lets take a look at the example: 

```elixir
Mix.install([
  {:dagger, path: "."}
])

client = Dagger.connect!()

client
|> Dagger.Query.container()
|> Dagger.Container.from("nginx")
|> Dagger.Container.env_variables()
|> IO.inspect()

Dagger.close(client)
```

Then run:

```
$ elixir test.exs
Connected to engine f63d9f1488ba
#1 resolve image config for docker.io/library/nginx:latest
{:ok,
 [
   %{
     "name" => "PATH",
     "value" => "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
   },
   %{"name" => "NGINX_VERSION", "value" => "1.25.1"},
   %{"name" => "NJS_VERSION", "value" => "0.7.12"},
   %{"name" => "PKG_RELEASE", "value" => "1~bookworm"}
 ]}
```

NOTE: this must be executed under `sdk/elixir` directory.

