### PR TITLE
fix: stop panic with packed struct fields in Go modules

### DIFF
--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -704,6 +704,7 @@ func (ps *parseState) goStructToAPIType(t *types.Struct, named *types.Named) (*S
 	}
 
 	// Fill out the static fields of the struct (if any)
+	astFields := unpackASTFields(astStructType.Fields)
 	for i := 0; i < t.NumFields(); i++ {
 		field := t.Field(i)
 		if !field.Exported() {
@@ -719,7 +720,7 @@ func (ps *parseState) goStructToAPIType(t *types.Struct, named *types.Named) (*S
 		}
 
 		var description string
-		if doc := astStructType.Fields.List[i].Doc; doc != nil {
+		if doc := astFields[i].Doc; doc != nil {
 			description = doc.Text()
 		}
 

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -973,7 +973,9 @@ func TestModuleGoDocsEdgeCases(t *testing.T) {
 		WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 			Contents: `package main
 
-type Minimal struct {}
+type Minimal struct {
+	X, Y string
+}
 
 // some docs
 func (m *Minimal) Hello(foo string, bar string,


### PR DESCRIPTION
We already fixed this *twice* with the arg types - but it can also occur in structs yay.

```go
type CustomType struct {
  Foo, Bar string
}
```

See:
- https://github.com/dagger/dagger/pull/5972
- https://github.com/dagger/dagger/pull/6068

There definitely don't seem to be any more cases of us using `FieldList` though thankfull! :disappointed_relieved: 