### PR TITLE
fix: install nix using script

### DIFF
--- a/internal/mage/cli.go
+++ b/internal/mage/cli.go
@@ -42,27 +42,10 @@ func (cl Cli) Publish(ctx context.Context, version string) error {
 		args = append(args, "--release-notes", fmt.Sprintf(".changes/%s.md", version))
 	}
 
-	ctr := c.Container().
-		From(fmt.Sprintf("ghcr.io/goreleaser/goreleaser-pro:%s", goReleaserVersion)).
-		WithEntrypoint([]string{}).
-		WithExec([]string{"apk", "add", "aws-cli"})
-
-	// install nix
-	ctr = ctr.
-		WithExec([]string{"apk", "add", "xz"}).
-		WithDirectory("/nix", c.Directory()).
-		WithNewFile("/etc/nix/nix.conf", dagger.ContainerWithNewFileOpts{
-			Contents: `build-users-group =`,
-		}).
-		WithExec([]string{"sh", "-c", "curl -L https://nixos.org/nix/install | sh -s -- --no-daemon"})
-	path, err := ctr.EnvVariable(ctx, "PATH")
+	ctr, err := publishEnv(ctx, c)
 	if err != nil {
 		return err
 	}
-	ctr = ctr.WithEnvVariable("PATH", path+":/nix/var/nix/profiles/default/bin")
-	// goreleaser requires nix-prefetch-url, so check we can run it
-	ctr = ctr.WithExec([]string{"sh", "-c", "nix-prefetch-url 2>&1 | grep 'error: you must specify a URL'"})
-
 	wd := c.Host().Directory(".")
 	_, err = ctr.
 		WithWorkdir("/app").
@@ -121,5 +104,40 @@ func (cl Cli) TestPublish(ctx context.Context) error {
 			})
 		}
 	}
+
+	eg.Go(func() error {
+		env, err := publishEnv(ctx, c)
+		if err != nil {
+			return err
+		}
+		_, err = env.Sync(ctx)
+		return err
+	})
+
 	return eg.Wait()
+}
+
+func publishEnv(ctx context.Context, c *dagger.Client) (*dagger.Container, error) {
+	ctr := c.Container().
+		From(fmt.Sprintf("ghcr.io/goreleaser/goreleaser-pro:%s", goReleaserVersion)).
+		WithEntrypoint([]string{}).
+		WithExec([]string{"apk", "add", "aws-cli"})
+
+	// install nix
+	ctr = ctr.
+		WithExec([]string{"apk", "add", "xz"}).
+		WithDirectory("/nix", c.Directory()).
+		WithNewFile("/etc/nix/nix.conf", dagger.ContainerWithNewFileOpts{
+			Contents: `build-users-group =`,
+		}).
+		WithExec([]string{"sh", "-c", "curl -L https://nixos.org/nix/install | sh -s -- --no-daemon"})
+	path, err := ctr.EnvVariable(ctx, "PATH")
+	if err != nil {
+		return nil, err
+	}
+	ctr = ctr.WithEnvVariable("PATH", path+":/nix/var/nix/profiles/default/bin")
+	// goreleaser requires nix-prefetch-url, so check we can run it
+	ctr = ctr.WithExec([]string{"sh", "-c", "nix-prefetch-url 2>&1 | grep 'error: you must specify a URL'"})
+
+	return ctr, nil
 }

--- a/internal/mage/cli.go
+++ b/internal/mage/cli.go
@@ -42,11 +42,29 @@ func (cl Cli) Publish(ctx context.Context, version string) error {
 		args = append(args, "--release-notes", fmt.Sprintf(".changes/%s.md", version))
 	}
 
-	wd := c.Host().Directory(".")
-	_, err = c.Container().
+	ctr := c.Container().
 		From(fmt.Sprintf("ghcr.io/goreleaser/goreleaser-pro:%s", goReleaserVersion)).
 		WithEntrypoint([]string{}).
-		WithExec([]string{"apk", "add", "aws-cli", "nix"}).
+		WithExec([]string{"apk", "add", "aws-cli"})
+
+	// install nix
+	ctr = ctr.
+		WithExec([]string{"apk", "add", "xz"}).
+		WithDirectory("/nix", c.Directory()).
+		WithNewFile("/etc/nix/nix.conf", dagger.ContainerWithNewFileOpts{
+			Contents: `build-users-group =`,
+		}).
+		WithExec([]string{"sh", "-c", "curl -L https://nixos.org/nix/install | sh -s -- --no-daemon"})
+	path, err := ctr.EnvVariable(ctx, "PATH")
+	if err != nil {
+		return err
+	}
+	ctr = ctr.WithEnvVariable("PATH", path+":/nix/var/nix/profiles/default/bin")
+	// goreleaser requires nix-prefetch-url, so check we can run it
+	ctr = ctr.WithExec([]string{"sh", "-c", "nix-prefetch-url 2>&1 | grep 'error: you must specify a URL'"})
+
+	wd := c.Host().Directory(".")
+	_, err = ctr.
 		WithWorkdir("/app").
 		WithMountedDirectory("/app", wd).
 		With(util.HostSecretVar(c, "GITHUB_TOKEN")).


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/pull/6245#issuecomment-1866175753 (cc @sagikazarmark)

The apk package for nix is only available in alpine:edge atm, and goreleaser does not use alpine:edge.

So, we can install it using the same method we were previously using in github actions - the logic is borrowed from https://github.com/cachix/install-nix-action/blob/master/install-nix.sh#L76 and https://github.com/cachix/install-nix-action/blob/master/install-nix.sh#L104.