### PR TITLE
Fix for mod deps blowing up ID size

### DIFF
--- a/core/schema/schema.go
+++ b/core/schema/schema.go
@@ -54,9 +54,10 @@ func New(params InitializeArgs) (*MergedSchemas, error) {
 		services:     svcs,
 		host:         core.NewHost(),
 
-		buildCache:  core.NewCacheMap[uint64, *core.Container](),
-		importCache: core.NewCacheMap[uint64, *specs.Descriptor](),
-		moduleCache: core.NewCacheMap[digest.Digest, *core.Module](),
+		buildCache:        core.NewCacheMap[uint64, *core.Container](),
+		importCache:       core.NewCacheMap[uint64, *specs.Descriptor](),
+		moduleCache:       core.NewCacheMap[digest.Digest, *core.Module](),
+		dependenciesCache: core.NewCacheMap[digest.Digest, []*core.Module](),
 
 		schemaViews:    map[digest.Digest]*schemaView{},
 		moduleContexts: map[digest.Digest]*moduleContext{},
@@ -75,9 +76,10 @@ type MergedSchemas struct {
 	host         *core.Host
 	services     *core.Services
 
-	buildCache  *core.CacheMap[uint64, *core.Container]
-	importCache *core.CacheMap[uint64, *specs.Descriptor]
-	moduleCache *core.CacheMap[digest.Digest, *core.Module]
+	buildCache        *core.CacheMap[uint64, *core.Container]
+	importCache       *core.CacheMap[uint64, *specs.Descriptor]
+	moduleCache       *core.CacheMap[digest.Digest, *core.Module]
+	dependenciesCache *core.CacheMap[digest.Digest, []*core.Module]
 
 	mu sync.RWMutex
 	// Map of module digest -> schema presented to module.
@@ -123,8 +125,9 @@ func (s *MergedSchemas) initializeSchemaView(viewDigest digest.Digest) (*schemaV
 		&serviceSchema{s, s.services},
 		&hostSchema{s, s.host, s.services},
 		&moduleSchema{
-			MergedSchemas: s,
-			moduleCache:   s.moduleCache,
+			MergedSchemas:     s,
+			moduleCache:       s.moduleCache,
+			dependenciesCache: s.dependenciesCache,
 		},
 		&httpSchema{s, s.services},
 		&platformSchema{s},


### PR DESCRIPTION
We were including the full ModuleID for all deps of a Module in each ModuleID, which meant that recursive deps all got combined into a single ID for the dep and massively increased the size of the ID.

Now we remove `Dependencies` from the actual Module ID and instead just include the module refs of the deps.

To make up for the reduction in memoization of loading deps, there's a new `CacheMap` internally that de-dupes loading deps for a given module.

---

- [x] Add integ test coverage for big DAG of deps
- [x] Add some caching to make up for lack of memoizing dep modules in ID

---

Ref: https://discord.com/channels/707636530424053791/1168341591606444122/1168343528183709768

cc @kpenfound 