### PR TITLE
docs: Adds host directory r/w example to guide and cookbook

### DIFF
--- a/docs/current/cookbook.md
+++ b/docs/current/cookbook.md
@@ -61,33 +61,6 @@ The following listing revises the previous one, obtaining a reference to the par
 
 [Learn more](./guides/421437-work-with-host-filesystem.md)
 
-### Mount host directory in container
-
-The following code listing mounts a host directory in a container at the `/host` container path and then executes a command in the container referencing the mounted directory.
-
-<Tabs groupId="language">
-<TabItem value="Go">
-
-```go file=./guides/snippets/work-with-host-filesystem/mount-dir/main.go
-```
-
-</TabItem>
-<TabItem value="Node.js">
-
-```typescript file=./guides/snippets/work-with-host-filesystem/mount-dir/index.mts
-```
-
-</TabItem>
-<TabItem value="Python">
-
-```python file=./guides/snippets/work-with-host-filesystem/mount-dir/main.py
-```
-
-</TabItem>
-</Tabs>
-
-[Learn more](./guides/421437-work-with-host-filesystem.md)
-
 ### Get host directory with filters
 
 The following code listing obtains a reference to the host working directory containing all files except `*.txt` files.
@@ -154,6 +127,62 @@ The following code listing obtains a reference to the host working directory con
 <TabItem value="Python">
 
 ```python file=./guides/snippets/work-with-host-filesystem/list-dir-exclude-include/main.py
+```
+
+</TabItem>
+</Tabs>
+
+[Learn more](./guides/421437-work-with-host-filesystem.md)
+
+### Mount and read host directory in container
+
+The following code listing mounts a host directory in a container at the `/host` container path and then reads the contents of the mounted directory.
+
+<Tabs groupId="language">
+<TabItem value="Go">
+
+```go file=./guides/snippets/work-with-host-filesystem/mount-dir/main.go
+```
+
+</TabItem>
+<TabItem value="Node.js">
+
+```typescript file=./guides/snippets/work-with-host-filesystem/mount-dir/index.mts
+```
+
+</TabItem>
+<TabItem value="Python">
+
+```python file=./guides/snippets/work-with-host-filesystem/mount-dir/main.py
+```
+
+</TabItem>
+</Tabs>
+
+### Mount and write to host directory from container
+
+The following code listing shows how to mount a host directory in a container at the `/host` container path, write a file to it, and then export the modified directory back to the host:
+
+:::note
+Modifications made to a host directory mounted in a container do not appear on the host. Data flows only one way between Dagger operations, because they are connected in a DAG. To write modifications back to the host directory, you must explicitly export the directory back to the host filesystem.
+:::
+
+<Tabs groupId="language">
+<TabItem value="Go">
+
+```go file=./guides/snippets/work-with-host-filesystem/mount-dir-export/main.go
+```
+
+</TabItem>
+<TabItem value="Node.js">
+
+```typescript file=./guides/snippets/work-with-host-filesystem/mount-dir-export/index.mts
+```
+
+</TabItem>
+<TabItem value="Python">
+
+```python file=./guides/snippets/work-with-host-filesystem/mount-dir-export/main.py
 ```
 
 </TabItem>

--- a/docs/current/guides/421437-work-with-host-filesystem.md
+++ b/docs/current/guides/421437-work-with-host-filesystem.md
@@ -158,33 +158,6 @@ The exclusion pattern overrides the inclusion pattern, but not vice-versa. The f
 </TabItem>
 </Tabs>
 
-## Mount a host directory in a container
-
-A common operation when working with containers is to mount a host directory to a path in the container and then perform operations on it. It is necessary to provide the mount point in the container and the directory to be mounted as method arguments.
-
-The following example shows how to mount a host directory in a container at the `/host` container path and then execute a command in the container referencing the mounted directory:
-
-<Tabs groupId="language">
-<TabItem value="Go">
-
-```go file=./snippets/work-with-host-filesystem/mount-dir/main.go
-```
-
-</TabItem>
-<TabItem value="Node.js">
-
-```typescript file=./snippets/work-with-host-filesystem/mount-dir/index.mts
-```
-
-</TabItem>
-<TabItem value="Python">
-
-```python file=./snippets/work-with-host-filesystem/mount-dir/main.py
-```
-
-</TabItem>
-</Tabs>
-
 ## Export a directory from a container to the host
 
 A directory can be exported to a different path. The destination path is supplied to the method as an argument.
@@ -207,6 +180,60 @@ The following example creates a file in a container's `/tmp` directory and then 
 <TabItem value="Python">
 
 ```python file=./snippets/work-with-host-filesystem/export-dir/main.py
+```
+
+</TabItem>
+</Tabs>
+
+## Mount a host directory in a container
+
+A common operation when working with containers is to mount a host directory to a path in the container and then perform operations on it. It is necessary to provide the mount point in the container and the directory to be mounted as method arguments.
+
+The following example shows how to mount a host directory in a container at the `/host` container path and then read the contents of the mounted directory:
+
+<Tabs groupId="language">
+<TabItem value="Go">
+
+```go file=./snippets/work-with-host-filesystem/mount-dir/main.go
+```
+
+</TabItem>
+<TabItem value="Node.js">
+
+```typescript file=./snippets/work-with-host-filesystem/mount-dir/index.mts
+```
+
+</TabItem>
+<TabItem value="Python">
+
+```python file=./snippets/work-with-host-filesystem/mount-dir/main.py
+```
+
+</TabItem>
+</Tabs>
+
+:::note
+Modifications made to a host directory mounted in a container do not appear on the host. Data flows only one way between Dagger operations, because they are connected in a DAG. To write modifications back to the host directory, you must explicitly export the directory back to the host filesystem.
+:::
+
+The following example shows how to mount a host directory in a container at the `/host` container path, write a file to it, and then export the modified directory back to the host:
+
+<Tabs groupId="language">
+<TabItem value="Go">
+
+```go file=./snippets/work-with-host-filesystem/mount-dir-export/main.go
+```
+
+</TabItem>
+<TabItem value="Node.js">
+
+```typescript file=./snippets/work-with-host-filesystem/mount-dir-export/index.mts
+```
+
+</TabItem>
+<TabItem value="Python">
+
+```python file=./snippets/work-with-host-filesystem/mount-dir-export/main.py
 ```
 
 </TabItem>

--- a/docs/current/guides/snippets/work-with-host-filesystem/mount-dir-export/index.mts
+++ b/docs/current/guides/snippets/work-with-host-filesystem/mount-dir-export/index.mts
@@ -1,0 +1,16 @@
+import { connect, Client } from "@dagger.io/dagger"
+
+connect(
+  async (client: Client) => {
+    const contents = await client
+      .container()
+      .from("alpine:latest")
+      .withDirectory("/host", client.host().directory("/tmp/sandbox"))
+      .withExec(["/bin/sh", "-c", `echo foo > /host/bar`])
+      .directory("/host")
+      .export("/tmp/sandbox")
+
+    console.log(contents)
+  },
+  { LogOutput: process.stderr }
+)

--- a/docs/current/guides/snippets/work-with-host-filesystem/mount-dir-export/main.go
+++ b/docs/current/guides/snippets/work-with-host-filesystem/mount-dir-export/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	ctx := context.Background()
+
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	defer client.Close()
+
+	contents, err := client.Container().
+		From("alpine:latest").
+		WithDirectory("/host", client.Host().Directory("/tmp/sandbox")).
+		WithExec([]string{"/bin/sh", "-c", `echo foo > /host/bar`}).
+		Directory("/host").
+		Export(ctx, "/tmp/sandbox")
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	fmt.Println(contents)
+}

--- a/docs/current/guides/snippets/work-with-host-filesystem/mount-dir-export/main.py
+++ b/docs/current/guides/snippets/work-with-host-filesystem/mount-dir-export/main.py
@@ -18,4 +18,5 @@ async def main():
 
     print(out)
 
+
 anyio.run(main)

--- a/docs/current/guides/snippets/work-with-host-filesystem/mount-dir-export/main.py
+++ b/docs/current/guides/snippets/work-with-host-filesystem/mount-dir-export/main.py
@@ -1,0 +1,21 @@
+import sys
+
+import anyio
+
+import dagger
+
+
+async def main():
+    async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
+        out = await (
+            client.container()
+            .from_("alpine:latest")
+            .with_directory("/host", client.host().directory("/tmp/sandbox"))
+            .with_exec(["/bin/sh", "-c", "`echo foo > /host/bar`"])
+            .directory("/host")
+            .export("/tmp/sandbox")
+        )
+
+    print(out)
+
+anyio.run(main)


### PR DESCRIPTION
This commit adds an example of reading and writing a host directory from a container to the host filesystems guide and to the cookbook.