### PR TITLE
fix: only add the main module object at the top-level

### DIFF
--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -147,8 +147,8 @@ func (funcs goTemplateFuncs) moduleMainSrc() (string, error) {
 				return "", fmt.Errorf("failed to generate function cases for %s: %w", obj.Name(), err)
 			}
 
-			if !ps.isMainModuleObject(obj.Name()) && len(objTypeSpec.fields) == 0 && len(objTypeSpec.methods) == 0 {
-				// nothing to define, skip it
+			if topLevel && !ps.isMainModuleObject(obj.Name()) {
+				// don't add a non-main object at the top-level (wait till it comes up as a sub-object)
 				continue
 			}
 


### PR DESCRIPTION
See https://github.com/dagger/dagger/issues/6272#issuecomment-1858003650:

https://github.com/dagger/dagger/commit/77760c2754575695f6a9329c79c4c6a2d6078a65#diff-42df7f581f0c9e41a3320a7be6c79027f0b373d77e57231d767b3539643a4da8L155-R152 modified the logic so that the following struct would be code-gened:

```go
type Foo struct {
    X string
}
```

However, if `Foo` is not *reachable* from methods/fields on the main struct, then we should not include it on our code-gen and field declarations.