### PR TITLE
Fix Nix publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,10 +28,6 @@ jobs:
         with:
           go-version: "1.21"
           cache-dependency-path: "internal/mage/go.sum"
-      - uses: cachix/install-nix-action@v23
-        with:
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: "Publish Engine & CLI"
         run: |
           ./hack/make dagger:publish ${{ github.ref_name }}

--- a/internal/mage/cli.go
+++ b/internal/mage/cli.go
@@ -46,7 +46,7 @@ func (cl Cli) Publish(ctx context.Context, version string) error {
 	_, err = c.Container().
 		From(fmt.Sprintf("ghcr.io/goreleaser/goreleaser-pro:%s", goReleaserVersion)).
 		WithEntrypoint([]string{}).
-		WithExec([]string{"apk", "add", "aws-cli"}).
+		WithExec([]string{"apk", "add", "aws-cli", "nix"}).
 		WithWorkdir("/app").
 		WithMountedDirectory("/app", wd).
 		With(util.HostSecretVar(c, "GITHUB_TOKEN")).


### PR DESCRIPTION
This is attempt numero due to fix Nix package publishing to dagger/nix.

https://github.com/dagger/dagger/pull/6063 added Nix to the GitHub Actions workflow, but GoReleaser actually runs in Dagger using a GoReleaser Pro image.

This PR removes Nix from the GHA workflow and adds Nix to the GoReleaser image.

(Reminder: we only need `nix-prefetch-url` for GoReleaser to work, but it's not bundled with their image and installing Nix from the Alpine package repo seems to be the easiest way to get `nix-prefetch-url`)