### PR TITLE
core: support optionally setting explicit mediatypes

### DIFF
--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -445,10 +445,11 @@ type containerPublishArgs struct {
 	Address           string
 	PlatformVariants  []core.ContainerID
 	ForcedCompression core.ImageLayerCompression
+	MediaTypes        core.ImageMediaTypes
 }
 
 func (s *containerSchema) publish(ctx *router.Context, parent *core.Container, args containerPublishArgs) (string, error) {
-	return parent.Publish(ctx, args.Address, args.PlatformVariants, args.ForcedCompression, s.bkClient, s.solveOpts, s.solveCh)
+	return parent.Publish(ctx, args.Address, args.PlatformVariants, args.ForcedCompression, args.MediaTypes, s.bkClient, s.solveOpts, s.solveCh)
 }
 
 type containerWithMountedFileArgs struct {
@@ -657,10 +658,11 @@ type containerExportArgs struct {
 	Path              string
 	PlatformVariants  []core.ContainerID
 	ForcedCompression core.ImageLayerCompression
+	MediaTypes        core.ImageMediaTypes
 }
 
 func (s *containerSchema) export(ctx *router.Context, parent *core.Container, args containerExportArgs) (bool, error) {
-	if err := parent.Export(ctx, s.host, args.Path, args.PlatformVariants, args.ForcedCompression, s.bkClient, s.solveOpts, s.solveCh); err != nil {
+	if err := parent.Export(ctx, s.host, args.Path, args.PlatformVariants, args.ForcedCompression, args.MediaTypes, s.bkClient, s.solveOpts, s.solveCh); err != nil {
 		return false, err
 	}
 

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -656,7 +656,7 @@ type Container {
     is largely compatible with most recent registries, but Docker may be needed for older
     registries without OCI support.
     """
-    mediaTypes: ImageMediaTypes
+    mediaTypes: ImageMediaTypes = OCIMediaTypes
   ): String!
 
   """
@@ -692,7 +692,7 @@ type Container {
     is largely compatible with most recent container runtimes, but Docker may be needed 
     for older runtimes without OCI support.
     """
-    mediaTypes: ImageMediaTypes
+    mediaTypes: ImageMediaTypes = OCIMediaTypes
   ): Boolean!
 
   """

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -650,6 +650,13 @@ type Container {
     engine's cache, then it will be compressed using Gzip.
     """
     forcedCompression: ImageLayerCompression
+
+    """
+    Use the specified media types for the published image's layers. Defaults to OCI, which
+    is largely compatible with most recent registries, but Docker may be needed for older
+    registries without OCI support.
+    """
+    mediaTypes: ImageMediaTypes
   ): String!
 
   """
@@ -679,6 +686,13 @@ type Container {
     engine's cache, then it will be compressed using Gzip.
     """
     forcedCompression: ImageLayerCompression
+
+    """
+    Use the specified media types for the exported image's layers. Defaults to OCI, which
+    is largely compatible with most recent container runtimes, but Docker may be needed 
+    for older runtimes without OCI support.
+    """
+    mediaTypes: ImageMediaTypes
   ): Boolean!
 
   """
@@ -867,10 +881,16 @@ enum NetworkProtocol {
   UDP
 }
 
-"Compression algorithm to use for image layers"
+"Compression algorithm to use for image layers."
 enum ImageLayerCompression {
   Gzip
   Zstd
   EStarGZ
   Uncompressed
+}
+
+"Mediatypes to use in published or exported image metadata."
+enum ImageMediaTypes {
+  OCIMediaTypes
+  DockerMediaTypes
 }

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -362,6 +362,10 @@ type ContainerExportOpts struct {
 	// different layers). If this is unset and a layer has no compressed blob in the
 	// engine's cache, then it will be compressed using Gzip.
 	ForcedCompression ImageLayerCompression
+	// Use the specified media types for the exported image's layers. Defaults to OCI, which
+	// is largely compatible with most recent container runtimes, but Docker may be needed
+	// for older runtimes without OCI support.
+	MediaTypes ImageMediaTypes
 }
 
 // Writes the container as an OCI tarball to the destination file path on the host for the specified platform variants.
@@ -381,6 +385,10 @@ func (r *Container) Export(ctx context.Context, path string, opts ...ContainerEx
 		// `forcedCompression` optional argument
 		if !querybuilder.IsZeroValue(opts[i].ForcedCompression) {
 			q = q.Arg("forcedCompression", opts[i].ForcedCompression)
+		}
+		// `mediaTypes` optional argument
+		if !querybuilder.IsZeroValue(opts[i].MediaTypes) {
+			q = q.Arg("mediaTypes", opts[i].MediaTypes)
 		}
 	}
 	q = q.Arg("path", path)
@@ -661,6 +669,10 @@ type ContainerPublishOpts struct {
 	// different layers). If this is unset and a layer has no compressed blob in the
 	// engine's cache, then it will be compressed using Gzip.
 	ForcedCompression ImageLayerCompression
+	// Use the specified media types for the published image's layers. Defaults to OCI, which
+	// is largely compatible with most recent registries, but Docker may be needed for older
+	// registries without OCI support.
+	MediaTypes ImageMediaTypes
 }
 
 // Publishes this container as a new image to the specified address.
@@ -680,6 +692,10 @@ func (r *Container) Publish(ctx context.Context, address string, opts ...Contain
 		// `forcedCompression` optional argument
 		if !querybuilder.IsZeroValue(opts[i].ForcedCompression) {
 			q = q.Arg("forcedCompression", opts[i].ForcedCompression)
+		}
+		// `mediaTypes` optional argument
+		if !querybuilder.IsZeroValue(opts[i].MediaTypes) {
+			q = q.Arg("mediaTypes", opts[i].MediaTypes)
 		}
 	}
 	q = q.Arg("address", address)
@@ -2881,6 +2897,13 @@ const (
 	Gzip         ImageLayerCompression = "Gzip"
 	Uncompressed ImageLayerCompression = "Uncompressed"
 	Zstd         ImageLayerCompression = "Zstd"
+)
+
+type ImageMediaTypes string
+
+const (
+	Dockermediatypes ImageMediaTypes = "DockerMediaTypes"
+	Ocimediatypes    ImageMediaTypes = "OCIMediaTypes"
 )
 
 type NetworkProtocol string

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -171,6 +171,13 @@ export type ContainerExportOpts = {
    * engine's cache, then it will be compressed using Gzip.
    */
   forcedCompression?: ImageLayerCompression
+
+  /**
+   * Use the specified media types for the exported image's layers. Defaults to OCI, which
+   * is largely compatible with most recent container runtimes, but Docker may be needed
+   * for older runtimes without OCI support.
+   */
+  mediaTypes?: ImageMediaTypes
 }
 
 export type ContainerImportOpts = {
@@ -208,6 +215,13 @@ export type ContainerPublishOpts = {
    * engine's cache, then it will be compressed using Gzip.
    */
   forcedCompression?: ImageLayerCompression
+
+  /**
+   * Use the specified media types for the published image's layers. Defaults to OCI, which
+   * is largely compatible with most recent registries, but Docker may be needed for older
+   * registries without OCI support.
+   */
+  mediaTypes?: ImageMediaTypes
 }
 
 export type ContainerWithDefaultArgsOpts = {
@@ -565,13 +579,20 @@ export type HostWorkdirOpts = {
 export type ID = string & { __ID: never }
 
 /**
- * Compression algorithm to use for image layers
+ * Compression algorithm to use for image layers.
  */
 export enum ImageLayerCompression {
   Estargz,
   Gzip,
   Uncompressed,
   Zstd,
+}
+/**
+ * Mediatypes to use in published or exported image metadata.
+ */
+export enum ImageMediaTypes {
+  Dockermediatypes,
+  Ocimediatypes,
 }
 /**
  * Transport layer network protocol associated to a port.
@@ -909,6 +930,9 @@ export class Container extends BaseClient {
    * cache, that will be used (this can result in a mix of compression algorithms for
    * different layers). If this is unset and a layer has no compressed blob in the
    * engine's cache, then it will be compressed using Gzip.
+   * @param opts.mediaTypes Use the specified media types for the exported image's layers. Defaults to OCI, which
+   * is largely compatible with most recent container runtimes, but Docker may be needed
+   * for older runtimes without OCI support.
    */
   async export(path: string, opts?: ContainerExportOpts): Promise<boolean> {
     const response: Awaited<boolean> = await computeQuery(
@@ -1184,6 +1208,9 @@ export class Container extends BaseClient {
    * cache, that will be used (this can result in a mix of compression algorithms for
    * different layers). If this is unset and a layer has no compressed blob in the
    * engine's cache, then it will be compressed using Gzip.
+   * @param opts.mediaTypes Use the specified media types for the published image's layers. Defaults to OCI, which
+   * is largely compatible with most recent registries, but Docker may be needed for older
+   * registries without OCI support.
    */
   async publish(address: string, opts?: ContainerPublishOpts): Promise<string> {
     const response: Awaited<string> = await computeQuery(

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -63,7 +63,7 @@ class CacheSharingMode(Enum):
 
 
 class ImageLayerCompression(Enum):
-    """Compression algorithm to use for image layers"""
+    """Compression algorithm to use for image layers."""
 
     EStarGZ = "EStarGZ"
 
@@ -72,6 +72,14 @@ class ImageLayerCompression(Enum):
     Uncompressed = "Uncompressed"
 
     Zstd = "Zstd"
+
+
+class ImageMediaTypes(Enum):
+    """Mediatypes to use in published or exported image metadata."""
+
+    DockerMediaTypes = "DockerMediaTypes"
+
+    OCIMediaTypes = "OCIMediaTypes"
 
 
 class NetworkProtocol(Enum):
@@ -403,6 +411,7 @@ class Container(Type):
         path: str,
         platform_variants: Optional[Sequence["Container"]] = None,
         forced_compression: Optional[ImageLayerCompression] = None,
+        media_types: Optional[ImageMediaTypes] = None,
     ) -> bool:
         """Writes the container as an OCI tarball to the destination file path on
         the host for the specified platform variants.
@@ -428,6 +437,12 @@ class Container(Type):
             different layers). If this is unset and a layer has no compressed
             blob in the
             engine's cache, then it will be compressed using Gzip.
+        media_types:
+            Use the specified media types for the exported image's layers.
+            Defaults to OCI, which
+            is largely compatible with most recent container runtimes, but
+            Docker may be needed
+            for older runtimes without OCI support.
 
         Returns
         -------
@@ -445,6 +460,7 @@ class Container(Type):
             Arg("path", path),
             Arg("platformVariants", platform_variants, None),
             Arg("forcedCompression", forced_compression, None),
+            Arg("mediaTypes", media_types, None),
         ]
         _ctx = self._select("export", _args)
         return await _ctx.execute(bool)
@@ -740,6 +756,7 @@ class Container(Type):
         address: str,
         platform_variants: Optional[Sequence["Container"]] = None,
         forced_compression: Optional[ImageLayerCompression] = None,
+        media_types: Optional[ImageMediaTypes] = None,
     ) -> str:
         """Publishes this container as a new image to the specified address.
 
@@ -765,6 +782,12 @@ class Container(Type):
             different layers). If this is unset and a layer has no compressed
             blob in the
             engine's cache, then it will be compressed using Gzip.
+        media_types:
+            Use the specified media types for the published image's layers.
+            Defaults to OCI, which
+            is largely compatible with most recent registries, but Docker may
+            be needed for older
+            registries without OCI support.
 
         Returns
         -------
@@ -784,6 +807,7 @@ class Container(Type):
             Arg("address", address),
             Arg("platformVariants", platform_variants, None),
             Arg("forcedCompression", forced_compression, None),
+            Arg("mediaTypes", media_types, None),
         ]
         _ctx = self._select("publish", _args)
         return await _ctx.execute(str)
@@ -3263,6 +3287,7 @@ __all__ = [
     "Host",
     "HostVariable",
     "ImageLayerCompression",
+    "ImageMediaTypes",
     "Label",
     "NetworkProtocol",
     "PipelineLabel",

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -63,7 +63,7 @@ class CacheSharingMode(Enum):
 
 
 class ImageLayerCompression(Enum):
-    """Compression algorithm to use for image layers"""
+    """Compression algorithm to use for image layers."""
 
     EStarGZ = "EStarGZ"
 
@@ -72,6 +72,14 @@ class ImageLayerCompression(Enum):
     Uncompressed = "Uncompressed"
 
     Zstd = "Zstd"
+
+
+class ImageMediaTypes(Enum):
+    """Mediatypes to use in published or exported image metadata."""
+
+    DockerMediaTypes = "DockerMediaTypes"
+
+    OCIMediaTypes = "OCIMediaTypes"
 
 
 class NetworkProtocol(Enum):
@@ -403,6 +411,7 @@ class Container(Type):
         path: str,
         platform_variants: Optional[Sequence["Container"]] = None,
         forced_compression: Optional[ImageLayerCompression] = None,
+        media_types: Optional[ImageMediaTypes] = None,
     ) -> bool:
         """Writes the container as an OCI tarball to the destination file path on
         the host for the specified platform variants.
@@ -428,6 +437,12 @@ class Container(Type):
             different layers). If this is unset and a layer has no compressed
             blob in the
             engine's cache, then it will be compressed using Gzip.
+        media_types:
+            Use the specified media types for the exported image's layers.
+            Defaults to OCI, which
+            is largely compatible with most recent container runtimes, but
+            Docker may be needed
+            for older runtimes without OCI support.
 
         Returns
         -------
@@ -445,6 +460,7 @@ class Container(Type):
             Arg("path", path),
             Arg("platformVariants", platform_variants, None),
             Arg("forcedCompression", forced_compression, None),
+            Arg("mediaTypes", media_types, None),
         ]
         _ctx = self._select("export", _args)
         return _ctx.execute_sync(bool)
@@ -740,6 +756,7 @@ class Container(Type):
         address: str,
         platform_variants: Optional[Sequence["Container"]] = None,
         forced_compression: Optional[ImageLayerCompression] = None,
+        media_types: Optional[ImageMediaTypes] = None,
     ) -> str:
         """Publishes this container as a new image to the specified address.
 
@@ -765,6 +782,12 @@ class Container(Type):
             different layers). If this is unset and a layer has no compressed
             blob in the
             engine's cache, then it will be compressed using Gzip.
+        media_types:
+            Use the specified media types for the published image's layers.
+            Defaults to OCI, which
+            is largely compatible with most recent registries, but Docker may
+            be needed for older
+            registries without OCI support.
 
         Returns
         -------
@@ -784,6 +807,7 @@ class Container(Type):
             Arg("address", address),
             Arg("platformVariants", platform_variants, None),
             Arg("forcedCompression", forced_compression, None),
+            Arg("mediaTypes", media_types, None),
         ]
         _ctx = self._select("publish", _args)
         return _ctx.execute_sync(str)
@@ -3254,6 +3278,7 @@ __all__ = [
     "Host",
     "HostVariable",
     "ImageLayerCompression",
+    "ImageMediaTypes",
     "Label",
     "NetworkProtocol",
     "PipelineLabel",


### PR DESCRIPTION
We previously made a change to default to using oci mediatypes, which helped compatibility with certain compression types that are only supported with oci types.

However, older registries ([specifically a user reported Artifactory versions from pre-2020](https://github.com/dagger/dagger/issues/5433)) don't have OCI support.

This change fixes that by leaving OCI as the default but enabling users to specify docker mediatypes to be used instead as a fallback.

---

Fixes #5433 