### PR TITLE
Configure dependabot to ignore npm dep updates in sdk/rust

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -77,3 +77,11 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+
+  # ignore all npm dependencies in sdk/rust
+  - package-ecosystem: "npm"
+    directory: "/sdk/rust"
+    schedule:
+      interval: "monthly"
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
Dependabot opened 12 npm dep bumps in sdk/rust in the last 4 days. These are super low value contributions that we want to avoid seeing alongside the other, genuinely valuable PRs (each dep bump gets its own PR, which means a lot of noise & no signal).