### PR TITLE
docs: add redirect for old nodejs sdk location

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -534,6 +534,11 @@
   to = "https://play.dagger.cloud/_next/:splat"
   status = 200
 
+[[redirects]]
+  from = "/current/sdk/nodejs/*"
+  to = "/sdk/nodejs/:splat"
+  status = 301
+
 [[headers]]
   for = "/*"
   [headers.values]

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -537,7 +537,7 @@
 [[redirects]]
   from = "/current/sdk/nodejs/*"
   to = "/sdk/nodejs/:splat"
-  status = 301
+  status = 302
 
 [[headers]]
   for = "/*"

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -8,11 +8,11 @@
   ignore = "false"
 
 [[redirects]]
-    # Embargoes compliance. DO NOT REMOVE
+  # Embargoes compliance. DO NOT REMOVE
   conditions = {Country = ["CU", "IR", "KP", "SY", "UA-43"]}
-    from = "/*"
-    to = "/restricted"
-    status = 302
+  from = "/*"
+  to = "/restricted"
+  status = 302
   force = true
 
 [[redirects]]
@@ -524,17 +524,17 @@
 # redirect to the playground's embed to maintain same origin
 # see https://github.com/dagger/dagger/pull/4753
 [[redirects]]
-    from = "/embed/*"
-    to = "https://play.dagger.cloud/embed/:splat"
-    status = 200
+  from = "/embed/*"
+  to = "https://play.dagger.cloud/embed/:splat"
+  status = 200
 
 # redirect to the playground's Next.js build artifacts
 [[redirects]]
-    from = "/_next/*"
-    to = "https://play.dagger.cloud/_next/:splat"
-    status = 200
+  from = "/_next/*"
+  to = "https://play.dagger.cloud/_next/:splat"
+  status = 200
 
 [[headers]]
   for = "/*"
   [headers.values]
-    Referrer-policy = "no-referrer-when-downgrade"
+  Referrer-policy = "no-referrer-when-downgrade"


### PR DESCRIPTION
Noticed by @gerhard during the v0.9.5 release:

> Noticed that the https://docs.dagger.io/current/sdk/nodejs/reference/modules/api_client_gen link is now broken, most likely after the Docusaurus v3.0 refactoring. The links comes from https://github.com/dagger/dagger/releases/tag/sdk%2Fnodejs%2Fv0.9.5

In #6311, I've fixed the docs link for future releases, but we should add a redirect for previous changelogs. It looks like the location for the page was changed during #6164.