### PR TITLE
ci: fix engine image publishing bugs

### DIFF
--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -95,6 +95,8 @@ func (t Engine) Publish(ctx context.Context, version string) error {
 		WithRegistryAuth(registry, username, password).
 		Publish(ctx, ref, dagger.ContainerPublishOpts{
 			PlatformVariants: util.DevEngineContainer(c, publishedEngineArches, version),
+			// use gzip to avoid incompatibility w/ older docker versions
+			ForcedCompression: dagger.Gzip,
 		})
 	if err != nil {
 		return err

--- a/internal/mage/util/engine.go
+++ b/internal/mage/util/engine.go
@@ -259,7 +259,7 @@ func goSDKImageTarBall(c *dagger.Client, arch string) *dagger.File {
 	defer os.RemoveAll(tmpDir)
 	tarballPath := filepath.Join(tmpDir, filepath.Base(consts.GoSDKEngineContainerTarballPath))
 
-	_, err = c.Container().
+	_, err = c.Container(dagger.ContainerOpts{Platform: dagger.Platform("linux/" + arch)}).
 		From(fmt.Sprintf("golang:%s-alpine%s", golangVersion, alpineVersion)).
 		WithFile("/usr/local/bin/codegen", goSDKCodegenBin(c, arch)).
 		WithEntrypoint([]string{"/usr/local/bin/codegen"}).


### PR DESCRIPTION
* Build the pre-loaded go sdk tarball for the specified platform, not the host platform
* Force use of gzip compression to ensure cloud cache layers that use zstd don't end up in the image; old docker versions don't support zstd