### PR TITLE
sdk: python: add workdir check when session already exists

### DIFF
--- a/sdk/python/src/dagger/_engine/conn.py
+++ b/sdk/python/src/dagger/_engine/conn.py
@@ -31,6 +31,13 @@ class Engine(SyncResourceManager):
             msg = "DAGGER_SESSION_TOKEN must be set when using DAGGER_SESSION_PORT"
             raise dagger.ProvisionError(msg)
         try:
+            if self.cfg.workdir != "":
+                msg = (
+                    "cannot configure workdir for existing session "
+                    "(please use - -workdir or host.directory "
+                    "with absolute paths instead)"
+                )
+                raise dagger.ProvisionError(msg)
             return ConnectParams(port=int(port), session_token=token)
         except ValueError as e:
             # only port is validated

--- a/sdk/python/src/dagger/_engine/conn.py
+++ b/sdk/python/src/dagger/_engine/conn.py
@@ -34,7 +34,7 @@ class Engine(SyncResourceManager):
             if self.cfg.workdir != "":
                 msg = (
                     "cannot configure workdir for existing session "
-                    "(please use - -workdir or host.directory "
+                    "(please use --workdir or host.directory "
                     "with absolute paths instead)"
                 )
                 raise dagger.ProvisionError(msg)


### PR DESCRIPTION
this is a follow up of the Go SDK check made by @vito here: https://github.com/dagger/dagger/pull/5126

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
