### PR TITLE
docs: `mount dir as secret` cookbook

### DIFF
--- a/docs/current/742989-cookbook.md
+++ b/docs/current/742989-cookbook.md
@@ -625,6 +625,31 @@ Set the Hashicorp Vault URI, namespace, role and secret identifiers as host envi
 
 [Learn more](./guides/723462-use-secrets.md)
 
+### Mount directories as secrets in a container
+
+The following code listing demonstrates how to securely mount directories as secrets in a container. The directory structure/file names will be accessible, but contents of the secrets will be scrubbed:
+
+<Tabs groupId="language">
+<TabItem value="Go">
+
+```go file=./cookbook/snippets/mount-directories-as-secrets/main.go
+```
+
+</TabItem>
+<TabItem value="Node.js">
+
+```javascript file=./cookbook/snippets/mount-directories-as-secrets/index.ts
+```
+
+</TabItem>
+<TabItem value="Python">
+
+```python file=./cookbook/snippets/mount-directories-as-secrets/main.py
+```
+
+</TabItem>
+</Tabs>
+
 ## Optimizations
 
 ### Cache dependencies

--- a/docs/current/cookbook/snippets/mount-directories-as-secrets/index.ts
+++ b/docs/current/cookbook/snippets/mount-directories-as-secrets/index.ts
@@ -1,0 +1,82 @@
+import Client, { connect, Container } from "@dagger.io/dagger"
+import * as fs from "fs"
+import * as path from "path"
+
+connect(async (client: Client) => {
+  const gpgFiles = [
+    "/home/USER/.gnupg/pubring.kbx",
+    "/home/USER/.gnupg/trustdb.gpg",
+    "/home/USER/.gnupg/public.key",
+  ]
+
+  const sourceDir = "/home/USER/.gnupg/private-keys-v1.d/"
+  const targetDir = "/root/.gnupg/private-keys-v1.d/"
+
+  let container = client.container().from("alpine:3.17")
+
+  // Mount GPG files
+  for (const filePath of gpgFiles) {
+    const secret = client
+      .host()
+      .setSecretFile(filePath.split("/").pop(), filePath)
+
+    container = container.withMountedSecret(
+      `/root/.gnupg/${filePath.split("/").pop()}`,
+      secret
+    )
+  }
+
+  // Mount private keys directory
+  container = container.with(
+    await mountDirectoryAsSecret(client, sourceDir, targetDir)
+  )
+
+  // Sign the binary
+  const binaryName = "binary-name"
+  container = container
+    .withExec(["apk", "add", "--no-cache", "gnupg"])
+    .withExec(["chmod", "700", "/root/.gnupg"])
+    .withExec(["chmod", "700", "/root/.gnupg/private-keys-v1.d"])
+    .withExec(["gpg", "--import", "/root/.gnupg/public.key"])
+    .withExec(["gpg", "--import", "/root/.gnupg/private-keys-v1.d/private.key"])
+    .withWorkdir("/root")
+    .withExec(["gpg", "--detach-sign", "--armor", binaryName])
+    .withExec(["ls", "-l", `${binaryName}.asc`])
+
+  console.log(await container.stdout())
+})
+
+async function mountDirectoryAsSecret(
+  client: Client,
+  sourceDir: string,
+  targetDir: string
+): Promise<(c: Container) => Container> {
+  async function processDirectory(
+    dir: string
+  ): Promise<(c: Container) => Container> {
+    const entries = await fs.promises.readdir(dir)
+    const containerUpdates: Array<(c: Container) => Container> = []
+
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry)
+      const entryStat = await fs.promises.stat(fullPath)
+
+      if (entryStat.isFile()) {
+        const secret = client
+          .host()
+          .setSecretFile(path.basename(fullPath), fullPath)
+        const targetPath = path.join(
+          targetDir,
+          path.relative(sourceDir, fullPath)
+        )
+        containerUpdates.push((c) => c.withMountedSecret(targetPath, secret))
+      } else if (entryStat.isDirectory()) {
+        containerUpdates.push(await processDirectory(fullPath))
+      }
+    }
+
+    return (c) => containerUpdates.reduce((acc, update) => update(acc), c)
+  }
+
+  return processDirectory(sourceDir)
+}

--- a/docs/current/cookbook/snippets/mount-directories-as-secrets/main.go
+++ b/docs/current/cookbook/snippets/mount-directories-as-secrets/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	// initialize Dagger client
+	ctx := context.Background()
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	// GPG files needed for signing
+	gpgFiles := []string{
+		"/home/USER/.gnupg/pubring.kbx",
+		"/home/USER/.gnupg/trustdb.gpg",
+		"/home/USER/.gnupg/public.key",
+	}
+
+	// Container setup
+	container := client.Container().From("alpine:3.17")
+
+	// Mount GPG files
+	for _, filePath := range gpgFiles {
+		secret := client.Host().SetSecretFile(filepath.Base(filePath), filePath)
+		container = container.WithMountedSecret("/root/.gnupg/"+filepath.Base(filePath), secret)
+	}
+
+	// Mount private keys directory
+	// /home/USER/.gnupg/private-keys-v1.d/ contains a private.key file in our example
+	sourceDir := "/home/USER/.gnupg/private-keys-v1.d/"
+	targetDir := "/root/.gnupg/private-keys-v1.d/"
+	container = container.With(mountDirectoryAsSecret(client, sourceDir, targetDir))
+
+	// Sign the binary, and output its signature
+	binaryName := "binary-name"
+	out, err := container.
+		WithExec([]string{"apk", "add", "--no-cache", "gnupg"}).
+		WithExec([]string{"chmod", "700", "/root/.gnupg"}).
+		WithExec([]string{"chmod", "700", "/root/.gnupg/private-keys-v1.d"}).
+		WithExec([]string{"gpg", "--import", "/root/.gnupg/public.key"}).
+		WithExec([]string{"gpg", "--import", "/root/.gnupg/private-keys-v1.d/private.key"}).
+		WithWorkdir("/root").
+		WithExec([]string{"gpg", "--detach-sign", "--armor", binaryName}).
+		WithExec([]string{"ls", "-l", binaryName + ".asc"}).
+		Stdout(ctx)
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(out)
+}
+
+func mountDirectoryAsSecret(client *dagger.Client, sourceDir, targetDir string) func(*dagger.Container) *dagger.Container {
+	return func(c *dagger.Container) *dagger.Container {
+		err := filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if !info.IsDir() {
+				relativePath, _ := filepath.Rel(sourceDir, path)
+				targetPath := filepath.Join(targetDir, relativePath)
+
+				// Set secret to file content
+				secret := client.Host().SetSecretFile(filepath.Base(path), path)
+
+				// Mount secret as file in container
+				c = c.WithMountedSecret(targetPath, secret)
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			panic(err)
+		}
+
+		return c
+	}
+}

--- a/docs/current/cookbook/snippets/mount-directories-as-secrets/main.py
+++ b/docs/current/cookbook/snippets/mount-directories-as-secrets/main.py
@@ -1,0 +1,62 @@
+import os
+import sys
+from pathlib import Path
+
+import anyio
+
+import dagger
+
+
+async def main():
+    async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
+        gpg_files = [
+            "/home/USER/.gnupg/pubring.kbx",
+            "/home/USER/.gnupg/trustdb.gpg",
+            "/home/USER/.gnupg/public.key",
+        ]
+
+        source_dir = "/home/USER/.gnupg/private-keys-v1.d/"
+        target_dir = "/root/.gnupg/private-keys-v1.d/"
+
+        ctr = client.container().from_("alpine:3.17")
+
+        for file_path in gpg_files:
+            secret = client.host().set_secret_file(Path.name(file_path), file_path)
+            ctr = ctr.with_mounted_secret(
+                f"/root/.gnupg/{Path.name(file_path)}", secret
+            )
+
+        ctr = ctr.with_(mount_directory_as_secret(client, source_dir, target_dir))
+
+        binary_name = "binary-name"
+        ctr = (
+            ctr.with_exec(["apk", "add", "--no-cache", "gnupg"])
+            .with_exec(["chmod", "700", "/root/.gnupg"])
+            .with_exec(["chmod", "700", "/root/.gnupg/private-keys-v1.d"])
+            .with_exec(["gpg", "--import", "/root/.gnupg/public.key"])
+            .with_exec(
+                ["gpg", "--import", "/root/.gnupg/private-keys-v1.d/private.key"]
+            )
+            .with_workdir("/root")
+            .with_exec(["gpg", "--detach-sign", "--armor", binary_name])
+            .with_exec(["ls", "-l", f"{binary_name}.asc"])
+        )
+
+        print(await ctr.stdout())
+
+
+def mount_directory_as_secret(client, source_dir, target_dir):
+    def mount_directory_as_secret_inner(ctr: dagger.Container):
+        for root, _dirs, files in os.walk(source_dir):
+            for file in files:
+                full_path = Path(root) / file
+                target_path = Path(target_dir) / Path(full_path).relative_to(source_dir)
+
+                secret = client.host().set_secret_file(Path.name(full_path), full_path)
+                ctr = ctr.with_mounted_secret(target_path, secret)
+        return ctr
+
+    return mount_directory_as_secret_inner
+
+
+anyio.run(main)


### PR DESCRIPTION
Fixes #4896

⚠️ PUBLISH AFTER v0.8.0 RELEASE, depends on #5500 

Small cookbook example / wrapper with the `.with()` method showing how to mount directories securely
