### PR TITLE
engine: ensure blob source layers are unlazied.

### DIFF
--- a/engine/buildkit/filesync.go
+++ b/engine/buildkit/filesync.go
@@ -23,7 +23,6 @@ import (
 	bksession "github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/filesync"
 	"github.com/moby/buildkit/snapshot"
-	bksolver "github.com/moby/buildkit/solver"
 	bksolverpb "github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/moby/buildkit/util/compression"
@@ -85,28 +84,14 @@ func (c *Client) LocalImport(
 
 	RecordVertexes(recorder, copyPB)
 
-	ctx, cancel, err := c.withClientCloseCancel(ctx)
+	res, err := c.Solve(ctx, bkgw.SolveRequest{
+		Definition: copyPB,
+		Evaluate:   true,
+	})
 	if err != nil {
 		return nil, err
 	}
-	defer cancel()
-	ctx = withOutgoingContext(ctx)
-
-	llbRes, err := c.llbBridge.Solve(ctx, bkgw.SolveRequest{
-		Definition: copyPB,
-		Evaluate:   true,
-	}, c.ID())
-	if err != nil {
-		return nil, wrapError(ctx, err, c.ID())
-	}
-	defer func() {
-		if llbRes != nil {
-			llbRes.EachRef(func(rp bksolver.ResultProxy) error {
-				return rp.Release(context.Background())
-			})
-		}
-	}()
-	resultProxy, err := llbRes.SingleRef()
+	resultProxy, err := res.SingleRef()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get single ref: %s", err)
 	}


### PR DESCRIPTION
The blob source type we use to safely refer to local dir sync contents relies on the previous local dir sync ops to exist locally.

Before this change, there was a case where use of remote cache could result in the contents still being lazy in the remote cache rather than actually existing locally. This led to error messages like "missing descriptor handlers for lazy blobs".

This specifically happens because we need to split local dir syncs across 3 ops:
1. The actual local dir source, which does the sync
2. A copy of the state of the local dir sync, which allows us to use the snapshot contents without making the local dir snapshot immutable, which prevents it from being re-used.
3. The blob source op, which allows our LLB to simply refer to the contents of the sync in a content-addressed way rather than as instructions for loading from a local dir (which is not reproducible and leads to various unsafe behavior).

Our remote cache service explicitly skips caching of 1 and 3, but it currently doesn't end up skipping of caching 2. This is not ideal as these layers aren't ever worth remote caching, but is more of a performance deficiency rather than actual bug.

However, in this case, the fact that remotely caching step 2 allowed cache refs for it to be lazy led to step 3 failing.

The fix here just forces an unlazy of step 2 by calling `Extract` on it. This results in it always being present and step 3 always working as expected.