### PR TITLE
Add release notes fragment instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,31 @@ git push my_feature_branch
 # Create a new pull request from https://github.com/dagger/$REPOSITORY
 ```
 
-### 3. Update your pull request with latest changes
+### 3. Add release notes fragment
+
+If this is a user-facing change, please add a line for the release notes.
+You will need to have [`changie` installed](https://changie.dev/guide/installation/).
+
+If this is a user-facing change in the 🚙 Engine or 🚗 CLI, run `changie new` in the top level directory.
+Here is an example of what that looks like:
+
+```shell
+changie new
+✔ Kind … Added
+✔ Body … engine: add `Directory.Sync`
+✔ GitHub PR … 5414
+✔ GitHub Author … helderco
+```
+
+If there are code changes in the SDKs, run `changie new` in the corresponding directory, e.g. `sdk/go`, `sdk/nodejs`, etc.
+
+Remember to add & commit the release notes fragment.
+This will be used at release time, in the changelog.
+Here is an example of the end-result for all release notes fragments: https://github.com/dagger/dagger/blob/v0.6.4/.changes/v0.6.4.md
+
+You can find an asciinema of how `changie` works on https://changie.dev
+
+### 4. Update your pull request with latest changes
 
 ```shell
 # Checkout main branch


### PR DESCRIPTION
This is a follow-up to:
- https://github.com/dagger/dagger/pull/5408

WDYT?

---
There is a related discussion in https://github.com/dagger/dagger/issues/5475 that you may be interested in.