### PR TITLE
docs: updated CLI code snippet with latest API reference

### DIFF
--- a/docs/current/cli/snippets/get-started/step3/build.sh
+++ b/docs/current/cli/snippets/get-started/step3/build.sh
@@ -21,9 +21,9 @@ build=$(dagger query <<EOF | jq -r .container.from.withDirectory.withWorkdir.wit
 {
   container {
     from(address:"golang:latest") {
-      withDirectory(path:"/src", source:"$source") {
-        withWorkdir(path:"/src") {
-          withExec(args:["go", "build", "-o", "dagger-builds-hello", "./hello/hello.go"]) {
+      withDirectory(path:"/src", directory:"$source") {
+        withWorkdir(path:"/src/hello") {
+          withExec(args:["go", "build", "-o", "dagger-builds-hello", "."]) {
             file(path:"./dagger-builds-hello") {
               export(path:"./dagger-builds-hello")
             }


### PR DESCRIPTION
Fix: #5423

This commit updates the documentation with the latest API reference of [Container-withDirectory](https://docs.dagger.io/api/reference/#Container-withDirectory).
