### PR TITLE
chore: prevent duplicate LLB names

### DIFF
--- a/engine/buildkit/filesync.go
+++ b/engine/buildkit/filesync.go
@@ -72,7 +72,7 @@ func (c *Client) LocalImport(
 	// blobSource.CacheKey for more context
 	copyLLB := llb.Scratch().File(
 		llb.Copy(localLLB, "/", "/"),
-		llb.WithCustomNamef(localName),
+		llb.WithCustomNamef("%scopy %s", InternalPrefix, localName),
 	)
 
 	copyDef, err := copyLLB.Marshal(ctx, llb.Platform(platform))


### PR DESCRIPTION
This prevents a tiny visual glitch which is confusing in the TUI output where we get identical custom names.

I noted this in a debugging session with @marcosnils where we were seeing the same message in the TUI and in the cloud. Eventually, it would be nice to remove this, but adding this in at least helps to remove the visual confusion as to why there are duplicates.