### PR TITLE
cli: rename `use` command to `install`.

### DIFF
--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -60,7 +60,7 @@ func init() {
 	// also include codegen flags since codegen will run on module init
 
 	moduleCmd.AddCommand(moduleInitCmd)
-	moduleCmd.AddCommand(moduleUseCmd)
+	moduleCmd.AddCommand(moduleInstallCmd)
 	moduleCmd.AddCommand(moduleSyncCmd)
 	moduleCmd.AddCommand(modulePublishCmd)
 }
@@ -136,10 +136,11 @@ var moduleInitCmd = &cobra.Command{
 	},
 }
 
-var moduleUseCmd = &cobra.Command{
-	Use:    "use",
-	Short:  "Add a new dependency to a dagger module",
-	Hidden: false,
+var moduleInstallCmd = &cobra.Command{
+	Use:     "install",
+	Aliases: []string{"use"},
+	Short:   "Add a new dependency to a dagger module",
+	Hidden:  false,
 	RunE: func(cmd *cobra.Command, extraArgs []string) (rerr error) {
 		ctx := cmd.Context()
 		return withEngineAndTUI(ctx, client.Params{}, func(ctx context.Context, engineClient *client.Client) (err error) {

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -1184,7 +1184,7 @@ func TestModuleUseLocal(t *testing.T) {
 			WithNewFile("/work/main.go", dagger.ContainerWithNewFileOpts{
 				Contents: useOuter,
 			}).
-			With(daggerExec("mod", "use", "./dep")).
+			With(daggerExec("mod", "install", "./dep")).
 			WithEnvVariable("BUST", identity.NewID()) // NB(vito): hmm...
 
 		logGen(ctx, t, modGen.Directory("."))
@@ -1211,7 +1211,7 @@ func TestModuleUseLocal(t *testing.T) {
 			}).
 			WithWorkdir("/work").
 			With(daggerExec("mod", "init", "--name=use", "--sdk=python")).
-			With(daggerExec("mod", "use", "./dep")).
+			With(daggerExec("mod", "install", "./dep")).
 			WithNewFile("/work/src/main.py", dagger.ContainerWithNewFileOpts{
 				Contents: `from dagger.mod import function
 import dagger
@@ -1253,7 +1253,7 @@ func TestModuleCodegenonDepChange(t *testing.T) {
 			WithNewFile("/work/main.go", dagger.ContainerWithNewFileOpts{
 				Contents: useOuter,
 			}).
-			With(daggerExec("mod", "use", "./dep"))
+			With(daggerExec("mod", "install", "./dep"))
 
 		logGen(ctx, t, modGen.Directory("."))
 
@@ -1298,7 +1298,7 @@ func TestModuleCodegenonDepChange(t *testing.T) {
 			}).
 			WithWorkdir("/work").
 			With(daggerExec("mod", "init", "--name=use", "--sdk=python")).
-			With(daggerExec("mod", "use", "./dep")).
+			With(daggerExec("mod", "install", "./dep")).
 			WithNewFile("/work/src/main.py", dagger.ContainerWithNewFileOpts{
 				Contents: `from dagger.mod import function
 import dagger
@@ -1373,8 +1373,8 @@ func (m *Bar) Name() string { return "bar" }
 		With(daggerExec("mod", "init", "--name=bar", "--sdk=go")).
 		WithWorkdir("/work").
 		With(daggerExec("mod", "init", "--name=use", "--sdk=go")).
-		With(daggerExec("mod", "use", "./foo")).
-		With(daggerExec("mod", "use", "./bar")).
+		With(daggerExec("mod", "install", "./foo")).
+		With(daggerExec("mod", "install", "./bar")).
 		WithNewFile("/work/main.go", dagger.ContainerWithNewFileOpts{
 			Contents: `package main
 
@@ -1792,7 +1792,7 @@ func TestModuleGoSyncDeps(t *testing.T) {
 		WithNewFile("/work/main.go", dagger.ContainerWithNewFileOpts{
 			Contents: useOuter,
 		}).
-		With(daggerExec("mod", "use", "./dep"))
+		With(daggerExec("mod", "install", "./dep"))
 
 	logGen(ctx, t, modGen.Directory("."))
 

--- a/docs/current/labs/project-zenith.md
+++ b/docs/current/labs/project-zenith.md
@@ -225,11 +225,11 @@ echo '{potato{helloWorld(message: "I am a potato"){message, from}}}' | dagger qu
 
 ### Call other modules
 
-Modules can call each other! To add a dependency to your module, you can use
-`dagger mod use`:
+Modules can call each other! To add a dependency to your module, you can run
+`dagger mod install`:
 
 ```sh
-dagger mod use github.com/shykes/daggerverse/helloWorld@26f8ed9f1748ec8c9345281add850fd392441990
+dagger mod install github.com/shykes/daggerverse/helloWorld@26f8ed9f1748ec8c9345281add850fd392441990
 ```
 
 This module will be added to your `dagger.json`:
@@ -240,11 +240,11 @@ This module will be added to your `dagger.json`:
   ]
 ```
 
-You can also use local modules as dependencies. However, they must be stored in
+You can also install local modules as dependencies. However, they must be stored in
 a sub-directory of your module. For example:
 
 ```sh
-dagger mod use ./path/to/module
+dagger mod install ./path/to/module
 ```
 
 The module will be added to your codegeneration, so you can access it from your
@@ -256,12 +256,12 @@ func (m *Potato) HelloWorld(ctx context.Context) (string, error) {
 }
 ```
 
-You can find other modules to use on <https://daggerverse.dev>.
+You can find other modules to install on <https://daggerverse.dev>.
 
 #### Module locations
 
 You can consume modules from lots of different sources. The easiest way to
-`dagger use`, `dagger call`, or `dagger query` a module is to reference it by its GitHub URL
+`dagger install`, `dagger call`, or `dagger query` a module is to reference it by its GitHub URL
 (similar to Go package strings).
 
 For example:


### PR DESCRIPTION
`install` is more common for this type of functionality in similar tools.

`use` remains as an alias of `install`.