### PR TITLE
Add missing release notes

### DIFF
--- a/.changes/unreleased/Added-20230717-173825.yaml
+++ b/.changes/unreleased/Added-20230717-173825.yaml
@@ -1,5 +1,5 @@
 kind: Added
-body: show total duration at the end of a run
+body: 'cli: show total duration at the end of a run'
 time: 2023-07-17T17:38:25.400368661-04:00
 custom:
   Author: vito

--- a/.changes/unreleased/Added-20230718-193123.yaml
+++ b/.changes/unreleased/Added-20230718-193123.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: 'engine: add Directory.Sync'
+time: 2023-07-18T19:31:23.522362+01:00
+custom:
+  Author: helderco
+  PR: "5414"

--- a/.changes/unreleased/Added-20230718-193229.yaml
+++ b/.changes/unreleased/Added-20230718-193229.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: 'engine: add File.Sync'
+time: 2023-07-18T19:32:29.870216+01:00
+custom:
+  Author: helderco
+  PR: "5416"

--- a/.changes/unreleased/Added-20230718-193402.yaml
+++ b/.changes/unreleased/Added-20230718-193402.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: 'engine: add `Container.WithFocus` & `Container.WithoutFocus`'
+time: 2023-07-18T19:34:02.652671+01:00
+custom:
+  Author: vito
+  PR: "5364"

--- a/.changes/unreleased/Added-20230718-193739.yaml
+++ b/.changes/unreleased/Added-20230718-193739.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: 'engine: add `include` & `exclude` to host dir copy name'
+time: 2023-07-18T19:37:39.871615+01:00
+custom:
+  Author: sipsma
+  PR: "5469"

--- a/.changes/unreleased/Deprecated-20230718-173905.yaml
+++ b/.changes/unreleased/Deprecated-20230718-173905.yaml
@@ -1,5 +1,5 @@
 kind: Deprecated
-body: Deprecate `exitCode`
+body: 'engine: deprecate `exitCode`'
 time: 2023-07-18T17:39:05.715807Z
 custom:
   Author: helderco

--- a/.changes/unreleased/Fixed-20230718-192426.yaml
+++ b/.changes/unreleased/Fixed-20230718-192426.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: 'engine: prevent session id from busting caches everywhere'
+time: 2023-07-18T19:24:26.184321+01:00
+custom:
+  Author: vito
+  PR: "5474"

--- a/.changes/unreleased/Fixed-20230718-192559.yaml
+++ b/.changes/unreleased/Fixed-20230718-192559.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: 'engine: optimize `WithDirectory` & `WithFile` via MergeOp'
+time: 2023-07-18T19:25:59.971743+01:00
+custom:
+  Author: sipsma
+  PR: "5400"

--- a/.changes/unreleased/Fixed-20230718-192834.yaml
+++ b/.changes/unreleased/Fixed-20230718-192834.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: 'engine: remove unimplemented git fields'
+time: 2023-07-18T19:28:34.672011+01:00
+custom:
+  Author: helderco
+  PR: "5410"

--- a/.changes/unreleased/Fixed-20230718-193825.yaml
+++ b/.changes/unreleased/Fixed-20230718-193825.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: 'engine: support optionally setting explicit OCI mediatypes'
+time: 2023-07-18T19:38:25.465609+01:00
+custom:
+  Author: sipsma
+  PR: "5467"


### PR DESCRIPTION
All changes seem to be Engine & CLI related, nothing SDK-specific.

This will make the next release quicker, since generating the release notes will be just a matter of running `changie batch patch`.

@vito @sipsma @helderco if somethings does not look right, please make the change and push directly to the fork, no need to comment. I don't think that we have anything for the SDKs (apart from the Engine bump), but please add anything that I may have missed.

@helderco I was not sure whether this one needed a changelog entry:
- https://github.com/dagger/dagger/pull/5447

---

FWIW, we want this in tomorrow noon (UTC), July 19th, so that producing `v0.6.4` will be smooth from release notes perspective. cc @mircubed @d3rp3tt3 @aluzzardi @shykes 