### PR TITLE
engine: record seen cache volumes at resolver level

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -561,7 +561,7 @@ func (container *Container) WithMountedFile(ctx context.Context, bk *buildkit.Cl
 	return container.withMounted(ctx, bk, target, file.LLB, file.File, file.Services, owner)
 }
 
-var SeenCacheKeys sync.Map
+var SeenCacheKeys = new(sync.Map)
 
 func (container *Container) WithMountedCache(ctx context.Context, bk *buildkit.Client, target string, cache *CacheVolume, source *Directory, concurrency CacheSharingMode, owner string) (*Container, error) {
 	container = container.Clone()

--- a/core/container.go
+++ b/core/container.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
@@ -560,6 +561,8 @@ func (container *Container) WithMountedFile(ctx context.Context, bk *buildkit.Cl
 	return container.withMounted(ctx, bk, target, file.LLB, file.File, file.Services, owner)
 }
 
+var SeenCacheKeys sync.Map
+
 func (container *Container) WithMountedCache(ctx context.Context, bk *buildkit.Client, target string, cache *CacheVolume, source *Directory, concurrency CacheSharingMode, owner string) (*Container, error) {
 	container = container.Clone()
 
@@ -605,6 +608,8 @@ func (container *Container) WithMountedCache(ctx context.Context, bk *buildkit.C
 
 	// set image ref to empty string
 	container.ImageRef = ""
+
+	SeenCacheKeys.Store(cache.Keys[0], struct{}{})
 
 	return container, nil
 }

--- a/core/schema/schema_test.go
+++ b/core/schema/schema_test.go
@@ -3,6 +3,8 @@ package schema
 import (
 	"testing"
 
+	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/engine/buildkit"
 	"github.com/stretchr/testify/require"
 )
 
@@ -197,4 +199,25 @@ func TestMergeScalarConflict(t *testing.T) {
 		}),
 	)
 	require.ErrorIs(t, err, ErrMergeScalarConflict)
+}
+
+func TestWithMountedCacheSeen(t *testing.T) {
+	t.Parallel()
+
+	cs := &containerSchema{
+		MergedSchemas: &MergedSchemas{bk: &buildkit.Client{}},
+	}
+
+	cid, err := core.NewCache("test-seen").ID()
+	require.NoError(t, err)
+
+	_, err = cs.withMountedCache(
+		&core.Context{},
+		&core.Container{},
+		containerWithMountedCacheArgs{Path: "/foo", Cache: cid},
+	)
+	require.NoError(t, err)
+
+	_, ok := core.SeenCacheKeys.Load("test-seen")
+	require.True(t, ok)
 }

--- a/engine/cache/mountsync.go
+++ b/engine/cache/mountsync.go
@@ -91,11 +91,22 @@ func (m *manager) StartCacheMountSynchronization(ctx context.Context) error {
 
 	m.stopCacheMountSync = func(ctx context.Context) error {
 		var eg errgroup.Group
+
+		allCacheMounts := map[string]struct{}{}
+		core.SeenCacheKeys.Range(func(k any, v any) bool {
+			allCacheMounts[k.(string)] = struct{}{}
+			return true
+		})
+
 		for _, syncedCacheMount := range syncedCacheMounts {
-			syncedCacheMount := syncedCacheMount
+			allCacheMounts[syncedCacheMount.Name] = struct{}{}
+		}
+
+		for cacheMountName := range allCacheMounts {
+			cacheMountName := cacheMountName
 			eg.Go(func() error {
-				bklog.G(ctx).Debugf("syncing cache mount remotely %s", syncedCacheMount.Name)
-				cacheKey := cacheKeyFromMountName(syncedCacheMount.Name)
+				bklog.G(ctx).Debugf("syncing cache mount remotely %s", cacheMountName)
+				cacheKey := cacheKeyFromMountName(cacheMountName)
 
 				return withCacheMount(ctx, m.MountManager, cacheKey, func(ctx context.Context, mnt mount.Mount) error {
 					// First compress the mount into the content store. We can't stream direct to S3 because we want
@@ -111,7 +122,7 @@ func (m *manager) StartCacheMountSynchronization(ctx context.Context) error {
 					defer done(ctx)
 
 					// compress the mount to a tar.zstd and write to the content store
-					contentRef := "dagger-cachemount-" + syncedCacheMount.Name
+					contentRef := "dagger-cachemount-" + cacheMountName
 					contentWriter, err := m.Worker.ContentStore().Writer(ctx, content.WithRef(contentRef))
 					if err != nil {
 						return fmt.Errorf("failed to create content writer: %w", err)
@@ -135,7 +146,7 @@ func (m *manager) StartCacheMountSynchronization(ctx context.Context) error {
 					if err := contentWriter.Commit(ctx, 0, ""); err != nil {
 						if errors.Is(err, errdefs.ErrAlreadyExists) {
 							// we should be releasing these, but if it was already there, that's weird but fine
-							bklog.G(ctx).Debugf("cache mount %q already committed", syncedCacheMount.Name)
+							bklog.G(ctx).Debugf("cache mount %q already committed", cacheMountName)
 						} else {
 							return fmt.Errorf("failed to commit content: %w", err)
 						}
@@ -152,7 +163,7 @@ func (m *manager) StartCacheMountSynchronization(ctx context.Context) error {
 					defer contentReaderAt.Close()
 					contentLength := contentReaderAt.Size()
 					getURLResp, err := m.cacheClient.GetCacheMountUploadURL(ctx, GetCacheMountUploadURLRequest{
-						CacheName: syncedCacheMount.Name,
+						CacheName: cacheMountName,
 						Digest:    contentDigest,
 						Size:      contentLength,
 					})
@@ -177,7 +188,7 @@ func (m *manager) StartCacheMountSynchronization(ctx context.Context) error {
 						return fmt.Errorf("failed to upload cache mount: %s", resp.Status)
 					}
 
-					bklog.G(ctx).Debugf("synced cache mount remotely %s", syncedCacheMount.Name)
+					bklog.G(ctx).Debugf("synced cache mount remotely %s", cacheMountName)
 					return nil
 				})
 			})


### PR DESCRIPTION
This PR tracks the seen cache volumes at the resolver level so they
can be automatically discovered for syncronization at the engine start
/ stop time. This solution isn't ideal since it should be getting the
cache mounts from buildkit's store instead of the resolver but we
couldn't find a way to make it work with @aluzzardi. We're falling back
to this workaround until maybe @sipsma can shed some light.

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
