### PR TITLE
chore: update release guide to remove rust.

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -186,11 +186,6 @@ cd ../elixir
 changie new --kind "Dependencies" --body "Bump Engine to $ENGINE_VERSION" --custom "Author=github-actions" --custom "PR=5657"
 changie batch patch
 changie merge
-
-cd ../rust
-changie new --kind "Dependencies" --body "Bump Engine to $ENGINE_VERSION" --custom "Author=github-actions" --custom "PR=5657"
-changie batch patch
-changie merge
 ```
 
 - [ ] Commit and push the changes


### PR DESCRIPTION
As discussed in #5676, Rust will not be part of the SDK release process and will have its own pipeline. By extension, we shall not mention rust in  `RELEASING.md` steps