### PR TITLE
Fix name of TUI experimental ENV variable

### DIFF
--- a/.changes/unreleased/Fixed-20230917-170956.yaml
+++ b/.changes/unreleased/Fixed-20230917-170956.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fix name of TUI experimental ENV variable
+time: 2023-09-17T17:09:56.165968+02:00
+custom:
+  Author: gmile
+  PR: "5789"

--- a/sdk/elixir/getting_started.livemd
+++ b/sdk/elixir/getting_started.livemd
@@ -19,7 +19,7 @@ And make sure all commands above presents in `$PATH`.
 
 Currently, we support only 2 modes:
 
-1. Session mode with `dagger run`. The benefit of running with this mode is it support rich Terminal User Interface (TUI) by set `_EXPERIMENTAL_DAGGER_TUI=1`
+1. Session mode with `dagger run`. The benefit of running with this mode is it support rich Terminal User Interface (TUI) by set `_EXPERIMENTAL_DAGGER_INTERACTIVE_TUI=1`
 2. Local CLI mode, this mode will start Dagger session and send a request through the session. This mode need to set `_EXPERIMENTAL_DAGGER_CLI_BIN=<path>/<to>/dagger`. We'll use this mode in this tutorial.
 
 ```elixir


### PR DESCRIPTION
As PR title suggests, it's a small fix to the name of ENV variable.