### PR TITLE
cli: set source subpath when loading git modules

### DIFF
--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -407,20 +407,6 @@ func loadMod(ctx context.Context, c *dagger.Client) (*dagger.Module, error) {
 		return nil, fmt.Errorf("failed to load module: %w", err)
 	}
 
-	// TODO: hack to unlazy mod so it's actually loaded
-	// TODO: is this still needed?
-	// TODO(vito): this came up again, specifically because I wanted the
-	// dependencies to be started and served before doing schema introspection
-	// for codegen. still seems useful, OR we could somehow have schema
-	// introspection block/synchronize on loading dependencies automatically
-	// _, err = loadedMod.ID(ctx)
-	// if err != nil {
-	// 	return nil, fmt.Errorf("failed to get loaded module ID: %w", err)
-	// }
-
-	// TODO(vito): immediate follow-up: turns out what I want is to Serve here
-	// but _not_ Serve for each dependency, since we don't want them all
-	// installed into the same schema - transitive deps should not be included.
 	_, err = loadedMod.Serve(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get loaded module ID: %w", err)

--- a/core/module.go
+++ b/core/module.go
@@ -160,7 +160,7 @@ func LoadModuleConfig(
 	configPath = modules.NormalizeConfigPath(configPath)
 	configFile, err := sourceDir.File(ctx, bk, svcs, configPath)
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to get config file: %w", err)
+		return "", nil, fmt.Errorf("failed to get config file from path %q: %w", configPath, err)
 	}
 	cfg, err := LoadModuleConfigFromFile(ctx, bk, svcs, configFile)
 	if err != nil {

--- a/core/modules/resolver.go
+++ b/core/modules/resolver.go
@@ -143,10 +143,14 @@ func (ref *Ref) AsModule(ctx context.Context, c *dagger.Client) (*dagger.Module,
 		if strings.HasPrefix(rootPath, "..") {
 			return nil, fmt.Errorf("module config path %q is not under module root %q", ref.SubPath, rootPath)
 		}
+		relSubPath, err := filepath.Rel(rootPath, ref.SubPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get relative subpath: %w", err)
+		}
 
 		return c.Git(ref.Git.CloneURL).Commit(ref.Version).Tree().
 			Directory(rootPath).
-			AsModule(), nil
+			AsModule(dagger.DirectoryAsModuleOpts{SourceSubpath: relSubPath}), nil
 
 	default:
 		return nil, fmt.Errorf("invalid module (local=%t, git=%t)", ref.Local, ref.Git != nil)


### PR DESCRIPTION
Fixes #5953

---

~~I'm working on adding integ test coverage right now, just verified manually so far. Will push it here or as separate commit, depending on timing of this being merged.~~

~~Integ test requires way more work than the fix itself because we need to re-add the ability to create a git repo from a module source dir and then run it as a service container that a dev engine talks to. @vito I'm going to try doing this by running the dev engine as a service that has a dependency on the git service; hopefully this should avoid the headaches of the old implementation where the dev engine had an implicit dependency on a service running in itself 🙂~~

EDIT: I didn't realize we only allowed git modules from `github.com` now, which throws a wrench into having an automated test here. We can obviously do another iteration on the refs to support more generalized git modules, but that's way out of scope of this simple fix, so I'll leave that as a separate effort from this PR.