### PR TITLE
docs: Adds note and information on cache types and invalidations

### DIFF
--- a/docs/current/cookbook.md
+++ b/docs/current/cookbook.md
@@ -532,14 +532,14 @@ The following code listing creates a temporary MariaDB database service and bind
 
 ### Invalidate cache
 
-The following code listing demonstrates how to invalidate the Dagger cache and thereby force execution of subsequent pipeline steps, by introducing a volatile time variable at a specific point in the Dagger pipeline.
+The following code listing demonstrates how to invalidate the Dagger pipeline operations cache and thereby force execution of subsequent pipeline steps, by introducing a volatile time variable at a specific point in the Dagger pipeline.
 
 :::note
 This is a temporary workaround until cache invalidation support is officially added to Dagger.
 :::
 
 :::note
-Changes in mounted volumes do not invalidate the Dagger cache.
+Changes in mounted cache volumes do not invalidate the Dagger pipeline operations cache.
 :::
 
 <Tabs groupId="language">

--- a/docs/current/cookbook.md
+++ b/docs/current/cookbook.md
@@ -538,6 +538,10 @@ The following code listing demonstrates how to invalidate the Dagger cache and t
 This is a temporary workaround until cache invalidation support is officially added to Dagger.
 :::
 
+:::note
+Changes in mounted volumes do not invalidate the Dagger cache.
+:::
+
 <Tabs groupId="language">
 <TabItem value="Go">
 

--- a/docs/current/guides/421437-work-with-host-filesystem.md
+++ b/docs/current/guides/421437-work-with-host-filesystem.md
@@ -243,7 +243,7 @@ The following example shows how to mount a host directory in a container at the 
 
 Using the host filesystem in your Dagger pipeline is convenient, but there are some important considerations to keep in mind:
 
-- If a file loaded from the host changes even slightly (including minor changes such as a timestamp change with the file contents left unmodified), then the Dagger cache will be invalidated. An extremely common source of invalidations occurs when loading the `.git` directory from the host filesystem, as that directory will change frequently, including when there have been no actual changes to any source code.
+- With the exception of mounted cache volumes, if a file or directory mounted from the host changes even slightly (including minor changes such as a timestamp change with the file contents left unmodified), then the Dagger pipeline operations cache will be invalidated. An extremely common source of invalidations occurs when loading the `.git` directory from the host filesystem, as that directory will change frequently, including when there have been no actual changes to any source code.
 
   :::tip
   To maximize cache re-use, it's important to use the include/exclude options for local directories to only include the files/directories needed for the pipeline. Excluding the `.git` directory is highly advisable unless there's a strong need to be able to perform Git operations on top of the loaded directory inside Dagger.

--- a/docs/current/quickstart/635927-caching.mdx
+++ b/docs/current/quickstart/635927-caching.mdx
@@ -22,11 +22,11 @@ export const ids = {
 
 ## Use caching
 
-One of Dagger's most powerful features is its ability to cache data across pipeline runs. Dagger lets you define one or more directories as cache volume and persists their contents across runs. This enables you to reuse the contents of the cache every time the pipeline runs, and thereby speed up pipeline operations.
+One of Dagger's most powerful features is its ability to cache data across pipeline runs. Dagger lets you define one or more directories as cache volumes and persists their contents across runs. This enables you to reuse the contents of the cache volume(s) every time the pipeline runs, and thereby speed up pipeline operations.
 
 You may have noticed that the example pipeline executes the `npm install` command to download the application's dependencies every time the pipeline runs. Since these dependencies are usually locked to specific versions in the application's manifest, re-downloading them on every pipeline run is inefficient and time-consuming.
 
-This step is, therefore, a good candidate for a cache. Let's update the pipeline accordingly.
+This step is, therefore, a good candidate for a cache volume. Let's update the pipeline accordingly.
 
 :::tip
 The `npm install` command is appropriate for a React application, but other applications are likely to use different commands. Modify your Dagger pipeline accordingly.
@@ -37,7 +37,7 @@ The `npm install` command is appropriate for a React application, but other appl
 
 <Embed id="64jT5CYA_2W" />
 
-This revised pipeline now uses a cache for the application dependencies.
+This revised pipeline now uses a cache volume for the application dependencies.
 
 - It uses the client's `CacheVolume()` method to initialize a new cache volume.
 - It uses the `Container.WithMountedCache()` method to mount this cache volume at the `node_modules/` mount point in the container.
@@ -54,7 +54,7 @@ go run ci/main.go
 
 <Embed id="XRfLHVA3Li8" />
 
-This revised pipeline now uses a cache for the application dependencies.
+This revised pipeline now uses a cache volume for the application dependencies.
 
 - It uses the client's `cacheVolume()` method to initialize a new cache volume.
 - It uses the `Container.withMountedCache()` method to mount this cache volume at the `node_modules/` mount point in the container.
@@ -71,7 +71,7 @@ node ci/index.mjs
 
 <Embed id="sNZQEeULT-M" />
 
-This revised pipeline now uses a cache for the application dependencies.
+This revised pipeline now uses a cache volume for the application dependencies.
 
 - It uses the client's `cache_volume()` method to initialize a new cache volume.
 - It uses the `Container.with_mounted_cache()` method to mount this cache volume at the `node_modules/` mount point in the container.
@@ -89,5 +89,9 @@ python ci/main.py
 This revised pipeline produces the same result as before.
 
 Run the pipeline a few times. Notice that on the first run, the application dependencies are downloaded as usual. However, since the dependencies are cached, subsequent pipeline runs will skip the download operation and be significantly faster (assuming that there are no other changes to the application code).
+
+:::note
+In addition to cache volumes, Dagger has a separate cache for pipeline operations. Changes in cache volumes do not invalidate the Dagger pipeline operations cache.
+:::
 
 </QuickstartDoc>


### PR DESCRIPTION
This commit introduces the term "Dagger pipeline operations cache" and distinguishes it from "Dagger cache volume". It also adds a note regarding invalidation of cache volumes or lack thereof. It is based on the discussion in Discord at https://discord.com/channels/707636530424053791/1143131629540364339/1143591546340520047