### PR TITLE
dedup vertices, switch journal back to Buildkit

### DIFF
--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"time"
 
@@ -93,7 +91,7 @@ func withEngineAndTUI(
 
 func progrockTee(progW progrock.Writer) (progrock.Writer, error) {
 	if log := os.Getenv("_EXPERIMENTAL_DAGGER_PROGROCK_JOURNAL"); log != "" {
-		fileW, err := newProgrockWriter(log)
+		fileW, err := progrock.CreateJournal(log)
 		if err != nil {
 			return nil, fmt.Errorf("open progrock log: %w", err)
 		}
@@ -204,31 +202,4 @@ func inlineTUI(
 	}
 
 	return nil
-}
-
-func newProgrockWriter(dest string) (progrock.Writer, error) {
-	f, err := os.Create(dest)
-	if err != nil {
-		return nil, err
-	}
-
-	return progrockFileWriter{
-		enc: json.NewEncoder(f),
-		c:   f,
-	}, nil
-}
-
-type progrockFileWriter struct {
-	enc *json.Encoder
-	c   io.Closer
-}
-
-var _ progrock.Writer = progrockFileWriter{}
-
-func (p progrockFileWriter) WriteStatus(update *progrock.StatusUpdate) error {
-	return p.enc.Encode(update)
-}
-
-func (p progrockFileWriter) Close() error {
-	return p.c.Close()
 }

--- a/core/bk2progrock.go
+++ b/core/bk2progrock.go
@@ -2,7 +2,9 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	bkclient "github.com/moby/buildkit/client"
@@ -30,13 +32,13 @@ func RecordBuildkitStatus(
 	}
 
 	for ev := range solveCh {
-		if err := rec.Record(bk2progrock(ev)); err != nil {
-			return fmt.Errorf("record: %w", err)
-		}
 		if enc != nil {
 			if err := enc.Encode(ev); err != nil {
 				return fmt.Errorf("journal: %w", err)
 			}
+		}
+		if err := rec.Record(bk2progrock(ev)); err != nil {
+			return fmt.Errorf("record: %w", err)
 		}
 	}
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net"
 	"net/url"
@@ -363,31 +362,4 @@ func progrockForwarder(w progrock.Writer) (string, progrock.Writer, func() error
 	}
 
 	return progSock, progW, l.Close, nil
-}
-
-type progrockFileWriter struct {
-	f   *os.File
-	enc *json.Encoder
-}
-
-func newProgrockFileWriter(filePath string) (progrock.Writer, error) {
-	f, err := os.Create(filePath)
-	if err != nil {
-		return nil, err
-	}
-
-	enc := json.NewEncoder(f)
-
-	return progrockFileWriter{
-		f:   f,
-		enc: enc,
-	}, nil
-}
-
-func (w progrockFileWriter) WriteStatus(ev *progrock.StatusUpdate) error {
-	return w.enc.Encode(ev)
-}
-
-func (w progrockFileWriter) Close() error {
-	return w.f.Close()
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -68,15 +68,6 @@ func Start(ctx context.Context, startOpts Config, fn StartCallback) error {
 		progMultiW = append(progMultiW, startOpts.ProgrockWriter)
 	}
 
-	if startOpts.JournalFile != "" {
-		fw, err := newProgrockFileWriter(startOpts.JournalFile)
-		if err != nil {
-			return err
-		}
-
-		progMultiW = append(progMultiW, fw)
-	}
-
 	tel := telemetry.New()
 
 	var cloudURL string
@@ -206,7 +197,11 @@ func Start(ctx context.Context, startOpts Config, fn StartCallback) error {
 	eg, groupCtx := errgroup.WithContext(ctx)
 	solveCh := make(chan *bkclient.SolveStatus)
 	eg.Go(func() error {
-		return core.RecordBuildkitStatus(recorder, solveCh)
+		return core.RecordBuildkitStatus(
+			recorder,
+			startOpts.JournalFile,
+			solveCh,
+		)
 	})
 
 	eg.Go(func() error {

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/prometheus/procfs v0.11.0
 	github.com/rs/zerolog v1.29.1
 	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29
-	github.com/vito/progrock v0.7.1-0.20230628234355-c8ce2c2e3c24
+	github.com/vito/progrock v0.9.0
 	github.com/vito/vt100 v0.1.2
 	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53
 	golang.org/x/oauth2 v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -1400,8 +1400,8 @@ github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
-github.com/vito/progrock v0.7.1-0.20230628234355-c8ce2c2e3c24 h1:E6NeGFp8/YGYHnWtwzP5lrphxXLmoKsoAvdwuIkUTOk=
-github.com/vito/progrock v0.7.1-0.20230628234355-c8ce2c2e3c24/go.mod h1:YjiMvY2X47zc9H5je8w4V59cTSrV2d0vQPwJOB5TLH8=
+github.com/vito/progrock v0.9.0 h1:K/eKa0loW1n5NXw0PIa1SH2/pxMHaFA2ltZzKZbvy8I=
+github.com/vito/progrock v0.9.0/go.mod h1:1KTQP8B56h0didAAY+/kmhGjp423TSBrNUrgUWYo9ec=
 github.com/vito/vt100 v0.1.2 h1:gRhKJ/shHTRfMHg+Wc5ExHJzV6HHZqyQIAL52x4EUmA=
 github.com/vito/vt100 v0.1.2/go.mod h1:ByMBsZZEP04RrkT9q/UxvZOjECM8Xc/MRLZ7GLrAUXs=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=


### PR DESCRIPTION
We've observed event payloads that have the same vertex repeated multiple times, with the exact same started/completed values. Judging by the code, the only possible place this can happen is when it comes straight from Buildkit; every other place that sets `Vertexes` always sets it to a 1-length slice. 

So this changes the bk2progrock path to dedupe on vertex digest, and prioritize keeping vertices that have a non-nil `Completed` value.

It also changes the journal file back to the raw Buildkit event stream format to eliminate variables while troubleshooting issues like this.