### PR TITLE
Update integration tests to use image constants

### DIFF
--- a/core/integration/cache_test.go
+++ b/core/integration/cache_test.go
@@ -79,7 +79,7 @@ func TestCacheVolumeWithSubmount(t *testing.T) {
 	t.Run("file mount", func(t *testing.T) {
 		t.Parallel()
 		subfile := c.Directory().WithNewFile("foo", "bar").File("foo")
-		ctr := c.Container().From("alpine:3.16.2").
+		ctr := c.Container().From(alpineImage).
 			WithMountedCache("/cache", c.CacheVolume(identity.NewID())).
 			WithMountedFile("/cache/subfile", subfile)
 
@@ -95,7 +95,7 @@ func TestCacheVolumeWithSubmount(t *testing.T) {
 	t.Run("dir mount", func(t *testing.T) {
 		t.Parallel()
 		subdir := c.Directory().WithNewFile("foo", "bar").WithNewFile("baz", "qux")
-		ctr := c.Container().From("alpine:3.16.2").
+		ctr := c.Container().From(alpineImage).
 			WithMountedCache("/cache", c.CacheVolume(identity.NewID())).
 			WithMountedDirectory("/cache/subdir", subdir)
 
@@ -128,7 +128,7 @@ func TestLocalImportCacheReuse(t *testing.T) {
 	require.NoError(t, err)
 
 	runExec := func(ctx context.Context, t *testing.T, c *dagger.Client) string {
-		out, err := c.Container().From("alpine:3.16.2").
+		out, err := c.Container().From(alpineImage).
 			WithDirectory("/fromhost", c.Host().Directory(hostDirPath)).
 			WithExec([]string{"stat", "/fromhost/foo"}).
 			WithExec([]string{"sh", "-c", "head -c 128 /dev/random | sha256sum"}).

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3886,7 +3886,7 @@ func TestContainerWithMountedSecretMode(t *testing.T) {
 
 	secret := c.SetSecret("test", "secret")
 
-	ctr := c.Container().From("alpine:3.18.2").WithMountedSecret("/secret", secret, dagger.ContainerWithMountedSecretOpts{
+	ctr := c.Container().From(alpineImage).WithMountedSecret("/secret", secret, dagger.ContainerWithMountedSecretOpts{
 		Mode:  0o666,
 		Owner: "root:root",
 	})

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -309,7 +309,7 @@ func TestContainerWithRootFSSubdir(t *testing.T) {
 	hello := c.Directory().WithNewFile("main.go", helloSrc).File("main.go")
 
 	ctr := c.Container().
-		From("golang:1.20.0-alpine").
+		From(golangImage).
 		WithMountedFile("/src/main.go", hello).
 		WithEnvVariable("CGO_ENABLED", "0").
 		WithExec([]string{"go", "build", "-o", "/out/hello", "/src/main.go"})

--- a/core/integration/engine_test.go
+++ b/core/integration/engine_test.go
@@ -198,7 +198,7 @@ func TestClientSendsLabelsInTelemetry(t *testing.T) {
 	eventsVol := c.CacheVolume("dagger-dev-engine-events-" + identity.NewID())
 
 	withCode := c.Container().
-		From("golang:1.20.6-alpine").
+		From(golangImage).
 		WithExec([]string{"apk", "add", "git"}).
 		With(goCache(c)).
 		WithMountedDirectory("/src", code).

--- a/core/integration/host_test.go
+++ b/core/integration/host_test.go
@@ -189,7 +189,7 @@ func TestHostSetSecretFile(t *testing.T) {
 	t.Run("non utf8 binary data is properly set as secret", func(t *testing.T) {
 		secret := c.Host().SetSecretFile("mysecret", filepath.Join(dir, "some-file"))
 
-		output, err := c.Container().From("alpine:3.17").
+		output, err := c.Container().From(alpineImage).
 			WithEnvVariable("CACHEBUST", identity.NewID()).
 			WithMountedSecret("/mysecret", secret).
 			WithExec([]string{"md5sum", "/mysecret"}).

--- a/core/integration/local_test.go
+++ b/core/integration/local_test.go
@@ -21,7 +21,7 @@ func TestLocalImportsAcrossSessions(t *testing.T) {
 
 	hostDir1 := c1.Host().Directory(tmpdir)
 
-	out1, err := c1.Container().From("alpine:3.16.2").
+	out1, err := c1.Container().From(alpineImage).
 		WithMountedDirectory("/mnt", hostDir1).
 		WithExec([]string{"cat", "/mnt/" + fileName}).
 		Stdout(ctx1)
@@ -42,7 +42,7 @@ func TestLocalImportsAcrossSessions(t *testing.T) {
 
 	hostDir2 := c2.Host().Directory(tmpdir)
 
-	out2, err := c2.Container().From("alpine:3.18").
+	out2, err := c2.Container().From(alpineImage).
 		WithMountedDirectory("/mnt", hostDir2).
 		WithExec([]string{"cat", "/mnt/" + fileName}).
 		Stdout(ctx2)

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -470,7 +470,7 @@ func TestContainerExecUDPServices(t *testing.T) {
 	c, ctx := connect(t)
 
 	srv := c.Container().
-		From("golang:1.18.2-alpine").
+		From(golangImage).
 		WithMountedFile("/src/main.go",
 			c.Directory().WithNewFile("main.go", udpSrc).File("main.go")).
 		WithExposedPort(4321, dagger.ContainerWithExposedPortOpts{
@@ -532,7 +532,7 @@ func TestContainerExecServicesDeduping(t *testing.T) {
 	c, ctx := connect(t)
 
 	srv := c.Container().
-		From("golang:1.18.2-alpine").
+		From(golangImage).
 		WithMountedFile("/src/main.go",
 			c.Directory().WithNewFile("main.go", pipeSrc).File("main.go")).
 		WithExposedPort(8080).
@@ -618,7 +618,7 @@ func TestContainerExecServicesNestedExec(t *testing.T) {
 	srv, svcURL := httpService(ctx, t, c, content)
 
 	fileContent, err := c.Container().
-		From("golang:1.20.6-alpine").
+		From(golangImage).
 		With(goCache(c)).
 		WithServiceBinding("www", srv).
 		WithMountedDirectory("/src", code).
@@ -652,7 +652,7 @@ func TestContainerExecServicesNestedHTTP(t *testing.T) {
 	srv, svcURL := httpService(ctx, t, c, content)
 
 	fileContent, err := c.Container().
-		From("golang:1.20.6-alpine").
+		From(golangImage).
 		WithServiceBinding("www", srv).
 		WithMountedDirectory("/src", code).
 		WithWorkdir("/src").
@@ -689,7 +689,7 @@ func TestContainerExecServicesNestedGit(t *testing.T) {
 	srv, svcURL := gitService(ctx, t, c, c.Directory().WithNewFile("/index.html", content))
 
 	fileContent, err := c.Container().
-		From("golang:1.20.6-alpine").
+		From(golangImage).
 		WithServiceBinding("www", srv).
 		WithMountedDirectory("/src", code).
 		WithWorkdir("/src").

--- a/core/integration/socket_test.go
+++ b/core/integration/socket_test.go
@@ -57,7 +57,7 @@ func TestContainerWithUnixSocket(t *testing.T) {
 	echo := c.Directory().WithNewFile("main.go", echoSocketSrc).File("main.go")
 
 	ctr := c.Container().
-		From("golang:1.20.0-alpine").
+		From(golangImage).
 		WithMountedFile("/src/main.go", echo).
 		WithUnixSocket("/tmp/test.sock", c.Host().UnixSocket(sock)).
 		WithExec([]string{"go", "run", "/src/main.go", "/tmp/test.sock", "hello"})


### PR DESCRIPTION
Update integration tests to use image constants defined in [`images.go`](https://github.com/dagger/dagger/blob/main/core/integration/images.go).