### PR TITLE
bump alpine image to fix dns resolution error

### DIFF
--- a/.changes/unreleased/Fixed-20230715-131052.yaml
+++ b/.changes/unreleased/Fixed-20230715-131052.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Bump engine alpine version to fix service DNS resolution
+time: 2023-07-15T13:10:52.157510517-03:00
+custom:
+  Author: marcosnils
+  PR: "5470"

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -71,7 +71,7 @@ func TestContainerFrom(t *testing.T) {
 	err := testutil.Query(
 		`{
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
                     file(path: "/etc/alpine-release") {
                         contents
                     }
@@ -79,7 +79,7 @@ func TestContainerFrom(t *testing.T) {
 			}
 		}`, &res, nil)
 	require.NoError(t, err)
-	require.Equal(t, res.Container.From.File.Contents, "3.16.2\n")
+	require.Equal(t, res.Container.From.File.Contents, "3.18.2\n")
 }
 
 func TestContainerBuild(t *testing.T) {
@@ -242,7 +242,7 @@ CMD cat /secret
 
 	t.Run("just build, don't execute", func(t *testing.T) {
 		src := contextDir.
-			WithNewFile("Dockerfile", "FROM alpine:3.16.2\nCMD false")
+			WithNewFile("Dockerfile", "FROM "+alpineImage+"\nCMD false")
 
 		_, err = c.Container().Build(src).Sync(ctx)
 		require.NoError(t, err)
@@ -254,7 +254,7 @@ CMD cat /secret
 
 	t.Run("just build, short-circuit", func(t *testing.T) {
 		src := contextDir.
-			WithNewFile("Dockerfile", "FROM alpine:3.16.2\nRUN false")
+			WithNewFile("Dockerfile", "FROM "+alpineImage+"\nRUN false")
 
 		_, err = c.Container().Build(src).Sync(ctx)
 		require.NotEmpty(t, err)
@@ -269,7 +269,7 @@ func TestContainerWithRootFS(t *testing.T) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	alpine316 := c.Container().From("alpine:3.16.2")
+	alpine316 := c.Container().From(alpineImage)
 
 	alpine316ReleaseStr, err := alpine316.File("/etc/alpine-release").Contents(ctx)
 	require.NoError(t, err)
@@ -284,7 +284,7 @@ func TestContainerWithRootFS(t *testing.T) {
 
 	require.NoError(t, err)
 
-	alpine315 := c.Container().From("alpine:3.15.6")
+	alpine315 := c.Container().From(alpineImage)
 
 	varVal := "testing123"
 
@@ -303,7 +303,7 @@ func TestContainerWithRootFS(t *testing.T) {
 	releaseStr, err := alpine315ReplacedFS.File("/etc/alpine-release").Contents(ctx)
 	require.NoError(t, err)
 
-	require.Equal(t, "3.16.2\n", releaseStr)
+	require.Equal(t, "3.18.2\n", releaseStr)
 }
 
 //go:embed testdata/hello.go
@@ -340,7 +340,7 @@ func TestContainerExecSync(t *testing.T) {
 	err := testutil.Query(
 		`{
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withExec(args: ["false"]) {
 						sync
 					}
@@ -366,7 +366,7 @@ func TestContainerExecExitCode(t *testing.T) {
 	err := testutil.Query(
 		`{
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withExec(args: ["true"]) {
 						exitCode
 					}
@@ -394,7 +394,7 @@ func TestContainerExecExitCode(t *testing.T) {
 		err = testutil.Query(
 			`{
 				container {
-					from(address: "alpine:3.16.2") {
+					from(address: "`+alpineImage+`") {
 						withExec(args: ["false"]) {
 							exitCode
 						}
@@ -423,7 +423,7 @@ func TestContainerExecStdoutStderr(t *testing.T) {
 	err := testutil.Query(
 		`{
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withExec(args: ["sh", "-c", "echo hello; echo goodbye >/dev/stderr"]) {
 						stdout
 						stderr
@@ -452,7 +452,7 @@ func TestContainerExecStdin(t *testing.T) {
 	err := testutil.Query(
 		`{
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withExec(args: ["cat"], stdin: "hello") {
 						stdout
 					}
@@ -481,7 +481,7 @@ func TestContainerExecRedirectStdoutStderr(t *testing.T) {
 	err := testutil.Query(
 		`{
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withExec(
 						args: ["sh", "-c", "echo hello; echo goodbye >/dev/stderr"],
 						redirectStdout: "out",
@@ -505,7 +505,7 @@ func TestContainerExecRedirectStdoutStderr(t *testing.T) {
 	c, ctx := connect(t)
 	defer c.Close()
 
-	execWithMount := c.Container().From("alpine:3.16.2").
+	execWithMount := c.Container().From(alpineImage).
 		WithMountedDirectory("/mnt", c.Directory()).
 		WithExec([]string{"sh", "-c", "echo hello; echo goodbye >/dev/stderr"}, dagger.ContainerWithExecOpts{
 			RedirectStdout: "/mnt/out",
@@ -546,7 +546,7 @@ func TestContainerExecWithWorkdir(t *testing.T) {
 	err := testutil.Query(
 		`{
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withWorkdir(path: "/usr") {
 						withExec(args: ["pwd"]) {
 							stdout
@@ -581,7 +581,7 @@ func TestContainerExecWithUser(t *testing.T) {
 		err := testutil.Query(
 			`{
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					user
 					withUser(name: "daemon") {
 						user
@@ -602,7 +602,7 @@ func TestContainerExecWithUser(t *testing.T) {
 		err := testutil.Query(
 			`{
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					user
 					withUser(name: "daemon:floppy") {
 						user
@@ -623,7 +623,7 @@ func TestContainerExecWithUser(t *testing.T) {
 		err := testutil.Query(
 			`{
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					user
 					withUser(name: "2") {
 						user
@@ -644,7 +644,7 @@ func TestContainerExecWithUser(t *testing.T) {
 		err := testutil.Query(
 			`{
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					user
 					withUser(name: "2:11") {
 						user
@@ -668,7 +668,7 @@ func TestContainerExecWithEntrypoint(t *testing.T) {
 	c, ctx := connect(t)
 	defer c.Close()
 
-	base := c.Container().From("alpine:3.16.2")
+	base := c.Container().From(alpineImage)
 	before, err := base.Entrypoint(ctx)
 	require.NoError(t, err)
 	require.Empty(t, before)
@@ -733,7 +733,7 @@ func TestContainerWithDefaultArgs(t *testing.T) {
 	err := testutil.Query(
 		`{
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					entrypoint
 					defaultArgs
 					withDefaultArgs {
@@ -807,7 +807,7 @@ func TestContainerExecWithEnvVariable(t *testing.T) {
 	err := testutil.Query(
 		`{
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withEnvVariable(name: "FOO", value: "bar") {
 						withExec(args: ["env"]) {
 							stdout
@@ -982,7 +982,7 @@ func TestContainerWithEnvVariableExpand(t *testing.T) {
 
 	t.Run("add env var without expansion", func(t *testing.T) {
 		out, err := c.Container().
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithEnvVariable("FOO", "foo:$PATH").
 			WithExec([]string{"printenv", "FOO"}).
 			Stdout(ctx)
@@ -993,7 +993,7 @@ func TestContainerWithEnvVariableExpand(t *testing.T) {
 
 	t.Run("add env var with expansion", func(t *testing.T) {
 		out, err := c.Container().
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithEnvVariable("USER_PATH", "/opt").
 			WithEnvVariable(
 				"PATH",
@@ -1020,7 +1020,7 @@ func TestContainerLabel(t *testing.T) {
 	defer c.Close()
 
 	t.Run("container with new label", func(t *testing.T) {
-		label, err := c.Container().From("alpine:3.16.2").WithLabel("FOO", "BAR").Label(ctx, "FOO")
+		label, err := c.Container().From(alpineImage).WithLabel("FOO", "BAR").Label(ctx, "FOO")
 
 		require.NoError(t, err)
 		require.Contains(t, label, "BAR")
@@ -1223,7 +1223,7 @@ func TestContainerWithMountedDirectory(t *testing.T) {
 	err = testutil.Query(
 		`query Test($id: DirectoryID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withMountedDirectory(path: "/mnt", source: $id) {
 						withExec(args: ["cat", "/mnt/some-file"]) {
 							stdout
@@ -1290,7 +1290,7 @@ func TestContainerWithMountedDirectorySourcePath(t *testing.T) {
 	err = testutil.Query(
 		`query Test($id: DirectoryID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withMountedDirectory(path: "/mnt", source: $id) {
 						withExec(args: ["sh", "-c", "echo >> /mnt/sub-file; echo -n more-content >> /mnt/sub-file"]) {
 							withExec(args: ["cat", "/mnt/sub-file"]) {
@@ -1357,7 +1357,7 @@ func TestContainerWithMountedDirectoryPropagation(t *testing.T) {
 	err = testutil.Query(
 		`query Test($id: DirectoryID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withMountedDirectory(path: "/mnt", source: $id) {
 						withExec(args: ["cat", "/mnt/some-file"]) {
 							# original content
@@ -1446,7 +1446,7 @@ func TestContainerWithMountedFile(t *testing.T) {
 	err = testutil.Query(
 		`query Test($id: FileID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withMountedFile(path: "/mnt/file", source: $id) {
 						withExec(args: ["cat", "/mnt/file"]) {
 							stdout
@@ -1482,7 +1482,7 @@ func TestContainerWithMountedCache(t *testing.T) {
 
 	query := `query Test($cache: CacheID!, $rand: String!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "` + alpineImage + `") {
 					withEnvVariable(name: "RAND", value: $rand) {
 						withMountedCache(path: "/mnt/cache", cache: $cache) {
 							withExec(args: ["sh", "-c", "echo $RAND >> /mnt/cache/file; cat /mnt/cache/file"]) {
@@ -1556,7 +1556,7 @@ func TestContainerWithMountedCacheFromDirectory(t *testing.T) {
 
 	query := `query Test($cache: CacheID!, $rand: String!, $init: DirectoryID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "` + alpineImage + `") {
 					withEnvVariable(name: "RAND", value: $rand) {
 						withMountedCache(path: "/mnt/cache", cache: $cache, source: $init) {
 							withExec(args: ["sh", "-c", "echo $RAND >> /mnt/cache/sub-file; cat /mnt/cache/sub-file"]) {
@@ -1604,7 +1604,7 @@ func TestContainerWithMountedTemp(t *testing.T) {
 
 	err := testutil.Query(`{
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withMountedTemp(path: "/mnt/tmp") {
 						withExec(args: ["grep", "/mnt/tmp", "/proc/mounts"]) {
 							stdout
@@ -1629,7 +1629,7 @@ func TestContainerWithDirectory(t *testing.T) {
 		Directory("some-dir")
 
 	ctr := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithWorkdir("/workdir").
 		WithDirectory("with-dir", dir)
 
@@ -1648,7 +1648,7 @@ func TestContainerWithDirectory(t *testing.T) {
 		WithNewFile("mounted-file", "mounted-content")
 
 	ctr = c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithWorkdir("/workdir").
 		WithMountedDirectory("mnt/mount", mount).
 		WithDirectory("mnt/mount/dst/with-dir", dir)
@@ -1665,7 +1665,7 @@ func TestContainerWithDirectory(t *testing.T) {
 	// Test with a relative mount
 	mnt := c.Directory().WithNewDirectory("/a/b/c")
 	ctr = c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithMountedDirectory("/mnt", mnt)
 	dir = c.Directory().
 		WithNewDirectory("/foo").
@@ -1688,7 +1688,7 @@ func TestContainerWithFile(t *testing.T) {
 		File("some-file")
 
 	ctr := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithWorkdir("/workdir").
 		WithFile("target-file", file)
 
@@ -1710,7 +1710,7 @@ func TestContainerWithNewFile(t *testing.T) {
 	defer c.Close()
 
 	ctr := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithWorkdir("/workdir").
 		WithNewFile("some-file", dagger.ContainerWithNewFileOpts{
 			Contents: "some-content",
@@ -1780,7 +1780,7 @@ func TestContainerMountsWithoutMount(t *testing.T) {
 	err = testutil.Query(
 		`query Test($id: DirectoryID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withDirectory(path: "/mnt/dir", directory: "") {
 						withMountedTemp(path: "/mnt/tmp") {
 							mounts
@@ -1822,7 +1822,7 @@ func TestContainerReplacedMounts(t *testing.T) {
 	upper := c.Directory().WithNewFile("some-file", "upper-content")
 
 	ctr := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithMountedDirectory("/mnt/dir", lower)
 
 	t.Run("initial content is lower", func(t *testing.T) {
@@ -1926,7 +1926,7 @@ func TestContainerDirectory(t *testing.T) {
 	err = testutil.Query(
 		`query Test($id: DirectoryID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withMountedDirectory(path: "/mnt/dir", source: $id) {
 						withMountedDirectory(path: "/mnt/dir/overlap", source: $id) {
 							withExec(args: ["sh", "-c", "echo hello >> /mnt/dir/overlap/another-file"]) {
@@ -1959,7 +1959,7 @@ func TestContainerDirectory(t *testing.T) {
 	err = testutil.Query(
 		`query Test($id: DirectoryID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withMountedDirectory(path: "/mnt/dir", source: $id) {
 						withExec(args: ["cat", "/mnt/dir/another-file"]) {
 							stdout
@@ -2005,7 +2005,7 @@ func TestContainerDirectoryErrors(t *testing.T) {
 	err = testutil.Query(
 		`query Test($id: DirectoryID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withMountedDirectory(path: "/mnt/dir", source: $id) {
 						directory(path: "/mnt/dir/some-file") {
 							id
@@ -2022,7 +2022,7 @@ func TestContainerDirectoryErrors(t *testing.T) {
 	err = testutil.Query(
 		`query Test($id: DirectoryID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withMountedDirectory(path: "/mnt/dir", source: $id) {
 						directory(path: "/mnt/dir/bogus") {
 							id
@@ -2039,7 +2039,7 @@ func TestContainerDirectoryErrors(t *testing.T) {
 	err = testutil.Query(
 		`{
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withMountedTemp(path: "/mnt/tmp") {
 						directory(path: "/mnt/tmp/bogus") {
 							id
@@ -2055,7 +2055,7 @@ func TestContainerDirectoryErrors(t *testing.T) {
 	err = testutil.Query(
 		`query Test($cache: CacheID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withMountedCache(path: "/mnt/cache", cache: $cache) {
 						directory(path: "/mnt/cache/bogus") {
 							id
@@ -2113,7 +2113,7 @@ func TestContainerDirectorySourcePath(t *testing.T) {
 	err = testutil.Query(
 		`query Test($id: DirectoryID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withMountedDirectory(path: "/mnt/dir", source: $id) {
 						withExec(args: ["sh", "-c", "echo more-content >> /mnt/dir/sub-dir/sub-file"]) {
 							directory(path: "/mnt/dir/sub-dir") {
@@ -2144,7 +2144,7 @@ func TestContainerDirectorySourcePath(t *testing.T) {
 	err = testutil.Query(
 		`query Test($id: DirectoryID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withMountedDirectory(path: "/mnt/dir", source: $id) {
 						withExec(args: ["cat", "/mnt/dir/sub-file"]) {
 							stdout
@@ -2183,7 +2183,7 @@ func TestContainerFile(t *testing.T) {
 	err := testutil.Query(
 		`query Test($id: DirectoryID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withMountedDirectory(path: "/mnt/dir", source: $id) {
 						withMountedDirectory(path: "/mnt/dir/overlap", source: $id) {
 							withExec(args: ["sh", "-c", "echo -n appended >> /mnt/dir/overlap/some-file"]) {
@@ -2216,7 +2216,7 @@ func TestContainerFile(t *testing.T) {
 	err = testutil.Query(
 		`query Test($id: FileID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withMountedFile(path: "/mnt/file", source: $id) {
 						withExec(args: ["cat", "/mnt/file"]) {
 							stdout
@@ -2240,7 +2240,7 @@ func TestContainerFileErrors(t *testing.T) {
 	err := testutil.Query(
 		`query Test($id: DirectoryID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withMountedDirectory(path: "/mnt/dir", source: $id) {
 						file(path: "/mnt/dir/bogus") {
 							id
@@ -2257,7 +2257,7 @@ func TestContainerFileErrors(t *testing.T) {
 	err = testutil.Query(
 		`query Test($id: DirectoryID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withMountedDirectory(path: "/mnt/dir", source: $id) {
 						file(path: "/mnt/dir") {
 							id
@@ -2274,7 +2274,7 @@ func TestContainerFileErrors(t *testing.T) {
 	err = testutil.Query(
 		`{
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withMountedTemp(path: "/mnt/tmp") {
 						file(path: "/mnt/tmp/bogus") {
 							id
@@ -2290,7 +2290,7 @@ func TestContainerFileErrors(t *testing.T) {
 	err = testutil.Query(
 		`query Test($cache: CacheID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withMountedCache(path: "/mnt/cache", cache: $cache) {
 						file(path: "/mnt/cache/bogus") {
 							id
@@ -2308,7 +2308,7 @@ func TestContainerFileErrors(t *testing.T) {
 	err = testutil.Query(
 		`query Test($secret: SecretID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withMountedSecret(path: "/sekret", source: $secret) {
 						file(path: "/sekret") {
 							contents
@@ -2338,7 +2338,7 @@ func TestContainerFSDirectory(t *testing.T) {
 	err := testutil.Query(
 		`{
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					directory(path: "/etc") {
 						id
 					}
@@ -2363,7 +2363,7 @@ func TestContainerFSDirectory(t *testing.T) {
 	err = testutil.Query(
 		`query Test($id: DirectoryID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withMountedDirectory(path: "/mnt/etc", source: $id) {
 						withExec(args: ["cat", "/mnt/etc/alpine-release"]) {
 							stdout
@@ -2376,7 +2376,7 @@ func TestContainerFSDirectory(t *testing.T) {
 		}})
 	require.NoError(t, err)
 
-	require.Equal(t, "3.16.2\n", execRes.Container.From.WithMountedDirectory.WithExec.Stdout)
+	require.Equal(t, "3.18.2\n", execRes.Container.From.WithMountedDirectory.WithExec.Stdout)
 }
 
 func TestContainerRelativePaths(t *testing.T) {
@@ -2435,7 +2435,7 @@ func TestContainerRelativePaths(t *testing.T) {
 	err = testutil.Query(
 		`query Test($id: DirectoryID!, $cache: CacheID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withExec(args: ["mkdir", "-p", "/mnt/sub"]) {
 						withWorkdir(path: "/mnt") {
 							withWorkdir(path: "sub") {
@@ -2490,7 +2490,7 @@ func TestContainerRelativePaths(t *testing.T) {
 	err = testutil.Query(
 		`query Test($id: DirectoryID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withMountedDirectory(path: "/mnt/dir", source: $id) {
 						withExec(args: ["ls", "/mnt/dir"]) {
 							stdout
@@ -2573,7 +2573,7 @@ func TestContainerPublish(t *testing.T) {
 
 	testRef := registryRef("container-publish")
 	pushedRef, err := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		Publish(ctx, testRef)
 	require.NoError(t, err)
 	require.NotEqual(t, testRef, pushedRef)
@@ -2582,7 +2582,7 @@ func TestContainerPublish(t *testing.T) {
 	contents, err := c.Container().
 		From(pushedRef).Rootfs().File("/etc/alpine-release").Contents(ctx)
 	require.NoError(t, err)
-	require.Equal(t, contents, "3.16.2\n")
+	require.Equal(t, contents, "3.18.2\n")
 }
 
 func TestExecFromScratch(t *testing.T) {
@@ -2617,7 +2617,7 @@ func TestContainerMultipleMounts(t *testing.T) {
 	two := c.Host().Directory(dir).File("two")
 	three := c.Host().Directory(dir).File("three")
 
-	build := c.Container().From("alpine:3.16.2").
+	build := c.Container().From(alpineImage).
 		WithMountedFile("/example/one", one).
 		WithMountedFile("/example/two", two).
 		WithMountedFile("/example/three", three)
@@ -2643,7 +2643,7 @@ func TestContainerExport(t *testing.T) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	ctr := c.Container().From("alpine:3.16.2")
+	ctr := c.Container().From(alpineImage)
 
 	t.Run("to absolute dir", func(t *testing.T) {
 		imagePath := filepath.Join(dest, "image.tar")
@@ -2705,7 +2705,7 @@ func TestContainerImport(t *testing.T) {
 
 	t.Run("OCI", func(t *testing.T) {
 		ctr := c.Container().
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithEnvVariable("FOO", "bar")
 
 		ok, err := ctr.Export(ctx, imagePath)
@@ -2720,7 +2720,7 @@ func TestContainerImport(t *testing.T) {
 	})
 
 	t.Run("Docker", func(t *testing.T) {
-		ref := name.MustParseReference("alpine:3.16.2")
+		ref := name.MustParseReference(alpineImage)
 
 		img, err := remote.Image(ref)
 		require.NoError(t, err)
@@ -2732,7 +2732,7 @@ func TestContainerImport(t *testing.T) {
 
 		out, err := imported.WithExec([]string{"cat", "/etc/alpine-release"}).Stdout(ctx)
 		require.NoError(t, err)
-		require.Equal(t, "3.16.2\n", out)
+		require.Equal(t, "3.18.2\n", out)
 	})
 }
 
@@ -2747,7 +2747,7 @@ func TestContainerMultiPlatformExport(t *testing.T) {
 	variants := make([]*dagger.Container, 0, len(platformToUname))
 	for platform := range platformToUname {
 		ctr := c.Container(dagger.ContainerOpts{Platform: platform}).
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithExec([]string{"uname", "-m"})
 
 		variants = append(variants, ctr)
@@ -2780,7 +2780,7 @@ func TestContainerMultiPlatformImport(t *testing.T) {
 	variants := make([]*dagger.Container, 0, len(platformToUname))
 	for platform := range platformToUname {
 		ctr := c.Container(dagger.ContainerOpts{Platform: platform}).
-			From("alpine:3.16.2")
+			From(alpineImage)
 
 		variants = append(variants, ctr)
 	}
@@ -2817,7 +2817,7 @@ func TestContainerWithDirectoryToMount(t *testing.T) {
 		WithNewDirectory("/top/sub-dir/sub-file").
 		Directory("/top") // <-- the important part!
 	ctr := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithMountedDirectory("/mnt", mnt)
 
 	dir := c.Directory().
@@ -2929,7 +2929,7 @@ func TestContainerExecError(t *testing.T) {
 
 	t.Run("includes output of failed exec in error", func(t *testing.T) {
 		_, err = c.Container().
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithExec([]string{"sh", "-c", fmt.Sprintf(
 				`echo %s | base64 -d >&1; echo %s | base64 -d >&2; exit 1`, encodedOutMsg, encodedErrMsg,
 			)}).
@@ -2944,7 +2944,7 @@ func TestContainerExecError(t *testing.T) {
 
 	t.Run("includes output of failed exec in error when redirects are enabled", func(t *testing.T) {
 		_, err = c.Container().
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithExec(
 				[]string{"sh", "-c", fmt.Sprintf(
 					`echo %s | base64 -d >&1; echo %s | base64 -d >&2; exit 1`, encodedOutMsg, encodedErrMsg,
@@ -2983,7 +2983,7 @@ func TestContainerExecError(t *testing.T) {
 		truncMsg := fmt.Sprintf(core.TruncationMessage, 50)
 
 		_, err = c.Container().
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithDirectory("/", c.Directory().
 				WithNewFile("encout", encodedOutMsg).
 				WithNewFile("encerr", encodedErrMsg),
@@ -3010,7 +3010,7 @@ func TestContainerWithRegistryAuth(t *testing.T) {
 	defer c.Close()
 
 	testRef := privateRegistryRef("container-with-registry-auth")
-	container := c.Container().From("alpine:3.16.2")
+	container := c.Container().From(alpineImage)
 
 	// Push without credentials should fail
 	_, err = container.Publish(ctx, testRef)
@@ -3063,13 +3063,13 @@ func TestContainerImageRef(t *testing.T) {
 		err := testutil.Query(
 			`{
 				container {
-					from(address: "alpine:3.16.2") {
+					from(address: "`+alpineImage+`") {
 						imageRef
 					}
 				}
 			}`, &res, nil)
 		require.NoError(t, err)
-		require.Contains(t, res.Container.From.ImageRef, "docker.io/library/alpine:3.16.2@sha256:")
+		require.Contains(t, res.Container.From.ImageRef, "docker.io/library/alpine:3.18.2@sha256:")
 	})
 
 	t.Run("should throw error after the container image modification with exec", func(t *testing.T) {
@@ -3128,7 +3128,7 @@ func TestContainerImageRef(t *testing.T) {
 			Directory("some-dir")
 
 		ctr := c.Container().
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithWorkdir("/workdir").
 			WithDirectory("with-dir", dir)
 
@@ -3180,7 +3180,7 @@ func TestContainerInsecureRootCapabilites(t *testing.T) {
 	}
 
 	for _, capSet := range []string{"CapPrm", "CapEff", "CapBnd"} {
-		out, err := c.Container().From("alpine:3.16.2").
+		out, err := c.Container().From(alpineImage).
 			WithExec([]string{"apk", "add", "libcap"}).
 			WithExec([]string{"sh", "-c", "capsh --decode=$(grep " + capSet + " /proc/self/status | awk '{print $2}')"}).
 			Stdout(ctx)
@@ -3191,7 +3191,7 @@ func TestContainerInsecureRootCapabilites(t *testing.T) {
 	}
 
 	for _, capSet := range []string{"CapPrm", "CapEff", "CapBnd", "CapInh", "CapAmb"} {
-		out, err := c.Container().From("alpine:3.16.2").
+		out, err := c.Container().From(alpineImage).
 			WithExec([]string{"apk", "add", "libcap"}).
 			WithExec([]string{"sh", "-c", "capsh --decode=$(grep " + capSet + " /proc/self/status | awk '{print $2}')"}, dagger.ContainerWithExecOpts{
 				InsecureRootCapabilities: true,
@@ -3252,20 +3252,20 @@ func TestContainerNoExec(t *testing.T) {
 	c, ctx := connect(t)
 	defer c.Close()
 
-	code, err := c.Container().From("alpine:3.16.2").ExitCode(ctx)
+	code, err := c.Container().From(alpineImage).ExitCode(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 0, code)
 
-	stdout, err := c.Container().From("alpine:3.16.2").Stdout(ctx)
+	stdout, err := c.Container().From(alpineImage).Stdout(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "", stdout)
 
-	stderr, err := c.Container().From("alpine:3.16.2").Stderr(ctx)
+	stderr, err := c.Container().From(alpineImage).Stderr(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "", stderr)
 
 	_, err = c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithDefaultArgs(dagger.ContainerWithDefaultArgsOpts{
 			Args: nil,
 		}).
@@ -3297,7 +3297,7 @@ func TestContainerWithMountedFileOwner(t *testing.T) {
 	t.Run("file from subdirectory", func(t *testing.T) {
 		tmp := t.TempDir()
 
-		err := os.Mkdir(filepath.Join(tmp, "subdir"), 0755)
+		err := os.Mkdir(filepath.Join(tmp, "subdir"), 0o755)
 		require.NoError(t, err)
 
 		err = os.WriteFile(filepath.Join(tmp, "subdir", "message.txt"), []byte("hello world"), 0o600)
@@ -3335,7 +3335,7 @@ func TestContainerWithMountedDirectoryOwner(t *testing.T) {
 	t.Run("subdirectory", func(t *testing.T) {
 		tmp := t.TempDir()
 
-		err := os.Mkdir(filepath.Join(tmp, "subdir"), 0755)
+		err := os.Mkdir(filepath.Join(tmp, "subdir"), 0o755)
 		require.NoError(t, err)
 
 		err = os.WriteFile(filepath.Join(tmp, "subdir", "message.txt"), []byte("hello world"), 0o600)
@@ -3353,14 +3353,14 @@ func TestContainerWithMountedDirectoryOwner(t *testing.T) {
 	t.Run("permissions", func(t *testing.T) {
 		dir := c.Directory().
 			WithNewDirectory("perms", dagger.DirectoryWithNewDirectoryOpts{
-				Permissions: 0745,
+				Permissions: 0o745,
 			}).
 			WithNewFile("perms/foo", "whee", dagger.DirectoryWithNewFileOpts{
-				Permissions: 0645,
+				Permissions: 0o645,
 			}).
 			Directory("perms")
 
-		ctr := c.Container().From("alpine:3.16.2").
+		ctr := c.Container().From(alpineImage).
 			WithExec([]string{"adduser", "-D", "inherituser"}).
 			WithExec([]string{"adduser", "-u", "1234", "-D", "auser"}).
 			WithExec([]string{"addgroup", "-g", "4321", "agroup"}).
@@ -3401,7 +3401,7 @@ func TestContainerWithFileOwner(t *testing.T) {
 	t.Run("file from subdirectory", func(t *testing.T) {
 		tmp := t.TempDir()
 
-		err := os.Mkdir(filepath.Join(tmp, "subdir"), 0755)
+		err := os.Mkdir(filepath.Join(tmp, "subdir"), 0o755)
 		require.NoError(t, err)
 
 		err = os.WriteFile(filepath.Join(tmp, "subdir", "message.txt"), []byte("hello world"), 0o600)
@@ -3439,7 +3439,7 @@ func TestContainerWithDirectoryOwner(t *testing.T) {
 	t.Run("subdirectory", func(t *testing.T) {
 		tmp := t.TempDir()
 
-		err := os.Mkdir(filepath.Join(tmp, "subdir"), 0755)
+		err := os.Mkdir(filepath.Join(tmp, "subdir"), 0o755)
 		require.NoError(t, err)
 
 		err = os.WriteFile(filepath.Join(tmp, "subdir", "message.txt"), []byte("hello world"), 0o600)
@@ -3479,7 +3479,7 @@ func TestContainerWithMountedCacheOwner(t *testing.T) {
 	})
 
 	t.Run("permissions (empty)", func(t *testing.T) {
-		ctr := c.Container().From("alpine:3.16.2").
+		ctr := c.Container().From(alpineImage).
 			WithExec([]string{"adduser", "-D", "inherituser"}).
 			WithExec([]string{"adduser", "-u", "1234", "-D", "auser"}).
 			WithExec([]string{"addgroup", "-g", "4321", "agroup"}).
@@ -3496,14 +3496,14 @@ func TestContainerWithMountedCacheOwner(t *testing.T) {
 	t.Run("permissions (source)", func(t *testing.T) {
 		dir := c.Directory().
 			WithNewDirectory("perms", dagger.DirectoryWithNewDirectoryOpts{
-				Permissions: 0745,
+				Permissions: 0o745,
 			}).
 			WithNewFile("perms/foo", "whee", dagger.DirectoryWithNewFileOpts{
-				Permissions: 0645,
+				Permissions: 0o645,
 			}).
 			Directory("perms")
 
-		ctr := c.Container().From("alpine:3.16.2").
+		ctr := c.Container().From(alpineImage).
 			WithExec([]string{"adduser", "-D", "inherituser"}).
 			WithExec([]string{"adduser", "-u", "1234", "-D", "auser"}).
 			WithExec([]string{"addgroup", "-g", "4321", "agroup"}).
@@ -3565,7 +3565,7 @@ func testOwnership(
 ) {
 	t.Parallel()
 
-	ctr := c.Container().From("alpine:3.16.2").
+	ctr := c.Container().From(alpineImage).
 		WithExec([]string{"adduser", "-D", "inherituser"}).
 		WithExec([]string{"adduser", "-u", "1234", "-D", "auser"}).
 		WithExec([]string{"addgroup", "-g", "4321", "agroup"}).
@@ -3686,7 +3686,7 @@ func TestContainerForceCompression(t *testing.T) {
 
 			ref := registryRef("testcontainerpublishforcecompression" + strings.ToLower(string(tc.compression)))
 			_, err := c.Container().
-				From("alpine:3.16.2").
+				From(alpineImage).
 				Publish(ctx, ref, dagger.ContainerPublishOpts{
 					ForcedCompression: tc.compression,
 				})
@@ -3709,7 +3709,7 @@ func TestContainerForceCompression(t *testing.T) {
 
 			tarPath := filepath.Join(t.TempDir(), "export.tar")
 			_, err = c.Container().
-				From("alpine:3.16.2").
+				From(alpineImage).
 				Export(ctx, tarPath, dagger.ContainerExportOpts{
 					ForcedCompression: tc.compression,
 				})
@@ -3818,7 +3818,7 @@ func TestContainerBuildMergesWithParent(t *testing.T) {
 
 	// Create a builder container
 	builderCtr := c.Directory().WithNewFile("Dockerfile",
-		`FROM alpine:3.16.2
+		`FROM `+alpineImage+`
 ENV FOO=BAR
 LABEL "com.example.test-should-replace"="foo"
 EXPOSE 8080
@@ -3976,7 +3976,7 @@ func TestContainerImageLoadCompatibility(t *testing.T) {
 					t.Parallel()
 					tmpdir := t.TempDir()
 					tmpfile := filepath.Join(tmpdir, fmt.Sprintf("test-%s-%s-%s.tar", dockerVersion, mediaType, compression))
-					_, err := c.Container().From("alpine:3.16.2").
+					_, err := c.Container().From(alpineImage).
 						// we need a unique image, otherwise docker load skips it after the first tar load
 						WithExec([]string{"sh", "-c", "echo '" + string(compression) + string(mediaType) + "' > /foo"}).
 						Export(ctx, tmpfile, dagger.ContainerExportOpts{

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -223,9 +223,9 @@ func TestDirectoryWithDirectory(t *testing.T) {
 
 	t.Run("respects permissions", func(t *testing.T) {
 		dir := c.Directory().
-			WithNewFile("some-file", "some content", dagger.DirectoryWithNewFileOpts{Permissions: 0444}).
-			WithNewDirectory("some-dir", dagger.DirectoryWithNewDirectoryOpts{Permissions: 0444}).
-			WithNewFile("some-dir/sub-file", "sub-content", dagger.DirectoryWithNewFileOpts{Permissions: 0444})
+			WithNewFile("some-file", "some content", dagger.DirectoryWithNewFileOpts{Permissions: 0o444}).
+			WithNewDirectory("some-dir", dagger.DirectoryWithNewDirectoryOpts{Permissions: 0o444}).
+			WithNewFile("some-dir/sub-file", "sub-content", dagger.DirectoryWithNewFileOpts{Permissions: 0o444})
 		ctr := c.Container().From("alpine").WithDirectory("/permissions-test", dir)
 
 		stdout, err := ctr.WithExec([]string{"ls", "-ld", "/permissions-test"}).Stdout(ctx)
@@ -385,7 +385,7 @@ func TestDirectoryWithFile(t *testing.T) {
 			WithNewFile(
 				"file-with-permissions",
 				"this should have rwxrwxrwx permissions",
-				dagger.DirectoryWithNewFileOpts{Permissions: 0777})
+				dagger.DirectoryWithNewFileOpts{Permissions: 0o777})
 
 		ctr := c.Container().From("alpine").WithDirectory("/permissions-test", dir)
 
@@ -414,7 +414,7 @@ func TestDirectoryWithTimestamps(t *testing.T) {
 	reallyImportantTime := time.Date(1985, 10, 26, 8, 15, 0, 0, time.UTC)
 
 	dir := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithExec([]string{"sh", "-c", `
 		  mkdir output
 			touch output/some-file
@@ -426,7 +426,7 @@ func TestDirectoryWithTimestamps(t *testing.T) {
 
 	t.Run("changes file and directory timestamps recursively", func(t *testing.T) {
 		ls, err := c.Container().
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithMountedDirectory("/dir", dir).
 			WithEnvVariable("RANDOM", identity.NewID()).
 			WithExec([]string{"sh", "-c", "ls -al /dir && ls -al /dir/sub-dir"}).
@@ -439,7 +439,7 @@ func TestDirectoryWithTimestamps(t *testing.T) {
 
 	t.Run("results in stable tar archiving", func(t *testing.T) {
 		content, err := c.Container().
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithMountedDirectory("/dir", dir).
 			WithEnvVariable("RANDOM", identity.NewID()).
 			// NB: there's a gotcha here: we need to tar * and not . because the
@@ -598,7 +598,7 @@ func TestDirectoryExport(t *testing.T) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	dir := c.Container().From("alpine:3.16.2").Directory("/etc/profile.d")
+	dir := c.Container().From(alpineImage).Directory("/etc/profile.d")
 
 	t.Run("to absolute dir", func(t *testing.T) {
 		ok, err := dir.Export(ctx, dest)
@@ -607,7 +607,7 @@ func TestDirectoryExport(t *testing.T) {
 
 		entries, err := ls(dest)
 		require.NoError(t, err)
-		require.Equal(t, []string{"README", "color_prompt.sh.disabled", "locale.sh"}, entries)
+		require.Equal(t, []string{"20locale.sh", "README", "color_prompt.sh.disabled"}, entries)
 	})
 
 	t.Run("to workdir", func(t *testing.T) {
@@ -617,7 +617,7 @@ func TestDirectoryExport(t *testing.T) {
 
 		entries, err := ls(wd)
 		require.NoError(t, err)
-		require.Equal(t, []string{"README", "color_prompt.sh.disabled", "locale.sh"}, entries)
+		require.Equal(t, []string{"20locale.sh", "README", "color_prompt.sh.disabled"}, entries)
 	})
 
 	t.Run("to outer dir", func(t *testing.T) {
@@ -845,13 +845,14 @@ func TestDirectoryDirectMerge(t *testing.T) {
 
 	getDirAndInodes := func(t *testing.T, fileNames ...string) (*dagger.Directory, []string) {
 		t.Helper()
-		ctr := c.Container().From("alpine:3.16.2").
+		ctr := c.Container().From(alpineImage).
 			WithMountedDirectory("/src", c.Directory()).
 			WithWorkdir("/src")
 
 		var inodes []string
 		for _, fileName := range fileNames {
-			ctr = ctr.WithExec([]string{"sh", "-e", "-x", "-c",
+			ctr = ctr.WithExec([]string{
+				"sh", "-e", "-x", "-c",
 				"touch " + fileName + " && stat -c '%i' " + fileName,
 			})
 			out, err := ctr.Stdout(ctx)
@@ -879,7 +880,7 @@ func TestDirectoryDirectMerge(t *testing.T) {
 		mergeDir = mergeDir.WithDirectory("/", newDir)
 	}
 
-	ctr := c.Container().From("alpine:3.16.2").
+	ctr := c.Container().From(alpineImage).
 		WithMountedDirectory("/mnt", mergeDir).
 		WithWorkdir("/mnt")
 
@@ -932,7 +933,7 @@ func TestDirectorySync(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no such file or directory")
 
-		_, err = c.Container().From("alpine:3.16.2").Directory("/bar").Sync(ctx)
+		_, err = c.Container().From(alpineImage).Directory("/bar").Sync(ctx)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no such file or directory")
 	})

--- a/core/integration/file_test.go
+++ b/core/integration/file_test.go
@@ -123,7 +123,7 @@ func TestFileExport(t *testing.T) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	file := c.Container().From("alpine:3.16.2").File("/etc/alpine-release")
+	file := c.Container().From(alpineImage).File("/etc/alpine-release")
 
 	t.Run("to absolute path", func(t *testing.T) {
 		dest := filepath.Join(targetDir, "some-file")
@@ -134,7 +134,7 @@ func TestFileExport(t *testing.T) {
 
 		contents, err := os.ReadFile(dest)
 		require.NoError(t, err)
-		require.Equal(t, "3.16.2\n", string(contents))
+		require.Equal(t, "3.18.2\n", string(contents))
 
 		entries, err := ls(targetDir)
 		require.NoError(t, err)
@@ -148,7 +148,7 @@ func TestFileExport(t *testing.T) {
 
 		contents, err := os.ReadFile(filepath.Join(wd, "some-file"))
 		require.NoError(t, err)
-		require.Equal(t, "3.16.2\n", string(contents))
+		require.Equal(t, "3.18.2\n", string(contents))
 
 		entries, err := ls(wd)
 		require.NoError(t, err)
@@ -187,7 +187,7 @@ func TestFileWithTimestamps(t *testing.T) {
 		WithTimestamps(int(reallyImportantTime.Unix()))
 
 	ls, err := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithMountedFile("/file", file).
 		WithEnvVariable("RANDOM", identity.NewID()).
 		WithExec([]string{"stat", "/file"}).
@@ -221,7 +221,7 @@ func TestFileContents(t *testing.T) {
 		for i := 0; i < testFile.size; i++ {
 			buf.WriteByte('a')
 		}
-		err := os.WriteFile(dest, buf.Bytes(), 0600)
+		err := os.WriteFile(dest, buf.Bytes(), 0o600)
 		require.NoError(t, err)
 
 		// Compute and store hash for generated test data:
@@ -230,7 +230,7 @@ func TestFileContents(t *testing.T) {
 
 	hostDir := c.Host().Directory(tempDir)
 	alpine := c.Container().
-		From("alpine:3.16.2").WithDirectory(".", hostDir)
+		From(alpineImage).WithDirectory(".", hostDir)
 
 	// Grab file contents and compare hashes to validate integrity:
 	for i, testFile := range testFiles {
@@ -260,7 +260,7 @@ func TestFileSync(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no such file")
 
-		_, err = c.Container().From("alpine:3.16.2").File("/bar").Sync(ctx)
+		_, err = c.Container().From(alpineImage).File("/bar").Sync(ctx)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no such file")
 	})

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -72,7 +72,7 @@ func TestGitSSHAuthSock(t *testing.T) {
 	defer c.Close()
 
 	gitSSH := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithExec([]string{"apk", "add", "git", "openssh"})
 
 	hostKeyGen := gitSSH.

--- a/core/integration/host_test.go
+++ b/core/integration/host_test.go
@@ -24,7 +24,7 @@ func TestHostWorkdir(t *testing.T) {
 
 	t.Run("contains the workdir's content", func(t *testing.T) {
 		contents, err := c.Container().
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithMountedDirectory("/host", c.Host().Directory(".")).
 			WithExec([]string{"ls", "/host"}).
 			Stdout(ctx)
@@ -37,7 +37,7 @@ func TestHostWorkdir(t *testing.T) {
 		require.NoError(t, err)
 
 		contents, err := c.Container().
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithMountedDirectory("/host", c.Host().Directory(".")).
 			WithExec([]string{"ls", "/host"}).
 			Stdout(ctx)
@@ -67,7 +67,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 		})
 
 		contents, err := c.Container().
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithMountedDirectory("/host", wd).
 			WithExec([]string{"ls", "/host"}).
 			Stdout(ctx)
@@ -81,7 +81,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 		})
 
 		contents, err := c.Container().
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithMountedDirectory("/host", wd).
 			WithExec([]string{"ls", "/host"}).
 			Stdout(ctx)
@@ -95,7 +95,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 		})
 
 		contents, err := c.Container().
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithMountedDirectory("/host", wd).
 			WithExec([]string{"ls", "/host"}).
 			Stdout(ctx)
@@ -110,7 +110,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 		})
 
 		contents, err := c.Container().
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithMountedDirectory("/host", wd).
 			WithExec([]string{"ls", "/host"}).
 			Stdout(ctx)
@@ -125,7 +125,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 		})
 
 		contents, err := c.Container().
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithMountedDirectory("/host", wd).
 			WithExec([]string{"ls", "/host"}).
 			Stdout(ctx)
@@ -281,7 +281,7 @@ func TestHostVariable(t *testing.T) {
 	require.Equal(t, "hello", varValue)
 
 	env, err := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		//nolint:staticcheck // SA1019 We want to test this API while we support it.
 		WithSecretVariable("SECRET", secret.Secret()).
 		WithExec([]string{"env"}).

--- a/core/integration/pipeline_test.go
+++ b/core/integration/pipeline_test.go
@@ -47,7 +47,7 @@ func TestPipeline(t *testing.T) {
 		_, err = c.
 			Container().
 			Pipeline("container pipeline").
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithExec([]string{"echo", cacheBuster}).
 			Sync(ctx)
 
@@ -95,7 +95,7 @@ func TestPipeline(t *testing.T) {
 		require.NoError(t, err)
 
 		client := c.Container().
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithServiceBinding("www", srv).
 			WithExec([]string{"apk", "add", "curl"}).
 			WithExec([]string{"curl", "-v", url})

--- a/core/integration/platform_test.go
+++ b/core/integration/platform_test.go
@@ -36,7 +36,7 @@ func TestPlatformEmulatedExecAndPush(t *testing.T) {
 	variants := make([]*dagger.Container, 0, len(platformToUname))
 	for platform, uname := range platformToUname {
 		ctr := c.Container(dagger.ContainerOpts{Platform: platform}).
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithExec([]string{"uname", "-m"})
 		variants = append(variants, ctr)
 
@@ -135,7 +135,7 @@ func TestPlatformCrossCompile(t *testing.T) {
 	require.NoError(t, err)
 
 	// pull the images, mount them all into a container and ensure the binaries are the right platform
-	ctr := c.Container().From("alpine:3.16").WithExec([]string{"apk", "add", "file"})
+	ctr := c.Container().From(alpineImage).WithExec([]string{"apk", "add", "file"})
 
 	cmds := make([]string, 0, len(platformToFileArch))
 	for platform, uname := range platformToFileArch {
@@ -171,7 +171,7 @@ func TestPlatformCacheMounts(t *testing.T) {
 	cmds := make([]string, 0, len(platformToUname))
 	for platform := range platformToUname {
 		_, err := c.Container(dagger.ContainerOpts{Platform: platform}).
-			From("alpine:3.16").
+			From(alpineImage).
 			WithMountedCache("/cache", cache).
 			WithExec([]string{"sh", "-x", "-c", strings.Join([]string{
 				"mkdir -p /cache/" + randomID + string(platform),
@@ -183,7 +183,7 @@ func TestPlatformCacheMounts(t *testing.T) {
 	}
 
 	_, err = c.Container().
-		From("alpine:3.16").
+		From(alpineImage).
 		WithMountedCache("/cache", cache).
 		WithExec([]string{"sh", "-x", "-c", strings.Join(cmds, " && ")}).
 		Sync(ctx)

--- a/core/integration/remotecache_test.go
+++ b/core/integration/remotecache_test.go
@@ -61,22 +61,23 @@ func TestRemoteCacheRegistry(t *testing.T) {
 
 	cliBinPath := "/.dagger-cli"
 
-	outputA, err := c.Container().From("alpine:3.17").
+	outputA, err := c.Container().From(alpineImage).
 		WithServiceBinding("dev-engine", devEngineA).
 		WithMountedFile(cliBinPath, daggerCli).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpointA).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CACHE_CONFIG", cacheEnv).
 		WithNewFile("/.dagger-query.txt", dagger.ContainerWithNewFileOpts{
-			Contents: `{ 
-				container { 
-					from(address: "alpine:3.17") { 
-						withExec(args: ["sh", "-c", "head -c 128 /dev/random | sha256sum"]) { 
-							stdout 
-						} 
-					} 
-				} 
-			}`}).
+			Contents: `{
+				container {
+					from(address: "` + alpineImage + `") {
+						withExec(args: ["sh", "-c", "head -c 128 /dev/random | sha256sum"]) {
+							stdout
+						}
+					}
+				}
+			}`,
+		}).
 		WithExec([]string{
 			"sh", "-c", cliBinPath + ` query --doc .dagger-query.txt`,
 		}).Stdout(ctx)
@@ -87,22 +88,23 @@ func TestRemoteCacheRegistry(t *testing.T) {
 	devEngineB, endpointB, err := getDevEngineForRemoteCache(ctx, c, registry, "registry", cacheEnv, 1)
 	require.NoError(t, err)
 
-	outputB, err := c.Container().From("alpine:3.17").
+	outputB, err := c.Container().From(alpineImage).
 		WithServiceBinding("dev-engine", devEngineB).
 		WithMountedFile(cliBinPath, daggerCli).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpointB).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CACHE_CONFIG", cacheEnv).
 		WithNewFile("/.dagger-query.txt", dagger.ContainerWithNewFileOpts{
-			Contents: `{ 
-				container { 
-					from(address: "alpine:3.17") { 
-						withExec(args: ["sh", "-c", "head -c 128 /dev/random | sha256sum"]) { 
-							stdout 
-						} 
-					} 
-				} 
-			}`}).
+			Contents: `{
+				container {
+					from(address: "` + alpineImage + `") {
+						withExec(args: ["sh", "-c", "head -c 128 /dev/random | sha256sum"]) {
+							stdout
+						}
+					}
+				}
+			}`,
+		}).
 		WithExec([]string{
 			"sh", "-c", cliBinPath + " query --doc .dagger-query.txt",
 		}).Stdout(ctx)
@@ -146,22 +148,23 @@ func TestRemoteCacheS3(t *testing.T) {
 		// internal/mage/engine.go:test. This is used to communicate with the dev engine.
 		daggerCli := c.Host().Directory("/dagger-dev/", dagger.HostDirectoryOpts{Include: []string{"dagger"}}).File("dagger")
 
-		outputA, err := c.Container().From("alpine:3.17").
+		outputA, err := c.Container().From(alpineImage).
 			WithServiceBinding("dev-engine", devEngineA).
 			WithMountedFile(cliBinPath, daggerCli).
 			WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
 			WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpointA).
 			WithEnvVariable("_EXPERIMENTAL_DAGGER_CACHE_CONFIG", s3Env).
 			WithNewFile("/.dagger-query.txt", dagger.ContainerWithNewFileOpts{
-				Contents: `{ 
-						container { 
-							from(address: "alpine:3.17") { 
-								withExec(args: ["sh", "-c", "head -c 128 /dev/random | sha256sum"]) { 
-									stdout 
-								} 
-							} 
-						} 
-					}`}).
+				Contents: `{
+						container {
+							from(address: "` + alpineImage + `") {
+								withExec(args: ["sh", "-c", "head -c 128 /dev/random | sha256sum"]) {
+									stdout
+								}
+							}
+						}
+					}`,
+			}).
 			WithExec([]string{
 				"sh", "-c", cliBinPath + ` query --doc .dagger-query.txt`,
 			}).Stdout(ctx)
@@ -172,22 +175,23 @@ func TestRemoteCacheS3(t *testing.T) {
 		devEngineB, endpointB, err := getDevEngineForRemoteCache(ctx, c, s3, "s3", s3Env, 1)
 		require.NoError(t, err)
 
-		outputB, err := c.Container().From("alpine:3.17").
+		outputB, err := c.Container().From(alpineImage).
 			WithServiceBinding("dev-engine", devEngineB).
 			WithMountedFile(cliBinPath, daggerCli).
 			WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
 			WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpointB).
 			WithEnvVariable("_EXPERIMENTAL_DAGGER_CACHE_CONFIG", s3Env).
 			WithNewFile("/.dagger-query.txt", dagger.ContainerWithNewFileOpts{
-				Contents: `{ 
-						container { 
-							from(address: "alpine:3.17") { 
-								withExec(args: ["sh", "-c", "head -c 128 /dev/random | sha256sum"]) { 
-									stdout 
-								} 
-							} 
-						} 
-					}`}).
+				Contents: `{
+						container {
+							from(address: "` + alpineImage + `") {
+								withExec(args: ["sh", "-c", "head -c 128 /dev/random | sha256sum"]) {
+									stdout
+								}
+							}
+						}
+					}`,
+			}).
 			WithExec([]string{
 				"sh", "-c", cliBinPath + " query --doc .dagger-query.txt",
 			}).Stdout(ctx)

--- a/core/integration/secret_test.go
+++ b/core/integration/secret_test.go
@@ -21,7 +21,7 @@ func TestSecretEnvFromFile(t *testing.T) {
 	err := testutil.Query(
 		`query Test($secret: SecretID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withSecretVariable(name: "SECRET", secret: $secret) {
 						withExec(args: ["sh", "-c", "test \"$SECRET\" = \"some-content\""]) {
 							sync
@@ -43,7 +43,7 @@ func TestSecretMountFromFile(t *testing.T) {
 	err := testutil.Query(
 		`query Test($secret: SecretID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withMountedSecret(path: "/sekret", source: $secret) {
 						withExec(args: ["sh", "-c", "test \"$(cat /sekret)\" = \"some-content\""]) {
 							sync
@@ -80,7 +80,7 @@ func TestSecretMountFromFileWithOverridingMount(t *testing.T) {
 	err := testutil.Query(
 		`query Test($secret: SecretID!, $file: FileID!) {
 			container {
-				from(address: "alpine:3.16.2") {
+				from(address: "`+alpineImage+`") {
 					withMountedSecret(path: "/sekret", source: $secret) {
 						withMountedFile(path: "/sekret", source: $file) {
 							withExec(args: ["sh", "-c", "test \"$(cat /sekret)\" = \"some-secret\""]) {
@@ -124,7 +124,7 @@ func TestNewSecret(t *testing.T) {
 
 	s := c.SetSecret("aws_key", secretValue)
 
-	_, err := c.Container().From("alpine:3.16.2").
+	_, err := c.Container().From(alpineImage).
 		WithSecretVariable("AWS_KEY", s).
 		WithExec([]string{"sh", "-c", "test \"$AWS_KEY\" = \"very-secret-text\""}).
 		Sync(ctx)
@@ -140,7 +140,7 @@ func TestWhitespaceSecretScrubbed(t *testing.T) {
 
 	s := c.SetSecret("aws_key", secretValue)
 
-	stdout, err := c.Container().From("alpine:3.16.2").
+	stdout, err := c.Container().From(alpineImage).
 		WithSecretVariable("AWS_KEY", s).
 		WithExec([]string{"sh", "-c", "test \"$AWS_KEY\" = \"very\nsecret\ntext\n\""}).
 		WithExec([]string{"sh", "-c", "echo -n \"$AWS_KEY\""}).
@@ -159,7 +159,7 @@ func TestBigSecretScrubbed(t *testing.T) {
 
 	s := c.SetSecret("key", string(secretValue))
 
-	sec := c.Container().From("alpine:3.16.2").
+	sec := c.Container().From(alpineImage).
 		WithSecretVariable("KEY", s).
 		WithExec([]string{"sh", "-c", "echo  -n \"$KEY\""})
 

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -354,7 +354,7 @@ func TestContainerExecServices(t *testing.T) {
 	require.NoError(t, err)
 
 	client := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithServiceBinding("www", srv).
 		WithExec([]string{"apk", "add", "curl"}).
 		WithExec([]string{"curl", "-v", url})
@@ -380,7 +380,7 @@ func TestContainerExecServicesError(t *testing.T) {
 	defer c.Close()
 
 	srv := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithExposedPort(8080).
 		WithExec([]string{"sh", "-c", "echo nope; exit 42"})
 
@@ -388,7 +388,7 @@ func TestContainerExecServicesError(t *testing.T) {
 	require.NoError(t, err)
 
 	client := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithServiceBinding("www", srv).
 		WithExec([]string{"wget", "http://www:8080"})
 
@@ -406,7 +406,7 @@ func TestContainerServiceNoExec(t *testing.T) {
 	defer c.Close()
 
 	srv := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithExposedPort(8080).
 		// using error to compare hostname after WithServiceBinding
 		WithDefaultArgs(dagger.ContainerWithDefaultArgsOpts{
@@ -417,7 +417,7 @@ func TestContainerServiceNoExec(t *testing.T) {
 	require.NoError(t, err)
 
 	client := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithServiceBinding("www", srv).
 		WithExec([]string{"wget", "http://www:8080"})
 
@@ -447,7 +447,7 @@ func TestContainerExecUDPServices(t *testing.T) {
 		WithExec([]string{"go", "run", "/src/main.go"})
 
 	client := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithExec([]string{"apk", "add", "socat"}).
 		WithServiceBinding("echo", srv).
 		WithExec([]string{"socat", "-", "udp:echo:4321"}, dagger.ContainerWithExecOpts{
@@ -473,7 +473,7 @@ func TestContainerExecServiceAlias(t *testing.T) {
 	srv, _ := httpService(ctx, t, c, "Hello, world!")
 
 	client := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithServiceBinding("hello", srv).
 		WithExec([]string{"apk", "add", "curl"}).
 		WithExec([]string{"curl", "-v", "http://hello:8000"})
@@ -509,7 +509,7 @@ func TestContainerExecServicesDeduping(t *testing.T) {
 		WithExec([]string{"go", "run", "/src/main.go"})
 
 	client := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithExec([]string{"apk", "add", "curl"}).
 		WithServiceBinding("www", srv).
 		WithEnvVariable("CACHEBUST", identity.NewID())
@@ -562,7 +562,7 @@ func TestContainerExecServicesChained(t *testing.T) {
 	}
 
 	fileContent, err := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithServiceBinding("www", srv).
 		WithExec([]string{"wget", "http://www:8000"}).
 		WithExec([]string{"cat", "index.html"}).
@@ -585,7 +585,7 @@ func TestContainerBuildService(t *testing.T) {
 
 		src := c.Directory().
 			WithNewFile("Dockerfile",
-				`FROM alpine:3.16.2
+				`FROM `+alpineImage+`
 WORKDIR /src
 RUN wget `+httpURL+`
 CMD cat index.html
@@ -605,7 +605,7 @@ CMD cat index.html
 
 		src := c.Directory().
 			WithNewFile("Dockerfile",
-				`FROM alpine:3.16.2
+				`FROM `+alpineImage+`
 WORKDIR /src
 RUN wget `+httpURL+`
 CMD cat index.html
@@ -631,7 +631,7 @@ CMD cat index.html
 
 		src := c.Directory().
 			WithNewFile("Dockerfile",
-				`FROM alpine:3.16.2
+				`FROM `+alpineImage+`
 WORKDIR /src
 RUN wget `+httpURL+`
 CMD cat index.html
@@ -664,7 +664,7 @@ func TestContainerExportServices(t *testing.T) {
 	srv, httpURL := httpService(ctx, t, c, content)
 
 	client := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithServiceBinding("www", srv).
 		WithExec([]string{"wget", httpURL})
 
@@ -687,7 +687,7 @@ func TestContainerMultiPlatformExportServices(t *testing.T) {
 		srv, url := httpService(ctx, t, c, string(platform))
 
 		ctr := c.Container(dagger.ContainerOpts{Platform: platform}).
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithServiceBinding("www", srv).
 			WithExec([]string{"wget", url}).
 			WithExec([]string{"uname", "-m"})
@@ -716,7 +716,7 @@ func TestServicesContainerPublish(t *testing.T) {
 
 	testRef := registryRef("services-container-publish")
 	pushedRef, err := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithServiceBinding("www", srv).
 		WithExec([]string{"wget", url}).
 		Publish(ctx, testRef)
@@ -742,7 +742,7 @@ func TestContainerRootFSServices(t *testing.T) {
 	srv, url := httpService(ctx, t, c, content)
 
 	fileContent, err := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithServiceBinding("www", srv).
 		WithWorkdir("/sub/out").
 		WithExec([]string{"wget", url}).
@@ -768,7 +768,7 @@ func TestContainerWithRootFSServices(t *testing.T) {
 	gitDaemon, repoURL := gitService(ctx, t, c,
 		// this little maneuver commits the entire rootfs into a git repo
 		c.Container().
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithServiceBinding("www", srv).
 			WithWorkdir("/sub/out").
 			WithExec([]string{"wget", url}).
@@ -802,7 +802,7 @@ func TestContainerDirectoryServices(t *testing.T) {
 	srv, url := httpService(ctx, t, c, content)
 
 	wget := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithServiceBinding("www", srv).
 		WithWorkdir("/sub/out").
 		WithExec([]string{"wget", url})
@@ -850,7 +850,7 @@ func TestContainerFileServices(t *testing.T) {
 	srv, url := httpService(ctx, t, c, content)
 
 	client := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithServiceBinding("www", srv).
 		WithWorkdir("/out").
 		WithExec([]string{"wget", url})
@@ -881,7 +881,7 @@ func TestContainerWithServiceFileDirectory(t *testing.T) {
 
 	t.Run("mounting", func(t *testing.T) {
 		useBoth := c.Container().
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithMountedDirectory("/mnt/repo", gitDir).
 			WithMountedFile("/mnt/index.html", httpFile)
 
@@ -896,7 +896,7 @@ func TestContainerWithServiceFileDirectory(t *testing.T) {
 
 	t.Run("copying", func(t *testing.T) {
 		useBoth := c.Container().
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithDirectory("/mnt/repo", gitDir).
 			WithFile("/mnt/index.html", httpFile)
 
@@ -987,7 +987,7 @@ func TestDirectoryServiceTimestamp(t *testing.T) {
 		Tree().
 		WithTimestamps(int(ts.Unix()))
 
-	stdout, err := c.Container().From("alpine:3.16.2").
+	stdout, err := c.Container().From(alpineImage).
 		WithDirectory("/repo", stamped).
 		WithExec([]string{"stat", "/repo/README.md"}).
 		Stdout(ctx)
@@ -1155,7 +1155,7 @@ func TestFileServiceTimestamp(t *testing.T) {
 	stamped := c.HTTP(httpURL, dagger.HTTPOpts{ExperimentalServiceHost: httpSrv}).
 		WithTimestamps(int(ts.Unix()))
 
-	stdout, err := c.Container().From("alpine:3.16.2").
+	stdout, err := c.Container().From(alpineImage).
 		WithFile("/index.html", stamped).
 		WithExec([]string{"stat", "/index.html"}).
 		Stdout(ctx)
@@ -1182,7 +1182,7 @@ func TestFileServiceSecret(t *testing.T) {
 
 	t.Run("secret env", func(t *testing.T) {
 		_, err := c.Container().
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithSecretVariable("SEKRIT", secret).
 			WithExec([]string{"sh", "-c", fmt.Sprintf(`test "$SEKRIT" = "%s"`, content)}).
 			Sync(ctx)
@@ -1191,7 +1191,7 @@ func TestFileServiceSecret(t *testing.T) {
 
 	t.Run("secret mount", func(t *testing.T) {
 		_, err := c.Container().
-			From("alpine:3.16.2").
+			From(alpineImage).
 			WithMountedSecret("/sekrit", secret).
 			WithExec([]string{"sh", "-c", fmt.Sprintf(`test "$(cat /sekrit)" = "%s"`, content)}).
 			Sync(ctx)
@@ -1225,7 +1225,7 @@ func gitService(ctx context.Context, t *testing.T, c *dagger.Client, content *da
 
 	const gitPort = 9418
 	gitDaemon := c.Container().
-		From("alpine:3.16.2").
+		From(alpineImage).
 		WithExec([]string{"apk", "add", "git", "git-daemon"}).
 		WithDirectory("/root/repo", content).
 		WithMountedFile("/root/start.sh",
@@ -1244,7 +1244,7 @@ mkdir srv
 cd repo
 	git init
 	git branch -m main
-	git add *
+	git add * || true
 	git commit -m "init"
 cd ..
 

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -264,7 +264,7 @@ const testCLIBinPath = "/bin/dagger"
 
 func CLITestContainer(ctx context.Context, t *testing.T, c *dagger.Client) *DaggerCLIContainer {
 	t.Helper()
-	ctr := c.Container().From("alpine:3.16.2").
+	ctr := c.Container().From(alpineImage).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", testCLIBinPath).
 		// TODO: this shouldn't be needed, dagger cli should pick up existing nestedness

--- a/internal/mage/util/engine.go
+++ b/internal/mage/util/engine.go
@@ -15,7 +15,7 @@ import (
 const (
 	engineBinName = "dagger-engine"
 	shimBinName   = "dagger-shim"
-	alpineVersion = "3.17"
+	alpineVersion = "3.18"
 	runcVersion   = "v1.1.5"
 	cniVersion    = "v1.2.0"
 	qemuBinImage  = "tonistiigi/binfmt:buildkit-v7.1.0-30@sha256:45dd57b4ba2f24e2354f71f1e4e51f073cb7a28fd848ce6f5f2a7701142a6bf0"


### PR DESCRIPTION
in a debugging session with @vito, we found out that alpine 3.16 and
3.17 has a regression where dns queries which have a "search ." in
  resolv.conf are not passed to the specified nameserver accordingly.

we came across this while I was trying to run dagger tests in my local
machine which is an ubuntu based system managed by
`systemd-resolved` which by defaults adds a `search .` entry in the
/etc/resolv.conf file

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
