### PR TITLE
telemetry: fix labels not being included

### DIFF
--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -619,13 +619,10 @@ func TestContainerExecServicesNestedExec(t *testing.T) {
 
 	fileContent, err := c.Container().
 		From("golang:1.20.6-alpine").
+		With(goCache(c)).
 		WithServiceBinding("www", srv).
 		WithMountedDirectory("/src", code).
 		WithWorkdir("/src").
-		WithMountedCache("/go/pkg/mod", c.CacheVolume("go-mod")).
-		WithEnvVariable("GOMODCACHE", "/go/pkg/mod").
-		WithMountedCache("/go/build-cache", c.CacheVolume("go-build")).
-		WithEnvVariable("GOCACHE", "/go/build-cache").
 		WithExec([]string{
 			"go", "run", "./core/integration/testdata/nested/",
 			"exec", strconv.Itoa(nestingLimit), svcURL,

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -371,3 +371,13 @@ func (ctr DaggerCLIContainer) CallProjectInit() *DaggerCLIContainer {
 	ctr.Container = ctr.WithExec(args, dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true})
 	return &ctr
 }
+
+func goCache(c *dagger.Client) dagger.WithContainerFunc {
+	return func(ctr *dagger.Container) *dagger.Container {
+		return ctr.
+			WithMountedCache("/go/pkg/mod", c.CacheVolume("go-mod")).
+			WithEnvVariable("GOMODCACHE", "/go/pkg/mod").
+			WithMountedCache("/go/build-cache", c.CacheVolume("go-build")).
+			WithEnvVariable("GOCACHE", "/go/build-cache")
+	}
+}

--- a/core/integration/testdata/basic-container/main.go
+++ b/core/integration/testdata/basic-container/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"context"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	ctx := context.Background()
+	c, err := dagger.Connect(ctx)
+	if err != nil {
+		panic(err)
+	}
+	defer c.Close()
+
+	_, err = c.Container().
+		From("alpine:3.16.2").
+		WithExec([]string{"echo", "Hello, world!"}).
+		Sync(ctx)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/core/integration/testdata/telemetry/main.go
+++ b/core/integration/testdata/telemetry/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+func main() {
+	err := http.ListenAndServe(":8080", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u, p, ok := r.BasicAuth()
+		if !ok {
+			panic("no basic auth")
+		}
+
+		if p != "" {
+			panic("password should be empty")
+		}
+
+		if u != "test" {
+			panic("token must be set to 'test'")
+		}
+
+		eventsFp := filepath.Join("/events", fmt.Sprintf("%s.json", r.URL.Path))
+
+		eventsF, err := os.OpenFile(eventsFp, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+		if err != nil {
+			panic(err)
+		}
+		defer eventsF.Close()
+
+		_, err = io.Copy(eventsF, r.Body)
+		if err != nil {
+			panic(err)
+		}
+
+		w.WriteHeader(http.StatusCreated)
+	}))
+	if !errors.Is(err, net.ErrClosed) {
+		panic(err)
+	}
+}


### PR DESCRIPTION
1. Backfill integration test for labels being sent to Cloud
2. Store collected labels on `Client` and include them in every `ClientMetadata`