### PR TITLE
hotfix(docs): quickstart layout width auto-expands so that playground fits better

### DIFF
--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -736,13 +736,13 @@ img[alt="github-contribute"] {
   }
 }
 
-.docs-doc-id-current\/quickstart\/quickstart-hello,
-.docs-doc-id-current\/quickstart\/quickstart-test,
-.docs-doc-id-current\/quickstart\/quickstart-build,
-.docs-doc-id-current\/quickstart\/quickstart-publish,
-.docs-doc-id-current\/quickstart\/quickstart-build-multi,
-.docs-doc-id-current\/quickstart\/quickstart-caching,
-.docs-doc-id-current\/quickstart\/quickstart-build-dockerfile {
+.docs-doc-id-current\/quickstart\/hello,
+.docs-doc-id-current\/quickstart\/test,
+.docs-doc-id-current\/quickstart\/build,
+.docs-doc-id-current\/quickstart\/publish,
+.docs-doc-id-current\/quickstart\/build-multi,
+.docs-doc-id-current\/quickstart\/caching,
+.docs-doc-id-current\/quickstart\/build-dockerfile {
   main {
     padding-right: 0px !important;
   }


### PR DESCRIPTION
This fix reverts the margins on Desktop when there's an instance of the Playground within the document:

![image](https://github.com/dagger/dagger/assets/70334844/3c0ff39d-0e61-48ee-b6a1-e5f676c952f5)

![image](https://github.com/dagger/dagger/assets/70334844/8be4c53f-b46b-4698-97c9-50a51bedc59f)