### PR TITLE
fix: switch to stable engine only case no local cli

### DIFF
--- a/sdk/elixir/.changes/unreleased/Fixed-20230817-221054.yaml
+++ b/sdk/elixir/.changes/unreleased/Fixed-20230817-221054.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fallback to stable cli when cannot find local cli binary
+time: 2023-08-17T22:10:54.35385+07:00
+custom:
+  Author: wingyplus
+  PR: "5654"

--- a/sdk/elixir/lib/dagger/engine_conn.ex
+++ b/sdk/elixir/lib/dagger/engine_conn.ex
@@ -16,7 +16,8 @@ defmodule Dagger.EngineConn do
       _otherwise ->
         case from_local_cli(opts) do
           {:ok, conn} -> {:ok, conn}
-          _otherwise -> from_remote_cli(opts)
+          {:error, :no_executable} -> from_remote_cli(opts)
+          otherwise -> otherwise
         end
     end
   end


### PR DESCRIPTION
When no local cli found, the engine will download stable engine and start it.

Fixes #5651