### PR TITLE
docs: Fix typo in cli install instructions.

### DIFF
--- a/docs/current/partials/_install-cli.md
+++ b/docs/current/partials/_install-cli.md
@@ -80,6 +80,7 @@ Alternatively, install the Dagger Engine to a different location, such as your h
 ```shell
 cd ~
 curl -L https://dl.dagger.io/dagger/install.sh | sh
+```
 
 If you want to install a specific version of `dagger`, you can run:
 


### PR DESCRIPTION
The Linux install instructions were missing some back tics to end a code block.

Let me know if this needs an issue too. 