### PR TITLE
fix: remove options structs in go sdk

### DIFF
--- a/.changes/unreleased/Breaking-20231024-152415.yaml
+++ b/.changes/unreleased/Breaking-20231024-152415.yaml
@@ -1,0 +1,6 @@
+kind: Breaking
+body: Migrate Go SDK to use new zenith opts convention
+time: 2023-10-24T15:24:15.600113203+01:00
+custom:
+  Author: jedevc
+  PR: "5907"

--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -321,6 +321,7 @@ func (ps *parseState) fillObjectFunctionCases(type_ types.Type, cases map[string
 
 		for i := 0; i < sig.Params().Len(); i++ {
 			arg := sig.Params().At(i)
+			variadic := sig.Variadic() && i == sig.Params().Len()-1
 
 			if i == 0 && arg.Type().String() == "context.Context" {
 				fnCallArgs = append(fnCallArgs, Id("ctx"))
@@ -347,7 +348,11 @@ func (ps *parseState) fillObjectFunctionCases(type_ types.Type, cases map[string
 						))
 				}
 
-				fnCallArgs = append(fnCallArgs, Id(optsName))
+				if variadic {
+					fnCallArgs = append(fnCallArgs, Id(optsName).Op("..."))
+				} else {
+					fnCallArgs = append(fnCallArgs, Id(optsName))
+				}
 			} else {
 				argName := strcase.ToLowerCamel(arg.Name())
 
@@ -360,7 +365,11 @@ func (ps *parseState) fillObjectFunctionCases(type_ types.Type, cases map[string
 					checkErrStatement,
 				)
 
-				fnCallArgs = append(fnCallArgs, Id(argName))
+				if variadic {
+					fnCallArgs = append(fnCallArgs, Id(argName).Op("..."))
+				} else {
+					fnCallArgs = append(fnCallArgs, Id(argName))
+				}
 			}
 		}
 

--- a/cmd/codegen/generator/go/templates/src/header.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/header.go.tmpl
@@ -31,3 +31,39 @@ func assertNotNil(argName string, value any) {
 		panic(fmt.Sprintf("unexpected nil pointer for argument %q", argName))
 	}
 }
+
+// ptr returns a pointer to the given value.
+func ptr[T any](v T) *T {
+	return &v
+}
+
+type Optional[T comparable] struct {
+	value T
+	isSet bool
+}
+
+func Opt[T comparable](v T) Optional[T] {
+	return Optional[T]{value: v, isSet: true}
+}
+
+func (o Optional[T]) Get() (T, bool) {
+	var zero T
+	return o.value, o.isSet || o.value != zero
+}
+
+func (o Optional[T]) GetOr(defaultValue T) T {
+	value, ok := o.Get()
+	if !ok {
+		return defaultValue
+	}
+	return value
+}
+
+func (o *Optional[T]) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&o.value)
+}
+
+func (o *Optional[T]) UnmarshalJSON(dt []byte) error {
+	o.isSet = true
+	return json.Unmarshal(dt, &o.value)
+}

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/iancoleman/strcase"
 	"github.com/moby/buildkit/identity"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -474,6 +475,16 @@ func TestModuleGoSignatures(t *testing.T) {
 		require.JSONEq(t, `{"minimal":{"echoPointerPointer":"hello...hello...hello..."}}`, out)
 	})
 
+	t.Run("func EchoOptional(string) string", func(t *testing.T) {
+		t.Parallel()
+		out, err := modGen.With(daggerQuery(`{minimal{echoOptional(msg: "hello")}}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"minimal":{"echoOptional":"hello...hello...hello..."}}`, out)
+		out, err = modGen.With(daggerQuery(`{minimal{echoOptional}}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"minimal":{"echoOptional":"default...default...default..."}}`, out)
+	})
+
 	t.Run("func Echoes([]string) []string", func(t *testing.T) {
 		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echoes(msgs: "hello")}}`)).Stdout(ctx)
@@ -481,7 +492,7 @@ func TestModuleGoSignatures(t *testing.T) {
 		require.JSONEq(t, `{"minimal":{"echoes":["hello...hello...hello..."]}}`, out)
 	})
 
-	t.Run("func Echoes(...string) string", func(t *testing.T) {
+	t.Run("func EchoesVariadic(...string) string", func(t *testing.T) {
 		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echoesVariadic(msgs: "hello")}}`)).Stdout(ctx)
 		require.NoError(t, err)
@@ -523,29 +534,200 @@ func TestModuleGoSignatures(t *testing.T) {
 		require.JSONEq(t, `{"minimal":{"helloVoidError":null}}`, out)
 	})
 
-	t.Run("func EchoOpts(string, Opts) error", func(t *testing.T) {
+	t.Run("func EchoOpts(string, string, int) error", func(t *testing.T) {
 		t.Parallel()
 
 		out, err := modGen.With(daggerQuery(`{minimal{echoOpts(msg: "hi")}}`)).Stdout(ctx)
 		require.NoError(t, err)
-		require.JSONEq(t, `{"minimal":{"echoOpts":"hi...hi...hi..."}}`, out)
+		require.JSONEq(t, `{"minimal":{"echoOpts":"hi"}}`, out)
 
 		out, err = modGen.With(daggerQuery(`{minimal{echoOpts(msg: "hi", suffix: "!", times: 2)}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoOpts":"hi!hi!"}}`, out)
 	})
 
-	t.Run("func EchoOptsInline(string, struct{Suffix string, Times int}) error", func(t *testing.T) {
+	t.Run("func EchoOptsInline(struct{string, string, int}) error", func(t *testing.T) {
 		t.Parallel()
 
 		out, err := modGen.With(daggerQuery(`{minimal{echoOptsInline(msg: "hi")}}`)).Stdout(ctx)
 		require.NoError(t, err)
-		require.JSONEq(t, `{"minimal":{"echoOptsInline":"hi...hi...hi..."}}`, out)
+		require.JSONEq(t, `{"minimal":{"echoOptsInline":"hi"}}`, out)
 
 		out, err = modGen.With(daggerQuery(`{minimal{echoOptsInline(msg: "hi", suffix: "!", times: 2)}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoOptsInline":"hi!hi!"}}`, out)
 	})
+
+	t.Run("func EchoOptsInlinePointer(*struct{string, string, int}) error", func(t *testing.T) {
+		t.Parallel()
+
+		out, err := modGen.With(daggerQuery(`{minimal{echoOptsInlinePointer(msg: "hi")}}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"minimal":{"echoOptsInlinePointer":"hi"}}`, out)
+
+		out, err = modGen.With(daggerQuery(`{minimal{echoOptsInlinePointer(msg: "hi", suffix: "!", times: 2)}}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"minimal":{"echoOptsInlinePointer":"hi!hi!"}}`, out)
+	})
+
+	t.Run("func EchoOptsInlineCtx(ctx, struct{string, string, int}) error", func(t *testing.T) {
+		t.Parallel()
+
+		out, err := modGen.With(daggerQuery(`{minimal{echoOptsInlineCtx(msg: "hi")}}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"minimal":{"echoOptsInlineCtx":"hi"}}`, out)
+
+		out, err = modGen.With(daggerQuery(`{minimal{echoOptsInlineCtx(msg: "hi", suffix: "!", times: 2)}}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"minimal":{"echoOptsInlineCtx":"hi!hi!"}}`, out)
+	})
+
+	t.Run("func EchoOptsInlineTags(struct{string, string, int}) error", func(t *testing.T) {
+		t.Parallel()
+
+		out, err := modGen.With(daggerQuery(`{minimal{echoOptsInlineTags(msg: "hi")}}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"minimal":{"echoOptsInlineTags":"hi"}}`, out)
+
+		out, err = modGen.With(daggerQuery(`{minimal{echoOptsInlineTags(msg: "hi", suffix: "!", times: 2)}}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"minimal":{"echoOptsInlineTags":"hi!hi!"}}`, out)
+	})
+}
+
+func TestModuleGoDocs(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := connect(t)
+
+	modGen := c.Container().From(golangImage).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithWorkdir("/work").
+		With(daggerExec("mod", "init", "--name=minimal", "--sdk=go")).
+		WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
+			Contents: goSignatures,
+		})
+
+	logGen(ctx, t, modGen.Directory("."))
+
+	inspectModule := daggerQuery(`
+query {
+  host {
+    directory(path: ".") {
+      asModule {
+        objects {
+          asObject {
+            name
+            functions {
+              name
+              description
+              args {
+                name
+                description
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+	`)
+
+	out, err := modGen.With(inspectModule).Stdout(ctx)
+	require.NoError(t, err)
+	obj := gjson.Get(out, "host.directory.asModule.objects.0.asObject")
+	require.Equal(t, "Minimal", obj.Get("name").String())
+
+	hello := obj.Get(`functions.#(name="hello")`)
+	require.Equal(t, "hello", hello.Get("name").String())
+	require.Empty(t, hello.Get("description").String())
+	require.Empty(t, hello.Get("args").Array())
+
+	// test the args-based form
+	echoOpts := obj.Get(`functions.#(name="echoOpts")`)
+	require.Equal(t, "echoOpts", echoOpts.Get("name").String())
+	require.Equal(t, "EchoOpts does some opts things", echoOpts.Get("description").String())
+	require.Len(t, echoOpts.Get("args").Array(), 3)
+	require.Equal(t, "msg", echoOpts.Get("args.0.name").String())
+	require.Equal(t, "suffix", echoOpts.Get("args.1.name").String())
+	require.Equal(t, "String to append to the echoed message", echoOpts.Get("args.1.description").String())
+	require.Equal(t, "times", echoOpts.Get("args.2.name").String())
+	require.Equal(t, "Number of times to repeat the message", echoOpts.Get("args.2.description").String())
+
+	// test the inline struct form
+	echoOpts = obj.Get(`functions.#(name="echoOptsInline")`)
+	require.Equal(t, "echoOptsInline", echoOpts.Get("name").String())
+	require.Equal(t, "EchoOptsInline does some opts things", echoOpts.Get("description").String())
+	require.Len(t, echoOpts.Get("args").Array(), 3)
+	require.Equal(t, "msg", echoOpts.Get("args.0.name").String())
+	require.Equal(t, "suffix", echoOpts.Get("args.1.name").String())
+	require.Equal(t, "String to append to the echoed message", echoOpts.Get("args.1.description").String())
+	require.Equal(t, "times", echoOpts.Get("args.2.name").String())
+	require.Equal(t, "Number of times to repeat the message", echoOpts.Get("args.2.description").String())
+}
+
+func TestModuleGoSignaturesMixMatch(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := connect(t)
+
+	modGen := c.Container().From(golangImage).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithWorkdir("/work").
+		With(daggerExec("mod", "init", "--name=minimal", "--sdk=go")).
+		WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
+			Contents: `package main
+
+type Minimal struct {}
+
+func (m *Minimal) Hello(name string, opts struct{}, opts2 struct{}) string {
+	return name
+}
+`,
+		})
+
+	logGen(ctx, t, modGen.Directory("."))
+
+	_, err := modGen.With(daggerQuery(`{minimal{hello}}`)).Stdout(ctx)
+	require.Error(t, err)
+}
+
+func TestModuleGoSignaturesIDable(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := connect(t)
+
+	modGen := c.Container().From(golangImage).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithWorkdir("/work").
+		With(daggerExec("mod", "init", "--name=minimal", "--sdk=go")).
+		WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
+			Contents: `package main
+
+type Minimal struct {}
+
+type Custom struct {
+	Data string
+}
+
+func (m *Minimal) Hello() string {
+	return "hello"
+}
+
+func (m *Minimal) UseCustom(custom *Custom) string {
+	return custom.Data
+}
+`,
+		})
+
+	logGen(ctx, t, modGen.Directory("."))
+
+	// Currently, IDable modules are *not* supported, and should fail with an
+	// error that fails to find the ID type.
+	_, err := modGen.With(daggerQuery(`{minimal{hello}}`)).Stdout(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Undefined type MinimalCustomID")
 }
 
 //go:embed testdata/modules/go/extend/main.go

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -481,6 +481,13 @@ func TestModuleGoSignatures(t *testing.T) {
 		require.JSONEq(t, `{"minimal":{"echoes":["hello...hello...hello..."]}}`, out)
 	})
 
+	t.Run("func Echoes(...string) string", func(t *testing.T) {
+		t.Parallel()
+		out, err := modGen.With(daggerQuery(`{minimal{echoesVariadic(msgs: "hello")}}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"minimal":{"echoesVariadic":"hello...hello...hello..."}}`, out)
+	})
+
 	t.Run("func HelloContext(context.Context) string", func(t *testing.T) {
 		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{helloContext}}`)).Stdout(ctx)

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -460,6 +460,27 @@ func TestModuleGoSignatures(t *testing.T) {
 		require.JSONEq(t, `{"minimal":{"echo":"hello...hello...hello..."}}`, out)
 	})
 
+	t.Run("func EchoPointer(*string) string", func(t *testing.T) {
+		t.Parallel()
+		out, err := modGen.With(daggerQuery(`{minimal{echoPointer(msg: "hello")}}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"minimal":{"echoPointer":"hello...hello...hello..."}}`, out)
+	})
+
+	t.Run("func EchoPointerPointer(**string) string", func(t *testing.T) {
+		t.Parallel()
+		out, err := modGen.With(daggerQuery(`{minimal{echoPointerPointer(msg: "hello")}}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"minimal":{"echoPointerPointer":"hello...hello...hello..."}}`, out)
+	})
+
+	t.Run("func Echoes([]string) []string", func(t *testing.T) {
+		t.Parallel()
+		out, err := modGen.With(daggerQuery(`{minimal{echoes(msgs: "hello")}}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"minimal":{"echoes":["hello...hello...hello..."]}}`, out)
+	})
+
 	t.Run("func HelloContext(context.Context) string", func(t *testing.T) {
 		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{helloContext}}`)).Stdout(ctx)

--- a/core/integration/testdata/modules/go/minimal/main.go
+++ b/core/integration/testdata/modules/go/minimal/main.go
@@ -22,6 +22,21 @@ func (m *Minimal) Echo(msg string) string {
 	})
 }
 
+func (m *Minimal) EchoPointer(msg *string) *string {
+	v := m.Echo(*msg)
+	return &v
+}
+
+func (m *Minimal) EchoPointerPointer(msg **string) **string {
+	v := m.Echo(**msg)
+	v2 := &v
+	return &v2
+}
+
+func (m *Minimal) Echoes(msgs []string) []string {
+	return []string{m.Echo(strings.Join(msgs, " "))}
+}
+
 func (m *Minimal) HelloContext(ctx context.Context) string {
 	return "hello context"
 }

--- a/core/integration/testdata/modules/go/minimal/main.go
+++ b/core/integration/testdata/modules/go/minimal/main.go
@@ -37,6 +37,10 @@ func (m *Minimal) Echoes(msgs []string) []string {
 	return []string{m.Echo(strings.Join(msgs, " "))}
 }
 
+func (m *Minimal) EchoesVariadic(msgs ...string) string {
+	return m.Echo(strings.Join(msgs, " "))
+}
+
 func (m *Minimal) HelloContext(ctx context.Context) string {
 	return "hello context"
 }

--- a/core/integration/testdata/modules/go/minimal/main.go
+++ b/core/integration/testdata/modules/go/minimal/main.go
@@ -34,6 +34,14 @@ func (m *Minimal) EchoOptional(msg Optional[string]) string {
 	return m.Echo(v)
 }
 
+func (m *Minimal) EchoOptionalPointer(msg **Optional[**string]) string {
+	v, ok := (*msg).Get()
+	if !ok {
+		v = ptr(ptr("default"))
+	}
+	return m.Echo(**v)
+}
+
 func (m *Minimal) Echoes(msgs []string) []string {
 	return []string{m.Echo(strings.Join(msgs, " "))}
 }
@@ -62,7 +70,7 @@ func (m *Minimal) HelloVoidError() error {
 
 // EchoOpts does some opts things
 func (m *Minimal) EchoOpts(
-	msg string,
+	msg string, // the message to echo
 
 	// String to append to the echoed message
 	suffix Optional[string],
@@ -75,7 +83,7 @@ func (m *Minimal) EchoOpts(
 
 // EchoOptsInline does some opts things
 func (m *Minimal) EchoOptsInline(opts struct {
-	Msg string
+	Msg string // the message to echo
 
 	// String to append to the echoed message
 	Suffix Optional[string]

--- a/core/integration/testdata/modules/go/minimal/main.go
+++ b/core/integration/testdata/modules/go/minimal/main.go
@@ -12,14 +12,7 @@ func (m *Minimal) Hello() string {
 }
 
 func (m *Minimal) Echo(msg string) string {
-	return m.EchoOpts(msg, EchoOpts{
-		// TODO(vito): gotcha! Because we're calling the method directly, defaults
-		// are not applied. Maybe the default:"..." struct tag should be removed in
-		// favor of handling it at runtime? Maybe it should be kept anyway as a
-		// convenience, and this won't be a common footgun?
-		Suffix: "...",
-		Times:  3,
-	})
+	return m.EchoOpts(msg, Opt("..."), Opt(3))
 }
 
 func (m *Minimal) EchoPointer(msg *string) *string {
@@ -31,6 +24,14 @@ func (m *Minimal) EchoPointerPointer(msg **string) **string {
 	v := m.Echo(**msg)
 	v2 := &v
 	return &v2
+}
+
+func (m *Minimal) EchoOptional(msg Optional[string]) string {
+	v, ok := msg.Get()
+	if !ok {
+		v = "default"
+	}
+	return m.Echo(v)
 }
 
 func (m *Minimal) Echoes(msgs []string) []string {
@@ -59,19 +60,60 @@ func (m *Minimal) HelloVoidError() error {
 	return nil
 }
 
-type EchoOpts struct {
-	Suffix string `doc:"String to append to the echoed message." default:"..."`
-	Times  int    `doc:"Number of times to repeat the message." default:"3"`
+// EchoOpts does some opts things
+func (m *Minimal) EchoOpts(
+	msg string,
+
+	// String to append to the echoed message
+	suffix Optional[string],
+	// Number of times to repeat the message
+	times Optional[int],
+) string {
+	msg += suffix.GetOr("")
+	return strings.Repeat(msg, times.GetOr(1))
 }
 
-func (m *Minimal) EchoOpts(msg string, opts EchoOpts) string {
-	return m.EchoOptsInline(msg, opts)
-}
+// EchoOptsInline does some opts things
+func (m *Minimal) EchoOptsInline(opts struct {
+	Msg string
 
-func (m *Minimal) EchoOptsInline(msg string, opts struct {
-	Suffix string `doc:"String to append to the echoed message." default:"..."`
-	Times  int    `doc:"Number of times to repeat the message." default:"3"`
+	// String to append to the echoed message
+	Suffix Optional[string]
+	// Number of times to repeat the message
+	Times Optional[int]
 }) string {
-	msg += opts.Suffix
-	return strings.Repeat(msg, opts.Times)
+	return m.EchoOpts(opts.Msg, opts.Suffix, opts.Times)
+}
+
+func (m *Minimal) EchoOptsInlinePointer(opts *struct {
+	Msg string
+
+	// String to append to the echoed message
+	Suffix Optional[string]
+	// Number of times to repeat the message
+	Times Optional[int]
+}) string {
+	return m.EchoOptsInline(*opts)
+}
+
+func (m *Minimal) EchoOptsInlineCtx(ctx context.Context, opts struct {
+	Msg string
+
+	// String to append to the echoed message
+	Suffix Optional[string]
+	// Number of times to repeat the message
+	Times Optional[int]
+}) string {
+	return m.EchoOpts(opts.Msg, opts.Suffix, opts.Times)
+}
+
+func (m *Minimal) EchoOptsInlineTags(ctx context.Context, opts struct {
+	Msg string
+
+	// String to append to the echoed message
+	Suffix Optional[string] `tag:"hello"`
+	// Number of times to repeat the message
+	Times Optional[int] `tag:"hello again"`
+}) string {
+	return m.EchoOpts(opts.Msg, opts.Suffix, opts.Times)
 }

--- a/docs/current/labs/project-zenith.md
+++ b/docs/current/labs/project-zenith.md
@@ -162,7 +162,7 @@ func (m *Potato) HelloWorld(
   // whether the potatoes are mashed (this is an optional parameter!)
   mashed Optional[bool],
 ) string {
-  if mashed.GetOr("false") {
+  if mashed.GetOr(false) {
     return fmt.Sprintf("Hello world, I have mashed %d potatoes", count)
   }
   return fmt.Sprintf("Hello world, I have %d potatoes", count)

--- a/docs/current/labs/project-zenith.md
+++ b/docs/current/labs/project-zenith.md
@@ -146,8 +146,8 @@ echo '{potato{helloWorld}}' | dagger query
 ```
 
 Your functions can accept and return multiple different types, not just basic
-builtin types. For example, to take an object (which you can use to provide
-optional parameters, or to group large numbers of parameters together):
+builtin types. For example, to take multiple parameters (some of which can be
+optional):
 
 ```go
 package main
@@ -156,16 +156,16 @@ import "fmt"
 
 type Potato struct{}
 
-type PotatoOptions struct {
-  Count  int
-  Mashed bool
-}
-
-func (m *Potato) HelloWorld(opts PotatoOptions) string {
-  if opts.Mashed {
-    return fmt.Sprintf("Hello world, I have mashed %d potatoes", opts.Count)
+func (m *Potato) HelloWorld(
+  // the number of potatoes to process
+  count  int,
+  // whether the potatoes are mashed (this is an optional parameter!)
+  mashed Optional[bool],
+) string {
+  if mashed.GetOr("false") {
+    return fmt.Sprintf("Hello world, I have mashed %d potatoes", count)
   }
-  return fmt.Sprintf("Hello world, I have %d potatoes", opts.Count)
+  return fmt.Sprintf("Hello world, I have %d potatoes", count)
 }
 ```
 
@@ -426,12 +426,9 @@ The result will be:
 ## Known issues
 
 - A module's public fields require a `json:"foo"` tag to be queriable.
-- Custom objects in a module require at least one method to be defined on them
-  to be detected by the codegen.
 - When referencing another module as a local dependency, the dependent module
   must be stored in a sub-directory of the parent module.
-- Custom struct types used as parameters cannot be nested and contain other
-  structs themselves.
+- Custom struct types cannot currently be used as parameters.
 - Calls to functions across modules will be run exactly _once_ per-session --
   after that, the result will be cached, but only until the next session (a new
   `dagger query`, etc).

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,6 @@ require (
 	github.com/dagger/dagger/internal/mage v0.0.0-00010101000000-000000000000
 	github.com/dave/jennifer v1.7.0
 	github.com/dschmidt/go-layerfs v0.1.0
-	github.com/fatih/structtag v1.2.0
 	github.com/go-git/go-git/v5 v5.9.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/go-github/v50 v50.2.0

--- a/go.sum
+++ b/go.sum
@@ -532,8 +532,6 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
-github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=
-github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -25,6 +25,42 @@ func assertNotNil(argName string, value any) {
 	}
 }
 
+// ptr returns a pointer to the given value.
+func ptr[T any](v T) *T {
+	return &v
+}
+
+type Optional[T comparable] struct {
+	value T
+	isSet bool
+}
+
+func Opt[T comparable](v T) Optional[T] {
+	return Optional[T]{value: v, isSet: true}
+}
+
+func (o Optional[T]) Get() (T, bool) {
+	var zero T
+	return o.value, o.isSet || o.value != zero
+}
+
+func (o Optional[T]) GetOr(defaultValue T) T {
+	value, ok := o.Get()
+	if !ok {
+		return defaultValue
+	}
+	return value
+}
+
+func (o *Optional[T]) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&o.value)
+}
+
+func (o *Optional[T]) UnmarshalJSON(dt []byte) error {
+	o.isSet = true
+	return json.Unmarshal(dt, &o.value)
+}
+
 // A global cache volume identifier.
 type CacheVolumeID string
 


### PR DESCRIPTION
:warning: Based on https://github.com/dagger/dagger/pull/5893
:hammer_and_wrench: Fixes https://github.com/dagger/dagger/issues/5904 https://github.com/dagger/dagger/issues/5864

This PR uses the approach detailed in https://github.com/dagger/dagger/issues/5864#issuecomment-1765040417:

> To resolve this, instead, we can just look at the Name of the struct - if it ends in "Opt" or similar, then we treat it as an opts struct.

All structs that end in "Opt"/"Opts"/"Option"/"Options" are treated as an opts-like struct, and we read parameters directly into them. However, because we're now not using the pointeriness of parameters to determine this, there's now a *bunch* of cases we need to handle - how should we handle `**Opts` or `[]Opts`, etc. These are all handled now by creating a single opts struct, and then working on how to put it into the target type.

