### PR TITLE
Node.js: Export `Client` as a named export, instead of default

### DIFF
--- a/codegen/generator/nodejs/templates/src/object.ts.gtpl
+++ b/codegen/generator/nodejs/templates/src/object.ts.gtpl
@@ -16,7 +16,7 @@
 {{""}}
 
 			{{- /* Write object name. */ -}}
-export {{- if eq .Name "Query" }} default{{ end }} class {{ .Name | FormatName }} extends BaseClient {
+export class {{ .Name | FormatName }} extends BaseClient {
 			{{- /* Write methods. */ -}}
 			{{- "" }}{{ range $field := .Fields }}
 				{{- if Solve . }}

--- a/sdk/nodejs/.changes/unreleased/Breaking-20230727-235539.yaml
+++ b/sdk/nodejs/.changes/unreleased/Breaking-20230727-235539.yaml
@@ -1,0 +1,6 @@
+kind: Breaking
+body: Export `Client` as a named export, instead of default
+time: 2023-07-27T23:55:39.919682Z
+custom:
+  Author: helderco
+  PR: "5517"

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -2901,7 +2901,7 @@ export class ProjectCommandFlag extends BaseClient {
   }
 }
 
-export default class Client extends BaseClient {
+export class Client extends BaseClient {
   /**
    * Constructs a cache volume for a given cache key.
    * @param key A string identifier to target this cache volume (e.g., "modules-cache").

--- a/sdk/nodejs/api/test/api.spec.ts
+++ b/sdk/nodejs/api/test/api.spec.ts
@@ -7,8 +7,9 @@ import {
   GraphQLRequestError,
   TooManyNestedObjectsError,
 } from "../../common/errors/index.js"
-import Client, {
+import {
   connect,
+  Client,
   ClientContainerOpts,
   Container,
   Directory,

--- a/sdk/nodejs/connect.ts
+++ b/sdk/nodejs/connect.ts
@@ -1,6 +1,6 @@
 import { Writable } from "node:stream"
 
-import Client from "./api/client.gen.js"
+import { Client } from "./api/client.gen.js"
 import { Bin, CLI_VERSION } from "./provisioning/index.js"
 
 /**

--- a/sdk/nodejs/index.ts
+++ b/sdk/nodejs/index.ts
@@ -1,6 +1,5 @@
 export * from "./api/client.gen.js"
 export * from "./common/errors/index.js"
-export { default } from "./api/client.gen.js"
 export { gql } from "graphql-tag"
 export { GraphQLClient } from "graphql-request"
 export { connect, ConnectOpts, CallbackFct } from "./connect.js"

--- a/sdk/nodejs/provisioning/bin.ts
+++ b/sdk/nodejs/provisioning/bin.ts
@@ -11,7 +11,7 @@ import readline from "readline"
 import * as tar from "tar"
 import { fileURLToPath } from "url"
 
-import Client from "../api/client.gen.js"
+import { Client } from "../api/client.gen.js"
 import {
   EngineSessionConnectionTimeoutError,
   EngineSessionConnectParamsParseError,

--- a/sdk/nodejs/provisioning/engineconn.ts
+++ b/sdk/nodejs/provisioning/engineconn.ts
@@ -1,6 +1,6 @@
 import { Writable } from "node:stream"
 
-import Client from "../api/client.gen.js"
+import { Client } from "../api/client.gen.js"
 
 export interface ConnectOpts {
   Workdir?: string


### PR DESCRIPTION
Closes #5434

Doc updates in https://github.com/dagger/dagger/pull/5518