### PR TITLE
chore: remove unneccessary secret store method

### DIFF
--- a/core/secret.go
+++ b/core/secret.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/dagger/dagger/core/resourceid"
-	"github.com/dagger/dagger/engine/buildkit"
 	"github.com/moby/buildkit/session/secrets"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
@@ -47,11 +46,6 @@ var _ secrets.SecretStore = &SecretStore{}
 type SecretStore struct {
 	mu      sync.Mutex
 	secrets map[string][]byte
-	bk      *buildkit.Client
-}
-
-func (store *SecretStore) SetBuildkitClient(bk *buildkit.Client) {
-	store.bk = bk
 }
 
 // AddSecret adds the secret identified by user defined name with its plaintext

--- a/engine/server/buildkitcontroller.go
+++ b/engine/server/buildkitcontroller.go
@@ -251,7 +251,6 @@ func (e *BuildkitController) Session(stream controlapi.Control_SessionServer) (r
 			e.serverMu.Unlock()
 			return err
 		}
-		secretStore.SetBuildkitClient(bkClient)
 
 		bklog.G(ctx).Debugf("initialized new server buildkit client")
 


### PR DESCRIPTION
`SecretStore.SetBuildkitClient` was not being used - it appears to be left over from a previous refactor, so we can remove it.
