### PR TITLE
Fix danger tag not rendering in 723462-use-secrets.md

### DIFF
--- a/docs/current/guides/723462-use-secrets.md
+++ b/docs/current/guides/723462-use-secrets.md
@@ -298,7 +298,7 @@ secret env data: *** || secret file data:
 ***
 ```
 
-::danger
+:::danger
 Any secret that is to be read from the container environment should always be loaded using `withSecretVariable()`. If `withEnvVariable()` is used instead, the value of the environment variable may leak via the build history of the container. Using `withSecretVariable()` guarantees that the secret will not leak in the container build history or image layers.
 :::
 


### PR DESCRIPTION
Fix danger tag on https://docs.dagger.io/723462/use-secrets#understand-how-dagger-secures-secrets