### PR TITLE
ci: bring back dagger cloud token so we have visibility

### DIFF
--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -65,7 +65,7 @@ jobs:
           ./hack/make ${{ inputs.mage-targets }}
         env:
           _EXPERIMENTAL_DAGGER_RUNNER_HOST: "unix:///var/run/buildkit/buildkitd.sock"
-          DAGGER_CLOUD_TOKEN: "${{ secrets.DAGGER_CLOUD_TOKEN }}"
+          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
       - name: "ALWAYS print kernel logs - especialy useful on failure"
         if: always()
         run: sudo dmesg


### PR DESCRIPTION
this doesn't have any security implications since the token onyl has
access to send telemtry to cloud and cannot access any caching
resources. The cache access in our self-hosted runners is handled by the
`DAGGER_CLOUD_TOKEN` env var which is set at the runner level

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
