### PR TITLE
inline tui: show run duration at the end

### DIFF
--- a/.changes/unreleased/Added-20230717-173825.yaml
+++ b/.changes/unreleased/Added-20230717-173825.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: show total duration at the end of a run
+time: 2023-07-17T17:38:25.400368661-04:00
+custom:
+  Author: vito
+  PR: "5476"

--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/dagger/dagger/engine"
@@ -183,14 +184,26 @@ func inlineTUI(
 
 	var cbErr error
 	engineErr = engine.Start(ctx, engineConf, func(ctx context.Context, api *router.Router) error {
+		before := time.Now()
+
 		cbErr = fn(ctx, api)
+
+		program.Send(progrock.StatusInfoMsg{
+			Name:  "Duration",
+			Value: time.Since(before).Truncate(time.Millisecond).String(),
+			Order: 3,
+		})
+
 		return cbErr
 	})
+
 	if cbErr != nil {
 		return cbErr
+	} else if engineErr != nil {
+		return engineErr
 	}
 
-	return engineErr
+	return nil
 }
 
 func newProgrockWriter(dest string) (progrock.Writer, error) {


### PR DESCRIPTION
Just some TUI low-hanging fruit:

![image](https://github.com/dagger/dagger/assets/1880/404a094d-9798-408a-ab6a-7b9244a8dea2)

via feedback from @cpdeethree :)