### PR TITLE
docs: Added Tailscale access recipe to cookbook

### DIFF
--- a/docs/current/cookbook.md
+++ b/docs/current/cookbook.md
@@ -910,11 +910,7 @@ The following code listing demonstrates how to add multiple environment variable
 
 ### Docker Engine
 
-The following code shows different ways to integrate with the Docker Engine.
-
-#### Connecting to Docker Engine on the host
-
-This shows how to connect to a Docker Engine on the host machine, by mounting the Docker unix socket into a container, and running the `docker` CLI.
+The following code listing shows how to connect to a Docker Engine on the host machine, by mounting the Docker UNIX socket into a container, and running the `docker` CLI.
 
 <Tabs groupId="language">
 <TabItem value="Go">
@@ -937,7 +933,33 @@ This shows how to connect to a Docker Engine on the host machine, by mounting th
 ```
 
 </TabItem>
+</Tabs>
 
+### Tailscale
+
+The following code listing shows how to have a container running in a Dagger pipeline access a Tailscale network using Tailscale's [userspace networking](https://tailscale.com/kb/1112/userspace-networking/). Replace the `TS-KEY` placeholder with a Tailscale authentication key and the `https://TS-NETWORK-URL` placeholder with a URL accessibly only over the Tailscale network.
+
+<Tabs groupId="language">
+<TabItem value="Go">
+
+```go file=./cookbook/snippets/tailscale-networking/main.go
+```
+
+</TabItem>
+
+<TabItem value="Node.js">
+
+```javascript file=./cookbook/snippets/tailscale-networking/index.mjs
+```
+
+</TabItem>
+
+<TabItem value="Python">
+
+```python file=./cookbook/snippets/tailscale-networking/main.py
+```
+
+</TabItem>
 </Tabs>
 
 ### AWS Cloud Development Kit

--- a/docs/current/cookbook.md
+++ b/docs/current/cookbook.md
@@ -937,7 +937,7 @@ The following code listing shows how to connect to a Docker Engine on the host m
 
 ### Tailscale
 
-The following code listing shows how to have a container running in a Dagger pipeline access a Tailscale network using Tailscale's [userspace networking](https://tailscale.com/kb/1112/userspace-networking/). Replace the `TS-KEY` placeholder with a Tailscale authentication key and the `https://TS-NETWORK-URL` placeholder with a URL accessibly only over the Tailscale network.
+The following code listing shows how to have a container running in a Dagger pipeline access a Tailscale network using Tailscale's [userspace networking](https://tailscale.com/kb/1112/userspace-networking/). You will need to set the `TAILSCALE_AUTHKEY` environment variable to a [Tailscale authentication key](https://tailscale.com/kb/1085/auth-keys/) & `TAILSCALE_SERVICE_URL` environment variable to a URL accessibly only on the Tailscale network.
 
 <Tabs groupId="language">
 <TabItem value="Go">

--- a/docs/current/cookbook.md
+++ b/docs/current/cookbook.md
@@ -937,7 +937,9 @@ The following code listing shows how to connect to a Docker Engine on the host m
 
 ### Tailscale
 
-The following code listing shows how to have a container running in a Dagger pipeline access a Tailscale network using Tailscale's [userspace networking](https://tailscale.com/kb/1112/userspace-networking/). You will need to set the `TAILSCALE_AUTHKEY` environment variable to a [Tailscale authentication key](https://tailscale.com/kb/1085/auth-keys/) & `TAILSCALE_SERVICE_URL` environment variable to a URL accessibly only on the Tailscale network.
+The following code listing shows how to have a container running in a Dagger pipeline access a Tailscale network using Tailscale's [userspace networking](https://tailscale.com/kb/1112/userspace-networking/).
+
+Set the `TAILSCALE_AUTHKEY` host environment variable to a [Tailscale authentication key](https://tailscale.com/kb/1085/auth-keys/) and the `TAILSCALE_SERVICE_URL` host environment variable to a URL accessibly only on the Tailscale network.
 
 <Tabs groupId="language">
 <TabItem value="Go">

--- a/docs/current/cookbook/snippets/tailscale-networking/go.mod
+++ b/docs/current/cookbook/snippets/tailscale-networking/go.mod
@@ -1,0 +1,16 @@
+module main
+
+go 1.20
+
+require (
+	dagger.io/dagger v0.7.4 // indirect
+	github.com/99designs/gqlgen v0.17.31 // indirect
+	github.com/Khan/genqlient v0.6.0 // indirect
+	github.com/adrg/xdg v0.4.0 // indirect
+	github.com/iancoleman/strcase v0.3.0 // indirect
+	github.com/vektah/gqlparser/v2 v2.5.6 // indirect
+	golang.org/x/mod v0.12.0 // indirect
+	golang.org/x/sync v0.3.0 // indirect
+	golang.org/x/sys v0.10.0 // indirect
+	golang.org/x/tools v0.11.0 // indirect
+)

--- a/docs/current/cookbook/snippets/tailscale-networking/index.mjs
+++ b/docs/current/cookbook/snippets/tailscale-networking/index.mjs
@@ -14,7 +14,7 @@ connect(
       .withExec([
         "/bin/sh",
         "-c",
-        "tailscaled --tun=userspace-networking --socks5-server=0.0.0.0:1055 --outbound-http-proxy-listen=0.0.0.0:1055 & tailscale up --authkey $TAILSCALE_AUTHKEY &"
+        "tailscaled --tun=userspace-networking --socks5-server=0.0.0.0:1055 --outbound-http-proxy-listen=0.0.0.0:1055 & tailscale up --authkey $TAILSCALE_AUTHKEY &",
       ])
       .withExposedPort(1055)
 

--- a/docs/current/cookbook/snippets/tailscale-networking/index.mjs
+++ b/docs/current/cookbook/snippets/tailscale-networking/index.mjs
@@ -16,7 +16,7 @@ connect(
       .withExposedPort(1055)
 
     // access Tailscale network
-    out = await client
+    const out = await client
       .container()
       .from("alpine:3.17")
       .withExec(["apk", "add", "curl"])

--- a/docs/current/cookbook/snippets/tailscale-networking/index.mjs
+++ b/docs/current/cookbook/snippets/tailscale-networking/index.mjs
@@ -13,7 +13,10 @@ vars.forEach((v) => {
 connect(
   async (client) => {
     // create Tailscale authentication key as secret
-    const authKeySecret = client.setSecret("tailscaleAuthkey", process.env.TAILSCALE_AUTHKEY)
+    const authKeySecret = client.setSecret(
+      "tailscaleAuthkey",
+      process.env.TAILSCALE_AUTHKEY
+    )
 
     const tailscaleServiceURL = process.env.TAILSCALE_SERVICE_URL
 

--- a/docs/current/cookbook/snippets/tailscale-networking/index.mjs
+++ b/docs/current/cookbook/snippets/tailscale-networking/index.mjs
@@ -3,7 +3,6 @@ import { connect } from "@dagger.io/dagger"
 // create Dagger client
 connect(
   async (client) => {
-
     // create Tailscale authentication key as secret
     const authKeySecret = client.setSecret("tailscaleAuthkey", "TS-KEY")
 
@@ -12,7 +11,11 @@ connect(
       .container()
       .from("tailscale/tailscale:stable")
       .withSecretVariable("TAILSCALE_AUTHKEY", authKeySecret)
-      .withExec(["/bin/sh", "-c", "tailscaled --tun=userspace-networking --socks5-server=0.0.0.0:1055 --outbound-http-proxy-listen=0.0.0.0:1055 & tailscale up --authkey $TAILSCALE_AUTHKEY &"])
+      .withExec([
+        "/bin/sh",
+        "-c",
+        "tailscaled --tun=userspace-networking --socks5-server=0.0.0.0:1055 --outbound-http-proxy-listen=0.0.0.0:1055 & tailscale up --authkey $TAILSCALE_AUTHKEY &"
+      ])
       .withExposedPort(1055)
 
     // access Tailscale network

--- a/docs/current/cookbook/snippets/tailscale-networking/index.mjs
+++ b/docs/current/cookbook/snippets/tailscale-networking/index.mjs
@@ -1,0 +1,30 @@
+import { connect } from "@dagger.io/dagger"
+
+// create Dagger client
+connect(
+  async (client) => {
+
+    // create Tailscale authentication key as secret
+    const authKeySecret = client.set_secret("tailscaleAuthkey", "TS-KEY")
+
+    // create Tailscale service container
+    tailscale = client
+      .container()
+      .from("tailscale/tailscale:stable")
+      .withSecretVariable(name="TAILSCALE_AUTHKEY", secret=authKeySecret)
+      .withExec(["/bin/sh", "-c", "tailscaled --tun=userspace-networking --socks5-server=0.0.0.0:1055 --outbound-http-proxy-listen=0.0.0.0:1055 & tailscale up --authkey $TAILSCALE_AUTHKEY &"])
+      .withExposedPort(1055)
+
+    // access Tailscale network
+    http = client
+      .container()
+      .from("alpine:3.17")
+      .withExec(["apk", "add", "curl"])
+      .withServiceBinding("tailscale", tailscale)
+      .withEnvVariable("ALL_PROXY", "socks5://tailscale:1055/")
+      .withExec(["curl https://my.url.only.accessible.on.tailscale.network.com"])
+
+    console.log(http.sync())
+  },
+  { LogOutput: process.stderr }
+)

--- a/docs/current/cookbook/snippets/tailscale-networking/main.go
+++ b/docs/current/cookbook/snippets/tailscale-networking/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"time"
 
 	"dagger.io/dagger"
 )
@@ -22,24 +21,23 @@ func main() {
 	authKeySecret := client.SetSecret("tailscaleAuthkey", "TS-KEY")
 
 	// create Tailscale service container
-	tailscale, err := client.Container().
+	tailscale := client.Container().
 		From("tailscale/tailscale:stable").
 		WithSecretVariable("TAILSCALE_AUTHKEY", authKeySecret).
 		WithExec([]string{"/bin/sh", "-c", "tailscaled --tun=userspace-networking --socks5-server=0.0.0.0:1055 --outbound-http-proxy-listen=0.0.0.0:1055 & tailscale up --authkey $TAILSCALE_AUTHKEY &"}).
 		WithExposedPort(1055)
 
 	// access Tailscale network
-	http, err := client.Container().
-		From("alpine:3.17")
+	out, err := client.Container().
+		From("alpine:3.17").
 		WithExec([]string{"apk", "add", "curl"}).
 		WithServiceBinding("tailscale", tailscale).
 		WithEnvVariable("ALL_PROXY", "socks5://tailscale:1055/").
-		WithExec([]string{"curl https://my.url.only.accessible.on.tailscale.network.com"})
-
-
-
+		WithExec([]string{"curl", "https://TS-NETWORK-URL"}).
+		Sync(ctx)
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println(output)
+
+	fmt.Println(out)
 }

--- a/docs/current/cookbook/snippets/tailscale-networking/main.go
+++ b/docs/current/cookbook/snippets/tailscale-networking/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	// create Dagger client
+	ctx := context.Background()
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	// set secret
+	authKeySecret := client.SetSecret("tailscaleAuthkey", "TS-KEY")
+
+	// create Tailscale service container
+	tailscale, err := client.Container().
+		From("tailscale/tailscale:stable").
+		WithSecretVariable("TAILSCALE_AUTHKEY", authKeySecret).
+		WithExec([]string{"/bin/sh", "-c", "tailscaled --tun=userspace-networking --socks5-server=0.0.0.0:1055 --outbound-http-proxy-listen=0.0.0.0:1055 & tailscale up --authkey $TAILSCALE_AUTHKEY &"}).
+		WithExposedPort(1055)
+
+	// access Tailscale network
+	http, err := client.Container().
+		From("alpine:3.17")
+		WithExec([]string{"apk", "add", "curl"}).
+		WithServiceBinding("tailscale", tailscale).
+		WithEnvVariable("ALL_PROXY", "socks5://tailscale:1055/").
+		WithExec([]string{"curl https://my.url.only.accessible.on.tailscale.network.com"})
+
+
+
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(output)
+}

--- a/docs/current/cookbook/snippets/tailscale-networking/main.go
+++ b/docs/current/cookbook/snippets/tailscale-networking/main.go
@@ -17,8 +17,17 @@ func main() {
 	}
 	defer client.Close()
 
+	tailscaleAuthKey := os.Getenv("TAILSCALE_AUTHKEY")
+	if tailscaleAuthKey == "" {
+		panic("TAILSCALE_AUTHKEY env var must be set")
+	}
 	// set secret
-	authKeySecret := client.SetSecret("tailscaleAuthkey", "TS-KEY")
+	authKeySecret := client.SetSecret("tailscaleAuthKey", tailscaleAuthKey)
+
+	tailscaleServiceURL := os.Getenv("TAILSCALE_SERVICE_URL")
+	if tailscaleServiceURL == "" {
+		panic("TAILSCALE_SERVICE_URL env var must be set")
+	}
 
 	// create Tailscale service container
 	tailscale := client.Container().
@@ -33,7 +42,7 @@ func main() {
 		WithExec([]string{"apk", "add", "curl"}).
 		WithServiceBinding("tailscale", tailscale).
 		WithEnvVariable("ALL_PROXY", "socks5://tailscale:1055/").
-		WithExec([]string{"curl", "https://TS-NETWORK-URL"}).
+		WithExec([]string{"curl", "--silent", "--verbose", tailscaleServiceURL}).
 		Sync(ctx)
 	if err != nil {
 		panic(err)

--- a/docs/current/cookbook/snippets/tailscale-networking/main.py
+++ b/docs/current/cookbook/snippets/tailscale-networking/main.py
@@ -1,5 +1,5 @@
 import sys
-
+import os
 import anyio
 
 import dagger
@@ -15,7 +15,9 @@ async def main():
     # create Dagger client
     async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
         # create Tailscale authentication key as secret
-        auth_key_secret = client.set_secret("tailscaleAuthkey", os.environ["TAILSCALE_AUTHKEY"])
+        auth_key_secret = client.set_secret(
+            "tailscaleAuthkey", os.environ["TAILSCALE_AUTHKEY"]
+        )
 
         tailscale_service_url = os.environ["TAILSCALE_SERVICE_URL"]
 
@@ -46,7 +48,7 @@ async def main():
             .with_exec(["apk", "add", "curl"])
             .with_service_binding("tailscale", tailscale)
             .with_env_variable("ALL_PROXY", "socks5://tailscale:1055/")
-            .with_exec(["curl", "--silent", "--verbose", tailscaleServiceURL])
+            .with_exec(["curl", "--silent", "--verbose", tailscale_service_url])
             .sync()
         )
         print(out)

--- a/docs/current/cookbook/snippets/tailscale-networking/main.py
+++ b/docs/current/cookbook/snippets/tailscale-networking/main.py
@@ -7,27 +7,28 @@ async def main():
     # create Dagger client
     async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
 
-    # create Tailscale authentication key as secret
-    auth_key_secret: Secret = client.set_secret("tailscaleAuthkey", "TS-KEY")
+        # create Tailscale authentication key as secret
+        auth_key_secret: Secret = client.set_secret("tailscaleAuthkey", "TS-KEY")
 
-    # create Tailscale service container
-    tailscale = (
-        client.container()
-        .from_("tailscale/tailscale:stable")
-        .with_secret_variable(name="TAILSCALE_AUTHKEY", secret=auth_key_secret)
-        .with_exec(["/bin/sh", "-c", "tailscaled --tun=userspace-networking --socks5-server=0.0.0.0:1055 --outbound-http-proxy-listen=0.0.0.0:1055 & tailscale up --authkey $TAILSCALE_AUTHKEY &"])
-        .with_exposed_port(1055)
-    )
+        # create Tailscale service container
+        tailscale = (
+            client.container()
+            .from_("tailscale/tailscale:stable")
+            .with_secret_variable(name="TAILSCALE_AUTHKEY", secret=auth_key_secret)
+            .with_exec(["/bin/sh", "-c", "tailscaled --tun=userspace-networking --socks5-server=0.0.0.0:1055 --outbound-http-proxy-listen=0.0.0.0:1055 & tailscale up --authkey $TAILSCALE_AUTHKEY &"])
+            .with_exposed_port(1055)
+        )
 
-    # access Tailscale network
-    http = (
-        client.container()
-        .from_("alpine:3.17")
-        .with_exec(["apk", "add", "curl"])
-        .with_service_binding("tailscale", tailscale)
-        .with_env_variable("ALL_PROXY", "socks5://tailscale:1055/")
-        .with_exec(["curl https://my.url.only.accessible.on.tailscale.network.com"])
-    )
-    print(http.sync())
+        # access Tailscale network
+        out = await (
+            client.container()
+            .from_("alpine:3.17")
+            .with_exec(["apk", "add", "curl"])
+            .with_service_binding("tailscale", tailscale)
+            .with_env_variable("ALL_PROXY", "socks5://tailscale:1055/")
+            .with_exec(["curl", "https://TS-NETWORK-URL"])
+            .sync()
+        )
+        print(out)
 
 anyio.run(main)

--- a/docs/current/cookbook/snippets/tailscale-networking/main.py
+++ b/docs/current/cookbook/snippets/tailscale-networking/main.py
@@ -1,5 +1,6 @@
-import sys
 import os
+import sys
+
 import anyio
 
 import dagger

--- a/docs/current/cookbook/snippets/tailscale-networking/main.py
+++ b/docs/current/cookbook/snippets/tailscale-networking/main.py
@@ -20,7 +20,12 @@ async def main():
                 [
                     "/bin/sh",
                     "-c",
-                    "tailscaled --tun=userspace-networking --socks5-server=0.0.0.0:1055 --outbound-http-proxy-listen=0.0.0.0:1055 & tailscale up --authkey $TAILSCALE_AUTHKEY &",
+                    (
+                        "tailscaled --tun=userspace-networking"
+                        " --socks5-server=0.0.0.0:1055"
+                        " --outbound-http-proxy-listen=0.0.0.0:1055 & tailscale up"
+                        " --authkey $TAILSCALE_AUTHKEY &"
+                    ),
                 ]
             )
             .with_exposed_port(1055)

--- a/docs/current/cookbook/snippets/tailscale-networking/main.py
+++ b/docs/current/cookbook/snippets/tailscale-networking/main.py
@@ -1,0 +1,33 @@
+import sys
+import anyio
+
+import dagger
+
+async def main():
+    # create Dagger client
+    async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
+
+    # create Tailscale authentication key as secret
+    auth_key_secret: Secret = client.set_secret("tailscaleAuthkey", "TS-KEY")
+
+    # create Tailscale service container
+    tailscale = (
+        client.container()
+        .from_("tailscale/tailscale:stable")
+        .with_secret_variable(name="TAILSCALE_AUTHKEY", secret=auth_key_secret)
+        .with_exec(["/bin/sh", "-c", "tailscaled --tun=userspace-networking --socks5-server=0.0.0.0:1055 --outbound-http-proxy-listen=0.0.0.0:1055 & tailscale up --authkey $TAILSCALE_AUTHKEY &"])
+        .with_exposed_port(1055)
+    )
+
+    # access Tailscale network
+    http = (
+        client.container()
+        .from_("alpine:3.17")
+        .with_exec(["apk", "add", "curl"])
+        .with_service_binding("tailscale", tailscale)
+        .with_env_variable("ALL_PROXY", "socks5://tailscale:1055/")
+        .with_exec(["curl https://my.url.only.accessible.on.tailscale.network.com"])
+    )
+    print(http.sync())
+
+anyio.run(main)

--- a/docs/current/cookbook/snippets/tailscale-networking/main.py
+++ b/docs/current/cookbook/snippets/tailscale-networking/main.py
@@ -4,10 +4,10 @@ import anyio
 
 import dagger
 
+
 async def main():
     # create Dagger client
     async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
-
         # create Tailscale authentication key as secret
         auth_key_secret = client.set_secret("tailscaleAuthkey", "TS-KEY")
 
@@ -16,7 +16,13 @@ async def main():
             client.container()
             .from_("tailscale/tailscale:stable")
             .with_secret_variable(name="TAILSCALE_AUTHKEY", secret=auth_key_secret)
-            .with_exec(["/bin/sh", "-c", "tailscaled --tun=userspace-networking --socks5-server=0.0.0.0:1055 --outbound-http-proxy-listen=0.0.0.0:1055 & tailscale up --authkey $TAILSCALE_AUTHKEY &"])
+            .with_exec(
+                [
+                    "/bin/sh",
+                    "-c",
+                    "tailscaled --tun=userspace-networking --socks5-server=0.0.0.0:1055 --outbound-http-proxy-listen=0.0.0.0:1055 & tailscale up --authkey $TAILSCALE_AUTHKEY &",
+                ]
+            )
             .with_exposed_port(1055)
         )
 
@@ -31,5 +37,6 @@ async def main():
             .sync()
         )
         print(out)
+
 
 anyio.run(main)

--- a/docs/current/cookbook/snippets/tailscale-networking/main.py
+++ b/docs/current/cookbook/snippets/tailscale-networking/main.py
@@ -8,7 +8,7 @@ async def main():
     async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
 
         # create Tailscale authentication key as secret
-        auth_key_secret: Secret = client.set_secret("tailscaleAuthkey", "TS-KEY")
+        auth_key_secret = client.set_secret("tailscaleAuthkey", "TS-KEY")
 
         # create Tailscale service container
         tailscale = (

--- a/docs/current/cookbook/snippets/tailscale-networking/main.py
+++ b/docs/current/cookbook/snippets/tailscale-networking/main.py
@@ -1,4 +1,5 @@
 import sys
+
 import anyio
 
 import dagger


### PR DESCRIPTION
This commit adds a cookbook recipe explaining how to use a container in a Dagger pipeline to access a Tailscale network.