### PR TITLE
feat(rust-sdk): set resolver v2

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "crates/dagger-sdk",
   "crates/dagger-bootstrap",
 ]
+resolver = "2"
 
 [workspace.dependencies]
 dagger-codegen = { path = "crates/dagger-codegen", version = "^0.2.5" }


### PR DESCRIPTION
This is how cargo workspaces resolves crates, and it v1 (default) produces a
warning on build
