### PR TITLE
fix: reduce verbosity of codegen errors

### DIFF
--- a/cmd/codegen/main.go
+++ b/cmd/codegen/main.go
@@ -24,6 +24,11 @@ var (
 var rootCmd = &cobra.Command{
 	Use:  "codegen",
 	RunE: ClientGen,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// if we got this far, CLI parsing worked just fine; no
+		// need to show usage for runtime errors
+		cmd.SilenceUsage = true
+	},
 }
 
 func init() {
@@ -94,7 +99,6 @@ func ClientGen(cmd *cobra.Command, args []string) error {
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This fixes [DEV-2936](https://linear.app/dagger/issue/DEV-2936/module-errors-obsfucated-by-codegen-usage) (cc @shykes).

Before:

```
1: generating go module: playground
1: generating go module: playground ERROR: generate code: template: module:59:3: executing "module" at <ModuleMainSrc>: error calling ModuleMainSrc: failed to convert method Read to function def: failed to convert param type: invalid type: invalid type
Error: generate code: template: module:59:3: executing "module" at <ModuleMainSrc>: error calling ModuleMainSrc: failed to convert method Read to function def: failed to convert param type: invalid type: invalid type
Usage:
  codegen [flags]

Flags:
  -h, --help                             help for codegen
      --introspection-json-path string   optional path to file containing pre-computed graphql introspection JSON
      --lang string                      language to generate (default "go")
      --module string                    module to load and codegen dependency code
  -o, --output string                    output directory (default ".")
      --propagate-logs                   propagate logs directly to progrock.sock

Error: generate code: template: module:59:3: executing "module" at <ModuleMainSrc>: error calling ModuleMainSrc: failed to convert method Read to function def: failed to convert param type: invalid type: invalid type
exit status 1
```

After:

```
1: generating go module: playground
1: generating go module: playground ERROR: generate code: template: module:59:3: executing "module" at <ModuleMainSrc>: error calling ModuleMainSrc: failed to convert method Read to function def: failed to convert param type: invalid type: invalid type
Error: generate code: template: module:59:3: executing "module" at <ModuleMainSrc>: error calling ModuleMainSrc: failed to convert method Read to function def: failed to convert param type: invalid type: invalid type
exit status 1
```

Ideally, later we should try and provide snippets of the code that we failed to generate over - however, this is a fun task for later, as it's a bit more complicated.