### PR TITLE
chore: add git binary to go sdk

### DIFF
--- a/cmd/codegen/generator/go/generator.go
+++ b/cmd/codegen/generator/go/generator.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/dschmidt/go-layerfs"
 	"github.com/iancoleman/strcase"
+	"github.com/opencontainers/go-digest"
 	"github.com/psanford/memfs"
 	"golang.org/x/mod/modfile"
 	"golang.org/x/tools/go/packages"
@@ -309,6 +310,12 @@ func generateCode(
 
 func loadPackage(ctx context.Context, dir string) (*packages.Package, *token.FileSet, error) {
 	fset := token.NewFileSet()
+
+	f, _ := os.Open(path.Join(dir, ".git/index"))
+	if f != nil {
+		fmt.Println(digest.FromReader(f))
+	}
+
 	pkgs, err := packages.Load(&packages.Config{
 		Context: ctx,
 		Dir:     dir,
@@ -323,6 +330,12 @@ func loadPackage(ctx context.Context, dir string) (*packages.Package, *token.Fil
 	if err != nil {
 		return nil, nil, err
 	}
+
+	f, _ = os.Open(path.Join(dir, ".git/index"))
+	if f != nil {
+		fmt.Println(digest.FromReader(f))
+	}
+
 	switch len(pkgs) {
 	case 0:
 		return nil, nil, fmt.Errorf("no packages found in %s", dir)

--- a/internal/mage/util/engine.go
+++ b/internal/mage/util/engine.go
@@ -376,6 +376,7 @@ func goSDKImageTarBall(c *dagger.Client, arch string) *dagger.File {
 
 	_, err = c.Container(dagger.ContainerOpts{Platform: dagger.Platform("linux/" + arch)}).
 		From(fmt.Sprintf("golang:%s-alpine%s", golangVersion, alpineVersion)).
+		WithExec([]string{"apk", "add", "git"}).
 		WithFile("/usr/local/bin/codegen", goSDKCodegenBin(c, arch)).
 		WithEntrypoint([]string{"/usr/local/bin/codegen"}).
 		Export(ctx, tarballPath)


### PR DESCRIPTION
When building a module that has a "go.mod" that depends on a commit sha from a repository, we may require the git binary to be present.

Since this is not included in "golang:alpine" official images, we should explicitly install it.

I seem to remember a discord discussion around this, but given discord's wonderous search, I can't seem to find it :scream: 