### PR TITLE
docs: Updated some guides to use "dagger run"

### DIFF
--- a/docs/current/guides/620941-github-google-cloud.md
+++ b/docs/current/guides/620941-github-google-cloud.md
@@ -33,6 +33,7 @@ This tutorial assumes that:
 - You have a basic understanding of the JavaScript programming language.
 - You have a basic understanding of GitHub Actions. If not, [learn about GitHub Actions](https://docs.github.com/en/actions).
 - You have a Go, Python or Node.js development environment. If not, install [Go](https://go.dev/doc/install), [Python](https://www.python.org/downloads/) or [Node.js](https://nodejs.org/en/download/).
+- You have the Dagger CLI installed in your development environment. If not, [install the Dagger CLI](../cli/465058-install.md).
 - You have Docker installed and running on the host system. If not, [install Docker](https://docs.docker.com/engine/install/).
 - You have the Google Cloud CLI installed. If not, [install the Google Cloud CLI](https://cloud.google.com/sdk/docs/install).
 - You have a Google Cloud account and a Google Cloud project with billing enabled. If not, [register for a Google Cloud account](https://cloud.google.com/), [create a Google Cloud project](https://console.cloud.google.com/project) and [enable billing](https://support.google.com/cloud/answer/6293499#enable-billing).
@@ -151,21 +152,21 @@ Once credentials are configured, test the Dagger pipeline by running the command
 <TabItem value="Go">
 
 ```shell
-go run ci/main.go
+dagger run go run ci/main.go
 ```
 
 </TabItem>
 <TabItem value="Node.js">
 
 ```shell
-node ci/index.mjs
+dagger run node ci/index.mjs
 ```
 
 </TabItem>
 <TabItem value="Python">
 
 ```shell
-python ci/main.py
+dagger run python ci/main.py
 ```
 
 </TabItem>
@@ -220,12 +221,13 @@ This also means that it's very easy to move your Dagger pipeline from your local
   </TabItem>
   </Tabs>
 
-  This workflow runs on every commit to the repository `master` branch. It consists of a single job with six steps, as below:
+  This workflow runs on every commit to the repository `master` branch. It consists of a single job with seven steps, as below:
     - The first step uses the [Checkout action](https://github.com/marketplace/actions/checkout) to check out the latest source code from the `main` branch to the GitHub runner.
     - The second step uses the [Authenticate to Google Cloud action](https://github.com/marketplace/actions/authenticate-to-google-cloud) to authenticate to Google Cloud. It requires a service account key in JSON format, which it expects to find in the `GOOGLE_CREDENTIALS` GitHub secret. This step sets various environment variables (including the GOOGLE_APPLICATION_CREDENTIALS variable required by the Google Cloud Run SDK) and returns an access token as output, which is used to authenticate the next step.
     - The third step uses the [Docker Login action](https://github.com/marketplace/actions/docker-login) and the access token from the previous step to authenticate to Google Container Registry from the GitHub runner. This is necessary because Dagger relies on the host's Docker credentials and authorizations when publishing to remote registries.
     - The fourth and fifth steps download and install the programming language and required dependencies (such as the Dagger SDK and the Google Cloud Run SDK) on the GitHub runner.
-    - The sixth and final step executes the Dagger pipeline.
+    - The sixth step downloads and installs the Dagger CLI on the GitHub runner.
+    - The seventh and final step executes the Dagger pipeline.
 
 The [Authenticate to Google Cloud action](https://github.com/marketplace/actions/authenticate-to-google-cloud) looks for a JSON service account key in the `GOOGLE_CREDENTIALS` GitHub secret. Create this secret as follows:
 

--- a/docs/current/guides/759201-gitlab-google-cloud.md
+++ b/docs/current/guides/759201-gitlab-google-cloud.md
@@ -29,6 +29,7 @@ This tutorial assumes that:
 - You have a basic understanding of the Go programming language.
 - You have a basic understanding of GitLab and GitLab CI/CD. If not, [learn about GitLab CI/CD](https://docs.gitlab.com/ee/ci/).
 - You have a Go, Python or Node.js development environment. If not, install [Go](https://go.dev/doc/install), [Python](https://www.python.org/downloads/) or [Node.js](https://nodejs.org/en/download/).
+- You have the Dagger CLI installed in your development environment. If not, [install the Dagger CLI](../cli/465058-install.md).
 - You have Docker installed and running on the host system. If not, [install Docker](https://docs.docker.com/engine/install/).
 - You have the Google Cloud CLI installed. If not, [install the Google Cloud CLI](https://cloud.google.com/sdk/docs/install).
 - You have a Google Cloud account and a Google Cloud project with billing enabled. If not, [register for a Google Cloud account](https://cloud.google.com/), [create a Google Cloud project](https://console.cloud.google.com/project) and [enable billing](https://support.google.com/cloud/answer/6293499#enable-billing).
@@ -154,21 +155,21 @@ Once credentials are configured, test the Dagger pipeline by running the command
 <TabItem value="Go">
 
 ```shell
-go run ci/main.go
+dagger run go run ci/main.go
 ```
 
 </TabItem>
 <TabItem value="Node.js">
 
 ```shell
-node ci/index.mjs
+dagger run node ci/index.mjs
 ```
 
 </TabItem>
 <TabItem value="Python">
 
 ```shell
-python ci/main.py
+dagger run python ci/main.py
 ```
 
 </TabItem>

--- a/docs/current/guides/snippets/ci/go/actions.yml
+++ b/docs/current/guides/snippets/ci/go/actions.yml
@@ -12,5 +12,7 @@ jobs:
         with:
           go-version: '1.20'
       - uses: actions/checkout@v3
+      - name: Install Dagger CLI
+        run: cd /usr/local && curl -L https://dl.dagger.io/dagger/install.sh | sh
       - name: Run Dagger pipeline
-        run: go run main.go
+        run: dagger run go run main.go

--- a/docs/current/guides/snippets/ci/go/actions.yml
+++ b/docs/current/guides/snippets/ci/go/actions.yml
@@ -8,10 +8,10 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version: '1.20'
-      - uses: actions/checkout@v3
       - name: Install Dagger CLI
         run: cd /usr/local && curl -L https://dl.dagger.io/dagger/install.sh | sh
       - name: Run Dagger pipeline

--- a/docs/current/guides/snippets/ci/go/gitlab.yml
+++ b/docs/current/guides/snippets/ci/go/gitlab.yml
@@ -12,8 +12,9 @@
 .dagger:
   extends: [.docker]
   before_script:
-    - apk add docker-cli
+    - apk add docker-cli curl
+    - cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
 build:
   extends: [.dagger]
   script:
-    - go run main.go
+    - dagger run go run main.go

--- a/docs/current/guides/snippets/ci/nodejs/actions.yml
+++ b/docs/current/guides/snippets/ci/nodejs/actions.yml
@@ -14,5 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install deps
         run: npm ci
+      - name: Install Dagger CLI
+        run: cd /usr/local && curl -L https://dl.dagger.io/dagger/install.sh | sh
       - name: Run Dagger pipeline
-        run: node index.mjs
+        run: dagger run node index.mjs

--- a/docs/current/guides/snippets/ci/nodejs/actions.yml
+++ b/docs/current/guides/snippets/ci/nodejs/actions.yml
@@ -8,10 +8,10 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - uses: actions/checkout@v3
       - name: Install deps
         run: npm ci
       - name: Install Dagger CLI

--- a/docs/current/guides/snippets/ci/nodejs/gitlab.yml
+++ b/docs/current/guides/snippets/ci/nodejs/gitlab.yml
@@ -12,9 +12,10 @@
 .dagger:
   extends: [.docker]
   before_script:
-    - apk add docker-cli
+    - apk add docker-cli curl
+    - cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
 build:
   extends: [.dagger]
   script:
     - npm ci
-    - node index.mjs
+    - dagger run node index.mjs

--- a/docs/current/guides/snippets/ci/python/actions.yml
+++ b/docs/current/guides/snippets/ci/python/actions.yml
@@ -8,10 +8,10 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - uses: actions/checkout@v3
       - name: Install deps
         run: pip install .
       - name: Install Dagger CLI

--- a/docs/current/guides/snippets/ci/python/actions.yml
+++ b/docs/current/guides/snippets/ci/python/actions.yml
@@ -14,5 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install deps
         run: pip install .
+      - name: Install Dagger CLI
+        run: cd /usr/local && curl -L https://dl.dagger.io/dagger/install.sh | sh
       - name: Run Dagger pipeline
-        run: python main.py
+        run: dagger run python main.py

--- a/docs/current/guides/snippets/ci/python/gitlab.yml
+++ b/docs/current/guides/snippets/ci/python/gitlab.yml
@@ -12,9 +12,10 @@
 .dagger:
   extends: [.docker]
   before_script:
-    - apk add docker-cli
+    - apk add docker-cli curl
+    - cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
 build:
   extends: [.dagger]
   script:
     - pip install .
-    - python main.py
+    - dagger run python main.py

--- a/docs/current/guides/snippets/github-google-cloud/github-go.yml
+++ b/docs/current/guides/snippets/github-google-cloud/github-go.yml
@@ -27,7 +27,7 @@ jobs:
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
       -
-        name: Setup node
+        name: Setup Go
         uses: actions/setup-go@v4
         with:
           go-version: '>=1.20'
@@ -35,5 +35,8 @@ jobs:
         name: Install
         run: go get dagger.io/dagger@latest cloud.google.com/go/run/apiv2
       -
+        name: Install Dagger CLI
+        run: cd /usr/local && curl -L https://dl.dagger.io/dagger/install.sh | sh
+      -
         name: Release and deploy with Dagger
-        run: go run ci/main.go
+        run: dagger run go run ci/main.go

--- a/docs/current/guides/snippets/github-google-cloud/github-nodejs.yml
+++ b/docs/current/guides/snippets/github-google-cloud/github-nodejs.yml
@@ -36,5 +36,8 @@ jobs:
         name: Install
         run: npm install
       -
+        name: Install Dagger CLI
+        run: cd /usr/local && curl -L https://dl.dagger.io/dagger/install.sh | sh
+      -
         name: Release and deploy with Dagger
-        run: node ci/index.mjs
+        run: dagger run node ci/index.mjs

--- a/docs/current/guides/snippets/github-google-cloud/github-python.yml
+++ b/docs/current/guides/snippets/github-google-cloud/github-python.yml
@@ -35,5 +35,8 @@ jobs:
         name: Install
         run: pip install dagger-io google-cloud-run
       -
+        name: Install Dagger CLI
+        run: cd /usr/local && curl -L https://dl.dagger.io/dagger/install.sh | sh
+      -
         name: Release and deploy with Dagger
-        run: python ci/main.py
+        run: dagger run python ci/main.py

--- a/docs/current/guides/snippets/gitlab-google-cloud/gitlab-ci-go.yml
+++ b/docs/current/guides/snippets/gitlab-google-cloud/gitlab-ci-go.yml
@@ -12,9 +12,10 @@
 .dagger:
   extends: [.docker]
   before_script:
-    - apk add docker-cli
+    - apk add docker-cli curl
+    - cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
     - cat $GOOGLE_APPLICATION_CREDENTIALS | docker login -u _json_key --password-stdin https://gcr.io
 build-deploy:
   extends: [.dagger]
   script:
-    - go run ci/main.go
+    - dagger run go run ci/main.go

--- a/docs/current/guides/snippets/gitlab-google-cloud/gitlab-ci-nodejs.yml
+++ b/docs/current/guides/snippets/gitlab-google-cloud/gitlab-ci-nodejs.yml
@@ -12,10 +12,11 @@
 .dagger:
   extends: [.docker]
   before_script:
-    - apk add docker-cli
+    - apk add docker-cli curl
+    - cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
     - cat $GOOGLE_APPLICATION_CREDENTIALS | docker login -u _json_key --password-stdin https://gcr.io
 build-deploy:
   extends: [.dagger]
   script:
     - npm install @dagger.io/dagger@latest @google-cloud/run --save-dev
-    - node ci/index.mjs
+    - dagger run node ci/index.mjs

--- a/docs/current/guides/snippets/gitlab-google-cloud/gitlab-ci-python.yml
+++ b/docs/current/guides/snippets/gitlab-google-cloud/gitlab-ci-python.yml
@@ -12,10 +12,11 @@
 .dagger:
   extends: [.docker]
   before_script:
-    - apk add docker-cli
+    - apk add docker-cli curl
+    - cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
     - cat $GOOGLE_APPLICATION_CREDENTIALS | docker login -u _json_key --password-stdin https://gcr.io
 build-deploy:
   extends: [.dagger]
   script:
     - pip install dagger-io google-cloud-run
-    - python ci/main.py
+    - dagger run python ci/main.py


### PR DESCRIPTION
This commit updates the Dagger + Google Cloud + GitHub/GitLab long-form guides to use "dagger run".

Additional PRs should be expected for other sections of the docs.

Follow-up to:

https://github.com/dagger/dagger/pull/5591
https://github.com/dagger/dagger/pull/5604