### PR TITLE
fix: add back default struct tags :shushing_face:

### DIFF
--- a/core/integration/testdata/modules/go/minimal/main.go
+++ b/core/integration/testdata/modules/go/minimal/main.go
@@ -130,3 +130,12 @@ func (m *Minimal) EchoOptsInlineTags(ctx context.Context, opts struct {
 }) string {
 	return m.EchoOpts(opts.Msg, opts.Suffix, opts.Times)
 }
+
+func (m *Minimal) EchoOptsInlineDefault(ctx context.Context, opts struct {
+	Msg string
+
+	Suffix Optional[string] `default:"+"`
+	Times  Optional[int]    `default:"2"`
+}) string {
+	return m.EchoOpts(opts.Msg, opts.Suffix, opts.Times)
+}


### PR DESCRIPTION
~~:warning: Requires #6068.~~

This adds the `default` tags back in for inline structs, as a bit of a workaround for doing so, since @vito asked nicely (see [here](https://discord.com/channels/707636530424053791/1167084892723617912/1167091917440421969) :smile:) I still think we should probably *avoid* directly pointing users at this, but maybe it might be fine for advanced users.

Not 100% sure about this, but given we *can* and have a place to put it, I think it might be fine to do so for now - leaving as draft, to prompt a discussion.