### PR TITLE
feat: allow go modules to accept/return foreign types

### DIFF
--- a/cmd/codegen/generator/go/generator.go
+++ b/cmd/codegen/generator/go/generator.go
@@ -318,7 +318,9 @@ func loadPackage(ctx context.Context, dir string) (*packages.Package, *token.Fil
 			packages.NeedTypes |
 			packages.NeedSyntax |
 			packages.NeedTypesInfo |
-			packages.NeedModule,
+			packages.NeedModule |
+			packages.NeedDeps |
+			packages.NeedImports,
 	}, ".")
 	if err != nil {
 		return nil, nil, err

--- a/cmd/codegen/generator/go/generator.go
+++ b/cmd/codegen/generator/go/generator.go
@@ -319,6 +319,8 @@ func loadPackage(ctx context.Context, dir string) (*packages.Package, *token.Fil
 			packages.NeedSyntax |
 			packages.NeedTypesInfo |
 			packages.NeedModule |
+			// NOTE: packages.NeedDeps | packages.NeedImports analyzes and typechecks all
+			// deps - this might be kinda expensive long-term
 			packages.NeedDeps |
 			packages.NeedImports,
 	}, ".")


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/6172 which I've actually wanted for *ages* (cc @aweris)

This allows go modules to accept arguments and return values that are of types from other packages that are not the current one.

For example, this allows module authors to structure their modules as they like with sub-packages while not exposing those details to the outside world.

This is a pretty straightforward change - to do this we need to:
- Disable the explicit check that disabled this behaviour
- Enabled packages.NeedDeps | packages.NeedImports to parse dependencies syntax so that we can analyze the struct and methods in those dependent packages.
- Update the logic when we reference type names to not always assume local, and to prefix the name of the package when we use it.
- Default to the main package when searching for syntax information, but fallback to the package that the type was declared in when we need to.

---

There's still the open question of how we should handle standard library types like `url.URL` and `time.Time` - we'd want to probably convert to/from these types when going over the wire. But I think we can handle that later separately.

Maybe we should also impose a restriction that means we only allow types from sub-packages instead of every single package on the internet, but I haven't added that yet since I'm not 100% sure about that idea. The benefit of doing so means that we force everyone to use modules as a way of consuming other people's modules instead of using go-specific imports which would maybe be a possibility with merging this.