### PR TITLE
engine: update to latest graphql-go version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,6 @@ linters:
     - dogsled
     - dupl
     - exportloopref
-    - goconst
     - gocritic
     - gocyclo
     - gofmt
@@ -42,9 +41,9 @@ issues:
 linters-settings:
   revive:
     rules:
-    # This rule is annoying. Often you want to name the
-    # parameters for clarity because it conforms to an
-    # interface.
-    - name: unused-parameter
-      severity: warning
-      disabled: true
+      # This rule is annoying. Often you want to name the
+      # parameters for clarity because it conforms to an
+      # interface.
+      - name: unused-parameter
+        severity: warning
+        disabled: true

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/containerd/stargz-snapshotter v0.14.3
 	github.com/containernetworking/cni v1.1.2
 	github.com/coreos/go-systemd/v22 v22.5.0
-	github.com/dagger/graphql v0.0.0-20230919174923-21d038582a21
+	github.com/dagger/graphql v0.0.0-20231103002502-b36795bcf171
 	github.com/dagger/graphql-go-tools v0.0.0-20231012004527-77189e400b6e
 	github.com/docker/distribution v2.8.2+incompatible
 	github.com/google/go-containerregistry v0.15.2

--- a/go.sum
+++ b/go.sum
@@ -430,8 +430,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
-github.com/dagger/graphql v0.0.0-20230919174923-21d038582a21 h1:6H/36Lk+mcSXxlbjjIMUYd4DR+aqCzeaRigK5dUe/a0=
-github.com/dagger/graphql v0.0.0-20230919174923-21d038582a21/go.mod h1:jxe8vuRdvEbdLR5nrc6F7gLPmPeJhGe2DbIgEok+pCA=
+github.com/dagger/graphql v0.0.0-20231103002502-b36795bcf171 h1:Kdgcv4zGccy/TMeSHdJq0NBk+PJCg3uIcFRtKDqHmaM=
+github.com/dagger/graphql v0.0.0-20231103002502-b36795bcf171/go.mod h1:jxe8vuRdvEbdLR5nrc6F7gLPmPeJhGe2DbIgEok+pCA=
 github.com/dagger/graphql-go-tools v0.0.0-20231012004527-77189e400b6e h1:5fyK89J8og+XMW5JetgXzaxRhoI9UrS0BhrNskj4cuA=
 github.com/dagger/graphql-go-tools v0.0.0-20231012004527-77189e400b6e/go.mod h1:SXt7tSY8l+OVghRddofY+eDdv8EK82N0JlrrfrkqFEw=
 github.com/dave/jennifer v1.7.0 h1:uRbSBH9UTS64yXbh4FrMHfgfY762RD+C7bUPKODpSJE=

--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -63,7 +63,7 @@ func (t Engine) Lint(ctx context.Context) error {
 	repo := util.RepositoryGoCodeOnly(c)
 
 	_, err = c.Container().
-		From("golangci/golangci-lint:v1.51-alpine").
+		From("golangci/golangci-lint:v1.55-alpine").
 		WithMountedDirectory("/app", repo).
 		WithWorkdir("/app").
 		WithExec([]string{"golangci-lint", "run", "-v", "--timeout", "5m"}).


### PR DESCRIPTION
Updates us to https://github.com/dagger/graphql/pull/3

The change there makes the return value of graphql introspection stable, which is important since it's an input to the SDK Codegen+Runtime functions.

Previously, we were re-running those SDK functions way too often, which wasted tons of time, especially in modules with larger dependency DAGs.

One of Kyle's demo's took a minimum of 25s every run due to that; now it's down to 7s with this fix in place.