### PR TITLE
fix: fix connect always timeout

### DIFF
--- a/.github/workflows/sdk-elixir.yml
+++ b/.github/workflows/sdk-elixir.yml
@@ -1,19 +1,14 @@
 name: Elixir SDK
 
 on:
-  # ⏸ TEMPORARILY SUSPENDED: https://github.com/dagger/dagger/pull/5628#issuecomment-1679378257
-  # Tests started failing intermittently since the previous PR, it's blocking the release.
-  # push:
-  #   branches: ["main"]
-  # pull_request:
-  #   types:
-  #     - opened
-  #     - synchronize
-  #     - reopened
-  #     - ready_for_review
-  # Enable manual trigger for easy debugging
-  # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs
-  workflow_dispatch:
+  push:
+    branches: ["main"]
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 permissions:
   contents: read

--- a/sdk/elixir/.changes/unreleased/Fixed-20230816-235838.yaml
+++ b/sdk/elixir/.changes/unreleased/Fixed-20230816-235838.yaml
@@ -1,5 +1,5 @@
 kind: Fixed
-body: 'fix: fix connect always timeout'
+body: 'fix connect always timeout'
 time: 2023-08-16T23:58:38.705088+07:00
 custom:
   Author: wingyplus

--- a/sdk/elixir/.changes/unreleased/Fixed-20230816-235838.yaml
+++ b/sdk/elixir/.changes/unreleased/Fixed-20230816-235838.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: 'fix: fix connect always timeout'
+time: 2023-08-16T23:58:38.705088+07:00
+custom:
+  Author: wingyplus
+  PR: "5646"


### PR DESCRIPTION
Somehow, when running inside dagger (`internal/mage` for example), the Elixir Port didn't separate line with `\n`. This cause `Dagger.Session` cannot retrieve the session port and token, causing session timeout.

To fix that, split data that come from port with `\n` and try parsing a JSON line by line to find the session.

Fixes #5642