### PR TITLE
ci: update all github workflows to go 1.21

### DIFF
--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.21"
           cache-dependency-path: "internal/mage/go.sum"
       - name: ${{ inputs.mage-targets }}
         run: |
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.21"
           cache-dependency-path: "internal/mage/go.sum"
       - name: ${{ inputs.mage-targets }}
         run: |

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.21"
           cache-dependency-path: "internal/mage/go.sum"
       - name: "Build Dev Engine"
         run: |

--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - name: "Publish Helm Chart"
         run: ./hack/make helm:publish ${{ github.ref_name }}

--- a/.github/workflows/publish-sdk-elixir.yml
+++ b/.github/workflows/publish-sdk-elixir.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - run: ./hack/make sdk:elixir:publish ${{ github.ref_name }}
         env:
           GITHUB_PAT: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}

--- a/.github/workflows/publish-sdk-go.yml
+++ b/.github/workflows/publish-sdk-go.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - run: ./hack/make sdk:go:publish ${{ github.ref_name }}
         env:
           GITHUB_PAT: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}

--- a/.github/workflows/publish-sdk-nodejs.yml
+++ b/.github/workflows/publish-sdk-nodejs.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - run: ./hack/make sdk:nodejs:publish ${{ github.ref_name }}
         env:
           NPM_TOKEN: ${{ secrets.RELEASE_NPM_TOKEN }}

--- a/.github/workflows/publish-sdk-python.yml
+++ b/.github/workflows/publish-sdk-python.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - run: ./hack/make sdk:python:publish ${{ github.ref_name }}
         env:
           PYPI_REPO: ${{ secrets.RELEASE_PYPI_REPO }}

--- a/.github/workflows/publish-sdk-rust.yml
+++ b/.github/workflows/publish-sdk-rust.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - run: ./hack/make sdk:rust:publish ${{ github.ref_name }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.21"
           cache-dependency-path: "internal/mage/go.sum"
       - name: "Publish Engine & CLI"
         run: |
@@ -121,7 +121,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - name: "Test Go SDK"
         run: |
@@ -192,7 +192,7 @@ jobs:
         shell: bash
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - name: "Test Go SDK"
         run: |
           cd sdk/go

--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - run: ./hack/make sdk:python:test
         env:
           DAGGER_CLOUD_TOKEN: "${{ secrets.DAGGER_CLOUD_TOKEN }}"

--- a/internal/mage/cli.go
+++ b/internal/mage/cli.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// https://github.com/goreleaser/goreleaser/releases
-	goReleaserVersion = "v1.19.2-pro"
+	goReleaserVersion = "v1.21.2-pro"
 )
 
 type Cli mg.Namespace


### PR DESCRIPTION
Needed to fix failure on main: https://github.com/dagger/dagger/actions/runs/6751412649/job/18355442139