### PR TITLE
core: disable support for modules extending core types

### DIFF
--- a/cmd/codegen/codegen.go
+++ b/cmd/codegen/codegen.go
@@ -11,10 +11,8 @@ import (
 	gogenerator "github.com/dagger/dagger/cmd/codegen/generator/go"
 	nodegenerator "github.com/dagger/dagger/cmd/codegen/generator/nodejs"
 	"github.com/dagger/dagger/cmd/codegen/introspection"
-	"github.com/dagger/dagger/core/modules"
 	"github.com/opencontainers/go-digest"
 	"github.com/vito/progrock"
-	"golang.org/x/sync/errgroup"
 )
 
 func Generate(ctx context.Context, cfg generator.Config, dag *dagger.Client) (rerr error) {
@@ -31,47 +29,6 @@ func Generate(ctx context.Context, cfg generator.Config, dag *dagger.Client) (re
 	defer func() { vtx.Done(rerr) }()
 
 	logsW := vtx.Stdout()
-
-	if cfg.ModuleConfig != nil {
-		// TODO: this works but isn't perfect.
-		//
-		// We want to introspect the module's 'schema view', but we're actually
-		// running from the SDK module, so this will also pick up any of the SDK
-		// module's dependencies. Thankfully there aren't any at the moment.
-		//
-		// In fact, this only matters for a manual `dagger mod sync'. For on-the-fly
-		// codegen, the `codegen` command will actually be running from within the
-		// module's schema view, so it will see the following code isn't needed. But
-		// even in that case it might be better to be more explicit rather than build
-		// up a Container that only "works" when it's run the right way.
-
-		ref := cfg.ModuleRef
-
-		loadDeps := new(errgroup.Group)
-
-		for _, dep := range cfg.ModuleConfig.Dependencies {
-			dep := dep
-			loadDeps.Go(func() error {
-				depRef, err := modules.ResolveModuleDependency(ctx, dag, ref, dep)
-				if err != nil {
-					return fmt.Errorf("resolve module dependency %q: %w", dep, err)
-				}
-				depMod, err := depRef.AsModule(ctx, dag)
-				if err != nil {
-					return fmt.Errorf("resolve module dependency %q: %w", dep, err)
-				}
-				_, err = depMod.Serve(ctx)
-				if err != nil {
-					return fmt.Errorf("serve module dependency %q: %w", dep, err)
-				}
-				return err
-			})
-		}
-
-		if err := loadDeps.Wait(); err != nil {
-			return err
-		}
-	}
 
 	introspectionSchema, err := generator.Introspect(ctx, dag)
 	if err != nil {

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -476,29 +476,6 @@ func TestModuleGoSignatures(t *testing.T) {
 	})
 }
 
-//go:embed testdata/modules/go/extend/main.go
-var goExtend string
-
-func TestModuleGoExtendCore(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
-
-	modGen := c.Container().From(golangImage).
-		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
-		WithWorkdir("/work").
-		With(daggerExec("mod", "init", "--name=test", "--sdk=go")).
-		WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
-			Contents: goExtend,
-		})
-
-	logGen(ctx, t, modGen.Directory("."))
-
-	out, err := modGen.With(daggerQuery(`{container{from(address:"` + alpineImage + `"){testEcho(msg:"hi!")}}}`)).Stdout(ctx)
-	require.NoError(t, err)
-	require.JSONEq(t, `{"container":{"from":{"testEcho":"hi!\n"}}}`, out)
-}
-
 //go:embed testdata/modules/go/custom-types/main.go
 var customTypes string
 
@@ -858,12 +835,6 @@ func TestModuleNamespacing(t *testing.T) {
 		Stdout(ctx)
 	require.NoError(t, err)
 	require.JSONEq(t, `{"test":{"fn":"1:yo 2:yo"}}`, out)
-
-	out, err = ctr.
-		With(daggerQuery(`{container{testBlah}}`)).
-		Stdout(ctx)
-	require.NoError(t, err)
-	require.JSONEq(t, `{"container":{"testBlah":"blurgh"}}`, out)
 }
 
 func TestEnvCmd(t *testing.T) {

--- a/core/integration/testdata/modules/go/extend/main.go
+++ b/core/integration/testdata/modules/go/extend/main.go
@@ -1,7 +1,0 @@
-package main
-
-import "context"
-
-func (c *Container) Echo(ctx context.Context, msg string) (string, error) {
-	return c.WithExec([]string{"echo", msg}).Stdout(ctx)
-}

--- a/core/integration/testdata/modules/go/extend/main.go
+++ b/core/integration/testdata/modules/go/extend/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "context"
+
+func (c *Container) Echo(ctx context.Context, msg string) (string, error) {
+	return c.WithExec([]string{"echo", msg}).Stdout(ctx)
+}

--- a/core/integration/testdata/modules/go/namespacing/main.go
+++ b/core/integration/testdata/modules/go/namespacing/main.go
@@ -24,7 +24,3 @@ func (m *Test) Fn(ctx context.Context, s string) (string, error) {
 
 	return fmt.Sprintf("%s %s", s1, s2), nil
 }
-
-func (ctr *Container) Blah() (string, error) {
-	return "blurgh", nil
-}

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -815,7 +815,11 @@ func (s *moduleSchema) moduleToSchemaFor(ctx context.Context, module *core.Modul
 		// check whether this is a pre-existing object (from core or another module)
 		_, preExistingObject := dest.resolvers()[objName]
 		if preExistingObject {
-			// we don't support extending objects from outside the module currently, so skip it
+			// modules can reference types from core/other modules as types, but they
+			// can't attach any new fields or functions to them
+			if len(objTypeDef.Fields) > 0 || len(objTypeDef.Functions) > 0 {
+				return nil, fmt.Errorf("cannot attach new fields or functions to object %q from outside module", objName)
+			}
 			continue
 		}
 

--- a/docs/current/labs/project-zenith.md
+++ b/docs/current/labs/project-zenith.md
@@ -17,7 +17,7 @@ documentation](../index.md).
 
 ## Overview
 
-*Project Zenith* is the codename of a future release of Dagger, currently in
+_Project Zenith_ is the codename of a future release of Dagger, currently in
 development (and hopefully released soon!)
 
 The goal of the project is to make Dagger more accessible, by delivering it as
@@ -25,21 +25,21 @@ a CLI tool rather than just a library.
 
 Features of Project Zenith include:
 
-* Major expansion of the `dagger` CLI, removing the need to create a custom CLI
+- Major expansion of the `dagger` CLI, removing the need to create a custom CLI
   for each project.
-* Major expansion of the Dagger API, with a complete cross-language extension
+- Major expansion of the Dagger API, with a complete cross-language extension
   and composition system.
-* An open ecosystem of reusable content, to take advantage of the extension and
+- An open ecosystem of reusable content, to take advantage of the extension and
   composition system called the [Daggerverse](https://daggerverse.fly.dev/).
 
 ## How to get involved
 
 The Dagger Engine is developed in the open, and Project Zenith is no exception.
 
-* Discussions take place [on the Dagger Discord](https://discord.gg/dagger-io)
+- Discussions take place [on the Dagger Discord](https://discord.gg/dagger-io)
   in the `#project-zenith` channel. We love to hear from you, and there are no
   stupid questions!
-* Contributors and testers meet every Friday at 09:00 Pacific time [on our
+- Contributors and testers meet every Friday at 09:00 Pacific time [on our
   Discord audio room](https://discord.com/channels/707636530424053791/911305510882513037).
 
 If you get stuck, check out the [Troubleshooting guide](#troubleshooting) below.
@@ -48,8 +48,8 @@ If you get stuck, check out the [Troubleshooting guide](#troubleshooting) below.
 
 Pre-requisites:
 
-* A shell (bash, zsh, etc)
-* [Docker](https://docs.docker.com/engine/install/)
+- A shell (bash, zsh, etc)
+- [Docker](https://docs.docker.com/engine/install/)
 
 ### Downloading an experimental build
 
@@ -125,17 +125,17 @@ running engine.
 
 1. If you use [direnv](https://direnv.net/), you can just:
 
-    ```sh
-    cd ./zenith
-    direnv allow .
-    ```
+   ```sh
+   cd ./zenith
+   direnv allow .
+   ```
 
 2. If not, you can directly `source` the provided `.envrc` file:
 
-    ```sh
-    cd ./zenith
-    source .envrc
-    ```
+   ```sh
+   cd ./zenith
+   source .envrc
+   ```
 
 At this point you should have a fully functioning `dagger` CLI and dev engine.
 
@@ -389,7 +389,7 @@ paste the GitHub link to your module (`github.com/<user>/daggerverse.git`),
 then click "Crawl".
 
 :::note
-You don't *have* to use `daggerverse` as the name of your Git repository -- it's just
+You don't _have_ to use `daggerverse` as the name of your Git repository -- it's just
 a handy way to have all your modules in one Git repository together. But you
 can always split them out into separate repositories, or name it something
 different if you like!
@@ -476,62 +476,26 @@ The result will be:
 }
 ```
 
-### Extend core types
-
-You can add a new function to accept and return a `*Container`.
-
-```go
-package main
-
-type Potato struct{}
-
-func (c *Container) AddPotato() *Container {
-  return c.WithNewFile("/potato", ContainerWithNewFileOpts{
-    Contents: "i'm a potato",
-  })
-}
-```
-
-Next, run `dagger mod sync`.
-
-To run the new function, once again use `dagger query`:
-
-```sh
-dagger query <<EOF
-{
-  container {
-    from(address:"alpine") {
-      potatoAddPotato {
-        withExec(args:["cat", "potato"]) {
-          stdout
-        }
-      }
-    }
-  }
-}
-EOF
-```
-
 ## Known issues
 
-* A module's public fields require a `json:"foo"` tag to be queriable.
-* Custom objects in a module require at least one method to be defined on them
+- A module's public fields require a `json:"foo"` tag to be queriable.
+- Custom objects in a module require at least one method to be defined on them
   to be detected by the codegen.
-* When referencing another module as a local dependency, the dependent module
+- When referencing another module as a local dependency, the dependent module
   must be stored in a sub-directory of the parent module.
-* Custom struct types used as parameters cannot be nested and contain other
+- Custom struct types used as parameters cannot be nested and contain other
   structs themselves.
-* Calls to functions across modules will be run exactly *once* per-session --
+- Calls to functions across modules will be run exactly _once_ per-session --
   after that, the result will be cached, but only until the next session (a new
   `dagger query`, etc).
-  * At some point, we will add more fine-grained cache-control.
-* Currently, Go is the only supported language for module development.
+  - At some point, we will add more fine-grained cache-control.
+- Currently, Go is the only supported language for module development.
 
 ## Tips and tricks
 
-* The context and error return are optional in the module's function signature;
+- The context and error return are optional in the module's function signature;
   remove them if you don't need them.
-* A module's private fields will not be persisted.
+- A module's private fields will not be persisted.
 
 ## Troubleshooting
 


### PR DESCRIPTION
We've decided to disable this ability for now since it creates hard to
solve problems w/ namespacing (simply prefixing extension functions with
Module name often creates extremely awkward names) and is unclear in
terms of benefits relative to confusion in terms of API design.

It will be possible to re-add support for this in the future if desired
and in the meantime it would still be possible for a custom SDK to
implement support for this by identifying fields in the graphql schema
that could be implemented as methods directly attached to core types.

Signed-off-by: Erik Sipsma <erik@dagger.io>