### PR TITLE
Sync codegen even on compilation error; fix general SDK codegen+runtime invocation problems

### DIFF
--- a/cmd/codegen/generator/generator.go
+++ b/cmd/codegen/generator/generator.go
@@ -34,6 +34,9 @@ type Config struct {
 	// Generate code for a Dagger module.
 	ModuleRef    *modules.Ref
 	ModuleConfig *modules.Config
+
+	// Optional pre-computed introspection json string
+	IntrospectionJSON string
 }
 
 type Generator interface {

--- a/cmd/codegen/main.go
+++ b/cmd/codegen/main.go
@@ -14,10 +14,11 @@ import (
 )
 
 var (
-	outputDir     string
-	moduleRef     string
-	lang          string
-	propagateLogs bool
+	outputDir             string
+	moduleRef             string
+	lang                  string
+	propagateLogs         bool
+	introspectionJSONPath string
 )
 
 var rootCmd = &cobra.Command{
@@ -30,6 +31,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&outputDir, "output", "o", ".", "output directory")
 	rootCmd.Flags().StringVar(&moduleRef, "module", "", "module to load and codegen dependency code")
 	rootCmd.Flags().BoolVar(&propagateLogs, "propagate-logs", false, "propagate logs directly to progrock.sock")
+	rootCmd.Flags().StringVar(&introspectionJSONPath, "introspection-json-path", "", "optional path to file containing pre-computed graphql introspection JSON")
 }
 
 const nestedSock = "/.progrock.sock"
@@ -81,6 +83,14 @@ func ClientGen(cmd *cobra.Command, args []string) error {
 
 		cfg.ModuleRef = ref
 		cfg.ModuleConfig = modCfg
+	}
+
+	if introspectionJSONPath != "" {
+		introspectionJSON, err := os.ReadFile(introspectionJSONPath)
+		if err != nil {
+			return fmt.Errorf("read introspection json: %w", err)
+		}
+		cfg.IntrospectionJSON = string(introspectionJSON)
 	}
 
 	return Generate(ctx, cfg, dag)

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -170,20 +170,6 @@ func pollForPort(network, addr string) (string, error) {
 }
 
 func shim() (returnExitCode int) {
-	cacheExitCodeStr, found := internalEnv("_DAGGER_CACHE_EXIT_CODE")
-	if found {
-		cacheExitCodeUint64, err := strconv.ParseUint(cacheExitCodeStr, 10, 32)
-		if err != nil {
-			panic(fmt.Errorf("cannot parse cache exit code: %w", err))
-		}
-		cacheExitCode := uint32(cacheExitCodeUint64)
-		defer func() {
-			if returnExitCode == int(cacheExitCode) {
-				returnExitCode = 0
-			}
-		}()
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	if len(os.Args) < 2 {
@@ -644,17 +630,22 @@ func runWithNesting(ctx context.Context, cmd *exec.Cmd) error {
 	}
 	sessionPort := l.Addr().(*net.TCPAddr).Port
 
-	serverID, ok := internalEnv("_DAGGER_SERVER_ID")
-	if !ok {
-		return fmt.Errorf("missing _DAGGER_SERVER_ID")
-	}
-	parentClientIDsVal, _ := internalEnv("_DAGGER_PARENT_CLIENT_IDS")
 	clientParams := client.Params{
-		ServerID:        serverID,
-		SecretToken:     sessionToken.String(),
-		RunnerHost:      "unix:///.runner.sock",
-		ParentClientIDs: strings.Fields(parentClientIDsVal),
+		SecretToken: sessionToken.String(),
+		RunnerHost:  "unix:///.runner.sock",
 	}
+
+	if _, ok := internalEnv("_DAGGER_ENABLE_NESTING_IN_SAME_SESSION"); ok {
+		serverID, ok := internalEnv("_DAGGER_SERVER_ID")
+		if !ok {
+			return fmt.Errorf("missing _DAGGER_SERVER_ID")
+		}
+		clientParams.ServerID = serverID
+
+		parentClientIDsVal, _ := internalEnv("_DAGGER_PARENT_CLIENT_IDS")
+		clientParams.ParentClientIDs = strings.Fields(parentClientIDsVal)
+	}
+
 	moduleContextDigest, ok := internalEnv("_DAGGER_MODULE_CONTEXT_DIGEST")
 	if ok {
 		clientParams.ModuleContextDigest = digest.Digest(moduleContextDigest)

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -655,13 +655,9 @@ func runWithNesting(ctx context.Context, cmd *exec.Cmd) error {
 		RunnerHost:      "unix:///.runner.sock",
 		ParentClientIDs: strings.Fields(parentClientIDsVal),
 	}
-	moduleDigest, ok := internalEnv("_DAGGER_MODULE_DIGEST")
+	moduleContextDigest, ok := internalEnv("_DAGGER_MODULE_CONTEXT_DIGEST")
 	if ok {
-		clientParams.ModuleDigest = digest.Digest(moduleDigest)
-	}
-	functionContextDigest, ok := internalEnv("_DAGGER_FUNCTION_CONTEXT_DIGEST")
-	if ok {
-		clientParams.FunctionContextDigest = digest.Digest(functionContextDigest)
+		clientParams.ModuleContextDigest = digest.Digest(moduleContextDigest)
 	}
 
 	progW, err := progrock.DialRPC(ctx, "unix:///.progrock.sock")

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -630,9 +630,12 @@ func runWithNesting(ctx context.Context, cmd *exec.Cmd) error {
 	}
 	sessionPort := l.Addr().(*net.TCPAddr).Port
 
+	parentClientIDsVal, _ := internalEnv("_DAGGER_PARENT_CLIENT_IDS")
+
 	clientParams := client.Params{
-		SecretToken: sessionToken.String(),
-		RunnerHost:  "unix:///.runner.sock",
+		SecretToken:     sessionToken.String(),
+		RunnerHost:      "unix:///.runner.sock",
+		ParentClientIDs: strings.Fields(parentClientIDsVal),
 	}
 
 	if _, ok := internalEnv("_DAGGER_ENABLE_NESTING_IN_SAME_SESSION"); ok {
@@ -641,9 +644,6 @@ func runWithNesting(ctx context.Context, cmd *exec.Cmd) error {
 			return fmt.Errorf("missing _DAGGER_SERVER_ID")
 		}
 		clientParams.ServerID = serverID
-
-		parentClientIDsVal, _ := internalEnv("_DAGGER_PARENT_CLIENT_IDS")
-		clientParams.ParentClientIDs = strings.Fields(parentClientIDsVal)
 	}
 
 	moduleContextDigest, ok := internalEnv("_DAGGER_MODULE_CONTEXT_DIGEST")

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -449,8 +449,6 @@ func setupBundle() int {
 				return errorExitCode
 			}
 			keepEnv = append(keepEnv, "_DAGGER_SERVER_ID="+execMetadata.ServerID)
-			keepEnv = append(keepEnv, "_DAGGER_MODULE_DIGEST="+execMetadata.ModuleDigest.String())
-			keepEnv = append(keepEnv, "_DAGGER_FUNCTION_CONTEXT_DIGEST="+execMetadata.FunctionContextDigest.String())
 
 			// mount buildkit sock since it's nesting
 			spec.Mounts = append(spec.Mounts, specs.Mount{

--- a/core/container.go
+++ b/core/container.go
@@ -1043,11 +1043,8 @@ func (container *Container) WithExec(ctx context.Context, bk *buildkit.Client, p
 	if opts.ExperimentalPrivilegedNesting {
 		runOpts = append(runOpts, llb.AddEnv("_DAGGER_ENABLE_NESTING", ""))
 
-		if opts.ModuleDigest != "" {
-			runOpts = append(runOpts, llb.AddEnv("_DAGGER_MODULE_DIGEST", opts.ModuleDigest.String()))
-		}
-		if opts.FunctionContextDigest != "" {
-			runOpts = append(runOpts, llb.AddEnv("_DAGGER_FUNCTION_CONTEXT_DIGEST", opts.FunctionContextDigest.String()))
+		if opts.ModuleContextDigest != "" {
+			runOpts = append(runOpts, llb.AddEnv("_DAGGER_MODULE_CONTEXT_DIGEST", opts.ModuleContextDigest.String()))
 		}
 	}
 
@@ -1860,9 +1857,7 @@ type ContainerExecOpts struct {
 	CacheExitCode uint32
 
 	// (Internal-only) TODO:(sipsma) DOC THIS
-	ModuleDigest digest.Digest
-	// (Internal-only) TODO:(sipsma) DOC THIS
-	FunctionContextDigest digest.Digest
+	ModuleContextDigest digest.Digest
 }
 
 type BuildArg struct {

--- a/core/container.go
+++ b/core/container.go
@@ -1042,6 +1042,13 @@ func (container *Container) WithExec(ctx context.Context, bk *buildkit.Client, p
 	// this allows executed containers to communicate back to this API
 	if opts.ExperimentalPrivilegedNesting {
 		runOpts = append(runOpts, llb.AddEnv("_DAGGER_ENABLE_NESTING", ""))
+
+		if opts.ModuleDigest != "" {
+			runOpts = append(runOpts, llb.AddEnv("_DAGGER_MODULE_DIGEST", opts.ModuleDigest.String()))
+		}
+		if opts.FunctionContextDigest != "" {
+			runOpts = append(runOpts, llb.AddEnv("_DAGGER_FUNCTION_CONTEXT_DIGEST", opts.FunctionContextDigest.String()))
+		}
 	}
 
 	if opts.CacheExitCode != 0 {
@@ -1851,6 +1858,11 @@ type ContainerExecOpts struct {
 	// the exec meta mount, but then result in the shim still exiting with 0 so that
 	// the exec is cached.
 	CacheExitCode uint32
+
+	// (Internal-only) TODO:(sipsma) DOC THIS
+	ModuleDigest digest.Digest
+	// (Internal-only) TODO:(sipsma) DOC THIS
+	FunctionContextDigest digest.Digest
 }
 
 type BuildArg struct {

--- a/core/container.go
+++ b/core/container.go
@@ -1857,10 +1857,13 @@ type ContainerExecOpts struct {
 	// Grant the process all root capabilities
 	InsecureRootCapabilities bool
 
-	// (Internal-only) TODO:(sipsma) DOC THIS
+	// (Internal-only) If this exec is for a module function, this digest will be set in the
+	// grpc context metadata for any api requests back to the engine. It's used by the API
+	// server to determine which schema to serve and other module context metadata.
 	ModuleContextDigest digest.Digest
 
-	// (Internal-only) TODO:(sipsma) DOC THIS
+	// (Internal-only) Used for module function execs to trigger the nested api client to
+	// be connected back to the same session.
 	NestedInSameSession bool
 }
 

--- a/core/file.go
+++ b/core/file.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"io/fs"
 
 	"io"
 	"path"
@@ -63,6 +64,24 @@ func NewFile(ctx context.Context, def *pb.Definition, file string, pipeline pipe
 		Platform: platform,
 		Services: services,
 	}
+}
+
+func NewFileWithContents(
+	ctx context.Context,
+	bk *buildkit.Client,
+	svcs *Services,
+	name string,
+	content []byte,
+	permissions fs.FileMode,
+	ownership *Ownership,
+	pipeline pipeline.Path,
+	platform specs.Platform,
+) (*File, error) {
+	dir, err := NewScratchDirectory(pipeline, platform).WithNewFile(ctx, name, content, permissions, ownership)
+	if err != nil {
+		return nil, err
+	}
+	return dir.File(ctx, bk, svcs, name)
 }
 
 func NewFileSt(ctx context.Context, st llb.State, dir string, pipeline pipeline.Path, platform specs.Platform, services ServiceBindings) (*File, error) {

--- a/core/function.go
+++ b/core/function.go
@@ -39,7 +39,6 @@ func (fn *Function) ID() (FunctionID, error) {
 }
 
 func (fn *Function) Digest() (digest.Digest, error) {
-	// TODO: does this need to unpack ModuleID and stable digest that?
 	return stableDigest(fn)
 }
 

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -1076,36 +1076,73 @@ var useInner string
 //go:embed testdata/modules/go/use/main.go
 var useOuter string
 
-func TestModuleGoUseLocal(t *testing.T) {
+func TestModuleUseLocal(t *testing.T) {
 	t.Parallel()
 
 	c, ctx := connect(t)
 
-	modGen := c.Container().From(golangImage).
-		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
-		WithWorkdir("/work/dep").
-		With(daggerExec("mod", "init", "--name=dep", "--sdk=go")).
-		WithWorkdir("/work").
-		With(daggerExec("mod", "init", "--name=use", "--sdk=go")).
-		WithNewFile("/work/dep/main.go", dagger.ContainerWithNewFileOpts{
-			Contents: useInner,
-		}).
-		WithNewFile("/work/main.go", dagger.ContainerWithNewFileOpts{
-			Contents: useOuter,
-		}).
-		With(daggerExec("mod", "use", "./dep")).
-		WithEnvVariable("BUST", identity.NewID()) // NB(vito): hmm...
+	t.Run("go uses go", func(t *testing.T) {
+		t.Parallel()
 
-	logGen(ctx, t, modGen.Directory("."))
+		modGen := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work/dep").
+			With(daggerExec("mod", "init", "--name=dep", "--sdk=go")).
+			WithWorkdir("/work").
+			With(daggerExec("mod", "init", "--name=use", "--sdk=go")).
+			WithNewFile("/work/dep/main.go", dagger.ContainerWithNewFileOpts{
+				Contents: useInner,
+			}).
+			WithNewFile("/work/main.go", dagger.ContainerWithNewFileOpts{
+				Contents: useOuter,
+			}).
+			With(daggerExec("mod", "use", "./dep")).
+			WithEnvVariable("BUST", identity.NewID()) // NB(vito): hmm...
 
-	out, err := modGen.With(daggerQuery(`{use{useHello}}`)).Stdout(ctx)
-	require.NoError(t, err)
-	require.JSONEq(t, `{"use":{"useHello":"hello"}}`, out)
+		logGen(ctx, t, modGen.Directory("."))
 
-	// cannot use transitive dependency directly
-	_, err = modGen.With(daggerQuery(`{dep{hello}}`)).Stdout(ctx)
-	require.Error(t, err)
-	require.ErrorContains(t, err, `Cannot query field "dep" on type "Query".`)
+		out, err := modGen.With(daggerQuery(`{use{useHello}}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"use":{"useHello":"hello"}}`, out)
+
+		// cannot use transitive dependency directly
+		_, err = modGen.With(daggerQuery(`{dep{hello}}`)).Stdout(ctx)
+		require.Error(t, err)
+		require.ErrorContains(t, err, `Cannot query field "dep" on type "Query".`)
+	})
+
+	t.Run("python uses go", func(t *testing.T) {
+		t.Parallel()
+
+		modGen := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work/dep").
+			With(daggerExec("mod", "init", "--name=dep", "--sdk=go")).
+			WithNewFile("/work/dep/main.go", dagger.ContainerWithNewFileOpts{
+				Contents: useInner,
+			}).
+			WithWorkdir("/work").
+			With(daggerExec("mod", "init", "--name=use", "--sdk=python")).
+			With(daggerExec("mod", "use", "./dep")).
+			WithNewFile("/work/src/main.py", dagger.ContainerWithNewFileOpts{
+				Contents: `from dagger.mod import function
+import dagger
+
+@function
+def use_hello() -> str:
+    return dagger.dep().hello()
+`,
+			})
+
+		out, err := modGen.With(daggerQuery(`{use{useHello}}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"use":{"useHello":"hello"}}`, out)
+
+		// cannot use transitive dependency directly
+		_, err = modGen.With(daggerQuery(`{dep{hello}}`)).Stdout(ctx)
+		require.Error(t, err)
+		require.ErrorContains(t, err, `Cannot query field "dep" on type "Query".`)
+	})
 }
 
 func TestModuleGoUseLocalMulti(t *testing.T) {

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -1145,6 +1145,117 @@ def use_hello() -> str:
 	})
 }
 
+func TestModuleCodegenonDepChange(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := connect(t)
+
+	t.Run("go uses go", func(t *testing.T) {
+		t.Parallel()
+
+		modGen := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work/dep").
+			With(daggerExec("mod", "init", "--name=dep", "--sdk=go")).
+			WithWorkdir("/work").
+			With(daggerExec("mod", "init", "--name=use", "--sdk=go")).
+			WithNewFile("/work/dep/main.go", dagger.ContainerWithNewFileOpts{
+				Contents: useInner,
+			}).
+			WithNewFile("/work/main.go", dagger.ContainerWithNewFileOpts{
+				Contents: useOuter,
+			}).
+			With(daggerExec("mod", "use", "./dep"))
+
+		logGen(ctx, t, modGen.Directory("."))
+
+		out, err := modGen.With(daggerQuery(`{use{useHello}}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"use":{"useHello":"hello"}}`, out)
+
+		// make back-incompatible change to dep
+		newInner := strings.ReplaceAll(useInner, `Hello()`, `Hellov2()`)
+		modGen = modGen.
+			WithNewFile("/work/dep/main.go", dagger.ContainerWithNewFileOpts{
+				Contents: newInner,
+			}).
+			WithExec([]string{"sh", "-c", "dagger mod sync"}, dagger.ContainerWithExecOpts{
+				ExperimentalPrivilegedNesting: true,
+			})
+
+		codegenContents, err := modGen.File("/work/dagger.gen.go").Contents(ctx)
+		require.NoError(t, err)
+		require.Contains(t, codegenContents, "Hellov2")
+
+		newOuter := strings.ReplaceAll(useOuter, `Hello(ctx)`, `Hellov2(ctx)`)
+		modGen = modGen.
+			WithNewFile("/work/main.go", dagger.ContainerWithNewFileOpts{
+				Contents: newOuter,
+			})
+
+		out, err = modGen.With(daggerQuery(`{use{useHello}}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"use":{"useHello":"hello"}}`, out)
+	})
+
+	t.Run("python uses go", func(t *testing.T) {
+		t.Parallel()
+
+		modGen := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work/dep").
+			With(daggerExec("mod", "init", "--name=dep", "--sdk=go")).
+			WithNewFile("/work/dep/main.go", dagger.ContainerWithNewFileOpts{
+				Contents: useInner,
+			}).
+			WithWorkdir("/work").
+			With(daggerExec("mod", "init", "--name=use", "--sdk=python")).
+			With(daggerExec("mod", "use", "./dep")).
+			WithNewFile("/work/src/main.py", dagger.ContainerWithNewFileOpts{
+				Contents: `from dagger.mod import function
+import dagger
+
+@function
+def use_hello() -> str:
+    return dagger.dep().hello()
+`,
+			})
+
+		out, err := modGen.With(daggerQuery(`{use{useHello}}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"use":{"useHello":"hello"}}`, out)
+
+		// make back-incompatible change to dep
+		newInner := strings.ReplaceAll(useInner, `Hello()`, `Hellov2()`)
+		modGen = modGen.
+			WithNewFile("/work/dep/main.go", dagger.ContainerWithNewFileOpts{
+				Contents: newInner,
+			}).
+			WithExec([]string{"sh", "-c", "dagger mod sync"}, dagger.ContainerWithExecOpts{
+				ExperimentalPrivilegedNesting: true,
+			})
+
+		codegenContents, err := modGen.File("/work/sdk/src/dagger/client/gen.py").Contents(ctx)
+		require.NoError(t, err)
+		require.Contains(t, codegenContents, "hellov2")
+
+		modGen = modGen.
+			WithNewFile("/work/src/main.py", dagger.ContainerWithNewFileOpts{
+				Contents: `from dagger.mod import function
+import dagger
+
+@function
+def use_hello() -> str:
+    return dagger.dep().hellov2()
+`,
+			})
+
+		out, err = modGen.With(daggerQuery(`{use{useHello}}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"use":{"useHello":"hello"}}`, out)
+	})
+}
+
 func TestModuleGoUseLocalMulti(t *testing.T) {
 	t.Parallel()
 

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -14,7 +14,6 @@ import (
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/pipeline"
 	"github.com/dagger/dagger/core/socket"
-	"github.com/dagger/dagger/engine"
 
 	"github.com/moby/buildkit/frontend/dockerfile/shell"
 	"github.com/moby/buildkit/util/leaseutil"
@@ -830,11 +829,8 @@ func (s *containerSchema) shellEndpoint(ctx context.Context, parent *core.Contai
 		return "", err
 	}
 
-	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
-	if err != nil {
+	if err := s.MuxEndpoint(ctx, path.Join("/", endpoint), handler); err != nil {
 		return "", err
 	}
-
-	s.MuxEndpoint(path.Join("/", endpoint), handler, clientMetadata.ModuleDigest)
 	return "ws://dagger/" + endpoint, nil
 }

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -356,9 +356,6 @@ type functionCallArgs struct {
 func (s *moduleSchema) functionCall(ctx context.Context, fn *core.Function, args functionCallArgs) (any, error) {
 	// TODO: if return type non-null, assert on that here
 
-	// TODO: re-add support for different exit codes
-	cacheExitCode := uint32(0)
-
 	// will already be set for internal calls, which close over a fn that doesn't
 	// have ModuleID set yet
 	mod := args.Module
@@ -437,9 +434,9 @@ func (s *moduleSchema) functionCall(ctx context.Context, fn *core.Function, args
 
 	// Setup the Exec for the Function call and evaluate it
 	ctr, err = ctr.WithExec(ctx, s.bk, s.progSockPath, mod.Platform, core.ContainerExecOpts{
-		ExperimentalPrivilegedNesting: true,
 		ModuleContextDigest:           moduleContextDigest,
-		CacheExitCode:                 cacheExitCode,
+		ExperimentalPrivilegedNesting: true,
+		NestedInSameSession:           true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to exec function: %w", err)

--- a/core/schema/schema.go
+++ b/core/schema/schema.go
@@ -77,7 +77,7 @@ type MergedSchemas struct {
 
 	buildCache         *core.CacheMap[uint64, *core.Container]
 	importCache        *core.CacheMap[uint64, *specs.Descriptor]
-	moduleContextCache *core.CacheMap[digest.Digest, *moduleContext]
+	moduleContextCache *core.CacheMap[digest.Digest, *moduleContext] // TODO: this could probably just be a map
 	moduleCache        *core.CacheMap[digest.Digest, *core.Module]
 
 	mu sync.RWMutex
@@ -150,14 +150,14 @@ func (s *MergedSchemas) getSchemaView(viewDigest digest.Digest) (*schemaView, er
 }
 
 func (s *MergedSchemas) getModuleSchemaView(mod *core.Module) (*schemaView, error) {
-	modDgst, err := mod.DigestWithoutObjects()
+	modDgst, err := mod.BaseDigest()
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute schema view digest: %w", err)
 	}
 	return s.getSchemaView(modDgst)
 }
 
-func (s *MergedSchemas) handleModuleFunctionCall(mod *core.Module, fnCall *core.FunctionCall) (*schemaView, digest.Digest, error) {
+func (s *MergedSchemas) registerModuleFunctionCall(mod *core.Module, fnCall *core.FunctionCall) (*schemaView, digest.Digest, error) {
 	schemaView, err := s.getModuleSchemaView(mod)
 	if err != nil {
 		return nil, "", err

--- a/core/schema/sdk.go
+++ b/core/schema/sdk.go
@@ -134,6 +134,15 @@ func (sdk *moduleSDK) Codegen(ctx context.Context, mod *core.Module) (*core.Gene
 		return nil, fmt.Errorf("failed to find required Codegen function in SDK module %s", sdkModuleName)
 	}
 
+	schemaView, err := sdk.installDeps(ctx, mod)
+	if err != nil {
+		return nil, fmt.Errorf("failed to install deps during %s module sdk codegen: %w", sdkModuleName, err)
+	}
+	introspectionJSON, err := schemaView.schemaIntrospectionJSON(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get schema introspection json during %s module sdk codegen: %w", sdkModuleName, err)
+	}
+
 	srcDirID, err := mod.SourceDirectory.ID()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get source directory id: %w", err)
@@ -141,13 +150,20 @@ func (sdk *moduleSDK) Codegen(ctx context.Context, mod *core.Module) (*core.Gene
 
 	result, err := sdk.moduleSchema.functionCall(ctx, codegenFn, functionCallArgs{
 		Module: sdk.mod,
-		Input: []*core.CallInput{{
-			Name:  "modSource",
-			Value: srcDirID,
-		}, {
-			Name:  "subPath",
-			Value: mod.SourceDirectorySubpath,
-		}},
+		Input: []*core.CallInput{
+			{
+				Name:  "modSource",
+				Value: srcDirID,
+			},
+			{
+				Name:  "subPath",
+				Value: mod.SourceDirectorySubpath,
+			},
+			{
+				Name:  "introspectionJson",
+				Value: introspectionJSON,
+			},
+		},
 		ParentOriginalName: sdkModuleOriginalName,
 		// TODO: params? somehow? maybe from module config? would be a good way to
 		// e.g. configure the language version.
@@ -187,6 +203,15 @@ func (sdk *moduleSDK) Runtime(ctx context.Context, mod *core.Module) (*core.Cont
 		return nil, fmt.Errorf("failed to find required ModuleRuntime function in SDK module %s", sdkModuleName)
 	}
 
+	schemaView, err := sdk.installDeps(ctx, mod)
+	if err != nil {
+		return nil, fmt.Errorf("failed to install deps during %s module sdk codegen: %w", sdkModuleName, err)
+	}
+	introspectionJSON, err := schemaView.schemaIntrospectionJSON(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get schema introspection json during %s module sdk codegen: %w", sdkModuleName, err)
+	}
+
 	srcDirID, err := mod.SourceDirectory.ID()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get source directory id: %w", err)
@@ -194,13 +219,20 @@ func (sdk *moduleSDK) Runtime(ctx context.Context, mod *core.Module) (*core.Cont
 
 	result, err := sdk.moduleSchema.functionCall(ctx, getRuntimeFn, functionCallArgs{
 		Module: sdk.mod,
-		Input: []*core.CallInput{{
-			Name:  "modSource",
-			Value: srcDirID,
-		}, {
-			Name:  "subPath",
-			Value: mod.SourceDirectorySubpath,
-		}},
+		Input: []*core.CallInput{
+			{
+				Name:  "modSource",
+				Value: srcDirID,
+			},
+			{
+				Name:  "subPath",
+				Value: mod.SourceDirectorySubpath,
+			},
+			{
+				Name:  "introspectionJson",
+				Value: introspectionJSON,
+			},
+		},
 		ParentOriginalName: sdkModuleOriginalName,
 		// TODO: params? somehow? maybe from module config? would be a good way to
 		// e.g. configure the language version.

--- a/core/schema/sdk.go
+++ b/core/schema/sdk.go
@@ -36,42 +36,51 @@ type SDK interface {
 
 	The Code field of the returned GeneratedCode object should be the generated contents of the module sourceDirSubpath,
 	in the case where that's different than the root of the sourceDir.
-	*/
-	Codegen(ctx context.Context, sourceDir *core.Directory, sourceDirSubpath string) (*core.GeneratedCode, error)
 
-	// Runtime returns a container that is used to execute module code at runtime in the Dagger engine.
-	Runtime(ctx context.Context, sourceDir *core.Directory, sourceDirSubpath string) (*core.Container, error)
+	The provided Module is not fully initialized; the Runtime field will not be set yet.
+	*/
+	Codegen(ctx context.Context, mod *core.Module) (*core.GeneratedCode, error)
+
+	/* Runtime returns a container that is used to execute module code at runtime in the Dagger engine.
+
+	The provided Module is not fully initialized; the Runtime field will not be set yet.
+	*/
+	Runtime(ctx context.Context, mod *core.Module) (*core.Container, error)
 }
 
 // load the Runtime Container for the module at the given source dir, subpath using the SDK with the given name.
-func (s *moduleSchema) runtimeForModule(
-	ctx context.Context,
-	sourceDir *core.Directory,
-	sourceDirSubpath string,
-	sdkName string,
-) (*core.Container, error) {
-	sdk, err := s.sdkForModule(ctx, sourceDir, sourceDirSubpath, sdkName)
+func (s *moduleSchema) runtimeForModule(ctx context.Context, mod *core.Module) (*core.Container, error) {
+	sdk, err := s.sdkForModule(ctx, mod)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get sdk %q for module: %w", sdkName, err)
+		return nil, err
 	}
-	return sdk.Runtime(ctx, sourceDir, sourceDirSubpath)
+	return sdk.Runtime(ctx, mod)
 }
 
 // load the SDK implementation with the given name for the module at the given source dir + subpath.
-func (s *moduleSchema) sdkForModule(
-	ctx context.Context,
-	sourceDir *core.Directory,
-	sourceDirSubpath string,
-	sdkName string,
-) (SDK, error) {
-	builtinSDK, err := s.builtinSDK(ctx, sdkName)
+func (s *moduleSchema) sdkForModule(ctx context.Context, mod *core.Module) (SDK, error) {
+	builtinSDK, err := s.builtinSDK(ctx, mod.SDK)
 	if err == nil {
 		return builtinSDK, nil
 	} else if !errors.Is(err, errUnknownBuiltinSDK) {
 		return nil, err
 	}
 
-	return s.newModuleSDK(ctx, sourceDir, sourceDirSubpath)
+	sdkMod, err := core.NewModule(s.platform, nil).FromRef(
+		ctx,
+		s.bk,
+		s.services,
+		s.progSockPath,
+		mod.SourceDirectory,
+		mod.SourceDirectorySubpath,
+		mod.SDK,
+		s.runtimeForModule,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load sdk module %s: %w", mod.SDK, err)
+	}
+
+	return s.newModuleSDK(ctx, sdkMod)
 }
 
 var errUnknownBuiltinSDK = fmt.Errorf("unknown builtin sdk")
@@ -95,36 +104,24 @@ type moduleSDK struct {
 	mod *core.Module
 }
 
-func (s *moduleSchema) newModuleSDK(ctx context.Context, sourceDir *core.Directory, configPath string) (*moduleSDK, error) {
-	mod, err := core.NewModule(s.platform, nil).FromConfig(
-		ctx,
-		s.bk,
-		s.services,
-		s.progSockPath,
-		sourceDir,
-		configPath,
-		s.runtimeForModule,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load sdk module: %w", err)
-	}
-	mod, err = s.loadModuleTypes(ctx, mod)
+func (s *moduleSchema) newModuleSDK(ctx context.Context, sdkMod *core.Module) (*moduleSDK, error) {
+	sdkMod, err := s.loadModuleTypes(ctx, sdkMod)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load sdk module types: %w", err)
 	}
 
-	return &moduleSDK{moduleSchema: s, mod: mod}, nil
+	return &moduleSDK{moduleSchema: s, mod: sdkMod}, nil
 }
 
 // Codegen calls the Codegen function on the SDK Module
-func (sdk *moduleSDK) Codegen(ctx context.Context, sourceDir *core.Directory, sourceDirSubpath string) (*core.GeneratedCode, error) {
-	moduleName := gqlObjectName(sdk.mod.Name)
-	var moduleOriginalName string
+func (sdk *moduleSDK) Codegen(ctx context.Context, mod *core.Module) (*core.GeneratedCode, error) {
+	sdkModuleName := gqlObjectName(sdk.mod.Name)
+	var sdkModuleOriginalName string
 	funcName := "Codegen"
 	var codegenFn *core.Function
 	for _, obj := range sdk.mod.Objects {
-		if obj.AsObject.Name == moduleName {
-			moduleOriginalName = obj.AsObject.OriginalName
+		if obj.AsObject.Name == sdkModuleName {
+			sdkModuleOriginalName = obj.AsObject.OriginalName
 			for _, fn := range obj.AsObject.Functions {
 				if fn.Name == gqlFieldName(funcName) {
 					codegenFn = fn
@@ -134,10 +131,10 @@ func (sdk *moduleSDK) Codegen(ctx context.Context, sourceDir *core.Directory, so
 		}
 	}
 	if codegenFn == nil {
-		return nil, fmt.Errorf("failed to find required Codegen function in SDK module %s", moduleName)
+		return nil, fmt.Errorf("failed to find required Codegen function in SDK module %s", sdkModuleName)
 	}
 
-	srcDirID, err := sourceDir.ID()
+	srcDirID, err := mod.SourceDirectory.ID()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get source directory id: %w", err)
 	}
@@ -149,9 +146,9 @@ func (sdk *moduleSDK) Codegen(ctx context.Context, sourceDir *core.Directory, so
 			Value: srcDirID,
 		}, {
 			Name:  "subPath",
-			Value: sourceDirSubpath,
+			Value: mod.SourceDirectorySubpath,
 		}},
-		ParentOriginalName: moduleOriginalName,
+		ParentOriginalName: sdkModuleOriginalName,
 		// TODO: params? somehow? maybe from module config? would be a good way to
 		// e.g. configure the language version.
 		Parent: map[string]any{},
@@ -170,14 +167,14 @@ func (sdk *moduleSDK) Codegen(ctx context.Context, sourceDir *core.Directory, so
 }
 
 // Runtime calls the Runtime function on the SDK Module
-func (sdk *moduleSDK) Runtime(ctx context.Context, sourceDir *core.Directory, sourceDirSubpath string) (*core.Container, error) {
-	moduleName := gqlObjectName(sdk.mod.Name)
-	var moduleOriginalName string
+func (sdk *moduleSDK) Runtime(ctx context.Context, mod *core.Module) (*core.Container, error) {
+	sdkModuleName := gqlObjectName(sdk.mod.Name)
+	var sdkModuleOriginalName string
 	funcName := "ModuleRuntime"
 	var getRuntimeFn *core.Function
 	for _, obj := range sdk.mod.Objects {
-		if obj.AsObject.Name == moduleName {
-			moduleOriginalName = obj.AsObject.OriginalName
+		if obj.AsObject.Name == sdkModuleName {
+			sdkModuleOriginalName = obj.AsObject.OriginalName
 			for _, fn := range obj.AsObject.Functions {
 				if fn.Name == gqlFieldName(funcName) {
 					getRuntimeFn = fn
@@ -187,10 +184,10 @@ func (sdk *moduleSDK) Runtime(ctx context.Context, sourceDir *core.Directory, so
 		}
 	}
 	if getRuntimeFn == nil {
-		return nil, fmt.Errorf("failed to find required ModuleRuntime function in SDK module %s", moduleName)
+		return nil, fmt.Errorf("failed to find required ModuleRuntime function in SDK module %s", sdkModuleName)
 	}
 
-	srcDirID, err := sourceDir.ID()
+	srcDirID, err := mod.SourceDirectory.ID()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get source directory id: %w", err)
 	}
@@ -202,9 +199,9 @@ func (sdk *moduleSDK) Runtime(ctx context.Context, sourceDir *core.Directory, so
 			Value: srcDirID,
 		}, {
 			Name:  "subPath",
-			Value: sourceDirSubpath,
+			Value: mod.SourceDirectorySubpath,
 		}},
-		ParentOriginalName: moduleOriginalName,
+		ParentOriginalName: sdkModuleOriginalName,
 		// TODO: params? somehow? maybe from module config? would be a good way to
 		// e.g. configure the language version.
 		Parent: map[string]any{},
@@ -268,12 +265,25 @@ func (s *moduleSchema) loadBuiltinSDK(ctx context.Context, name string, engineCo
 		return nil, fmt.Errorf("failed to get relative path of module sdk config file %s: %w", name, err)
 	}
 
-	return s.newModuleSDK(ctx, core.NewDirectory(ctx, pbDef, "/", nil, s.platform, nil), cfgRelPath)
+	sdkMod, err := core.NewModule(s.platform, nil).FromConfig(
+		ctx,
+		s.bk,
+		s.services,
+		s.progSockPath,
+		core.NewDirectory(ctx, pbDef, "/", nil, s.platform, nil),
+		cfgRelPath,
+		s.runtimeForModule,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load sdk module: %w", err)
+	}
+	return s.newModuleSDK(ctx, sdkMod)
 }
 
 const (
-	goSDKUserModSourceDirPath = "/src"
-	goSDKRuntimePath          = "/runtime"
+	goSDKUserModSourceDirPath  = "/src"
+	goSDKRuntimePath           = "/runtime"
+	goSDKIntrospectionJSONPath = "/schema.json"
 )
 
 /*
@@ -288,8 +298,8 @@ type goSDK struct {
 	*moduleSchema
 }
 
-func (sdk *goSDK) Codegen(ctx context.Context, sourceDir *core.Directory, sourceDirSubpath string) (*core.GeneratedCode, error) {
-	ctr, err := sdk.baseWithCodegen(ctx, sourceDir, sourceDirSubpath)
+func (sdk *goSDK) Codegen(ctx context.Context, mod *core.Module) (*core.GeneratedCode, error) {
+	ctr, err := sdk.baseWithCodegen(ctx, mod)
 	if err != nil {
 		return nil, err
 	}
@@ -299,12 +309,12 @@ func (sdk *goSDK) Codegen(ctx context.Context, sourceDir *core.Directory, source
 		return nil, fmt.Errorf("failed to get modified source directory for go module sdk codegen: %w", err)
 	}
 
-	diff, err := sourceDir.Diff(ctx, modifiedSrcDir)
+	diff, err := mod.SourceDirectory.Diff(ctx, modifiedSrcDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get diff: %w", err)
 	}
 	// diff needs to be of the subdir, if any, not necessarily the root
-	diff, err = diff.Directory(ctx, sdk.bk, sdk.services, sourceDirSubpath)
+	diff, err = diff.Directory(ctx, sdk.bk, sdk.services, mod.SourceDirectorySubpath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to re-root diff: %w", err)
 	}
@@ -319,8 +329,8 @@ func (sdk *goSDK) Codegen(ctx context.Context, sourceDir *core.Directory, source
 	}, nil
 }
 
-func (sdk *goSDK) Runtime(ctx context.Context, sourceDir *core.Directory, sourceDirSubpath string) (*core.Container, error) {
-	ctr, err := sdk.baseWithCodegen(ctx, sourceDir, sourceDirSubpath)
+func (sdk *goSDK) Runtime(ctx context.Context, mod *core.Module) (*core.Container, error) {
+	ctr, err := sdk.baseWithCodegen(ctx, mod)
 	if err != nil {
 		return nil, err
 	}
@@ -349,18 +359,39 @@ func (sdk *goSDK) Runtime(ctx context.Context, sourceDir *core.Directory, source
 	return ctr, nil
 }
 
-func (sdk *goSDK) baseWithCodegen(ctx context.Context, sourceDir *core.Directory, sourceDirSubpath string) (*core.Container, error) {
+func (sdk *goSDK) baseWithCodegen(ctx context.Context, mod *core.Module) (*core.Container, error) {
+	schemaView, err := sdk.installDeps(ctx, mod)
+	if err != nil {
+		return nil, fmt.Errorf("failed to install deps during go module sdk codegen: %w", err)
+	}
+	introspectionJSON, err := schemaView.schemaIntrospectionJSON(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get schema introspection json during go module sdk codegen: %w", err)
+	}
+	introspectionJSONFile, err := core.NewFileWithContents(ctx, sdk.bk, sdk.services,
+		filepath.Base(goSDKIntrospectionJSONPath),
+		[]byte(introspectionJSON), 0444, nil,
+		nil, sdk.platform,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create introspection json file during go module sdk codegen: %w", err)
+	}
+
 	ctr, err := sdk.base(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	ctr, err = ctr.WithMountedDirectory(ctx, sdk.bk, goSDKUserModSourceDirPath, sourceDir, "", false)
+	ctr, err = ctr.WithMountedFile(ctx, sdk.bk, goSDKIntrospectionJSONPath, introspectionJSONFile, "", true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to mount introspection json file into go module sdk container codegen: %w", err)
+	}
+	ctr, err = ctr.WithMountedDirectory(ctx, sdk.bk, goSDKUserModSourceDirPath, mod.SourceDirectory, "", false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to mount module source into go module sdk container codegen: %w", err)
 	}
 	ctr, err = ctr.UpdateImageConfig(ctx, func(cfg specs.ImageConfig) specs.ImageConfig {
-		cfg.WorkingDir = filepath.Join(goSDKUserModSourceDirPath, sourceDirSubpath)
+		cfg.WorkingDir = filepath.Join(goSDKUserModSourceDirPath, mod.SourceDirectorySubpath)
 		cfg.Cmd = nil
 		return cfg
 	})
@@ -372,6 +403,7 @@ func (sdk *goSDK) baseWithCodegen(ctx context.Context, sourceDir *core.Directory
 		Args: []string{
 			"--module", ".",
 			"--propagate-logs=true",
+			"--introspection-json-path", goSDKIntrospectionJSONPath,
 		},
 		ExperimentalPrivilegedNesting: true,
 	})

--- a/core/schema/sdk.go
+++ b/core/schema/sdk.go
@@ -343,6 +343,7 @@ func (sdk *goSDK) Runtime(ctx context.Context, mod *core.Module) (*core.Containe
 		},
 		SkipEntrypoint:                true,
 		ExperimentalPrivilegedNesting: true,
+		NestedInSameSession:           true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to exec go build in go module sdk container runtime: %w", err)
@@ -413,6 +414,7 @@ func (sdk *goSDK) baseWithCodegen(ctx context.Context, mod *core.Module) (*core.
 			"--introspection-json-path", goSDKIntrospectionJSONPath,
 		},
 		ExperimentalPrivilegedNesting: true,
+		NestedInSameSession:           true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to exec go build in go module sdk container codegen: %w", err)

--- a/core/service.go
+++ b/core/service.go
@@ -355,11 +355,9 @@ func (svc *Service) startContainer(
 	}
 
 	execOp.Meta.ProxyEnv.FtpProxy, err = buildkit.ContainerExecUncachedMetadata{
-		ParentClientIDs:       clientMetadata.ClientIDs(),
-		ServerID:              clientMetadata.ServerID,
-		ProgSockPath:          bk.ProgSockPath,
-		ModuleDigest:          clientMetadata.ModuleDigest,
-		FunctionContextDigest: clientMetadata.FunctionContextDigest,
+		ParentClientIDs: clientMetadata.ClientIDs(),
+		ServerID:        clientMetadata.ServerID,
+		ProgSockPath:    bk.ProgSockPath,
 	}.ToPBFtpProxyVal()
 	if err != nil {
 		return nil, err

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -250,11 +250,9 @@ func (c *Client) Solve(ctx context.Context, req bkgw.SolveRequest) (_ *Result, r
 			}
 			var err error
 			execOp.Meta.ProxyEnv.FtpProxy, err = ContainerExecUncachedMetadata{
-				ParentClientIDs:       clientMetadata.ClientIDs(),
-				ServerID:              clientMetadata.ServerID,
-				ProgSockPath:          c.ProgSockPath,
-				ModuleDigest:          clientMetadata.ModuleDigest,
-				FunctionContextDigest: clientMetadata.FunctionContextDigest,
+				ParentClientIDs: clientMetadata.ClientIDs(),
+				ServerID:        clientMetadata.ServerID,
+				ProgSockPath:    c.ProgSockPath,
 			}.ToPBFtpProxyVal()
 			if err != nil {
 				return err
@@ -686,11 +684,9 @@ func withOutgoingContext(ctx context.Context) context.Context {
 // the "real" ftp proxy setting in here too and have the shim handle
 // leaving only that set in the actual env var.
 type ContainerExecUncachedMetadata struct {
-	ParentClientIDs       []string      `json:"parentClientIDs,omitempty"`
-	ServerID              string        `json:"serverID,omitempty"`
-	ProgSockPath          string        `json:"progSockPath,omitempty"`
-	ModuleDigest          digest.Digest `json:"moduleDigest,omitempty"`
-	FunctionContextDigest digest.Digest `json:"functionContextDigest,omitempty"`
+	ParentClientIDs []string `json:"parentClientIDs,omitempty"`
+	ServerID        string   `json:"serverID,omitempty"`
+	ProgSockPath    string   `json:"progSockPath,omitempty"`
 }
 
 func (md ContainerExecUncachedMetadata) ToPBFtpProxyVal() (string, error) {

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -67,7 +67,9 @@ type Params struct {
 	EngineNameCallback func(string)
 	CloudURLCallback   func(string)
 
-	// TODO:(sipsma) DOC
+	// If this client is for a module function, this digest will be set in the
+	// grpc context metadata for any api requests back to the engine. It's used by the API
+	// server to determine which schema to serve and other module context metadata.
 	ModuleContextDigest digest.Digest
 }
 

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -67,9 +67,8 @@ type Params struct {
 	EngineNameCallback func(string)
 	CloudURLCallback   func(string)
 
-	// TODO: doc if this stays in
-	ModuleDigest          digest.Digest
-	FunctionContextDigest digest.Digest
+	// TODO:(sipsma) DOC
+	ModuleContextDigest digest.Digest
 }
 
 type Client struct {
@@ -233,14 +232,13 @@ func Connect(ctx context.Context, params Params) (_ *Client, _ context.Context, 
 	c.labels = append(c.labels, pipeline.LoadClientLabels(engine.Version)...)
 
 	c.internalCtx = engine.ContextWithClientMetadata(c.internalCtx, &engine.ClientMetadata{
-		ClientID:              c.ID(),
-		ClientSecretToken:     c.SecretToken,
-		ServerID:              c.ServerID,
-		ClientHostname:        c.hostname,
-		Labels:                c.labels,
-		ParentClientIDs:       c.ParentClientIDs,
-		ModuleDigest:          c.ModuleDigest,
-		FunctionContextDigest: c.FunctionContextDigest,
+		ClientID:            c.ID(),
+		ClientSecretToken:   c.SecretToken,
+		ServerID:            c.ServerID,
+		ClientHostname:      c.hostname,
+		Labels:              c.labels,
+		ParentClientIDs:     c.ParentClientIDs,
+		ModuleContextDigest: c.ModuleContextDigest,
 	})
 
 	// progress
@@ -278,8 +276,7 @@ func Connect(ctx context.Context, params Params) (_ *Client, _ context.Context, 
 				ClientHostname:            hostname,
 				UpstreamCacheImportConfig: c.upstreamCacheImportOptions,
 				Labels:                    c.labels,
-				ModuleDigest:              c.ModuleDigest,
-				FunctionContextDigest:     c.FunctionContextDigest,
+				ModuleContextDigest:       c.ModuleContextDigest,
 			}.AppendToMD(meta))
 		})
 	})
@@ -463,14 +460,13 @@ func (c *Client) DialContext(ctx context.Context, _, _ string) (conn net.Conn, e
 		}).Dial("tcp", "127.0.0.1:"+strconv.Itoa(c.nestedSessionPort))
 	} else {
 		conn, err = grpchijack.Dialer(c.bkClient.ControlClient())(ctx, "", engine.ClientMetadata{
-			ClientID:              c.ID(),
-			ClientSecretToken:     c.SecretToken,
-			ServerID:              c.ServerID,
-			ClientHostname:        c.hostname,
-			ParentClientIDs:       c.ParentClientIDs,
-			Labels:                c.labels,
-			ModuleDigest:          c.ModuleDigest,
-			FunctionContextDigest: c.FunctionContextDigest,
+			ClientID:            c.ID(),
+			ClientSecretToken:   c.SecretToken,
+			ServerID:            c.ServerID,
+			ClientHostname:      c.hostname,
+			ParentClientIDs:     c.ParentClientIDs,
+			Labels:              c.labels,
+			ModuleContextDigest: c.ModuleContextDigest,
 		}.ToGRPCMD())
 	}
 	if err != nil {

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -61,11 +61,8 @@ type ClientMetadata struct {
 	// parent of the parent, and so on.
 	ParentClientIDs []string `json:"parent_client_ids"`
 
-	// TODO: doc if stays in
-	ModuleDigest digest.Digest `json:"module_digest"`
-
-	// TODO: doc if stays in
-	FunctionContextDigest digest.Digest `json:"function_context_digest"`
+	// TODO:(sipsma) DOC
+	ModuleContextDigest digest.Digest `json:"module_context_digest"`
 
 	// Import configuration for Buildkit's remote cache
 	UpstreamCacheImportConfig []*controlapi.CacheOptionsEntry

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -61,7 +61,9 @@ type ClientMetadata struct {
 	// parent of the parent, and so on.
 	ParentClientIDs []string `json:"parent_client_ids"`
 
-	// TODO:(sipsma) DOC
+	// If this client is for a module function, this digest will be set in the
+	// grpc context metadata for any api requests back to the engine. It's used by the API
+	// server to determine which schema to serve and other module context metadata.
 	ModuleContextDigest digest.Digest `json:"module_context_digest"`
 
 	// Import configuration for Buildkit's remote cache

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -198,10 +198,6 @@ func (srv *DaggerServer) ServeClientConn(
 }
 
 func (srv *DaggerServer) HTTPHandlerForClient(clientMetadata *engine.ClientMetadata, conn net.Conn, lg *logrus.Entry) (http.Handler, <-chan struct{}, error) {
-	handler, err := srv.schema.HTTPHandler(clientMetadata.ModuleDigest)
-	if err != nil {
-		return nil, nil, err
-	}
 	doneCh := make(chan struct{})
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer close(doneCh)
@@ -212,7 +208,7 @@ func (srv *DaggerServer) HTTPHandlerForClient(clientMetadata *engine.ClientMetad
 		req = req.WithContext(progrock.ToContext(req.Context(), srv.recorder))
 		req = req.WithContext(engine.ContextWithClientMetadata(req.Context(), clientMetadata))
 
-		handler.ServeHTTP(w, req)
+		srv.schema.ServeHTTP(w, req)
 	}), doneCh, nil
 }
 

--- a/sdk/python/src/dagger/client/_session.py
+++ b/sdk/python/src/dagger/client/_session.py
@@ -1,7 +1,9 @@
 import contextlib
+import json
 import logging
 import os
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 import graphql
@@ -69,9 +71,17 @@ class ClientSession(ResourceManager):
             auth=(conn.session_token, ""),
         )
 
+        # test if /schema.json exists, if so, use that as the introspection schema
+        schema_path = Path("/schema.json")
+        introspection = None
+        if schema_path.exists():
+            with schema_path.open() as f:
+                introspection = json.load(f)
+
         client = GraphQLClient(
             transport=transport,
-            fetch_schema_from_transport=True,
+            introspection=introspection,
+            fetch_schema_from_transport=introspection is None,
             # We're using the timeout from the httpx transport.
             execute_timeout=None,
         )


### PR DESCRIPTION
# Problems being solved

This started out as just fixing https://github.com/dagger/dagger/issues/5872, but looking into that uncovered a lot of deeper problems that needed fixes+cleanups as a pre-req.

## Problem A
This relates to the conversation the other day w/ @vito and @helderco: https://github.com/dagger/dagger/pull/5954#issuecomment-1776545239

I now understand *why* things seemed to mostly work before, but it turns out to have been a mildly astonishing set of coincidences rather than anything solid. Quick explanation:
1. Runtime+Codegen is executed as containers in `core/schema/sdk.go`, but those were staying lazy, not actually evaluated at the time that code is called (if you forced them to synchronously evaluate, they no longer worked as expected due to missing dependency schemas)
2. They didn't get actually evaluated until we asked the actual module itself for its typedefs (i.e. after the runtime+codegen was theoretically supposed to have run)
3. The context we use during that evaluation is the one used for normal module function invocation, which meant that the context had the module digest for the module itself, which meant that the SDK runtime+codegen was being evaluated in the context of the *module's* schema view.
   * So by extreme coincidence, the SDK ended up with mostly the right schema view in order to run codegen for the module's dependencies

This situation was extremely delicate and eventually would have broken down, but trying to fix the problem w/ exporting codegen even on compilation failures caused it to collapse instantly.

### Solution
1. The `ModuleDigest` that's used to determine which schema to present to a client is no longer _set on execs_ by passing it through context; it's now an internal-only option to `Container.WithExec`.
   * We still need to pass this through context from a nested client -> api server (there's no other choice); it's just after that point it becomes an explicitly set value rather than magical ambient thing that is hard to keep track of.
   * I also took this opportunity to fix up the crazy complication around maintaining two digests (one for module schema view and one for function context) and general simplification of that code. There's only one digest now and most of the code for dealing with that is in `schema/schema.go` now.
2. We don't rely on SDKs (whether SDK module or special-case Go) being able to make an introspection call back to the API to get the schema for the deps of the module they are codegen'ing for.
   * This doesn't work because the schema available to an SDK module needs to consist of *its* deps, not those of the module its codegen'ing for
   * Instead we just give the SDK the introspection json of the module's deps as an input to use directly.

## Problem B
There's also the _original_ problem I was working on of needing to be able get generated code even when user code doesn't compile with it. Currently, if a dep has a breaking change, users get into this incredibly frustrating situation where they can't get the new API codegen'd and thus have to "guess" at what changes are needed util they get it right (or more likely, give up).

The source of that problem was that `generatedCode` is on `Module`, but we always tried to load the module types immediately for every module. If you can't compile the code, you can't load the types and thus can't load the module and thus can't get the generated code from the API.

### Solution
1. We now just delay calling `loadModuleTypes` until strictly necessary in order to provide consistent api call results.
   * This crucially does *not* include `generatedCode`, so that can be called without needing the user code to compile now

I also spent some time going down the rabbit hole of trying to move `generatedCode` to different parts of the API. This is still the best long-term solution IMO, but I think the best approach would be to integrate the `ModuleConfig` API better into the overall schema.

Unfortunately, that's much easier said than done due to various subtleties (as discussed previously [here](https://github.com/dagger/dagger/pull/5900#discussion_r1362322800)) and generally impacting *lots* of code all over. It started cascading way too far, especially given all the other fixes needed here, so I decided to cut it from this effort for now. 

## Problem C

Finally, in order to be able to test any of this, we need **at least** a case where we init+call a module with a dependency, change the dependency, and then call again to verify we get the new codegen from the updated dep even though there's compilation failures.

Turns out this doesn't work in the current module integ tests because of the way ExperimentalPrivilegedNesting works. That flag gives the exec dagger API access back to the engine, but it specifically also does it back to the same session as the original client.

This means that even when our integ tests do dagger query/call/mod/etc. calls across execs, it's all back to the same session. This breaks in the test case I'm adding (and all the more complicated ones we need to add) because you are trying to re-load modules back into the same session, which expectedly doesn't work.

### Solution
1. We change the behavior of ExperimentalPrivilegedNesting to not connect back to the same session but instead create its own new one
   * Modules however use an internal-only flag that allows them to retain the previous behavior, so they are not impacted.

# TODOs
- [x] Update Python SDK Module (and SDK modules in general) to accept JSON introspection as arg rather than forcing them to get it from actual query
   * Equivalent is already implemented for the (special, non-module) Go SDK
- [x] Add integ tests
   * Verified the issue is fixed manually so far
- [x] Fill in doc strings/comments marked as TODO 