### PR TITLE
Fix corner case where WithDirectory included wrong contents.

### DIFF
--- a/core/directory.go
+++ b/core/directory.go
@@ -442,7 +442,8 @@ func mergeStates(input mergeStateInput) llb.State {
 		copyInfo.ChownOpt == nil &&
 		len(copyInfo.ExcludePatterns) == 0 &&
 		len(copyInfo.IncludePatterns) == 0 &&
-		input.DestDir == input.SrcDir &&
+		input.DestDir == "/" &&
+		input.SrcDir == "/" &&
 		// TODO:(sipsma) we could support direct merge-op with individual files if we can verify
 		// there are no other files in the dir, but doing so by just calling ReadDir would result
 		// in unlazying the inputs, which defeats some of the performance benefits of merge-op.


### PR DESCRIPTION
The previous MergeOp optimization missed a corner case where if the selector of the source dir was the same as the destination path, direct MergeOp could be triggered and reveal anything above the selector of the source during the merge.

This fixes it by only triggering direct merge when both src and dest paths (including any selectors) are "/".

---

Fixes #5437

Noticed this while working on Zenith, just patching quick before I forget.