### PR TITLE
core: fix huge module/func IDs by removing Function.call

### DIFF
--- a/core/function.go
+++ b/core/function.go
@@ -13,9 +13,6 @@ type Function struct {
 	Description string         `json:"description"`
 	Args        []*FunctionArg `json:"args"`
 	ReturnType  *TypeDef       `json:"returnType"`
-
-	// Below are not in public API
-	ParentName string `json:"parentName,omitempty"`
 }
 
 func NewFunction(name string, returnType *TypeDef) *Function {
@@ -153,7 +150,6 @@ func (typeDef *TypeDef) WithObjectFunction(fn *Function) (*TypeDef, error) {
 	}
 	typeDef = typeDef.Clone()
 	fn = fn.Clone()
-	fn.ParentName = typeDef.AsObject.Name
 	typeDef.AsObject.Functions = append(typeDef.AsObject.Functions, fn)
 	return typeDef, nil
 }

--- a/core/function.go
+++ b/core/function.go
@@ -14,11 +14,8 @@ type Function struct {
 	Args        []*FunctionArg `json:"args"`
 	ReturnType  *TypeDef       `json:"returnType"`
 
-	// (Not in public API) Used to invoke function in the context of its module.
-	// We don't use *Module directly because it causes JSON serialization to fail
-	// due to circular references.
-	ModuleID   ModuleID `json:"moduleID,omitempty"`
-	ParentName string   `json:"parentName,omitempty"`
+	// Below are not in public API
+	ParentName string `json:"parentName,omitempty"`
 }
 
 func NewFunction(name string, returnType *TypeDef) *Function {

--- a/core/ids.go
+++ b/core/ids.go
@@ -19,7 +19,7 @@ type FileID = resourceid.ID[File]
 
 type SecretID = resourceid.ID[Secret]
 
-type ModuleID resourceid.ID[Module]
+type ModuleID = resourceid.ID[Module]
 
 type FunctionID = resourceid.ID[Function]
 

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -804,7 +804,7 @@ func TestModuleLotsOfFunctions(t *testing.T) {
 			mainSrc += fmt.Sprintf(`
 @function
 def potato_%d() -> str:
-    return "potato #%d!"
+    return "potato #%d"
 `, i, i)
 		}
 
@@ -813,7 +813,7 @@ def potato_%d() -> str:
 			WithWorkdir("/work").
 			WithNewFile("./pyproject.toml", dagger.ContainerWithNewFileOpts{
 				Contents: `[project]
-name = "test"
+name = "potatoSack"
 version = "0.0.0"
 `,
 			}).

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/iancoleman/strcase"
 	"github.com/moby/buildkit/identity"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 )
 
 /* TODO: add coverage for
@@ -379,7 +380,7 @@ func TestModuleGoGitRemovesIgnored(t *testing.T) {
 	require.Contains(t, changedAfterSync, "D  dagger.gen.go\n")
 	require.Contains(t, changedAfterSync, "D  querybuilder/marshal.go\n")
 	require.Contains(t, changedAfterSync, "D  querybuilder/querybuilder.go\n")
-    require.Contains(t, changedAfterSync, "D  internal/querybuilder/marshal.go\n")
+	require.Contains(t, changedAfterSync, "D  internal/querybuilder/marshal.go\n")
 	require.Contains(t, changedAfterSync, "D  internal/querybuilder/querybuilder.go\n")
 }
 
@@ -737,6 +738,105 @@ def hello(name: str) -> str:
 		out, err := modGen.With(daggerQuery(`{test{hello(name: "there")}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"test":{"hello":"Hello, there!"}}`, out)
+	})
+}
+
+func TestModuleLotsOfFunctions(t *testing.T) {
+	t.Parallel()
+
+	const funcCount = 100
+
+	t.Run("go sdk", func(t *testing.T) {
+		t.Parallel()
+
+		c, ctx := connect(t)
+
+		mainSrc := `
+		package main
+
+		type PotatoSack struct {}
+		`
+
+		for i := 0; i < funcCount; i++ {
+			mainSrc += fmt.Sprintf(`
+			func (m *PotatoSack) Potato%d() string {
+				return "potato #%d"
+			}
+			`, i, i)
+		}
+
+		modGen := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work").
+			WithNewFile("/work/main.go", dagger.ContainerWithNewFileOpts{
+				Contents: mainSrc,
+			}).
+			With(daggerExec("mod", "init", "--name=potatoSack", "--sdk=go"))
+
+		logGen(ctx, t, modGen.Directory("."))
+
+		var eg errgroup.Group
+		for i := 0; i < funcCount; i++ {
+			i := i
+			// just verify a subset work
+			if i%10 != 0 {
+				continue
+			}
+			eg.Go(func() error {
+				_, err := modGen.
+					With(daggerCall(fmt.Sprintf("Potato%d", i))).
+					Sync(ctx)
+				return err
+			})
+		}
+		require.NoError(t, eg.Wait())
+	})
+
+	t.Run("python sdk", func(t *testing.T) {
+		t.Parallel()
+
+		c, ctx := connect(t)
+
+		mainSrc := `from dagger.ext import function
+		`
+
+		for i := 0; i < funcCount; i++ {
+			mainSrc += fmt.Sprintf(`
+@function
+def potato_%d() -> str:
+    return "potato #%d!"
+`, i, i)
+		}
+
+		modGen := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work").
+			WithNewFile("./pyproject.toml", dagger.ContainerWithNewFileOpts{
+				Contents: `[project]
+name = "test"
+version = "0.0.0"
+`,
+			}).
+			WithNewFile("./src/main.py", dagger.ContainerWithNewFileOpts{
+				Contents: mainSrc,
+			}).
+			With(daggerExec("mod", "init", "--name=potatoSack", "--sdk=python"))
+
+		var eg errgroup.Group
+		for i := 0; i < funcCount; i++ {
+			i := i
+			// just verify a subset work
+			if i%10 != 0 {
+				continue
+			}
+			eg.Go(func() error {
+				_, err := modGen.
+					With(daggerCall(fmt.Sprintf("potato%d", i))).
+					Sync(ctx)
+				return err
+			})
+		}
+		require.NoError(t, eg.Wait())
 	})
 }
 
@@ -1138,6 +1238,15 @@ func daggerQuery(query string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
 		return c.WithExec([]string{"dagger", "--debug", "query"}, dagger.ContainerWithExecOpts{
 			Stdin:                         query,
+			ExperimentalPrivilegedNesting: true,
+		})
+	}
+}
+
+// TODO: support args
+func daggerCall(fnName string) dagger.WithContainerFunc {
+	return func(c *dagger.Container) *dagger.Container {
+		return c.WithExec([]string{"dagger", "--debug", "call", fnName}, dagger.ContainerWithExecOpts{
 			ExperimentalPrivilegedNesting: true,
 		})
 	}

--- a/core/schema/function.graphqls
+++ b/core/schema/function.graphqls
@@ -44,17 +44,6 @@ type Function {
     "A default value to use for this argument if not explicitly set by the caller, if any"
     defaultValue: JSON
   ): Function!
-
-  """
-  Execute this function using dynamic input+output types.
-
-  Typically, it's preferable to invoke a function using a type
-  safe graphql query rather than using this call field. However,
-  call is useful for some advanced use cases where dynamically
-  loading arbitrary modules and invoking functions in them is
-  required.
-  """
-  call(input: [FunctionCallInput!]): JSON!
 }
 
 "A reference to a FunctionArg."
@@ -88,14 +77,6 @@ type FunctionArg {
 
   "A default value to use for this argument when not explicitly set by the caller, if any"
   defaultValue: JSON
-}
-
-input FunctionCallInput {
-  "The name of the argument to the function"
-  name: String!
-
-  "The value of the argument represented as a string of the JSON serialization."
-  value: JSON!
 }
 
 "A reference to a TypeDef."
@@ -152,7 +133,7 @@ type TypeDef {
   "Adds a static field for an Object TypeDef, failing if the type is not an object."
   withField(
     "The name of the field in the object"
-    name: String!,
+    name: String!
     "The type of the field"
     typeDef: TypeDefID!
     "A doc string for the field, if any"

--- a/sdk/elixir/lib/dagger/gen/function.ex
+++ b/sdk/elixir/lib/dagger/gen/function.ex
@@ -15,23 +15,6 @@ defmodule Dagger.Function do
   )
 
   (
-    @doc "Execute this function using dynamic input+output types.\n\nTypically, it's preferable to invoke a function using a type\nsafe graphql query rather than using this call field. However,\ncall is useful for some advanced use cases where dynamically\nloading arbitrary modules and invoking functions in them is\nrequired.\n\n\n\n## Optional Arguments\n\n* `input` -"
-    @spec call(t(), keyword()) :: {:ok, Dagger.JSON.t()} | {:error, term()}
-    def call(%__MODULE__{} = function, optional_args \\ []) do
-      selection = select(function.selection, "call")
-
-      selection =
-        if is_nil(optional_args[:input]) do
-          selection
-        else
-          arg(selection, "input", optional_args[:input])
-        end
-
-      execute(selection, function.client)
-    end
-  )
-
-  (
     @doc "A doc string for the function, if any"
     @spec description(t()) :: {:ok, Dagger.String.t() | nil} | {:error, term()}
     def description(%__MODULE__{} = function) do

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -83,14 +83,6 @@ type BuildArg struct {
 	Value string `json:"value"`
 }
 
-type FunctionCallInput struct {
-	// The name of the argument to the function
-	Name string `json:"name"`
-
-	// The value of the argument represented as a string of the JSON serialization.
-	Value JSON `json:"value"`
-}
-
 // Key value object that represents a Pipeline label.
 type PipelineLabel struct {
 	// Label name.
@@ -2051,7 +2043,6 @@ type Function struct {
 	q *querybuilder.Selection
 	c graphql.Client
 
-	call        *JSON
 	description *string
 	id          *FunctionID
 	name        *string
@@ -2097,36 +2088,6 @@ func (r *Function) Args(ctx context.Context) ([]FunctionArg, error) {
 	}
 
 	return convert(response), nil
-}
-
-// FunctionCallOpts contains options for Function.Call
-type FunctionCallOpts struct {
-	Input []FunctionCallInput
-}
-
-// Execute this function using dynamic input+output types.
-//
-// Typically, it's preferable to invoke a function using a type
-// safe graphql query rather than using this call field. However,
-// call is useful for some advanced use cases where dynamically
-// loading arbitrary modules and invoking functions in them is
-// required.
-func (r *Function) Call(ctx context.Context, opts ...FunctionCallOpts) (JSON, error) {
-	if r.call != nil {
-		return *r.call, nil
-	}
-	q := r.q.Select("call")
-	for i := len(opts) - 1; i >= 0; i-- {
-		// `input` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Input) {
-			q = q.Arg("input", opts[i].Input)
-		}
-	}
-
-	var response JSON
-
-	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.c)
 }
 
 // A doc string for the function, if any

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -564,10 +564,6 @@ export type FileExportOpts = {
  */
 export type FileID = string & { __FileID: never }
 
-export type FunctionCallOpts = {
-  input?: FunctionCallInput[]
-}
-
 export type FunctionWithArgOpts = {
   /**
    * A doc string for the argument, if any
@@ -584,18 +580,6 @@ export type FunctionWithArgOpts = {
  * A reference to a FunctionArg.
  */
 export type FunctionArgID = string & { __FunctionArgID: never }
-
-export type FunctionCallInput = {
-  /**
-   * The name of the argument to the function
-   */
-  name: string
-
-  /**
-   * The value of the argument represented as a string of the JSON serialization.
-   */
-  value: JSON
-}
 
 /**
  * A reference to a Function.
@@ -3067,7 +3051,6 @@ export class File extends BaseClient {
  */
 export class Function_ extends BaseClient {
   private readonly _id?: FunctionID = undefined
-  private readonly _call?: JSON = undefined
   private readonly _description?: string = undefined
   private readonly _name?: string = undefined
 
@@ -3077,14 +3060,12 @@ export class Function_ extends BaseClient {
   constructor(
     parent?: { queryTree?: QueryTree[]; host?: string; sessionToken?: string },
     _id?: FunctionID,
-    _call?: JSON,
     _description?: string,
     _name?: string
   ) {
     super(parent)
 
     this._id = _id
-    this._call = _call
     this._description = _description
     this._name = _name
   }
@@ -3142,34 +3123,6 @@ export class Function_ extends BaseClient {
           r.id
         )
     )
-  }
-
-  /**
-   * Execute this function using dynamic input+output types.
-   *
-   * Typically, it's preferable to invoke a function using a type
-   * safe graphql query rather than using this call field. However,
-   * call is useful for some advanced use cases where dynamically
-   * loading arbitrary modules and invoking functions in them is
-   * required.
-   */
-  async call(opts?: FunctionCallOpts): Promise<JSON> {
-    if (this._call) {
-      return this._call
-    }
-
-    const response: Awaited<JSON> = await computeQuery(
-      [
-        ...this._queryTree,
-        {
-          operation: "call",
-          args: { ...opts },
-        },
-      ],
-      this.client
-    )
-
-    return response
   }
 
   /**

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -164,15 +164,6 @@ class BuildArg(Input):
 
 
 @dataclass(slots=True)
-class FunctionCallInput(Input):
-    name: str
-    """The name of the argument to the function"""
-
-    value: JSON
-    """The value of the argument represented as a string of the JSON serialization."""
-
-
-@dataclass(slots=True)
 class PipelineLabel(Input):
     """Key value object that represents a Pipeline label."""
 
@@ -2386,12 +2377,10 @@ class Function(Type):
     arguments."""
 
     __slots__ = (
-        "_call",
         "_description",
         "_name",
     )
 
-    _call: Optional[JSON]
     _description: Optional[str]
     _name: Optional[str]
 
@@ -2406,40 +2395,6 @@ class Function(Type):
             _name="name",
         )
         return await _ctx.execute(list[FunctionArg])
-
-    @typecheck
-    async def call(
-        self,
-        *,
-        input: Optional[Sequence[FunctionCallInput]] = None,
-    ) -> JSON:
-        """Execute this function using dynamic input+output types.
-
-        Typically, it's preferable to invoke a function using a type
-        safe graphql query rather than using this call field. However,
-        call is useful for some advanced use cases where dynamically
-        loading arbitrary modules and invoking functions in them is
-        required.
-
-        Returns
-        -------
-        JSON
-            An arbitrary JSON-encoded value.
-
-        Raises
-        ------
-        ExecuteTimeoutError
-            If the time to execute the query exceeds the configured timeout.
-        QueryError
-            If the API returns an error.
-        """
-        if hasattr(self, "_call"):
-            return self._call
-        _args = [
-            Arg("input", input, None),
-        ]
-        _ctx = self._select("call", _args)
-        return await _ctx.execute(JSON)
 
     @typecheck
     async def description(self) -> Optional[str]:
@@ -3702,7 +3657,6 @@ class ObjectTypeDef(Type):
         _args: list[Arg] = []
         _ctx = self._select("functions", _args)
         _ctx = Function(_ctx)._select_multiple(
-            _call="call",
             _description="description",
             _name="name",
         )
@@ -4765,7 +4719,6 @@ __all__ = [
     "FunctionArgID",
     "FunctionCall",
     "FunctionCallArgValue",
-    "FunctionCallInput",
     "FunctionID",
     "GeneratedCode",
     "GeneratedCodeID",

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -267,11 +267,6 @@ pub struct BuildArg {
     pub value: String,
 }
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct FunctionCallInput {
-    pub name: String,
-    pub value: Json,
-}
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct PipelineLabel {
     pub name: String,
     pub value: String,
@@ -2558,11 +2553,6 @@ pub struct Function {
     pub graphql_client: DynGraphQLClient,
 }
 #[derive(Builder, Debug, PartialEq)]
-pub struct FunctionCallOpts {
-    #[builder(setter(into, strip_option), default)]
-    pub input: Option<Vec<FunctionCallInput>>,
-}
-#[derive(Builder, Debug, PartialEq)]
 pub struct FunctionWithArgOpts<'a> {
     /// A default value to use for this argument if not explicitly set by the caller, if any
     #[builder(setter(into, strip_option), default)]
@@ -2580,37 +2570,6 @@ impl Function {
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }];
-    }
-    /// Execute this function using dynamic input+output types.
-    /// Typically, it's preferable to invoke a function using a type
-    /// safe graphql query rather than using this call field. However,
-    /// call is useful for some advanced use cases where dynamically
-    /// loading arbitrary modules and invoking functions in them is
-    /// required.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn call(&self) -> Result<Json, DaggerError> {
-        let query = self.selection.select("call");
-        query.execute(self.graphql_client.clone()).await
-    }
-    /// Execute this function using dynamic input+output types.
-    /// Typically, it's preferable to invoke a function using a type
-    /// safe graphql query rather than using this call field. However,
-    /// call is useful for some advanced use cases where dynamically
-    /// loading arbitrary modules and invoking functions in them is
-    /// required.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn call_opts(&self, opts: FunctionCallOpts) -> Result<Json, DaggerError> {
-        let mut query = self.selection.select("call");
-        if let Some(input) = opts.input {
-            query = query.arg("input", input);
-        }
-        query.execute(self.graphql_client.clone()).await
     }
     /// A doc string for the function, if any
     pub async fn description(&self) -> Result<String, DaggerError> {


### PR DESCRIPTION
We are hitting some problems with IDs growing to enormous size and exceeding gRPC messages limits in relatively normal cases (i.e. 13 functions defined in a module).

I didn't fully track down exactly what was happening, but suspected that it was related to the annoyance we were dealing with internally to store ModuleID on the Function object.

That annoyance only existed in order to support the Function.call "dynamic" API. That API isn't actually used anywhere right now, so I just tried removing that API call and the associated ModuleID handling in Function and sure enough the problem w/ huge IDs went away.

This feels like the best solution for now. If a request for the Function.call API arises in the future it can be re-added but rather than adding it to the Function object, it can be put on the Module object (and just require object+func name in addition to existing args), which should avoid the problem we're hitting now.