### PR TITLE
zenith: remove .Sync from module default main.go in go sdk

### DIFF
--- a/cmd/codegen/generator/go/generator.go
+++ b/cmd/codegen/generator/go/generator.go
@@ -344,8 +344,20 @@ import (
 
 type %s struct {}
 
-func (m *%s) MyFunction(ctx context.Context, stringArg string) (*Container, error) {
-	return dag.Container().From("alpine:latest").WithExec([]string{"echo", stringArg}), nil
+// example usage: "dagger call container-echo --string-arg yo"
+func (m *%s) ContainerEcho(stringArg string) *Container {
+	return dag.Container().From("alpine:latest").WithExec([]string{"echo", stringArg})
 }
-`, moduleStructName, moduleStructName)
+
+// example usage: "dagger call grep-dir --directory-arg . --pattern GrepDir"
+func (m *%s) GrepDir(ctx context.Context, directoryArg *Directory, pattern string) (string, error) {
+	return dag.Container().
+		From("alpine:latest").
+		WithMountedDirectory("/mnt", directoryArg).
+		WithWorkdir("/mnt").
+		WithExec([]string{"grep", "-R", pattern, "."}).
+		Stdout(ctx)
+}
+
+`, moduleStructName, moduleStructName, moduleStructName)
 }

--- a/cmd/codegen/generator/go/generator.go
+++ b/cmd/codegen/generator/go/generator.go
@@ -345,7 +345,7 @@ import (
 type %s struct {}
 
 func (m *%s) MyFunction(ctx context.Context, stringArg string) (*Container, error) {
-	return dag.Container().From("alpine:latest").WithExec([]string{"echo", stringArg}).Sync(ctx)
+	return dag.Container().From("alpine:latest").WithExec([]string{"echo", stringArg}), nil
 }
 `, moduleStructName, moduleStructName)
 }

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -40,10 +40,10 @@ func TestModuleGoInit(t *testing.T) {
 		logGen(ctx, t, modGen.Directory("."))
 
 		out, err := modGen.
-			With(daggerQuery(`{bare{myFunction(stringArg:"hello"){stdout}}}`)).
+			With(daggerQuery(`{bare{containerEcho(stringArg:"hello"){stdout}}}`)).
 			Stdout(ctx)
 		require.NoError(t, err)
-		require.JSONEq(t, `{"bare":{"myFunction":{"stdout":"hello\n"}}}`, out)
+		require.JSONEq(t, `{"bare":{"containerEcho":{"stdout":"hello\n"}}}`, out)
 	})
 
 	t.Run("kebab-cases Go module name, camel-cases Dagger module name", func(t *testing.T) {
@@ -59,10 +59,10 @@ func TestModuleGoInit(t *testing.T) {
 		logGen(ctx, t, modGen.Directory("."))
 
 		out, err := modGen.
-			With(daggerQuery(`{myModule{myFunction(stringArg:"hello"){stdout}}}`)).
+			With(daggerQuery(`{myModule{containerEcho(stringArg:"hello"){stdout}}}`)).
 			Stdout(ctx)
 		require.NoError(t, err)
-		require.JSONEq(t, `{"myModule":{"myFunction":{"stdout":"hello\n"}}}`, out)
+		require.JSONEq(t, `{"myModule":{"containerEcho":{"stdout":"hello\n"}}}`, out)
 
 		generated, err := modGen.File("go.mod").Contents(ctx)
 		require.NoError(t, err)
@@ -89,10 +89,10 @@ func TestModuleGoInit(t *testing.T) {
 		logGen(ctx, t, modGen.Directory("."))
 
 		out, err := modGen.
-			With(daggerQuery(`{beneathGoMod{myFunction(stringArg:"hello"){stdout}}}`)).
+			With(daggerQuery(`{beneathGoMod{containerEcho(stringArg:"hello"){stdout}}}`)).
 			Stdout(ctx)
 		require.NoError(t, err)
-		require.JSONEq(t, `{"beneathGoMod":{"myFunction":{"stdout":"hello\n"}}}`, out)
+		require.JSONEq(t, `{"beneathGoMod":{"containerEcho":{"stdout":"hello\n"}}}`, out)
 
 		t.Run("names Go module after Dagger module", func(t *testing.T) {
 			generated, err := modGen.File("go.mod").Contents(ctx)
@@ -115,10 +115,10 @@ func TestModuleGoInit(t *testing.T) {
 		logGen(ctx, t, modGen.Directory("."))
 
 		out, err := modGen.
-			With(daggerQuery(`{hasGoMod{myFunction(stringArg:"hello"){stdout}}}`)).
+			With(daggerQuery(`{hasGoMod{containerEcho(stringArg:"hello"){stdout}}}`)).
 			Stdout(ctx)
 		require.NoError(t, err)
-		require.JSONEq(t, `{"hasGoMod":{"myFunction":{"stdout":"hello\n"}}}`, out)
+		require.JSONEq(t, `{"hasGoMod":{"containerEcho":{"stdout":"hello\n"}}}`, out)
 
 		t.Run("preserves module name", func(t *testing.T) {
 			generated, err := modGen.File("go.mod").Contents(ctx)
@@ -359,13 +359,18 @@ func TestModuleGit(t *testing.T) {
 
 			if tc.sdk == "go" {
 				logGen(ctx, t, modGen.Directory("."))
+				out, err := modGen.
+					With(daggerQuery(`{bare{containerEcho(stringArg:"hello"){stdout}}}`)).
+					Stdout(ctx)
+				require.NoError(t, err)
+				require.JSONEq(t, `{"bare":{"containerEcho":{"stdout":"hello\n"}}}`, out)
+			} else {
+				out, err := modGen.
+					With(daggerQuery(`{bare{myFunction(stringArg:"hello"){stdout}}}`)).
+					Stdout(ctx)
+				require.NoError(t, err)
+				require.JSONEq(t, `{"bare":{"myFunction":{"stdout":"hello\n"}}}`, out)
 			}
-
-			out, err := modGen.
-				With(daggerQuery(`{bare{myFunction(stringArg:"hello"){stdout}}}`)).
-				Stdout(ctx)
-			require.NoError(t, err)
-			require.JSONEq(t, `{"bare":{"myFunction":{"stdout":"hello\n"}}}`, out)
 
 			t.Run("configures .gitignore", func(t *testing.T) {
 				ignore, err := modGen.File(".gitignore").Contents(ctx)

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -823,7 +823,7 @@ func (s *moduleSchema) moduleToSchemaFor(ctx context.Context, module *core.Modul
 
 		astDef := &ast.Definition{
 			Name:        objName,
-			Description: objTypeDef.Description,
+			Description: formatGqlDescription(objTypeDef.Description),
 			Kind:        ast.Object,
 		}
 
@@ -836,7 +836,7 @@ func (s *moduleSchema) moduleToSchemaFor(ctx context.Context, module *core.Modul
 			fieldName := gqlFieldName(field.Name)
 			astDef.Fields = append(astDef.Fields, &ast.FieldDefinition{
 				Name:        fieldName,
-				Description: field.Description,
+				Description: formatGqlDescription(field.Description),
 				Type:        fieldASTType,
 			})
 
@@ -907,6 +907,18 @@ func (s *moduleSchema) moduleToSchemaFor(ctx context.Context, module *core.Modul
 		Schema:    schemaStr,
 		Resolvers: newResolvers,
 	}), nil
+}
+
+/*
+This formats comments in the schema as:
+"""
+comment
+"""
+
+Which avoids corner cases where the comment ends in a `"`.
+*/
+func formatGqlDescription(desc string) string {
+	return "\n" + strings.TrimSpace(desc) + "\n"
 }
 
 func (s *moduleSchema) typeDefToSchema(typeDef *core.TypeDef, isInput bool) (*ast.Type, error) {
@@ -984,7 +996,7 @@ func (s *moduleSchema) functionResolver(
 		}
 		argASTTypes = append(argASTTypes, &ast.ArgumentDefinition{
 			Name:         gqlArgName(fnArg.Name),
-			Description:  fnArg.Description,
+			Description:  formatGqlDescription(fnArg.Description),
 			Type:         argASTType,
 			DefaultValue: defaultValue,
 		})
@@ -992,7 +1004,7 @@ func (s *moduleSchema) functionResolver(
 
 	fieldDef := &ast.FieldDefinition{
 		Name:        fnName,
-		Description: fn.Description,
+		Description: formatGqlDescription(fn.Description),
 		Type:        returnASTType,
 		Arguments:   argASTTypes,
 	}


### PR DESCRIPTION
Calling sync isn't required there and just creates confusion, so it's better to remove it.

---

Discord discussion: https://discord.com/channels/707636530424053791/1120503349599543376/1166774396820672512