### PR TITLE
Python: Fix module field name override

### DIFF
--- a/sdk/python/src/dagger/mod/_module.py
+++ b/sdk/python/src/dagger/mod/_module.py
@@ -496,7 +496,7 @@ class Module:
                     cls,
                     self._converter,
                     **overrides,
-                )
+                ),
             )
             self._converter.register_structure_hook(
                 cls,
@@ -504,7 +504,7 @@ class Module:
                     cls,
                     self._converter,
                     **overrides,
-                )
+                ),
             )
 
         # Update origin in methods decorated with `mod.function()`.

--- a/sdk/python/tests/modules/test_registration.py
+++ b/sdk/python/tests/modules/test_registration.py
@@ -157,4 +157,3 @@ class TestNameOverrides:
 
     async def test_field_structure(self, mod: Module):
         assert await get_result(mod, "Bar", '{"with": "baz"}', "with", {}) == "baz"
-


### PR DESCRIPTION
Fixes a bug where object fields didn't rename:

```python
@object_type
class PotatoMessage:
    from_: str = field(name="from")
```

Attempting to access `from` via the API would produce the following error:
```
Cannot return null for non-nullable field PotatoMessage.from
```