### PR TITLE
core: support multiple cache configs for upstream remote cache

### DIFF
--- a/core/integration/remotecache_test.go
+++ b/core/integration/remotecache_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-func getDevEngineForRemoteCache(ctx context.Context, c *dagger.Client, cache *dagger.Service, cacheName, cacheEnv string, index uint8) (*dagger.Service, string, error) {
+func getDevEngineForRemoteCache(ctx context.Context, c *dagger.Client, cache *dagger.Service, cacheName string, index uint8) (devEngineSvc *dagger.Service, endpoint string, err error) {
 	id := identity.NewID()
 	networkCIDR := fmt.Sprintf("10.%d.0.0/16", 100+index)
-	devEngineSvc := devEngineContainer(c).
+	devEngineSvc = devEngineContainer(c).
 		WithServiceBinding(cacheName, cache).
 		WithExposedPort(1234, dagger.ContainerWithExposedPortOpts{Protocol: dagger.Tcp}).
 		WithEnvVariable("ENGINE_ID", id).
@@ -28,7 +28,7 @@ func getDevEngineForRemoteCache(ctx context.Context, c *dagger.Client, cache *da
 		}).
 		AsService()
 
-	endpoint, err := devEngineSvc.Endpoint(ctx, dagger.ServiceEndpointOpts{
+	endpoint, err = devEngineSvc.Endpoint(ctx, dagger.ServiceEndpointOpts{
 		Port:   1234,
 		Scheme: "tcp",
 	})
@@ -46,7 +46,7 @@ func TestRemoteCacheRegistry(t *testing.T) {
 
 	cacheEnv := "type=registry,ref=registry:5000/test-cache,mode=max"
 
-	devEngineA, endpointA, err := getDevEngineForRemoteCache(ctx, c, registry, "registry", cacheEnv, 0)
+	devEngineA, endpointA, err := getDevEngineForRemoteCache(ctx, c, registry, "registry", 0)
 	require.NoError(t, err)
 
 	// This loads the dagger-cli binary from the host into the container, that was set up by
@@ -79,7 +79,7 @@ func TestRemoteCacheRegistry(t *testing.T) {
 	shaA := strings.TrimSpace(gjson.Get(outputA, "container.from.withExec.stdout").String())
 	require.NotEmpty(t, shaA, "shaA is empty")
 
-	devEngineB, endpointB, err := getDevEngineForRemoteCache(ctx, c, registry, "registry", cacheEnv, 1)
+	devEngineB, endpointB, err := getDevEngineForRemoteCache(ctx, c, registry, "registry", 1)
 	require.NoError(t, err)
 
 	outputB, err := c.Container().From(alpineImage).
@@ -129,7 +129,7 @@ func TestRemoteCacheLazyBlobs(t *testing.T) {
 
 	cacheEnv := "type=registry,ref=registry:5000/test-cache,mode=max"
 
-	devEngineA, endpointA, err := getDevEngineForRemoteCache(ctx, c, registry, "registry", cacheEnv, 10)
+	devEngineA, endpointA, err := getDevEngineForRemoteCache(ctx, c, registry, "registry", 10)
 	require.NoError(t, err)
 
 	daggerCli := daggerCliFile(t, c)
@@ -157,7 +157,7 @@ func TestRemoteCacheLazyBlobs(t *testing.T) {
 		}).Stdout(ctx)
 	require.NoErrorf(t, err, "outputA: %s", outputA)
 
-	devEngineB, endpointB, err := getDevEngineForRemoteCache(ctx, c, registry, "registry", cacheEnv, 11)
+	devEngineB, endpointB, err := getDevEngineForRemoteCache(ctx, c, registry, "registry", 11)
 	require.NoError(t, err)
 
 	outputB, err := c.Container().From(alpineImage).
@@ -207,7 +207,7 @@ func TestRemoteCacheS3(t *testing.T) {
 
 		s3Env := "type=s3,mode=max,endpoint_url=" + s3Endpoint + ",access_key_id=minioadmin,secret_access_key=minioadmin,region=mars,use_path_style=true,bucket=" + bucket
 
-		devEngineA, endpointA, err := getDevEngineForRemoteCache(ctx, c, s3, "s3", s3Env, 0)
+		devEngineA, endpointA, err := getDevEngineForRemoteCache(ctx, c, s3, "s3", 0)
 		require.NoError(t, err)
 
 		cliBinPath := "/.dagger-cli"
@@ -239,7 +239,7 @@ func TestRemoteCacheS3(t *testing.T) {
 		shaA := strings.TrimSpace(gjson.Get(outputA, "container.from.withExec.stdout").String())
 		require.NotEmpty(t, shaA, "shaA is empty")
 
-		devEngineB, endpointB, err := getDevEngineForRemoteCache(ctx, c, s3, "s3", s3Env, 1)
+		devEngineB, endpointB, err := getDevEngineForRemoteCache(ctx, c, s3, "s3", 1)
 		require.NoError(t, err)
 
 		outputB, err := c.Container().From(alpineImage).
@@ -268,4 +268,109 @@ func TestRemoteCacheS3(t *testing.T) {
 
 		require.Equal(t, shaA, shaB)
 	})
+}
+
+func TestRemoteCacheRegistryMultipleConfigs(t *testing.T) {
+	c, ctx := connect(t)
+	defer c.Close()
+
+	registry := c.Pipeline("registry").Container().From("registry:2").
+		WithMountedCache("/var/lib/registry/", c.CacheVolume("remote-cache-registry-"+identity.NewID())).
+		WithExposedPort(5000, dagger.ContainerWithExposedPortOpts{Protocol: dagger.Tcp}).
+		AsService()
+
+	cacheConfigEnv1 := "type=registry,ref=registry:5000/test-cache:latest,mode=max"
+	cacheConfigEnv2 := "type=registry,ref=registry:5000/test-cache-b:latest,mode=max"
+	cacheEnv := strings.Join([]string{cacheConfigEnv1, cacheConfigEnv2}, ";")
+
+	devEngineA, endpointA, err := getDevEngineForRemoteCache(ctx, c, registry, "registry", 20)
+	require.NoError(t, err)
+
+	// This loads the dagger-cli binary from the host into the container, that was set up by
+	// internal/mage/engine.go:test. This is used to communicate with the dev engine.
+	daggerCli := daggerCliFile(t, c)
+
+	cliBinPath := "/.dagger-cli"
+
+	outputA, err := c.Container().From(alpineImage).
+		WithServiceBinding("dev-engine", devEngineA).
+		WithMountedFile(cliBinPath, daggerCli).
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpointA).
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_CACHE_CONFIG", cacheEnv).
+		WithNewFile("/.dagger-query.txt", dagger.ContainerWithNewFileOpts{
+			Contents: `{
+ 				container {
+ 					from(address: "` + alpineImage + `") {
+ 						withExec(args: ["sh", "-c", "head -c 128 /dev/random | sha256sum"]) {
+ 							stdout
+ 						}
+ 					}
+ 				}
+ 			}`,
+		}).
+		WithExec([]string{
+			"sh", "-c", cliBinPath + ` query --doc .dagger-query.txt`,
+		}).Stdout(ctx)
+	require.NoError(t, err)
+	shaA := strings.TrimSpace(gjson.Get(outputA, "container.from.withExec.stdout").String())
+	require.NotEmpty(t, shaA, "shaA is empty")
+
+	devEngineB, endpointB, err := getDevEngineForRemoteCache(ctx, c, registry, "registry", 21)
+	require.NoError(t, err)
+
+	outputB, err := c.Container().From(alpineImage).
+		WithServiceBinding("dev-engine", devEngineB).
+		WithMountedFile(cliBinPath, daggerCli).
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpointB).
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_CACHE_CONFIG", cacheConfigEnv1).
+		WithNewFile("/.dagger-query.txt", dagger.ContainerWithNewFileOpts{
+			Contents: `{
+ 				container {
+ 					from(address: "` + alpineImage + `") {
+ 						withExec(args: ["sh", "-c", "head -c 128 /dev/random | sha256sum"]) {
+ 							stdout
+ 						}
+ 					}
+ 				}
+ 			}`,
+		}).
+		WithExec([]string{
+			"sh", "-c", cliBinPath + " query --doc .dagger-query.txt",
+		}).Stdout(ctx)
+	require.NoError(t, err)
+	shaB := strings.TrimSpace(gjson.Get(outputB, "container.from.withExec.stdout").String())
+	require.NotEmpty(t, shaB, "shaB is empty")
+
+	require.Equal(t, shaA, shaB)
+
+	devEngineC, endpointC, err := getDevEngineForRemoteCache(ctx, c, registry, "registry", 22)
+	require.NoError(t, err)
+
+	outputC, err := c.Container().From(alpineImage).
+		WithServiceBinding("dev-engine", devEngineC).
+		WithMountedFile(cliBinPath, daggerCli).
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpointC).
+		WithEnvVariable("_EXPERIMENTAL_DAGGER_CACHE_CONFIG", cacheConfigEnv2).
+		WithNewFile("/.dagger-query.txt", dagger.ContainerWithNewFileOpts{
+			Contents: `{
+ 				container {
+ 					from(address: "` + alpineImage + `") {
+ 						withExec(args: ["sh", "-c", "head -c 128 /dev/random | sha256sum"]) {
+ 							stdout
+ 						}
+ 					}
+ 				}
+ 			}`,
+		}).
+		WithExec([]string{
+			"sh", "-c", cliBinPath + " query --doc .dagger-query.txt",
+		}).Stdout(ctx)
+	require.NoError(t, err)
+	shaC := strings.TrimSpace(gjson.Get(outputC, "container.from.withExec.stdout").String())
+	require.NotEmpty(t, shaC, "shaC is empty")
+
+	require.Equal(t, shaA, shaC)
 }

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -92,7 +92,8 @@ type Client struct {
 	// Currently used for the dagger CLI so it can avoid making a subprocess of itself...
 	daggerClient *dagger.Client
 
-	upstreamCacheOptions []*controlapi.CacheOptionsEntry
+	upstreamCacheImportOptions []*controlapi.CacheOptionsEntry
+	upstreamCacheExportOptions []*controlapi.CacheOptionsEntry
 
 	hostname string
 
@@ -173,15 +174,10 @@ func Connect(ctx context.Context, params Params) (_ *Client, _ context.Context, 
 	// Note that this is not the cache service support in engine/cache/, that
 	// is a different feature which is configured in the engine daemon.
 
-	cacheConfigs, err := cacheConfigFromEnv()
+	var err error
+	c.upstreamCacheImportOptions, c.upstreamCacheExportOptions, err = allCacheConfigsFromEnv()
 	if err != nil {
 		return nil, nil, fmt.Errorf("cache config from env: %w", err)
-	}
-	for _, cfg := range cacheConfigs {
-		c.upstreamCacheOptions = append(c.upstreamCacheOptions, &controlapi.CacheOptionsEntry{
-			Type:  cfg.typeName,
-			Attrs: cfg.attrs,
-		})
 	}
 
 	remote, err := url.Parse(c.RunnerHost)
@@ -274,16 +270,16 @@ func Connect(ctx context.Context, params Params) (_ *Client, _ context.Context, 
 	c.eg.Go(func() error {
 		return bkSession.Run(c.internalCtx, func(ctx context.Context, proto string, meta map[string][]string) (net.Conn, error) {
 			return grpchijack.Dialer(c.bkClient.ControlClient())(ctx, proto, engine.ClientMetadata{
-				RegisterClient:        true,
-				ClientID:              c.ID(),
-				ClientSecretToken:     c.SecretToken,
-				ServerID:              c.ServerID,
-				ParentClientIDs:       c.ParentClientIDs,
-				ClientHostname:        hostname,
-				UpstreamCacheConfig:   c.upstreamCacheOptions,
-				Labels:                c.labels,
-				ModuleDigest:          c.ModuleDigest,
-				FunctionContextDigest: c.FunctionContextDigest,
+				RegisterClient:            true,
+				ClientID:                  c.ID(),
+				ClientSecretToken:         c.SecretToken,
+				ServerID:                  c.ServerID,
+				ParentClientIDs:           c.ParentClientIDs,
+				ClientHostname:            hostname,
+				UpstreamCacheImportConfig: c.upstreamCacheImportOptions,
+				Labels:                    c.labels,
+				ModuleDigest:              c.ModuleDigest,
+				FunctionContextDigest:     c.FunctionContextDigest,
 			}.AppendToMD(meta))
 		})
 	})
@@ -354,12 +350,12 @@ func (c *Client) Close() (rerr error) {
 	default:
 	}
 
-	if len(c.upstreamCacheOptions) > 0 {
+	if len(c.upstreamCacheExportOptions) > 0 {
 		cacheExportCtx, cacheExportCancel := context.WithTimeout(c.internalCtx, 600*time.Second)
 		defer cacheExportCancel()
 		_, err := c.bkClient.ControlClient().Solve(cacheExportCtx, &controlapi.SolveRequest{
 			Cache: controlapi.CacheOptions{
-				Exports: c.upstreamCacheOptions,
+				Exports: c.upstreamCacheExportOptions,
 			},
 		})
 		rerr = errors.Join(rerr, err)
@@ -739,22 +735,24 @@ func (a progRockAttachable) Register(srv *grpc.Server) {
 }
 
 const (
+	// cache configs that should be applied to be import and export
 	cacheConfigEnvName = "_EXPERIMENTAL_DAGGER_CACHE_CONFIG"
+	// cache configs for imports only
+	cacheImportsConfigEnvName = "_EXPERIMENTAL_DAGGER_CACHE_IMPORT_CONFIG"
+	// cache configs for exports only
+	cacheExportsConfigEnvName = "_EXPERIMENTAL_DAGGER_CACHE_EXPORT_CONFIG"
 )
-
-type cacheConfig struct {
-	typeName string
-	attrs    map[string]string
-}
 
 // env is in form k1=v1,k2=v2;k3=v3... with ';' used to separate multiple cache configs.
 // any value that itself needs ';' can use '\;' to escape it.
-func cacheConfigFromEnv() ([]cacheConfig, error) {
-	envVal, ok := os.LookupEnv(cacheConfigEnvName)
+func cacheConfigFromEnv(envName string) ([]*controlapi.CacheOptionsEntry, error) {
+	envVal, ok := os.LookupEnv(envName)
 	if !ok {
 		return nil, nil
 	}
 	configKVs := strings.Split(envVal, ";")
+	// handle '\;' as an escape in case ';' needs to be used in a cache config setting rather than as
+	// a delimiter between multiple cache configs
 	for i := len(configKVs) - 2; i >= 0; i-- {
 		if strings.HasSuffix(configKVs[i], `\`) {
 			configKVs[i] = configKVs[i][:len(configKVs[i])-1] + ";" + configKVs[i+1]
@@ -762,7 +760,7 @@ func cacheConfigFromEnv() ([]cacheConfig, error) {
 		}
 	}
 
-	var cacheConfigs []cacheConfig
+	cacheConfigs := make([]*controlapi.CacheOptionsEntry, 0, len(configKVs))
 	for _, kvsStr := range configKVs {
 		kvs := strings.Split(kvsStr, ",")
 		if len(kvs) == 0 {
@@ -781,12 +779,38 @@ func cacheConfigFromEnv() ([]cacheConfig, error) {
 			return nil, fmt.Errorf("missing type in cache config: %q", envVal)
 		}
 		delete(attrs, "type")
-		cacheConfigs = append(cacheConfigs, cacheConfig{
-			typeName: typeVal,
-			attrs:    attrs,
+		cacheConfigs = append(cacheConfigs, &controlapi.CacheOptionsEntry{
+			Type:  typeVal,
+			Attrs: attrs,
 		})
 	}
 	return cacheConfigs, nil
+}
+
+func allCacheConfigsFromEnv() (cacheImportConfigs []*controlapi.CacheOptionsEntry, cacheExportConfigs []*controlapi.CacheOptionsEntry, rerr error) {
+	// cache import only configs
+	cacheImportConfigs, err := cacheConfigFromEnv(cacheImportsConfigEnvName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cache import config from env: %w", err)
+	}
+
+	// cache export only configs
+	cacheExportConfigs, err = cacheConfigFromEnv(cacheExportsConfigEnvName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cache export config from env: %w", err)
+	}
+
+	// this env sets configs for both imports and exports
+	cacheConfigs, err := cacheConfigFromEnv(cacheConfigEnvName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cache config from env: %w", err)
+	}
+	for _, cfg := range cacheConfigs {
+		cacheImportConfigs = append(cacheImportConfigs, cfg)
+		cacheExportConfigs = append(cacheExportConfigs, cfg)
+	}
+
+	return cacheImportConfigs, cacheExportConfigs, nil
 }
 
 type doerWithHeaders struct {

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -61,14 +61,14 @@ type ClientMetadata struct {
 	// parent of the parent, and so on.
 	ParentClientIDs []string `json:"parent_client_ids"`
 
-	// Import configuration for Buildkit's remote cache
-	UpstreamCacheConfig []*controlapi.CacheOptionsEntry `json:"upstream_cache_config"`
-
 	// TODO: doc if stays in
 	ModuleDigest digest.Digest `json:"module_digest"`
 
 	// TODO: doc if stays in
 	FunctionContextDigest digest.Digest `json:"function_context_digest"`
+
+	// Import configuration for Buildkit's remote cache
+	UpstreamCacheImportConfig []*controlapi.CacheOptionsEntry
 }
 
 // ClientIDs returns the ClientID followed by ParentClientIDs.

--- a/engine/server/buildkitcontroller.go
+++ b/engine/server/buildkitcontroller.go
@@ -224,6 +224,13 @@ func (e *BuildkitController) Session(stream controlapi.Control_SessionServer) (r
 				e.serverMu.Unlock()
 				return fmt.Errorf("unknown cache importer type %q", cacheImportCfg.Type)
 			}
+			// TODO:
+			// TODO:
+			// TODO:
+			// TODO:
+			// TODO:
+			bklog.G(ctx).Debugf("CACHE CONFIG!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! %s, %+v", cacheImportCfg.Type, cacheImportCfg.Attrs)
+
 			cacheImporterCfgs = append(cacheImporterCfgs, bkgw.CacheOptionsEntry{
 				Type:  cacheImportCfg.Type,
 				Attrs: cacheImportCfg.Attrs,
@@ -332,6 +339,7 @@ func (e *BuildkitController) Solve(ctx context.Context, req *controlapi.SolveReq
 
 	cacheExporterFuncs := make([]buildkit.ResolveCacheExporterFunc, len(req.Cache.Exports))
 	for i, cacheExportCfg := range req.Cache.Exports {
+		cacheExportCfg := cacheExportCfg
 		exporterFunc, ok := e.UpstreamCacheExporters[cacheExportCfg.Type]
 		if !ok {
 			return nil, fmt.Errorf("unknown cache exporter type %q", cacheExportCfg.Type)

--- a/engine/server/buildkitcontroller.go
+++ b/engine/server/buildkitcontroller.go
@@ -218,19 +218,12 @@ func (e *BuildkitController) Session(stream controlapi.Control_SessionServer) (r
 		authProvider := auth.NewRegistryAuthProvider()
 
 		var cacheImporterCfgs []bkgw.CacheOptionsEntry
-		for _, cacheImportCfg := range opts.UpstreamCacheConfig {
+		for _, cacheImportCfg := range opts.UpstreamCacheImportConfig {
 			_, ok := e.UpstreamCacheImporters[cacheImportCfg.Type]
 			if !ok {
 				e.serverMu.Unlock()
 				return fmt.Errorf("unknown cache importer type %q", cacheImportCfg.Type)
 			}
-			// TODO:
-			// TODO:
-			// TODO:
-			// TODO:
-			// TODO:
-			bklog.G(ctx).Debugf("CACHE CONFIG!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! %s, %+v", cacheImportCfg.Type, cacheImportCfg.Attrs)
-
 			cacheImporterCfgs = append(cacheImporterCfgs, bkgw.CacheOptionsEntry{
 				Type:  cacheImportCfg.Type,
 				Attrs: cacheImportCfg.Attrs,


### PR DESCRIPTION
Adds support for providing separate import/export configs for upstream remote cache and for providing multiple values of each (separated by `;`).