### PR TITLE
Python modules: Prevent documenting regular unions

### DIFF
--- a/sdk/python/src/dagger/mod/_utils.py
+++ b/sdk/python/src/dagger/mod/_utils.py
@@ -76,7 +76,11 @@ def get_doc(obj: Any) -> str | None:
             ),
             None,
         )
-    return None if inspect.getmodule(obj) == builtins else inspect.getdoc(obj)
+    if inspect.getmodule(obj) != builtins and (
+        inspect.isclass(obj) or inspect.isfunction(obj)
+    ):
+        return inspect.getdoc(obj)
+    return None
 
 
 def get_arg_name(annotation: type) -> str | None:

--- a/sdk/python/tests/modules/test_utils.py
+++ b/sdk/python/tests/modules/test_utils.py
@@ -40,13 +40,18 @@ def func_with_docstring():
     """Foo."""
 
 
+async def async_func_with_docstring():
+    """Foo."""
+
+
 @pytest.mark.parametrize(
     "annotation",
     [
         ClassWithDocstring,
-        ClassWithDocstring(),
         func_with_docstring,
+        async_func_with_docstring,
         Annotated[str, Doc("Foo.")],
+        Annotated[str | None, Doc("Foo.")],
         Annotated[str, Doc("Foo."), "Not supported"],
         Annotated[str, Doc("Bar."), Doc("Foo.")],
     ],
@@ -63,13 +68,18 @@ def func_without_docstring():
     ...
 
 
+async def async_func_without_docstring():
+    ...
+
+
 @pytest.mark.parametrize(
     "annotation",
     [
         ClassWithoutDocstring,
-        ClassWithoutDocstring(),
         func_without_docstring,
+        async_func_without_docstring,
         str,
+        str | None,
         Annotated[str, "Not supported"],
         Annotated[str, Arg("foo")],
     ],


### PR DESCRIPTION
Fixes #6096

## Example:

```python
from dagger.mod import function

@function
def foo(bar: str | None = None) -> str:
    return bar or "foobar"
```

Help output:

```diff
  Usage:
    dagger call foo [flags]

  Flags:
-       --bar string   Represent a PEP 604 union type
-
-                      E.g. for int | str
+       --bar string
    -h, --help         help for foo
```