### PR TITLE
fix: Elixir SDK doesn't expand tilde

### DIFF
--- a/sdk/elixir/lib/dagger/engine_conn.ex
+++ b/sdk/elixir/lib/dagger/engine_conn.ex
@@ -36,6 +36,7 @@ defmodule Dagger.EngineConn do
   @doc false
   def from_local_cli(opts) do
     with {:ok, bin} <- System.fetch_env("_EXPERIMENTAL_DAGGER_CLI_BIN"),
+         bin = Path.expand(bin),
          bin_path when is_binary(bin_path) <- System.find_executable(bin) do
       start_cli_session(bin_path, opts)
     else


### PR DESCRIPTION
If user run with local cli mode and use home directory with tilde (`~`), the SDK will always fallback to download engine method. This happens because of `System.find_executable` returns `nil` when home directory is `~`. Fixes by expand bin path before sending it to `System.find_executable`.