### PR TITLE
remote cache: improve http error checking

### DIFF
--- a/engine/cache/manager.go
+++ b/engine/cache/manager.go
@@ -344,7 +344,7 @@ func (m *manager) pushLayer(ctx context.Context, layerDesc ocispecs.Descriptor, 
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
+	if !httpOk(resp.StatusCode) {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("unexpected status code: %d: %s", resp.StatusCode, body)
 	}

--- a/engine/cache/manager.go
+++ b/engine/cache/manager.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -344,7 +345,8 @@ func (m *manager) pushLayer(ctx context.Context, layerDesc ocispecs.Descriptor, 
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status code: %d: %s", resp.StatusCode, body)
 	}
 	return nil
 }

--- a/engine/cache/manager.go
+++ b/engine/cache/manager.go
@@ -3,7 +3,6 @@ package cache
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -344,9 +343,8 @@ func (m *manager) pushLayer(ctx context.Context, layerDesc ocispecs.Descriptor, 
 		return err
 	}
 	defer resp.Body.Close()
-	if !httpOk(resp.StatusCode) {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("unexpected status code: %d: %s", resp.StatusCode, body)
+	if err := checkResponse(resp); err != nil {
+		return err
 	}
 	return nil
 }

--- a/engine/cache/provider.go
+++ b/engine/cache/provider.go
@@ -102,3 +102,7 @@ func (r *urlReaderAt) Close() error {
 	}
 	return nil
 }
+
+func httpOk(code int) bool {
+	return code >= 200 && code < 300
+}

--- a/engine/cache/provider.go
+++ b/engine/cache/provider.go
@@ -102,7 +102,3 @@ func (r *urlReaderAt) Close() error {
 	}
 	return nil
 }
-
-func httpOk(code int) bool {
-	return code >= 200 && code < 300
-}

--- a/engine/cache/service.go
+++ b/engine/cache/service.go
@@ -271,7 +271,8 @@ func (c *client) GetConfig(ctx context.Context, req GetConfigRequest) (*Config, 
 	}
 	defer httpResp.Body.Close()
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", httpResp.StatusCode)
+		body, _ := io.ReadAll(httpReq.Body)
+		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
 
 	config := &Config{}
@@ -310,7 +311,8 @@ func (c *client) UpdateCacheRecords(
 	}
 	defer httpResp.Body.Close()
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", httpResp.StatusCode)
+		body, _ := io.ReadAll(httpReq.Body)
+		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
 
 	resp := &UpdateCacheRecordsResponse{}
@@ -349,7 +351,8 @@ func (c *client) UpdateCacheLayers(
 	}
 	defer httpResp.Body.Close()
 	if httpResp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status code: %d", httpResp.StatusCode)
+		body, _ := io.ReadAll(httpReq.Body)
+		return fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
 
 	return nil
@@ -371,7 +374,8 @@ func (c *client) ImportCache(ctx context.Context) (*remotecache.CacheConfig, err
 	}
 	defer httpResp.Body.Close()
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", httpResp.StatusCode)
+		body, _ := io.ReadAll(httpReq.Body)
+		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
 
 	config := &remotecache.CacheConfig{}
@@ -407,7 +411,8 @@ func (c *client) GetLayerDownloadURL(ctx context.Context, req GetLayerDownloadUR
 	}
 	defer httpResp.Body.Close()
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", httpResp.StatusCode)
+		body, _ := io.ReadAll(httpReq.Body)
+		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
 
 	resp := &GetLayerDownloadURLResponse{}
@@ -443,7 +448,8 @@ func (c *client) GetLayerUploadURL(ctx context.Context, req GetLayerUploadURLReq
 	}
 	defer httpResp.Body.Close()
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", httpResp.StatusCode)
+		body, _ := io.ReadAll(httpReq.Body)
+		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
 
 	resp := &GetLayerUploadURLResponse{}
@@ -479,7 +485,8 @@ func (c *client) GetCacheMountConfig(ctx context.Context, req GetCacheMountConfi
 	}
 	defer httpResp.Body.Close()
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", httpResp.StatusCode)
+		body, _ := io.ReadAll(httpReq.Body)
+		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
 
 	resp := &GetCacheMountConfigResponse{}
@@ -515,7 +522,8 @@ func (c *client) GetCacheMountUploadURL(ctx context.Context, req GetCacheMountUp
 	}
 	defer httpResp.Body.Close()
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", httpResp.StatusCode)
+		body, _ := io.ReadAll(httpReq.Body)
+		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
 
 	resp := &GetCacheMountUploadURLResponse{}

--- a/engine/cache/service.go
+++ b/engine/cache/service.go
@@ -3,7 +3,6 @@ package cache
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -270,9 +269,8 @@ func (c *client) GetConfig(ctx context.Context, req GetConfigRequest) (*Config, 
 		return nil, err
 	}
 	defer httpResp.Body.Close()
-	if !httpOk(httpResp.StatusCode) {
-		body, _ := io.ReadAll(httpReq.Body)
-		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
+	if err := checkResponse(httpResp); err != nil {
+		return nil, err
 	}
 
 	config := &Config{}
@@ -310,9 +308,8 @@ func (c *client) UpdateCacheRecords(
 		return nil, err
 	}
 	defer httpResp.Body.Close()
-	if !httpOk(httpResp.StatusCode) {
-		body, _ := io.ReadAll(httpReq.Body)
-		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
+	if err := checkResponse(httpResp); err != nil {
+		return nil, err
 	}
 
 	resp := &UpdateCacheRecordsResponse{}
@@ -350,9 +347,8 @@ func (c *client) UpdateCacheLayers(
 		return err
 	}
 	defer httpResp.Body.Close()
-	if !httpOk(httpResp.StatusCode) {
-		body, _ := io.ReadAll(httpReq.Body)
-		return fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
+	if err := checkResponse(httpResp); err != nil {
+		return err
 	}
 
 	return nil
@@ -373,9 +369,8 @@ func (c *client) ImportCache(ctx context.Context) (*remotecache.CacheConfig, err
 		return nil, err
 	}
 	defer httpResp.Body.Close()
-	if !httpOk(httpResp.StatusCode) {
-		body, _ := io.ReadAll(httpReq.Body)
-		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
+	if err := checkResponse(httpResp); err != nil {
+		return nil, err
 	}
 
 	config := &remotecache.CacheConfig{}
@@ -410,9 +405,8 @@ func (c *client) GetLayerDownloadURL(ctx context.Context, req GetLayerDownloadUR
 		return nil, err
 	}
 	defer httpResp.Body.Close()
-	if !httpOk(httpResp.StatusCode) {
-		body, _ := io.ReadAll(httpReq.Body)
-		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
+	if err := checkResponse(httpResp); err != nil {
+		return nil, err
 	}
 
 	resp := &GetLayerDownloadURLResponse{}
@@ -447,9 +441,8 @@ func (c *client) GetLayerUploadURL(ctx context.Context, req GetLayerUploadURLReq
 		return nil, err
 	}
 	defer httpResp.Body.Close()
-	if !httpOk(httpResp.StatusCode) {
-		body, _ := io.ReadAll(httpReq.Body)
-		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
+	if err := checkResponse(httpResp); err != nil {
+		return nil, err
 	}
 
 	resp := &GetLayerUploadURLResponse{}
@@ -484,9 +477,8 @@ func (c *client) GetCacheMountConfig(ctx context.Context, req GetCacheMountConfi
 		return nil, err
 	}
 	defer httpResp.Body.Close()
-	if !httpOk(httpResp.StatusCode) {
-		body, _ := io.ReadAll(httpReq.Body)
-		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
+	if err := checkResponse(httpResp); err != nil {
+		return nil, err
 	}
 
 	resp := &GetCacheMountConfigResponse{}
@@ -521,9 +513,8 @@ func (c *client) GetCacheMountUploadURL(ctx context.Context, req GetCacheMountUp
 		return nil, err
 	}
 	defer httpResp.Body.Close()
-	if !httpOk(httpResp.StatusCode) {
-		body, _ := io.ReadAll(httpReq.Body)
-		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
+	if err := checkResponse(httpResp); err != nil {
+		return nil, err
 	}
 
 	resp := &GetCacheMountUploadURLResponse{}

--- a/engine/cache/service.go
+++ b/engine/cache/service.go
@@ -270,7 +270,7 @@ func (c *client) GetConfig(ctx context.Context, req GetConfigRequest) (*Config, 
 		return nil, err
 	}
 	defer httpResp.Body.Close()
-	if httpResp.StatusCode != http.StatusOK {
+	if !httpOk(httpResp.StatusCode) {
 		body, _ := io.ReadAll(httpReq.Body)
 		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
@@ -310,7 +310,7 @@ func (c *client) UpdateCacheRecords(
 		return nil, err
 	}
 	defer httpResp.Body.Close()
-	if httpResp.StatusCode != http.StatusOK {
+	if !httpOk(httpResp.StatusCode) {
 		body, _ := io.ReadAll(httpReq.Body)
 		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
@@ -350,7 +350,7 @@ func (c *client) UpdateCacheLayers(
 		return err
 	}
 	defer httpResp.Body.Close()
-	if httpResp.StatusCode != http.StatusOK {
+	if !httpOk(httpResp.StatusCode) {
 		body, _ := io.ReadAll(httpReq.Body)
 		return fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
@@ -373,7 +373,7 @@ func (c *client) ImportCache(ctx context.Context) (*remotecache.CacheConfig, err
 		return nil, err
 	}
 	defer httpResp.Body.Close()
-	if httpResp.StatusCode != http.StatusOK {
+	if !httpOk(httpResp.StatusCode) {
 		body, _ := io.ReadAll(httpReq.Body)
 		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
@@ -410,7 +410,7 @@ func (c *client) GetLayerDownloadURL(ctx context.Context, req GetLayerDownloadUR
 		return nil, err
 	}
 	defer httpResp.Body.Close()
-	if httpResp.StatusCode != http.StatusOK {
+	if !httpOk(httpResp.StatusCode) {
 		body, _ := io.ReadAll(httpReq.Body)
 		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
@@ -447,7 +447,7 @@ func (c *client) GetLayerUploadURL(ctx context.Context, req GetLayerUploadURLReq
 		return nil, err
 	}
 	defer httpResp.Body.Close()
-	if httpResp.StatusCode != http.StatusOK {
+	if !httpOk(httpResp.StatusCode) {
 		body, _ := io.ReadAll(httpReq.Body)
 		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
@@ -484,7 +484,7 @@ func (c *client) GetCacheMountConfig(ctx context.Context, req GetCacheMountConfi
 		return nil, err
 	}
 	defer httpResp.Body.Close()
-	if httpResp.StatusCode != http.StatusOK {
+	if !httpOk(httpResp.StatusCode) {
 		body, _ := io.ReadAll(httpReq.Body)
 		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
@@ -521,7 +521,7 @@ func (c *client) GetCacheMountUploadURL(ctx context.Context, req GetCacheMountUp
 		return nil, err
 	}
 	defer httpResp.Body.Close()
-	if httpResp.StatusCode != http.StatusOK {
+	if !httpOk(httpResp.StatusCode) {
 		body, _ := io.ReadAll(httpReq.Body)
 		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}

--- a/engine/cache/util.go
+++ b/engine/cache/util.go
@@ -1,0 +1,25 @@
+package cache
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+)
+
+var (
+	urlRegex = regexp.MustCompile("(https://[^/]*)/[^ ]*")
+)
+
+func checkResponse(resp *http.Response) error {
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	return fmt.Errorf("unexpected status code: %d: %s",
+		resp.StatusCode,
+		// strip away URL paths to avoid leaking pre-signed URLs
+		urlRegex.ReplaceAllString(string(body), "$1/*****"),
+	)
+}

--- a/engine/cache/util_test.go
+++ b/engine/cache/util_test.go
@@ -1,0 +1,31 @@
+package cache
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckResponse(t *testing.T) {
+	require.NoError(t, checkResponse(&http.Response{
+		StatusCode: 200,
+	}))
+	require.NoError(t, checkResponse(&http.Response{
+		StatusCode: 201,
+	}))
+	require.ErrorContains(t, checkResponse(&http.Response{
+		StatusCode: 400,
+		Body:       io.NopCloser(strings.NewReader("error message")),
+	}), "error message")
+	require.ErrorContains(t, checkResponse(&http.Response{
+		StatusCode: 400,
+		Body:       io.NopCloser(strings.NewReader("https://foo.com/bar")),
+	}), "https://foo.com/*****")
+	require.ErrorContains(t, checkResponse(&http.Response{
+		StatusCode: 400,
+		Body:       io.NopCloser(strings.NewReader("some other https://foo.com/bar error")),
+	}), "some other https://foo.com/***** error")
+}


### PR DESCRIPTION
- Assume success on HTTP 2xx (some blob providers will return 201 rather than 200)
- Dump HTTP error body on failure, stripping away any URL path to avoid leaking pre-signed URLs