### PR TITLE
fix: supports single quote default argument

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -4361,6 +4361,51 @@ func TestModuleReservedWords(t *testing.T) {
 	})
 }
 
+//go:embed testdata/modules/typescript/syntax/index.ts
+var tsSyntax string
+
+func TestModuleTypescriptSyntaxSupport(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := connect(t)
+
+	modGen := c.Container().From(golangImage).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithWorkdir("/work").
+		With(daggerExec("mod", "init", "--name=syntax", "--sdk=typescript")).
+		WithNewFile("src/index.ts", dagger.ContainerWithNewFileOpts{
+			Contents: tsSyntax,
+		})
+
+	t.Run("singleQuoteDefaultArgHello(msg: string = 'world'): string", func(t *testing.T) {
+		t.Parallel()
+
+		defaultOut, err := modGen.With(daggerQuery(`{syntax{singleQuoteDefaultArgHello}}`)).Stdout(ctx)
+
+		require.NoError(t, err)
+		require.JSONEq(t, `{"syntax":{"singleQuoteDefaultArgHello":"hello world"}}`, defaultOut)
+
+		out, err := modGen.With(daggerQuery(`{syntax{singleQuoteDefaultArgHello(msg: "dagger")}}`)).Stdout(ctx)
+
+		require.NoError(t, err)
+		require.JSONEq(t, `{"syntax":{"singleQuoteDefaultArgHello":"hello dagger"}}`, out)
+	})
+
+	t.Run("doubleQuotesDefaultArgHello(msg: string = \"world\"): string", func(t *testing.T) {
+		t.Parallel()
+
+		defaultOut, err := modGen.With(daggerQuery(`{syntax{doubleQuotesDefaultArgHello}}`)).Stdout(ctx)
+
+		require.NoError(t, err)
+		require.JSONEq(t, `{"syntax":{"doubleQuotesDefaultArgHello":"hello world"}}`, defaultOut)
+
+		out, err := modGen.With(daggerQuery(`{syntax{doubleQuotesDefaultArgHello(msg: "dagger")}}`)).Stdout(ctx)
+
+		require.NoError(t, err)
+		require.JSONEq(t, `{"syntax":{"doubleQuotesDefaultArgHello":"hello dagger"}}`, out)
+	})
+}
+
 func daggerExec(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
 		return c.WithExec(append([]string{"dagger", "--debug"}, args...), dagger.ContainerWithExecOpts{

--- a/core/integration/testdata/modules/typescript/syntax/index.ts
+++ b/core/integration/testdata/modules/typescript/syntax/index.ts
@@ -1,0 +1,14 @@
+import { object, func } from "@dagger.io/dagger"
+
+@object
+class Syntax {
+	@func
+	singleQuoteDefaultArgHello(msg: string = 'world'): string {
+		return `hello ${msg}`
+	}
+
+	@func
+	doubleQuotesDefaultArgHello(msg: string = "world"): string {
+		return `hello ${msg}`
+	}
+}

--- a/sdk/nodejs/entrypoint/load.ts
+++ b/sdk/nodejs/entrypoint/load.ts
@@ -22,11 +22,13 @@ export async function loadArg(value: string): Promise<any> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let parsedValue: any
 
-  // Apply JSON parse to parse array or string if the value is wrapped into a string or array
-  if (
+  const isString = (): boolean =>
     (value.startsWith('"') && value.endsWith('"')) ||
-    (value.startsWith("[") && value.endsWith("]"))
-  ) {
+    (value.startsWith(`'`) && value.endsWith(`'`))
+  const isArray = (): boolean => value.startsWith("[") && value.endsWith("]")
+
+  // Apply JSON parse to parse array or string if the value is wrapped into a string or array
+  if (isString() || isArray()) {
     parsedValue = JSON.parse(value)
   } else {
     parsedValue = value

--- a/sdk/nodejs/introspector/scanner/utils.ts
+++ b/sdk/nodejs/introspector/scanner/utils.ts
@@ -108,12 +108,25 @@ export function isOptional(param: ts.Symbol): OptionalValue {
         parameterDeclaration.initializer !== undefined
 
       if (parameterDeclaration.initializer !== undefined) {
-        result.defaultValue = parameterDeclaration.initializer.getText()
+        result.defaultValue = formatDefaultValue(
+          parameterDeclaration.initializer.getText()
+        )
       }
     }
   }
 
   return result
+}
+
+function formatDefaultValue(value: string): string {
+  const isSingleQuoteString = (): boolean =>
+    value.startsWith("'") && value.endsWith("'")
+
+  if (isSingleQuoteString()) {
+    return `"${value.slice(1, value.length - 1)}"`
+  }
+
+  return value
 }
 
 /**


### PR DESCRIPTION
Example:
```ts
function hello(msg = 'hey') {}
```