### PR TITLE
docs: fix exclude option for quickstart examples.

### DIFF
--- a/docs/current/quickstart/349011-build.mdx
+++ b/docs/current/quickstart/349011-build.mdx
@@ -14,8 +14,8 @@ import Embed from '@site/src/components/atoms/embed.js'
 
 export const ids = {
     Go: "smjo0gkeiFz",
-    "Node.js": "5mAEEtpy6mE",
-    Python: "iOhSGUn7nFq"
+    "Node.js": "5i8mcHTVJ-x",
+    Python: "E8rjb5DFd2m"
 }
 
 <QuickstartDoc embeds={ids}>
@@ -48,7 +48,7 @@ dagger run go run ci/main.go
 </TabItem>
 <TabItem value="Node.js">
 
-<Embed id="5mAEEtpy6mE" />
+<Embed id="5i8mcHTVJ-x" />
 
 This revised pipeline does everything described in the previous step, and then performs the following additional operations:
 
@@ -65,7 +65,7 @@ dagger run node ci/index.mjs
 </TabItem>
 <TabItem value="Python">
 
-<Embed id="iOhSGUn7nFq" />
+<Embed id="E8rjb5DFd2m />
 
 This revised pipeline does everything described in the previous step, and then performs the following additional operations:
 

--- a/docs/current/quickstart/472910-build-multi.mdx
+++ b/docs/current/quickstart/472910-build-multi.mdx
@@ -13,9 +13,9 @@ import QuickstartDoc from '@site/src/components/molecules/quickstartDoc.js'
 import Embed from '@site/src/components/atoms/embed.js'
 
 export const ids = {
-    Go: "24HdDB4RFY7",
-    "Node.js": "IAe6sLfyUxi",
-    Python: "LAC3B8Poada"
+    Go: "NJF-IQ7XzG-",
+    "Node.js": "loDAHfMcysK",
+    Python: "3xJIBUQdEkp"
 }
 
 <QuickstartDoc embeds={ids}>
@@ -39,7 +39,7 @@ Let's now update our pipeline to use a multi-stage build, as described above.
 <Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
-<Embed id="24HdDB4RFY7"/>
+<Embed id="NJF-IQ7XzG-"/>
 
 Run the pipeline by executing the command below from the application directory:
 
@@ -50,7 +50,7 @@ dagger run go run ci/main.go
 </TabItem>
 <TabItem value="Node.js">
 
-<Embed id="IAe6sLfyUxi"/>
+<Embed id="loDAHfMcysK"/>
 
 Run the pipeline by executing the command below from the application directory:
 
@@ -61,7 +61,7 @@ dagger run node ci/index.mjs
 </TabItem>
 <TabItem value="Python">
 
-<Embed id="LAC3B8Poada"/>
+<Embed id="3xJIBUQdEkp"/>
 
 Run the pipeline by executing the command below from the application directory:
 

--- a/docs/current/quickstart/635927-caching.mdx
+++ b/docs/current/quickstart/635927-caching.mdx
@@ -13,9 +13,9 @@ import QuickstartDoc from "@site/src/components/molecules/quickstartDoc.js"
 import Embed from "@site/src/components/atoms/embed.js"
 
 export const ids = {
-    Go: "RN_JLVR1jWl",
-    "Node.js": "XRfLHVA3Li8",
-    Python: "sNZQEeULT-M"
+    Go: "1J5Fs4NoQcW",
+    "Node.js": "HjFX8td15TX",
+    Python: "TCdOYrKMfV_d"
 }
 
 <QuickstartDoc embeds={ids}>
@@ -41,7 +41,7 @@ The `npm install` command is appropriate for a React application, but other appl
 <Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
-<Embed id="RN_JLVR1jWl" />
+<Embed id="1J5Fs4NoQcW" />
 
 This revised pipeline now uses a cache volume for the application dependencies.
 
@@ -58,7 +58,7 @@ dagger run go run ci/main.go
 </TabItem>
 <TabItem value="Node.js">
 
-<Embed id="XRfLHVA3Li8" />
+<Embed id="HjFX8td15TX" />
 
 This revised pipeline now uses a cache volume for the application dependencies.
 
@@ -75,7 +75,7 @@ dagger run node ci/index.mjs
 </TabItem>
 <TabItem value="Python">
 
-<Embed id="sNZQEeULT-M" />
+<Embed id="TCdOYrKMfV_d" />
 
 This revised pipeline now uses a cache volume for the application dependencies.
 

--- a/docs/current/quickstart/730264-publish.mdx
+++ b/docs/current/quickstart/730264-publish.mdx
@@ -13,9 +13,9 @@ import QuickstartDoc from "@site/src/components/molecules/quickstartDoc.js"
 import Embed from "@site/src/components/atoms/embed.js"
 
 export const ids = {
-    Go: "zMNvs5zwLQK",
-    "Node.js": "I4sXINdejnV",
-    Python: "TtfHpGFRukx"
+    Go: "PgPJUlg4Aq8",
+    "Node.js": "1P5-90wivSP",
+    Python: "8vUQnWJ6mxe"
 }
 
 <QuickstartDoc embeds={ids}>
@@ -29,7 +29,7 @@ Dagger SDKs have built-in support to publish container images. So, let's update 
 <Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
-<Embed id="zMNvs5zwLQK"></Embed>
+<Embed id="PgPJUlg4Aq8"></Embed>
 
 Run the pipeline by executing the command below from the application directory:
 
@@ -40,7 +40,7 @@ dagger run go run ci/main.go
 </TabItem>
 <TabItem value="Node.js">
 
-<Embed id="I4sXINdejnV"></Embed>
+<Embed id="1P5-90wivSP"></Embed>
 
 Run the pipeline by executing the command below from the application directory:
 
@@ -51,7 +51,7 @@ dagger run node ci/index.mjs
 </TabItem>
 <TabItem value="Python">
 
-<Embed id="TtfHpGFRukx"></Embed>
+<Embed id="8vUQnWJ6mxe"></Embed>
 
 Run the pipeline by executing the command below from the application directory:
 

--- a/docs/current/quickstart/947391-test.mdx
+++ b/docs/current/quickstart/947391-test.mdx
@@ -39,8 +39,8 @@ This code listing does the following:
 
 - It creates a Dagger client with `Connect()` as before.
 - It uses the client's `Container().From()` method to initialize a new container from a base image - again, the `node:16-slim` image. This base image is the Node.js version to use for testing. The `From()` method returns a new `Container` object with the result.
-- It uses the `Container.WithDirectory()` method to write the host directory to the `/src` path in the container, and the `Container.WithWorkdir()` method to set the working directory to that filesystem location.
-  - Notice that the `Container.WithDirectory()` accepts additional options to exclude (or include) specific files from the mount. In this case, it excludes the `node_modules` (locally-installed dependencies) and `ci` (pipeline code) directories.
+- It uses the `Container.WithDirectory()` method to mount the source code directory on the host at the `/src` mount point in the container, and the `Container.WithWorkdir()` method to set the working directory to that mount point.
+  - Notice that the `Container.WithDirectory()` accepts additional options to exclude (or include) specific files from the mount. In this case, it excludes the `node_modules` (locally-installed dependencies), `ci` (pipeline code) and build (build artifacts) irectories.
 - It uses the `Container.WithExec()` method to define the commands to install dependencies and run tests in the container - in this case, the commands `npm install` and `npm test -- --watchAll=false`.
 - It uses the `Container.Stderr()` method to return the error stream of the last executed command. No error output implies successful execution (all tests pass).
   - Failure, indicated by error output, will cause the pipeline to terminate.

--- a/docs/current/quickstart/947391-test.mdx
+++ b/docs/current/quickstart/947391-test.mdx
@@ -40,7 +40,7 @@ This code listing does the following:
 - It creates a Dagger client with `Connect()` as before.
 - It uses the client's `Container().From()` method to initialize a new container from a base image - again, the `node:16-slim` image. This base image is the Node.js version to use for testing. The `From()` method returns a new `Container` object with the result.
 - It uses the `Container.WithDirectory()` method to mount the source code directory on the host at the `/src` mount point in the container, and the `Container.WithWorkdir()` method to set the working directory to that mount point.
-  - Notice that the `Container.WithDirectory()` accepts additional options to exclude (or include) specific files from the mount. In this case, it excludes the `node_modules` (locally-installed dependencies), `ci` (pipeline code) and build (build artifacts) irectories.
+  - Notice that the `Container.WithDirectory()` accepts additional options to exclude (or include) specific files from the mount. In this case, it excludes the `node_modules` (locally-installed dependencies), `ci` (pipeline code) and `build` (build artifacts) directories.
 - It uses the `Container.WithExec()` method to define the commands to install dependencies and run tests in the container - in this case, the commands `npm install` and `npm test -- --watchAll=false`.
 - It uses the `Container.Stderr()` method to return the error stream of the last executed command. No error output implies successful execution (all tests pass).
   - Failure, indicated by error output, will cause the pipeline to terminate.

--- a/docs/current/quickstart/947391-test.mdx
+++ b/docs/current/quickstart/947391-test.mdx
@@ -13,9 +13,9 @@ import QuickstartDoc from '@site/src/components/molecules/quickstartDoc.js'
 import Embed from '@site/src/components/atoms/embed.js'
 
 export const ids = {
-    Go: "qV2Ib6S2nvq",
-    "Node.js": "PN7ayA3rjOB",
-    Python: "2XgPeWiQsRX"
+    Go: "v676qm2pxae",
+    "Node.js": "Wb_vszr9Ule",
+    Python: "yZj9P2N03-D"
 }
 
 <QuickstartDoc embeds={ids}>
@@ -33,7 +33,7 @@ The `npm run test` command is appropriate for a React application, but other app
 <Tabs groupId="language" className="embeds">
 <TabItem value="Go">
 
-<Embed id="qV2Ib6S2nvq" />
+<Embed id="v676qm2pxae" />
 
 This code listing does the following:
 
@@ -58,14 +58,14 @@ The `From()`, `WithDirectory()`, `WithWorkdir()` and `WithExec()` methods all re
 </TabItem>
 <TabItem value="Node.js">
 
-<Embed id="PN7ayA3rjOB" />
+<Embed id="Wb_vszr9Ule" />
 
 This code listing does the following:
 
 - It creates a Dagger client with `connect()` as before.
 - It uses the client's `container().from()` method to initialize a new container from a base image - again, the `node:16-slim` image. This base image is the Node.js version to use for testing. The `from()` method returns a new `Container` object with the result.
-- It uses the `Container.withDirectory()` method to write the host directory to the `/src` path in the container, and the `Container.withWorkdir()` method to set the working directory to that filesystem location.
-  - Notice that the `Container.withDirectory()` accepts additional options to exclude (or include) specific files from the mount. In this case, it excludes the `node_modules` (locally-installed dependencies) and `ci` (pipeline code) directories.
+- It uses the `Container.withDirectory()` method to mount the source code directory on the host at the `/src` mount point in the container, and the `Container.withWorkdir()` method to set the working directory to that mount point.
+  - Notice that the `Container.WithDirectory()` accepts additional options to exclude (or include) specific files from the mount. In this case, it excludes the `node_modules` (locally-installed dependencies), `ci` (pipeline code) and `build` (build artifacts) directories.
 - It uses the `Container.withExec()` method to define the commands to install dependencies and run tests in the container - in this case, the commands `npm install` and `npm test -- --watchAll=false`.
 - It uses the `Container.stderr()` method to return the error stream of the last executed command. No error output implies successful execution (all tests pass).
   - Failure, indicated by error output, will cause the pipeline to terminate.
@@ -83,14 +83,14 @@ The `from()`, `withDirectory()`, `withWorkdir()` and `withExec()` methods all re
 </TabItem>
 <TabItem value="Python">
 
-<Embed id="2XgPeWiQsRX" />
+<Embed id="yZj9P2N03-D" />
 
 This code listing does the following:
 
 - It creates a Dagger client with `with dagger.Connection()` as before.
 - It uses the client's `container().from_()` method to initialize a new container from a base image - again, the `node:16-slim` image. This base image is the Node.js version to use for testing. The `from_()` method returns a new `Container` object with the result.
 - It uses the `Container.with_directory()` method to mount the source code directory on the host at the `/src` mount point in the container, and the `Container.with_workdir()` method to set the working directory to that mount point.
-  - Notice that the `Container.with_directory()` accepts additional options to exclude (or include) specific files from the mount. In this case, it excludes the `node_modules` (locally-installed dependencies) and `ci` (pipeline code) directories.
+  - Notice that the `Container.WithDirectory()` accepts additional options to exclude (or include) specific files from the mount. In this case, it excludes the `node_modules` (locally-installed dependencies), `ci` (pipeline code) and `build` (build artifacts) directories.
 - It uses the `Container.with_exec()` method to define the commands to install dependencies and run tests in the container - in this case, the commands `npm install` and `npm test -- --watchAll=false`.
 - It uses the `Container.stderr()` method to return the error stream of the last executed command. No error output implies successful execution (all tests pass).
   - Failure, indicated by error output, will cause the pipeline to terminate.

--- a/docs/current/quickstart/snippets/build-multi/index.mjs
+++ b/docs/current/quickstart/snippets/build-multi/index.mjs
@@ -8,9 +8,12 @@ connect(
     const source = client
       .container()
       .from("node:16-slim")
-      .withDirectory("/src", client.host().directory(".", {
-        exclude: ["node_modules/", "ci/", "build/"],
-      }))
+      .withDirectory(
+        "/src",
+        client
+          .host()
+          .directory(".", { exclude: ["node_modules/", "ci/", "build/"] })
+      )
 
     // set the working directory in the container
     // install application dependencies

--- a/docs/current/quickstart/snippets/build-multi/index.mjs
+++ b/docs/current/quickstart/snippets/build-multi/index.mjs
@@ -8,9 +8,9 @@ connect(
     const source = client
       .container()
       .from("node:16-slim")
-      .withDirectory("/src", client.host().directory("."), {
-        exclude: ["node_modules/", "ci/"],
-      })
+      .withDirectory("/src", client.host().directory(".", {
+        exclude: ["node_modules/", "ci/", "build/"],
+      }))
 
     // set the working directory in the container
     // install application dependencies

--- a/docs/current/quickstart/snippets/build-multi/main.go
+++ b/docs/current/quickstart/snippets/build-multi/main.go
@@ -15,7 +15,6 @@ func main() {
 
 	// initialize Dagger client
 	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
-
 	if err != nil {
 		panic(err)
 	}
@@ -26,9 +25,9 @@ func main() {
 	// at /src in the container
 	source := client.Container().
 		From("node:16-slim").
-		WithDirectory("/src", client.Host().Directory("."), dagger.ContainerWithDirectoryOpts{
-			Exclude: []string{"node_modules/", "ci/"},
-		})
+		WithDirectory("/src", client.Host().Directory(".", dagger.HostDirectoryOpts{
+			Exclude: []string{"node_modules/", "ci/", "build/"},
+		}))
 
 		// set the working directory in the container
 		// install application dependencies
@@ -51,7 +50,6 @@ func main() {
 		From("nginx:1.23-alpine").
 		WithDirectory("/usr/share/nginx/html", buildDir).
 		Publish(ctx, fmt.Sprintf("ttl.sh/hello-dagger-%.0f", math.Floor(rand.Float64()*10000000))) //#nosec
-
 	if err != nil {
 		panic(err)
 	}

--- a/docs/current/quickstart/snippets/build-multi/main.py
+++ b/docs/current/quickstart/snippets/build-multi/main.py
@@ -18,8 +18,8 @@ async def main():
             .from_("node:16-slim")
             .with_directory(
                 "/src",
-                client.host().directory("."),
-                exclude=["node_modules/", "ci/"],
+                client.host().directory(
+                    ".", exclude=["node_modules/", "ci/", "build/"]),
             )
         )
 
@@ -32,7 +32,8 @@ async def main():
 
         # first stage
         # build application
-        build_dir = test.with_exec(["npm", "run", "build"]).directory("./build")
+        build_dir = test.with_exec(
+            ["npm", "run", "build"]).directory("./build")
 
         # second stage
         # use an nginx:alpine container

--- a/docs/current/quickstart/snippets/build-multi/main.py
+++ b/docs/current/quickstart/snippets/build-multi/main.py
@@ -19,7 +19,8 @@ async def main():
             .with_directory(
                 "/src",
                 client.host().directory(
-                    ".", exclude=["node_modules/", "ci/", "build/"]),
+                    ".", exclude=["node_modules/", "ci/", "build/"]
+                ),
             )
         )
 
@@ -32,8 +33,7 @@ async def main():
 
         # first stage
         # build application
-        build_dir = test.with_exec(
-            ["npm", "run", "build"]).directory("./build")
+        build_dir = test.with_exec(["npm", "run", "build"]).directory("./build")
 
         # second stage
         # use an nginx:alpine container

--- a/docs/current/quickstart/snippets/build/main.py
+++ b/docs/current/quickstart/snippets/build/main.py
@@ -17,8 +17,9 @@ async def main():
             .from_("node:16-slim")
             .with_directory(
                 "/src",
-                client.host().directory("."),
-                exclude=["node_modules/", "ci/"]
+                client.host().directory(
+                    ".", exclude=["node_modules/", "ci/", "build/"]
+                ),
             )
         )
 

--- a/docs/current/quickstart/snippets/caching/index.mjs
+++ b/docs/current/quickstart/snippets/caching/index.mjs
@@ -12,9 +12,9 @@ connect(
     const source = client
       .container()
       .from("node:16-slim")
-      .withDirectory("/src", client.host().directory("."), {
-        exclude: ["node_modules/", "ci/"],
-      })
+      .withDirectory("/src", client.host().directory(".", {
+        exclude: ["node_modules/", "ci/", "build/"],
+      }))
       .withMountedCache("/src/node_modules", nodeCache)
 
     // set the working directory in the container

--- a/docs/current/quickstart/snippets/caching/index.mjs
+++ b/docs/current/quickstart/snippets/caching/index.mjs
@@ -12,9 +12,12 @@ connect(
     const source = client
       .container()
       .from("node:16-slim")
-      .withDirectory("/src", client.host().directory(".", {
-        exclude: ["node_modules/", "ci/", "build/"],
-      }))
+      .withDirectory(
+        "/src",
+        client
+          .host()
+          .directory(".", { exclude: ["node_modules/", "ci/", "build/"] })
+      )
       .withMountedCache("/src/node_modules", nodeCache)
 
     // set the working directory in the container

--- a/docs/current/quickstart/snippets/caching/main.go
+++ b/docs/current/quickstart/snippets/caching/main.go
@@ -15,7 +15,6 @@ func main() {
 
 	// initialize Dagger client
 	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
-
 	if err != nil {
 		panic(err)
 	}
@@ -30,9 +29,9 @@ func main() {
 	// mount the cache volume to persist dependencies
 	source := client.Container().
 		From("node:16-slim").
-		WithDirectory("/src", client.Host().Directory("."), dagger.ContainerWithDirectoryOpts{
-			Exclude: []string{"node_modules/", "ci/"},
-		}).
+		WithDirectory("/src", client.Host().Directory(".", dagger.HostDirectoryOpts{
+			Exclude: []string{"node_modules/", "ci/", "build/"},
+		})).
 		WithMountedCache("/src/node_modules", nodeCache)
 
 		// set the working directory in the container

--- a/docs/current/quickstart/snippets/caching/main.py
+++ b/docs/current/quickstart/snippets/caching/main.py
@@ -22,8 +22,8 @@ async def main():
             .from_("node:16-slim")
             .with_directory(
                 "/src",
-                client.host().directory("."),
-                exclude=["node_modules/", "ci/"],
+                client.host().directory(
+                    ".", exclude=["node_modules/", "ci/", "build/"]),
             )
             .with_mounted_cache("/src/node_modules", node_cache)
         )
@@ -37,7 +37,8 @@ async def main():
 
         # first stage
         # build application
-        build_dir = test.with_exec(["npm", "run", "build"]).directory("./build")
+        build_dir = test.with_exec(
+            ["npm", "run", "build"]).directory("./build")
 
         # second stage
         # use an nginx:alpine container

--- a/docs/current/quickstart/snippets/caching/main.py
+++ b/docs/current/quickstart/snippets/caching/main.py
@@ -23,7 +23,8 @@ async def main():
             .with_directory(
                 "/src",
                 client.host().directory(
-                    ".", exclude=["node_modules/", "ci/", "build/"]),
+                    ".", exclude=["node_modules/", "ci/", "build/"]
+                ),
             )
             .with_mounted_cache("/src/node_modules", node_cache)
         )
@@ -37,8 +38,7 @@ async def main():
 
         # first stage
         # build application
-        build_dir = test.with_exec(
-            ["npm", "run", "build"]).directory("./build")
+        build_dir = test.with_exec(["npm", "run", "build"]).directory("./build")
 
         # second stage
         # use an nginx:alpine container

--- a/docs/current/quickstart/snippets/publish/index.mjs
+++ b/docs/current/quickstart/snippets/publish/index.mjs
@@ -10,7 +10,9 @@ connect(
       .from("node:16-slim")
       .withDirectory(
         "/src",
-        client.host().directory(".", { exclude: ["node_modules/", "ci/", "build/"] })
+        client
+          .host()
+          .directory(".", { exclude: ["node_modules/", "ci/", "build/"] })
       )
 
     // set the working directory in the container

--- a/docs/current/quickstart/snippets/publish/index.mjs
+++ b/docs/current/quickstart/snippets/publish/index.mjs
@@ -10,7 +10,7 @@ connect(
       .from("node:16-slim")
       .withDirectory(
         "/src",
-        client.host().directory(".", { exclude: ["node_modules/", "ci/"] })
+        client.host().directory(".", { exclude: ["node_modules/", "ci/", "build/"] })
       )
 
     // set the working directory in the container

--- a/docs/current/quickstart/snippets/publish/main.go
+++ b/docs/current/quickstart/snippets/publish/main.go
@@ -15,7 +15,6 @@ func main() {
 
 	// initialize Dagger client
 	client, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
-
 	if err != nil {
 		panic(err)
 	}
@@ -23,9 +22,9 @@ func main() {
 
 	source := client.Container().
 		From("node:16").
-		WithDirectory("/src", client.Host().Directory("."), dagger.ContainerWithDirectoryOpts{
-			Exclude: []string{"node_modules/", "ci/"},
-		})
+		WithDirectory("/src", client.Host().Directory(".", dagger.HostDirectoryOpts{
+			Exclude: []string{"node_modules/", "ci/", "build/"},
+		}))
 
 	runner := source.WithWorkdir("/src").
 		WithExec([]string{"npm", "install"})

--- a/docs/current/quickstart/snippets/publish/main.py
+++ b/docs/current/quickstart/snippets/publish/main.py
@@ -18,8 +18,8 @@ async def main():
             .from_("node:16-slim")
             .with_directory(
                 "/src",
-                client.host().directory("."),
-                exclude=["node_modules/", "ci/"],
+                client.host().directory(
+                    ".", exclude=["node_modules/", "ci/", "build/"]),
             )
         )
 

--- a/docs/current/quickstart/snippets/publish/main.py
+++ b/docs/current/quickstart/snippets/publish/main.py
@@ -19,7 +19,8 @@ async def main():
             .with_directory(
                 "/src",
                 client.host().directory(
-                    ".", exclude=["node_modules/", "ci/", "build/"]),
+                    ".", exclude=["node_modules/", "ci/", "build/"]
+                ),
             )
         )
 

--- a/docs/current/quickstart/snippets/test/index.mjs
+++ b/docs/current/quickstart/snippets/test/index.mjs
@@ -8,9 +8,12 @@ connect(
     const source = client
       .container()
       .from("node:16-slim")
-      .withDirectory("/src", client.host().directory(".", {
-        exclude: ["node_modules/", "ci/", "build/"],
-      }))
+      .withDirectory(
+        "/src",
+        client
+          .host()
+          .directory(".", { exclude: ["node_modules/", "ci/", "build/"] })
+      )
 
     // set the working directory in the container
     // install application dependencies

--- a/docs/current/quickstart/snippets/test/index.mjs
+++ b/docs/current/quickstart/snippets/test/index.mjs
@@ -8,9 +8,9 @@ connect(
     const source = client
       .container()
       .from("node:16-slim")
-      .withDirectory("/src", client.host().directory("."), {
-        exclude: ["node_modules/", "ci/"],
-      })
+      .withDirectory("/src", client.host().directory(".", {
+        exclude: ["node_modules/", "ci/", "build/"],
+      }))
 
     // set the working directory in the container
     // install application dependencies

--- a/docs/current/quickstart/snippets/test/main.go
+++ b/docs/current/quickstart/snippets/test/main.go
@@ -23,9 +23,9 @@ func main() {
 	// at /src in the container
 	source := client.Container().
 		From("node:16-slim").
-		WithDirectory("/src", client.Host().Directory("."), dagger.ContainerWithDirectoryOpts{
-			Exclude: []string{"node_modules/", "ci/"},
-		})
+		WithDirectory("/src", client.Host().Directory(".", dagger.HostDirectoryOpts{
+			Exclude: []string{"node_modules/", "ci/", "build/"},
+		}))
 
 		// set the working directory in the container
 		// install application dependencies

--- a/docs/current/quickstart/snippets/test/main.py
+++ b/docs/current/quickstart/snippets/test/main.py
@@ -17,8 +17,8 @@ async def main():
             .from_("node:16-slim")
             .with_directory(
                 "/src",
-                client.host().directory("."),
-                exclude=["node_modules/", "ci/"],
+                client.host().directory(
+                    ".", exclude=["node_modules/", "ci/", "build/"]),
             )
         )
 

--- a/docs/current/quickstart/snippets/test/main.py
+++ b/docs/current/quickstart/snippets/test/main.py
@@ -18,7 +18,8 @@ async def main():
             .with_directory(
                 "/src",
                 client.host().directory(
-                    ".", exclude=["node_modules/", "ci/", "build/"]),
+                    ".", exclude=["node_modules/", "ci/", "build/"]
+                ),
             )
         )
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -82,8 +82,8 @@ fmt = [
     "black {args:. ../../docs/current}",
 ]
 lint = [
-    "ruff check {args:. ../../docs/current}",
-    "black --check {args:. ../../docs/current}",
+    "ruff check --diff {args:. ../../docs/current}",
+    "black --check --diff {args:. ../../docs/current}",
 ]
 test = "pytest -W default"
 testunit = "pytest -m 'not slow'"


### PR DESCRIPTION
this adds the exclude option to the proper `client.Host().Directory`
operation to avoid sending the files over the wire each time

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
