### PR TITLE
docs: Improves dependency caching recipes

### DIFF
--- a/docs/current/cookbook.md
+++ b/docs/current/cookbook.md
@@ -901,19 +901,19 @@ The following code listing uses a cache volume for application dependencies. Thi
 <Tabs groupId="language">
 <TabItem value="Go">
 
-```go file=./quickstart/snippets/caching/main.go
+```go file=./cookbook/snippets/cache-dependencies/main.go
 ```
 
 </TabItem>
 <TabItem value="Node.js">
 
-```javascript file=./quickstart/snippets/caching/index.mjs
+```javascript file=./cookbook/snippets/cache-dependencies/index.mjs
 ```
 
 </TabItem>
 <TabItem value="Python">
 
-```python file=./quickstart/snippets/caching/main.py
+```python file=./cookbook/snippets/cache-dependencies/main.py
 ```
 
 </TabItem>

--- a/docs/current/cookbook/snippets/cache-dependencies/index.mjs
+++ b/docs/current/cookbook/snippets/cache-dependencies/index.mjs
@@ -15,9 +15,7 @@ connect(
         "/src/node_modules",
         client.cacheVolume("node-18-myapp-myenv")
       )
-      .withMountedCache(
-        "/root/.npm",
-        client.cacheVolume("node-18")
+      .withMountedCache("/root/.npm", client.cacheVolume("node-18")
       )
 
     // set the working directory in the container

--- a/docs/current/cookbook/snippets/cache-dependencies/index.mjs
+++ b/docs/current/cookbook/snippets/cache-dependencies/index.mjs
@@ -10,6 +10,7 @@ connect(
       .container()
       .from("node:18")
       .withDirectory("/src", client.host().directory("."))
+      .withWorkdir("/src")
       .withMountedCache(
         "/src/node_modules",
         client.cacheVolume("node-18-myapp-myenv")
@@ -18,11 +19,8 @@ connect(
     // set the working directory in the container
     // install application dependencies
     const runner = await source
-      .withWorkdir("/src")
       .withExec(["npm", "install"])
       .sync()
-
-    console.log(await runner.id())
   },
   { LogOutput: process.stderr }
 )

--- a/docs/current/cookbook/snippets/cache-dependencies/index.mjs
+++ b/docs/current/cookbook/snippets/cache-dependencies/index.mjs
@@ -15,8 +15,7 @@ connect(
         "/src/node_modules",
         client.cacheVolume("node-18-myapp-myenv")
       )
-      .withMountedCache("/root/.npm", client.cacheVolume("node-18")
-      )
+      .withMountedCache("/root/.npm", client.cacheVolume("node-18"))
 
     // set the working directory in the container
     // install application dependencies

--- a/docs/current/cookbook/snippets/cache-dependencies/index.mjs
+++ b/docs/current/cookbook/snippets/cache-dependencies/index.mjs
@@ -15,6 +15,10 @@ connect(
         "/src/node_modules",
         client.cacheVolume("node-18-myapp-myenv")
       )
+      .withMountedCache(
+        "/root/.npm",
+        client.cacheVolume("node-18")
+      )
 
     // set the working directory in the container
     // install application dependencies

--- a/docs/current/cookbook/snippets/cache-dependencies/index.mjs
+++ b/docs/current/cookbook/snippets/cache-dependencies/index.mjs
@@ -2,9 +2,6 @@ import { connect } from "@dagger.io/dagger"
 
 connect(
   async (client) => {
-    // create a cache volume
-    const cache = client.cacheVolume("node")
-
     // use a node:18 container
     // mount the source code directory on the host
     // at /src in the container
@@ -13,11 +10,14 @@ connect(
       .container()
       .from("node:18")
       .withDirectory("/src", client.host().directory("."))
-      .withMountedCache("/src/node_modules", cache)
+      .withMountedCache("/src/node_modules", client.cacheVolume("node"))
 
     // set the working directory in the container
     // install application dependencies
-    const runner = await source.withWorkdir("/src").withExec(["npm", "install"]).sync()
+    const runner = await source
+      .withWorkdir("/src")
+      .withExec(["npm", "install"])
+      .sync()
 
     console.log(await runner.id())
   },

--- a/docs/current/cookbook/snippets/cache-dependencies/index.mjs
+++ b/docs/current/cookbook/snippets/cache-dependencies/index.mjs
@@ -10,7 +10,10 @@ connect(
       .container()
       .from("node:18")
       .withDirectory("/src", client.host().directory("."))
-      .withMountedCache("/src/node_modules", client.cacheVolume("node-18-myapp-myenv"))
+      .withMountedCache(
+        "/src/node_modules",
+        client.cacheVolume("node-18-myapp-myenv")
+      )
 
     // set the working directory in the container
     // install application dependencies

--- a/docs/current/cookbook/snippets/cache-dependencies/index.mjs
+++ b/docs/current/cookbook/snippets/cache-dependencies/index.mjs
@@ -18,8 +18,7 @@ connect(
 
     // set the working directory in the container
     // install application dependencies
-    const runner = await source
-      .withExec(["npm", "install"])
+    await source.withExec(["npm", "install"])
       .sync()
   },
   { LogOutput: process.stderr }

--- a/docs/current/cookbook/snippets/cache-dependencies/index.mjs
+++ b/docs/current/cookbook/snippets/cache-dependencies/index.mjs
@@ -18,8 +18,7 @@ connect(
 
     // set the working directory in the container
     // install application dependencies
-    await source.withExec(["npm", "install"])
-      .sync()
+    await source.withExec(["npm", "install"]).sync()
   },
   { LogOutput: process.stderr }
 )

--- a/docs/current/cookbook/snippets/cache-dependencies/index.mjs
+++ b/docs/current/cookbook/snippets/cache-dependencies/index.mjs
@@ -10,7 +10,7 @@ connect(
       .container()
       .from("node:18")
       .withDirectory("/src", client.host().directory("."))
-      .withMountedCache("/src/node_modules", client.cacheVolume("node"))
+      .withMountedCache("/src/node_modules", client.cacheVolume("node-18-myapp-myenv"))
 
     // set the working directory in the container
     // install application dependencies

--- a/docs/current/cookbook/snippets/cache-dependencies/index.mjs
+++ b/docs/current/cookbook/snippets/cache-dependencies/index.mjs
@@ -1,0 +1,25 @@
+import { connect } from "@dagger.io/dagger"
+
+connect(
+  async (client) => {
+    // create a cache volume
+    const cache = client.cacheVolume("node")
+
+    // use a node:18 container
+    // mount the source code directory on the host
+    // at /src in the container
+    // mount the cache volume to persist dependencies
+    const source = client
+      .container()
+      .from("node:18")
+      .withDirectory("/src", client.host().directory("."))
+      .withMountedCache("/src/node_modules", cache)
+
+    // set the working directory in the container
+    // install application dependencies
+    const runner = await source.withWorkdir("/src").withExec(["npm", "install"]).sync()
+
+    console.log(await runner.id())
+  },
+  { LogOutput: process.stderr }
+)

--- a/docs/current/cookbook/snippets/cache-dependencies/main.go
+++ b/docs/current/cookbook/snippets/cache-dependencies/main.go
@@ -25,9 +25,9 @@ func main() {
 		From("golang:1.21").
 		WithDirectory("/src", client.Host().Directory(".")).
 		WithWorkdir("/src").
-		WithMountedCache("/go/pkg/mod", client.CacheVolume("go-mod-121-myapp-myenv")).
+		WithMountedCache("/go/pkg/mod", client.CacheVolume("go-mod-121")).
 		WithEnvVariable("GOMODCACHE", "/go/pkg/mod").
-		WithMountedCache("/go/build-cache", client.CacheVolume("go-build-121-myapp-myenv")).
+		WithMountedCache("/go/build-cache", client.CacheVolume("go-build-121")).
 		WithEnvVariable("GOCACHE", "/go/build-cache")
 
 	// set the working directory in the container

--- a/docs/current/cookbook/snippets/cache-dependencies/main.go
+++ b/docs/current/cookbook/snippets/cache-dependencies/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"dagger.io/dagger"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// initialize Dagger client
+	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	// use a golang:1.21 container
+	// mount the source code directory on the host
+	// at /src in the container
+	// mount the cache volume to persist dependencies
+	source := client.Container().
+		From("golang:1.21").
+		WithDirectory("/src", client.Host().Directory(".")).
+		WithMountedCache("/go/pkg/mod", client.CacheVolume("go-mod")).
+		WithEnvVariable("GOMODCACHE", "/go/pkg/mod").
+		WithMountedCache("/go/build-cache", client.CacheVolume("go-build")).
+		WithEnvVariable("GOCACHE", "/go/build-cache")
+
+	// set the working directory in the container
+	// install application dependencies
+	runner, err := source.WithWorkdir("/src").
+		WithExec([]string{"go", "build"}).
+		Sync(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(runner.ID(ctx))
+}

--- a/docs/current/cookbook/snippets/cache-dependencies/main.go
+++ b/docs/current/cookbook/snippets/cache-dependencies/main.go
@@ -25,9 +25,9 @@ func main() {
 	source := client.Container().
 		From("golang:1.21").
 		WithDirectory("/src", client.Host().Directory(".")).
-		WithMountedCache("/go/pkg/mod", client.CacheVolume("go-mod")).
+		WithMountedCache("/go/pkg/mod", client.CacheVolume("go-mod-121-myapp-myenv")).
 		WithEnvVariable("GOMODCACHE", "/go/pkg/mod").
-		WithMountedCache("/go/build-cache", client.CacheVolume("go-build")).
+		WithMountedCache("/go/build-cache", client.CacheVolume("go-build-121-myapp-myenv")).
 		WithEnvVariable("GOCACHE", "/go/build-cache")
 
 	// set the working directory in the container

--- a/docs/current/cookbook/snippets/cache-dependencies/main.go
+++ b/docs/current/cookbook/snippets/cache-dependencies/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"dagger.io/dagger"
@@ -25,6 +24,7 @@ func main() {
 	source := client.Container().
 		From("golang:1.21").
 		WithDirectory("/src", client.Host().Directory(".")).
+		WithWorkdir("/src").
 		WithMountedCache("/go/pkg/mod", client.CacheVolume("go-mod-121-myapp-myenv")).
 		WithEnvVariable("GOMODCACHE", "/go/pkg/mod").
 		WithMountedCache("/go/build-cache", client.CacheVolume("go-build-121-myapp-myenv")).
@@ -32,12 +32,10 @@ func main() {
 
 	// set the working directory in the container
 	// install application dependencies
-	runner, err := source.WithWorkdir("/src").
+	_, err = source.
 		WithExec([]string{"go", "build"}).
 		Sync(ctx)
 	if err != nil {
 		panic(err)
 	}
-
-	fmt.Println(runner.ID(ctx))
 }

--- a/docs/current/cookbook/snippets/cache-dependencies/main.py
+++ b/docs/current/cookbook/snippets/cache-dependencies/main.py
@@ -1,0 +1,45 @@
+import sys
+
+import anyio
+
+import dagger
+
+
+async def main():
+    config = dagger.Config(log_output=sys.stdout)
+
+    async with dagger.Connection(config) as client:
+        # create cache volumes as needed
+        pip_cache = client.cache_volume("pip")
+        pipx_cache = client.cache_volume("pipx")
+        hatch_cache = client.cache_volume("hatch")
+
+        # use a python:3.11 container
+        # mount the source code directory on the host
+        # at /src in the container
+        # mount the cache volumes to persist dependencies
+        source = (
+            client.container()
+            .from_("python:3.11")
+            .with_directory(
+                "/src",
+                client.host().directory("."),
+                exclude=[".venv/", ".cache/", "ci/"],
+            )
+            .with_mounted_cache("/root/.cache/pip", pip_cache)
+            .with_mounted_cache("/root/.local/pipx/cache", pipx_cache)
+            .with_mounted_cache("/root/.cache/hatch", hatch_cache)
+        )
+
+        # set the working directory in the container
+        # install application dependencies
+        runner = (
+            await source.with_workdir("/src")
+            .with_exec(["pip", "install", "-r", "requirements.txt"])
+            .sync()
+        )
+
+        print(await runner.id())
+
+
+anyio.run(main)

--- a/docs/current/cookbook/snippets/cache-dependencies/main.py
+++ b/docs/current/cookbook/snippets/cache-dependencies/main.py
@@ -18,9 +18,7 @@ async def main():
             .from_("python:3.11")
             .with_directory("/src", client.host().directory("."))
             .with_workdir("/src")
-            .with_mounted_cache(
-                "/root/.cache/pip", client.cache_volume("python-311")
-            )
+            .with_mounted_cache("/root/.cache/pip", client.cache_volume("python-311"))
         )
 
         # set the working directory in the container

--- a/docs/current/cookbook/snippets/cache-dependencies/main.py
+++ b/docs/current/cookbook/snippets/cache-dependencies/main.py
@@ -37,7 +37,7 @@ async def main():
 
         # set the working directory in the container
         # install application dependencies
-        runner = await source.with_exec(
+        await source.with_exec(
             ["pip", "install", "-r", "requirements.txt"]
         ).sync()
 

--- a/docs/current/cookbook/snippets/cache-dependencies/main.py
+++ b/docs/current/cookbook/snippets/cache-dependencies/main.py
@@ -37,9 +37,7 @@ async def main():
 
         # set the working directory in the container
         # install application dependencies
-        await source.with_exec(
-            ["pip", "install", "-r", "requirements.txt"]
-        ).sync()
+        await source.with_exec(["pip", "install", "-r", "requirements.txt"]).sync()
 
 
 anyio.run(main)

--- a/docs/current/cookbook/snippets/cache-dependencies/main.py
+++ b/docs/current/cookbook/snippets/cache-dependencies/main.py
@@ -6,7 +6,7 @@ import dagger
 
 
 async def main():
-    config = dagger.Config(log_output=sys.stdout)
+    config = dagger.Config(log_output=sys.stderr)
 
     async with dagger.Connection(config) as client:
         # use a python:3.11 container
@@ -18,20 +18,19 @@ async def main():
             .from_("python:3.11")
             .with_directory(
                 "/src",
-                client.host().directory("."),
-                exclude=[".venv/", ".cache/", "ci/"],
+                client.host().directory(".")
             )
             .with_workdir("/src")
             .with_mounted_cache(
-                "/root/.cache/pip", client.cache_volume("pip-python-311-myapp-myenv")
+                "/root/.cache/pip", client.cache_volume("pip-python-311")
             )
             .with_mounted_cache(
                 "/root/.local/pipx/cache",
-                client.cache_volume("pipx-python-311-myapp-myenv"),
+                client.cache_volume("pipx-python-311"),
             )
             .with_mounted_cache(
                 "/root/.cache/hatch",
-                client.cache_volume("hatch-python-311-myapp-myenv"),
+                client.cache_volume("hatch-python-311"),
             )
         )
 

--- a/docs/current/cookbook/snippets/cache-dependencies/main.py
+++ b/docs/current/cookbook/snippets/cache-dependencies/main.py
@@ -19,15 +19,7 @@ async def main():
             .with_directory("/src", client.host().directory("."))
             .with_workdir("/src")
             .with_mounted_cache(
-                "/root/.cache/pip", client.cache_volume("pip-python-311")
-            )
-            .with_mounted_cache(
-                "/root/.local/pipx/cache",
-                client.cache_volume("pipx-python-311"),
-            )
-            .with_mounted_cache(
-                "/root/.cache/hatch",
-                client.cache_volume("hatch-python-311"),
+                "/root/.cache/pip", client.cache_volume("python-311")
             )
         )
 

--- a/docs/current/cookbook/snippets/cache-dependencies/main.py
+++ b/docs/current/cookbook/snippets/cache-dependencies/main.py
@@ -16,10 +16,7 @@ async def main():
         source = (
             client.container()
             .from_("python:3.11")
-            .with_directory(
-                "/src",
-                client.host().directory(".")
-            )
+            .with_directory("/src", client.host().directory("."))
             .with_workdir("/src")
             .with_mounted_cache(
                 "/root/.cache/pip", client.cache_volume("pip-python-311")

--- a/docs/current/cookbook/snippets/cache-dependencies/main.py
+++ b/docs/current/cookbook/snippets/cache-dependencies/main.py
@@ -9,11 +9,6 @@ async def main():
     config = dagger.Config(log_output=sys.stdout)
 
     async with dagger.Connection(config) as client:
-        # create cache volumes as needed
-        pip_cache = client.cache_volume("pip")
-        pipx_cache = client.cache_volume("pipx")
-        hatch_cache = client.cache_volume("hatch")
-
         # use a python:3.11 container
         # mount the source code directory on the host
         # at /src in the container
@@ -26,9 +21,17 @@ async def main():
                 client.host().directory("."),
                 exclude=[".venv/", ".cache/", "ci/"],
             )
-            .with_mounted_cache("/root/.cache/pip", pip_cache)
-            .with_mounted_cache("/root/.local/pipx/cache", pipx_cache)
-            .with_mounted_cache("/root/.cache/hatch", hatch_cache)
+            .with_mounted_cache(
+                "/root/.cache/pip", client.cache_volume("pip-python-311-myapp-myenv")
+            )
+            .with_mounted_cache(
+                "/root/.local/pipx/cache",
+                client.cache_volume("pipx-python-311-myapp-myenv"),
+            )
+            .with_mounted_cache(
+                "/root/.cache/hatch",
+                client.cache_volume("hatch-python-311-myapp-myenv"),
+            )
         )
 
         # set the working directory in the container

--- a/docs/current/cookbook/snippets/cache-dependencies/main.py
+++ b/docs/current/cookbook/snippets/cache-dependencies/main.py
@@ -21,6 +21,7 @@ async def main():
                 client.host().directory("."),
                 exclude=[".venv/", ".cache/", "ci/"],
             )
+            .with_workdir("/src")
             .with_mounted_cache(
                 "/root/.cache/pip", client.cache_volume("pip-python-311-myapp-myenv")
             )
@@ -36,13 +37,9 @@ async def main():
 
         # set the working directory in the container
         # install application dependencies
-        runner = (
-            await source.with_workdir("/src")
-            .with_exec(["pip", "install", "-r", "requirements.txt"])
-            .sync()
-        )
-
-        print(await runner.id())
+        runner = await source.with_exec(
+            ["pip", "install", "-r", "requirements.txt"]
+        ).sync()
 
 
 anyio.run(main)


### PR DESCRIPTION
This commit updates the recipes for dependency caching using cache volumes with examples for Python and Go.