### PR TITLE
ci: add --no-cache to alpine apk add

### DIFF
--- a/internal/mage/util/engine.go
+++ b/internal/mage/util/engine.go
@@ -205,7 +205,7 @@ func devEngineContainer(c *dagger.Client, arch string, version string, opts ...D
 	return c.Container(dagger.ContainerOpts{Platform: dagger.Platform("linux/" + arch)}).
 		From("alpine:"+alpineVersion).
 		WithExec([]string{
-			"apk", "add",
+			"apk", "add", "--no-cache",
 			// for Buildkit
 			"git", "openssh", "pigz", "xz",
 			// for CNI


### PR DESCRIPTION
This is better in general. It also just so happens to be enough to not cache a previous install of some libs that is likely causing us to end up with an old vulnerable version of libcurl due to our new use of shared dagger runners.