### PR TITLE
feat: fail when connecting to vanilla buildkit

### DIFF
--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -188,7 +188,7 @@ func Connect(ctx context.Context, params Params) (_ *Client, _ context.Context, 
 	}
 
 	engineTask := loader.Task("starting engine")
-	bkClient, err := newBuildkitClient(ctx, remote, c.UserAgent)
+	bkClient, bkInfo, err := newBuildkitClient(ctx, remote, c.UserAgent)
 	engineTask.Done(err)
 	if err != nil {
 		return nil, nil, fmt.Errorf("new client: %w", err)
@@ -202,11 +202,7 @@ func Connect(ctx context.Context, params Params) (_ *Client, _ context.Context, 
 	}()
 
 	if c.EngineNameCallback != nil {
-		info, err := c.bkClient.Info(ctx)
-		if err != nil {
-			return nil, nil, fmt.Errorf("get info: %w", err)
-		}
-		engineName := fmt.Sprintf("%s (version %s)", info.BuildkitVersion.Package, info.BuildkitVersion.Version)
+		engineName := fmt.Sprintf("%s (version %s)", bkInfo.BuildkitVersion.Revision, bkInfo.BuildkitVersion.Version)
 		c.EngineNameCallback(engineName)
 	}
 

--- a/engine/server/buildkitcontroller.go
+++ b/engine/server/buildkitcontroller.go
@@ -443,8 +443,9 @@ func (e *BuildkitController) Prune(req *controlapi.PruneRequest, stream controla
 func (e *BuildkitController) Info(ctx context.Context, r *controlapi.InfoRequest) (*controlapi.InfoResponse, error) {
 	return &controlapi.InfoResponse{
 		BuildkitVersion: &apitypes.BuildkitVersion{
-			Package: e.EngineName,
-			Version: engine.Version,
+			Package:  engine.Package,
+			Version:  engine.Version,
+			Revision: e.EngineName,
 		},
 	}, nil
 }

--- a/engine/version.go
+++ b/engine/version.go
@@ -10,6 +10,8 @@ import (
 
 var (
 	EngineImageRepo = "registry.dagger.io/engine"
+
+	Package = "github.com/dagger/dagger"
 )
 
 var DevelopmentVersion = fmt.Sprintf("devel (%s)", vcsRevision())


### PR DESCRIPTION
This adds a sanity check to check that when we connect to a remote buildkit instance, that it's running the dagger engine, and not a vanilla instance of buildkit.

See https://github.com/dagger/dagger/issues/5852#issuecomment-1756568885:

> If you are trying to connect to a host that was provisioned via buildx then it's not expected to work at this time. Dagger has a bit of divergence from the buildkitd that buildx uses.

We should hard fail on this kind of scenario, since it's possible to detect this by inspecting the `Package` value from buildkit's `Info` call. However, to do this, I've had to change the meaning of `Package` to contain the go package name, and smuggle the engine name through the `Revision` field. This would make this a breaking change for users with mismatched cli and engine versions - I'm not sure if this is important, if it is, we could do a weaker form of the check and just fail on the case that `info.BuildkitVersion.Package == "github.com/moby/buildkit"`.

It might be useful to upstream the "engine name" functionality into buildkit (e.g. https://github.com/jedevc/buildkit/commit/f0fe58a1a991f915131c1f6e89871c0f11f03ec5), to avoid the need to smuggle through another field, wdyt @sipsma?