### PR TITLE
core: omit execution of multi GPU tests on single GPU environments

### DIFF
--- a/core/integration/gpu_test.go
+++ b/core/integration/gpu_test.go
@@ -128,7 +128,7 @@ func TestGPUAccess(t *testing.T) {
 				}
 
 				if len(gpus) <= 1 {
-					t.Fatal("this test requires at least 2 GPUs to run")
+					t.Skip("skipping - this test requires at least 2 GPUs to run")
 				}
 
 				// Pick first GPU and initialize a Dagger container for it:


### PR DESCRIPTION
Follow up of #5605.

Improves the experience when running integration tests locally. If multi GPU integration tests ran on single GPU environments we were previously doing `t.Fatal()`, with this PR those tests are safely skipped with a log line.

In the same way, multi GPU tests should run as expected on multi GPU environments.