### PR TITLE
feat: correctly handle enumeration on Node SDK

### DIFF
--- a/codegen/generator/nodejs/templates/functions.go
+++ b/codegen/generator/nodejs/templates/functions.go
@@ -41,8 +41,23 @@ var (
 		"ToLowerCase":         commonFunc.ToLowerCase,
 		"ToUpperCase":         commonFunc.ToUpperCase,
 		"ToSingleType":        toSingleType,
+		"ListOfEnum":          listOfEnum,
 	}
 )
+
+func listOfEnum() string {
+	schema := generator.GetSchema()
+
+	var result []string
+
+	for _, t := range schema.Types {
+		if t.Kind == introspection.TypeKindEnum && !strings.HasPrefix(t.Name, "__") {
+			result = append(result, t.Name)
+		}
+	}
+
+	return strings.Join(result, ", ")
+}
 
 // pascalCase change a type name into pascalCase
 func pascalCase(name string) string {

--- a/codegen/generator/nodejs/templates/src/header.ts.gtpl
+++ b/codegen/generator/nodejs/templates/src/header.ts.gtpl
@@ -25,6 +25,14 @@ interface ClientConfig {
   sessionToken?: string
 }
 
+export function isEnum(value: never): boolean {
+    const enums = [{{ ListOfEnum }}]
+
+    return enums
+      .map((e) => Object.values(e).includes(value))
+      .includes(true)
+}
+
 class BaseClient {
   protected _queryTree: QueryTree[]
   protected client: GraphQLClient

--- a/codegen/generator/nodejs/templates/src/types.ts.gtpl
+++ b/codegen/generator/nodejs/templates/src/types.ts.gtpl
@@ -49,7 +49,7 @@ export enum {{ .Name }} {
 				{{- end }}
    */
 			{{- end }}
-  {{ .Name | FormatEnum }},
+  {{ .Name | FormatEnum }} = "{{ .Name }}",
 		{{- end }}
 }
 	{{- end }}

--- a/sdk/nodejs/.changes/unreleased/Fixed-20230809-184725.yaml
+++ b/sdk/nodejs/.changes/unreleased/Fixed-20230809-184725.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Correctly handle enumration into string instead of integer
+time: 2023-08-09T18:47:25.427897+02:00
+custom:
+  Author: TomChv
+  PR: "5594"

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -20,6 +20,17 @@ interface ClientConfig {
   sessionToken?: string
 }
 
+export function isEnum(value: never): boolean {
+  const enums = [
+    CacheSharingMode,
+    ImageLayerCompression,
+    ImageMediaTypes,
+    NetworkProtocol,
+  ]
+
+  return enums.map((e) => Object.values(e).includes(value)).includes(true)
+}
+
 class BaseClient {
   protected _queryTree: QueryTree[]
   protected client: GraphQLClient
@@ -77,17 +88,17 @@ export enum CacheSharingMode {
    * Shares the cache volume amongst many build pipelines,
    * but will serialize the writes
    */
-  Locked,
+  Locked = "LOCKED",
 
   /**
    * Keeps a cache volume for a single build pipeline
    */
-  Private,
+  Private = "PRIVATE",
 
   /**
    * Shares the cache volume amongst many build pipelines
    */
-  Shared,
+  Shared = "SHARED",
 }
 export type ContainerBuildOpts = {
   /**
@@ -541,17 +552,17 @@ export type ID = string & { __ID: never }
  * Compression algorithm to use for image layers.
  */
 export enum ImageLayerCompression {
-  Estargz,
-  Gzip,
-  Uncompressed,
-  Zstd,
+  Estargz = "EStarGZ",
+  Gzip = "Gzip",
+  Uncompressed = "Uncompressed",
+  Zstd = "Zstd",
 }
 /**
  * Mediatypes to use in published or exported image metadata.
  */
 export enum ImageMediaTypes {
-  Dockermediatypes,
-  Ocimediatypes,
+  Dockermediatypes = "DockerMediaTypes",
+  Ocimediatypes = "OCIMediaTypes",
 }
 /**
  * Transport layer network protocol associated to a port.
@@ -560,12 +571,12 @@ export enum NetworkProtocol {
   /**
    * TCP (Transmission Control Protocol)
    */
-  Tcp,
+  Tcp = "TCP",
 
   /**
    * UDP (User Datagram Protocol)
    */
-  Udp,
+  Udp = "UDP",
 }
 export type PipelineLabel = {
   /**

--- a/sdk/nodejs/api/test/api.spec.ts
+++ b/sdk/nodejs/api/test/api.spec.ts
@@ -8,13 +8,14 @@ import {
   TooManyNestedObjectsError,
 } from "../../common/errors/index.js"
 import {
-  connect,
   Client,
   ClientContainerOpts,
+  connect,
   Container,
   Directory,
+  ImageMediaTypes,
 } from "../../index.js"
-import { queryFlatten, buildQuery } from "../utils.js"
+import { buildQuery, queryFlatten } from "../utils.js"
 
 const querySanitizer = (query: string) => query.replace(/\s+/g, " ")
 
@@ -368,6 +369,24 @@ describe("NodeJS SDK api", function () {
       },
       { LogOutput: process.stderr }
     )
+  })
+
+  it("Handle enumeration", async function () {
+    this.timeout(60000)
+
+    await connect(async (client) => {
+      const exportID = `./export-${randomUUID()}`
+
+      const isSuccess = await client
+        .container()
+        .from("alpine:3.16.2")
+        .export(exportID, {
+          mediaTypes: ImageMediaTypes.Dockermediatypes,
+        })
+
+      await fs.unlinkSync(exportID)
+      assert.strictEqual(isSuccess, true)
+    })
   })
 
   it("Handle list of objects", async function () {

--- a/sdk/nodejs/api/test/api.spec.ts
+++ b/sdk/nodejs/api/test/api.spec.ts
@@ -13,7 +13,7 @@ import {
   connect,
   Container,
   Directory,
-  ImageMediaTypes,
+  NetworkProtocol,
 } from "../../index.js"
 import { buildQuery, queryFlatten } from "../utils.js"
 
@@ -375,17 +375,15 @@ describe("NodeJS SDK api", function () {
     this.timeout(60000)
 
     await connect(async (client) => {
-      const exportID = `./export-${randomUUID()}`
-
-      const isSuccess = await client
+      const ports = await client
         .container()
         .from("alpine:3.16.2")
-        .export(exportID, {
-          mediaTypes: ImageMediaTypes.Dockermediatypes,
+        .withExposedPort(8000, {
+          protocol: NetworkProtocol.Udp,
         })
+        .exposedPorts()
 
-      await fs.unlinkSync(exportID)
-      assert.strictEqual(isSuccess, true)
+      assert.strictEqual(await ports[0].protocol(), NetworkProtocol.Udp)
     })
   })
 

--- a/sdk/nodejs/api/utils.ts
+++ b/sdk/nodejs/api/utils.ts
@@ -8,17 +8,25 @@ import {
   NotAwaitedRequestError,
   ExecError,
 } from "../common/errors/index.js"
-import { QueryTree } from "./client.gen.js"
+import { isEnum, QueryTree } from "./client.gen.js"
 
 /**
  * Format argument into GraphQL query format.
  */
 function buildArgs(args: any): string {
   // Remove unwanted quotes
-  const formatValue = (value: string) =>
-    JSON.stringify(value).replace(/\{"[a-zA-Z]+":|,"[a-zA-Z]+":/gi, (str) =>
-      str.replace(/"/g, "")
+  const formatValue = (value: string) => {
+    if (isEnum(value as never)) {
+      return JSON.stringify(value).replace(/['"]+/g, "")
+    }
+
+    return JSON.stringify(value).replace(
+      /\{"[a-zA-Z]+":|,"[a-zA-Z]+":/gi,
+      (str) => {
+        return str.replace(/"/g, "")
+      }
     )
+  }
 
   if (args === undefined || args === null) {
     return ""


### PR DESCRIPTION
GQL enumeration are sent as string without quotes, they need a special format to be sent that way by the client.
Update Node client with a custom function to check for Dagger enumeration.
Update Node query format to reformat enumeration.

Resolves: #5575