### PR TITLE
Fix utf8 labels causing hang, clean up + fix label collection in general

### DIFF
--- a/.changes/unreleased/Fixed-20230815-142820.yaml
+++ b/.changes/unreleased/Fixed-20230815-142820.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fix Engine connection hang when UTF8 characters present in labels
+time: 2023-08-15T14:28:20.654314+01:00
+custom:
+  Author: vito
+  PR: "5628"

--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -74,7 +74,14 @@ func withEngineAndTUI(
 			return inlineTUI(ctx, params, fn)
 		}
 
-		params.ProgrockWriter = console.NewWriter(os.Stderr, console.ShowInternal(debug))
+		opts := []console.WriterOpt{
+			console.ShowInternal(debug),
+		}
+		if debug {
+			opts = append(opts, console.WithMessageLevel(progrock.MessageLevel_DEBUG))
+		}
+
+		params.ProgrockWriter = console.NewWriter(os.Stderr, opts...)
 
 		params.EngineNameCallback = func(name string) {
 			fmt.Fprintln(os.Stderr, "Connected to engine", name)
@@ -150,6 +157,9 @@ func inlineTUI(
 	tape := progrock.NewTape()
 	tape.ShowInternal(debug)
 	tape.Focus(focus)
+	if debug {
+		tape.MessageLevel(progrock.MessageLevel_DEBUG)
+	}
 
 	progW, engineErr := progrockTee(tape)
 	if engineErr != nil {

--- a/core/context.go
+++ b/core/context.go
@@ -9,6 +9,7 @@ import (
 
 type Context struct {
 	context.Context
+
 	ResolveParams graphql.ResolveParams
 
 	// Vertex is a recorder for sending logs to the request's vertex in the

--- a/core/integration/engine_test.go
+++ b/core/integration/engine_test.go
@@ -228,7 +228,8 @@ func TestClientSendsLabelsInTelemetry(t *testing.T) {
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLOUD_TOKEN", "test").
 		WithExec([]string{"git", "config", "--global", "init.defaultBranch", "main"}).
 		WithExec([]string{"git", "config", "--global", "user.email", "test@example.com"}).
-		WithExec([]string{"git", "config", "--global", "user.name", "Test User"}).
+		// make sure we handle non-ASCII usernames
+		WithExec([]string{"git", "config", "--global", "user.name", "Tiësto User"}).
 		WithExec([]string{"git", "init"}). // init a git repo to test git labels
 		WithExec([]string{"git", "add", "."}).
 		WithExec([]string{"git", "commit", "-m", "init test repo"}).

--- a/core/pipeline/label.go
+++ b/core/pipeline/label.go
@@ -7,17 +7,10 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"sync"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/google/go-github/v50/github"
 	"github.com/sirupsen/logrus"
-)
-
-var (
-	setOnce       sync.Once
-	setDoneCh     = make(chan struct{})
-	defaultLabels []Label
 )
 
 type Label struct {
@@ -26,25 +19,6 @@ type Label struct {
 }
 
 type Labels []Label
-
-// RootLabels returns default labels for Pipelines.
-//
-// `SetRootLabels` *must* be called before invoking this function.
-// `RootLabels` will wait until `SetRootLabels` has completed.
-func RootLabels() []Label {
-	<-setDoneCh
-	return defaultLabels
-}
-
-// SetRootLabels sets the default Pipeline labels one time, unblocking RootLabels.
-// TODO: this doesn't need to be async anymore, can just be passed to schema or through
-// query context now
-func SetRootLabels(labels []Label) {
-	setOnce.Do(func() {
-		defer close(setDoneCh)
-		defaultLabels = labels
-	})
-}
 
 func EngineLabel(engineName string) Label {
 	return Label{

--- a/core/pipeline/pipeline.go
+++ b/core/pipeline/pipeline.go
@@ -66,9 +66,6 @@ func (g Path) RecorderGroup(rec *progrock.Recorder) *progrock.Recorder {
 		return rec
 	}
 
-	// drop the "root" pipeline; it's already initialized by Progrock
-	g = g[1:]
-
 	for _, p := range g {
 		var labels []*progrock.Label
 

--- a/core/query.go
+++ b/core/query.go
@@ -5,30 +5,13 @@ import (
 )
 
 type Query struct {
-	Context QueryContext
-}
-
-// PipelinePath returns the current pipeline path prepended with a "root"
-// pipeline containing default labels. The pipeline has no name, so it won't
-// confuse the user in the UI.
-//
-// When called against a nil receiver, as will happen if no pipelines have
-// been created, it will return a path with only the root pipeline.
-func (query *Query) PipelinePath() pipeline.Path {
-	pipeline := pipeline.Path{
-		{
-			Labels: pipeline.RootLabels(),
-		},
-	}
-
-	if query != nil {
-		pipeline = append(pipeline, query.Context.Pipeline...)
-	}
-
-	return pipeline
-}
-
-type QueryContext struct {
 	// Pipeline
 	Pipeline pipeline.Path `json:"pipeline"`
+}
+
+func (query *Query) PipelinePath() pipeline.Path {
+	if query == nil {
+		return nil
+	}
+	return query.Pipeline
 }

--- a/core/schema/http.go
+++ b/core/schema/http.go
@@ -40,8 +40,6 @@ type httpArgs struct {
 }
 
 func (s *httpSchema) http(ctx *core.Context, parent *core.Query, args httpArgs) (*core.File, error) {
-	pipeline := parent.PipelinePath()
-
 	// Use a filename that is set to the URL. Buildkit internally stores some cache metadata of etags
 	// and http checksums using an id based on this name, so setting it to the URL maximizes our chances
 	// of following more optimized cache codepaths.
@@ -78,5 +76,5 @@ func (s *httpSchema) http(ctx *core.Context, parent *core.Query, args httpArgs) 
 		st = llb.HTTP(args.URL, opts...)
 	}
 
-	return core.NewFileSt(ctx, st, filename, pipeline, s.platform, svcs)
+	return core.NewFileSt(ctx, st, filename, parent.PipelinePath(), s.platform, svcs)
 }

--- a/core/schema/query.go
+++ b/core/schema/query.go
@@ -49,7 +49,7 @@ func (s *querySchema) pipeline(ctx *core.Context, parent *core.Query, args pipel
 	if parent == nil {
 		parent = &core.Query{}
 	}
-	parent.Context.Pipeline = parent.Context.Pipeline.Add(pipeline.Pipeline{
+	parent.Pipeline = parent.Pipeline.Add(pipeline.Pipeline{
 		Name:        args.Name,
 		Description: args.Description,
 		Labels:      args.Labels,

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -290,7 +290,11 @@ func Connect(ctx context.Context, params Params) (_ *Client, _ context.Context, 
 	err = backoff.Retry(func() error {
 		ctx, cancel := context.WithTimeout(connectRetryCtx, bo.NextBackOff())
 		defer cancel()
-		return c.Do(ctx, `{defaultPlatform}`, "", nil, nil)
+		innerErr := c.Do(ctx, `{defaultPlatform}`, "", nil, nil)
+		if innerErr != nil {
+			recorder.Debug("Failed to connect; retrying...", progrock.ErrorLabel(innerErr))
+		}
+		return innerErr
 	}, backoff.WithContext(bo, connectRetryCtx))
 
 	sessionTask.Done(err)

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -51,7 +51,7 @@ func NewDaggerServer(
 	serverID string,
 	secretStore *core.SecretStore,
 	authProvider *auth.RegistryAuthProvider,
-	pipelineLabels []pipeline.Label,
+	rootLabels []pipeline.Label,
 ) (*DaggerServer, error) {
 	srv := &DaggerServer{
 		serverID: serverID,
@@ -77,9 +77,8 @@ func NewDaggerServer(
 	}
 	srv.progCleanup = progCleanup
 
-	pipeline.SetRootLabels(pipelineLabels)
 	progrockLabels := []*progrock.Label{}
-	for _, label := range pipelineLabels {
+	for _, label := range rootLabels {
 		progrockLabels = append(progrockLabels, &progrock.Label{
 			Name:  label.Name,
 			Value: label.Value,

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.20 // indirect
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.31.3 // indirect
 	github.com/charmbracelet/bubbles v0.16.1
-	github.com/charmbracelet/bubbletea v0.24.1
+	github.com/charmbracelet/bubbletea v0.24.2
 	github.com/containerd/containerd v1.7.2
 	github.com/containerd/fuse-overlayfs-snapshotter v1.0.2
 	github.com/containerd/stargz-snapshotter v0.14.3
@@ -77,7 +77,7 @@ require (
 	github.com/prometheus/procfs v0.11.0
 	github.com/rs/zerolog v1.29.1
 	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29
-	github.com/vito/progrock v0.9.0
+	github.com/vito/progrock v0.9.1-0.20230815145556-518f2dcd6e2f
 	github.com/vito/vt100 v0.1.2
 	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53
 	golang.org/x/oauth2 v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -173,9 +173,7 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
-github.com/alexflint/go-arg v1.4.2/go.mod h1:9iRbDxne7LcR/GSvEr7ma++GLpdIU1zrghf2y2768kM=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
-github.com/alexflint/go-scalar v1.0.0/go.mod h1:GpHzbCOZXEKMEcygYQ5n/aa4Aq84zbxjy3MxYW0gjYw=
 github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092 h1:aM1rlcoLz8y5B2r4tTLMiVTrMtpfY0O8EScKJxaSaEc=
 github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092/go.mod h1:rYqSE9HbjzpHTI74vwPvae4ZVYZd1lue2ta6xHPdblA=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
@@ -272,7 +270,6 @@ github.com/bombsimon/wsl/v2 v2.2.0/go.mod h1:Azh8c3XGEJl9LyX0/sFC+CKMc7Ssgua0g+6
 github.com/bombsimon/wsl/v3 v3.0.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
 github.com/bombsimon/wsl/v3 v3.1.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
-github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
@@ -293,8 +290,8 @@ github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charmbracelet/bubbles v0.16.1 h1:6uzpAAaT9ZqKssntbvZMlksWHruQLNxg49H5WdeuYSY=
 github.com/charmbracelet/bubbles v0.16.1/go.mod h1:2QCp9LFlEsBQMvIYERr7Ww2H2bA7xen1idUDIzm/+Xc=
-github.com/charmbracelet/bubbletea v0.24.1 h1:LpdYfnu+Qc6XtvMz6d/6rRY71yttHTP5HtrjMgWvixc=
-github.com/charmbracelet/bubbletea v0.24.1/go.mod h1:rK3g/2+T8vOSEkNHvtq40umJpeVYDn6bLaqbgzhL/hg=
+github.com/charmbracelet/bubbletea v0.24.2 h1:uaQIKx9Ai6Gdh5zpTbGiWpytMU+CfsPp06RaW2cx/SY=
+github.com/charmbracelet/bubbletea v0.24.2/go.mod h1:XdrNrV4J8GiyshTtx3DNuYkR1FDaJmO3l2nejekbsgg=
 github.com/charmbracelet/harmonica v0.2.0 h1:8NxJWRWg/bzKqqEaaeFNipOu77YR5t8aSwG4pgaUBiQ=
 github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/charmbracelet/lipgloss v0.7.1 h1:17WMwi7N1b1rVWOjMT+rCh7sQkvDU75B2hbZpc5Kc1E=
@@ -925,7 +922,6 @@ github.com/jung-kurt/gofpdf v1.16.2 h1:jgbatWHfRlPYiK85qgevsZTHviWXKwB1TTiKdz5Pt
 github.com/jung-kurt/gofpdf v1.16.2/go.mod h1:1hl7y57EsiPAkLbOwzpzqgx1A30nQCk/YmFV8S2vmK0=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
-github.com/kevinmbeaulieu/eq-go v1.0.0/go.mod h1:G3S8ajA56gKBZm4UB9AOyoOS37JO3roToPzKNM8dtdM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -964,7 +960,6 @@ github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
-github.com/logrusorgru/aurora/v3 v3.0.0/go.mod h1:vsR12bk5grlLvLXAYrBsb5Oc/N+LxAlxggSjiwMnCUc=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mackerelio/go-osstat v0.2.4 h1:qxGbdPkFo65PXOb/F/nhDKpF2nGmGaCFDLXoZjJTtUs=
@@ -1422,10 +1417,10 @@ github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
-github.com/vito/progrock v0.8.2-0.20230724234534-63ac51106f69 h1:L0XfyEeCQCf9IGyV8kn584YWvijbki66nr/BQod4QOg=
-github.com/vito/progrock v0.8.2-0.20230724234534-63ac51106f69/go.mod h1:1KTQP8B56h0didAAY+/kmhGjp423TSBrNUrgUWYo9ec=
 github.com/vito/progrock v0.9.0 h1:K/eKa0loW1n5NXw0PIa1SH2/pxMHaFA2ltZzKZbvy8I=
 github.com/vito/progrock v0.9.0/go.mod h1:1KTQP8B56h0didAAY+/kmhGjp423TSBrNUrgUWYo9ec=
+github.com/vito/progrock v0.9.1-0.20230815145556-518f2dcd6e2f h1:Gh2GwkSopn7qbdbk6fZrCECTy86CZyry7iSw5nHCdmw=
+github.com/vito/progrock v0.9.1-0.20230815145556-518f2dcd6e2f/go.mod h1:KTuI7LkISnoOTc/EehHHvnpVNwp11928948+ZSMLDvc=
 github.com/vito/vt100 v0.1.2 h1:gRhKJ/shHTRfMHg+Wc5ExHJzV6HHZqyQIAL52x4EUmA=
 github.com/vito/vt100 v0.1.2/go.mod h1:ByMBsZZEP04RrkT9q/UxvZOjECM8Xc/MRLZ7GLrAUXs=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=

--- a/sdk/elixir/lib/dagger/internal/client.ex
+++ b/sdk/elixir/lib/dagger/internal/client.ex
@@ -37,7 +37,7 @@ defmodule Dagger.Internal.Client do
       connect_timeout: [
         type: :timeout,
         doc: "Sets timeout when connect to the engine.",
-        default: :timer.seconds(10)
+        default: :timer.seconds(30)
       ],
       query_timeout: [
         type: :timeout,


### PR DESCRIPTION
3 changes:

* Log a `--debug` message in the connection retry loop to make it easier to troubleshoot hangs.
* Base64-encode client metadata so fancy UTF8 letters don't cause errors
* Fix/clean up label collection flow to make more sense with the new architecture
  * Fix weird server-global label cache, which really shouldn't have been there anymore, and was probably causing the first connection's labels to be used for all subsequent connections.
  * Rather than putting the root labels into every single object, just let it stay on the root Group. the telemetry progrock.Writer also turns these into labels sent to Cloud, so we don't need to duplicate them anymore.

As a result of that last change, all IDs should now be much smaller, since they don't have to contain the root pipeline + labels. :tada: 

fixes #5627