### PR TITLE
sdk(elixir): fix crash on any functions that requires ID

### DIFF
--- a/sdk/elixir/lib/dagger/codegen/elixir/templates/object_tmpl.ex
+++ b/sdk/elixir/lib/dagger/codegen/elixir/templates/object_tmpl.ex
@@ -202,12 +202,8 @@ defmodule Dagger.Codegen.Elixir.Templates.Object do
           mod = Module.concat([Dagger, Mod.format_name(Mod.id_module_to_module(type_name))])
 
           quote do
-            selection =
-              arg(
-                selection,
-                unquote(arg["name"]),
-                unquote(mod).id(unquote(to_macro_var(name)))
-              )
+            {:ok, id} = unquote(mod).id(unquote(to_macro_var(name)))
+            selection = arg(selection, unquote(arg["name"]), id)
           end
 
         _ ->

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -10,7 +10,11 @@ defmodule Dagger.Container do
     @spec build(t(), Dagger.Directory.t(), keyword()) :: Dagger.Container.t()
     def build(%__MODULE__{} = container, context, optional_args \\ []) do
       selection = select(container.selection, "build")
-      selection = arg(selection, "context", Dagger.Directory.id(context))
+
+      (
+        {:ok, id} = Dagger.Directory.id(context)
+        selection = arg(selection, "context", id)
+      )
 
       selection =
         if is_nil(optional_args[:dockerfile]) do
@@ -272,7 +276,11 @@ defmodule Dagger.Container do
     @spec import(t(), Dagger.File.t(), keyword()) :: Dagger.Container.t()
     def import(%__MODULE__{} = container, source, optional_args \\ []) do
       selection = select(container.selection, "import")
-      selection = arg(selection, "source", Dagger.File.id(source))
+
+      (
+        {:ok, id} = Dagger.File.id(source)
+        selection = arg(selection, "source", id)
+      )
 
       selection =
         if is_nil(optional_args[:tag]) do
@@ -441,7 +449,11 @@ defmodule Dagger.Container do
     def with_directory(%__MODULE__{} = container, path, directory, optional_args \\ []) do
       selection = select(container.selection, "withDirectory")
       selection = arg(selection, "path", path)
-      selection = arg(selection, "directory", Dagger.Directory.id(directory))
+
+      (
+        {:ok, id} = Dagger.Directory.id(directory)
+        selection = arg(selection, "directory", id)
+      )
 
       selection =
         if is_nil(optional_args[:exclude]) do
@@ -585,7 +597,12 @@ defmodule Dagger.Container do
     @spec with_fs(t(), Dagger.Directory.t()) :: Dagger.Container.t()
     def with_fs(%__MODULE__{} = container, directory) do
       selection = select(container.selection, "withFS")
-      selection = arg(selection, "id", Dagger.Directory.id(directory))
+
+      (
+        {:ok, id} = Dagger.Directory.id(directory)
+        selection = arg(selection, "id", id)
+      )
+
       %Dagger.Container{selection: selection, client: container.client}
     end
   )
@@ -596,7 +613,11 @@ defmodule Dagger.Container do
     def with_file(%__MODULE__{} = container, path, source, optional_args \\ []) do
       selection = select(container.selection, "withFile")
       selection = arg(selection, "path", path)
-      selection = arg(selection, "source", Dagger.File.id(source))
+
+      (
+        {:ok, id} = Dagger.File.id(source)
+        selection = arg(selection, "source", id)
+      )
 
       selection =
         if is_nil(optional_args[:permissions]) do
@@ -633,7 +654,11 @@ defmodule Dagger.Container do
     def with_mounted_cache(%__MODULE__{} = container, path, cache, optional_args \\ []) do
       selection = select(container.selection, "withMountedCache")
       selection = arg(selection, "path", path)
-      selection = arg(selection, "cache", Dagger.CacheVolume.id(cache))
+
+      (
+        {:ok, id} = Dagger.CacheVolume.id(cache)
+        selection = arg(selection, "cache", id)
+      )
 
       selection =
         if is_nil(optional_args[:source]) do
@@ -667,7 +692,11 @@ defmodule Dagger.Container do
     def with_mounted_directory(%__MODULE__{} = container, path, source, optional_args \\ []) do
       selection = select(container.selection, "withMountedDirectory")
       selection = arg(selection, "path", path)
-      selection = arg(selection, "source", Dagger.Directory.id(source))
+
+      (
+        {:ok, id} = Dagger.Directory.id(source)
+        selection = arg(selection, "source", id)
+      )
 
       selection =
         if is_nil(optional_args[:owner]) do
@@ -686,7 +715,11 @@ defmodule Dagger.Container do
     def with_mounted_file(%__MODULE__{} = container, path, source, optional_args \\ []) do
       selection = select(container.selection, "withMountedFile")
       selection = arg(selection, "path", path)
-      selection = arg(selection, "source", Dagger.File.id(source))
+
+      (
+        {:ok, id} = Dagger.File.id(source)
+        selection = arg(selection, "source", id)
+      )
 
       selection =
         if is_nil(optional_args[:owner]) do
@@ -706,7 +739,11 @@ defmodule Dagger.Container do
     def with_mounted_secret(%__MODULE__{} = container, path, source, optional_args \\ []) do
       selection = select(container.selection, "withMountedSecret")
       selection = arg(selection, "path", path)
-      selection = arg(selection, "source", Dagger.Secret.id(source))
+
+      (
+        {:ok, id} = Dagger.Secret.id(source)
+        selection = arg(selection, "source", id)
+      )
 
       selection =
         if is_nil(optional_args[:owner]) do
@@ -769,7 +806,12 @@ defmodule Dagger.Container do
       selection = select(container.selection, "withRegistryAuth")
       selection = arg(selection, "address", address)
       selection = arg(selection, "username", username)
-      selection = arg(selection, "secret", Dagger.Secret.id(secret))
+
+      (
+        {:ok, id} = Dagger.Secret.id(secret)
+        selection = arg(selection, "secret", id)
+      )
+
       %Dagger.Container{selection: selection, client: container.client}
     end
   )
@@ -779,7 +821,12 @@ defmodule Dagger.Container do
     @spec with_rootfs(t(), Dagger.Directory.t()) :: Dagger.Container.t()
     def with_rootfs(%__MODULE__{} = container, directory) do
       selection = select(container.selection, "withRootfs")
-      selection = arg(selection, "id", Dagger.Directory.id(directory))
+
+      (
+        {:ok, id} = Dagger.Directory.id(directory)
+        selection = arg(selection, "id", id)
+      )
+
       %Dagger.Container{selection: selection, client: container.client}
     end
   )
@@ -790,7 +837,12 @@ defmodule Dagger.Container do
     def with_secret_variable(%__MODULE__{} = container, name, secret) do
       selection = select(container.selection, "withSecretVariable")
       selection = arg(selection, "name", name)
-      selection = arg(selection, "secret", Dagger.Secret.id(secret))
+
+      (
+        {:ok, id} = Dagger.Secret.id(secret)
+        selection = arg(selection, "secret", id)
+      )
+
       %Dagger.Container{selection: selection, client: container.client}
     end
   )
@@ -801,7 +853,12 @@ defmodule Dagger.Container do
     def with_service_binding(%__MODULE__{} = container, alias, service) do
       selection = select(container.selection, "withServiceBinding")
       selection = arg(selection, "alias", alias)
-      selection = arg(selection, "service", Dagger.Container.id(service))
+
+      (
+        {:ok, id} = Dagger.Container.id(service)
+        selection = arg(selection, "service", id)
+      )
+
       %Dagger.Container{selection: selection, client: container.client}
     end
   )
@@ -812,7 +869,11 @@ defmodule Dagger.Container do
     def with_unix_socket(%__MODULE__{} = container, path, source, optional_args \\ []) do
       selection = select(container.selection, "withUnixSocket")
       selection = arg(selection, "path", path)
-      selection = arg(selection, "source", Dagger.Socket.id(source))
+
+      (
+        {:ok, id} = Dagger.Socket.id(source)
+        selection = arg(selection, "source", id)
+      )
 
       selection =
         if is_nil(optional_args[:owner]) do

--- a/sdk/elixir/lib/dagger/gen/directory.ex
+++ b/sdk/elixir/lib/dagger/gen/directory.ex
@@ -10,7 +10,12 @@ defmodule Dagger.Directory do
     @spec diff(t(), Dagger.Directory.t()) :: Dagger.Directory.t()
     def diff(%__MODULE__{} = directory, other) do
       selection = select(directory.selection, "diff")
-      selection = arg(selection, "other", Dagger.Directory.id(other))
+
+      (
+        {:ok, id} = Dagger.Directory.id(other)
+        selection = arg(selection, "other", id)
+      )
+
       %Dagger.Directory{selection: selection, client: directory.client}
     end
   )
@@ -147,7 +152,11 @@ defmodule Dagger.Directory do
     def with_directory(%__MODULE__{} = directory, path, directory, optional_args \\ []) do
       selection = select(directory.selection, "withDirectory")
       selection = arg(selection, "path", path)
-      selection = arg(selection, "directory", Dagger.Directory.id(directory))
+
+      (
+        {:ok, id} = Dagger.Directory.id(directory)
+        selection = arg(selection, "directory", id)
+      )
 
       selection =
         if is_nil(optional_args[:exclude]) do
@@ -173,7 +182,11 @@ defmodule Dagger.Directory do
     def with_file(%__MODULE__{} = directory, path, source, optional_args \\ []) do
       selection = select(directory.selection, "withFile")
       selection = arg(selection, "path", path)
-      selection = arg(selection, "source", Dagger.File.id(source))
+
+      (
+        {:ok, id} = Dagger.File.id(source)
+        selection = arg(selection, "source", id)
+      )
 
       selection =
         if is_nil(optional_args[:permissions]) do

--- a/sdk/elixir/lib/dagger/gen/project.ex
+++ b/sdk/elixir/lib/dagger/gen/project.ex
@@ -28,7 +28,12 @@ defmodule Dagger.Project do
     @spec load(t(), Dagger.Directory.t(), String.t()) :: Dagger.Project.t()
     def load(%__MODULE__{} = project, source, config_path) do
       selection = select(project.selection, "load")
-      selection = arg(selection, "source", Dagger.Directory.id(source))
+
+      (
+        {:ok, id} = Dagger.Directory.id(source)
+        selection = arg(selection, "source", id)
+      )
+
       selection = arg(selection, "configPath", config_path)
       %Dagger.Project{selection: selection, client: project.client}
     end

--- a/sdk/elixir/lib/dagger/gen/query.ex
+++ b/sdk/elixir/lib/dagger/gen/query.ex
@@ -70,7 +70,12 @@ defmodule Dagger.Query do
     @spec file(t(), Dagger.File.t()) :: Dagger.File.t()
     def file(%__MODULE__{} = query, file) do
       selection = select(query.selection, "file")
-      selection = arg(selection, "id", Dagger.File.id(file))
+
+      (
+        {:ok, id} = Dagger.File.id(file)
+        selection = arg(selection, "id", id)
+      )
+
       execute(selection, query.client)
     end
   )
@@ -191,7 +196,12 @@ defmodule Dagger.Query do
     @spec secret(t(), Dagger.Secret.t()) :: Dagger.Secret.t()
     def secret(%__MODULE__{} = query, secret) do
       selection = select(query.selection, "secret")
-      selection = arg(selection, "id", Dagger.Secret.id(secret))
+
+      (
+        {:ok, id} = Dagger.Secret.id(secret)
+        selection = arg(selection, "id", id)
+      )
+
       %Dagger.Secret{selection: selection, client: query.client}
     end
   )


### PR DESCRIPTION
Any id functions returns `{:ok, id}`. But we didn't handle it. This patch fix it.

Fixes #5412