### PR TITLE
feat: lay foundations for engine drivers

### DIFF
--- a/engine/client/buildkit.go
+++ b/engine/client/buildkit.go
@@ -3,52 +3,57 @@ package client
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/url"
+	"os"
+	"sync/atomic"
 	"time"
 
 	"github.com/dagger/dagger/engine"
+	"github.com/dagger/dagger/engine/client/drivers"
 	bkclient "github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/util/tracing/detect"
 	"github.com/vito/progrock"
 	"go.opentelemetry.io/otel"
+)
 
-	// load connection helpers
-	_ "github.com/moby/buildkit/client/connhelper/dockercontainer"
-	_ "github.com/moby/buildkit/client/connhelper/kubepod"
-	_ "github.com/moby/buildkit/client/connhelper/podmancontainer"
-	_ "github.com/moby/buildkit/client/connhelper/ssh"
+const (
+	// TODO: deprecate in a future release
+	envDaggerCloudCachetoken = "_EXPERIMENTAL_DAGGER_CACHESERVICE_TOKEN"
 )
 
 func newBuildkitClient(ctx context.Context, rec *progrock.VertexRecorder, remote *url.URL, userAgent string) (*bkclient.Client, *bkclient.Info, error) {
-	var c *bkclient.Client
-	var err error
-	switch remote.Scheme {
-	case DockerImageProvider:
-		c, err = buildkitConnectDocker(ctx, rec, remote, userAgent)
-	default:
-		task := rec.Task("starting engine")
-		c, err = buildkitConnectDefault(ctx, rec, remote)
-		task.Done(err)
-	}
+	driver, err := drivers.GetDriver(remote.Scheme)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	info, err := c.Info(ctx)
+	var cloudToken string
+	if v, ok := os.LookupEnv(drivers.EnvDaggerCloudToken); ok {
+		cloudToken = v
+	} else if _, ok := os.LookupEnv(envDaggerCloudCachetoken); ok {
+		cloudToken = v
+	}
+
+	conn, err := driver.Connect(ctx, rec, remote, &drivers.DriverOpts{
+		UserAgent:        userAgent,
+		DaggerCloudToken: cloudToken,
+		GPUSupport:       os.Getenv(drivers.EnvGPUSupport),
+	})
 	if err != nil {
 		return nil, nil, err
 	}
-	if info.BuildkitVersion.Package != engine.Package {
-		return nil, nil, fmt.Errorf("remote is not a valid dagger server (expected %q, got %q)", engine.Package, info.BuildkitVersion.Package)
-	}
 
-	return c, info, nil
-}
-
-func buildkitConnectDefault(ctx context.Context, rec *progrock.VertexRecorder, remote *url.URL) (*bkclient.Client, error) {
 	opts := []bkclient.ClientOpt{
 		bkclient.WithTracerProvider(otel.GetTracerProvider()),
 	}
+	var counter int64
+	opts = append(opts, bkclient.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		if atomic.AddInt64(&counter, 1) > 1 {
+			return nil, net.ErrClosed
+		}
+		return conn, nil
+	}))
 
 	exp, _, err := detect.Exporter()
 	if err == nil {
@@ -61,14 +66,22 @@ func buildkitConnectDefault(ctx context.Context, rec *progrock.VertexRecorder, r
 
 	c, err := bkclient.New(ctx, remote.String(), opts...)
 	if err != nil {
-		return nil, fmt.Errorf("buildkit client: %w", err)
+		return nil, nil, fmt.Errorf("buildkit client: %w", err)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 	if err := c.Wait(ctx); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return c, nil
+	info, err := c.Info(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	if info.BuildkitVersion.Package != engine.Package {
+		return nil, nil, fmt.Errorf("remote is not a valid dagger server (expected %q, got %q)", engine.Package, info.BuildkitVersion.Package)
+	}
+
+	return c, info, nil
 }

--- a/engine/client/drivers/dial.go
+++ b/engine/client/drivers/dial.go
@@ -1,0 +1,59 @@
+package drivers
+
+import (
+	"context"
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/vito/progrock"
+
+	connh "github.com/moby/buildkit/client/connhelper"
+	connhDocker "github.com/moby/buildkit/client/connhelper/dockercontainer"
+	connhKube "github.com/moby/buildkit/client/connhelper/kubepod"
+	connhPodman "github.com/moby/buildkit/client/connhelper/podmancontainer"
+	connhSSH "github.com/moby/buildkit/client/connhelper/ssh"
+)
+
+func init() {
+	register("tcp", &dialDriver{})
+	register("unix", &dialDriver{})
+	register("ssh", &dialDriver{connhSSH.Helper})
+	register("docker-container", &dialDriver{connhDocker.Helper})
+	register("kube-pod", &dialDriver{connhKube.Helper})
+	register("podman-container", &dialDriver{connhPodman.Helper})
+}
+
+// dialDriver uses the buildkit connhelpers to directly connect
+type dialDriver struct {
+	fn func(*url.URL) (*connh.ConnectionHelper, error)
+}
+
+func (d *dialDriver) Connect(ctx context.Context, rec *progrock.VertexRecorder, target *url.URL, _ *DriverOpts) (c net.Conn, rerr error) {
+	startTask := rec.Task("starting engine")
+	defer startTask.Done(rerr)
+
+	return d.dial(ctx, target)
+}
+
+func (d *dialDriver) dial(ctx context.Context, target *url.URL) (net.Conn, error) {
+	if d.fn == nil {
+		return defaultDialer(ctx, target.String())
+	}
+
+	helper, err := d.fn(target)
+	if err != nil {
+		return nil, err
+	}
+	return helper.ContextDialer(ctx, target.String())
+}
+
+func defaultDialer(ctx context.Context, address string) (net.Conn, error) {
+	addrParts := strings.SplitN(address, "://", 2)
+	if len(addrParts) != 2 {
+		return nil, errors.Errorf("invalid address %s", address)
+	}
+	var d net.Dialer
+	return d.DialContext(ctx, addrParts[0], addrParts[1])
+}

--- a/engine/client/drivers/driver.go
+++ b/engine/client/drivers/driver.go
@@ -1,0 +1,45 @@
+package drivers
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+
+	"github.com/vito/progrock"
+)
+
+// Driver allows dialing to a dagger backend.
+//
+// It's slightly similar to the docker connhelpers, however, the function
+// signatures are slightly different.
+type Driver interface {
+	// Connect creates a buildkit client to a dagger instance from the given URL
+	Connect(ctx context.Context, rec *progrock.VertexRecorder, url *url.URL, opts *DriverOpts) (net.Conn, error)
+}
+
+type DriverOpts struct {
+	UserAgent string
+
+	DaggerCloudToken string
+	GPUSupport       string
+}
+
+const (
+	EnvDaggerCloudToken = "DAGGER_CLOUD_TOKEN"
+	EnvGPUSupport       = "_EXPERIMENTAL_DAGGER_GPU_SUPPORT"
+)
+
+var drivers = map[string]Driver{}
+
+func register(scheme string, driver Driver) {
+	drivers[scheme] = driver
+}
+
+func GetDriver(name string) (Driver, error) {
+	driver, ok := drivers[name]
+	if !ok {
+		return nil, fmt.Errorf("no driver for scheme %q found", name)
+	}
+	return driver, nil
+}


### PR DESCRIPTION
This patch starts to simplify the connhelpers and docker-image helper into specific engine drivers (see https://github.com/dagger/dagger/issues/5583) - adding new drivers now becomes easier.

Each driver registers itself under a name, and is called when connecting to a URL with that scheme. Additionally, during connection, we provide a set of additional parameters.

This is mostly just a refactor around the connhelpers, which we can't use directly out of the box, since we want to support a set of additional parameters as well. Since each driver just returns a net.Conn, then we can build the buildkit connection on top of it, which allow us to potentially change the connection mechanism in the future.