### PR TITLE
fix: engine CLI flags typo

### DIFF
--- a/cmd/engine/main_oci_worker.go
+++ b/cmd/engine/main_oci_worker.go
@@ -124,7 +124,7 @@ func init() {
 		},
 		cli.StringFlag{
 			Name:  "oci-max-parallelism",
-			Usage: "maximum number of parallel build steps that can be run at the same time (or \"num-cpus\" to automatically set to the number of CPUs). 0 means unlimited parallelism.",
+			Usage: "maximum number of parallel build steps that can be run at the same time (or \"num-cpu\" to automatically set to the number of CPUs). 0 means unlimited parallelism.",
 		},
 	}
 	n := "oci-worker-rootless"


### PR DESCRIPTION
it's `num-cpu`, not `num-cpus`...