### PR TITLE
fix: handle more edge cases with custom comment parsing

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -1037,11 +1037,17 @@ func (m *Minimal) HelloMore(
 	return foo + bar
 }
 
-func (m *Minimal) HelloAgain(
-	foo string, // docs for foo
-	bar string,
+func (m *Minimal) HelloAgain( // docs for helloagain
+	foo string,
+	bar string, // docs for bar
+	baz string,
 ) string {
 	return foo + bar
+}
+
+func (m *Minimal) HelloFinal(
+	foo string) string { // woops
+	return foo
 }
 `,
 		})
@@ -1075,13 +1081,21 @@ func (m *Minimal) HelloAgain(
 	require.Equal(t, "bar", hello.Get("args.1.name").String())
 	require.Equal(t, "bar here", hello.Get("args.1.description").String())
 
-	// hello = obj.Get(`functions.#(name="helloAgain")`)
-	// require.Equal(t, "helloAgain", hello.Get("name").String())
-	// require.Len(t, hello.Get("args").Array(), 2)
-	// require.Equal(t, "foo", hello.Get("args.0.name").String())
-	// require.Equal(t, "docs for foo", hello.Get("args.0.description").String())
-	// require.Equal(t, "bar", hello.Get("args.1.name").String())
-	// require.Equal(t, "", hello.Get("args.1.description").String())
+	hello = obj.Get(`functions.#(name="helloAgain")`)
+	require.Equal(t, "helloAgain", hello.Get("name").String())
+	require.Len(t, hello.Get("args").Array(), 3)
+	require.Equal(t, "foo", hello.Get("args.0.name").String())
+	require.Equal(t, "", hello.Get("args.0.description").String())
+	require.Equal(t, "bar", hello.Get("args.1.name").String())
+	require.Equal(t, "docs for bar", hello.Get("args.1.description").String())
+	require.Equal(t, "baz", hello.Get("args.2.name").String())
+	require.Equal(t, "", hello.Get("args.2.description").String())
+
+	hello = obj.Get(`functions.#(name="helloFinal")`)
+	require.Equal(t, "helloFinal", hello.Get("name").String())
+	require.Len(t, hello.Get("args").Array(), 1)
+	require.Equal(t, "foo", hello.Get("args.0.name").String())
+	require.Equal(t, "", hello.Get("args.0.description").String())
 }
 
 //go:embed testdata/modules/go/extend/main.go

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -1037,6 +1037,13 @@ func (m *Minimal) HelloMore(
 	return foo + bar
 }
 
+func (m *Minimal) HelloMoreInline(opts struct{
+	// foo here
+	foo, bar string
+}) string {
+	return opts.foo + opts.bar
+}
+
 func (m *Minimal) HelloAgain( // docs for helloagain
 	foo string,
 	bar string, // docs for bar
@@ -1080,6 +1087,14 @@ func (m *Minimal) HelloFinal(
 	require.Equal(t, "foo here", hello.Get("args.0.description").String())
 	require.Equal(t, "bar", hello.Get("args.1.name").String())
 	require.Equal(t, "bar here", hello.Get("args.1.description").String())
+
+	hello = obj.Get(`functions.#(name="helloMoreInline")`)
+	require.Equal(t, "helloMoreInline", hello.Get("name").String())
+	require.Len(t, hello.Get("args").Array(), 2)
+	require.Equal(t, "foo", hello.Get("args.0.name").String())
+	require.Equal(t, "foo here", hello.Get("args.0.description").String())
+	require.Equal(t, "bar", hello.Get("args.1.name").String())
+	require.Equal(t, "", hello.Get("args.1.description").String())
 
 	hello = obj.Get(`functions.#(name="helloAgain")`)
 	require.Equal(t, "helloAgain", hello.Get("name").String())


### PR DESCRIPTION
Follow-up to https://github.com/dagger/dagger/pull/5907#discussion_r1371873008, worked out a neat way to properly handle those weird edge cases.

This PR fixes (and tests for) a couple edge cases with our custom comment parsing:

- Don't read previous lines line-comments as doc-comments

  ```go
  foo string, // this documents foo, not bar 
  bar string, // this should document bar
  ```

- Don't read comments after the function as line-comments for the last arg

  ```go
  func (x *X) DoThing(foo string) { // this should not document foo
  ```