### PR TITLE
Fix various input normalization issues

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -1180,6 +1180,46 @@ func (m *Minimal) Qux(opts struct {
 	}
 }
 
+func TestModuleGoFieldMustBeNil(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := connect(t)
+
+	modGen := c.Container().From(golangImage).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithWorkdir("/work").
+		With(daggerExec("mod", "init", "--name=minimal", "--sdk=go")).
+		WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
+			Contents: `package main
+			
+import "fmt"
+
+type Minimal struct {
+	Src *Directory
+	Name *string
+}
+
+func New() *Minimal {
+	return &Minimal{}
+}
+
+func (m *Minimal) IsEmpty() bool {
+	if m.Name != nil {
+		panic(fmt.Sprintf("name should be nil but is %v", m.Name))
+	}
+	if m.Src != nil {
+		panic(fmt.Sprintf("src should be nil but is %v", m.Src))
+	}
+	return true
+}
+`,
+		})
+
+	out, err := modGen.With(daggerQuery(`{minimal{isEmpty}}`)).Stdout(ctx)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"minimal": {"isEmpty": true}}`, out)
+}
+
 func TestModuleGoPrivateField(t *testing.T) {
 	t.Parallel()
 

--- a/core/schema/coremod.go
+++ b/core/schema/coremod.go
@@ -91,6 +91,9 @@ func (obj *CoreModObject) ConvertFromSDKResult(_ context.Context, value any) (an
 }
 
 func (obj *CoreModObject) ConvertToSDKInput(ctx context.Context, value any) (any, error) {
+	if value == nil {
+		return nil, nil
+	}
 	return obj.resolver.ToID(value)
 }
 

--- a/core/schema/usermod.go
+++ b/core/schema/usermod.go
@@ -401,7 +401,7 @@ func (obj *UserModObject) ConvertToSDKInput(ctx context.Context, value any) (any
 				continue
 			}
 
-			value[k], err = field.modType.ConvertToSDKInput(ctx, v)
+			value[field.metadata.Name], err = field.modType.ConvertToSDKInput(ctx, v)
 			if err != nil {
 				return nil, fmt.Errorf("failed to convert field %q: %w", k, err)
 			}


### PR DESCRIPTION
Fixes #6252 (the equivalent #6227, but for core types instead of user module types).

In #6167, it looks like we missed another `nil` check, which manifests as core module types not being set to their zero value but to an empty struct.

Additionally, it looks we regressed on #6057, and we weren't correctly converting field names back into the field names that the module requested. Thankfully, this is a pretty simple fix, and I've verified manually this works. I'm not quite sure of a test that can make this break neatly, since it didn't really (`encoding/json` "prefer[s] an exact match but also accept[s] a case-insensitive match"). 