### PR TITLE
feat: skip namespacing when already prefixed

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -3015,7 +3015,7 @@ func TestModuleNamespacing(t *testing.T) {
 		With(daggerQuery(`{test{fn(s:"yo")}}`)).
 		Stdout(ctx)
 	require.NoError(t, err)
-	require.JSONEq(t, `{"test":{"fn":"1:yo 2:yo"}}`, out)
+	require.JSONEq(t, `{"test":{"fn":["*main.Sub1Obj made 1:yo", "*main.Sub2Obj made 2:yo"]}}`, out)
 }
 
 func TestModuleRoots(t *testing.T) {

--- a/core/integration/testdata/modules/go/namespacing/main.go
+++ b/core/integration/testdata/modules/go/namespacing/main.go
@@ -7,20 +7,23 @@ import (
 
 type Test struct{}
 
-func (m *Test) Fn(ctx context.Context, s string) (string, error) {
+func (m *Test) Fn(ctx context.Context, s string) ([]string, error) {
 	var sub1Obj *Sub1Obj
 	sub1Obj = dag.Sub1().Fn(s)
 	s1, err := sub1Obj.GetFoo(ctx)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	var sub2Obj *Sub2Obj
 	sub2Obj = dag.Sub2().Fn(s)
 	s2, err := sub2Obj.GetBar(ctx)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return fmt.Sprintf("%s %s", s1, s2), nil
+	return []string{
+		fmt.Sprintf("%T made %s", sub1Obj, s1),
+		fmt.Sprintf("%T made %s", sub2Obj, s2),
+	}, nil
 }

--- a/core/integration/testdata/modules/go/namespacing/sub2/main.go
+++ b/core/integration/testdata/modules/go/namespacing/sub2/main.go
@@ -6,14 +6,14 @@ import (
 
 type Sub2 struct{}
 
-func (m *Sub2) Fn(ctx context.Context, s string) *Obj {
-	return &Obj{Bar: "2:" + s}
+func (m *Sub2) Fn(ctx context.Context, s string) *Sub2Obj {
+	return &Sub2Obj{Bar: "2:" + s}
 }
 
-type Obj struct {
+type Sub2Obj struct {
 	Bar string `json:"bar"`
 }
 
-func (m *Obj) GetBar(ctx context.Context) (string, error) {
+func (m *Sub2Obj) GetBar(ctx context.Context) (string, error) {
 	return m.Bar, nil
 }

--- a/core/schema/schema.go
+++ b/core/schema/schema.go
@@ -774,10 +774,22 @@ func gqlObjectName(name string) string {
 }
 
 func namespaceObject(objName, namespace string) string {
-	// don't namespace the main module object itself (already is named after the module)
-	if gqlObjectName(objName) == gqlObjectName(namespace) {
-		return objName
+	gqlObjName := gqlObjectName(objName)
+	if rest := strings.TrimPrefix(gqlObjName, gqlObjectName(namespace)); rest != gqlObjName {
+		if len(rest) == 0 {
+			// objName equals namespace, don't namespace this
+			return gqlObjName
+		}
+		// we have this case check here to check for a boundary
+		// e.g. if objName="Postman" and namespace="Post", then we should still namespace
+		// this to "PostPostman" instead of just going for "Postman" (but we should do that
+		// if objName="PostMan")
+		if 'A' <= rest[0] && rest[0] <= 'Z' {
+			// objName has namespace prefixed, don't namespace this
+			return gqlObjName
+		}
 	}
+
 	return gqlObjectName(namespace + "_" + objName)
 }
 

--- a/core/schema/schema_test.go
+++ b/core/schema/schema_test.go
@@ -242,3 +242,51 @@ func TestWithMountedCacheSeen(t *testing.T) {
 	_, ok := core.SeenCacheKeys.Load("test-seen")
 	require.True(t, ok)
 }
+
+func TestNamespaceObjects(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		testCase  string
+		namespace string
+		obj       string
+		result    string
+	}{
+		{
+			testCase:  "namespace",
+			namespace: "Foo",
+			obj:       "Bar",
+			result:    "FooBar",
+		},
+		{
+			testCase:  "namespace into camel case",
+			namespace: "foo",
+			obj:       "bar-baz",
+			result:    "FooBarBaz",
+		},
+		{
+			testCase:  "don't namespace when equal",
+			namespace: "foo",
+			obj:       "Foo",
+			result:    "Foo",
+		},
+		{
+			testCase:  "don't namespace when prefixed",
+			namespace: "foo",
+			obj:       "FooBar",
+			result:    "FooBar",
+		},
+		{
+			testCase:  "still namespace when prefixed if not full",
+			namespace: "foo",
+			obj:       "Foobar",
+			result:    "FooFoobar",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.testCase, func(t *testing.T) {
+			result := namespaceObject(tc.obj, tc.namespace)
+			require.Equal(t, tc.result, result)
+		})
+	}
+}


### PR DESCRIPTION
This goes some way to fixing #6071 (@sipsma up to you if you want to leave it open for tracking the subpackage aspect, or splitting up core)

This allows a module "foo" to define it's own "FooContainer" type that won't be additionally namespaced into "FooFooContainer".

---

Previously, we skipped namespacing if the object was named the same as the module.

However, with this patch we can now additionally skip namespacing if the object if prefixed with the namespace.