### PR TITLE
engine: add DAGGERL_CLOUD_TOKEN env variable support

### DIFF
--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -748,6 +748,12 @@ func newController(ctx context.Context, c *cli.Context, cfg *config.Config) (*se
 	cacheServiceURL := os.Getenv("_EXPERIMENTAL_DAGGER_CACHESERVICE_URL")
 	cacheServiceToken := os.Getenv("_EXPERIMENTAL_DAGGER_CACHESERVICE_TOKEN")
 
+	// add DAGGER_CLOUD_TOKEN in a backwards compat way.
+	// TODO: deprecate in a future release
+	if v, ok := os.LookupEnv("DAGGER_CLOUD_TOKEN"); ok {
+		cacheServiceToken = v
+	}
+
 	if cacheServiceURL == "" {
 		cacheServiceURL = daggerCacheServiceURL
 	}

--- a/core/pipeline/label.go
+++ b/core/pipeline/label.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"github.com/go-git/go-git/v5"
@@ -26,6 +27,44 @@ func EngineLabel(engineName string) Label {
 		Name:  "dagger.io/engine",
 		Value: engineName,
 	}
+}
+
+func LoadServerLabels(engineVersion, os, arch string) []Label {
+	labels := []Label{
+		{
+			Name:  "dagger.io/server.os",
+			Value: os,
+		},
+		{
+			Name:  "dagger.io/server.arch",
+			Value: arch,
+		},
+		{
+			Name:  "dagger.io/server.version",
+			Value: engineVersion,
+		},
+	}
+
+	return labels
+}
+
+func LoadClientLabels(engineVersion string) []Label {
+	labels := []Label{
+		{
+			Name:  "dagger.io/client.os",
+			Value: runtime.GOOS,
+		},
+		{
+			Name:  "dagger.io/client.arch",
+			Value: runtime.GOARCH,
+		},
+		{
+			Name:  "dagger.io/client.version",
+			Value: engineVersion,
+		},
+	}
+
+	return labels
 }
 
 func LoadVCSLabels(workdir string) []Label {

--- a/core/pipeline/label_test.go
+++ b/core/pipeline/label_test.go
@@ -3,12 +3,38 @@ package pipeline_test
 import (
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/dagger/dagger/core/pipeline"
+	"github.com/dagger/dagger/engine"
 	"github.com/stretchr/testify/require"
 )
+
+func TestLoadClientLabels(t *testing.T) {
+	labels := pipeline.LoadClientLabels(engine.Version)
+
+	expected := []pipeline.Label{
+		{"dagger.io/client.os", runtime.GOOS},
+		{"dagger.io/client.arch", runtime.GOARCH},
+		{"dagger.io/client.version", engine.Version},
+	}
+
+	require.ElementsMatch(t, expected, labels)
+}
+
+func TestLoadServerLabels(t *testing.T) {
+	labels := pipeline.LoadServerLabels("0.8.4", "linux", "amd64")
+
+	expected := []pipeline.Label{
+		{"dagger.io/server.os", "linux"},
+		{"dagger.io/server.arch", "amd64"},
+		{"dagger.io/server.version", "0.8.4"},
+	}
+
+	require.ElementsMatch(t, expected, labels)
+}
 
 func TestLoadGitLabels(t *testing.T) {
 	normalRepo := setupRepo(t)

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -223,6 +223,7 @@ func Connect(ctx context.Context, params Params) (_ *Client, _ context.Context, 
 	}
 
 	c.labels = pipeline.LoadVCSLabels(workdir)
+	c.labels = append(c.labels, pipeline.LoadClientLabels(engine.Version)...)
 
 	c.internalCtx = engine.ContextWithClientMetadata(c.internalCtx, &engine.ClientMetadata{
 		ClientID:          c.ID(),
@@ -580,7 +581,7 @@ func (AnyDirTarget) DiffCopy(stream filesync.FileSend_DiffCopyServer) (rerr erro
 
 	if !opts.IsFileStream {
 		// we're writing a full directory tree, normal fsutil.Receive is good
-		if err := os.MkdirAll(opts.Path, 0700); err != nil {
+		if err := os.MkdirAll(opts.Path, 0o700); err != nil {
 			return fmt.Errorf("failed to create synctarget dest dir %s: %w", opts.Path, err)
 		}
 
@@ -641,12 +642,12 @@ func (AnyDirTarget) DiffCopy(stream filesync.FileSend_DiffCopyServer) (rerr erro
 		finalDestPath = filepath.Join(destParentDir, fileOriginalName)
 	}
 
-	if err := os.MkdirAll(destParentDir, 0700); err != nil {
+	if err := os.MkdirAll(destParentDir, 0o700); err != nil {
 		return fmt.Errorf("failed to create synctarget dest dir %s: %w", destParentDir, err)
 	}
 
 	if opts.FileMode == 0 {
-		opts.FileMode = 0600
+		opts.FileMode = 0o600
 	}
 	destF, err := os.OpenFile(finalDestPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, opts.FileMode)
 	if err != nil {

--- a/engine/client/docker.go
+++ b/engine/client/docker.go
@@ -21,6 +21,7 @@ const (
 
 	ServicesDNSEnvName    = "_EXPERIMENTAL_DAGGER_SERVICES_DNS"
 	DaggerCloudCacheToken = "_EXPERIMENTAL_DAGGER_CACHESERVICE_TOKEN"
+	DaggerCloudToken      = "DAGGER_CLOUD_TOKEN"
 
 	// trim image digests to 16 characters to makeoutput more readable
 	hashLen             = 16
@@ -85,6 +86,13 @@ func dockerImageProvider(ctx context.Context, runnerHost *url.URL, userAgent str
 	}
 	id = id[:hashLen]
 
+	// add DAGGER_CLOUD_TOKEN in backwards compat way.
+	// TODO: deprecate in a future release
+	cloudToken := DaggerCloudCacheToken
+	if _, ok := os.LookupEnv(DaggerCloudToken); ok {
+		cloudToken = DaggerCloudToken
+	}
+
 	// run the container using that id in the name
 	containerName := containerNamePrefix + id
 	runArgs := []string{
@@ -93,7 +101,7 @@ func dockerImageProvider(ctx context.Context, runnerHost *url.URL, userAgent str
 		"-d",
 		"--restart", "always",
 		"-e", ServicesDNSEnvName,
-		"-e", DaggerCloudCacheToken,
+		"-e", cloudToken,
 		"-v", DefaultStateDir,
 		"--privileged",
 	}

--- a/engine/server/buildkitcontroller.go
+++ b/engine/server/buildkitcontroller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"runtime/debug"
 	"sync"
 	"time"
@@ -239,6 +240,7 @@ func (e *BuildkitController) Session(stream controlapi.Control_SessionServer) (r
 
 		labels := opts.Labels
 		labels = append(labels, pipeline.EngineLabel(e.EngineName))
+		labels = append(labels, pipeline.LoadServerLabels(engine.Version, runtime.GOOS, runtime.GOARCH)...)
 
 		srv, err = NewDaggerServer(ctx, bkClient, e.worker, caller, opts.ServerID, secretStore, authProvider, labels)
 		if err != nil {

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -35,10 +35,17 @@ type Telemetry struct {
 }
 
 func New() *Telemetry {
+	cloudToken := os.Getenv("_EXPERIMENTAL_DAGGER_CLOUD_TOKEN")
+	// add DAGGER_CLOUD_TOKEN in backwards compat way.
+	// TODO: deprecate in a future release
+	if v, ok := os.LookupEnv("DAGGER_CLOUD_TOKEN"); ok {
+		cloudToken = v
+	}
+
 	t := &Telemetry{
 		runID:   uuid.NewString(),
 		pushURL: os.Getenv("_EXPERIMENTAL_DAGGER_CLOUD_URL"),
-		token:   os.Getenv("_EXPERIMENTAL_DAGGER_CLOUD_TOKEN"),
+		token:   cloudToken,
 		stopCh:  make(chan struct{}),
 		doneCh:  make(chan struct{}),
 	}


### PR DESCRIPTION
this is implemented in a backwards compatible way so that old
variables will still work but will be deprecated in a future.

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
