### PR TITLE
fix(docs): remove duplicated graphql api section

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -187,27 +187,6 @@ module.exports = {
     },
     {
       type: "category",
-      label: "GraphQL API",
-      collapsible: true,
-      collapsed: true,
-      items: [
-        {
-          type: "doc",
-          label: "Overview",
-          id: "current/api/index",
-        },
-        "current/api/concepts",
-        "current/api/playground",
-        "current/api/build-custom-client",
-        {
-          type: "link",
-          label: "Reference",
-          href: "https://docs.dagger.io/api/reference",
-        },
-      ],
-    },
-    {
-      type: "category",
       label: "Dagger CLI",
       collapsible: true,
       collapsed: true,


### PR DESCRIPTION
This PR removes a duplicated GraphQL API section from the dagger.io docs sidebar.
