### PR TITLE
docs(feat): mark deprecated args in graphql reference

### DIFF
--- a/website/.gitignore
+++ b/website/.gitignore
@@ -8,6 +8,7 @@
 .docusaurus
 .cache-loader
 /static/api/reference
+introspection.json
 /static/guides.json
 
 # Misc

--- a/website/docs-graphql/README.md
+++ b/website/docs-graphql/README.md
@@ -2,19 +2,29 @@
 
 ## Context
 
-We chose to use `spectaql` as a quick way to generate a static HTML webpage for our GraphQL API reference, because it generates documentation based on a GraphQL schema.
-For generating documentation based on a schema, `spectaql` uses [Handlebars](https://handlebarsjs.com/) and [Microfiber](https://www.npmjs.com/package/microfiber).  
+We chose to use `spectaql` as a quick way to generate a static HTML webpage for our GraphQL API reference, because it generates documentation based on a GraphQL schema. For generating documentation based on a schema, `spectaql` uses [Handlebars](https://handlebarsjs.com/) and [Microfiber](https://www.npmjs.com/package/microfiber).
 
 In order to tailor the documentation to our needs, we have to override the current styling and data produced from the schema.
 
 ## Examples Generation
 
-The examples are rendered with `spectaql` with the use of [helpers](https://github.com/anvilco/spectaql/tree/1c125e0c735f354337b18c4bd773759c4e65075b/src/themes/default/helpers) that live in the default theme. Helpers are a core concept in Handlebars.  
+The examples are rendered with `spectaql` with the use of [helpers](https://github.com/anvilco/spectaql/tree/1c125e0c735f354337b18c4bd773759c4e65075b/src/themes/default/helpers) that live in the default theme. Helpers are a core concept in Handlebars.
 
-The examples live in the [`./data/examples`](./data/examples/) folder and are read at the time of generation with a script that lives in [`./custom-theme/data/index.js`](`./custom-theme/data/index.js`).  
+The examples live in the [`./data/examples`](./data/examples/) folder and are read at the time of generation with a script that lives in [`./custom-theme/data/index.js`](`./custom-theme/data/index.js`).
 
-The script does not fail if there is a missing example for a given query, but it outputs the results to the console with a warning.  
+The script does not fail if there is a missing example for a given query, but it outputs the results to the console with a warning.
 
-## Introduction Content  
+## Introduction Content
 
-To modify the content in the introduction section, modify the info field in [the configuration file](./config.yml).  
+To modify the content in the introduction section, modify the info field in [the configuration file](./config.yml).
+
+## Debugging
+
+A good way to debug the metadata extracted from the core schema is to write a file with the output.
+You can do this by adding the following line inside the `website/docs-graphql/custom-theme/data/index.js` file.
+
+```bash
+  fs.writeFileSync(path.resolve(`${__dirname}/../../data/introspection.json`), JSON.stringify(introspectionResponse, null, 2))
+```
+
+This will write the introspection response to the `data/introspection.json` file.

--- a/website/docs-graphql/config.yml
+++ b/website/docs-graphql/config.yml
@@ -13,6 +13,7 @@ introspection:
   metadatas: true
   hideMutationsWithUndocumentedReturnType: false
   hideUnusedTypes: false
+  inputValueDeprecation: true
 
 extensions:
   graphqlScalarExamples: true
@@ -24,3 +25,5 @@ info:
   #   - title: Welcome! 
   #     description: We are using a GraphQL server as the API to interact with our engine. This allows us to make interoperation between programming languages possible.
   x-url: https://api.dagger.cloud/playgrounds
+  x-hideIsDeprecated: false
+  x-hideDeprecationReason: false

--- a/website/docs-graphql/custom-theme/views/partials/graphql/_query-or-mutation-arguments.hbs
+++ b/website/docs-graphql/custom-theme/views/partials/graphql/_query-or-mutation-arguments.hbs
@@ -1,0 +1,33 @@
+{{#if args}}
+  <div class="operation-arguments test doc-copy-section">
+    <h5>Arguments</h5>
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        {{#each args}}
+          <tr>
+            <td>
+              {{! The Name column }}
+              {{~> graphql/name-and-type }}`
+            </td>
+            <td>
+              {{! The Description column }}
+              {{>graphql/_description-with-defaults}}
+                {{#if (and deprecationReason (not @root.info.x-hideDeprecationReason))}}
+                  <div class="deprecation-reason">
+                    {{ md deprecationReason stripParagraph=true }}
+                  </div>
+                {{/if}}
+            </td>
+          </tr>
+        {{/each}}
+      </tbody>
+    </table>
+  </div>
+{{/if}}

--- a/website/docs-graphql/custom-theme/views/partials/graphql/_query-or-mutation-arguments.hbs
+++ b/website/docs-graphql/custom-theme/views/partials/graphql/_query-or-mutation-arguments.hbs
@@ -14,7 +14,7 @@
           <tr>
             <td>
               {{! The Name column }}
-              {{~> graphql/name-and-type }}`
+              {{~> graphql/name-and-type }}
             </td>
             <td>
               {{! The Description column }}

--- a/website/package.json
+++ b/website/package.json
@@ -37,7 +37,7 @@
     "react-social-login-buttons": "^3.9.1",
     "remark-code-import": "^1.2.0",
     "sass": "^1.66.1",
-    "spectaql": "^2.0.5",
+    "spectaql": "^2.3.0",
     "typedoc": "^0.24.7",
     "typedoc-plugin-markdown": "^3.16.0",
     "typescript": "^5.0.4",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -3909,10 +3909,17 @@ ci-info@^3.2.0:
   resolved "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz"
   integrity sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==
 
-clean-css@^5.0.1, clean-css@^5.2.2, clean-css@^5.3.0:
+clean-css@^5.2.2, clean-css@^5.3.0:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.3.1.tgz#d0610b0b90d125196a2894d35366f734e5d7aa32"
   integrity sha512-lCr8OHhiWCTw4v8POJovCoh4T7I9U11yVsPjMWWnnMmp9ZowCxyad1Pathle/9HjaDp+fdQKjO9fQydE6RHTZg==
+  dependencies:
+    source-map "~0.6.0"
+
+clean-css@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.3.2.tgz#70ecc7d4d4114921f5d298349ff86a31a9975224"
+  integrity sha512-JVJbM+f3d3Q704rF4bqQ5UUyTtuJ0JRKNbTKVEeujCCBoMdkEi+V+e8oktO9qGQNSvHrFTM6JZRXrUvGR1czww==
   dependencies:
     source-map "~0.6.0"
 
@@ -5189,6 +5196,15 @@ domutils@^3.0.1:
     domelementtype "^2.3.0"
     domhandler "^5.0.1"
 
+domutils@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.1.0.tgz#c47f551278d3dc4b0b1ab8cbb42d751a6f0d824e"
+  integrity sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+
 dot-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz"
@@ -5359,6 +5375,11 @@ entities@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
   integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
+
+entities@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 err-code@^1.0.0:
   version "1.1.2"
@@ -6413,13 +6434,13 @@ grunt-contrib-copy@^1.0.0:
     chalk "^1.1.1"
     file-sync-cmp "^0.1.0"
 
-grunt-contrib-cssmin@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/grunt-contrib-cssmin/-/grunt-contrib-cssmin-4.0.0.tgz#ffe7460d0fa53dbc5c7879e80088404cfed93d3b"
-  integrity sha512-jXU+Zlk8Q8XztOGNGpjYlD/BDQ0n95IHKrQKtFR7Gd8hZrzgqiG1Ra7cGYc8h2DD9vkSFGNlweb9Q00rBxOK2w==
+grunt-contrib-cssmin@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/grunt-contrib-cssmin/-/grunt-contrib-cssmin-5.0.0.tgz#c572bc20e8d085fcd66fc1c53dcd20d2c6e9b547"
+  integrity sha512-SNp4H4+85mm2xaHYi83FBHuOXylpi5vcwgtNoYCZBbkgeXQXoeTAKa59VODRb0woTDBvxouP91Ff5PzCkikg6g==
   dependencies:
-    chalk "^4.1.0"
-    clean-css "^5.0.1"
+    chalk "^4.1.2"
+    clean-css "^5.3.2"
     maxmin "^3.0.0"
 
 grunt-contrib-uglify@^5.0.1:
@@ -6781,7 +6802,7 @@ htmlparser2@^6.1.0:
     domutils "^2.5.2"
     entities "^2.0.0"
 
-htmlparser2@^8.0.1, htmlparser2@~8.0.1:
+htmlparser2@^8.0.1:
   version "8.0.1"
   resolved "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz"
   integrity sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==
@@ -6790,6 +6811,16 @@ htmlparser2@^8.0.1, htmlparser2@~8.0.1:
     domhandler "^5.0.2"
     domutils "^3.0.1"
     entities "^4.3.0"
+
+htmlparser2@~9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-9.0.0.tgz#e431142b7eeb1d91672742dea48af8ac7140cddb"
+  integrity sha512-uxbSI98wmFT/G4P2zXx4OVx04qWUmyFPrD2/CNepa2Zo3GPNaCaaxElDgwUrwYWkK1nr9fft0Ya8dws8coDLLQ==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.1.0"
+    entities "^4.5.0"
 
 http-basic@^8.1.1:
   version "8.1.3"
@@ -11029,10 +11060,10 @@ spdy@^4.0.2:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
-spectaql@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/spectaql/-/spectaql-2.0.5.tgz#af692cfee4ef0c396424b2a349d9d65d3bcd933f"
-  integrity sha512-AkODv4O42XomRFBCKc2f9Knmd4f4N/TTsgs9tuv8drojPiT0Tc0Q4R8xo97o+S1OawnhRxzCK+OYkfAUzEXRCg==
+spectaql@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/spectaql/-/spectaql-2.3.0.tgz#6072b949f8bfb91efe2d0534dc39c48e993df594"
+  integrity sha512-fk0zWo6R8F/5l5Gy6dpbTyiituXXRpCUcIxj8VTRwbSw2+Xj2xNRkYJC3fIEwTaeNshL88Pts5fnFxFGNA1K7A==
   dependencies:
     "@anvilco/apollo-server-plugin-introspection-metadata" "^2.0.1"
     "@graphql-tools/load-files" "^6.3.2"
@@ -11051,13 +11082,13 @@ spectaql@^2.0.5:
     grunt-contrib-concat "^2.1.0"
     grunt-contrib-connect "^3.0.0"
     grunt-contrib-copy "^1.0.0"
-    grunt-contrib-cssmin "^4.0.0"
+    grunt-contrib-cssmin "^5.0.0"
     grunt-contrib-uglify "^5.0.1"
     grunt-contrib-watch "^1.1.0"
     grunt-sass "^3.0.2"
     handlebars "^4.7.7"
     highlight.js "^11.4.0"
-    htmlparser2 "~8.0.1"
+    htmlparser2 "~9.0.0"
     js-beautify "~1.14.7"
     js-yaml "^4.1.0"
     json-stringify-pretty-compact "^3.0.0"


### PR DESCRIPTION
This PR adds a deprecation notice next to the query arguments set as `@deprecated` in the schema files inside the `/core/schema` directory.

This also adds a tip in the `docs-graphql` README to improve the debugging experience a bit.