### PR TITLE
feat: add tests for Node Typescript SDK

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -845,7 +845,7 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 			Contents: tsSignatures,
 		})
 
-	t.Run("func Hello() string", func(t *testing.T) {
+	t.Run("hello(): string", func(t *testing.T) {
 		t.Parallel()
 
 		out, err := modGen.With(daggerQuery(`{minimal{hello}}`)).Stdout(ctx)
@@ -854,7 +854,7 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 		require.JSONEq(t, `{"minimal":{"hello":"hello"}}`, out)
 	})
 
-	t.Run("func Echoes([]string) []string", func(t *testing.T) {
+	t.Run("echoes(msgs: string[]): string[]", func(t *testing.T) {
 		t.Parallel()
 
 		out, err := modGen.With(daggerQuery(`{minimal{echoes(msgs: "hello")}}`)).Stdout(ctx)
@@ -863,7 +863,7 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 		require.JSONEq(t, `{"minimal":{"echoes":["hello...hello...hello..."]}}`, out)
 	})
 
-	t.Run("func EchoOptional(string) string", func(t *testing.T) {
+	t.Run("echoOptional(msg = 'default'): string", func(t *testing.T) {
 		t.Parallel()
 
 		out, err := modGen.With(daggerQuery(`{minimal{echoOptional(msg: "hello")}}`)).Stdout(ctx)
@@ -877,7 +877,7 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 		require.JSONEq(t, `{"minimal":{"echoOptional":"default...default...default..."}}`, out)
 	})
 
-	t.Run("func EchoesVariadic(...string) string", func(t *testing.T) {
+	t.Run("echoesVariadic(...msgs: string[]): string", func(t *testing.T) {
 		t.Parallel()
 
 		out, err := modGen.With(daggerQuery(`{minimal{echoesVariadic(msgs: "hello")}}`)).Stdout(ctx)
@@ -886,7 +886,7 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 		require.JSONEq(t, `{"minimal":{"echoesVariadic":"hello...hello...hello..."}}`, out)
 	})
 
-	t.Run("func Echo(string) string", func(t *testing.T) {
+	t.Run("echo(msg: string): string", func(t *testing.T) {
 		t.Parallel()
 
 		out, err := modGen.With(daggerQuery(`{minimal{echo(msg: "hello")}}`)).Stdout(ctx)
@@ -895,7 +895,7 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 		require.JSONEq(t, `{"minimal":{"echo":"hello...hello...hello..."}}`, out)
 	})
 
-	t.Run("func EchoOptionalSlice([]string) string", func(t *testing.T) {
+	t.Run("echoOptionalSlice(msg = ['foobar']): string", func(t *testing.T) {
 		t.Parallel()
 
 		out, err := modGen.With(daggerQuery(`{minimal{echoOptionalSlice(msg: ["hello", "there"])}}`)).Stdout(ctx)
@@ -909,16 +909,7 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 		require.JSONEq(t, `{"minimal":{"echoOptionalSlice":"foobar...foobar...foobar..."}}`, out)
 	})
 
-	t.Run("func Echoes([]string) []string", func(t *testing.T) {
-		t.Parallel()
-
-		out, err := modGen.With(daggerQuery(`{minimal{echoes(msgs: "hello")}}`)).Stdout(ctx)
-
-		require.NoError(t, err)
-		require.JSONEq(t, `{"minimal":{"echoes":["hello...hello...hello..."]}}`, out)
-	})
-
-	t.Run("func HelloVoid()", func(t *testing.T) {
+	t.Run("helloVoid(): void", func(t *testing.T) {
 		t.Parallel()
 
 		out, err := modGen.With(daggerQuery(`{minimal{helloVoid}}`)).Stdout(ctx)
@@ -927,7 +918,7 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 		require.JSONEq(t, `{"minimal":{"helloVoid":null}}`, out)
 	})
 
-	t.Run("func EchoOpts(string, string, int) error", func(t *testing.T) {
+	t.Run("echoOpts(msg: string, suffix: string = '', times: number = 1): string", func(t *testing.T) {
 		t.Parallel()
 
 		out, err := modGen.With(daggerQuery(`{minimal{echoOpts(msg: "hi")}}`)).Stdout(ctx)
@@ -3765,8 +3756,6 @@ func TestModuleTypescriptInit(t *testing.T) {
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
 			With(daggerExec("mod", "init", "--name=My-Module", "--sdk=go"))
-
-		logGen(ctx, t, modGen.Directory("."))
 
 		out, err := modGen.
 			With(daggerQuery(`{myModule{containerEcho(stringArg:"hello"){stdout}}}`)).

--- a/core/integration/testdata/modules/typescript/minimal/index.ts
+++ b/core/integration/testdata/modules/typescript/minimal/index.ts
@@ -1,0 +1,44 @@
+import { dag, object, func } from "@dagger.io/dagger"
+
+@object
+class Minimal {
+	@func
+	hello(): string {
+		return "hello"
+	}
+
+	@func
+	echo(msg: string): string {
+		return this.echoOpts(msg, "...", 3)
+	}
+
+	@func
+	echoOpts(msg: string, suffix: string = "", times: number = 1): string {
+		msg = msg += suffix
+
+		return msg.repeat(times)
+	}
+
+	@func
+	echoOptional(msg = "default"): string {
+		return this.echo(msg)
+	}
+
+	@func
+	echoOptionalSlice(msg = ["foobar"]): string {
+		return this.echo(msg.join("+"))
+	}
+
+	@func
+	echoes(msgs: string[]): string[] {
+		return [this.echo(msgs.join(" "))]
+	}
+
+	@func
+	echoesVariadic(...msgs: string[]): string {
+		return this.echo(msgs.join(" "))
+	}
+
+	@func
+	helloVoid(): void {}
+}

--- a/sdk/nodejs/entrypoint/entrypoint.ts
+++ b/sdk/nodejs/entrypoint/entrypoint.ts
@@ -37,29 +37,50 @@ async function entrypoint() {
       } else {
         // Invocation
         const fnName = await fnCall.name()
-        const parentJson = await fnCall.parent()
+        const parentJson = JSON.parse(await fnCall.parent())
         const fnArgs = await fnCall.inputArgs()
 
         const args: Args = {}
+        const parentArgs: Args = {}
 
         for (const arg of fnArgs) {
           args[await arg.name()] = await loadArg(await arg.value())
         }
 
+        if (parentJson) {
+          for (const [key, value] of Object.entries(parentJson)) {
+            parentArgs[key] = await loadArg(value as string)
+          }
+        }
+
         await load(files)
 
-        result = await invoke(parentName, fnName, JSON.parse(parentJson), args)
+        result = await invoke(parentName, fnName, parentArgs, args)
 
         // Load ID if it's a Dagger type with an id
-        if (result.id && typeof result.id === "function") {
+        if (result && result.id && typeof result.id === "function") {
           result = await result.id()
+        }
+
+        // Load its field ID if there are
+        if (typeof result === "object") {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          for (const [key, value] of Object.entries<any>(result)) {
+            if (value.id && typeof value.id === "function") {
+              result[key] = await value.id()
+            }
+          }
         }
       }
 
+      if (result) {
+        result = JSON.stringify(result)
+      } else {
+        result = "null"
+      }
+
       // Send the result to Dagger
-      await fnCall.returnValue(
-        JSON.stringify(result) as string & { __JSON: never }
-      )
+      await fnCall.returnValue(result as string & { __JSON: never })
     },
     { LogOutput: process.stdout }
   )

--- a/sdk/nodejs/entrypoint/entrypoint.ts
+++ b/sdk/nodejs/entrypoint/entrypoint.ts
@@ -58,7 +58,7 @@ async function entrypoint() {
         result = await invoke(parentName, fnName, parentArgs, args)
 
         // Load ID if it's a Dagger type with an id
-        if (result && result.id && typeof result.id === "function") {
+        if (typeof result?.id === "function") {
           result = await result.id()
         }
 
@@ -73,7 +73,8 @@ async function entrypoint() {
         }
       }
 
-      if (result) {
+      // If result is set, we stringify it
+      if (result !== undefined && result !== null) {
         result = JSON.stringify(result)
       } else {
         result = "null"

--- a/sdk/nodejs/entrypoint/load.ts
+++ b/sdk/nodejs/entrypoint/load.ts
@@ -19,17 +19,31 @@ export async function load(files: string[]): Promise<void> {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function loadArg(value: string): Promise<any> {
-  const trimmedValue = value.slice(1, value.length - 1)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let parsedValue: any
 
-  const [source] = trimmedValue.split(":")
-
-  const [origin, type] = source.split(".")
-  if (origin === "core") {
-    // Workaround to call get any object that has an id
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    return dag[`load${type}FromID`](trimmedValue as ID)
+  // Apply JSON parse to parse array or string if the value is wrapped into a string or array
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("[") && value.endsWith("]"))
+  ) {
+    parsedValue = JSON.parse(value)
   } else {
-    return trimmedValue
+    parsedValue = value
   }
+
+  // If it's a string, it might contain an identifier to load ,or it might be a hidden array
+  if (typeof parsedValue === "string") {
+    const [source] = parsedValue.split(":")
+
+    const [origin, type] = source.split(".")
+    if (origin === "core") {
+      // Workaround to call get any object that has an id
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      return dag[`load${type}FromID`](parsedValue as ID)
+    }
+  }
+
+  return parsedValue
 }

--- a/sdk/nodejs/entrypoint/register.ts
+++ b/sdk/nodejs/entrypoint/register.ts
@@ -119,6 +119,8 @@ function addTypeDef(type: ScannerTypeDef<TypeDefKind>): TypeDef {
       return dag.typeDef().withObject((type as ObjectTypeDef).name)
     case TypeDefKind.Listkind:
       return dag.typeDef().withListOf(addTypeDef((type as ListTypeDef).typeDef))
+    case TypeDefKind.Voidkind:
+      return dag.typeDef().withKind(type.kind).withOptional(true)
     default:
       return dag.typeDef().withKind(type.kind)
   }

--- a/sdk/nodejs/introspector/registry/registry.ts
+++ b/sdk/nodejs/introspector/registry/registry.ts
@@ -170,7 +170,7 @@ export class Registry {
     return (
       fnStr
         .slice(fnStr.indexOf("(") + 1, fnStr.indexOf(")"))
-        .match(/([^\s,]+)/g) ?? []
+        .match(/\b(\w+)\b(?:(?=\s*[:=?]|,\s*|$))/g) ?? []
     )
   }
 }

--- a/sdk/nodejs/introspector/test/registry.spec.ts
+++ b/sdk/nodejs/introspector/test/registry.spec.ts
@@ -315,4 +315,37 @@ describe("Registry", function () {
     )
     assert.deepEqual(result, "Hello Dagger")
   })
+
+  it("Should support overriding default arg", async function () {
+    this.timeout(60000)
+
+    const registry = new Registry()
+
+    @registry.object
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    class HelloWorld {
+      @registry.func
+      sayHi(msg = ["foobar"]): string {
+        return msg.join(" ")
+      }
+    }
+
+    const defaultResult = await registry.getResult(
+      "HelloWorld",
+      "sayHi",
+      {},
+      {}
+    )
+    assert.deepEqual(defaultResult, "foobar")
+
+    const result = await registry.getResult(
+      "HelloWorld",
+      "sayHi",
+      {},
+      {
+        msg: ["hello", "there"],
+      }
+    )
+    assert.deepEqual(result, "hello there")
+  })
 })

--- a/sdk/nodejs/runtime/main.go
+++ b/sdk/nodejs/runtime/main.go
@@ -42,7 +42,7 @@ func (t *TypescriptSdk) ModuleRuntime(ctx context.Context, modSource *Directory,
 		// Install dependencies
 		WithExec([]string{"npm", "install"}).
 		// Add tsx to execute the entrypoint
-		WithExec([]string{"yarn", "global", "add", "tsx"}).
+		WithExec([]string{"npm", "install", "-g", "tsx"}).
 		WithEntrypoint([]string{"tsx", EntrypointExecutablePath}).
 		WithDefaultArgs(), nil
 }


### PR DESCRIPTION
Fixes argOrder regexp when default arg is set.
Add test on overriding default arg on registry test. Set return type as optional when input type is void. 
Add tests for Typescript in `module_test.go`.

Fix ModuleRuntime to include codebase.
- This fixes the `dagger mod install` command
- This fixes using a module without `sdk` generated in the host.

Fix loading arg to handle array and strings.
Fix entrypoint to load parent state too.
Check for defined result.
Serialize fields that have identifiers.
Handle `void` return value with returnValue set to `"nul"`.

Related to DEV-3147