### PR TITLE
Python modules: Allow using `Optional` in parameters

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -224,6 +224,8 @@ extend-immutable-calls = ["typer.Option"]
     "D1",
     # Allow accessing private fields in tests.
     "SLF001",
+    # Allow covering `Optional` in tests.
+    "UP007",
 ]
 # Allow some patterns to redefine imports in __init__.
 "__init__.py" = ["I001", "F401", "F403", "PLC0414"]

--- a/sdk/python/src/dagger/mod/_converter.py
+++ b/sdk/python/src/dagger/mod/_converter.py
@@ -10,6 +10,7 @@ from ._types import MissingType, ObjectDefinition
 from ._utils import (
     get_doc,
     is_optional,
+    is_union,
     non_optional,
     strip_annotations,
     syncify,
@@ -87,12 +88,12 @@ def to_typedef(annotation: type) -> "TypeDef":  # noqa: C901
     if annotation in builtins:
         return td.with_kind(builtins[annotation])
 
-    if origin := typing.get_origin(annotation):
-        # Can't represent unions in the API.
-        if origin is typing.Union:
-            msg = f"Unsupported union type: {annotation}"
-            raise TypeError(msg)
+    # Can't represent unions in the API.
+    if is_union(annotation):
+        msg = f"Unsupported union type: {annotation}"
+        raise TypeError(msg)
 
+    if origin := typing.get_origin(annotation):
         if issubclass(origin, Sequence):
             of_type, *rest = typing.get_args(annotation)
             if rest:

--- a/sdk/python/src/dagger/mod/_utils.py
+++ b/sdk/python/src/dagger/mod/_utils.py
@@ -97,6 +97,11 @@ def get_arg_name(annotation: type) -> str | None:
     return None
 
 
+def is_union(tp: type) -> bool:
+    """Returns True if the unsubscripted part of a type is a Union."""
+    return get_origin(tp) in (types.UnionType, typing.Union)
+
+
 def is_optional(tp: type) -> bool:
     """Returns True if the annotation is SomeType | None.
 
@@ -104,7 +109,7 @@ def is_optional(tp: type) -> bool:
     resolved with get_type_hints.
     """
     # Optionals are represented as unions
-    if get_origin(tp) is not types.UnionType:
+    if not is_union(tp):
         return False
 
     # For a Union to be optional it needs to have at least one None type.

--- a/sdk/python/tests/modules/test_utils.py
+++ b/sdk/python/tests/modules/test_utils.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Optional
 
 import pytest
 from typing_extensions import Doc
@@ -13,6 +13,7 @@ from dagger.mod._utils import get_arg_name, get_doc, is_optional, non_optional
         (str, False),
         (str | int, False),
         (str | None, True),
+        (Optional[str], True),
     ],
 )
 def test_is_optional(typ, expected):
@@ -24,6 +25,7 @@ def test_is_optional(typ, expected):
     [
         (str, str),
         (str | None, str),
+        (Optional[str], str),
         (str | int | None, str | int),
         (str | int, str | int),
     ],


### PR DESCRIPTION
Fixes #6094 

It's recommended to use the `str | None` syntax instead of the older (and misnamed) `Optional[str]`. However, the latter should still be supported which is what this PR fixes.

The problem was a bad assumption on my part, as I thought these would be the same:

```python
>>> get_origin(str | None)
<class 'types.UnionType'>
>>> get_origin(Optional[str])
typing.Union
```