### PR TITLE
fix container name in 389936-run-pipelines-cli.md

### DIFF
--- a/docs/current/cli/389936-run-pipelines-cli.md
+++ b/docs/current/cli/389936-run-pipelines-cli.md
@@ -76,7 +76,7 @@ The first query:
 
 The second query:
 
-- initializes a new `alpine:latest` container (returned as a `Container` object);
+- initializes a new `golang:latest` container (returned as a `Container` object);
 - mounts the `Directory` from the first query within the container filesystem at the `/src` mount point (returned as a revised `Container`);
 - sets the working directory within the container to the mounted filesystem (returned as a revised `Container`);
 - requests execution of the `go build` command (returned as a revised `Container` containing the execution plan);


### PR DESCRIPTION
changed container name from alpine to golang to match the code: https://github.com/dagger/dagger/blob/8f21a24e7fc2186519876093a84ac1963395c73a/docs/current/cli/snippets/get-started/step3/build.sh#L23
