### PR TITLE
core: handle nil in core mod object ID conversions

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -1307,6 +1307,8 @@ func (m *Playground) MySlice() []*Container {
 
 type Foo struct {
 	Con *Container
+	// verify fields can remain nil w/out error too
+	UnsetFile *File
 }
 
 func (m *Playground) MyStruct() *Foo {
@@ -2213,6 +2215,7 @@ type Test struct {
 	Bar int
 	Baz []string
 	Dir *Directory
+	NeverSetDir *Directory
 }
 
 func (m *Test) GimmeFoo() string {
@@ -2243,6 +2246,7 @@ class Test:
     dir: dagger.Directory = field()
     bar: int = field(default=42)
     baz: list[str] = field(default=list)
+    never_set_dir: dagger.Directory | None = field(default=None)
 
     @function
     def gimme_foo(self) -> str:

--- a/core/schema/coremod.go
+++ b/core/schema/coremod.go
@@ -80,6 +80,9 @@ type CoreModObject struct {
 var _ ModType = (*CoreModObject)(nil)
 
 func (obj *CoreModObject) ConvertFromSDKResult(_ context.Context, value any) (any, error) {
+	if value == nil {
+		return nil, nil
+	}
 	id, ok := value.(string)
 	if !ok {
 		return value, nil

--- a/core/schema/resolver.go
+++ b/core/schema/resolver.go
@@ -73,6 +73,8 @@ func (r idableObjectResolver[T, I]) FromID(id string) (any, error) {
 
 func (r idableObjectResolver[T, I]) ToID(x any) (string, error) {
 	switch t := x.(type) {
+	case nil:
+		return "", nil
 	case string:
 		if err := resourceid.ID[T](t).Validate(); err != nil {
 			return "", err


### PR DESCRIPTION
Missed this case, which resulted in objects with fields of a core type that were unset to result in an error. Now we just check nil and handle appropriately (id becomes empty string).

Noticed by @jedevc here https://github.com/dagger/dagger/pull/6167#issuecomment-1843298338