### PR TITLE
fix: allow fast-cache hits on custom BlobSource

### DIFF
--- a/engine/buildkit/filesync.go
+++ b/engine/buildkit/filesync.go
@@ -63,8 +63,13 @@ func (c *Client) LocalImport(
 	localOpts = append(localOpts, llb.WithCustomName(localName))
 	localLLB := llb.Local(srcPath, localOpts...)
 
-	// We still need to do a copy here for now because buildkit's cache calls Finalize on refs when getting their blobs
-	// which makes the cache ref for the local ref unable to be reused.
+	// We still need to do a copy here for now because buildkit's cache calls
+	// Finalize on refs when getting their blobs which makes the cache ref for the
+	// local ref unable to be reused.
+	//
+	// TODO: we should ensure that this doesn't create a new cache entry, without
+	// this the entire local directory is uploaded to the cache. See also
+	// blobSource.CacheKey for more context
 	copyLLB := llb.Scratch().File(
 		llb.Copy(localLLB, "/", "/"),
 		llb.WithCustomNamef(localName),


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/6163 :tada: (cc @gerhard @marcosnils)

By prefixing the returned CacheKey with "session:" we activated the code path in buildkit that randomizes the digest to ensure that we don't get fast-cast hits (since session ids can be reused). See https://github.com/moby/buildkit/blob/06c971ffb4d3873207fe8ff7672026a718784060/solver/llbsolver/ops/source.go#L91-L94.

However, unlike LocalSources, BlobSources are not tied to a specific session (after initializing them), so we actually want to avoid this behavior.

With this change, digests aren't randomized, so we can get the fast-cache hits.