### PR TITLE
ci: use per-version python caches

### DIFF
--- a/internal/mage/sdk/python.go
+++ b/internal/mage/sdk/python.go
@@ -212,9 +212,9 @@ func pythonBaseEnv(c *dagger.Client, version string) *dagger.Container {
 	return c.Container().
 		From(fmt.Sprintf("python:%s-slim", version)).
 		WithEnvVariable("PIPX_BIN_DIR", "/usr/local/bin").
-		WithMountedCache("/root/.cache/pip", c.CacheVolume("pip_cache")).
-		WithMountedCache("/root/.local/pipx/cache", c.CacheVolume("pipx_cache")).
-		WithMountedCache("/root/.cache/hatch", c.CacheVolume("hatch_cache")).
+		WithMountedCache("/root/.cache/pip", c.CacheVolume("pip_cache_"+version)).
+		WithMountedCache("/root/.local/pipx/cache", c.CacheVolume("pipx_cache_"+version)).
+		WithMountedCache("/root/.cache/hatch", c.CacheVolume("hatch_cache_"+version)).
 		WithMountedFile("/pipx.pyz", pipx).
 		WithExec([]string{"python", "/pipx.pyz", "install", "hatch==1.7.0"}).
 		WithExec([]string{"python", "-m", "venv", venv}).


### PR DESCRIPTION
We started getting flaky failures in python tests recently about corruption in the pip cache. e.g. https://github.com/dagger/dagger/pull/5915#pullrequestreview-1686180892

Helder's theory is that we need separate caches per-version of Python, so making that change to confirm it fixes.

Fixes #5917 