### PR TITLE
fix: remove comparable constraint from Optional

### DIFF
--- a/cmd/codegen/generator/go/templates/src/header.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/header.go.tmpl
@@ -41,31 +41,29 @@ func ptr[T any](v T) *T {
 // that use this wrapper type will be set as optional in the generated API.
 //
 // To construct an Optional from within a module, use the Opt helper function.
-type Optional[T comparable] struct {
+type Optional[T any] struct {
 	value T
 	isSet bool
 }
 
 // Opt is a helper function to construct an Optional with the given value set.
-func Opt[T comparable](v T) Optional[T] {
+func Opt[T any](v T) Optional[T] {
 	return Optional[T]{value: v, isSet: true}
 }
 
 // Get returns the internal value of the optional and a boolean indicating if
 // the value was set explicitly by the caller.
 func (o Optional[T]) Get() (T, bool) {
-	var zero T
-	return o.value, o.isSet || o.value != zero
+	return o.value, o.isSet
 }
 
 // GetOr returns the internal value of the optional or the given default value
 // if the value was not explicitly set by the caller.
 func (o Optional[T]) GetOr(defaultValue T) T {
-	value, ok := o.Get()
-	if !ok {
-		return defaultValue
+	if o.isSet {
+		return o.value
 	}
-	return value
+	return defaultValue
 }
 
 func (o *Optional[T]) MarshalJSON() ([]byte, error) {

--- a/cmd/codegen/generator/go/templates/src/header.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/header.go.tmpl
@@ -51,6 +51,11 @@ func Opt[T any](v T) Optional[T] {
 	return Optional[T]{value: v, isSet: true}
 }
 
+// OptEmpty is a helper function to construct an empty Optional.
+func OptEmpty[T any]() Optional[T] {
+	return Optional[T]{}
+}
+
 // Get returns the internal value of the optional and a boolean indicating if
 // the value was set explicitly by the caller.
 func (o Optional[T]) Get() (T, bool) {

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -585,6 +585,16 @@ func TestModuleGoSignatures(t *testing.T) {
 		require.JSONEq(t, `{"minimal":{"echoOptionalPointer":"default...default...default..."}}`, out)
 	})
 
+	t.Run("func EchoOptionalSlice([]string) string", func(t *testing.T) {
+		t.Parallel()
+		out, err := modGen.With(daggerQuery(`{minimal{echoOptionalSlice(msg: ["hello", "there"])}}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"minimal":{"echoOptionalSlice":"hello+there...hello+there...hello+there..."}}`, out)
+		out, err = modGen.With(daggerQuery(`{minimal{echoOptionalSlice}}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"minimal":{"echoOptionalSlice":"foobar...foobar...foobar..."}}`, out)
+	})
+
 	t.Run("func Echoes([]string) []string", func(t *testing.T) {
 		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echoes(msgs: "hello")}}`)).Stdout(ctx)

--- a/core/integration/testdata/modules/go/minimal/main.go
+++ b/core/integration/testdata/modules/go/minimal/main.go
@@ -42,6 +42,11 @@ func (m *Minimal) EchoOptionalPointer(msg **Optional[**string]) string {
 	return m.Echo(**v)
 }
 
+func (m *Minimal) EchoOptionalSlice(msg Optional[[]string]) string {
+	v := msg.GetOr([]string{"foobar"})
+	return m.Echo(strings.Join(v, "+"))
+}
+
 func (m *Minimal) Echoes(msgs []string) []string {
 	return []string{m.Echo(strings.Join(msgs, " "))}
 }

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -44,6 +44,11 @@ func Opt[T any](v T) Optional[T] {
 	return Optional[T]{value: v, isSet: true}
 }
 
+// OptEmpty is a helper function to construct an empty Optional.
+func OptEmpty[T any]() Optional[T] {
+	return Optional[T]{}
+}
+
 // Get returns the internal value of the optional and a boolean indicating if
 // the value was set explicitly by the caller.
 func (o Optional[T]) Get() (T, bool) {

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -34,31 +34,29 @@ func ptr[T any](v T) *T {
 // that use this wrapper type will be set as optional in the generated API.
 //
 // To construct an Optional from within a module, use the Opt helper function.
-type Optional[T comparable] struct {
+type Optional[T any] struct {
 	value T
 	isSet bool
 }
 
 // Opt is a helper function to construct an Optional with the given value set.
-func Opt[T comparable](v T) Optional[T] {
+func Opt[T any](v T) Optional[T] {
 	return Optional[T]{value: v, isSet: true}
 }
 
 // Get returns the internal value of the optional and a boolean indicating if
 // the value was set explicitly by the caller.
 func (o Optional[T]) Get() (T, bool) {
-	var zero T
-	return o.value, o.isSet || o.value != zero
+	return o.value, o.isSet
 }
 
 // GetOr returns the internal value of the optional or the given default value
 // if the value was not explicitly set by the caller.
 func (o Optional[T]) GetOr(defaultValue T) T {
-	value, ok := o.Get()
-	if !ok {
-		return defaultValue
+	if o.isSet {
+		return o.value
 	}
-	return value
+	return defaultValue
 }
 
 func (o *Optional[T]) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Fixes [DEV-2948](https://linear.app/dagger/issue/DEV-2948/go-sdk-doesnt-support-optional-string-array).

This allows making slice types (`[]any`) optional, which is permitted at the API level, but wasn't allowed at the type constraint level.

We previously used this constraint because it was assumed that a user might constraint an Optional manually, and not set `isSet`. However, this is an edge case that pokes into the private internals of `dagger.gen.go`, and we now have the `Opt` helper for this. Users doing this kind of access should be aware of what they're doing.
    
Additionally, to really avoid poking around the internals, we add the `OptEmpty` helper, which creates an empty optional - note that the type constraint cannot be automatically derived, at least in the current version of Go.
