### PR TITLE
fix: cannot connect to Dagger Engine and always raise error

### DIFF
--- a/sdk/elixir/.changes/unreleased/Fixed-20230818-231100.yaml
+++ b/sdk/elixir/.changes/unreleased/Fixed-20230818-231100.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Dagger.connect!/1 always returns `:error` when using stable engine
+time: 2023-08-18T23:11:00.741628+07:00
+custom:
+  Author: wingyplus
+  PR: "5665"

--- a/sdk/elixir/lib/dagger/engine_conn.ex
+++ b/sdk/elixir/lib/dagger/engine_conn.ex
@@ -41,6 +41,7 @@ defmodule Dagger.EngineConn do
          bin_path when is_binary(bin_path) <- System.find_executable(bin) do
       start_cli_session(bin_path, opts)
     else
+      :error -> {:error, :no_executable}
       nil -> {:error, :no_executable}
       otherwise -> otherwise
     end


### PR DESCRIPTION
`System.fetch_env` returns `:error`. The `Dagger.EngineConn.get/0` didn't handle it causing always returns `:error` instead of connect to stable engine.

Fixes #5664