### PR TITLE
docs: Added Dagger CLI step to quickstart

### DIFF
--- a/docs/current/quickstart/729236-cli.mdx
+++ b/docs/current/quickstart/729236-cli.mdx
@@ -1,0 +1,19 @@
+---
+slug: /quickstart/729236/cli
+displayed_sidebar: "quickstart"
+hide_table_of_contents: true
+title: "Install the Dagger CLI"
+---
+
+# Quickstart
+
+## Install the Dagger CLI
+
+The next step is to install the Dagger CLI. Run the following commands:
+
+```shell
+cd /usr/local
+curl -L https://dl.dagger.io/dagger/install.sh | sh
+```
+
+The above command will create `/usr/local/bin/dagger`.

--- a/docs/current/quickstart/index.mdx
+++ b/docs/current/quickstart/index.mdx
@@ -22,6 +22,7 @@ It walks you, step by step, through the process of creating and refining a CI pi
 
 In this tutorial, you will learn how to:
 
+- Install the Dagger CLI
 - Install the Dagger SDK for your preferred language
 - Create a Dagger client using the SDK
 - Create a simple Dagger pipeline to understand the basics of Dagger

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -173,6 +173,7 @@ module.exports = {
         "current/quickstart/index",
         "current/quickstart/basics",
         "current/quickstart/setup",
+        "current/quickstart/cli",
         "current/quickstart/sdk",
         "current/quickstart/hello",
         "current/quickstart/test",


### PR DESCRIPTION
This commit adds a step tp the quickstart explaining how to download the Dagger CLI.