### PR TITLE
core: Optimize *.WithDirectory and *.WithFile via MergeOp.

### DIFF
--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -250,6 +250,9 @@ func shim() int {
 		}
 
 		code, err := os.ReadFile(exitCodePath)
+		if os.IsNotExist(err) {
+			return -1
+		}
 		if err != nil {
 			panic(err)
 		}

--- a/core/container.go
+++ b/core/container.go
@@ -527,16 +527,16 @@ func (container *Container) WithDirectory(ctx context.Context, gw bkgw.Client, s
 	})
 }
 
-func (container *Container) WithFile(ctx context.Context, gw bkgw.Client, subdir string, src *File, permissions fs.FileMode, owner string) (*Container, error) {
+func (container *Container) WithFile(ctx context.Context, gw bkgw.Client, destPath string, src *File, permissions fs.FileMode, owner string) (*Container, error) {
 	container = container.Clone()
 
-	return container.writeToPath(ctx, gw, subdir, func(dir *Directory) (*Directory, error) {
+	return container.writeToPath(ctx, gw, path.Dir(destPath), func(dir *Directory) (*Directory, error) {
 		ownership, err := container.ownership(ctx, gw, owner)
 		if err != nil {
 			return nil, err
 		}
 
-		return dir.WithFile(ctx, ".", src, permissions, ownership)
+		return dir.WithFile(ctx, path.Base(destPath), src, permissions, ownership)
 	})
 }
 

--- a/core/directory.go
+++ b/core/directory.go
@@ -303,10 +303,10 @@ func (dir *Directory) File(ctx context.Context, file string) (*File, error) {
 	}, nil
 }
 
-func (dir *Directory) WithDirectory(ctx context.Context, subdir string, src *Directory, filter CopyFilter, owner *Ownership) (*Directory, error) {
+func (dir *Directory) WithDirectory(ctx context.Context, destDir string, src *Directory, filter CopyFilter, owner *Ownership) (*Directory, error) {
 	dir = dir.Clone()
 
-	st, err := dir.State()
+	destSt, err := dir.State()
 	if err != nil {
 		return nil, err
 	}
@@ -316,28 +316,115 @@ func (dir *Directory) WithDirectory(ctx context.Context, subdir string, src *Dir
 		return nil, err
 	}
 
-	opts := []llb.CopyOption{
-		&llb.CopyInfo{
-			CreateDestPath:      true,
-			CopyDirContentsOnly: true,
-			IncludePatterns:     filter.Include,
-			ExcludePatterns:     filter.Exclude,
-		},
-	}
-	if owner != nil {
-		opts = append(opts, owner.Opt())
-	}
-
-	st = st.File(llb.Copy(srcSt, src.Dir, path.Join(dir.Dir, subdir), opts...))
-
-	err = dir.SetState(ctx, st)
-	if err != nil {
+	if err := dir.SetState(ctx, mergeStates(mergeStateInput{
+		Dest:            destSt,
+		DestDir:         path.Join(dir.Dir, destDir),
+		Src:             srcSt,
+		SrcDir:          src.Dir,
+		IncludePatterns: filter.Include,
+		ExcludePatterns: filter.Exclude,
+		Owner:           owner,
+	})); err != nil {
 		return nil, err
 	}
 
 	dir.Services.Merge(src.Services)
 
 	return dir, nil
+}
+
+func (dir *Directory) WithFile(ctx context.Context, destPath string, src *File, permissions fs.FileMode, owner *Ownership) (*Directory, error) {
+	dir = dir.Clone()
+
+	destSt, err := dir.State()
+	if err != nil {
+		return nil, err
+	}
+
+	srcSt, err := src.State()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := dir.SetState(ctx, mergeStates(mergeStateInput{
+		Dest:         destSt,
+		DestDir:      path.Join(dir.Dir, path.Dir(destPath)),
+		DestFileName: path.Base(destPath),
+		Src:          srcSt,
+		SrcDir:       path.Dir(src.File),
+		SrcFileName:  path.Base(src.File),
+		Permissions:  permissions,
+		Owner:        owner,
+	})); err != nil {
+		return nil, err
+	}
+
+	dir.Services.Merge(src.Services)
+
+	return dir, nil
+}
+
+type mergeStateInput struct {
+	Dest         llb.State
+	DestDir      string
+	DestFileName string
+
+	Src         llb.State
+	SrcDir      string
+	SrcFileName string
+
+	IncludePatterns []string
+	ExcludePatterns []string
+
+	Permissions fs.FileMode
+	Owner       *Ownership
+}
+
+func mergeStates(input mergeStateInput) llb.State {
+	input.DestDir = path.Join("/", input.DestDir)
+	input.SrcDir = path.Join("/", input.SrcDir)
+
+	copyInfo := &llb.CopyInfo{
+		CreateDestPath:      true,
+		CopyDirContentsOnly: true,
+		IncludePatterns:     input.IncludePatterns,
+		ExcludePatterns:     input.ExcludePatterns,
+	}
+	if input.DestFileName == "" && input.SrcFileName != "" {
+		input.DestFileName = input.SrcFileName
+	}
+	if input.Permissions != 0 {
+		copyInfo.Mode = &input.Permissions
+	}
+	if input.Owner != nil {
+		input.Owner.Opt().SetCopyOption(copyInfo)
+	}
+
+	// MergeOp currently only supports merging the "/" of states together without any
+	// modifications or filtering
+	canDoDirectMerge := copyInfo.Mode == nil &&
+		copyInfo.ChownOpt == nil &&
+		len(copyInfo.ExcludePatterns) == 0 &&
+		len(copyInfo.IncludePatterns) == 0 &&
+		input.DestDir == input.SrcDir &&
+		input.DestFileName == input.SrcFileName
+
+	mergeStates := []llb.State{input.Dest}
+	if canDoDirectMerge {
+		// Directly merge the states together, which is lazy, uses hardlinks instead of
+		// copies and caches inputs individually instead of invalidating the whole
+		// chain following any modified input.
+		mergeStates = append(mergeStates, input.Src)
+	} else {
+		// Even if we can't merge directly, we can still get some optimization by
+		// copying to scratch and then merging that. This still results in an on-disk
+		// copy but preserves the other caching benefits of MergeOp. This is the same
+		// behavior as "COPY --link" in Dockerfiles.
+		mergeStates = append(mergeStates, llb.Scratch().File(llb.Copy(
+			input.Src, path.Join(input.SrcDir, input.SrcFileName), path.Join(input.DestDir, input.DestFileName), copyInfo,
+		)))
+	}
+	return llb.Merge(mergeStates)
 }
 
 func (dir *Directory) WithTimestamps(ctx context.Context, unix int) (*Directory, error) {
@@ -394,71 +481,6 @@ func (dir *Directory) WithNewDirectory(ctx context.Context, dest string, permiss
 	}
 
 	return dir, nil
-}
-
-func (dir *Directory) WithFile(ctx context.Context, subdir string, src *File, permissions fs.FileMode, ownership *Ownership) (*Directory, error) {
-	dir = dir.Clone()
-
-	st, err := dir.State()
-	if err != nil {
-		return nil, err
-	}
-
-	srcSt, err := src.State()
-	if err != nil {
-		return nil, err
-	}
-
-	var perm *fs.FileMode
-	if permissions != 0 {
-		perm = &permissions
-	}
-
-	opts := []llb.CopyOption{
-		&llb.CopyInfo{
-			CreateDestPath: true,
-			Mode:           perm,
-		},
-	}
-
-	if ownership != nil {
-		opts = append(opts, ownership.Opt())
-	}
-
-	st = st.File(llb.Copy(srcSt, src.File, path.Join(dir.Dir, subdir), opts...))
-
-	err = dir.SetState(ctx, st)
-	if err != nil {
-		return nil, err
-	}
-
-	dir.Services.Merge(src.Services)
-
-	return dir, nil
-}
-
-func MergeDirectories(ctx context.Context, dirs []*Directory, platform specs.Platform) (*Directory, error) {
-	states := make([]llb.State, 0, len(dirs))
-	var pipeline pipeline.Path
-	for _, dir := range dirs {
-		if !reflect.DeepEqual(platform, dir.Platform) {
-			// TODO(vito): work around with llb.Copy shenanigans?
-			return nil, fmt.Errorf("TODO: cannot merge across platforms: %+v != %+v", platform, dir.Platform)
-		}
-
-		if pipeline.Name() == "" {
-			pipeline = dir.Pipeline
-		}
-
-		state, err := dir.State()
-		if err != nil {
-			return nil, err
-		}
-
-		states = append(states, state)
-	}
-
-	return NewDirectorySt(ctx, llb.Merge(states), "", pipeline, platform, nil)
 }
 
 func (dir *Directory) Diff(ctx context.Context, other *Directory) (*Directory, error) {

--- a/core/directory.go
+++ b/core/directory.go
@@ -407,7 +407,11 @@ func mergeStates(input mergeStateInput) llb.State {
 		len(copyInfo.ExcludePatterns) == 0 &&
 		len(copyInfo.IncludePatterns) == 0 &&
 		input.DestDir == input.SrcDir &&
-		input.DestFileName == input.SrcFileName
+		// TODO:(sipsma) we could support direct merge-op with individual files if we can verify
+		// there are no other files in the dir, but doing so by just calling ReadDir would result
+		// in unlazying the inputs, which defeats some of the performance benefits of merge-op.
+		input.DestFileName == "" &&
+		input.SrcFileName == ""
 
 	mergeStates := []llb.State{input.Dest}
 	if canDoDirectMerge {

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"context"
-	"path"
 	"regexp"
 	"strings"
 	"testing"
@@ -354,13 +353,26 @@ func TestDirectoryWithFile(t *testing.T) {
 
 	file := c.Directory().
 		WithNewFile("some-file", "some-content").
+		WithNewFile("some-other-file", "some-other-content").
 		File("some-file")
 
-	content, err := c.Directory().
-		WithFile("target-file", file).
+	dirWithFile := c.Directory().WithFile("target-file", file)
+	content, err := dirWithFile.
 		File("target-file").Contents(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "some-content", content)
+	_, err = dirWithFile.File("some-other-file").Contents(ctx)
+	require.Error(t, err)
+
+	// Same as above, but use the same name for the file rather than changing it.
+	// Needed for testing merge-op corner cases.
+	dirWithFile = c.Directory().WithFile("some-file", file)
+	content, err = dirWithFile.
+		File("some-file").Contents(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "some-content", content)
+	_, err = dirWithFile.File("some-other-file").Contents(ctx)
+	require.Error(t, err)
 
 	content, err = c.Directory().
 		WithFile("sub-dir/target-file", file).
@@ -831,41 +843,48 @@ func TestDirectoryDirectMerge(t *testing.T) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	getFileAndInode := func(t *testing.T, filePath string) (*dagger.Directory, string) {
+	getDirAndInodes := func(t *testing.T, fileNames ...string) (*dagger.Directory, []string) {
 		t.Helper()
-		parentDir := path.Dir(filePath)
 		ctr := c.Container().From("alpine:3.16.2").
-			WithMountedDirectory(parentDir, c.Directory()).
-			WithExec([]string{"sh", "-e", "-x", "-c",
-				"mkdir -p " + parentDir + " && touch " + filePath + " && stat -c '%i' " + filePath,
+			WithMountedDirectory("/src", c.Directory()).
+			WithWorkdir("/src")
+
+		var inodes []string
+		for _, fileName := range fileNames {
+			ctr = ctr.WithExec([]string{"sh", "-e", "-x", "-c",
+				"touch " + fileName + " && stat -c '%i' " + fileName,
 			})
-		out, err := ctr.Stdout(ctx)
-		require.NoError(t, err)
-		return ctr.Directory(parentDir), strings.TrimSpace(out)
+			out, err := ctr.Stdout(ctx)
+			require.NoError(t, err)
+			inodes = append(inodes, strings.TrimSpace(out))
+		}
+		return ctr.Directory("/src"), inodes
 	}
 
 	// verify optimized hardlink based merge-op is used by verifying inodes are preserved
 	// across WithDirectory calls
 	mergeDir := c.Directory()
-	filePaths := []string{
-		"/dir/abc",
-		"/dir/xyz",
-		"/dir2/dir3/idk",
-		"/dir2/dir4/lol",
-		"/dir3/dir3/lmao",
+	fileGroups := [][]string{
+		{"abc", "xyz"},
+		{"123", "456", "789"},
+		{"foo"},
+		{"bar"},
 	}
-	filePathToInode := map[string]string{}
-	for _, filePath := range filePaths {
-		newDir, inode := getFileAndInode(t, filePath)
-		filePathToInode[filePath] = inode
+	fileNameToInode := map[string]string{}
+	for _, fileNames := range fileGroups {
+		newDir, inodes := getDirAndInodes(t, fileNames...)
+		for i, fileName := range fileNames {
+			fileNameToInode[fileName] = inodes[i]
+		}
 		mergeDir = mergeDir.WithDirectory("/", newDir)
 	}
 
 	ctr := c.Container().From("alpine:3.16.2").
-		WithMountedDirectory("/mnt", mergeDir)
+		WithMountedDirectory("/mnt", mergeDir).
+		WithWorkdir("/mnt")
 
-	for filePath, inode := range filePathToInode {
-		out, err := ctr.WithExec([]string{"stat", "-c", "%i", path.Join("/mnt", path.Base(filePath))}).Stdout(ctx)
+	for fileName, inode := range fileNameToInode {
+		out, err := ctr.WithExec([]string{"stat", "-c", "%i", fileName}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, strings.TrimSpace(out), inode)
 	}


### PR DESCRIPTION
We now use MergeOp as much as possible to optimize copying from one LLB state onto another. See the comments in the mergeStates function in core/directory.go for more details.