### PR TITLE
break: Move global client to `dag` in Python

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -1389,7 +1389,7 @@ func (m *Foo) Get() string {
 			sdk: "python",
 			source: `from typing import Self
 
-from dagger.mod import field, function, object_type
+from dagger import field, function, object_type
 
 @object_type
 class Foo:
@@ -1481,7 +1481,7 @@ func (m *Foo) Uppers(msg []Message) []Message {
 		},
 		{
 			sdk: "python",
-			source: `from dagger.mod import field, function, object_type
+			source: `from dagger import field, function, object_type
 
 @object_type
 class Message:
@@ -1895,12 +1895,11 @@ func TestModuleUseLocal(t *testing.T) {
 			With(daggerExec("mod", "init", "--name=use", "--sdk=python")).
 			With(daggerExec("mod", "install", "./dep")).
 			WithNewFile("/work/src/main.py", dagger.ContainerWithNewFileOpts{
-				Contents: `from dagger.mod import function
-import dagger
+				Contents: `from dagger import dag, function
 
 @function
 def use_hello() -> str:
-    return dagger.dep().hello()
+    return dag.dep().hello()
 `,
 			})
 
@@ -1982,12 +1981,11 @@ func TestModuleCodegenonDepChange(t *testing.T) {
 			With(daggerExec("mod", "init", "--name=use", "--sdk=python")).
 			With(daggerExec("mod", "install", "./dep")).
 			WithNewFile("/work/src/main.py", dagger.ContainerWithNewFileOpts{
-				Contents: `from dagger.mod import function
-import dagger
+				Contents: `from dagger import dag, function
 
 @function
 def use_hello() -> str:
-    return dagger.dep().hello()
+    return dag.dep().hello()
 `,
 			})
 
@@ -2011,12 +2009,11 @@ def use_hello() -> str:
 
 		modGen = modGen.
 			WithNewFile("/work/src/main.py", dagger.ContainerWithNewFileOpts{
-				Contents: `from dagger.mod import function
-import dagger
+				Contents: `from dagger import dag, function
 
 @function
 def use_hello() -> str:
-    return dagger.dep().hellov2()
+    return dag.dep().hellov2()
 `,
 			})
 
@@ -2151,7 +2148,7 @@ func (m *Test) GimmeDirEnts(ctx context.Context) ([]string, error) {
 			{
 				sdk: "python",
 				source: `import dagger
-from dagger.mod import field, function, object_type
+from dagger import field, function, object_type
 
 @object_type
 class Test:
@@ -2257,8 +2254,7 @@ type Test struct {
 			},
 			{
 				sdk: "python",
-				source: `import dagger
-from dagger.mod import field, function, object_type
+				source: `from dagger import dag, field, function, object_type
 
 @object_type
 class Test:
@@ -2267,7 +2263,7 @@ class Test:
     @classmethod
     async def create(cls) -> "Test":
         return cls(alpine_version=await (
-            dagger.container()
+            dag.container()
             .from_("alpine:3.18.4")
             .file("/etc/alpine-release")
             .contents()
@@ -2316,7 +2312,7 @@ type Test struct {
 			},
 			{
 				sdk: "python",
-				source: `from dagger.mod import object_type, field
+				source: `from dagger import object_type, field
 
 @object_type
 class Test:
@@ -2358,12 +2354,12 @@ class Test:
 			WithWorkdir("/work/test").
 			With(daggerExec("mod", "init", "--name=test", "--sdk=python")).
 			With(sdkSource("python", fmt.Sprintf(`import dagger
-from dagger.mod import object_type, field
+from dagger import dag, object_type, field
 
 @object_type
 class Test:
     foo: dagger.File = field(default=lambda: (
-        dagger.directory()
+        dag.directory()
         .with_new_file("foo.txt", contents="%s")
         .file("foo.txt")
     ))
@@ -2514,7 +2510,7 @@ version = "0.0.0"
 				Contents: "from . import notmain\n",
 			}).
 			WithNewFile("/work/src/main/notmain.py", dagger.ContainerWithNewFileOpts{
-				Contents: `from dagger.mod import function
+				Contents: `from dagger import function
 
 @function
 def hello() -> str:
@@ -2543,7 +2539,7 @@ func TestModulePythonReturnSelf(t *testing.T) {
 		WithNewFile("src/main.py", dagger.ContainerWithNewFileOpts{
 			Contents: `from typing import Self
 
-from dagger.mod import field, function, object_type
+from dagger import field, function, object_type
 
 @object_type
 class Foo:
@@ -2617,7 +2613,7 @@ func TestModuleLotsOfFunctions(t *testing.T) {
 
 		c, ctx := connect(t)
 
-		mainSrc := `from dagger.mod import function
+		mainSrc := `from dagger import function
 		`
 
 		for i := 0; i < funcCount; i++ {

--- a/core/integration/testdata/modules/python/custom-types/main.py
+++ b/core/integration/testdata/modules/python/custom-types/main.py
@@ -1,4 +1,6 @@
-from dagger.mod import Annotated, Doc, field, function, object_type
+from typing import Annotated
+
+from dagger import Doc, field, function, object_type
 
 
 @object_type

--- a/core/integration/testdata/modules/python/id/arg/src/main.py
+++ b/core/integration/testdata/modules/python/id/arg/src/main.py
@@ -1,4 +1,4 @@
-from dagger.mod import function
+from dagger import function
 
 @function
 def fn(id: str) -> str:

--- a/core/integration/testdata/modules/python/id/fn/src/main.py
+++ b/core/integration/testdata/modules/python/id/fn/src/main.py
@@ -1,4 +1,4 @@
-from dagger.mod import function
+from dagger import function
 
 @function
 def id() -> str:

--- a/docs/zenith/developer/python/snippets/advanced-programming/chaining/main.py
+++ b/docs/zenith/developer/python/snippets/advanced-programming/chaining/main.py
@@ -1,5 +1,5 @@
 """A Dagger module for saying hello world!."""
-from dagger.mod import field, function, object_type
+from dagger import field, function, object_type
 
 
 @object_type

--- a/docs/zenith/developer/python/snippets/quickstart/step2/main.py
+++ b/docs/zenith/developer/python/snippets/quickstart/step2/main.py
@@ -1,4 +1,4 @@
-from dagger.mod import function
+from dagger import function
 
 
 @function

--- a/docs/zenith/developer/python/snippets/quickstart/step3a/main.py
+++ b/docs/zenith/developer/python/snippets/quickstart/step3a/main.py
@@ -1,4 +1,6 @@
-from dagger.mod import Annotated, Doc, function
+from typing import Annotated
+
+from dagger import Doc, function
 
 
 @function

--- a/docs/zenith/developer/python/snippets/quickstart/step3b/main.py
+++ b/docs/zenith/developer/python/snippets/quickstart/step3b/main.py
@@ -1,4 +1,4 @@
-from dagger.mod import field, function, object_type
+from dagger import field, function, object_type
 
 
 @object_type

--- a/docs/zenith/developer/python/snippets/quickstart/trivy/main.py
+++ b/docs/zenith/developer/python/snippets/quickstart/trivy/main.py
@@ -1,5 +1,4 @@
-import dagger
-from dagger.mod import function
+from dagger import dag, function
 
 
 @function
@@ -10,7 +9,7 @@ async def scan_image(
     format: str = "table",
 ) -> str:
     return await (
-        dagger.container()
+        dag.container()
         .from_("aquasec/trivy:latest")
         .with_exec(
             [

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -43,13 +43,14 @@ import sys
 
 import anyio
 import dagger
+from dagger import dag
 
 
 async def main(args: list[str]):
-    async with dagger.Connection() as client:
+    async with dagger.connection():
         # build container with cowsay entrypoint
         ctr = (
-            client.container()
+            dag.container()
             .from_("python:alpine")
             .with_exec(["pip", "install", "cowsay"])
             .with_entrypoint(["cowsay"])
@@ -87,7 +88,7 @@ If you need to debug, you can stream the logs from the engine with the `log_outp
 
 ```python
 config = dagger.Config(log_output=sys.stderr)
-async with dagger.Connection(config) as client:
+async with dagger.connection(config):
     ...
 ```
 

--- a/sdk/python/docs/connection.rst
+++ b/sdk/python/docs/connection.rst
@@ -3,44 +3,10 @@ Connection
 
 .. currentmodule:: dagger
 
-.. autoclass:: Config
-   :no-show-inheritance:
+.. autofunction:: connection
 
 .. autoclass:: Connection
    :no-show-inheritance:
 
-
-Experimental
-------------
-
-.. warning::
-   These functions are part of an experimental feature to use a globally available client instead of getting an instance from a connection. Their interfaces and availability may change in the future.
-
-.. autofunction:: connection
-
-.. autofunction:: closing
-
-.. autofunction:: connect
-
-    Connect to a Dagger Engine using the global client.
-
-    Similar to :py:func:`dagger.closing` but establishes the connection
-    explicitly rather than on first use.
-
-    Example::
-
-        import anyio
-        import dagger
-
-        async def main():
-            async with await dagger.connect():
-                ctr = dagger.container().from_("python:3.11.1-alpine")
-                # Connection is only established when needed.
-                version = await ctr.with_exec(["python", "-V"]).stdout()
-
-            # Connection is closed when leaving the context manager's scope.
-
-            print(version)
-            # Output: Python 3.11.1
-
-        anyio.run(main)
+.. autoclass:: Config
+   :no-show-inheritance:

--- a/sdk/python/docs/module.rst
+++ b/sdk/python/docs/module.rst
@@ -3,7 +3,7 @@ Module
 
 Experimental Dagger modules support.
 
-.. currentmodule:: dagger.mod
+.. currentmodule:: dagger
 
 .. autodecorator:: object_type
 

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    hatch run lock
 #
-aiohttp==3.9.0
+aiohttp==3.9.1
     # via -r -
 aiosignal==1.3.1
     # via aiohttp
@@ -48,7 +48,7 @@ httpx==0.25.2
     # via
     #   -r -
     #   pytest-httpx
-idna==3.5
+idna==3.6
     # via
     #   anyio
     #   httpx

--- a/sdk/python/runtime/template/src/main.py
+++ b/sdk/python/runtime/template/src/main.py
@@ -1,18 +1,18 @@
 import dagger
-from dagger.mod import function
+from dagger import dag, function
 
 
 @function
 def container_echo(string_arg: str) -> dagger.Container:
     # Example usage: "dagger call container-echo --string-arg hello"
-    return dagger.container().from_("alpine:latest").with_exec(["echo", string_arg])
+    return dag.container().from_("alpine:latest").with_exec(["echo", string_arg])
 
 
 @function
 async def grep_dir(directory_arg: dagger.Directory, pattern: str) -> str:
     # Example usage: "dagger call grep-dir --directory-arg . --patern grep_dir"
     return await (
-        dagger.container()
+        dag.container()
         .from_("alpine:latest")
         .with_mounted_directory("/mnt", directory_arg)
         .with_workdir("/mnt")

--- a/sdk/python/src/dagger/__init__.py
+++ b/sdk/python/src/dagger/__init__.py
@@ -24,7 +24,13 @@ from ._connection import Connection as Connection
 from ._connection import connection as connection
 from ._connection import connect as connect
 from ._connection import close as close
-from ._connection import closing as closing
+
+# Modules.
+from .mod import Arg as Arg
+from .mod import Doc as Doc
+from .mod import field as field
+from .mod import function as function
+from .mod import object_type as object_type
 
 # Re-export imports so they look like they live directly in this package.
 for _value in list(locals().values()):

--- a/sdk/python/src/dagger/_codegen/generator.py
+++ b/sdk/python/src/dagger/_codegen/generator.py
@@ -221,10 +221,10 @@ def generate(schema: GraphQLSchema) -> Iterator[str]:
         yield handler.render(named_type)
         ctx.process_type(type_name)
 
-    yield render_default_client(
-        ctx.defined,
-        get_root_fields(schema.type_map),
-    )
+    yield ""
+    yield "dag = Client()"
+    yield '"""The global client instance."""'
+    ctx.defined.add("dag")
 
     yield ""
     yield "__all__ = ["
@@ -287,26 +287,6 @@ def create_id_query_map(id_map: IDMap, type_map: TypeMap) -> IDQueryMap:
 def get_root_fields(type_map: TypeMap) -> GraphQLFieldMap:
     """Get all fields under Query."""
     return cast(GraphQLObjectType, type_map["Query"]).fields
-
-
-@joiner
-def render_default_client(
-    defined: set[str], root_fields: GraphQLFieldMap
-) -> Iterator[str]:
-    names = sorted(format_name(name) for name in root_fields)
-
-    yield "_client = Client()"
-    yield from (f"{name} = _client.{name}" for name in names)
-    defined.update(names)
-
-    yield textwrap.dedent(
-        '''\
-        def default_client() -> Client:
-            """Return the default client instance."""
-            return _client
-        '''
-    )
-    defined.add("default_client")
 
 
 @dataclass(slots=True)

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -4763,45 +4763,8 @@ class TypeDef(Type):
         return cb(self)
 
 
-_client = Client()
-cache_volume = _client.cache_volume
-check_version_compatibility = _client.check_version_compatibility
-container = _client.container
-current_function_call = _client.current_function_call
-current_module = _client.current_module
-default_platform = _client.default_platform
-directory = _client.directory
-file = _client.file
-function = _client.function
-generated_code = _client.generated_code
-git = _client.git
-host = _client.host
-http = _client.http
-load_cache_volume_from_id = _client.load_cache_volume_from_id
-load_container_from_id = _client.load_container_from_id
-load_directory_from_id = _client.load_directory_from_id
-load_file_from_id = _client.load_file_from_id
-load_function_arg_from_id = _client.load_function_arg_from_id
-load_function_from_id = _client.load_function_from_id
-load_generated_code_from_id = _client.load_generated_code_from_id
-load_module_from_id = _client.load_module_from_id
-load_secret_from_id = _client.load_secret_from_id
-load_service_from_id = _client.load_service_from_id
-load_socket_from_id = _client.load_socket_from_id
-load_type_def_from_id = _client.load_type_def_from_id
-module = _client.module
-module_config = _client.module_config
-pipeline = _client.pipeline
-secret = _client.secret
-set_secret = _client.set_secret
-socket = _client.socket
-type_def = _client.type_def
-
-
-def default_client() -> Client:
-    """Return the default client instance."""
-    return _client
-
+dag = Client()
+"""The global client instance."""
 
 __all__ = [
     "BuildArg",
@@ -4852,37 +4815,5 @@ __all__ = [
     "TypeDefID",
     "TypeDefKind",
     "Void",
-    "cache_volume",
-    "check_version_compatibility",
-    "container",
-    "current_function_call",
-    "current_module",
-    "default_client",
-    "default_platform",
-    "directory",
-    "file",
-    "function",
-    "generated_code",
-    "git",
-    "host",
-    "http",
-    "load_cache_volume_from_id",
-    "load_container_from_id",
-    "load_directory_from_id",
-    "load_file_from_id",
-    "load_function_arg_from_id",
-    "load_function_from_id",
-    "load_generated_code_from_id",
-    "load_module_from_id",
-    "load_secret_from_id",
-    "load_service_from_id",
-    "load_socket_from_id",
-    "load_type_def_from_id",
-    "module",
-    "module_config",
-    "pipeline",
-    "secret",
-    "set_secret",
-    "socket",
-    "type_def",
+    "dag",
 ]

--- a/sdk/python/src/dagger/mod/__init__.py
+++ b/sdk/python/src/dagger/mod/__init__.py
@@ -1,4 +1,3 @@
-from typing import Annotated
 from typing_extensions import Doc
 
 
@@ -18,10 +17,8 @@ def default_module() -> Module:
 
 
 __all__ = [
-    "Annotated",
     "Arg",
-    "Doc",
-    "Module",
+    "Doc",  # Only re-exported because it's in `typing_extensions`.
     "field",
     "function",
     "object_type",

--- a/sdk/python/src/dagger/mod/_converter.py
+++ b/sdk/python/src/dagger/mod/_converter.py
@@ -26,20 +26,17 @@ if typing.TYPE_CHECKING:
 
 
 def make_converter():
-    import dagger
+    from dagger import dag
     from dagger.client._guards import is_id_type, is_id_type_subclass
 
     conv = make_json_converter(
         detailed_validation=True,
     )
 
-    # TODO: register cache volume for custom handling since it's different
-    # than the other types.
-
     def dagger_type_structure(id_, cls):
         """Get dagger object type from id."""
         cls = strip_annotations(cls)
-        return dagger.default_client()._get_object_instance(id_, cls)  # noqa: SLF001
+        return dag._get_object_instance(id_, cls)  # noqa: SLF001
 
     def dagger_type_unstructure(obj):
         """Get id from dagger object."""
@@ -69,9 +66,10 @@ def to_typedef(annotation: type) -> "TypeDef":  # noqa: C901
     ), "Annotated types should be handled by the caller."
 
     import dagger
+    from dagger import dag
     from dagger.client._guards import is_id_type_subclass
 
-    td = dagger.type_def()
+    td = dag.type_def()
 
     if isinstance(annotation, dataclasses.InitVar):
         annotation = annotation.type

--- a/sdk/python/src/dagger/mod/_module.py
+++ b/sdk/python/src/dagger/mod/_module.py
@@ -18,6 +18,7 @@ from rich.console import Console
 from typing_extensions import dataclass_transform, overload
 
 import dagger
+from dagger import dag
 from dagger.log import configure_logging
 
 from ._converter import make_converter
@@ -73,8 +74,8 @@ class Module:
         self._log_level = log_level  # TODO: Hook debug from `--debug` flag in CLI?
         self._converter: cattrs.Converter = make_converter()
         self._resolvers: list[Resolver] = []
-        self._fn_call = dagger.current_function_call()
-        self._mod = dagger.current_module()
+        self._fn_call = dag.current_function_call()
+        self._mod = dag.current_module()
 
     def add_resolver(self, resolver: Resolver):
         self._resolvers.append(resolver)
@@ -212,7 +213,7 @@ class Module:
         mod = self._mod
 
         for obj, obj_resolvers in resolvers.items():
-            typedef = dagger.type_def().with_object(
+            typedef = dag.type_def().with_object(
                 obj.name,
                 description=obj.doc,
             )

--- a/sdk/python/src/dagger/mod/_resolver.py
+++ b/sdk/python/src/dagger/mod/_resolver.py
@@ -22,6 +22,7 @@ from graphql.pyutils import camel_to_snake
 from typing_extensions import Self, override
 
 import dagger
+from dagger import dag
 
 from ._arguments import Parameter
 from ._converter import to_typedef
@@ -123,7 +124,7 @@ class FunctionResolver(Resolver, Generic[P, F]):
     @override
     def register(self, typedef: dagger.TypeDef) -> dagger.TypeDef:
         """Add a new object to current module."""
-        fn = dagger.function(self.name, to_typedef(self.return_type))
+        fn = dag.function(self.name, to_typedef(self.return_type))
 
         if self.doc:
             fn = fn.with_description(self.doc)

--- a/sdk/python/tests/modules/test_results.py
+++ b/sdk/python/tests/modules/test_results.py
@@ -1,11 +1,13 @@
 import json
 from dataclasses import InitVar
+from typing import Annotated
 
 import pytest
 from typing_extensions import Self
 
 import dagger
-from dagger.mod import Annotated, Arg, Doc, Module
+from dagger import Arg, Doc, dag
+from dagger.mod import Module
 from dagger.mod._exceptions import FatalError
 
 pytestmark = [
@@ -50,7 +52,7 @@ async def test_unstructure_structure():
 
     @mod.function
     def foo() -> Bar:
-        return Bar(ctr=dagger.container().from_("alpine"))
+        return Bar(ctr=dag.container().from_("alpine"))
 
     async with dagger.connection():
         resolver = mod.get_resolver(mod.get_resolvers("foo"), "Foo", "foo")

--- a/sdk/python/tests/modules/test_utils.py
+++ b/sdk/python/tests/modules/test_utils.py
@@ -4,7 +4,8 @@ import pytest
 from beartype.door import TypeHint
 from typing_extensions import Doc
 
-from dagger.mod import Arg, Module, field
+from dagger import Arg, field
+from dagger.mod import Module
 from dagger.mod._utils import get_arg_name, get_doc, is_optional, non_optional
 
 


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/6127

> ⚠️ **Warning**
> This is a breaking change for those using the global client or python modules. 

## What changed?

### Global client instance

Previously the global client was accessible via the global `dagger` namespace, now they're in `dagger.dag`:
```diff
import dagger
+from dagger import dag

def fn() -> dagger.Container:
-    return dagger.container()
+    return dag.container()
```

Internally:
```python
dag = dagger.Client()
```

### Imports in modules

- Common imports for `field`, `function`, `object_type`, `Arg` and `Doc` were added to `dagger` since now `dagger.mod.function` won't conflict with `dag.function` anymore and it allows importing `dag` in the same line.
- `Annotated` is no longer re-exported. The initial intent was to keep one `from dagger.mod import ...` line, but users should import from the stdlib instead.

### Closing context manager

`async with dagger.closing()` is no longer available. Use `async with dagger.connection()` instead.

