### PR TITLE
feat: throw error on workdir config on session

### DIFF
--- a/sdk/nodejs/connect.ts
+++ b/sdk/nodejs/connect.ts
@@ -54,6 +54,13 @@ export async function connect(
         "DAGGER_SESSION_TOKEN must be set when using DAGGER_SESSION_PORT"
       )
     }
+
+    if (config.Workdir && config.Workdir !== "") {
+      throw new Error(
+        "cannot configure workdir for existing session (please use --workdir or host.directory with absolute paths instead)"
+      )
+    }
+
     client = new Client({
       host: `127.0.0.1:${daggerSessionPort}`,
       sessionToken: sessionToken,


### PR DESCRIPTION
Same as `Go` SDK, throw an error if workdir is set while an existing session is already running