### PR TITLE
tests: use `connect(t)` everywhere, send logs to `t.Log`

### DIFF
--- a/core/integration/cache_test.go
+++ b/core/integration/cache_test.go
@@ -75,7 +75,6 @@ func TestCacheVolume(t *testing.T) {
 func TestCacheVolumeWithSubmount(t *testing.T) {
 	t.Parallel()
 	c, ctx := connect(t)
-	t.Cleanup(func() { c.Close() })
 
 	t.Run("file mount", func(t *testing.T) {
 		t.Parallel()
@@ -139,15 +138,9 @@ func TestLocalImportCacheReuse(t *testing.T) {
 	}
 
 	c1, ctx1 := connect(t)
-	defer c1.Close()
-	ctx1, cancel1 := context.WithCancel(ctx1)
-	defer cancel1()
 	out1 := runExec(ctx1, t, c1)
 
 	c2, ctx2 := connect(t)
-	defer c2.Close()
-	ctx2, cancel2 := context.WithCancel(ctx2)
-	defer cancel2()
 	out2 := runExec(ctx2, t, c2)
 
 	require.Equal(t, out1, out2)

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -85,10 +85,7 @@ func TestContainerFrom(t *testing.T) {
 }
 
 func TestContainerBuild(t *testing.T) {
-	ctx := context.Background()
-	c, err := dagger.Connect(ctx)
-	require.NoError(t, err)
-	defer c.Close()
+	c, ctx := connect(t)
 
 	contextDir := c.Directory().
 		WithNewFile("main.go",
@@ -224,7 +221,6 @@ CMD echo "stage2"
 
 	t.Run("with build secrets", func(t *testing.T) {
 		sec := c.SetSecret("my-secret", "barbar")
-		require.NoError(t, err)
 
 		src := contextDir.
 			WithNewFile("Dockerfile",
@@ -246,7 +242,7 @@ CMD cat /secret
 		src := contextDir.
 			WithNewFile("Dockerfile", "FROM "+alpineImage+"\nCMD false")
 
-		_, err = c.Container().Build(src).Sync(ctx)
+		_, err := c.Container().Build(src).Sync(ctx)
 		require.NoError(t, err)
 
 		// unless there's a WithExec
@@ -258,7 +254,7 @@ CMD cat /secret
 		src := contextDir.
 			WithNewFile("Dockerfile", "FROM "+alpineImage+"\nRUN false")
 
-		_, err = c.Container().Build(src).Sync(ctx)
+		_, err := c.Container().Build(src).Sync(ctx)
 		require.NotEmpty(t, err)
 	})
 }
@@ -266,10 +262,7 @@ CMD cat /secret
 func TestContainerWithRootFS(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-	c, err := dagger.Connect(ctx)
-	require.NoError(t, err)
-	defer c.Close()
+	c, ctx := connect(t)
 
 	alpine316 := c.Container().From(alpineImage)
 
@@ -315,7 +308,6 @@ func TestContainerWithRootFSSubdir(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	hello := c.Directory().WithNewFile("main.go", helloSrc).File("main.go")
 
@@ -449,7 +441,6 @@ func TestContainerExecRedirectStdoutStderr(t *testing.T) {
 	require.Equal(t, res.Container.From.WithExec.Err.Contents, "goodbye\n")
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	execWithMount := c.Container().From(alpineImage).
 		WithMountedDirectory("/mnt", c.Directory()).
@@ -612,7 +603,6 @@ func TestContainerExecWithEntrypoint(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	base := c.Container().From(alpineImage)
 	before, err := base.Entrypoint(ctx)
@@ -921,10 +911,7 @@ func TestContainerEnvVariablesReplace(t *testing.T) {
 
 func TestContainerWithEnvVariableExpand(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
-	c, err := dagger.Connect(ctx)
-	require.NoError(t, err)
-	defer c.Close()
+	c, ctx := connect(t)
 
 	t.Run("add env var without expansion", func(t *testing.T) {
 		out, err := c.Container().
@@ -960,10 +947,7 @@ func TestContainerWithEnvVariableExpand(t *testing.T) {
 }
 
 func TestContainerLabel(t *testing.T) {
-	ctx := context.Background()
-	c, err := dagger.Connect(ctx)
-	require.NoError(t, err)
-	defer c.Close()
+	c, ctx := connect(t)
 
 	t.Run("container with new label", func(t *testing.T) {
 		label, err := c.Container().From(alpineImage).WithLabel("FOO", "BAR").Label(ctx, "FOO")
@@ -1567,7 +1551,6 @@ func TestContainerWithDirectory(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	dir := c.Directory().
 		WithNewFile("some-file", "some-content").
@@ -1627,7 +1610,6 @@ func TestContainerWithFile(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	file := c.Directory().
 		WithNewFile("some-file", "some-content").
@@ -1653,7 +1635,6 @@ func TestContainerWithNewFile(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	ctr := c.Container().
 		From(alpineImage).
@@ -1761,7 +1742,6 @@ func TestContainerReplacedMounts(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	lower := c.Directory().WithNewFile("some-file", "lower-content")
 
@@ -2514,7 +2494,6 @@ func TestContainerMultiFrom(t *testing.T) {
 
 func TestContainerPublish(t *testing.T) {
 	c, ctx := connect(t)
-	defer c.Close()
 
 	testRef := registryRef("container-publish")
 
@@ -2538,11 +2517,7 @@ func TestContainerPublish(t *testing.T) {
 }
 
 func TestExecFromScratch(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	c, err := dagger.Connect(ctx)
-	require.NoError(t, err)
-	defer c.Close()
+	c, ctx := connect(t)
 
 	// execute it from scratch, where there is no default platform, make sure it works and can be pushed
 	execBusybox := c.Container().
@@ -2550,7 +2525,7 @@ func TestExecFromScratch(t *testing.T) {
 		WithMountedFile("/busybox", c.Container().From("busybox:musl").File("/bin/busybox")).
 		WithExec([]string{"/busybox"})
 
-	_, err = execBusybox.Stdout(ctx)
+	_, err := execBusybox.Stdout(ctx)
 	require.NoError(t, err)
 	_, err = execBusybox.Publish(ctx, registryRef("from-scratch"))
 	require.NoError(t, err)
@@ -2558,7 +2533,6 @@ func TestExecFromScratch(t *testing.T) {
 
 func TestContainerMultipleMounts(t *testing.T) {
 	c, ctx := connect(t)
-	defer c.Close()
 
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "one"), []byte("1"), 0o600))
@@ -2586,14 +2560,10 @@ func TestContainerMultipleMounts(t *testing.T) {
 func TestContainerExport(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-
 	wd := t.TempDir()
 	dest := t.TempDir()
 
-	c, err := dagger.Connect(ctx, dagger.WithWorkdir(wd), dagger.WithLogOutput(os.Stderr))
-	require.NoError(t, err)
-	defer c.Close()
+	c, ctx := connect(t, dagger.WithWorkdir(wd))
 
 	entrypoint := []string{"sh", "-c", "im-a-entrypoint"}
 	ctr := c.Container().From(alpineImage).
@@ -2670,11 +2640,8 @@ func TestContainerExport(t *testing.T) {
 func TestContainerImport(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	c, ctx := connect(t)
 
-	c, err := dagger.Connect(ctx)
-	require.NoError(t, err)
-	defer c.Close()
 	pf, err := c.DefaultPlatform(ctx)
 	require.NoError(t, err)
 
@@ -2744,12 +2711,7 @@ func TestContainerImport(t *testing.T) {
 }
 
 func TestContainerMultiPlatformExport(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	c, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
-	require.NoError(t, err)
-	defer c.Close()
+	c, ctx := connect(t)
 
 	variants := make([]*dagger.Container, 0, len(platformToUname))
 	for platform, uname := range platformToUname {
@@ -2809,12 +2771,7 @@ func TestContainerMultiPlatformExport(t *testing.T) {
 
 // Multiplatform publish is also tested in more complicated scenarios in platform_test.go
 func TestContainerMultiPlatformPublish(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	c, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
-	require.NoError(t, err)
-	defer c.Close()
+	c, ctx := connect(t)
 
 	variants := make([]*dagger.Container, 0, len(platformToUname))
 	for platform, uname := range platformToUname {
@@ -2843,12 +2800,7 @@ func TestContainerMultiPlatformPublish(t *testing.T) {
 }
 
 func TestContainerMultiPlatformImport(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	c, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
-	require.NoError(t, err)
-	defer c.Close()
+	c, ctx := connect(t)
 
 	variants := make([]*dagger.Container, 0, len(platformToUname))
 	for platform := range platformToUname {
@@ -2880,11 +2832,7 @@ func TestContainerMultiPlatformImport(t *testing.T) {
 func TestContainerWithDirectoryToMount(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-
-	c, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
-	require.NoError(t, err)
-	defer c.Close()
+	c, ctx := connect(t)
 
 	mnt := c.Directory().
 		WithNewDirectory("/top/sub-dir/sub-file").
@@ -2914,7 +2862,6 @@ var echoSocketSrc string
 
 func TestContainerWithUnixSocket(t *testing.T) {
 	c, ctx := connect(t)
-	defer c.Close()
 
 	tmp := t.TempDir()
 	sock := filepath.Join(tmp, "test.sock")
@@ -2991,9 +2938,7 @@ func TestContainerWithUnixSocket(t *testing.T) {
 func TestContainerExecError(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-	c, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
-	require.NoError(t, err)
+	c, ctx := connect(t)
 
 	outMsg := "THIS SHOULD GO TO STDOUT"
 	encodedOutMsg := base64.StdEncoding.EncodeToString([]byte(outMsg))
@@ -3001,7 +2946,7 @@ func TestContainerExecError(t *testing.T) {
 	encodedErrMsg := base64.StdEncoding.EncodeToString([]byte(errMsg))
 
 	t.Run("includes output of failed exec in error", func(t *testing.T) {
-		_, err = c.Container().
+		_, err := c.Container().
 			From(alpineImage).
 			WithExec([]string{"sh", "-c", fmt.Sprintf(
 				`echo %s | base64 -d >&1; echo %s | base64 -d >&2; exit 1`, encodedOutMsg, encodedErrMsg,
@@ -3016,7 +2961,7 @@ func TestContainerExecError(t *testing.T) {
 	})
 
 	t.Run("includes output of failed exec in error when redirects are enabled", func(t *testing.T) {
-		_, err = c.Container().
+		_, err := c.Container().
 			From(alpineImage).
 			WithExec(
 				[]string{"sh", "-c", fmt.Sprintf(
@@ -3055,7 +3000,7 @@ func TestContainerExecError(t *testing.T) {
 
 		truncMsg := fmt.Sprintf(buildkit.TruncationMessage, 50)
 
-		_, err = c.Container().
+		_, err := c.Container().
 			From(alpineImage).
 			WithDirectory("/", c.Directory().
 				WithNewFile("encout", encodedOutMsg).
@@ -3075,18 +3020,13 @@ func TestContainerExecError(t *testing.T) {
 func TestContainerWithRegistryAuth(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-
-	c, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
-
-	require.NoError(t, err)
-	defer c.Close()
+	c, ctx := connect(t)
 
 	testRef := privateRegistryRef("container-with-registry-auth")
 	container := c.Container().From(alpineImage)
 
 	// Push without credentials should fail
-	_, err = container.Publish(ctx, testRef)
+	_, err := container.Publish(ctx, testRef)
 	require.Error(t, err)
 
 	pushedRef, err := container.
@@ -3174,7 +3114,6 @@ func TestContainerImageRef(t *testing.T) {
 
 	t.Run("should throw error after the container image modification with directory", func(t *testing.T) {
 		c, ctx := connect(t)
-		defer c.Close()
 
 		dir := c.Directory().
 			WithNewFile("some-file", "some-content").
@@ -3196,15 +3135,8 @@ func TestContainerImageRef(t *testing.T) {
 func TestContainerBuildNilContextError(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-
-	c, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stdout))
-
-	require.NoError(t, err)
-	defer c.Close()
-
 	// regression test, this previously caused the engine to panic
-	err = testutil.Query(
+	err := testutil.Query(
 		`{
 			container {
 				build(context: "") {
@@ -3217,9 +3149,6 @@ func TestContainerBuildNilContextError(t *testing.T) {
 
 func TestContainerInsecureRootCapabilites(t *testing.T) {
 	c, ctx := connect(t)
-	defer c.Close()
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
 
 	// This isn't exhaustive, but it's the major important ones. Being exhaustive
 	// is trickier since the full list of caps is host dependent based on the kernel version.
@@ -3260,9 +3189,6 @@ func TestContainerInsecureRootCapabilites(t *testing.T) {
 
 func TestContainerInsecureRootCapabilitesWithService(t *testing.T) {
 	c, ctx := connect(t)
-	defer c.Close()
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
 
 	// verify the root capabilities setting works by executing dockerd with it and
 	// testing it can startup, create containers and bind mount from its filesystem to
@@ -3304,7 +3230,6 @@ func TestContainerInsecureRootCapabilitesWithService(t *testing.T) {
 
 func TestContainerNoExec(t *testing.T) {
 	c, ctx := connect(t)
-	defer c.Close()
 
 	stdout, err := c.Container().From(alpineImage).Stdout(ctx)
 	require.NoError(t, err)
@@ -3327,7 +3252,6 @@ func TestContainerNoExec(t *testing.T) {
 
 func TestContainerWithMountedFileOwner(t *testing.T) {
 	c, ctx := connect(t)
-	t.Cleanup(func() { c.Close() })
 
 	t.Run("simple file", func(t *testing.T) {
 		tmp := t.TempDir()
@@ -3365,7 +3289,6 @@ func TestContainerWithMountedFileOwner(t *testing.T) {
 
 func TestContainerWithMountedDirectoryOwner(t *testing.T) {
 	c, ctx := connect(t)
-	t.Cleanup(func() { c.Close() })
 
 	t.Run("simple directory", func(t *testing.T) {
 		tmp := t.TempDir()
@@ -3431,7 +3354,6 @@ func TestContainerWithMountedDirectoryOwner(t *testing.T) {
 
 func TestContainerWithFileOwner(t *testing.T) {
 	c, ctx := connect(t)
-	t.Cleanup(func() { c.Close() })
 
 	t.Run("simple file", func(t *testing.T) {
 		tmp := t.TempDir()
@@ -3469,7 +3391,6 @@ func TestContainerWithFileOwner(t *testing.T) {
 
 func TestContainerWithDirectoryOwner(t *testing.T) {
 	c, ctx := connect(t)
-	t.Cleanup(func() { c.Close() })
 
 	t.Run("simple directory", func(t *testing.T) {
 		tmp := t.TempDir()
@@ -3507,7 +3428,6 @@ func TestContainerWithDirectoryOwner(t *testing.T) {
 
 func TestContainerWithNewFileOwner(t *testing.T) {
 	c, ctx := connect(t)
-	t.Cleanup(func() { c.Close() })
 
 	testOwnership(ctx, t, c, func(ctr *dagger.Container, name string, owner string) *dagger.Container {
 		return ctr.WithNewFile(name, dagger.ContainerWithNewFileOpts{
@@ -3518,7 +3438,6 @@ func TestContainerWithNewFileOwner(t *testing.T) {
 
 func TestContainerWithMountedCacheOwner(t *testing.T) {
 	c, ctx := connect(t)
-	t.Cleanup(func() { c.Close() })
 
 	cache := c.CacheVolume("test")
 
@@ -3575,7 +3494,6 @@ func TestContainerWithMountedCacheOwner(t *testing.T) {
 
 func TestContainerWithMountedSecretOwner(t *testing.T) {
 	c, ctx := connect(t)
-	t.Cleanup(func() { c.Close() })
 
 	secret := c.SetSecret("test", "hunter2")
 
@@ -3588,7 +3506,6 @@ func TestContainerWithMountedSecretOwner(t *testing.T) {
 
 func TestContainerWithUnixSocketOwner(t *testing.T) {
 	c, ctx := connect(t)
-	t.Cleanup(func() { c.Close() })
 
 	tmp := t.TempDir()
 	sock := filepath.Join(tmp, "test.sock")
@@ -3732,7 +3649,6 @@ func TestContainerForceCompression(t *testing.T) {
 			t.Parallel()
 
 			c, ctx := connect(t)
-			defer c.Close()
 
 			ref := registryRef("testcontainerpublishforcecompression" + strings.ToLower(string(tc.compression)))
 			_, err := c.Container().
@@ -3809,7 +3725,6 @@ func TestContainerMediaTypes(t *testing.T) {
 			t.Parallel()
 
 			c, ctx := connect(t)
-			defer c.Close()
 
 			ref := registryRef("testcontainerpublishmediatypes" + strings.ToLower(string(tc.mediaTypes)))
 			_, err := c.Container().
@@ -3993,9 +3908,6 @@ func TestContainerFromMergesWithParent(t *testing.T) {
 func TestContainerImageLoadCompatibility(t *testing.T) {
 	t.Parallel()
 	c, ctx := connect(t)
-	t.Cleanup(func() { c.Close() })
-	ctx, cancel := context.WithCancel(ctx)
-	t.Cleanup(cancel)
 
 	for i, dockerVersion := range []string{"20.10", "23.0", "24.0"} {
 		dockerVersion := dockerVersion

--- a/core/integration/engine_test.go
+++ b/core/integration/engine_test.go
@@ -47,7 +47,6 @@ func engineClientContainer(ctx context.Context, t *testing.T, c *dagger.Client, 
 
 func TestEngineExitsZeroOnSignal(t *testing.T) {
 	c, ctx := connect(t)
-	defer c.Close()
 
 	// engine should shutdown with exit code 0 when receiving SIGTERM
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -78,7 +77,6 @@ func TestClientWaitsForEngine(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	devEngine := devEngineContainer(c)
 	entrypoint, err := devEngine.File("/usr/local/bin/dagger-entrypoint.sh").Contents(ctx)
@@ -111,7 +109,6 @@ func TestClientWaitsForEngine(t *testing.T) {
 
 func TestEngineSetsNameFromEnv(t *testing.T) {
 	c, ctx := connect(t)
-	defer c.Close()
 
 	engineName := "my-special-engine"
 	devEngine := devEngineContainer(c).
@@ -138,7 +135,6 @@ func TestDaggerRun(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	devEngine := devEngineContainer(c).
 		WithMountedCache("/var/lib/dagger", c.CacheVolume("dagger-dev-engine-state-"+identity.NewID())).
@@ -173,7 +169,6 @@ func TestDaggerRun(t *testing.T) {
 
 func TestClientSendsLabelsInTelemetry(t *testing.T) {
 	c, ctx := connect(t)
-	defer c.Close()
 
 	devEngine := devEngineContainer(c).
 		WithMountedCache("/var/lib/dagger", c.CacheVolume("dagger-dev-engine-state-"+identity.NewID())).

--- a/core/integration/file_test.go
+++ b/core/integration/file_test.go
@@ -121,9 +121,7 @@ func TestFileExport(t *testing.T) {
 	wd := t.TempDir()
 	targetDir := t.TempDir()
 
-	c, err := dagger.Connect(ctx, dagger.WithWorkdir(wd), dagger.WithLogOutput(os.Stderr))
-	require.NoError(t, err)
-	defer c.Close()
+	c, ctx := connect(t, dagger.WithWorkdir(wd))
 
 	file := c.Container().From(alpineImage).File("/etc/alpine-release")
 
@@ -227,7 +225,6 @@ func TestFileExport(t *testing.T) {
 func TestFileWithTimestamps(t *testing.T) {
 	t.Parallel()
 	c, ctx := connect(t)
-	defer c.Close()
 
 	reallyImportantTime := time.Date(1985, 10, 26, 8, 15, 0, 0, time.UTC)
 
@@ -250,7 +247,6 @@ func TestFileWithTimestamps(t *testing.T) {
 func TestFileContents(t *testing.T) {
 	t.Parallel()
 	c, ctx := connect(t)
-	defer c.Close()
 
 	// Set three types of file sizes for test data,
 	// the third one uses a size larger than the max chunk size:
@@ -303,7 +299,6 @@ func TestFileSync(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	t.Run("triggers error", func(t *testing.T) {
 		_, err := c.Directory().File("baz").Sync(ctx)

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -68,7 +68,6 @@ func TestGitSSHAuthSock(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	gitSSH := c.Container().
 		From(alpineImage).
@@ -175,18 +174,16 @@ sleep infinity
 func TestGitKeepGitDir(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-	client, _ := dagger.Connect(ctx)
-	defer client.Close()
+	c, ctx := connect(t)
 
 	t.Run("git dir is present", func(t *testing.T) {
-		dir := client.Git("https://github.com/dagger/dagger", dagger.GitOpts{KeepGitDir: true}).Branch("main").Tree()
+		dir := c.Git("https://github.com/dagger/dagger", dagger.GitOpts{KeepGitDir: true}).Branch("main").Tree()
 		ent, _ := dir.Entries(ctx)
 		require.Contains(t, ent, ".git")
 	})
 
 	t.Run("git dir is not present", func(t *testing.T) {
-		dir := client.Git("https://github.com/dagger/dagger").Branch("main").Tree()
+		dir := c.Git("https://github.com/dagger/dagger").Branch("main").Tree()
 		ent, _ := dir.Entries(ctx)
 		require.NotContains(t, ent, ".git")
 	})
@@ -211,10 +208,6 @@ func TestGitServiceStableDigest(t *testing.T) {
 	}
 
 	c1, ctx1 := connect(t)
-	defer c1.Close()
-
 	c2, ctx2 := connect(t)
-	defer c2.Close()
-
 	require.Equal(t, hostname(ctx1, c1), hostname(ctx2, c2))
 }

--- a/core/integration/host_test.go
+++ b/core/integration/host_test.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"context"
 	"crypto/md5"
 	"crypto/rand"
 	"encoding/hex"
@@ -22,10 +21,7 @@ func TestHostWorkdir(t *testing.T) {
 	err := os.WriteFile(filepath.Join(dir, "foo"), []byte("bar"), 0600)
 	require.NoError(t, err)
 
-	ctx := context.Background()
-	c, err := dagger.Connect(ctx, dagger.WithWorkdir(dir))
-	require.NoError(t, err)
-	defer c.Close()
+	c, ctx := connect(t, dagger.WithWorkdir(dir))
 
 	t.Run("contains the workdir's content", func(t *testing.T) {
 		contents, err := c.Container().
@@ -61,10 +57,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "subdir"), 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "subdir", "sub-file"), []byte("goodbye"), 0600))
 
-	ctx := context.Background()
-	c, err := dagger.Connect(ctx, dagger.WithWorkdir(dir), dagger.WithLogOutput(os.Stderr))
-	require.NoError(t, err)
-	defer c.Close()
+	c, ctx := connect(t, dagger.WithWorkdir(dir))
 
 	t.Run("exclude", func(t *testing.T) {
 		wd := c.Host().Directory(".", dagger.HostDirectoryOpts{
@@ -146,10 +139,7 @@ func TestHostDirectoryRelative(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "some-dir"), 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "some-dir", "sub-file"), []byte("goodbye"), 0600))
 
-	ctx := context.Background()
-	c, err := dagger.Connect(ctx, dagger.WithWorkdir(dir))
-	require.NoError(t, err)
-	defer c.Close()
+	c, ctx := connect(t, dagger.WithWorkdir(dir))
 
 	t.Run(". is same as workdir", func(t *testing.T) {
 		wdID1, err := c.Host().Directory(".").ID(ctx)
@@ -194,10 +184,7 @@ func TestHostSetSecretFile(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "some-file"), []byte(data), 0600))
 
-	ctx := context.Background()
-	c, err := dagger.Connect(ctx, dagger.WithWorkdir(dir))
-	require.NoError(t, err)
-	defer c.Close()
+	c, ctx := connect(t, dagger.WithWorkdir(dir))
 
 	t.Run("non utf8 binary data is properly set as secret", func(t *testing.T) {
 		secret := c.Host().SetSecretFile("mysecret", filepath.Join(dir, "some-file"))
@@ -224,10 +211,7 @@ func TestHostDirectoryAbsolute(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "some-dir"), 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "some-dir", "sub-file"), []byte("goodbye"), 0600))
 
-	ctx := context.Background()
-	c, err := dagger.Connect(ctx, dagger.WithWorkdir(dir), dagger.WithLogOutput(os.Stderr))
-	require.NoError(t, err)
-	defer c.Close()
+	c, ctx := connect(t, dagger.WithWorkdir(dir))
 
 	entries, err := c.Host().Directory(filepath.Join(dir, "some-dir")).Entries(ctx)
 	require.NoError(t, err)
@@ -247,7 +231,6 @@ func TestHostDirectoryExcludeInclude(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "subdir", "f.txt.rar"), []byte("3"), 0600))
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	t.Run("exclude", func(t *testing.T) {
 		entries, err := c.Host().Directory(dir, dagger.HostDirectoryOpts{
@@ -293,7 +276,6 @@ func TestHostFile(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "subdir", "d.txt"), []byte("hello world"), 0600))
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	t.Run("get simple file", func(t *testing.T) {
 		content, err := c.Host().File(filepath.Join(dir, "a.txt")).Contents(ctx)

--- a/core/integration/http_test.go
+++ b/core/integration/http_test.go
@@ -13,7 +13,6 @@ func TestHTTP(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	// do two in a row to ensure each gets downloaded correctly
 	url := "https://raw.githubusercontent.com/dagger/dagger/main/TESTING.md"
@@ -31,7 +30,6 @@ func TestHTTPService(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	svc, url := httpService(ctx, t, c, "Hello, world!")
 
@@ -60,10 +58,6 @@ func TestHTTPServiceStableDigest(t *testing.T) {
 	}
 
 	c1, ctx1 := connect(t)
-	defer c1.Close()
-
 	c2, ctx2 := connect(t)
-	defer c2.Close()
-
 	require.Equal(t, hostname(ctx1, c1), hostname(ctx2, c2))
 }

--- a/core/integration/local_test.go
+++ b/core/integration/local_test.go
@@ -1,27 +1,21 @@
 package core
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"dagger.io/dagger"
 	"github.com/stretchr/testify/require"
 )
 
 func TestLocalImportsAcrossSessions(t *testing.T) {
-	ctx := context.Background()
-
 	tmpdir := t.TempDir()
 
-	c1, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
-	require.NoError(t, err)
-	t.Cleanup(func() { c1.Close() })
+	c1, ctx1 := connect(t)
 
 	fileName := "afile"
-	err = os.WriteFile(filepath.Join(tmpdir, fileName), []byte("1"), 0644)
+	err := os.WriteFile(filepath.Join(tmpdir, fileName), []byte("1"), 0644)
 	require.NoError(t, err)
 
 	hostDir1 := c1.Host().Directory(tmpdir)
@@ -29,7 +23,7 @@ func TestLocalImportsAcrossSessions(t *testing.T) {
 	out1, err := c1.Container().From("alpine:3.16.2").
 		WithMountedDirectory("/mnt", hostDir1).
 		WithExec([]string{"cat", "/mnt/" + fileName}).
-		Stdout(ctx)
+		Stdout(ctx1)
 	require.NoError(t, err)
 	out1 = strings.TrimSpace(out1)
 	require.Equal(t, "1", out1)
@@ -43,16 +37,14 @@ func TestLocalImportsAcrossSessions(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "2", string(contents))
 
-	c2, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
-	require.NoError(t, err)
-	t.Cleanup(func() { c2.Close() })
+	c2, ctx2 := connect(t)
 
 	hostDir2 := c2.Host().Directory(tmpdir)
 
 	out2, err := c2.Container().From("alpine:3.18").
 		WithMountedDirectory("/mnt", hostDir2).
 		WithExec([]string{"cat", "/mnt/" + fileName}).
-		Stdout(ctx)
+		Stdout(ctx2)
 	require.NoError(t, err)
 	out2 = strings.TrimSpace(out2)
 	require.Equal(t, "2", out2)

--- a/core/integration/pipeline_test.go
+++ b/core/integration/pipeline_test.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -13,19 +12,15 @@ import (
 func TestPipeline(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-
 	cacheBuster := fmt.Sprintf("%d", time.Now().UTC().UnixNano())
 
 	t.Run("container pipeline", func(t *testing.T) {
 		t.Parallel()
 
 		var logs safeBuffer
-		c, err := dagger.Connect(ctx, dagger.WithLogOutput(&logs))
-		require.NoError(t, err)
-		defer c.Close()
+		c, ctx := connect(t, dagger.WithLogOutput(&logs))
 
-		_, err = c.
+		_, err := c.
 			Container().
 			Pipeline("container pipeline").
 			From(alpineImage).
@@ -43,9 +38,7 @@ func TestPipeline(t *testing.T) {
 		t.Parallel()
 
 		var logs safeBuffer
-		c, err := dagger.Connect(ctx, dagger.WithLogOutput(&logs))
-		require.NoError(t, err)
-		defer c.Close()
+		c, ctx := connect(t, dagger.WithLogOutput(&logs))
 
 		contents, err := c.
 			Directory().
@@ -66,9 +59,7 @@ func TestPipeline(t *testing.T) {
 		t.Parallel()
 
 		var logs safeBuffer
-		c, err := dagger.Connect(ctx, dagger.WithLogOutput(&logs))
-		require.NoError(t, err)
-		defer c.Close()
+		c, ctx := connect(t, dagger.WithLogOutput(&logs))
 
 		srv, url := httpService(ctx, t, c, "Hello, world!")
 
@@ -93,22 +84,18 @@ func TestPipeline(t *testing.T) {
 func TestInternalVertexes(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-
 	cacheBuster := fmt.Sprintf("%d", time.Now().UTC().UnixNano())
 
 	t.Run("merge pipeline", func(t *testing.T) {
 		t.Parallel()
 
 		var logs safeBuffer
-		c, err := dagger.Connect(ctx, dagger.WithLogOutput(&logs))
-		require.NoError(t, err)
-		defer c.Close()
+		c, ctx := connect(t, dagger.WithLogOutput(&logs))
 
 		dirA := c.Directory().WithNewFile("/foo", "foo")
 		dirB := c.Directory().WithNewFile("/bar", "bar")
 
-		_, err = c.
+		_, err := c.
 			Container().
 			From(alpineImage).
 			WithDirectory("/foo", dirA).

--- a/core/integration/pipeline_test.go
+++ b/core/integration/pipeline_test.go
@@ -1,33 +1,14 @@
 package core
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
 	"dagger.io/dagger"
 	"github.com/stretchr/testify/require"
 )
-
-type safeBuffer struct {
-	bu bytes.Buffer
-	mu sync.Mutex
-}
-
-func (s *safeBuffer) Write(p []byte) (n int, err error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.bu.Write(p)
-}
-
-func (s *safeBuffer) String() string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.bu.String()
-}
 
 func TestPipeline(t *testing.T) {
 	t.Parallel()

--- a/core/integration/project_test.go
+++ b/core/integration/project_test.go
@@ -52,7 +52,6 @@ func TestProjectCmd(t *testing.T) {
 			t.Run(testName, func(t *testing.T) {
 				t.Parallel()
 				c, ctx := connect(t)
-				defer c.Close()
 				stderr, err := CLITestContainer(ctx, t, c).
 					WithLoadedProject(tc.projectPath, testGitProject).
 					CallProject().
@@ -129,7 +128,6 @@ func TestProjectCmdInit(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 			c, ctx := connect(t)
-			defer c.Close()
 			ctr := CLITestContainer(ctx, t, c).
 				WithProjectArg(tc.projectPath).
 				WithSDKArg(tc.sdk).
@@ -159,7 +157,6 @@ func TestProjectCmdInit(t *testing.T) {
 	t.Run("error on existing project", func(t *testing.T) {
 		t.Parallel()
 		c, ctx := connect(t)
-		defer c.Close()
 		_, err := CLITestContainer(ctx, t, c).
 			WithLoadedProject("core/integration/testdata/projects/go/basic", false).
 			WithSDKArg("go").
@@ -179,7 +176,6 @@ func TestProjectCommandHierarchy(t *testing.T) {
 		t.Run(projectDir, func(t *testing.T) {
 			t.Parallel()
 			c, ctx := connect(t)
-			defer c.Close()
 
 			stderr, err := CLITestContainer(ctx, t, c).
 				WithLoadedProject(projectDir, false).
@@ -235,7 +231,6 @@ func TestProjectHostExport(t *testing.T) {
 				t.Run("file export implicit output", func(t *testing.T) {
 					t.Parallel()
 					c, ctx := connect(t)
-					defer c.Close()
 					ctr, err := CLITestContainer(ctx, t, c).
 						WithLoadedProject(projectDir, testGitProject).
 						WithTarget("test-file").
@@ -254,7 +249,6 @@ func TestProjectHostExport(t *testing.T) {
 				t.Run("dir export implicit output", func(t *testing.T) {
 					t.Parallel()
 					c, ctx := connect(t)
-					defer c.Close()
 					ctr, err := CLITestContainer(ctx, t, c).
 						WithLoadedProject(projectDir, testGitProject).
 						WithTarget("test-dir").
@@ -279,7 +273,6 @@ func TestProjectHostExport(t *testing.T) {
 				t.Run("file export explicit output", func(t *testing.T) {
 					t.Parallel()
 					c, ctx := connect(t)
-					defer c.Close()
 
 					outputPath := "/var/blahblah.txt"
 					ctr, err := CLITestContainer(ctx, t, c).
@@ -296,7 +289,6 @@ func TestProjectHostExport(t *testing.T) {
 				t.Run("file export explicit output to parent dir", func(t *testing.T) {
 					t.Parallel()
 					c, ctx := connect(t)
-					defer c.Close()
 
 					outputDir := "/var"
 					ctr, err := CLITestContainer(ctx, t, c).
@@ -313,7 +305,6 @@ func TestProjectHostExport(t *testing.T) {
 				t.Run("dir export explicit output", func(t *testing.T) {
 					t.Parallel()
 					c, ctx := connect(t)
-					defer c.Close()
 
 					outputDir := "/var"
 					ctr, err := CLITestContainer(ctx, t, c).
@@ -337,7 +328,6 @@ func TestProjectHostExport(t *testing.T) {
 				t.Run("export from container host", func(t *testing.T) {
 					t.Parallel()
 					c, ctx := connect(t)
-					defer c.Close()
 					outputDir := "/var"
 					ctr, err := CLITestContainer(ctx, t, c).
 						WithLoadedProject(projectDir, testGitProject).
@@ -386,7 +376,6 @@ func TestProjectDirImported(t *testing.T) {
 			t.Run(testName, func(t *testing.T) {
 				t.Parallel()
 				c, ctx := connect(t)
-				defer c.Close()
 				stderr, err := CLITestContainer(ctx, t, c).
 					WithLoadedProject(projectDir, testGitProject).
 					WithTarget("test-imported-project-dir").
@@ -418,7 +407,6 @@ func TestProjectDirImported(t *testing.T) {
 func TestProjectGoCodeToSchema(t *testing.T) {
 	t.Parallel()
 	c, ctx := connect(t)
-	defer c.Close()
 
 	// manually load project TODO: maybe this test should just use `dagger do`
 	dirWithGoMod, err := filepath.Abs("../../")

--- a/core/integration/remotecache_test.go
+++ b/core/integration/remotecache_test.go
@@ -43,7 +43,6 @@ func getDevEngineForRemoteCache(ctx context.Context, c *dagger.Client, cache *da
 
 func TestRemoteCacheRegistry(t *testing.T) {
 	c, ctx := connect(t)
-	defer c.Close()
 
 	registry := c.Pipeline("registry").Container().From("registry:2").
 		WithMountedCache("/var/lib/registry/", c.CacheVolume("remote-cache-registry-"+identity.NewID())).
@@ -117,7 +116,6 @@ func TestRemoteCacheRegistry(t *testing.T) {
 func TestRemoteCacheS3(t *testing.T) {
 	t.Run("buildkit s3 caching", func(t *testing.T) {
 		c, ctx := connect(t)
-		defer c.Close()
 
 		bucket := "dagger-test-remote-cache-s3-" + identity.NewID()
 

--- a/core/integration/secret_test.go
+++ b/core/integration/secret_test.go
@@ -102,7 +102,6 @@ func TestSecretMountFromFileWithOverridingMount(t *testing.T) {
 func TestSecretSet(t *testing.T) {
 	t.Parallel()
 	c, ctx := connect(t)
-	defer c.Close()
 
 	secretValue := "very-secret-text"
 
@@ -122,7 +121,6 @@ func TestSecretSet(t *testing.T) {
 func TestSecretWhitespaceScrubbed(t *testing.T) {
 	t.Parallel()
 	c, ctx := connect(t)
-	defer c.Close()
 
 	secretValue := "very\nsecret\ntext\n"
 
@@ -140,7 +138,6 @@ func TestSecretWhitespaceScrubbed(t *testing.T) {
 func TestSecretBigScrubbed(t *testing.T) {
 	t.Parallel()
 	c, ctx := connect(t)
-	defer c.Close()
 	secretKeyReader := bytes.NewReader(secretKeyBytes)
 	secretValue, err := io.ReadAll(secretKeyReader)
 	require.NoError(t, err)

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -63,7 +63,6 @@ func TestServiceHostnamesAreStable(t *testing.T) {
 
 	t.Run("hostnames are different for different services", func(t *testing.T) {
 		c, ctx := connect(t)
-		defer c.Close()
 
 		srv1 := c.Container().
 			From("python").
@@ -85,7 +84,6 @@ func TestServiceHostnamesAreStable(t *testing.T) {
 
 	t.Run("hostnames are stable within a session", func(t *testing.T) {
 		c, ctx := connect(t)
-		defer c.Close()
 
 		hosts := map[string]int{}
 		for i := 0; i < 10; i++ {
@@ -112,7 +110,6 @@ func TestContainerHostnameEndpoint(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	t.Run("hostname is same as endpoint", func(t *testing.T) {
 		srv := c.Container().
@@ -179,7 +176,6 @@ func TestContainerPortLifecycle(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	withPorts := c.Container().
 		From("python").
@@ -300,7 +296,6 @@ func TestContainerPortOCIConfig(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	withPorts := c.Container().
 		From("python").
@@ -363,7 +358,6 @@ func TestContainerExecServices(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		t.Parallel()
 		c, ctx := connect(t)
-		defer c.Close()
 
 		srv, url := httpService(ctx, t, c, "Hello, world!")
 
@@ -391,7 +385,6 @@ func TestContainerExecServices(t *testing.T) {
 	t.Run("not an exec", func(t *testing.T) {
 		t.Parallel()
 		c, ctx := connect(t)
-		defer c.Close()
 
 		srv, _ := httpService(ctx, t, c, "Hello, world!")
 		srv = srv.WithNewFile("/foo")
@@ -409,7 +402,6 @@ func TestContainerExecServicesError(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	srv := c.Container().
 		From(alpineImage).
@@ -433,7 +425,6 @@ func TestContainerServiceNoExec(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	srv := c.Container().
 		From(alpineImage).
@@ -463,7 +454,6 @@ func TestContainerExecUDPServices(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	srv := c.Container().
 		From("golang:1.18.2-alpine").
@@ -497,7 +487,6 @@ func TestContainerExecServiceAlias(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	srv, _ := httpService(ctx, t, c, "Hello, world!")
 
@@ -526,7 +515,6 @@ func TestContainerExecServicesDeduping(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	srv := c.Container().
 		From("golang:1.18.2-alpine").
@@ -562,7 +550,6 @@ func TestContainerExecServicesChained(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	srv, _ := httpService(ctx, t, c, "0\n")
 
@@ -600,7 +587,6 @@ func TestContainerExecServicesNestedExec(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	nestingLimit := calculateNestingLimit(ctx, c, t)
 
@@ -635,7 +621,6 @@ func TestContainerExecServicesNestedHTTP(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	nestingLimit := calculateNestingLimit(ctx, c, t)
 
@@ -673,7 +658,6 @@ func TestContainerExecServicesNestedGit(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	nestingLimit := calculateNestingLimit(ctx, c, t)
 
@@ -711,7 +695,6 @@ func TestContainerExportServices(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	content := identity.NewID()
 	srv, httpURL := httpService(ctx, t, c, content)
@@ -731,7 +714,6 @@ func TestContainerMultiPlatformExportServices(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	variants := make([]*dagger.Container, 0, len(platformToUname))
 	for platform := range platformToUname {
@@ -758,7 +740,6 @@ func TestServicesContainerPublish(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	content := identity.NewID()
 	srv, url := httpService(ctx, t, c, content)
@@ -783,7 +764,6 @@ func TestContainerRootFSServices(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	content := identity.NewID()
 	srv, url := httpService(ctx, t, c, content)
@@ -805,7 +785,6 @@ func TestContainerWithRootFSServices(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	content := identity.NewID()
 	srv, url := httpService(ctx, t, c, content)
@@ -839,7 +818,6 @@ func TestContainerDirectoryServices(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	content := identity.NewID()
 	srv, url := httpService(ctx, t, c, content)
@@ -885,7 +863,6 @@ func TestContainerFileServices(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	content := identity.NewID()
 	srv, url := httpService(ctx, t, c, content)
@@ -905,7 +882,6 @@ func TestContainerWithServiceFileDirectory(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	response := identity.NewID()
 	srv, httpURL := httpService(ctx, t, c, response)
@@ -953,7 +929,6 @@ func TestDirectoryServiceEntries(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	content := identity.NewID()
 
@@ -974,7 +949,6 @@ func TestDirectoryServiceSync(t *testing.T) {
 		t.Parallel()
 
 		c, ctx := connect(t)
-		defer c.Close()
 
 		content := identity.NewID()
 		gitDaemon, repoURL := gitService(ctx, t, c, c.Directory().WithNewFile("README.md", content))
@@ -989,7 +963,6 @@ func TestDirectoryServiceSync(t *testing.T) {
 		t.Parallel()
 
 		c, ctx := connect(t)
-		defer c.Close()
 
 		content := identity.NewID()
 		gitDaemon, repoURL := gitService(ctx, t, c, c.Directory().WithNewFile("README.md", content))
@@ -1009,7 +982,6 @@ func TestDirectoryServiceTimestamp(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	content := identity.NewID()
 	gitDaemon, repoURL := gitService(ctx, t, c, c.Directory().WithNewFile("README.md", content))
@@ -1032,7 +1004,6 @@ func TestDirectoryWithDirectoryFileServices(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	content := identity.NewID()
 
@@ -1057,7 +1028,6 @@ func TestDirectoryServiceExport(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	content := identity.NewID()
 
@@ -1081,7 +1051,6 @@ func TestFileServiceContents(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	content := identity.NewID()
 
@@ -1103,7 +1072,6 @@ func TestFileServiceSync(t *testing.T) {
 		t.Parallel()
 
 		c, ctx := connect(t)
-		defer c.Close()
 
 		content := identity.NewID()
 		httpSrv, httpURL := httpService(ctx, t, c, content)
@@ -1120,7 +1088,6 @@ func TestFileServiceSync(t *testing.T) {
 		t.Parallel()
 
 		c, ctx := connect(t)
-		defer c.Close()
 
 		content := identity.NewID()
 		httpSrv, httpURL := httpService(ctx, t, c, content)
@@ -1140,7 +1107,6 @@ func TestFileServiceExport(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	content := identity.NewID()
 
@@ -1166,7 +1132,6 @@ func TestFileServiceTimestamp(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
-	defer c.Close()
 
 	content := identity.NewID()
 

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"archive/tar"
+	"bytes"
 	"context"
 	"crypto/md5"
 	"errors"
@@ -10,6 +11,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 
 	"dagger.io/dagger"
@@ -20,7 +23,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	os.Setenv("_DAGGER_DEBUG_HEALTHCHECKS", "1")
 	// start with fresh test registries once per suite; they're an engine-global
 	// dependency
 	// startRegistry()
@@ -28,20 +30,25 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func connect(t require.TestingT) (*dagger.Client, context.Context) {
-	return connectWithLogOutput(t, os.Stderr)
+func connect(t *testing.T) (*dagger.Client, context.Context) {
+	tw := newTWriter(t)
+	t.Cleanup(tw.Flush)
+	return connectWithLogOutput(t, tw)
 }
 
-func connectWithBufferedLogs(t require.TestingT) (*dagger.Client, context.Context, *safeBuffer) {
+func connectWithBufferedLogs(t *testing.T) (*dagger.Client, context.Context, *safeBuffer) {
+	tw := newTWriter(t)
+	t.Cleanup(tw.Flush)
 	output := &safeBuffer{}
-	c, ctx := connectWithLogOutput(t, io.MultiWriter(os.Stderr, output))
+	c, ctx := connectWithLogOutput(t, io.MultiWriter(tw, output))
 	return c, ctx, output
 }
 
-func connectWithLogOutput(t require.TestingT, logOutput io.Writer) (*dagger.Client, context.Context) {
+func connectWithLogOutput(t *testing.T, logOutput io.Writer) (*dagger.Client, context.Context) {
 	ctx := context.Background()
 	client, err := dagger.Connect(ctx, dagger.WithLogOutput(logOutput))
 	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() })
 	return client, ctx
 }
 
@@ -380,4 +387,66 @@ func goCache(c *dagger.Client) dagger.WithContainerFunc {
 			WithMountedCache("/go/build-cache", c.CacheVolume("go-build")).
 			WithEnvVariable("GOCACHE", "/go/build-cache")
 	}
+}
+
+// tWriter is a writer that writes to testing.T
+type tWriter struct {
+	t   *testing.T
+	buf bytes.Buffer
+	mu  sync.Mutex
+}
+
+// newTWriter creates a new TWriter
+func newTWriter(t *testing.T) *tWriter {
+	return &tWriter{t: t}
+}
+
+// Write writes data to the testing.T
+func (tw *tWriter) Write(p []byte) (n int, err error) {
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
+
+	tw.t.Helper()
+
+	if n, err = tw.buf.Write(p); err != nil {
+		return n, err
+	}
+
+	for {
+		line, err := tw.buf.ReadBytes('\n')
+		if err == io.EOF {
+			// If we've reached the end of the buffer, write it back, because it doesn't have a newline
+			tw.buf.Write(line)
+			break
+		}
+		if err != nil {
+			return n, err
+		}
+
+		tw.t.Log(strings.TrimSuffix(string(line), "\n"))
+	}
+	return n, nil
+}
+
+func (tw *tWriter) Flush() {
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
+	tw.t.Log(tw.buf.String())
+}
+
+type safeBuffer struct {
+	bu bytes.Buffer
+	mu sync.Mutex
+}
+
+func (s *safeBuffer) Write(p []byte) (n int, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.bu.Write(p)
+}
+
+func (s *safeBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.bu.String()
 }


### PR DESCRIPTION
I've been carrying this refactor around between various long-running branches because it's nearly impossible to grok test failure output without it.

Previously all of our tests would just dump their client logs to `os.Stdout` or `os.Stderr`, resulting in all of them interleaving so it's impossible to tell one parallel test's output from another. Now each test's client logs are sent to an `io.Writer` that writes to `t.Log`, so the client logs will show up in each individual test failure's output.

Additionally this refactors all existing tests to 1) use the `connect()` helper and 2) remove the now-redundant `defer c.Close()`.