### PR TITLE
ci: add some primitive tests for daggerverse modules

### DIFF
--- a/core/integration/daggerverse_test.go
+++ b/core/integration/daggerverse_test.go
@@ -1,0 +1,68 @@
+//go:build daggerverse_tests
+
+package core
+
+import (
+	"testing"
+
+	"dagger.io/dagger"
+	"github.com/stretchr/testify/require"
+)
+
+// TODO: dynamically update this list? Currently would require web-scraping...
+// This is incomplete. Also nothing is pinned.
+var testedModules = []string{
+	"github.com/kpenfound/dagger-modules/golang",
+	"github.com/kpenfound/dagger-modules/netlify",
+	"github.com/kpenfound/dagger-modules/fly",
+	"github.com/kpenfound/dagger-modules/encircle",
+	"github.com/kpenfound/dagger-modules/vault",
+	"github.com/kpenfound/dagger-modules/proxy",
+	"github.com/kpenfound/dagger-modules/secretsmanager",
+
+	"github.com/jpadams/daggerverse/trivy",
+	"github.com/jpadams/daggerverse/drupalTest",
+	"github.com/jpadams/daggerverse/mariadb",
+	"github.com/jpadams/daggerverse/drupal",
+	"github.com/jpadams/daggerverse/staticcheck",
+	"github.com/jpadams/daggerverse/goVersion",
+	"github.com/jpadams/daggerverse/helloSecret",
+
+	"github.com/shykes/daggerverse/imagemagick",
+	"github.com/shykes/daggerverse/dagger",
+	"github.com/shykes/daggerverse/helloWorld",
+	"github.com/shykes/daggerverse/make",
+	"github.com/shykes/daggerverse/myip",
+	"github.com/shykes/daggerverse/datetime",
+	"github.com/shykes/daggerverse/tailscale",
+
+	"github.com/aweris/daggerverse/kind",
+	"github.com/aweris/daggerverse/gh",
+	"github.com/aweris/daggerverse/helm",
+	"github.com/aweris/daggerverse/kubectl",
+	"github.com/aweris/daggerverse/gale",
+
+	"github.com/quartz-technology/daggerverse/node",
+	"github.com/quartz-technology/daggerverse/redis",
+}
+
+func TestDaggerverse(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := connect(t)
+
+	for _, moduleName := range testedModules {
+		moduleName := moduleName
+		t.Run(moduleName, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := c.Container().From("alpine:3.18").
+				WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+				WithExec([]string{testCLIBinPath, "-m", moduleName, "functions"}, dagger.ContainerWithExecOpts{
+					ExperimentalPrivilegedNesting: true,
+				}).
+				Stdout(ctx)
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -179,18 +179,22 @@ func privateRegistry(c *dagger.Client) *dagger.Service {
 
 // Test runs Engine tests
 func (t Engine) Test(ctx context.Context) error {
-	return t.test(ctx, false, "")
+	return t.test(ctx, false, "", nil)
 }
 
 // TestRace runs Engine tests with go race detector enabled
 func (t Engine) TestRace(ctx context.Context) error {
-	return t.test(ctx, true, "")
+	return t.test(ctx, true, "", nil)
 }
 
 // TestImportant runs Engine Container+Module tests, which give good basic coverage
 // of functionality w/out having to run everything
 func (t Engine) TestImportant(ctx context.Context) error {
-	return t.test(ctx, true, `^(TestModule|TestContainer)`)
+	return t.test(ctx, true, `^(TestModule|TestContainer)`, nil)
+}
+
+func (t Engine) TestDaggerverse(ctx context.Context) error {
+	return t.test(ctx, false, "TestDaggerverse", []string{"daggerverse_tests"})
 }
 
 // TestRace runs Engine tests with go race detector enabled
@@ -324,7 +328,7 @@ func (t Engine) Dev(ctx context.Context) error {
 	return nil
 }
 
-func (t Engine) test(ctx context.Context, race bool, testRegex string) error {
+func (t Engine) test(ctx context.Context, race bool, testRegex string, tags []string) error {
 	c, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
 	if err != nil {
 		return err
@@ -351,6 +355,10 @@ func (t Engine) test(ctx context.Context, race bool, testRegex string) error {
 
 	if testRegex != "" {
 		args = append(args, "-run", testRegex)
+	}
+
+	if len(tags) > 0 {
+		args = append(args, "-tags", strings.Join(tags, ","))
 	}
 
 	args = append(args, "./...")


### PR DESCRIPTION
Long-term goal is to be able to know if we are breaking existing daggerverse modules as we make changes in PRs. Short-term goal is to know if we are breaking existing daggerverse modules being used in KubeCon.

This is incredibly barebones at the moment; just a hardcoded list of modules w/out any pinning and a test case that calls `dagger functions` on all of them in parallel in subtests. The hope is it's still useful and potentially the start of something more fleshed out over the long-term.

For now, given these modules are sometimes expected to break due to backwards-incompatible changes and/or the module code just having problems, we aren't running them in GHA (see below for details on my attempts to do that).

Instead, we'll just run these locally as needed. This is obviously very far from ideal but better than nothing to start 🤷‍♂️

They can be run locally w/ `./hack/make engine:testdaggerverse`.

---

- [x] ~~Figure out how to make a GHA workflow non-blocking ("advisory-only"). We want devs to know if they are breaking modules, but sometimes that's known and sometimes the modules are just broken.~~
   * I had to give up on this 😢. Github has ignored [feature requests](https://github.com/actions/runner/issues/662) to support "neutral" status for many years. ChatGPT had a nice suggestion to add a step that automatically writes a comment on the PR if the tests failed but let the step itself be marked as succeeded; however I ran into permission issues that I couldn't figure out and felt like they would result in PRs having too many permissions on our GH repo to create comments/issues even if solved.
   * This is still an admirable goal sometime but too much a time sink at this exact moment.