### PR TITLE
feat: add typescript introspector

### DIFF
--- a/sdk/nodejs/.prettierrc.cjs
+++ b/sdk/nodejs/.prettierrc.cjs
@@ -7,5 +7,6 @@ module.exports = {
   bracketSpacing: true,
   arrowParens: "always",
   importOrder: ["^[./]"],
-  importOrderSeparation: true
+  importOrderSeparation: true,
+  importOrderParserPlugins: ["typescript", "decorators-legacy"]
 }

--- a/sdk/nodejs/introspector/analysis/analysis.ts
+++ b/sdk/nodejs/introspector/analysis/analysis.ts
@@ -1,0 +1,107 @@
+import ts from "typescript"
+
+import { UnknownDaggerError } from "../../common/errors/UnknownDaggerError.js"
+import { ClassMetadata, FunctionMetadata, Metadata } from "./metadata.js"
+import { serializeSignature, serializeSymbol } from "./serialize.js"
+import { isFunction, isObject } from "./utils.js"
+
+export function analysis(files: string[]): Metadata {
+  if (files.length === 0) {
+    throw new UnknownDaggerError("no files to introspect found", {})
+  }
+
+  // Interpret the given typescript source files
+  const program = ts.createProgram(files, { experimentalDecorators: true })
+  const checker = program.getTypeChecker()
+
+  const metadata: Metadata = {
+    classes: [],
+    functions: [],
+  }
+
+  for (const file of program.getSourceFiles()) {
+    // Ignore type declaration files.
+    if (file.isDeclarationFile) {
+      continue
+    }
+
+    ts.forEachChild(file, (node) => {
+      // Handle class
+      if (ts.isClassDeclaration(node) && node.name) {
+        const classMetadata = introspectClass(checker, node)
+        if (classMetadata) {
+          metadata.classes.push(classMetadata)
+        }
+      }
+    })
+  }
+
+  return metadata
+}
+
+function introspectClass(
+  checker: ts.TypeChecker,
+  node: ts.ClassDeclaration
+): ClassMetadata | undefined {
+  if (!isObject(node) || !node.name) {
+    return
+  }
+
+  const classSymbol = checker.getSymbolAtLocation(node.name)
+  if (!classSymbol) {
+    throw new UnknownDaggerError(
+      `could not get class symbol: ${node.name.getText()}`,
+      {}
+    )
+  }
+
+  const classMetadata = serializeSymbol(checker, classSymbol)
+
+  const metadata: ClassMetadata = {
+    name: classMetadata.name,
+    doc: classMetadata.doc,
+    methods: [],
+  }
+
+  const members = node.members
+  members.forEach((member) => {
+    if (!member.name) {
+      return
+    }
+
+    if (ts.isMethodDeclaration(member) && isFunction(member)) {
+      metadata.methods.push(introspectMethod(checker, member))
+    }
+  })
+
+  return metadata
+}
+
+function introspectMethod(
+  checker: ts.TypeChecker,
+  method: ts.MethodDeclaration
+): FunctionMetadata {
+  const memberSymbol = checker.getSymbolAtLocation(method.name)
+  if (!memberSymbol) {
+    throw new UnknownDaggerError(
+      `could not get method symbol: ${method.name.getText()}`,
+      {}
+    )
+  }
+
+  const memberMetadata = serializeSymbol(checker, memberSymbol)
+  const memberSignatures = memberMetadata.type
+    .getCallSignatures()
+    .map((memberSignature) => serializeSignature(checker, memberSignature))[0]
+
+  return {
+    name: memberMetadata.name,
+    doc: memberMetadata.doc,
+    params: memberSignatures.params.map((signature) => ({
+      name: signature.name,
+      typeName: signature.typeName,
+      doc: signature.doc,
+    })),
+    returnType: memberSignatures.returnType,
+  }
+}

--- a/sdk/nodejs/introspector/analysis/metadata.ts
+++ b/sdk/nodejs/introspector/analysis/metadata.ts
@@ -1,0 +1,26 @@
+export type SymbolMetadata = {
+  name: string
+  doc: string
+  typeName: string
+}
+
+export type ParamMetadata = SymbolMetadata
+
+export type SignatureMetadata = {
+  params: ParamMetadata[]
+  returnType: string
+}
+
+export type FunctionMetadata = Omit<SymbolMetadata, "typeName"> & {
+  params: ParamMetadata[]
+  returnType: string
+}
+
+export type ClassMetadata = Omit<SymbolMetadata, "typeName"> & {
+  methods: FunctionMetadata[]
+}
+
+export type Metadata = {
+  classes: ClassMetadata[]
+  functions: FunctionMetadata[]
+}

--- a/sdk/nodejs/introspector/analysis/serialize.ts
+++ b/sdk/nodejs/introspector/analysis/serialize.ts
@@ -1,0 +1,48 @@
+import ts from "typescript"
+
+import { UnknownDaggerError } from "../../common/errors/UnknownDaggerError.js"
+import { SignatureMetadata, SymbolMetadata } from "./metadata.js"
+
+export function serializeSignature(
+  checker: ts.TypeChecker,
+  signature: ts.Signature
+): SignatureMetadata {
+  return {
+    params: signature.parameters.map((param) =>
+      serializeSymbol(checker, param)
+    ),
+    returnType: serializeType(checker, signature.getReturnType()),
+  }
+}
+
+export function serializeSymbol(
+  checker: ts.TypeChecker,
+  symbol: ts.Symbol
+): SymbolMetadata & { type: ts.Type } {
+  if (!symbol.valueDeclaration) {
+    throw new UnknownDaggerError("could not find symbol value declaration", {})
+  }
+
+  const type = checker.getTypeOfSymbolAtLocation(
+    symbol,
+    symbol.valueDeclaration
+  )
+
+  return {
+    name: symbol.getName(),
+    doc: ts.displayPartsToString(symbol.getDocumentationComment(checker)),
+    typeName: serializeType(checker, type),
+    type,
+  }
+}
+
+export function serializeType(checker: ts.TypeChecker, type: ts.Type): string {
+  const strType = checker.typeToString(type)
+
+  // Remove Promise<> wrapper around type if it's a promise.
+  if (strType.startsWith("Promise")) {
+    return strType.substring("Promise<".length, strType.length - 1)
+  }
+
+  return strType
+}

--- a/sdk/nodejs/introspector/analysis/utils.ts
+++ b/sdk/nodejs/introspector/analysis/utils.ts
@@ -1,0 +1,15 @@
+import ts from "typescript"
+
+export function isObject(node: ts.ClassDeclaration): boolean {
+  return (
+    ts.getDecorators(node)?.find((d) => d.expression.getText() === "object") !==
+    undefined
+  )
+}
+
+export function isFunction(node: ts.MethodDeclaration): boolean {
+  return (
+    ts.getDecorators(node)?.find((d) => d.expression.getText() === "fct") !==
+    undefined
+  )
+}

--- a/sdk/nodejs/introspector/decorators/decorators.ts
+++ b/sdk/nodejs/introspector/decorators/decorators.ts
@@ -1,0 +1,15 @@
+export function fct(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  target: any,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  propertyKey: string,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  descriptor: PropertyDescriptor
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+) {}
+
+export function object<T extends { new (...args: unknown[]): unknown }>(
+  constructor: T
+) {
+  return constructor
+}

--- a/sdk/nodejs/introspector/main.ts
+++ b/sdk/nodejs/introspector/main.ts
@@ -1,0 +1,17 @@
+import { analysis } from "./analysis/analysis.js"
+import { listFiles } from "./utils/files.js"
+
+async function main() {
+  let directory = "."
+
+  if (process.argv.length == 3) {
+    directory = process.argv[2]
+  }
+
+  const files = await listFiles(directory)
+
+  // Analysis files
+  analysis(files)
+}
+
+main()

--- a/sdk/nodejs/introspector/test/analysis.spec.ts
+++ b/sdk/nodejs/introspector/test/analysis.spec.ts
@@ -1,0 +1,100 @@
+import assert from "assert"
+import * as path from "path"
+import { fileURLToPath } from "url"
+
+import { analysis } from "../analysis/analysis.js"
+import { Metadata } from "../analysis/metadata.js"
+import { listFiles } from "../utils/files.js"
+import { HelloWorld } from "./testdata/helloWorld/helloWorld"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const rootDirectory = `${__dirname}/testdata`
+
+describe("Analysis static Typescript", function () {
+  it("Should correctly analyse a basic class with one method", async function () {
+    const files = await listFiles(`${rootDirectory}/helloWorld`)
+
+    const result = analysis(files)
+    const expected: Metadata = {
+      classes: [
+        {
+          name: "HelloWorld",
+          doc: "HelloWorld class",
+          methods: [
+            {
+              name: "helloWorld",
+              returnType: "string",
+              doc: "",
+              params: [
+                {
+                  name: "name",
+                  typeName: "string",
+                  doc: "",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      functions: [],
+    }
+
+    assert.deepEqual(result, expected)
+  })
+
+  it("Should ignore class that does not have the object decorator", async function () {
+    const files = await listFiles(`${rootDirectory}/noDecorators`)
+
+    const result = analysis(files)
+    const expected: Metadata = {
+      classes: [],
+      functions: [],
+    }
+
+    assert.deepEqual(result, expected)
+  })
+
+  it("Should supports multiple files and classes that returns classes", async function () {
+    const files = await listFiles(`${rootDirectory}/multipleObjects`)
+
+    const result = analysis(files)
+    const expected: Metadata = {
+      classes: [
+        {
+          name: "Bar",
+          doc: "Bar class",
+          methods: [
+            {
+              name: "exec",
+              doc: "Execute the command and return its result",
+              returnType: "string",
+              params: [
+                {
+                  name: "cmd",
+                  typeName: "string[]",
+                  doc: "Command to execute",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: "Foo",
+          doc: "Foo class",
+          methods: [
+            {
+              name: "bar",
+              doc: "Return Bar object",
+              returnType: "Bar",
+              params: [],
+            },
+          ],
+        },
+      ],
+      functions: [],
+    }
+
+    assert.deepEqual(result, expected)
+  })
+})

--- a/sdk/nodejs/introspector/test/files.spec.ts
+++ b/sdk/nodejs/introspector/test/files.spec.ts
@@ -1,0 +1,20 @@
+import assert from "assert"
+import * as path from "path"
+import { fileURLToPath } from "url"
+
+import { listFiles } from "../utils/files.js"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const rootDirectory = `${__dirname}/testdata`
+
+describe("ListFiles", function () {
+  it("Should correctly list files from hello world example and ignore unwanted files", async function () {
+    const files = await listFiles(`${rootDirectory}/helloWorld`)
+
+    assert.deepEqual(
+      files.map((f) => path.basename(f)),
+      ["helloWorld.ts"]
+    )
+  })
+})

--- a/sdk/nodejs/introspector/test/testdata/helloWorld/helloWorld.ts
+++ b/sdk/nodejs/introspector/test/testdata/helloWorld/helloWorld.ts
@@ -1,0 +1,12 @@
+import { fct, object } from '@dagger.io/dagger'
+
+/**
+ * HelloWorld class
+ */
+@object
+export class HelloWorld {
+    @fct
+    helloWorld(name: string): string {
+        return `hello ${name}`
+    }
+}

--- a/sdk/nodejs/introspector/test/testdata/multipleObjects/bar.ts
+++ b/sdk/nodejs/introspector/test/testdata/multipleObjects/bar.ts
@@ -1,0 +1,20 @@
+import { fct, object, dag } from '@dagger.io/dagger'
+
+/**
+ * Bar class
+ */
+@object
+export class Bar {
+    /**
+     * Execute the command and return its result
+     * @param cmd Command to execute
+     */
+    @fct
+    async exec(cmd: string[]): Promise<string> {
+        return await dag
+            .container()
+            .from("alpine")
+            .withExec(cmd)
+            .stdout()
+    }
+}

--- a/sdk/nodejs/introspector/test/testdata/multipleObjects/foo.ts
+++ b/sdk/nodejs/introspector/test/testdata/multipleObjects/foo.ts
@@ -1,0 +1,18 @@
+import { fct, object } from '@dagger.io/dagger'
+
+import { Bar } from './bar.js'
+
+
+/**
+ * Foo class
+ */
+@object
+export class Foo {
+    /**
+     * Return Bar object
+     */
+    @fct
+    bar(): Bar {
+        return new Bar()
+    }
+}

--- a/sdk/nodejs/introspector/test/testdata/noDecorators/noDecorators.ts
+++ b/sdk/nodejs/introspector/test/testdata/noDecorators/noDecorators.ts
@@ -1,0 +1,12 @@
+import { fct } from '@dagger.io/dagger'
+
+/**
+ * HelloWorld class
+ * @object decorator is missing so this class should be ignored.
+ */
+export class Foo {
+    @fct
+    bar(name: string): string {
+        return `hello ${name}`
+    }
+}

--- a/sdk/nodejs/introspector/utils/files.ts
+++ b/sdk/nodejs/introspector/utils/files.ts
@@ -1,0 +1,34 @@
+import * as fs from "fs"
+import * as path from "path"
+
+// Extensions supported by the convertor
+const allowedExtensions = [".ts", ".mts"]
+
+// Returns a list of path of all files in the given directory
+export async function listFiles(dir = "."): Promise<string[]> {
+  const res = await Promise.all(
+    fs.readdirSync(dir).map(async (file) => {
+      const filepath = path.join(dir, file)
+
+      // Ignore node_modules and transpiled typescript
+      if (filepath.includes("node_modules") || filepath.includes("dist")) {
+        return []
+      }
+
+      const stat = fs.statSync(filepath)
+
+      if (stat.isDirectory()) {
+        return await listFiles(filepath)
+      }
+
+      const ext = path.extname(filepath)
+      if (allowedExtensions.find((allowedExt) => allowedExt === ext)) {
+        return [`${dir}/${file}`]
+      }
+
+      return []
+    })
+  )
+
+  return res.reduce((p, c) => [...c, ...p], [])
+}

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 // Inspired by TSConfig bases: https://github.com/tsconfig/bases/blob/main/bases/recommended.json
 {
   "include": ["./**/*"],
-  "exclude": ["./**/*.spec.ts", "./dist/**/*"],
+  "exclude": ["./**/*.spec.ts", "./dist/**/*", "./**/testdata/*"],
   "compilerOptions": {
     "target": "ES2022",
     "strict": true,
@@ -12,6 +12,7 @@
     "module": "ES2022",
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    "experimentalDecorators": true,
     "moduleResolution": "Node",
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
Add a program to introspect typescript files and convert it to a GraphQL schema.
Enable decorators in Node SDK.
Add analysis function.
Add typescript compiler.
Add decorators to declare expose object and methods to a GQL schema.
Add unit tests

TODO:
- [ ] Add more tests
- [ ] Convert analysed metadata to GraphQL schema

Related to DEV-3029