### PR TITLE
core: add include/exclude name to host dir copy name

### DIFF
--- a/core/host.go
+++ b/core/host.go
@@ -75,11 +75,15 @@ func (host *Host) Directory(ctx context.Context, gw bkgw.Client, dirPath string,
 		llb.SessionID(gw.BuildOpts().SessionID),
 	}
 
+	opName := fmt.Sprintf("copy %s", absPath)
+
 	if len(filter.Exclude) > 0 {
+		opName += fmt.Sprintf(" (exclude %s)", strings.Join(filter.Exclude, ", "))
 		localOpts = append(localOpts, llb.ExcludePatterns(filter.Exclude))
 	}
 
 	if len(filter.Include) > 0 {
+		opName += fmt.Sprintf(" (include %s)", strings.Join(filter.Include, ", "))
 		localOpts = append(localOpts, llb.IncludePatterns(filter.Include))
 	}
 
@@ -89,7 +93,7 @@ func (host *Host) Directory(ctx context.Context, gw bkgw.Client, dirPath string,
 	// mount when possible
 	st := llb.Scratch().File(
 		llb.Copy(llb.Local(absPath, localOpts...), "/", "/"),
-		llb.WithCustomNamef("copy %s", absPath),
+		llb.WithCustomNamef(opName),
 	)
 
 	def, err := st.Marshal(ctx, llb.Platform(platform))

--- a/core/integration/host_test.go
+++ b/core/integration/host_test.go
@@ -57,7 +57,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "subdir", "sub-file"), []byte("goodbye"), 0600))
 
 	ctx := context.Background()
-	c, err := dagger.Connect(ctx, dagger.WithWorkdir(dir))
+	c, err := dagger.Connect(ctx, dagger.WithWorkdir(dir), dagger.WithLogOutput(os.Stderr))
 	require.NoError(t, err)
 	defer c.Close()
 


### PR DESCRIPTION
Helps make it more obvious why two copy operations that look similar are cached differently and vice versa.