### PR TITLE
remove llb.SessionID from Host.Directory for now

### DIFF
--- a/core/host.go
+++ b/core/host.go
@@ -72,7 +72,16 @@ func (host *Host) Directory(ctx context.Context, gw bkgw.Client, dirPath string,
 
 		// sync this dir from this session specifically, even if this ends up passed
 		// to a different session (e.g. a project container)
-		llb.SessionID(gw.BuildOpts().SessionID),
+		//
+		// TODO(vito): disabled this and brought back LocalUniqueID as this is
+		// causing downstream container hostnames to change every session and
+		// busting all the caches
+		// llb.SessionID(gw.BuildOpts().SessionID),
+
+		// make the LLB stable so we can test invariants like:
+		//
+		//   workdir == directory(".")
+		llb.LocalUniqueID(localID),
 	}
 
 	if len(filter.Exclude) > 0 {

--- a/core/integration/cache_test.go
+++ b/core/integration/cache_test.go
@@ -1,8 +1,12 @@
 package core
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"dagger.io/dagger"
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/internal/testutil"
 	"github.com/stretchr/testify/require"
@@ -64,4 +68,35 @@ func TestCacheVolume(t *testing.T) {
 
 		require.NotEqual(t, idOrig, idDiff)
 	})
+}
+
+func TestLocalImportCacheReuse(t *testing.T) {
+	t.Parallel()
+
+	hostDirPath := t.TempDir()
+	err := os.WriteFile(filepath.Join(hostDirPath, "foo"), []byte("bar"), 0o644)
+	require.NoError(t, err)
+
+	runExec := func(ctx context.Context, t *testing.T, c *dagger.Client) string {
+		out, err := c.Container().From("alpine:3.16.2").
+			WithDirectory("/fromhost", c.Host().Directory(hostDirPath)).
+			WithExec([]string{"sh", "-c", "head -c 128 /dev/random | sha256sum"}).
+			Stdout(ctx)
+		require.NoError(t, err)
+		return out
+	}
+
+	c1, ctx1 := connect(t)
+	defer c1.Close()
+	ctx1, cancel1 := context.WithCancel(ctx1)
+	defer cancel1()
+	out1 := runExec(ctx1, t, c1)
+
+	c2, ctx2 := connect(t)
+	defer c2.Close()
+	ctx2, cancel2 := context.WithCancel(ctx2)
+	defer cancel2()
+	out2 := runExec(ctx2, t, c2)
+
+	require.Equal(t, out1, out2)
 }

--- a/core/integration/project_test.go
+++ b/core/integration/project_test.go
@@ -207,6 +207,8 @@ func TestProjectCommandHierarchy(t *testing.T) {
 }
 
 func TestProjectHostExport(t *testing.T) {
+	t.Skip("disabled by https://github.com/dagger/dagger/pull/5468")
+
 	t.Parallel()
 
 	prefix := identity.NewID()


### PR DESCRIPTION
This is causing container hostnames to change on every run, causing caches to bust.

We tried changing Container.WithExec to only set a hostname if the container exposes ports, but that breaks two use cases:

1. Calling WithExec before WithExposedPort.
1. Using a container as a service without explicitly exposed ports.

We could stomach temporarily breaking the latter case, but the former case is probably pretty common, since that's what our docs show.

The impact of this change on the other hand should be pretty minor, only breaking the unannounced `dagger do` command, which is already being completely rearchitected such that we can probably approach the intended fix here in a different manner. (#5415)