### PR TITLE
Rename `id` argument in `Container.withRootfs`

### DIFF
--- a/.changes/unreleased/Breaking-20230727-115352.yaml
+++ b/.changes/unreleased/Breaking-20230727-115352.yaml
@@ -1,0 +1,6 @@
+kind: Breaking
+body: 'engine: Rename `id` argument in `Container.withRootfs`'
+time: 2023-07-27T11:53:52.409372Z
+custom:
+  Author: helderco
+  PR: "5513"

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -165,11 +165,11 @@ func (s *containerSchema) build(ctx *router.Context, parent *core.Container, arg
 }
 
 type containerWithRootFSArgs struct {
-	ID core.DirectoryID
+	Directory core.DirectoryID
 }
 
 func (s *containerSchema) withRootfs(ctx *router.Context, parent *core.Container, args containerWithRootFSArgs) (*core.Container, error) {
-	dir, err := args.ID.ToDirectory()
+	dir, err := args.Directory.ToDirectory()
 	if err != nil {
 		return nil, err
 	}

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -86,7 +86,7 @@ type Container {
   fs: Directory! @deprecated(reason: "Replaced by `rootfs`.")
 
   "Initializes this container from this DirectoryID."
-  withRootfs(id: DirectoryID!): Container!
+  withRootfs(directory: DirectoryID!): Container!
 
   "Initializes this container from this DirectoryID."
   withFS(id: DirectoryID!): Container!

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -1228,9 +1228,9 @@ func (r *Container) WithRegistryAuth(address string, username string, secret *Se
 }
 
 // Initializes this container from this DirectoryID.
-func (r *Container) WithRootfs(id *Directory) *Container {
+func (r *Container) WithRootfs(directory *Directory) *Container {
 	q := r.q.Select("withRootfs")
-	q = q.Arg("id", id)
+	q = q.Arg("directory", directory)
 
 	return &Container{
 		q: q,

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -1746,13 +1746,13 @@ export class Container extends BaseClient {
   /**
    * Initializes this container from this DirectoryID.
    */
-  withRootfs(id: Directory): Container {
+  withRootfs(directory: Directory): Container {
     return new Container({
       queryTree: [
         ...this._queryTree,
         {
           operation: "withRootfs",
-          args: { id },
+          args: { directory },
         },
       ],
       host: this.clientHost,

--- a/sdk/python/src/dagger/api/gen.py
+++ b/sdk/python/src/dagger/api/gen.py
@@ -1425,10 +1425,10 @@ class Container(Type):
         return Container(_ctx)
 
     @typecheck
-    def with_rootfs(self, id: "Directory") -> "Container":
+    def with_rootfs(self, directory: "Directory") -> "Container":
         """Initializes this container from this DirectoryID."""
         _args = [
-            Arg("id", id),
+            Arg("directory", directory),
         ]
         _ctx = self._select("withRootfs", _args)
         return Container(_ctx)

--- a/sdk/python/src/dagger/api/gen_sync.py
+++ b/sdk/python/src/dagger/api/gen_sync.py
@@ -1422,10 +1422,10 @@ class Container(Type):
         return Container(_ctx)
 
     @typecheck
-    def with_rootfs(self, id: "Directory") -> "Container":
+    def with_rootfs(self, directory: "Directory") -> "Container":
         """Initializes this container from this DirectoryID."""
         _args = [
-            Arg("id", id),
+            Arg("directory", directory),
         ]
         _ctx = self._select("withRootfs", _args)
         return Container(_ctx)

--- a/sdk/python/src/dagger/codegen.py
+++ b/sdk/python/src/dagger/codegen.py
@@ -507,8 +507,7 @@ class _InputField:
 
         # On object type fields, don't replace ID scalar with object
         # only if field name is `id` and the corresponding type is different
-        # from the output type (e.g., `file(id: FileID) -> File`, but also
-        # `with_rootfs(id: Directory) -> Container`).
+        # from the output type (e.g., `file(id: FileID) -> File`).
         id_map = ctx.id_map
         if (
             name == "id"


### PR DESCRIPTION
Closes #4192

This has minimal impact since the renamed argument is required/positional in the SDKs. Will only break if someone's using the argument name directly such as in a GraphQL query string.