### PR TITLE
docs: Fixes method names in quickstart

### DIFF
--- a/docs/current/quickstart/947391-test.mdx
+++ b/docs/current/quickstart/947391-test.mdx
@@ -40,7 +40,7 @@ This code listing does the following:
 - It creates a Dagger client with `Connect()` as before.
 - It uses the client's `Container().From()` method to initialize a new container from a base image - again, the `node:16-slim` image. This base image is the Node.js version to use for testing. The `From()` method returns a new `Container` object with the result.
 - It uses the `Container.WithDirectory()` method to mount the source code directory on the host at the `/src` mount point in the container, and the `Container.WithWorkdir()` method to set the working directory to that mount point.
-  - Notice that the `Container.WithDirectory()` accepts additional options to exclude (or include) specific files from the mount. In this case, it excludes the `node_modules` (locally-installed dependencies), `ci` (pipeline code) and `build` (build artifacts) directories.
+  - Notice that the `Container.WithDirectory()` method accepts additional options to exclude (or include) specific files from the mount. In this case, it excludes the `node_modules` (locally-installed dependencies), `ci` (pipeline code) and `build` (build artifacts) directories.
 - It uses the `Container.WithExec()` method to define the commands to install dependencies and run tests in the container - in this case, the commands `npm install` and `npm test -- --watchAll=false`.
 - It uses the `Container.Stderr()` method to return the error stream of the last executed command. No error output implies successful execution (all tests pass).
   - Failure, indicated by error output, will cause the pipeline to terminate.
@@ -65,7 +65,7 @@ This code listing does the following:
 - It creates a Dagger client with `connect()` as before.
 - It uses the client's `container().from()` method to initialize a new container from a base image - again, the `node:16-slim` image. This base image is the Node.js version to use for testing. The `from()` method returns a new `Container` object with the result.
 - It uses the `Container.withDirectory()` method to mount the source code directory on the host at the `/src` mount point in the container, and the `Container.withWorkdir()` method to set the working directory to that mount point.
-  - Notice that the `Container.WithDirectory()` accepts additional options to exclude (or include) specific files from the mount. In this case, it excludes the `node_modules` (locally-installed dependencies), `ci` (pipeline code) and `build` (build artifacts) directories.
+  - Notice that the `Container.withDirectory()` method accepts additional options to exclude (or include) specific files from the mount. In this case, it excludes the `node_modules` (locally-installed dependencies), `ci` (pipeline code) and `build` (build artifacts) directories.
 - It uses the `Container.withExec()` method to define the commands to install dependencies and run tests in the container - in this case, the commands `npm install` and `npm test -- --watchAll=false`.
 - It uses the `Container.stderr()` method to return the error stream of the last executed command. No error output implies successful execution (all tests pass).
   - Failure, indicated by error output, will cause the pipeline to terminate.
@@ -90,7 +90,7 @@ This code listing does the following:
 - It creates a Dagger client with `with dagger.Connection()` as before.
 - It uses the client's `container().from_()` method to initialize a new container from a base image - again, the `node:16-slim` image. This base image is the Node.js version to use for testing. The `from_()` method returns a new `Container` object with the result.
 - It uses the `Container.with_directory()` method to mount the source code directory on the host at the `/src` mount point in the container, and the `Container.with_workdir()` method to set the working directory to that mount point.
-  - Notice that the `Container.WithDirectory()` accepts additional options to exclude (or include) specific files from the mount. In this case, it excludes the `node_modules` (locally-installed dependencies), `ci` (pipeline code) and `build` (build artifacts) directories.
+  - Notice that the `Container.with_directory()` method accepts additional options to exclude (or include) specific files from the mount. In this case, it excludes the `node_modules` (locally-installed dependencies), `ci` (pipeline code) and `build` (build artifacts) directories.
 - It uses the `Container.with_exec()` method to define the commands to install dependencies and run tests in the container - in this case, the commands `npm install` and `npm test -- --watchAll=false`.
 - It uses the `Container.stderr()` method to return the error stream of the last executed command. No error output implies successful execution (all tests pass).
   - Failure, indicated by error output, will cause the pipeline to terminate.


### PR DESCRIPTION
This commit is a follow-up to https://github.com/dagger/dagger/pull/5854