### PR TITLE
fix: local cli doesn't expand tilde to home path in Go SDK

### DIFF
--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -21,6 +21,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/pretty v0.2.1 // indirect
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/sys v0.10.0 // indirect

--- a/sdk/go/go.sum
+++ b/sdk/go/go.sum
@@ -21,6 +21,8 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=

--- a/sdk/go/internal/engineconn/cli.go
+++ b/sdk/go/internal/engineconn/cli.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/adrg/xdg"
+	"github.com/mitchellh/go-homedir"
 )
 
 const (
@@ -39,8 +40,11 @@ func FromLocalCLI(ctx context.Context, cfg *Config) (EngineConn, bool, error) {
 	if !ok {
 		return nil, false, nil
 	}
-
-	binPath, err := exec.LookPath(binPath)
+	binPath, err := homedir.Expand(binPath)
+	if err != nil {
+		return nil, false, err
+	}
+	binPath, err = exec.LookPath(binPath)
 	if err != nil {
 		return nil, false, err
 	}


### PR DESCRIPTION
I accidentally found when using local cli mode like this:

```
$ env _EXPERIMENTAL_DAGGER_CLI_BIN=~/src/github.com/dagger/dagger/bin/dagger go run ./ci build local-version
```

And it returns:

```
Error: exec: "~/src/github.com/dagger/dagger/bin/dagger": stat ~/src/github.com/dagger/dagger/bin/dagger: no such file or directory
Please visit https://dagger.io/help#go for troubleshooting guidance.
Usage:
  ci build [flags]

Flags:
      --dry-run        Build an image but do not publish image to the registry
  -x, --export-local   Export image into local docker engine
  -h, --help           help for build

exit status 1
```

I just recognize that `exec.LookupPath` would not resolve tilde (~) into `$HOME` directory. ><) This PR fix this issue. 