### PR TITLE
feat: make module types id-able 

### DIFF
--- a/core/function.go
+++ b/core/function.go
@@ -109,6 +109,15 @@ func (typeDef *TypeDef) Digest() (digest.Digest, error) {
 	return stableDigest(typeDef)
 }
 
+func (typeDef *TypeDef) Underlying() *TypeDef {
+	switch typeDef.Kind {
+	case TypeDefKindList:
+		return typeDef.AsList.ElementTypeDef.Underlying()
+	default:
+		return typeDef
+	}
+}
+
 func (typeDef TypeDef) Clone() *TypeDef {
 	cp := typeDef
 	if typeDef.AsList != nil {

--- a/core/resourceid/module_id.go
+++ b/core/resourceid/module_id.go
@@ -20,28 +20,31 @@ func EncodeModule(typeName string, value any) (string, error) {
 
 // DecodeModule base64-decodes and JSON unmarshals an ID, returning the module
 // typename and its data.
-func DecodeModule(rest string) (string, any, error) {
-	prefix, rest, ok := strings.Cut(rest, ":")
+func DecodeModuleID(id string, expectedTypeName string) (any, error) {
+	prefix, rest, ok := strings.Cut(id, ":")
 	if !ok {
-		return "", nil, fmt.Errorf("invalid id")
+		return nil, fmt.Errorf("invalid id")
 	}
 	if prefix != "moddata" {
-		return "", nil, fmt.Errorf("invalid id prefix %q", prefix)
+		return nil, fmt.Errorf("invalid id prefix %q", prefix)
 	}
 
 	typeName, rest, ok := strings.Cut(rest, ":")
 	if !ok {
-		return "", nil, fmt.Errorf("invalid id")
+		return nil, fmt.Errorf("invalid id")
+	}
+	if typeName != expectedTypeName {
+		return nil, fmt.Errorf("invalid type name %q, expected %q", typeName, expectedTypeName)
 	}
 
 	jsonBytes, err := base64.StdEncoding.DecodeString(rest)
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to decode id: %w", err)
+		return nil, fmt.Errorf("failed to decode id: %w", err)
 	}
 
 	obj := map[string]any{}
 	if err := json.Unmarshal(jsonBytes, &obj); err != nil {
-		return "", nil, fmt.Errorf("failed to unmarshal id: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal id: %w", err)
 	}
-	return typeName, obj, nil
+	return obj, nil
 }

--- a/core/resourceid/module_id.go
+++ b/core/resourceid/module_id.go
@@ -1,0 +1,47 @@
+package resourceid
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// EncodeModule JSON marshals and base64-encodes a module ID from its typename
+// and data.
+func EncodeModule(typeName string, value any) (string, error) {
+	jsonBytes, err := json.Marshal(value)
+	if err != nil {
+		return "", fmt.Errorf("failed to json marshal %T: %w", value, err)
+	}
+	idEnc := base64.StdEncoding.EncodeToString(jsonBytes)
+	return fmt.Sprintf("moddata:%s:%s", typeName, idEnc), nil
+}
+
+// DecodeModule base64-decodes and JSON unmarshals an ID, returning the module
+// typename and its data.
+func DecodeModule(rest string) (string, any, error) {
+	prefix, rest, ok := strings.Cut(rest, ":")
+	if !ok {
+		return "", nil, fmt.Errorf("invalid id")
+	}
+	if prefix != "moddata" {
+		return "", nil, fmt.Errorf("invalid id prefix %q", prefix)
+	}
+
+	typeName, rest, ok := strings.Cut(rest, ":")
+	if !ok {
+		return "", nil, fmt.Errorf("invalid id")
+	}
+
+	jsonBytes, err := base64.StdEncoding.DecodeString(rest)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to decode id: %w", err)
+	}
+
+	obj := map[string]any{}
+	if err := json.Unmarshal(jsonBytes, &obj); err != nil {
+		return "", nil, fmt.Errorf("failed to unmarshal id: %w", err)
+	}
+	return typeName, obj, nil
+}

--- a/core/schema/cache.go
+++ b/core/schema/cache.go
@@ -16,6 +16,10 @@ func (s *cacheSchema) Name() string {
 	return "cache"
 }
 
+func (s *cacheSchema) SourceModuleName() string {
+	return coreModuleName
+}
+
 func (s *cacheSchema) Schema() string {
 	return Cache
 }

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -37,6 +37,10 @@ func (s *containerSchema) Name() string {
 	return "container"
 }
 
+func (s *containerSchema) SourceModuleName() string {
+	return coreModuleName
+}
+
 func (s *containerSchema) Schema() string {
 	return Container
 }
@@ -109,10 +113,6 @@ func (s *containerSchema) Resolvers() Resolvers {
 	})
 
 	return rs
-}
-
-func (s *containerSchema) Dependencies() []ExecutableSchema {
-	return nil
 }
 
 type containerArgs struct {

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -24,6 +24,10 @@ func (s *directorySchema) Name() string {
 	return "directory"
 }
 
+func (s *directorySchema) SourceModuleName() string {
+	return coreModuleName
+}
+
 func (s *directorySchema) Schema() string {
 	return Directory
 }
@@ -55,10 +59,6 @@ func (s *directorySchema) Resolvers() Resolvers {
 	})
 
 	return rs
-}
-
-func (s *directorySchema) Dependencies() []ExecutableSchema {
-	return nil
 }
 
 type directoryPipelineArgs struct {

--- a/core/schema/file.go
+++ b/core/schema/file.go
@@ -19,6 +19,10 @@ func (s *fileSchema) Name() string {
 	return "file"
 }
 
+func (s *fileSchema) SourceModuleName() string {
+	return coreModuleName
+}
+
 func (s *fileSchema) Schema() string {
 	return File
 }
@@ -39,10 +43,6 @@ func (s *fileSchema) Resolvers() Resolvers {
 	})
 
 	return rs
-}
-
-func (s *fileSchema) Dependencies() []ExecutableSchema {
-	return nil
 }
 
 type fileArgs struct {

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -19,6 +19,10 @@ func (s *gitSchema) Name() string {
 	return "git"
 }
 
+func (s *gitSchema) SourceModuleName() string {
+	return coreModuleName
+}
+
 func (s *gitSchema) Schema() string {
 	return Git
 }
@@ -38,10 +42,6 @@ func (s *gitSchema) Resolvers() Resolvers {
 			"commit": ToResolver(s.fetchCommit),
 		},
 	}
-}
-
-func (s *gitSchema) Dependencies() []ExecutableSchema {
-	return nil
 }
 
 type gitArgs struct {

--- a/core/schema/host.go
+++ b/core/schema/host.go
@@ -22,6 +22,10 @@ func (s *hostSchema) Name() string {
 	return "host"
 }
 
+func (s *hostSchema) SourceModuleName() string {
+	return coreModuleName
+}
+
 func (s *hostSchema) Schema() string {
 	return Host
 }
@@ -40,10 +44,6 @@ func (s *hostSchema) Resolvers() Resolvers {
 			"service":       ToResolver(s.service),
 		},
 	}
-}
-
-func (s *hostSchema) Dependencies() []ExecutableSchema {
-	return nil
 }
 
 type setSecretFileArgs struct {

--- a/core/schema/http.go
+++ b/core/schema/http.go
@@ -22,6 +22,10 @@ func (s *httpSchema) Name() string {
 	return "http"
 }
 
+func (s *httpSchema) SourceModuleName() string {
+	return coreModuleName
+}
+
 func (s *httpSchema) Schema() string {
 	return HTTP
 }
@@ -32,10 +36,6 @@ func (s *httpSchema) Resolvers() Resolvers {
 			"http": ToResolver(s.http),
 		},
 	}
-}
-
-func (s *httpSchema) Dependencies() []ExecutableSchema {
-	return nil
 }
 
 type httpArgs struct {

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -1311,15 +1311,9 @@ func (s *moduleSchema) createIDResolver(typeDef *core.TypeDef, schemaView *schem
 					return nil, fmt.Errorf("expected map %s, or string %sID, got %T", typeDef.AsObject.Name, typeDef.AsObject.Name, a)
 				}
 
-				typeName, value, err := resourceid.DecodeModule(id)
+				value, err := resourceid.DecodeModuleID(id, typeDef.AsObject.Name)
 				if err != nil {
-					return a, nil
-				}
-				if typeName != typeDef.AsObject.Name {
-					// if we hit this, the module is misbehaving - it's
-					// declared it returns a different module type than it's
-					// actually returned
-					return nil, fmt.Errorf("invalid type name %q, expected %q", typeName, typeDef.AsObject.Name)
+					return nil, err
 				}
 				return value, nil
 			}

--- a/core/schema/platform.go
+++ b/core/schema/platform.go
@@ -19,6 +19,10 @@ func (s *platformSchema) Name() string {
 	return "platform"
 }
 
+func (s *platformSchema) SourceModuleName() string {
+	return coreModuleName
+}
+
 func (s *platformSchema) Schema() string {
 	return Platform
 }
@@ -68,10 +72,6 @@ func (s *platformSchema) Resolvers() Resolvers {
 			},
 		},
 	}
-}
-
-func (s *platformSchema) Dependencies() []ExecutableSchema {
-	return nil
 }
 
 func (s *platformSchema) defaultPlatform(ctx context.Context, parent, args any) (specs.Platform, error) {

--- a/core/schema/query.go
+++ b/core/schema/query.go
@@ -23,6 +23,10 @@ func (s *querySchema) Name() string {
 	return "query"
 }
 
+func (s *querySchema) SourceModuleName() string {
+	return coreModuleName
+}
+
 func (s *querySchema) Schema() string {
 	return Query
 }
@@ -39,10 +43,6 @@ func (s *querySchema) Resolvers() Resolvers {
 			"protocol": ToResolver(s.portProtocolHack),
 		},
 	}
-}
-
-func (s *querySchema) Dependencies() []ExecutableSchema {
-	return nil
 }
 
 type pipelineArgs struct {

--- a/core/schema/secret.go
+++ b/core/schema/secret.go
@@ -16,6 +16,10 @@ func (s *secretSchema) Name() string {
 	return "secret"
 }
 
+func (s *secretSchema) SourceModuleName() string {
+	return coreModuleName
+}
+
 func (s *secretSchema) Schema() string {
 	return Secret
 }
@@ -33,10 +37,6 @@ func (s *secretSchema) Resolvers() Resolvers {
 	})
 
 	return rs
-}
-
-func (s *secretSchema) Dependencies() []ExecutableSchema {
-	return nil
 }
 
 type secretArgs struct {

--- a/core/schema/service.go
+++ b/core/schema/service.go
@@ -19,6 +19,10 @@ func (s *serviceSchema) Name() string {
 	return "service"
 }
 
+func (s *serviceSchema) SourceModuleName() string {
+	return coreModuleName
+}
+
 func (s *serviceSchema) Schema() string {
 	return Service
 }
@@ -39,10 +43,6 @@ func (s *serviceSchema) Resolvers() Resolvers {
 	})
 
 	return rs
-}
-
-func (s *serviceSchema) Dependencies() []ExecutableSchema {
-	return nil
 }
 
 func (s *serviceSchema) containerAsService(ctx context.Context, parent *core.Container, args any) (*core.Service, error) {

--- a/core/schema/socket.go
+++ b/core/schema/socket.go
@@ -19,6 +19,10 @@ func (s *socketSchema) Name() string {
 	return "socket"
 }
 
+func (s *socketSchema) SourceModuleName() string {
+	return coreModuleName
+}
+
 func (s *socketSchema) Schema() string {
 	return Socket
 }
@@ -33,10 +37,6 @@ func (s *socketSchema) Resolvers() Resolvers {
 	ResolveIDable[socket.Socket](rs, "Socket", ObjectResolver{})
 
 	return rs
-}
-
-func (s *socketSchema) Dependencies() []ExecutableSchema {
-	return nil
 }
 
 type socketArgs struct {


### PR DESCRIPTION
:warning: Depends on https://github.com/dagger/dagger/pull/6057 (marking as draft until that one is merged)

This feature allows all module declared objects to be converted to a respective ID-type using the "id" field, and converted from an ID-type using the "loadFromID" helper. This effectively makes these types fully idable.

IDs are essentially the contents of the module type's data, JSON-encoded, and then base64-encoded, similar (but not identical) to standard IDs. At the moment, they don't share exactly the same codepaths to normal modules, but this could be adapted to be so in the future. We also include a note of *what type* generated this ID - this is so we can prevent type confusion.

Essentially, this enables a number of previously impossible use cases:

1. Returning a custom object from another module from a function

   - This case is the simplest - we just extend our conversion that unpacks all returned IDs from functions into their underlying types (so while a module returns an XID, it can be queried as if it was X).

2. Accepting a custom object as a parameter to a function

   - Because graphql doesn't support creating inline objects, we get around this in the core api by instead passing IDs everywhere. All the code-gen is setup to expect this, but module types weren't IDable, so we failed during schema-checking.

     Additionally, we need to transparently convert the ID from the graphql request into the underlying storage data for the module.

3. Accepting a custom object from another module as a parameter to a function

   - This is the same case as above, but also involves ensuring that we stitch in the type declarations from the module into our own schema so that we have the right type.

     However, here, we **don't** decode the ID into its underlying data, it's a foreign type, so the module should only see the ID.

So, I'm not actually sure about the actual method by which this encodes the module data into the ID - I *think* this is the right approach? It's pretty much the easiest way to store the state, but we could also randomly assign IDs and simply cache the results (potentially useful if the IDs start getting really long), or we could do something similar to the core API and just store the parents (though I'm not 100% sure how this would work, I think this might be the thing that needs IDs v2?).