### PR TITLE
Fix Rust SDK errors

### DIFF
--- a/internal/mage/sdk/rust.go
+++ b/internal/mage/sdk/rust.go
@@ -18,6 +18,8 @@ import (
 const (
 	rustGeneratedAPIPath = "sdk/rust/crates/dagger-sdk/src/gen.rs"
 	rustVersionFilePath  = "sdk/rust/crates/dagger-sdk/src/core/mod.rs"
+	rustDockerStable     = "rust:1.70.0-bookworm"
+	rustDockerNightly    = "rustlang/rust:nightly-slim"
 )
 
 var _ SDK = Rust{}
@@ -74,8 +76,7 @@ func (r Rust) Generate(ctx context.Context) error {
 
 	cliBinPath := "/.dagger-cli"
 
-	version := "rust:1.70.0-bookworm"
-	generated := r.rustBase(ctx, c.Pipeline(version), version).
+	generated := r.rustBase(ctx, c.Pipeline(rustDockerStable), rustDockerStable).
 		WithServiceBinding("dagger-engine", devEngine).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint).
 		WithMountedFile(cliBinPath, util.DaggerBinary(c)).
@@ -109,7 +110,7 @@ func (r Rust) Lint(ctx context.Context) error {
 
 	eg, gctx := errgroup.WithContext(ctx)
 
-	base := r.rustBase(ctx, c, "rustlang/rust:nightly-slim")
+	base := r.rustBase(ctx, c, rustDockerStable)
 
 	eg.Go(func() error {
 		_, err = base.
@@ -160,7 +161,7 @@ func (r Rust) Publish(ctx context.Context, tag string) error {
 	}
 
 	base := r.
-		rustBase(ctx, c, "rust:1.69-bullseye").
+		rustBase(ctx, c, rustDockerStable).
 		WithExec([]string{
 			"cargo", "install", "cargo-edit",
 		}).WithExec([]string{
@@ -208,7 +209,7 @@ func (r Rust) Test(ctx context.Context) error {
 
 	eg, egctx := errgroup.WithContext(ctx)
 	for _, version := range []string{
-		"rust:1.69-slim-bullseye", "rustlang/rust:nightly-slim",
+		rustDockerStable, rustDockerNightly,
 	} {
 		version := version
 		eg.Go(func() error {

--- a/internal/mage/sdk/rust.go
+++ b/internal/mage/sdk/rust.go
@@ -81,7 +81,6 @@ func (r Rust) Generate(ctx context.Context) error {
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint).
 		WithMountedFile(cliBinPath, util.DaggerBinary(c)).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
-		WithExec([]string{"rustup", "component", "add", "rustfmt"}).
 		WithExec([]string{"cargo", "run", "-p", "dagger-bootstrap", "generate", "--output", fmt.Sprintf("/%s", rustGeneratedAPIPath)}).
 		WithExec([]string{"cargo", "fix", "--all", "--allow-no-vcs"}).
 		WithExec([]string{"cargo", "fmt"})
@@ -240,6 +239,7 @@ func (Rust) rustBase(ctx context.Context, c *dagger.Client, image string) *dagge
 		Container().
 		From(image).
 		WithMountedCache("~/.cargo", c.CacheVolume("rust-cargo")).
+		WithExec([]string{"rustup", "component", "add", "rustfmt"}).
 		WithExec([]string{"cargo", "install", "cargo-chef"}).
 		WithWorkdir(mountPath).
 		WithDirectory(mountPath, src, dagger.ContainerWithDirectoryOpts{

--- a/internal/mage/sdk/rust.go
+++ b/internal/mage/sdk/rust.go
@@ -74,12 +74,13 @@ func (r Rust) Generate(ctx context.Context) error {
 
 	cliBinPath := "/.dagger-cli"
 
-	version := "rustlang/rust:nightly-slim"
+	version := "rust:1.70.0-bookworm"
 	generated := r.rustBase(ctx, c.Pipeline(version), version).
 		WithServiceBinding("dagger-engine", devEngine).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint).
 		WithMountedFile(cliBinPath, util.DaggerBinary(c)).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
+		WithExec([]string{"rustup", "component", "add", "rustfmt"}).
 		WithExec([]string{"cargo", "run", "-p", "dagger-bootstrap", "generate", "--output", fmt.Sprintf("/%s", rustGeneratedAPIPath)}).
 		WithExec([]string{"cargo", "fix", "--all", "--allow-no-vcs"}).
 		WithExec([]string{"cargo", "fmt"})

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
 dependencies = [
  "gimli",
 ]
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "anstream"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6342bd4f5a1205d7f41e94a41a901f5647c938cdfa96036338e8533c9d6c2450"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -34,15 +34,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
 dependencies = [
  "utf8parse",
 ]
@@ -53,7 +53,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -63,7 +63,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -80,7 +80,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -91,9 +91,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
 dependencies = [
  "addr2line",
  "cc",
@@ -106,15 +106,21 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "block-buffer"
@@ -127,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.1"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byteorder"
@@ -157,31 +163,30 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.2.4"
+version = "4.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ac1f6381d8d82ab4684768f89c0ea3afe66925ceadb4eeb3fc452ffc55d62"
+checksum = "384e169cc618c613d5e3ca6404dda77a8685a63e08660dcc64abaf7da7cb0c7a"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.2.4"
+version = "4.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84080e799e54cff944f4b4a4b0e71630b0e0443b25b985175c7dddc1a859b749"
+checksum = "ef137bbe35aab78bdb468ccfba75a5f4d8321ae011d34063770780545176af2d"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
  "clap_lex",
  "strsim",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "color-eyre"
@@ -240,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
 dependencies = [
  "libc",
 ]
@@ -409,9 +414,9 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -460,7 +465,7 @@ checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -501,14 +506,14 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall 0.2.16",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -522,9 +527,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
@@ -585,7 +590,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -652,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -663,9 +668,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "graphql-introspection-query"
@@ -728,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.18"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
+checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
 dependencies = [
  "bytes",
  "fnv",
@@ -756,15 +761,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -820,9 +816,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.26"
+version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -844,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
 dependencies = [
  "http",
  "hyper",
@@ -863,9 +859,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -898,31 +894,30 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.7.2"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
 dependencies = [
- "hermit-abi 0.3.1",
- "io-lifetimes",
- "rustix",
- "windows-sys 0.48.0",
+ "hermit-abi",
+ "rustix 0.38.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -942,9 +937,9 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -957,21 +952,27 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.4"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -979,12 +980,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "matchers"
@@ -1009,23 +1007,22 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "log",
  "wasi",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1040,28 +1037,28 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.30.3"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "output_vt100"
@@ -1096,22 +1093,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall 0.3.5",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets",
 ]
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project-lite"
@@ -1155,18 +1152,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -1207,7 +1204,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1216,7 +1213,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1232,11 +1229,11 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
- "regex-syntax 0.7.1",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -1256,9 +1253,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "relative-path"
@@ -1268,9 +1265,9 @@ checksum = "4bf2521270932c3c7bed1a59151222bd7643c79310f2916f01925e1e16255698"
 
 [[package]]
 name = "reqwest"
-version = "0.11.16"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
  "base64",
  "bytes",
@@ -1330,37 +1327,60 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.37.14"
+version = "0.37.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b864d3c18a5785a05953adeed93e2dca37ed30f18e69bba9f30079d51f363f"
+checksum = "62f25693a73057a1b4cb56179dd3c7ea21a7c6c5ee7d85781f5749b46f34b79c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
- "windows-sys 0.48.0",
+ "linux-raw-sys 0.3.8",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc6396159432b5c8490d4e301d8c705f61860b8b6c863bf79942ce5401968f3"
+dependencies = [
+ "bitflags 2.3.3",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.3",
+ "windows-sys",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.20.8"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+checksum = "e32ca28af694bc1bbf399c33a516dbdf1c90090b8ab23c2bc24f834aa2247f5f"
 dependencies = [
  "log",
  "ring",
+ "rustls-webpki",
  "sct",
- "webpki",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
  "base64",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1387,29 +1407,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.22",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
 dependencies = [
  "itoa",
  "ryu",
@@ -1430,9 +1450,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1507,9 +1527,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1529,15 +1549,16 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix",
- "windows-sys 0.45.0",
+ "rustix 0.37.21",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1557,7 +1578,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -1587,11 +1608,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.27.0"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -1601,36 +1623,35 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.22",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
  "tokio",
- "webpki",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1661,20 +1682,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.22",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1762,9 +1783,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-normalization"
@@ -1798,9 +1819,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1833,11 +1854,10 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log",
  "try-lock",
 ]
 
@@ -1849,9 +1869,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1859,24 +1879,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.22",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.34"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1886,9 +1906,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1896,22 +1916,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.22",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-streams"
@@ -1928,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1979,57 +1999,27 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2039,21 +2029,9 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2063,21 +2041,9 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2087,21 +2053,9 @@ checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -320,7 +320,6 @@ dependencies = [
  "eyre",
  "flate2",
  "futures",
- "genco",
  "graphql_client",
  "hex",
  "hex-literal",

--- a/sdk/rust/crates/dagger-codegen/src/rust/functions.rs
+++ b/sdk/rust/crates/dagger-codegen/src/rust/functions.rs
@@ -334,9 +334,9 @@ fn format_function_args(
             });
 
             let description = quote! {
-                $(if argument_description.len() > 0 => $(format!("/// ")))
-                $(if argument_description.len() > 0 => $(format!("/// # Arguments")))
-                $(if argument_description.len() > 0 => $(format!("/// ")))
+                $(if argument_description.len() > 0 => $(format!("///\n")))
+                $(if argument_description.len() > 0 => $(format!("/// # Arguments\n")))
+                $(if argument_description.len() > 0 => $(format!("///\n")))
                 $(for arg_desc in argument_description join ($['\r']) => $arg_desc)
             };
 
@@ -350,9 +350,9 @@ fn format_function_args(
             ))
         } else {
             let description = quote! {
-                $(if argument_description.len() > 0 => $(format!("/// ")))
-                $(if argument_description.len() > 0 => $(format!("/// # Arguments")))
-                $(if argument_description.len() > 0 => $(format!("/// ")))
+                $(if argument_description.len() > 0 => $(format!("///\n")))
+                $(if argument_description.len() > 0 => $(format!("/// # Arguments\n")))
+                $(if argument_description.len() > 0 => $(format!("///\n")))
                 $(for arg_desc in argument_description join ($['\r']) => $arg_desc)
             };
             Some((required_args, description, false))

--- a/sdk/rust/crates/dagger-sdk/Cargo.toml
+++ b/sdk/rust/crates/dagger-sdk/Cargo.toml
@@ -46,7 +46,6 @@ async-trait = "0.1.67"
 [dev-dependencies]
 pretty_assertions = "1.3.0"
 rand = "0.8.5"
-genco = "0.17.3"
 tracing-test = "0.2.4"
 
 [features]

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -333,7 +333,10 @@ pub struct ContainerWithoutExposedPortOpts {
 }
 impl Container {
     /// Initializes this container from a Dockerfile build.
-    ///  /// # Arguments ///  /// * `context` - Directory context used by the Dockerfile.
+    ///
+    /// # Arguments
+    ///
+    /// * `context` - Directory context used by the Dockerfile.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn build(&self, context: DirectoryId) -> Container {
         let mut query = self.selection.select("build");
@@ -345,7 +348,10 @@ impl Container {
         };
     }
     /// Initializes this container from a Dockerfile build.
-    ///  /// # Arguments ///  /// * `context` - Directory context used by the Dockerfile.
+    ///
+    /// # Arguments
+    ///
+    /// * `context` - Directory context used by the Dockerfile.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn build_opts<'a>(&self, context: DirectoryId, opts: ContainerBuildOpts<'a>) -> Container {
         let mut query = self.selection.select("build");
@@ -375,7 +381,10 @@ impl Container {
     }
     /// Retrieves a directory at the given path.
     /// Mounts are included.
-    ///  /// # Arguments ///  /// * `path` - The path of the directory to retrieve (e.g., "./src").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path of the directory to retrieve (e.g., "./src").
     pub fn directory(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("directory");
         query = query.arg("path", path.into());
@@ -389,7 +398,10 @@ impl Container {
     /// If no port is specified, the first exposed port is used. If none exist an error is returned.
     /// If a scheme is specified, a URL is returned. Otherwise, a host:port pair is returned.
     /// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
-    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn endpoint(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("endpoint");
         query.execute(self.graphql_client.clone()).await
@@ -398,7 +410,10 @@ impl Container {
     /// If no port is specified, the first exposed port is used. If none exist an error is returned.
     /// If a scheme is specified, a URL is returned. Otherwise, a host:port pair is returned.
     /// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
-    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn endpoint_opts<'a>(
         &self,
         opts: ContainerEndpointOpts<'a>,
@@ -418,7 +433,10 @@ impl Container {
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the value of the specified environment variable.
-    ///  /// # Arguments ///  /// * `name` - The name of the environment variable to retrieve (e.g., "PATH").
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the environment variable to retrieve (e.g., "PATH").
     pub async fn env_variable(&self, name: impl Into<String>) -> Result<String, DaggerError> {
         let mut query = self.selection.select("envVariable");
         query = query.arg("name", name.into());
@@ -434,7 +452,10 @@ impl Container {
         }];
     }
     /// Retrieves this container after executing the specified command inside it.
-    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn exec(&self) -> Container {
         let query = self.selection.select("exec");
         return Container {
@@ -444,7 +465,10 @@ impl Container {
         };
     }
     /// Retrieves this container after executing the specified command inside it.
-    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn exec_opts<'a>(&self, opts: ContainerExecOpts<'a>) -> Container {
         let mut query = self.selection.select("exec");
         if let Some(args) = opts.args {
@@ -480,7 +504,10 @@ impl Container {
     /// Writes the container as an OCI tarball to the destination file path on the host for the specified platform variants.
     /// Return true on success.
     /// It can also publishes platform variants.
-    ///  /// # Arguments ///  /// * `path` - Host's destination path (e.g., "./tarball").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Host's destination path (e.g., "./tarball").
     /// Path can be relative to the engine's workdir or absolute.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn export(&self, path: impl Into<String>) -> Result<bool, DaggerError> {
@@ -491,7 +518,10 @@ impl Container {
     /// Writes the container as an OCI tarball to the destination file path on the host for the specified platform variants.
     /// Return true on success.
     /// It can also publishes platform variants.
-    ///  /// # Arguments ///  /// * `path` - Host's destination path (e.g., "./tarball").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Host's destination path (e.g., "./tarball").
     /// Path can be relative to the engine's workdir or absolute.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn export_opts(
@@ -518,7 +548,10 @@ impl Container {
     }
     /// Retrieves a file at the given path.
     /// Mounts are included.
-    ///  /// # Arguments ///  /// * `path` - The path of the file to retrieve (e.g., "./README.md").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path of the file to retrieve (e.g., "./README.md").
     pub fn file(&self, path: impl Into<String>) -> File {
         let mut query = self.selection.select("file");
         query = query.arg("path", path.into());
@@ -529,7 +562,10 @@ impl Container {
         };
     }
     /// Initializes this container from a pulled base image.
-    ///  /// # Arguments ///  /// * `address` - Image's address from its registry.
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - Image's address from its registry.
     ///
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g., "docker.io/dagger/dagger:main").
     pub fn from(&self, address: impl Into<String>) -> Container {
@@ -569,7 +605,10 @@ impl Container {
     /// Reads the container from an OCI tarball.
     /// NOTE: this involves unpacking the tarball to an OCI store on the host at
     /// $XDG_CACHE_DIR/dagger/oci. This directory can be removed whenever you like.
-    ///  /// # Arguments ///  /// * `source` - File to read the container from.
+    ///
+    /// # Arguments
+    ///
+    /// * `source` - File to read the container from.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn import(&self, source: FileId) -> Container {
         let mut query = self.selection.select("import");
@@ -583,7 +622,10 @@ impl Container {
     /// Reads the container from an OCI tarball.
     /// NOTE: this involves unpacking the tarball to an OCI store on the host at
     /// $XDG_CACHE_DIR/dagger/oci. This directory can be removed whenever you like.
-    ///  /// # Arguments ///  /// * `source` - File to read the container from.
+    ///
+    /// # Arguments
+    ///
+    /// * `source` - File to read the container from.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn import_opts<'a>(&self, source: FileId, opts: ContainerImportOpts<'a>) -> Container {
         let mut query = self.selection.select("import");
@@ -618,7 +660,10 @@ impl Container {
         query.execute(self.graphql_client.clone()).await
     }
     /// Creates a named sub-pipeline
-    ///  /// # Arguments ///  /// * `name` - Pipeline name.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Pipeline name.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn pipeline(&self, name: impl Into<String>) -> Container {
         let mut query = self.selection.select("pipeline");
@@ -630,7 +675,10 @@ impl Container {
         };
     }
     /// Creates a named sub-pipeline
-    ///  /// # Arguments ///  /// * `name` - Pipeline name.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Pipeline name.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn pipeline_opts<'a>(
         &self,
@@ -659,7 +707,10 @@ impl Container {
     /// Publishes this container as a new image to the specified address.
     /// Publish returns a fully qualified ref.
     /// It can also publish platform variants.
-    ///  /// # Arguments ///  /// * `address` - Registry's address to publish the image to.
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - Registry's address to publish the image to.
     ///
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g. "docker.io/dagger/dagger:main").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -671,7 +722,10 @@ impl Container {
     /// Publishes this container as a new image to the specified address.
     /// Publish returns a fully qualified ref.
     /// It can also publish platform variants.
-    ///  /// # Arguments ///  /// * `address` - Registry's address to publish the image to.
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - Registry's address to publish the image to.
     ///
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g. "docker.io/dagger/dagger:main").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -714,7 +768,10 @@ impl Container {
         query.execute(self.graphql_client.clone()).await
     }
     /// Configures default arguments for future commands.
-    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_default_args(&self) -> Container {
         let query = self.selection.select("withDefaultArgs");
         return Container {
@@ -724,7 +781,10 @@ impl Container {
         };
     }
     /// Configures default arguments for future commands.
-    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_default_args_opts<'a>(&self, opts: ContainerWithDefaultArgsOpts<'a>) -> Container {
         let mut query = self.selection.select("withDefaultArgs");
         if let Some(args) = opts.args {
@@ -737,7 +797,10 @@ impl Container {
         };
     }
     /// Retrieves this container plus a directory written at the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the written directory (e.g., "/tmp/directory").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the written directory (e.g., "/tmp/directory").
     /// * `directory` - Identifier of the directory to write
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_directory(&self, path: impl Into<String>, directory: DirectoryId) -> Container {
@@ -751,7 +814,10 @@ impl Container {
         };
     }
     /// Retrieves this container plus a directory written at the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the written directory (e.g., "/tmp/directory").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the written directory (e.g., "/tmp/directory").
     /// * `directory` - Identifier of the directory to write
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_directory_opts<'a>(
@@ -779,7 +845,10 @@ impl Container {
         };
     }
     /// Retrieves this container but with a different command entrypoint.
-    ///  /// # Arguments ///  /// * `args` - Entrypoint to use for future executions (e.g., ["go", "run"]).
+    ///
+    /// # Arguments
+    ///
+    /// * `args` - Entrypoint to use for future executions (e.g., ["go", "run"]).
     pub fn with_entrypoint(&self, args: Vec<impl Into<String>>) -> Container {
         let mut query = self.selection.select("withEntrypoint");
         query = query.arg(
@@ -793,7 +862,10 @@ impl Container {
         };
     }
     /// Retrieves this container plus the given environment variable.
-    ///  /// # Arguments ///  /// * `name` - The name of the environment variable (e.g., "HOST").
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the environment variable (e.g., "HOST").
     /// * `value` - The value of the environment variable. (e.g., "localhost").
     pub fn with_env_variable(
         &self,
@@ -810,7 +882,10 @@ impl Container {
         };
     }
     /// Retrieves this container after executing the specified command inside it.
-    ///  /// # Arguments ///  /// * `args` - Command to run instead of the container's default command (e.g., ["run", "main.go"]).
+    ///
+    /// # Arguments
+    ///
+    /// * `args` - Command to run instead of the container's default command (e.g., ["run", "main.go"]).
     ///
     /// If empty, the container's default command is used.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -827,7 +902,10 @@ impl Container {
         };
     }
     /// Retrieves this container after executing the specified command inside it.
-    ///  /// # Arguments ///  /// * `args` - Command to run instead of the container's default command (e.g., ["run", "main.go"]).
+    ///
+    /// # Arguments
+    ///
+    /// * `args` - Command to run instead of the container's default command (e.g., ["run", "main.go"]).
     ///
     /// If empty, the container's default command is used.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -873,7 +951,10 @@ impl Container {
     /// - For health checks and introspection, when running services
     /// - For setting the EXPOSE OCI field when publishing the container
     /// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
-    ///  /// # Arguments ///  /// * `port` - Port number to expose
+    ///
+    /// # Arguments
+    ///
+    /// * `port` - Port number to expose
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_exposed_port(&self, port: isize) -> Container {
         let mut query = self.selection.select("withExposedPort");
@@ -889,7 +970,10 @@ impl Container {
     /// - For health checks and introspection, when running services
     /// - For setting the EXPOSE OCI field when publishing the container
     /// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
-    ///  /// # Arguments ///  /// * `port` - Port number to expose
+    ///
+    /// # Arguments
+    ///
+    /// * `port` - Port number to expose
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_exposed_port_opts<'a>(
         &self,
@@ -921,7 +1005,10 @@ impl Container {
         };
     }
     /// Retrieves this container plus the contents of the given file copied to the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the copied file (e.g., "/tmp/file.txt").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the copied file (e.g., "/tmp/file.txt").
     /// * `source` - Identifier of the file to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_file(&self, path: impl Into<String>, source: FileId) -> Container {
@@ -935,7 +1022,10 @@ impl Container {
         };
     }
     /// Retrieves this container plus the contents of the given file copied to the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the copied file (e.g., "/tmp/file.txt").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the copied file (e.g., "/tmp/file.txt").
     /// * `source` - Identifier of the file to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_file_opts<'a>(
@@ -960,7 +1050,10 @@ impl Container {
         };
     }
     /// Retrieves this container plus the given label.
-    ///  /// # Arguments ///  /// * `name` - The name of the label (e.g., "org.opencontainers.artifact.created").
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the label (e.g., "org.opencontainers.artifact.created").
     /// * `value` - The value of the label (e.g., "2023-01-01T00:00:00Z").
     pub fn with_label(&self, name: impl Into<String>, value: impl Into<String>) -> Container {
         let mut query = self.selection.select("withLabel");
@@ -973,7 +1066,10 @@ impl Container {
         };
     }
     /// Retrieves this container plus a cache volume mounted at the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the cache directory (e.g., "/cache/node_modules").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the cache directory (e.g., "/cache/node_modules").
     /// * `cache` - Identifier of the cache volume to mount.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_mounted_cache(&self, path: impl Into<String>, cache: CacheId) -> Container {
@@ -987,7 +1083,10 @@ impl Container {
         };
     }
     /// Retrieves this container plus a cache volume mounted at the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the cache directory (e.g., "/cache/node_modules").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the cache directory (e.g., "/cache/node_modules").
     /// * `cache` - Identifier of the cache volume to mount.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_mounted_cache_opts<'a>(
@@ -1015,7 +1114,10 @@ impl Container {
         };
     }
     /// Retrieves this container plus a directory mounted at the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the mounted directory (e.g., "/mnt/directory").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the mounted directory (e.g., "/mnt/directory").
     /// * `source` - Identifier of the mounted directory.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_mounted_directory(
@@ -1033,7 +1135,10 @@ impl Container {
         };
     }
     /// Retrieves this container plus a directory mounted at the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the mounted directory (e.g., "/mnt/directory").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the mounted directory (e.g., "/mnt/directory").
     /// * `source` - Identifier of the mounted directory.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_mounted_directory_opts<'a>(
@@ -1055,7 +1160,10 @@ impl Container {
         };
     }
     /// Retrieves this container plus a file mounted at the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the mounted file (e.g., "/tmp/file.txt").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the mounted file (e.g., "/tmp/file.txt").
     /// * `source` - Identifier of the mounted file.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_mounted_file(&self, path: impl Into<String>, source: FileId) -> Container {
@@ -1069,7 +1177,10 @@ impl Container {
         };
     }
     /// Retrieves this container plus a file mounted at the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the mounted file (e.g., "/tmp/file.txt").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the mounted file (e.g., "/tmp/file.txt").
     /// * `source` - Identifier of the mounted file.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_mounted_file_opts<'a>(
@@ -1091,7 +1202,10 @@ impl Container {
         };
     }
     /// Retrieves this container plus a secret mounted into a file at the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the secret file (e.g., "/tmp/secret.txt").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the secret file (e.g., "/tmp/secret.txt").
     /// * `source` - Identifier of the secret to mount.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_mounted_secret(&self, path: impl Into<String>, source: SecretId) -> Container {
@@ -1105,7 +1219,10 @@ impl Container {
         };
     }
     /// Retrieves this container plus a secret mounted into a file at the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the secret file (e.g., "/tmp/secret.txt").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the secret file (e.g., "/tmp/secret.txt").
     /// * `source` - Identifier of the secret to mount.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_mounted_secret_opts<'a>(
@@ -1127,7 +1244,10 @@ impl Container {
         };
     }
     /// Retrieves this container plus a temporary directory mounted at the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the temporary directory (e.g., "/tmp/temp_dir").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the temporary directory (e.g., "/tmp/temp_dir").
     pub fn with_mounted_temp(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withMountedTemp");
         query = query.arg("path", path.into());
@@ -1138,7 +1258,10 @@ impl Container {
         };
     }
     /// Retrieves this container plus a new file written at the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the written file (e.g., "/tmp/file.txt").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the written file (e.g., "/tmp/file.txt").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_new_file(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withNewFile");
@@ -1150,7 +1273,10 @@ impl Container {
         };
     }
     /// Retrieves this container plus a new file written at the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the written file (e.g., "/tmp/file.txt").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the written file (e.g., "/tmp/file.txt").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_new_file_opts<'a>(
         &self,
@@ -1175,7 +1301,10 @@ impl Container {
         };
     }
     /// Retrieves this container with a registry authentication for a given address.
-    ///  /// # Arguments ///  /// * `address` - Registry's address to bind the authentication to.
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - Registry's address to bind the authentication to.
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g. docker.io/dagger/dagger:main).
     /// * `username` - The username of the registry's account (e.g., "Dagger").
     /// * `secret` - The API key, password or token to authenticate to this registry.
@@ -1206,7 +1335,10 @@ impl Container {
         };
     }
     /// Retrieves this container plus an env variable containing the given secret.
-    ///  /// # Arguments ///  /// * `name` - The name of the secret variable (e.g., "API_SECRET").
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the secret variable (e.g., "API_SECRET").
     /// * `secret` - The identifier of the secret value.
     pub fn with_secret_variable(&self, name: impl Into<String>, secret: SecretId) -> Container {
         let mut query = self.selection.select("withSecretVariable");
@@ -1224,7 +1356,10 @@ impl Container {
     /// The service will be reachable from the container via the provided hostname alias.
     /// The service dependency will also convey to any files or directories produced by the container.
     /// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
-    ///  /// # Arguments ///  /// * `alias` - A name that can be used to reach the service from the container
+    ///
+    /// # Arguments
+    ///
+    /// * `alias` - A name that can be used to reach the service from the container
     /// * `service` - Identifier of the service container
     pub fn with_service_binding(
         &self,
@@ -1241,7 +1376,10 @@ impl Container {
         };
     }
     /// Retrieves this container plus a socket forwarded to the given Unix socket path.
-    ///  /// # Arguments ///  /// * `path` - Location of the forwarded Unix socket (e.g., "/tmp/socket").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the forwarded Unix socket (e.g., "/tmp/socket").
     /// * `source` - Identifier of the socket to forward.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_unix_socket(&self, path: impl Into<String>, source: SocketId) -> Container {
@@ -1255,7 +1393,10 @@ impl Container {
         };
     }
     /// Retrieves this container plus a socket forwarded to the given Unix socket path.
-    ///  /// # Arguments ///  /// * `path` - Location of the forwarded Unix socket (e.g., "/tmp/socket").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the forwarded Unix socket (e.g., "/tmp/socket").
     /// * `source` - Identifier of the socket to forward.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_unix_socket_opts<'a>(
@@ -1277,7 +1418,10 @@ impl Container {
         };
     }
     /// Retrieves this container with a different command user.
-    ///  /// # Arguments ///  /// * `name` - The user to set (e.g., "root").
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The user to set (e.g., "root").
     pub fn with_user(&self, name: impl Into<String>) -> Container {
         let mut query = self.selection.select("withUser");
         query = query.arg("name", name.into());
@@ -1288,7 +1432,10 @@ impl Container {
         };
     }
     /// Retrieves this container with a different working directory.
-    ///  /// # Arguments ///  /// * `path` - The path to set as the working directory (e.g., "/app").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path to set as the working directory (e.g., "/app").
     pub fn with_workdir(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withWorkdir");
         query = query.arg("path", path.into());
@@ -1299,7 +1446,10 @@ impl Container {
         };
     }
     /// Retrieves this container minus the given environment variable.
-    ///  /// # Arguments ///  /// * `name` - The name of the environment variable (e.g., "HOST").
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the environment variable (e.g., "HOST").
     pub fn without_env_variable(&self, name: impl Into<String>) -> Container {
         let mut query = self.selection.select("withoutEnvVariable");
         query = query.arg("name", name.into());
@@ -1311,7 +1461,10 @@ impl Container {
     }
     /// Unexpose a previously exposed port.
     /// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
-    ///  /// # Arguments ///  /// * `port` - Port number to unexpose
+    ///
+    /// # Arguments
+    ///
+    /// * `port` - Port number to unexpose
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn without_exposed_port(&self, port: isize) -> Container {
         let mut query = self.selection.select("withoutExposedPort");
@@ -1324,7 +1477,10 @@ impl Container {
     }
     /// Unexpose a previously exposed port.
     /// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
-    ///  /// # Arguments ///  /// * `port` - Port number to unexpose
+    ///
+    /// # Arguments
+    ///
+    /// * `port` - Port number to unexpose
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn without_exposed_port_opts(
         &self,
@@ -1343,7 +1499,10 @@ impl Container {
         };
     }
     /// Retrieves this container minus the given environment label.
-    ///  /// # Arguments ///  /// * `name` - The name of the label to remove (e.g., "org.opencontainers.artifact.created").
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the label to remove (e.g., "org.opencontainers.artifact.created").
     pub fn without_label(&self, name: impl Into<String>) -> Container {
         let mut query = self.selection.select("withoutLabel");
         query = query.arg("name", name.into());
@@ -1354,7 +1513,10 @@ impl Container {
         };
     }
     /// Retrieves this container after unmounting everything at the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the cache directory (e.g., "/cache/node_modules").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the cache directory (e.g., "/cache/node_modules").
     pub fn without_mount(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withoutMount");
         query = query.arg("path", path.into());
@@ -1365,7 +1527,10 @@ impl Container {
         };
     }
     /// Retrieves this container without the registry authentication of a given address.
-    ///  /// # Arguments ///  /// * `address` - Registry's address to remove the authentication from.
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - Registry's address to remove the authentication from.
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g. docker.io/dagger/dagger:main).
     pub fn without_registry_auth(&self, address: impl Into<String>) -> Container {
         let mut query = self.selection.select("withoutRegistryAuth");
@@ -1377,7 +1542,10 @@ impl Container {
         };
     }
     /// Retrieves this container with a previously added Unix socket removed.
-    ///  /// # Arguments ///  /// * `path` - Location of the socket to remove (e.g., "/tmp/socket").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the socket to remove (e.g., "/tmp/socket").
     pub fn without_unix_socket(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withoutUnixSocket");
         query = query.arg("path", path.into());
@@ -1466,7 +1634,10 @@ pub struct DirectoryWithNewFileOpts {
 }
 impl Directory {
     /// Gets the difference between this directory and an another directory.
-    ///  /// # Arguments ///  /// * `other` - Identifier of the directory to compare.
+    ///
+    /// # Arguments
+    ///
+    /// * `other` - Identifier of the directory to compare.
     pub fn diff(&self, other: DirectoryId) -> Directory {
         let mut query = self.selection.select("diff");
         query = query.arg("other", other);
@@ -1477,7 +1648,10 @@ impl Directory {
         };
     }
     /// Retrieves a directory at the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the directory to retrieve (e.g., "/src").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the directory to retrieve (e.g., "/src").
     pub fn directory(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("directory");
         query = query.arg("path", path.into());
@@ -1488,7 +1662,10 @@ impl Directory {
         };
     }
     /// Builds a new Docker container from this directory.
-    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn docker_build(&self) -> Container {
         let query = self.selection.select("dockerBuild");
         return Container {
@@ -1498,7 +1675,10 @@ impl Directory {
         };
     }
     /// Builds a new Docker container from this directory.
-    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn docker_build_opts<'a>(&self, opts: DirectoryDockerBuildOpts<'a>) -> Container {
         let mut query = self.selection.select("dockerBuild");
         if let Some(dockerfile) = opts.dockerfile {
@@ -1523,13 +1703,19 @@ impl Directory {
         };
     }
     /// Returns a list of files and directories at the given path.
-    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn entries(&self) -> Result<Vec<String>, DaggerError> {
         let query = self.selection.select("entries");
         query.execute(self.graphql_client.clone()).await
     }
     /// Returns a list of files and directories at the given path.
-    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn entries_opts<'a>(
         &self,
         opts: DirectoryEntriesOpts<'a>,
@@ -1541,14 +1727,20 @@ impl Directory {
         query.execute(self.graphql_client.clone()).await
     }
     /// Writes the contents of the directory to a path on the host.
-    ///  /// # Arguments ///  /// * `path` - Location of the copied directory (e.g., "logs/").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the copied directory (e.g., "logs/").
     pub async fn export(&self, path: impl Into<String>) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
         query = query.arg("path", path.into());
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves a file at the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the file to retrieve (e.g., "README.md").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the file to retrieve (e.g., "README.md").
     pub fn file(&self, path: impl Into<String>) -> File {
         let mut query = self.selection.select("file");
         query = query.arg("path", path.into());
@@ -1574,7 +1766,10 @@ impl Directory {
         };
     }
     /// Creates a named sub-pipeline
-    ///  /// # Arguments ///  /// * `name` - Pipeline name.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Pipeline name.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn pipeline(&self, name: impl Into<String>) -> Directory {
         let mut query = self.selection.select("pipeline");
@@ -1586,7 +1781,10 @@ impl Directory {
         };
     }
     /// Creates a named sub-pipeline
-    ///  /// # Arguments ///  /// * `name` - Pipeline name.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Pipeline name.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn pipeline_opts<'a>(
         &self,
@@ -1608,7 +1806,10 @@ impl Directory {
         };
     }
     /// Retrieves this directory plus a directory written at the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the written directory (e.g., "/src/").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the written directory (e.g., "/src/").
     /// * `directory` - Identifier of the directory to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_directory(&self, path: impl Into<String>, directory: DirectoryId) -> Directory {
@@ -1622,7 +1823,10 @@ impl Directory {
         };
     }
     /// Retrieves this directory plus a directory written at the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the written directory (e.g., "/src/").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the written directory (e.g., "/src/").
     /// * `directory` - Identifier of the directory to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_directory_opts<'a>(
@@ -1647,7 +1851,10 @@ impl Directory {
         };
     }
     /// Retrieves this directory plus the contents of the given file copied to the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the copied file (e.g., "/file.txt").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the copied file (e.g., "/file.txt").
     /// * `source` - Identifier of the file to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_file(&self, path: impl Into<String>, source: FileId) -> Directory {
@@ -1661,7 +1868,10 @@ impl Directory {
         };
     }
     /// Retrieves this directory plus the contents of the given file copied to the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the copied file (e.g., "/file.txt").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the copied file (e.g., "/file.txt").
     /// * `source` - Identifier of the file to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_file_opts(
@@ -1683,7 +1893,10 @@ impl Directory {
         };
     }
     /// Retrieves this directory plus a new directory created at the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the directory created (e.g., "/logs").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the directory created (e.g., "/logs").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_new_directory(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("withNewDirectory");
@@ -1695,7 +1908,10 @@ impl Directory {
         };
     }
     /// Retrieves this directory plus a new directory created at the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the directory created (e.g., "/logs").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the directory created (e.g., "/logs").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_new_directory_opts(
         &self,
@@ -1714,7 +1930,10 @@ impl Directory {
         };
     }
     /// Retrieves this directory plus a new file written at the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the written file (e.g., "/file.txt").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the written file (e.g., "/file.txt").
     /// * `contents` - Content of the written file (e.g., "Hello world!").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_new_file(&self, path: impl Into<String>, contents: impl Into<String>) -> Directory {
@@ -1728,7 +1947,10 @@ impl Directory {
         };
     }
     /// Retrieves this directory plus a new file written at the given path.
-    ///  /// # Arguments ///  /// * `path` - Location of the written file (e.g., "/file.txt").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the written file (e.g., "/file.txt").
     /// * `contents` - Content of the written file (e.g., "Hello world!").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_new_file_opts(
@@ -1750,7 +1972,10 @@ impl Directory {
         };
     }
     /// Retrieves this directory with all file/dir timestamps set to the given time.
-    ///  /// # Arguments ///  /// * `timestamp` - Timestamp to set dir/files in.
+    ///
+    /// # Arguments
+    ///
+    /// * `timestamp` - Timestamp to set dir/files in.
     ///
     /// Formatted in seconds following Unix epoch (e.g., 1672531199).
     pub fn with_timestamps(&self, timestamp: isize) -> Directory {
@@ -1763,7 +1988,10 @@ impl Directory {
         };
     }
     /// Retrieves this directory with the directory at the given path removed.
-    ///  /// # Arguments ///  /// * `path` - Location of the directory to remove (e.g., ".github/").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the directory to remove (e.g., ".github/").
     pub fn without_directory(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("withoutDirectory");
         query = query.arg("path", path.into());
@@ -1774,7 +2002,10 @@ impl Directory {
         };
     }
     /// Retrieves this directory with the file at the given path removed.
-    ///  /// # Arguments ///  /// * `path` - Location of the file to remove (e.g., "/file.txt").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the file to remove (e.g., "/file.txt").
     pub fn without_file(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("withoutFile");
         query = query.arg("path", path.into());
@@ -1816,7 +2047,10 @@ impl File {
         query.execute(self.graphql_client.clone()).await
     }
     /// Writes the file to a file path on the host.
-    ///  /// # Arguments ///  /// * `path` - Location of the written directory (e.g., "output.txt").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the written directory (e.g., "output.txt").
     pub async fn export(&self, path: impl Into<String>) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
         query = query.arg("path", path.into());
@@ -1842,7 +2076,10 @@ impl File {
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves this file with its created/modified timestamps set to the given time.
-    ///  /// # Arguments ///  /// * `timestamp` - Timestamp to set dir/files in.
+    ///
+    /// # Arguments
+    ///
+    /// * `timestamp` - Timestamp to set dir/files in.
     ///
     /// Formatted in seconds following Unix epoch (e.g., 1672531199).
     pub fn with_timestamps(&self, timestamp: isize) -> File {
@@ -1875,7 +2112,10 @@ impl GitRef {
         query.execute(self.graphql_client.clone()).await
     }
     /// The filesystem tree at this ref.
-    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn tree(&self) -> Directory {
         let query = self.selection.select("tree");
         return Directory {
@@ -1885,7 +2125,10 @@ impl GitRef {
         };
     }
     /// The filesystem tree at this ref.
-    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn tree_opts<'a>(&self, opts: GitRefTreeOpts<'a>) -> Directory {
         let mut query = self.selection.select("tree");
         if let Some(ssh_known_hosts) = opts.ssh_known_hosts {
@@ -1909,7 +2152,10 @@ pub struct GitRepository {
 }
 impl GitRepository {
     /// Returns details on one branch.
-    ///  /// # Arguments ///  /// * `name` - Branch's name (e.g., "main").
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Branch's name (e.g., "main").
     pub fn branch(&self, name: impl Into<String>) -> GitRef {
         let mut query = self.selection.select("branch");
         query = query.arg("name", name.into());
@@ -1925,7 +2171,10 @@ impl GitRepository {
         query.execute(self.graphql_client.clone()).await
     }
     /// Returns details on one commit.
-    ///  /// # Arguments ///  /// * `id` - Identifier of the commit (e.g., "b6315d8f2810962c601af73f86831f6866ea798b").
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - Identifier of the commit (e.g., "b6315d8f2810962c601af73f86831f6866ea798b").
     pub fn commit(&self, id: impl Into<String>) -> GitRef {
         let mut query = self.selection.select("commit");
         query = query.arg("id", id.into());
@@ -1936,7 +2185,10 @@ impl GitRepository {
         };
     }
     /// Returns details on one tag.
-    ///  /// # Arguments ///  /// * `name` - Tag's name (e.g., "v0.3.9").
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Tag's name (e.g., "v0.3.9").
     pub fn tag(&self, name: impl Into<String>) -> GitRef {
         let mut query = self.selection.select("tag");
         query = query.arg("name", name.into());
@@ -1978,7 +2230,10 @@ pub struct HostWorkdirOpts<'a> {
 }
 impl Host {
     /// Accesses a directory on the host.
-    ///  /// # Arguments ///  /// * `path` - Location of the directory to access (e.g., ".").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the directory to access (e.g., ".").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn directory(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("directory");
@@ -1990,7 +2245,10 @@ impl Host {
         };
     }
     /// Accesses a directory on the host.
-    ///  /// # Arguments ///  /// * `path` - Location of the directory to access (e.g., ".").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the directory to access (e.g., ".").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn directory_opts<'a>(
         &self,
@@ -2012,7 +2270,10 @@ impl Host {
         };
     }
     /// Accesses an environment variable on the host.
-    ///  /// # Arguments ///  /// * `name` - Name of the environment variable (e.g., "PATH").
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Name of the environment variable (e.g., "PATH").
     pub fn env_variable(&self, name: impl Into<String>) -> HostVariable {
         let mut query = self.selection.select("envVariable");
         query = query.arg("name", name.into());
@@ -2023,7 +2284,10 @@ impl Host {
         };
     }
     /// Accesses a Unix socket on the host.
-    ///  /// # Arguments ///  /// * `path` - Location of the Unix socket (e.g., "/var/run/docker.sock").
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the Unix socket (e.g., "/var/run/docker.sock").
     pub fn unix_socket(&self, path: impl Into<String>) -> Socket {
         let mut query = self.selection.select("unixSocket");
         query = query.arg("path", path.into());
@@ -2034,7 +2298,10 @@ impl Host {
         };
     }
     /// Retrieves the current working directory on the host.
-    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn workdir(&self) -> Directory {
         let query = self.selection.select("workdir");
         return Directory {
@@ -2044,7 +2311,10 @@ impl Host {
         };
     }
     /// Retrieves the current working directory on the host.
-    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn workdir_opts<'a>(&self, opts: HostWorkdirOpts<'a>) -> Directory {
         let mut query = self.selection.select("workdir");
         if let Some(exclude) = opts.exclude {
@@ -2218,7 +2488,10 @@ pub struct QuerySocketOpts {
 }
 impl Query {
     /// Constructs a cache volume for a given cache key.
-    ///  /// # Arguments ///  /// * `key` - A string identifier to target this cache volume (e.g., "modules-cache").
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - A string identifier to target this cache volume (e.g., "modules-cache").
     pub fn cache_volume(&self, key: impl Into<String>) -> CacheVolume {
         let mut query = self.selection.select("cacheVolume");
         query = query.arg("key", key.into());
@@ -2232,7 +2505,10 @@ impl Query {
     /// Null ID returns an empty container (scratch).
     /// Optional platform argument initializes new containers to execute and publish as that platform.
     /// Platform defaults to that of the builder's host.
-    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn container(&self) -> Container {
         let query = self.selection.select("container");
         return Container {
@@ -2245,7 +2521,10 @@ impl Query {
     /// Null ID returns an empty container (scratch).
     /// Optional platform argument initializes new containers to execute and publish as that platform.
     /// Platform defaults to that of the builder's host.
-    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn container_opts(&self, opts: QueryContainerOpts) -> Container {
         let mut query = self.selection.select("container");
         if let Some(id) = opts.id {
@@ -2266,7 +2545,10 @@ impl Query {
         query.execute(self.graphql_client.clone()).await
     }
     /// Load a directory by ID. No argument produces an empty directory.
-    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn directory(&self) -> Directory {
         let query = self.selection.select("directory");
         return Directory {
@@ -2276,7 +2558,10 @@ impl Query {
         };
     }
     /// Load a directory by ID. No argument produces an empty directory.
-    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn directory_opts(&self, opts: QueryDirectoryOpts) -> Directory {
         let mut query = self.selection.select("directory");
         if let Some(id) = opts.id {
@@ -2299,7 +2584,10 @@ impl Query {
         };
     }
     /// Queries a git repository.
-    ///  /// # Arguments ///  /// * `url` - Url of the git repository.
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - Url of the git repository.
     /// Can be formatted as https://{host}/{owner}/{repo}, git@{host}/{owner}/{repo}
     /// Suffix ".git" is optional.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -2313,7 +2601,10 @@ impl Query {
         };
     }
     /// Queries a git repository.
-    ///  /// # Arguments ///  /// * `url` - Url of the git repository.
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - Url of the git repository.
     /// Can be formatted as https://{host}/{owner}/{repo}, git@{host}/{owner}/{repo}
     /// Suffix ".git" is optional.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -2342,7 +2633,10 @@ impl Query {
         };
     }
     /// Returns a file containing an http remote url content.
-    ///  /// # Arguments ///  /// * `url` - HTTP url to get the content from (e.g., "https://docs.dagger.io").
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - HTTP url to get the content from (e.g., "https://docs.dagger.io").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn http(&self, url: impl Into<String>) -> File {
         let mut query = self.selection.select("http");
@@ -2354,7 +2648,10 @@ impl Query {
         };
     }
     /// Returns a file containing an http remote url content.
-    ///  /// # Arguments ///  /// * `url` - HTTP url to get the content from (e.g., "https://docs.dagger.io").
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - HTTP url to get the content from (e.g., "https://docs.dagger.io").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn http_opts(&self, url: impl Into<String>, opts: QueryHttpOpts) -> File {
         let mut query = self.selection.select("http");
@@ -2369,7 +2666,10 @@ impl Query {
         };
     }
     /// Creates a named sub-pipeline.
-    ///  /// # Arguments ///  /// * `name` - Pipeline name.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Pipeline name.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn pipeline(&self, name: impl Into<String>) -> Query {
         let mut query = self.selection.select("pipeline");
@@ -2381,7 +2681,10 @@ impl Query {
         };
     }
     /// Creates a named sub-pipeline.
-    ///  /// # Arguments ///  /// * `name` - Pipeline name.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Pipeline name.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn pipeline_opts<'a>(&self, name: impl Into<String>, opts: QueryPipelineOpts<'a>) -> Query {
         let mut query = self.selection.select("pipeline");
@@ -2419,7 +2722,10 @@ impl Query {
         };
     }
     /// Sets a secret given a user defined name to its plaintext and returns the secret.
-    ///  /// # Arguments ///  /// * `name` - The user defined name for this secret
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The user defined name for this secret
     /// * `plaintext` - The plaintext of the secret
     pub fn set_secret(&self, name: impl Into<String>, plaintext: impl Into<String>) -> Secret {
         let mut query = self.selection.select("setSecret");
@@ -2432,7 +2738,10 @@ impl Query {
         };
     }
     /// Loads a socket by its ID.
-    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn socket(&self) -> Socket {
         let query = self.selection.select("socket");
         return Socket {
@@ -2442,7 +2751,10 @@ impl Query {
         };
     }
     /// Loads a socket by its ID.
-    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn socket_opts(&self, opts: QuerySocketOpts) -> Socket {
         let mut query = self.selection.select("socket");
         if let Some(id) = opts.id {

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -8,13 +8,11 @@ use tokio::process::Child;
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct CacheId(pub String);
-
 impl Into<CacheId> for &str {
     fn into(self) -> CacheId {
         CacheId(self.to_string())
     }
 }
-
 impl Into<CacheId> for String {
     fn into(self) -> CacheId {
         CacheId(self.clone())
@@ -22,13 +20,11 @@ impl Into<CacheId> for String {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct ContainerId(pub String);
-
 impl Into<ContainerId> for &str {
     fn into(self) -> ContainerId {
         ContainerId(self.to_string())
     }
 }
-
 impl Into<ContainerId> for String {
     fn into(self) -> ContainerId {
         ContainerId(self.clone())
@@ -36,13 +32,11 @@ impl Into<ContainerId> for String {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct DirectoryId(pub String);
-
 impl Into<DirectoryId> for &str {
     fn into(self) -> DirectoryId {
         DirectoryId(self.to_string())
     }
 }
-
 impl Into<DirectoryId> for String {
     fn into(self) -> DirectoryId {
         DirectoryId(self.clone())
@@ -50,13 +44,11 @@ impl Into<DirectoryId> for String {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct FileId(pub String);
-
 impl Into<FileId> for &str {
     fn into(self) -> FileId {
         FileId(self.to_string())
     }
 }
-
 impl Into<FileId> for String {
     fn into(self) -> FileId {
         FileId(self.clone())
@@ -64,13 +56,11 @@ impl Into<FileId> for String {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct Platform(pub String);
-
 impl Into<Platform> for &str {
     fn into(self) -> Platform {
         Platform(self.to_string())
     }
 }
-
 impl Into<Platform> for String {
     fn into(self) -> Platform {
         Platform(self.clone())
@@ -78,13 +68,11 @@ impl Into<Platform> for String {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct SecretId(pub String);
-
 impl Into<SecretId> for &str {
     fn into(self) -> SecretId {
         SecretId(self.to_string())
     }
 }
-
 impl Into<SecretId> for String {
     fn into(self) -> SecretId {
         SecretId(self.clone())
@@ -92,13 +80,11 @@ impl Into<SecretId> for String {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct SocketId(pub String);
-
 impl Into<SocketId> for &str {
     fn into(self) -> SocketId {
         SocketId(self.to_string())
     }
 }
-
 impl Into<SocketId> for String {
     fn into(self) -> SocketId {
         SocketId(self.clone())
@@ -120,11 +106,9 @@ pub struct CacheVolume {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl CacheVolume {
     pub async fn id(&self) -> Result<CacheId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -134,7 +118,6 @@ pub struct Container {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerBuildOpts<'a> {
     /// Additional build arguments.
@@ -348,35 +331,24 @@ pub struct ContainerWithoutExposedPortOpts {
     #[builder(setter(into, strip_option), default)]
     pub protocol: Option<NetworkProtocol>,
 }
-
 impl Container {
     /// Initializes this container from a Dockerfile build.
-    ///
-    /// # Arguments
-    ///
-    /// * `context` - Directory context used by the Dockerfile.
+    ///  /// # Arguments ///  /// * `context` - Directory context used by the Dockerfile.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn build(&self, context: DirectoryId) -> Container {
         let mut query = self.selection.select("build");
-
         query = query.arg("context", context);
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Initializes this container from a Dockerfile build.
-    ///
-    /// # Arguments
-    ///
-    /// * `context` - Directory context used by the Dockerfile.
+    ///  /// # Arguments ///  /// * `context` - Directory context used by the Dockerfile.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn build_opts<'a>(&self, context: DirectoryId, opts: ContainerBuildOpts<'a>) -> Container {
         let mut query = self.selection.select("build");
-
         query = query.arg("context", context);
         if let Some(dockerfile) = opts.dockerfile {
             query = query.arg("dockerfile", dockerfile);
@@ -390,7 +362,6 @@ impl Container {
         if let Some(secrets) = opts.secrets {
             query = query.arg("secrets", secrets);
         }
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -400,20 +371,14 @@ impl Container {
     /// Retrieves default arguments for future commands.
     pub async fn default_args(&self) -> Result<Vec<String>, DaggerError> {
         let query = self.selection.select("defaultArgs");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves a directory at the given path.
     /// Mounts are included.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - The path of the directory to retrieve (e.g., "./src").
+    ///  /// # Arguments ///  /// * `path` - The path of the directory to retrieve (e.g., "./src").
     pub fn directory(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("directory");
-
         query = query.arg("path", path.into());
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -424,61 +389,44 @@ impl Container {
     /// If no port is specified, the first exposed port is used. If none exist an error is returned.
     /// If a scheme is specified, a URL is returned. Otherwise, a host:port pair is returned.
     /// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn endpoint(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("endpoint");
-
         query.execute(self.graphql_client.clone()).await
     }
-
     /// Retrieves an endpoint that clients can use to reach this container.
     /// If no port is specified, the first exposed port is used. If none exist an error is returned.
     /// If a scheme is specified, a URL is returned. Otherwise, a host:port pair is returned.
     /// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn endpoint_opts<'a>(
         &self,
         opts: ContainerEndpointOpts<'a>,
     ) -> Result<String, DaggerError> {
         let mut query = self.selection.select("endpoint");
-
         if let Some(port) = opts.port {
             query = query.arg("port", port);
         }
         if let Some(scheme) = opts.scheme {
             query = query.arg("scheme", scheme);
         }
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves entrypoint to be prepended to the arguments of all commands.
     pub async fn entrypoint(&self) -> Result<Vec<String>, DaggerError> {
         let query = self.selection.select("entrypoint");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the value of the specified environment variable.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the environment variable to retrieve (e.g., "PATH").
+    ///  /// # Arguments ///  /// * `name` - The name of the environment variable to retrieve (e.g., "PATH").
     pub async fn env_variable(&self, name: impl Into<String>) -> Result<String, DaggerError> {
         let mut query = self.selection.select("envVariable");
-
         query = query.arg("name", name.into());
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the list of environment variables passed to commands.
     pub fn env_variables(&self) -> Vec<EnvVariable> {
         let query = self.selection.select("envVariables");
-
         return vec![EnvVariable {
             proc: self.proc.clone(),
             selection: query,
@@ -486,28 +434,19 @@ impl Container {
         }];
     }
     /// Retrieves this container after executing the specified command inside it.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn exec(&self) -> Container {
         let query = self.selection.select("exec");
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Retrieves this container after executing the specified command inside it.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn exec_opts<'a>(&self, opts: ContainerExecOpts<'a>) -> Container {
         let mut query = self.selection.select("exec");
-
         if let Some(args) = opts.args {
             query = query.arg("args", args);
         }
@@ -526,7 +465,6 @@ impl Container {
                 experimental_privileged_nesting,
             );
         }
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -537,33 +475,23 @@ impl Container {
     /// Will execute default command if none is set, or error if there's no default.
     pub async fn exit_code(&self) -> Result<isize, DaggerError> {
         let query = self.selection.select("exitCode");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Writes the container as an OCI tarball to the destination file path on the host for the specified platform variants.
     /// Return true on success.
     /// It can also publishes platform variants.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Host's destination path (e.g., "./tarball").
+    ///  /// # Arguments ///  /// * `path` - Host's destination path (e.g., "./tarball").
     /// Path can be relative to the engine's workdir or absolute.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn export(&self, path: impl Into<String>) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
-
         query = query.arg("path", path.into());
-
         query.execute(self.graphql_client.clone()).await
     }
-
     /// Writes the container as an OCI tarball to the destination file path on the host for the specified platform variants.
     /// Return true on success.
     /// It can also publishes platform variants.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Host's destination path (e.g., "./tarball").
+    ///  /// # Arguments ///  /// * `path` - Host's destination path (e.g., "./tarball").
     /// Path can be relative to the engine's workdir or absolute.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn export_opts(
@@ -572,19 +500,16 @@ impl Container {
         opts: ContainerExportOpts,
     ) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
-
         query = query.arg("path", path.into());
         if let Some(platform_variants) = opts.platform_variants {
             query = query.arg("platformVariants", platform_variants);
         }
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the list of exposed ports.
     /// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
     pub fn exposed_ports(&self) -> Vec<Port> {
         let query = self.selection.select("exposedPorts");
-
         return vec![Port {
             proc: self.proc.clone(),
             selection: query,
@@ -593,15 +518,10 @@ impl Container {
     }
     /// Retrieves a file at the given path.
     /// Mounts are included.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - The path of the file to retrieve (e.g., "./README.md").
+    ///  /// # Arguments ///  /// * `path` - The path of the file to retrieve (e.g., "./README.md").
     pub fn file(&self, path: impl Into<String>) -> File {
         let mut query = self.selection.select("file");
-
         query = query.arg("path", path.into());
-
         return File {
             proc: self.proc.clone(),
             selection: query,
@@ -609,17 +529,12 @@ impl Container {
         };
     }
     /// Initializes this container from a pulled base image.
-    ///
-    /// # Arguments
-    ///
-    /// * `address` - Image's address from its registry.
+    ///  /// # Arguments ///  /// * `address` - Image's address from its registry.
     ///
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g., "docker.io/dagger/dagger:main").
     pub fn from(&self, address: impl Into<String>) -> Container {
         let mut query = self.selection.select("from");
-
         query = query.arg("address", address.into());
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -629,7 +544,6 @@ impl Container {
     /// Retrieves this container's root filesystem. Mounts are not included.
     pub fn fs(&self) -> Directory {
         let query = self.selection.select("fs");
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -640,57 +554,43 @@ impl Container {
     /// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
     pub async fn hostname(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("hostname");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this container.
     pub async fn id(&self) -> Result<ContainerId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The unique image reference which can only be retrieved immediately after the 'Container.From' call.
     pub async fn image_ref(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("imageRef");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Reads the container from an OCI tarball.
     /// NOTE: this involves unpacking the tarball to an OCI store on the host at
     /// $XDG_CACHE_DIR/dagger/oci. This directory can be removed whenever you like.
-    ///
-    /// # Arguments
-    ///
-    /// * `source` - File to read the container from.
+    ///  /// # Arguments ///  /// * `source` - File to read the container from.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn import(&self, source: FileId) -> Container {
         let mut query = self.selection.select("import");
-
         query = query.arg("source", source);
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Reads the container from an OCI tarball.
     /// NOTE: this involves unpacking the tarball to an OCI store on the host at
     /// $XDG_CACHE_DIR/dagger/oci. This directory can be removed whenever you like.
-    ///
-    /// # Arguments
-    ///
-    /// * `source` - File to read the container from.
+    ///  /// # Arguments ///  /// * `source` - File to read the container from.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn import_opts<'a>(&self, source: FileId, opts: ContainerImportOpts<'a>) -> Container {
         let mut query = self.selection.select("import");
-
         query = query.arg("source", source);
         if let Some(tag) = opts.tag {
             query = query.arg("tag", tag);
         }
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -700,15 +600,12 @@ impl Container {
     /// Retrieves the value of the specified label.
     pub async fn label(&self, name: impl Into<String>) -> Result<String, DaggerError> {
         let mut query = self.selection.select("label");
-
         query = query.arg("name", name.into());
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the list of labels passed to container.
     pub fn labels(&self) -> Vec<Label> {
         let query = self.selection.select("labels");
-
         return vec![Label {
             proc: self.proc.clone(),
             selection: query,
@@ -718,32 +615,22 @@ impl Container {
     /// Retrieves the list of paths where a directory is mounted.
     pub async fn mounts(&self) -> Result<Vec<String>, DaggerError> {
         let query = self.selection.select("mounts");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Creates a named sub-pipeline
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - Pipeline name.
+    ///  /// # Arguments ///  /// * `name` - Pipeline name.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn pipeline(&self, name: impl Into<String>) -> Container {
         let mut query = self.selection.select("pipeline");
-
         query = query.arg("name", name.into());
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Creates a named sub-pipeline
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - Pipeline name.
+    ///  /// # Arguments ///  /// * `name` - Pipeline name.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn pipeline_opts<'a>(
         &self,
@@ -751,7 +638,6 @@ impl Container {
         opts: ContainerPipelineOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("pipeline");
-
         query = query.arg("name", name.into());
         if let Some(description) = opts.description {
             query = query.arg("description", description);
@@ -759,7 +645,6 @@ impl Container {
         if let Some(labels) = opts.labels {
             query = query.arg("labels", labels);
         }
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -769,34 +654,24 @@ impl Container {
     /// The platform this container executes and publishes as.
     pub async fn platform(&self) -> Result<Platform, DaggerError> {
         let query = self.selection.select("platform");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Publishes this container as a new image to the specified address.
     /// Publish returns a fully qualified ref.
     /// It can also publish platform variants.
-    ///
-    /// # Arguments
-    ///
-    /// * `address` - Registry's address to publish the image to.
+    ///  /// # Arguments ///  /// * `address` - Registry's address to publish the image to.
     ///
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g. "docker.io/dagger/dagger:main").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn publish(&self, address: impl Into<String>) -> Result<String, DaggerError> {
         let mut query = self.selection.select("publish");
-
         query = query.arg("address", address.into());
-
         query.execute(self.graphql_client.clone()).await
     }
-
     /// Publishes this container as a new image to the specified address.
     /// Publish returns a fully qualified ref.
     /// It can also publish platform variants.
-    ///
-    /// # Arguments
-    ///
-    /// * `address` - Registry's address to publish the image to.
+    ///  /// # Arguments ///  /// * `address` - Registry's address to publish the image to.
     ///
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g. "docker.io/dagger/dagger:main").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -806,18 +681,15 @@ impl Container {
         opts: ContainerPublishOpts,
     ) -> Result<String, DaggerError> {
         let mut query = self.selection.select("publish");
-
         query = query.arg("address", address.into());
         if let Some(platform_variants) = opts.platform_variants {
             query = query.arg("platformVariants", platform_variants);
         }
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves this container's root filesystem. Mounts are not included.
     pub fn rootfs(&self) -> Directory {
         let query = self.selection.select("rootfs");
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -828,49 +700,36 @@ impl Container {
     /// Will execute default command if none is set, or error if there's no default.
     pub async fn stderr(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("stderr");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The output stream of the last executed command.
     /// Will execute default command if none is set, or error if there's no default.
     pub async fn stdout(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("stdout");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the user to be set for all commands.
     pub async fn user(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("user");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Configures default arguments for future commands.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_default_args(&self) -> Container {
         let query = self.selection.select("withDefaultArgs");
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Configures default arguments for future commands.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_default_args_opts<'a>(&self, opts: ContainerWithDefaultArgsOpts<'a>) -> Container {
         let mut query = self.selection.select("withDefaultArgs");
-
         if let Some(args) = opts.args {
             query = query.arg("args", args);
         }
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -878,30 +737,21 @@ impl Container {
         };
     }
     /// Retrieves this container plus a directory written at the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the written directory (e.g., "/tmp/directory").
+    ///  /// # Arguments ///  /// * `path` - Location of the written directory (e.g., "/tmp/directory").
     /// * `directory` - Identifier of the directory to write
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_directory(&self, path: impl Into<String>, directory: DirectoryId) -> Container {
         let mut query = self.selection.select("withDirectory");
-
         query = query.arg("path", path.into());
         query = query.arg("directory", directory);
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Retrieves this container plus a directory written at the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the written directory (e.g., "/tmp/directory").
+    ///  /// # Arguments ///  /// * `path` - Location of the written directory (e.g., "/tmp/directory").
     /// * `directory` - Identifier of the directory to write
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_directory_opts<'a>(
@@ -911,7 +761,6 @@ impl Container {
         opts: ContainerWithDirectoryOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withDirectory");
-
         query = query.arg("path", path.into());
         query = query.arg("directory", directory);
         if let Some(exclude) = opts.exclude {
@@ -923,7 +772,6 @@ impl Container {
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -931,18 +779,13 @@ impl Container {
         };
     }
     /// Retrieves this container but with a different command entrypoint.
-    ///
-    /// # Arguments
-    ///
-    /// * `args` - Entrypoint to use for future executions (e.g., ["go", "run"]).
+    ///  /// # Arguments ///  /// * `args` - Entrypoint to use for future executions (e.g., ["go", "run"]).
     pub fn with_entrypoint(&self, args: Vec<impl Into<String>>) -> Container {
         let mut query = self.selection.select("withEntrypoint");
-
         query = query.arg(
             "args",
             args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
         );
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -950,10 +793,7 @@ impl Container {
         };
     }
     /// Retrieves this container plus the given environment variable.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the environment variable (e.g., "HOST").
+    ///  /// # Arguments ///  /// * `name` - The name of the environment variable (e.g., "HOST").
     /// * `value` - The value of the environment variable. (e.g., "localhost").
     pub fn with_env_variable(
         &self,
@@ -961,10 +801,8 @@ impl Container {
         value: impl Into<String>,
     ) -> Container {
         let mut query = self.selection.select("withEnvVariable");
-
         query = query.arg("name", name.into());
         query = query.arg("value", value.into());
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -972,33 +810,24 @@ impl Container {
         };
     }
     /// Retrieves this container after executing the specified command inside it.
-    ///
-    /// # Arguments
-    ///
-    /// * `args` - Command to run instead of the container's default command (e.g., ["run", "main.go"]).
+    ///  /// # Arguments ///  /// * `args` - Command to run instead of the container's default command (e.g., ["run", "main.go"]).
     ///
     /// If empty, the container's default command is used.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_exec(&self, args: Vec<impl Into<String>>) -> Container {
         let mut query = self.selection.select("withExec");
-
         query = query.arg(
             "args",
             args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
         );
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Retrieves this container after executing the specified command inside it.
-    ///
-    /// # Arguments
-    ///
-    /// * `args` - Command to run instead of the container's default command (e.g., ["run", "main.go"]).
+    ///  /// # Arguments ///  /// * `args` - Command to run instead of the container's default command (e.g., ["run", "main.go"]).
     ///
     /// If empty, the container's default command is used.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -1008,7 +837,6 @@ impl Container {
         opts: ContainerWithExecOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withExec");
-
         query = query.arg(
             "args",
             args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
@@ -1034,7 +862,6 @@ impl Container {
         if let Some(insecure_root_capabilities) = opts.insecure_root_capabilities {
             query = query.arg("insecureRootCapabilities", insecure_root_capabilities);
         }
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1046,32 +873,23 @@ impl Container {
     /// - For health checks and introspection, when running services
     /// - For setting the EXPOSE OCI field when publishing the container
     /// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
-    ///
-    /// # Arguments
-    ///
-    /// * `port` - Port number to expose
+    ///  /// # Arguments ///  /// * `port` - Port number to expose
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_exposed_port(&self, port: isize) -> Container {
         let mut query = self.selection.select("withExposedPort");
-
         query = query.arg("port", port);
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Expose a network port.
     /// Exposed ports serve two purposes:
     /// - For health checks and introspection, when running services
     /// - For setting the EXPOSE OCI field when publishing the container
     /// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
-    ///
-    /// # Arguments
-    ///
-    /// * `port` - Port number to expose
+    ///  /// # Arguments ///  /// * `port` - Port number to expose
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_exposed_port_opts<'a>(
         &self,
@@ -1079,7 +897,6 @@ impl Container {
         opts: ContainerWithExposedPortOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withExposedPort");
-
         query = query.arg("port", port);
         if let Some(protocol) = opts.protocol {
             query = query.arg_enum("protocol", protocol);
@@ -1087,7 +904,6 @@ impl Container {
         if let Some(description) = opts.description {
             query = query.arg("description", description);
         }
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1097,9 +913,7 @@ impl Container {
     /// Initializes this container from this DirectoryID.
     pub fn with_fs(&self, id: DirectoryId) -> Container {
         let mut query = self.selection.select("withFS");
-
         query = query.arg("id", id);
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1107,30 +921,21 @@ impl Container {
         };
     }
     /// Retrieves this container plus the contents of the given file copied to the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the copied file (e.g., "/tmp/file.txt").
+    ///  /// # Arguments ///  /// * `path` - Location of the copied file (e.g., "/tmp/file.txt").
     /// * `source` - Identifier of the file to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_file(&self, path: impl Into<String>, source: FileId) -> Container {
         let mut query = self.selection.select("withFile");
-
         query = query.arg("path", path.into());
         query = query.arg("source", source);
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Retrieves this container plus the contents of the given file copied to the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the copied file (e.g., "/tmp/file.txt").
+    ///  /// # Arguments ///  /// * `path` - Location of the copied file (e.g., "/tmp/file.txt").
     /// * `source` - Identifier of the file to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_file_opts<'a>(
@@ -1140,7 +945,6 @@ impl Container {
         opts: ContainerWithFileOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withFile");
-
         query = query.arg("path", path.into());
         query = query.arg("source", source);
         if let Some(permissions) = opts.permissions {
@@ -1149,7 +953,6 @@ impl Container {
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1157,17 +960,12 @@ impl Container {
         };
     }
     /// Retrieves this container plus the given label.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the label (e.g., "org.opencontainers.artifact.created").
+    ///  /// # Arguments ///  /// * `name` - The name of the label (e.g., "org.opencontainers.artifact.created").
     /// * `value` - The value of the label (e.g., "2023-01-01T00:00:00Z").
     pub fn with_label(&self, name: impl Into<String>, value: impl Into<String>) -> Container {
         let mut query = self.selection.select("withLabel");
-
         query = query.arg("name", name.into());
         query = query.arg("value", value.into());
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1175,30 +973,21 @@ impl Container {
         };
     }
     /// Retrieves this container plus a cache volume mounted at the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the cache directory (e.g., "/cache/node_modules").
+    ///  /// # Arguments ///  /// * `path` - Location of the cache directory (e.g., "/cache/node_modules").
     /// * `cache` - Identifier of the cache volume to mount.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_mounted_cache(&self, path: impl Into<String>, cache: CacheId) -> Container {
         let mut query = self.selection.select("withMountedCache");
-
         query = query.arg("path", path.into());
         query = query.arg("cache", cache);
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Retrieves this container plus a cache volume mounted at the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the cache directory (e.g., "/cache/node_modules").
+    ///  /// # Arguments ///  /// * `path` - Location of the cache directory (e.g., "/cache/node_modules").
     /// * `cache` - Identifier of the cache volume to mount.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_mounted_cache_opts<'a>(
@@ -1208,7 +997,6 @@ impl Container {
         opts: ContainerWithMountedCacheOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withMountedCache");
-
         query = query.arg("path", path.into());
         query = query.arg("cache", cache);
         if let Some(source) = opts.source {
@@ -1220,7 +1008,6 @@ impl Container {
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1228,10 +1015,7 @@ impl Container {
         };
     }
     /// Retrieves this container plus a directory mounted at the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the mounted directory (e.g., "/mnt/directory").
+    ///  /// # Arguments ///  /// * `path` - Location of the mounted directory (e.g., "/mnt/directory").
     /// * `source` - Identifier of the mounted directory.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_mounted_directory(
@@ -1240,22 +1024,16 @@ impl Container {
         source: DirectoryId,
     ) -> Container {
         let mut query = self.selection.select("withMountedDirectory");
-
         query = query.arg("path", path.into());
         query = query.arg("source", source);
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Retrieves this container plus a directory mounted at the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the mounted directory (e.g., "/mnt/directory").
+    ///  /// # Arguments ///  /// * `path` - Location of the mounted directory (e.g., "/mnt/directory").
     /// * `source` - Identifier of the mounted directory.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_mounted_directory_opts<'a>(
@@ -1265,13 +1043,11 @@ impl Container {
         opts: ContainerWithMountedDirectoryOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withMountedDirectory");
-
         query = query.arg("path", path.into());
         query = query.arg("source", source);
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1279,30 +1055,21 @@ impl Container {
         };
     }
     /// Retrieves this container plus a file mounted at the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the mounted file (e.g., "/tmp/file.txt").
+    ///  /// # Arguments ///  /// * `path` - Location of the mounted file (e.g., "/tmp/file.txt").
     /// * `source` - Identifier of the mounted file.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_mounted_file(&self, path: impl Into<String>, source: FileId) -> Container {
         let mut query = self.selection.select("withMountedFile");
-
         query = query.arg("path", path.into());
         query = query.arg("source", source);
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Retrieves this container plus a file mounted at the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the mounted file (e.g., "/tmp/file.txt").
+    ///  /// # Arguments ///  /// * `path` - Location of the mounted file (e.g., "/tmp/file.txt").
     /// * `source` - Identifier of the mounted file.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_mounted_file_opts<'a>(
@@ -1312,13 +1079,11 @@ impl Container {
         opts: ContainerWithMountedFileOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withMountedFile");
-
         query = query.arg("path", path.into());
         query = query.arg("source", source);
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1326,30 +1091,21 @@ impl Container {
         };
     }
     /// Retrieves this container plus a secret mounted into a file at the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the secret file (e.g., "/tmp/secret.txt").
+    ///  /// # Arguments ///  /// * `path` - Location of the secret file (e.g., "/tmp/secret.txt").
     /// * `source` - Identifier of the secret to mount.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_mounted_secret(&self, path: impl Into<String>, source: SecretId) -> Container {
         let mut query = self.selection.select("withMountedSecret");
-
         query = query.arg("path", path.into());
         query = query.arg("source", source);
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Retrieves this container plus a secret mounted into a file at the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the secret file (e.g., "/tmp/secret.txt").
+    ///  /// # Arguments ///  /// * `path` - Location of the secret file (e.g., "/tmp/secret.txt").
     /// * `source` - Identifier of the secret to mount.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_mounted_secret_opts<'a>(
@@ -1359,13 +1115,11 @@ impl Container {
         opts: ContainerWithMountedSecretOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withMountedSecret");
-
         query = query.arg("path", path.into());
         query = query.arg("source", source);
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1373,15 +1127,10 @@ impl Container {
         };
     }
     /// Retrieves this container plus a temporary directory mounted at the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the temporary directory (e.g., "/tmp/temp_dir").
+    ///  /// # Arguments ///  /// * `path` - Location of the temporary directory (e.g., "/tmp/temp_dir").
     pub fn with_mounted_temp(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withMountedTemp");
-
         query = query.arg("path", path.into());
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1389,28 +1138,19 @@ impl Container {
         };
     }
     /// Retrieves this container plus a new file written at the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the written file (e.g., "/tmp/file.txt").
+    ///  /// # Arguments ///  /// * `path` - Location of the written file (e.g., "/tmp/file.txt").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_new_file(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withNewFile");
-
         query = query.arg("path", path.into());
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Retrieves this container plus a new file written at the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the written file (e.g., "/tmp/file.txt").
+    ///  /// # Arguments ///  /// * `path` - Location of the written file (e.g., "/tmp/file.txt").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_new_file_opts<'a>(
         &self,
@@ -1418,7 +1158,6 @@ impl Container {
         opts: ContainerWithNewFileOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withNewFile");
-
         query = query.arg("path", path.into());
         if let Some(contents) = opts.contents {
             query = query.arg("contents", contents);
@@ -1429,7 +1168,6 @@ impl Container {
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1437,10 +1175,7 @@ impl Container {
         };
     }
     /// Retrieves this container with a registry authentication for a given address.
-    ///
-    /// # Arguments
-    ///
-    /// * `address` - Registry's address to bind the authentication to.
+    ///  /// # Arguments ///  /// * `address` - Registry's address to bind the authentication to.
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g. docker.io/dagger/dagger:main).
     /// * `username` - The username of the registry's account (e.g., "Dagger").
     /// * `secret` - The API key, password or token to authenticate to this registry.
@@ -1451,11 +1186,9 @@ impl Container {
         secret: SecretId,
     ) -> Container {
         let mut query = self.selection.select("withRegistryAuth");
-
         query = query.arg("address", address.into());
         query = query.arg("username", username.into());
         query = query.arg("secret", secret);
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1465,9 +1198,7 @@ impl Container {
     /// Initializes this container from this DirectoryID.
     pub fn with_rootfs(&self, id: DirectoryId) -> Container {
         let mut query = self.selection.select("withRootfs");
-
         query = query.arg("id", id);
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1475,17 +1206,12 @@ impl Container {
         };
     }
     /// Retrieves this container plus an env variable containing the given secret.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the secret variable (e.g., "API_SECRET").
+    ///  /// # Arguments ///  /// * `name` - The name of the secret variable (e.g., "API_SECRET").
     /// * `secret` - The identifier of the secret value.
     pub fn with_secret_variable(&self, name: impl Into<String>, secret: SecretId) -> Container {
         let mut query = self.selection.select("withSecretVariable");
-
         query = query.arg("name", name.into());
         query = query.arg("secret", secret);
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1498,10 +1224,7 @@ impl Container {
     /// The service will be reachable from the container via the provided hostname alias.
     /// The service dependency will also convey to any files or directories produced by the container.
     /// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
-    ///
-    /// # Arguments
-    ///
-    /// * `alias` - A name that can be used to reach the service from the container
+    ///  /// # Arguments ///  /// * `alias` - A name that can be used to reach the service from the container
     /// * `service` - Identifier of the service container
     pub fn with_service_binding(
         &self,
@@ -1509,10 +1232,8 @@ impl Container {
         service: ContainerId,
     ) -> Container {
         let mut query = self.selection.select("withServiceBinding");
-
         query = query.arg("alias", alias.into());
         query = query.arg("service", service);
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1520,30 +1241,21 @@ impl Container {
         };
     }
     /// Retrieves this container plus a socket forwarded to the given Unix socket path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the forwarded Unix socket (e.g., "/tmp/socket").
+    ///  /// # Arguments ///  /// * `path` - Location of the forwarded Unix socket (e.g., "/tmp/socket").
     /// * `source` - Identifier of the socket to forward.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_unix_socket(&self, path: impl Into<String>, source: SocketId) -> Container {
         let mut query = self.selection.select("withUnixSocket");
-
         query = query.arg("path", path.into());
         query = query.arg("source", source);
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Retrieves this container plus a socket forwarded to the given Unix socket path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the forwarded Unix socket (e.g., "/tmp/socket").
+    ///  /// # Arguments ///  /// * `path` - Location of the forwarded Unix socket (e.g., "/tmp/socket").
     /// * `source` - Identifier of the socket to forward.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_unix_socket_opts<'a>(
@@ -1553,13 +1265,11 @@ impl Container {
         opts: ContainerWithUnixSocketOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withUnixSocket");
-
         query = query.arg("path", path.into());
         query = query.arg("source", source);
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1567,15 +1277,10 @@ impl Container {
         };
     }
     /// Retrieves this container with a different command user.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The user to set (e.g., "root").
+    ///  /// # Arguments ///  /// * `name` - The user to set (e.g., "root").
     pub fn with_user(&self, name: impl Into<String>) -> Container {
         let mut query = self.selection.select("withUser");
-
         query = query.arg("name", name.into());
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1583,15 +1288,10 @@ impl Container {
         };
     }
     /// Retrieves this container with a different working directory.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - The path to set as the working directory (e.g., "/app").
+    ///  /// # Arguments ///  /// * `path` - The path to set as the working directory (e.g., "/app").
     pub fn with_workdir(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withWorkdir");
-
         query = query.arg("path", path.into());
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1599,15 +1299,10 @@ impl Container {
         };
     }
     /// Retrieves this container minus the given environment variable.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the environment variable (e.g., "HOST").
+    ///  /// # Arguments ///  /// * `name` - The name of the environment variable (e.g., "HOST").
     pub fn without_env_variable(&self, name: impl Into<String>) -> Container {
         let mut query = self.selection.select("withoutEnvVariable");
-
         query = query.arg("name", name.into());
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1616,29 +1311,20 @@ impl Container {
     }
     /// Unexpose a previously exposed port.
     /// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
-    ///
-    /// # Arguments
-    ///
-    /// * `port` - Port number to unexpose
+    ///  /// # Arguments ///  /// * `port` - Port number to unexpose
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn without_exposed_port(&self, port: isize) -> Container {
         let mut query = self.selection.select("withoutExposedPort");
-
         query = query.arg("port", port);
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Unexpose a previously exposed port.
     /// Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
-    ///
-    /// # Arguments
-    ///
-    /// * `port` - Port number to unexpose
+    ///  /// # Arguments ///  /// * `port` - Port number to unexpose
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn without_exposed_port_opts(
         &self,
@@ -1646,12 +1332,10 @@ impl Container {
         opts: ContainerWithoutExposedPortOpts,
     ) -> Container {
         let mut query = self.selection.select("withoutExposedPort");
-
         query = query.arg("port", port);
         if let Some(protocol) = opts.protocol {
             query = query.arg_enum("protocol", protocol);
         }
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1659,15 +1343,10 @@ impl Container {
         };
     }
     /// Retrieves this container minus the given environment label.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The name of the label to remove (e.g., "org.opencontainers.artifact.created").
+    ///  /// # Arguments ///  /// * `name` - The name of the label to remove (e.g., "org.opencontainers.artifact.created").
     pub fn without_label(&self, name: impl Into<String>) -> Container {
         let mut query = self.selection.select("withoutLabel");
-
         query = query.arg("name", name.into());
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1675,15 +1354,10 @@ impl Container {
         };
     }
     /// Retrieves this container after unmounting everything at the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the cache directory (e.g., "/cache/node_modules").
+    ///  /// # Arguments ///  /// * `path` - Location of the cache directory (e.g., "/cache/node_modules").
     pub fn without_mount(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withoutMount");
-
         query = query.arg("path", path.into());
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1691,16 +1365,11 @@ impl Container {
         };
     }
     /// Retrieves this container without the registry authentication of a given address.
-    ///
-    /// # Arguments
-    ///
-    /// * `address` - Registry's address to remove the authentication from.
+    ///  /// # Arguments ///  /// * `address` - Registry's address to remove the authentication from.
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g. docker.io/dagger/dagger:main).
     pub fn without_registry_auth(&self, address: impl Into<String>) -> Container {
         let mut query = self.selection.select("withoutRegistryAuth");
-
         query = query.arg("address", address.into());
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1708,15 +1377,10 @@ impl Container {
         };
     }
     /// Retrieves this container with a previously added Unix socket removed.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the socket to remove (e.g., "/tmp/socket").
+    ///  /// # Arguments ///  /// * `path` - Location of the socket to remove (e.g., "/tmp/socket").
     pub fn without_unix_socket(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withoutUnixSocket");
-
         query = query.arg("path", path.into());
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1726,7 +1390,6 @@ impl Container {
     /// Retrieves the working directory for all commands.
     pub async fn workdir(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("workdir");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -1736,7 +1399,6 @@ pub struct Directory {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryDockerBuildOpts<'a> {
     /// Build arguments to use in the build.
@@ -1802,18 +1464,12 @@ pub struct DirectoryWithNewFileOpts {
     #[builder(setter(into, strip_option), default)]
     pub permissions: Option<isize>,
 }
-
 impl Directory {
     /// Gets the difference between this directory and an another directory.
-    ///
-    /// # Arguments
-    ///
-    /// * `other` - Identifier of the directory to compare.
+    ///  /// # Arguments ///  /// * `other` - Identifier of the directory to compare.
     pub fn diff(&self, other: DirectoryId) -> Directory {
         let mut query = self.selection.select("diff");
-
         query = query.arg("other", other);
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -1821,15 +1477,10 @@ impl Directory {
         };
     }
     /// Retrieves a directory at the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the directory to retrieve (e.g., "/src").
+    ///  /// # Arguments ///  /// * `path` - Location of the directory to retrieve (e.g., "/src").
     pub fn directory(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("directory");
-
         query = query.arg("path", path.into());
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -1837,28 +1488,19 @@ impl Directory {
         };
     }
     /// Builds a new Docker container from this directory.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn docker_build(&self) -> Container {
         let query = self.selection.select("dockerBuild");
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Builds a new Docker container from this directory.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn docker_build_opts<'a>(&self, opts: DirectoryDockerBuildOpts<'a>) -> Container {
         let mut query = self.selection.select("dockerBuild");
-
         if let Some(dockerfile) = opts.dockerfile {
             query = query.arg("dockerfile", dockerfile);
         }
@@ -1874,7 +1516,6 @@ impl Directory {
         if let Some(secrets) = opts.secrets {
             query = query.arg("secrets", secrets);
         }
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1882,55 +1523,35 @@ impl Directory {
         };
     }
     /// Returns a list of files and directories at the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn entries(&self) -> Result<Vec<String>, DaggerError> {
         let query = self.selection.select("entries");
-
         query.execute(self.graphql_client.clone()).await
     }
-
     /// Returns a list of files and directories at the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn entries_opts<'a>(
         &self,
         opts: DirectoryEntriesOpts<'a>,
     ) -> Result<Vec<String>, DaggerError> {
         let mut query = self.selection.select("entries");
-
         if let Some(path) = opts.path {
             query = query.arg("path", path);
         }
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Writes the contents of the directory to a path on the host.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the copied directory (e.g., "logs/").
+    ///  /// # Arguments ///  /// * `path` - Location of the copied directory (e.g., "logs/").
     pub async fn export(&self, path: impl Into<String>) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
-
         query = query.arg("path", path.into());
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves a file at the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the file to retrieve (e.g., "README.md").
+    ///  /// # Arguments ///  /// * `path` - Location of the file to retrieve (e.g., "README.md").
     pub fn file(&self, path: impl Into<String>) -> File {
         let mut query = self.selection.select("file");
-
         query = query.arg("path", path.into());
-
         return File {
             proc: self.proc.clone(),
             selection: query,
@@ -1940,15 +1561,12 @@ impl Directory {
     /// The content-addressed identifier of the directory.
     pub async fn id(&self) -> Result<DirectoryId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// load a project's metadata
     pub fn load_project(&self, config_path: impl Into<String>) -> Project {
         let mut query = self.selection.select("loadProject");
-
         query = query.arg("configPath", config_path.into());
-
         return Project {
             proc: self.proc.clone(),
             selection: query,
@@ -1956,28 +1574,19 @@ impl Directory {
         };
     }
     /// Creates a named sub-pipeline
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - Pipeline name.
+    ///  /// # Arguments ///  /// * `name` - Pipeline name.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn pipeline(&self, name: impl Into<String>) -> Directory {
         let mut query = self.selection.select("pipeline");
-
         query = query.arg("name", name.into());
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Creates a named sub-pipeline
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - Pipeline name.
+    ///  /// # Arguments ///  /// * `name` - Pipeline name.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn pipeline_opts<'a>(
         &self,
@@ -1985,7 +1594,6 @@ impl Directory {
         opts: DirectoryPipelineOpts<'a>,
     ) -> Directory {
         let mut query = self.selection.select("pipeline");
-
         query = query.arg("name", name.into());
         if let Some(description) = opts.description {
             query = query.arg("description", description);
@@ -1993,7 +1601,6 @@ impl Directory {
         if let Some(labels) = opts.labels {
             query = query.arg("labels", labels);
         }
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -2001,30 +1608,21 @@ impl Directory {
         };
     }
     /// Retrieves this directory plus a directory written at the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the written directory (e.g., "/src/").
+    ///  /// # Arguments ///  /// * `path` - Location of the written directory (e.g., "/src/").
     /// * `directory` - Identifier of the directory to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_directory(&self, path: impl Into<String>, directory: DirectoryId) -> Directory {
         let mut query = self.selection.select("withDirectory");
-
         query = query.arg("path", path.into());
         query = query.arg("directory", directory);
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Retrieves this directory plus a directory written at the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the written directory (e.g., "/src/").
+    ///  /// # Arguments ///  /// * `path` - Location of the written directory (e.g., "/src/").
     /// * `directory` - Identifier of the directory to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_directory_opts<'a>(
@@ -2034,7 +1632,6 @@ impl Directory {
         opts: DirectoryWithDirectoryOpts<'a>,
     ) -> Directory {
         let mut query = self.selection.select("withDirectory");
-
         query = query.arg("path", path.into());
         query = query.arg("directory", directory);
         if let Some(exclude) = opts.exclude {
@@ -2043,7 +1640,6 @@ impl Directory {
         if let Some(include) = opts.include {
             query = query.arg("include", include);
         }
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -2051,30 +1647,21 @@ impl Directory {
         };
     }
     /// Retrieves this directory plus the contents of the given file copied to the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the copied file (e.g., "/file.txt").
+    ///  /// # Arguments ///  /// * `path` - Location of the copied file (e.g., "/file.txt").
     /// * `source` - Identifier of the file to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_file(&self, path: impl Into<String>, source: FileId) -> Directory {
         let mut query = self.selection.select("withFile");
-
         query = query.arg("path", path.into());
         query = query.arg("source", source);
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Retrieves this directory plus the contents of the given file copied to the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the copied file (e.g., "/file.txt").
+    ///  /// # Arguments ///  /// * `path` - Location of the copied file (e.g., "/file.txt").
     /// * `source` - Identifier of the file to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_file_opts(
@@ -2084,13 +1671,11 @@ impl Directory {
         opts: DirectoryWithFileOpts,
     ) -> Directory {
         let mut query = self.selection.select("withFile");
-
         query = query.arg("path", path.into());
         query = query.arg("source", source);
         if let Some(permissions) = opts.permissions {
             query = query.arg("permissions", permissions);
         }
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -2098,28 +1683,19 @@ impl Directory {
         };
     }
     /// Retrieves this directory plus a new directory created at the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the directory created (e.g., "/logs").
+    ///  /// # Arguments ///  /// * `path` - Location of the directory created (e.g., "/logs").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_new_directory(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("withNewDirectory");
-
         query = query.arg("path", path.into());
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Retrieves this directory plus a new directory created at the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the directory created (e.g., "/logs").
+    ///  /// # Arguments ///  /// * `path` - Location of the directory created (e.g., "/logs").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_new_directory_opts(
         &self,
@@ -2127,12 +1703,10 @@ impl Directory {
         opts: DirectoryWithNewDirectoryOpts,
     ) -> Directory {
         let mut query = self.selection.select("withNewDirectory");
-
         query = query.arg("path", path.into());
         if let Some(permissions) = opts.permissions {
             query = query.arg("permissions", permissions);
         }
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -2140,30 +1714,21 @@ impl Directory {
         };
     }
     /// Retrieves this directory plus a new file written at the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the written file (e.g., "/file.txt").
+    ///  /// # Arguments ///  /// * `path` - Location of the written file (e.g., "/file.txt").
     /// * `contents` - Content of the written file (e.g., "Hello world!").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_new_file(&self, path: impl Into<String>, contents: impl Into<String>) -> Directory {
         let mut query = self.selection.select("withNewFile");
-
         query = query.arg("path", path.into());
         query = query.arg("contents", contents.into());
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Retrieves this directory plus a new file written at the given path.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the written file (e.g., "/file.txt").
+    ///  /// # Arguments ///  /// * `path` - Location of the written file (e.g., "/file.txt").
     /// * `contents` - Content of the written file (e.g., "Hello world!").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_new_file_opts(
@@ -2173,13 +1738,11 @@ impl Directory {
         opts: DirectoryWithNewFileOpts,
     ) -> Directory {
         let mut query = self.selection.select("withNewFile");
-
         query = query.arg("path", path.into());
         query = query.arg("contents", contents.into());
         if let Some(permissions) = opts.permissions {
             query = query.arg("permissions", permissions);
         }
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -2187,17 +1750,12 @@ impl Directory {
         };
     }
     /// Retrieves this directory with all file/dir timestamps set to the given time.
-    ///
-    /// # Arguments
-    ///
-    /// * `timestamp` - Timestamp to set dir/files in.
+    ///  /// # Arguments ///  /// * `timestamp` - Timestamp to set dir/files in.
     ///
     /// Formatted in seconds following Unix epoch (e.g., 1672531199).
     pub fn with_timestamps(&self, timestamp: isize) -> Directory {
         let mut query = self.selection.select("withTimestamps");
-
         query = query.arg("timestamp", timestamp);
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -2205,15 +1763,10 @@ impl Directory {
         };
     }
     /// Retrieves this directory with the directory at the given path removed.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the directory to remove (e.g., ".github/").
+    ///  /// # Arguments ///  /// * `path` - Location of the directory to remove (e.g., ".github/").
     pub fn without_directory(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("withoutDirectory");
-
         query = query.arg("path", path.into());
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -2221,15 +1774,10 @@ impl Directory {
         };
     }
     /// Retrieves this directory with the file at the given path removed.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the file to remove (e.g., "/file.txt").
+    ///  /// # Arguments ///  /// * `path` - Location of the file to remove (e.g., "/file.txt").
     pub fn without_file(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("withoutFile");
-
         query = query.arg("path", path.into());
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -2243,18 +1791,15 @@ pub struct EnvVariable {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl EnvVariable {
     /// The environment variable name.
     pub async fn name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("name");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The environment variable value.
     pub async fn value(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("value");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -2264,36 +1809,27 @@ pub struct File {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl File {
     /// Retrieves the contents of the file.
     pub async fn contents(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("contents");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Writes the file to a file path on the host.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the written directory (e.g., "output.txt").
+    ///  /// # Arguments ///  /// * `path` - Location of the written directory (e.g., "output.txt").
     pub async fn export(&self, path: impl Into<String>) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
-
         query = query.arg("path", path.into());
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the content-addressed identifier of the file.
     pub async fn id(&self) -> Result<FileId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves a secret referencing the contents of this file.
     pub fn secret(&self) -> Secret {
         let query = self.selection.select("secret");
-
         return Secret {
             proc: self.proc.clone(),
             selection: query,
@@ -2303,21 +1839,15 @@ impl File {
     /// Gets the size of the file, in bytes.
     pub async fn size(&self) -> Result<isize, DaggerError> {
         let query = self.selection.select("size");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves this file with its created/modified timestamps set to the given time.
-    ///
-    /// # Arguments
-    ///
-    /// * `timestamp` - Timestamp to set dir/files in.
+    ///  /// # Arguments ///  /// * `timestamp` - Timestamp to set dir/files in.
     ///
     /// Formatted in seconds following Unix epoch (e.g., 1672531199).
     pub fn with_timestamps(&self, timestamp: isize) -> File {
         let mut query = self.selection.select("withTimestamps");
-
         query = query.arg("timestamp", timestamp);
-
         return File {
             proc: self.proc.clone(),
             selection: query,
@@ -2331,7 +1861,6 @@ pub struct GitRef {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 #[derive(Builder, Debug, PartialEq)]
 pub struct GitRefTreeOpts<'a> {
     #[builder(setter(into, strip_option), default)]
@@ -2339,44 +1868,32 @@ pub struct GitRefTreeOpts<'a> {
     #[builder(setter(into, strip_option), default)]
     pub ssh_known_hosts: Option<&'a str>,
 }
-
 impl GitRef {
     /// The digest of the current value of this ref.
     pub async fn digest(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("digest");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The filesystem tree at this ref.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn tree(&self) -> Directory {
         let query = self.selection.select("tree");
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// The filesystem tree at this ref.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn tree_opts<'a>(&self, opts: GitRefTreeOpts<'a>) -> Directory {
         let mut query = self.selection.select("tree");
-
         if let Some(ssh_known_hosts) = opts.ssh_known_hosts {
             query = query.arg("sshKnownHosts", ssh_known_hosts);
         }
         if let Some(ssh_auth_socket) = opts.ssh_auth_socket {
             query = query.arg("sshAuthSocket", ssh_auth_socket);
         }
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -2390,18 +1907,12 @@ pub struct GitRepository {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl GitRepository {
     /// Returns details on one branch.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - Branch's name (e.g., "main").
+    ///  /// # Arguments ///  /// * `name` - Branch's name (e.g., "main").
     pub fn branch(&self, name: impl Into<String>) -> GitRef {
         let mut query = self.selection.select("branch");
-
         query = query.arg("name", name.into());
-
         return GitRef {
             proc: self.proc.clone(),
             selection: query,
@@ -2411,19 +1922,13 @@ impl GitRepository {
     /// Lists of branches on the repository.
     pub async fn branches(&self) -> Result<Vec<String>, DaggerError> {
         let query = self.selection.select("branches");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Returns details on one commit.
-    ///
-    /// # Arguments
-    ///
-    /// * `id` - Identifier of the commit (e.g., "b6315d8f2810962c601af73f86831f6866ea798b").
+    ///  /// # Arguments ///  /// * `id` - Identifier of the commit (e.g., "b6315d8f2810962c601af73f86831f6866ea798b").
     pub fn commit(&self, id: impl Into<String>) -> GitRef {
         let mut query = self.selection.select("commit");
-
         query = query.arg("id", id.into());
-
         return GitRef {
             proc: self.proc.clone(),
             selection: query,
@@ -2431,15 +1936,10 @@ impl GitRepository {
         };
     }
     /// Returns details on one tag.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - Tag's name (e.g., "v0.3.9").
+    ///  /// # Arguments ///  /// * `name` - Tag's name (e.g., "v0.3.9").
     pub fn tag(&self, name: impl Into<String>) -> GitRef {
         let mut query = self.selection.select("tag");
-
         query = query.arg("name", name.into());
-
         return GitRef {
             proc: self.proc.clone(),
             selection: query,
@@ -2449,7 +1949,6 @@ impl GitRepository {
     /// Lists of tags on the repository.
     pub async fn tags(&self) -> Result<Vec<String>, DaggerError> {
         let query = self.selection.select("tags");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -2459,7 +1958,6 @@ pub struct Host {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 #[derive(Builder, Debug, PartialEq)]
 pub struct HostDirectoryOpts<'a> {
     /// Exclude artifacts that match the given pattern (e.g., ["node_modules/", ".git*"]).
@@ -2478,31 +1976,21 @@ pub struct HostWorkdirOpts<'a> {
     #[builder(setter(into, strip_option), default)]
     pub include: Option<Vec<&'a str>>,
 }
-
 impl Host {
     /// Accesses a directory on the host.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the directory to access (e.g., ".").
+    ///  /// # Arguments ///  /// * `path` - Location of the directory to access (e.g., ".").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn directory(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("directory");
-
         query = query.arg("path", path.into());
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Accesses a directory on the host.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the directory to access (e.g., ".").
+    ///  /// # Arguments ///  /// * `path` - Location of the directory to access (e.g., ".").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn directory_opts<'a>(
         &self,
@@ -2510,7 +1998,6 @@ impl Host {
         opts: HostDirectoryOpts<'a>,
     ) -> Directory {
         let mut query = self.selection.select("directory");
-
         query = query.arg("path", path.into());
         if let Some(exclude) = opts.exclude {
             query = query.arg("exclude", exclude);
@@ -2518,7 +2005,6 @@ impl Host {
         if let Some(include) = opts.include {
             query = query.arg("include", include);
         }
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -2526,15 +2012,10 @@ impl Host {
         };
     }
     /// Accesses an environment variable on the host.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - Name of the environment variable (e.g., "PATH").
+    ///  /// # Arguments ///  /// * `name` - Name of the environment variable (e.g., "PATH").
     pub fn env_variable(&self, name: impl Into<String>) -> HostVariable {
         let mut query = self.selection.select("envVariable");
-
         query = query.arg("name", name.into());
-
         return HostVariable {
             proc: self.proc.clone(),
             selection: query,
@@ -2542,15 +2023,10 @@ impl Host {
         };
     }
     /// Accesses a Unix socket on the host.
-    ///
-    /// # Arguments
-    ///
-    /// * `path` - Location of the Unix socket (e.g., "/var/run/docker.sock").
+    ///  /// # Arguments ///  /// * `path` - Location of the Unix socket (e.g., "/var/run/docker.sock").
     pub fn unix_socket(&self, path: impl Into<String>) -> Socket {
         let mut query = self.selection.select("unixSocket");
-
         query = query.arg("path", path.into());
-
         return Socket {
             proc: self.proc.clone(),
             selection: query,
@@ -2558,35 +2034,25 @@ impl Host {
         };
     }
     /// Retrieves the current working directory on the host.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn workdir(&self) -> Directory {
         let query = self.selection.select("workdir");
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Retrieves the current working directory on the host.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn workdir_opts<'a>(&self, opts: HostWorkdirOpts<'a>) -> Directory {
         let mut query = self.selection.select("workdir");
-
         if let Some(exclude) = opts.exclude {
             query = query.arg("exclude", exclude);
         }
         if let Some(include) = opts.include {
             query = query.arg("include", include);
         }
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -2600,12 +2066,10 @@ pub struct HostVariable {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl HostVariable {
     /// A secret referencing the value of this variable.
     pub fn secret(&self) -> Secret {
         let query = self.selection.select("secret");
-
         return Secret {
             proc: self.proc.clone(),
             selection: query,
@@ -2615,7 +2079,6 @@ impl HostVariable {
     /// The value of this variable.
     pub async fn value(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("value");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -2625,18 +2088,15 @@ pub struct Label {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl Label {
     /// The label name.
     pub async fn name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("name");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The label value.
     pub async fn value(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("value");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -2646,24 +2106,20 @@ pub struct Port {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl Port {
     /// The port description.
     pub async fn description(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("description");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The port number.
     pub async fn port(&self) -> Result<isize, DaggerError> {
         let query = self.selection.select("port");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The transport layer network protocol.
     pub async fn protocol(&self) -> Result<NetworkProtocol, DaggerError> {
         let query = self.selection.select("protocol");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -2673,12 +2129,10 @@ pub struct Project {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl Project {
     /// extensions in this project
     pub fn extensions(&self) -> Vec<Project> {
         let query = self.selection.select("extensions");
-
         return vec![Project {
             proc: self.proc.clone(),
             selection: query,
@@ -2688,7 +2142,6 @@ impl Project {
     /// Code files generated by the SDKs in the project
     pub fn generated_code(&self) -> Directory {
         let query = self.selection.select("generatedCode");
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -2698,25 +2151,21 @@ impl Project {
     /// install the project's schema
     pub async fn install(&self) -> Result<bool, DaggerError> {
         let query = self.selection.select("install");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// name of the project
     pub async fn name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("name");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// schema provided by the project
     pub async fn schema(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("schema");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// sdk used to generate code for and/or execute this project
     pub async fn sdk(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("sdk");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -2726,7 +2175,6 @@ pub struct Query {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 #[derive(Builder, Debug, PartialEq)]
 pub struct QueryContainerOpts {
     #[builder(setter(into, strip_option), default)]
@@ -2768,18 +2216,12 @@ pub struct QuerySocketOpts {
     #[builder(setter(into, strip_option), default)]
     pub id: Option<SocketId>,
 }
-
 impl Query {
     /// Constructs a cache volume for a given cache key.
-    ///
-    /// # Arguments
-    ///
-    /// * `key` - A string identifier to target this cache volume (e.g., "modules-cache").
+    ///  /// # Arguments ///  /// * `key` - A string identifier to target this cache volume (e.g., "modules-cache").
     pub fn cache_volume(&self, key: impl Into<String>) -> CacheVolume {
         let mut query = self.selection.select("cacheVolume");
-
         query = query.arg("key", key.into());
-
         return CacheVolume {
             proc: self.proc.clone(),
             selection: query,
@@ -2790,38 +2232,28 @@ impl Query {
     /// Null ID returns an empty container (scratch).
     /// Optional platform argument initializes new containers to execute and publish as that platform.
     /// Platform defaults to that of the builder's host.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn container(&self) -> Container {
         let query = self.selection.select("container");
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Loads a container from ID.
     /// Null ID returns an empty container (scratch).
     /// Optional platform argument initializes new containers to execute and publish as that platform.
     /// Platform defaults to that of the builder's host.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn container_opts(&self, opts: QueryContainerOpts) -> Container {
         let mut query = self.selection.select("container");
-
         if let Some(id) = opts.id {
             query = query.arg("id", id);
         }
         if let Some(platform) = opts.platform {
             query = query.arg("platform", platform);
         }
-
         return Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2831,36 +2263,25 @@ impl Query {
     /// The default platform of the builder.
     pub async fn default_platform(&self) -> Result<Platform, DaggerError> {
         let query = self.selection.select("defaultPlatform");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Load a directory by ID. No argument produces an empty directory.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn directory(&self) -> Directory {
         let query = self.selection.select("directory");
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Load a directory by ID. No argument produces an empty directory.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn directory_opts(&self, opts: QueryDirectoryOpts) -> Directory {
         let mut query = self.selection.select("directory");
-
         if let Some(id) = opts.id {
             query = query.arg("id", id);
         }
-
         return Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -2870,9 +2291,7 @@ impl Query {
     /// Loads a file by ID.
     pub fn file(&self, id: FileId) -> File {
         let mut query = self.selection.select("file");
-
         query = query.arg("id", id);
-
         return File {
             proc: self.proc.clone(),
             selection: query,
@@ -2880,36 +2299,26 @@ impl Query {
         };
     }
     /// Queries a git repository.
-    ///
-    /// # Arguments
-    ///
-    /// * `url` - Url of the git repository.
+    ///  /// # Arguments ///  /// * `url` - Url of the git repository.
     /// Can be formatted as https://{host}/{owner}/{repo}, git@{host}/{owner}/{repo}
     /// Suffix ".git" is optional.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn git(&self, url: impl Into<String>) -> GitRepository {
         let mut query = self.selection.select("git");
-
         query = query.arg("url", url.into());
-
         return GitRepository {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Queries a git repository.
-    ///
-    /// # Arguments
-    ///
-    /// * `url` - Url of the git repository.
+    ///  /// # Arguments ///  /// * `url` - Url of the git repository.
     /// Can be formatted as https://{host}/{owner}/{repo}, git@{host}/{owner}/{repo}
     /// Suffix ".git" is optional.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn git_opts(&self, url: impl Into<String>, opts: QueryGitOpts) -> GitRepository {
         let mut query = self.selection.select("git");
-
         query = query.arg("url", url.into());
         if let Some(keep_git_dir) = opts.keep_git_dir {
             query = query.arg("keepGitDir", keep_git_dir);
@@ -2917,7 +2326,6 @@ impl Query {
         if let Some(experimental_service_host) = opts.experimental_service_host {
             query = query.arg("experimentalServiceHost", experimental_service_host);
         }
-
         return GitRepository {
             proc: self.proc.clone(),
             selection: query,
@@ -2927,7 +2335,6 @@ impl Query {
     /// Queries the host environment.
     pub fn host(&self) -> Host {
         let query = self.selection.select("host");
-
         return Host {
             proc: self.proc.clone(),
             selection: query,
@@ -2935,37 +2342,26 @@ impl Query {
         };
     }
     /// Returns a file containing an http remote url content.
-    ///
-    /// # Arguments
-    ///
-    /// * `url` - HTTP url to get the content from (e.g., "https://docs.dagger.io").
+    ///  /// # Arguments ///  /// * `url` - HTTP url to get the content from (e.g., "https://docs.dagger.io").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn http(&self, url: impl Into<String>) -> File {
         let mut query = self.selection.select("http");
-
         query = query.arg("url", url.into());
-
         return File {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Returns a file containing an http remote url content.
-    ///
-    /// # Arguments
-    ///
-    /// * `url` - HTTP url to get the content from (e.g., "https://docs.dagger.io").
+    ///  /// # Arguments ///  /// * `url` - HTTP url to get the content from (e.g., "https://docs.dagger.io").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn http_opts(&self, url: impl Into<String>, opts: QueryHttpOpts) -> File {
         let mut query = self.selection.select("http");
-
         query = query.arg("url", url.into());
         if let Some(experimental_service_host) = opts.experimental_service_host {
             query = query.arg("experimentalServiceHost", experimental_service_host);
         }
-
         return File {
             proc: self.proc.clone(),
             selection: query,
@@ -2973,32 +2369,22 @@ impl Query {
         };
     }
     /// Creates a named sub-pipeline.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - Pipeline name.
+    ///  /// # Arguments ///  /// * `name` - Pipeline name.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn pipeline(&self, name: impl Into<String>) -> Query {
         let mut query = self.selection.select("pipeline");
-
         query = query.arg("name", name.into());
-
         return Query {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Creates a named sub-pipeline.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - Pipeline name.
+    ///  /// # Arguments ///  /// * `name` - Pipeline name.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn pipeline_opts<'a>(&self, name: impl Into<String>, opts: QueryPipelineOpts<'a>) -> Query {
         let mut query = self.selection.select("pipeline");
-
         query = query.arg("name", name.into());
         if let Some(description) = opts.description {
             query = query.arg("description", description);
@@ -3006,7 +2392,6 @@ impl Query {
         if let Some(labels) = opts.labels {
             query = query.arg("labels", labels);
         }
-
         return Query {
             proc: self.proc.clone(),
             selection: query,
@@ -3016,9 +2401,7 @@ impl Query {
     /// Look up a project by name
     pub fn project(&self, name: impl Into<String>) -> Project {
         let mut query = self.selection.select("project");
-
         query = query.arg("name", name.into());
-
         return Project {
             proc: self.proc.clone(),
             selection: query,
@@ -3028,9 +2411,7 @@ impl Query {
     /// Loads a secret from its ID.
     pub fn secret(&self, id: SecretId) -> Secret {
         let mut query = self.selection.select("secret");
-
         query = query.arg("id", id);
-
         return Secret {
             proc: self.proc.clone(),
             selection: query,
@@ -3038,17 +2419,12 @@ impl Query {
         };
     }
     /// Sets a secret given a user defined name to its plaintext and returns the secret.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - The user defined name for this secret
+    ///  /// # Arguments ///  /// * `name` - The user defined name for this secret
     /// * `plaintext` - The plaintext of the secret
     pub fn set_secret(&self, name: impl Into<String>, plaintext: impl Into<String>) -> Secret {
         let mut query = self.selection.select("setSecret");
-
         query = query.arg("name", name.into());
         query = query.arg("plaintext", plaintext.into());
-
         return Secret {
             proc: self.proc.clone(),
             selection: query,
@@ -3056,32 +2432,22 @@ impl Query {
         };
     }
     /// Loads a socket by its ID.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn socket(&self) -> Socket {
         let query = self.selection.select("socket");
-
         return Socket {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         };
     }
-
     /// Loads a socket by its ID.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    ///  /// # Arguments ///  /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn socket_opts(&self, opts: QuerySocketOpts) -> Socket {
         let mut query = self.selection.select("socket");
-
         if let Some(id) = opts.id {
             query = query.arg("id", id);
         }
-
         return Socket {
             proc: self.proc.clone(),
             selection: query,
@@ -3095,18 +2461,15 @@ pub struct Secret {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl Secret {
     /// The identifier for this secret.
     pub async fn id(&self) -> Result<SecretId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The value of this secret.
     pub async fn plaintext(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("plaintext");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -3116,12 +2479,10 @@ pub struct Socket {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl Socket {
     /// The content-addressed identifier of the socket.
     pub async fn id(&self) -> Result<SocketId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
 }


### PR DESCRIPTION
They started happening right after
https://github.com/dagger/dagger/pull/5372 got merged, even though this commit didn't change anything in the Rust SDK: https://github.com/dagger/dagger/actions/runs/5424732578/jobs/9864713099

The relevant errors:

```rust
error[E0422]: cannot find struct, variant or union type `LineColumn` in crate `proc_macro`
   --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.56/src/wrapper.rs:475:33
    |
475 |                 let proc_macro::LineColumn { line, column } = s.start();
    |                                 ^^^^^^^^^^ not found in `proc_macro`
    |
help: consider importing this struct through its public re-export
    |
1   + use crate::LineColumn;
    |
help: if you import `LineColumn`, refer to it directly
    |
475 -                 let proc_macro::LineColumn { line, column } = s.start();
475 +                 let LineColumn { line, column } = s.start();
    |

error[E0422]: cannot find struct, variant or union type `LineColumn` in crate `proc_macro`
   --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.56/src/wrapper.rs:489:33
    |
489 |                 let proc_macro::LineColumn { line, column } = s.end();
    |                                 ^^^^^^^^^^ not found in `proc_macro`
    |
help: consider importing this struct through its public re-export
    |
1   + use crate::LineColumn;
    |
help: if you import `LineColumn`, refer to it directly
    |
489 -                 let proc_macro::LineColumn { line, column } = s.end();
489 +                 let LineColumn { line, column } = s.end();
    |

   Compiling pin-utils v0.1.0
   Compiling thiserror v1.0.40
error[E0635]: unknown feature `proc_macro_span_shrink`
  --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.56/src/lib.rs:92:30
   |
92 |     feature(proc_macro_span, proc_macro_span_shrink)
   |                              ^^^^^^^^^^^^^^^^^^^^^^
``` 

Updating all dependencies to latest via `cargo update` & re-running the Rust SDK codegen (which seems to create incorrect comments) fixed the issue for both lint & test.

WDYT @kjuulh?