### PR TITLE
Move python module codegen introspection to cli

### DIFF
--- a/internal/mage/sdk/python.go
+++ b/internal/mage/sdk/python.go
@@ -147,7 +147,7 @@ func (t Python) Generate(ctx context.Context) error {
 		WithMountedFile(cliBinPath, util.DaggerBinary(c)).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
 		WithWorkdir("/").
-		WithExec([]string{cliBinPath, "run", "python", "-m", "dagger", "generate", pythonGeneratedAPIPath}).
+		WithExec([]string{cliBinPath, "run", "python", "-m", "dagger", "codegen", "-o", pythonGeneratedAPIPath}).
 		WithExec([]string{"black", pythonGeneratedAPIPath}).
 		File(pythonGeneratedAPIPath).
 		Contents(ctx)

--- a/sdk/python/runtime/main.go
+++ b/sdk/python/runtime/main.go
@@ -81,7 +81,11 @@ func (m *PythonSdk) CodegenBase(modSource *Directory, subPath string, introspect
 		WithNewFile("/schema.json", ContainerWithNewFileOpts{
 			Contents: introspectionJson,
 		}).
-		WithExec([]string{"python", "-m", "dagger", "generate", path.Join(sdkSrc, genPath)}, ContainerWithExecOpts{
+		WithExec([]string{
+			"python", "-m", "dagger", "codegen",
+			"--output", path.Join(sdkSrc, genPath),
+			"--introspection", "/schema.json",
+		}, ContainerWithExecOpts{
 			ExperimentalPrivilegedNesting: true,
 		}).
 		WithExec([]string{"sh", "-c", "[ -f pyproject.toml ] || cp /templates/pyproject.toml ."}).

--- a/sdk/python/src/dagger/_codegen/cli.py
+++ b/sdk/python/src/dagger/_codegen/cli.py
@@ -1,30 +1,52 @@
+import argparse
+import json
 import sys
 
 import anyio
+import graphql
 
 from . import generator
 
+parser = argparse.ArgumentParser(
+    prog="python -m dagger", description="Dagger Python SDK"
+)
+
 
 def main():
-    path = None
-    match sys.argv[1:]:
-        case ["generate", arg]:
-            if arg != "-":
-                path = anyio.Path(arg)
-        case _:
-            sys.stderr.write("usage: python -m dagger generate PATH\n")
-            sys.exit(1)
-    anyio.run(generate, path)
+    subparsers = parser.add_subparsers(
+        title="additional commands",
+        required=True,
+    )
+    gen_parser = subparsers.add_parser(
+        "codegen",
+        help="generate a Python client for the API",
+    )
+    gen_parser.add_argument(
+        "-i",
+        "--introspection",
+        type=anyio.Path,
+        help=(
+            "path to a .json file holding the introspection result "
+            "(defaults to fetching from the API)"
+        ),
+    )
+    gen_parser.add_argument(
+        "-o",
+        "--output",
+        type=anyio.Path,
+        help=(
+            "path to save the generated python module "
+            "(defaults to printing it to stdout)"
+        ),
+    )
+    args = parser.parse_args()
+
+    # TODO: Add argument for module init.
+    anyio.run(codegen, args.output, args.introspection)
 
 
-async def generate(output: anyio.Path | None = None):
-    """Generate a client for the Dagger API."""
-    import dagger
-
-    async with await dagger.connect() as conn:
-        schema = await conn.session.get_schema()
-
-    code = generator.generate(schema)
+async def codegen(output: anyio.Path | None, introspection: anyio.Path | None):
+    code = generator.generate(await _get_schema(introspection))
 
     if output:
         await output.write_text(code)
@@ -32,6 +54,20 @@ async def generate(output: anyio.Path | None = None):
         sys.stdout.write(f"Client generated successfully to {output}\n")
     else:
         sys.stdout.write(f"{code}\n")
+
+
+async def _get_schema(path: anyio.Path | None) -> graphql.GraphQLSchema:
+    if path:
+        introspection = json.loads(await path.read_text())
+        return graphql.build_client_schema(introspection)
+
+    import dagger
+
+    try:
+        async with await dagger.connect() as conn:
+            return await conn.session.get_schema()
+    except dagger.ClientError as e:
+        parser.exit(1, f"Error: {e}\n")
 
 
 async def _update_gitattributes(output: anyio.Path) -> None:

--- a/sdk/python/src/dagger/client/_session.py
+++ b/sdk/python/src/dagger/client/_session.py
@@ -1,9 +1,7 @@
 import contextlib
-import json
 import logging
 import os
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Any
 
 import graphql
@@ -71,17 +69,9 @@ class ClientSession(ResourceManager):
             auth=(conn.session_token, ""),
         )
 
-        # test if /schema.json exists, if so, use that as the introspection schema
-        schema_path = Path("/schema.json")
-        introspection = None
-        if schema_path.exists():
-            with schema_path.open() as f:
-                introspection = json.load(f)
-
         client = GraphQLClient(
             transport=transport,
-            introspection=introspection,
-            fetch_schema_from_transport=introspection is None,
+            fetch_schema_from_transport=True,
             # We're using the timeout from the httpx transport.
             execute_timeout=None,
         )


### PR DESCRIPTION
This is a missing commit from https://github.com/dagger/dagger/pull/5964

With the introspection we avoid having to make a connection to the API at all, which also avoids any issue importing an incomplete or non-importable `dagger` package (due to errors).

Cleaned up the python cli in preparation for moving the `mod init` templates there. Typer would have been a better choice for sys.argv parsing but I still wanted to avoid adding a dependency just for this.