### PR TITLE
go sdk: fix user global var that references dag

### DIFF
--- a/cmd/codegen/generator/go/templates/src/module.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/module.go.tmpl
@@ -3,11 +3,14 @@ type Client struct {
 	q *querybuilder.Selection
 }
 
-var dag *Client
+var dag = initDag()
 
-func init() {
+// initializing the var dag directly rather than using
+// an init func so that users can successfully use dag
+// in any global var initialization of their own code
+func initDag() *Client {
   gqlClient, q := getClientParams()
-	dag = &Client{
+	return &Client{
 		c: gqlClient,
 		q: q,
 	}


### PR DESCRIPTION
Before this, if a user defined a var that called `dag`, they'd hit a panic because `dag` wasn't initialized yet.

This was because we were initializing `dag` in an `init` func, but go evaluates global vars first.

This fixes that situation by initializing `dag` as a var.

---

Ref: https://discord.com/channels/707636530424053791/1168640248666914846/1168640461460750396