### PR TITLE
engine: fix combined cache manager to query local cache too.

### DIFF
--- a/engine/cache/manager.go
+++ b/engine/cache/manager.go
@@ -388,8 +388,8 @@ func (m *manager) Import(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	importedCache := solver.NewCacheManager(ctx, m.ID(), keyStore, resultStore)
-	newInner := solver.NewCombinedCacheManager([]solver.CacheManager{importedCache}, m.localCache)
+	importedCache := solver.NewCacheManager(ctx, m.ID()+"-import", keyStore, resultStore)
+	newInner := solver.NewCombinedCacheManager([]solver.CacheManager{m.localCache, importedCache}, m.localCache)
 
 	m.mu.Lock()
 	defer m.mu.Unlock()


### PR DESCRIPTION
Before this, we were providing just our remote cache import to the list of "cms" given to the combined cache manager and setting the "main" cache to the local cache.

However, it turns out that the combined cache will only query the list of cache managers provided in "cms"; it will never query the "main" cache.

Now we provide the local cache both in the list of cms and as the main cache manager so that it's queried too.