### PR TITLE
fix: Do not try to use dynamic provisioning when port and session token env vars are set

### DIFF
--- a/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/engineconn/Connection.java
+++ b/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/engineconn/Connection.java
@@ -68,7 +68,9 @@ public final class Connection {
   }
 
   public static Connection get(String workingDir) throws IOException {
-    return fromEnv().orElse(fromCLI(new CLIRunner(workingDir, new CLIDownloader())));
+    Optional<Connection> connection = fromEnv();
+    return connection.isPresent() ? connection.get()
+        : fromCLI(new CLIRunner(workingDir, new CLIDownloader()));
   }
 
   private static Connection getConnection(int port, String token, Optional<CLIRunner> runner) {

--- a/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/engineconn/Connection.java
+++ b/sdk/java/dagger-java-sdk/src/main/java/io/dagger/client/engineconn/Connection.java
@@ -69,7 +69,8 @@ public final class Connection {
 
   public static Connection get(String workingDir) throws IOException {
     Optional<Connection> connection = fromEnv();
-    return connection.isPresent() ? connection.get()
+    return connection.isPresent()
+        ? connection.get()
         : fromCLI(new CLIRunner(workingDir, new CLIDownloader()));
   }
 

--- a/sdk/java/dagger-java-sdk/src/test/java/io/dagger/client/engineconn/ConnectionTest.java
+++ b/sdk/java/dagger-java-sdk/src/test/java/io/dagger/client/engineconn/ConnectionTest.java
@@ -2,7 +2,11 @@ package io.dagger.client.engineconn;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -11,6 +15,7 @@ import java.io.IOException;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
@@ -57,6 +62,16 @@ public class ConnectionTest {
     verify(runner, times(1)).getConnectionParams();
     conn.close();
     verify(runner, times(1)).shutdown();
+  }
+
+  @Test
+  public void should_not_call_dynamic_provisioning_when_env_vars_are_present() throws Exception {
+    MockedStatic<Connection> connectionMockedStatic = mockStatic(Connection.class, CALLS_REAL_METHODS);
+    environmentVariables.set("DAGGER_SESSION_PORT", "52037");
+    environmentVariables.set("DAGGER_SESSION_TOKEN", "189de95f-07df-415d-b42a-7851c731359d");
+    Connection conn = Connection.get("/tmp");
+    assertThat(conn).isNotNull();
+    connectionMockedStatic.verify(() -> Connection.fromCLI(any()), never());
   }
 
   @Test

--- a/sdk/java/dagger-java-sdk/src/test/java/io/dagger/client/engineconn/ConnectionTest.java
+++ b/sdk/java/dagger-java-sdk/src/test/java/io/dagger/client/engineconn/ConnectionTest.java
@@ -66,7 +66,8 @@ public class ConnectionTest {
 
   @Test
   public void should_not_call_dynamic_provisioning_when_env_vars_are_present() throws Exception {
-    MockedStatic<Connection> connectionMockedStatic = mockStatic(Connection.class, CALLS_REAL_METHODS);
+    MockedStatic<Connection> connectionMockedStatic =
+        mockStatic(Connection.class, CALLS_REAL_METHODS);
     environmentVariables.set("DAGGER_SESSION_PORT", "52037");
     environmentVariables.set("DAGGER_SESSION_TOKEN", "189de95f-07df-415d-b42a-7851c731359d");
     Connection conn = Connection.get("/tmp");


### PR DESCRIPTION
this PR fixes a bug:
Even if port and session token env vars were set, the SDK tried to open a connection with dynamic provisioning. This behaviour was leading to an unexpected behaviour. This PR makes the `Connection.get` does not try to dynamically provision a Dagger CLI when the env vars are already set