### PR TITLE
chore: clean up module path handling from local

### DIFF
--- a/cmd/codegen/generator/go/generator.go
+++ b/cmd/codegen/generator/go/generator.go
@@ -144,6 +144,10 @@ func (g *GoGenerator) bootstrapMod(ctx context.Context, mfs *memfs.FS) (*Package
 		info.PackageImport = currentMod.Module.Mod.Path
 	} else {
 		if g.Config.ModuleConfig != nil {
+			outDir, err := filepath.Abs(outDir)
+			if err != nil {
+				return nil, false, fmt.Errorf("get absolute path: %w", err)
+			}
 			rootDir, subdirRelPath, err := g.Config.ModuleConfig.RootAndSubpath(outDir)
 			if err != nil {
 				return nil, false, fmt.Errorf("failed to get module root: %w", err)

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -1836,6 +1836,7 @@ func TestModuleRoots(t *testing.T) {
 				require.JSONEq(t, fmt.Sprintf(`{"%s":{"hello": "hello"}}`, strcase.ToLowerCamel(entry.Name())), out)
 			} else if strings.HasPrefix(entry.Name(), "bad-") {
 				require.Error(t, err)
+				require.Regexp(t, "is not under( module)? root", err.Error())
 			}
 		})
 	}

--- a/core/integration/testdata/modules/go/roots/bad-self-dir/dagger.json
+++ b/core/integration/testdata/modules/go/roots/bad-self-dir/dagger.json
@@ -1,0 +1,5 @@
+{
+  "name": "bad-self-dir",
+  "sdk": "go",
+  "root": "../bad-self-dir"
+}

--- a/core/integration/testdata/modules/go/roots/bad-self-dir/main.go
+++ b/core/integration/testdata/modules/go/roots/bad-self-dir/main.go
@@ -1,0 +1,7 @@
+package main
+
+type BadSelfDir struct{}
+
+func (m *BadSelfDir) Hello() string {
+	return "hello"
+}

--- a/core/integration/testdata/modules/go/roots/bad-sibling-dep/dagger.json
+++ b/core/integration/testdata/modules/go/roots/bad-sibling-dep/dagger.json
@@ -1,0 +1,8 @@
+{
+  "name": "bad-sibling-dep",
+  "sdk": "go",
+  "root": ".",
+  "dependencies": [
+    "../good-base"
+  ]
+}

--- a/core/integration/testdata/modules/go/roots/bad-sibling-dep/main.go
+++ b/core/integration/testdata/modules/go/roots/bad-sibling-dep/main.go
@@ -1,0 +1,7 @@
+package main
+
+type BadSiblingDep struct{}
+
+func (m *BadSiblingDep) Hello() string {
+	return "hello"
+}

--- a/core/integration/testdata/modules/go/roots/bad-sibling-dir/dagger.json
+++ b/core/integration/testdata/modules/go/roots/bad-sibling-dir/dagger.json
@@ -1,0 +1,5 @@
+{
+  "name": "bad-sibling-dir",
+  "sdk": "go",
+  "root": "../root"
+}

--- a/core/integration/testdata/modules/go/roots/bad-sibling-dir/main.go
+++ b/core/integration/testdata/modules/go/roots/bad-sibling-dir/main.go
@@ -1,0 +1,7 @@
+package main
+
+type BadSiblingDir struct{}
+
+func (m *BadSiblingDir) Hello() string {
+	return "hello"
+}

--- a/core/integration/testdata/modules/go/roots/bad-sub-dir/dagger.json
+++ b/core/integration/testdata/modules/go/roots/bad-sub-dir/dagger.json
@@ -1,0 +1,5 @@
+{
+  "name": "bad-sub-dir",
+  "sdk": "go",
+  "root": "subdir"
+}

--- a/core/integration/testdata/modules/go/roots/bad-sub-dir/main.go
+++ b/core/integration/testdata/modules/go/roots/bad-sub-dir/main.go
@@ -1,0 +1,7 @@
+package main
+
+type BadSubDir struct{}
+
+func (m *BadSubDir) Hello() string {
+	return "hello"
+}

--- a/core/integration/testdata/modules/go/roots/good-base/dagger.json
+++ b/core/integration/testdata/modules/go/roots/good-base/dagger.json
@@ -1,0 +1,5 @@
+{
+  "name": "good-base",
+  "sdk": "go",
+  "root": "."
+}

--- a/core/integration/testdata/modules/go/roots/good-base/main.go
+++ b/core/integration/testdata/modules/go/roots/good-base/main.go
@@ -1,0 +1,7 @@
+package main
+
+type GoodBase struct{}
+
+func (m *GoodBase) Hello() string {
+	return "hello"
+}

--- a/core/integration/testdata/modules/go/roots/good-parent-dir/dagger.json
+++ b/core/integration/testdata/modules/go/roots/good-parent-dir/dagger.json
@@ -1,0 +1,5 @@
+{
+  "name": "good-parent-dir",
+  "sdk": "go",
+  "root": ".."
+}

--- a/core/integration/testdata/modules/go/roots/good-parent-dir/main.go
+++ b/core/integration/testdata/modules/go/roots/good-parent-dir/main.go
@@ -1,0 +1,7 @@
+package main
+
+type GoodParentDir struct{}
+
+func (m *GoodParentDir) Hello() string {
+	return "hello"
+}

--- a/core/integration/testdata/modules/go/roots/good-sibling-dep/dagger.json
+++ b/core/integration/testdata/modules/go/roots/good-sibling-dep/dagger.json
@@ -1,0 +1,8 @@
+{
+  "name": "good-sibling-dep",
+  "sdk": "go",
+  "root": "..",
+  "dependencies": [
+    "../good-base"
+  ]
+}

--- a/core/integration/testdata/modules/go/roots/good-sibling-dep/main.go
+++ b/core/integration/testdata/modules/go/roots/good-sibling-dep/main.go
@@ -1,0 +1,7 @@
+package main
+
+type GoodSiblingDep struct{}
+
+func (m *GoodSiblingDep) Hello() string {
+	return "hello"
+}

--- a/core/module.go
+++ b/core/module.go
@@ -179,7 +179,16 @@ func (mod *Module) FromConfig(
 	if filepath.Clean(cfg.Root) != "." {
 		rootPath := filepath.Join(filepath.Dir(configPath), cfg.Root)
 		if rootPath != filepath.Dir(configPath) {
-			configPath, err = filepath.Rel(rootPath, configPath)
+			configPathAbs, err := filepath.Abs(configPath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get config absolute path: %w", err)
+			}
+			rootPathAbs, err := filepath.Abs(rootPath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get root absolute path: %w", err)
+			}
+
+			configPath, err = filepath.Rel(rootPathAbs, configPathAbs)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get config relative to root: %w", err)
 			}


### PR DESCRIPTION
This patch detects some additional edge cases when loading modules, notably:

- Fail if the server tries to load a module where the config is not under the root - this is still also checked client-side for the main module. However, by adding checks server-side, we also get this for dependencies as well.

Additionally, a few small nitpicks:

- Use `path/filepath` instead of `path`.

  `path/filepath` uses OS-depedendant separators, which, while we're not using this, highlights that these are files.

- Use filepath utilities wherever possible (e.g. use `filepath.Rel` instead of `strings.TrimPrefix`).

- Check if a path is a parent to the current directory - `strings.HasPrefix(target, "..")` wasn't right, since a normal filename *can* begin with `..`.