### PR TITLE
engine: set version stamp on engine image builds

### DIFF
--- a/.changes/unreleased/Fixed-20230804-083720.yaml
+++ b/.changes/unreleased/Fixed-20230804-083720.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: 'engine: report correct engine version by stamping engine image too'
+time: 2023-08-04T08:37:20.482919496-07:00
+custom:
+  Author: sipsma
+  PR: "5578"

--- a/.changes/unreleased/Fixed-20230804-085622.yaml
+++ b/.changes/unreleased/Fixed-20230804-085622.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: 'core: handle v prefix in version compatibility check'
+time: 2023-08-04T08:56:22.404513041-07:00
+custom:
+  Author: sipsma
+  PR: "5578"

--- a/core/schema/query.go
+++ b/core/schema/query.go
@@ -71,14 +71,16 @@ func (s *querySchema) checkVersionCompatibility(ctx *core.Context, _ *core.Query
 		return true, nil
 	}
 
-	engineVersion, err := semver.Parse(engine.Version)
+	engineVersionStr := strings.TrimPrefix(engine.Version, "v")
+	engineVersion, err := semver.Parse(engineVersionStr)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to parse engine version as semver: %s", err)
 	}
 
-	sdkVersion, err := semver.Parse(args.Version)
+	sdkVersionStr := strings.TrimPrefix(args.Version, "v")
+	sdkVersion, err := semver.Parse(sdkVersionStr)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to parse SDK version as semver: %s", err)
 	}
 
 	// If the Engine is a major version above the SDK version, fails

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -124,10 +124,6 @@ func Connect(ctx context.Context, params Params) (_ *Client, _ context.Context, 
 		cloudURL = tel.URL()
 		progMultiW = append(progMultiW, telemetry.NewWriter(tel))
 	}
-	if c.CloudURLCallback != nil && cloudURL != "" {
-		c.CloudURLCallback(cloudURL)
-	}
-
 	// NB(vito): use a _passthrough_ recorder at this layer, since we don't want
 	// to initialize a group; that's handled by the other side.
 	//
@@ -277,6 +273,10 @@ func Connect(ctx context.Context, params Params) (_ *Client, _ context.Context, 
 	}, backoff.WithContext(bo, connectRetryCtx))
 	if err != nil {
 		return nil, nil, fmt.Errorf("connect: %w", err)
+	}
+
+	if c.CloudURLCallback != nil && cloudURL != "" {
+		c.CloudURLCallback(cloudURL)
 	}
 
 	return c, ctx, nil

--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -87,7 +87,7 @@ func (t Engine) Publish(ctx context.Context, version string) error {
 	)
 
 	digest, err := c.Container().Publish(ctx, ref, dagger.ContainerPublishOpts{
-		PlatformVariants: util.DevEngineContainer(c, publishedEngineArches),
+		PlatformVariants: util.DevEngineContainer(c, publishedEngineArches, version),
 	})
 	if err != nil {
 		return err
@@ -119,7 +119,7 @@ func (t Engine) TestPublish(ctx context.Context) error {
 
 	c = c.Pipeline("engine").Pipeline("test-publish")
 	_, err = c.Container().Export(ctx, "./engine.tar.gz", dagger.ContainerExportOpts{
-		PlatformVariants: util.DevEngineContainer(c, publishedEngineArches),
+		PlatformVariants: util.DevEngineContainer(c, publishedEngineArches, ""),
 	})
 	return err
 }
@@ -156,7 +156,7 @@ func (t Engine) test(ctx context.Context, race bool) error {
 			`registry."privateregistry:5000"`: "http = true",
 		},
 	}
-	devEngine := util.DevEngineContainer(c.Pipeline("dev-engine"), []string{runtime.GOARCH}, util.DefaultDevEngineOpts, opts)[0]
+	devEngine := util.DevEngineContainer(c.Pipeline("dev-engine"), []string{runtime.GOARCH}, "", util.DefaultDevEngineOpts, opts)[0]
 
 	// This creates an engine.tar container file that can be used by the integration tests.
 	// In particular, it is used by core/integration/remotecache_test.go to create a
@@ -270,7 +270,7 @@ func (t Engine) Dev(ctx context.Context) error {
 	tarPath := "./bin/engine.tar"
 
 	_, err = c.Container().Export(ctx, tarPath, dagger.ContainerExportOpts{
-		PlatformVariants: util.DevEngineContainer(c, arches),
+		PlatformVariants: util.DevEngineContainer(c, arches, ""),
 	})
 	if err != nil {
 		return err

--- a/internal/mage/util/engine.go
+++ b/internal/mage/util/engine.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"runtime"
 	"sort"
+	"strings"
 	"text/template"
 
 	"dagger.io/dagger"
@@ -167,7 +168,7 @@ func CIDevEngineContainer(c *dagger.Client, opts ...DevEngineOpts) *dagger.Conta
 		cacheVolumeName = "dagger-dev-engine-state"
 	}
 
-	devEngine := devEngineContainer(c, runtime.GOARCH, engineOpts...)
+	devEngine := devEngineContainer(c, runtime.GOARCH, "", engineOpts...)
 
 	devEngine = devEngine.WithExposedPort(1234, dagger.ContainerWithExposedPortOpts{Protocol: dagger.Tcp}).
 		WithMountedCache("/var/lib/dagger", c.CacheVolume(cacheVolumeName)).
@@ -180,11 +181,11 @@ func CIDevEngineContainer(c *dagger.Client, opts ...DevEngineOpts) *dagger.Conta
 }
 
 // DevEngineContainer returns a container that runs a dev engine
-func DevEngineContainer(c *dagger.Client, arches []string, opts ...DevEngineOpts) []*dagger.Container {
-	return devEngineContainers(c, arches, opts...)
+func DevEngineContainer(c *dagger.Client, arches []string, version string, opts ...DevEngineOpts) []*dagger.Container {
+	return devEngineContainers(c, arches, version, opts...)
 }
 
-func devEngineContainer(c *dagger.Client, arch string, opts ...DevEngineOpts) *dagger.Container {
+func devEngineContainer(c *dagger.Client, arch string, version string, opts ...DevEngineOpts) *dagger.Container {
 	engineConfig, err := getConfig(opts...)
 	if err != nil {
 		panic(err)
@@ -207,7 +208,7 @@ func devEngineContainer(c *dagger.Client, arch string, opts ...DevEngineOpts) *d
 		}).
 		WithFile("/usr/local/bin/buildctl", buildctlBin(c, arch)).
 		WithFile("/usr/local/bin/"+shimBinName, shimBin(c, arch)).
-		WithFile("/usr/local/bin/"+engineBinName, engineBin(c, arch)).
+		WithFile("/usr/local/bin/"+engineBinName, engineBin(c, arch, version)).
 		WithDirectory("/usr/local/bin", qemuBins(c, arch)).
 		WithDirectory("/opt/cni/bin", cniPlugins(c, arch)).
 		WithDirectory(EngineDefaultStateDir, c.Directory()).
@@ -222,10 +223,10 @@ func devEngineContainer(c *dagger.Client, arch string, opts ...DevEngineOpts) *d
 		WithEntrypoint([]string{"dagger-entrypoint.sh"})
 }
 
-func devEngineContainers(c *dagger.Client, arches []string, opts ...DevEngineOpts) []*dagger.Container {
+func devEngineContainers(c *dagger.Client, arches []string, version string, opts ...DevEngineOpts) []*dagger.Container {
 	platformVariants := make([]*dagger.Container, 0, len(arches))
 	for _, arch := range arches {
-		platformVariants = append(platformVariants, devEngineContainer(c, arch, opts...))
+		platformVariants = append(platformVariants, devEngineContainer(c, arch, version, opts...))
 	}
 
 	return platformVariants
@@ -301,16 +302,22 @@ func shimBin(c *dagger.Client, arch string) *dagger.File {
 		File("./bin/" + shimBinName)
 }
 
-func engineBin(c *dagger.Client, arch string) *dagger.File {
+func engineBin(c *dagger.Client, arch string, version string) *dagger.File {
+	buildArgs := []string{
+		"go", "build",
+		"-o", "./bin/" + engineBinName,
+		"-ldflags",
+	}
+	ldflags := []string{"-s", "-w"}
+	if version != "" {
+		ldflags = append(ldflags, "-X", "github.com/dagger/dagger/engine.Version="+version)
+	}
+	buildArgs = append(buildArgs, strings.Join(ldflags, " "))
+	buildArgs = append(buildArgs, "/app/cmd/engine")
 	return goBase(c).
 		WithEnvVariable("GOOS", "linux").
 		WithEnvVariable("GOARCH", arch).
-		WithExec([]string{
-			"go", "build",
-			"-o", "./bin/" + engineBinName,
-			"-ldflags", "-s -w",
-			"/app/cmd/engine",
-		}).
+		WithExec(buildArgs).
 		File("./bin/" + engineBinName)
 }
 


### PR DESCRIPTION
The version is now reported from the graphql server to the client, which means we need to set the version string in the engine image too.

---

Tested manually so far by publishing to my dockerhub repo and setting `_EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-image://eriksipsma/testdagger:v0.0.999`:
<img width="337" alt="Screenshot 2023-08-04 at 8 27 29 AM" src="https://github.com/dagger/dagger/assets/30126853/3a16f09a-ce9b-4d9d-867b-e896c181e746">

I'm also going to give a quick shot at adding an automated test, but will either include here or a follow up depending on timing.

@marcosnils also put the cloud url callback after we've connected to the engine successfully 

Fixes #5572 