### PR TITLE
Run Engine tests in dev Engine (on top of stable Engine)

### DIFF
--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -4,16 +4,20 @@ on:
   workflow_call:
     inputs:
       mage-targets:
-        description: 'The mage target(s) to execute'
+        description: "The mage target(s) to execute"
         type: string
         required: true
+      dev-engine:
+        description: "Whether to run against a dev Engine"
+        type: boolean
+        default: false
+        required: false
 
 jobs:
-  # Use a free runner when
+  # Use a free GitHub Actions runner when
   # NOT running in the dagger/dagger repo 
-  # & NOT a PR
   github-free-runner:
-    if: ${{ github.repository != 'dagger/dagger' && github.base_ref == '' }}
+    if: ${{ github.repository != 'dagger/dagger' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -21,23 +25,26 @@ jobs:
         with:
           go-version: "1.20"
           cache-dependency-path: "internal/mage/go.sum"
-      - run: ./hack/make ${{ inputs.mage-targets }}
+      - name: ${{ inputs.mage-targets }}
+        run: |
+          if [ "${{ inputs.dev-engine }}" != "false" ]
+          then
+            ./hack/dev
+            export _EXPERIMENTAL_DAGGER_CLI_BIN="$PWD/bin/dagger"
+            chmod +x $_EXPERIMENTAL_DAGGER_CLI_BIN
+            export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev
+          fi
+          ./hack/make ${{ inputs.mage-targets }}
         env:
-          _EXPERIMENTAL_DAGGER_JOURNAL: "/tmp/journal.log"
           _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
-      - uses: actions/upload-artifact@v3
+      - name: "ALWAYS print kernel logs - especialy useful on failure"
         if: always()
-        name: "Upload journal.log"
-        continue-on-error: true
-        with:
-          name: ${{ github.workflow }}-${{ github.job }}-journal.log
-          path: /tmp/journal.log
+        run: sudo dmesg
 
-  # Use a paid runner when
-  # NOT running in the dagger/dagger repo 
-  # & this is PR
+  # Use a larger (paid) GitHub runner when
+  # running the dagger/dagger repo (including PRs)
   github-paid-runner:
-    if: ${{ github.repository != 'dagger/dagger' && github.base_ref != '' }}
+    if: ${{ github.repository == 'dagger/dagger' }}
     runs-on: ubuntu-22.04-16c-64g-600gb
     steps:
       - uses: actions/checkout@v3
@@ -45,38 +52,41 @@ jobs:
         with:
           go-version: "1.20"
           cache-dependency-path: "internal/mage/go.sum"
-      - run: ./hack/make ${{ inputs.mage-targets }}
+      - name: ${{ inputs.mage-targets }}
+        run: |
+          if [ "${{ inputs.dev-engine }}" != "false" ]
+          then
+            ./hack/dev
+            export _EXPERIMENTAL_DAGGER_CLI_BIN="$PWD/bin/dagger"
+            chmod +x $_EXPERIMENTAL_DAGGER_CLI_BIN
+            export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev
+          fi
+          ./hack/make ${{ inputs.mage-targets }}
         env:
-          _EXPERIMENTAL_DAGGER_JOURNAL: "/tmp/journal.log"
           _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
-      - uses: actions/upload-artifact@v3
+      - name: "ALWAYS print kernel logs - especialy useful on failure"
         if: always()
-        name: "Upload journal.log"
-        continue-on-error: true
-        with:
-          name: ${{ github.workflow }}-${{ github.job }}-journal.log
-          path: /tmp/journal.log
+        run: sudo dmesg
 
-  # Use our own Dagger runner when
-  # running in the dagger/dagger repo
+  # Also use our own Dagger runner when
+  # running in the dagger/dagger repo (including PRs)
+  # CONTINUE ON ERROR until we figure out why multiple runners are trying to use the same Dagger Engine
   dagger-runner:
     if: ${{ github.repository == 'dagger/dagger' }}
-    runs-on: dagger-runner-4c-16g
+    runs-on: dagger-runner-16c-64g
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version: "1.20"
           cache-dependency-path: "internal/mage/go.sum"
-      - run: ./hack/make ${{ inputs.mage-targets }}
+      - name: ${{ inputs.mage-targets }}
+        run: |
+          ./hack/make ${{ inputs.mage-targets }}
         env:
-          _EXPERIMENTAL_DAGGER_JOURNAL: "/tmp/journal.log"
           _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
-      - uses: actions/upload-artifact@v3
+          _EXPERIMENTAL_DAGGER_RUNNER_HOST: "unix:///var/run/buildkit/buildkitd.sock"
+      - name: "ALWAYS print kernel logs - especialy useful on failure"
         if: always()
-        name: "Upload journal.log"
-        continue-on-error: true
-        with:
-          name: ${{ github.workflow }}-${{ github.job }}-journal.log
-          path: /tmp/journal.log
-
+        run: sudo dmesg

--- a/.github/workflows/sdk-elixir.yml
+++ b/.github/workflows/sdk-elixir.yml
@@ -9,6 +9,8 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+  # Enable manual trigger for easier debugging
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,89 +19,26 @@ permissions:
 
 jobs:
   engine:
-    runs-on: ubuntu-22.04-16c-64g-600gb
-    steps:
-      - name: "Set up QEMU"
-        run: |
-          docker run --rm --privileged tonistiigi/binfmt:latest --install all
-      - uses: actions/setup-go@v3
-        with:
-          go-version: "1.20"
-      - uses: actions/checkout@v3
-      - run: ./hack/make engine:test
-        env:
-          _EXPERIMENTAL_DAGGER_JOURNAL: "/tmp/journal.log"
-          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
-      - name: "ALWAYS print kernel logs - especialy useful on failure"
-        if: always()
-        run: sudo dmesg
-      - run: go build ./cmd/otel-collector
-        if: always()
-      - name: "Upload logs & traces"
-        continue-on-error: true
-        run: |
-          ./otel-collector /tmp/journal.log \
-            --name "${{ github.repository }}-${{ github.workflow }}:${{ github.job }}" \
-            --tag "github.repository=${{ github.repository }}" \
-            --tag "github.ref=${{ github.ref }}" \
-            --tag "github.workflow=${{ github.workflow }}" \
-            --tag "github.job=engine" \
-            --tag "github.run_number=${{ github.run_number }}" \
-            --tag "github.run_attempt=${{ github.run_attempt }}" \
-            --tag "github.run_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --tag "github.runner_name=${{ runner.name }}" \
-            --tag "github.runner_arch=${{ runner.arch }}" \
-            > ./comment.md
-        shell: bash
-        if: always()
-        env:
-          OTEL_SERVICE_NAME: "dagger"
-          OTEL_EXPORTER_OTLP_ENDPOINT: "https://tempo-us-central1.grafana.net:443"
-          OTEL_EXPORTER_OTLP_HEADERS: "Authorization=Basic MzUzMzUzOmdsY19leUp2SWpvaU56Y3dOelkwSWl3aWJpSTZJbTFsZEhKcFkzTnNiMmR6ZEhKaFkyVnpkM0pwZEdWeUxXZHBkR2gxWWkxa1lXZG5aWEl0WkdGbloyVnlMWEpsY0c4dFlXNWtMV1p2Y210eklpd2lheUk2SWprNE15MU1YM00wZkhwZExETWpOSG8vTXlzd0t5ZzFNQ0lzSW0waU9uc2ljaUk2SW5WekluMTk="
-          GRAFANA_CLOUD_USER_ID: "356840"
-          GRAFANA_CLOUD_URL: "https://logs-prod-017.grafana.net"
-          GRAFANA_CLOUD_API_KEY: "glc_eyJvIjoiNzcwNzY0IiwibiI6Im1ldHJpY3Nsb2dzdHJhY2Vzd3JpdGVyLWdpdGh1Yi1kYWdnZXItZGFnZ2VyLXJlcG8tYW5kLWZvcmtzIiwiayI6Ijk4My1MX3M0fHpdLDMjNHo/MyswKyg1MCIsIm0iOnsiciI6InVzIn19"
-      - uses: actions/upload-artifact@v3
-        if: always()
-        name: "Upload journal.log"
-        continue-on-error: true
-        with:
-          name: ${{ github.workflow }}-${{ github.job }}-journal.log
-          path: /tmp/journal.log
-      - uses: actions/upload-artifact@v3
-        name: "Upload otel-collector summary"
-        continue-on-error: true
-        with:
-          name: ${{ github.workflow }}-${{ github.job }}-summary.md
-          path: ./comment.md
+    uses: ./.github/workflows/_hack_make.yml
+    with:
+      mage-targets: engine:test
 
-  # Run egine tests with race condition detection
+  # Run Egine tests with race condition detection
   # https://go.dev/blog/race-detector
   #
   # Run in parallel to the regular tests so that the entire pipeline finishes quicker
   engine-race-detection:
-    runs-on: ubuntu-22.04-16c-64g-600gb
-    steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: "1.20"
-      - uses: actions/checkout@v3
-      - run: ./hack/make engine:build
-      - run: echo $PWD/bin >> $GITHUB_PATH
-      - run: ./hack/make engine:testrace
-        env:
-          _EXPERIMENTAL_DAGGER_JOURNAL: "/tmp/journal.log"
-          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
-      - name: "ALWAYS print kernel logs - especialy useful on failure"
-        if: always()
-        run: sudo dmesg
-      - uses: actions/upload-artifact@v3
-        if: always()
-        name: "Upload journal.log"
-        continue-on-error: true
-        with:
-          name: ${{ github.workflow }}-${{ github.job }}-journal.log
-          path: /tmp/journal.log
+    uses: ./.github/workflows/_hack_make.yml
+    with:
+      mage-targets: engine:testrace
+
+  # Run Engine tests in dev Engine so that we can spot integration failures early
+  # It's OK for this one to fail, it's more of an advisory
+  engine-in-engine-dev:
+    uses: ./.github/workflows/_hack_make.yml
+    with:
+      mage-targets: engine:test
+      dev-engine: true
 
   sdk-go:
     name: "sdk / go"


### PR DESCRIPTION
So that we can find potential failures earlier, as we've learned from v0.8.0 & v0.8.3 releases. cc @sipsma @vito

Allow PRs to use both Dagger runners & paid GitHub runners (same size). It's OK if these fail for now - `continue-on-error` - since we seem to have a configuration issue on the self-hosted runners themselves (they are attempting to use the same Engine). We can follow-up with a fix. cc @jlongtine

By the way, if we like this change, we can roll it out to other jobs - supersedes https://github.com/dagger/dagger/pull/5359


---
Stop uploading journal.log. Since we are reusing workflows, we cannot easily determine the journal log file name (the same one gets overwritten by different workflows). If we use inputs.mage-targets to distinguish, this fails since it contains ':', an unsupported character by the upload-artifact action. We could do this better (e.g. by requiring another input, by handling this in code, etc.), but I am unsure what is the current value of journal.log when we use Dagger Cloud. Removing it for now, let's see if others miss it.