### PR TITLE
Run python tests in dagger runner

### DIFF
--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -24,12 +24,7 @@ jobs:
       mage-targets: sdk:python:lint
 
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version: "1.21"
-      - run: ./hack/make sdk:python:test
-        env:
-          DAGGER_CLOUD_TOKEN: "${{ secrets.DAGGER_CLOUD_TOKEN }}"
+    uses: ./.github/workflows/_hack_make.yml
+    secrets: inherit
+    with:
+      mage-targets: sdk:python:test

--- a/docs/current/cookbook/snippets/error-handling/postmortem/main.py
+++ b/docs/current/cookbook/snippets/error-handling/postmortem/main.py
@@ -25,14 +25,16 @@ async def test(client: dagger.Client):
     # need to handle anything here.
 
     # The result of `sync` is the container, which allows continued chaining.
-    ctr = await (
-        client.container()
-        .from_("alpine")
-        # Add script with execution permission to simulate a testing tool.
-        .with_new_file("run-tests", contents=SCRIPT, permissions=0o750)
-        # If the exit code isn't needed: "run-tests; true"
-        .with_exec(["sh", "-c", "/run-tests; echo -n $? > /exit_code"])
-        .sync()
+    ctr = (
+        await (
+            client.container()
+            .from_("alpine")
+            # Add script with execution permission to simulate a testing tool.
+            .with_new_file("run-tests", contents=SCRIPT, permissions=0o750)
+            # If the exit code isn't needed: "run-tests; true"
+            .with_exec(["sh", "-c", "/run-tests; echo -n $? > /exit_code"])
+            .sync()
+        )
     )
 
     # Save report locally for inspection.

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -68,6 +68,7 @@ packages = ["src/dagger"]
 dependencies = [
     "black>=22.3.0",
     "ruff>=0.0.218",
+    "aiohttp>=3.8.6",
     "pytest>=7.2.0",
     "pytest-mock>=3.10.0",
     "pytest-subprocess>=1.4.2",

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -4,17 +4,25 @@
 #
 #    hatch run lock
 #
+aiohttp==3.8.6
+    # via -r -
+aiosignal==1.3.1
+    # via aiohttp
 anyio==4.0.0
     # via
     #   -r -
-    #   httpcore
+    #   httpx
+async-timeout==4.0.3
+    # via aiohttp
 attrs==23.1.0
-    # via cattrs
+    # via
+    #   aiohttp
+    #   cattrs
 backoff==2.2.1
     # via gql
 beartype==0.16.4
     # via -r -
-black==23.10.1
+black==23.11.0
     # via -r -
 cattrs==23.1.2
     # via -r -
@@ -22,8 +30,14 @@ certifi==2023.7.22
     # via
     #   httpcore
     #   httpx
+charset-normalizer==3.3.2
+    # via aiohttp
 click==8.1.7
     # via black
+frozenlist==1.4.0
+    # via
+    #   aiohttp
+    #   aiosignal
 gql==3.4.1
     # via -r -
 graphql-core==3.2.3
@@ -32,9 +46,9 @@ graphql-core==3.2.3
     #   gql
 h11==0.14.0
     # via httpcore
-httpcore==0.18.0
+httpcore==1.0.2
     # via httpx
-httpx==0.25.0
+httpx==0.25.1
     # via
     #   -r -
     #   pytest-httpx
@@ -50,7 +64,9 @@ markdown-it-py==3.0.0
 mdurl==0.1.2
     # via markdown-it-py
 multidict==6.0.4
-    # via yarl
+    # via
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via black
 packaging==23.2
@@ -59,7 +75,7 @@ packaging==23.2
     #   pytest
 pathspec==0.11.2
     # via black
-platformdirs==3.11.0
+platformdirs==4.0.0
     # via
     #   -r -
     #   black
@@ -74,7 +90,7 @@ pytest==7.4.3
     #   pytest-lazy-fixture
     #   pytest-mock
     #   pytest-subprocess
-pytest-httpx==0.26.0
+pytest-httpx==0.27.0
     # via -r -
 pytest-lazy-fixture==0.6.3
     # via -r -
@@ -82,16 +98,17 @@ pytest-mock==3.12.0
     # via -r -
 pytest-subprocess==1.5.0
     # via -r -
-rich==13.6.0
+rich==13.7.0
     # via -r -
-ruff==0.1.3
+ruff==0.1.5
     # via -r -
 sniffio==1.3.0
     # via
     #   anyio
-    #   httpcore
     #   httpx
 typing-extensions==4.8.0
     # via -r -
 yarl==1.9.2
-    # via gql
+    # via
+    #   aiohttp
+    #   gql

--- a/sdk/python/src/dagger/_managers.py
+++ b/sdk/python/src/dagger/_managers.py
@@ -1,7 +1,7 @@
 import contextlib
 import typing
 
-import anyio
+import anyio.to_thread
 from typing_extensions import Self
 
 asyncify = anyio.to_thread.run_sync

--- a/sdk/python/tests/client/test_integration_connection.py
+++ b/sdk/python/tests/client/test_integration_connection.py
@@ -11,7 +11,7 @@ pytestmark = [
 
 
 async def test_connection_closed_error():
-    async with dagger.Connection() as client:
+    async with dagger.Connection(dagger.Config(retry=None)) as client:
         ...
     with pytest.raises(
         dagger.TransportError, match="Connection to engine has been closed"

--- a/sdk/python/tests/engine/test_download.py
+++ b/sdk/python/tests/engine/test_download.py
@@ -1,145 +1,136 @@
 import hashlib
-import io
 import os
+import pathlib
 import shutil
 import tarfile
 import zipfile
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from collections.abc import Awaitable, Callable
+from contextlib import AsyncExitStack
 from pathlib import Path
 
 import anyio
 import anyio.from_thread
-import httpx
+import anyio.to_thread
 import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+from anyio.streams.file import FileReadStream
 
 import dagger
 from dagger._engine import download
-
-
-@pytest.fixture(autouse=True)
-def cache_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """Create a temp cache_dir for testing & set XDG_CACHE_HOME."""
-    cache_dir = tmp_path / "dagger"
-    cache_dir.mkdir()
-    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
-    return cache_dir
+from dagger._managers import asyncify
 
 
 @pytest.mark.anyio()
 @pytest.fixture(autouse=True)
-async def _temporary_cli_server(monkeypatch: pytest.MonkeyPatch):
+async def _setup(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_cli_server: Callable[[str], Awaitable[str]],
+):
     # ignore DAGGER_SESSION_PORT
     monkeypatch.delenv("DAGGER_SESSION_PORT", raising=False)
 
     # if explicitly requested to test against a certain URL, use that
-    archive_url = os.environ.get("_INTERNAL_DAGGER_TEST_CLI_URL")
-    checksum_url = os.environ.get("_INTERNAL_DAGGER_TEST_CLI_CHECKSUMS_URL")
+    archive_url = os.getenv("_INTERNAL_DAGGER_TEST_CLI_URL")
+    checksum_url = os.getenv("_INTERNAL_DAGGER_TEST_CLI_CHECKSUMS_URL")
 
     if archive_url and checksum_url:
         monkeypatch.setattr(download.Downloader, "archive_url", archive_url)
         monkeypatch.setattr(download.Downloader, "checksum_url", checksum_url)
-        yield
-        return
 
     # if _EXPERIMENTAL_DAGGER_CLI_BIN is set, create a temporary http server for it
-    if cli_bin := os.environ.get("_EXPERIMENTAL_DAGGER_CLI_BIN"):
+    if cli_bin := os.getenv("_EXPERIMENTAL_DAGGER_CLI_BIN"):
         monkeypatch.delenv("_EXPERIMENTAL_DAGGER_CLI_BIN", raising=False)
 
-        downloader = download.Downloader()
-        archive_url = httpx.URL(downloader.archive_url)
-        checksum_url = httpx.URL(downloader.checksum_url)
+        base_url = await mock_cli_server(cli_bin)
 
-        # create an in-memory archive with the cli_bin in it
-        archive = io.BytesIO()
+        monkeypatch.setattr(download.Downloader, "CLI_BASE_URL", base_url)
 
-        with Path(cli_bin).open("rb") as f:
-            if downloader.archive_name.endswith(".zip"):
-                with (
-                    zipfile.ZipFile(archive, mode="w") as zar,
-                    zar.open(
-                        "dagger.exe",
-                        mode="w",
-                    ) as zf,
-                ):
-                    shutil.copyfileobj(f, zf)
-            else:
-                with tarfile.open(fileobj=archive, mode="w:gz") as tar:
-                    tarinfo = tar.gettarinfo(arcname="dagger", fileobj=f)
-                    tar.addfile(tarinfo, f)
 
-        # get the sha256 checksum of the tar_bytes
-        checksum = hashlib.sha256(archive.getvalue()).hexdigest()
-        checksum_file_contents = f"{checksum}  {downloader.archive_name}"
+@pytest.mark.anyio()
+@pytest.fixture()
+async def mock_cli_server(tmp_path: pathlib.Path):
+    async with AsyncExitStack() as stack:
 
-        # define the files our in-memory http server will serve
-        files = {
-            archive_url.path: archive.getvalue(),
-            checksum_url.path: checksum_file_contents.encode(),
-        }
+        async def go(cli_bin: str):
+            downloader = download.Downloader()
 
-        class RequestHandler(BaseHTTPRequestHandler):
-            def do_GET(self):  # noqa: N802
-                response = files.get(self.path)
-                if not response:
-                    self.send_response(404)
-                    self.end_headers()
-                    return
-                self.send_response(200)
-                self.send_header("Content-Length", str(len(response)))
-                self.end_headers()
-                self.wfile.write(response)
+            root_dir = tmp_path / "resources"
+            cli_path = pathlib.Path(cli_bin)
+            archive_path = root_dir.joinpath(downloader.archive_url.path.lstrip("/"))
+            checksum_path = root_dir.joinpath(downloader.checksum_url.path.lstrip("/"))
 
-        # create a listener on a random localhost port and start the server
-        with HTTPServer(("127.0.0.1", 0), RequestHandler) as httpd:
-            host, port = httpd.socket.getsockname()
-            kwargs = {
-                "scheme": "http",
-                "host": host,
-                "port": int(port),
-            }
-            monkeypatch.setattr(
-                download.Downloader,
-                "archive_url",
-                str(archive_url.copy_with(**kwargs)),
+            await asyncify(create_archive, cli_path, archive_path)
+
+            checksum = hashlib.sha256()
+
+            async with await FileReadStream.from_path(archive_path) as stream:
+                async for chunk in stream:
+                    checksum.update(chunk)
+
+            await anyio.Path(checksum_path).write_text(
+                f"{checksum.hexdigest()} {downloader.archive_name}"
             )
-            monkeypatch.setattr(
-                download.Downloader,
-                "checksum_url",
-                str(checksum_url.copy_with(**kwargs)),
-            )
-            with anyio.from_thread.start_blocking_portal() as portal:
-                server = portal.start_task_soon(httpd.serve_forever)
-                yield
-                httpd.shutdown()
-                server.cancel()
-                return
 
-    yield
+            app = web.Application()
+            app.add_routes([web.static("/", root_dir, show_index=True)])
+            server = await stack.enter_async_context(TestServer(app))
+
+            return str(server.make_url("/"))
+
+        yield go
+
+
+def create_archive(cli_path: pathlib.Path, archive_path: pathlib.Path):
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    with cli_path.open("rb") as f:
+        # .zip is used in Windows.
+        if archive_path.name.endswith(".zip"):
+            with (
+                zipfile.ZipFile(archive_path, mode="w") as zar,
+                zar.open("dagger.exe", mode="w") as zf,
+            ):
+                shutil.copyfileobj(f, zf)
+        else:
+            with tarfile.open(archive_path, mode="w:gz") as tar:
+                tarinfo = tar.gettarinfo(arcname="dagger", fileobj=f)
+                tar.addfile(tarinfo, f)
+
+
+@pytest.fixture()
+def cache_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> anyio.Path:
+    """Create a temp cache_dir for testing & set XDG_CACHE_HOME."""
+    cache_dir = tmp_path / "dagger"
+    cache_dir.mkdir()
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    return anyio.Path(cache_dir)
 
 
 @pytest.mark.anyio()
 @pytest.mark.slow()
 @pytest.mark.provision()
-async def test_download_bin(cache_dir: Path):
+async def test_download_bin(cache_dir: anyio.Path):
     # make some garbage for the image provisioner to collect
-    garbage_path = cache_dir / "dagger-gcme"
-    garbage_path.touch()
+    garbage_path = cache_dir / "dagger-0.0.0"
+    await garbage_path.touch()
 
     # clean up of existing containers is handled in dagger binary
     # and is already tested in go, skipping coverage here
 
     # run a bunch of provisions concurrently
     async def connect_once():
-        async with dagger.Connection() as client:
-            assert await client.container().from_("alpine:3.16.2").id()
+        async with dagger.Connection(dagger.Config(retry=None)) as client:
+            assert await client.default_platform()
 
     async with anyio.create_task_group() as tg:
         for _ in range(os.cpu_count() or 4):
             tg.start_soon(connect_once)
 
     # assert that there's only one dagger binary in the cache
-    files = cache_dir.iterdir()
-    bins = [file for file in files if file.name.startswith("dagger-")]
-    assert len(bins) == 1
+    i = 0
+    async for _ in cache_dir.glob("dagger-*"):
+        assert not i, "cache not garbage collected"
+        i += 1
+
     # assert the garbage was cleaned up
-    assert not garbage_path.exists()
+    assert not await garbage_path.exists()


### PR DESCRIPTION
Python tests didn't move to our dagger runners because the provisioning test has been failing when `_EXPERIMENTAL_DAGGER_CLI_BIN` is set, at least locally on macOS and on the custom runners. This test could have been skipped by adding `, "-m", "not provision"` in mage, but better to fix the test:

https://github.com/dagger/dagger/blob/1f63a3cdd6fbe861c5637f965bc3cd96e24cd9d3/internal/mage/sdk/python.go#L97

Refactored to be more fully async, and also simplified by relying on aiohttp for the async server.