### PR TITLE
BREAKING: Make default args parameter required 

### DIFF
--- a/.changes/unreleased/Breaking-20231215-120318.yaml
+++ b/.changes/unreleased/Breaking-20231215-120318.yaml
@@ -1,0 +1,6 @@
+kind: Breaking
+body: Argument to `withDefaultArgs` is now required
+time: 2023-12-15T12:03:18.896065-01:00
+custom:
+  Author: helderco
+  PR: "6281"

--- a/ci/main.go
+++ b/ci/main.go
@@ -139,7 +139,7 @@ func daggerCLI() *File {
 func devEngineContainer() *Container {
 	return dag.Container().
 		From("alpine:"+alpineVersion).
-		WithDefaultArgs().
+		WithoutDefaultArgs().
 		WithExec([]string{
 			"apk", "add",
 			// for Buildkit

--- a/cmd/codegen/generator/nodejs/templates/functions_test.go
+++ b/cmd/codegen/generator/nodejs/templates/functions_test.go
@@ -40,7 +40,7 @@ func TestSplitRequiredOptionalArgs(t *testing.T) {
 	t.Run("container withDefaultArgs", func(t *testing.T) {
 		container := currentSchema.Types.Get("Container")
 		require.NotNil(t, container)
-		execField := getField(container, "withDefaultArgs")
+		execField := getField(container, "asTarball")
 
 		t.Log(container)
 		required, optional := splitRequiredOptionalArgs(execField.Args)

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -674,9 +674,7 @@ func TestContainerExecWithEntrypoint(t *testing.T) {
 	t.Run("unset default args", func(t *testing.T) {
 		t.Parallel()
 		removed, err := base.
-			WithDefaultArgs(dagger.ContainerWithDefaultArgsOpts{
-				Args: []string{"foobar"},
-			}).
+			WithDefaultArgs([]string{"foobar"}).
 			WithEntrypoint([]string{"echo"}).
 			Stdout(ctx)
 		require.NoError(t, err)
@@ -686,9 +684,7 @@ func TestContainerExecWithEntrypoint(t *testing.T) {
 	t.Run("kept default args", func(t *testing.T) {
 		t.Parallel()
 		kept, err := base.
-			WithDefaultArgs(dagger.ContainerWithDefaultArgsOpts{
-				Args: []string{"foobar"},
-			}).
+			WithDefaultArgs([]string{"foobar"}).
 			WithEntrypoint([]string{"echo"}, dagger.ContainerWithEntrypointOpts{
 				KeepDefaultArgs: true,
 			}).
@@ -726,9 +722,7 @@ func TestContainerExecWithoutEntrypoint(t *testing.T) {
 		res, err := c.Container().
 			From(alpineImage).
 			WithEntrypoint([]string{"foo"}).
-			WithDefaultArgs(dagger.ContainerWithDefaultArgsOpts{
-				Args: []string{"echo", "-n", "foobar"},
-			}).
+			WithDefaultArgs([]string{"echo", "-n", "foobar"}).
 			WithoutEntrypoint().
 			Stdout(ctx)
 		require.ErrorContains(t, err, "no command has been set")
@@ -739,9 +733,7 @@ func TestContainerExecWithoutEntrypoint(t *testing.T) {
 		res, err := c.Container().
 			From(alpineImage).
 			WithEntrypoint([]string{"foo"}).
-			WithDefaultArgs(dagger.ContainerWithDefaultArgsOpts{
-				Args: []string{"echo", "-n", "foobar"},
-			}).
+			WithDefaultArgs([]string{"echo", "-n", "foobar"}).
 			WithoutEntrypoint(dagger.ContainerWithoutEntrypointOpts{
 				KeepDefaultArgs: true,
 			}).
@@ -790,7 +782,7 @@ func TestContainerWithDefaultArgs(t *testing.T) {
 				from(address: "`+alpineImage+`") {
 					entrypoint
 					defaultArgs
-					withDefaultArgs {
+					withDefaultArgs(args: []) {
 						entrypoint
 						defaultArgs
 					}
@@ -850,9 +842,7 @@ func TestContainerExecWithoutDefaultArgs(t *testing.T) {
 	res, err := c.Container().
 		From(alpineImage).
 		WithEntrypoint([]string{"echo", "-n"}).
-		WithDefaultArgs(dagger.ContainerWithDefaultArgsOpts{
-			Args: []string{"foo"},
-		}).
+		WithDefaultArgs([]string{"foo"}).
 		WithoutDefaultArgs().
 		WithExec([]string{}).
 		Stdout(ctx)
@@ -3346,9 +3336,7 @@ func TestContainerNoExec(t *testing.T) {
 
 	_, err = c.Container().
 		From(alpineImage).
-		WithDefaultArgs(dagger.ContainerWithDefaultArgsOpts{
-			Args: nil,
-		}).
+		WithoutDefaultArgs().
 		Stdout(ctx)
 
 	require.Error(t, err)

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -443,9 +443,7 @@ func TestContainerServiceNoExec(t *testing.T) {
 		From(alpineImage).
 		WithExposedPort(8080).
 		// using error to compare hostname after WithServiceBinding
-		WithDefaultArgs(dagger.ContainerWithDefaultArgsOpts{
-			Args: []string{"sh", "-c", "echo nope; exit 42"},
-		}).
+		WithDefaultArgs([]string{"sh", "-c", "echo nope; exit 42"}).
 		AsService()
 
 	host, err := srv.Hostname(ctx)

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -270,7 +270,7 @@ func (s *containerSchema) entrypoint(ctx context.Context, parent *core.Container
 }
 
 type containerWithDefaultArgs struct {
-	Args *[]string
+	Args []string
 }
 
 func (s *containerSchema) withDefaultArgs(ctx context.Context, parent *core.Container, args containerWithDefaultArgs) (*core.Container, error) {
@@ -280,7 +280,7 @@ func (s *containerSchema) withDefaultArgs(ctx context.Context, parent *core.Cont
 			return cfg
 		}
 
-		cfg.Cmd = *args.Args
+		cfg.Cmd = args.Args
 		return cfg
 	})
 }

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -288,7 +288,7 @@ type Container {
     """
     Arguments to prepend to future executions (e.g., ["-v", "--no-cache"]).
     """
-    args: [String!]
+    args: [String!]!
   ): Container!
 
   """

--- a/docs/current_docs/guides/snippets/aws-codebuild-codepipeline/index.mjs
+++ b/docs/current_docs/guides/snippets/aws-codebuild-codepipeline/index.mjs
@@ -36,7 +36,7 @@ connect(
       .withWorkdir("/src")
       .withExec(["npm", "install"])
       .withExec(["npm", "run", "build"])
-      .withDefaultArgs({ args: ["npm", "start"] })
+      .withDefaultArgs(["npm", "start"])
 
     // publish image to registry
     // at registry path [registry-username]/myapp

--- a/docs/current_docs/guides/snippets/aws-codebuild-codepipeline/main.go
+++ b/docs/current_docs/guides/snippets/aws-codebuild-codepipeline/main.go
@@ -49,9 +49,7 @@ func main() {
 		WithWorkdir("/src").
 		WithExec([]string{"npm", "install"}).
 		WithExec([]string{"npm", "run", "build"}).
-		WithDefaultArgs(dagger.ContainerWithDefaultArgsOpts{
-			Args: []string{"npm", "start"},
-		})
+		WithDefaultArgs([]string{"npm", "start"})
 
 	// publish image to registry
 	// at registry path [registry-username]/myapp

--- a/docs/current_docs/guides/snippets/aws-codebuild-codepipeline/main.py
+++ b/docs/current_docs/guides/snippets/aws-codebuild-codepipeline/main.py
@@ -37,7 +37,7 @@ async def main():
             .with_workdir("/src")
             .with_exec(["npm", "install"])
             .with_exec(["npm", "run", "build"])
-            .with_default_args(args=["npm", "start"])
+            .with_default_args(["npm", "start"])
         )
 
         # publish image to registry

--- a/docs/current_docs/guides/snippets/replace-dockerfile/index.mjs
+++ b/docs/current_docs/guides/snippets/replace-dockerfile/index.mjs
@@ -43,7 +43,7 @@ connect(
       ])
       .withEntrypoint(["docker-entrypoint.sh"])
       .withUser("memcache")
-      .withDefaultArgs({ args: ["memcached"] })
+      .withDefaultArgs(["memcached"])
 
     // publish the container image
     const addr = await memcached.publish(PUBLISH_ADDRESS)

--- a/docs/current_docs/guides/snippets/replace-dockerfile/main.go
+++ b/docs/current_docs/guides/snippets/replace-dockerfile/main.go
@@ -50,9 +50,7 @@ func main() {
 		WithExec([]string{"ln", "-s", "usr/local/bin/docker-entrypoint.sh", "/entrypoint.sh"}).
 		WithEntrypoint([]string{"docker-entrypoint.sh"}).
 		WithUser("memcache").
-		WithDefaultArgs(dagger.ContainerWithDefaultArgsOpts{
-			Args: []string{"memcached"},
-		})
+		WithDefaultArgs([]string{"memcached"})
 
 	// publish the container image
 	addr, err := memcached.Publish(ctx, publishAddr)

--- a/docs/current_docs/guides/snippets/replace-dockerfile/main.py
+++ b/docs/current_docs/guides/snippets/replace-dockerfile/main.py
@@ -54,7 +54,7 @@ async def main():
             )
             .with_entrypoint(["docker-entrypoint.sh"])
             .with_user("memcache")
-            .with_default_args(args=["memcached"])
+            .with_default_args(["memcached"])
         )
 
         # publish the container image

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -448,18 +448,11 @@ defmodule Dagger.Container do
   )
 
   (
-    @doc "Configures default arguments for future commands.\n\n\n\n## Optional Arguments\n\n* `args` - Arguments to prepend to future executions (e.g., [\"-v\", \"--no-cache\"])."
-    @spec with_default_args(t(), keyword()) :: Dagger.Container.t()
-    def with_default_args(%__MODULE__{} = container, optional_args \\ []) do
+    @doc "Configures default arguments for future commands.\n\n## Required Arguments\n\n* `args` - Arguments to prepend to future executions (e.g., [\"-v\", \"--no-cache\"])."
+    @spec with_default_args(t(), [Dagger.String.t()]) :: Dagger.Container.t()
+    def with_default_args(%__MODULE__{} = container, args) do
       selection = select(container.selection, "withDefaultArgs")
-
-      selection =
-        if is_nil(optional_args[:args]) do
-          selection
-        else
-          arg(selection, "args", optional_args[:args])
-        end
-
+      selection = arg(selection, "args", args)
       %Dagger.Container{selection: selection, client: container.client}
     end
   )

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -882,21 +882,10 @@ func (r *Container) User(ctx context.Context) (string, error) {
 	return response, q.Execute(ctx, r.c)
 }
 
-// ContainerWithDefaultArgsOpts contains options for Container.WithDefaultArgs
-type ContainerWithDefaultArgsOpts struct {
-	// Arguments to prepend to future executions (e.g., ["-v", "--no-cache"]).
-	Args []string
-}
-
 // Configures default arguments for future commands.
-func (r *Container) WithDefaultArgs(opts ...ContainerWithDefaultArgsOpts) *Container {
+func (r *Container) WithDefaultArgs(args []string) *Container {
 	q := r.q.Select("withDefaultArgs")
-	for i := len(opts) - 1; i >= 0; i-- {
-		// `args` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Args) {
-			q = q.Arg("args", opts[i].Args)
-		}
-	}
+	q = q.Arg("args", args)
 
 	return &Container{
 		q: q,

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -206,13 +206,6 @@ export type ContainerPublishOpts = {
   mediaTypes?: ImageMediaTypes
 }
 
-export type ContainerWithDefaultArgsOpts = {
-  /**
-   * Arguments to prepend to future executions (e.g., ["-v", "--no-cache"]).
-   */
-  args?: string[]
-}
-
 export type ContainerWithDirectoryOpts = {
   /**
    * Patterns to exclude in the written directory (e.g., ["node_modules/**", ".gitignore", ".git/"]).
@@ -1688,15 +1681,15 @@ export class Container extends BaseClient {
 
   /**
    * Configures default arguments for future commands.
-   * @param opts.args Arguments to prepend to future executions (e.g., ["-v", "--no-cache"]).
+   * @param args Arguments to prepend to future executions (e.g., ["-v", "--no-cache"]).
    */
-  withDefaultArgs = (opts?: ContainerWithDefaultArgsOpts): Container => {
+  withDefaultArgs = (args: string[]): Container => {
     return new Container({
       queryTree: [
         ...this._queryTree,
         {
           operation: "withDefaultArgs",
-          args: { ...opts },
+          args: { args },
         },
       ],
       ctx: this._ctx,

--- a/sdk/python/dev/src/main/utils.py
+++ b/sdk/python/dev/src/main/utils.py
@@ -20,7 +20,7 @@ def python_base(
     return (
         dag.container()
         .from_(f"python:{version}-{IMAGE}")
-        .with_default_args(args=["/bin/bash"])  # for dagger shell
+        .with_default_args(["/bin/bash"])  # for dagger shell
         .with_(cache("/root/.cache/pip", keys=["pip", version, IMAGE]))
         .with_(venv)
     )

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -938,11 +938,7 @@ class Container(Type):
         return await _ctx.execute(str | None)
 
     @typecheck
-    def with_default_args(
-        self,
-        *,
-        args: Sequence[str] | None = None,
-    ) -> "Container":
+    def with_default_args(self, args: Sequence[str]) -> "Container":
         """Configures default arguments for future commands.
 
         Parameters
@@ -952,7 +948,7 @@ class Container(Type):
             cache"]).
         """
         _args = [
-            Arg("args", args, None),
+            Arg("args", args),
         ]
         _ctx = self._select("withDefaultArgs", _args)
         return Container(_ctx)

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -423,12 +423,6 @@ pub struct ContainerPublishOpts {
     pub platform_variants: Option<Vec<ContainerId>>,
 }
 #[derive(Builder, Debug, PartialEq)]
-pub struct ContainerWithDefaultArgsOpts<'a> {
-    /// Arguments to prepend to future executions (e.g., ["-v", "--no-cache"]).
-    #[builder(setter(into, strip_option), default)]
-    pub args: Option<Vec<&'a str>>,
-}
-#[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithDirectoryOpts<'a> {
     /// Patterns to exclude in the written directory (e.g., ["node_modules/**", ".gitignore", ".git/"]).
     #[builder(setter(into, strip_option), default)]
@@ -1049,25 +1043,13 @@ impl Container {
     ///
     /// # Arguments
     ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_default_args(&self) -> Container {
-        let query = self.selection.select("withDefaultArgs");
-        return Container {
-            proc: self.proc.clone(),
-            selection: query,
-            graphql_client: self.graphql_client.clone(),
-        };
-    }
-    /// Configures default arguments for future commands.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_default_args_opts<'a>(&self, opts: ContainerWithDefaultArgsOpts<'a>) -> Container {
+    /// * `args` - Arguments to prepend to future executions (e.g., ["-v", "--no-cache"]).
+    pub fn with_default_args(&self, args: Vec<impl Into<String>>) -> Container {
         let mut query = self.selection.select("withDefaultArgs");
-        if let Some(args) = opts.args {
-            query = query.arg("args", args);
-        }
+        query = query.arg(
+            "args",
+            args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
+        );
         return Container {
             proc: self.proc.clone(),
             selection: query,


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/6051

## What?

The `args` field of `Container.withDefaultArgs` is no longer optional:

```diff
- ctr = ctr.WithDefaultArgs(ContainerWithDefaultArgsOpts{Args: []string{"foo"}})
+ ctr = ctr.WithDefaultArgs([]string{"foo"})
```

To unset:

```diff
- ctr = ctr.WithDefaultArgs([]string{})
+ ctr = ctr.WithoutDefaultArgs() 
```

This also works (in practice) but it will set `CMD` to `[]` rather than truly unsetting:
```go
ctr = ctr.WithDefaultArgs([]string{}) 
```

## Breaking change

This breaks all current `withDefaultArgs` usage, in all SDKs since it's a core change.