### PR TITLE
add instructions to test sdk changes locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -285,3 +285,20 @@ git commit --amend -s
 # Force push the new commit to re-run all GitHub Actions jobs:
 git push -f mybranch
 ```
+
+### How to test SDK changes locally?
+
+NodeJS:
+
+- In `sdk/nodejs`, run `npm run build`
+- In your `package.json`, update `@dagger.io/dagger` to reference your local path. For example `"@dagger.io/dagger": "<PATH TO DAGGER FORK>/dagger/sdk/nodejs",`
+
+Python:
+
+- While in a VirtualEnvironment, run `pip install <PATH TO DAGGER FORK>/sdk/python`
+
+Go:
+
+- In your Go project, run `go mod edit -replace dagger.io/dagger=<PATH TO DAGGER FORK>/sdk/go`
+- Then `go mod tidy`
+


### PR DESCRIPTION
Could not find existing instructions to test local SDK changes. Added to the FAQ of `CONTRIBUTING.md`