### PR TITLE
fix: set KeepGitDir for git remote directories for call

### DIFF
--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -207,7 +207,9 @@ func (v *directoryValue) Get(dag *dagger.Client) any {
 	// Try parsing as a Git URL
 	parsedGit, err := parseGit(v.String())
 	if err == nil {
-		gitOpts := dagger.GitOpts{}
+		gitOpts := dagger.GitOpts{
+			KeepGitDir: true,
+		}
 		if authSock, ok := os.LookupEnv("SSH_AUTH_SOCK"); ok {
 			gitOpts.SSHAuthSocket = dag.Host().UnixSocket(authSock)
 		}


### PR DESCRIPTION
When setting a remote git repository as a directory from the CLI, it makes sense to default to keeping the remote git directory. Some modules may use it - if it's there it can be used, and it doesn't really actually add any extra time to download.

I encountered this while attempting to run my hugo module https://github.com/jedevc/daggerverse/tree/main/hugo against a git repo - since hugo can use git metadata as part of the build, it needs access to those files. There's not really a way to configure this, and it feels like keeping the git directory around is a reasonable default.