### PR TITLE
fix(go-sdk): check nil ptr.

### DIFF
--- a/codegen/generator/go/templates/functions.go
+++ b/codegen/generator/go/templates/functions.go
@@ -27,6 +27,7 @@ var (
 		"FieldOptionsStructName":  fieldOptionsStructName,
 		"FieldFunction":           fieldFunction,
 		"IsEnum":                  isEnum,
+		"IsPointer":               isPointer,
 		"GetArrayField":           commonFunc.GetArrayField,
 		"IsListOfObject":          commonFunc.IsListOfObject,
 		"ToLowerCase":             commonFunc.ToLowerCase,
@@ -71,6 +72,19 @@ func isEnum(t introspection.Type) bool {
 	return t.Kind == introspection.TypeKindEnum &&
 		// We ignore the internal GraphQL enums
 		!strings.HasPrefix(t.Name, "__")
+}
+
+// isPointer returns true if value is a pointer.
+func isPointer(t introspection.InputValue) bool {
+	// Ignore id since it's converted to special ID type later.
+	if t.Name == "id" {
+		return false
+	}
+
+	// Convert to a string representation to avoid code repetition.
+	representation := commonFunc.FormatInputType(t.TypeRef)
+
+	return strings.Index(representation, "*") == 0
 }
 
 // formatName formats a GraphQL name (e.g. object, field, arg) into a Go equivalent

--- a/codegen/generator/go/templates/src/header.go.tmpl
+++ b/codegen/generator/go/templates/src/header.go.tmpl
@@ -18,6 +18,6 @@ func assertNotNil(value any) {
 	// the value is wrapped into a type when passed as parameter.
 	// E.g., nil become (*dagger.File)(nil).
 	if reflect.ValueOf(value).IsNil() {
-		panic("unexpected nil pointer")
+		panic(fmt.Sprintf("unexpected nil pointer for argument %q", argName))
 	}
 }

--- a/codegen/generator/go/templates/src/header.go.tmpl
+++ b/codegen/generator/go/templates/src/header.go.tmpl
@@ -4,6 +4,7 @@ package {{ .Package }}
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	"github.com/Khan/genqlient/graphql"
@@ -13,7 +14,7 @@ import (
 // assertNotNil panic if the given value is nil.
 // This function is used to validate that input with pointer type are not nil.
 // See https://github.com/dagger/dagger/issues/5696 for more context.
-func assertNotNil(value any) {
+func assertNotNil(argName string, value any) {
 	// We use reflect because just comparing value to nil is not working since
 	// the value is wrapped into a type when passed as parameter.
 	// E.g., nil become (*dagger.File)(nil).

--- a/codegen/generator/go/templates/src/header.go.tmpl
+++ b/codegen/generator/go/templates/src/header.go.tmpl
@@ -4,7 +4,20 @@ package {{ .Package }}
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/Khan/genqlient/graphql"
 	"dagger.io/dagger/internal/querybuilder"
 )
+
+// assertNotNil panic if the given value is nil.
+// This function is used to validate that input with pointer type are not nil.
+// See https://github.com/dagger/dagger/issues/5696 for more context.
+func assertNotNil(value any) {
+	// We use reflect because just comparing value to nil is not working since
+	// the value is wrapped into a type when passed as parameter.
+	// E.g., nil become (*dagger.File)(nil).
+	if reflect.ValueOf(value).IsNil() {
+		panic("unexpected nil pointer")
+	}
+}

--- a/codegen/generator/go/templates/src/object.go.tmpl
+++ b/codegen/generator/go/templates/src/object.go.tmpl
@@ -50,6 +50,12 @@ type {{ $field | FieldOptionsStructName }} struct {
 {{- end }}
 {{- $convertID := $field | ConvertID }}
 {{ $field | FieldFunction }} {
+	{{- range $arg := $field.Args }}
+	    {{- if and (IsPointer $arg) (not $arg.TypeRef.IsOptional) }}
+        assertNotNil({{ $arg.Name }})
+        {{- end }}
+    {{- end }}
+
     {{- if and ($field.TypeRef.IsScalar) (ne $field.ParentObject.Name "Query") (not $convertID) }}
     if r.{{ $field.Name }} != nil {
         return *r.{{ $field.Name }}, nil

--- a/codegen/generator/go/templates/src/object.go.tmpl
+++ b/codegen/generator/go/templates/src/object.go.tmpl
@@ -52,7 +52,7 @@ type {{ $field | FieldOptionsStructName }} struct {
 {{ $field | FieldFunction }} {
 	{{- range $arg := $field.Args }}
 	    {{- if and (IsPointer $arg) (not $arg.TypeRef.IsOptional) }}
-        assertNotNil({{ $arg.Name }})
+        assertNotNil("{{ $arg.Name}}", {{ $arg.Name }})
         {{- end }}
     {{- end }}
 

--- a/sdk/go/.changes/unreleased/Fixed-20230915-131930.yaml
+++ b/sdk/go/.changes/unreleased/Fixed-20230915-131930.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Check and panic if a nil pointer is sent as argument to a query
+time: 2023-09-15T13:19:30.834418+02:00
+custom:
+  Author: TomChv
+  PR: "5785"

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -4,10 +4,23 @@ package dagger
 
 import (
 	"context"
+	"reflect"
 
 	"dagger.io/dagger/internal/querybuilder"
 	"github.com/Khan/genqlient/graphql"
 )
+
+// assertNotNil panic if the given value is nil.
+// This function is used to validate that input with pointer type are not nil.
+// See https://github.com/dagger/dagger/issues/5696 for more context.
+func assertNotNil(value any) {
+	// We use reflect because just comparing value to nil is not working since
+	// the value is wrapped into a type when passed as parameter.
+	// E.g., nil become (*dagger.File)(nil).
+	if reflect.ValueOf(value).IsNil() {
+		panic("unexpected nil pointer")
+	}
+}
 
 // A global cache volume identifier.
 type CacheID string
@@ -146,6 +159,7 @@ type ContainerBuildOpts struct {
 
 // Initializes this container from a Dockerfile build.
 func (r *Container) Build(context *Directory, opts ...ContainerBuildOpts) *Container {
+	assertNotNil(context)
 	q := r.q.Select("build")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `dockerfile` optional argument
@@ -471,6 +485,7 @@ type ContainerImportOpts struct {
 // NOTE: this involves unpacking the tarball to an OCI store on the host at
 // $XDG_CACHE_DIR/dagger/oci. This directory can be removed whenever you like.
 func (r *Container) Import(source *File, opts ...ContainerImportOpts) *Container {
+	assertNotNil(source)
 	q := r.q.Select("import")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `tag` optional argument
@@ -732,6 +747,7 @@ type ContainerWithDirectoryOpts struct {
 
 // Retrieves this container plus a directory written at the given path.
 func (r *Container) WithDirectory(path string, directory *Directory, opts ...ContainerWithDirectoryOpts) *Container {
+	assertNotNil(directory)
 	q := r.q.Select("withDirectory")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `exclude` optional argument
@@ -902,6 +918,7 @@ type ContainerWithFileOpts struct {
 
 // Retrieves this container plus the contents of the given file copied to the given path.
 func (r *Container) WithFile(path string, source *File, opts ...ContainerWithFileOpts) *Container {
+	assertNotNil(source)
 	q := r.q.Select("withFile")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `permissions` optional argument
@@ -965,6 +982,7 @@ type ContainerWithMountedCacheOpts struct {
 
 // Retrieves this container plus a cache volume mounted at the given path.
 func (r *Container) WithMountedCache(path string, cache *CacheVolume, opts ...ContainerWithMountedCacheOpts) *Container {
+	assertNotNil(cache)
 	q := r.q.Select("withMountedCache")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `source` optional argument
@@ -1001,6 +1019,7 @@ type ContainerWithMountedDirectoryOpts struct {
 
 // Retrieves this container plus a directory mounted at the given path.
 func (r *Container) WithMountedDirectory(path string, source *Directory, opts ...ContainerWithMountedDirectoryOpts) *Container {
+	assertNotNil(source)
 	q := r.q.Select("withMountedDirectory")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `owner` optional argument
@@ -1029,6 +1048,7 @@ type ContainerWithMountedFileOpts struct {
 
 // Retrieves this container plus a file mounted at the given path.
 func (r *Container) WithMountedFile(path string, source *File, opts ...ContainerWithMountedFileOpts) *Container {
+	assertNotNil(source)
 	q := r.q.Select("withMountedFile")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `owner` optional argument
@@ -1062,6 +1082,7 @@ type ContainerWithMountedSecretOpts struct {
 
 // Retrieves this container plus a secret mounted into a file at the given path.
 func (r *Container) WithMountedSecret(path string, source *Secret, opts ...ContainerWithMountedSecretOpts) *Container {
+	assertNotNil(source)
 	q := r.q.Select("withMountedSecret")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `owner` optional argument
@@ -1136,6 +1157,7 @@ func (r *Container) WithNewFile(path string, opts ...ContainerWithNewFileOpts) *
 
 // Retrieves this container with a registry authentication for a given address.
 func (r *Container) WithRegistryAuth(address string, username string, secret *Secret) *Container {
+	assertNotNil(secret)
 	q := r.q.Select("withRegistryAuth")
 	q = q.Arg("address", address)
 	q = q.Arg("username", username)
@@ -1149,6 +1171,7 @@ func (r *Container) WithRegistryAuth(address string, username string, secret *Se
 
 // Initializes this container from this DirectoryID.
 func (r *Container) WithRootfs(directory *Directory) *Container {
+	assertNotNil(directory)
 	q := r.q.Select("withRootfs")
 	q = q.Arg("directory", directory)
 
@@ -1160,6 +1183,7 @@ func (r *Container) WithRootfs(directory *Directory) *Container {
 
 // Retrieves this container plus an env variable containing the given secret.
 func (r *Container) WithSecretVariable(name string, secret *Secret) *Container {
+	assertNotNil(secret)
 	q := r.q.Select("withSecretVariable")
 	q = q.Arg("name", name)
 	q = q.Arg("secret", secret)
@@ -1181,6 +1205,7 @@ func (r *Container) WithSecretVariable(name string, secret *Secret) *Container {
 //
 // Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
 func (r *Container) WithServiceBinding(alias string, service *Container) *Container {
+	assertNotNil(service)
 	q := r.q.Select("withServiceBinding")
 	q = q.Arg("alias", alias)
 	q = q.Arg("service", service)
@@ -1203,6 +1228,7 @@ type ContainerWithUnixSocketOpts struct {
 
 // Retrieves this container plus a socket forwarded to the given Unix socket path.
 func (r *Container) WithUnixSocket(path string, source *Socket, opts ...ContainerWithUnixSocketOpts) *Container {
+	assertNotNil(source)
 	q := r.q.Select("withUnixSocket")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `owner` optional argument
@@ -1367,6 +1393,7 @@ func (r *Directory) With(f WithDirectoryFunc) *Directory {
 
 // Gets the difference between this directory and an another directory.
 func (r *Directory) Diff(other *Directory) *Directory {
+	assertNotNil(other)
 	q := r.q.Select("diff")
 	q = q.Arg("other", other)
 
@@ -1562,6 +1589,7 @@ type DirectoryWithDirectoryOpts struct {
 
 // Retrieves this directory plus a directory written at the given path.
 func (r *Directory) WithDirectory(path string, directory *Directory, opts ...DirectoryWithDirectoryOpts) *Directory {
+	assertNotNil(directory)
 	q := r.q.Select("withDirectory")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `exclude` optional argument
@@ -1592,6 +1620,7 @@ type DirectoryWithFileOpts struct {
 
 // Retrieves this directory plus the contents of the given file copied to the given path.
 func (r *Directory) WithFile(path string, source *File, opts ...DirectoryWithFileOpts) *Directory {
+	assertNotNil(source)
 	q := r.q.Select("withFile")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `permissions` optional argument
@@ -2161,6 +2190,7 @@ func (r *Project) XXX_GraphQLID(ctx context.Context) (string, error) {
 
 // Initialize this project from the given directory and config path
 func (r *Project) Load(source *Directory, configPath string) *Project {
+	assertNotNil(source)
 	q := r.q.Select("load")
 	q = q.Arg("source", source)
 	q = q.Arg("configPath", configPath)

--- a/sdk/go/api.gen.go
+++ b/sdk/go/api.gen.go
@@ -4,6 +4,7 @@ package dagger
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	"dagger.io/dagger/internal/querybuilder"
@@ -13,12 +14,12 @@ import (
 // assertNotNil panic if the given value is nil.
 // This function is used to validate that input with pointer type are not nil.
 // See https://github.com/dagger/dagger/issues/5696 for more context.
-func assertNotNil(value any) {
+func assertNotNil(argName string, value any) {
 	// We use reflect because just comparing value to nil is not working since
 	// the value is wrapped into a type when passed as parameter.
 	// E.g., nil become (*dagger.File)(nil).
 	if reflect.ValueOf(value).IsNil() {
-		panic("unexpected nil pointer")
+		panic(fmt.Sprintf("unexpected nil pointer for argument %q", argName))
 	}
 }
 
@@ -159,7 +160,7 @@ type ContainerBuildOpts struct {
 
 // Initializes this container from a Dockerfile build.
 func (r *Container) Build(context *Directory, opts ...ContainerBuildOpts) *Container {
-	assertNotNil(context)
+	assertNotNil("context", context)
 	q := r.q.Select("build")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `dockerfile` optional argument
@@ -485,7 +486,7 @@ type ContainerImportOpts struct {
 // NOTE: this involves unpacking the tarball to an OCI store on the host at
 // $XDG_CACHE_DIR/dagger/oci. This directory can be removed whenever you like.
 func (r *Container) Import(source *File, opts ...ContainerImportOpts) *Container {
-	assertNotNil(source)
+	assertNotNil("source", source)
 	q := r.q.Select("import")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `tag` optional argument
@@ -747,7 +748,7 @@ type ContainerWithDirectoryOpts struct {
 
 // Retrieves this container plus a directory written at the given path.
 func (r *Container) WithDirectory(path string, directory *Directory, opts ...ContainerWithDirectoryOpts) *Container {
-	assertNotNil(directory)
+	assertNotNil("directory", directory)
 	q := r.q.Select("withDirectory")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `exclude` optional argument
@@ -918,7 +919,7 @@ type ContainerWithFileOpts struct {
 
 // Retrieves this container plus the contents of the given file copied to the given path.
 func (r *Container) WithFile(path string, source *File, opts ...ContainerWithFileOpts) *Container {
-	assertNotNil(source)
+	assertNotNil("source", source)
 	q := r.q.Select("withFile")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `permissions` optional argument
@@ -982,7 +983,7 @@ type ContainerWithMountedCacheOpts struct {
 
 // Retrieves this container plus a cache volume mounted at the given path.
 func (r *Container) WithMountedCache(path string, cache *CacheVolume, opts ...ContainerWithMountedCacheOpts) *Container {
-	assertNotNil(cache)
+	assertNotNil("cache", cache)
 	q := r.q.Select("withMountedCache")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `source` optional argument
@@ -1019,7 +1020,7 @@ type ContainerWithMountedDirectoryOpts struct {
 
 // Retrieves this container plus a directory mounted at the given path.
 func (r *Container) WithMountedDirectory(path string, source *Directory, opts ...ContainerWithMountedDirectoryOpts) *Container {
-	assertNotNil(source)
+	assertNotNil("source", source)
 	q := r.q.Select("withMountedDirectory")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `owner` optional argument
@@ -1048,7 +1049,7 @@ type ContainerWithMountedFileOpts struct {
 
 // Retrieves this container plus a file mounted at the given path.
 func (r *Container) WithMountedFile(path string, source *File, opts ...ContainerWithMountedFileOpts) *Container {
-	assertNotNil(source)
+	assertNotNil("source", source)
 	q := r.q.Select("withMountedFile")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `owner` optional argument
@@ -1082,7 +1083,7 @@ type ContainerWithMountedSecretOpts struct {
 
 // Retrieves this container plus a secret mounted into a file at the given path.
 func (r *Container) WithMountedSecret(path string, source *Secret, opts ...ContainerWithMountedSecretOpts) *Container {
-	assertNotNil(source)
+	assertNotNil("source", source)
 	q := r.q.Select("withMountedSecret")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `owner` optional argument
@@ -1157,7 +1158,7 @@ func (r *Container) WithNewFile(path string, opts ...ContainerWithNewFileOpts) *
 
 // Retrieves this container with a registry authentication for a given address.
 func (r *Container) WithRegistryAuth(address string, username string, secret *Secret) *Container {
-	assertNotNil(secret)
+	assertNotNil("secret", secret)
 	q := r.q.Select("withRegistryAuth")
 	q = q.Arg("address", address)
 	q = q.Arg("username", username)
@@ -1171,7 +1172,7 @@ func (r *Container) WithRegistryAuth(address string, username string, secret *Se
 
 // Initializes this container from this DirectoryID.
 func (r *Container) WithRootfs(directory *Directory) *Container {
-	assertNotNil(directory)
+	assertNotNil("directory", directory)
 	q := r.q.Select("withRootfs")
 	q = q.Arg("directory", directory)
 
@@ -1183,7 +1184,7 @@ func (r *Container) WithRootfs(directory *Directory) *Container {
 
 // Retrieves this container plus an env variable containing the given secret.
 func (r *Container) WithSecretVariable(name string, secret *Secret) *Container {
-	assertNotNil(secret)
+	assertNotNil("secret", secret)
 	q := r.q.Select("withSecretVariable")
 	q = q.Arg("name", name)
 	q = q.Arg("secret", secret)
@@ -1205,7 +1206,7 @@ func (r *Container) WithSecretVariable(name string, secret *Secret) *Container {
 //
 // Currently experimental; set _EXPERIMENTAL_DAGGER_SERVICES_DNS=0 to disable.
 func (r *Container) WithServiceBinding(alias string, service *Container) *Container {
-	assertNotNil(service)
+	assertNotNil("service", service)
 	q := r.q.Select("withServiceBinding")
 	q = q.Arg("alias", alias)
 	q = q.Arg("service", service)
@@ -1228,7 +1229,7 @@ type ContainerWithUnixSocketOpts struct {
 
 // Retrieves this container plus a socket forwarded to the given Unix socket path.
 func (r *Container) WithUnixSocket(path string, source *Socket, opts ...ContainerWithUnixSocketOpts) *Container {
-	assertNotNil(source)
+	assertNotNil("source", source)
 	q := r.q.Select("withUnixSocket")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `owner` optional argument
@@ -1393,7 +1394,7 @@ func (r *Directory) With(f WithDirectoryFunc) *Directory {
 
 // Gets the difference between this directory and an another directory.
 func (r *Directory) Diff(other *Directory) *Directory {
-	assertNotNil(other)
+	assertNotNil("other", other)
 	q := r.q.Select("diff")
 	q = q.Arg("other", other)
 
@@ -1589,7 +1590,7 @@ type DirectoryWithDirectoryOpts struct {
 
 // Retrieves this directory plus a directory written at the given path.
 func (r *Directory) WithDirectory(path string, directory *Directory, opts ...DirectoryWithDirectoryOpts) *Directory {
-	assertNotNil(directory)
+	assertNotNil("directory", directory)
 	q := r.q.Select("withDirectory")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `exclude` optional argument
@@ -1620,7 +1621,7 @@ type DirectoryWithFileOpts struct {
 
 // Retrieves this directory plus the contents of the given file copied to the given path.
 func (r *Directory) WithFile(path string, source *File, opts ...DirectoryWithFileOpts) *Directory {
-	assertNotNil(source)
+	assertNotNil("source", source)
 	q := r.q.Select("withFile")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `permissions` optional argument
@@ -2190,7 +2191,7 @@ func (r *Project) XXX_GraphQLID(ctx context.Context) (string, error) {
 
 // Initialize this project from the given directory and config path
 func (r *Project) Load(source *Directory, configPath string) *Project {
-	assertNotNil(source)
+	assertNotNil("source", source)
 	q := r.q.Select("load")
 	q = q.Arg("source", source)
 	q = q.Arg("configPath", configPath)


### PR DESCRIPTION
Update Go SDK to check for nil pointer before executing the query to throw a smaller stack trace simpler to debug for the user.
The new panic error is `unexpected nil pointer`.
Add `assertNotNil` error to check for nil value.

**Example of display**

```shell
┃ panic: unexpected nil pointer                                                                                                                                                       
┃                                                                                                                                                                                     
┃ goroutine 1 [running]:                                                                                                                                                              
┃ dagger.io/dagger.assertNotNil({0x102af3c20?, 0x0?})                                                                                                                                 
┃         /Users/tomchauveau/Documents/DAGGER/dagger/sdk/go/api.gen.go:21 +0x138                                                                                                      
┃ dagger.io/dagger.(*Container).WithMountedFile(0x140000ec7e0, {0x102a010ef, 0x5}, 0x0, {0x0, 0x0, 0x14000048768?})                                                                   
┃         /Users/tomchauveau/Documents/DAGGER/dagger/sdk/go/api.gen.go:1051 +0x40                                                                                                     
┃ main.main()                                                                                                                                                                         
┃         /Users/tomchauveau/Documents/DAGGER/dagger/test-5696.go:19 +0xdc                                                                                                            
┃ exit status 2  
```

Resolves: #5696