### PR TITLE
rust: ensure CI generate+test targets run against dev cli+engine.

### DIFF
--- a/internal/mage/sdk/rust.go
+++ b/internal/mage/sdk/rust.go
@@ -81,9 +81,9 @@ func (r Rust) Generate(ctx context.Context) error {
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint).
 		WithMountedFile(cliBinPath, util.DaggerBinary(c)).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
-		WithExec([]string{"cargo", "run", "-p", "dagger-bootstrap", "generate", "--output", fmt.Sprintf("/%s", rustGeneratedAPIPath)}).
-		WithExec([]string{"cargo", "fix", "--all", "--allow-no-vcs"}).
-		WithExec([]string{"cargo", "fmt"})
+		WithExec([]string{cliBinPath, "run", "cargo", "run", "-p", "dagger-bootstrap", "generate", "--output", fmt.Sprintf("/%s", rustGeneratedAPIPath)}).
+		WithExec([]string{cliBinPath, "run", "cargo", "fix", "--all", "--allow-no-vcs"}).
+		WithExec([]string{cliBinPath, "run", "cargo", "fmt"})
 
 	contents, err := generated.File(strings.TrimPrefix(rustGeneratedAPIPath, "sdk/rust/")).
 		Contents(ctx)
@@ -215,7 +215,7 @@ func (r Rust) Test(ctx context.Context) error {
 				WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint).
 				WithMountedFile(cliBinPath, util.DaggerBinary(c)).
 				WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
-				WithExec([]string{"cargo", "test", "--release", "--all"}).
+				WithExec([]string{cliBinPath, "run", "cargo", "test", "--release", "--all"}).
 				Sync(ctx)
 			return err
 		})


### PR DESCRIPTION
Before this, the rust CI steps were not actually running w/ the dev CLI because the SDK doesn't yet support `_EXPERIMENTAL_DAGGER_CLI_BIN`.

This resulted in the steps always downloading the CLI based on the version last bumped.

Unfortunately, correcting this seems to have possibly revealed a catch-22 situation in that the generate step fails due to backwards incompatible changes recently made in our API. Not sure the best way to go about fixing.

---

I ran into this due to the fact that that [this PR](https://github.com/dagger/dagger/pull/5415) creates an internal-only incompatibility between the old CLI and new engine server, which should be fine but revealed that the rust CI steps were always using the old CLI.

It seems like the steps now fail because it's trying to compile code that needs to be updated based on backwards incompatible changes made in main for the upcoming [0.8 release](https://github.com/dagger/dagger/milestone/18).