### PR TITLE
core: hide merge vertexes from output

### DIFF
--- a/core/directory.go
+++ b/core/directory.go
@@ -465,7 +465,7 @@ func mergeStates(input mergeStateInput) llb.State {
 			input.Src, path.Join(input.SrcDir, input.SrcFileName), path.Join(input.DestDir, input.DestFileName), copyInfo,
 		)))
 	}
-	return llb.Merge(mergeStates)
+	return llb.Merge(mergeStates, llb.WithCustomName(buildkit.InternalPrefix+"merge"))
 }
 
 func (dir *Directory) WithTimestamps(ctx context.Context, unix int) (*Directory, error) {


### PR DESCRIPTION
The update to use merge-op to optimize copies also resulted in us receiving tons of progress vertexes about merges. These are kind of confusing to users since merge is entirely an internal optimization and the format we receive them in can be extremely ugly due to the fact that they don't show the flattened merge that actually takes place.

Now that vertex is marked as internal and thus shouldn't show up in output by default.

cc @jpadams I believe this will stop these from polluting progress output, which I know was causing confusion recently.