### PR TITLE
docs: Adds Zenith programming section intro

### DIFF
--- a/docs/zenith/developer/index.md
+++ b/docs/zenith/developer/index.md
@@ -6,3 +6,16 @@ displayed_sidebar: "zenith"
 # Introduction
 
 {@include: ../partials/_experimental.md}
+
+Dagger lets you encapsulate all your project's tasks and workflows into simple modules, written in your programming language of choice.
+
+Modules can contain one or more functions. Module functions can accept and return both basic built-in types and more complex custom types.
+
+Modules can call each other. Dagger lets you add dependencies to your modules, so that you can build on modules created by others. Dagger also lets you publish your own modules to the [Daggerverse](https://daggerverse.dev), so that other users can easily discover and use them.
+
+Start your journey into Dagger programming with the following resources:
+
+- The [Go](./go/525021-quickstart.md) and [Python](./python/419481-quickstart.md) quickstarts
+- The [Daggerverse](https://daggerverse.dev), an online catalog of Dagger modules for you to use and learn from
+- Guide on [publishing modules to the Daggerverse](../821742-publishing-modules.md)
+- Reference documentation for the [Go](https://pkg.go.dev/dagger.io/dagger) and [Python](https://dagger-io.readthedocs.org/) SDKs

--- a/docs/zenith/developer/index.md
+++ b/docs/zenith/developer/index.md
@@ -17,5 +17,5 @@ Start your journey into Dagger programming with the following resources:
 
 - The [Go](./go/525021-quickstart.md) and [Python](./python/419481-quickstart.md) quickstarts
 - The [Daggerverse](https://daggerverse.dev), an online catalog of Dagger modules for you to use and learn from
-- Guide on [publishing modules to the Daggerverse](../821742-publishing-modules.md)
+- Guide on [publishing modules to the Daggerverse](./821742-publishing-modules.md)
 - Reference documentation for the [Go](https://pkg.go.dev/dagger.io/dagger) and [Python](https://dagger-io.readthedocs.org/) SDKs


### PR DESCRIPTION
This commit adds a brief introduction to the "programming Dagger" section.