### PR TITLE
engine: cache: fallback to local cache if remote cache returns an error

### DIFF
--- a/engine/cache/manager.go
+++ b/engine/cache/manager.go
@@ -75,7 +75,8 @@ func NewManager(ctx context.Context, managerConfig ManagerConfig) (Manager, erro
 		EngineID: m.EngineID,
 	})
 	if err != nil {
-		return nil, err
+		bklog.G(ctx).WithError(err).Warnf("cache init failed, falling back to local cache")
+		return defaultCacheManager{m.localCache}, nil
 	}
 	if config.ImportPeriod == 0 || config.ExportPeriod == 0 || config.ExportTimeout == 0 {
 		return nil, fmt.Errorf("invalid cache config: import/export periods must be non-zero")


### PR DESCRIPTION
This is used when the Cache Service returns an error (for instance, if the account doesn't support caching).

Also useful if the Cache Service is down or misbehaving.

Caveats: The check only happens at initialization time. Once it's initialized, both cache backends are used (via 	`solver.NewCombinedCacheManager`) so it's anyone's guess what happens at that time.

I believe Erik had planned to revamp that part /cc @sipsma 

/cc @grouville 