### PR TITLE
chore: avoid panics in go sdk template functions

### DIFF
--- a/cmd/codegen/generator/go/templates/modules_test.go
+++ b/cmd/codegen/generator/go/templates/modules_test.go
@@ -51,8 +51,7 @@ go 1.20
 	}
 
 	// TODO: assert on contents
-	require.NotPanics(t, func() {
-		generatedMain := funcs.moduleMainSrc()
-		t.Log(generatedMain)
-	})
+	generatedMain, err := funcs.moduleMainSrc()
+	require.NoError(t, err)
+	t.Log(generatedMain)
 }


### PR DESCRIPTION
This cleans up the panic-ing behavior inside go sdk template functions. The important change is to try and recover and print a stack trace from panics during module code generation since this is the code that's most likely to actually panic.

This resolves https://discord.com/channels/707636530424053791/1120503349599543376/1167157523275579422:

> Hard to debug because I'm not getting a filename or line

The other functions *can panic*, but are much less likely to - they're also small enough that it should be more trivial to debug failures. I did try writing a more generic wrapper to wrap all the template functions to capture stack traces, but this requires re-defining lots of the custom logic for how function calls work in text/template, which I didn't really feel like re-implementing :cry: 