### PR TITLE
Python: add status updates during automatic provisioning

### DIFF
--- a/sdk/python/.changes/unreleased/Added-20230728-182700.yaml
+++ b/sdk/python/.changes/unreleased/Added-20230728-182700.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Add status updates during automatic provisioning
+time: 2023-07-28T18:27:00.11106Z
+custom:
+  Author: helderco
+  PR: "5522"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "beartype>=0.11.0",
     "platformdirs>=2.6.2",
     "typing_extensions>=4.4.0",
+    "rich>=10.11.0",
 ]
 
 [project.optional-dependencies]

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -90,7 +90,9 @@ pytest-subprocess==1.5.0
 python-dateutil==2.8.2
     # via strawberry-graphql
 rich==13.4.2
-    # via typer
+    # via
+    #   -r -
+    #   typer
 ruff==0.0.280
     # via -r -
 shellingham==1.5.0.post1

--- a/sdk/python/src/dagger/_progress.py
+++ b/sdk/python/src/dagger/_progress.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass, field
+
+from rich.console import Console
+from rich.status import Status
+from typing_extensions import Self
+
+
+@dataclass(slots=True)
+class Progress:
+    console: Console
+    status: Status | None = field(default=None, init=False)
+
+    def start(self, status: str) -> None:
+        self.status = Status(status, console=self.console)
+        self.status.start()
+
+    def stop(self) -> None:
+        if self.status:
+            self.status.stop()
+            self.status = None
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *_) -> None:
+        self.stop()
+
+    def update(self, message: str) -> None:
+        if self.status:
+            self.status.update(message)

--- a/sdk/python/src/dagger/config.py
+++ b/sdk/python/src/dagger/config.py
@@ -3,9 +3,10 @@ from dataclasses import dataclass, field
 from os import PathLike
 
 import httpx
+from rich.console import Console
 
 
-@dataclass
+@dataclass(slots=True, kw_only=True)
 class Config:
     """Options for connecting to the Dagger engine.
 
@@ -30,9 +31,16 @@ class Config:
     log_output: typing.TextIO | None = None
     timeout: int = 10
     execute_timeout: int | float | None = None
+    console: Console = field(init=False)
+
+    def __post_init__(self):
+        self.console = Console(
+            file=self.log_output,
+            stderr=True,
+        )
 
 
-@dataclass(kw_only=True)
+@dataclass(slots=True, kw_only=True)
 class ConnectParams:
     """Options for making a session connection. For internal use only."""
 

--- a/sdk/python/src/dagger/engine/download.py
+++ b/sdk/python/src/dagger/engine/download.py
@@ -17,6 +17,7 @@ from typing import IO
 import httpx
 import platformdirs
 
+from dagger._progress import Progress
 from dagger.context import SyncResourceManager
 from dagger.exceptions import DownloadError
 
@@ -147,7 +148,7 @@ class Downloader:
         cache_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
         return cache_dir
 
-    def get(self) -> str:
+    def get(self, progress: Progress) -> str:
         """Download CLI to cache and return its path."""
         cli_bin_path = self.cache_dir / f"{self.CLI_BIN_PREFIX}{self.version}"
 
@@ -155,6 +156,7 @@ class Downloader:
             cli_bin_path = cli_bin_path.with_suffix(".exe")
 
         if not cli_bin_path.exists():
+            progress.update("Downloading dagger CLI")
             cli_bin_path = self._download(cli_bin_path)
 
         # garbage collection of old binaries

--- a/sdk/python/tests/engine/test_download.py
+++ b/sdk/python/tests/engine/test_download.py
@@ -133,7 +133,7 @@ async def test_download_bin(cache_dir: Path):
             assert await client.container().from_("alpine:3.16.2").id()
 
     async with anyio.create_task_group() as tg:
-        for _ in range(os.cpu_count()):
+        for _ in range(os.cpu_count() or 4):
             tg.start_soon(connect_once)
 
     # assert that there's only one dagger binary in the cache


### PR DESCRIPTION
This is the Python implementation for:
- https://github.com/dagger/dagger/issues/4456
- https://github.com/dagger/dagger/issues/4820.

It takes a slightly different approach than Go and Node.js in:
- https://github.com/dagger/dagger/pull/5488

Instead of `Message... OK!` lines written only to `log_output`, this change is less obtrusive, more animated and works even without `log_output`[^1]:
- Shows an animation which gives a better experience than a static "…", and replaces status updates in-line.
- In the end this line disappears so there’s no lingering record in the logs. It's ok because the intent is to provide interactive feedback, without polluting logs.
- Writes to `log_output` if it’s **interactive** (e.g., pseudo terminal, not a file).
- Supports an escape hatch if you need to turn this off (independently of `log_output`).
- Without `log_output` it defaults to `stderr` and makes a last update of “Running pipelines” when the provisioning has finished. This doesn’t show on `log_output` because the engine logs already provide progress feedback.
- Only activates when automatic provisioning kicks in, so it’s disabled inside a running session like `dagger run` so that the TUI (progrock) can take over.

[^1]: Not that the same can’t be done in the other SDKs, but the library that does this was already a dependency, it was simple to implement and I already experimented with it very early on for this purpose (see https://github.com/dagger/dagger/issues/4186).

I've tested this under multiple conditions:
- Empty `dagger.Connection()`
- With `log_output=sys.stderr`
- With `log_output` to write to a file (non-interactive)
- All of the above, wrapped in `dagger run`
- All of the above with escape hatch to disable

👇 I'm providing a sample app to easily test these multiple conditions.

<details><summary><strong>Testing app</strong></summary>

<img width="861" alt="Screenshot 2023-07-28 at 17 37 29" src="https://github.com/dagger/dagger/assets/174525/94aa7cf4-7eb6-4da4-b254-70ca4e97149b">

You'll need to `pip install typer` and save this code in a `progress.py` file:

```python
# ruff: noqa: FBT002, UP007, T201
import contextlib
import pathlib
import sys
from typing import Annotated, Optional

import anyio
import typer

import dagger

app = typer.Typer()
q_opt = typer.Option("-q", help="Quiet console (i.e., no provisioning status updates)")
l_opt = typer.Option("-l", help="Add log_output")
f_opt = typer.Option(
    "-f",
    help="File for log_output (defaults to stderr)",
    file_okay=True,
    writable=True,
    resolve_path=True,
    show_default=False,
)


@app.command()
def entrypoint(
    quiet: Annotated[bool, q_opt] = False,
    log_output: Annotated[bool, l_opt] = False,
    path: Annotated[Optional[pathlib.Path], f_opt] = None,
):
    if path:
        if not log_output:
            msg = "Cannot use -f without -l"
            raise typer.BadParameter(msg)
        cm = contextlib.closing(path.open("w"))
    else:
        cm = contextlib.nullcontext(sys.stderr if log_output else None)

    with cm as file:
        cfg = dagger.Config(log_output=file)
        if quiet:
            cfg.console.quiet = True
        anyio.run(main, cfg)


async def main(cfg: dagger.Config):
    async with dagger.Connection(cfg) as client:
        print(
            await (
                client.container()
                .from_("python:3.11.1-alpine")
                .with_exec(["sleep", "3"])
                .with_exec(["python", "-V"])
                .stdout()
            )
        )


if __name__ == "__main__":
    app()
```

</details>

## `dagger.Connection()`

![default](https://github.com/dagger/dagger/assets/174525/8fddf246-f318-494c-bbf6-c7ab351e07a2)

## `dagger.Connection(log_output=sys.stderr)`

Notice the status disappears and there's no "Running pipelines" when engine logs start.

![stderr](https://github.com/dagger/dagger/assets/174525/be4a8962-4a19-4d97-bca3-211d611856dc)

## `dagger run`

![dagger-run](https://github.com/dagger/dagger/assets/174525/5a2e1212-4079-41fe-9250-a4109faf9d37)

