### PR TITLE
Fix secret scrubbing log latency

### DIFF
--- a/cmd/shim/secret_scrub_test.go
+++ b/cmd/shim/secret_scrub_test.go
@@ -6,11 +6,17 @@ import (
 	_ "embed"
 	"fmt"
 	"io"
+	"math/rand"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"testing/fstest"
+	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/dagger/dagger/core"
-	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -240,4 +246,330 @@ func TestScrubSecretWrite(t *testing.T) {
 		require.Equal(t, len(outputLines), i)
 	})
 
+}
+
+func TestScrubSecretLogLatency(t *testing.T) {
+	t.Parallel()
+	envMap := map[string]string{
+		"foo": "TOP_SECRET",
+		"bar": strings.Repeat("a", 10_000),
+		"baz": "x",
+		"qux": "yyy",
+	}
+	env := []string{}
+	envNames := []string{}
+	for k, v := range envMap {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+		envNames = append(envNames, k)
+	}
+	secretToScrubInfo := core.SecretToScrubInfo{
+		Envs:  envNames,
+		Files: []string{},
+	}
+
+	t.Run("plain", func(t *testing.T) {
+		in, out := io.Pipe()
+		r, err := NewSecretScrubReader(in, "/", fstest.MapFS{}, env, secretToScrubInfo)
+		require.NoError(t, err)
+
+		var done atomic.Uint32
+		go func() {
+			_, err := out.Write([]byte("hello world\n"))
+			require.NoError(t, err)
+			done.Add(1)
+		}()
+		go func() {
+			buf := make([]byte, 1024)
+			n, err := r.Read(buf)
+			require.NoError(t, err)
+			require.Equal(t, "hello world\n", string(buf[:n]))
+			done.Add(1)
+		}()
+		require.Eventually(t, func() bool {
+			return done.Load() == 2
+		}, 2*time.Second, 10*time.Millisecond, "output not received")
+	})
+
+	t.Run("secret", func(t *testing.T) {
+		in, out := io.Pipe()
+		r, err := NewSecretScrubReader(in, "/", fstest.MapFS{}, env, secretToScrubInfo)
+		require.NoError(t, err)
+
+		var done atomic.Uint32
+		go func() {
+			_, err := out.Write([]byte("hello TOP_SECRET\n"))
+			require.NoError(t, err)
+			done.Add(1)
+		}()
+		go func() {
+			buf := make([]byte, 1024)
+			n, err := r.Read(buf)
+			require.NoError(t, err)
+			require.Equal(t, "hello ***\n", string(buf[:n]))
+			done.Add(1)
+		}()
+		require.Eventually(t, func() bool {
+			return done.Load() == 2
+		}, 2*time.Second, 10*time.Millisecond, "output not received")
+	})
+
+	t.Run("secret double", func(t *testing.T) {
+		in, out := io.Pipe()
+		r, err := NewSecretScrubReader(in, "/", fstest.MapFS{}, env, secretToScrubInfo)
+		require.NoError(t, err)
+
+		var done atomic.Uint32
+		go func() {
+			_, err := out.Write([]byte("hello TOP_TOP_SECRETTOP_SECRETTOP_\n"))
+			require.NoError(t, err)
+			done.Add(1)
+		}()
+		go func() {
+			buf := make([]byte, 1024)
+			n, err := r.Read(buf)
+			require.NoError(t, err)
+			require.Equal(t, "hello TOP_******TOP_\n", string(buf[:n]))
+			done.Add(1)
+		}()
+		require.Eventually(t, func() bool {
+			return done.Load() == 2
+		}, 2*time.Second, 10*time.Millisecond, "output not received")
+	})
+
+	t.Run("secret one byte", func(t *testing.T) {
+		in, out := io.Pipe()
+		r, err := NewSecretScrubReader(in, "/", fstest.MapFS{}, env, secretToScrubInfo)
+		require.NoError(t, err)
+
+		var done atomic.Uint32
+		go func() {
+			_, err := out.Write([]byte("yyx\n"))
+			require.NoError(t, err)
+			done.Add(1)
+		}()
+		go func() {
+			buf := make([]byte, 1024)
+			n, err := r.Read(buf)
+			require.NoError(t, err)
+			require.Equal(t, "yy***\n", string(buf[:n]))
+			done.Add(1)
+		}()
+		require.Eventually(t, func() bool {
+			return done.Load() == 2
+		}, 2*time.Second, 10*time.Millisecond, "output not received")
+	})
+
+	t.Run("secret half", func(t *testing.T) {
+		in, out := io.Pipe()
+		r, err := NewSecretScrubReader(in, "/", fstest.MapFS{}, env, secretToScrubInfo)
+		require.NoError(t, err)
+
+		var done atomic.Uint32
+		go func() {
+			_, err := out.Write([]byte("hello TOP_"))
+			require.NoError(t, err)
+			_, err = out.Write([]byte("SECRET!\n"))
+			require.NoError(t, err)
+			done.Add(1)
+		}()
+		go func() {
+			buf := make([]byte, 1024)
+			n, err := r.Read(buf)
+			require.NoError(t, err)
+			require.Equal(t, "hello ", string(buf[:n]))
+			n, err = r.Read(buf)
+			require.NoError(t, err)
+			require.Equal(t, "***!\n", string(buf[:n]))
+			done.Add(1)
+		}()
+		require.Eventually(t, func() bool {
+			return done.Load() == 2
+		}, 2*time.Second, 10*time.Millisecond, "output not received")
+	})
+
+	t.Run("eof", func(t *testing.T) {
+		in, out := io.Pipe()
+		r, err := NewSecretScrubReader(in, "/", fstest.MapFS{}, env, secretToScrubInfo)
+		require.NoError(t, err)
+
+		var done atomic.Uint32
+		go func() {
+			_, err := out.Write([]byte("hello TOP_"))
+			require.NoError(t, err)
+			err = out.Close()
+			require.NoError(t, err)
+			done.Add(1)
+		}()
+		go func() {
+			buf := make([]byte, 1024)
+			n, err := r.Read(buf)
+			require.NoError(t, err)
+			require.Equal(t, "hello ", string(buf[:n]))
+			n, err = r.Read(buf)
+			require.ErrorIs(t, err, io.EOF)
+			require.Equal(t, "TOP_", string(buf[:n]))
+			done.Add(1)
+		}()
+		require.Eventually(t, func() bool {
+			return done.Load() == 2
+		}, 2*time.Second, 10*time.Millisecond, "output not received")
+	})
+
+	t.Run("massive", func(t *testing.T) {
+		in, out := io.Pipe()
+		r, err := NewSecretScrubReader(in, "/", fstest.MapFS{}, env, secretToScrubInfo)
+		require.NoError(t, err)
+
+		var done atomic.Uint32
+		go func() {
+			_, err := out.Write([]byte("hello\n" + strings.Repeat("a", 7000)))
+			require.NoError(t, err)
+			_, err = out.Write([]byte(strings.Repeat("a", 3001) + "\n"))
+			require.NoError(t, err)
+
+			_, err = out.Write([]byte("hello\n" + strings.Repeat("a", 7000)))
+			require.NoError(t, err)
+			_, err = out.Write([]byte(strings.Repeat("a", 2999) + "\n"))
+			require.NoError(t, err)
+
+			done.Add(1)
+		}()
+		go func() {
+			buf := make([]byte, 4096)
+			n, err := r.Read(buf)
+			require.NoError(t, err)
+			require.Equal(t, "hello\n", string(buf[:n]))
+			n, err = r.Read(buf)
+			require.NoError(t, err)
+			require.Equal(t, "***a\n", string(buf[:n]))
+
+			n, err = r.Read(buf)
+			require.NoError(t, err)
+			require.Equal(t, "hello\n", string(buf[:n]))
+			n, err = r.Read(buf)
+			require.NoError(t, err)
+			require.Equal(t, strings.Repeat("a", 4096), string(buf[:n]))
+			n, err = r.Read(buf)
+			require.NoError(t, err)
+			require.Equal(t, strings.Repeat("a", 4096), string(buf[:n]))
+			n, err = r.Read(buf)
+			require.NoError(t, err)
+			require.Equal(t, strings.Repeat("a", 1807)+"\n", string(buf[:n]))
+
+			done.Add(1)
+		}()
+		require.Eventually(t, func() bool {
+			return done.Load() == 2
+		}, 2*time.Second, 10*time.Millisecond, "output not received")
+	})
+
+	t.Run("massive_eof", func(t *testing.T) {
+		in, out := io.Pipe()
+		r, err := NewSecretScrubReader(in, "/", fstest.MapFS{}, env, secretToScrubInfo)
+		require.NoError(t, err)
+
+		var done atomic.Uint32
+		go func() {
+			_, err := out.Write([]byte(strings.Repeat("a", 9999)))
+			require.NoError(t, err)
+			err = out.Close()
+			require.NoError(t, err)
+			done.Add(1)
+		}()
+		go func() {
+			buf := make([]byte, 4096)
+			n, err := r.Read(buf)
+			require.NoError(t, err)
+			require.Equal(t, strings.Repeat("a", 4096), string(buf[:n]))
+			n, err = r.Read(buf)
+			require.NoError(t, err)
+			require.Equal(t, strings.Repeat("a", 4096), string(buf[:n]))
+			n, err = r.Read(buf)
+			require.ErrorIs(t, err, io.EOF)
+			require.Equal(t, strings.Repeat("a", 1807), string(buf[:n]))
+			done.Add(1)
+		}()
+		require.Eventually(t, func() bool {
+			return done.Load() == 2
+		}, 2*time.Second, 10*time.Millisecond, "output not received")
+	})
+}
+
+func BenchmarkScrubSecret(b *testing.B) {
+	envMap := map[string]string{
+		"foo": strings.Repeat("a", 50),
+		"bar": strings.Repeat("b", 50),
+		"baz": strings.Repeat("c", 50),
+		"qux": strings.Repeat("d", 50),
+		"quu": strings.Repeat("e", 50),
+		"quv": strings.Repeat("f", 50),
+		"quw": strings.Repeat("g", 50),
+		"quy": strings.Repeat("i", 50),
+		"quz": strings.Repeat("j", 50),
+	}
+	env := []string{}
+	envNames := []string{}
+	for k, v := range envMap {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+		envNames = append(envNames, k)
+	}
+	secretToScrubInfo := core.SecretToScrubInfo{
+		Envs:  envNames,
+		Files: []string{},
+	}
+	in, out := io.Pipe()
+	r, err := NewSecretScrubReader(in, "/", fstest.MapFS{}, env, secretToScrubInfo)
+	require.NoError(b, err)
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	// randomly generate data to feed in
+	go func() {
+		for i := 0; i < b.N; i++ {
+			// generate random data
+			data := make([]byte, 4096)
+			for i := range data {
+				data[i] = byte(rand.Intn(256))
+			}
+
+			// insert some secret-like thing to the random data
+			secret := []byte(strings.Repeat("a", rand.Intn(50)+25))
+			idx := rand.Intn(len(data) - len(secret))
+			copy(data[idx:], secret)
+
+			// write to the pipe
+			_, err := out.Write(data)
+			require.NoError(b, err)
+		}
+		err := out.Close()
+		require.NoError(b, err)
+
+		wg.Done()
+	}()
+	go func() {
+		data, err := io.ReadAll(r)
+		require.NoError(b, err)
+		require.NotContains(b, string(data), strings.Repeat("a", 50))
+
+		wg.Done()
+	}()
+
+	wg.Wait()
+}
+
+func TestTrie(t *testing.T) {
+	trie := Trie{}
+
+	trie.Insert([]byte("foo"), []byte("bar"))
+	require.Equal(t, []byte("bar"), trie.Step('f').Step('o').Step('o').Value())
+	require.Nil(t, trie.Step('f').Step('o').Value())
+
+	trie.Insert([]byte("fox"), []byte("bax"))
+	require.Equal(t, []byte("bar"), trie.Step('f').Step('o').Step('o').Value())
+	require.Equal(t, []byte("bax"), trie.Step('f').Step('o').Step('x').Value())
+
+	trie.Insert([]byte("fax"), []byte("brx"))
+	require.Equal(t, []byte("bar"), trie.Step('f').Step('o').Step('o').Value())
+	require.Equal(t, []byte("bax"), trie.Step('f').Step('o').Step('x').Value())
+	require.Equal(t, []byte("brx"), trie.Step('f').Step('a').Step('x').Value())
 }


### PR DESCRIPTION
Fix #5791

This was a fun exercise in processing streams in go, and an absolutely massive nerd-snipe :cry: 

Essentially, we need a custom transformer to handle *precisely* matching Reads on the underlying source with the output - we shouldn't hold output any longer than is absolutely neccessary (which was the issue with the previous implementation).

To be able to do this at all in any reasonable way, we need a trie, and handle *all* the secrets at once, instead of doing multiple passes. Multiple passes won't work, since it's possible to accidentally trim too much at each step, which would be very sad.

> e.g. imagine secrets (aaa, bbb, ccc, etc), and an input (cba)
>
> In removing secret aaa, we would trim to cb, then we'd remove bbb to trim to c, then finally trim to nothing. However, this is overly enthusiastic, we could easily just trim to cb, if we knew about all the secrets at once.

So, we need a trie, and we need a custom implementation of one. This is because *no off the shelf implementation* seems to allow traversing the trie state-by-state. Thankfully, it's a pretty short implementation to implement one from scratch, and not too much harder to turn it into a radix tree (which lets us use quite a lot less memory).

With our trie, we can implement our custom transformer, which is *an utter pain*. Honestly, the comments should explain all the fun edge cases it's possible to hit. There's a lot of tests added as well, each of which was a real horrible thing I hit while implementing it.

I played around a bit with benchmarking, but ugh, it's a *tiny* bit slower than the original implementation (maybe by like ~25%?). It's not huge, but the latency problem is **actually solved**. Some potential things I did look into and gave up on:
- Only copy into dstBuf when dst is full (requires tons of extra conditionals, so slows everything down).
- Avoid copies at all costs by having "virtual buffer pointers" into src, that indicate future data to copy (not only is this *slower*, the logic becomes truly incomprehensible).
- Playing with off-the-shelf radix tree implementations, but they're so inconvenient to use for this specific use case, it'd be way more trouble than it'd be worth.

Any ideas welcome, but honestly, I've looked at enough flamegraphs today.


