### PR TITLE
docs: Adds note for Docker mediatypes in cookbook

### DIFF
--- a/docs/current/cookbook/snippets/oci-annotations/index.mjs
+++ b/docs/current/cookbook/snippets/oci-annotations/index.mjs
@@ -18,6 +18,12 @@ connect(
 
     const addr = await container.publish("ttl.sh/my-alpine")
 
+    // note: some registries (e.g. ghcr.io) may require explicit use
+    // of Docker mediatypes rather than the default OCI mediatypes
+    // const addr = await container.publish("ttl.sh/my-alpine", {
+    //   mediaTypes: "Dockermediatypes",
+    // })
+
     console.log(addr)
   },
   { LogOutput: process.stderr }

--- a/docs/current/cookbook/snippets/oci-annotations/main.go
+++ b/docs/current/cookbook/snippets/oci-annotations/main.go
@@ -28,6 +28,13 @@ func main() {
 		WithLabel("org.opencontainers.image.licenses", "MIT")
 
 	addr, err := ctr.Publish(ctx, "ttl.sh/my-alpine")
+
+	// note: some registries (e.g. ghcr.io) may require explicit use
+	// of Docker mediatypes rather than the default OCI mediatypes
+	// addr, err := ctr.Publish(ctx, "ttl.sh/my-alpine", dagger.ContainerPublishOpts{
+	//   MediaTypes: dagger.Dockermediatypes,
+	// })
+
 	if err != nil {
 		panic(err)
 	}

--- a/docs/current/cookbook/snippets/oci-annotations/main.py
+++ b/docs/current/cookbook/snippets/oci-annotations/main.py
@@ -10,7 +10,7 @@ async def main():
     # create Dagger client
     async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
         # publish app on alpine base
-        addr = await (
+        ctr = (
             client.container()
             .from_("alpine")
             .with_label("org.opencontainers.image.title", "my-alpine")
@@ -24,8 +24,13 @@ async def main():
                 "https://github.com/alpinelinux/docker-alpine",
             )
             .with_label("org.opencontainers.image.licenses", "MIT")
-            .publish("ttl.sh/my-alpine")
         )
+
+        addr = await ctr.publish("ttl.sh/my-alpine")
+
+        # note: some registries (e.g. ghcr.io) may require explicit use
+        # of Docker mediatypes rather than the default OCI mediatypes
+        # addr = await ctr.publish("ttl.sh/my-alpine", media_types="DockerMediaTypes")
 
     print(addr)
 


### PR DESCRIPTION
This commit adds an example of using Docker mediatypes to the cookbook.

Ref Discord thread in https://discord.com/channels/707636530424053791/1179434337725337600/1180204397121241199