### PR TITLE
ci: Bump GoReleaser to v1.22.1

### DIFF
--- a/internal/mage/cli.go
+++ b/internal/mage/cli.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// https://github.com/goreleaser/goreleaser/releases
-	goReleaserVersion = "v1.21.2-pro"
+	goReleaserVersion = "v1.22.1-pro"
 )
 
 type Cli mg.Namespace


### PR DESCRIPTION
Closes https://github.com/dagger/nix/pull/4 via https://github.com/goreleaser/goreleaser/pull/4389

cc @sagikazarmark @RaitoBezarius @caarlos0