### PR TITLE
chore: add my missing changelog entries

### DIFF
--- a/.changes/unreleased/Added-20231207-124744.yaml
+++ b/.changes/unreleased/Added-20231207-124744.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: New secret scrubbing implementation for more responsive logs
+time: 2023-12-07T12:47:44.765756343Z
+custom:
+  Author: jedevc
+  PR: "6034"

--- a/.changes/unreleased/Added-20231207-124852.yaml
+++ b/.changes/unreleased/Added-20231207-124852.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Improved logging during engine startup
+time: 2023-12-07T12:48:52.744612327Z
+custom:
+  Author: jedevc
+  PR: "6075"

--- a/.changes/unreleased/Fixed-20231207-124611.yaml
+++ b/.changes/unreleased/Fixed-20231207-124611.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fix `WithMountedDirectory` invalidating cache
+time: 2023-12-07T12:46:11.471013421Z
+custom:
+  Author: jedevc
+  PR: "6211"


### PR DESCRIPTION
In a few previous PRs, I'd forgotten to include relevant changelog entries - this patch includes those backdated entries.

Follow-ups from:
- #6034 
- #6211
- #6075

Sorry for not noticing this until now!