### PR TITLE
fix(docs): quickstart css selectors

### DIFF
--- a/website/src/components/molecules/quickstartDoc.js
+++ b/website/src/components/molecules/quickstartDoc.js
@@ -1,13 +1,29 @@
 import styles from "../../css/molecules/quickstartDoc.module.scss";
-import React from "react";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import Embed from "../atoms/embed";
+import { HtmlClassNameProvider } from "@docusaurus/theme-common";
+import React from "react";
 
+/**
+ * This component is used to render the quickstart documentation 
+ * pages that have an embedded iframe.
+ * 
+ * It creates a two column layout with the first column containing
+ * the documentation and the second column containing the iframe.
+ * 
+ * The iframe is rendered using the Embed component.
+ * 
+ * The embeds prop is an object that contains the language and the
+ * id of the Playground snippet to render.
+ *  
+ * @param children
+ * @param embeds
+ * @returns 
+ */
 const QuickstartDoc = ({children, embeds}) => {
-
   return (
-    <>
+    <HtmlClassNameProvider className="quickstart-page-with-embed">
       <div className={styles.quickstartDoc}>
         <div className={styles.stepContent}>{children}</div>
         <div className={styles.stepEmbed}>
@@ -15,14 +31,14 @@ const QuickstartDoc = ({children, embeds}) => {
             {Object.keys(embeds).map((x, index) => {
               return (
                 <TabItem key={x} value={x}>
-                  <Embed id={embeds[x]} index={index}/>
+                  <Embed id={embeds[x]} index={index} />
                 </TabItem>
               );
             })}
           </Tabs>
         </div>
       </div>
-    </>
+    </HtmlClassNameProvider>
   );
 };
 

--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -736,13 +736,10 @@ img[alt="github-contribute"] {
   }
 }
 
-.docs-doc-id-current\/quickstart\/hello,
-.docs-doc-id-current\/quickstart\/test,
-.docs-doc-id-current\/quickstart\/build,
-.docs-doc-id-current\/quickstart\/publish,
-.docs-doc-id-current\/quickstart\/build-multi,
-.docs-doc-id-current\/quickstart\/caching,
-.docs-doc-id-current\/quickstart\/build-dockerfile {
+// This selects the quickstart pages that contains embeds.
+// A class is added in the pages with embeds using a Docusarus
+// internal helper declared in the quickstartDoc.js component.
+.quickstart-page-with-embed {
   main {
     padding-right: 0px !important;
   }


### PR DESCRIPTION
This fixes the fragility of the current slug-dependent CSS selectors we are using in the quickstart docs.

As discussed in https://github.com/dagger/dagger/pull/5610, we cannot depend on slugs and docs names for CSS selectors, as it might change in the future and the layout might break.

This solution uses an [undocumented](https://github.com/facebook/docusaurus/issues/4280#issuecomment-1193800323) [Docusarus internal helper](https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-theme-common/src/utils/metadataUtils.tsx#L72) to dynamically append a class name to the HTML element and make it easy to flag pages that contain an embedded `<iframe>`.

I also took the liberty to add comments that provide a bit of context.