### PR TITLE
CLI: support git URLs as directory arguments

### DIFF
--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"os"
 	"reflect"
 	"strings"
 
@@ -200,7 +201,11 @@ func (v *directoryValue) Get(dag *dagger.Client) any {
 	// Try parsing as a Git URL
 	parsedGit, err := parseGit(v.String())
 	if err == nil {
-		gitDir := dag.Git(parsedGit.url.String()).Branch(parsedGit.ref).Tree()
+		gitOpts := dagger.GitOpts{}
+		if authSock, ok := os.LookupEnv("SSH_AUTH_SOCK"); ok {
+			gitOpts.SSHAuthSocket = dag.Host().UnixSocket(authSock)
+		}
+		gitDir := dag.Git(parsedGit.url.String(), gitOpts).Branch(parsedGit.ref).Tree()
 		if parsedGit.subdir != "" {
 			gitDir = gitDir.Directory(parsedGit.subdir)
 		}

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -40,7 +40,7 @@ const (
 )
 
 func init() {
-	moduleFlags.StringVarP(&moduleURL, "mod", "m", "", "Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. \"/path/to/some/dir\") or a git repo (e.g. \"git://github.com/dagger/dagger?ref=branch?subpath=path/to/some/dir\").")
+	moduleFlags.StringVarP(&moduleURL, "mod", "m", "", "Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. \"/path/to/some/dir\") or a github repo (e.g. \"github.com/dagger/dagger/path/to/some/subdir\").")
 	moduleFlags.BoolVar(&focus, "focus", true, "Only show output for focused commands.")
 
 	moduleCmd.PersistentFlags().AddFlagSet(moduleFlags)

--- a/cmd/dagger/module_test.go
+++ b/cmd/dagger/module_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -39,5 +40,172 @@ func TestOriginToPath(t *testing.T) {
 		p, err := originToPath(tc.origin)
 		require.NoError(t, err)
 		require.Equal(t, tc.want, p)
+	}
+}
+
+// This covers cases that the full integ test in core/integration/module_test.go can't
+// cover right now due to limitation in needing real SSH keys to test e2e.
+func TestParseGit(t *testing.T) {
+	for _, tc := range []struct {
+		urlStr string
+		want   parsedGitURL
+	}{
+		{
+			urlStr: "ssh://git@github.com/shykes/daggerverse",
+			want: parsedGitURL{
+				url: &url.URL{
+					Scheme: "ssh",
+					User:   url.User("git"),
+					Host:   "github.com",
+					Path:   "/shykes/daggerverse",
+				},
+				ref: "main",
+			},
+		},
+		{
+			urlStr: "ssh://git@github.com/shykes/daggerverse.git",
+			want: parsedGitURL{
+				url: &url.URL{
+					Scheme: "ssh",
+					User:   url.User("git"),
+					Host:   "github.com",
+					Path:   "/shykes/daggerverse.git",
+				},
+				ref: "main",
+			},
+		},
+		{
+			urlStr: "ssh://git@github.com/shykes/daggerverse#v0.9.1",
+			want: parsedGitURL{
+				url: &url.URL{
+					Scheme: "ssh",
+					User:   url.User("git"),
+					Host:   "github.com",
+					Path:   "/shykes/daggerverse",
+				},
+				ref: "v0.9.1",
+			},
+		},
+		{
+			urlStr: "ssh://git@github.com/shykes/daggerverse.git#v0.9.1",
+			want: parsedGitURL{
+				url: &url.URL{
+					Scheme: "ssh",
+					User:   url.User("git"),
+					Host:   "github.com",
+					Path:   "/shykes/daggerverse.git",
+				},
+				ref: "v0.9.1",
+			},
+		},
+		{
+			urlStr: "ssh://git@github.com/shykes/daggerverse#v0.9.1:subdir1/subdir2",
+			want: parsedGitURL{
+				url: &url.URL{
+					Scheme: "ssh",
+					User:   url.User("git"),
+					Host:   "github.com",
+					Path:   "/shykes/daggerverse",
+				},
+				ref:    "v0.9.1",
+				subdir: "subdir1/subdir2",
+			},
+		},
+		{
+			urlStr: "ssh://git@github.com/shykes/daggerverse.git#v0.9.1:subdir1/subdir2",
+			want: parsedGitURL{
+				url: &url.URL{
+					Scheme: "ssh",
+					User:   url.User("git"),
+					Host:   "github.com",
+					Path:   "/shykes/daggerverse.git",
+				},
+				ref:    "v0.9.1",
+				subdir: "subdir1/subdir2",
+			},
+		},
+		{
+			urlStr: "git@github.com:sipsma/daggerverse",
+			want: parsedGitURL{
+				url: &url.URL{
+					Scheme: "ssh",
+					User:   url.User("git"),
+					Host:   "github.com",
+					Path:   "/sipsma/daggerverse",
+				},
+				ref: "main",
+			},
+		},
+		{
+			urlStr: "git@github.com:sipsma/daggerverse.git",
+			want: parsedGitURL{
+				url: &url.URL{
+					Scheme: "ssh",
+					User:   url.User("git"),
+					Host:   "github.com",
+					Path:   "/sipsma/daggerverse.git",
+				},
+				ref: "main",
+			},
+		},
+		{
+			urlStr: "git@github.com:sipsma/daggerverse#v0.9.1",
+			want: parsedGitURL{
+				url: &url.URL{
+					Scheme: "ssh",
+					User:   url.User("git"),
+					Host:   "github.com",
+					Path:   "/sipsma/daggerverse",
+				},
+				ref: "v0.9.1",
+			},
+		},
+		{
+			urlStr: "git@github.com:sipsma/daggerverse.git#v0.9.1",
+			want: parsedGitURL{
+				url: &url.URL{
+					Scheme: "ssh",
+					User:   url.User("git"),
+					Host:   "github.com",
+					Path:   "/sipsma/daggerverse.git",
+				},
+				ref: "v0.9.1",
+			},
+		},
+		{
+			urlStr: "git@github.com:sipsma/daggerverse#v0.9.1:subdir1/subdir2",
+			want: parsedGitURL{
+				url: &url.URL{
+					Scheme: "ssh",
+					User:   url.User("git"),
+					Host:   "github.com",
+					Path:   "/sipsma/daggerverse",
+				},
+				ref:    "v0.9.1",
+				subdir: "subdir1/subdir2",
+			},
+		},
+		{
+			urlStr: "git@github.com:sipsma/daggerverse.git#v0.9.1:subdir1/subdir2",
+			want: parsedGitURL{
+				url: &url.URL{
+					Scheme: "ssh",
+					User:   url.User("git"),
+					Host:   "github.com",
+					Path:   "/sipsma/daggerverse.git",
+				},
+				ref:    "v0.9.1",
+				subdir: "subdir1/subdir2",
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.urlStr, func(t *testing.T) {
+			t.Parallel()
+			parsedGit, err := parseGit(tc.urlStr)
+			require.NoError(t, err)
+			require.NotNil(t, parsedGit)
+			require.Equal(t, tc.want, *parsedGit)
+		})
 	}
 }

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -1812,6 +1812,8 @@ func TestModuleDaggerCall(t *testing.T) {
 	c, ctx := connect(t)
 
 	t.Run("list args", func(t *testing.T) {
+		t.Parallel()
+
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
@@ -1858,6 +1860,8 @@ func (m *Minimal) Reads(ctx context.Context, files []File) (string, error) {
 	})
 
 	t.Run("return list objects", func(t *testing.T) {
+		t.Parallel()
+
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
@@ -1885,6 +1889,98 @@ func (m *Minimal) Fn() []*Foo {
 		out, err := modGen.With(daggerCall("fn", "bar")).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, strings.TrimSpace(out), "0\n1\n2")
+	})
+
+	t.Run("directory arg inputs", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("local dir", func(t *testing.T) {
+			t.Parallel()
+			modGen := c.Container().From(golangImage).
+				WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+				WithWorkdir("/work").
+				With(daggerExec("mod", "init", "--name=test", "--sdk=go")).
+				WithNewFile("/dir/subdir/foo.txt", dagger.ContainerWithNewFileOpts{
+					Contents: "foo",
+				}).
+				WithNewFile("/dir/subdir/bar.txt", dagger.ContainerWithNewFileOpts{
+					Contents: "bar",
+				}).
+				WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
+					Contents: `package main
+type Test struct {}
+
+func (m *Test) Fn(dir *Directory) *Directory {
+	return dir
+}
+	`,
+				})
+
+			out, err := modGen.With(daggerCall("fn", "--dir", "/dir/subdir")).Stdout(ctx)
+			require.NoError(t, err)
+			require.Equal(t, strings.TrimSpace(out), "bar.txt\nfoo.txt")
+
+			out, err = modGen.With(daggerCall("fn", "--dir", "file:///dir/subdir")).Stdout(ctx)
+			require.NoError(t, err)
+			require.Equal(t, strings.TrimSpace(out), "bar.txt\nfoo.txt")
+		})
+
+		t.Run("git dir", func(t *testing.T) {
+			t.Parallel()
+
+			modGen := c.Container().From(golangImage).
+				WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+				WithWorkdir("/work").
+				With(daggerExec("mod", "init", "--name=test", "--sdk=go")).
+				WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
+					Contents: `package main
+type Test struct {}
+
+func (m *Test) Fn(dir *Directory, subpath Optional[string]) *Directory {
+	return dir.Directory(subpath.GetOr("."))
+}
+	`,
+				})
+
+			for _, tc := range []struct {
+				baseURL string
+				subpath string
+			}{
+				{
+					baseURL: "https://github.com/dagger/dagger",
+				},
+				{
+					baseURL: "https://github.com/dagger/dagger",
+					subpath: ".changes",
+				},
+				{
+					baseURL: "https://github.com/dagger/dagger.git",
+				},
+				{
+					baseURL: "https://github.com/dagger/dagger.git",
+					subpath: ".changes",
+				},
+			} {
+				tc := tc
+				t.Run(fmt.Sprintf("%s:%s", tc.baseURL, tc.subpath), func(t *testing.T) {
+					t.Parallel()
+					url := tc.baseURL + "#v0.9.1"
+					if tc.subpath != "" {
+						url += ":" + tc.subpath
+					}
+
+					args := []string{"fn", "--dir", url}
+					if tc.subpath == "" {
+						args = append(args, "--subpath", ".changes")
+					}
+					out, err := modGen.With(daggerCall(args...)).Stdout(ctx)
+					require.NoError(t, err)
+
+					require.Contains(t, out, "v0.9.1.md")
+					require.NotContains(t, out, "v0.9.2.md")
+				})
+			}
+		})
 	})
 }
 


### PR DESCRIPTION
Support values include:

- `./mydir`
- `file://mydir`
- Various url schemes for git remote: `git://`, `ssh://`, `https://`, `git+ssh://`, `git+https://`
- Encode git ref in URL fragment (defaults to `main`): `https://github.com/dagger/dagger#v0.9.2`
- Not yet supported: tarball-over-https
- Not yet supported: interpret local dir as a git repo, by encoding a git ref in the fragment, eg. `file://.#main`