### PR TITLE
stabilize container hostnames against SessionID

### DIFF
--- a/core/digest.go
+++ b/core/digest.go
@@ -2,15 +2,16 @@ package core
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"reflect"
 	"sort"
 
+	"github.com/moby/buildkit/solver/llbsolver"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 )
 
 func stableDigest(value any) (digest.Digest, error) {
@@ -21,6 +22,28 @@ func stableDigest(value any) (digest.Digest, error) {
 	}
 
 	return digest.FromReader(buf)
+}
+
+// stabilizeSourcePolicy removes ephemeral metadata from ops to prevent it from
+// busting caches.
+type stabilizeSourcePolicy struct{}
+
+func (stabilizeSourcePolicy) Evaluate(ctx context.Context, op *pb.Op) (bool, error) {
+	if src := op.GetSource(); src != nil {
+		var modified bool
+		for k := range src.Attrs {
+			switch k {
+			case pb.AttrLocalSessionID,
+				pb.AttrLocalUniqueID,
+				pb.AttrSharedKeyHint: // contains session ID
+				delete(src.Attrs, k)
+				modified = true
+			}
+		}
+		return modified, nil
+	}
+
+	return false, nil
 }
 
 func digestInto(value any, dest io.Writer) (err error) {
@@ -36,12 +59,13 @@ func digestInto(value any, dest io.Writer) (err error) {
 			break
 		}
 
-		cp, err := stabilizeDef(x)
+		edge, err := llbsolver.Load(context.TODO(), x, stabilizeSourcePolicy{})
 		if err != nil {
 			return err
 		}
 
-		value = cp
+		_, err = fmt.Fprintln(dest, edge.Vertex.Digest())
+		return err
 
 	case []byte:
 		// base64-encode bytes rather than treating it like a slice
@@ -123,107 +147,6 @@ func digestMapInto(rv reflect.Value, dest io.Writer) error {
 		if err := digestInto(rv.MapIndex(k).Interface(), dest); err != nil {
 			return fmt.Errorf("value for key %v: %w", k, err)
 		}
-	}
-
-	return nil
-}
-
-// stabilizeDef returns a copy of def that has been pruned of any ephemeral
-// data so that it may be used as a cache key that is stable across sessions.
-func stabilizeDef(def *pb.Definition) (*pb.Definition, error) {
-	cp := *def
-	cp.Def = cloneSlice(def.Def)
-	cp.Metadata = cloneMap(def.Metadata)
-	cp.Source = nil // discard source map
-
-	stabilized := map[digest.Digest]digest.Digest{}
-
-	// first, stabilize all Ops
-	for i, dt := range cp.Def {
-		digBefore := digest.FromBytes(dt)
-		var op pb.Op
-		if err := (&op).Unmarshal(dt); err != nil {
-			return nil, errors.Wrap(err, "failed to parse llb proto op")
-		}
-
-		if src := op.GetSource(); src != nil {
-			// prevent ephemeral metadata from busting caches
-			delete(src.Attrs, pb.AttrLocalSessionID)
-			delete(src.Attrs, pb.AttrLocalUniqueID)
-			delete(src.Attrs, pb.AttrSharedKeyHint) // has session ID + path
-		}
-
-		stableDt, err := op.Marshal()
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to marshal llb proto op")
-		}
-
-		digAfter := digest.FromBytes(stableDt)
-		if digAfter != digBefore {
-			stabilized[digBefore] = digAfter
-		}
-
-		cp.Def[i] = stableDt
-	}
-
-	// update all inputs to reference the new digests
-	if err := stabilizeInputs(&cp, stabilized); err != nil {
-		return nil, errors.Wrap(err, "failed to stabilize inputs")
-	}
-
-	// finally, sort Def since it's in unstable topological order
-	sort.Slice(cp.Def, func(i, j int) bool {
-		return bytes.Compare(cp.Def[i], cp.Def[j]) < 0
-	})
-
-	return &cp, nil
-}
-
-// stabilizeInputs takes a mapping from old digests to new digests and updates
-// all Op inputs to use the new digests instead. Because inputs are addressed
-// by Op digests, any Ops that needed to be updated will thereby yield a new
-// mapping, so stabilizeInputs will keep recursing until no new mappings are
-// yielded.
-func stabilizeInputs(cp *pb.Definition, stabilized map[digest.Digest]digest.Digest) error {
-	nextPass := map[digest.Digest]digest.Digest{}
-
-	for before, after := range stabilized {
-		meta, found := cp.Metadata[before]
-		if !found {
-			return fmt.Errorf("missing metadata for %s", before)
-		}
-
-		cp.Metadata[after] = meta
-		delete(cp.Metadata, before)
-	}
-
-	for i, dt := range cp.Def {
-		digBefore := digest.FromBytes(dt)
-
-		var op pb.Op
-		if err := (&op).Unmarshal(dt); err != nil {
-			return errors.Wrap(err, "failed to parse llb proto op")
-		}
-		for before, after := range stabilized {
-			for _, input := range op.Inputs {
-				if input.Digest == before {
-					input.Digest = after
-				}
-			}
-		}
-		stableDt, err := op.Marshal()
-		if err != nil {
-			return errors.Wrap(err, "failed to marshal llb proto op")
-		}
-		digAfter := digest.FromBytes(stableDt)
-		if digAfter != digBefore {
-			nextPass[digBefore] = digAfter
-		}
-		cp.Def[i] = stableDt
-	}
-
-	if len(nextPass) > 0 {
-		return stabilizeInputs(cp, nextPass)
 	}
 
 	return nil

--- a/core/digest.go
+++ b/core/digest.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -36,12 +37,13 @@ func digestInto(value any, dest io.Writer) (err error) {
 			break
 		}
 
-		cp, err := stabilizeDef(x)
+		digest, err := digestLLB(context.TODO(), x, stabilizeSourcePolicy{})
 		if err != nil {
 			return err
 		}
 
-		value = cp
+		_, err = fmt.Fprintln(dest, digest)
+		return err
 
 	case []byte:
 		// base64-encode bytes rather than treating it like a slice
@@ -128,103 +130,134 @@ func digestMapInto(rv reflect.Value, dest io.Writer) error {
 	return nil
 }
 
-// stabilizeDef returns a copy of def that has been pruned of any ephemeral
-// data so that it may be used as a cache key that is stable across sessions.
-func stabilizeDef(def *pb.Definition) (*pb.Definition, error) {
-	cp := *def
-	cp.Def = cloneSlice(def.Def)
-	cp.Metadata = cloneMap(def.Metadata)
-	cp.Source = nil // discard source map
-
-	stabilized := map[digest.Digest]digest.Digest{}
-
-	// first, stabilize all Ops
-	for i, dt := range cp.Def {
-		digBefore := digest.FromBytes(dt)
-		var op pb.Op
-		if err := (&op).Unmarshal(dt); err != nil {
-			return nil, errors.Wrap(err, "failed to parse llb proto op")
-		}
-
-		if src := op.GetSource(); src != nil {
-			// prevent ephemeral metadata from busting caches
-			delete(src.Attrs, pb.AttrLocalSessionID)
-			delete(src.Attrs, pb.AttrLocalUniqueID)
-			delete(src.Attrs, pb.AttrSharedKeyHint) // has session ID + path
-		}
-
-		stableDt, err := op.Marshal()
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to marshal llb proto op")
-		}
-
-		digAfter := digest.FromBytes(stableDt)
-		if digAfter != digBefore {
-			stabilized[digBefore] = digAfter
-		}
-
-		cp.Def[i] = stableDt
-	}
-
-	// update all inputs to reference the new digests
-	if err := stabilizeInputs(&cp, stabilized); err != nil {
-		return nil, errors.Wrap(err, "failed to stabilize inputs")
-	}
-
-	// finally, sort Def since it's in unstable topological order
-	sort.Slice(cp.Def, func(i, j int) bool {
-		return bytes.Compare(cp.Def[i], cp.Def[j]) < 0
-	})
-
-	return &cp, nil
+type sourcePolicyEvaluator interface {
+	Evaluate(ctx context.Context, op *pb.Op) (bool, error)
 }
 
-// stabilizeInputs takes a mapping from old digests to new digests and updates
-// all Op inputs to use the new digests instead. Because inputs are addressed
-// by Op digests, any Ops that needed to be updated will thereby yield a new
-// mapping, so stabilizeInputs will keep recursing until no new mappings are
-// yielded.
-func stabilizeInputs(cp *pb.Definition, stabilized map[digest.Digest]digest.Digest) error {
-	nextPass := map[digest.Digest]digest.Digest{}
-
-	for before, after := range stabilized {
-		meta, found := cp.Metadata[before]
-		if !found {
-			return fmt.Errorf("missing metadata for %s", before)
-		}
-
-		cp.Metadata[after] = meta
-		delete(cp.Metadata, before)
+// TODO(vito): this is an extracted/trimmed down implementation of
+// llbsolver.Load from upstream Buildkit. Ideally we would use it directly but
+// we have to avoid importing that package because it breaks the Darwin build.
+func digestLLB(ctx context.Context, def *pb.Definition, polEngine sourcePolicyEvaluator) (digest.Digest, error) {
+	if len(def.Def) == 0 {
+		return "", errors.New("invalid empty definition")
 	}
 
-	for i, dt := range cp.Def {
-		digBefore := digest.FromBytes(dt)
+	allOps := make(map[digest.Digest]*pb.Op)
+	mutatedDigests := make(map[digest.Digest]digest.Digest) // key: old, val: new
 
+	var lastDgst digest.Digest
+
+	for _, dt := range def.Def {
 		var op pb.Op
 		if err := (&op).Unmarshal(dt); err != nil {
-			return errors.Wrap(err, "failed to parse llb proto op")
+			return "", errors.Wrap(err, "failed to parse llb proto op")
 		}
-		for before, after := range stabilized {
-			for _, input := range op.Inputs {
-				if input.Digest == before {
-					input.Digest = after
+		dgst := digest.FromBytes(dt)
+		if polEngine != nil {
+			mutated, err := polEngine.Evaluate(ctx, &op)
+			if err != nil {
+				return "", errors.Wrap(err, "error evaluating the source policy")
+			}
+			if mutated {
+				dtMutated, err := op.Marshal()
+				if err != nil {
+					return "", err
 				}
+				dgstMutated := digest.FromBytes(dtMutated)
+				mutatedDigests[dgst] = dgstMutated
+				dgst = dgstMutated
 			}
 		}
-		stableDt, err := op.Marshal()
+		allOps[dgst] = &op
+		lastDgst = dgst
+	}
+
+	for dgst := range allOps {
+		_, err := recomputeDigests(ctx, allOps, mutatedDigests, dgst)
 		if err != nil {
-			return errors.Wrap(err, "failed to marshal llb proto op")
+			return "", err
 		}
-		digAfter := digest.FromBytes(stableDt)
-		if digAfter != digBefore {
-			nextPass[digBefore] = digAfter
-		}
-		cp.Def[i] = stableDt
 	}
 
-	if len(nextPass) > 0 {
-		return stabilizeInputs(cp, nextPass)
+	if len(allOps) < 2 {
+		return "", errors.Errorf("invalid LLB with %d vertexes", len(allOps))
 	}
 
-	return nil
+	for {
+		newDgst, ok := mutatedDigests[lastDgst]
+		if !ok || newDgst == lastDgst {
+			break
+		}
+		lastDgst = newDgst
+	}
+
+	lastOp := allOps[lastDgst]
+	delete(allOps, lastDgst)
+	if len(lastOp.Inputs) == 0 {
+		return "", errors.Errorf("invalid LLB with no inputs on last vertex")
+	}
+
+	dgst := lastOp.Inputs[0].Digest
+
+	return dgst, nil
+}
+
+func recomputeDigests(ctx context.Context, all map[digest.Digest]*pb.Op, visited map[digest.Digest]digest.Digest, dgst digest.Digest) (digest.Digest, error) {
+	if dgst, ok := visited[dgst]; ok {
+		return dgst, nil
+	}
+	op := all[dgst]
+
+	var mutated bool
+	for _, input := range op.Inputs {
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+
+		iDgst, err := recomputeDigests(ctx, all, visited, input.Digest)
+		if err != nil {
+			return "", err
+		}
+		if input.Digest != iDgst {
+			mutated = true
+			input.Digest = iDgst
+		}
+	}
+
+	if !mutated {
+		visited[dgst] = dgst
+		return dgst, nil
+	}
+
+	dt, err := op.Marshal()
+	if err != nil {
+		return "", err
+	}
+	newDgst := digest.FromBytes(dt)
+	visited[dgst] = newDgst
+	all[newDgst] = op
+	delete(all, dgst)
+	return newDgst, nil
+}
+
+// stabilizeSourcePolicy removes ephemeral metadata from ops to prevent it from
+// busting caches.
+type stabilizeSourcePolicy struct{}
+
+func (stabilizeSourcePolicy) Evaluate(ctx context.Context, op *pb.Op) (bool, error) {
+	if src := op.GetSource(); src != nil {
+		var modified bool
+		for k := range src.Attrs {
+			switch k {
+			case pb.AttrLocalSessionID,
+				pb.AttrLocalUniqueID,
+				pb.AttrSharedKeyHint: // contains session ID
+				delete(src.Attrs, k)
+				modified = true
+			}
+		}
+		return modified, nil
+	}
+
+	return false, nil
 }

--- a/core/digest.go
+++ b/core/digest.go
@@ -2,16 +2,15 @@ package core
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"reflect"
 	"sort"
 
-	"github.com/moby/buildkit/solver/llbsolver"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
 )
 
 func stableDigest(value any) (digest.Digest, error) {
@@ -22,28 +21,6 @@ func stableDigest(value any) (digest.Digest, error) {
 	}
 
 	return digest.FromReader(buf)
-}
-
-// stabilizeSourcePolicy removes ephemeral metadata from ops to prevent it from
-// busting caches.
-type stabilizeSourcePolicy struct{}
-
-func (stabilizeSourcePolicy) Evaluate(ctx context.Context, op *pb.Op) (bool, error) {
-	if src := op.GetSource(); src != nil {
-		var modified bool
-		for k := range src.Attrs {
-			switch k {
-			case pb.AttrLocalSessionID,
-				pb.AttrLocalUniqueID,
-				pb.AttrSharedKeyHint: // contains session ID
-				delete(src.Attrs, k)
-				modified = true
-			}
-		}
-		return modified, nil
-	}
-
-	return false, nil
 }
 
 func digestInto(value any, dest io.Writer) (err error) {
@@ -59,13 +36,12 @@ func digestInto(value any, dest io.Writer) (err error) {
 			break
 		}
 
-		edge, err := llbsolver.Load(context.TODO(), x, stabilizeSourcePolicy{})
+		cp, err := stabilizeDef(x)
 		if err != nil {
 			return err
 		}
 
-		_, err = fmt.Fprintln(dest, edge.Vertex.Digest())
-		return err
+		value = cp
 
 	case []byte:
 		// base64-encode bytes rather than treating it like a slice
@@ -147,6 +123,107 @@ func digestMapInto(rv reflect.Value, dest io.Writer) error {
 		if err := digestInto(rv.MapIndex(k).Interface(), dest); err != nil {
 			return fmt.Errorf("value for key %v: %w", k, err)
 		}
+	}
+
+	return nil
+}
+
+// stabilizeDef returns a copy of def that has been pruned of any ephemeral
+// data so that it may be used as a cache key that is stable across sessions.
+func stabilizeDef(def *pb.Definition) (*pb.Definition, error) {
+	cp := *def
+	cp.Def = cloneSlice(def.Def)
+	cp.Metadata = cloneMap(def.Metadata)
+	cp.Source = nil // discard source map
+
+	stabilized := map[digest.Digest]digest.Digest{}
+
+	// first, stabilize all Ops
+	for i, dt := range cp.Def {
+		digBefore := digest.FromBytes(dt)
+		var op pb.Op
+		if err := (&op).Unmarshal(dt); err != nil {
+			return nil, errors.Wrap(err, "failed to parse llb proto op")
+		}
+
+		if src := op.GetSource(); src != nil {
+			// prevent ephemeral metadata from busting caches
+			delete(src.Attrs, pb.AttrLocalSessionID)
+			delete(src.Attrs, pb.AttrLocalUniqueID)
+			delete(src.Attrs, pb.AttrSharedKeyHint) // has session ID + path
+		}
+
+		stableDt, err := op.Marshal()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to marshal llb proto op")
+		}
+
+		digAfter := digest.FromBytes(stableDt)
+		if digAfter != digBefore {
+			stabilized[digBefore] = digAfter
+		}
+
+		cp.Def[i] = stableDt
+	}
+
+	// update all inputs to reference the new digests
+	if err := stabilizeInputs(&cp, stabilized); err != nil {
+		return nil, errors.Wrap(err, "failed to stabilize inputs")
+	}
+
+	// finally, sort Def since it's in unstable topological order
+	sort.Slice(cp.Def, func(i, j int) bool {
+		return bytes.Compare(cp.Def[i], cp.Def[j]) < 0
+	})
+
+	return &cp, nil
+}
+
+// stabilizeInputs takes a mapping from old digests to new digests and updates
+// all Op inputs to use the new digests instead. Because inputs are addressed
+// by Op digests, any Ops that needed to be updated will thereby yield a new
+// mapping, so stabilizeInputs will keep recursing until no new mappings are
+// yielded.
+func stabilizeInputs(cp *pb.Definition, stabilized map[digest.Digest]digest.Digest) error {
+	nextPass := map[digest.Digest]digest.Digest{}
+
+	for before, after := range stabilized {
+		meta, found := cp.Metadata[before]
+		if !found {
+			return fmt.Errorf("missing metadata for %s", before)
+		}
+
+		cp.Metadata[after] = meta
+		delete(cp.Metadata, before)
+	}
+
+	for i, dt := range cp.Def {
+		digBefore := digest.FromBytes(dt)
+
+		var op pb.Op
+		if err := (&op).Unmarshal(dt); err != nil {
+			return errors.Wrap(err, "failed to parse llb proto op")
+		}
+		for before, after := range stabilized {
+			for _, input := range op.Inputs {
+				if input.Digest == before {
+					input.Digest = after
+				}
+			}
+		}
+		stableDt, err := op.Marshal()
+		if err != nil {
+			return errors.Wrap(err, "failed to marshal llb proto op")
+		}
+		digAfter := digest.FromBytes(stableDt)
+		if digAfter != digBefore {
+			nextPass[digBefore] = digAfter
+		}
+		cp.Def[i] = stableDt
+	}
+
+	if len(nextPass) > 0 {
+		return stabilizeInputs(cp, nextPass)
 	}
 
 	return nil

--- a/core/digest.go
+++ b/core/digest.go
@@ -1,0 +1,228 @@
+package core
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+)
+
+func stableDigest(value any) (digest.Digest, error) {
+	buf := new(bytes.Buffer)
+
+	if err := digestInto(value, buf); err != nil {
+		return "", err
+	}
+
+	return digest.FromReader(buf)
+}
+
+func digestInto(value any, dest io.Writer) (err error) {
+	defer func() {
+		if err := recover(); err != nil {
+			panic(fmt.Errorf("digest %T: %v", value, err))
+		}
+	}()
+
+	switch x := value.(type) {
+	case *pb.Definition:
+		if x == nil {
+			break
+		}
+
+		cp, err := stabilizeDef(x)
+		if err != nil {
+			return err
+		}
+
+		value = cp
+
+	case []byte:
+		// base64-encode bytes rather than treating it like a slice
+		return json.NewEncoder(dest).Encode(value)
+	}
+
+	rt := reflect.TypeOf(value)
+	rv := reflect.ValueOf(value)
+	if rt.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			_, err := fmt.Fprintln(dest, "nil")
+			return err
+		}
+		rt = rt.Elem()
+		rv = rv.Elem()
+	}
+
+	switch rt.Kind() {
+	case reflect.Struct:
+		if err := digestStructInto(rt, rv, dest); err != nil {
+			return fmt.Errorf("digest struct: %w", err)
+		}
+	case reflect.Slice, reflect.Array:
+		if err := digestSliceInto(rv, dest); err != nil {
+			return fmt.Errorf("digest slice/array: %w", err)
+		}
+	case reflect.Map:
+		if err := digestMapInto(rv, dest); err != nil {
+			return fmt.Errorf("digest map: %w", err)
+		}
+	case reflect.String,
+		reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		if err := json.NewEncoder(dest).Encode(value); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("don't know how to digest %T", value)
+	}
+
+	return nil
+}
+
+func digestStructInto(rt reflect.Type, rv reflect.Value, dest io.Writer) error {
+	for i := 0; i < rt.NumField(); i++ {
+		name := rt.Field(i).Name
+		fmt.Fprintln(dest, name)
+		if err := digestInto(rv.Field(i).Interface(), dest); err != nil {
+			return fmt.Errorf("field %s: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
+func digestSliceInto(rv reflect.Value, dest io.Writer) error {
+	for i := 0; i < rv.Len(); i++ {
+		fmt.Fprintln(dest, i)
+		if err := digestInto(rv.Index(i).Interface(), dest); err != nil {
+			return fmt.Errorf("index %d: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+func digestMapInto(rv reflect.Value, dest io.Writer) error {
+	keys := rv.MapKeys()
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i].String() < keys[j].String()
+	})
+
+	for _, k := range keys {
+		if err := digestInto(k.Interface(), dest); err != nil {
+			return fmt.Errorf("key %v: %w", k, err)
+		}
+		if err := digestInto(rv.MapIndex(k).Interface(), dest); err != nil {
+			return fmt.Errorf("value for key %v: %w", k, err)
+		}
+	}
+
+	return nil
+}
+
+// stabilizeDef returns a copy of def that has been pruned of any ephemeral
+// data so that it may be used as a cache key that is stable across sessions.
+func stabilizeDef(def *pb.Definition) (*pb.Definition, error) {
+	cp := *def
+	cp.Def = cloneSlice(def.Def)
+	cp.Metadata = cloneMap(def.Metadata)
+	cp.Source = nil // discard source map
+
+	stabilized := map[digest.Digest]digest.Digest{}
+
+	// first, stabilize all Ops
+	for i, dt := range cp.Def {
+		var op pb.Op
+		if err := (&op).Unmarshal(dt); err != nil {
+			return nil, errors.Wrap(err, "failed to parse llb proto op")
+		}
+
+		digBefore := digest.FromBytes(dt)
+
+		if src := op.GetSource(); src != nil {
+			// prevent ephemeral metadata from busting caches
+			delete(src.Attrs, pb.AttrLocalSessionID)
+			delete(src.Attrs, pb.AttrLocalUniqueID)
+			delete(src.Attrs, pb.AttrSharedKeyHint) // has session ID + path
+		}
+
+		stableDt, err := op.Marshal()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to marshal llb proto op")
+		}
+
+		digAfter := digest.FromBytes(stableDt)
+		if digAfter != digBefore {
+			stabilized[digBefore] = digAfter
+		}
+
+		cp.Def[i] = stableDt
+	}
+
+	// update all inputs to reference the new digests
+	if err := stabilizeInputs(&cp, stabilized); err != nil {
+		return nil, errors.Wrap(err, "failed to stabilize inputs")
+	}
+
+	// finally, sort Def since it's in unstable topological order
+	sort.Slice(cp.Def, func(i, j int) bool {
+		return bytes.Compare(cp.Def[i], cp.Def[j]) < 0
+	})
+
+	return &cp, nil
+}
+
+// stabilizeInputs takes a mapping from old digests to new digests and updates
+// all Op inputs to use the new digests instead. Because inputs are addressed
+// by Op digests, any Ops that needed to be updated will thereby yield a new
+// mapping, so stabilizeInputs will keep recursing until no new mappings are
+// yielded.
+func stabilizeInputs(cp *pb.Definition, stabilized map[digest.Digest]digest.Digest) error {
+	nextPass := map[digest.Digest]digest.Digest{}
+
+	for before, after := range stabilized {
+		meta, found := cp.Metadata[before]
+		if !found {
+			return fmt.Errorf("missing metadata for %s", before)
+		}
+
+		cp.Metadata[after] = meta
+		delete(cp.Metadata, before)
+
+		for i, dt := range cp.Def {
+			var op pb.Op
+			if err := (&op).Unmarshal(dt); err != nil {
+				return errors.Wrap(err, "failed to parse llb proto op")
+			}
+			digBefore := digest.FromBytes(dt)
+			for _, input := range op.Inputs {
+				if input.Digest == before {
+					input.Digest = after
+				}
+			}
+			stableDt, err := op.Marshal()
+			if err != nil {
+				return errors.Wrap(err, "failed to marshal llb proto op")
+			}
+			digAfter := digest.FromBytes(stableDt)
+			if digAfter != digBefore {
+				nextPass[digBefore] = digAfter
+			}
+			cp.Def[i] = stableDt
+		}
+	}
+
+	if len(nextPass) > 0 {
+		return stabilizeInputs(cp, nextPass)
+	}
+
+	return nil
+}

--- a/core/host.go
+++ b/core/host.go
@@ -61,7 +61,8 @@ func (host *Host) Directory(ctx context.Context, gw bkgw.Client, dirPath string,
 	pipelineName := fmt.Sprintf("%s %s", pipelineNamePrefix, absPath)
 	ctx, subRecorder := progrock.WithGroup(ctx, pipelineName, progrock.Weak())
 
-	localID := fmt.Sprintf("host:%s", absPath)
+	sessionID := gw.BuildOpts().SessionID
+	localID := fmt.Sprintf("host:%s:%s", sessionID, absPath)
 
 	localOpts := []llb.LocalOption{
 		// Custom name
@@ -71,8 +72,9 @@ func (host *Host) Directory(ctx context.Context, gw bkgw.Client, dirPath string,
 		llb.SharedKeyHint(localID),
 
 		// sync this dir from this session specifically, even if this ends up passed
-		// to a different session (e.g. a project container)
-		llb.SessionID(gw.BuildOpts().SessionID),
+		// to a different session (e.g. a project container). this also helps
+		// protect against cross-session solver collisions in Buildkit.
+		llb.SessionID(sessionID),
 	}
 
 	opName := fmt.Sprintf("copy %s", absPath)

--- a/core/integration/cache_test.go
+++ b/core/integration/cache_test.go
@@ -1,8 +1,12 @@
 package core
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"dagger.io/dagger"
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/internal/testutil"
 	"github.com/stretchr/testify/require"
@@ -64,4 +68,35 @@ func TestCacheVolume(t *testing.T) {
 
 		require.NotEqual(t, idOrig, idDiff)
 	})
+}
+
+func TestLocalImportCacheReuse(t *testing.T) {
+	t.Parallel()
+
+	hostDirPath := t.TempDir()
+	err := os.WriteFile(filepath.Join(hostDirPath, "foo"), []byte("bar"), 0o644)
+	require.NoError(t, err)
+
+	runExec := func(ctx context.Context, t *testing.T, c *dagger.Client) string {
+		out, err := c.Container().From("alpine:3.16.2").
+			WithDirectory("/fromhost", c.Host().Directory(hostDirPath)).
+			WithExec([]string{"sh", "-c", "head -c 128 /dev/random | sha256sum"}).
+			Stdout(ctx)
+		require.NoError(t, err)
+		return out
+	}
+
+	c1, ctx1 := connect(t)
+	defer c1.Close()
+	ctx1, cancel1 := context.WithCancel(ctx1)
+	defer cancel1()
+	out1 := runExec(ctx1, t, c1)
+
+	c2, ctx2 := connect(t)
+	defer c2.Close()
+	ctx2, cancel2 := context.WithCancel(ctx2)
+	defer cancel2()
+	out2 := runExec(ctx2, t, c2)
+
+	require.Equal(t, out1, out2)
 }

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -309,7 +309,7 @@ func (ctr DaggerCLIContainer) WithLoadedProject(
 	require.NoError(ctr.t, err)
 
 	thisRepoDir := ctr.c.Host().Directory(thisRepoPath, dagger.HostDirectoryOpts{
-		Exclude: []string{".git", "bin", "docs", "website"},
+		Include: []string{"core", "sdk", "go.mod", "go.sum"},
 	})
 	projectArg := filepath.Join(cliContainerRepoMntPath, projectPath)
 


### PR DESCRIPTION
SessionID is important to keep on host directories, because otherwise the Buildkit solver's vertex is keyed only on a local client's path, whose contents may differ when clients are running in containers with different content mounted to the same path. This primarily affects setups with a long-running external engine.

To prevent the SessionID from busting caches everywhere, hostnames are now calculated by taking a stable hash of the *pb.Definition, which is a pretty invasive process:

First it loops over the inner Ops and removes the relevant ephemeral metadata from SourceOps. This results in a new Op with a different digest, so it keeps track of the old and new digests along the way.

Next it loops over the old => new digest mapping and converts any occurrences of the old digest to the new digest, both in the definition's OpMetadata and in each inner Op's inputs. Any Ops whose inputs had to be modified will result in yet another old => new digest mapping, so this process repeats until everything stabilizes.

Finally, the inner Ops are sorted lexicographically because otherwise they are in topological order, meaning two root Ops may change places without changing semantics, but in this case we need everything to be deterministic.
