### PR TITLE
Backfill integ tests for dagger shell + assorted fixes

### DIFF
--- a/core/integration/module_shell_test.go
+++ b/core/integration/module_shell_test.go
@@ -1,0 +1,135 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/Netflix/go-expect"
+	"github.com/creack/pty"
+	"github.com/stretchr/testify/require"
+)
+
+// Shells tests are run directly on the host rather than in exec containers because we want to
+// directly interact with the dagger shell tui without resorting to embedding more go code
+// into a container for driving it.
+
+func TestModuleDaggerShell(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	modDir := t.TempDir()
+	err := os.WriteFile(filepath.Join(modDir, "main.go"), []byte(`package main
+import "context"
+
+func New(ctx context.Context) *Test {
+	return &Test{
+		Ctr: dag.Container().From("mirror.gcr.io/alpine:3.18").WithEnvVariable("COOLENV", "woo").WithWorkdir("/coolworkdir"),
+	}
+}
+
+type Test struct {
+	Ctr *Container
+}
+`), 0644)
+	require.NoError(t, err)
+
+	_, err = hostDaggerExec(ctx, t, modDir, "--debug", "mod", "init", "--name=test", "--sdk=go")
+	require.NoError(t, err)
+
+	// timeout for waiting for each expected line is very generous in case CI is under heavy load or something
+	console, err := newShellTestConsole(60 * time.Second)
+	require.NoError(t, err)
+	defer console.Close()
+
+	tty := console.Tty()
+
+	// We want the size to be big enough to fit the output we're expecting, but increasing
+	// the size also eventually slows down the tests due to more output being generated and
+	// needing parsing.
+	err = pty.Setsize(tty, &pty.Winsize{Rows: 32, Cols: 32})
+	require.NoError(t, err)
+
+	cmd := hostDaggerCommand(ctx, t, modDir, "shell", "ctr")
+	cmd.Stdin = tty
+	cmd.Stdout = tty
+	cmd.Stderr = tty
+
+	err = cmd.Start()
+	require.NoError(t, err)
+
+	err = console.ExpectLineRegex(ctx, "/coolworkdir #")
+	require.NoError(t, err)
+
+	_, err = console.SendLine("echo $COOLENV")
+	require.NoError(t, err)
+
+	err = console.ExpectLineRegex(ctx, "woo")
+	require.NoError(t, err)
+
+	err = console.ExpectLineRegex(ctx, "/coolworkdir #")
+	require.NoError(t, err)
+
+	_, err = console.SendLine("exit")
+	require.NoError(t, err)
+
+	go console.ExpectEOF()
+
+	err = cmd.Wait()
+	require.NoError(t, err)
+}
+
+// shellTestConsole wraps expect.Console with methods that allow us to enforce timeouts despite
+// the fact that the TUI is constantly writing more data (which invalidates the expect lib's builtin
+// read timeout mechanisms).
+type shellTestConsole struct {
+	*expect.Console
+	expectLineTimeout time.Duration
+	output            *bytes.Buffer
+}
+
+func newShellTestConsole(expectLineTimeout time.Duration) (*shellTestConsole, error) {
+	output := bytes.NewBuffer(nil)
+	console, err := expect.NewConsole(expect.WithStdout(output), expect.WithDefaultTimeout(expectLineTimeout))
+	if err != nil {
+		return nil, err
+	}
+	return &shellTestConsole{
+		Console:           console,
+		expectLineTimeout: expectLineTimeout,
+		output:            output,
+	}, nil
+}
+
+func (e *shellTestConsole) ExpectLineRegex(ctx context.Context, pattern string) error {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, e.expectLineTimeout)
+	defer cancel()
+	lineMatcher := expect.RegexpPattern(".*\n")
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for line matching %s, most recent output:\n%s", pattern, e.output.String())
+		default:
+		}
+
+		line, err := e.Expect(lineMatcher)
+		if err != nil {
+			return err
+		}
+		if re.MatchString(line) {
+			return nil
+		}
+	}
+}

--- a/core/service.go
+++ b/core/service.go
@@ -416,7 +416,19 @@ func (svc *Service) startContainer(
 
 	exited := make(chan error, 1)
 	go func() {
-		defer close(exited)
+		defer func() {
+			if stdinClient != nil {
+				stdinClient.Close()
+			}
+			if stdoutClient != nil {
+				stdoutClient.Close()
+			}
+			if stderrClient != nil {
+				stderrClient.Close()
+			}
+			close(exited)
+		}()
+
 		exited <- svcProc.Wait()
 
 		// detach dependent services when process exits

--- a/core/shell.go
+++ b/core/shell.go
@@ -39,6 +39,7 @@ func (container *Container) ShellEndpoint(bk *buildkit.Client, progSock string, 
 		defer ws.Close()
 
 		bklog.G(r.Context()).Debugf("shell handler for %s has been upgraded", endpoint)
+		defer bklog.G(context.Background()).Debugf("shell handler for %s finished", endpoint)
 
 		if err := container.runShell(r.Context(), ws, bk, progSock, clientMetadata, svcs); err != nil {
 			bklog.G(r.Context()).WithError(err).Error("shell handler failed")

--- a/go.mod
+++ b/go.mod
@@ -58,8 +58,10 @@ require (
 )
 
 require (
+	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/charmbracelet/lipgloss v0.9.1
+	github.com/creack/pty v1.1.18
 	github.com/dagger/dagger/internal/mage v0.0.0-00010101000000-000000000000
 	github.com/dave/jennifer v1.7.0
 	github.com/dschmidt/go-layerfs v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -170,6 +170,8 @@ github.com/Microsoft/hcsshim v0.11.1 h1:hJ3s7GbWlGK4YVV92sO88BQSyF4ZLVy7/awqOlPx
 github.com/Microsoft/hcsshim v0.11.1/go.mod h1:nFJmaO4Zr5Y7eADdFOpYswDDlNVbvcIJJNJLECr5JQg=
 github.com/Microsoft/hcsshim/test v0.0.0-20200826032352-301c83a30e7c/go.mod h1:30A5igQ91GEmhYJF8TaRP79pMBOYynRsyOByfVV0dU4=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
+github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
+github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OpenPeeDeeP/depguard v1.0.1/go.mod h1:xsIw86fROiiwelg+jB2uM9PiKihMMmUx/1V+TNhjQvM=
 github.com/ProtonMail/go-crypto v0.0.0-20230828082145-3c4c8a2d2371 h1:kkhsdkhsCvIsutKu5zLMgWtgh9YxGCNAw8Ad8hjwfYg=
@@ -443,6 +445,9 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHH
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=


### PR DESCRIPTION
Main goal here was to add integ test coverage for dagger shell after missing a really straightforward nil panic as a result of not having coverage: https://github.com/dagger/dagger/pull/6240

 We didn't have coverage before because integ testing TUI programs is not usually straightforward. The solution here uses the https://github.com/Netflix/go-expect library to drive the program and run some simple commands in an alpine shell and verify their output. It worked out reasonably well and based on local testing is not flaky. 

Along the way a few other problems were noticed+fixed (commits have details in message):
1. [shell: support shell from nested sessions](https://github.com/dagger/dagger/commit/63bd7ee01051b899ff7893d1f504005a5d95c9b4)
2. [core: fix goroutine leak in shell service](https://github.com/dagger/dagger/commit/e6677a99d4f2f6b0fb6339e42c862e67d7b0b2e4)