### PR TITLE
Zenith (Go SDK): allow omitting JSON types in structs

### DIFF
--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -8,6 +8,7 @@ import (
 	"go/types"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime/debug"
 	"sort"
 	"strings"
@@ -665,8 +666,21 @@ func (ps *parseState) goStructToAPIType(t *types.Struct, named *types.Named) (*S
 			description = doc.Text()
 		}
 
+		name := field.Name()
+
+		// override the name with the json tag if it was set - otherwise, we
+		// end up asking for a name that we won't unmarshal correctly
+		tag := reflect.StructTag(t.Tag(i))
+		if dt := tag.Get("json"); dt != "" {
+			dt, _, _ = strings.Cut(dt, ",")
+			if dt == "-" {
+				continue
+			}
+			name = dt
+		}
+
 		withFieldArgs := []Code{
-			Lit(field.Name()),
+			Lit(name),
 			fieldTypeDef,
 		}
 

--- a/core/function.go
+++ b/core/function.go
@@ -152,9 +152,10 @@ func (typeDef *TypeDef) WithObjectField(name string, fieldType *TypeDef, desc st
 	}
 	typeDef = typeDef.Clone()
 	typeDef.AsObject.Fields = append(typeDef.AsObject.Fields, &FieldTypeDef{
-		Name:        name,
-		Description: desc,
-		TypeDef:     fieldType,
+		Name:         strcase.ToLowerCamel(name),
+		OriginalName: name,
+		Description:  desc,
+		TypeDef:      fieldType,
 	})
 	return typeDef, nil
 }
@@ -229,6 +230,12 @@ type FieldTypeDef struct {
 	Name        string   `json:"name"`
 	Description string   `json:"description"`
 	TypeDef     *TypeDef `json:"typeDef"`
+
+	// Below are not in public API
+
+	// The original name of the object as provided by the SDK that defined it, used
+	// when invoking the SDK so it doesn't need to think as hard about case conversions
+	OriginalName string `json:"originalName,omitempty"`
 }
 
 func (typeDef FieldTypeDef) Clone() *FieldTypeDef {

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -2251,7 +2251,7 @@ func TestModuleReservedWords(t *testing.T) {
 					}).
 					With(daggerQuery(`{test{fn{id}}}`)).
 					Sync(ctx)
-				require.ErrorContains(t, err, "cannot define field with reserved name \"ID\"")
+				require.ErrorContains(t, err, "cannot define field with reserved name \"id\"")
 			})
 		})
 

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -797,32 +797,30 @@ func (s *moduleSchema) moduleToSchemaFor(ctx context.Context, module *core.Modul
 			if err != nil {
 				return nil, err
 			}
-			fieldName := gqlFieldName(field.Name)
 			astDef.Fields = append(astDef.Fields, &ast.FieldDefinition{
-				Name:        fieldName,
+				Name:        field.Name,
 				Description: formatGqlDescription(field.Description),
 				Type:        fieldASTType,
 			})
 
-			// if this is an IDable type, add a resolver that converts the ID into
-			// the real object, otherwise its schema will be called against the
-			// string
-			if field.TypeDef.Kind == core.TypeDefKindObject {
-				newObjResolver[fieldName] = func(p graphql.ResolveParams) (any, error) {
-					res, err := graphql.DefaultResolveFn(p)
-					if err != nil {
-						return nil, err
-					}
+			newObjResolver[field.Name] = func(p graphql.ResolveParams) (any, error) {
+				p.Info.FieldName = field.OriginalName
+				res, err := graphql.DefaultResolveFn(p)
+				if err != nil {
+					return nil, err
+				}
+				if field.TypeDef.Kind == core.TypeDefKindObject {
+					// if this is an IDable type, convert the ID into the real
+					// object, otherwise its schema will be called against the
+					// string
 					id, ok := res.(string)
 					if !ok {
 						return nil, fmt.Errorf("expected string %sID, got %T", field.TypeDef.AsObject.Name, res)
 					}
 					return core.ResourceFromID(id)
 				}
-			} else {
-				// no resolver to add; fields rely on the graphql "trivial resolver"
-				// where the value is just read from the parent object
-				_ = 1
+
+				return res, nil
 			}
 		}
 
@@ -967,6 +965,11 @@ func (s *moduleSchema) functionResolver(
 		})
 	}
 
+	argNames := make(map[string]string, len(fn.Args))
+	for _, arg := range fn.Args {
+		argNames[arg.Name] = arg.OriginalName
+	}
+
 	fieldDef := &ast.FieldDefinition{
 		Name:        fnName,
 		Description: formatGqlDescription(fn.Description),
@@ -996,11 +999,6 @@ func (s *moduleSchema) functionResolver(
 				return nil, fmt.Errorf("failed to get parent ID: %w", err)
 			}
 			parent = id
-		}
-
-		argNames := make(map[string]string, len(fn.Args))
-		for _, arg := range fn.Args {
-			argNames[arg.Name] = arg.OriginalName
 		}
 
 		var callInput []*core.CallInput

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -791,6 +791,8 @@ func (s *moduleSchema) moduleToSchemaFor(ctx context.Context, module *core.Modul
 
 		newObjResolver := ObjectResolver{}
 		for _, field := range objTypeDef.Fields {
+			field := field
+
 			fieldASTType, err := s.typeDefToSchema(field.TypeDef, false)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/5860.

Essentially, we configure the Go SDK to make sure that we always request the name of the field that we want the server to send/receive from. If we ask for field "A", we should get "A" and not the camel-cased "a". As a nice effect to do this, we need to add `OriginalName` support for fields. (@helderco I remember you saying something about this *somewhere*, but I couldn't find where you mentioned it, sorry).

This is still... not great (but it's an alright stop-gap). It fixes the temporary nastiness of needing these json tags, but we still have the issue that the user might still want to use JSON tags - it would be *awesome* if we could have our own `dagger` tags. For example, I need to maintain a manual mapping of structs in one of my modules to work around this, since I don't want to expose the GitHub API JSON into the Dagger API: https://github.com/jedevc/daggerverse/blob/main/github/main.go#L79-L106. Unfortunately, this requires a custom JSON marshaller, since I don't see an easy way to configure the tag we should use.