### PR TITLE
ci: add HEX_API_KEY to publish-sdk-elixir workflow

### DIFF
--- a/.github/workflows/publish-sdk-elixir.yaml
+++ b/.github/workflows/publish-sdk-elixir.yaml
@@ -16,6 +16,7 @@ jobs:
           GITHUB_PAT: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}
           _EXPERIMENTAL_DAGGER_JOURNAL: "/tmp/journal.log"
           _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
       - uses: actions/upload-artifact@v3
         if: always()
         name: "Upload journal.log"


### PR DESCRIPTION
To publish Elixir SDK to https://hex.pm, it require to set `HEX_API_KEY` to use for authenticate with it.