### PR TITLE
Update circle.yml Example

### DIFF
--- a/docs/current_docs/cloud/snippets/get-started/ci/circle.yml
+++ b/docs/current_docs/cloud/snippets/get-started/ci/circle.yml
@@ -29,6 +29,7 @@ jobs:
       - run:
           name: Stop Dagger Engine
           command: docker stop -t 300 $(docker ps --filter name="dagger-engine-*" -q)
+          when: always
 workflows:
       // highlight-end
   dagger:


### PR DESCRIPTION
Stopping the engine regardless of build status is a recommended best practice to make sure cache is always uploaded.