### PR TITLE
sdk(nodejs): don't download binary if already exists

### DIFF
--- a/sdk/nodejs/provisioning/bin.ts
+++ b/sdk/nodejs/provisioning/bin.ts
@@ -57,6 +57,10 @@ export class Bin implements EngineConn {
   }
 
   async Connect(opts: ConnectOpts): Promise<GraphQLClient> {
+    if (!this.binPath && fs.existsSync(this.buildBinPath())) {
+      this.binPath = this.buildBinPath()
+    }
+
     if (!this.binPath) {
       if (opts.LogOutput) {
         opts.LogOutput.write("Downloading CLI... ")


### PR DESCRIPTION
backport missing from the other SDK's

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
