### PR TITLE
docs: Updates repository path for example

### DIFF
--- a/docs/zenith/user/quickstart/120928-setup.mdx
+++ b/docs/zenith/user/quickstart/120928-setup.mdx
@@ -13,12 +13,12 @@ The example module used in this tutorial contains all the code necessary to test
 Begin by cloning the module repository into your local development environment:
 
 ```shell
-git clone https://github.com/sipsma/daggerverse.git
-cd daggerverse/example
+git clone https://github.com/dagger/hello-dagger.git
+cd hello-dagger
 ```
 
 Cloning the repository locally makes it easy to explore and/or modify the module code, and is the recommended approach for this quickstart. However, if you prefer not to do this, you can instead use the following command, which exports the module location to an environment variable so that Dagger automatically uses it in all subsequent CLI commands:
 
 ```shell
-export DAGGER_MODULE=github.com/sipsma/daggerverse/example`
+export DAGGER_MODULE=github.com/dagger/hello-dagger`
 ```


### PR DESCRIPTION
This commit updates the repository path in the user quickstart to point to the hello-dagger repository instead of the sipsma repository