### PR TITLE
docs: Added cookbook examples for Git dir ops

### DIFF
--- a/docs/current/cookbook.md
+++ b/docs/current/cookbook.md
@@ -88,7 +88,7 @@ The following code listing mounts a host directory in a container at the `/host`
 
 [Learn more](./guides/421437-work-with-host-filesystem.md)
 
-### Get host directory with exclusions
+### Get host directory with filters
 
 The following code listing obtains a reference to the host working directory containing all files except `*.txt` files.
 
@@ -113,10 +113,6 @@ The following code listing obtains a reference to the host working directory con
 </TabItem>
 </Tabs>
 
-[Learn more](./guides/421437-work-with-host-filesystem.md)
-
-### Get host directory with inclusions
-
 The following code listing obtains a reference to the host working directory containing only `*.rar` files.
 
 <Tabs groupId="language">
@@ -139,10 +135,6 @@ The following code listing obtains a reference to the host working directory con
 
 </TabItem>
 </Tabs>
-
-[Learn more](./guides/421437-work-with-host-filesystem.md)
-
-### Get host directory with exclusions and inclusions
 
 The following code listing obtains a reference to the host working directory containing all files except `*.rar` files.
 
@@ -168,6 +160,102 @@ The following code listing obtains a reference to the host working directory con
 </Tabs>
 
 [Learn more](./guides/421437-work-with-host-filesystem.md)
+
+### Add Git repository as directory to container
+
+The following code listing adds a remote Git repository branch to a container as a directory at the `/src` container path and then executes a command in the container to list the directory contents.
+
+<Tabs groupId="language">
+<TabItem value="Go">
+
+```go file=./cookbook/snippets/filesystem-operations/add-git-dir/main.go
+```
+
+</TabItem>
+<TabItem value="Node.js">
+
+```javascript file=./cookbook/snippets/filesystem-operations/add-git-dir/index.mjs
+```
+
+</TabItem>
+<TabItem value="Python">
+
+```python file=./cookbook/snippets/filesystem-operations/add-git-dir/main.py
+```
+
+</TabItem>
+</Tabs>
+
+### Add Git repository as directory to container with filters
+
+The following code listing adds a remote Git repository branch as a directory at the `/src` container path, excluding `*.md` files.
+
+<Tabs groupId="language">
+<TabItem value="Go">
+
+```go file=./cookbook/snippets/filesystem-operations/add-git-dir-exclude/main.go
+```
+
+</TabItem>
+<TabItem value="Node.js">
+
+```javascript file=./cookbook/snippets/filesystem-operations/add-git-dir-exclude/index.mjs
+```
+
+</TabItem>
+<TabItem value="Python">
+
+```python file=./cookbook/snippets/filesystem-operations/add-git-dir-exclude/main.py
+```
+
+</TabItem>
+</Tabs>
+
+The following code listing adds a remote Git repository branch as a directory at the `/src` container path, including only `*.md` files.
+
+<Tabs groupId="language">
+<TabItem value="Go">
+
+```go file=./cookbook/snippets/filesystem-operations/add-git-dir-include/main.go
+```
+
+</TabItem>
+<TabItem value="Node.js">
+
+```javascript file=./cookbook/snippets/filesystem-operations/add-git-dir-include/index.mjs
+```
+
+</TabItem>
+<TabItem value="Python">
+
+```python file=./cookbook/snippets/filesystem-operations/add-git-dir-include/main.py
+```
+
+</TabItem>
+</Tabs>
+
+The following code listing adds a remote Git repository branch as a directory at the `/src` container path, including all files except files beginning with `.git`.
+
+<Tabs groupId="language">
+<TabItem value="Go">
+
+```go file=./cookbook/snippets/filesystem-operations/add-git-dir-exclude-include/main.go
+```
+
+</TabItem>
+<TabItem value="Node.js">
+
+```javascript file=./cookbook/snippets/filesystem-operations/add-git-dir-exclude-include/index.mjs
+```
+
+</TabItem>
+<TabItem value="Python">
+
+```python file=./cookbook/snippets/filesystem-operations/add-git-dir-exclude-include/main.py
+```
+
+</TabItem>
+</Tabs>
 
 ## Builds
 

--- a/docs/current/cookbook/snippets/filesystem-operations/add-git-dir-exclude-include/index.mjs
+++ b/docs/current/cookbook/snippets/filesystem-operations/add-git-dir-exclude-include/index.mjs
@@ -1,0 +1,26 @@
+import { connect } from "@dagger.io/dagger"
+
+// create Dagger client
+connect(
+  async (client) => {
+    // get repository at specified branch
+    const project = client
+      .git("https://github.com/dagger/dagger")
+      .branch("main")
+      .tree()
+
+    // return container with repository
+    // at /src path
+    // include all *.md files except README.md
+    const contents = await client
+      .container()
+      .from("alpine:latest")
+      .withDirectory("/src", project, { include: ["*.md"], exclude: ["README.md"] })
+      .withWorkdir("/src")
+      .withExec(["ls", "/src"])
+      .stdout()
+
+    console.log(contents)
+  },
+  { LogOutput: process.stderr }
+)

--- a/docs/current/cookbook/snippets/filesystem-operations/add-git-dir-exclude-include/main.go
+++ b/docs/current/cookbook/snippets/filesystem-operations/add-git-dir-exclude-include/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	// create Dagger client
+	ctx := context.Background()
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	// get repository at specified branch
+	project := client.
+		Git("https://github.com/dagger/dagger").
+		Branch("main").
+		Tree()
+
+	// return container with repository
+	// at /src path
+	// include all *.md files except README.md
+	contents, err := client.Container().
+		From("alpine:latest").
+		WithDirectory("/src", project, dagger.ContainerWithDirectoryOpts{
+			Include: []string{"*.md"},
+			Exclude: []string{"README.md"},
+		}).
+		WithWorkdir("/src").
+		WithExec([]string{"ls", "/src"}).
+		Stdout(ctx)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	fmt.Println(contents)
+}

--- a/docs/current/cookbook/snippets/filesystem-operations/add-git-dir-exclude-include/main.py
+++ b/docs/current/cookbook/snippets/filesystem-operations/add-git-dir-exclude-include/main.py
@@ -1,0 +1,34 @@
+import sys
+
+import anyio
+
+import dagger
+
+
+async def main():
+    # create Dagger client
+    async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
+
+        # get repository at specified branch
+        project = (
+          client
+          .git("https://github.com/dagger/dagger")
+          .branch("main")
+          .tree()
+        )
+
+        # return container with repository
+        # at /src path
+        # include all *.md files except README.md
+        out = await (
+            client.container()
+            .from_("alpine:latest")
+            .with_directory("/src", project, include=["*.md"], exclude=["README.md"])
+            .with_workdir("/src")
+            .with_exec(["ls", "/src"])
+            .stdout()
+        )
+
+    print(out)
+
+anyio.run(main)

--- a/docs/current/cookbook/snippets/filesystem-operations/add-git-dir-exclude/index.mjs
+++ b/docs/current/cookbook/snippets/filesystem-operations/add-git-dir-exclude/index.mjs
@@ -1,0 +1,26 @@
+import { connect } from "@dagger.io/dagger"
+
+// create Dagger client
+connect(
+  async (client) => {
+    // get repository at specified branch
+    const project = client
+      .git("https://github.com/dagger/dagger")
+      .branch("main")
+      .tree()
+
+    // return container with repository
+    // at /src path
+  	// excluding *.md files
+    const contents = await client
+      .container()
+      .from("alpine:latest")
+      .withDirectory("/src", project, { exclude: ["*.md"] })
+      .withWorkdir("/src")
+      .withExec(["ls", "/src"])
+      .stdout()
+
+    console.log(contents)
+  },
+  { LogOutput: process.stderr }
+)

--- a/docs/current/cookbook/snippets/filesystem-operations/add-git-dir-exclude/main.go
+++ b/docs/current/cookbook/snippets/filesystem-operations/add-git-dir-exclude/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	// create Dagger client
+	ctx := context.Background()
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	// get repository at specified branch
+	project := client.
+		Git("https://github.com/dagger/dagger").
+		Branch("main").
+		Tree()
+
+	// return container with repository
+	// at /src path
+	// excluding *.md files
+	contents, err := client.Container().
+		From("alpine:latest").
+		WithDirectory("/src", project, dagger.ContainerWithDirectoryOpts{
+			Exclude: []string{"*.md"},
+		}).
+		WithWorkdir("/src").
+		WithExec([]string{"ls", "/src"}).
+		Stdout(ctx)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	fmt.Println(contents)
+}

--- a/docs/current/cookbook/snippets/filesystem-operations/add-git-dir-exclude/main.py
+++ b/docs/current/cookbook/snippets/filesystem-operations/add-git-dir-exclude/main.py
@@ -1,0 +1,35 @@
+import sys
+
+import anyio
+
+import dagger
+
+
+async def main():
+    # create Dagger client
+    async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
+
+        # get repository at specified branch
+        project = (
+          client
+          .git("https://github.com/dagger/dagger")
+          .branch("main")
+          .tree()
+        )
+
+        # return container with repository
+        # at /src path
+        # excluding *.md files
+        out = await (
+          client
+          .container()
+          .from_("alpine:latest")
+          .with_directory("/src", project, exclude=["*.md"])
+          .with_workdir("/src")
+          .with_exec(["ls", "/src"])
+          .stdout()
+        )
+
+    print(out)
+
+anyio.run(main)

--- a/docs/current/cookbook/snippets/filesystem-operations/add-git-dir-include/index.mjs
+++ b/docs/current/cookbook/snippets/filesystem-operations/add-git-dir-include/index.mjs
@@ -1,0 +1,30 @@
+import { connect } from "@dagger.io/dagger"
+
+// create Dagger client
+connect(
+  async (client) => {
+    // get repository at specified branch
+    const project = client
+      .git("https://github.com/dagger/dagger")
+      .branch("main")
+      .tree()
+
+    // return container with repository
+    // at /src path
+<<<<<<< HEAD
+    // including only *.md files
+=======
+  	// including only *.md files
+>>>>>>> 9cafd301 (Added recipes)
+    const contents = await client
+      .container()
+      .from("alpine:latest")
+      .withDirectory("/src", project, { include: ["*.md"] })
+      .withWorkdir("/src")
+      .withExec(["ls", "/src"])
+      .stdout()
+
+    console.log(contents)
+  },
+  { LogOutput: process.stderr }
+)

--- a/docs/current/cookbook/snippets/filesystem-operations/add-git-dir-include/main.go
+++ b/docs/current/cookbook/snippets/filesystem-operations/add-git-dir-include/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	// create Dagger client
+	ctx := context.Background()
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	// get repository at specified branch
+	project := client.
+		Git("https://github.com/dagger/dagger").
+		Branch("main").
+		Tree()
+
+	// return container with repository
+	// at /src path
+	// including only *.md files
+	contents, err := client.Container().
+		From("alpine:latest").
+		WithDirectory("/src", project, dagger.ContainerWithDirectoryOpts{
+			Include: []string{"*.md"},
+		}).
+		WithWorkdir("/src").
+		WithExec([]string{"ls", "/src"}).
+		Stdout(ctx)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	fmt.Println(contents)
+}

--- a/docs/current/cookbook/snippets/filesystem-operations/add-git-dir-include/main.py
+++ b/docs/current/cookbook/snippets/filesystem-operations/add-git-dir-include/main.py
@@ -1,0 +1,53 @@
+import sys
+
+import anyio
+
+import dagger
+
+
+async def main():
+    # create Dagger client
+    async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
+<<<<<<< HEAD
+        # get repository at specified branch
+        project = client.git("https://github.com/dagger/dagger").branch("main").tree()
+=======
+
+        # get repository at specified branch
+        project = (
+          client
+          .git("https://github.com/dagger/dagger")
+          .branch("main")
+          .tree()
+        )
+>>>>>>> 9cafd301 (Added recipes)
+
+        # return container with repository
+        # at /src path
+        # including only *.md files
+        out = await (
+<<<<<<< HEAD
+            client.container()
+            .from_("alpine:latest")
+            .with_directory("/src", project, include=["*.md"])
+            .with_workdir("/src")
+            .with_exec(["ls", "/src"])
+            .stdout()
+=======
+          client
+          .container()
+          .from_("alpine:latest")
+          .with_directory("/src", project, include=["*.md"])
+          .with_workdir("/src")
+          .with_exec(["ls", "/src"])
+          .stdout()
+>>>>>>> 9cafd301 (Added recipes)
+        )
+
+    print(out)
+
+<<<<<<< HEAD
+
+=======
+>>>>>>> 9cafd301 (Added recipes)
+anyio.run(main)

--- a/docs/current/cookbook/snippets/filesystem-operations/add-git-dir/index.mjs
+++ b/docs/current/cookbook/snippets/filesystem-operations/add-git-dir/index.mjs
@@ -1,0 +1,25 @@
+import { connect } from "@dagger.io/dagger"
+
+// create Dagger client
+connect(
+  async (client) => {
+    // get repository at specified branch
+    const project = client
+      .git("https://github.com/dagger/dagger")
+      .branch("main")
+      .tree()
+
+    // return container with repository
+    // at /src path
+    const contents = await client
+      .container()
+      .from("alpine:latest")
+      .withDirectory("/src", project)
+      .withWorkdir("/src")
+      .withExec(["ls", "/src"])
+      .stdout()
+
+    console.log(contents)
+  },
+  { LogOutput: process.stderr }
+)

--- a/docs/current/cookbook/snippets/filesystem-operations/add-git-dir/main.go
+++ b/docs/current/cookbook/snippets/filesystem-operations/add-git-dir/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"log"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	// create Dagger client
+	ctx := context.Background()
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	// get repository at specified branch
+	project := client.
+			Git("https://github.com/dagger/dagger").
+			Branch("main").
+			Tree()
+
+	// return container with repository
+	// at /src path
+	contents, err := client.Container().
+			From("alpine:latest").
+			WithDirectory("/src", project).
+			WithWorkdir("/src").
+			WithExec([]string{"ls", "/src"}).
+			Stdout(ctx)
+	if err != nil {
+        log.Println(err)
+        return
+  }
+
+	fmt.Println(contents)
+}

--- a/docs/current/cookbook/snippets/filesystem-operations/add-git-dir/main.py
+++ b/docs/current/cookbook/snippets/filesystem-operations/add-git-dir/main.py
@@ -1,0 +1,36 @@
+import sys
+import anyio
+
+import dagger
+
+async def main():
+    # create Dagger client
+    async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
+
+        # get repository at specified branch
+        project = (
+          client
+          .git("https://github.com/dagger/dagger")
+          .branch("main")
+          .tree()
+        )
+
+        # return container with repository
+        # at /src path
+        out = await (
+          client
+          .container()
+          .from_("alpine:latest")
+          .with_directory("/src", project)
+          .with_workdir("/src")
+          .with_exec(["ls", "/src"])
+          .stdout()
+        )
+
+    print(out)
+
+<<<<<<< HEAD
+
+=======
+>>>>>>> 94586f11 (docs: Added cookbook recipe for Git dir ops)
+anyio.run(main)


### PR DESCRIPTION
This commit adds various examples related to using Git repositories in containers.