### PR TITLE
refactor(core): remove redundant nil check

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -93,18 +93,16 @@ func (container *Container) PBDefinitions() ([]*pb.Definition, error) {
 			defs = append(defs, mnt.Source)
 		}
 	}
-	if container.Services != nil {
-		for _, bnd := range container.Services {
-			ctr := bnd.Service.Container
-			if ctr == nil {
-				continue
-			}
-			ctrDefs, err := ctr.PBDefinitions()
-			if err != nil {
-				return nil, err
-			}
-			defs = append(defs, ctrDefs...)
+	for _, bnd := range container.Services {
+		ctr := bnd.Service.Container
+		if ctr == nil {
+			continue
 		}
+		ctrDefs, err := ctr.PBDefinitions()
+		if err != nil {
+			return nil, err
+		}
+		defs = append(defs, ctrDefs...)
 	}
 	return defs, nil
 }

--- a/core/directory.go
+++ b/core/directory.go
@@ -42,18 +42,16 @@ func (dir *Directory) PBDefinitions() ([]*pb.Definition, error) {
 	if dir.LLB != nil {
 		defs = append(defs, dir.LLB)
 	}
-	if dir.Services != nil {
-		for _, bnd := range dir.Services {
-			ctr := bnd.Service.Container
-			if ctr == nil {
-				continue
-			}
-			ctrDefs, err := ctr.PBDefinitions()
-			if err != nil {
-				return nil, err
-			}
-			defs = append(defs, ctrDefs...)
+	for _, bnd := range dir.Services {
+		ctr := bnd.Service.Container
+		if ctr == nil {
+			continue
 		}
+		ctrDefs, err := ctr.PBDefinitions()
+		if err != nil {
+			return nil, err
+		}
+		defs = append(defs, ctrDefs...)
 	}
 	return defs, nil
 }

--- a/core/file.go
+++ b/core/file.go
@@ -40,18 +40,16 @@ func (file *File) PBDefinitions() ([]*pb.Definition, error) {
 	if file.LLB != nil {
 		defs = append(defs, file.LLB)
 	}
-	if file.Services != nil {
-		for _, bnd := range file.Services {
-			ctr := bnd.Service.Container
-			if ctr == nil {
-				continue
-			}
-			ctrDefs, err := ctr.PBDefinitions()
-			if err != nil {
-				return nil, err
-			}
-			defs = append(defs, ctrDefs...)
+	for _, bnd := range file.Services {
+		ctr := bnd.Service.Container
+		if ctr == nil {
+			continue
 		}
+		ctrDefs, err := ctr.PBDefinitions()
+		if err != nil {
+			return nil, err
+		}
+		defs = append(defs, ctrDefs...)
 	}
 	return defs, nil
 }


### PR DESCRIPTION
From the Go specification:

> "1. For a nil slice, the number of iterations is 0." https://go.dev/ref/spec#For_range

Therefore, an additional nil check for before the loop is unnecessary.