### PR TITLE
feat: support version compatibility check

### DIFF
--- a/sdk/elixir/.changes/unreleased/Added-20230816-122257.yaml
+++ b/sdk/elixir/.changes/unreleased/Added-20230816-122257.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Support version compatibility check
+time: 2023-08-16T12:22:57.71592+02:00
+custom:
+  Author: wingyplus
+  PR: "5577"

--- a/sdk/elixir/lib/dagger.ex
+++ b/sdk/elixir/lib/dagger.ex
@@ -15,12 +15,18 @@ defmodule Dagger do
   #{NimbleOptions.docs(Dagger.Internal.Client.connect_schema())}
   """
   def connect(opts \\ []) do
-    with {:ok, client} <- Dagger.Internal.Client.connect(opts) do
-      {:ok,
-       %Dagger.Client{
-         client: client,
-         selection: Dagger.QueryBuilder.Selection.query()
-       }}
+    with {:ok, graphql_client} <- Dagger.Internal.Client.connect(opts) do
+      client = %Dagger.Client{
+        client: graphql_client,
+        selection: Dagger.QueryBuilder.Selection.query()
+      }
+
+      case Dagger.Client.check_version_compatibility(client, Dagger.EngineConn.engine_version()) do
+        {:error, reason} -> IO.warn("failed to check version compatibility: #{inspect(reason)}")
+        _ -> nil
+      end
+
+      {:ok, client}
     end
   end
 

--- a/sdk/elixir/lib/dagger/engine_conn.ex
+++ b/sdk/elixir/lib/dagger/engine_conn.ex
@@ -85,4 +85,6 @@ defmodule Dagger.EngineConn do
   def disconnect(%__MODULE__{session_pid: pid}) do
     Dagger.Session.stop(pid)
   end
+
+  def engine_version(), do: @dagger_cli_version
 end


### PR DESCRIPTION
Calls `Dagger.Client.check_version_compatibility/2` against the engine
version and warning it if the result is failure. This requires
`Dagger.EngineConn` to expose engine version to make usable in
`Dagger.connect/1`.