### PR TITLE
cli: call asService if container provided to dagger up

### DIFF
--- a/cmd/dagger/up.go
+++ b/cmd/dagger/up.go
@@ -22,8 +22,12 @@ var upCmd = &FuncCommand{
 		cmd.PersistentFlags().BoolVarP(&portForwardsNative, "native", "n", false, "Forward all ports natively, i.e. match frontend port to backend.")
 	},
 	OnSelectObjectLeaf: func(c *FuncCommand, name string) error {
-		if name != Service {
-			return fmt.Errorf("up can only be called on a service")
+		switch name {
+		case Service:
+		case Container:
+			c.Select("asService")
+		default:
+			return fmt.Errorf("up can only be called on a service or container")
 		}
 		c.Select("id")
 		return nil


### PR DESCRIPTION
Before this, you'd get an error if you tried to call dagger up on a container type, but now we just automatically call asService on it in that case.

---

I'd like to add a test case for `dagger up` as part of this, but this fix is just a quick side quest (from writing docs), so I will either update this PR or follow-up later w/ a test depending on timing.