### PR TITLE
docs: Makes minor change to inline code refs

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -37,6 +37,9 @@
   ```
 
 - Use API Playground embeds where possible (see "API Playground embeds" section below).
+- In inline text, when referring to an SDK method, instead of explicitly specifying the name for each language method (they have minor differences), use the GraphQL API type and field instead e.g `Container.withServiceBinding` instead of `Container.WithServiceBinding (Go), Container.with_service_binding (Python) and Container.withServiceBinding (Node.js)`.
+  - Always `Capitalize` types, and always `lowerCamelCase` fields, to match GraphQL syntax as the common compromise.
+  - Omit the `()` since a lot of the time it's either not necessary, or implies no args are needed, and sometimes you just want to refer to a method call and ignore its required args e.g. `Container.asService`.
 
 ## Images
 

--- a/docs/current/guides/128409-build-test-publish-php.md
+++ b/docs/current/guides/128409-build-test-publish-php.md
@@ -357,7 +357,7 @@ The `runUnitTests()` method executes two GraphQL queries:
 1. The second query uses the test image returned by the `buildTestImage()` method and adds a service binding for the database service to it using the `container.withServiceBinding()` API method. It then chains multiple `container.withEnvVariable()` methods to configure the database service credentials for the Laravel application. Finally, it uses the `container.withExec()` method to launch the PHPUnit test runner and return the output stream (the test summary).
 
 :::tip
-When creating the database service container, using `container.withExposedPort()` is important. Without this method, Dagger will start the service container and immediately allow access to the test runner, without waiting for the service to start listening. This can result in test failures if the test runner is unable to connect to the service. With this method, Dagger will wait for the service to be listening first before allowing the test runner access to it. [Learn more about service containers in Dagger](./757394-use-service-containers.md).
+When creating the database service container, using the `Container.withExposedPort` field is important. Without this field, Dagger will start the service container and immediately allow access to the test runner, without waiting for the service to start listening. This can result in test failures if the test runner is unable to connect to the service. With this field, Dagger will wait for the service to be listening first before allowing the test runner access to it. [Learn more about service containers in Dagger](./757394-use-service-containers.md).
 :::
 
 ### Build a production image

--- a/docs/current/guides/757394-use-service-containers.md
+++ b/docs/current/guides/757394-use-service-containers.md
@@ -96,7 +96,7 @@ Service containers never use IP addresses to reach each other directly. IP addre
 
 This hash value is derived from the same value that determines whether an operation is a cache hit in Buildkit: the vertex digest.
 
-To get a container's address, you wouldn't normally run the `hostname` command, because you'd just be getting the hostname of a container that runs `hostname`, which isn't very helpful. Instead, you would use the `Hostname()` (Go) or `hostname()` (Python and Node.js) SDK method, which returns a domain name reachable by other containers:
+To get a container's address, you wouldn't normally run the `hostname` command, because you'd just be getting the hostname of a container that runs `hostname`, which isn't very helpful. Instead, you would use the `hostname` field (or equivalent SDK method), which returns a domain name reachable by other containers:
 
 <Tabs groupId="language" className="embeds">
 <TabItem value="Go">
@@ -365,7 +365,7 @@ The application used in this example is [Drupal](https://www.drupal.org/), a pop
 This example begins by creating a MariaDB service container and initializing a new MariaDB database. It then creates a Drupal container and installs required dependencies into it. Next, it adds a binding for the MariaDB service (`db`) in the Drupal container and sets a container environment variable (`SIMPLETEST_DB`) with the database DSN. Finally, it runs Drupal's kernel tests (which [require a database connection](https://www.drupal.org/docs/automated-testing/phpunit-in-drupal/running-phpunit-tests#non-unit-tests)) using PHPUnit and prints the test summary to the console.
 
 :::tip
-Explicitly specifying the service container port with `WithExposedPort()` (Go), `withExposedPort()` (Node.js) or `with_exposed_port()` (Python) is particularly important here. Without it, Dagger will start the service container and immediately allow access to service clients. With it, Dagger will wait for the service to be listening first.
+Explicitly specifying the service container port with the `Container.withExposedPort` field (via the equivalent SDK method) is particularly important here. Without it, Dagger will start the service container and immediately allow access to service clients. With it, Dagger will wait for the service to be listening first.
 :::
 
 ## Conclusion


### PR DESCRIPTION
This commit updates inline code refs to match GraphQL API syntax.