### PR TITLE
Add link to Conda repository in reference docs

### DIFF
--- a/sdk/python/docs/index.rst
+++ b/sdk/python/docs/index.rst
@@ -20,6 +20,7 @@ Project links
 =============
 
 * `PyPI Project <https://pypi.org/project/dagger-io/>`_
+* `Conda Package <https://anaconda.org/conda-forge/dagger-io>`_
 * `Documentation <https://docs.dagger.io/sdk/python>`_
 * `Source code <https://github.com/dagger/dagger/tree/main/sdk/python>`_
 * `Release Notes <https://github.com/dagger/dagger/releases?q=tag%3Asdk%2Fpython%2Fv0>`_


### PR DESCRIPTION
Forgot this in #5558 for #4704 