### PR TITLE
feat: throw error when workdir config on session

### DIFF
--- a/sdk/elixir/.changes/unreleased/Added-20230824-164137.yaml
+++ b/sdk/elixir/.changes/unreleased/Added-20230824-164137.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Throw error when workdir config on session
+time: 2023-08-24T16:41:37.563814+07:00
+custom:
+  Author: wingyplus
+  PR: "5689"

--- a/sdk/elixir/lib/dagger/engine_conn.ex
+++ b/sdk/elixir/lib/dagger/engine_conn.ex
@@ -13,6 +13,9 @@ defmodule Dagger.EngineConn do
       {:ok, conn} ->
         {:ok, conn}
 
+      {:error, :workdir_configure_on_session} = error ->
+        error
+
       _otherwise ->
         case from_local_cli(opts) do
           {:ok, conn} -> {:ok, conn}
@@ -23,14 +26,18 @@ defmodule Dagger.EngineConn do
   end
 
   @doc false
-  def from_session_env(_opts) do
+  def from_session_env(opts) do
     with {:ok, port} <- System.fetch_env("DAGGER_SESSION_PORT"),
-         {:ok, token} <- System.fetch_env("DAGGER_SESSION_TOKEN") do
+         {:ok, token} <- System.fetch_env("DAGGER_SESSION_TOKEN"),
+         false <- Keyword.has_key?(opts, :workdir) do
       {:ok,
        %__MODULE__{
          port: port,
          token: token
        }}
+    else
+      true -> {:error, :workdir_configure_on_session}
+      :error -> {:error, :no_session}
     end
   end
 


### PR DESCRIPTION
Throw `{:error, :work_configure_on_session}` when run on session mode (`dagger run`).