### PR TITLE
support both buildkit + progrock journals

### DIFF
--- a/cmd/dagger/session.go
+++ b/cmd/dagger/session.go
@@ -54,12 +54,13 @@ func EngineSession(cmd *cobra.Command, args []string) error {
 	}
 
 	startOpts := engine.Config{
-		Workdir:        workdir,
-		RunnerHost:     internalengine.RunnerHost(),
-		ProgrockWriter: console.NewWriter(os.Stderr),
-		SessionToken:   sessionToken.String(),
-		JournalFile:    os.Getenv("_EXPERIMENTAL_DAGGER_JOURNAL"),
-		UserAgent:      labels.AppendCILabel().AppendAnonymousGitLabels(workdir).String(),
+		Workdir:             workdir,
+		RunnerHost:          internalengine.RunnerHost(),
+		ProgrockWriter:      console.NewWriter(os.Stderr),
+		SessionToken:        sessionToken.String(),
+		BuildkitJournalFile: os.Getenv("_EXPERIMENTAL_DAGGER_JOURNAL"),
+		ProgrockJournalFile: os.Getenv("_EXPERIMENTAL_DAGGER_PROGROCK_JOURNAL"),
+		UserAgent:           labels.AppendCILabel().AppendAnonymousGitLabels(workdir).String(),
 	}
 
 	signalCh := make(chan os.Signal, 1)

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/prometheus/procfs v0.11.0
 	github.com/rs/zerolog v1.29.1
 	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29
-	github.com/vito/progrock v0.8.1
+	github.com/vito/progrock v0.9.0
 	github.com/vito/vt100 v0.1.2
 	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53
 	golang.org/x/oauth2 v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -1401,10 +1401,8 @@ github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
-github.com/vito/progrock v0.7.1-0.20230628234355-c8ce2c2e3c24 h1:E6NeGFp8/YGYHnWtwzP5lrphxXLmoKsoAvdwuIkUTOk=
-github.com/vito/progrock v0.7.1-0.20230628234355-c8ce2c2e3c24/go.mod h1:YjiMvY2X47zc9H5je8w4V59cTSrV2d0vQPwJOB5TLH8=
-github.com/vito/progrock v0.8.1 h1:F+evv4gmQHO+cj8LbW4SCY1yvmbqw3pnAUw4SclWN8k=
-github.com/vito/progrock v0.8.1/go.mod h1:1KTQP8B56h0didAAY+/kmhGjp423TSBrNUrgUWYo9ec=
+github.com/vito/progrock v0.9.0 h1:K/eKa0loW1n5NXw0PIa1SH2/pxMHaFA2ltZzKZbvy8I=
+github.com/vito/progrock v0.9.0/go.mod h1:1KTQP8B56h0didAAY+/kmhGjp423TSBrNUrgUWYo9ec=
 github.com/vito/vt100 v0.1.2 h1:gRhKJ/shHTRfMHg+Wc5ExHJzV6HHZqyQIAL52x4EUmA=
 github.com/vito/vt100 v0.1.2/go.mod h1:ByMBsZZEP04RrkT9q/UxvZOjECM8Xc/MRLZ7GLrAUXs=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=


### PR DESCRIPTION
* buildkit journals are useful for seeing the "raw" data coming from Buildkit to isolate variables during troubleshooting
* progrock journals are useful for seeing the "cooked" data being sent to Cloud, which also includes our custom vertex logs/etc.