### PR TITLE
docs: Updates some guides to use "dagger run"

### DIFF
--- a/docs/current/guides/110632-embed-directories.md
+++ b/docs/current/guides/110632-embed-directories.md
@@ -33,7 +33,7 @@ The following example demonstrates how to copy an embedded directory:
 Attempt to run the code and print the content of the `/embed` directory:
 
 ```shell
-➜  go run .
+➜  dagger run go run .
 /embed/:
 total 4
 drwxr-xr-x    1 root     root          4096 Oct 31 16:49 example

--- a/docs/current/guides/183109-aws-codebuild-codepipeline.md
+++ b/docs/current/guides/183109-aws-codebuild-codepipeline.md
@@ -28,6 +28,7 @@ This tutorial assumes that:
 - You have a basic understanding of the AWS CodeCommit, AWS CodeBuild and AWS CodePipeline service. If not, learn about [AWS CodeCommit](https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html), [AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/welcome.html) and [AWS CodePipeline](https://docs.aws.amazon.com/codepipeline/latest/userguide/welcome.html).
 - You have a Go, Python or Node.js development environment. If not, install [Go](https://go.dev/doc/install), [Python](https://www.python.org/downloads/) or [Node.js](https://nodejs.org/en/download/).
 - You have Docker installed and running on the host system. If not, [install Docker](https://docs.docker.com/engine/install/).
+- You have the Dagger CLI installed in your development environment. If not, [install the Dagger CLI](../cli/465058-install.md).
 - You have an account with a container registry, such as Docker Hub, and privileges to push images to it. If not, [register for a free Docker Hub account](https://hub.docker.com/signup).
 - You have an AWS account with appropriate privileges to create and manage AWS CodeBuild and AWS CodePipeline resources. If not, [register for an AWS account](https://aws.amazon.com/).
 - You have an AWS CodeCommit repository containing a Node.js Web application. This repository should also be cloned locally in your development environment. If not, follow the steps in Appendix A to [create and populate a local and AWS CodeCommit repository with an example Express application](#appendix-a-create-an-aws-codecommit-repository-with-an-example-express-application).
@@ -209,10 +210,11 @@ AWS CodeBuild relies on a [build specification file](https://docs.aws.amazon.com
   </TabItem>
   </Tabs>
 
-  This build specification defines three steps, as below:
+  This build specification defines four steps, as below:
     - The first step installs the Dagger SDK on the CI runner.
-    - The second step executes the Dagger pipeline.
-    - The third step displays a message with the date and time of build completion.
+    - The second step installs the Dagger CLI on the CI runner.
+    - The third step executes the Dagger pipeline.
+    - The fourth step displays a message with the date and time of build completion.
 
 1. Commit the Dagger pipeline and build specification file to the repository:
 

--- a/docs/current/guides/573829-aws-lambda.md
+++ b/docs/current/guides/573829-aws-lambda.md
@@ -24,6 +24,7 @@ This tutorial assumes that:
 - You have a basic understanding of the AWS Lambda service. If not, learn about [AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/welcome.html).
 - You have a Go, Node.js or Python development environment. If not, install [Go](https://go.dev/doc/install), [Python](https://www.python.org/downloads/) or [Node.js](https://nodejs.org/en/download/).
 - You have Docker installed and running on the host system. If not, [install Docker](https://docs.docker.com/engine/install/).
+- You have the Dagger CLI installed in your development environment. If not, [install the Dagger CLI](../cli/465058-install.md).
 - You have an AWS account with appropriate privileges to create and manage AWS Lambda resources. If not, [register for an AWS account](https://aws.amazon.com/).
 - You have an existing AWS Lambda function with a publicly-accessible URL in Go, Node.js or Python, deployed as a ZIP archive. If not, follow the steps in Appendix A to [create an example AWS Lambda function](#appendix-a-create-an-example-aws-lambda-function).
 
@@ -152,21 +153,21 @@ After modifying the function code, execute the Dagger pipeline:
 <TabItem value="Go">
 
 ```shell
-go run ci/main.go
+dagger run go run ci/main.go
 ```
 
 </TabItem>
 <TabItem value="Node.js">
 
 ```shell
-node ci/index.mjs
+dagger run node ci/index.mjs
 ```
 
 </TabItem>
 <TabItem value="Python">
 
 ```shell
-python ci/main.py
+dagger run python ci/main.py
 ```
 
 </TabItem>

--- a/docs/current/guides/620301-azure-pipelines-container-instances.md
+++ b/docs/current/guides/620301-azure-pipelines-container-instances.md
@@ -286,10 +286,10 @@ This also means that it's very easy to move your Dagger pipeline from your local
   </TabItem>
   </Tabs>
 
-  This Azure Pipeline runs on every commit to the repository `master` branch. It consists of a single job with three steps, as below:
+  This Azure Pipeline runs on every commit to the repository `master` branch. It consists of a single job with four steps, as below:
     - The first step uses a language-specific task to download and install the programing language on the CI runner.
-    - The second step downloads and installs the required dependencies (such as the Dagger SDK and the Azure SDK) on the CI runner.
-    - The third step adds executes the Dagger pipeline. It also explicity adds those variables defined as secret to the CI runner environment (other variables are automatically injected by Azure Pipelines).
+    - The second and third steps download and install the required dependencies (such as the Dagger SDK, the Azure SDK and the Dagger CLI) on the CI runner.
+    - The fourth step adds executes the Dagger pipeline. It also explicity adds those variables defined as secret to the CI runner environment (other variables are automatically injected by Azure Pipelines).
 
   :::tip
   Azure Pipelines automatically transfers pipeline variables to the CI runner environment, except for those marked as secret. Secret variables need to be explicitly defined in the Azure Pipelines configuration file.

--- a/docs/current/guides/620301-azure-pipelines-container-instances.md
+++ b/docs/current/guides/620301-azure-pipelines-container-instances.md
@@ -28,6 +28,7 @@ This tutorial assumes that:
 - You have a basic understanding of the JavaScript programming language.
 - You have a basic understanding of Azure DevOps and Azure Container Instances. If not, learn about [Azure DevOps](https://learn.microsoft.com/en-us/azure/devops) and [Azure Container Instances](https://azure.microsoft.com/en-us/products/container-instances).
 - You have a Go, Python or Node.js development environment. If not, install [Go](https://go.dev/doc/install), [Python](https://www.python.org/downloads/) or [Node.js](https://nodejs.org/en/download/).
+- You have the Dagger CLI installed in your development environment. If not, [install the Dagger CLI](../cli/465058-install.md).
 - You have Docker installed and running on the host system. If not, [install Docker](https://docs.docker.com/engine/install/).
 - You have the Azure CLI installed. If not, [install the Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli).
 - You have a Docker Hub account. If not, [register for a free Docker Hub account](https://hub.docker.com/signup).
@@ -195,21 +196,21 @@ Once credentials are configured, test the Dagger pipeline by running the command
 <TabItem value="Go">
 
 ```shell
-go run ci/main.go
+dagger run go run ci/main.go
 ```
 
 </TabItem>
 <TabItem value="Node.js">
 
 ```shell
-node ci/index.mjs
+dagger run node ci/index.mjs
 ```
 
 </TabItem>
 <TabItem value="Python">
 
 ```shell
-python ci/main.py
+dagger run python ci/main.py
 ```
 
 </TabItem>

--- a/docs/current/guides/620301-azure-pipelines-container-instances.md
+++ b/docs/current/guides/620301-azure-pipelines-container-instances.md
@@ -28,8 +28,8 @@ This tutorial assumes that:
 - You have a basic understanding of the JavaScript programming language.
 - You have a basic understanding of Azure DevOps and Azure Container Instances. If not, learn about [Azure DevOps](https://learn.microsoft.com/en-us/azure/devops) and [Azure Container Instances](https://azure.microsoft.com/en-us/products/container-instances).
 - You have a Go, Python or Node.js development environment. If not, install [Go](https://go.dev/doc/install), [Python](https://www.python.org/downloads/) or [Node.js](https://nodejs.org/en/download/).
-- You have the Dagger CLI installed in your development environment. If not, [install the Dagger CLI](../cli/465058-install.md).
 - You have Docker installed and running on the host system. If not, [install Docker](https://docs.docker.com/engine/install/).
+- You have the Dagger CLI installed in your development environment. If not, [install the Dagger CLI](../cli/465058-install.md).
 - You have the Azure CLI installed. If not, [install the Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli).
 - You have a Docker Hub account. If not, [register for a free Docker Hub account](https://hub.docker.com/signup).
 - You have an Azure subscription with "Owner" (or higher) privileges. If not, [register for an Azure account](https://azure.microsoft.com/en-us/free/).

--- a/docs/current/guides/710884-private-repositories.md
+++ b/docs/current/guides/710884-private-repositories.md
@@ -86,7 +86,7 @@ Now, add the SSH key to the authentication agent on the host and try again:
 ```shell
 ➜ ssh-add
 Identity added: xxxxx
-go run .
+dagger run go run .
 readme #
 ```
 
@@ -96,7 +96,7 @@ readme #
 ```shell
 ➜ ssh-add
 Identity added: xxxxx
-➜ node --loader ts-node/esm clone.ts
+➜ dagger run node --loader ts-node/esm clone.ts
 readme #
 ```
 
@@ -106,7 +106,7 @@ readme #
 ```shell
 ➜ ssh-add
 Identity added: xxxxx
-➜ python clone.py
+➜ dagger run python clone.py
 readme #
 ```
 

--- a/docs/current/guides/882813-build-test-publish-java-spring.md
+++ b/docs/current/guides/882813-build-test-publish-java-spring.md
@@ -223,11 +223,11 @@ This also means that it's very easy to move your Dagger pipeline from your local
   </TabItem>
   </Tabs>
 
-  This workflow runs on every commit to the repository `main` branch. It consists of a single job with five steps, as below:
+  This workflow runs on every commit to the repository `main` branch. It consists of a single job with six steps, as below:
     1. The first step uses the [Checkout action](https://github.com/marketplace/actions/checkout) to check out the latest source code from the `main` branch to the GitHub runner.
     1. The second step uses the [Docker Login action](https://github.com/marketplace/actions/docker-login) to authenticate to Docker Hub from the GitHub runner. This is necessary because [Docker rate-limits unauthenticated registry pulls](https://docs.docker.com/docker-hub/download-rate-limit/).
     1. The third step downloads and installs the required programming language on the GitHub runner.
-    1. The fourth step downloads and installs the Dagger SDK on the GitHub runner.
+    1. The fourth and fifth steps download and install the Dagger SDK and the Dagger CLI on the GitHub runner.
     1. The final step executes the Dagger pipeline.
 
 The Docker Login action and the Dagger pipeline both expect to find Docker Hub credentials in the `DOCKERHUB_USERNAME` and `DOCKERHUB_PASSWORD` variables. Create these variables as GitHub secrets as follows:

--- a/docs/current/guides/snippets/aws-codebuild-codepipeline/buildspec-go.yml
+++ b/docs/current/guides/snippets/aws-codebuild-codepipeline/buildspec-go.yml
@@ -5,11 +5,13 @@ phases:
     commands:
       - echo "Installing Dagger SDK for Go"
       - go get dagger.io/dagger
+      - echo "Installing Dagger CLI"
+      - cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
 
   build:
     commands:
       - echo "Running Dagger pipeline"
-      - go run ci/main.go
+      - dagger run go run ci/main.go
 
   post_build:
     commands:

--- a/docs/current/guides/snippets/aws-codebuild-codepipeline/buildspec-nodejs.yml
+++ b/docs/current/guides/snippets/aws-codebuild-codepipeline/buildspec-nodejs.yml
@@ -5,11 +5,13 @@ phases:
     commands:
       - echo "Installing Dagger SDK for Node.js"
       - npm install @dagger.io/dagger@latest
+      - echo "Installing Dagger CLI"
+      - cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
 
   build:
     commands:
       - echo "Running Dagger pipeline"
-      - node ci/index.mjs
+      - dagger run node ci/index.mjs
 
   post_build:
     commands:

--- a/docs/current/guides/snippets/aws-codebuild-codepipeline/buildspec-python.yml
+++ b/docs/current/guides/snippets/aws-codebuild-codepipeline/buildspec-python.yml
@@ -5,11 +5,13 @@ phases:
     commands:
       - echo "Installing Dagger SDK for Python"
       - pip install dagger-io
+      - echo "Installing Dagger CLI"
+      - cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
 
   build:
     commands:
       - echo "Running Dagger pipeline"
-      - python ci/main.py
+      - dagger run python ci/main.py
 
   post_build:
     commands:

--- a/docs/current/guides/snippets/azure-pipelines-container-instances/azure-pipeline-go.yml
+++ b/docs/current/guides/snippets/azure-pipelines-container-instances/azure-pipeline-go.yml
@@ -18,7 +18,10 @@ steps:
     go get github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerinstance/armcontainerinstance/v2
   displayName: 'Install Dagger Go SDK and related'
 
-- script: go run ci/main.go
+- script: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
+  displayName: 'Install Dagger CLI'
+
+- script: dagger run go run ci/main.go
   displayName: 'Run Dagger'
   env:
     DOCKERHUB_PASSWORD: $(DOCKERHUB_PASSWORD)

--- a/docs/current/guides/snippets/azure-pipelines-container-instances/azure-pipeline-nodejs.yml
+++ b/docs/current/guides/snippets/azure-pipelines-container-instances/azure-pipeline-nodejs.yml
@@ -14,7 +14,10 @@ steps:
 - script: npm install @dagger.io/dagger @azure/arm-containerinstance @azure/identity
   displayName: 'Install Dagger and Azure SDKs'
 
-- script: node ci/index.mjs
+- script: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
+  displayName: 'Install Dagger CLI'
+
+- script: dagger run node ci/index.mjs
   displayName: 'Run Dagger'
   env:
     DOCKERHUB_PASSWORD: $(DOCKERHUB_PASSWORD)

--- a/docs/current/guides/snippets/azure-pipelines-container-instances/azure-pipeline-python.yml
+++ b/docs/current/guides/snippets/azure-pipelines-container-instances/azure-pipeline-python.yml
@@ -14,7 +14,10 @@ steps:
 - script: pip install dagger-io aiohttp azure-identity azure-mgmt-containerinstance
   displayName: 'Install Dagger and Azure SDKs'
 
-- script: python ci/main.py
+- script: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
+  displayName: 'Install Dagger CLI'
+
+- script: dagger run python ci/main.py
   displayName: 'Run Dagger'
   env:
     DOCKERHUB_PASSWORD: $(DOCKERHUB_PASSWORD)

--- a/docs/current/guides/snippets/build-test-publish-java-spring/github-go.yml
+++ b/docs/current/guides/snippets/build-test-publish-java-spring/github-go.yml
@@ -27,8 +27,11 @@ jobs:
         name: Install Dagger
         run: go get dagger.io/dagger@latest
       -
+        name: Install Dagger CLI
+        run: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
+      -
         name:  Build and publish with Dagger
-        run: go run ci/main.go
+        run: dagger run go run ci/main.go
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/docs/current/guides/snippets/build-test-publish-java-spring/github-nodejs.yml
+++ b/docs/current/guides/snippets/build-test-publish-java-spring/github-nodejs.yml
@@ -28,8 +28,11 @@ jobs:
         name: Install Dagger
         run: npm install @dagger.io/dagger@latest
       -
+        name: Install Dagger CLI
+        run: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
+      -
         name: Build and publish with Dagger
-        run: node ci/index.mjs
+        run: dagger run node ci/index.mjs
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/docs/current/guides/snippets/build-test-publish-java-spring/github-python.yml
+++ b/docs/current/guides/snippets/build-test-publish-java-spring/github-python.yml
@@ -27,8 +27,11 @@ jobs:
         name: Install Dagger
         run: pip install dagger-io
       -
+        name: Install Dagger CLI
+        run: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
+      -
         name: Build and publish with Dagger
-        run: python ci/main.py
+        run: dagger run python ci/main.py
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/docs/current/guides/snippets/ci/go/actions.yml
+++ b/docs/current/guides/snippets/ci/go/actions.yml
@@ -13,6 +13,6 @@ jobs:
         with:
           go-version: '1.20'
       - name: Install Dagger CLI
-        run: cd /usr/local && curl -L https://dl.dagger.io/dagger/install.sh | sh
+        run: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
       - name: Run Dagger pipeline
         run: dagger run go run main.go

--- a/docs/current/guides/snippets/ci/go/azure-pipelines.yml
+++ b/docs/current/guides/snippets/ci/go/azure-pipelines.yml
@@ -10,5 +10,8 @@ steps:
   inputs:
     version: '1.20'
 
-- script: go run main.go
+- script: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
+  displayName: 'Install Dagger CLI'
+
+- script: dagger run go run main.go
   displayName: 'Run Dagger'

--- a/docs/current/guides/snippets/ci/go/buildspec.yml
+++ b/docs/current/guides/snippets/ci/go/buildspec.yml
@@ -1,7 +1,12 @@
 version: 0.2
 
 phases:
+  pre_build:
+    commands:
+      - echo "Installing Dagger CLI"
+      - cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
+
   build:
     commands:
       - echo "Running Dagger pipeline"
-      - go run main.go
+      - dagger run go run main.go

--- a/docs/current/guides/snippets/ci/nodejs/actions.yml
+++ b/docs/current/guides/snippets/ci/nodejs/actions.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Install deps
         run: npm ci
       - name: Install Dagger CLI
-        run: cd /usr/local && curl -L https://dl.dagger.io/dagger/install.sh | sh
+        run: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
       - name: Run Dagger pipeline
         run: dagger run node index.mjs

--- a/docs/current/guides/snippets/ci/nodejs/azure-pipelines.yml
+++ b/docs/current/guides/snippets/ci/nodejs/azure-pipelines.yml
@@ -13,5 +13,8 @@ steps:
 - script: npm ci
   displayName: 'Install dependencies'
 
-- script: node index.mjs
+- script: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
+  displayName: 'Install Dagger CLI'
+
+- script: dagger run node index.mjs
   displayName: 'Run Dagger'

--- a/docs/current/guides/snippets/ci/nodejs/buildspec.yml
+++ b/docs/current/guides/snippets/ci/nodejs/buildspec.yml
@@ -11,4 +11,4 @@ phases:
   build:
     commands:
       - echo "Running Dagger pipeline"
-      - node index.mjs
+      - dagger run node index.mjs

--- a/docs/current/guides/snippets/ci/nodejs/buildspec.yml
+++ b/docs/current/guides/snippets/ci/nodejs/buildspec.yml
@@ -5,6 +5,8 @@ phases:
     commands:
       - echo "Installing dependencies"
       - npm ci
+      - echo "Installing Dagger CLI"
+      - cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
 
   build:
     commands:

--- a/docs/current/guides/snippets/ci/python/actions.yml
+++ b/docs/current/guides/snippets/ci/python/actions.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Install deps
         run: pip install .
       - name: Install Dagger CLI
-        run: cd /usr/local && curl -L https://dl.dagger.io/dagger/install.sh | sh
+        run: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
       - name: Run Dagger pipeline
         run: dagger run python main.py

--- a/docs/current/guides/snippets/ci/python/azure-pipelines.yml
+++ b/docs/current/guides/snippets/ci/python/azure-pipelines.yml
@@ -13,5 +13,8 @@ steps:
 - script: pip install .
   displayName: 'Install dependencies'
 
-- script: python main.py
+- script: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
+  displayName: 'Install Dagger CLI'
+
+- script: dagger run python main.py
   displayName: 'Run Dagger'

--- a/docs/current/guides/snippets/ci/python/buildspec.yml
+++ b/docs/current/guides/snippets/ci/python/buildspec.yml
@@ -5,6 +5,8 @@ phases:
     commands:
       - echo "Installing dependencies"
       - pip install .
+      - echo "Installing Dagger CLI"
+      - cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
 
   build:
     commands:

--- a/docs/current/guides/snippets/ci/python/buildspec.yml
+++ b/docs/current/guides/snippets/ci/python/buildspec.yml
@@ -11,4 +11,4 @@ phases:
   build:
     commands:
       - echo "Running Dagger pipeline"
-      - python main.py
+      - dagger run python main.py

--- a/docs/current/guides/snippets/github-google-cloud/github-go.yml
+++ b/docs/current/guides/snippets/github-google-cloud/github-go.yml
@@ -36,7 +36,7 @@ jobs:
         run: go get dagger.io/dagger@latest cloud.google.com/go/run/apiv2
       -
         name: Install Dagger CLI
-        run: cd /usr/local && curl -L https://dl.dagger.io/dagger/install.sh | sh
+        run: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
       -
         name: Release and deploy with Dagger
         run: dagger run go run ci/main.go

--- a/docs/current/guides/snippets/github-google-cloud/github-nodejs.yml
+++ b/docs/current/guides/snippets/github-google-cloud/github-nodejs.yml
@@ -37,7 +37,7 @@ jobs:
         run: npm install
       -
         name: Install Dagger CLI
-        run: cd /usr/local && curl -L https://dl.dagger.io/dagger/install.sh | sh
+        run: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
       -
         name: Release and deploy with Dagger
         run: dagger run node ci/index.mjs

--- a/docs/current/guides/snippets/github-google-cloud/github-python.yml
+++ b/docs/current/guides/snippets/github-google-cloud/github-python.yml
@@ -36,7 +36,7 @@ jobs:
         run: pip install dagger-io google-cloud-run
       -
         name: Install Dagger CLI
-        run: cd /usr/local && curl -L https://dl.dagger.io/dagger/install.sh | sh
+        run: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
       -
         name: Release and deploy with Dagger
         run: dagger run python ci/main.py


### PR DESCRIPTION
This commit updates various Dagger long-form guides to use "dagger run".

Additional PRs should be expected for other sections of the docs.

Follow-up to:

https://github.com/dagger/dagger/pull/5591
https://github.com/dagger/dagger/pull/5604
https://github.com/dagger/dagger/pull/5637