### PR TITLE
docs: fix typo in quickstart build page

### DIFF
--- a/docs/current/quickstart/349011-build.mdx
+++ b/docs/current/quickstart/349011-build.mdx
@@ -65,7 +65,7 @@ dagger run node ci/index.mjs
 </TabItem>
 <TabItem value="Python">
 
-<Embed id="E8rjb5DFd2m />
+<Embed id="E8rjb5DFd2m" />
 
 This revised pipeline does everything described in the previous step, and then performs the following additional operations:
 


### PR DESCRIPTION
I've been observing a few Netlify build errors here: https://app.netlify.com/sites/devel-docs-dagger-io/deploys/655d6da10b815d00089336b7

Seems it's caused by a missing quote in the docs.