### PR TITLE
fix: remove redundant file stat from LocalFileExport

### DIFF
--- a/engine/buildkit/filesync.go
+++ b/engine/buildkit/filesync.go
@@ -335,11 +335,7 @@ func (c *Client) LocalFileExport(
 	}
 	defer diffCopyClient.CloseSend()
 
-	fileStat, err := file.Stat()
-	if err != nil {
-		return fmt.Errorf("failed to stat file: %s", err)
-	}
-	fileSizeLeft := fileStat.Size()
+	fileSizeLeft := stat.Size()
 	chunkSize := int64(MaxFileContentsChunkSize)
 	for fileSizeLeft > 0 {
 		buf := new(bytes.Buffer) // TODO: more efficient to use bufio.Writer, reuse buffers, sync.Pool, etc.


### PR DESCRIPTION
When `LocalFileExport` is called the following operations occur. `stat` is already populated with `FileInfo`:
```go
...
	file, err := os.Open(mntFilePath)
	if err != nil {
		return fmt.Errorf("failed to open file: %s", err)
	}
	defer file.Close()
	stat, err := file.Stat()
	if err != nil {
		return fmt.Errorf("failed to stat file: %s", err)
	}
...
```
It seems there's a redundant `file.Stat` call in https://github.com/matiasinsaurralde/dagger/blob/main/engine/buildkit/filesync.go#L255

This PR removes this redundant call and modifies `fileSizeLeft` so that it reuses the original `FileInfo` value that's loaded into `stat`.

Guessing this was accidentally introduced during a big merge or similar.