### PR TITLE
docs: cookbook: mount directories as secrets after v.0.8.0

### DIFF
--- a/docs/current/742989-cookbook.md
+++ b/docs/current/742989-cookbook.md
@@ -625,6 +625,31 @@ Set the Hashicorp Vault URI, namespace, role and secret identifiers as host envi
 
 [Learn more](./guides/723462-use-secrets.md)
 
+### Mount directories as secrets in a container
+
+The following code listing demonstrates how to securely mount directories as secrets in a container. The directory structure/file names will be accessible, but contents of the secrets will be scrubbed:
+
+<Tabs groupId="language">
+<TabItem value="Go">
+
+```go file=./cookbook/snippets/mount-directories-as-secrets/main.go
+```
+
+</TabItem>
+<TabItem value="Node.js">
+
+```javascript file=./cookbook/snippets/mount-directories-as-secrets/index.ts
+```
+
+</TabItem>
+<TabItem value="Python">
+
+```python file=./cookbook/snippets/mount-directories-as-secrets/main.py
+```
+
+</TabItem>
+</Tabs>
+
 ## Error handling
 
 ### Terminate gracefully

--- a/docs/current/cookbook/snippets/mount-directories-as-secrets/index.ts
+++ b/docs/current/cookbook/snippets/mount-directories-as-secrets/index.ts
@@ -1,0 +1,55 @@
+import { Client, connect, Container } from "@dagger.io/dagger"
+import * as fs from "fs"
+import * as glob from "glob"
+import * as path from "path"
+
+const GPG_KEY = process.env.GPG_KEY || "public"
+
+connect(
+  async (client: Client) => {
+    await client
+      .container()
+      .from("alpine:3.17")
+      .withExec(["apk", "add", "--no-cache", "gnupg"])
+      .with(await mountedSecretDirectory(client, "/root/.gnupg", "~/.gnupg"))
+      .withWorkdir("/root")
+      .withMountedFile("myapp", client.host().file("myapp"))
+      .withExec(["gpg", "--detach-sign", "--armor", "-u", GPG_KEY, "myapp"])
+      .file("myapp.asc")
+      .export("myapp.asc")
+  },
+  { LogOutput: process.stderr }
+)
+
+async function mountedSecretDirectory(
+  client: Client,
+  targetPath: string,
+  sourcePath: string
+): Promise<(c: Container) => Container> {
+  sourcePath = path.resolve(
+    process.env.HOME || process.env.USERPROFILE || "",
+    sourcePath.substring(2)
+  )
+  const globFiles = glob.sync(`${sourcePath}/**/*`, { nodir: true })
+  const files = globFiles.filter((file) => fs.statSync(file).isFile())
+
+  function _mountedSecretDirectory(container: Container) {
+    for (const file of files) {
+      const relative = path.relative(sourcePath, file)
+      const secret = client.host().setSecretFile(relative, file)
+      container = container.withMountedSecret(
+        path.join(targetPath, relative),
+        secret
+      )
+    }
+
+    // Fix directory permissions
+    return container.withExec([
+      "sh",
+      "-c",
+      `find ${targetPath} -type d -exec chmod 700 {} \\;`,
+    ])
+  }
+
+  return _mountedSecretDirectory
+}

--- a/docs/current/cookbook/snippets/mount-directories-as-secrets/main.go
+++ b/docs/current/cookbook/snippets/mount-directories-as-secrets/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	gpgKey := os.Getenv("GPG_KEY")
+	if gpgKey == "" {
+		gpgKey = "public"
+	}
+
+	// Export file signature
+	ok, err := client.Container().
+		From("alpine:3.17").
+		WithExec([]string{"apk", "add", "--no-cache", "gnupg"}).
+		With(mountedSecretDirectory(client, "/root/.gnupg", "~/.gnupg")).
+		WithWorkdir("/root").
+		WithMountedFile("myapp", client.Host().File("myapp")).
+		WithExec([]string{"gpg", "--detach-sign", "--armor", "-u", gpgKey, "myapp"}).
+		File("myapp.asc").
+		Export(ctx, "myapp.asc")
+	if !ok || err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Signature exported successfully")
+}
+
+func mountedSecretDirectory(client *dagger.Client, targetPath, sourcePath string) func(*dagger.Container) *dagger.Container {
+	return func(c *dagger.Container) *dagger.Container {
+		sourceDir := filepath.Join(os.Getenv("HOME"), sourcePath[2:])
+		filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if info.Mode().IsRegular() {
+				relativePath, _ := filepath.Rel(sourceDir, path)
+				target := filepath.Join(targetPath, relativePath)
+				secret := client.Host().SetSecretFile(filepath.Base(path), path)
+				c = c.WithMountedSecret(target, secret)
+			}
+
+			return nil
+		})
+
+		// Fix directory permissions
+		c = c.WithExec([]string{"sh", "-c", fmt.Sprintf("find %s -type d -exec chmod 700 {} \\;", targetPath)})
+
+		return c
+	}
+}

--- a/docs/current/cookbook/snippets/mount-directories-as-secrets/main.py
+++ b/docs/current/cookbook/snippets/mount-directories-as-secrets/main.py
@@ -1,0 +1,44 @@
+import os
+import sys
+
+import anyio
+
+import dagger
+
+GPG_KEY = os.environ.get("GPG_KEY", "public")
+
+
+async def main():
+    async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
+        await (
+            client.container()
+            .from_("alpine:3.17")
+            .with_exec(["apk", "add", "--no-cache", "gnupg"])
+            .with_(await mounted_secret_directory(client, "/root/.gnupg", "~/.gnupg"))
+            .with_workdir("/root")
+            .with_mounted_file("myapp", client.host().file("myapp"))
+            .with_exec(["gpg", "--detach-sign", "--armor", "-u", GPG_KEY, "myapp"])
+            .export("myapp.asc")
+        )
+
+
+async def mounted_secret_directory(client: dagger.Client, target_path: str, source_path: str):
+    target = anyio.Path(target_path)
+    base = await anyio.Path(source_path).expanduser()
+    files = [path async for path in base.rglob("*") if await path.is_file()]
+
+    def _mounted_secret_directory(ctr: dagger.Container) -> dagger.Container:
+        for path in files:
+            relative = path.relative_to(base)
+            secret = client.host().set_secret_file(str(relative), str(path))
+            ctr = ctr.with_mounted_secret(str(target / relative), secret)
+
+        # Fix directory permissions.
+        return ctr.with_exec(
+            ["sh", "-c", f"find {target} -type d -exec chmod 700 {{}} \\;"]
+        )
+
+    return _mounted_secret_directory
+
+
+anyio.run(main)

--- a/docs/current/cookbook/snippets/mount-directories-as-secrets/main.py
+++ b/docs/current/cookbook/snippets/mount-directories-as-secrets/main.py
@@ -22,7 +22,11 @@ async def main():
         )
 
 
-async def mounted_secret_directory(client: dagger.Client, target_path: str, source_path: str):
+async def mounted_secret_directory(
+    client: dagger.Client,
+    target_path: str,
+    source_path: str,
+):
     target = anyio.Path(target_path)
     base = await anyio.Path(source_path).expanduser()
     files = [path async for path in base.rglob("*") if await path.is_file()]

--- a/docs/current/cookbook/snippets/mount-directories-as-secrets/main.py
+++ b/docs/current/cookbook/snippets/mount-directories-as-secrets/main.py
@@ -18,6 +18,7 @@ async def main():
             .with_workdir("/root")
             .with_mounted_file("myapp", client.host().file("myapp"))
             .with_exec(["gpg", "--detach-sign", "--armor", "-u", GPG_KEY, "myapp"])
+            .file("myapp.asc")
             .export("myapp.asc")
         )
 


### PR DESCRIPTION
Closes https://github.com/dagger/dagger/issues/4896

Re-opening following the [revert](https://github.com/dagger/dagger/pull/5519). Most of the context is on the [initial PR](https://github.com/dagger/dagger/pull/5502)

Small cookbook example / wrapper with the `.with()` method showing how to mount directories securely.

cc @helderco 