### PR TITLE
docs: add Elixir to Cookbook Filesystem section

### DIFF
--- a/docs/current/cookbook.md
+++ b/docs/current/cookbook.md
@@ -32,6 +32,12 @@ The following code listing obtains a reference to the host working directory and
 ```
 
 </TabItem>
+<TabItem value="Elixir">
+
+```elixir file=./guides/snippets/work-with-host-filesystem/list-dir/main.exs
+```
+
+</TabItem>
 </Tabs>
 
 When the Dagger pipeline code is in a sub-directory, it may be more useful to set the parent directory (the project's root directory) as the working directory.
@@ -54,6 +60,12 @@ The following listing revises the previous one, obtaining a reference to the par
 <TabItem value="Python">
 
 ```python file=./guides/snippets/work-with-host-filesystem/list-dir-parent/main.py
+```
+
+</TabItem>
+<TabItem value="Elixir">
+
+```elixir file=./guides/snippets/work-with-host-filesystem/list-dir-parent/main.exs
 ```
 
 </TabItem>
@@ -84,6 +96,12 @@ The following code listing obtains a reference to the host working directory con
 ```
 
 </TabItem>
+<TabItem value="Elixir">
+
+```elixir file=./guides/snippets/work-with-host-filesystem/list-dir-exclude/main.exs
+```
+
+</TabItem>
 </Tabs>
 
 The following code listing obtains a reference to the host working directory containing only `*.rar` files.
@@ -107,6 +125,12 @@ The following code listing obtains a reference to the host working directory con
 ```
 
 </TabItem>
+<TabItem value="Elixir">
+
+```elixir file=./guides/snippets/work-with-host-filesystem/list-dir-include/main.exs
+```
+
+</TabItem>
 </Tabs>
 
 The following code listing obtains a reference to the host working directory containing all files except `*.rar` files.
@@ -127,6 +151,12 @@ The following code listing obtains a reference to the host working directory con
 <TabItem value="Python">
 
 ```python file=./guides/snippets/work-with-host-filesystem/list-dir-exclude-include/main.py
+```
+
+</TabItem>
+<TabItem value="Elixir">
+
+```elixir file=./guides/snippets/work-with-host-filesystem/list-dir-exclude-include/main.exs
 ```
 
 </TabItem>
@@ -154,6 +184,12 @@ The following code listing mounts a host directory in a container at the `/host`
 <TabItem value="Python">
 
 ```python file=./guides/snippets/work-with-host-filesystem/mount-dir/main.py
+```
+
+</TabItem>
+<TabItem value="Elixir">
+
+```elixir file=./guides/snippets/work-with-host-filesystem/mount-dir/main.exs
 ```
 
 </TabItem>
@@ -186,6 +222,12 @@ Modifications made to a host directory mounted in a container do not appear on t
 ```
 
 </TabItem>
+<TabItem value="Elixir">
+
+```elixir file=./guides/snippets/work-with-host-filesystem/mount-dir-export/main.exs
+```
+
+</TabItem>
 </Tabs>
 
 [Learn more](./guides/421437-work-with-host-filesystem.md)
@@ -210,6 +252,12 @@ The following code listing adds a remote Git repository branch to a container as
 <TabItem value="Python">
 
 ```python file=./cookbook/snippets/filesystem-operations/add-git-dir/main.py
+```
+
+</TabItem>
+<TabItem value="Elixir">
+
+```elixir file=./cookbook/snippets/filesystem-operations/add-git-dir/main.exs
 ```
 
 </TabItem>
@@ -238,6 +286,12 @@ The following code listing adds a remote Git repository branch as a directory at
 ```
 
 </TabItem>
+<TabItem value="Elixir">
+
+```elixir file=./cookbook/snippets/filesystem-operations/add-git-dir-exclude/main.exs
+```
+
+</TabItem>
 </Tabs>
 
 The following code listing adds a remote Git repository branch as a directory at the `/src` container path, including only `*.md` files.
@@ -261,6 +315,12 @@ The following code listing adds a remote Git repository branch as a directory at
 ```
 
 </TabItem>
+<TabItem value="Elixir">
+
+```elixir file=./cookbook/snippets/filesystem-operations/add-git-dir-include/main.exs
+```
+
+</TabItem>
 </Tabs>
 
 The following code listing adds a remote Git repository branch as a directory at the `/src` container path, including all `*.md` files except `README.md`.
@@ -281,6 +341,12 @@ The following code listing adds a remote Git repository branch as a directory at
 <TabItem value="Python">
 
 ```python file=./cookbook/snippets/filesystem-operations/add-git-dir-exclude-include/main.py
+```
+
+</TabItem>
+<TabItem value="Elixir">
+
+```elixir file=./cookbook/snippets/filesystem-operations/add-git-dir-exclude-include/main.exs
 ```
 
 </TabItem>

--- a/docs/current/cookbook/snippets/filesystem-operations/add-git-dir-exclude-include/main.exs
+++ b/docs/current/cookbook/snippets/filesystem-operations/add-git-dir-exclude-include/main.exs
@@ -1,0 +1,22 @@
+Mix.install([:dagger])
+
+client = Dagger.connect!()
+
+project =
+  client
+  |> Dagger.Client.git("https://github.com/dagger/dagger")
+  |> Dagger.GitRepository.branch("main")
+  |> Dagger.GitRef.tree()
+
+{:ok, contents} =
+  client
+  |> Dagger.Client.container()
+  |> Dagger.Container.from("alpine:latest")
+  |> Dagger.Container.with_directory("/src", project, include: ["*.md"], exclude: ["README.md"])
+  |> Dagger.Container.with_workdir("/src")
+  |> Dagger.Container.with_exec(["ls", "/src"])
+  |> Dagger.Container.stdout()
+
+IO.puts(contents)
+
+Dagger.close(client)

--- a/docs/current/cookbook/snippets/filesystem-operations/add-git-dir-exclude/main.exs
+++ b/docs/current/cookbook/snippets/filesystem-operations/add-git-dir-exclude/main.exs
@@ -1,0 +1,22 @@
+Mix.install([:dagger])
+
+client = Dagger.connect!()
+
+project =
+  client
+  |> Dagger.Client.git("https://github.com/dagger/dagger")
+  |> Dagger.GitRepository.branch("main")
+  |> Dagger.GitRef.tree()
+
+{:ok, contents} =
+  client
+  |> Dagger.Client.container()
+  |> Dagger.Container.from("alpine:latest")
+  |> Dagger.Container.with_directory("/src", project, exclude: ["*.md"])
+  |> Dagger.Container.with_workdir("/src")
+  |> Dagger.Container.with_exec(["ls", "/src"])
+  |> Dagger.Container.stdout()
+
+IO.puts(contents)
+
+Dagger.close(client)

--- a/docs/current/cookbook/snippets/filesystem-operations/add-git-dir-include/main.exs
+++ b/docs/current/cookbook/snippets/filesystem-operations/add-git-dir-include/main.exs
@@ -1,0 +1,22 @@
+Mix.install([:dagger])
+
+client = Dagger.connect!()
+
+project =
+  client
+  |> Dagger.Client.git("https://github.com/dagger/dagger")
+  |> Dagger.GitRepository.branch("main")
+  |> Dagger.GitRef.tree()
+
+{:ok, contents} =
+  client
+  |> Dagger.Client.container()
+  |> Dagger.Container.from("alpine:latest")
+  |> Dagger.Container.with_directory("/src", project, include: ["*.md"])
+  |> Dagger.Container.with_workdir("/src")
+  |> Dagger.Container.with_exec(["ls", "/src"])
+  |> Dagger.Container.stdout()
+
+IO.puts(contents)
+
+Dagger.close(client)

--- a/docs/current/cookbook/snippets/filesystem-operations/add-git-dir/main.exs
+++ b/docs/current/cookbook/snippets/filesystem-operations/add-git-dir/main.exs
@@ -1,0 +1,22 @@
+Mix.install([:dagger])
+
+client = Dagger.connect!()
+
+project =
+  client
+  |> Dagger.Client.git("https://github.com/dagger/dagger")
+  |> Dagger.GitRepository.branch("main")
+  |> Dagger.GitRef.tree()
+
+{:ok, contents} =
+  client
+  |> Dagger.Client.container()
+  |> Dagger.Container.from("alpine:latest")
+  |> Dagger.Container.with_directory("/src", project)
+  |> Dagger.Container.with_workdir("/src")
+  |> Dagger.Container.with_exec(["ls", "/src"])
+  |> Dagger.Container.stdout()
+
+IO.puts(contents)
+
+Dagger.close(client)

--- a/docs/current/guides/snippets/work-with-host-filesystem/list-dir-exclude-include/main.exs
+++ b/docs/current/guides/snippets/work-with-host-filesystem/list-dir-exclude-include/main.exs
@@ -1,0 +1,21 @@
+Mix.install([:dagger])
+
+tmp_dir = System.tmp_dir!()
+target = Path.join([tmp_dir, "out"])
+
+File.mkdir_p!(target)
+File.write!(Path.join([target, "foo.txt"]), "1")
+File.write!(Path.join([target, "bar.txt"]), "2")
+File.write!(Path.join([target, "bar.rar"]), "3")
+
+client = Dagger.connect!(workdir: target)
+
+{:ok, entries} =
+  client
+  |> Dagger.Client.host()
+  |> Dagger.Host.directory(".", include: ["*.*"], exclude: ["*.rar"])
+  |> Dagger.Directory.entries()
+
+IO.inspect(entries)
+
+Dagger.close(client)

--- a/docs/current/guides/snippets/work-with-host-filesystem/list-dir-exclude/main.exs
+++ b/docs/current/guides/snippets/work-with-host-filesystem/list-dir-exclude/main.exs
@@ -1,0 +1,21 @@
+Mix.install([:dagger])
+
+tmp_dir = System.tmp_dir!()
+target = Path.join([tmp_dir, "out"])
+
+File.mkdir_p!(target)
+File.write!(Path.join([target, "foo.txt"]), "1")
+File.write!(Path.join([target, "bar.txt"]), "2")
+File.write!(Path.join([target, "bar.rar"]), "3")
+
+client = Dagger.connect!(workdir: target)
+
+{:ok, entries} =
+  client
+  |> Dagger.Client.host()
+  |> Dagger.Host.directory(".", exclude: ["*.txt"])
+  |> Dagger.Directory.entries()
+
+IO.inspect(entries)
+
+Dagger.close(client)

--- a/docs/current/guides/snippets/work-with-host-filesystem/list-dir-include/main.exs
+++ b/docs/current/guides/snippets/work-with-host-filesystem/list-dir-include/main.exs
@@ -1,0 +1,21 @@
+Mix.install([:dagger])
+
+tmp_dir = System.tmp_dir!()
+target = Path.join([tmp_dir, "out"])
+
+File.mkdir_p!(target)
+File.write!(Path.join([target, "foo.txt"]), "1")
+File.write!(Path.join([target, "bar.txt"]), "2")
+File.write!(Path.join([target, "bar.rar"]), "3")
+
+client = Dagger.connect!(workdir: target)
+
+{:ok, entries} =
+  client
+  |> Dagger.Client.host()
+  |> Dagger.Host.directory(".", include: ["*.rar"])
+  |> Dagger.Directory.entries()
+
+IO.inspect(entries)
+
+Dagger.close(client)

--- a/docs/current/guides/snippets/work-with-host-filesystem/list-dir-parent/main.exs
+++ b/docs/current/guides/snippets/work-with-host-filesystem/list-dir-parent/main.exs
@@ -1,0 +1,13 @@
+Mix.install([:dagger])
+
+client = Dagger.connect!(workdir: "..")
+
+{:ok, entries} =
+  client
+  |> Dagger.Client.host()
+  |> Dagger.Host.directory(".")
+  |> Dagger.Directory.entries()
+
+IO.inspect(entries)
+
+Dagger.close(client)

--- a/docs/current/guides/snippets/work-with-host-filesystem/list-dir/main.exs
+++ b/docs/current/guides/snippets/work-with-host-filesystem/list-dir/main.exs
@@ -1,0 +1,13 @@
+Mix.install([:dagger])
+
+client = Dagger.connect!()
+
+{:ok, entries} =
+  client
+  |> Dagger.Client.host()
+  |> Dagger.Host.directory(".")
+  |> Dagger.Directory.entries()
+
+IO.inspect(entries)
+
+Dagger.close(client)

--- a/docs/current/guides/snippets/work-with-host-filesystem/mount-dir-export/main.exs
+++ b/docs/current/guides/snippets/work-with-host-filesystem/mount-dir-export/main.exs
@@ -1,0 +1,18 @@
+Mix.install([:dagger])
+
+client = Dagger.connect!()
+
+host_dir =
+  client
+  |> Dagger.Client.host()
+  |> Dagger.Host.directory("/tmp/sandbox")
+
+client
+|> Dagger.Client.container()
+|> Dagger.Container.from("alpine:latest")
+|> Dagger.Container.with_directory("/host", host_dir)
+|> Dagger.Container.with_exec(["/bin/sh", "-c", "`echo foo > /host/bar`"])
+|> Dagger.Container.directory("/host")
+|> Dagger.Directory.export("/tmp/sandbox")
+
+Dagger.close(client)

--- a/docs/current/guides/snippets/work-with-host-filesystem/mount-dir/main.exs
+++ b/docs/current/guides/snippets/work-with-host-filesystem/mount-dir/main.exs
@@ -1,0 +1,20 @@
+Mix.install([:dagger])
+
+client = Dagger.connect!()
+
+host_dir =
+  client
+  |> Dagger.Client.host()
+  |> Dagger.Host.directory(".")
+
+{:ok, out} =
+  client
+  |> Dagger.Client.container()
+  |> Dagger.Container.from("alpine:latest")
+  |> Dagger.Container.with_directory("/host", host_dir)
+  |> Dagger.Container.with_exec(["ls", "/host"])
+  |> Dagger.Container.stdout()
+
+IO.puts(out)
+
+Dagger.close(client)

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -19,7 +19,7 @@ async function createConfig() {
       sidebarCollapsed: false,
       metadata: [{ name: 'og:image', content: '/img/favicon.png' }],
       prism: {
-        additionalLanguages: ["php", "rust"],
+        additionalLanguages: ["php", "rust", "elixir"],
         theme: require("prism-react-renderer/themes/okaidia"),
       },
       navbar: {


### PR DESCRIPTION
These changes add Elixir tab and Elixir script file to Cookbook Filesystem
section. All Elixir script files can execute by running `elixir
main.exs` the compiler will install Dagger SDK and execute it
automatically.
