### PR TITLE
Fix python provisioning test flakiness

### DIFF
--- a/sdk/python/src/dagger/_engine/download.py
+++ b/sdk/python/src/dagger/_engine/download.py
@@ -182,7 +182,7 @@ class Downloader:
         # garbage collection of old binaries
         for file in self.cache_dir.glob(f"{self.CLI_BIN_PREFIX}*"):
             if file != cli_bin_path:
-                file.unlink()
+                file.unlink(missing_ok=True)
 
         return str(cli_bin_path.absolute())
 

--- a/sdk/python/tests/engine/test_download.py
+++ b/sdk/python/tests/engine/test_download.py
@@ -133,13 +133,17 @@ async def test_download_bin(cache_dir: anyio.Path):
     # and is already tested in go, skipping coverage here
 
     # run a bunch of provisions concurrently
+    start = anyio.Event()
+
     async def connect_once():
-        async with dagger.Connection(dagger.Config(retry=None)) as client:
-            assert await client.default_platform()
+        await start.wait()
+        async with dagger.connection(dagger.Config(retry=None)):
+            assert await dagger.dag.default_platform()
 
     async with anyio.create_task_group() as tg:
         for _ in range(os.cpu_count() or 4):
             tg.start_soon(connect_once)
+        start.set()
 
     # assert that there's only one dagger binary in the cache
     i = 0

--- a/sdk/python/tests/engine/test_download.py
+++ b/sdk/python/tests/engine/test_download.py
@@ -137,8 +137,10 @@ async def test_download_bin(cache_dir: anyio.Path):
 
     async def connect_once():
         await start.wait()
-        async with dagger.connection(dagger.Config(retry=None)):
-            assert await dagger.dag.default_platform()
+        # NB: Don't use global connection here since we want to test
+        # multiple concurrent connections.
+        async with dagger.Connection(dagger.Config(retry=None)) as client:
+            assert await client.default_platform()
 
     async with anyio.create_task_group() as tg:
         for _ in range(os.cpu_count() or 4):


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/6265

I considered adding a file lock to the provisioning which would also prevent downloading the CLI multiple times, but it's not done in the other SDKs. Quick fix here is to just not complain if the file to remove doesn't exist anymore (race condition).

The synchronization primitive is not necessary to fix the issue but since I was looking at the Go implementation this matches it a bit more closely.