### PR TITLE
Reveal errored vertices by default

### DIFF
--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -45,6 +45,11 @@ func init() {
 // show only focused vertices
 var focus bool
 
+// show errored vertices even if focused
+//
+// set this to false if your command handles errors (e.g. dagger checks)
+var revealErrored = true
+
 var interactive = os.Getenv("_EXPERIMENTAL_DAGGER_INTERACTIVE_TUI") != ""
 
 type runClientCallback func(context.Context, *client.Client) error
@@ -158,6 +163,8 @@ func inlineTUI(
 	tape := progrock.NewTape()
 	tape.ShowInternal(debug)
 	tape.Focus(focus)
+	tape.RevealErrored(revealErrored)
+
 	if debug {
 		tape.MessageLevel(progrock.MessageLevel_DEBUG)
 	}


### PR DESCRIPTION
Added this feature to Progrock and never went back and enabled it! :facepalm: 

This should reduce the need for `--focus=false` since errors will be shown regardless.

related to #5894 