### PR TITLE
dagger call: fix returning a list of objects with functions

### DIFF
--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -27,13 +27,28 @@ var callCmd = &FuncCommand{
 		return nil
 	},
 	AfterResponse: func(_ *FuncCommand, cmd *cobra.Command, _ *modTypeDef, response any) error {
-		if list, ok := (response).([]any); ok {
-			for _, v := range list {
-				cmd.Printf("%+v\n", v)
-			}
-			return nil
-		}
-		cmd.Printf("%+v\n", response)
-		return nil
+		return printResponse(cmd, response)
 	},
+}
+
+func printResponse(cmd *cobra.Command, r any) error {
+	switch t := r.(type) {
+	case []any:
+		for _, v := range t {
+			if err := printResponse(cmd, v); err != nil {
+				return err
+			}
+		}
+		return nil
+	case map[string]any:
+		for _, v := range t {
+			if err := printResponse(cmd, v); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		cmd.Printf("%+v\n", t)
+	}
+	return nil
 }

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -507,7 +507,11 @@ func (fc *FuncCommand) makeSubCmd(dag *dagger.Client, fn *modFunction) *cobra.Co
 				}
 			}
 
-			fc.addSubCommands(cmd, dag, fn.ReturnType.AsObject)
+			obj := fn.ReturnType.AsObject
+			if obj == nil && fn.ReturnType.AsList != nil {
+				obj = fn.ReturnType.AsList.ElementTypeDef.AsObject
+			}
+			fc.addSubCommands(cmd, dag, obj)
 
 			// Show help for first command that has the --help flag.
 			if help {
@@ -521,7 +525,12 @@ func (fc *FuncCommand) makeSubCmd(dag *dagger.Client, fn *modFunction) *cobra.Co
 		// This is going to be executed in the "execution" vertex, when
 		// we have the final/leaf command.
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			if fn.ReturnType.AsObject != nil && len(fn.ReturnType.AsObject.GetFunctions()) > 0 {
+			obj := fn.ReturnType.AsObject
+			if obj == nil && fn.ReturnType.AsList != nil {
+				obj = fn.ReturnType.AsList.ElementTypeDef.AsObject
+			}
+
+			if obj != nil && len(obj.GetFunctions()) > 0 {
 				fc.showUsage = true
 				return fmt.Errorf("%q requires a sub-command", cmd.Name())
 			}

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -598,6 +598,9 @@ func (m *moduleDef) LoadObject(typeDef *modTypeDef) {
 			typeDef.AsObject = obj
 		}
 	}
+	if typeDef.AsList != nil {
+		m.LoadObject(typeDef.AsList.ElementTypeDef)
+	}
 }
 
 // modTypeDef is a representation of dagger.TypeDef.


### PR DESCRIPTION
### Before

```console
$ dagger -m github.com/shykes/daggerverse/supergit call remote --url https://github.com/dagger/dagger tags name
✘ dagger call remote tags ERROR [0.00s]
┃ Error: unknown command "name" for "dagger call remote tags"                        
• Cloud URL: https://dagger.cloud/runs/143cd139-e3d5-423b-8558-09a118923dd6
• Engine: 002636d876e8 (version devel ())
⧗ 2.50s ✔ 175 ∅ 4 ✘ 1
```

### After

```console
$ dagger -m github.com/shykes/daggerverse/supergit call remote --url https://github.com/dagger/dagger tags name
✔ dagger call remote tags name [1.62s]
┃ sdk/cue/v0.1.0
┃ sdk/cue/v0.2.232
┃ sdk/elixir/v0.8.2
┃ sdk/elixir/v0.8.4
┃ sdk/elixir/v0.8.5
┃ sdk/elixir/v0.8.6
┃ sdk/elixir/v0.8.7
┃ sdk/elixir/v0.8.8
┃ sdk/elixir/v0.9.0
┃ sdk/elixir/v0.9.1
┃ sdk/go/v0.3.0
┃ sdk/go/v0.3.0-alpha.1
┃ sdk/go/v0.3.0-alpha.2
┃ sdk/go/v0.3.0-alpha.3
┃ sdk/go/v0.3.0-alpha.4
┃ sdk/go/v0.3.0-alpha.5
┃ sdk/go/v0.3.1
┃ sdk/go/v0.4.0
┃ sdk/go/v0.4.1
┃ sdk/go/v0.4.2
┃ sdk/go/v0.4.3
┃ sdk/go/v0.4.4
┃ sdk/go/v0.4.5
┃ sdk/go/v0.4.6
┃ sdk/go/v0.5.0
┃ sdk/go/v0.5.1
┃ sdk/go/v0.5.2
┃ sdk/go/v0.6.0
┃ sdk/go/v0.6.1
┃ sdk/go/v0.6.2
┃ sdk/go/v0.6.3
┃ sdk/go/v0.7.0
┃ sdk/go/v0.7.1
┃ sdk/go/v0.7.2
┃ sdk/go/v0.7.3
┃ sdk/go/v0.7.4
┃ sdk/go/v0.8.0
┃ sdk/go/v0.8.1
┃ sdk/go/v0.8.2
┃ sdk/go/v0.8.3
┃ sdk/go/v0.8.4
┃ sdk/go/v0.8.5
┃ sdk/go/v0.8.6
┃ sdk/go/v0.8.7
┃ sdk/go/v0.8.8
┃ sdk/go/v0.9.0
┃ sdk/go/v0.9.1
┃ sdk/nodejs/v0.1.0
┃ sdk/nodejs/v0.1.0-alpha.4
┃ sdk/nodejs/v0.1.1
┃ sdk/nodejs/v0.2.0
┃ sdk/nodejs/v0.2.1
┃ sdk/nodejs/v0.3.0
┃ sdk/nodejs/v0.3.1
┃ sdk/nodejs/v0.3.2
┃ sdk/nodejs/v0.3.3
┃ sdk/nodejs/v0.3.4
┃ sdk/nodejs/v0.3.5
┃ sdk/nodejs/v0.4.0
┃ sdk/nodejs/v0.4.1
┃ sdk/nodejs/v0.4.2
┃ sdk/nodejs/v0.5.0
┃ sdk/nodejs/v0.5.1
┃ sdk/nodejs/v0.5.2
┃ sdk/nodejs/v0.5.3
┃ sdk/nodejs/v0.6.0
┃ sdk/nodejs/v0.6.1
┃ sdk/nodejs/v0.6.2
┃ sdk/nodejs/v0.6.3
┃ sdk/nodejs/v0.6.4
┃ sdk/nodejs/v0.8.0
┃ sdk/nodejs/v0.8.1
┃ sdk/nodejs/v0.8.2
┃ sdk/nodejs/v0.8.4
┃ sdk/nodejs/v0.8.5
┃ sdk/nodejs/v0.8.6
┃ sdk/nodejs/v0.8.7
┃ sdk/nodejs/v0.8.8
┃ sdk/nodejs/v0.9.0
┃ sdk/nodejs/v0.9.1
┃ sdk/python/v0.1.0-alpha.1
┃ sdk/python/v0.1.0-alpha.1^{}
┃ sdk/python/v0.1.1
┃ sdk/python/v0.2.0
┃ sdk/python/v0.2.1
┃ sdk/python/v0.3.0
┃ sdk/python/v0.3.1
┃ sdk/python/v0.3.2
┃ sdk/python/v0.3.3
┃ sdk/python/v0.4.0
┃ sdk/python/v0.4.1
┃ sdk/python/v0.4.2
┃ sdk/python/v0.5.0
┃ sdk/python/v0.5.1
┃ sdk/python/v0.5.2
┃ sdk/python/v0.5.3
┃ sdk/python/v0.5.4
┃ sdk/python/v0.6.0
┃ sdk/python/v0.6.1
┃ sdk/python/v0.6.2
┃ sdk/python/v0.6.3
┃ sdk/python/v0.6.4
┃ sdk/python/v0.8.0
┃ sdk/python/v0.8.1
┃ sdk/python/v0.8.2
┃ sdk/python/v0.8.4
┃ sdk/python/v0.8.5
┃ sdk/python/v0.8.6
┃ sdk/python/v0.8.7
┃ sdk/python/v0.8.8
┃ sdk/python/v0.9.0
┃ sdk/python/v0.9.1
┃ v0.1.0
┃ v0.1.0-alpha.1
┃ v0.1.0-alpha.10
┃ v0.1.0-alpha.11
┃ v0.1.0-alpha.12
┃ v0.1.0-alpha.13
┃ v0.1.0-alpha.14
┃ v0.1.0-alpha.15
┃ v0.1.0-alpha.16
┃ v0.1.0-alpha.17
┃ v0.1.0-alpha.18
┃ v0.1.0-alpha.19
┃ v0.1.0-alpha.2
┃ v0.1.0-alpha.2^{}
┃ v0.1.0-alpha.20
┃ v0.1.0-alpha.21
┃ v0.1.0-alpha.22
┃ v0.1.0-alpha.23
┃ v0.1.0-alpha.24
┃ v0.1.0-alpha.25
┃ v0.1.0-alpha.26
┃ v0.1.0-alpha.27
┃ v0.1.0-alpha.28
┃ v0.1.0-alpha.29
┃ v0.1.0-alpha.3
┃ v0.1.0-alpha.3^{}
┃ v0.1.0-alpha.30
┃ v0.1.0-alpha.31
┃ v0.1.0-alpha.32
┃ v0.1.0-alpha.32^{}
┃ v0.1.0-alpha.4
┃ v0.1.0-alpha.4^{}
┃ v0.1.0-alpha.5
┃ v0.1.0-alpha.6
┃ v0.1.0-alpha.6^{}
┃ v0.1.0-alpha.7
┃ v0.1.0-alpha.8
┃ v0.1.0-alpha.8^{}
┃ v0.1.0-alpha.9
┃ v0.2.0
┃ v0.2.0-alpha.1
┃ v0.2.0-alpha.2
┃ v0.2.0-alpha.3
┃ v0.2.0-alpha.4
┃ v0.2.0-alpha.5
┃ v0.2.0-alpha.6
┃ v0.2.0-beta.1
┃ v0.2.0-beta.2
┃ v0.2.0-rc.1
┃ v0.2.1
┃ v0.2.10
┃ v0.2.11
┃ v0.2.12
┃ v0.2.13
┃ v0.2.14
┃ v0.2.15
┃ v0.2.16
┃ v0.2.17
┃ v0.2.18
┃ v0.2.19
┃ v0.2.2
┃ v0.2.20
┃ v0.2.21
┃ v0.2.22
┃ v0.2.23
┃ v0.2.24
┃ v0.2.25
┃ v0.2.26
┃ v0.2.27
┃ v0.2.28
┃ v0.2.29
┃ v0.2.3
┃ v0.2.30
┃ v0.2.31
┃ v0.2.32
┃ v0.2.33
┃ v0.2.34
┃ v0.2.35
┃ v0.2.36
┃ v0.2.4
┃ v0.2.5
┃ v0.2.6
┃ v0.2.7
┃ v0.2.8
┃ v0.2.9
┃ v0.3.0
┃ v0.3.0-alpha.1
┃ v0.3.1
┃ v0.3.10
┃ v0.3.12
┃ v0.3.13
┃ v0.3.2
┃ v0.3.3
┃ v0.3.4
┃ v0.3.5
┃ v0.3.6
┃ v0.3.7
┃ v0.3.8
┃ v0.3.9
┃ v0.4.0
┃ v0.4.1
┃ v0.4.2
┃ v0.5.0
┃ v0.5.1
┃ v0.5.2
┃ v0.5.3
┃ v0.6.0
┃ v0.6.1
┃ v0.6.1^{}
┃ v0.6.2
┃ v0.6.3
┃ v0.6.4
┃ v0.8.0
┃ v0.8.1
┃ v0.8.2
┃ v0.8.3
┃ v0.8.4
┃ v0.8.5
┃ v0.8.6
┃ v0.8.7
┃ v0.8.8
┃ v0.9.0
┃ v0.9.1
• Engine: ce7e1c9c80d0 (version devel ())
⧗ 6.23s ✔ 212 ∅ 7
```