### PR TITLE
go: decouple type parsing from code generation in module

### DIFF
--- a/cmd/codegen/generator/go/templates/module_funcs.go
+++ b/cmd/codegen/generator/go/templates/module_funcs.go
@@ -1,0 +1,337 @@
+package templates
+
+import (
+	"encoding/json"
+	"fmt"
+	"go/types"
+	"maps"
+	"strconv"
+	"strings"
+
+	. "github.com/dave/jennifer/jen" // nolint:revive,stylecheck
+	"github.com/iancoleman/strcase"
+)
+
+const errorTypeName = "error"
+
+var voidDef = Qual("dag", "TypeDef").Call().
+	Dot("WithKind").Call(Id("Voidkind")).
+	Dot("WithOptional").Call(Lit(true))
+
+func (ps *parseState) parseGoFunc(receiverTypeName string, fn *types.Func) (*funcTypeSpec, error) {
+	spec := &funcTypeSpec{
+		name: fn.Name(),
+	}
+
+	funcDecl, err := ps.declForFunc(fn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find decl for method %s: %w", fn.Name(), err)
+	}
+	spec.doc = funcDecl.Doc.Text()
+
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok {
+		return nil, fmt.Errorf("expected method to be a func, got %T", fn.Type())
+	}
+
+	spec.argSpecs, err = ps.parseParamSpecs(fn)
+	if err != nil {
+		return nil, err
+	}
+	// stash away the method signature so we can remember details on how it's
+	// invoked (e.g. no error return, no ctx arg, error-only return, etc)
+	// TODO: clean up w/ new approach of everything being a TypeSpec?
+	if receiverTypeName != "" {
+		ps.methods[receiverTypeName] = append(ps.methods[receiverTypeName], method{fn: fn, paramSpecs: spec.argSpecs})
+	}
+
+	results := sig.Results()
+	switch results.Len() {
+	case 0:
+		// returnSpec stays nil, indicating void return
+	case 1:
+		result := results.At(0).Type()
+		if result.String() == errorTypeName {
+			spec.returnsError = true
+			break
+		}
+		spec.returnSpec, err = ps.parseGoTypeReference(result, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse return type: %w", err)
+		}
+	case 2:
+		spec.returnsError = true
+		result := results.At(0).Type()
+		spec.returnSpec, err = ps.parseGoTypeReference(result, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse return type: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("method %s has too many return values", fn.Name())
+	}
+
+	return spec, nil
+}
+
+type funcTypeSpec struct {
+	name string
+	doc  string
+
+	argSpecs []paramSpec
+
+	returnSpec   ParsedType // nil if void return
+	returnsError bool
+}
+
+var _ ParsedType = &funcTypeSpec{}
+
+func (spec *funcTypeSpec) TypeDefCode() (*Statement, error) {
+	var fnReturnTypeDefCode *Statement
+	if spec.returnSpec == nil {
+		fnReturnTypeDefCode = voidDef
+	} else {
+		var err error
+		fnReturnTypeDefCode, err = spec.returnSpec.TypeDefCode()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate return type code: %w", err)
+		}
+	}
+
+	fnTypeDefCode := Qual("dag", "Function").Call(Lit(spec.name), Add(Line(), fnReturnTypeDefCode))
+
+	if spec.doc != "" {
+		fnTypeDefCode = dotLine(fnTypeDefCode, "WithDescription").Call(Lit(strings.TrimSpace(spec.doc)))
+	}
+
+	for i, argSpec := range spec.argSpecs {
+		if i == 0 && argSpec.paramType.String() == contextTypename {
+			// ignore ctx arg
+			continue
+		}
+
+		argTypeDefCode, err := argSpec.typeSpec.TypeDefCode()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate arg type code: %w", err)
+		}
+		if argSpec.optional {
+			argTypeDefCode = argTypeDefCode.Dot("WithOptional").Call(Lit(true))
+		}
+
+		argOptsCode := []Code{}
+		if argSpec.description != "" {
+			argOptsCode = append(argOptsCode, Id("Description").Op(":").Lit(argSpec.description))
+		}
+		if argSpec.defaultValue != "" {
+			var jsonEnc string
+			if argSpec.baseType.String() == "string" {
+				enc, err := json.Marshal(argSpec.defaultValue)
+				if err != nil {
+					return nil, fmt.Errorf("failed to marshal default value: %w", err)
+				}
+				jsonEnc = string(enc)
+			} else {
+				jsonEnc = argSpec.defaultValue
+			}
+			argOptsCode = append(argOptsCode, Id("DefaultValue").Op(":").Id("JSON").Call(Lit(jsonEnc)))
+		}
+
+		// arguments to WithArg (args to arg... ugh, at least the name of the variable is honest?)
+		argTypeDefArgCode := []Code{Lit(argSpec.graphqlName()), argTypeDefCode}
+		if len(argOptsCode) > 0 {
+			argTypeDefArgCode = append(argTypeDefArgCode, Id("FunctionWithArgOpts").Values(argOptsCode...))
+		}
+		fnTypeDefCode = dotLine(fnTypeDefCode, "WithArg").Call(argTypeDefArgCode...)
+	}
+
+	return fnTypeDefCode, nil
+}
+
+func (spec *funcTypeSpec) GoSubTypes() []types.Type {
+	var types []types.Type
+	if spec.returnSpec != nil {
+		types = append(types, spec.returnSpec.GoSubTypes()...)
+	}
+	for _, argSpec := range spec.argSpecs {
+		if argSpec.typeSpec == nil {
+			// ignore context
+			continue
+		}
+		types = append(types, argSpec.typeSpec.GoSubTypes()...)
+	}
+	return types
+}
+
+func (ps *parseState) parseParamSpecs(fn *types.Func) ([]paramSpec, error) {
+	sig := fn.Type().(*types.Signature)
+	params := sig.Params()
+	if params.Len() == 0 {
+		return nil, nil
+	}
+
+	specs := make([]paramSpec, 0, params.Len())
+
+	i := 0
+	if params.At(i).Type().String() == contextTypename {
+		spec, err := ps.parseParamSpecVar(params.At(i), "", "")
+		if err != nil {
+			return nil, err
+		}
+		specs = append(specs, spec)
+
+		i++
+	}
+
+	fnDecl, err := ps.declForFunc(fn)
+	if err != nil {
+		return nil, err
+	}
+
+	// is the first data param an inline struct? if so, process each field of
+	// the struct as a top-level param
+	if i+1 == params.Len() {
+		param := params.At(i)
+		paramType, ok := asInlineStruct(param.Type())
+		if ok {
+			stype, ok := asInlineStructAst(fnDecl.Type.Params.List[i].Type)
+			if !ok {
+				return nil, fmt.Errorf("expected struct type for %s", param.Name())
+			}
+
+			parent := &paramSpec{
+				name:      params.At(i).Name(),
+				paramType: param.Type(),
+				baseType:  param.Type(),
+			}
+
+			paramFields := unpackASTFields(stype.Fields)
+			for f := 0; f < paramType.NumFields(); f++ {
+				spec, err := ps.parseParamSpecVar(paramType.Field(f), paramFields[f].Doc.Text(), paramFields[f].Comment.Text())
+				if err != nil {
+					return nil, err
+				}
+				spec.parent = parent
+				specs = append(specs, spec)
+			}
+			return specs, nil
+		}
+	}
+
+	// if other parameter passing schemes fail, just treat each remaining arg
+	// as a top-level param
+	paramFields := unpackASTFields(fnDecl.Type.Params)
+	for ; i < params.Len(); i++ {
+		docComment, lineComment := ps.commentForFuncField(fnDecl, paramFields, i)
+		spec, err := ps.parseParamSpecVar(params.At(i), docComment.Text(), lineComment.Text())
+		if err != nil {
+			return nil, err
+		}
+		if sig.Variadic() && i == params.Len()-1 {
+			spec.variadic = true
+		}
+		specs = append(specs, spec)
+	}
+	return specs, nil
+}
+
+func (ps *parseState) parseParamSpecVar(field *types.Var, docComment string, lineComment string) (paramSpec, error) {
+	if _, ok := field.Type().(*types.Struct); ok {
+		return paramSpec{}, fmt.Errorf("nested structs are not supported")
+	}
+
+	paramType := field.Type()
+	baseType := paramType
+	for {
+		ptr, ok := baseType.(*types.Pointer)
+		if !ok {
+			break
+		}
+		baseType = ptr.Elem()
+	}
+
+	optional := false
+	defaultValue := ""
+
+	if named, ok := ps.isOptionalWrapper(baseType); ok {
+		typeArgs := named.TypeArgs()
+		if typeArgs.Len() != 1 {
+			return paramSpec{}, fmt.Errorf("optional type must have exactly one type argument")
+		}
+		optional = true
+
+		baseType = typeArgs.At(0)
+		for {
+			ptr, ok := baseType.(*types.Pointer)
+			if !ok {
+				break
+			}
+			baseType = ptr.Elem()
+		}
+	}
+
+	docPragmas, docComment := parsePragmaComment(docComment)
+	linePragmas, lineComment := parsePragmaComment(lineComment)
+	comment := strings.TrimSpace(docComment)
+	if comment == "" {
+		comment = strings.TrimSpace(lineComment)
+	}
+
+	pragmas := make(map[string]string)
+	maps.Copy(pragmas, docPragmas)
+	maps.Copy(pragmas, linePragmas)
+	if v, ok := pragmas["default"]; ok {
+		defaultValue = v
+	}
+	if v, ok := pragmas["optional"]; ok {
+		if v == "" {
+			optional = true
+		} else {
+			optional, _ = strconv.ParseBool(v)
+		}
+	}
+
+	// ignore ctx arg for parsing type reference
+	var typeSpec ParsedType
+	if paramType.String() != contextTypename {
+		var err error
+		typeSpec, err = ps.parseGoTypeReference(baseType, nil)
+		if err != nil {
+			return paramSpec{}, fmt.Errorf("failed to parse type reference: %w", err)
+		}
+	}
+
+	return paramSpec{
+		name:         field.Name(),
+		paramType:    paramType,
+		baseType:     baseType,
+		typeSpec:     typeSpec,
+		optional:     optional,
+		defaultValue: defaultValue,
+		description:  comment,
+	}, nil
+}
+
+type paramSpec struct {
+	name        string
+	description string
+
+	optional bool
+	variadic bool
+
+	defaultValue string
+
+	// paramType is the full type declared in the function signature, which may
+	// include pointer types, Optional, etc
+	paramType types.Type
+	// baseType is the simplified base type derived from the function signature
+	baseType types.Type
+	// typeSpec is the parsed TypeSpec of the argument's baseType
+	typeSpec ParsedType
+
+	// parent is set if this paramSpec is nested inside a parent inline struct,
+	// and is used to create a declaration of the entire inline struct
+	parent *paramSpec
+}
+
+func (spec *paramSpec) graphqlName() string {
+	return strcase.ToLowerCamel(spec.name)
+}

--- a/cmd/codegen/generator/go/templates/module_objects.go
+++ b/cmd/codegen/generator/go/templates/module_objects.go
@@ -14,7 +14,9 @@ import (
 )
 
 func (ps *parseState) parseGoStruct(t *types.Struct, named *types.Named) (*parsedObjectType, error) {
-	spec := &parsedObjectType{}
+	spec := &parsedObjectType{
+		goType: t,
+	}
 
 	if named == nil {
 		return nil, fmt.Errorf("struct types must be named")
@@ -152,6 +154,8 @@ type parsedObjectType struct {
 	fields      []*fieldSpec
 	methods     []*funcTypeSpec
 	constructor *funcTypeSpec
+
+	goType *types.Struct
 }
 
 func (spec *parsedObjectType) TypeDefCode() (*Statement, error) {
@@ -203,6 +207,10 @@ func (spec *parsedObjectType) TypeDefCode() (*Statement, error) {
 	}
 
 	return typeDefCode, nil
+}
+
+func (spec *parsedObjectType) GoType() types.Type {
+	return spec.goType
 }
 
 func (spec *parsedObjectType) GoSubTypes() []types.Type {

--- a/cmd/codegen/generator/go/templates/module_objects.go
+++ b/cmd/codegen/generator/go/templates/module_objects.go
@@ -1,0 +1,226 @@
+package templates
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"maps"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+
+	. "github.com/dave/jennifer/jen" // nolint:revive,stylecheck
+)
+
+func (ps *parseState) parseGoStruct(t *types.Struct, named *types.Named) (*parsedObjectType, error) {
+	spec := &parsedObjectType{}
+
+	if named == nil {
+		return nil, fmt.Errorf("struct types must be named")
+	}
+	spec.name = named.Obj().Name()
+	if spec.name == "" {
+		return nil, fmt.Errorf("struct types must be named")
+	}
+
+	// We don't support extending objects from outside this module, so we will
+	// be skipping it. But first we want to verify the user isn't adding methods
+	// to it (in which case we error out).
+	objectIsDaggerGenerated := ps.isDaggerGenerated(named.Obj())
+
+	goFuncTypes := []*types.Func{}
+	methodSet := types.NewMethodSet(types.NewPointer(named))
+	for i := 0; i < methodSet.Len(); i++ {
+		methodObj := methodSet.At(i).Obj()
+
+		if ps.isDaggerGenerated(methodObj) {
+			// We don't care about pre-existing methods on core types or objects from dependency modules.
+			continue
+		}
+		if objectIsDaggerGenerated {
+			return nil, fmt.Errorf("cannot define methods on objects from outside this module")
+		}
+
+		goFuncType, ok := methodObj.(*types.Func)
+		if !ok {
+			return nil, fmt.Errorf("expected method to be a func, got %T", methodObj)
+		}
+
+		if !goFuncType.Exported() {
+			continue
+		}
+
+		goFuncTypes = append(goFuncTypes, goFuncType)
+	}
+	if objectIsDaggerGenerated {
+		return nil, nil
+	}
+	sort.Slice(goFuncTypes, func(i, j int) bool {
+		return goFuncTypes[i].Pos() < goFuncTypes[j].Pos()
+	})
+
+	for _, goFuncType := range goFuncTypes {
+		funcTypeSpec, err := ps.parseGoFunc(spec.name, goFuncType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse method %s: %w", goFuncType.Name(), err)
+		}
+		spec.methods = append(spec.methods, funcTypeSpec)
+	}
+
+	// get the comment above the struct (if any)
+	astSpec, err := ps.astSpecForNamedType(named)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find decl for named type %s: %w", spec.name, err)
+	}
+	spec.doc = astSpec.Doc.Text()
+
+	astStructType, ok := astSpec.Type.(*ast.StructType)
+	if !ok {
+		return nil, fmt.Errorf("expected type spec to be a struct, got %T", astSpec.Type)
+	}
+
+	// Fill out the static fields of the struct (if any)
+	astFields := unpackASTFields(astStructType.Fields)
+	for i := 0; i < t.NumFields(); i++ {
+		field := t.Field(i)
+		if !field.Exported() {
+			continue
+		}
+		name := field.Name()
+
+		docPragmas, docComment := parsePragmaComment(astFields[i].Doc.Text())
+		linePragmas, lineComment := parsePragmaComment(astFields[i].Comment.Text())
+		comment := strings.TrimSpace(docComment)
+		if comment == "" {
+			comment = strings.TrimSpace(lineComment)
+		}
+		pragmas := make(map[string]string)
+		maps.Copy(pragmas, docPragmas)
+		maps.Copy(pragmas, linePragmas)
+		if v, ok := pragmas["private"]; ok {
+			private := false
+			if v == "" {
+				private = true
+			} else {
+				private, _ = strconv.ParseBool(v)
+			}
+			if private {
+				// don't generate WithField for private fields
+				continue
+			}
+		}
+
+		fieldSpec := &fieldSpec{}
+		fieldSpec.typeSpec, err = ps.parseGoTypeReference(field.Type(), nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse field type: %w", err)
+		}
+
+		fieldSpec.doc = comment
+
+		fieldSpec.name = name
+
+		// override the name with the json tag if it was set - otherwise, we
+		// end up asking for a name that we won't unmarshal correctly
+		tag := reflect.StructTag(t.Tag(i))
+		if dt := tag.Get("json"); dt != "" {
+			dt, _, _ = strings.Cut(dt, ",")
+			if dt == "-" {
+				continue
+			}
+			fieldSpec.name = dt
+		}
+
+		spec.fields = append(spec.fields, fieldSpec)
+	}
+
+	if ps.isMainModuleObject(spec.name) && ps.constructor != nil {
+		spec.constructor, err = ps.parseGoFunc("", ps.constructor)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse constructor: %w", err)
+		}
+	}
+
+	return spec, nil
+}
+
+type parsedObjectType struct {
+	name string
+	doc  string
+
+	fields      []*fieldSpec
+	methods     []*funcTypeSpec
+	constructor *funcTypeSpec
+}
+
+func (spec *parsedObjectType) TypeDefCode() (*Statement, error) {
+	withObjectArgsCode := []Code{
+		Lit(spec.name),
+	}
+	withObjectOptsCode := []Code{}
+	if spec.doc != "" {
+		withObjectOptsCode = append(withObjectOptsCode, Id("Description").Op(":").Lit(strings.TrimSpace(spec.doc)))
+	}
+	if len(withObjectOptsCode) > 0 {
+		withObjectArgsCode = append(withObjectArgsCode, Id("TypeDefWithObjectOpts").Values(withObjectOptsCode...))
+	}
+
+	typeDefCode := Qual("dag", "TypeDef").Call().Dot("WithObject").Call(withObjectArgsCode...)
+
+	for _, method := range spec.methods {
+		fnTypeDefCode, err := method.TypeDefCode()
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert method %s to function def: %w", method.name, err)
+		}
+		typeDefCode = dotLine(typeDefCode, "WithFunction").Call(Add(Line(), fnTypeDefCode))
+	}
+
+	for _, field := range spec.fields {
+		fieldTypeDefCode, err := field.typeSpec.TypeDefCode()
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert field type: %w", err)
+		}
+		withFieldArgsCode := []Code{
+			Lit(field.name),
+			fieldTypeDefCode,
+		}
+		if field.doc != "" {
+			withFieldArgsCode = append(withFieldArgsCode,
+				Id("TypeDefWithFieldOpts").Values(
+					Id("Description").Op(":").Lit(field.doc),
+				))
+		}
+		typeDefCode = dotLine(typeDefCode, "WithField").Call(withFieldArgsCode...)
+	}
+
+	if spec.constructor != nil {
+		fnTypeDefCode, err := spec.constructor.TypeDefCode()
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert constructor to function def: %w", err)
+		}
+		typeDefCode = dotLine(typeDefCode, "WithConstructor").Call(Add(Line(), fnTypeDefCode))
+	}
+
+	return typeDefCode, nil
+}
+
+func (spec *parsedObjectType) GoSubTypes() []types.Type {
+	var subTypes []types.Type
+	for _, method := range spec.methods {
+		subTypes = append(subTypes, method.GoSubTypes()...)
+	}
+	for _, field := range spec.fields {
+		subTypes = append(subTypes, field.typeSpec.GoSubTypes()...)
+	}
+	if spec.constructor != nil {
+		subTypes = append(subTypes, spec.constructor.GoSubTypes()...)
+	}
+	return subTypes
+}
+
+type fieldSpec struct {
+	name     string
+	doc      string
+	typeSpec ParsedType
+}

--- a/cmd/codegen/generator/go/templates/module_types.go
+++ b/cmd/codegen/generator/go/templates/module_types.go
@@ -1,0 +1,134 @@
+package templates
+
+import (
+	"fmt"
+	"go/types"
+
+	. "github.com/dave/jennifer/jen" // nolint:revive,stylecheck
+)
+
+// A Go type that has been parsed and can be registered with the dagger API
+type ParsedType interface {
+	// Generated code for registering the type with the dagger API
+	TypeDefCode() (*Statement, error)
+
+	// Go type referred to by this type
+	GoSubTypes() []types.Type
+}
+
+// parseGoTypeReference parses a Go type and returns a TypeSpec for the type *reference* only.
+// So if the type is a struct or interface, the returned TypeSpec will not have all the fields,
+// only the type name and kind.
+func (ps *parseState) parseGoTypeReference(typ types.Type, named *types.Named) (ParsedType, error) {
+	switch t := typ.(type) {
+	case *types.Named:
+		// Named types are any types declared like `type Foo <...>`
+		typeSpec, err := ps.parseGoTypeReference(t.Underlying(), t)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse named type: %w", err)
+		}
+		return typeSpec, nil
+
+	case *types.Pointer:
+		typeSpec, err := ps.parseGoTypeReference(t.Elem(), named)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse pointer type: %w", err)
+		}
+		return typeSpec, nil
+
+	case *types.Slice:
+		elemTypeSpec, err := ps.parseGoTypeReference(t.Elem(), nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse slice element type: %w", err)
+		}
+		return &parsedSliceType{elemTypeSpec}, nil
+
+	case *types.Basic:
+		if t.Kind() == types.Invalid {
+			return nil, fmt.Errorf("invalid type: %+v", t)
+		}
+		return &parsedPrimitiveType{t}, nil
+
+	case *types.Struct:
+		if named == nil {
+			return nil, fmt.Errorf("struct types must be named")
+		}
+		typeName := named.Obj().Name()
+		if typeName == "" {
+			return nil, fmt.Errorf("struct types must be named")
+		}
+		return &parsedObjectTypeReference{
+			name:           typeName,
+			referencedType: named,
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported type for named type reference %T", t)
+	}
+}
+
+// parsedPrimitiveType is a parsed type that is a primitive type like string, int, bool, etc.
+type parsedPrimitiveType struct {
+	goType *types.Basic
+}
+
+var _ ParsedType = &parsedPrimitiveType{}
+
+func (spec *parsedPrimitiveType) TypeDefCode() (*Statement, error) {
+	var kind Code
+	switch spec.goType.Info() {
+	case types.IsString:
+		kind = Id("Stringkind")
+	case types.IsInteger:
+		kind = Id("Integerkind")
+	case types.IsBoolean:
+		kind = Id("Booleankind")
+	default:
+		return nil, fmt.Errorf("unsupported basic type: %+v", spec.goType)
+	}
+	return Qual("dag", "TypeDef").Call().Dot("WithKind").Call(
+		kind,
+	), nil
+}
+
+func (spec *parsedPrimitiveType) GoSubTypes() []types.Type {
+	return nil
+}
+
+// parsedSliceType is a parsed type that is a slice of other types
+type parsedSliceType struct {
+	underlying ParsedType // the element TypeSpec
+}
+
+var _ ParsedType = &parsedSliceType{}
+
+func (spec *parsedSliceType) TypeDefCode() (*Statement, error) {
+	underlyingCode, err := spec.underlying.TypeDefCode()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate underlying type code: %w", err)
+	}
+	return Qual("dag", "TypeDef").Call().Dot("WithListOf").Call(underlyingCode), nil
+}
+
+func (spec *parsedSliceType) GoSubTypes() []types.Type {
+	return spec.underlying.GoSubTypes()
+}
+
+// parsedObjectTypeReference is a parsed object type that is referred to just by name rather
+// than with the full type definition
+type parsedObjectTypeReference struct {
+	name           string
+	referencedType types.Type
+}
+
+var _ ParsedType = &parsedObjectTypeReference{}
+
+func (spec *parsedObjectTypeReference) TypeDefCode() (*Statement, error) {
+	return Qual("dag", "TypeDef").Call().Dot("WithObject").Call(
+		Lit(spec.name),
+	), nil
+}
+
+func (spec *parsedObjectTypeReference) GoSubTypes() []types.Type {
+	return []types.Type{spec.referencedType}
+}

--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -1,19 +1,15 @@
 package templates
 
 import (
-	"encoding/json"
 	"fmt"
 	"go/ast"
 	"go/token"
 	"go/types"
-	"maps"
 	"os"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"runtime/debug"
 	"sort"
-	"strconv"
 	"strings"
 
 	. "github.com/dave/jennifer/jen" // nolint:revive,stylecheck
@@ -112,6 +108,7 @@ func (funcs goTemplateFuncs) moduleMainSrc() (string, error) {
 			if !isNamed {
 				continue
 			}
+
 			obj := named.Obj()
 			if obj.Pkg() != funcs.modulePkg.Types {
 				// the type must be created in the target package
@@ -136,13 +133,11 @@ func (funcs goTemplateFuncs) moduleMainSrc() (string, error) {
 				continue
 			}
 
-			// TODO(vito): hacky: need to run this before fillObjectFunctionCases so it
-			// collects all the methods
-			objType, extraTypes, err := ps.goStructToAPIType(strct, named)
+			objTypeSpec, err := ps.parseGoStruct(strct, named)
 			if err != nil {
 				return "", err
 			}
-			if objType == nil {
+			if objTypeSpec == nil {
 				// not including in module schema, skip it
 				continue
 			}
@@ -152,24 +147,22 @@ func (funcs goTemplateFuncs) moduleMainSrc() (string, error) {
 				return "", fmt.Errorf("failed to generate function cases for %s: %w", obj.Name(), err)
 			}
 
-			if len(objFunctionCases[obj.Name()]) == 0 && !ps.isMainModuleObject(obj.Name()) {
-				if topLevel {
-					// no functions on this top-level object, so don't add it to the module
-					continue
-				}
-				if ps.isDaggerGenerated(named.Obj()) {
-					// skip objects from outside this module
-					continue
-				}
+			if !ps.isMainModuleObject(obj.Name()) && len(objTypeSpec.fields) == 0 && len(objTypeSpec.methods) == 0 {
+				// nothing to define, skip it
+				continue
 			}
 
 			// Add the object to the module
-			createMod = dotLine(createMod, "WithObject").Call(Add(Line(), objType))
+			objTypeDefCode, err := objTypeSpec.TypeDefCode()
+			if err != nil {
+				return "", fmt.Errorf("failed to generate type def code for %s: %w", obj.Name(), err)
+			}
+			createMod = dotLine(createMod, "WithObject").Call(Add(Line(), objTypeDefCode))
 			added[obj.Name()] = struct{}{}
 
 			// If the object has any extra sub-types (e.g. for function return
 			// values), add them to the list of types to process
-			nextTps = append(nextTps, extraTypes...)
+			nextTps = append(nextTps, objTypeSpec.GoSubTypes()...)
 		}
 
 		tps, nextTps = nextTps, nil
@@ -579,499 +572,10 @@ type method struct {
 	paramSpecs []paramSpec
 }
 
-func (ps *parseState) goTypeToAPIType(typ types.Type, named *types.Named) (*Statement, *types.Named, error) {
-	switch t := typ.(type) {
-	case *types.Named:
-		// Named types are any types declared like `type Foo <...>`
-		typeDef, _, err := ps.goTypeToAPIType(t.Underlying(), t)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to convert named type: %w", err)
-		}
-		return typeDef, t, nil
-	case *types.Pointer:
-		return ps.goTypeToAPIType(t.Elem(), named)
-	case *types.Slice:
-		elemTypeDef, underlying, err := ps.goTypeToAPIType(t.Elem(), nil)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to convert slice element type: %w", err)
-		}
-		return Qual("dag", "TypeDef").Call().Dot("WithListOf").Call(
-			elemTypeDef,
-		), underlying, nil
-	case *types.Basic:
-		if t.Kind() == types.Invalid {
-			return nil, nil, fmt.Errorf("invalid type: %+v", t)
-		}
-		var kind Code
-		switch t.Info() {
-		case types.IsString:
-			kind = Id("Stringkind")
-		case types.IsInteger:
-			kind = Id("Integerkind")
-		case types.IsBoolean:
-			kind = Id("Booleankind")
-		default:
-			return nil, nil, fmt.Errorf("unsupported basic type: %+v", t)
-		}
-		return Qual("dag", "TypeDef").Call().Dot("WithKind").Call(
-			kind,
-		), named, nil
-	case *types.Struct:
-		if named == nil {
-			return nil, nil, fmt.Errorf("struct types must be named")
-		}
-		typeName := named.Obj().Name()
-		if typeName == "" {
-			return nil, nil, fmt.Errorf("struct types must be named")
-		}
-		return Qual("dag", "TypeDef").Call().Dot("WithObject").Call(
-			Lit(typeName),
-		), named, nil
-	default:
-		return nil, nil, fmt.Errorf("unsupported type %T", t)
-	}
-}
-
-const errorTypeName = "error"
-
-func (ps *parseState) goStructToAPIType(t *types.Struct, named *types.Named) (*Statement, []types.Type, error) {
-	if named == nil {
-		return nil, nil, fmt.Errorf("struct types must be named")
-	}
-	typeName := named.Obj().Name()
-	if typeName == "" {
-		return nil, nil, fmt.Errorf("struct types must be named")
-	}
-
-	// We don't support extending objects from outside this module, so we will
-	// be skipping it. But first we want to verify the user isn't adding methods
-	// to it (in which case we error out).
-	objectIsDaggerGenerated := ps.isDaggerGenerated(named.Obj())
-
-	methods := []*types.Func{}
-	methodSet := types.NewMethodSet(types.NewPointer(named))
-	// Fill out any Functions on the object, which are methods on the struct
-	// TODO: support methods defined on non-pointer receivers
-	for i := 0; i < methodSet.Len(); i++ {
-		methodObj := methodSet.At(i).Obj()
-
-		if ps.isDaggerGenerated(methodObj) {
-			// We don't care about pre-existing methods on core types or objects from dependency modules.
-			continue
-		}
-		if objectIsDaggerGenerated {
-			return nil, nil, fmt.Errorf("cannot define methods on objects from outside this module")
-		}
-
-		method, ok := methodObj.(*types.Func)
-		if !ok {
-			return nil, nil, fmt.Errorf("expected method to be a func, got %T", methodObj)
-		}
-
-		if !method.Exported() {
-			continue
-		}
-
-		methods = append(methods, method)
-	}
-	if objectIsDaggerGenerated {
-		return nil, nil, nil
-	}
-
-	sort.Slice(methods, func(i, j int) bool {
-		return methods[i].Pos() < methods[j].Pos()
-	})
-
-	// args for WithObject
-	withObjectArgs := []Code{
-		Lit(typeName),
-	}
-	withObjectOpts := []Code{}
-
-	// Fill out the Description with the comment above the struct (if any)
-	typeSpec, err := ps.typeSpecForNamedType(named)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to find decl for named type %s: %w", typeName, err)
-	}
-	if comment := typeSpec.Doc.Text(); comment != "" {
-		withObjectOpts = append(withObjectOpts, Id("Description").Op(":").Lit(strings.TrimSpace(comment)))
-	}
-	if len(withObjectOpts) > 0 {
-		withObjectArgs = append(withObjectArgs, Id("TypeDefWithObjectOpts").Values(withObjectOpts...))
-	}
-
-	typeDef := Qual("dag", "TypeDef").Call().Dot("WithObject").Call(withObjectArgs...)
-
-	var subTypes []types.Type
-
-	for _, method := range methods {
-		fnTypeDef, functionSubTypes, err := ps.goFuncToAPIFunctionDef(typeName, method)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to convert method %s to function def: %w", method.Name(), err)
-		}
-		subTypes = append(subTypes, functionSubTypes...)
-
-		typeDef = dotLine(typeDef, "WithFunction").Call(Add(Line(), fnTypeDef))
-	}
-
-	astStructType, ok := typeSpec.Type.(*ast.StructType)
-	if !ok {
-		return nil, nil, fmt.Errorf("expected type spec to be a struct, got %T", typeSpec.Type)
-	}
-
-	// Fill out the static fields of the struct (if any)
-	astFields := unpackASTFields(astStructType.Fields)
-	for i := 0; i < t.NumFields(); i++ {
-		field := t.Field(i)
-		if !field.Exported() {
-			continue
-		}
-		name := field.Name()
-
-		docPragmas, docComment := parsePragmaComment(astFields[i].Doc.Text())
-		linePragmas, lineComment := parsePragmaComment(astFields[i].Comment.Text())
-		comment := strings.TrimSpace(docComment)
-		if comment == "" {
-			comment = strings.TrimSpace(lineComment)
-		}
-		pragmas := make(map[string]string)
-		maps.Copy(pragmas, docPragmas)
-		maps.Copy(pragmas, linePragmas)
-		if v, ok := pragmas["private"]; ok {
-			private := false
-			if v == "" {
-				private = true
-			} else {
-				private, _ = strconv.ParseBool(v)
-			}
-			if private {
-				// don't generate WithField for private fields
-				continue
-			}
-		}
-
-		fieldTypeDef, subType, err := ps.goTypeToAPIType(field.Type(), nil)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to convert field type: %w", err)
-		}
-		if subType != nil {
-			subTypes = append(subTypes, subType)
-		}
-
-		// override the name with the json tag if it was set - otherwise, we
-		// end up asking for a name that we won't unmarshal correctly
-		tag := reflect.StructTag(t.Tag(i))
-		if dt := tag.Get("json"); dt != "" {
-			dt, _, _ = strings.Cut(dt, ",")
-			if dt == "-" {
-				continue
-			}
-			name = dt
-		}
-
-		withFieldArgs := []Code{
-			Lit(name),
-			fieldTypeDef,
-		}
-
-		if comment != "" {
-			withFieldArgs = append(withFieldArgs,
-				Id("TypeDefWithFieldOpts").Values(
-					Id("Description").Op(":").Lit(comment),
-				))
-		}
-
-		typeDef = dotLine(typeDef, "WithField").Call(withFieldArgs...)
-	}
-
-	if ps.isMainModuleObject(typeName) && ps.constructor != nil {
-		fnTypeDef, _, err := ps.goFuncToAPIFunctionDef("", ps.constructor)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to convert constructor to function def: %w", err)
-		}
-		typeDef = dotLine(typeDef, "WithConstructor").Call(Add(Line(), fnTypeDef))
-	}
-
-	return typeDef, subTypes, nil
-}
-
-var voidDef = Qual("dag", "TypeDef").Call().
-	Dot("WithKind").Call(Id("Voidkind")).
-	Dot("WithOptional").Call(Lit(true))
-
-func (ps *parseState) goFuncToAPIFunctionDef(receiverTypeName string, fn *types.Func) (*Statement, []types.Type, error) {
-	sig, ok := fn.Type().(*types.Signature)
-	if !ok {
-		return nil, nil, fmt.Errorf("expected method to be a func, got %T", fn.Type())
-	}
-
-	// stash away the method signature so we can remember details on how it's
-	// invoked (e.g. no error return, no ctx arg, error-only return, etc)
-	specs, err := ps.parseParamSpecs(fn)
-	if err != nil {
-		return nil, nil, err
-	}
-	if receiverTypeName != "" {
-		ps.methods[receiverTypeName] = append(ps.methods[receiverTypeName], method{fn: fn, paramSpecs: specs})
-	}
-
-	var fnReturnType *Statement
-
-	var subTypes []types.Type
-
-	results := sig.Results()
-	var returnSubType *types.Named
-	switch results.Len() {
-	case 0:
-		fnReturnType = voidDef
-	case 1:
-		result := results.At(0).Type()
-		if result.String() == errorTypeName {
-			fnReturnType = voidDef
-		} else {
-			fnReturnType, returnSubType, err = ps.goTypeToAPIType(result, nil)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to convert result type: %w", err)
-			}
-		}
-	case 2:
-		result := results.At(0).Type()
-		subTypes = append(subTypes, result)
-		fnReturnType, returnSubType, err = ps.goTypeToAPIType(result, nil)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to convert result type: %w", err)
-		}
-	default:
-		return nil, nil, fmt.Errorf("method %s has too many return values", fn.Name())
-	}
-	if returnSubType != nil {
-		subTypes = append(subTypes, returnSubType)
-	}
-
-	fnDef := Qual("dag", "Function").Call(Lit(fn.Name()), Add(Line(), fnReturnType))
-
-	funcDecl, err := ps.declForFunc(fn)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to find decl for method %s: %w", fn.Name(), err)
-	}
-	if comment := funcDecl.Doc.Text(); comment != "" {
-		fnDef = dotLine(fnDef, "WithDescription").Call(Lit(strings.TrimSpace(comment)))
-	}
-
-	for i, spec := range specs {
-		if i == 0 && spec.paramType.String() == contextTypename {
-			// ignore ctx arg
-			continue
-		}
-
-		typeDef, subType, err := ps.goTypeToAPIType(spec.baseType, nil)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to convert param type: %w", err)
-		}
-		if subType != nil {
-			subTypes = append(subTypes, subType)
-		}
-
-		if spec.optional {
-			typeDef = typeDef.Dot("WithOptional").Call(Lit(true))
-		}
-
-		// arguments to WithArg
-		args := []Code{Lit(spec.graphqlName()), typeDef}
-
-		argOpts := []Code{}
-		if spec.description != "" {
-			argOpts = append(argOpts, Id("Description").Op(":").Lit(spec.description))
-		}
-		if spec.defaultValue != "" {
-			var jsonEnc string
-			if spec.baseType.String() == "string" {
-				enc, err := json.Marshal(spec.defaultValue)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to marshal default value: %w", err)
-				}
-				jsonEnc = string(enc)
-			} else {
-				jsonEnc = spec.defaultValue
-			}
-			argOpts = append(argOpts, Id("DefaultValue").Op(":").Id("JSON").Call(Lit(jsonEnc)))
-		}
-		if len(argOpts) > 0 {
-			args = append(args, Id("FunctionWithArgOpts").Values(argOpts...))
-		}
-
-		fnDef = dotLine(fnDef, "WithArg").Call(args...)
-	}
-
-	return fnDef, subTypes, nil
-}
-
-func (ps *parseState) parseParamSpecs(fn *types.Func) ([]paramSpec, error) {
-	sig := fn.Type().(*types.Signature)
-	params := sig.Params()
-	if params.Len() == 0 {
-		return nil, nil
-	}
-
-	specs := make([]paramSpec, 0, params.Len())
-
-	i := 0
-	if params.At(i).Type().String() == contextTypename {
-		spec, err := ps.parseParamSpecVar(params.At(i), "", "")
-		if err != nil {
-			return nil, err
-		}
-		specs = append(specs, spec)
-
-		i++
-	}
-
-	fnDecl, err := ps.declForFunc(fn)
-	if err != nil {
-		return nil, err
-	}
-
-	// is the first data param an inline struct? if so, process each field of
-	// the struct as a top-level param
-	if i+1 == params.Len() {
-		param := params.At(i)
-		paramType, ok := asInlineStruct(param.Type())
-		if ok {
-			stype, ok := asInlineStructAst(fnDecl.Type.Params.List[i].Type)
-			if !ok {
-				return nil, fmt.Errorf("expected struct type for %s", param.Name())
-			}
-
-			parent := &paramSpec{
-				name:      params.At(i).Name(),
-				paramType: param.Type(),
-				baseType:  param.Type(),
-			}
-
-			paramFields := unpackASTFields(stype.Fields)
-			for f := 0; f < paramType.NumFields(); f++ {
-				spec, err := ps.parseParamSpecVar(paramType.Field(f), paramFields[f].Doc.Text(), paramFields[f].Comment.Text())
-				if err != nil {
-					return nil, err
-				}
-				spec.parent = parent
-				specs = append(specs, spec)
-			}
-			return specs, nil
-		}
-	}
-
-	// if other parameter passing schemes fail, just treat each remaining arg
-	// as a top-level param
-	paramFields := unpackASTFields(fnDecl.Type.Params)
-	for ; i < params.Len(); i++ {
-		docComment, lineComment := ps.commentForFuncField(fnDecl, paramFields, i)
-		spec, err := ps.parseParamSpecVar(params.At(i), docComment.Text(), lineComment.Text())
-		if err != nil {
-			return nil, err
-		}
-		if sig.Variadic() && i == params.Len()-1 {
-			spec.variadic = true
-		}
-		specs = append(specs, spec)
-	}
-	return specs, nil
-}
-
-func (ps *parseState) parseParamSpecVar(field *types.Var, docComment string, lineComment string) (paramSpec, error) {
-	if _, ok := field.Type().(*types.Struct); ok {
-		return paramSpec{}, fmt.Errorf("nested structs are not supported")
-	}
-
-	paramType := field.Type()
-	baseType := paramType
-	for {
-		ptr, ok := baseType.(*types.Pointer)
-		if !ok {
-			break
-		}
-		baseType = ptr.Elem()
-	}
-
-	optional := false
-	defaultValue := ""
-
-	if named, ok := ps.isOptionalWrapper(baseType); ok {
-		typeArgs := named.TypeArgs()
-		if typeArgs.Len() != 1 {
-			return paramSpec{}, fmt.Errorf("optional type must have exactly one type argument")
-		}
-		optional = true
-
-		baseType = typeArgs.At(0)
-		for {
-			ptr, ok := baseType.(*types.Pointer)
-			if !ok {
-				break
-			}
-			baseType = ptr.Elem()
-		}
-	}
-
-	docPragmas, docComment := parsePragmaComment(docComment)
-	linePragmas, lineComment := parsePragmaComment(lineComment)
-	comment := strings.TrimSpace(docComment)
-	if comment == "" {
-		comment = strings.TrimSpace(lineComment)
-	}
-
-	pragmas := make(map[string]string)
-	maps.Copy(pragmas, docPragmas)
-	maps.Copy(pragmas, linePragmas)
-	if v, ok := pragmas["default"]; ok {
-		defaultValue = v
-	}
-	if v, ok := pragmas["optional"]; ok {
-		if v == "" {
-			optional = true
-		} else {
-			optional, _ = strconv.ParseBool(v)
-		}
-	}
-
-	return paramSpec{
-		name:         field.Name(),
-		paramType:    paramType,
-		baseType:     baseType,
-		optional:     optional,
-		defaultValue: defaultValue,
-		description:  comment,
-	}, nil
-}
-
-type paramSpec struct {
-	name        string
-	description string
-
-	optional bool
-	variadic bool
-
-	defaultValue string
-
-	// paramType is the full type declared in the function signature, which may
-	// include pointer types, Optional, etc
-	paramType types.Type
-	// baseType is the simplified base type derived from the function signature
-	baseType types.Type
-
-	// parent is set if this paramSpec is nested inside a parent inline struct,
-	// and is used to create a declaration of the entire inline struct
-	parent *paramSpec
-}
-
-func (spec *paramSpec) graphqlName() string {
-	return strcase.ToLowerCamel(spec.name)
-}
-
-// typeSpecForNamedType returns the *ast* type spec for the given Named type. This is needed
+// astSpecForNamedType returns the *ast* type spec for the given Named type. This is needed
 // because the types.Named object does not have the comments associated with the type, which
 // we want to parse.
-func (ps *parseState) typeSpecForNamedType(namedType *types.Named) (*ast.TypeSpec, error) {
+func (ps *parseState) astSpecForNamedType(namedType *types.Named) (*ast.TypeSpec, error) {
 	tokenFile := ps.fset.File(namedType.Obj().Pos())
 	if tokenFile == nil {
 		return nil, fmt.Errorf("no file for %s", namedType.Obj().Name())


### PR DESCRIPTION
This is a small-ish scale refactor that modifies the code we use to parse various types/functions/etc. in the go module codegen code. There should be no functional changes, just code refactor+cleanup.

The gist of the idea is that rather than having single methods that do both the type parsing and then return generated code for typedefs, we have a method that does the type parsing and then returns a type that implements an interface which has separate methods for getting the generated code and getting subtypes references by the type (with the possibility of adding more methods as needed, as is done in the interfaces work)

The main motivation is to support the interface work, where we need to use parsed type information for more than just codegen. Before this change I had just copy pasted hundreds of lines of code and slightly tweaked them; this refactor felt like the best relatively quick approach that wasn't unreasonable.
* Splitting this to its own PR in an effort to make the interfaces PR possible to review and *less* of a million changes all over the place.

The secondary goal is just general cleanup of this code, which has been growing organically+quickly as we've been iterating on it. This change is far from a full cleanup, but does nudge it in the right direction by detangling a lot of large blobs of code w/ mixed parsing and codegen and splitting out to separate files a bit more.