### PR TITLE
fix: calling id for any optional arguments that is ID type

### DIFF
--- a/sdk/elixir/.changes/unreleased/Fixed-20230821-223927.yaml
+++ b/sdk/elixir/.changes/unreleased/Fixed-20230821-223927.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Calling `id/1` before constructing GraphQL argument
+time: 2023-08-21T22:39:27.196719+07:00
+custom:
+  Author: wingyplus
+  PR: "5674"

--- a/sdk/elixir/lib/dagger/gen/client.ex
+++ b/sdk/elixir/lib/dagger/gen/client.ex
@@ -36,7 +36,8 @@ defmodule Dagger.Client do
         if is_nil(optional_args[:id]) do
           selection
         else
-          arg(selection, "id", optional_args[:id])
+          {:ok, id} = Dagger.Container.id(optional_args[:id])
+          arg(selection, "id", id)
         end
 
       selection =
@@ -69,7 +70,8 @@ defmodule Dagger.Client do
         if is_nil(optional_args[:id]) do
           selection
         else
-          arg(selection, "id", optional_args[:id])
+          {:ok, id} = Dagger.Directory.id(optional_args[:id])
+          arg(selection, "id", id)
         end
 
       %Dagger.Directory{selection: selection, client: query.client}
@@ -104,7 +106,8 @@ defmodule Dagger.Client do
         if is_nil(optional_args[:experimental_service_host]) do
           selection
         else
-          arg(selection, "experimentalServiceHost", optional_args[:experimental_service_host])
+          {:ok, id} = Dagger.Container.id(optional_args[:experimental_service_host])
+          arg(selection, "experimentalServiceHost", id)
         end
 
       %Dagger.GitRepository{selection: selection, client: query.client}
@@ -131,7 +134,8 @@ defmodule Dagger.Client do
         if is_nil(optional_args[:experimental_service_host]) do
           selection
         else
-          arg(selection, "experimentalServiceHost", optional_args[:experimental_service_host])
+          {:ok, id} = Dagger.Container.id(optional_args[:experimental_service_host])
+          arg(selection, "experimentalServiceHost", id)
         end
 
       %Dagger.File{selection: selection, client: query.client}
@@ -173,7 +177,8 @@ defmodule Dagger.Client do
         if is_nil(optional_args[:id]) do
           selection
         else
-          arg(selection, "id", optional_args[:id])
+          {:ok, id} = Dagger.Project.id(optional_args[:id])
+          arg(selection, "id", id)
         end
 
       %Dagger.Project{selection: selection, client: query.client}
@@ -190,7 +195,8 @@ defmodule Dagger.Client do
         if is_nil(optional_args[:id]) do
           selection
         else
-          arg(selection, "id", optional_args[:id])
+          {:ok, id} = Dagger.ProjectCommand.id(optional_args[:id])
+          arg(selection, "id", id)
         end
 
       %Dagger.ProjectCommand{selection: selection, client: query.client}
@@ -228,7 +234,8 @@ defmodule Dagger.Client do
         if is_nil(optional_args[:id]) do
           selection
         else
-          arg(selection, "id", optional_args[:id])
+          {:ok, id} = Dagger.Socket.id(optional_args[:id])
+          arg(selection, "id", id)
         end
 
       %Dagger.Socket{selection: selection, client: query.client}

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -42,7 +42,14 @@ defmodule Dagger.Container do
         if is_nil(optional_args[:secrets]) do
           selection
         else
-          arg(selection, "secrets", optional_args[:secrets])
+          ids =
+            optional_args[:secrets]
+            |> Enum.map(fn value ->
+              {:ok, id} = Dagger.Secret.id(value)
+              id
+            end)
+
+          arg(selection, "secrets", ids)
         end
 
       %Dagger.Container{selection: selection, client: container.client}
@@ -137,7 +144,14 @@ defmodule Dagger.Container do
         if is_nil(optional_args[:platform_variants]) do
           selection
         else
-          arg(selection, "platformVariants", optional_args[:platform_variants])
+          ids =
+            optional_args[:platform_variants]
+            |> Enum.map(fn value ->
+              {:ok, id} = Dagger.Container.id(value)
+              id
+            end)
+
+          arg(selection, "platformVariants", ids)
         end
 
       selection =
@@ -318,7 +332,14 @@ defmodule Dagger.Container do
         if is_nil(optional_args[:platform_variants]) do
           selection
         else
-          arg(selection, "platformVariants", optional_args[:platform_variants])
+          ids =
+            optional_args[:platform_variants]
+            |> Enum.map(fn value ->
+              {:ok, id} = Dagger.Container.id(value)
+              id
+            end)
+
+          arg(selection, "platformVariants", ids)
         end
 
       selection =
@@ -618,7 +639,8 @@ defmodule Dagger.Container do
         if is_nil(optional_args[:source]) do
           selection
         else
-          arg(selection, "source", optional_args[:source])
+          {:ok, id} = Dagger.Directory.id(optional_args[:source])
+          arg(selection, "source", id)
         end
 
       selection =

--- a/sdk/elixir/lib/dagger/gen/directory.ex
+++ b/sdk/elixir/lib/dagger/gen/directory.ex
@@ -69,7 +69,14 @@ defmodule Dagger.Directory do
         if is_nil(optional_args[:secrets]) do
           selection
         else
-          arg(selection, "secrets", optional_args[:secrets])
+          ids =
+            optional_args[:secrets]
+            |> Enum.map(fn value ->
+              {:ok, id} = Dagger.Secret.id(value)
+              id
+            end)
+
+          arg(selection, "secrets", ids)
         end
 
       %Dagger.Container{selection: selection, client: directory.client}

--- a/sdk/elixir/lib/dagger/gen/git_ref.ex
+++ b/sdk/elixir/lib/dagger/gen/git_ref.ex
@@ -22,7 +22,8 @@ defmodule Dagger.GitRef do
         if is_nil(optional_args[:ssh_auth_socket]) do
           selection
         else
-          arg(selection, "sshAuthSocket", optional_args[:ssh_auth_socket])
+          {:ok, id} = Dagger.Socket.id(optional_args[:ssh_auth_socket])
+          arg(selection, "sshAuthSocket", id)
         end
 
       %Dagger.Directory{selection: selection, client: git_ref.client}


### PR DESCRIPTION
Some functions, it has optional argument that is ID type. Before this change, if we calling that function, it will crash because that function didn't calling `id/1` to convert into ID string. This change fix that issue by calling `id/1` or iterate calling `id/1` for any function that accept list of ID type, such as, `Dagger.Directory.docker_build/2`.