### PR TITLE
tests: run dagger shell test in isolation + pre-cached

### DIFF
--- a/core/integration/module_shell_test.go
+++ b/core/integration/module_shell_test.go
@@ -20,8 +20,6 @@ import (
 // into a container for driving it.
 
 func TestModuleDaggerShell(t *testing.T) {
-	t.Parallel()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -42,6 +40,10 @@ type Test struct {
 	require.NoError(t, err)
 
 	_, err = hostDaggerExec(ctx, t, modDir, "--debug", "mod", "init", "--name=test", "--sdk=go")
+	require.NoError(t, err)
+
+	// cache the module load itself so there's less to wait for in the shell invocation below
+	_, err = hostDaggerExec(ctx, t, modDir, "--debug", "functions")
 	require.NoError(t, err)
 
 	// timeout for waiting for each expected line is very generous in case CI is under heavy load or something

--- a/core/integration/module_shell_test.go
+++ b/core/integration/module_shell_test.go
@@ -56,7 +56,7 @@ type Test struct {
 	// We want the size to be big enough to fit the output we're expecting, but increasing
 	// the size also eventually slows down the tests due to more output being generated and
 	// needing parsing.
-	err = pty.Setsize(tty, &pty.Winsize{Rows: 32, Cols: 32})
+	err = pty.Setsize(tty, &pty.Winsize{Rows: 8, Cols: 16})
 	require.NoError(t, err)
 
 	cmd := hostDaggerCommand(ctx, t, modDir, "shell", "ctr")


### PR DESCRIPTION
Saw while reviewing PRs that the TestModuleDaggerShell test was flaking sometimes specifically in the testdev workflow. Have never seen this flake in the other "normal" integ test workflow or locally.

From the logs I saw it looks like it is running as expected but just extremely slow, to the point that the generous timeouts weren't enough.

The testdev workflow is extra slow and overloaded for various unrelated reasons (doesn't actually run on the shared runner and doesn't have the same parallelism limits in the engine set).

Since I can't repro, this change is just an attempt at accounting for those tests being really extra slow. It:
1. Causes the Shell test to not run in parallel with the others, so it should be less bogged down by other noise.
2. Calls "functions" on the module first so the module load is cached before we actually call "shell" (from the log output I saw, it seemed like that module load part was the one taking forever and causing the shell test timeout to get hit)