### PR TITLE
docs: Update docs on `withEntrypoint` usage 

### DIFF
--- a/examples/sdk/go/multistage/main.go
+++ b/examples/sdk/go/multistage/main.go
@@ -30,7 +30,6 @@ func main() {
 
 	prodImage := client.Container().
 		From("cgr.dev/chainguard/wolfi-base:latest").
-		WithDefaultArgs(). // Set CMD to []
 		WithFile("/bin/dagger", build.File("/src/dagger")).
 		WithEntrypoint([]string{"/bin/dagger"})
 

--- a/examples/sdk/nodejs/multistage/build.js
+++ b/examples/sdk/nodejs/multistage/build.js
@@ -13,7 +13,6 @@ connect(async (client) => {
 
   const prodImage = client.container()
   .from("cgr.dev/chainguard/wolfi-base:latest")
-  .withDefaultArgs() // Set CMD to []
   .withFile("/bin/dagger", build.file("/src/dagger"))
   .withEntrypoint(["/bin/dagger"])
 

--- a/examples/sdk/python/multistage/pipeline.py
+++ b/examples/sdk/python/multistage/pipeline.py
@@ -19,7 +19,6 @@ async def pipeline():
         prod_image = (
             client.container()
             .from_("cgr.dev/chainguard/wolfi-base:latest")
-            .with_default_args() # Set CMD to []
             .with_file("/bin/dagger", build.file("/src/dagger"))
             .with_entrypoint(["/bin/dagger"])
         )


### PR DESCRIPTION
Follow up to https://github.com/dagger/dagger/pull/6280 for doc snippet updates.

> ⚠️ **Warning**
> To merge after or when the above is released.