### PR TITLE
docs: Modified releases link to point to changelog

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -154,8 +154,8 @@ module.exports = {
     },
     {
       type: "link",
-      label: "Releases 🔗",
-      href: "https://github.com/dagger/dagger/releases",
+      label: "Changelog 🔗",
+      href: "https://github.com/dagger/dagger/blob/main/CHANGELOG.md",
     },
   ],
   quickstart: [


### PR DESCRIPTION
This commit modifies the "Releases" link in the docs navbar to "Changelog" and modifies it to point to https://github.com/dagger/dagger/blob/main/CHANGELOG.md