### PR TITLE
chore: add engine logs for failed queries

### DIFF
--- a/engine/server/handler.go
+++ b/engine/server/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dagger/dagger/engine/buildkit"
 	"github.com/dagger/graphql"
 	"github.com/dagger/graphql/gqlerrors"
+	"github.com/moby/buildkit/util/bklog"
 )
 
 const (
@@ -152,6 +153,9 @@ func (h *Handler) ContextHandler(ctx context.Context, w http.ResponseWriter, r *
 			formatted[i] = formatErrorFn(formattedError.OriginalError())
 		}
 		result.Errors = formatted
+	}
+	for _, err := range result.Errors {
+		bklog.G(ctx).WithError(err.OriginalError()).Debug("error while executing query")
 	}
 
 	// use proper JSON Header


### PR DESCRIPTION
This can be massively helpful for debugging - especially when debugging weird failures.

The errors are only added as debug level, since these errors generally aren't actually critical to the server.