### PR TITLE
Fix for annotated dagger types

### DIFF
--- a/sdk/python/src/dagger/mod/_converter.py
+++ b/sdk/python/src/dagger/mod/_converter.py
@@ -7,7 +7,13 @@ import typing_extensions
 from cattrs.preconf.json import make_converter as make_json_converter
 
 from ._types import MissingType, ObjectDefinition
-from ._utils import get_doc, is_optional, non_optional, syncify
+from ._utils import (
+    get_doc,
+    is_optional,
+    non_optional,
+    strip_annotations,
+    syncify,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +35,7 @@ def make_converter():
 
     def dagger_type_structure(id_, cls):
         """Get dagger object type from id."""
+        cls = strip_annotations(cls)
         return dagger.default_client()._get_object_instance(id_, cls)  # noqa: SLF001
 
     def dagger_type_unstructure(obj):

--- a/sdk/python/src/dagger/mod/_module.py
+++ b/sdk/python/src/dagger/mod/_module.py
@@ -4,6 +4,7 @@ import dataclasses
 import inspect
 import json
 import logging
+import textwrap
 import types
 import typing
 from collections import Counter, defaultdict
@@ -190,7 +191,10 @@ class Module:
             msg = f"Failed to serialize result: {e}"
             raise InternalError(msg) from e
 
-        logger.debug("output => %s", repr(output))
+        logger.debug(
+            "output => %s",
+            textwrap.shorten(repr(output), 144),
+        )
         await self._fn_call.return_value(dagger.JSON(output))
 
     async def _register(self, resolvers: Resolvers) -> dagger.ModuleID:
@@ -254,7 +258,10 @@ class Module:
             msg = "Result is a coroutine. Did you forget to add async/await?"
             raise UserError(msg)
 
-        logger.debug("result => %s", repr(result))
+        logger.debug(
+            "result => %s",
+            textwrap.shorten(repr(result), 144),
+        )
 
         try:
             unstructured = await asyncify(
@@ -270,7 +277,10 @@ class Module:
             )
             raise UserError(msg) from e
 
-        logger.debug("unstructured result => %s", repr(unstructured))
+        logger.debug(
+            "unstructured result => %s",
+            textwrap.shorten(repr(unstructured), 144),
+        )
 
         return unstructured
 

--- a/sdk/python/src/dagger/mod/_utils.py
+++ b/sdk/python/src/dagger/mod/_utils.py
@@ -67,7 +67,7 @@ def to_camel_case(s: str) -> str:
 
 def get_doc(obj: Any) -> str | None:
     """Get the last Doc() in an annotated type or the docstring of an object."""
-    if typing.get_origin(obj) in (typing.Annotated, typing_extensions.Annotated):
+    if is_annotated(obj):
         return next(
             (
                 arg.documentation
@@ -81,7 +81,7 @@ def get_doc(obj: Any) -> str | None:
 
 def get_arg_name(annotation: type) -> str | None:
     """Get an alternative name in last Arg() of an annotated type."""
-    if typing.get_origin(annotation) in (typing.Annotated, typing_extensions.Annotated):
+    if is_annotated(annotation):
         return next(
             (
                 arg.name
@@ -117,3 +117,19 @@ def non_optional(tp: type) -> type:
         return tp
     args = [x for x in get_args(tp) if x != None.__class__]
     return args[0] if len(args) == 1 else functools.reduce(operator.or_, args)
+
+
+_T = TypeVar("_T", bound=type)
+
+
+def is_annotated(annotation: type) -> typing.TypeGuard[typing.Annotated]:
+    """Check if the given type is an annotated type."""
+    return typing.get_origin(annotation) in (
+        typing.Annotated,
+        typing_extensions.Annotated,
+    )
+
+
+def strip_annotations(t: _T) -> _T:
+    """Strip the annotations from a given type."""
+    return strip_annotations(typing.get_args(t)[0]) if is_annotated(t) else t

--- a/sdk/python/tests/modules/test_serialization.py
+++ b/sdk/python/tests/modules/test_serialization.py
@@ -1,9 +1,10 @@
 import json
+from typing import Annotated
 
 import pytest
 
 import dagger
-from dagger.mod import Module
+from dagger.mod import Doc, Module
 
 
 @pytest.mark.anyio()
@@ -12,11 +13,12 @@ async def test_unstructure_structure():
 
     @mod.object_type
     class Bar:
-        ctr: dagger.Container = mod.field()
+        msg: Annotated[str, Doc("Echo message")] = mod.field(default="foobar")
+        ctr: Annotated[dagger.Container, Doc("A container")] = mod.field()
 
         @mod.function
         async def bar(self) -> str:
-            return await self.ctr.with_exec(["echo", "-n", "hello"]).stdout()
+            return await self.ctr.with_exec(["echo", "-n", self.msg]).stdout()
 
     @mod.function
     def foo() -> Bar:
@@ -31,4 +33,4 @@ async def test_unstructure_structure():
         resolver = mod.get_resolver(mod.get_resolvers("foo"), "Bar", "bar")
         result = await mod.get_result(resolver, parent, {})
 
-        assert result == "hello"
+        assert result == "foobar"


### PR DESCRIPTION
There was an issue having a dagger type in `Annotated`:
```python
        ctr: Annotated[dagger.Container, Doc("A container")] = mod.field()
```
Fixed in this PR.

There's a remaining issue in the _cattrs_ library for handling unions and generics in `Annotated`. Fixed but not released yet.