### PR TITLE
engine: remove syncedCacheMount check for cache manager

### DIFF
--- a/engine/cache/mountsync.go
+++ b/engine/cache/mountsync.go
@@ -33,10 +33,6 @@ func (m *manager) StartCacheMountSynchronization(ctx context.Context) error {
 	}
 	syncedCacheMounts := getCacheMountConfigResp.SyncedCacheMounts
 
-	if len(syncedCacheMounts) == 0 {
-		return nil
-	}
-
 	var eg errgroup.Group
 	for _, syncedCacheMount := range syncedCacheMounts {
 		syncedCacheMount := syncedCacheMount


### PR DESCRIPTION
this is a follow-up of https://github.com/dagger/dagger/pull/5786 where
we have introduced automatic discovery of cache mounts so it's not
needed to check if the list is empty now.

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
