### PR TITLE
Python modules: allow annotating a chainable method with `Self`

### DIFF
--- a/sdk/python/src/dagger/mod/_resolver.py
+++ b/sdk/python/src/dagger/mod/_resolver.py
@@ -2,7 +2,6 @@ import dataclasses
 import inspect
 import json
 import logging
-import typing
 from abc import ABC, abstractmethod, abstractproperty
 from collections.abc import Callable
 from functools import cached_property
@@ -14,8 +13,7 @@ from typing import (
 )
 
 import cattrs
-import typing_extensions
-from typing_extensions import override
+from typing_extensions import Self, override
 
 import dagger
 
@@ -134,7 +132,7 @@ class FunctionResolver(Resolver, Generic[Func]):
             r = self._type_hints["return"]
         except KeyError:
             return MissingType
-        if r in (typing.Self, typing_extensions.Self):
+        if r is Self:
             if self.origin is None:
                 msg = "Can't return Self without parent class"
                 raise UserError(msg)

--- a/sdk/python/tests/modules/test_forward_reference.py
+++ b/sdk/python/tests/modules/test_forward_reference.py
@@ -1,0 +1,15 @@
+from dagger.mod import Module
+
+mod = Module()
+
+
+@mod.object_type
+class Foo:
+    @mod.function
+    def method(self) -> "Foo":
+        ...
+
+
+def test_method_returns_resolved_forward_reference():
+    resolver = mod.get_resolver(mod.get_resolvers("foo"), "Foo", "method")
+    assert resolver.return_type == Foo


### PR DESCRIPTION
Allows using `Self` when creating chainable methods:

```diff
+from typing import Self
+
from dagger.mod import function, object_type

@object_type
class Foo:
    name: str = "Bar"

-    def with_bar(self, name: str) -> "Foo"
+    def with_bar(self, name: str) -> Self
        self.name = name
        return self
```