### PR TITLE
Fix coroutines not showing in Python reference docs

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -111,7 +111,14 @@ dependencies = [
     "sphinx>=5.3.0",
     "sphinx-rtd-theme~=1.1.1",
 ]
-scripts = {build = "sphinx-build -v docs docs/_build"}
+
+[tool.hatch.envs.docs.scripts]
+build = "sphinx-build -v docs docs/_build"
+server = "python -m http.server -d docs/_build"
+preview = [
+    "build",
+    "server",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests/"]


### PR DESCRIPTION
Fixes #4856

## Why?

It makes it clearer from the reference documentation which methods need an `await`.

## Before

<img width="705" alt="Screenshot 2023-07-18 at 12 08 25" src="https://github.com/dagger/dagger/assets/174525/4940605f-ebfa-4f92-86b3-ba7546d5adda">


## After

<img width="719" alt="Screenshot 2023-07-18 at 12 07 11" src="https://github.com/dagger/dagger/assets/174525/4bc2589c-c531-4aae-a4ae-86a57b377f99">

