### PR TITLE
fix: ensure go sdk generates docs for enum values

### DIFF
--- a/cmd/codegen/generator/go/templates/src/enum.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/enum.go.tmpl
@@ -5,9 +5,10 @@ type {{ $enumName }} string
 func ({{ $enumName }}) IsEnum() {}
 
 const (
-	{{- range $index, $field :=  .EnumValues | SortEnumFields }}
+	{{- range $index, $field := .EnumValues | SortEnumFields }}
+	{{ $field.Description | Comment }}
 	{{ $field.Name | FormatEnum}} {{ $enumName }} = "{{ $field.Name }}"
-	{{- end }}
+	{{ end }}
 )
 
 {{- end }}

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -4344,9 +4344,15 @@ type CacheSharingMode string
 func (CacheSharingMode) IsEnum() {}
 
 const (
-	Locked  CacheSharingMode = "LOCKED"
+	// Shares the cache volume amongst many build pipelines,
+	// but will serialize the writes
+	Locked CacheSharingMode = "LOCKED"
+
+	// Keeps a cache volume for a single build pipeline
 	Private CacheSharingMode = "PRIVATE"
-	Shared  CacheSharingMode = "SHARED"
+
+	// Shares the cache volume amongst many build pipelines
+	Shared CacheSharingMode = "SHARED"
 )
 
 type ImageLayerCompression string
@@ -4354,10 +4360,13 @@ type ImageLayerCompression string
 func (ImageLayerCompression) IsEnum() {}
 
 const (
-	Estargz      ImageLayerCompression = "EStarGZ"
-	Gzip         ImageLayerCompression = "Gzip"
+	Estargz ImageLayerCompression = "EStarGZ"
+
+	Gzip ImageLayerCompression = "Gzip"
+
 	Uncompressed ImageLayerCompression = "Uncompressed"
-	Zstd         ImageLayerCompression = "Zstd"
+
+	Zstd ImageLayerCompression = "Zstd"
 )
 
 type ImageMediaTypes string
@@ -4366,7 +4375,8 @@ func (ImageMediaTypes) IsEnum() {}
 
 const (
 	Dockermediatypes ImageMediaTypes = "DockerMediaTypes"
-	Ocimediatypes    ImageMediaTypes = "OCIMediaTypes"
+
+	Ocimediatypes ImageMediaTypes = "OCIMediaTypes"
 )
 
 type NetworkProtocol string
@@ -4374,7 +4384,10 @@ type NetworkProtocol string
 func (NetworkProtocol) IsEnum() {}
 
 const (
+	// TCP (Transmission Control Protocol)
 	Tcp NetworkProtocol = "TCP"
+
+	// UDP (User Datagram Protocol)
 	Udp NetworkProtocol = "UDP"
 )
 
@@ -4383,10 +4396,29 @@ type TypeDefKind string
 func (TypeDefKind) IsEnum() {}
 
 const (
+	// A boolean value
 	Booleankind TypeDefKind = "BooleanKind"
+
+	// An integer value
 	Integerkind TypeDefKind = "IntegerKind"
-	Listkind    TypeDefKind = "ListKind"
-	Objectkind  TypeDefKind = "ObjectKind"
-	Stringkind  TypeDefKind = "StringKind"
-	Voidkind    TypeDefKind = "VoidKind"
+
+	// A list of values all having the same type.
+	//
+	// Always paired with a ListTypeDef.
+	Listkind TypeDefKind = "ListKind"
+
+	// A named type defined in the GraphQL schema, with fields and functions.
+	//
+	// Always paired with an ObjectTypeDef.
+	Objectkind TypeDefKind = "ObjectKind"
+
+	// A string value
+	Stringkind TypeDefKind = "StringKind"
+
+	// A special kind used to signify that no value is returned.
+	//
+	// This is used for functions that have no return value. The outer TypeDef
+	// specifying this Kind is always Optional, as the Void is never actually
+	// represented.
+	Voidkind TypeDefKind = "VoidKind"
 )


### PR DESCRIPTION
Discovered while replying to https://discord.com/channels/707636530424053791/1179628240738975744/1179733881100959824:

> This depends on the above CacheSharingMode - the docs for what those all do are here: https://github.com/dagger/dagger/blob/main/core/schema/cache.graphqls#L4-L17
Not quite sure why these aren't documented in the sdk docs though, that's a bit odd and might be worth a bit of a dig (will take a look!)

Turns out we weren't outputting the comments for enums - these fields are populated, so we can add them in.