### PR TITLE
docs: Added "dagger run" to get started guides

### DIFF
--- a/docs/current/cli/389936-run-pipelines-cli.md
+++ b/docs/current/cli/389936-run-pipelines-cli.md
@@ -48,10 +48,10 @@ Add the executable bit to the shell script and then run the script by executing 
 
 ```shell
 chmod +x ./build.sh
-./build.sh
+dagger run ./build.sh
 ```
 
-The script outputs a string similar to the one below.
+The `dagger run` command executes the script in a Dagger session and displays live progress. On completion, the script outputs a string similar to the one below.
 
 ```shell
 Linux buildkitsandbox 5.15.0-53-generic #59-Ubuntu SMP Mon Oct 17 18:53:30 UTC 2022 x86_64 Linux
@@ -88,10 +88,12 @@ The return value of the final `export` field is a Boolean value indicating wheth
 Run the shell script by executing the command below:
 
 ```shell
-./build.sh
+dagger run ./build.sh
 ```
 
-As described above, the script retrieves the source code repository, mounts and builds it in a container, and writes the resulting binary file to the host. At the end of the process, the built Go application is available in the working directory on the host, as shown below:
+As described above, the script retrieves the source code repository, mounts and builds it in a container, and writes the resulting binary file to the host. You can follow along with the actions performed by the script using the live terminal output provided by the `dagger run` command.
+
+At the end of the process, the built Go application is available in the working directory on the host, as shown below:
 
 ```shell
 tree
@@ -102,6 +104,6 @@ tree
 
 ## Conclusion
 
-This tutorial introduced you to the Dagger CLI and its `dagger query` sub-command. It explained how to install the CLI and how to use it to execute Dagger GraphQL API queries. It also provided a working example of how to run a Dagger pipeline from the command line using a Bash shell script.
+This tutorial introduced you to the Dagger CLI and its `dagger query` and `dagger run` sub-commands. It explained how to install the CLI and how to use it to execute Dagger GraphQL API queries. It also provided a working example of how to run a Dagger pipeline from the command line using a Bash shell script.
 
 Use the [API Reference](https://docs.dagger.io/api/reference) and the [CLI Reference](./979595-reference.md) to learn more about the Dagger GraphQL API and the Dagger CLI respectively.

--- a/docs/current/sdk/go/959738-get-started.md
+++ b/docs/current/sdk/go/959738-get-started.md
@@ -17,20 +17,20 @@ This tutorial assumes that:
 
 - You have a basic understanding of the Go programming language. If not, [read the Go tutorial](https://go.dev/doc/tutorial/getting-started).
 - You have a Go development environment with Go 1.20 or later. If not, [download and install Go](https://go.dev/doc/install).
+- You have the Dagger CLI installed on the host system. If not, [install the Dagger CLI](../../cli/465058-install.md).
 - You have Docker installed and running on the host system. If not, [install Docker](https://docs.docker.com/engine/install/).
 
 :::note
-This tutorial creates a Go CI tool using the Dagger Go SDK. It uses this tool to build the Go application in the current directory. The binary from this guide can be used to build any Go project.
+This tutorial creates a Go CI tool using the Dagger CLI and the Go SDK. It uses this tool to build the Go application in the current directory. The binary from this guide can be used to build any Go project.
 :::
 
 ## Step 1: Create a Go module for the tool
 
-The first step is to create a new Go module for the tool.
+The first step is to create a new Go module and sub-directory for the tool.
 
 ```shell
-mkdir multibuild
-cd multibuild
 go mod init multibuild
+mkdir multibuild
 ```
 
 ## Step 2: Create a Dagger client in Go
@@ -39,7 +39,7 @@ go mod init multibuild
 If you would prefer to use the final `main.go` file right away, it can be found in [Step 5](#step-5-create-a-multi-build-pipeline)
 :::
 
-Create a new file named `main.go` and add the following code to it.
+Create a new file in the `multibuild` sub-directory named `main.go` and add the following code to it.
 
 ```go file=snippets/get-started/step2/main.go
 ```
@@ -55,10 +55,10 @@ The `build()` function creates a Dagger client with [`dagger.Connect()`](https:/
 Try the Go CI tool by executing the commands below:
 
 ```shell
-go run main.go
+dagger run go run multibuild/main.go
 ```
 
-The tool outputs the string below, although it isn't actually building anything yet.
+The `dagger run` command executes the specified command in a Dagger session and displays live progress. Once complete, the Go CI tool outputs the string below, although it isn't actually building anything yet.
 
 ```shell
 Building with Dagger
@@ -89,7 +89,7 @@ The revised `build()` function is the main workhorse here, so let's step through
 Try the tool by executing the commands below:
 
 ```shell
-go run main.go
+dagger run go run multibuild/main.go
 ```
 
 The Go CI tool builds the current Go project and writes the build result to `build/` on the host.
@@ -120,10 +120,10 @@ This revision of the Go CI tool does much the same as before, except that it now
 Try the Go CI tool by executing the commands below:
 
 ```shell
-go run main.go
+dagger run go run multibuild/main.go
 ```
 
-The Go CI tool builds the application for each OS/architecture combination and writes the build results to the host. You will see the build process run four times, once for each combination. Note that the each build is happening concurrently, because each build in the DAG do not depend on eachother.
+The Go CI tool builds the application for each OS/architecture combination and writes the build results to the host. You will see the build process run four times, once for each combination. Note that the builds are happening concurrently, because the builds do not depend on eachother.
 
 Use the `tree` command to see the build artifacts on the host, as shown below:
 
@@ -152,7 +152,7 @@ This revision of the Go CI tool adds another layer to the build matrix, this tim
 Try the Go CI tool by executing the commands below:
 
 ```shell
-go run main.go
+dagger run go run multibuild/main.go
 ```
 
 The Go CI tool builds the application for each OS/architecture/version combination and writes the results to the host. You will see the build process run eight times, once for each combination. Note that the builds are happening concurrently, because each build in the DAG does not depend on any other build.

--- a/docs/current/sdk/nodejs/783645-get-started.md
+++ b/docs/current/sdk/nodejs/783645-get-started.md
@@ -19,6 +19,7 @@ This tutorial assumes that:
 
 - You have a Node.js development environment with Node.js 16.x or later. If not, install [NodeJS](https://nodejs.org/en/download/).
 - You have a Node.js application developed in either JavaScript or TypeScript. If not, follow the steps in Appendix A to [create an example React application in TypeScript](#appendix-a-create-a-react-application).
+- You have the Dagger CLI installed on the host system. If not, [install the Dagger CLI](../../cli/465058-install.md).
 - You have Docker installed and running on the host system. If not, [install Docker](https://docs.docker.com/engine/install/).
 
 ## Step 1: Install the Dagger Node.js SDK
@@ -101,27 +102,27 @@ Run the Node.js CI tool by executing the command below from the project director
   <TabItem value="ts" label="TypeScript">
 
 ```shell
-node --loader ts-node/esm ./build.mts
+dagger run node --loader ts-node/esm ./build.mts
 ```
 
   </TabItem>
   <TabItem value="js-esm" label="JavaScript (ESM)">
 
 ```shell
-node ./build.mjs
+dagger run node ./build.mjs
 ```
 
   </TabItem>
   <TabItem value="js-cjs" label="JavaScript (CommonJS)">
 
 ```shell
-node ./build.js
+dagger run node ./build.js
 ```
 
   </TabItem>
 </Tabs>
 
-The tool outputs a string similar to the one below.
+The `dagger run` command executes the specified command in a Dagger session and displays live progress. At the end of the process, the tool outputs a string similar to the one below.
 
 ```shell
 Hello from Dagger and Node v16.18.1
@@ -180,21 +181,21 @@ Run the Node.js CI tool by executing the command below:
   <TabItem value="ts" label="TypeScript">
 
 ```shell
-node --loader ts-node/esm ./build.mts
+dagger run node --loader ts-node/esm ./build.mts
 ```
 
   </TabItem>
   <TabItem value="js-esm" label="JavaScript (ESM)">
 
 ```shell
-node ./build.mjs
+dagger run node ./build.mjs
 ```
 
   </TabItem>
   <TabItem value="js-cjs" label="JavaScript (CommonJS)">
 
 ```shell
-node ./build.js
+dagger run node ./build.js
 ```
 
   </TabItem>
@@ -268,7 +269,7 @@ Run the Node.js CI tool by executing the command below:
   <TabItem value="ts" label="TypeScript">
 
 ```shell
-node --loader ts-node/esm ./build.mts
+dagger run node --loader ts-node/esm ./build.mts
 ```
 
   </TabItem>
@@ -276,14 +277,14 @@ node --loader ts-node/esm ./build.mts
   <TabItem value="js-esm" label="JavaScript (ESM)">
 
 ```shell
-node ./build.mjs
+dagger run node ./build.mjs
 ```
 
   </TabItem>
   <TabItem value="js-cjs" label="JavaScript (CommonJS)">
 
 ```shell
-node ./build.js
+dagger run node ./build.js
 ```
 
   </TabItem>

--- a/docs/current/sdk/python/628797-get-started.md
+++ b/docs/current/sdk/python/628797-get-started.md
@@ -18,6 +18,7 @@ This tutorial assumes that:
 
 - You have a basic understanding of the Python programming language. If not, [read the Python tutorial](https://www.python.org/about/gettingstarted/).
 - You have a Python development environment with Python 3.10 or later. If not, install [Python](https://www.python.org/downloads/).
+- You have the Dagger CLI installed on the host system. If not, [install the Dagger CLI](../../cli/465058-install.md).
 - You have Docker installed and running on the host system. If not, [install Docker](https://docs.docker.com/engine/install/).
 - You have a Python application with tests defined and in a [virtual environment](https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments).
 
@@ -66,10 +67,10 @@ This Python stub imports the Dagger SDK and defines an asynchronous function nam
 Run the Python CI tool by executing the command below from the project directory:
 
 ```shell
-python test.py
+dagger run python test.py
 ```
 
-The tool outputs a string similar to the one below.
+The `dagger run` command executes the specified command in a Dagger session and displays live progress. The tool outputs a string similar to the one below.
 
 ```shell
 Hello from Dagger and Python 3.11.1
@@ -101,7 +102,7 @@ The `from_()`, `with_directory()`, `with_workdir()` and `with_exec()` methods al
 Run the Python CI tool by executing the command below:
 
 ```shell
-python test.py
+dagger run python test.py
 ```
 
 The tool tests the application, logging its operations to the console as it works. If all tests pass, it displays the final output below:
@@ -127,7 +128,7 @@ This revision of the CI tool does much the same as before, except that it now su
 Run the CI tool by executing the command below:
 
 ```shell
-python test.py
+dagger run python test.py
 ```
 
 The tool tests the application against each version in sequence and displays the following final output:
@@ -154,7 +155,7 @@ One further improvement is to speed things up by having the tests run concurrent
 Run the tool again by executing the command below:
 
 ```shell
-python test.py
+dagger run python test.py
 ```
 
 Now, the tool performs tests concurrently, with a noticeable difference in the total time required.

--- a/docs/current/sdk/python/628797-get-started.md
+++ b/docs/current/sdk/python/628797-get-started.md
@@ -26,10 +26,10 @@ This tutorial assumes that:
 This tutorial creates a CI tool to test your Python application against multiple Python versions. If you don't have a Python application already, clone an existing Python project with a well-defined test suite before proceeding. A good example is the [FastAPI](https://github.com/tiangolo/fastapi) library, which you can clone as below:
 
 ```shell
-git clone https://github.com/tiangolo/fastapi
+git clone  --branch 0.101.0 https://github.com/tiangolo/fastapi
 ```
 
-The code samples in this tutorial are based on the above FastAPI project. If using a different project, adjust the code samples accordingly.
+The code samples in this tutorial are based on the above FastAPI project and tag. If using a different project, adjust the code samples accordingly.
 :::
 
 ## Step 1: Install the Dagger Python SDK

--- a/docs/current/sdk/python/snippets/get-started/step3/test.py
+++ b/docs/current/sdk/python/snippets/get-started/step3/test.py
@@ -20,7 +20,7 @@ async def test():
             # set current working directory for next commands
             .with_workdir("/src")
             # install test dependencies
-            .with_exec(["pip", "install", "-e", ".[test]"])
+            .with_exec(["pip", "install", "-r", "requirements.txt"])
             # run tests
             .with_exec(["pytest", "tests"])
         )

--- a/docs/current/sdk/python/snippets/get-started/step4a/test.py
+++ b/docs/current/sdk/python/snippets/get-started/step4a/test.py
@@ -29,7 +29,7 @@ async def test():
                 # set current working directory for next commands
                 .with_workdir("/src")
                 # install test dependencies
-                .with_exec(["pip", "install", "-e", ".[test]"])
+                .with_exec(["pip", "install", "-r", "requirements.txt"])
                 # run tests
                 .with_exec(["pytest", "tests"])
             )

--- a/docs/current/sdk/python/snippets/get-started/step4b/test.py
+++ b/docs/current/sdk/python/snippets/get-started/step4b/test.py
@@ -24,7 +24,7 @@ async def test():
                 # set current working directory for next commands
                 .with_workdir("/src")
                 # install test dependencies
-                .with_exec(["pip", "install", "-e", ".[test]"])
+                .with_exec(["pip", "install", "-r", "requirements.txt"])
                 # run tests
                 .with_exec(["pytest", "tests"])
             )


### PR DESCRIPTION
This commit updates the Go, Node.js, Python and CLI get started guides to use "dagger run".

Additional PRs should be expected for other sections of the docs.