### PR TITLE
Update BuildKit dependency to use upstream Wait

### DIFF
--- a/core/directory.go
+++ b/core/directory.go
@@ -579,7 +579,7 @@ func (dir *Directory) Without(ctx context.Context, path string) (*Directory, err
 		return nil, err
 	}
 
-	err = dir.SetState(ctx, st.File(llb.Rm(path, llb.WithAllowWildcard(true))))
+	err = dir.SetState(ctx, st.File(llb.Rm(path, llb.WithAllowWildcard(true), llb.WithAllowNotFound(true))))
 	if err != nil {
 		return nil, err
 	}

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -455,6 +455,13 @@ func TestDirectoryWithoutDirectoryWithoutFile(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"some-file"}, entries)
 
+	entries, err = dir1.
+		WithoutDirectory("non-existent").
+		Entries(ctx)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"some-dir", "some-file"}, entries)
+
 	dir := c.Directory().
 		WithNewFile("foo.txt", "foo").
 		WithNewFile("a/bar.txt", "bar").

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -247,7 +247,7 @@ func Connect(ctx context.Context, params Params) (_ *Client, _ context.Context, 
 	})
 
 	// registry auth
-	bkSession.Allow(authprovider.NewDockerAuthProvider(config.LoadDefaultConfigFile(os.Stderr)))
+	bkSession.Allow(authprovider.NewDockerAuthProvider(config.LoadDefaultConfigFile(os.Stderr), nil))
 
 	// connect to the server, registering our session attachables and starting the server if not
 	// already started

--- a/engine/sources/gitdns/gitsource.go
+++ b/engine/sources/gitdns/gitsource.go
@@ -25,9 +25,12 @@ import (
 	"github.com/moby/buildkit/session/sshforward"
 	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/source"
+	srcgit "github.com/moby/buildkit/source/git"
 	srctypes "github.com/moby/buildkit/source/types"
 	"github.com/moby/buildkit/util/bklog"
+	"github.com/moby/buildkit/util/sshutil"
 	"github.com/moby/buildkit/util/urlutil"
 	"github.com/moby/locker"
 	"github.com/pkg/errors"
@@ -66,8 +69,44 @@ func NewSource(opt Opt) (source.Source, error) {
 	return gs, nil
 }
 
-func (gs *gitSource) ID() string {
-	return srctypes.GitScheme
+func (gs *gitSource) Schemes() []string {
+	return []string{srctypes.GitScheme}
+}
+
+func (gs *gitSource) Identifier(scheme, ref string, attrs map[string]string, platform *pb.Platform) (source.Identifier, error) {
+	id, err := srcgit.NewGitIdentifier(ref)
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range attrs {
+		switch k {
+		case pb.AttrKeepGitDir:
+			if v == "true" {
+				id.KeepGitDir = true
+			}
+		case pb.AttrFullRemoteURL:
+			if !isGitTransport(v) {
+				v = "https://" + v
+			}
+			id.Remote = v
+		case pb.AttrAuthHeaderSecret:
+			id.AuthHeaderSecret = v
+		case pb.AttrAuthTokenSecret:
+			id.AuthTokenSecret = v
+		case pb.AttrKnownSSHHosts:
+			id.KnownSSHHosts = v
+		case pb.AttrMountSSHSock:
+			id.MountSSHSock = v
+		}
+	}
+
+	return id, nil
+}
+
+// TODO: this logic should be public in buildkit
+func isGitTransport(str string) bool {
+	return strings.HasPrefix(str, "http://") || strings.HasPrefix(str, "https://") || strings.HasPrefix(str, "git://") || strings.HasPrefix(str, "ssh://") || sshutil.IsImplicitSSHTransport(str)
 }
 
 // needs to be called with repo lock
@@ -160,7 +199,7 @@ func (gs *gitSource) mountRemote(ctx context.Context, remote string, auth []stri
 
 type gitSourceHandler struct {
 	*gitSource
-	src       source.GitIdentifier
+	src       srcgit.GitIdentifier
 	clientIDs []string
 	cacheKey  string
 	sm        *session.Manager
@@ -186,7 +225,7 @@ type DaggerGitURLHack struct {
 }
 
 func (gs *gitSource) Resolve(ctx context.Context, id source.Identifier, sm *session.Manager, _ solver.Vertex) (source.SourceInstance, error) {
-	gitIdentifier, ok := id.(*source.GitIdentifier)
+	gitIdentifier, ok := id.(*srcgit.GitIdentifier)
 	if !ok {
 		return nil, errors.Errorf("invalid git identifier %v", id)
 	}

--- a/engine/sources/httpdns/httpsource.go
+++ b/engine/sources/httpdns/httpsource.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -23,7 +24,9 @@ import (
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/snapshot"
 	"github.com/moby/buildkit/solver"
+	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/source"
+	srchttp "github.com/moby/buildkit/source/http"
 	srctypes "github.com/moby/buildkit/source/types"
 	"github.com/moby/buildkit/util/tracing"
 	"github.com/moby/locker"
@@ -58,13 +61,53 @@ func NewSource(opt Opt) (source.Source, error) {
 	return hs, nil
 }
 
-func (hs *httpSource) ID() string {
-	return srctypes.HTTPSScheme
+func (hs *httpSource) Schemes() []string {
+	return []string{srctypes.HTTPSScheme}
+}
+
+func (hs *httpSource) Identifier(scheme, ref string, attrs map[string]string, platform *pb.Platform) (source.Identifier, error) {
+	id, err := srchttp.NewHTTPIdentifier(ref, scheme == "https")
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range attrs {
+		switch k {
+		case pb.AttrHTTPChecksum:
+			dgst, err := digest.Parse(v)
+			if err != nil {
+				return nil, err
+			}
+			id.Checksum = dgst
+		case pb.AttrHTTPFilename:
+			id.Filename = v
+		case pb.AttrHTTPPerm:
+			i, err := strconv.ParseInt(v, 0, 64)
+			if err != nil {
+				return nil, err
+			}
+			id.Perm = int(i)
+		case pb.AttrHTTPUID:
+			i, err := strconv.ParseInt(v, 0, 64)
+			if err != nil {
+				return nil, err
+			}
+			id.UID = int(i)
+		case pb.AttrHTTPGID:
+			i, err := strconv.ParseInt(v, 0, 64)
+			if err != nil {
+				return nil, err
+			}
+			id.GID = int(i)
+		}
+	}
+
+	return id, nil
 }
 
 type httpSourceHandler struct {
 	*httpSource
-	src       source.HTTPIdentifier
+	src       srchttp.HTTPIdentifier
 	clientIDs []string
 	refID     string
 	cacheKey  digest.Digest
@@ -79,7 +122,7 @@ type DaggerHTTPURLHack struct {
 }
 
 func (hs *httpSource) Resolve(ctx context.Context, id source.Identifier, sm *session.Manager, _ solver.Vertex) (source.SourceInstance, error) {
-	httpIdentifier, ok := id.(*source.HTTPIdentifier)
+	httpIdentifier, ok := id.(*srchttp.HTTPIdentifier)
 	if !ok {
 		return nil, errors.Errorf("invalid http identifier %v", id)
 	}

--- a/go.mod
+++ b/go.mod
@@ -27,8 +27,8 @@ require (
 	github.com/google/go-containerregistry v0.15.2
 	github.com/google/uuid v1.3.0
 	github.com/iancoleman/strcase v0.3.0
-	// https://github.com/moby/buildkit/commit/2267f0022b359933bfbdb369bd257e7d9cd2514f
-	github.com/moby/buildkit v0.12.1-0.20230801135201-2267f0022b35
+	// https://github.com/moby/buildkit/commit/bbe48e778f9df07eabc7fc05023c8e97e3c5c5ce
+	github.com/moby/buildkit v0.12.1-0.20230919110756-bbe48e778f9d
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc3
 	github.com/opencontainers/runtime-spec v1.1.0-rc.2
@@ -71,7 +71,7 @@ require (
 	github.com/mattn/go-isatty v0.0.18
 	github.com/moby/sys/mount v0.3.3
 	github.com/nxadm/tail v1.4.8
-	github.com/opencontainers/runc v1.1.7
+	github.com/opencontainers/runc v1.1.9
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/prometheus/procfs v0.11.0
 	github.com/rs/zerolog v1.30.0
@@ -131,6 +131,7 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
+	github.com/distribution/reference v0.5.0 // indirect
 	github.com/dlclark/regexp2 v1.9.0 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/dop251/goja v0.0.0-20230402114112-623f9dda9079 // indirect
@@ -228,7 +229,7 @@ require (
 	github.com/containerd/ttrpc v1.2.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/cli v24.0.5+incompatible
-	github.com/docker/docker v24.0.0-rc.2.0.20230723142919-afd4805278b4+incompatible
+	github.com/docker/docker v24.0.0-rc.2.0.20230905130451-032797ea4bcb+incompatible
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
@@ -246,7 +247,7 @@ require (
 	github.com/klauspost/compress v1.16.5
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/moby/locker v1.0.1
-	github.com/moby/patternmatcher v0.5.0 // indirect
+	github.com/moby/patternmatcher v0.6.0 // indirect
 	github.com/moby/sys/signal v0.7.0 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -398,6 +398,8 @@ github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
+github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0=
+github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dlclark/regexp2 v1.7.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
@@ -421,8 +423,8 @@ github.com/docker/docker v1.4.2-0.20180531152204-71cd53e4a197/go.mod h1:eEKB0N0r
 github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200730172259-9f28837c1d93+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v20.10.0-beta1.0.20201110211921-af34b94a78a1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/docker v24.0.0-rc.2.0.20230723142919-afd4805278b4+incompatible h1:yOBqqGhB3VKTJm7qai+wOSJqYStT/Eo87XPKAkQzMd0=
-github.com/docker/docker v24.0.0-rc.2.0.20230723142919-afd4805278b4+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v24.0.0-rc.2.0.20230905130451-032797ea4bcb+incompatible h1:1UUPAB9PAPUbM10+qIKPL5tKZ+VAddWgbQUf+x1QBfI=
+github.com/docker/docker v24.0.0-rc.2.0.20230905130451-032797ea4bcb+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
 github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=
@@ -939,12 +941,12 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/mapstructure v1.3.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/moby/buildkit v0.8.1/go.mod h1:/kyU1hKy/aYCuP39GZA9MaKioovHku57N6cqlKZIaiQ=
-github.com/moby/buildkit v0.12.1-0.20230801135201-2267f0022b35 h1:BrGIcZ/HV4TRCXh+JrMyIPt3pbcxn95bdO/huvWFu9Y=
-github.com/moby/buildkit v0.12.1-0.20230801135201-2267f0022b35/go.mod h1:bs0LeDdh7AQpYXLiPNUt+hzDjRxMg+QeLq1a1r0awFM=
+github.com/moby/buildkit v0.12.1-0.20230919110756-bbe48e778f9d h1:/4IpMt6LiGSQEPY5BLBz6E9gkcTrYTuf7662JHunYhY=
+github.com/moby/buildkit v0.12.1-0.20230919110756-bbe48e778f9d/go.mod h1:oSHnUZH7sNtAFLyeN1syf46SuzMThKsCQaioNEqJVUk=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
-github.com/moby/patternmatcher v0.5.0 h1:YCZgJOeULcxLw1Q+sVR636pmS7sPEn1Qo2iAN6M7DBo=
-github.com/moby/patternmatcher v0.5.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
+github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk=
+github.com/moby/patternmatcher v0.6.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/sys/mount v0.1.0/go.mod h1:FVQFLDRWwyBjDTBNQXDlWnSFREqOo3OKX9aqhmeoo74=
 github.com/moby/sys/mount v0.1.1/go.mod h1:FVQFLDRWwyBjDTBNQXDlWnSFREqOo3OKX9aqhmeoo74=
 github.com/moby/sys/mount v0.3.3 h1:fX1SVkXFJ47XWDoeFW4Sq7PdQJnV2QIDZAqjNqgEjUs=
@@ -1026,8 +1028,8 @@ github.com/opencontainers/image-spec v1.1.0-rc3/go.mod h1:X4pATf0uXsnn3g5aiGIsVn
 github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc10/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc92/go.mod h1:X1zlU4p7wOlX4+WRCz+hvlRv8phdL7UqbYD+vQwNMmE=
-github.com/opencontainers/runc v1.1.7 h1:y2EZDS8sNng4Ksf0GUYNhKbTShZJPJg1FiXJNH/uoCk=
-github.com/opencontainers/runc v1.1.7/go.mod h1:CbUumNnWCuTGFukNXahoo/RFBZvDAgRh/smNYNOhA50=
+github.com/opencontainers/runc v1.1.9 h1:XR0VIHTGce5eWPkaPesqTBrhW2yAcaraWfsEalNwQLM=
+github.com/opencontainers/runc v1.1.9/go.mod h1:CbUumNnWCuTGFukNXahoo/RFBZvDAgRh/smNYNOhA50=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=


### PR DESCRIPTION
This allow us to replace our custom logic for waiting for buildkit to be ready with the logic implemented upstream in https://github.com/moby/buildkit/pull/4200.

Additionally, we need a minor fix to ensure that `Directory.Without` continues working, since due to a bug in buildkit, allow not found was effectively always enabled (see https://github.com/moby/buildkit/pull/4051).

We also need to import some additional logic from buildkit now that the sources logic is reasonably significantly moved around, this hopefully enables the removal of the encode id hack as a follow-up.