### PR TITLE
fix: fix Dagger.Container.with_env_variable/4 crash

### DIFF
--- a/sdk/elixir/.changes/unreleased/Fixed-20231011-215344.yaml
+++ b/sdk/elixir/.changes/unreleased/Fixed-20231011-215344.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: fix Dagger.Container.with_env_variable/4 crash
+time: 2023-10-11T21:53:44.664027+07:00
+custom:
+  Author: Thanabodee Charoenpiriyakij
+  PR: "5837"

--- a/sdk/elixir/lib/dagger/query_builder.ex
+++ b/sdk/elixir/lib/dagger/query_builder.ex
@@ -48,7 +48,8 @@ defmodule Dagger.QueryBuilder.Selection do
     [~c"(", Enum.map(args, fun) |> Enum.intersperse(","), ~c")"]
   end
 
-  defp encode_value(value) when is_atom(value), do: encode_value(to_string(value))
+  defp encode_value(value) when is_atom(value) and not is_boolean(value),
+    do: encode_value(to_string(value))
 
   defp encode_value(value) when is_binary(value) do
     string =

--- a/sdk/elixir/test/dagger/client_test.exs
+++ b/sdk/elixir/test/dagger/client_test.exs
@@ -256,4 +256,16 @@ defmodule Dagger.ClientTest do
     container = Client.container(client)
     assert %Container{} = Client.container(client, id: container)
   end
+
+  test "env variable expand", %{client: client} do
+    {:ok, env} =
+      client
+      |> Client.container()
+      |> Container.from("alpine:3.16.2")
+      |> Container.with_env_variable("A", "B")
+      |> Container.with_env_variable("A", "C:${A}", expand: true)
+      |> Container.env_variable("A")
+
+    assert env == "C:B"
+  end
 end

--- a/sdk/elixir/test/dagger/querybuilder_test.exs
+++ b/sdk/elixir/test/dagger/querybuilder_test.exs
@@ -106,4 +106,13 @@ defmodule Dagger.QueryBuilder.SelectionTest do
 
     assert Selection.build(root) == "query{a(arg:\"\\n\\t\\\"\")}"
   end
+
+  test "boolean arg" do
+    root =
+      Selection.query()
+      |> Selection.select("a")
+      |> Selection.arg("arg", true)
+
+    assert Selection.build(root) == "query{a(arg:true)}"
+  end
 end


### PR DESCRIPTION
The issue is `true` value will consider as `atom`. When passing it to `is_atom`, it returns true and convert it to GraphQL string value.

Fixes by do not let boolean value enter the `is_atom` clause.

Fixes #5836