### PR TITLE
ci: Add DAGGER_CLOUD_TOKEN client-side

### DIFF
--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -63,10 +63,12 @@ jobs:
             export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev
           fi
           env
-          DAGGER_CLOUD_TOKEN="${{ secrets.DAGGER_CLOUD_TOKEN }}" ./hack/make ${{ inputs.mage-targets }}
+          DAGGER_CLOUD_TOKEN="${{ secrets.DAGGER_CLOUD_TOKEN }}" ADD_TO_PROJECT_PAT="${{ secrets.ADD_TO_PROJECT_PAT }}" HEX_API_KEY="${{ secrets.HEX_API_KEY }}" ./hack/make ${{ inputs.mage-targets }}
         env:
           _EXPERIMENTAL_DAGGER_RUNNER_HOST: "unix:///var/run/buildkit/buildkitd.sock"
           DAGGER_CLOUD_TOKEN: "${{ secrets.DAGGER_CLOUD_TOKEN }}"
+          ADD_TO_PROJECT_PAT: "${{ secrets.ADD_TO_PROJECT_PAT }}"
+          HEX_API_KEY: "${{ secrets.HEX_API_KEY }}"
       - name: "ALWAYS print kernel logs - especialy useful on failure"
         if: always()
         run: sudo dmesg

--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -39,8 +39,6 @@ jobs:
             export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev
           fi
           ./hack/make ${{ inputs.mage-targets }}
-        env:
-          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
       - name: "ALWAYS print kernel logs - especialy useful on failure"
         if: always()
         run: sudo dmesg

--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -62,7 +62,8 @@ jobs:
             chmod +x $_EXPERIMENTAL_DAGGER_CLI_BIN
             export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev
           fi
-          ./hack/make ${{ inputs.mage-targets }}
+          env
+          DAGGER_CLOUD_TOKEN="${{ secrets.DAGGER_CLOUD_TOKEN }}" ./hack/make ${{ inputs.mage-targets }}
         env:
           _EXPERIMENTAL_DAGGER_RUNNER_HOST: "unix:///var/run/buildkit/buildkitd.sock"
           DAGGER_CLOUD_TOKEN: "${{ secrets.DAGGER_CLOUD_TOKEN }}"

--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -67,6 +67,7 @@ jobs:
           ./hack/make ${{ inputs.mage-targets }}
         env:
           _EXPERIMENTAL_DAGGER_RUNNER_HOST: "unix:///var/run/buildkit/buildkitd.sock"
+          DAGGER_CLOUD_TOKEN: "${{ secrets.DAGGER_CLOUD_TOKEN }}"
       - name: "ALWAYS print kernel logs - especialy useful on failure"
         if: always()
         run: sudo dmesg


### PR DESCRIPTION
Without this, even though the Engine already has this env var, runs will **NOT** appear in https://dagger.cloud

To test the above, I have not yet configured this secret in the repository. I will do a follow-up commit after the secret is set. If the above is correct, the run for the first commit will not show in https://dagger.cloud