### PR TITLE
feat: show export host target

### DIFF
--- a/.changes/unreleased/Added-20230815-154334.yaml
+++ b/.changes/unreleased/Added-20230815-154334.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Show host target on directory or file export
+time: 2023-08-15T15:43:34.544324+02:00
+custom:
+  Author: TomChv
+  PR: "5632"

--- a/core/directory.go
+++ b/core/directory.go
@@ -3,8 +3,6 @@ package core
 import (
 	"context"
 	"fmt"
-	"github.com/moby/buildkit/identity"
-	"github.com/vito/progrock"
 	"io/fs"
 	"path"
 	"path/filepath"
@@ -14,11 +12,13 @@ import (
 
 	"github.com/moby/buildkit/client/llb"
 	bkgw "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	fstypes "github.com/tonistiigi/fsutil/types"
+	"github.com/vito/progrock"
 
 	"github.com/dagger/dagger/core/pipeline"
 	"github.com/dagger/dagger/core/resourceid"

--- a/core/directory.go
+++ b/core/directory.go
@@ -603,8 +603,7 @@ func (dir *Directory) Export(
 
 	vtx := rec.Vertex(
 		digest.Digest(identity.NewID()),
-		strings.Join([]string{"export directory", dir.Dir, "to host", destPath},
-			" "),
+		fmt.Sprintf("export directory %s to host %s", dir.Dir, destPath),
 	)
 	defer vtx.Done(rerr)
 

--- a/core/file.go
+++ b/core/file.go
@@ -3,20 +3,24 @@ package core
 import (
 	"context"
 	"fmt"
+	"github.com/moby/buildkit/identity"
+	"github.com/vito/progrock"
 	"io"
 	"path"
+	"strings"
 	"time"
 
-	"github.com/dagger/dagger/core/pipeline"
-	"github.com/dagger/dagger/core/reffs"
-	"github.com/dagger/dagger/core/resourceid"
-	"github.com/dagger/dagger/engine/buildkit"
 	"github.com/moby/buildkit/client/llb"
 	bkgw "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	fstypes "github.com/tonistiigi/fsutil/types"
+
+	"github.com/dagger/dagger/core/pipeline"
+	"github.com/dagger/dagger/core/reffs"
+	"github.com/dagger/dagger/core/resourceid"
+	"github.com/dagger/dagger/engine/buildkit"
 )
 
 // File is a content-addressed file.
@@ -229,6 +233,16 @@ func (file *File) Export(
 	if err != nil {
 		return err
 	}
+
+	rec := progrock.RecorderFromContext(ctx)
+
+	vtx := rec.Vertex(
+		digest.Digest(identity.NewID()),
+		strings.Join([]string{"export file", file.File, "to host", dest},
+			" "),
+	)
+	defer vtx.Done(err)
+
 	_, err = WithServices(ctx, bk, file.Services, func() (any, error) {
 		err = bk.LocalFileExport(ctx, def.ToPB(), dest, file.File, allowParentDirPath)
 		return nil, err

--- a/core/file.go
+++ b/core/file.go
@@ -3,8 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
-	"github.com/moby/buildkit/identity"
-	"github.com/vito/progrock"
+
 	"io"
 	"path"
 	"strings"
@@ -12,10 +11,12 @@ import (
 
 	"github.com/moby/buildkit/client/llb"
 	bkgw "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	fstypes "github.com/tonistiigi/fsutil/types"
+	"github.com/vito/progrock"
 
 	"github.com/dagger/dagger/core/pipeline"
 	"github.com/dagger/dagger/core/reffs"

--- a/core/file.go
+++ b/core/file.go
@@ -6,7 +6,6 @@ import (
 
 	"io"
 	"path"
-	"strings"
 	"time"
 
 	"github.com/moby/buildkit/client/llb"
@@ -239,8 +238,7 @@ func (file *File) Export(
 
 	vtx := rec.Vertex(
 		digest.Digest(identity.NewID()),
-		strings.Join([]string{"export file", file.File, "to host", dest},
-			" "),
+		fmt.Sprintf("export file %s to host %s", file.File, dest),
 	)
 	defer vtx.Done(err)
 


### PR DESCRIPTION
Update directory export resolver to log additional context about the export. It logs a simple message: `export directory <name of the dir> to host <path>`.

EDIT: also include this change for file export

Resolves: #5084