### PR TITLE
dagger mod init creates LICENSE if none found

### DIFF
--- a/cmd/dagger/licenses.go
+++ b/cmd/dagger/licenses.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/mitchellh/go-spdx"
+	"github.com/vito/progrock"
+)
+
+const (
+	defaultLicense = "Apache-2.0"
+)
+
+// TODO: dedupe this from Daggerverse, originally hoisted from pkg.go.dev
+var licenseFiles = []string{
+	"COPYING",
+	"COPYING.md",
+	"COPYING.markdown",
+	"COPYING.txt",
+	"LICENCE",
+	"LICENCE.md",
+	"LICENCE.markdown",
+	"LICENCE.txt",
+	"LICENSE",
+	"LICENSE.md",
+	"LICENSE.markdown",
+	"LICENSE.txt",
+	"LICENSE-2.0.txt",
+	"LICENCE-2.0.txt",
+	"LICENSE-APACHE",
+	"LICENCE-APACHE",
+	"LICENSE-APACHE-2.0.txt",
+	"LICENCE-APACHE-2.0.txt",
+	"LICENSE-MIT",
+	"LICENCE-MIT",
+	"LICENSE.MIT",
+	"LICENCE.MIT",
+	"LICENSE.code",
+	"LICENCE.code",
+	"LICENSE.docs",
+	"LICENCE.docs",
+	"LICENSE.rst",
+	"LICENCE.rst",
+	"MIT-LICENSE",
+	"MIT-LICENCE",
+	"MIT-LICENSE.md",
+	"MIT-LICENCE.md",
+	"MIT-LICENSE.markdown",
+	"MIT-LICENCE.markdown",
+	"MIT-LICENSE.txt",
+	"MIT-LICENCE.txt",
+	"MIT_LICENSE",
+	"MIT_LICENCE",
+	"UNLICENSE",
+	"UNLICENCE",
+}
+
+func findOrCreateLicense(ctx context.Context, dir string) error {
+	rec := progrock.FromContext(ctx)
+
+	id := licenseID
+	if id == "" {
+		if foundLicense, err := searchForLicense(dir); err == nil {
+			rec.Debug("found existing LICENSE file", progrock.Labelf("path", foundLicense))
+			return nil
+		}
+
+		id = defaultLicense
+	}
+
+	rec.Warn("no LICENSE file found; generating one for you, feel free to change or remove",
+		progrock.Labelf("license", id))
+
+	license, err := spdx.License(id)
+	if err != nil {
+		return fmt.Errorf("failed to get license: %w", err)
+	}
+
+	newLicense := filepath.Join(dir, "LICENSE")
+
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	if err := os.WriteFile(newLicense, []byte(license.Text), 0600); err != nil {
+		return fmt.Errorf("failed to write license: %w", err)
+	}
+
+	return nil
+}
+
+func searchForLicense(dir string) (string, error) {
+	if dir == "" {
+		dir = "."
+	}
+
+	for _, fileName := range licenseFiles {
+		licensePath := filepath.Join(dir, fileName)
+		if _, err := os.Stat(licensePath); err == nil {
+			return licensePath, nil
+		}
+	}
+
+	var atRoot bool
+	if dir == "/" {
+		atRoot = true
+	} else if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+		atRoot = true
+	}
+
+	if atRoot {
+		// we reached the module root; time to give up
+		return "", errors.New("not found")
+	}
+
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+
+	return searchForLicense(filepath.Dir(abs))
+}

--- a/go.mod
+++ b/go.mod
@@ -180,6 +180,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/mazznoer/csscolorparser v0.1.3 // indirect
+	github.com/mitchellh/go-spdx v0.1.0 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/moby/sys/mountinfo v0.6.2 // indirect
 	github.com/moby/sys/sequential v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -838,6 +838,7 @@ github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FK
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
@@ -1038,6 +1039,8 @@ github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-ps v0.0.0-20190716172923-621e5597135b/go.mod h1:r1VsdOzOPt1ZSrGZWFoNhsAedKnEd6r9Np1+5blZCWk=
+github.com/mitchellh/go-spdx v0.1.0 h1:50JnVzkL3kWreQ5Qb4Pi3Qx9e+bbYrt8QglJDpfeBEs=
+github.com/mitchellh/go-spdx v0.1.0/go.mod h1:FFi4Cg1fBuN/JCtPtP8PEDmcBjvO3gijQVl28YjIBVQ=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=


### PR DESCRIPTION
`dagger mod init` will now create a LICENSE file for you, defaulting to Apache-2.0.

![image](https://github.com/dagger/dagger/assets/1880/58941f3d-b7e9-4ef3-93db-72fef319ce0e)

If it finds an existing LICENSE file, searching up to the root of the repo, it won't do anything and will just log the file it found at debug level.

Note that this only happens on `init`, not `sync`, since it's perfectly valid to not want a LICENSE file if you just don't want anyone else to use your stuff.

There is a `--license` flag too which lets you specify which license you want, and it'll generate the requested license even if one is found in the upper directories, in case you want a different one.

Along the way, refactors a bunch of the `dagger mod` command/flag handling:

* replace remaining usage of `*moduleFlagConfig` with `*modules.Ref`
* pass a `moduleDir string` into `updateModuleConfig`, using `(*modules.Ref).LocalSourcePath` outside of it to double as the non-local path err check
* move dependency installation to `(*modules.Config).Use`

closes DEV-2864