### PR TITLE
Add DAGGER_CLOUD_TOKEN client-side so that we get telemetry in Cloud

### DIFF
--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -39,8 +39,6 @@ jobs:
             export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev
           fi
           ./hack/make ${{ inputs.mage-targets }}
-        env:
-          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
       - name: "ALWAYS print kernel logs - especialy useful on failure"
         if: always()
         run: sudo dmesg

--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -67,6 +67,7 @@ jobs:
           ./hack/make ${{ inputs.mage-targets }}
         env:
           _EXPERIMENTAL_DAGGER_RUNNER_HOST: "unix:///var/run/buildkit/buildkitd.sock"
+          DAGGER_CLOUD_TOKEN: "${{ secrets.DAGGER_CLOUD_TOKEN }}"
       - name: "ALWAYS print kernel logs - especialy useful on failure"
         if: always()
         run: sudo dmesg

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,5 +20,6 @@ permissions:
 jobs:
   lint:
     uses: ./.github/workflows/_hack_make.yml
+    secrets: inherit
     with:
       mage-targets: docs:lint

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -19,11 +19,13 @@ permissions:
 jobs:
   lint:
     uses: ./.github/workflows/_hack_make.yml
+    secrets: inherit
     with:
       mage-targets: engine:lint
 
   test:
     uses: ./.github/workflows/_hack_make.yml
+    secrets: inherit
     with:
       mage-targets: engine:test
       size: dagger-runner-16c-64g
@@ -34,6 +36,7 @@ jobs:
   # Run in parallel to the regular tests so that the entire pipeline finishes quicker
   testrace:
     uses: ./.github/workflows/_hack_make.yml
+    secrets: inherit
     with:
       mage-targets: engine:testrace
       size: dagger-runner-16c-64g
@@ -41,6 +44,7 @@ jobs:
   # Run Engine tests in dev Engine so that we can spot integration failures early
   testdev:
     uses: ./.github/workflows/_hack_make.yml
+    secrets: inherit
     with:
       mage-targets: engine:test
       size: dagger-runner-16c-64g
@@ -48,11 +52,13 @@ jobs:
 
   test-publish-cli:
     uses: ./.github/workflows/_hack_make.yml
+    secrets: inherit
     with:
       mage-targets: cli:testpublish
 
   test-publish-engine:
     uses: ./.github/workflows/_hack_make.yml
+    secrets: inherit
     with:
       mage-targets: engine:testpublish
 
@@ -69,6 +75,9 @@ jobs:
       - name: "Build Dev Engine"
         run: |
           ./hack/dev
+        env:
+          _EXPERIMENTAL_DAGGER_RUNNER_HOST: "unix:///var/run/buildkit/buildkitd.sock"
+          DAGGER_CLOUD_TOKEN: "${{ secrets.DAGGER_CLOUD_TOKEN }}"
       - name: "Scan Dev Engine for Vulnerabilities"
         uses: aquasecurity/trivy-action@0.11.2
         with:

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -19,5 +19,6 @@ permissions:
 jobs:
   test:
     uses: ./.github/workflows/_hack_make.yml
+    secrets: inherit
     with:
       mage-targets: helm:test

--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -17,16 +17,7 @@ jobs:
           go-version: "1.20"
 
       - name: "Publish Helm Chart"
+        run: ./hack/make helm:publish ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}
-          _EXPERIMENTAL_DAGGER_JOURNAL: "/tmp/journal.log"
-          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
-        run: ./hack/make helm:publish ${{ github.ref_name }}
-
-      - uses: actions/upload-artifact@v3
-        if: always()
-        name: "Upload journal.log"
-        continue-on-error: true
-        with:
-          name: ${{ github.workflow }}-${{ github.job }}-journal.log
-          path: /tmp/journal.log
+          DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}

--- a/.github/workflows/publish-sdk-elixir.yml
+++ b/.github/workflows/publish-sdk-elixir.yml
@@ -14,13 +14,5 @@ jobs:
       - run: ./hack/make sdk:elixir:publish ${{ github.ref_name }}
         env:
           GITHUB_PAT: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}
-          _EXPERIMENTAL_DAGGER_JOURNAL: "/tmp/journal.log"
-          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
           HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
-      - uses: actions/upload-artifact@v3
-        if: always()
-        name: "Upload journal.log"
-        continue-on-error: true
-        with:
-          name: ${{ github.workflow }}-${{ github.job }}-journal.log
-          path: /tmp/journal.log
+          DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}

--- a/.github/workflows/publish-sdk-go.yml
+++ b/.github/workflows/publish-sdk-go.yml
@@ -15,12 +15,4 @@ jobs:
       - run: ./hack/make sdk:go:publish ${{ github.ref_name }}
         env:
           GITHUB_PAT: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}
-          _EXPERIMENTAL_DAGGER_JOURNAL: "/tmp/journal.log"
-          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
-      - uses: actions/upload-artifact@v3
-        if: always()
-        name: "Upload journal.log"
-        continue-on-error: true
-        with:
-          name: ${{ github.workflow }}-${{ github.job }}-journal.log
-          path: /tmp/journal.log
+          DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}

--- a/.github/workflows/publish-sdk-nodejs.yml
+++ b/.github/workflows/publish-sdk-nodejs.yml
@@ -13,12 +13,4 @@ jobs:
       - run: ./hack/make sdk:nodejs:publish ${{ github.ref_name }}
         env:
           NPM_TOKEN: ${{ secrets.RELEASE_NPM_TOKEN }}
-          _EXPERIMENTAL_DAGGER_JOURNAL: "/tmp/journal.log"
-          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
-      - uses: actions/upload-artifact@v3
-        if: always()
-        name: "Upload journal.log"
-        continue-on-error: true
-        with:
-          name: ${{ github.workflow }}-${{ github.job }}-journal.log
-          path: /tmp/journal.log
+          DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}

--- a/.github/workflows/publish-sdk-python.yml
+++ b/.github/workflows/publish-sdk-python.yml
@@ -14,12 +14,4 @@ jobs:
         env:
           PYPI_REPO: ${{ secrets.RELEASE_PYPI_REPO }}
           PYPI_TOKEN: ${{ secrets.RELEASE_PYPI_TOKEN }}
-          _EXPERIMENTAL_DAGGER_JOURNAL: "/tmp/journal.log"
-          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
-      - uses: actions/upload-artifact@v3
-        if: always()
-        name: "Upload journal.log"
-        continue-on-error: true
-        with:
-          name: ${{ github.workflow }}-${{ github.job }}-journal.log
-          path: /tmp/journal.log
+          DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}

--- a/.github/workflows/publish-sdk-rust.yml
+++ b/.github/workflows/publish-sdk-rust.yml
@@ -15,12 +15,4 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           CARGO_PUBLISH_DRYRUN: "false"
-          _EXPERIMENTAL_DAGGER_JOURNAL: "/tmp/journal.log"
-          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
-      - uses: actions/upload-artifact@v3
-        if: always()
-        name: "Upload journal.log"
-        continue-on-error: true
-        with:
-          name: ${{ github.workflow }}-${{ github.job }}-journal.log
-          path: /tmp/journal.log
+          DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}

--- a/.github/workflows/sdk-elixir.yml
+++ b/.github/workflows/sdk-elixir.yml
@@ -19,10 +19,12 @@ permissions:
 jobs:
   lint:
     uses: ./.github/workflows/_hack_make.yml
+    secrets: inherit
     with:
       mage-targets: sdk:elixir:lint
 
   test:
     uses: ./.github/workflows/_hack_make.yml
+    secrets: inherit
     with:
       mage-targets: sdk:elixir:test

--- a/.github/workflows/sdk-go.yml
+++ b/.github/workflows/sdk-go.yml
@@ -19,10 +19,12 @@ permissions:
 jobs:
   lint:
     uses: ./.github/workflows/_hack_make.yml
+    secrets: inherit
     with:
       mage-targets: sdk:go:lint
 
   test:
     uses: ./.github/workflows/_hack_make.yml
+    secrets: inherit
     with:
       mage-targets: sdk:go:test

--- a/.github/workflows/sdk-java.yml
+++ b/.github/workflows/sdk-java.yml
@@ -19,10 +19,12 @@ permissions:
 jobs:
   lint:
     uses: ./.github/workflows/_hack_make.yml
+    secrets: inherit
     with:
       mage-targets: sdk:java:lint
 
   test:
     uses: ./.github/workflows/_hack_make.yml
+    secrets: inherit
     with:
       mage-targets: sdk:java:test

--- a/.github/workflows/sdk-nodejs.yml
+++ b/.github/workflows/sdk-nodejs.yml
@@ -19,10 +19,12 @@ permissions:
 jobs:
   lint:
     uses: ./.github/workflows/_hack_make.yml
+    secrets: inherit
     with:
       mage-targets: sdk:nodejs:lint
 
   test:
     uses: ./.github/workflows/_hack_make.yml
+    secrets: inherit
     with:
       mage-targets: sdk:nodejs:test

--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   lint:
     uses: ./.github/workflows/_hack_make.yml
+    secrets: inherit
     with:
       mage-targets: sdk:python:lint
 
@@ -31,4 +32,4 @@ jobs:
           go-version: "1.20"
       - run: ./hack/make sdk:python:test
         env:
-          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
+          DAGGER_CLOUD_TOKEN: "${{ secrets.DAGGER_CLOUD_TOKEN }}"

--- a/.github/workflows/sdk-rust.yml
+++ b/.github/workflows/sdk-rust.yml
@@ -19,12 +19,14 @@ permissions:
 jobs:
   lint:
     uses: ./.github/workflows/_hack_make.yml
+    secrets: inherit
     with:
       mage-targets: sdk:rust:lint
       size: dagger-runner-16c-64g
 
   test:
     uses: ./.github/workflows/_hack_make.yml
+    secrets: inherit
     with:
       mage-targets: sdk:rust:test
       size: dagger-runner-16c-64g


### PR DESCRIPTION
Without this, runs will **not** appear in <https://dagger.cloud>

Since this is an org-wide secret, and secrets are not shared with PRs coming from forks, we will not see runs in <https://dagger.cloud> until the change executes in the context of our repository (most likely merge to `main`).

---

This is a follow-up to:
- https://github.com/dagger/dagger/pull/6019