### PR TITLE
Python: Fix input defaults

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -222,6 +222,8 @@ extend-immutable-calls = ["typer.Option"]
     "PT012",
     # No public interfaces.
     "D1",
+    # Allow accessing private fields in tests.
+    "SLF001",
 ]
 # Allow some patterns to redefine imports in __init__.
 "__init__.py" = ["I001", "F401", "F403", "PLC0414"]

--- a/sdk/python/src/dagger/client/_guards.py
+++ b/sdk/python/src/dagger/client/_guards.py
@@ -3,20 +3,14 @@ import functools
 import inspect
 import typing
 from collections.abc import Callable, Coroutine, Sequence
-from dataclasses import is_dataclass
 from typing import Annotated, Any, ParamSpec, TypeGuard, TypeVar, overload
 
 from beartype import beartype
 from beartype.door import TypeHint
 from beartype.roar import BeartypeCallHintViolation
-from beartype.vale import Is, IsInstance, IsSubclass
+from beartype.vale import IsInstance, IsSubclass
 
-from .base import Input, Scalar, Type
-
-InputType = Annotated[Input, Is[lambda o: is_dataclass(o)]]
-InputHint = TypeHint(InputType)
-InputTypeSeq = Annotated[Sequence[InputType], ~IsInstance[str]]
-InputSeqHint = TypeHint(InputTypeSeq)
+from .base import Scalar, Type
 
 
 @typing.runtime_checkable

--- a/sdk/python/tests/client/test_codegen.py
+++ b/sdk/python/tests/client/test_codegen.py
@@ -29,7 +29,7 @@ from dagger._codegen.generator import Scalar as ScalarHandler
 def ctx():
     return Context(
         id_map={
-            "CacheID": "CacheVolume",
+            "CacheVolumeID": "CacheVolume",
             "FileID": "File",
             "SecretID": "Secret",
         },
@@ -59,7 +59,7 @@ def test_format_name(graphql, expected):
 opts = InputObject(
     "Options",
     fields={
-        "key": InputField(NonNull(Scalar("CacheID"))),
+        "key": InputField(NonNull(Scalar("CacheVolumeID"))),
         "name": InputField(String),
     },
 )
@@ -89,7 +89,7 @@ cache_volume = Object(
     "CacheVolume",
     fields={
         "id": Field(
-            NonNull(Scalar("CacheID")),
+            NonNull(Scalar("CacheVolumeID")),
             {},
         ),
     },

--- a/sdk/python/tests/client/test_default_client.py
+++ b/sdk/python/tests/client/test_default_client.py
@@ -45,7 +45,7 @@ class TestConnectionManagement:
             # We want to test connect and disconnect.
             conn = engine.get_shared_client_connection()
 
-            conn_params = conn._params  # noqa: SLF001
+            conn_params = conn._params
             engine_params = engine.connect_params
 
             assert conn_params is not None, "Connection params should be set."

--- a/sdk/python/tests/client/test_integration.py
+++ b/sdk/python/tests/client/test_integration.py
@@ -47,7 +47,7 @@ async def test_container_build():
     assert words[0] == "dagger"
 
 
-async def test_container_build_args():
+async def test_input_arg():
     dockerfile = """\
     FROM alpine:3.16.2
     ARG SPAM=spam
@@ -63,6 +63,12 @@ async def test_container_build_args():
         .stdout()
     )
     assert "SPAM=egg" in out
+
+
+async def test_optionals_in_input_fields():
+    svc = dagger.host().service([dagger.PortForward(8000)])
+    field = svc._ctx.selections.pop()
+    assert field.args == {"ports": [{"backend": 8000}]}
 
 
 @pytest.mark.parametrize("val", ["spam", ""])
@@ -225,8 +231,8 @@ async def test_env_variable_set(mocker):
     ctx.execute = mocker.AsyncMock(return_value="BAR")
 
     env_var = dagger.EnvVariable(ctx)
-    env_var._name = "FOO"  # noqa: SLF001
-    env_var._value = "foo"  # noqa: SLF001
+    env_var._name = "FOO"
+    env_var._value = "foo"
 
     ctx.select.assert_not_called()
     assert await env_var.name() == "FOO"

--- a/sdk/python/tests/modules/test_registration.py
+++ b/sdk/python/tests/modules/test_registration.py
@@ -28,8 +28,7 @@ def test_object_type_resolvers():
         ...
 
     resolvers = [
-        (r.name, r.origin.__name__ if r.origin else None)
-        for r in mod._resolvers  # noqa: SLF001
+        (r.name, r.origin.__name__ if r.origin else None) for r in mod._resolvers
     ]
 
     assert resolvers == [


### PR DESCRIPTION
Fixes #5927

With this change, default values in **input object** fields are omitted.

For example:

```python
svc = dagger.host().service([dagger.PortForward(8000)])
```
Destructures now as:
```python
{"ports": [{"backend": 8000}]}
```

Previously it was destructuring with defaults included:
```python
{'ports': [{'backend': 8000, 'frontend': None, 'protocol': None}]}
```
Where `PortForward`, on server side, `frontend` is set to be equal to `backend` unless it's set. By sending the default of `None`, it was overriding that.


