### PR TITLE
cli: handle optional arguments in module functions

### DIFF
--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -398,9 +398,12 @@ func (fc *FuncCommand) makeSubCmd(ctx context.Context, dag *dagger.Client, fn *m
 				return fmt.Errorf("parse flags: %w", err)
 			}
 
-			if err := cmd.ValidateRequiredFlags(); err != nil {
-				return err
-			}
+			help, _ := cmd.Flags().GetBool("help")
+            if !help {
+                if err := cmd.ValidateRequiredFlags(); err != nil {
+                    return err
+                }
+            }
 
 			fc.addSubCommands(ctx, dag, fn.ReturnType.AsObject, c, cmd)
 
@@ -410,7 +413,6 @@ func (fc *FuncCommand) makeSubCmd(ctx context.Context, dag *dagger.Client, fn *m
 				return fmt.Errorf("query selection: %w", err)
 			}
 
-			help, _ := cmd.Flags().GetBool("help")
 			cmdArgs := cmd.Flags().Args()
 
 			subCmd, subArgs, err := cmd.Find(cmdArgs)

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -486,8 +486,6 @@ func (fc *FuncCommand) makeSubCmd(ctx context.Context, dag *dagger.Client, fn *m
 func (fc *FuncCommand) selectFunc(fn *modFunction, c *callContext, cmd *cobra.Command, dag *dagger.Client) (*modTypeDef, error) {
 	c.Select(fn.Name)
 
-	// TODO: Check required flags.
-
 	for _, arg := range fn.Args {
 		var val any
 

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -399,11 +399,11 @@ func (fc *FuncCommand) makeSubCmd(ctx context.Context, dag *dagger.Client, fn *m
 			}
 
 			help, _ := cmd.Flags().GetBool("help")
-            if !help {
-                if err := cmd.ValidateRequiredFlags(); err != nil {
-                    return err
-                }
-            }
+			if !help {
+				if err := cmd.ValidateRequiredFlags(); err != nil {
+					return err
+				}
+			}
 
 			fc.addSubCommands(ctx, dag, fn.ReturnType.AsObject, c, cmd)
 

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -380,18 +380,11 @@ func (fc *FuncCommand) makeSubCmd(ctx context.Context, dag *dagger.Client, fn *m
 				c.mod.LoadObject(arg.TypeDef)
 			}
 
-			argValues := make(map[string]any)
-
 			for _, arg := range fn.Args {
-				p, err := arg.AddFlag(cmd.Flags(), dag)
+				_, err := arg.AddFlag(cmd.Flags(), dag)
 				if err != nil {
-					return fmt.Errorf("set flag %q: %w", arg.FlagName(), err)
+					return fmt.Errorf("add flag %q: %w", arg.FlagName(), err)
 				}
-				argValues[arg.Name] = p
-
-				// TODO: This won't work on its own because cobra checks required
-				// flags before the RunE function is called. We need to manually
-				// check the flags after parsing them.
 				if !arg.TypeDef.Optional {
 					cmd.MarkFlagRequired(arg.FlagName())
 				}
@@ -402,13 +395,17 @@ func (fc *FuncCommand) makeSubCmd(ctx context.Context, dag *dagger.Client, fn *m
 			}
 
 			if err := cmd.ParseFlags(args); err != nil {
-				return fmt.Errorf("parse sub-command flags: %w", err)
+				return fmt.Errorf("parse flags: %w", err)
+			}
+
+			if err := cmd.ValidateRequiredFlags(); err != nil {
+				return err
 			}
 
 			fc.addSubCommands(ctx, dag, fn.ReturnType.AsObject, c, cmd)
 
 			// Need to make the query selection before chaining off.
-			returnType, err := fc.selectFunc(fn, c, argValues, dag)
+			returnType, err := fc.selectFunc(fn, c, cmd, dag)
 			if err != nil {
 				return fmt.Errorf("query selection: %w", err)
 			}
@@ -484,17 +481,26 @@ func (fc *FuncCommand) makeSubCmd(ctx context.Context, dag *dagger.Client, fn *m
 
 // selectFunc adds the function selection to the query.
 // Note that the type can change if there's an extra selection for supported types.
-func (fc *FuncCommand) selectFunc(fn *modFunction, c *callContext, argValues map[string]any, dag *dagger.Client) (*modTypeDef, error) {
+func (fc *FuncCommand) selectFunc(fn *modFunction, c *callContext, cmd *cobra.Command, dag *dagger.Client) (*modTypeDef, error) {
 	c.Select(fn.Name)
 
 	// TODO: Check required flags.
-	// TODO: Handle default values.
 
 	for _, arg := range fn.Args {
-		val, ok := argValues[arg.Name]
-		if !ok {
-			return nil, fmt.Errorf("no value for argument: %s", arg.Name)
+		var val any
+
+		flag := cmd.Flags().Lookup(arg.FlagName())
+		if flag == nil {
+			return nil, fmt.Errorf("no flag for %q", arg.FlagName())
 		}
+
+		// Don't send optional arguments that weren't set.
+		if arg.TypeDef.Optional && !flag.Changed {
+			continue
+		}
+
+		val = flag.Value
+
 		dv, ok := val.(DaggerValue)
 		if ok {
 			obj := dv.Get(dag)

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -463,6 +463,7 @@ func loadModObjects(ctx context.Context, dag *dagger.Client, mod *dagger.Module)
                                 args {
                                     name
                                     description
+                                    defaultValue
                                     typeDef {
                                         kind
                                         optional
@@ -599,10 +600,11 @@ type modFunction struct {
 
 // modFunctionArg is a representation of dagger.FunctionArg.
 type modFunctionArg struct {
-	Name        string
-	Description string
-	TypeDef     *modTypeDef
-	flagName    string
+	Name         string
+	Description  string
+	TypeDef      *modTypeDef
+	DefaultValue dagger.JSON
+	flagName     string
 }
 
 // FlagName returns the name of the argument using CLI naming conventions.
@@ -611,6 +613,12 @@ func (r *modFunctionArg) FlagName() string {
 		r.flagName = cliName(r.Name)
 	}
 	return r.flagName
+}
+
+func getDefaultValue[T any](r *modFunctionArg) (T, error) {
+    var val T
+    err := json.Unmarshal([]byte(r.DefaultValue), &val)
+    return val, err
 }
 
 // gqlObjectName converts casing to a GraphQL object  name

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -616,9 +616,9 @@ func (r *modFunctionArg) FlagName() string {
 }
 
 func getDefaultValue[T any](r *modFunctionArg) (T, error) {
-    var val T
-    err := json.Unmarshal([]byte(r.DefaultValue), &val)
-    return val, err
+	var val T
+	err := json.Unmarshal([]byte(r.DefaultValue), &val)
+	return val, err
 }
 
 // gqlObjectName converts casing to a GraphQL object  name

--- a/sdk/python/src/dagger/ext/_functions.py
+++ b/sdk/python/src/dagger/ext/_functions.py
@@ -25,7 +25,7 @@ class FunctionResolver(Resolver[FunctionReturnType]):
         for arg_name, param in self.parameters.items():
             fn = fn.with_arg(
                 arg_name,
-                to_typedef(param.signature.annotation),
+                to_typedef(param.signature.annotation).with_optional(param.is_optional),
                 description=param.description,
                 default_value=(
                     dagger.JSON(json.dumps(param.signature.default))


### PR DESCRIPTION
This includes not sending default values in the query, showing them in `--help` and validating missing required flags.

**Example**
```python
@function
def hello(
    greeting: Annotated[str, "Your greeting"],
    name: Annotated[str, "The name to say hello to"] = "World!",
) -> str:
    # Say hello to someone
    return f"{greeting}, {name}!"
```

**Showing help**
```
> dagger call hello --help
✔ running "dagger call hello" [0.00s]
┃ Usage:
┃   dagger call hello [flags]
┃
┃ Flags:
┃       --greeting string   Your greeting
┃   -h, --help              help for hello
┃       --name string       The name to say hello to (default "World!")
```

**Required argument validation**

```
> dagger call hello
Error: required flag(s) "greeting" not set
exit status 1
```

**Default value not sent**
```
> dagger call hello --greeting Bonjour
✔ running "dagger call hello" [1.06s]
┃ Bonjour, World!!
DEBUG: executing query="query{test{hello(greeting:\"Bonjour\")}}"
```

**Changing default**
```
> dagger call hello --greeting Bonjour --name Monde
✔ running "dagger call hello" [1.02s]
┃ Bonjour, Monde!
DEBUG: executing query="query{test{hello(greeting:\"Bonjour\", name:\"Monde\")}}"
```
