### PR TITLE
fix: do not fail when value set to file flag

### DIFF
--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -107,7 +107,7 @@ func (v *fileValue) Type() string {
 }
 
 func (v *fileValue) Set(s string) error {
-	if s != "" {
+	if s == "" {
 		return fmt.Errorf("file path cannot be empty")
 	}
 	v.path = s


### PR DESCRIPTION
Fixes typo in file flag value check

```
dagger call workflows run --source /Users/aweris/development/workspaces/github.com/aweris/gale --workflow-file "/Users/aweris/development/workspaces/github.com/aweris/gale/ci/workflows/job-outputs.yaml" result
✘ build "dagger call" ERROR [1.13s]
├ [0.78s] loading module
├ [0.35s] loading objects
• Engine: 61b34bf9d33e (version v0.9.0)
⧗ 2.14s ✔ 30 ∅ 12 ✘ 1
Error: parse flags: invalid argument "/Users/aweris/development/workspaces/github.com/aweris/gale/ci/workflows/job-outputs.yaml" for "--workflow-file" flag: file path cannot be empty
```