### PR TITLE
`FunctionCall.parent` doesn't return original field names

### DIFF
--- a/cmd/codegen/generator/go/templates/module_funcs.go
+++ b/cmd/codegen/generator/go/templates/module_funcs.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	. "github.com/dave/jennifer/jen" // nolint:revive,stylecheck
-	"github.com/iancoleman/strcase"
 )
 
 const errorTypeName = "error"
@@ -139,7 +138,7 @@ func (spec *funcTypeSpec) TypeDefCode() (*Statement, error) {
 		}
 
 		// arguments to WithArg (args to arg... ugh, at least the name of the variable is honest?)
-		argTypeDefArgCode := []Code{Lit(argSpec.graphqlName()), argTypeDefCode}
+		argTypeDefArgCode := []Code{Lit(argSpec.name), argTypeDefCode}
 		if len(argOptsCode) > 0 {
 			argTypeDefArgCode = append(argTypeDefArgCode, Id("FunctionWithArgOpts").Values(argOptsCode...))
 		}
@@ -340,8 +339,4 @@ type paramSpec struct {
 	// parent is set if this paramSpec is nested inside a parent inline struct,
 	// and is used to create a declaration of the entire inline struct
 	parent *paramSpec
-}
-
-func (spec *paramSpec) graphqlName() string {
-	return strcase.ToLowerCamel(spec.name)
 }

--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -480,9 +480,9 @@ func (ps *parseState) fillObjectFunctionCase(
 		}
 
 		statements = append(statements,
-			If(Id(inputArgsVar).Index(Lit(spec.graphqlName())).Op("!=").Nil()).Block(
+			If(Id(inputArgsVar).Index(Lit(spec.name)).Op("!=").Nil()).Block(
 				Err().Op("=").Qual("json", "Unmarshal").Call(
-					Index().Byte().Parens(Id(inputArgsVar).Index(Lit(spec.graphqlName()))),
+					Index().Byte().Parens(Id(inputArgsVar).Index(Lit(spec.name))),
 					Op("&").Add(target),
 				),
 				checkErrStatement,

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -443,10 +443,7 @@ def hello() -> str:
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
 			With(daggerExec("mod", "init", "--name=hello-world", "--sdk=python")).
-			With(sdkSource("python", `import logging
-from dagger import field, function, log, object_type
-
-log.configure_logging(level=logging.DEBUG)
+			With(sdkSource("python", `from dagger import field, function, object_type
 
 @object_type
 class HelloWorld:

--- a/core/schema/usermod.go
+++ b/core/schema/usermod.go
@@ -401,7 +401,8 @@ func (obj *UserModObject) ConvertToSDKInput(ctx context.Context, value any) (any
 				continue
 			}
 
-			value[field.metadata.Name], err = field.modType.ConvertToSDKInput(ctx, v)
+			delete(value, k)
+			value[field.metadata.OriginalName], err = field.modType.ConvertToSDKInput(ctx, v)
 			if err != nil {
 				return nil, fmt.Errorf("failed to convert field %q: %w", k, err)
 			}


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/6286

Problem was that the parent value of a function call is sending the GraphQL cased field names instead of original names.

## Example

```python
from dagger import field, function, object_type

@object_type
class HelloWorld:
    my_name: str = field(default="World")

    @function
    def message(self) -> str:
        return f"Hello, {self.my_name}!"
```
So for the following query:
```graphql
{ 
    helloWorld(myName: "Monde") { 
        message 
    } 
}
```
You got the output:
```console
Hello World!
```
Because the following call context was sent:
```python
{
    "parent_name": "HelloWorld",
    "parent_json": '{"greeting":"Hello","myName":"Monde"}',
    "name": "message",
    "input_args": "{}",
}
```
Expected `parent_json` to use `my_name` instead of `myName`, so it was ignored.

\cc @sipsma 