### PR TITLE
core: Remove unimplemented git fields

### DIFF
--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -27,15 +27,12 @@ func (s *gitSchema) Resolvers() router.Resolvers {
 			"git": router.ToResolver(s.git),
 		},
 		"GitRepository": router.ObjectResolver{
-			"branches": router.ToResolver(s.branches),
-			"branch":   router.ToResolver(s.branch),
-			"tags":     router.ToResolver(s.tags),
-			"tag":      router.ToResolver(s.tag),
-			"commit":   router.ToResolver(s.commit),
+			"branch": router.ToResolver(s.branch),
+			"tag":    router.ToResolver(s.tag),
+			"commit": router.ToResolver(s.commit),
 		},
 		"GitRef": router.ObjectResolver{
-			"digest": router.ToResolver(s.digest),
-			"tree":   router.ToResolver(s.tree),
+			"tree": router.ToResolver(s.tree),
 		},
 	}
 }
@@ -45,10 +42,11 @@ func (s *gitSchema) Dependencies() []router.ExecutableSchema {
 }
 
 type gitRepository struct {
-	URL         string            `json:"url"`
-	KeepGitDir  bool              `json:"keepGitDir"`
-	Pipeline    pipeline.Path     `json:"pipeline"`
-	ServiceHost *core.ContainerID `json:"serviceHost,omitempty"`
+	URL             string            `json:"url"`
+	KeepGitDir      bool              `json:"keepGitDir"`
+	AuthTokenSecret *core.SecretID    `json:"authTokenSecret,omitempty"`
+	Pipeline        pipeline.Path     `json:"pipeline"`
+	ServiceHost     *core.ContainerID `json:"serviceHost,omitempty"`
 }
 
 type gitRef struct {
@@ -93,10 +91,6 @@ func (s *gitSchema) branch(ctx *router.Context, parent gitRepository, args branc
 	}, nil
 }
 
-func (s *gitSchema) branches(ctx *router.Context, parent any, args any) (any, error) {
-	return nil, ErrNotImplementedYet
-}
-
 type tagArgs struct {
 	Name string
 }
@@ -106,14 +100,6 @@ func (s *gitSchema) tag(ctx *router.Context, parent gitRepository, args tagArgs)
 		Repository: parent,
 		Name:       args.Name,
 	}, nil
-}
-
-func (s *gitSchema) tags(ctx *router.Context, parent any, args any) (any, error) {
-	return nil, ErrNotImplementedYet
-}
-
-func (s *gitSchema) digest(ctx *router.Context, parent any, args any) (any, error) {
-	return nil, ErrNotImplementedYet
 }
 
 type gitTreeArgs struct {

--- a/core/schema/git.graphqls
+++ b/core/schema/git.graphqls
@@ -20,8 +20,6 @@ extend type Query {
 
 "A git repository."
 type GitRepository {
-  "Lists of branches on the repository."
-  branches: [String!]!
 
   """
   Returns details on one branch.
@@ -32,9 +30,6 @@ type GitRepository {
     """
     name: String!
   ): GitRef!
-
-  "Lists of tags on the repository."
-  tags: [String!]!
 
   """
   Returns details on one tag.
@@ -59,9 +54,6 @@ type GitRepository {
 
 "A git ref (tag, branch or commit)."
 type GitRef {
-  "The digest of the current value of this ref."
-  digest: String!
-
   "The filesystem tree at this ref."
   tree(sshKnownHosts: String, sshAuthSocket: SocketID): Directory!
 }

--- a/core/schema/util.go
+++ b/core/schema/util.go
@@ -1,17 +1,12 @@
 package schema
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/dagger/dagger/internal/engine"
 	"github.com/dagger/dagger/router"
 	"github.com/dagger/graphql/language/ast"
 )
-
-// ErrNotImplementedYet is used to stub out API fields that aren't implemented
-// yet.
-var ErrNotImplementedYet = errors.New("not implemented yet")
 
 var ErrServicesDisabled = fmt.Errorf("services are disabled; unset %s to enable", engine.ServicesDNSEnvName)
 

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -1874,21 +1874,6 @@ func (r *File) WithTimestamps(timestamp int) *File {
 type GitRef struct {
 	q *querybuilder.Selection
 	c graphql.Client
-
-	digest *string
-}
-
-// The digest of the current value of this ref.
-func (r *GitRef) Digest(ctx context.Context) (string, error) {
-	if r.digest != nil {
-		return *r.digest, nil
-	}
-	q := r.q.Select("digest")
-
-	var response string
-
-	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.c)
 }
 
 // GitRefTreeOpts contains options for GitRef.Tree
@@ -1935,16 +1920,6 @@ func (r *GitRepository) Branch(name string) *GitRef {
 	}
 }
 
-// Lists of branches on the repository.
-func (r *GitRepository) Branches(ctx context.Context) ([]string, error) {
-	q := r.q.Select("branches")
-
-	var response []string
-
-	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.c)
-}
-
 // Returns details on one commit.
 func (r *GitRepository) Commit(id string) *GitRef {
 	q := r.q.Select("commit")
@@ -1965,16 +1940,6 @@ func (r *GitRepository) Tag(name string) *GitRef {
 		q: q,
 		c: r.c,
 	}
-}
-
-// Lists of tags on the repository.
-func (r *GitRepository) Tags(ctx context.Context) ([]string, error) {
-	q := r.q.Select("tags")
-
-	var response []string
-
-	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.c)
 }
 
 // Information about the host execution environment.

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -2565,23 +2565,6 @@ export class File extends BaseClient {
 
 export class GitRef extends BaseClient {
   /**
-   * The digest of the current value of this ref.
-   */
-  async digest(): Promise<string> {
-    const response: Awaited<string> = await computeQuery(
-      [
-        ...this._queryTree,
-        {
-          operation: "digest",
-        },
-      ],
-      this.client
-    )
-
-    return response
-  }
-
-  /**
    * The filesystem tree at this ref.
    */
   tree(opts?: GitRefTreeOpts): Directory {
@@ -2648,23 +2631,6 @@ export class GitRepository extends BaseClient {
   }
 
   /**
-   * Lists of branches on the repository.
-   */
-  async branches(): Promise<string[]> {
-    const response: Awaited<string[]> = await computeQuery(
-      [
-        ...this._queryTree,
-        {
-          operation: "branches",
-        },
-      ],
-      this.client
-    )
-
-    return response
-  }
-
-  /**
    * Returns details on one commit.
    * @param id Identifier of the commit (e.g., "b6315d8f2810962c601af73f86831f6866ea798b").
    */
@@ -2698,23 +2664,6 @@ export class GitRepository extends BaseClient {
       host: this.clientHost,
       sessionToken: this.sessionToken,
     })
-  }
-
-  /**
-   * Lists of tags on the repository.
-   */
-  async tags(): Promise<string[]> {
-    const response: Awaited<string[]> = await computeQuery(
-      [
-        ...this._queryTree,
-        {
-          operation: "tags",
-        },
-      ],
-      this.client
-    )
-
-    return response
   }
 
   /**

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -2186,28 +2186,6 @@ class GitRef(Type):
     """A git ref (tag, branch or commit)."""
 
     @typecheck
-    async def digest(self) -> str:
-        """The digest of the current value of this ref.
-
-        Returns
-        -------
-        str
-            The `String` scalar type represents textual data, represented as
-            UTF-8 character sequences. The String type is most often used by
-            GraphQL to represent free-form human-readable text.
-
-        Raises
-        ------
-        ExecuteTimeoutError
-            If the time to execute the query exceeds the configured timeout.
-        QueryError
-            If the API returns an error.
-        """
-        _args: list[Arg] = []
-        _ctx = self._select("digest", _args)
-        return await _ctx.execute(str)
-
-    @typecheck
     def tree(
         self,
         ssh_known_hosts: Optional[str] = None,
@@ -2241,28 +2219,6 @@ class GitRepository(Type):
         return GitRef(_ctx)
 
     @typecheck
-    async def branches(self) -> list[str]:
-        """Lists of branches on the repository.
-
-        Returns
-        -------
-        list[str]
-            The `String` scalar type represents textual data, represented as
-            UTF-8 character sequences. The String type is most often used by
-            GraphQL to represent free-form human-readable text.
-
-        Raises
-        ------
-        ExecuteTimeoutError
-            If the time to execute the query exceeds the configured timeout.
-        QueryError
-            If the API returns an error.
-        """
-        _args: list[Arg] = []
-        _ctx = self._select("branches", _args)
-        return await _ctx.execute(list[str])
-
-    @typecheck
     def commit(self, id: str) -> GitRef:
         """Returns details on one commit.
 
@@ -2292,28 +2248,6 @@ class GitRepository(Type):
         ]
         _ctx = self._select("tag", _args)
         return GitRef(_ctx)
-
-    @typecheck
-    async def tags(self) -> list[str]:
-        """Lists of tags on the repository.
-
-        Returns
-        -------
-        list[str]
-            The `String` scalar type represents textual data, represented as
-            UTF-8 character sequences. The String type is most often used by
-            GraphQL to represent free-form human-readable text.
-
-        Raises
-        ------
-        ExecuteTimeoutError
-            If the time to execute the query exceeds the configured timeout.
-        QueryError
-            If the API returns an error.
-        """
-        _args: list[Arg] = []
-        _ctx = self._select("tags", _args)
-        return await _ctx.execute(list[str])
 
 
 class Host(Type):

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -2183,28 +2183,6 @@ class GitRef(Type):
     """A git ref (tag, branch or commit)."""
 
     @typecheck
-    def digest(self) -> str:
-        """The digest of the current value of this ref.
-
-        Returns
-        -------
-        str
-            The `String` scalar type represents textual data, represented as
-            UTF-8 character sequences. The String type is most often used by
-            GraphQL to represent free-form human-readable text.
-
-        Raises
-        ------
-        ExecuteTimeoutError
-            If the time to execute the query exceeds the configured timeout.
-        QueryError
-            If the API returns an error.
-        """
-        _args: list[Arg] = []
-        _ctx = self._select("digest", _args)
-        return _ctx.execute_sync(str)
-
-    @typecheck
     def tree(
         self,
         ssh_known_hosts: Optional[str] = None,
@@ -2238,28 +2216,6 @@ class GitRepository(Type):
         return GitRef(_ctx)
 
     @typecheck
-    def branches(self) -> list[str]:
-        """Lists of branches on the repository.
-
-        Returns
-        -------
-        list[str]
-            The `String` scalar type represents textual data, represented as
-            UTF-8 character sequences. The String type is most often used by
-            GraphQL to represent free-form human-readable text.
-
-        Raises
-        ------
-        ExecuteTimeoutError
-            If the time to execute the query exceeds the configured timeout.
-        QueryError
-            If the API returns an error.
-        """
-        _args: list[Arg] = []
-        _ctx = self._select("branches", _args)
-        return _ctx.execute_sync(list[str])
-
-    @typecheck
     def commit(self, id: str) -> GitRef:
         """Returns details on one commit.
 
@@ -2289,28 +2245,6 @@ class GitRepository(Type):
         ]
         _ctx = self._select("tag", _args)
         return GitRef(_ctx)
-
-    @typecheck
-    def tags(self) -> list[str]:
-        """Lists of tags on the repository.
-
-        Returns
-        -------
-        list[str]
-            The `String` scalar type represents textual data, represented as
-            UTF-8 character sequences. The String type is most often used by
-            GraphQL to represent free-form human-readable text.
-
-        Raises
-        ------
-        ExecuteTimeoutError
-            If the time to execute the query exceeds the configured timeout.
-        QueryError
-            If the API returns an error.
-        """
-        _args: list[Arg] = []
-        _ctx = self._select("tags", _args)
-        return _ctx.execute_sync(list[str])
 
 
 class Host(Type):


### PR DESCRIPTION
Removing unimplemented fields in the API because it's confusing to users:
- https://github.com/dagger/dagger/issues/5367

There's no indication that it's not implemented other than trying and failing. We could at least update these fields' descriptions, but I don't see the point.

**Side question:** How would we implement these? 

For example, to get the list of branches, we'd have to do what users already need to do: run `git` in a container, requiring setting the `keepGitDir: true` option. There's no core API resolver that runs an exec in an "built-in" image (e.g., "alpine"). Maybe executing it in the runner (e.g, `cmd := exec.Command("git", args...)`) which is what Buildkit does in `llb.Git` source.