### PR TITLE
fix: skip `head merge commits` on pull requests

### DIFF
--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -16,6 +16,11 @@ on:
         type: string
         default: "dagger-runner-2c-8g"
         required: false
+      setup-tmate:
+        description: "Whether to setup a tmate session for debugging"
+        type: boolean
+        default: false
+        required: false
 
 jobs:
   # Use a free GitHub Actions runner when
@@ -53,6 +58,9 @@ jobs:
         with:
           go-version: "1.21"
           cache-dependency-path: "internal/mage/go.sum"
+      - name: Setup tmate session
+        if: ${{ inputs.setup-tmate }}
+        uses: mxschmitt/action-tmate@v3
       - name: ${{ inputs.mage-targets }}
         run: |
           if [ "${{ inputs.dev-engine }}" == "true" ]

--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -16,11 +16,6 @@ on:
         type: string
         default: "dagger-runner-2c-8g"
         required: false
-      setup-tmate:
-        description: "Whether to setup a tmate session for debugging"
-        type: boolean
-        default: false
-        required: false
 
 jobs:
   # Use a free GitHub Actions runner when
@@ -58,9 +53,6 @@ jobs:
         with:
           go-version: "1.21"
           cache-dependency-path: "internal/mage/go.sum"
-      - name: Setup tmate session
-        if: ${{ inputs.setup-tmate }}
-        uses: mxschmitt/action-tmate@v3
       - name: ${{ inputs.mage-targets }}
         run: |
           if [ "${{ inputs.dev-engine }}" == "true" ]

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -40,7 +40,6 @@ jobs:
       mage-targets: engine:testimportant
       size: dagger-runner-16c-64g
       dev-engine: true
-      setup-tmate: false
 
 
   test-publish-cli:

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -40,6 +40,8 @@ jobs:
       mage-targets: engine:testimportant
       size: dagger-runner-16c-64g
       dev-engine: true
+      setup-tmate: true
+
 
   test-publish-cli:
     uses: ./.github/workflows/_hack_make.yml

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -40,7 +40,7 @@ jobs:
       mage-targets: engine:testimportant
       size: dagger-runner-16c-64g
       dev-engine: true
-      setup-tmate: true
+      setup-tmate: false
 
 
   test-publish-cli:

--- a/core/pipeline/label.go
+++ b/core/pipeline/label.go
@@ -148,7 +148,8 @@ func LoadGitLabels(workdir string) ([]Label, error) {
 		branch := os.Getenv("GITHUB_HEAD_REF")
 
 		// Execute git fetch using git CLI because GitHub Action adds the GITHUB_TOKEN
-		// to any git client operation automatically. With go-git, user have to add it
+		// to any git client operation automatically. With go-git, would have to
+		// add the GITHUB_TOKEN secret to their pipeline
 		cmd := exec.Command("git", "fetch", "origin", branch)
 		err = cmd.Run()
 		if err != nil {

--- a/core/pipeline/label.go
+++ b/core/pipeline/label.go
@@ -106,7 +106,7 @@ type fetchFunc func(repo *git.Repository, branch string) (*object.Commit, error)
 // Function to fetch from the origin remote
 func fetchFromOrigin(repo *git.Repository, branch string) (*object.Commit, error) {
 	// Fetch from the origin remote
-	cmd := exec.Command("git", "fetch", "origin", branch)
+	cmd := exec.Command("git", "fetch", "--depth", "1", "origin", branch)
 	err := cmd.Run()
 	if err != nil {
 		return nil, fmt.Errorf("error fetching branch from origin: %w", err)
@@ -150,7 +150,7 @@ func fetchFromFork(repo *git.Repository, branch string) (*object.Commit, error) 
 		return nil, fmt.Errorf("error adding fork as remote: %w", err)
 	}
 
-	cmd = exec.Command("git", "fetch", "fork", branch)
+	cmd = exec.Command("git", "fetch", "--depth", "1", "fork", branch)
 	err = cmd.Run()
 	if err != nil {
 		return nil, fmt.Errorf("error fetching branch from fork: %w", err)

--- a/core/pipeline/label.go
+++ b/core/pipeline/label.go
@@ -144,7 +144,7 @@ func LoadGitLabels(workdir string) ([]Label, error) {
 	// Checks if the commit is a merge commit in the context of pull request
 	// Only GitHub needs to be handled, as GitLab doesn't detach the head in MR context
 	if os.Getenv("GITHUB_EVENT_NAME") == "pull_request" && commit.NumParents() > 1 {
-		// Get the pull request's origin branch name
+		// Get the pull request's origin branch name.
 		branch := os.Getenv("GITHUB_HEAD_REF")
 
 		// Execute git fetch using git CLI because GitHub Action adds the GITHUB_TOKEN

--- a/core/pipeline/label.go
+++ b/core/pipeline/label.go
@@ -140,8 +140,10 @@ func LoadGitLabels(workdir string) ([]Label, error) {
 		return nil, err
 	}
 
-	// Check if the commit is a merge commit (GitHub context)
-	if commit.NumParents() > 1 {
+	// Check if the commit is a merge commit in the context of PR / MR
+	if (os.Getenv("GITHUB_EVENT_NAME") == "pull_request" ||
+		os.Getenv("CI_PIPELINE_SOURCE") == "merge_request_event") &&
+		commit.NumParents() > 1 {
 		// Get the parent commits
 		parents, err := commit.Parents().Next()
 		if err != nil {

--- a/core/pipeline/label.go
+++ b/core/pipeline/label.go
@@ -142,7 +142,11 @@ func fetchFromFork(repo *git.Repository, branch string) (*object.Commit, error) 
 		return nil, fmt.Errorf("invalid repository format: %s", repository)
 	}
 
-	forkURL := "https://github.com/" + username + "/" + parts[1]
+	// Get the server URL: "https://github.com/" in general,
+	// but can be different for GitHub Enterprise
+	serverURL := os.Getenv("GITHUB_SERVER_URL")
+
+	forkURL := fmt.Sprintf("%s/%s/%s", serverURL, username, parts[1])
 
 	cmd := exec.Command("git", "remote", "add", "fork", forkURL)
 	err := cmd.Run()

--- a/core/pipeline/label_test.go
+++ b/core/pipeline/label_test.go
@@ -101,6 +101,10 @@ func TestLoadGitLabels(t *testing.T) {
 					Value: "example.com",
 				},
 				{
+					Name:  "dagger.io/git.branch",
+					Value: "main",
+				},
+				{
 					Name:  "dagger.io/git.ref",
 					Value: detachedHead,
 				},


### PR DESCRIPTION
Fixes https://linear.app/dagger/issue/DEV-3086/pull-user-commit-message-in-a-context-pr

When collecting labels on the engine in a VCS context, sometimes, the commit head is an appended commit (from that VCS) [PR / MR]. This fix skips the merge request commit when it is the head.

Repro/test: https://gist.github.com/grouville/6cf442d86c41c0746bbef1812160e7c0

### 12/13 Advancements

> Realization: only GitHub puts the PR in a detached HEAD with only the merge commit. GitLab keeps the git history of the branch being tested

After reviews + some testing, a few changes have been implemented:
1. Make sure that the main branch doesn't skip the merge commits. Only `pull_requests` shall be be impacted
2. Due to the realization, we need to fetch the branch and get the commits from there. However, this is an operation requiring authorization. To circumvent this, we rely on the fact that GitHub runners automatically add the `GITHUB_TOKEN` secrets to git CLI commands

### 12/15 Advancements
Previous implementation was introducing a bug by printing errors to stdout, which polluted the `dagger listen` connection string.

The error came from the fact that on Dagger, the PRs come from a fork and not the origin. However, after spending some time reverse engineering Github Actions' runner context, I did not find a 100% solution to retrieve the origin of a fork. This is a best try approach, where we build the fork's remote of a repo from available information. If we do not manage to do it, then we fallback on the current logic