### PR TITLE
Change Daggerverse url

### DIFF
--- a/docs/current/labs/project-zenith.md
+++ b/docs/current/labs/project-zenith.md
@@ -368,7 +368,7 @@ EOF
 #### Publishing your own modules
 
 You can publish your own modules to the
-[Daggerverse](https://daggerverse.fly.dev), so that other users can easily
+[Daggerverse](https://daggerverse.dev), so that other users can easily
 discover them. At the moment, the Daggerverse is only used to discover other
 modules, all the data is stored and fetched from GitHub.
 
@@ -384,7 +384,7 @@ git remote add origin git@github.com:<user>/daggerverse.git
 git push origin main
 ```
 
-Next, navigate to <https://daggerverse.fly.dev>, and use the top-module bar to
+Next, navigate to <https://daggerverse.dev>, and use the top-module bar to
 paste the GitHub link to your module (`github.com/<user>/daggerverse.git`),
 then click "Crawl".
 


### PR DESCRIPTION
Just see that https://daggerverse.dev/ already up and running but the documentation didn't get update.