### PR TITLE
feat: add Elixir to sdk:all task

### DIFF
--- a/internal/mage/sdk/all.go
+++ b/internal/mage/sdk/all.go
@@ -25,6 +25,7 @@ var availableSDKs = []SDK{
 	&Go{},
 	&Python{},
 	&Nodejs{},
+	&Elixir{},
 }
 
 var _ SDK = All{}


### PR DESCRIPTION
Make `sdk:all` to run `sdk:elixir` tasks.