### PR TITLE
ci: pin buildctl source image to multiplatform index

### DIFF
--- a/internal/mage/util/engine.go
+++ b/internal/mage/util/engine.go
@@ -357,7 +357,7 @@ func buildctlBin(c *dagger.Client, arch string) *dagger.File {
 	*/
 
 	return c.Container(dagger.ContainerOpts{Platform: dagger.Platform("linux/" + arch)}).
-		From("moby/buildkit:master@sha256:f73a7d2d2441cfa5ced27bee8283f3b090a2232698484f7e4876e69a16d68a07").
+		From("moby/buildkit:master@sha256:5d05b3dc8dbab4422d3017014e47322b0a6168a5a2f88928baf9c607e3ac9fe1").
 		File("/usr/bin/buildctl")
 }
 


### PR DESCRIPTION
Noticed this while squashing another issue; this was accidentally pinning to an amd64 image rather than the multiplatform index.

I'm mildly confused how this went unnoticed as I previously ran `./hack/dev ./hack/make engine:test` successfully locally on my arm64 machine after the previous update, but later saw it failing due to buildctl being amd64. Possibly I had some qemu setting enabled that got reset after a reboot?

Either way, verified `./hack/dev` produces buildctl w/ right arch on my machine; CI machines are amd64 so we'll verify it works there too.