### PR TITLE
sdk(java): Improve schema (re)generation

### DIFF
--- a/internal/mage/sdk/java.go
+++ b/internal/mage/sdk/java.go
@@ -116,12 +116,14 @@ func (Java) Generate(ctx context.Context) error {
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint).
 		WithMountedFile(cliBinPath, util.DaggerBinary(c)).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
-		WithExec([]string{"mvn", "help:evaluate", "-q", "-DforceStdout", "-Dexpression=daggerengine.version"}).
+		WithExec([]string{cliBinPath, "version"}).
 		Stdout(ctx)
 
 	if err != nil {
 		return err
 	}
+
+	engineVersion = strings.TrimPrefix(strings.Fields(engineVersion)[1], "v")
 
 	return os.WriteFile(javaSchemasDirPath+fmt.Sprintf("/schema-%s.json", engineVersion), []byte(generatedSchema), 0o600)
 }

--- a/sdk/java/README.md
+++ b/sdk/java/README.md
@@ -119,8 +119,12 @@ property `daggerengine.version`.
 ./mvnw package -Ddaggerengine.version=0.8.1
 ```
 
-By setting the variable to the special `local` value, it is possible to query a dagger CLI to
-generate the API schema.
+> **Warning**
+> If the targeted version mismatches the actual CLI version, the code generation will fail
+
+By setting the variable to the special `local` value (or the alias `devel`), it is possible to query
+a dagger CLI to generate the API schema.
+
 It is also possible to specify the Dagger CLI binary to use to generate the schema...
 
 Either by setting the `_EXPERIMENTAL_DAGGER_CLI_BIN` environment variable

--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -233,7 +233,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <daggerengine.version>0.6.4</daggerengine.version>
+        <daggerengine.version>devel</daggerengine.version>
 
         <assertj-core.version>3.24.2</assertj-core.version>
         <commons-compress.version>1.21</commons-compress.version>


### PR DESCRIPTION
This PR improves the generation of the API schema file (used by codegen phase)
- ensure the targeted version matches the CLI version
- add "devel" alias and set the current targeted version to `devel` (a specific version should be set to a stable version when releasing the library)
- infer the schema version from the CLI in sdk:java:generate build target

fixes #5823 