### PR TITLE
chore: add docs for Optional type in go SDK

### DIFF
--- a/cmd/codegen/generator/go/templates/src/header.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/header.go.tmpl
@@ -37,20 +37,29 @@ func ptr[T any](v T) *T {
 	return &v
 }
 
+// Optional is a helper type to represent optional values. Any method arguments
+// that use this wrapper type will be set as optional in the generated API.
+//
+// To construct an Optional from within a module, use the Opt helper function.
 type Optional[T comparable] struct {
 	value T
 	isSet bool
 }
 
+// Opt is a helper function to construct an Optional with the given value set.
 func Opt[T comparable](v T) Optional[T] {
 	return Optional[T]{value: v, isSet: true}
 }
 
+// Get returns the internal value of the optional and a boolean indicating if
+// the value was set explicitly by the caller.
 func (o Optional[T]) Get() (T, bool) {
 	var zero T
 	return o.value, o.isSet || o.value != zero
 }
 
+// GetOr returns the internal value of the optional or the given default value
+// if the value was not explicitly set by the caller.
 func (o Optional[T]) GetOr(defaultValue T) T {
 	value, ok := o.Get()
 	if !ok {

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -30,20 +30,29 @@ func ptr[T any](v T) *T {
 	return &v
 }
 
+// Optional is a helper type to represent optional values. Any method arguments
+// that use this wrapper type will be set as optional in the generated API.
+//
+// To construct an Optional from within a module, use the Opt helper function.
 type Optional[T comparable] struct {
 	value T
 	isSet bool
 }
 
+// Opt is a helper function to construct an Optional with the given value set.
 func Opt[T comparable](v T) Optional[T] {
 	return Optional[T]{value: v, isSet: true}
 }
 
+// Get returns the internal value of the optional and a boolean indicating if
+// the value was set explicitly by the caller.
 func (o Optional[T]) Get() (T, bool) {
 	var zero T
 	return o.value, o.isSet || o.value != zero
 }
 
+// GetOr returns the internal value of the optional or the given default value
+// if the value was not explicitly set by the caller.
 func (o Optional[T]) GetOr(defaultValue T) T {
 	value, ok := o.Get()
 	if !ok {


### PR DESCRIPTION
As discussed in https://discord.com/channels/707636530424053791/1120503349599543376/1167237283318071296:

> @jedevc:
>
> If you call Optional.Get then it returns the string and a bool that's true if it was set and false if it wasn't - there's also a helper .GetOr that returns the provided default if it wasn't set.
>
> These need doc comments actually, I'll do that ASAP tomorrow

This should help users use `Optional`s a bit more easily.