### PR TITLE
docs: Adds "dagger run" to quickstart

### DIFF
--- a/docs/current/quickstart/349011-build.mdx
+++ b/docs/current/quickstart/349011-build.mdx
@@ -42,7 +42,7 @@ The `npm run build` command is appropriate for a React application, but other ap
 Run the pipeline by executing the command below from the application directory:
 
 ```shell
-go run ci/main.go
+dagger run go run ci/main.go
 ```
 
 </TabItem>
@@ -59,7 +59,7 @@ This revised pipeline does everything described in the previous step, and then p
 Run the pipeline by executing the command below from the application directory:
 
 ```shell
-node ci/index.mjs
+dagger run node ci/index.mjs
 ```
 
 </TabItem>
@@ -76,7 +76,7 @@ This revised pipeline does everything described in the previous step, and then p
 Run the pipeline by executing the command below from the application directory:
 
 ```shell
-python ci/main.py
+dagger run python ci/main.py
 ```
 
 </TabItem>

--- a/docs/current/quickstart/429462-build-dockerfile.mdx
+++ b/docs/current/quickstart/429462-build-dockerfile.mdx
@@ -45,7 +45,7 @@ This code listing does the following:
 Run the pipeline by executing the command below from the application directory:
 
 ```shell
-go run ci/main.go
+dagger run go run ci/main.go
 ```
 
 </TabItem>
@@ -63,7 +63,7 @@ This code listing does the following:
 Run the pipeline by executing the command below from the application directory:
 
 ```shell
-node ci/index.mjs
+dagger run node ci/index.mjs
 ```
 
 </TabItem>
@@ -81,7 +81,7 @@ This code listing does the following:
 Run the pipeline by executing the command below from the application directory:
 
 ```shell
-python ci/main.py
+dagger run python ci/main.py
 ```
 
 </TabItem>

--- a/docs/current/quickstart/472910-build-multi.mdx
+++ b/docs/current/quickstart/472910-build-multi.mdx
@@ -44,7 +44,7 @@ Let's now update our pipeline to use a multi-stage build, as described above.
 Run the pipeline by executing the command below from the application directory:
 
 ```shell
-go run ci/main.go
+dagger run go run ci/main.go
 ```
 
 </TabItem>
@@ -55,7 +55,7 @@ go run ci/main.go
 Run the pipeline by executing the command below from the application directory:
 
 ```shell
-node ci/index.mjs
+dagger run node ci/index.mjs
 ```
 
 </TabItem>
@@ -66,7 +66,7 @@ node ci/index.mjs
 Run the pipeline by executing the command below from the application directory:
 
 ```shell
-python ci/main.py
+dagger run python ci/main.py
 ```
 
 </TabItem>

--- a/docs/current/quickstart/593914-hello.mdx
+++ b/docs/current/quickstart/593914-hello.mdx
@@ -43,10 +43,10 @@ This Go program imports the Dagger SDK and defines a `main()` function for the p
 Run the pipeline by executing the command below from the application directory:
 
 ```shell
-go run ci/main.go
+dagger run go run ci/main.go
 ```
 
-Dagger resolves the pipeline and outputs a string similar to the one below.
+Dagger performs the operations defined in the pipeline script, logging each operation to the console. Once the pipeline is resolved, it outputs a string similar to the one below.
 
 ```shell
 Hello from Dagger and go version go1.19.5 linux/amd64
@@ -69,10 +69,10 @@ This Node.js script imports the Dagger SDK and defines an asynchronous function.
 Run the pipeline by executing the command below from the application directory:
 
 ```shell
-node ci/index.mjs
+dagger run node ci/index.mjs
 ```
 
-Dagger resolves the pipeline and outputs a string similar to the one below.
+Dagger performs the operations defined in the pipeline script, logging each operation to the console. Once the pipeline is resolved, it outputs a string similar to the one below.
 
 ```shell
 Hello from Dagger and Node v16.18.1
@@ -95,10 +95,10 @@ This Python script imports the Dagger SDK and defines an asynchronous function. 
 Run the pipeline by executing the command below from the application directory:
 
 ```shell
-python ci/main.py
+dagger run python ci/main.py
 ```
 
-Dagger resolves the pipeline and outputs a string similar to the one below.
+Dagger performs the operations defined in the pipeline script, logging each operation to the console. Once the pipeline is resolved, it outputs a string similar to the one below.
 
 ```shell
 Hello from Dagger and Python v3.11.1

--- a/docs/current/quickstart/635927-caching.mdx
+++ b/docs/current/quickstart/635927-caching.mdx
@@ -46,7 +46,7 @@ This revised pipeline now uses a cache for the application dependencies.
 Run the pipeline by executing the command below from the application directory:
 
 ```shell
-go run ci/main.go
+dagger run go run ci/main.go
 ```
 
 </TabItem>
@@ -63,7 +63,7 @@ This revised pipeline now uses a cache for the application dependencies.
 Run the pipeline by executing the command below from the application directory:
 
 ```shell
-node ci/index.mjs
+dagger run node ci/index.mjs
 ```
 
 </TabItem>
@@ -80,7 +80,7 @@ This revised pipeline now uses a cache for the application dependencies.
 Run the pipeline by executing the command below from the application directory:
 
 ```shell
-python ci/main.py
+dagger run python ci/main.py
 ```
 
 </TabItem>

--- a/docs/current/quickstart/730264-publish.mdx
+++ b/docs/current/quickstart/730264-publish.mdx
@@ -34,7 +34,7 @@ Dagger SDKs have built-in support to publish container images. So, let's update 
 Run the pipeline by executing the command below from the application directory:
 
 ```shell
-go run ci/main.go
+dagger run go run ci/main.go
 ```
 
 </TabItem>
@@ -45,7 +45,7 @@ go run ci/main.go
 Run the pipeline by executing the command below from the application directory:
 
 ```shell
-node ci/index.mjs
+dagger run node ci/index.mjs
 ```
 
 </TabItem>
@@ -56,7 +56,7 @@ node ci/index.mjs
 Run the pipeline by executing the command below from the application directory:
 
 ```shell
-python ci/main.py
+dagger run python ci/main.py
 ```
 
 </TabItem>

--- a/docs/current/quickstart/947391-test.mdx
+++ b/docs/current/quickstart/947391-test.mdx
@@ -30,7 +30,6 @@ The code listing below demonstrates a Dagger pipeline that runs tests for the ex
 The `npm run test` command is appropriate for a React application, but other applications are likely to use different commands. Modify your Dagger pipeline accordingly.
 :::
 
-
 <Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
@@ -49,7 +48,7 @@ This code listing does the following:
 Run the pipeline by executing the command below from the application directory:
 
 ```shell
-go run ci/main.go
+dagger run go run ci/main.go
 ```
 
 :::tip
@@ -74,7 +73,7 @@ This code listing does the following:
 Run the pipeline by executing the command below from the application directory:
 
 ```shell
-node ci/index.mjs
+dagger run node ci/index.mjs
 ```
 
 :::tip
@@ -99,7 +98,7 @@ This code listing does the following:
 Run the pipeline by executing the command below from the application directory:
 
 ```shell
-python ci/main.py
+dagger run python ci/main.py
 ```
 
 :::tip


### PR DESCRIPTION
This commit updates the Dagger quickstart to use "dagger run".

Additional PRs should be expected for other sections of the docs.

Follow-up to:

https://github.com/dagger/dagger/pull/5591
https://github.com/dagger/dagger/pull/5604
https://github.com/dagger/dagger/pull/5637
https://github.com/dagger/dagger/pull/5701