### PR TITLE
fix: parse struct comments same as inline opt structs

### DIFF
--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -677,8 +677,8 @@ func (ps *parseState) goStructToAPIType(t *types.Struct, named *types.Named) (*S
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to find decl for named type %s: %w", typeName, err)
 	}
-	if doc := typeSpec.Doc; doc != nil { // TODO(vito): for some reason this is always nil
-		withObjectOpts = append(withObjectOpts, Id("Description").Op(":").Lit(doc.Text()))
+	if comment := typeSpec.Doc.Text(); comment != "" {
+		withObjectOpts = append(withObjectOpts, Id("Description").Op(":").Lit(strings.TrimSpace(comment)))
 	}
 	if len(withObjectOpts) > 0 {
 		withObjectArgs = append(withObjectArgs, Id("TypeDefWithObjectOpts").Values(withObjectOpts...))
@@ -1046,6 +1046,9 @@ func (ps *parseState) typeSpecForNamedType(namedType *types.Named) (*ast.TypeSpe
 					continue
 				}
 				if typeSpec.Name.Name == namedType.Obj().Name() {
+					if typeSpec.Doc == nil {
+						typeSpec.Doc = genDecl.Doc
+					}
 					return typeSpec, nil
 				}
 			}

--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -719,10 +719,11 @@ func (ps *parseState) goStructToAPIType(t *types.Struct, named *types.Named) (*S
 			subTypes = append(subTypes, subType)
 		}
 
-		var description string
-		if doc := astFields[i].Doc; doc != nil {
-			description = doc.Text()
+		description := astFields[i].Doc.Text()
+		if description == "" {
+			description = astFields[i].Comment.Text()
 		}
+		description = strings.TrimSpace(description)
 
 		name := field.Name()
 
@@ -822,8 +823,8 @@ func (ps *parseState) goFuncToAPIFunctionDef(receiverTypeName string, fn *types.
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to find decl for method %s: %w", fn.Name(), err)
 	}
-	if doc := funcDecl.Doc; doc != nil {
-		fnDef = dotLine(fnDef, "WithDescription").Call(Lit(doc.Text()))
+	if comment := funcDecl.Doc.Text(); comment != "" {
+		fnDef = dotLine(fnDef, "WithDescription").Call(Lit(strings.TrimSpace(comment)))
 	}
 
 	for i, spec := range specs {

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -901,7 +901,7 @@ query {
         objects {
           asObject {
             name
-			description
+            description
             functions {
               name
               description
@@ -909,6 +909,10 @@ query {
                 name
                 description
               }
+            }
+            fields {
+              name
+              description
             }
           }
         }
@@ -982,7 +986,8 @@ func TestModuleGoDocsEdgeCases(t *testing.T) {
 
 // Minimal is a thing
 type Minimal struct {
-	X, Y string
+	// X is this
+	X, Y string  // Y is not this
 }
 
 // some docs
@@ -1077,6 +1082,13 @@ func (m *Minimal) HelloFinal(
 	require.Len(t, hello.Get("args").Array(), 1)
 	require.Equal(t, "foo", hello.Get("args.0.name").String())
 	require.Equal(t, "", hello.Get("args.0.description").String())
+
+	prop := obj.Get(`fields.#(name="x")`)
+	require.Equal(t, "x", prop.Get("name").String())
+	require.Equal(t, "X is this", prop.Get("description").String())
+	prop = obj.Get(`fields.#(name="y")`)
+	require.Equal(t, "y", prop.Get("name").String())
+	require.Equal(t, "", prop.Get("description").String())
 }
 
 //go:embed testdata/modules/go/extend/main.go

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -901,6 +901,7 @@ query {
         objects {
           asObject {
             name
+			description
             functions {
               name
               description
@@ -979,6 +980,7 @@ func TestModuleGoDocsEdgeCases(t *testing.T) {
 		WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 			Contents: `package main
 
+// Minimal is a thing
 type Minimal struct {
 	X, Y string
 }
@@ -1028,6 +1030,7 @@ func (m *Minimal) HelloFinal(
 	require.NoError(t, err)
 	obj := gjson.Get(out, "host.directory.asModule.objects.0.asObject")
 	require.Equal(t, "Minimal", obj.Get("name").String())
+	require.Equal(t, "Minimal is a thing", obj.Get("description").String())
 
 	hello := obj.Get(`functions.#(name="hello")`)
 	require.Equal(t, "hello", hello.Get("name").String())

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -215,6 +215,7 @@ func NewObjectTypeDef(name, description string) *ObjectTypeDef {
 	return &ObjectTypeDef{
 		Name:         strcase.ToCamel(name),
 		OriginalName: name,
+		Description:  description,
 	}
 }
 


### PR DESCRIPTION
Depends on #6181 (also kiiiinda related to #6179)

This parses doc comments on top-level objects the same as we do for inline comments:
    
- Ensure that the comments are trimmed to not have spaces.
- Fallback to the line comment if no doc comment was found.

---

While doing this, I also found a bug that meant that the description for objects in the graphql API was being discarded and not appropriately set on the struct. And also found that we weren't even correctly detecting the struct comments from the go parser, from the commit message:

> Comments for go structs can either be attached to the TypeSpec, or the GenDecl - so we should fallback to the GenDecl doc comment if the TypeSpec does not have one.