### PR TITLE
hack/dev: add dagger to $PATH, add with-dev

### DIFF
--- a/hack/with-dev
+++ b/hack/with-dev
@@ -1,19 +1,12 @@
 #!/usr/bin/env bash
 
-set -e -u -x
+set -e -u
 
 DAGGER_SRC_ROOT="$(cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)"
-MAGEDIR="$DAGGER_SRC_ROOT/internal/mage"
-
-pushd $MAGEDIR
-go run main.go -w $DAGGER_SRC_ROOT engine:dev
-popd
 
 export _EXPERIMENTAL_DAGGER_CLI_BIN=$DAGGER_SRC_ROOT/bin/dagger
 export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev
-export _DAGGER_TESTS_ENGINE_TAR=$DAGGER_SRC_ROOT/bin/engine.tar
 
-# support ./hack/dev dagger run foo
 export PATH=$DAGGER_SRC_ROOT/bin:$PATH
 
 exec "$@"


### PR DESCRIPTION
* adding `dagger` to `$PATH` is helpful for `./hack/dev dagger run`
* `with-dev` is a subset of `dev` that doesn't build the engine first

I usually put `with-dev` in my `$PATH` instead and just hardcode it against my `~/src/dagger` path, but might as well have a version in-repo as a reference.