### PR TITLE
Fix several validation and presentation issues in function commands

### DIFF
--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -8,7 +8,7 @@ var callCmd = &FuncCommand{
 	Name:  "call",
 	Short: "Call a module's function and print the result",
 	Long:  "On a container, the stdout will be returned. On a directory, the list of entries, and on a file, its contents.",
-	OnSelectObjectLeaf: func(c *callContext, name string) error {
+	OnSelectObjectLeaf: func(c *FuncCommand, name string) error {
 		switch name {
 		case Container:
 			// TODO: Combined `output` in the API. Querybuilder
@@ -21,7 +21,7 @@ var callCmd = &FuncCommand{
 		}
 		return nil
 	},
-	AfterResponse: func(_ *callContext, cmd *cobra.Command, _ *modTypeDef, response any) error {
+	AfterResponse: func(_ *FuncCommand, cmd *cobra.Command, _ *modTypeDef, response any) error {
 		if list, ok := (response).([]any); ok {
 			for _, v := range list {
 				cmd.Printf("%+v\n", v)

--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"dagger.io/dagger"
 	"github.com/spf13/cobra"
 )
 
@@ -9,27 +8,20 @@ var callCmd = &FuncCommand{
 	Name:  "call",
 	Short: "Call a module's function and print the result",
 	Long:  "On a container, the stdout will be returned. On a directory, the list of entries, and on a file, its contents.",
-	OnSelectObject: func(c *callContext, name string) (*modTypeDef, error) {
+	OnSelectObjectLeaf: func(c *callContext, name string) error {
 		switch name {
 		case Container:
 			// TODO: Combined `output` in the API. Querybuilder
 			// doesn't support querying sibling fields.
 			c.Select("stdout")
-			return &modTypeDef{Kind: dagger.Stringkind}, nil
 		case Directory:
 			c.Select("entries")
-			return &modTypeDef{Kind: dagger.Listkind,
-				AsList: &modList{
-					ElementTypeDef: &modTypeDef{
-						Kind: dagger.Stringkind},
-				}}, nil
 		case File:
 			c.Select("contents")
-			return &modTypeDef{Kind: dagger.Stringkind}, nil
 		}
-		return nil, nil
+		return nil
 	},
-	AfterResponse: func(_ *callContext, cmd *cobra.Command, _ modTypeDef, response any) error {
+	AfterResponse: func(_ *callContext, cmd *cobra.Command, _ *modTypeDef, response any) error {
 		if list, ok := (response).([]any); ok {
 			for _, v := range list {
 				cmd.Printf("%+v\n", v)

--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -1,13 +1,15 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
 var callCmd = &FuncCommand{
 	Name:  "call",
-	Short: "Call a module's function and print the result",
-	Long:  "On a container, the stdout will be returned. On a directory, the list of entries, and on a file, its contents.",
+	Short: "Call a module function",
+	Long:  "Call a module function and print the result.\n\nOn a container, the stdout will be returned. On a directory, the list of entries, and on a file, its contents.",
 	OnSelectObjectLeaf: func(c *FuncCommand, name string) error {
 		switch name {
 		case Container:
@@ -18,6 +20,9 @@ var callCmd = &FuncCommand{
 			c.Select("entries")
 		case File:
 			c.Select("contents")
+		default:
+			// TODO: Check if it's a core object and sub-select `id` by default.
+			return fmt.Errorf("return type not supported: %s", name)
 		}
 		return nil
 	},

--- a/cmd/dagger/download.go
+++ b/cmd/dagger/download.go
@@ -20,6 +20,9 @@ var downloadCmd = &FuncCommand{
 		case Directory, File, Container:
 			c.Select("export")
 			c.Arg("path", exportPath)
+			if name == File {
+				c.Arg("allowParentDirPath", true)
+			}
 		}
 		return nil
 	},

--- a/cmd/dagger/download.go
+++ b/cmd/dagger/download.go
@@ -10,7 +10,8 @@ var exportPath string
 
 var downloadCmd = &FuncCommand{
 	Name:  "download",
-	Short: "Download an asset to the host (directory, file, container).",
+	Short: "Download an asset from module function",
+	Long:  "Download an asset returned by a module function and save it to the host.\n\nWorks with a Directory, File or Container.",
 	Init: func(cmd *cobra.Command) {
 		cmd.PersistentFlags().StringVar(&exportPath, "export-path", ".", "Path to export to")
 	},
@@ -22,7 +23,7 @@ var downloadCmd = &FuncCommand{
 		}
 		return nil
 	},
-	BeforeRequest: func(_ *FuncCommand, returnType *modTypeDef) error {
+	BeforeRequest: func(_ *FuncCommand, _ *cobra.Command, returnType *modTypeDef) error {
 		switch returnType.ObjectName() {
 		case Directory, File, Container:
 			return nil

--- a/cmd/dagger/download.go
+++ b/cmd/dagger/download.go
@@ -26,9 +26,13 @@ var downloadCmd = &FuncCommand{
 		}
 		return nil
 	},
-	BeforeRequest: func(_ *FuncCommand, _ *cobra.Command, returnType *modTypeDef) error {
+	BeforeRequest: func(_ *FuncCommand, cmd *cobra.Command, returnType *modTypeDef) error {
 		switch returnType.ObjectName() {
 		case Directory, File, Container:
+			flag := cmd.Flags().Lookup("export-path")
+			if returnType.ObjectName() == Container && flag != nil && !flag.Changed {
+				return fmt.Errorf("flag --export-path is required for containers")
+			}
 			return nil
 		}
 		return fmt.Errorf("return type not supported: %s", printReturnType(returnType))

--- a/cmd/dagger/download.go
+++ b/cmd/dagger/download.go
@@ -9,9 +9,10 @@ import (
 var exportPath string
 
 var downloadCmd = &FuncCommand{
-	Name:  "download",
-	Short: "Download an asset from module function",
-	Long:  "Download an asset returned by a module function and save it to the host.\n\nWorks with a Directory, File or Container.",
+	Name:    "download",
+	Aliases: []string{"export", "dl"},
+	Short:   "Download an asset from module function",
+	Long:    "Download an asset returned by a module function and save it to the host.\n\nWorks with a Directory, File or Container.",
 	Init: func(cmd *cobra.Command) {
 		cmd.PersistentFlags().StringVar(&exportPath, "export-path", ".", "Path to export to")
 	},

--- a/cmd/dagger/download.go
+++ b/cmd/dagger/download.go
@@ -12,20 +12,19 @@ var downloadCmd = &FuncCommand{
 	Name:  "download",
 	Short: "Download an asset to the host (directory, file, container).",
 	Init: func(cmd *cobra.Command) {
-		cmd.PersistentFlags().StringVar(&exportPath, "export-path", "", "Path to export to")
-		cmd.MarkFlagRequired("export-path")
+		cmd.PersistentFlags().StringVar(&exportPath, "export-path", ".", "Path to export to")
 	},
-	OnSelectObjectLeaf: func(c *FuncCommand, _ string) error {
-		c.Select("export")
-		c.Arg("path", exportPath)
+	OnSelectObjectLeaf: func(c *FuncCommand, name string) error {
+		switch name {
+		case Directory, File, Container:
+			c.Select("export")
+			c.Arg("path", exportPath)
+		}
 		return nil
 	},
 	BeforeRequest: func(_ *FuncCommand, returnType *modTypeDef) error {
 		switch returnType.ObjectName() {
 		case Directory, File, Container:
-			if exportPath == "" {
-				return fmt.Errorf("missing --export-path flag")
-			}
 			return nil
 		}
 		return fmt.Errorf("return type not supported: %s", printReturnType(returnType))

--- a/cmd/dagger/download.go
+++ b/cmd/dagger/download.go
@@ -15,12 +15,12 @@ var downloadCmd = &FuncCommand{
 		cmd.PersistentFlags().StringVar(&exportPath, "export-path", "", "Path to export to")
 		cmd.MarkFlagRequired("export-path")
 	},
-	OnSelectObjectLeaf: func(c *callContext, _ string) error {
+	OnSelectObjectLeaf: func(c *FuncCommand, _ string) error {
 		c.Select("export")
 		c.Arg("path", exportPath)
 		return nil
 	},
-	BeforeRequest: func(_ *callContext, returnType *modTypeDef) error {
+	BeforeRequest: func(_ *FuncCommand, returnType *modTypeDef) error {
 		switch returnType.ObjectName() {
 		case Directory, File, Container:
 			if exportPath == "" {
@@ -30,7 +30,7 @@ var downloadCmd = &FuncCommand{
 		}
 		return fmt.Errorf("return type not supported: %s", printReturnType(returnType))
 	},
-	AfterResponse: func(_ *callContext, cmd *cobra.Command, _ *modTypeDef, response any) error {
+	AfterResponse: func(_ *FuncCommand, cmd *cobra.Command, _ *modTypeDef, response any) error {
 		status, ok := response.(bool)
 		if !ok {
 			return fmt.Errorf("unexpected response %T: %+v", response, response)

--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -164,8 +164,8 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet, dag *dagger.Client) (any,
 	name := r.FlagName()
 	usage := r.Description
 
-	if flag := flags.Lookup(name); flag != nil {
-		return nil, fmt.Errorf("already exists")
+	if flags.Lookup(name) != nil {
+		return nil, fmt.Errorf("flag already exists: %s", name)
 	}
 
 	switch r.TypeDef.Kind {
@@ -190,7 +190,7 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet, dag *dagger.Client) (any,
 		}
 
 		// TODO: default to JSON?
-		return nil, fmt.Errorf("unsupported object type %q", objName)
+		return nil, fmt.Errorf("unsupported object type %q for flag: %s", objName, name)
 
 	case dagger.Listkind:
 		elementType := r.TypeDef.AsList.ElementTypeDef
@@ -209,10 +209,10 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet, dag *dagger.Client) (any,
 			return flags.BoolSlice(name, val, usage), nil
 
 		case dagger.Objectkind:
-			return nil, fmt.Errorf("unsupported list of %q objects", elementType.AsObject.Name)
+			return nil, fmt.Errorf("unsupported list of %q objects for flag: %s", elementType.AsObject.Name, name)
 
 		case dagger.Listkind:
-			return nil, fmt.Errorf("unsupported list of lists")
+			return nil, fmt.Errorf("unsupported list of lists for flag: %s", name)
 		}
 	}
 

--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -12,13 +12,13 @@ import (
 // GetCustomFlagValue returns a pflag.Value instance for a dagger.ObjectTypeDef name.
 func GetCustomFlagValue(name string) pflag.Value {
 	switch name {
-	case "Container":
+	case Container:
 		return &containerValue{}
-	case "Directory":
+	case Directory:
 		return &directoryValue{}
-	case "File":
+	case File:
 		return &fileValue{}
-	case "Secret":
+	case Secret:
 		return &secretValue{}
 	}
 	return nil
@@ -39,7 +39,7 @@ type containerValue struct {
 }
 
 func (v *containerValue) Type() string {
-	return "Container"
+	return Container
 }
 
 func (v *containerValue) Set(s string) error {
@@ -71,7 +71,7 @@ type directoryValue struct {
 }
 
 func (v *directoryValue) Type() string {
-	return "Directory"
+	return Directory
 }
 
 func (v *directoryValue) Set(s string) error {
@@ -103,7 +103,7 @@ type fileValue struct {
 }
 
 func (v *fileValue) Type() string {
-	return "File"
+	return File
 }
 
 func (v *fileValue) Set(s string) error {
@@ -135,7 +135,7 @@ type secretValue struct {
 }
 
 func (v *secretValue) Type() string {
-	return "Secret"
+	return Secret
 }
 
 func (v *secretValue) Set(s string) error {

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -147,6 +147,9 @@ type FuncCommand struct {
 	// The name of the command (or verb), as shown in usage.
 	Name string
 
+	// Aliases is an array of aliases that can be used instead of the first word in Use.
+	Aliases []string
+
 	// Short is the short description shown in the 'help' output.
 	Short string
 
@@ -224,6 +227,7 @@ func (fc *FuncCommand) Command() *cobra.Command {
 
 		fc.cmd = &cobra.Command{
 			Use:     use,
+			Aliases: fc.Aliases,
 			Short:   fc.Short,
 			Long:    fc.Long,
 			Example: fc.Example,
@@ -324,7 +328,11 @@ func (fc *FuncCommand) execute(c *cobra.Command) (rerr error) {
 
 	// TODO: Move help output out of progrock?
 	if fc.showHelp {
-		cmd.Aliases = nil
+		// Hide aliases for sub-commands. They just allow using the SDK's
+		// casing for functions but there's no need to advertise.
+		if cmd != c {
+			cmd.Aliases = nil
+		}
 		return cmd.Help()
 	}
 

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -246,9 +246,9 @@ func (fc *FuncCommand) Command() *cobra.Command {
 				// not just flags. We want to stop parsing at the first
 				// possible dynamic sub-command since they've not been
 				// added yet.
-				c.Flags().SetInterspersed(false) // stop parsing at first possible dynamic subcommand
+				c.Flags().SetInterspersed(false)
 
-				// Allow using flags with the the name that was reported
+				// Allow using flags with the name that was reported
 				// by the SDK. This avoids confusion as users are editing
 				// a module and trying to test its functions.
 				c.SetGlobalNormalizationFunc(func(f *pflag.FlagSet, name string) pflag.NormalizedName {
@@ -257,6 +257,8 @@ func (fc *FuncCommand) Command() *cobra.Command {
 
 				err := c.ParseFlags(a)
 				if err != nil {
+					// This gives a chance for FuncCommand implementations to
+					// handle errors from parsing flags.
 					return c.FlagErrorFunc()(c, err)
 				}
 
@@ -507,6 +509,9 @@ func (fc *FuncCommand) makeSubCmd(dag *dagger.Client, fn *modFunction) *cobra.Co
 			// Need to make the query selection before chaining off.
 			return fc.selectFunc(fn, cmd, dag)
 		},
+
+		// This is going to be executed in the "execution" vertex, when
+		// we have the final/leaf command.
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if fn.ReturnType.AsObject != nil && len(fn.ReturnType.AsObject.GetFunctions()) > 0 {
 				fc.showUsage = true

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -571,6 +571,21 @@ type modObject struct {
 	Fields    []*modField
 }
 
+// GetFunctions returns the object's function definitions as well as the fields,
+// which are treated as functions with no arguments.
+func (o *modObject) GetFunctions() []*modFunction {
+	fns := make([]*modFunction, 0, len(o.Functions)+len(o.Fields))
+	for _, f := range o.Fields {
+		fns = append(fns, &modFunction{
+			Name:        f.Name,
+			Description: f.Description,
+			ReturnType:  f.TypeDef,
+		})
+	}
+	fns = append(fns, o.Functions...)
+	return fns
+}
+
 // modList is a representation of dagger.ListTypeDef.
 type modList struct {
 	ElementTypeDef *modTypeDef

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -557,6 +557,13 @@ type modTypeDef struct {
 	AsList   *modList
 }
 
+func (t *modTypeDef) ObjectName() string {
+	if t.AsObject != nil {
+		return t.AsObject.Name
+	}
+	return ""
+}
+
 // modObject is a representation of dagger.ObjectTypeDef.
 type modObject struct {
 	Name      string

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -27,18 +27,17 @@ var shellCmd = &FuncCommand{
 	Name:  "shell",
 	Short: "Open a shell in a container",
 	Long:  "If no entrypoint is specified and the container doesn't have a default command, `sh` will be used.",
-	OnInit: func(cmd *cobra.Command) {
+	Init: func(cmd *cobra.Command) {
 		cmd.PersistentFlags().StringSliceVar(&shellEntrypoint, "entrypoint", nil, "entrypoint to use")
 	},
-	OnSelectObject: func(c *callContext, name string) (*modTypeDef, error) {
+	OnSelectObjectLeaf: func(c *callContext, name string) error {
 		if name == Container {
 			c.Select("id")
 			shellIsContainer = true
-			return &modTypeDef{Kind: dagger.Stringkind}, nil
 		}
-		return nil, nil
+		return nil
 	},
-	CheckReturnType: func(_ *callContext, _ *modTypeDef) error {
+	BeforeRequest: func(_ *callContext, _ *modTypeDef) error {
 		if !shellIsContainer {
 			return fmt.Errorf("shell can only be called on a container")
 		}
@@ -55,7 +54,7 @@ var shellCmd = &FuncCommand{
 
 		return nil
 	},
-	AfterResponse: func(c *callContext, cmd *cobra.Command, returnType modTypeDef, response any) error {
+	AfterResponse: func(c *callContext, cmd *cobra.Command, returnType *modTypeDef, response any) error {
 		ctrID, ok := (response).(string)
 		if !ok {
 			return fmt.Errorf("unexpected response %T: %+v", response, response)

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -30,14 +30,14 @@ var shellCmd = &FuncCommand{
 	Init: func(cmd *cobra.Command) {
 		cmd.PersistentFlags().StringSliceVar(&shellEntrypoint, "entrypoint", nil, "entrypoint to use")
 	},
-	OnSelectObjectLeaf: func(c *callContext, name string) error {
+	OnSelectObjectLeaf: func(c *FuncCommand, name string) error {
 		if name == Container {
 			c.Select("id")
 			shellIsContainer = true
 		}
 		return nil
 	},
-	BeforeRequest: func(_ *callContext, _ *modTypeDef) error {
+	BeforeRequest: func(_ *FuncCommand, _ *modTypeDef) error {
 		if !shellIsContainer {
 			return fmt.Errorf("shell can only be called on a container")
 		}
@@ -54,14 +54,14 @@ var shellCmd = &FuncCommand{
 
 		return nil
 	},
-	AfterResponse: func(c *callContext, cmd *cobra.Command, returnType *modTypeDef, response any) error {
+	AfterResponse: func(c *FuncCommand, cmd *cobra.Command, returnType *modTypeDef, response any) error {
 		ctrID, ok := (response).(string)
 		if !ok {
 			return fmt.Errorf("unexpected response %T: %+v", response, response)
 		}
 
 		ctx := cmd.Context()
-		ctr := c.e.Dagger().Container(dagger.ContainerOpts{
+		ctr := c.c.Dagger().Container(dagger.ContainerOpts{
 			ID: dagger.ContainerID(ctrID),
 		})
 
@@ -70,7 +70,7 @@ var shellCmd = &FuncCommand{
 			return fmt.Errorf("failed to get shell endpoint: %w", err)
 		}
 
-		return attachToShell(ctx, c.e, shellEndpoint)
+		return attachToShell(ctx, c.c, shellEndpoint)
 	},
 }
 

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -23,7 +23,7 @@ var shellEntrypoint []string
 var shellCmd = &FuncCommand{
 	Name:  "shell",
 	Short: "Open a shell in a container",
-	Long:  "If no entrypoint is specified and the container doesn't have a default command, `sh` will be used.",
+	Long:  "Open a shell in a container.\n\nIf no entrypoint is specified and the container doesn't have a default command, `sh` will be used.",
 	Init: func(cmd *cobra.Command) {
 		cmd.PersistentFlags().StringSliceVar(&shellEntrypoint, "entrypoint", nil, "entrypoint to use")
 	},
@@ -34,7 +34,7 @@ var shellCmd = &FuncCommand{
 		c.Select("id")
 		return nil
 	},
-	BeforeRequest: func(_ *FuncCommand, _ *modTypeDef) error {
+	BeforeRequest: func(_ *FuncCommand, _ *cobra.Command, _ *modTypeDef) error {
 		// Even though these flags are global, we only check them just before query
 		// execution because you may want to debug an error during loading or for
 		// --help.

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -18,10 +18,7 @@ import (
 	"github.com/vito/progrock"
 )
 
-var (
-	shellIsContainer bool
-	shellEntrypoint  []string
-)
+var shellEntrypoint []string
 
 var shellCmd = &FuncCommand{
 	Name:  "shell",
@@ -31,17 +28,13 @@ var shellCmd = &FuncCommand{
 		cmd.PersistentFlags().StringSliceVar(&shellEntrypoint, "entrypoint", nil, "entrypoint to use")
 	},
 	OnSelectObjectLeaf: func(c *FuncCommand, name string) error {
-		if name == Container {
-			c.Select("id")
-			shellIsContainer = true
+		if name != Container {
+			return fmt.Errorf("shell can only be called on a container")
 		}
+		c.Select("id")
 		return nil
 	},
 	BeforeRequest: func(_ *FuncCommand, _ *modTypeDef) error {
-		if !shellIsContainer {
-			return fmt.Errorf("shell can only be called on a container")
-		}
-
 		// Even though these flags are global, we only check them just before query
 		// execution because you may want to debug an error during loading or for
 		// --help.
@@ -51,7 +44,6 @@ var shellCmd = &FuncCommand{
 		if debug {
 			return fmt.Errorf("running shell with --debug is not supported")
 		}
-
 		return nil
 	},
 	AfterResponse: func(c *FuncCommand, cmd *cobra.Command, returnType *modTypeDef, response any) error {

--- a/cmd/dagger/up.go
+++ b/cmd/dagger/up.go
@@ -18,26 +18,24 @@ var (
 var upCmd = &FuncCommand{
 	Name:  "up",
 	Short: "Start a service and expose its ports to the host",
-	OnInit: func(cmd *cobra.Command) {
+	Init: func(cmd *cobra.Command) {
 		cmd.PersistentFlags().StringSliceVarP(&portForwards, "port", "p", nil, "Port forwarding rule in FRONTEND[:BACKEND][/PROTO] format.")
 		cmd.PersistentFlags().BoolVarP(&portForwardsNative, "native", "n", false, "Forward all ports natively, i.e. match frontend port to backend.")
 	},
-	OnSelectObject: func(c *callContext, name string) (*modTypeDef, error) {
+	OnSelectObjectLeaf: func(c *callContext, name string) error {
 		if name == Service {
 			c.Select("id")
 			upIsService = true
-			return &modTypeDef{Kind: dagger.Stringkind}, nil
 		}
-		return nil, nil
+		return nil
 	},
-	CheckReturnType: func(_ *callContext, _ *modTypeDef) error {
+	BeforeRequest: func(_ *callContext, _ *modTypeDef) error {
 		if !upIsService {
 			return fmt.Errorf("up can only be called on a service")
 		}
-
 		return nil
 	},
-	AfterResponse: func(c *callContext, cmd *cobra.Command, returnType modTypeDef, result any) error {
+	AfterResponse: func(c *callContext, cmd *cobra.Command, returnType *modTypeDef, result any) error {
 		srvID, ok := (result).(string)
 		if !ok {
 			return fmt.Errorf("unexpected type %T", result)

--- a/cmd/dagger/up.go
+++ b/cmd/dagger/up.go
@@ -10,7 +10,6 @@ import (
 )
 
 var (
-	upIsService        bool
 	portForwards       []string
 	portForwardsNative bool
 )
@@ -23,16 +22,10 @@ var upCmd = &FuncCommand{
 		cmd.PersistentFlags().BoolVarP(&portForwardsNative, "native", "n", false, "Forward all ports natively, i.e. match frontend port to backend.")
 	},
 	OnSelectObjectLeaf: func(c *FuncCommand, name string) error {
-		if name == Service {
-			c.Select("id")
-			upIsService = true
-		}
-		return nil
-	},
-	BeforeRequest: func(_ *FuncCommand, _ *modTypeDef) error {
-		if !upIsService {
+		if name != Service {
 			return fmt.Errorf("up can only be called on a service")
 		}
+		c.Select("id")
 		return nil
 	},
 	AfterResponse: func(c *FuncCommand, cmd *cobra.Command, returnType *modTypeDef, result any) error {


### PR DESCRIPTION
Follow-up to #5882

There’s more checks and validations. Also better printing with progrock, making the loading vertex unfocused and pushing `-help` and `dagger functions` to the execution vertex (focused).