### PR TITLE
docs: Updated multiarch examples with `mediatypes`

### DIFF
--- a/docs/current/guides/snippets/multiplatform-support/build-images-cross-compilation/main.go
+++ b/docs/current/guides/snippets/multiplatform-support/build-images-cross-compilation/main.go
@@ -84,6 +84,7 @@ func main() {
 		Container().
 		Publish(ctx, imageRepo, dagger.ContainerPublishOpts{
 			PlatformVariants: platformVariants,
+			MediaTypes: dagger.Dockermediatypes,
 		})
 	if err != nil {
 		panic(err)

--- a/docs/current/guides/snippets/multiplatform-support/build-images-cross-compilation/main.go
+++ b/docs/current/guides/snippets/multiplatform-support/build-images-cross-compilation/main.go
@@ -86,7 +86,7 @@ func main() {
 			PlatformVariants: platformVariants,
 			// Some registries may require explicit use of docker mediatypes
 			// rather than the default OCI mediatypes
- 			// MediaTypes: dagger.Dockermediatypes,
+			// MediaTypes: dagger.Dockermediatypes,
 		})
 	if err != nil {
 		panic(err)

--- a/docs/current/guides/snippets/multiplatform-support/build-images-cross-compilation/main.go
+++ b/docs/current/guides/snippets/multiplatform-support/build-images-cross-compilation/main.go
@@ -84,7 +84,9 @@ func main() {
 		Container().
 		Publish(ctx, imageRepo, dagger.ContainerPublishOpts{
 			PlatformVariants: platformVariants,
-			MediaTypes: dagger.Dockermediatypes,
+			// Some registries may require explicit use of docker mediatypes
+			// rather than the default OCI mediatypes
+ 			// MediaTypes: dagger.Dockermediatypes,
 		})
 	if err != nil {
 		panic(err)

--- a/docs/current/guides/snippets/multiplatform-support/build-images-emulation/main.go
+++ b/docs/current/guides/snippets/multiplatform-support/build-images-emulation/main.go
@@ -76,7 +76,7 @@ func main() {
 			PlatformVariants: platformVariants,
 			// Some registries may require explicit use of docker mediatypes
 			// rather than the default OCI mediatypes
- 			// MediaTypes: dagger.Dockermediatypes,
+			// MediaTypes: dagger.Dockermediatypes,
 		})
 	if err != nil {
 		panic(err)

--- a/docs/current/guides/snippets/multiplatform-support/build-images-emulation/main.go
+++ b/docs/current/guides/snippets/multiplatform-support/build-images-emulation/main.go
@@ -74,6 +74,7 @@ func main() {
 		Container().
 		Publish(ctx, imageRepo, dagger.ContainerPublishOpts{
 			PlatformVariants: platformVariants,
+			MediaTypes: dagger.Dockermediatypes,
 		})
 	if err != nil {
 		panic(err)

--- a/docs/current/guides/snippets/multiplatform-support/build-images-emulation/main.go
+++ b/docs/current/guides/snippets/multiplatform-support/build-images-emulation/main.go
@@ -74,7 +74,9 @@ func main() {
 		Container().
 		Publish(ctx, imageRepo, dagger.ContainerPublishOpts{
 			PlatformVariants: platformVariants,
-			MediaTypes: dagger.Dockermediatypes,
+			// Some registries may require explicit use of docker mediatypes
+			// rather than the default OCI mediatypes
+ 			// MediaTypes: dagger.Dockermediatypes,
 		})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
This commit updates the multi-architecture code examples / guide to include the additional `mediatypes` parameter.