### PR TITLE
chore: update `AppendAnonymousGitLabels()`

### DIFF
--- a/core/pipeline/label.go
+++ b/core/pipeline/label.go
@@ -1,7 +1,7 @@
 package pipeline
 
 import (
-	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"os"
@@ -319,7 +319,7 @@ func (labels *Labels) AppendAnonymousGitLabels(workdir string) *Labels {
 
 	for _, gitLabel := range gitLabels {
 		if gitLabel.Name == "dagger.io/git.author.email" || gitLabel.Name == "dagger.io/git.remote" {
-			labels.Add(gitLabel.Name, fmt.Sprintf("%x", sha256.Sum256([]byte(gitLabel.Value))))
+			labels.Add(gitLabel.Name, fmt.Sprintf("%x", base64.StdEncoding.EncodeToString([]byte(gitLabel.Value))))
 		}
 	}
 


### PR DESCRIPTION
While trying to understand who uses Dagger, we realized that some Go SDK users were periodically heavily using us. As we are currently sha256 encoding some Git Labels, we currently have no idea who, and where they are using us.

Relying on base64 instead of sha256 would help us understand better the usage of the Go SDK

cc @gerhard

> PS: this might create some noise with the current hashes