### PR TITLE
core: disallow reserved ID field in user modules

### DIFF
--- a/core/integration/cache_test.go
+++ b/core/integration/cache_test.go
@@ -89,7 +89,7 @@ func TestCacheVolumeWithSubmount(t *testing.T) {
 
 		contents, err := ctr.File("/cache/subfile").Contents(ctx)
 		require.NoError(t, err)
-		require.Equal(t, "bar", strings.TrimSpace(string(contents)))
+		require.Equal(t, "bar", strings.TrimSpace(contents))
 	})
 
 	t.Run("dir mount", func(t *testing.T) {
@@ -110,12 +110,12 @@ func TestCacheVolumeWithSubmount(t *testing.T) {
 
 			contents, err := ctr.File(subpath).Contents(ctx)
 			require.NoError(t, err)
-			require.Equal(t, expectedContents, strings.TrimSpace(string(contents)))
+			require.Equal(t, expectedContents, strings.TrimSpace(contents))
 
 			dir := ctr.Directory("/cache/subdir")
 			contents, err = dir.File(fileName).Contents(ctx)
 			require.NoError(t, err)
-			require.Equal(t, expectedContents, strings.TrimSpace(string(contents)))
+			require.Equal(t, expectedContents, strings.TrimSpace(contents))
 		}
 	})
 }

--- a/core/integration/file_test.go
+++ b/core/integration/file_test.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -115,8 +114,6 @@ func TestFileSize(t *testing.T) {
 
 func TestFileExport(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 
 	wd := t.TempDir()
 	targetDir := t.TempDir()

--- a/core/integration/gpu_test.go
+++ b/core/integration/gpu_test.go
@@ -105,7 +105,6 @@ func TestGPUAccess(t *testing.T) {
 	// Iterate through the image matrix:
 	for _, cudaImage := range cudaImageMatrix {
 		t.Run(cudaImage, func(t *testing.T) {
-
 			// Query the same on the Dagger container and compare output:
 			ctr := c.Container().From(cudaImage)
 			contents, err := ctr.

--- a/core/integration/host_test.go
+++ b/core/integration/host_test.go
@@ -182,7 +182,7 @@ func TestHostSetSecretFile(t *testing.T) {
 	hashStr := hex.EncodeToString(hash[:])
 
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "some-file"), []byte(data), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "some-file"), data, 0600))
 
 	c, ctx := connect(t, dagger.WithWorkdir(dir))
 
@@ -198,7 +198,7 @@ func TestHostSetSecretFile(t *testing.T) {
 		require.NoError(t, err)
 
 		// Extract the MD5 hash from the command output
-		hashStrCmd := strings.Split(string(output), " ")[0]
+		hashStrCmd := strings.Split(output, " ")[0]
 
 		require.Equal(t, hashStr, hashStrCmd)
 	})

--- a/core/integration/images.go
+++ b/core/integration/images.go
@@ -2,7 +2,7 @@ package core
 
 const (
 	alpineImage = "alpine:3.18.2"
-	golangImage = "golang:1.21.1-alpine"
+	golangImage = "golang:1.21.3-alpine"
 
 	// TODO: use these
 	// registryImage   = "registry:2"

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -418,9 +418,8 @@ func TestModuleGit(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
-		sdk           string
-		gitignores    []string
-		gitattributes string
+		sdk        string
+		gitignores []string
 	}
 	for _, tc := range []testCase{
 		{
@@ -1531,7 +1530,6 @@ def hello() -> str:
 		require.NoError(t, err)
 		require.JSONEq(t, `{"hasMainPy":{"hello":"Hello, world!"}}`, out)
 	})
-
 }
 
 func TestModuleLotsOfFunctions(t *testing.T) {

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -742,39 +742,39 @@ func (m *Minimal) ReadOptional(ctx context.Context, dir Optional[Directory]) (st
 
 	out, err := modGen.With(daggerQuery(`{directory{withNewFile(path: "foo", contents: "bar"){id}}}`)).Stdout(ctx)
 	require.NoError(t, err)
-	dirId := gjson.Get(out, "directory.withNewFile.id").String()
+	dirID := gjson.Get(out, "directory.withNewFile.id").String()
 
 	t.Run("func Read(ctx, Directory) (string, error)", func(t *testing.T) {
 		t.Parallel()
-		out, err := modGen.With(daggerQuery(fmt.Sprintf(`{minimal{read(dir: "%s")}}`, dirId))).Stdout(ctx)
+		out, err := modGen.With(daggerQuery(fmt.Sprintf(`{minimal{read(dir: "%s")}}`, dirID))).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"read":"bar"}}`, out)
 	})
 
 	t.Run("func ReadPointer(ctx, *Directory) (string, error)", func(t *testing.T) {
 		t.Parallel()
-		out, err := modGen.With(daggerQuery(fmt.Sprintf(`{minimal{readPointer(dir: "%s")}}`, dirId))).Stdout(ctx)
+		out, err := modGen.With(daggerQuery(fmt.Sprintf(`{minimal{readPointer(dir: "%s")}}`, dirID))).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"readPointer":"bar"}}`, out)
 	})
 
 	t.Run("func ReadSlice(ctx, []Directory) (string, error)", func(t *testing.T) {
 		t.Parallel()
-		out, err := modGen.With(daggerQuery(fmt.Sprintf(`{minimal{readSlice(dir: ["%s"])}}`, dirId))).Stdout(ctx)
+		out, err := modGen.With(daggerQuery(fmt.Sprintf(`{minimal{readSlice(dir: ["%s"])}}`, dirID))).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"readSlice":"bar"}}`, out)
 	})
 
 	t.Run("func ReadVariadic(ctx, ...Directory) (string, error)", func(t *testing.T) {
 		t.Parallel()
-		out, err := modGen.With(daggerQuery(fmt.Sprintf(`{minimal{readVariadic(dir: ["%s"])}}`, dirId))).Stdout(ctx)
+		out, err := modGen.With(daggerQuery(fmt.Sprintf(`{minimal{readVariadic(dir: ["%s"])}}`, dirID))).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"readVariadic":"bar"}}`, out)
 	})
 
 	t.Run("func ReadOptional(ctx, Optional[Directory]) (string, error)", func(t *testing.T) {
 		t.Parallel()
-		out, err := modGen.With(daggerQuery(fmt.Sprintf(`{minimal{readOptional(dir: "%s")}}`, dirId))).Stdout(ctx)
+		out, err := modGen.With(daggerQuery(fmt.Sprintf(`{minimal{readOptional(dir: "%s")}}`, dirID))).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"readOptional":"bar"}}`, out)
 		out, err = modGen.With(daggerQuery(`{minimal{readOptional}}`)).Stdout(ctx)

--- a/core/integration/pipeline_test.go
+++ b/core/integration/pipeline_test.go
@@ -1,9 +1,7 @@
 package core
 
 import (
-	"context"
 	"fmt"
-	"io"
 	"testing"
 	"time"
 
@@ -111,11 +109,4 @@ func TestInternalVertexes(t *testing.T) {
 		require.NoError(t, c.Close()) // close + flush logs
 		require.NotContains(t, logs.String(), "merge (")
 	})
-}
-
-func connectWithLogs(t *testing.T, opts ...dagger.ClientOpt) (*dagger.Client, context.Context, *safeBuffer) {
-	var logs safeBuffer
-	out := io.MultiWriter(&logs, newTWriter(t))
-	c, ctx := connect(t, append(opts, dagger.WithLogOutput(out))...)
-	return c, ctx, &logs
 }

--- a/core/integration/remotecache_test.go
+++ b/core/integration/remotecache_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+const cliBinPath = "/.dagger-cli"
+
 func getDevEngineForRemoteCache(ctx context.Context, c *dagger.Client, cache *dagger.Service, cacheName string, index uint8) (devEngineSvc *dagger.Service, endpoint string, err error) {
 	id := identity.NewID()
 	networkCIDR := fmt.Sprintf("10.%d.0.0/16", 100+index)
@@ -52,8 +54,6 @@ func TestRemoteCacheRegistry(t *testing.T) {
 	// This loads the dagger-cli binary from the host into the container, that was set up by
 	// internal/mage/engine.go:test. This is used to communicate with the dev engine.
 	daggerCli := daggerCliFile(t, c)
-
-	cliBinPath := "/.dagger-cli"
 
 	outputA, err := c.Container().From(alpineImage).
 		WithServiceBinding("dev-engine", devEngineA).
@@ -134,8 +134,6 @@ func TestRemoteCacheLazyBlobs(t *testing.T) {
 
 	daggerCli := daggerCliFile(t, c)
 
-	cliBinPath := "/.dagger-cli"
-
 	outputA, err := c.Container().From(alpineImage).
 		WithDirectory("/foo", c.Directory().WithDirectory("bar", c.Directory().WithNewFile("baz", "blah")).WithTimestamps(0)).
 		WithServiceBinding("dev-engine", devEngineA).
@@ -210,7 +208,6 @@ func TestRemoteCacheS3(t *testing.T) {
 		devEngineA, endpointA, err := getDevEngineForRemoteCache(ctx, c, s3, "s3", 0)
 		require.NoError(t, err)
 
-		cliBinPath := "/.dagger-cli"
 		// This loads the dagger-cli binary from the host into the container, that was set up by
 		// internal/mage/engine.go:test. This is used to communicate with the dev engine.
 		daggerCli := c.Host().Directory("/dagger-dev/", dagger.HostDirectoryOpts{Include: []string{"dagger"}}).File("dagger")
@@ -289,8 +286,6 @@ func TestRemoteCacheRegistryMultipleConfigs(t *testing.T) {
 	// This loads the dagger-cli binary from the host into the container, that was set up by
 	// internal/mage/engine.go:test. This is used to communicate with the dev engine.
 	daggerCli := daggerCliFile(t, c)
-
-	cliBinPath := "/.dagger-cli"
 
 	outputA, err := c.Container().From(alpineImage).
 		WithServiceBinding("dev-engine", devEngineA).
@@ -387,8 +382,6 @@ func TestRemoteCacheRegistrySeparateImportExport(t *testing.T) {
 	// This loads the dagger-cli binary from the host into the container, that was set up by
 	// internal/mage/engine.go:test. This is used to communicate with the dev engine.
 	daggerCli := daggerCliFile(t, c)
-
-	cliBinPath := "/.dagger-cli"
 
 	cacheEnvA := "type=registry,ref=registry:5000/test-cache-a:latest,mode=max"
 	cacheEnvB := "type=registry,ref=registry:5000/test-cache-b:latest,mode=max"

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -588,7 +588,6 @@ func TestContainerExecServicesChained(t *testing.T) {
 			WithExposedPort(8000).
 			WithExec([]string{"python", "-m", "http.server"}).
 			AsService()
-
 	}
 
 	fileContent, err := c.Container().

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -356,9 +356,7 @@ func (ctr DaggerCLIContainer) CallEnvExtend(extensions ...string) *DaggerCLICont
 	if ctr.HelpArg {
 		args = append(args, "--help")
 	}
-	for _, ext := range extensions {
-		args = append(args, ext)
-	}
+	args = append(args, extensions...)
 	ctr.Container = ctr.WithExec(args, dagger.ContainerWithExecOpts{ExperimentalPrivilegedNesting: true})
 	return &ctr
 }

--- a/core/integration/testdata/modules/go/id/arg/main.go
+++ b/core/integration/testdata/modules/go/id/arg/main.go
@@ -1,0 +1,7 @@
+package main
+
+type Test struct{}
+
+func (m *Test) Fn(id string) string {
+	return "NOOOO!!!!"
+}

--- a/core/integration/testdata/modules/go/id/field/main.go
+++ b/core/integration/testdata/modules/go/id/field/main.go
@@ -1,0 +1,11 @@
+package main
+
+type Test struct{}
+
+func (m *Test) Fn() *CustomObject {
+	return &CustomObject{ID: "NOOOO!!!!"}
+}
+
+type CustomObject struct {
+	ID string `json:"id"`
+}

--- a/core/integration/testdata/modules/go/id/fn/main.go
+++ b/core/integration/testdata/modules/go/id/fn/main.go
@@ -1,0 +1,7 @@
+package main
+
+type Test struct{}
+
+func (m *Test) Id() string {
+	return "NOOOO!!!!"
+}

--- a/core/integration/testdata/modules/python/id/arg/src/main.py
+++ b/core/integration/testdata/modules/python/id/arg/src/main.py
@@ -1,0 +1,5 @@
+from dagger.mod import function
+
+@function
+def fn(id: str) -> str:
+    return "NOOOO!!!!"

--- a/core/integration/testdata/modules/python/id/fn/src/main.py
+++ b/core/integration/testdata/modules/python/id/fn/src/main.py
@@ -1,0 +1,5 @@
+from dagger.mod import function
+
+@function
+def id() -> str:
+    return "NOOOO!!!!"

--- a/internal/mage/util/util.go
+++ b/internal/mage/util/util.go
@@ -80,6 +80,7 @@ func RepositoryGoCodeOnly(c *dagger.Client) *dagger.Directory {
 			"**/README.md", // needed for examples test
 			"**/help.txt",  // needed for linting module bootstrap code
 			"sdk/go/codegen/generator/nodejs/templates/src/testdata/**/*",
+			"core/integration/testdata/**/*",
 
 			// Go SDK runtime codegen
 			"**/dagger.json",


### PR DESCRIPTION
ID is a special reserved word in our schema and before this change resulted in incomprehensible errors when trying to consume modules that used it in field names. Now we just block these modules from being loaded and return a more comprehensible error.

Ref: https://discord.com/channels/707636530424053791/1167533512652509324/1167541884785266718