### PR TITLE
fix: ensure readonly option is correctly propagated

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -876,6 +876,7 @@ func (container *Container) withMounted(
 		Source:     srcDef,
 		SourcePath: srcPath,
 		Target:     target,
+		Readonly:   readonly,
 	})
 
 	container.Services.Merge(svcs)


### PR DESCRIPTION
Found while investigating #6163 (this isn't the root cause, but while attempting to reproduce this I had the idea to change `WithMountedDirectory` to use `llb.Readonly` - which causes the caching issue in #6163 to "go away").

This seems to have been introduced as an oversight in #5757 - we do use the `readonly bool` option in some places, so this should improve the performance of those operations.

Absolutely *no* idea how to test this :cry:

---

We were passing a boolean to indicate if mounted files/directories should be marked as read-only.

Note that this has caching implications! Content-based cache is *not* used for non-readonly directories.