### PR TITLE
fix: Python module codegen with different root

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -1568,6 +1568,23 @@ func TestModulePythonInit(t *testing.T) {
 		require.JSONEq(t, `{"bare":{"containerEcho":{"stdout":"hello\n"}}}`, out)
 	})
 
+	t.Run("with different root", func(t *testing.T) {
+		t.Parallel()
+
+		c, ctx := connect(t)
+
+		modGen := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work/child").
+			With(daggerExec("mod", "init", "--name=bare", "--sdk=python", "--root=.."))
+
+		out, err := modGen.
+			With(daggerQuery(`{bare{containerEcho(stringArg:"hello"){stdout}}}`)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"bare":{"containerEcho":{"stdout":"hello\n"}}}`, out)
+	})
+
 	t.Run("respects existing pyproject.toml", func(t *testing.T) {
 		t.Parallel()
 

--- a/sdk/python/runtime/main.go
+++ b/sdk/python/runtime/main.go
@@ -43,7 +43,7 @@ func (m *PythonSdk) Codegen(modSource *Directory, subPath string, introspectionJ
 	})
 
 	modified := ctr.Directory(ModSourceDirPath)
-	diff := modSource.Diff(modified)
+	diff := modSource.Diff(modified).Directory(subPath)
 
 	return dag.GeneratedCode(diff).
 		WithVCSIgnoredPaths([]string{


### PR DESCRIPTION
Codegen wasn't including the module's `subPath` when generating files.

## Example

```shell
dagger mod init --sdk=python --name=bare --root=..
```

### Before
```
.
├── bare
│  ├── sdk
│  ├── src
│  └── pyproject.toml
├── .gitignore
└── dagger.json
```
### After
```
.
├── sdk
├── src
├── .gitignore
├── dagger.json
└── pyproject.toml
```
