### PR TITLE
feat: make withoutEntrypoint clear default args as well

### DIFF
--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -246,9 +246,16 @@ func (s *containerSchema) withEntrypoint(ctx context.Context, parent *core.Conta
 	})
 }
 
-func (s *containerSchema) withoutEntrypoint(ctx context.Context, parent *core.Container, _ any) (*core.Container, error) {
+type containerWithoutEntrypointArgs struct {
+	KeepDefaultArgs bool
+}
+
+func (s *containerSchema) withoutEntrypoint(ctx context.Context, parent *core.Container, args containerWithoutEntrypointArgs) (*core.Container, error) {
 	return parent.UpdateImageConfig(ctx, func(cfg specs.ImageConfig) specs.ImageConfig {
 		cfg.Entrypoint = nil
+		if !args.KeepDefaultArgs {
+			cfg.Cmd = nil
+		}
 		return cfg
 	})
 }

--- a/core/schema/container.graphqls
+++ b/core/schema/container.graphqls
@@ -271,7 +271,12 @@ type Container {
   """
   Retrieves this container with an unset command entrypoint.
   """
-  withoutEntrypoint: Container!
+  withoutEntrypoint(
+    """
+    Don't remove the default arguments when unsetting the entrypoint.
+    """
+    keepDefaultArgs: Boolean = false
+  ): Container!
 
   "Retrieves default arguments for future commands."
   defaultArgs: [String!]

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -951,10 +951,18 @@ defmodule Dagger.Container do
   )
 
   (
-    @doc "Retrieves this container with an unset command entrypoint."
-    @spec without_entrypoint(t()) :: Dagger.Container.t()
-    def without_entrypoint(%__MODULE__{} = container) do
+    @doc "Retrieves this container with an unset command entrypoint.\n\n\n\n## Optional Arguments\n\n* `keep_default_args` - Don't remove the default arguments when unsetting the entrypoint."
+    @spec without_entrypoint(t(), keyword()) :: Dagger.Container.t()
+    def without_entrypoint(%__MODULE__{} = container, optional_args \\ []) do
       selection = select(container.selection, "withoutEntrypoint")
+
+      selection =
+        if is_nil(optional_args[:keep_default_args]) do
+          selection
+        else
+          arg(selection, "keepDefaultArgs", optional_args[:keep_default_args])
+        end
+
       %Dagger.Container{selection: selection, client: container.client}
     end
   )

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -1442,9 +1442,21 @@ func (r *Container) WithoutDefaultArgs() *Container {
 	}
 }
 
+// ContainerWithoutEntrypointOpts contains options for Container.WithoutEntrypoint
+type ContainerWithoutEntrypointOpts struct {
+	// Don't remove the default arguments when unsetting the entrypoint.
+	KeepDefaultArgs bool
+}
+
 // Retrieves this container with an unset command entrypoint.
-func (r *Container) WithoutEntrypoint() *Container {
+func (r *Container) WithoutEntrypoint(opts ...ContainerWithoutEntrypointOpts) *Container {
 	q := r.q.Select("withoutEntrypoint")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `keepDefaultArgs` optional argument
+		if !querybuilder.IsZeroValue(opts[i].KeepDefaultArgs) {
+			q = q.Arg("keepDefaultArgs", opts[i].KeepDefaultArgs)
+		}
+	}
 
 	return &Container{
 		q: q,

--- a/sdk/nodejs/api/client.gen.ts
+++ b/sdk/nodejs/api/client.gen.ts
@@ -417,6 +417,13 @@ export type ContainerWithUnixSocketOpts = {
   owner?: string
 }
 
+export type ContainerWithoutEntrypointOpts = {
+  /**
+   * Don't remove the default arguments when unsetting the entrypoint.
+   */
+  keepDefaultArgs?: boolean
+}
+
 export type ContainerWithoutExposedPortOpts = {
   /**
    * Port protocol to unexpose
@@ -2211,13 +2218,15 @@ export class Container extends BaseClient {
 
   /**
    * Retrieves this container with an unset command entrypoint.
+   * @param opts.keepDefaultArgs Don't remove the default arguments when unsetting the entrypoint.
    */
-  withoutEntrypoint = (): Container => {
+  withoutEntrypoint = (opts?: ContainerWithoutEntrypointOpts): Container => {
     return new Container({
       queryTree: [
         ...this._queryTree,
         {
           operation: "withoutEntrypoint",
+          args: { ...opts },
         },
       ],
       ctx: this._ctx,

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -1548,9 +1548,21 @@ class Container(Type):
         return Container(_ctx)
 
     @typecheck
-    def without_entrypoint(self) -> "Container":
-        """Retrieves this container with an unset command entrypoint."""
-        _args: list[Arg] = []
+    def without_entrypoint(
+        self,
+        *,
+        keep_default_args: bool | None = False,
+    ) -> "Container":
+        """Retrieves this container with an unset command entrypoint.
+
+        Parameters
+        ----------
+        keep_default_args:
+            Don't remove the default arguments when unsetting the entrypoint.
+        """
+        _args = [
+            Arg("keepDefaultArgs", keep_default_args, False),
+        ]
         _ctx = self._select("withoutEntrypoint", _args)
         return Container(_ctx)
 

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -572,6 +572,12 @@ pub struct ContainerWithUnixSocketOpts<'a> {
     pub owner: Option<&'a str>,
 }
 #[derive(Builder, Debug, PartialEq)]
+pub struct ContainerWithoutEntrypointOpts {
+    /// Don't remove the default arguments when unsetting the entrypoint.
+    #[builder(setter(into, strip_option), default)]
+    pub keep_default_args: Option<bool>,
+}
+#[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithoutExposedPortOpts {
     /// Port protocol to unexpose
     #[builder(setter(into, strip_option), default)]
@@ -1879,8 +1885,28 @@ impl Container {
         };
     }
     /// Retrieves this container with an unset command entrypoint.
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn without_entrypoint(&self) -> Container {
         let query = self.selection.select("withoutEntrypoint");
+        return Container {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        };
+    }
+    /// Retrieves this container with an unset command entrypoint.
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub fn without_entrypoint_opts(&self, opts: ContainerWithoutEntrypointOpts) -> Container {
+        let mut query = self.selection.select("withoutEntrypoint");
+        if let Some(keep_default_args) = opts.keep_default_args {
+            query = query.arg("keepDefaultArgs", keep_default_args);
+        }
         return Container {
             proc: self.proc.clone(),
             selection: query,


### PR DESCRIPTION
This implements my suggestion from https://github.com/dagger/dagger/pull/6280#issuecomment-1864269265.

`withoutEntrypoint` also modifies the entrypoint, and so should follow the same style and reset the default args (allowing toggling this behavior in the same way as `withEntrypoint`).