### PR TITLE
docs: Adds "dagger run" to Jenkins/Circle samples

### DIFF
--- a/docs/current/guides/snippets/ci/go/Jenkinsfile
+++ b/docs/current/guides/snippets/ci/go/Jenkinsfile
@@ -5,7 +5,8 @@ pipeline {
     stage("dagger") {
       steps {
         sh '''
-            go run main.go
+            cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
+            dagger run go run main.go
         '''
       }
     }

--- a/docs/current/guides/snippets/ci/go/circle.yml
+++ b/docs/current/guides/snippets/ci/go/circle.yml
@@ -12,7 +12,7 @@ jobs:
           command: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sudo sh; cd -; }
       - run:
           name: Run Dagger pipeline
-          command: dagger run go run main.go
+          command: dagger run --progress plain go run main.go
 workflows:
   dagger:
     jobs:

--- a/docs/current/guides/snippets/ci/go/circle.yml
+++ b/docs/current/guides/snippets/ci/go/circle.yml
@@ -8,8 +8,11 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          name: Dagger Pipeline
-          command: go run main.go
+          name: Install Dagger CLI
+          command: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
+      - run:
+          name: Run Dagger pipeline
+          command: dagger run go run main.go
 workflows:
   dagger:
     jobs:

--- a/docs/current/guides/snippets/ci/go/circle.yml
+++ b/docs/current/guides/snippets/ci/go/circle.yml
@@ -9,7 +9,7 @@ jobs:
           docker_layer_caching: true
       - run:
           name: Install Dagger CLI
-          command: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
+          command: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sudo sh; cd -; }
       - run:
           name: Run Dagger pipeline
           command: dagger run go run main.go

--- a/docs/current/guides/snippets/ci/nodejs/Jenkinsfile
+++ b/docs/current/guides/snippets/ci/nodejs/Jenkinsfile
@@ -6,7 +6,8 @@ pipeline {
       steps {
         sh '''
             npm ci
-            node index.mjs
+            cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
+            dagger run node index.mjs
         '''
       }
     }

--- a/docs/current/guides/snippets/ci/nodejs/circle.yml
+++ b/docs/current/guides/snippets/ci/nodejs/circle.yml
@@ -11,8 +11,11 @@ jobs:
           name: Install deps
           command: npm ci
       - run:
-          name: Dagger Pipeline
-          command: node index.mjs
+          name: Install Dagger CLI
+          command: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
+      - run:
+          name: Run Dagger pipeline
+          command: dagger run node index.mjs
 workflows:
   dagger:
     jobs:

--- a/docs/current/guides/snippets/ci/nodejs/circle.yml
+++ b/docs/current/guides/snippets/ci/nodejs/circle.yml
@@ -15,7 +15,7 @@ jobs:
           command: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sudo sh; cd -; }
       - run:
           name: Run Dagger pipeline
-          command: dagger run node index.mjs
+          command: dagger run --progress plain node index.mjs
 workflows:
   dagger:
     jobs:

--- a/docs/current/guides/snippets/ci/nodejs/circle.yml
+++ b/docs/current/guides/snippets/ci/nodejs/circle.yml
@@ -12,7 +12,7 @@ jobs:
           command: npm ci
       - run:
           name: Install Dagger CLI
-          command: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
+          command: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sudo sh; cd -; }
       - run:
           name: Run Dagger pipeline
           command: dagger run node index.mjs

--- a/docs/current/guides/snippets/ci/python/Jenkinsfile
+++ b/docs/current/guides/snippets/ci/python/Jenkinsfile
@@ -6,7 +6,8 @@ pipeline {
       steps {
         sh '''
             pip install .
-            python main.py
+            cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
+            dagger run python main.py
         '''
       }
     }

--- a/docs/current/guides/snippets/ci/python/circle.yml
+++ b/docs/current/guides/snippets/ci/python/circle.yml
@@ -11,8 +11,11 @@ jobs:
           name: Install deps
           command: pip install .
       - run:
-          name: Dagger Pipeline
-          command: python main.py
+          name: Install Dagger CLI
+          command: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
+      - run:
+          name: Run Dagger pipeline
+          command: dagger run python main.py
 workflows:
   dagger:
     jobs:

--- a/docs/current/guides/snippets/ci/python/circle.yml
+++ b/docs/current/guides/snippets/ci/python/circle.yml
@@ -12,7 +12,7 @@ jobs:
           command: pip install .
       - run:
           name: Install Dagger CLI
-          command: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sh; cd -; }
+          command: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sudo sh; cd -; }
       - run:
           name: Run Dagger pipeline
           command: dagger run python main.py

--- a/docs/current/guides/snippets/ci/python/circle.yml
+++ b/docs/current/guides/snippets/ci/python/circle.yml
@@ -15,7 +15,7 @@ jobs:
           command: cd /usr/local && { curl -L https://dl.dagger.io/dagger/install.sh | sudo sh; cd -; }
       - run:
           name: Run Dagger pipeline
-          command: dagger run python main.py
+          command: dagger run --progress plain python main.py
 workflows:
   dagger:
     jobs:


### PR DESCRIPTION
This commit updates the Jenkins and CircleCI samples in the "Use Dagger with CI" guide to use "dagger run".

Additional PRs should be expected for other sections of the docs.

Follow-up to:

https://github.com/dagger/dagger/pull/5591
https://github.com/dagger/dagger/pull/5604
https://github.com/dagger/dagger/pull/5637
https://github.com/dagger/dagger/pull/5701
https://github.com/dagger/dagger/pull/5702