### PR TITLE
More field manipulation in go

### DIFF
--- a/cmd/codegen/generator/go/templates/module_funcs.go
+++ b/cmd/codegen/generator/go/templates/module_funcs.go
@@ -305,8 +305,14 @@ func (ps *parseState) parseParamSpecVar(field *types.Var, docComment string, lin
 		}
 	}
 
+	name := field.Name()
+	if name == "" {
+		// emulate struct behaviour, where a field with no name gets the type name
+		name = typeSpec.GoType().String()
+	}
+
 	return paramSpec{
-		name:         field.Name(),
+		name:         name,
 		paramType:    paramType,
 		typeSpec:     typeSpec,
 		optional:     optional,

--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -792,6 +792,10 @@ func asInlineStructAst(t ast.Node) (*ast.StructType, bool) {
 func unpackASTFields(fields *ast.FieldList) []*ast.Field {
 	var unpacked []*ast.Field
 	for _, field := range fields.List {
+		if len(field.Names) == 0 {
+			unpacked = append(unpacked, field)
+			continue
+		}
 		for i, name := range field.Names {
 			field := *field
 			field.Names = []*ast.Ident{name}

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -1014,7 +1014,7 @@ type Minimal struct {
 	X, Y string  // Y is not this
 
 	// +private
-	// Z string
+	Z string
 }
 
 // some docs

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -1119,6 +1119,102 @@ func (m *Minimal) HelloFinal(
 	require.Equal(t, "", prop.Get("description").String())
 }
 
+func TestModuleGoWeirdFields(t *testing.T) {
+	// these are all cases that used to panic due to the disparity in the type spec and the ast
+
+	t.Parallel()
+
+	c, ctx := connect(t)
+
+	modGen := c.Container().From(golangImage).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithWorkdir("/work").
+		With(daggerExec("mod", "init", "--name=minimal", "--sdk=go")).
+		WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
+			Contents: `package main
+
+type Z string
+
+type Minimal struct {
+	// field with single (normal) name
+	W string
+
+	// field with multiple names
+	X, Y string
+
+	// field with no names
+	Z
+}
+
+func New() Minimal {
+	return Minimal{
+		W: "-",
+		X: "-",
+		Y: "-",
+		Z: Z("-"),
+	}
+}
+
+// struct with no fields
+type Bar struct{}
+
+func (m *Minimal) Say(
+	// field with single (normal) name
+	a string,
+	// field with multiple names
+	b, c string,
+	// field with no names (not included, mixed names not allowed)
+	// string
+) string {
+	return a + " " + b + " " + c
+}
+
+func (m *Minimal) Hello(
+	// field with no names
+	string,
+) string {
+	return "hello"
+}
+
+func (m *Minimal) SayOpts(opts struct{
+	// field with single (normal) name
+	A string
+	// field with multiple names
+	B, C string
+	// field with no names (not included because of above)
+	// string
+}) string {
+	return opts.A + " " + opts.B + " " + opts.C
+}
+
+func (m *Minimal) HelloOpts(opts struct{
+	// field with no names
+	string
+}) string {
+	return "hello"
+}
+`,
+		})
+
+	logGen(ctx, t, modGen.Directory("."))
+
+	out, err := modGen.With(daggerQuery(`{minimal{w, x, y, z}}`)).Stdout(ctx)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"minimal": {"w": "-", "x": "-", "y": "-", "z": "-"}}`, out)
+
+	for _, name := range []string{"say", "sayOpts"} {
+		out, err := modGen.With(daggerQuery(`{minimal{%s(a: "hello", b: "world", c: "!")}}`, name)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, fmt.Sprintf(`{"minimal": {"%s": "hello world !"}}`, name), out)
+	}
+
+	for _, name := range []string{"hello", "helloOpts"} {
+		out, err := modGen.With(daggerQuery(`{minimal{%s(string: "")}}`, name)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, fmt.Sprintf(`{"minimal": {"%s": "hello"}}`, name), out)
+	}
+}
+
 func TestModuleGoOptionalMustBeNil(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Oh look it's #6181 #5972 #6068 again (cc @vito *this* is the issue you sent me)

This behavior regressed in v0.9.4 (with #6181 lol).

Fields can have *zero* names - in which case we shouldn't accidentally discard the entire field, woops.

I've added a pretty comprehensive test for all these scenarios, getting very annoyed having to fix them all.

Also some other smallish related fixes I ran into while trying to get this working.