### PR TITLE
fix: NodeJS conflict between enumeration and string

### DIFF
--- a/codegen/generator/nodejs/templates/functions.go
+++ b/codegen/generator/nodejs/templates/functions.go
@@ -41,23 +41,9 @@ var (
 		"ToLowerCase":         commonFunc.ToLowerCase,
 		"ToUpperCase":         commonFunc.ToUpperCase,
 		"ToSingleType":        toSingleType,
-		"ListOfEnum":          listOfEnum,
+		"GetEnumValues":       getEnumValues,
 	}
 )
-
-func listOfEnum() string {
-	schema := generator.GetSchema()
-
-	var result []string
-
-	for _, t := range schema.Types {
-		if t.Kind == introspection.TypeKindEnum && !strings.HasPrefix(t.Name, "__") {
-			result = append(result, t.Name)
-		}
-	}
-
-	return strings.Join(result, ", ")
-}
 
 // pascalCase change a type name into pascalCase
 func pascalCase(name string) string {
@@ -152,6 +138,18 @@ func splitRequiredOptionalArgs(values introspection.InputValues) (required intro
 		return values[:i], values[i:]
 	}
 	return values, nil
+}
+
+func getEnumValues(values introspection.InputValues) introspection.InputValues {
+	enums := introspection.InputValues{}
+
+	for _, v := range values {
+		if v.TypeRef != nil && v.TypeRef.Kind == introspection.TypeKindEnum {
+			enums = append(enums, v)
+		}
+	}
+
+	return enums
 }
 
 func getRequiredArgs(values introspection.InputValues) introspection.InputValues {

--- a/codegen/generator/nodejs/templates/src/header.ts.gtpl
+++ b/codegen/generator/nodejs/templates/src/header.ts.gtpl
@@ -19,18 +19,19 @@ export type QueryTree = {
   args?: Record<string, unknown>
 }
 
+/**
+ * @hidden
+ */
+export type Metadata = {
+  [key: string]: {
+    is_enum?: boolean
+  }
+}
+
 interface ClientConfig {
   queryTree?: QueryTree[]
   host?: string
   sessionToken?: string
-}
-
-export function isEnum(value: never): boolean {
-    const enums = [{{ ListOfEnum }}]
-
-    return enums
-      .map((e) => Object.values(e).includes(value))
-      .includes(true)
 }
 
 class BaseClient {

--- a/codegen/generator/nodejs/templates/src/method.ts.gtpl
+++ b/codegen/generator/nodejs/templates/src/method.ts.gtpl
@@ -28,7 +28,17 @@
 
 	{{- /* Write return type. */ -}}
 	{{- "" }}){{- "" }}: {{ .TypeRef | FormatOutputType  }} {
-	
+
+	{{- $enums := GetEnumValues .Args }}
+	{{- if gt (len $enums) 0 }}
+	const metadata: Metadata = {
+	    {{- range $v := $enums }}
+	    {{ $v.Name -}}: { is_enum: true },
+	    {{- end }}
+	}
+{{ "" -}}
+	{{- end }}
+
 	{{- if .TypeRef }}
     return new {{ .TypeRef | FormatOutputType }}({
       queryTree: [
@@ -45,7 +55,7 @@
 
       		{{- with $optionals }}
       			{{- if $required }}, {{ end -}}
-        ...opts
+        ...opts{{- if gt (len $enums) 0 -}}, __metadata: metadata{{- end -}}
 			{{- end -}}
 {{""}} },
 		{{- end }}

--- a/codegen/generator/nodejs/templates/src/method_solve.ts.gtpl
+++ b/codegen/generator/nodejs/templates/src/method_solve.ts.gtpl
@@ -50,6 +50,17 @@
     {{- $promiseRetType = printf "%s[]" (.Name | ToLowerCase) }}
     {{- end }}
 
+	{{- $enums := GetEnumValues .Args }}
+	{{- if gt (len $enums) 0 }}
+	const metadata: Metadata = {
+	    {{- range $v := $enums }}
+	    {{ $v.Name -}}: { is_enum: true },
+	    {{- end }}
+	}
+{{ "" -}}
+
+	{{- end }}
+
 	{{- if .TypeRef }}
     {{ if not $convertID }}const response: Awaited<{{ $promiseRetType }}> = {{ end }}await computeQuery(
       [
@@ -66,7 +77,7 @@
 
       		{{- with $optionals }}
       			{{- if $required }}, {{ end }}
-				{{- "" }}...opts
+				{{- "" }}...opts{{- if gt (len $enums) 0 -}}, __metadata: metadata{{- end -}}
 			{{- end }}
 {{- "" }} },
 		{{- end }}

--- a/sdk/nodejs/.changes/unreleased/Fixed-20230816-184800.yaml
+++ b/sdk/nodejs/.changes/unreleased/Fixed-20230816-184800.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Improve enum management to not conflict with string
+time: 2023-08-16T18:48:00.256689+02:00
+custom:
+  Author: TomChv
+  PR: "5645"

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -14,21 +14,19 @@ export type QueryTree = {
   args?: Record<string, unknown>
 }
 
+/**
+ * @hidden
+ */
+export type Metadata = {
+  [key: string]: {
+    is_enum?: boolean
+  }
+}
+
 interface ClientConfig {
   queryTree?: QueryTree[]
   host?: string
   sessionToken?: string
-}
-
-export function isEnum(value: never): boolean {
-  const enums = [
-    CacheSharingMode,
-    ImageLayerCompression,
-    ImageMediaTypes,
-    NetworkProtocol,
-  ]
-
-  return enums.map((e) => Object.values(e).includes(value)).includes(true)
 }
 
 class BaseClient {
@@ -962,12 +960,17 @@ export class Container extends BaseClient {
       return this._export
     }
 
+    const metadata: Metadata = {
+      forcedCompression: { is_enum: true },
+      mediaTypes: { is_enum: true },
+    }
+
     const response: Awaited<boolean> = await computeQuery(
       [
         ...this._queryTree,
         {
           operation: "export",
-          args: { path, ...opts },
+          args: { path, ...opts, __metadata: metadata },
         },
       ],
       this.client
@@ -1287,12 +1290,17 @@ export class Container extends BaseClient {
       return this._publish
     }
 
+    const metadata: Metadata = {
+      forcedCompression: { is_enum: true },
+      mediaTypes: { is_enum: true },
+    }
+
     const response: Awaited<string> = await computeQuery(
       [
         ...this._queryTree,
         {
           operation: "publish",
-          args: { address, ...opts },
+          args: { address, ...opts, __metadata: metadata },
         },
       ],
       this.client
@@ -1542,12 +1550,16 @@ export class Container extends BaseClient {
     port: number,
     opts?: ContainerWithExposedPortOpts
   ): Container {
+    const metadata: Metadata = {
+      protocol: { is_enum: true },
+    }
+
     return new Container({
       queryTree: [
         ...this._queryTree,
         {
           operation: "withExposedPort",
-          args: { port, ...opts },
+          args: { port, ...opts, __metadata: metadata },
         },
       ],
       host: this.clientHost,
@@ -1643,12 +1655,16 @@ export class Container extends BaseClient {
     cache: CacheVolume,
     opts?: ContainerWithMountedCacheOpts
   ): Container {
+    const metadata: Metadata = {
+      sharing: { is_enum: true },
+    }
+
     return new Container({
       queryTree: [
         ...this._queryTree,
         {
           operation: "withMountedCache",
-          args: { path, cache, ...opts },
+          args: { path, cache, ...opts, __metadata: metadata },
         },
       ],
       host: this.clientHost,
@@ -1967,12 +1983,16 @@ export class Container extends BaseClient {
     port: number,
     opts?: ContainerWithoutExposedPortOpts
   ): Container {
+    const metadata: Metadata = {
+      protocol: { is_enum: true },
+    }
+
     return new Container({
       queryTree: [
         ...this._queryTree,
         {
           operation: "withoutExposedPort",
-          args: { port, ...opts },
+          args: { port, ...opts, __metadata: metadata },
         },
       ],
       host: this.clientHost,

--- a/sdk/nodejs/api/test/api.spec.ts
+++ b/sdk/nodejs/api/test/api.spec.ts
@@ -409,4 +409,18 @@ describe("NodeJS SDK api", function () {
       { LogOutput: process.stderr }
     )
   })
+
+  it("Check conflict with enum", async function () {
+    this.timeout(60000)
+
+    await connect(async (client) => {
+      const env = await client
+        .container()
+        .from("alpine:3.16.2")
+        .withEnvVariable("FOO", "TCP")
+        .envVariable("FOO")
+
+      assert.strictEqual(env, "TCP")
+    })
+  })
 })


### PR DESCRIPTION
Include a new internal logic to get more information about type during query building.
This is a first step before moving to an actual query builder.

This internal data structure called `metadata` let the query builder knows if the value is an enum or not.
This avoids any possible type conflict.

This replaces the old enumeration handling implementation so old code has been deleted.

Include new tests to ensure no conflict is possible anymore.

Resolves: #5638