### PR TITLE
Python: Fix sdist build

### DIFF
--- a/internal/mage/util/util.go
+++ b/internal/mage/util/util.go
@@ -20,7 +20,7 @@ func Repository(c *dagger.Client) *dagger.Directory {
 		Exclude: []string{
 			".git",
 			"bin",
-			".DS_Store",
+			"**/.DS_Store",
 
 			// node
 			"**/node_modules",
@@ -31,6 +31,8 @@ func Repository(c *dagger.Client) *dagger.Directory {
 			"**/.mypy_cache",
 			"**/.pytest_cache",
 			"**/.ruff_cache",
+			"sdk/python/dist",
+			"sdk/python/experimental",
 
 			// go
 			// go.work is ignored so that you can use ../foo during local dev and let

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -61,7 +61,15 @@ server = [
 source = "vcs"
 fallback-version = "0.0.0"
 
-[tool.hatch.build]
+[tool.hatch.build.targets.sdist]
+only-include = [
+    "src",
+    "tests",
+    "docs",
+    "CHANGELOG.md",
+]
+
+[tool.hatch.build.targets.wheel]
 packages = ["src/dagger"]
 
 [tool.hatch.envs.default]


### PR DESCRIPTION
This fixes an issue with the source distribution that's published in [PyPI](https://pypi.org/project/dagger-io/#files) since the [move to hatch](https://github.com/dagger/dagger/pull/5401) because of the difference in the distribution name (i.e., `dagger-io`) and importable package name (i.e, `dagger`). This was only detected when trying to release in [conda](https://github.com/conda-forge/dagger-io-feedstock/pull/18), so I've added a test in CI.