### PR TITLE
core: serve modules their own API schema

### DIFF
--- a/core/schema/moddag.go
+++ b/core/schema/moddag.go
@@ -126,16 +126,18 @@ func (d *ModDeps) lazilyLoadSchema(ctx context.Context) (loadedSchema *CompiledS
 	}()
 
 	var schemas []SchemaResolvers
+	var modNames []string // for debugging+error messages
 	for _, mod := range d.mods {
 		modSchemas, err := mod.Schema(ctx)
 		if err != nil {
 			return nil, "", fmt.Errorf("failed to get schema for module %q: %w", mod.Name(), err)
 		}
 		schemas = append(schemas, modSchemas...)
+		modNames = append(modNames, mod.Name())
 	}
 	schema, err := mergeSchemaResolvers(schemas...)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to merge schemas: %w", err)
+		return nil, "", fmt.Errorf("failed to merge schemas of %+v: %w", modNames, err)
 	}
 	introspectionJSON, err := schemaIntrospectionJSON(ctx, *schema.Compiled)
 	if err != nil {

--- a/core/schema/schema.go
+++ b/core/schema/schema.go
@@ -100,7 +100,7 @@ func New(ctx context.Context, params InitializeArgs) (*APIServer, error) {
 		return nil, err
 	}
 
-	// the main client caller starts out the core API loaded
+	// the main client caller starts out with the core API loaded
 	api.clientCallContext[""] = &clientCallContext{
 		deps: api.defaultDeps,
 	}
@@ -351,7 +351,7 @@ func (s *APIServer) ServeModuleToMainClient(ctx context.Context, modMeta *core.M
 	return nil
 }
 
-func (s *APIServer) RegisterFunctionCall(dgst digest.Digest, mod *UserMod, call *core.FunctionCall) error {
+func (s *APIServer) RegisterFunctionCall(dgst digest.Digest, deps *ModDeps, mod *UserMod, call *core.FunctionCall) error {
 	if dgst == "" {
 		return fmt.Errorf("cannot register function call with empty digest")
 	}
@@ -363,7 +363,7 @@ func (s *APIServer) RegisterFunctionCall(dgst digest.Digest, mod *UserMod, call 
 		return nil
 	}
 	s.clientCallContext[dgst] = &clientCallContext{
-		deps:   mod.deps,
+		deps:   deps,
 		mod:    mod,
 		fnCall: call,
 	}
@@ -445,37 +445,37 @@ func mergeSchemaResolvers(newSchemas ...SchemaResolvers) (*CompiledSchema, error
 	mergedSchema := StaticSchemaParams{Resolvers: make(Resolvers)}
 	for _, newSchema := range newSchemas {
 		mergedSchema.Schema += newSchema.Schema() + "\n"
-		for name, resolver := range newSchema.Resolvers() {
-			switch resolver := resolver.(type) {
+		for typeName, newResolver := range newSchema.Resolvers() {
+			switch newResolver := newResolver.(type) {
 			case FieldResolvers:
-				existing, alreadyExisted := mergedSchema.Resolvers[name]
-				if !alreadyExisted {
-					existing = resolver
+				existingResolver, typeResolverAlreadyExisted := mergedSchema.Resolvers[typeName]
+				if !typeResolverAlreadyExisted {
+					existingResolver = newResolver.Clone()
 				}
-				existingObject, ok := existing.(FieldResolvers)
+				existingObject, ok := existingResolver.(FieldResolvers)
 				if !ok {
-					return nil, fmt.Errorf("unexpected resolver type %T", existing)
+					return nil, fmt.Errorf("unexpected resolver type %T", existingResolver)
 				}
-				for fieldName, fieldResolveFn := range resolver.Fields() {
-					if alreadyExisted {
+				for fieldName, fieldResolveFn := range newResolver.Fields() {
+					if typeResolverAlreadyExisted {
 						// check for field conflicts if we are merging more fields into the existing object
 						if _, ok := existingObject.Fields()[fieldName]; ok {
-							return nil, fmt.Errorf("conflict on type %q field %q: %w", name, fieldName, ErrMergeFieldConflict)
+							return nil, fmt.Errorf("conflict on type %q field %q: %w", typeName, fieldName, ErrMergeFieldConflict)
 						}
 					}
 					existingObject.SetField(fieldName, fieldResolveFn)
 				}
-				mergedSchema.Resolvers[name] = existingObject
+				mergedSchema.Resolvers[typeName] = existingObject
 			case ScalarResolver:
-				if existing, ok := mergedSchema.Resolvers[name]; ok {
+				if existing, ok := mergedSchema.Resolvers[typeName]; ok {
 					if _, ok := existing.(ScalarResolver); !ok {
-						return nil, fmt.Errorf("conflict on type %q: %w", name, ErrMergeTypeConflict)
+						return nil, fmt.Errorf("conflict on type %q: %w", typeName, ErrMergeTypeConflict)
 					}
-					return nil, fmt.Errorf("conflict on type %q: %w", name, ErrMergeScalarConflict)
+					return nil, fmt.Errorf("conflict on type %q: %w", typeName, ErrMergeScalarConflict)
 				}
-				mergedSchema.Resolvers[name] = resolver
+				mergedSchema.Resolvers[typeName] = newResolver
 			default:
-				return nil, fmt.Errorf("unexpected resolver type %T", resolver)
+				return nil, fmt.Errorf("unexpected resolver type %T", newResolver)
 			}
 		}
 	}

--- a/core/schema/usermod.go
+++ b/core/schema/usermod.go
@@ -101,14 +101,14 @@ func (m *UserMod) Objects(ctx context.Context) (loadedObjects []*UserModObject, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create module definition function for module %q: %w", m.Name(), err)
 	}
-	result, err := getModDefFn.Call(ctx, &CallOpts{Cache: true})
+	result, err := getModDefFn.Call(ctx, &CallOpts{Cache: true, SkipSelfSchema: true})
 	if err != nil {
 		return nil, fmt.Errorf("failed to call module %q to get functions: %w", m.Name(), err)
 	}
 
 	modMeta, ok := result.(*core.Module)
 	if !ok {
-		return nil, fmt.Errorf("expected ModuleMetadata result, got %T", result)
+		return nil, fmt.Errorf("expected Module result, got %T", result)
 	}
 
 	objs := make([]*UserModObject, 0, len(modMeta.Objects))


### PR DESCRIPTION
This is a pre-req for [interface support](https://github.com/dagger/dagger/issues/6213) but also stands on its own fairly well and fixes a bug along the way, so spinning it out to its own PR.

This change results in a module's own API being served to it by the engine when invoked. Note that this is a change to the API being served *only* and not full-blown `dag.Self`-like support, which would require modules also generate client bindings to themselves (and is where all the tricky issues arise). This change is a step in that direction though.

The reason this is needed for interfaces is that modules need to be able to define an interface like:
```go
type Duck interface {
  Quack() string
}
```
register that type with the module and then internally be able to call a graphql api `loadDuckFromID(id: String!) Duck`, where `Duck` is a graphql interface.

Fortunately, we can get away with implementing that as a raw graphql query internally since the `load*FromID` APIs all follow a well-known pattern (and that pattern is already depended on elsewhere in our client codegen). So interface support only needs the change in this PR rather than full-blown `dag.Self`.

This also fixes a bug along the way that got revealed after implementing support. Namely, [on this line](https://github.com/dagger/dagger/blob/c9c11391b82a7b91c7f6f460f7814fe233816d9a/core/schema/schema.go#L453) we were re-using an existing `ObjectResolver` and then also potentially calling `SetField` on it later. In my tests this ended up triggering a codepath where we added fields from modules to the `ObjectResolver` for `Query` on `core`, which is not desired behavior to say the least...
* Fixed for now by just copying the map. While working on it I did think of an actually good way to eliminate `IDableObjectResolver`, which would cascade into simplifications that remove the complication in `mergeSchemaResolvers` that caused this in the first place. However it's a fairly large scale change to how the core schemas get loaded, so I'm going to kick the can one more time and not get overly distracted from interfaces