### PR TITLE
core: set endpoint map when initializing APIServer

### DIFF
--- a/core/schema/schema.go
+++ b/core/schema/schema.go
@@ -57,6 +57,8 @@ func New(ctx context.Context, params InitializeArgs) (*APIServer, error) {
 		services:     svcs,
 		host:         core.NewHost(),
 
+		endpoints: map[string]http.Handler{},
+
 		buildCache:  core.NewCacheMap[uint64, *core.Container](),
 		importCache: core.NewCacheMap[uint64, *specs.Descriptor](),
 


### PR DESCRIPTION
Without this we're getting nil panics when using dagger shell.

Went unnoticed because we haven't added test coverage for dagger shell to the integ tests yet due to the fact that testing tty programs in our current testing setup is very non-obvious.

I will add whatever best test I can in a follow up to this PR, but sending the fix separately since it is quite trivial and probably an order of magnitude less time consuming than figuring out a test.