### PR TITLE
core: fix max file chunk size

### DIFF
--- a/engine/buildkit/ref.go
+++ b/engine/buildkit/ref.go
@@ -32,9 +32,9 @@ const (
 	TruncationMessage = "[omitting %d bytes]..."
 
 	// MaxFileContentsChunkSize sets the maximum chunk size for ReadFile calls
-	// Equals around 95% of the max message size (16777216) in
+	// Equals around 95% of the max message size (4MB) in
 	// order to keep space for any Protocol Buffers overhead:
-	MaxFileContentsChunkSize = 15938355
+	MaxFileContentsChunkSize = 3984588
 
 	// MaxFileContentsSize sets the limit of the maximum file size
 	// that can be retrieved using File.Contents, currently set to 128MB:


### PR DESCRIPTION
Previously, we were using a max chunk size based on a non-grpc-default set inside the buildkit client implementation, but the actual grpc default is much smaller than that.

This didn't impact us previously because we only ever ended up hitting the codepaths where the larger max message size was used, but after the recent re-architecture we ended up sometimes using streams where the smaller grpc default was set.

This updates us to just always assume the 4MB grpc default chunk size is being enforced, which is safer at the moment than trying to play whack-a-mole to update the max size on every grpc stream we open. We can play that game in the future if there's ever a need to tune this for performance reasons.

Also added integ test coverage for this now.

---

Fixes the problem uncovered here: https://github.com/dagger/dagger/pull/5569#issuecomment-1664359753