### PR TITLE
fix: panic if services DNS is disabled

### DIFF
--- a/cmd/engine/config.go
+++ b/cmd/engine/config.go
@@ -27,14 +27,16 @@ func setDaggerDefaults(cfg *config.Config, netConf *networkConfig) error {
 		cfg.DNS = &config.DNSConfig{}
 	}
 
-	// set dnsmasq as the default nameserver
-	cfg.DNS.Nameservers = []string{netConf.Bridge.String()}
+	if netConf != nil {
+		// set dnsmasq as the default nameserver
+		cfg.DNS.Nameservers = []string{netConf.Bridge.String()}
 
-	if netConf.CNIConfigPath != "" {
-		setNetworkDefaults(&cfg.Workers.OCI.NetworkConfig, netConf.CNIConfigPath)
+		if netConf.CNIConfigPath != "" {
+			setNetworkDefaults(&cfg.Workers.OCI.NetworkConfig, netConf.CNIConfigPath)
 
-		// we don't use containerd, but make it match anyway
-		setNetworkDefaults(&cfg.Workers.Containerd.NetworkConfig, netConf.CNIConfigPath)
+			// we don't use containerd, but make it match anyway
+			setNetworkDefaults(&cfg.Workers.Containerd.NetworkConfig, netConf.CNIConfigPath)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
if `_EXPERIMENTAL_DAGGER_SERVICES_DNS` is disabled, dagger-engine crashes when starting, because the network config is nil

let's ensure that we don't fail if the network config is nil