### PR TITLE
ci: improve test workflow runtimes

### DIFF
--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -31,11 +31,13 @@ jobs:
       size: dagger-runner-16c-64g
 
   # Run Engine tests in dev Engine so that we can spot integration failures early
+  # Only run a subset of important test cases since we just need to verify basic
+  # functionality rather than repeat every test already run in the other targets.
   testdev:
     uses: ./.github/workflows/_hack_make.yml
     secrets: inherit
     with:
-      mage-targets: engine:test
+      mage-targets: engine:testimportant
       size: dagger-runner-16c-64g
       dev-engine: true
 

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -27,17 +27,6 @@ jobs:
     uses: ./.github/workflows/_hack_make.yml
     secrets: inherit
     with:
-      mage-targets: engine:test
-      size: dagger-runner-16c-64g
-
-  # Run Engine tests with race condition detection
-  # https://go.dev/blog/race-detector
-  #
-  # Run in parallel to the regular tests so that the entire pipeline finishes quicker
-  testrace:
-    uses: ./.github/workflows/_hack_make.yml
-    secrets: inherit
-    with:
       mage-targets: engine:testrace
       size: dagger-runner-16c-64g
 


### PR DESCRIPTION
ci: just run testrace in CI, not it and test

Since runs get grouped together on our new CI runners, I am wondering if
the overhead of duplicating the same test suite (one w/ -race enabled,
one without) actually slows us down more relative to just running
testrace.

---

ci: only run container+module tests for testdev workflow.

These tests are painfully slow currently. They also are only needed to
ensure that the dev engine can build itself. Running the full test suite
against it is not necessary; running this important subset is more than
sufficient (may even be overkill still).
