### PR TITLE
fix: return upstream ErrNotFound from secret store

### DIFF
--- a/core/secret.go
+++ b/core/secret.go
@@ -2,13 +2,13 @@ package core
 
 import (
 	"context"
-	"errors"
 	"sync"
 
 	"github.com/dagger/dagger/core/resourceid"
 	"github.com/dagger/dagger/engine/buildkit"
 	"github.com/moby/buildkit/session/secrets"
 	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
 )
 
 // Secret is a content-addressed secret.
@@ -35,9 +35,6 @@ func (secret *Secret) ID() (SecretID, error) {
 func (secret *Secret) Digest() (digest.Digest, error) {
 	return stableDigest(secret)
 }
-
-// ErrNotFound indicates a secret can not be found.
-var ErrNotFound = errors.New("secret not found")
 
 func NewSecretStore() *SecretStore {
 	return &SecretStore{
@@ -93,7 +90,7 @@ func (store *SecretStore) GetSecret(ctx context.Context, idOrName string) ([]byt
 
 	plaintext, ok := store.secrets[name]
 	if !ok {
-		return nil, ErrNotFound
+		return nil, errors.Wrapf(secrets.ErrNotFound, "secret %s", name)
 	}
 
 	return plaintext, nil

--- a/core/secret_test.go
+++ b/core/secret_test.go
@@ -1,0 +1,23 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/moby/buildkit/session/secrets"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretStore(t *testing.T) {
+	store := NewSecretStore()
+	store.AddSecret(context.Background(), "foo", []byte("bar"))
+	result, err := store.GetSecret(context.Background(), "foo")
+	require.NoError(t, err)
+	require.Equal(t, []byte("bar"), result)
+}
+
+func TestSecretStoreNotFound(t *testing.T) {
+	store := NewSecretStore()
+	_, err := store.GetSecret(context.Background(), "foo")
+	require.ErrorIs(t, err, secrets.ErrNotFound)
+}


### PR DESCRIPTION
Partially resolves https://github.com/dagger/dagger/issues/5930#issuecomment-1775291664.

Having duplicate error types meant that the git llb source attempting to look for the git secrets would not get an ErrNotFound, and would instead bail after looking for the first secret. See https://github.com/moby/buildkit/blob/d5c1d785b042cf834a05b08b73479d55b6acb533/source/git/source.go#L259-L265.

This update fixes this by ensuring that we use the same error type, so we properly look for all specified secrets.