### PR TITLE
docs: Update CLI warning for hidden commands

### DIFF
--- a/docs/current/cli/979595-reference.md
+++ b/docs/current/cli/979595-reference.md
@@ -33,7 +33,7 @@ The options below can be used with all CLI commands.
 ## dagger call
 
 :::note
-This command is currently under development and is therefore hidden in the CLI.
+This command is currently under development, may change in future and is therefore hidden in the CLI.
 :::
 
 Call a module function and print the result. When called:
@@ -87,7 +87,7 @@ dagger completion bash > $(brew --prefix)/etc/bash_completion.d/dagger
 ## dagger functions
 
 :::note
-This command is currently under development and is therefore hidden in the CLI.
+This command is currently under development, may change in future and is therefore hidden in the CLI.
 :::
 
 List all functions in a module.
@@ -395,7 +395,7 @@ dagger --silent run go run ci.go 2>&1 | tee foo.out
 ## dagger shell
 
 :::note
-This command is currently under development and is therefore hidden in the CLI.
+This command is currently under development, may change in future and is therefore hidden in the CLI.
 :::
 
 Open a shell in a container returned by a function. If no entrypoint is specified and the container doesn't have a default command, `sh` will be used for the shell.
@@ -429,7 +429,7 @@ dagger shell --entrypoint /bin/zsh debug
 ## dagger up
 
 :::note
-This command is currently under development and is therefore hidden in the CLI.
+This command is currently under development, may change in future and is therefore hidden in the CLI.
 :::
 
 Start a service returned by a function and expose its ports to the host.


### PR DESCRIPTION
This commit updates the warning in the CLI reference to be more explicit.