### PR TITLE
zenith: use main as default go module name

### DIFF
--- a/cmd/codegen/generator/go/generator.go
+++ b/cmd/codegen/generator/go/generator.go
@@ -164,7 +164,7 @@ func (g *GoGenerator) bootstrapMod(ctx context.Context, mfs *memfs.FS) (*Package
 
 			// bootstrap go.mod using dependencies from the embedded Go SDK
 
-			newModName := strcase.ToKebab(g.Config.ModuleConfig.Name)
+			newModName := "main" // use a safe default, no going to be a reserved word. User is free to modify
 
 			newMod.AddModuleStmt(newModName)
 			newMod.SetRequire(sdkMod.Require)


### PR DESCRIPTION
Previously we were using the dagger module as the go module name, but that allows users to accidentally use reserved words ("go", "toolchain", "replace", etc.).

There's no harm in using a safe default like "main"; users are free to update it later if they want.

---

Ref: https://discord.com/channels/707636530424053791/1120503349599543376/1167178632557494342

Fixes https://github.com/dagger/dagger/issues/5975