### PR TITLE
ci: always print engine logs on job failure

### DIFF
--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -39,6 +39,9 @@ jobs:
             export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev
           fi
           ./hack/make ${{ inputs.mage-targets }}
+      - name: "ALWAYS print engine logs - especially useful on failure"
+        if: always()
+        run: docker logs $(docker ps -q --filter name=dagger-engine)
       - name: "ALWAYS print kernel logs - especialy useful on failure"
         if: always()
         run: sudo dmesg
@@ -66,6 +69,9 @@ jobs:
         env:
           _EXPERIMENTAL_DAGGER_RUNNER_HOST: "unix:///var/run/buildkit/buildkitd.sock"
           DAGGER_CLOUD_TOKEN: "${{ secrets.DAGGER_CLOUD_TOKEN }}"
+      - name: "ALWAYS print engine logs - especially useful on failure"
+        if: always()
+        run: docker logs $(docker ps -q --filter name=dagger-engine)
       - name: "ALWAYS print kernel logs - especialy useful on failure"
         if: always()
         run: sudo dmesg


### PR DESCRIPTION
Previously, these logging messages were only added on the publish job provisioning tests: https://github.com/dagger/dagger/blob/9a0f81a7367a675b13854f0be82694d4ebc44dd3/.github/workflows/publish.yml#L251-L256

This meant that failures in the engine and cli jobs didn't trigger this type of message, and so makes crashes more difficult to debug. We already print the kernel logs, we just don't grab the engine logs.

This would have been useful when encountering https://github.com/dagger/dagger/issues/6234 when building off of master. Some clients returned the useful buildkit panic, however, at the same time, other clients simply got a 502 error - I suspect this was the same crash that brought down the whole engine, but it's difficult to confirm this currently without the engine logs.