### PR TITLE
Improve "dagger functions"

### DIFF
--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -45,7 +45,7 @@ var funcListCmd = &FuncCommand{
 	Short: `List available functions`,
 	Execute: func(fc *FuncCommand, cmd *cobra.Command) error {
 		tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 3, ' ', tabwriter.DiscardEmptyColumns)
-		o := fc.mod.GetMainObject()
+		var o functionProvider = fc.mod.GetMainObject()
 		fmt.Fprintf(tw, "%s\t%s\n",
 			termenv.String("Name").Bold(),
 			termenv.String("Description").Bold(),
@@ -58,7 +58,7 @@ var funcListCmd = &FuncCommand{
 				return err
 			}
 			nextType := nextFunc.ReturnType
-			if nextType.AsObject != nil {
+			if nextType.AsFunctionProvider() != nil {
 				// sipsma explains why 'nextType.AsObject' is not enough:
 				// > when we're returning the hierarchies of TypeDefs from the API,
 				// > and an object shows up as an output/input type to a function,
@@ -69,7 +69,7 @@ var funcListCmd = &FuncCommand{
 				// > you'd at best be using O(n^2) space in the result,
 				// > and at worst cause json serialization errors due to cyclic references
 				// > (i.e. with* functions on an object that return the object itself).
-				o = fc.mod.GetObject(nextType.AsObject.Name)
+				o = fc.mod.GetFunctionProvider(nextType.Name())
 				continue
 			}
 			// FIXME: handle arrays of objects
@@ -86,7 +86,7 @@ var funcListCmd = &FuncCommand{
 				desc = "-"
 			}
 			fmt.Fprintf(tw, "%s\t%s\n",
-				fn.Name,
+				cliName(fn.Name),
 				desc,
 			)
 		}

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -846,6 +846,24 @@ func (o *modObject) GetFunctions() []*modFunction {
 	return fns
 }
 
+func (o *modObject) GetFunction(name string) (*modFunction, error) {
+	for _, fn := range o.Functions {
+		if fn.Name == name {
+			return fn, nil
+		}
+	}
+	for _, f := range o.Fields {
+		if f.Name == name {
+			return &modFunction{
+				Name:        f.Name,
+				Description: f.Description,
+				ReturnType:  f.TypeDef,
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("no function '%s' in object type '%s'", name, o.Name)
+}
+
 type modInterface struct {
 	Name      string
 	Functions []*modFunction

--- a/core/integration/module_functions_test.go
+++ b/core/integration/module_functions_test.go
@@ -1,0 +1,147 @@
+package core
+
+import (
+	"strings"
+	"testing"
+
+	"dagger.io/dagger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModuleDaggerCLIFunctions(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := connect(t)
+
+	ctr := c.Container().From(golangImage).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithWorkdir("/work").
+		With(daggerExec("mod", "init", "--name=test", "--sdk=go")).
+		WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
+			Contents: `package main
+
+import (
+	"context"
+)
+
+type Test struct{}
+
+// doc for FnA
+func (m *Test) FnA() *Container {
+	return nil
+}
+
+// doc for FnB
+func (m *Test) FnB() Duck {
+	return nil
+}
+
+type Duck interface {
+	DaggerObject
+	// quack that thang
+	Quack(ctx context.Context) (string, error)
+}
+
+// doc for FnC
+func (m *Test) FnC() *Obj {
+	return nil
+}
+
+type Obj struct {
+	// doc for FieldA
+	FieldA *Container
+	// doc for FieldB
+	FieldB string
+	// doc for FieldC
+	FieldC *Obj
+	// doc for FieldD
+	FieldD *OtherObj
+}
+
+// doc for FnD
+func (m *Obj) FnD() *Container {
+	return nil
+}
+
+type OtherObj struct {
+	// doc for OtherFieldA
+	OtherFieldA *Container
+	// doc for OtherFieldB
+	OtherFieldB string
+	// doc for OtherFieldC
+	OtherFieldC *Obj
+	// doc for OtherFieldD
+	OtherFieldD *OtherObj
+}
+
+// doc for FnE
+func (m *OtherObj) FnE() *Container {
+	return nil
+}
+`,
+		})
+
+	t.Run("top-level", func(t *testing.T) {
+		t.Parallel()
+		out, err := ctr.With(daggerFunctions()).Stdout(ctx)
+		require.NoError(t, err)
+		lines := strings.Split(out, "\n")
+		require.Contains(t, lines, "fn-a   doc for FnA")
+		require.Contains(t, lines, "fn-b   doc for FnB")
+		require.Contains(t, lines, "fn-c   doc for FnC")
+	})
+
+	t.Run("return core object", func(t *testing.T) {
+		t.Parallel()
+		out, err := ctr.With(daggerFunctions("fn-a")).Stdout(ctx)
+		require.NoError(t, err)
+		lines := strings.Split(out, "\n")
+		// just verify some of the container funcs are there, too many to be exhaustive
+		require.Contains(t, lines, "file                          Retrieves a file at the given path.")
+		require.Contains(t, lines, "as-tarball                    Returns a File representing the container serialized to a tarball.")
+	})
+
+	t.Run("alt casing", func(t *testing.T) {
+		t.Parallel()
+		out, err := ctr.With(daggerFunctions("fnA")).Stdout(ctx)
+		require.NoError(t, err)
+		lines := strings.Split(out, "\n")
+		// just verify some of the container funcs are there, too many to be exhaustive
+		require.Contains(t, lines, "file                          Retrieves a file at the given path.")
+		require.Contains(t, lines, "as-tarball                    Returns a File representing the container serialized to a tarball.")
+	})
+
+	t.Run("return user interface", func(t *testing.T) {
+		t.Parallel()
+		out, err := ctr.With(daggerFunctions("fn-b")).Stdout(ctx)
+		require.NoError(t, err)
+		lines := strings.Split(out, "\n")
+		require.Contains(t, lines, "quack   quack that thang")
+	})
+
+	t.Run("return user object", func(t *testing.T) {
+		t.Parallel()
+		out, err := ctr.With(daggerFunctions("fn-c")).Stdout(ctx)
+		require.NoError(t, err)
+		lines := strings.Split(out, "\n")
+		// just verify some of the container funcs are there, too many to be exhaustive
+		require.Contains(t, lines, "field-a   doc for FieldA")
+		require.Contains(t, lines, "field-b   doc for FieldB")
+		require.Contains(t, lines, "field-c   doc for FieldC")
+		require.Contains(t, lines, "field-d   doc for FieldD")
+		require.Contains(t, lines, "fn-d      doc for FnD")
+	})
+
+	t.Run("return user object nested", func(t *testing.T) {
+		t.Parallel()
+		out, err := ctr.With(daggerFunctions("fn-c", "field-d")).Stdout(ctx)
+		require.NoError(t, err)
+		lines := strings.Split(out, "\n")
+		// just verify some of the container funcs are there, too many to be exhaustive
+		require.Contains(t, lines, "other-field-a   doc for OtherFieldA")
+		require.Contains(t, lines, "other-field-b   doc for OtherFieldB")
+		require.Contains(t, lines, "other-field-c   doc for OtherFieldC")
+		require.Contains(t, lines, "other-field-d   doc for OtherFieldD")
+		require.Contains(t, lines, "fn-e            doc for FnE")
+	})
+}


### PR DESCRIPTION
## Before

`dagger functions` dumps all functions available in all types for a given module, regardless of arguments. So I can't see what functions are available at a given stage of the pipeline.

Example:

```console
$ dagger -s -m github.com/shykes/daggerverse/wolfi functions
object name                                                         function name   description                                    return type
*Wolfi                                                              base            Initialize a Wolfi base configuration          WolfiConfig!
WolfiConfig                                                         packages                                                       [String!]!
WolfiConfig                                                         overlays                                                       [Container!]!
WolfiConfig                                                         withPackage     At a package to this configuration             WolfiConfig!
WolfiConfig                                                         withPackages    Add a list of packages to this configuration   WolfiConfig!
WolfiConfig                                                         withOverlay     Add an overlay to the current configuration.
See https://twitter.com/ibuildthecloud/status/1721306361999597884   WolfiConfig!
WolfiConfig                                                         container   The container for this configuration   Container!
```

```console
$ dagger -s -m github.com/shykes/daggerverse/wolfi functions base
object name                                                         function name   description                                    return type
*Wolfi                                                              base            Initialize a Wolfi base configuration          WolfiConfig!
WolfiConfig                                                         packages                                                       [String!]!
WolfiConfig                                                         overlays                                                       [Container!]!
WolfiConfig                                                         withPackage     At a package to this configuration             WolfiConfig!
WolfiConfig                                                         withPackages    Add a list of packages to this configuration   WolfiConfig!
WolfiConfig                                                         withOverlay     Add an overlay to the current configuration.
See https://twitter.com/ibuildthecloud/status/1721306361999597884   WolfiConfig!
WolfiConfig                                                         container   The container for this configuration   Container!
```

## After

`dagger functions [PIPELINE]` shows only available functions at the given stage of a pipeline of functions. I can use the arguments to see what functions are available at a given stage of the pipeline.

For example:

```console
$ dagger functions -s -m github.com/shykes/daggerverse/wolfi
Name   Description
base   Initialize a Wolfi base configuration
```

```console
$ dagger functions -s -m github.com/shykes/daggerverse/wolfi base
Name           Description
container      The container for this configuration
overlays       -
packages       -
withOverlay    Add an overlay to the current configuration.
withPackage    At a package to this configuration
withPackages   Add a list of packages to this configuration
```
