### PR TITLE
feat: add go sdk pragma parsing for default and optional

### DIFF
--- a/cmd/codegen/generator/go/templates/modules_test.go
+++ b/cmd/codegen/generator/go/templates/modules_test.go
@@ -64,8 +64,16 @@ func TestParsePragmaComment(t *testing.T) {
 		rest     string
 	}{
 		{
+			name:    "single key",
+			comment: "+foo",
+			expected: map[string]string{
+				"foo": "",
+			},
+			rest: "",
+		},
+		{
 			name:    "single key-value",
-			comment: "dagger:foo=bar",
+			comment: "+foo=bar",
 			expected: map[string]string{
 				"foo": "bar",
 			},
@@ -73,7 +81,7 @@ func TestParsePragmaComment(t *testing.T) {
 		},
 		{
 			name:    "single key-value with trailing",
-			comment: "dagger:foo=bar\n",
+			comment: "+foo=bar\n",
 			expected: map[string]string{
 				"foo": "bar",
 			},
@@ -81,7 +89,7 @@ func TestParsePragmaComment(t *testing.T) {
 		},
 		{
 			name:    "multiple key-value",
-			comment: "dagger:foo=bar\ndagger:baz=qux",
+			comment: "+foo=bar\n+baz=qux",
 			expected: map[string]string{
 				"foo": "bar",
 				"baz": "qux",
@@ -90,7 +98,7 @@ func TestParsePragmaComment(t *testing.T) {
 		},
 		{
 			name:    "interpolated key-value",
-			comment: "line 1\ndagger:foo=bar\nline 2\ndagger:baz=qux\nline 3",
+			comment: "line 1\n+foo=bar\nline 2\n+baz=qux\nline 3",
 			expected: map[string]string{
 				"foo": "bar",
 				"baz": "qux",
@@ -99,7 +107,7 @@ func TestParsePragmaComment(t *testing.T) {
 		},
 		{
 			name:    "interpolated key-value with trailing",
-			comment: "line 1\ndagger:foo=bar\nline 2\ndagger:baz=qux\nline 3\n",
+			comment: "line 1\n+foo=bar\nline 2\n+baz=qux\nline 3\n",
 			expected: map[string]string{
 				"foo": "bar",
 				"baz": "qux",

--- a/cmd/codegen/generator/go/templates/modules_test.go
+++ b/cmd/codegen/generator/go/templates/modules_test.go
@@ -55,3 +55,64 @@ go 1.20
 	require.NoError(t, err)
 	t.Log(generatedMain)
 }
+
+func TestParsePragmaComment(t *testing.T) {
+	tests := []struct {
+		name     string
+		comment  string
+		expected map[string]string
+		rest     string
+	}{
+		{
+			name:    "single key-value",
+			comment: "dagger:foo=bar",
+			expected: map[string]string{
+				"foo": "bar",
+			},
+			rest: "",
+		},
+		{
+			name:    "single key-value with trailing",
+			comment: "dagger:foo=bar\n",
+			expected: map[string]string{
+				"foo": "bar",
+			},
+			rest: "",
+		},
+		{
+			name:    "multiple key-value",
+			comment: "dagger:foo=bar\ndagger:baz=qux",
+			expected: map[string]string{
+				"foo": "bar",
+				"baz": "qux",
+			},
+			rest: "",
+		},
+		{
+			name:    "interpolated key-value",
+			comment: "line 1\ndagger:foo=bar\nline 2\ndagger:baz=qux\nline 3",
+			expected: map[string]string{
+				"foo": "bar",
+				"baz": "qux",
+			},
+			rest: "line 1\nline 2\nline 3",
+		},
+		{
+			name:    "interpolated key-value with trailing",
+			comment: "line 1\ndagger:foo=bar\nline 2\ndagger:baz=qux\nline 3\n",
+			expected: map[string]string{
+				"foo": "bar",
+				"baz": "qux",
+			},
+			rest: "line 1\nline 2\nline 3\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, rest := parsePragmaComment(test.comment)
+			require.Equal(t, test.expected, actual)
+			require.Equal(t, test.rest, rest)
+		})
+	}
+}

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -695,6 +695,14 @@ func TestModuleGoSignatures(t *testing.T) {
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoOptsInlineTags":"hi!hi!"}}`, out)
 	})
+
+	t.Run("func EchoOptsPragmas(string, string, int) error", func(t *testing.T) {
+		t.Parallel()
+
+		out, err := modGen.With(daggerQuery(`{minimal{echoOptsPragmas(msg: "hi")}}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"minimal":{"echoOptsPragmas":"hi...hi...hi..."}}`, out)
+	})
 }
 
 func TestModuleGoSignaturesBuiltinTypes(t *testing.T) {
@@ -901,6 +909,7 @@ query {
               args {
                 name
                 description
+                defaultValue
               }
             }
           }
@@ -958,6 +967,19 @@ func TestModuleGoDocs(t *testing.T) {
 	require.Equal(t, "suffix", echoOpts.Get("args.1.name").String())
 	require.Equal(t, "String to append to the echoed message", echoOpts.Get("args.1.description").String())
 	require.Equal(t, "times", echoOpts.Get("args.2.name").String())
+	require.Equal(t, "Number of times to repeat the message", echoOpts.Get("args.2.description").String())
+
+	// test the arg-based form (with pragmas)
+	echoOpts = obj.Get(`functions.#(name="echoOptsPragmas")`)
+	require.Equal(t, "echoOptsPragmas", echoOpts.Get("name").String())
+	require.Len(t, echoOpts.Get("args").Array(), 3)
+	require.Equal(t, "msg", echoOpts.Get("args.0.name").String())
+	require.Equal(t, "", echoOpts.Get("args.0.defaultValue").String())
+	require.Equal(t, "suffix", echoOpts.Get("args.1.name").String())
+	require.Equal(t, "String to append to the echoed message", echoOpts.Get("args.1.description").String())
+	require.Equal(t, "\"...\"", echoOpts.Get("args.1.defaultValue").String())
+	require.Equal(t, "times", echoOpts.Get("args.2.name").String())
+	require.Equal(t, "3", echoOpts.Get("args.2.defaultValue").String())
 	require.Equal(t, "Number of times to repeat the message", echoOpts.Get("args.2.description").String())
 }
 

--- a/core/integration/testdata/modules/go/minimal/main.go
+++ b/core/integration/testdata/modules/go/minimal/main.go
@@ -135,12 +135,12 @@ func (m *Minimal) EchoOptsPragmas(
 	msg string,
 
 	// String to append to the echoed message
-	// dagger: optional=true
-	// dagger: default=...
+	// +optional=true
+	// +default=...
 	suffix string,
 	// Number of times to repeat the message
-	// dagger: optional=true
-	times int, // dagger: default=3
+	// +optional
+	times int, // +default=3
 ) string {
 	return strings.Repeat(msg+suffix, times)
 }

--- a/core/integration/testdata/modules/go/minimal/main.go
+++ b/core/integration/testdata/modules/go/minimal/main.go
@@ -130,3 +130,17 @@ func (m *Minimal) EchoOptsInlineTags(ctx context.Context, opts struct {
 }) string {
 	return m.EchoOpts(opts.Msg, opts.Suffix, opts.Times)
 }
+
+func (m *Minimal) EchoOptsPragmas(
+	msg string,
+
+	// String to append to the echoed message
+	// dagger: optional=true
+	// dagger: default=...
+	suffix string,
+	// Number of times to repeat the message
+	// dagger: optional=true
+	times int, // dagger: default=3
+) string {
+	return strings.Repeat(msg+suffix, times)
+}


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/6162.

This allows defining defaults and optional parameters for Go modules using "dagger" pragmas. These are inspired in style by "go" pragmas.
    
Thankfully, this is actually a pretty simple patch, so we can bikeshed exact syntax - the earlier refactoring of opts through parsing args into paramSpecs makes this relatively simple to work with (also because of the way `baseType` and `paramType` are separated out, it's no extra effort to keep supporting the `Optional` generic as well, though I do think if this approach is successful, we might want to remove that at some point).

Personally, I think I prefer the more explicit `//dagger: default=abc` instead of `//+default abc`, but I also don't *realllly* have strong opinions on this. I've written the code so we just need to update the regexp and the respective tests for this - no other code is dependent on this.
