### PR TITLE
fix: split out docker pull step in progress

### DIFF
--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -186,9 +186,7 @@ func Connect(ctx context.Context, params Params) (_ *Client, _ context.Context, 
 		return nil, nil, fmt.Errorf("parse runner host: %w", err)
 	}
 
-	engineTask := loader.Task("starting engine")
-	bkClient, bkInfo, err := newBuildkitClient(ctx, remote, c.UserAgent, loader)
-	engineTask.Done(err)
+	bkClient, bkInfo, err := newBuildkitClient(ctx, loader, remote, c.UserAgent)
 	if err != nil {
 		return nil, nil, fmt.Errorf("new client: %w", err)
 	}


### PR DESCRIPTION
This patch splits out the pull step to a separate place in the progress output, which is only printed if the image is actually pulled from the registry. This is added so we can have better insight into *what* part of connecting to the dagger engine is actually taking time (currently this is very opaque).

> **Note**
>
> For a follow-up, we should look at getting progress information from the pull, so that we can implement a progress bar, which would be even better. I think this requires talking directly to the docker api though, instead of just using the docker cli.

The first simple step to this is to split out the pull step, since this is often the very slow part. Additionally, we make "starting engine" include the "docker run" and the waiting for the client to be ready.

To actually do this, we need to do a fairly reasonable amount of refactoring so that we don't end up adding too much new clutter to the progress output (and also the refactoring felt quite natural). We only want to add the pulling output when necessary, but it shouldn't be the child of "starting engine", that step should come after.

---

As a side-note: while doing this, I noticed that `garbageCollectEngines` is fairly difficult:
- It's only called when using the docker image provider, so it won't clean up when connecting to a manually specified dagger engine (like in k8s).
- It's impossible to run multiple dagger engines using the image provider at once (since the other will get cleaned up) - this occasionally screws up my local testing environment.
- It's actually quite slow. Haven't dug into why this is, but it's annoying that we have to call this in-serial - ideally we could launch it in another goroutine, but then we can't actually get any reasonable output from it (so what do we do if it errors).

It would be really nice to clean this up as part of #5484, and have locally running dagger engines aware of their own lifetimes, and exit after X time with no ongoing sessions.