### PR TITLE
Python SDK: fix codegen docstring ending in `"`

### DIFF
--- a/sdk/python/.changes/unreleased/Fixed-20231113-164527.yaml
+++ b/sdk/python/.changes/unreleased/Fixed-20231113-164527.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fix codegen docstring ending in `"`
+time: 2023-11-13T16:45:27.038813-01:00
+custom:
+  Author: helderco
+  PR: "6104"

--- a/sdk/python/src/dagger/_codegen/generator.py
+++ b/sdk/python/src/dagger/_codegen/generator.py
@@ -505,6 +505,8 @@ def doc(s: str) -> str:
     """Wrap string in docstring quotes."""
     if "\n" in s:
         s = f"{s}\n"
+    elif s.endswith('"'):
+        s += " "
     return f'"""{s}"""'
 
 

--- a/sdk/python/tests/client/test_codegen.py
+++ b/sdk/python/tests/client/test_codegen.py
@@ -291,6 +291,10 @@ def test_enum_render(type_, expected, ctx: Context):
             ),
         ),
         (
+            '"Foo": bar.',
+            r'""""Foo": bar."""',
+        ),
+        (
             'Example: "foobar"',
             r'"""Example: "foobar" """',
         ),

--- a/sdk/python/tests/client/test_codegen.py
+++ b/sdk/python/tests/client/test_codegen.py
@@ -1,4 +1,5 @@
 from textwrap import dedent
+import textwrap
 
 import pytest
 from graphql import GraphQLArgument as Argument
@@ -15,6 +16,7 @@ from graphql import GraphQLScalarType as Scalar
 from graphql import GraphQLString as String
 
 from dagger._codegen.generator import (
+    doc,
     Context,
     _InputField,
     format_input_type,
@@ -270,3 +272,41 @@ def test_scalar_render(type_, expected, ctx: Context):
 def test_enum_render(type_, expected, ctx: Context):
     handler = EnumHandler(ctx)
     assert handler.render(type_) == expected
+
+
+
+@pytest.mark.parametrize(
+    ("original", "expected"),
+    [
+        (
+            "Lorem ipsum dolores est.",
+            '"""Lorem ipsum dolores est."""',
+        ),
+        (
+            "Lorem ipsum dolores est.\n\nSecond paragraph.",
+            dedent(
+                '''\
+                """Lorem ipsum dolores est.
+
+                Second paragraph.
+                """''',
+            ),
+        ),
+        (
+            'Example: "foobar"',
+            r'"""Example: "foobar" """',
+        ),
+        (
+            'Lorem ipsum dolores est.\n\nExample: "foobar"',
+            dedent(
+                '''\
+                """Lorem ipsum dolores est.
+
+                Example: "foobar"
+                """''',
+            )
+        ),
+    ],
+)
+def test_doc(original: str, expected:str):
+    assert doc(original) == expected

--- a/sdk/python/tests/client/test_codegen.py
+++ b/sdk/python/tests/client/test_codegen.py
@@ -1,5 +1,4 @@
 from textwrap import dedent
-import textwrap
 
 import pytest
 from graphql import GraphQLArgument as Argument
@@ -16,9 +15,9 @@ from graphql import GraphQLScalarType as Scalar
 from graphql import GraphQLString as String
 
 from dagger._codegen.generator import (
-    doc,
     Context,
     _InputField,
+    doc,
     format_input_type,
     format_name,
     format_output_type,
@@ -274,7 +273,6 @@ def test_enum_render(type_, expected, ctx: Context):
     assert handler.render(type_) == expected
 
 
-
 @pytest.mark.parametrize(
     ("original", "expected"),
     [
@@ -304,9 +302,9 @@ def test_enum_render(type_, expected, ctx: Context):
 
                 Example: "foobar"
                 """''',
-            )
+            ),
         ),
     ],
 )
-def test_doc(original: str, expected:str):
+def test_doc(original: str, expected: str):
     assert doc(original) == expected


### PR DESCRIPTION
Fixes #6090