### PR TITLE
fix: fix example query in dagger query

### DIFF
--- a/cmd/dagger/query.go
+++ b/cmd/dagger/query.go
@@ -30,7 +30,7 @@ dagger query <<EOF
 {
   container {
     from(address:"hello-world") {
-      exec(args:["/hello"]) {
+      withExec(args:["/hello"]) {
         stdout
       }
     }


### PR DESCRIPTION
Found from https://discord.com/channels/707636530424053791/1139744521886908416/1139744521886908416. The `exec` query already gone since 0.8 in favor of `withExec`.