### PR TITLE
fix(docs): remove node version from config file

### DIFF
--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -1,7 +1,6 @@
 [build]
   publish = "build/"
   command = "yarn run graphql-docs && yarn run docusaurus build"
-  environment = { NODE_VERSION = "16.14" }
 
 [context.production]
   ignore = "false"


### PR DESCRIPTION
This PR removes the override for the Node version of the build in Netlify.