### PR TITLE
cloud cache status codes

### DIFF
--- a/engine/cache/manager.go
+++ b/engine/cache/manager.go
@@ -344,7 +344,7 @@ func (m *manager) pushLayer(ctx context.Context, layerDesc ocispecs.Descriptor, 
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
+	if !httpOk(resp.StatusCode) {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("unexpected status code: %d: %s", resp.StatusCode, body)
 	}

--- a/engine/cache/manager.go
+++ b/engine/cache/manager.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -344,7 +345,8 @@ func (m *manager) pushLayer(ctx context.Context, layerDesc ocispecs.Descriptor, 
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status code: %d: %s", resp.StatusCode, body)
 	}
 	return nil
 }

--- a/engine/cache/provider.go
+++ b/engine/cache/provider.go
@@ -102,3 +102,7 @@ func (r *urlReaderAt) Close() error {
 	}
 	return nil
 }
+
+func httpOk(code int) bool {
+	return code >= 200 && code < 300
+}

--- a/engine/cache/service.go
+++ b/engine/cache/service.go
@@ -271,7 +271,8 @@ func (c *client) GetConfig(ctx context.Context, req GetConfigRequest) (*Config, 
 	}
 	defer httpResp.Body.Close()
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", httpResp.StatusCode)
+		body, _ := io.ReadAll(httpReq.Body)
+		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
 
 	config := &Config{}
@@ -310,7 +311,8 @@ func (c *client) UpdateCacheRecords(
 	}
 	defer httpResp.Body.Close()
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", httpResp.StatusCode)
+		body, _ := io.ReadAll(httpReq.Body)
+		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
 
 	resp := &UpdateCacheRecordsResponse{}
@@ -349,7 +351,8 @@ func (c *client) UpdateCacheLayers(
 	}
 	defer httpResp.Body.Close()
 	if httpResp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status code: %d", httpResp.StatusCode)
+		body, _ := io.ReadAll(httpReq.Body)
+		return fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
 
 	return nil
@@ -371,7 +374,8 @@ func (c *client) ImportCache(ctx context.Context) (*remotecache.CacheConfig, err
 	}
 	defer httpResp.Body.Close()
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", httpResp.StatusCode)
+		body, _ := io.ReadAll(httpReq.Body)
+		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
 
 	config := &remotecache.CacheConfig{}
@@ -407,7 +411,8 @@ func (c *client) GetLayerDownloadURL(ctx context.Context, req GetLayerDownloadUR
 	}
 	defer httpResp.Body.Close()
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", httpResp.StatusCode)
+		body, _ := io.ReadAll(httpReq.Body)
+		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
 
 	resp := &GetLayerDownloadURLResponse{}
@@ -443,7 +448,8 @@ func (c *client) GetLayerUploadURL(ctx context.Context, req GetLayerUploadURLReq
 	}
 	defer httpResp.Body.Close()
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", httpResp.StatusCode)
+		body, _ := io.ReadAll(httpReq.Body)
+		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
 
 	resp := &GetLayerUploadURLResponse{}
@@ -479,7 +485,8 @@ func (c *client) GetCacheMountConfig(ctx context.Context, req GetCacheMountConfi
 	}
 	defer httpResp.Body.Close()
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", httpResp.StatusCode)
+		body, _ := io.ReadAll(httpReq.Body)
+		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
 
 	resp := &GetCacheMountConfigResponse{}
@@ -515,7 +522,8 @@ func (c *client) GetCacheMountUploadURL(ctx context.Context, req GetCacheMountUp
 	}
 	defer httpResp.Body.Close()
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", httpResp.StatusCode)
+		body, _ := io.ReadAll(httpReq.Body)
+		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
 
 	resp := &GetCacheMountUploadURLResponse{}

--- a/engine/cache/service.go
+++ b/engine/cache/service.go
@@ -270,7 +270,7 @@ func (c *client) GetConfig(ctx context.Context, req GetConfigRequest) (*Config, 
 		return nil, err
 	}
 	defer httpResp.Body.Close()
-	if httpResp.StatusCode != http.StatusOK {
+	if !httpOk(httpResp.StatusCode) {
 		body, _ := io.ReadAll(httpReq.Body)
 		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
@@ -310,7 +310,7 @@ func (c *client) UpdateCacheRecords(
 		return nil, err
 	}
 	defer httpResp.Body.Close()
-	if httpResp.StatusCode != http.StatusOK {
+	if !httpOk(httpResp.StatusCode) {
 		body, _ := io.ReadAll(httpReq.Body)
 		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
@@ -350,7 +350,7 @@ func (c *client) UpdateCacheLayers(
 		return err
 	}
 	defer httpResp.Body.Close()
-	if httpResp.StatusCode != http.StatusOK {
+	if !httpOk(httpResp.StatusCode) {
 		body, _ := io.ReadAll(httpReq.Body)
 		return fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
@@ -373,7 +373,7 @@ func (c *client) ImportCache(ctx context.Context) (*remotecache.CacheConfig, err
 		return nil, err
 	}
 	defer httpResp.Body.Close()
-	if httpResp.StatusCode != http.StatusOK {
+	if !httpOk(httpResp.StatusCode) {
 		body, _ := io.ReadAll(httpReq.Body)
 		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
@@ -410,7 +410,7 @@ func (c *client) GetLayerDownloadURL(ctx context.Context, req GetLayerDownloadUR
 		return nil, err
 	}
 	defer httpResp.Body.Close()
-	if httpResp.StatusCode != http.StatusOK {
+	if !httpOk(httpResp.StatusCode) {
 		body, _ := io.ReadAll(httpReq.Body)
 		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
@@ -447,7 +447,7 @@ func (c *client) GetLayerUploadURL(ctx context.Context, req GetLayerUploadURLReq
 		return nil, err
 	}
 	defer httpResp.Body.Close()
-	if httpResp.StatusCode != http.StatusOK {
+	if !httpOk(httpResp.StatusCode) {
 		body, _ := io.ReadAll(httpReq.Body)
 		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
@@ -484,7 +484,7 @@ func (c *client) GetCacheMountConfig(ctx context.Context, req GetCacheMountConfi
 		return nil, err
 	}
 	defer httpResp.Body.Close()
-	if httpResp.StatusCode != http.StatusOK {
+	if !httpOk(httpResp.StatusCode) {
 		body, _ := io.ReadAll(httpReq.Body)
 		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}
@@ -521,7 +521,7 @@ func (c *client) GetCacheMountUploadURL(ctx context.Context, req GetCacheMountUp
 		return nil, err
 	}
 	defer httpResp.Body.Close()
-	if httpResp.StatusCode != http.StatusOK {
+	if !httpOk(httpResp.StatusCode) {
 		body, _ := io.ReadAll(httpReq.Body)
 		return nil, fmt.Errorf("unexpected status code: %d: %s", httpResp.StatusCode, body)
 	}


### PR DESCRIPTION
**depends on #5506**

cache: assume success on HTTP 2xx

Some blob providers (e.g. Azure) will return 201 (created) rather than 200 (ok)