### PR TITLE
Update Go getting started guide

### DIFF
--- a/docs/current/sdk/go/959738-get-started.md
+++ b/docs/current/sdk/go/959738-get-started.md
@@ -162,7 +162,7 @@ Use the `tree` command to see the build artifacts on the host, as shown below:
 ```shell
 tree build
 build/
-├── 1.18
+├── 1.20
 │   ├── darwin
 │   │   ├── amd64
 │   │   │   └── multibuild
@@ -173,7 +173,7 @@ build/
 │       │   └── multibuild
 │       └── arm64
 │           └── multibuild
-└── 1.19
+└── 1.21
     ├── darwin
     │   ├── amd64
     │   │   └── multibuild

--- a/docs/current/sdk/go/snippets/get-started/step5b/main.go
+++ b/docs/current/sdk/go/snippets/get-started/step5b/main.go
@@ -21,7 +21,7 @@ func build(ctx context.Context) error {
 	oses := []string{"linux", "darwin"}
 	arches := []string{"amd64", "arm64"}
 	// highlight-start
-	goVersions := []string{"1.18", "1.19"}
+	goVersions := []string{"1.20", "1.21"}
 	// highlight-end
 
 	// initialize Dagger client


### PR DESCRIPTION
Currently step 5b breaks because the SDK is not compatible with Go 1.18 or 1.19. This updates step 5b to use 1.20 and 1.21