### PR TITLE
core: fix setting image config during multiplatform export+publish

### DIFF
--- a/.changes/unreleased/Fixed-20230803-142805.yaml
+++ b/.changes/unreleased/Fixed-20230803-142805.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: 'core: fix setting image config during multiplatform export+publish'
+time: 2023-08-03T14:28:05.283620408-07:00
+custom:
+  Author: sipsma
+  PR: "5574"

--- a/.changes/unreleased/Fixed-20230803-142956.yaml
+++ b/.changes/unreleased/Fixed-20230803-142956.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: 'core: fix exports of files larger than default grpc max message size'
+time: 2023-08-03T14:29:56.093508143-07:00
+custom:
+  Author: sipsma
+  PR: "5570"

--- a/core/container.go
+++ b/core/container.go
@@ -1458,7 +1458,7 @@ func (container *Container) Publish(
 		}
 		inputByPlatform[platforms.Format(variant.Platform)] = buildkit.ContainerExport{
 			Definition: def.ToPB(),
-			Config:     container.Config,
+			Config:     variant.Config,
 		}
 		services.Merge(variant.Services)
 	}
@@ -1553,7 +1553,7 @@ func (container *Container) Export(
 		}
 		inputByPlatform[platforms.Format(variant.Platform)] = buildkit.ContainerExport{
 			Definition: def.ToPB(),
-			Config:     container.Config,
+			Config:     variant.Config,
 		}
 		services.Merge(variant.Services)
 	}

--- a/engine/buildkit/containerimage.go
+++ b/engine/buildkit/containerimage.go
@@ -153,11 +153,11 @@ func (c *Client) getContainerResult(
 		if err != nil {
 			return nil, err
 		}
+		combinedResult.AddMeta(fmt.Sprintf("%s/%s", exptypes.ExporterImageConfigKey, platformString), cfgBytes)
 		if len(inputByPlatform) == 1 {
 			combinedResult.AddMeta(exptypes.ExporterImageConfigKey, cfgBytes)
 			combinedResult.SetRef(ref)
 		} else {
-			combinedResult.AddMeta(fmt.Sprintf("%s/%s", exptypes.ExporterImageConfigKey, platformString), cfgBytes)
 			expPlatforms.Platforms[len(combinedResult.Refs)] = exptypes.Platform{
 				ID:       platformString,
 				Platform: platform,


### PR DESCRIPTION
We accidentally were exporting the config of the container that export was being called on, but meant to use the config of the platform variant in that part of the loop.

Wasn't caught because we didn't have test coverage for image config being retained for either export or publish. Added that now.