### PR TITLE
We only want to publish the Elixir SDK when there is a tag

### DIFF
--- a/.github/workflows/publish-sdk-elixir.yaml
+++ b/.github/workflows/publish-sdk-elixir.yaml
@@ -1,7 +1,6 @@
 name: "Publish Elixir SDK"
 on:
   push:
-    branches: ["main"]
     tags: ["sdk/elixir/v**"]
 jobs:
   publish:


### PR DESCRIPTION
We do not want to publish when there is a push to `main`.

This will fix the check which is currently failing on `main`.

FWIW, only the Go SDK does this since it needs to sync to the repository where users `go get` from, https://github.com/dagger/dagger-go-sdk - this is when users want to run the latest dev version of Go SDK.