### PR TITLE
feat: add Java API schema for dagger 0.9.4 and 0.9.5

### DIFF
--- a/sdk/java/dagger-codegen-maven-plugin/src/main/resources/schemas/schema-0.9.4.json
+++ b/sdk/java/dagger-codegen-maven-plugin/src/main/resources/schemas/schema-0.9.4.json
@@ -1,0 +1,7937 @@
+{
+    "__schema": {
+        "directives": [
+            {
+                "args": [
+                    {
+                        "defaultValue": "\"No longer supported\"",
+                        "description": "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formattedin [Markdown](https://daringfireball.net/projects/markdown/).",
+                        "name": "reason",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    }
+                ],
+                "description": "Marks an element of a GraphQL schema as no longer supported.",
+                "locations": [
+                    "FIELD_DEFINITION",
+                    "ENUM_VALUE"
+                ],
+                "name": "deprecated"
+            },
+            {
+                "args": [],
+                "description": "Hide a field, useful when generating types from the AST where the backend type has more fields than the graphql type",
+                "locations": [
+                    "FIELD_DEFINITION"
+                ],
+                "name": "hide"
+            },
+            {
+                "args": [
+                    {
+                        "defaultValue": null,
+                        "description": "Included when true.",
+                        "name": "if",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
+                "locations": [
+                    "FIELD",
+                    "FRAGMENT_SPREAD",
+                    "INLINE_FRAGMENT"
+                ],
+                "name": "include"
+            },
+            {
+                "args": [
+                    {
+                        "defaultValue": null,
+                        "description": "Skipped when true.",
+                        "name": "if",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
+                "locations": [
+                    "FIELD",
+                    "FRAGMENT_SPREAD",
+                    "INLINE_FRAGMENT"
+                ],
+                "name": "skip"
+            }
+        ],
+        "mutationType": null,
+        "queryType": {
+            "name": "Query"
+        },
+        "subscriptionType": null,
+        "types": [
+            {
+                "description": "The `Boolean` scalar type represents `true` or `false`.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "possibleTypes": null
+            },
+            {
+                "description": "Key value object that represents a build argument.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": [
+                    {
+                        "defaultValue": null,
+                        "description": "The build argument name.",
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "defaultValue": null,
+                        "description": "The build argument value.",
+                        "name": "value",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "interfaces": null,
+                "kind": "INPUT_OBJECT",
+                "name": "BuildArg",
+                "possibleTypes": null
+            },
+            {
+                "description": "Sharing mode of the cache volume.",
+                "enumValues": [
+                    {
+                        "deprecationReason": null,
+                        "description": "Shares the cache volume amongst many build pipelines,\nbut will serialize the writes",
+                        "isDeprecated": false,
+                        "name": "LOCKED"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Keeps a cache volume for a single build pipeline",
+                        "isDeprecated": false,
+                        "name": "PRIVATE"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Shares the cache volume amongst many build pipelines",
+                        "isDeprecated": false,
+                        "name": "SHARED"
+                    }
+                ],
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "ENUM",
+                "name": "CacheSharingMode",
+                "possibleTypes": null
+            },
+            {
+                "description": "A directory whose contents persist across runs.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "CacheVolumeID",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "CacheVolume",
+                "possibleTypes": null
+            },
+            {
+                "description": "A global cache volume identifier.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "CacheVolumeID",
+                "possibleTypes": null
+            },
+            {
+                "description": "An OCI-compatible container, also known as a docker container.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Turn the container into a Service.\n\nBe sure to set any exposed ports before this conversion.",
+                        "isDeprecated": false,
+                        "name": "asService",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Service",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Identifiers for other platform specific containers.\nUsed for multi-platform image.",
+                                "name": "platformVariants",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "ContainerID",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Force each layer of the image to use the specified compression algorithm.\nIf this is unset, then if a layer already has a compressed blob in the engine's\ncache, that will be used (this can result in a mix of compression algorithms for\ndifferent layers). If this is unset and a layer has no compressed blob in the\nengine's cache, then it will be compressed using Gzip.",
+                                "name": "forcedCompression",
+                                "type": {
+                                    "kind": "ENUM",
+                                    "name": "ImageLayerCompression",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": "\"OCIMediaTypes\"",
+                                "description": "Use the specified media types for the image's layers. Defaults to OCI, which\nis largely compatible with most recent container runtimes, but Docker may be needed\nfor older runtimes without OCI support.",
+                                "name": "mediaTypes",
+                                "type": {
+                                    "kind": "ENUM",
+                                    "name": "ImageMediaTypes",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Returns a File representing the container serialized to a tarball.",
+                        "isDeprecated": false,
+                        "name": "asTarball",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "File",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Directory context used by the Dockerfile.",
+                                "name": "context",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "DirectoryID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Path to the Dockerfile to use.\n\nDefault: './Dockerfile'.",
+                                "name": "dockerfile",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Additional build arguments.",
+                                "name": "buildArgs",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "BuildArg",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Target build stage to build.",
+                                "name": "target",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Secrets to pass to the build.\n\nThey will be mounted at /run/secrets/[secret-name] in the build container\n\nThey can be accessed in the Dockerfile using the \"secret\" mount type\nand mount path /run/secrets/[secret-name]\ne.g. RUN --mount=type=secret,id=my-secret curl url?token=$(cat /run/secrets/my-secret)\"",
+                                "name": "secrets",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "SecretID",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Initializes this container from a Dockerfile build.",
+                        "isDeprecated": false,
+                        "name": "build",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves default arguments for future commands.",
+                        "isDeprecated": false,
+                        "name": "defaultArgs",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The path of the directory to retrieve (e.g., \"./src\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves a directory at the given path.\n\nMounts are included.",
+                        "isDeprecated": false,
+                        "name": "directory",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves entrypoint to be prepended to the arguments of all commands.",
+                        "isDeprecated": false,
+                        "name": "entrypoint",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The name of the environment variable to retrieve (e.g., \"PATH\").",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves the value of the specified environment variable.",
+                        "isDeprecated": false,
+                        "name": "envVariable",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves the list of environment variables passed to commands.",
+                        "isDeprecated": false,
+                        "name": "envVariables",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "EnvVariable",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "EXPERIMENTAL API! Subject to change/removal at any time.\n\nexperimentalWithAllGPUs configures all available GPUs on the host to be accessible to this container.\nThis currently works for Nvidia devices only.",
+                        "isDeprecated": false,
+                        "name": "experimentalWithAllGPUs",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "devices",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "LIST",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "NON_NULL",
+                                            "name": null,
+                                            "ofType": {
+                                                "kind": "SCALAR",
+                                                "name": "String",
+                                                "ofType": null
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "EXPERIMENTAL API! Subject to change/removal at any time.\n\nexperimentalWithGPU configures the provided list of devices to be accesible to this container.\nThis currently works for Nvidia devices only.",
+                        "isDeprecated": false,
+                        "name": "experimentalWithGPU",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Host's destination path (e.g., \"./tarball\").\nPath can be relative to the engine's workdir or absolute.",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifiers for other platform specific containers.\nUsed for multi-platform image.",
+                                "name": "platformVariants",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "ContainerID",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Force each layer of the exported image to use the specified compression algorithm.\nIf this is unset, then if a layer already has a compressed blob in the engine's\ncache, that will be used (this can result in a mix of compression algorithms for\ndifferent layers). If this is unset and a layer has no compressed blob in the\nengine's cache, then it will be compressed using Gzip.",
+                                "name": "forcedCompression",
+                                "type": {
+                                    "kind": "ENUM",
+                                    "name": "ImageLayerCompression",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": "\"OCIMediaTypes\"",
+                                "description": "Use the specified media types for the exported image's layers. Defaults to OCI, which\nis largely compatible with most recent container runtimes, but Docker may be needed\nfor older runtimes without OCI support.",
+                                "name": "mediaTypes",
+                                "type": {
+                                    "kind": "ENUM",
+                                    "name": "ImageMediaTypes",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Writes the container as an OCI tarball to the destination file path on the host for the specified platform variants.\n\nReturn true on success.\nIt can also publishes platform variants.",
+                        "isDeprecated": false,
+                        "name": "export",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves the list of exposed ports.\n\nThis includes ports already exposed by the image, even if not\nexplicitly added with dagger.",
+                        "isDeprecated": false,
+                        "name": "exposedPorts",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "Port",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The path of the file to retrieve (e.g., \"./README.md\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves a file at the given path.\n\nMounts are included.",
+                        "isDeprecated": false,
+                        "name": "file",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "File",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Image's address from its registry.\n\nFormatted as [host]/[user]/[repo]:[tag] (e.g., \"docker.io/dagger/dagger:main\").",
+                                "name": "address",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Initializes this container from a pulled base image.",
+                        "isDeprecated": false,
+                        "name": "from",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "A unique identifier for this container.",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "ContainerID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The unique image reference which can only be retrieved immediately after the 'Container.From' call.",
+                        "isDeprecated": false,
+                        "name": "imageRef",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "File to read the container from.",
+                                "name": "source",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "FileID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifies the tag to import from the archive, if the archive bundles\nmultiple tags.",
+                                "name": "tag",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Reads the container from an OCI tarball.\n\nNOTE: this involves unpacking the tarball to an OCI store on the host at\n$XDG_CACHE_DIR/dagger/oci. This directory can be removed whenever you like.",
+                        "isDeprecated": false,
+                        "name": "import",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves the value of the specified label.",
+                        "isDeprecated": false,
+                        "name": "label",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves the list of labels passed to container.",
+                        "isDeprecated": false,
+                        "name": "labels",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "Label",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves the list of paths where a directory is mounted.",
+                        "isDeprecated": false,
+                        "name": "mounts",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Pipeline name.",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Pipeline description.",
+                                "name": "description",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Pipeline labels.",
+                                "name": "labels",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "PipelineLabel",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Creates a named sub-pipeline",
+                        "isDeprecated": false,
+                        "name": "pipeline",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The platform this container executes and publishes as.",
+                        "isDeprecated": false,
+                        "name": "platform",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Platform",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Registry's address to publish the image to.\n\nFormatted as [host]/[user]/[repo]:[tag] (e.g. \"docker.io/dagger/dagger:main\").",
+                                "name": "address",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifiers for other platform specific containers.\nUsed for multi-platform image.",
+                                "name": "platformVariants",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "ContainerID",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Force each layer of the published image to use the specified compression algorithm.\nIf this is unset, then if a layer already has a compressed blob in the engine's\ncache, that will be used (this can result in a mix of compression algorithms for\ndifferent layers). If this is unset and a layer has no compressed blob in the\nengine's cache, then it will be compressed using Gzip.",
+                                "name": "forcedCompression",
+                                "type": {
+                                    "kind": "ENUM",
+                                    "name": "ImageLayerCompression",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": "\"OCIMediaTypes\"",
+                                "description": "Use the specified media types for the published image's layers. Defaults to OCI, which\nis largely compatible with most recent registries, but Docker may be needed for older\nregistries without OCI support.",
+                                "name": "mediaTypes",
+                                "type": {
+                                    "kind": "ENUM",
+                                    "name": "ImageMediaTypes",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Publishes this container as a new image to the specified address.\n\nPublish returns a fully qualified ref.\nIt can also publish platform variants.",
+                        "isDeprecated": false,
+                        "name": "publish",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container's root filesystem. Mounts are not included.",
+                        "isDeprecated": false,
+                        "name": "rootfs",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Return a websocket endpoint that, if connected to, will start the container with a TTY streamed\nover the websocket.\n\nPrimarily intended for internal use with the dagger CLI.",
+                        "isDeprecated": false,
+                        "name": "shellEndpoint",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The error stream of the last executed command.\n\nWill execute default command if none is set, or error if there's no default.",
+                        "isDeprecated": false,
+                        "name": "stderr",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The output stream of the last executed command.\n\nWill execute default command if none is set, or error if there's no default.",
+                        "isDeprecated": false,
+                        "name": "stdout",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Forces evaluation of the pipeline in the engine.\n\nIt doesn't run the default command if no exec has been set.",
+                        "isDeprecated": false,
+                        "name": "sync",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "ContainerID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves the user to be set for all commands.",
+                        "isDeprecated": false,
+                        "name": "user",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Arguments to prepend to future executions (e.g., [\"-v\", \"--no-cache\"]).",
+                                "name": "args",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "String",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Configures default arguments for future commands.",
+                        "isDeprecated": false,
+                        "name": "withDefaultArgs",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the written directory (e.g., \"/tmp/directory\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the directory to write",
+                                "name": "directory",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "DirectoryID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Patterns to exclude in the written directory (e.g., [\"node_modules/**\", \".gitignore\", \".git/\"]).",
+                                "name": "exclude",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "String",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Patterns to include in the written directory (e.g., [\"*.go\", \"go.mod\", \"go.sum\"]).",
+                                "name": "include",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "String",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A user:group to set for the directory and its contents.\n\nThe user and group can either be an ID (1000:1000) or a name (foo:bar).\n\nIf the group is omitted, it defaults to the same as the user.",
+                                "name": "owner",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container plus a directory written at the given path.",
+                        "isDeprecated": false,
+                        "name": "withDirectory",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Entrypoint to use for future executions (e.g., [\"go\", \"run\"]).",
+                                "name": "args",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "LIST",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "NON_NULL",
+                                            "name": null,
+                                            "ofType": {
+                                                "kind": "SCALAR",
+                                                "name": "String",
+                                                "ofType": null
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container but with a different command entrypoint.",
+                        "isDeprecated": false,
+                        "name": "withEntrypoint",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The name of the environment variable (e.g., \"HOST\").",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "The value of the environment variable. (e.g., \"localhost\").",
+                                "name": "value",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Replace ${VAR} or $VAR in the value according to the current environment\nvariables defined in the container (e.g., \"/opt/bin:$PATH\").",
+                                "name": "expand",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container plus the given environment variable.",
+                        "isDeprecated": false,
+                        "name": "withEnvVariable",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Command to run instead of the container's default command (e.g., [\"run\", \"main.go\"]).\n\nIf empty, the container's default command is used.",
+                                "name": "args",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "LIST",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "NON_NULL",
+                                            "name": null,
+                                            "ofType": {
+                                                "kind": "SCALAR",
+                                                "name": "String",
+                                                "ofType": null
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "If the container has an entrypoint, ignore it for args rather than using it to wrap them.",
+                                "name": "skipEntrypoint",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Content to write to the command's standard input before closing (e.g., \"Hello world\").",
+                                "name": "stdin",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Redirect the command's standard output to a file in the container (e.g., \"/tmp/stdout\").",
+                                "name": "redirectStdout",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Redirect the command's standard error to a file in the container (e.g., \"/tmp/stderr\").",
+                                "name": "redirectStderr",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Provides dagger access to the executed command.\n\nDo not use this option unless you trust the command being executed.\nThe command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.",
+                                "name": "experimentalPrivilegedNesting",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Execute the command with all root capabilities. This is similar to running a command\nwith \"sudo\" or executing `docker run` with the `--privileged` flag. Containerization\ndoes not provide any security guarantees when using this option. It should only be used\nwhen absolutely necessary and only with trusted commands.",
+                                "name": "insecureRootCapabilities",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container after executing the specified command inside it.",
+                        "isDeprecated": false,
+                        "name": "withExec",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Port number to expose",
+                                "name": "port",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "Int",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": "\"TCP\"",
+                                "description": "Transport layer network protocol",
+                                "name": "protocol",
+                                "type": {
+                                    "kind": "ENUM",
+                                    "name": "NetworkProtocol",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Optional port description",
+                                "name": "description",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Expose a network port.\n\nExposed ports serve two purposes:\n  - For health checks and introspection, when running services\n  - For setting the EXPOSE OCI field when publishing the container",
+                        "isDeprecated": false,
+                        "name": "withExposedPort",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the copied file (e.g., \"/tmp/file.txt\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the file to copy.",
+                                "name": "source",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "FileID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Permission given to the copied file (e.g., 0600).\n\nDefault: 0644.",
+                                "name": "permissions",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Int",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A user:group to set for the file.\n\nThe user and group can either be an ID (1000:1000) or a name (foo:bar).\n\nIf the group is omitted, it defaults to the same as the user.",
+                                "name": "owner",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container plus the contents of the given file copied to the given path.",
+                        "isDeprecated": false,
+                        "name": "withFile",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Indicate that subsequent operations should be featured more prominently in\nthe UI.",
+                        "isDeprecated": false,
+                        "name": "withFocus",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The name of the label (e.g., \"org.opencontainers.artifact.created\").",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "The value of the label (e.g., \"2023-01-01T00:00:00Z\").",
+                                "name": "value",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container plus the given label.",
+                        "isDeprecated": false,
+                        "name": "withLabel",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the cache directory (e.g., \"/cache/node_modules\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the cache volume to mount.",
+                                "name": "cache",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "CacheVolumeID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the directory to use as the cache volume's root.",
+                                "name": "source",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "DirectoryID",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Sharing mode of the cache volume.",
+                                "name": "sharing",
+                                "type": {
+                                    "kind": "ENUM",
+                                    "name": "CacheSharingMode",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A user:group to set for the mounted cache directory.\n\nNote that this changes the ownership of the specified mount along with the\ninitial filesystem provided by source (if any). It does not have any effect\nif/when the cache has already been created.\n\nThe user and group can either be an ID (1000:1000) or a name (foo:bar).\n\nIf the group is omitted, it defaults to the same as the user.",
+                                "name": "owner",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container plus a cache volume mounted at the given path.",
+                        "isDeprecated": false,
+                        "name": "withMountedCache",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the mounted directory (e.g., \"/mnt/directory\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the mounted directory.",
+                                "name": "source",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "DirectoryID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A user:group to set for the mounted directory and its contents.\n\nThe user and group can either be an ID (1000:1000) or a name (foo:bar).\n\nIf the group is omitted, it defaults to the same as the user.",
+                                "name": "owner",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container plus a directory mounted at the given path.",
+                        "isDeprecated": false,
+                        "name": "withMountedDirectory",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the mounted file (e.g., \"/tmp/file.txt\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the mounted file.",
+                                "name": "source",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "FileID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A user or user:group to set for the mounted file.\n\nThe user and group can either be an ID (1000:1000) or a name (foo:bar).\n\nIf the group is omitted, it defaults to the same as the user.",
+                                "name": "owner",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container plus a file mounted at the given path.",
+                        "isDeprecated": false,
+                        "name": "withMountedFile",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the secret file (e.g., \"/tmp/secret.txt\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the secret to mount.",
+                                "name": "source",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "SecretID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A user:group to set for the mounted secret.\n\nThe user and group can either be an ID (1000:1000) or a name (foo:bar).\n\nIf the group is omitted, it defaults to the same as the user.",
+                                "name": "owner",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Permission given to the mounted secret (e.g., 0600).\nThis option requires an owner to be set to be active.\n\nDefault: 0400.",
+                                "name": "mode",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Int",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container plus a secret mounted into a file at the given path.",
+                        "isDeprecated": false,
+                        "name": "withMountedSecret",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the temporary directory (e.g., \"/tmp/temp_dir\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container plus a temporary directory mounted at the given path.",
+                        "isDeprecated": false,
+                        "name": "withMountedTemp",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the written file (e.g., \"/tmp/file.txt\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Content of the file to write (e.g., \"Hello world!\").",
+                                "name": "contents",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Permission given to the written file (e.g., 0600).\n\nDefault: 0644.",
+                                "name": "permissions",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Int",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A user:group to set for the file.\n\nThe user and group can either be an ID (1000:1000) or a name (foo:bar).\n\nIf the group is omitted, it defaults to the same as the user.",
+                                "name": "owner",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container plus a new file written at the given path.",
+                        "isDeprecated": false,
+                        "name": "withNewFile",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Registry's address to bind the authentication to.\nFormatted as [host]/[user]/[repo]:[tag] (e.g. docker.io/dagger/dagger:main).",
+                                "name": "address",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "The username of the registry's account (e.g., \"Dagger\").",
+                                "name": "username",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "The API key, password or token to authenticate to this registry.",
+                                "name": "secret",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "SecretID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container with a registry authentication for a given address.",
+                        "isDeprecated": false,
+                        "name": "withRegistryAuth",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "directory",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "DirectoryID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Initializes this container from this DirectoryID.",
+                        "isDeprecated": false,
+                        "name": "withRootfs",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The name of the secret variable (e.g., \"API_SECRET\").",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "The identifier of the secret value.",
+                                "name": "secret",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "SecretID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container plus an env variable containing the given secret.",
+                        "isDeprecated": false,
+                        "name": "withSecretVariable",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "A name that can be used to reach the service from the container",
+                                "name": "alias",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the service container",
+                                "name": "service",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "ServiceID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Establish a runtime dependency on a service.\n\nThe service will be started automatically when needed and detached when it is\nno longer needed, executing the default command if none is set.\n\nThe service will be reachable from the container via the provided hostname alias.\n\nThe service dependency will also convey to any files or directories produced by the container.",
+                        "isDeprecated": false,
+                        "name": "withServiceBinding",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the forwarded Unix socket (e.g., \"/tmp/socket\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the socket to forward.",
+                                "name": "source",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "SocketID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A user:group to set for the mounted socket.\n\nThe user and group can either be an ID (1000:1000) or a name (foo:bar).\n\nIf the group is omitted, it defaults to the same as the user.",
+                                "name": "owner",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container plus a socket forwarded to the given Unix socket path.",
+                        "isDeprecated": false,
+                        "name": "withUnixSocket",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The user to set (e.g., \"root\").",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container with a different command user.",
+                        "isDeprecated": false,
+                        "name": "withUser",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The path to set as the working directory (e.g., \"/app\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container with a different working directory.",
+                        "isDeprecated": false,
+                        "name": "withWorkdir",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The name of the environment variable (e.g., \"HOST\").",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container minus the given environment variable.",
+                        "isDeprecated": false,
+                        "name": "withoutEnvVariable",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Port number to unexpose",
+                                "name": "port",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "Int",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": "\"TCP\"",
+                                "description": "Port protocol to unexpose",
+                                "name": "protocol",
+                                "type": {
+                                    "kind": "ENUM",
+                                    "name": "NetworkProtocol",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Unexpose a previously exposed port.",
+                        "isDeprecated": false,
+                        "name": "withoutExposedPort",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Indicate that subsequent operations should not be featured more prominently\nin the UI.\n\nThis is the initial state of all containers.",
+                        "isDeprecated": false,
+                        "name": "withoutFocus",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The name of the label to remove (e.g., \"org.opencontainers.artifact.created\").",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container minus the given environment label.",
+                        "isDeprecated": false,
+                        "name": "withoutLabel",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the cache directory (e.g., \"/cache/node_modules\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container after unmounting everything at the given path.",
+                        "isDeprecated": false,
+                        "name": "withoutMount",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Registry's address to remove the authentication from.\nFormatted as [host]/[user]/[repo]:[tag] (e.g. docker.io/dagger/dagger:main).",
+                                "name": "address",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container without the registry authentication of a given address.",
+                        "isDeprecated": false,
+                        "name": "withoutRegistryAuth",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the socket to remove (e.g., \"/tmp/socket\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container with a previously added Unix socket removed.",
+                        "isDeprecated": false,
+                        "name": "withoutUnixSocket",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves the working directory for all commands.",
+                        "isDeprecated": false,
+                        "name": "workdir",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "Container",
+                "possibleTypes": null
+            },
+            {
+                "description": "A unique container identifier. Null designates an empty container (scratch).",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "ContainerID",
+                "possibleTypes": null
+            },
+            {
+                "description": "The `DateTime` scalar type represents a DateTime. The DateTime is serialized as an RFC 3339 quoted string",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "possibleTypes": null
+            },
+            {
+                "description": "A directory.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "An optional subpath of the directory which contains the module's source\ncode.\n\nThis is needed when the module code is in a subdirectory but requires\nparent directories to be loaded in order to execute. For example, the\nmodule source code may need a go.mod, project.toml, package.json, etc. file\nfrom a parent directory.\n\nIf not set, the module source code is loaded from the root of the\ndirectory.",
+                                "name": "sourceSubpath",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load the directory as a Dagger module",
+                        "isDeprecated": false,
+                        "name": "asModule",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Module",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the directory to compare.",
+                                "name": "other",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "DirectoryID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Gets the difference between this directory and an another directory.",
+                        "isDeprecated": false,
+                        "name": "diff",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the directory to retrieve (e.g., \"/src\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves a directory at the given path.",
+                        "isDeprecated": false,
+                        "name": "directory",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Path to the Dockerfile to use (e.g., \"frontend.Dockerfile\").\n\nDefaults: './Dockerfile'.",
+                                "name": "dockerfile",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "The platform to build.",
+                                "name": "platform",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Platform",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Build arguments to use in the build.",
+                                "name": "buildArgs",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "BuildArg",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Target build stage to build.",
+                                "name": "target",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Secrets to pass to the build.\n\nThey will be mounted at /run/secrets/[secret-name].",
+                                "name": "secrets",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "SecretID",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Builds a new Docker container from this directory.",
+                        "isDeprecated": false,
+                        "name": "dockerBuild",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the directory to look at (e.g., \"/src\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Returns a list of files and directories at the given path.",
+                        "isDeprecated": false,
+                        "name": "entries",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the copied directory (e.g., \"logs/\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Writes the contents of the directory to a path on the host.",
+                        "isDeprecated": false,
+                        "name": "export",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the file to retrieve (e.g., \"README.md\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves a file at the given path.",
+                        "isDeprecated": false,
+                        "name": "file",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "File",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Pattern to match (e.g., \"*.md\").",
+                                "name": "pattern",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Returns a list of files and directories that matche the given pattern.",
+                        "isDeprecated": false,
+                        "name": "glob",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The content-addressed identifier of the directory.",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "DirectoryID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Pipeline name.",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Pipeline description.",
+                                "name": "description",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Pipeline labels.",
+                                "name": "labels",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "PipelineLabel",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Creates a named sub-pipeline",
+                        "isDeprecated": false,
+                        "name": "pipeline",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Force evaluation in the engine.",
+                        "isDeprecated": false,
+                        "name": "sync",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "DirectoryID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the written directory (e.g., \"/src/\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the directory to copy.",
+                                "name": "directory",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "DirectoryID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Exclude artifacts that match the given pattern (e.g., [\"node_modules/\", \".git*\"]).",
+                                "name": "exclude",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "String",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Include only artifacts that match the given pattern (e.g., [\"app/\", \"package.*\"]).",
+                                "name": "include",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "String",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this directory plus a directory written at the given path.",
+                        "isDeprecated": false,
+                        "name": "withDirectory",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the copied file (e.g., \"/file.txt\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the file to copy.",
+                                "name": "source",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "FileID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Permission given to the copied file (e.g., 0600).\n\nDefault: 0644.",
+                                "name": "permissions",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Int",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this directory plus the contents of the given file copied to the given path.",
+                        "isDeprecated": false,
+                        "name": "withFile",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the directory created (e.g., \"/logs\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Permission granted to the created directory (e.g., 0777).\n\nDefault: 0755.",
+                                "name": "permissions",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Int",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this directory plus a new directory created at the given path.",
+                        "isDeprecated": false,
+                        "name": "withNewDirectory",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the written file (e.g., \"/file.txt\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Content of the written file (e.g., \"Hello world!\").",
+                                "name": "contents",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Permission given to the copied file (e.g., 0600).\n\nDefault: 0644.",
+                                "name": "permissions",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Int",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this directory plus a new file written at the given path.",
+                        "isDeprecated": false,
+                        "name": "withNewFile",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Timestamp to set dir/files in.\n\nFormatted in seconds following Unix epoch (e.g., 1672531199).",
+                                "name": "timestamp",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "Int",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this directory with all file/dir timestamps set to the given time.",
+                        "isDeprecated": false,
+                        "name": "withTimestamps",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the directory to remove (e.g., \".github/\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this directory with the directory at the given path removed.",
+                        "isDeprecated": false,
+                        "name": "withoutDirectory",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the file to remove (e.g., \"/file.txt\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this directory with the file at the given path removed.",
+                        "isDeprecated": false,
+                        "name": "withoutFile",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "Directory",
+                "possibleTypes": null
+            },
+            {
+                "description": "A content-addressed directory identifier.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "DirectoryID",
+                "possibleTypes": null
+            },
+            {
+                "description": "A simple key value object that represents an environment variable.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The environment variable name.",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The environment variable value.",
+                        "isDeprecated": false,
+                        "name": "value",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "EnvVariable",
+                "possibleTypes": null
+            },
+            {
+                "description": "A definition of a field on a custom object defined in a Module.\nA field on an object has a static value, as opposed to a function on an\nobject whose value is computed by invoking code (and can accept arguments).",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "A doc string for the field, if any",
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The name of the field in the object",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The type of the field",
+                        "isDeprecated": false,
+                        "name": "typeDef",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "FieldTypeDef",
+                "possibleTypes": null
+            },
+            {
+                "description": "A file.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves the contents of the file.",
+                        "isDeprecated": false,
+                        "name": "contents",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the written directory (e.g., \"output.txt\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "If allowParentDirPath is true, the path argument can be a directory path, in which case\nthe file will be created in that directory.",
+                                "name": "allowParentDirPath",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Writes the file to a file path on the host.",
+                        "isDeprecated": false,
+                        "name": "export",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves the content-addressed identifier of the file.",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "FileID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Gets the size of the file, in bytes.",
+                        "isDeprecated": false,
+                        "name": "size",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Force evaluation in the engine.",
+                        "isDeprecated": false,
+                        "name": "sync",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "FileID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Timestamp to set dir/files in.\n\nFormatted in seconds following Unix epoch (e.g., 1672531199).",
+                                "name": "timestamp",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "Int",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this file with its created/modified timestamps set to the given time.",
+                        "isDeprecated": false,
+                        "name": "withTimestamps",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "File",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "File",
+                "possibleTypes": null
+            },
+            {
+                "description": "A file identifier.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "FileID",
+                "possibleTypes": null
+            },
+            {
+                "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point). ",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "Float",
+                "possibleTypes": null
+            },
+            {
+                "description": "Function represents a resolver provided by a Module.\n\nA function always evaluates against a parent object and is given a set of\nnamed arguments.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Arguments accepted by this function, if any",
+                        "isDeprecated": false,
+                        "name": "args",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "FunctionArg",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "A doc string for the function, if any",
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The ID of the function",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "FunctionID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The name of the function",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The type returned by this function",
+                        "isDeprecated": false,
+                        "name": "returnType",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The name of the argument",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "The type of the argument",
+                                "name": "typeDef",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "TypeDefID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A doc string for the argument, if any",
+                                "name": "description",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A default value to use for this argument if not explicitly set by the caller, if any",
+                                "name": "defaultValue",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "JSON",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Returns the function with the provided argument",
+                        "isDeprecated": false,
+                        "name": "withArg",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Function",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "description",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Returns the function with the doc string",
+                        "isDeprecated": false,
+                        "name": "withDescription",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Function",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "Function",
+                "possibleTypes": null
+            },
+            {
+                "description": "An argument accepted by a function.\n\nThis is a specification for an argument at function definition time, not an\nargument passed at function call time.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "A default value to use for this argument when not explicitly set by the caller, if any",
+                        "isDeprecated": false,
+                        "name": "defaultValue",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "JSON",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "A doc string for the argument, if any",
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The ID of the argument",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "FunctionArgID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The name of the argument",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The type of the argument",
+                        "isDeprecated": false,
+                        "name": "typeDef",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "FunctionArg",
+                "possibleTypes": null
+            },
+            {
+                "description": "A reference to a FunctionArg.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "FunctionArgID",
+                "possibleTypes": null
+            },
+            {
+                "description": "",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The argument values the function is being invoked with.",
+                        "isDeprecated": false,
+                        "name": "inputArgs",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "FunctionCallArgValue",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The name of the function being called.",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The value of the parent object of the function being called.\nIf the function is \"top-level\" to the module, this is always an empty object.",
+                        "isDeprecated": false,
+                        "name": "parent",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The name of the parent object of the function being called.\nIf the function is \"top-level\" to the module, this is the name of the module.",
+                        "isDeprecated": false,
+                        "name": "parentName",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "value",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "JSON",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Set the return value of the function call to the provided value.\nThe value should be a string of the JSON serialization of the return value.",
+                        "isDeprecated": false,
+                        "name": "returnValue",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "Void",
+                            "ofType": null
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "FunctionCall",
+                "possibleTypes": null
+            },
+            {
+                "description": "",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The name of the argument.",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The value of the argument represented as a string of the JSON serialization.",
+                        "isDeprecated": false,
+                        "name": "value",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "FunctionCallArgValue",
+                "possibleTypes": null
+            },
+            {
+                "description": "A reference to a Function.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "FunctionID",
+                "possibleTypes": null
+            },
+            {
+                "description": "",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The directory containing the generated code",
+                        "isDeprecated": false,
+                        "name": "code",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "GeneratedCodeID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "List of paths to mark generated in version control (i.e. .gitattributes)",
+                        "isDeprecated": false,
+                        "name": "vcsGeneratedPaths",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "List of paths to ignore in version control (i.e. .gitignore)",
+                        "isDeprecated": false,
+                        "name": "vcsIgnoredPaths",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "paths",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "LIST",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "NON_NULL",
+                                            "name": null,
+                                            "ofType": {
+                                                "kind": "SCALAR",
+                                                "name": "String",
+                                                "ofType": null
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Set the list of paths to mark generated in version control",
+                        "isDeprecated": false,
+                        "name": "withVCSGeneratedPaths",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "GeneratedCode",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "paths",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "LIST",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "NON_NULL",
+                                            "name": null,
+                                            "ofType": {
+                                                "kind": "SCALAR",
+                                                "name": "String",
+                                                "ofType": null
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Set the list of paths to ignore in version control",
+                        "isDeprecated": false,
+                        "name": "withVCSIgnoredPaths",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "GeneratedCode",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "GeneratedCode",
+                "possibleTypes": null
+            },
+            {
+                "description": "A reference to GeneratedCode.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "GeneratedCodeID",
+                "possibleTypes": null
+            },
+            {
+                "description": "A git ref (tag, branch or commit).",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The resolved commit id at this ref.",
+                        "isDeprecated": false,
+                        "name": "commit",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves the content-addressed identifier of the git ref.",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "GitRefID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "sshKnownHosts",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "sshAuthSocket",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "SocketID",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "The filesystem tree at this ref.",
+                        "isDeprecated": false,
+                        "name": "tree",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "GitRef",
+                "possibleTypes": null
+            },
+            {
+                "description": "A git reference identifier.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "GitRefID",
+                "possibleTypes": null
+            },
+            {
+                "description": "A git repository.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Branch's name (e.g., \"main\").",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Returns details on one branch.",
+                        "isDeprecated": false,
+                        "name": "branch",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "GitRef",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the commit (e.g., \"b6315d8f2810962c601af73f86831f6866ea798b\").",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Returns details on one commit.",
+                        "isDeprecated": false,
+                        "name": "commit",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "GitRef",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves the content-addressed identifier of the git repository.",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "GitRepositoryID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Tag's name (e.g., \"v0.3.9\").",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Returns details on one tag.",
+                        "isDeprecated": false,
+                        "name": "tag",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "GitRef",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "GitRepository",
+                "possibleTypes": null
+            },
+            {
+                "description": "A git repository identifier.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "GitRepositoryID",
+                "possibleTypes": null
+            },
+            {
+                "description": "Information about the host execution environment.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the directory to access (e.g., \".\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Exclude artifacts that match the given pattern (e.g., [\"node_modules/\", \".git*\"]).",
+                                "name": "exclude",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "String",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Include only artifacts that match the given pattern (e.g., [\"app/\", \"package.*\"]).",
+                                "name": "include",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "String",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Accesses a directory on the host.",
+                        "isDeprecated": false,
+                        "name": "directory",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the file to retrieve (e.g., \"README.md\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Accesses a file on the host.",
+                        "isDeprecated": false,
+                        "name": "file",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "File",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Ports to expose via the service, forwarding through the host network.\n\nIf a port's frontend is unspecified or 0, it defaults to the same as the\nbackend port.\n\nAn empty set of ports is not valid; an error will be returned.",
+                                "name": "ports",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "LIST",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "NON_NULL",
+                                            "name": null,
+                                            "ofType": {
+                                                "kind": "INPUT_OBJECT",
+                                                "name": "PortForward",
+                                                "ofType": null
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": "\"localhost\"",
+                                "description": "Upstream host to forward traffic to.",
+                                "name": "host",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Creates a service that forwards traffic to a specified address via the host.",
+                        "isDeprecated": false,
+                        "name": "service",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Service",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The user defined name for this secret.",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the file to set as a secret.",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Sets a secret given a user-defined name and the file path on the host, and returns the secret.\nThe file is limited to a size of 512000 bytes.",
+                        "isDeprecated": false,
+                        "name": "setSecretFile",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Secret",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Service to send traffic from the tunnel.",
+                                "name": "service",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "ServiceID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": "false",
+                                "description": "Map each service port to the same port on the host, as if the service were\nrunning natively.\n\nNote: enabling may result in port conflicts.",
+                                "name": "native",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Configure explicit port forwarding rules for the tunnel.\n\nIf a port's frontend is unspecified or 0, a random port will be chosen by\nthe host.\n\nIf no ports are given, all of the service's ports are forwarded. If native\nis true, each port maps to the same port on the host. If native is false,\neach port maps to a random port chosen by the host.\n\nIf ports are given and native is true, the ports are additive.",
+                                "name": "ports",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "PortForward",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Creates a tunnel that forwards traffic from the host to a service.",
+                        "isDeprecated": false,
+                        "name": "tunnel",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Service",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the Unix socket (e.g., \"/var/run/docker.sock\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Accesses a Unix socket on the host.",
+                        "isDeprecated": false,
+                        "name": "unixSocket",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Socket",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "Host",
+                "possibleTypes": null
+            },
+            {
+                "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "ID",
+                "possibleTypes": null
+            },
+            {
+                "description": "Compression algorithm to use for image layers.",
+                "enumValues": [
+                    {
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "EStarGZ"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "Gzip"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "Uncompressed"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "Zstd"
+                    }
+                ],
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "ENUM",
+                "name": "ImageLayerCompression",
+                "possibleTypes": null
+            },
+            {
+                "description": "Mediatypes to use in published or exported image metadata.",
+                "enumValues": [
+                    {
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "DockerMediaTypes"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "OCIMediaTypes"
+                    }
+                ],
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "ENUM",
+                "name": "ImageMediaTypes",
+                "possibleTypes": null
+            },
+            {
+                "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "Int",
+                "possibleTypes": null
+            },
+            {
+                "description": "An arbitrary JSON-encoded value.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "JSON",
+                "possibleTypes": null
+            },
+            {
+                "description": "A simple key value object that represents a label.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The label name.",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The label value.",
+                        "isDeprecated": false,
+                        "name": "value",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "Label",
+                "possibleTypes": null
+            },
+            {
+                "description": "A definition of a list type in a Module.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The type of the elements in the list",
+                        "isDeprecated": false,
+                        "name": "elementTypeDef",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "ListTypeDef",
+                "possibleTypes": null
+            },
+            {
+                "description": "",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Modules used by this module",
+                        "isDeprecated": false,
+                        "name": "dependencies",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "Module",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The dependencies as configured by the module",
+                        "isDeprecated": false,
+                        "name": "dependencyConfig",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The doc string of the module, if any",
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The code generated by the SDK's runtime",
+                        "isDeprecated": false,
+                        "name": "generatedCode",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "GeneratedCode",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The ID of the module",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "ModuleID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The name of the module",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Objects served by this module",
+                        "isDeprecated": false,
+                        "name": "objects",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "TypeDef",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The SDK used by this module. Either a name of a builtin SDK or a module ref pointing to the SDK's implementation.",
+                        "isDeprecated": false,
+                        "name": "sdk",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Serve a module's API in the current session.\n    Note: this can only be called once per session.\n    In the future, it could return a stream or service to remove the side effect.",
+                        "isDeprecated": false,
+                        "name": "serve",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "Void",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The directory containing the module's source code",
+                        "isDeprecated": false,
+                        "name": "sourceDirectory",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The module's subpath within the source directory",
+                        "isDeprecated": false,
+                        "name": "sourceDirectorySubPath",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "object",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "TypeDefID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "This module plus the given Object type and associated functions",
+                        "isDeprecated": false,
+                        "name": "withObject",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Module",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "Module",
+                "possibleTypes": null
+            },
+            {
+                "description": "Static configuration for a module (e.g. parsed contents of dagger.json)",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Modules that this module depends on.",
+                        "isDeprecated": false,
+                        "name": "dependencies",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Exclude these file globs when loading the module root.",
+                        "isDeprecated": false,
+                        "name": "exclude",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Include only these file globs when loading the module root.",
+                        "isDeprecated": false,
+                        "name": "include",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The name of the module.",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The root directory of the module's project, which may be above the module source code.",
+                        "isDeprecated": false,
+                        "name": "root",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Either the name of a built-in SDK ('go', 'python', etc.) OR a module reference pointing to the SDK's module implementation.",
+                        "isDeprecated": false,
+                        "name": "sdk",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "ModuleConfig",
+                "possibleTypes": null
+            },
+            {
+                "description": "A reference to a Module.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "ModuleID",
+                "possibleTypes": null
+            },
+            {
+                "description": "Transport layer network protocol associated to a port.",
+                "enumValues": [
+                    {
+                        "deprecationReason": null,
+                        "description": "TCP (Transmission Control Protocol)",
+                        "isDeprecated": false,
+                        "name": "TCP"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "UDP (User Datagram Protocol)",
+                        "isDeprecated": false,
+                        "name": "UDP"
+                    }
+                ],
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "ENUM",
+                "name": "NetworkProtocol",
+                "possibleTypes": null
+            },
+            {
+                "description": "A definition of a custom object defined in a Module.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The function used to construct new instances of this object, if any",
+                        "isDeprecated": false,
+                        "name": "constructor",
+                        "type": {
+                            "kind": "OBJECT",
+                            "name": "Function",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The doc string for the object, if any",
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Static fields defined on this object, if any",
+                        "isDeprecated": false,
+                        "name": "fields",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "FieldTypeDef",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Functions defined on this object, if any",
+                        "isDeprecated": false,
+                        "name": "functions",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "Function",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The name of the object",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "ObjectTypeDef",
+                "possibleTypes": null
+            },
+            {
+                "description": "Key value object that represents a Pipeline label.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": [
+                    {
+                        "defaultValue": null,
+                        "description": "Label name.",
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "defaultValue": null,
+                        "description": "Label value.",
+                        "name": "value",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "interfaces": null,
+                "kind": "INPUT_OBJECT",
+                "name": "PipelineLabel",
+                "possibleTypes": null
+            },
+            {
+                "description": "The platform config OS and architecture in a Container.\n\nThe format is [os]/[platform]/[version] (e.g., \"darwin/arm64/v7\", \"windows/amd64\", \"linux/arm64\").",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "Platform",
+                "possibleTypes": null
+            },
+            {
+                "description": "A port exposed by a container.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The port description.",
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The port number.",
+                        "isDeprecated": false,
+                        "name": "port",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The transport layer network protocol.",
+                        "isDeprecated": false,
+                        "name": "protocol",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "ENUM",
+                                "name": "NetworkProtocol",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "Port",
+                "possibleTypes": null
+            },
+            {
+                "description": "Port forwarding rules for tunneling network traffic.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": [
+                    {
+                        "defaultValue": null,
+                        "description": "Destination port for traffic.",
+                        "name": "backend",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "defaultValue": null,
+                        "description": "Port to expose to clients. If unspecified, a default will be chosen.",
+                        "name": "frontend",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "Int",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "defaultValue": "\"TCP\"",
+                        "description": "Protocol to use for traffic.",
+                        "name": "protocol",
+                        "type": {
+                            "kind": "ENUM",
+                            "name": "NetworkProtocol",
+                            "ofType": null
+                        }
+                    }
+                ],
+                "interfaces": null,
+                "kind": "INPUT_OBJECT",
+                "name": "PortForward",
+                "possibleTypes": null
+            },
+            {
+                "description": "",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "A string identifier to target this cache volume (e.g., \"modules-cache\").",
+                                "name": "key",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Constructs a cache volume for a given cache key.",
+                        "isDeprecated": false,
+                        "name": "cacheVolume",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "CacheVolume",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The SDK's required version.",
+                                "name": "version",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Checks if the current Dagger Engine is compatible with an SDK's required version.",
+                        "isDeprecated": false,
+                        "name": "checkVersionCompatibility",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "ContainerID",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "platform",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Platform",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Creates a scratch container or loads one by ID.\n\nOptional platform argument initializes new containers to execute and publish\nas that platform. Platform defaults to that of the builder's host.",
+                        "isDeprecated": false,
+                        "name": "container",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The FunctionCall context that the SDK caller is currently executing in.\nIf the caller is not currently executing in a function, this will return\nan error.",
+                        "isDeprecated": false,
+                        "name": "currentFunctionCall",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "FunctionCall",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The module currently being served in the session, if any.",
+                        "isDeprecated": false,
+                        "name": "currentModule",
+                        "type": {
+                            "kind": "OBJECT",
+                            "name": "Module",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The default platform of the builder.",
+                        "isDeprecated": false,
+                        "name": "defaultPlatform",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Platform",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "DirectoryID",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Creates an empty directory or loads one by ID.",
+                        "isDeprecated": false,
+                        "name": "directory",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "FileID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": "Use `loadFileFromID` instead.",
+                        "description": "Loads a file by ID.",
+                        "isDeprecated": true,
+                        "name": "file",
+                        "type": {
+                            "kind": "OBJECT",
+                            "name": "File",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "returnType",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "TypeDefID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Create a function.",
+                        "isDeprecated": false,
+                        "name": "function",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Function",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "code",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "DirectoryID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Create a code generation result, given a directory containing the generated\ncode.",
+                        "isDeprecated": false,
+                        "name": "generatedCode",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "GeneratedCode",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Url of the git repository.\nCan be formatted as https://{host}/{owner}/{repo}, git@{host}:{owner}/{repo}\nSuffix \".git\" is optional.",
+                                "name": "url",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Set to true to keep .git directory.",
+                                "name": "keepGitDir",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Set SSH known hosts",
+                                "name": "sshKnownHosts",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Set SSH auth socket",
+                                "name": "sshAuthSocket",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "SocketID",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A service which must be started before the repo is fetched.",
+                                "name": "experimentalServiceHost",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "ServiceID",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Queries a git repository.",
+                        "isDeprecated": false,
+                        "name": "git",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "GitRepository",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Queries the host environment.",
+                        "isDeprecated": false,
+                        "name": "host",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Host",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "HTTP url to get the content from (e.g., \"https://docs.dagger.io\").",
+                                "name": "url",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A service which must be started before the URL is fetched.",
+                                "name": "experimentalServiceHost",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "ServiceID",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Returns a file containing an http remote url content.",
+                        "isDeprecated": false,
+                        "name": "http",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "File",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "CacheVolumeID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load a CacheVolume from its ID.",
+                        "isDeprecated": false,
+                        "name": "loadCacheVolumeFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "CacheVolume",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "ContainerID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Loads a container from an ID.",
+                        "isDeprecated": false,
+                        "name": "loadContainerFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "DirectoryID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load a Directory from its ID.",
+                        "isDeprecated": false,
+                        "name": "loadDirectoryFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "FileID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load a File from its ID.",
+                        "isDeprecated": false,
+                        "name": "loadFileFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "File",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "FunctionArgID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load a function argument by ID.",
+                        "isDeprecated": false,
+                        "name": "loadFunctionArgFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "FunctionArg",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "FunctionID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load a function by ID.",
+                        "isDeprecated": false,
+                        "name": "loadFunctionFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Function",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "GeneratedCodeID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load a GeneratedCode by ID.",
+                        "isDeprecated": false,
+                        "name": "loadGeneratedCodeFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "GeneratedCode",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "GitRefID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load a git ref from its ID.",
+                        "isDeprecated": false,
+                        "name": "loadGitRefFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "GitRef",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "GitRepositoryID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load a git repository from its ID.",
+                        "isDeprecated": false,
+                        "name": "loadGitRepositoryFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "GitRepository",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "ModuleID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load a module by ID.",
+                        "isDeprecated": false,
+                        "name": "loadModuleFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Module",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "SecretID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load a Secret from its ID.",
+                        "isDeprecated": false,
+                        "name": "loadSecretFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Secret",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "ServiceID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Loads a service from ID.",
+                        "isDeprecated": false,
+                        "name": "loadServiceFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Service",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "SocketID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load a Socket from its ID.",
+                        "isDeprecated": false,
+                        "name": "loadSocketFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Socket",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "TypeDefID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load a TypeDef by ID.",
+                        "isDeprecated": false,
+                        "name": "loadTypeDefFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Create a new module.",
+                        "isDeprecated": false,
+                        "name": "module",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Module",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "sourceDirectory",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "DirectoryID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "subpath",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load the static configuration for a module from the given source directory and optional subpath.",
+                        "isDeprecated": false,
+                        "name": "moduleConfig",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "ModuleConfig",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Pipeline name.",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Pipeline description.",
+                                "name": "description",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Pipeline labels.",
+                                "name": "labels",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "PipelineLabel",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Creates a named sub-pipeline.",
+                        "isDeprecated": false,
+                        "name": "pipeline",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Query",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "SecretID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": "Use `loadSecretFromID` instead",
+                        "description": "Loads a secret from its ID.",
+                        "isDeprecated": true,
+                        "name": "secret",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Secret",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The user defined name for this secret",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "The plaintext of the secret",
+                                "name": "plaintext",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Sets a secret given a user defined name to its plaintext and returns the secret.\nThe plaintext value is limited to a size of 128000 bytes.",
+                        "isDeprecated": false,
+                        "name": "setSecret",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Secret",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "SocketID",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": "Use `loadSocketFromID` instead.",
+                        "description": "Loads a socket by its ID.",
+                        "isDeprecated": true,
+                        "name": "socket",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Socket",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Create a new TypeDef.",
+                        "isDeprecated": false,
+                        "name": "typeDef",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "Query",
+                "possibleTypes": null
+            },
+            {
+                "description": "A reference to a secret value, which can be handled more safely than the value itself.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The identifier for this secret.",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "SecretID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The value of this secret.",
+                        "isDeprecated": false,
+                        "name": "plaintext",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "Secret",
+                "possibleTypes": null
+            },
+            {
+                "description": "A unique identifier for a secret.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "SecretID",
+                "possibleTypes": null
+            },
+            {
+                "description": "",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The exposed port number for the endpoint",
+                                "name": "port",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Int",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Return a URL with the given scheme, eg. http for http://",
+                                "name": "scheme",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves an endpoint that clients can use to reach this container.\n\nIf no port is specified, the first exposed port is used. If none exist an error is returned.\n\nIf a scheme is specified, a URL is returned. Otherwise, a host:port pair is returned.",
+                        "isDeprecated": false,
+                        "name": "endpoint",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves a hostname which can be used by clients to reach this container.",
+                        "isDeprecated": false,
+                        "name": "hostname",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "A unique identifier for this service.",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "ServiceID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves the list of ports provided by the service.",
+                        "isDeprecated": false,
+                        "name": "ports",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "Port",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Start the service and wait for its health checks to succeed.\n\nServices bound to a Container do not need to be manually started.",
+                        "isDeprecated": false,
+                        "name": "start",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "ServiceID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Stop the service.",
+                        "isDeprecated": false,
+                        "name": "stop",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "ServiceID",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "Service",
+                "possibleTypes": null
+            },
+            {
+                "description": "A unique service identifier.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "ServiceID",
+                "possibleTypes": null
+            },
+            {
+                "description": "",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The content-addressed identifier of the socket.",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "SocketID",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "Socket",
+                "possibleTypes": null
+            },
+            {
+                "description": "A content-addressed socket identifier.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "SocketID",
+                "possibleTypes": null
+            },
+            {
+                "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "String",
+                "possibleTypes": null
+            },
+            {
+                "description": "A definition of a parameter or return type in a Module.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "If kind is LIST, the list-specific type definition.\nIf kind is not LIST, this will be null.",
+                        "isDeprecated": false,
+                        "name": "asList",
+                        "type": {
+                            "kind": "OBJECT",
+                            "name": "ListTypeDef",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "If kind is OBJECT, the object-specific type definition.\nIf kind is not OBJECT, this will be null.",
+                        "isDeprecated": false,
+                        "name": "asObject",
+                        "type": {
+                            "kind": "OBJECT",
+                            "name": "ObjectTypeDef",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "TypeDefID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The kind of type this is (e.g. primitive, list, object)",
+                        "isDeprecated": false,
+                        "name": "kind",
+                        "type": {
+                            "kind": "ENUM",
+                            "name": "TypeDefKind",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Whether this type can be set to null. Defaults to false.",
+                        "isDeprecated": false,
+                        "name": "optional",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "function",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "FunctionID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Adds a function for constructing a new instance of an Object TypeDef, failing if the type is not an object.",
+                        "isDeprecated": false,
+                        "name": "withConstructor",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The name of the field in the object",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "The type of the field",
+                                "name": "typeDef",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "TypeDefID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A doc string for the field, if any",
+                                "name": "description",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Adds a static field for an Object TypeDef, failing if the type is not an object.",
+                        "isDeprecated": false,
+                        "name": "withField",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "function",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "FunctionID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Adds a function for an Object TypeDef, failing if the type is not an object.",
+                        "isDeprecated": false,
+                        "name": "withFunction",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "kind",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "ENUM",
+                                        "name": "TypeDefKind",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Sets the kind of the type.",
+                        "isDeprecated": false,
+                        "name": "withKind",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "elementType",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "TypeDefID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Returns a TypeDef of kind List with the provided type for its elements.",
+                        "isDeprecated": false,
+                        "name": "withListOf",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "description",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Returns a TypeDef of kind Object with the provided name.\n\nNote that an object's fields and functions may be omitted if the intent is\nonly to refer to an object. This is how functions are able to return their\nown object, or any other circular reference.",
+                        "isDeprecated": false,
+                        "name": "withObject",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "optional",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "Boolean",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Sets whether this type can be set to null.",
+                        "isDeprecated": false,
+                        "name": "withOptional",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "TypeDef",
+                "possibleTypes": null
+            },
+            {
+                "description": "A reference to a TypeDef.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "TypeDefID",
+                "possibleTypes": null
+            },
+            {
+                "description": "Distinguishes the different kinds of TypeDefs.",
+                "enumValues": [
+                    {
+                        "deprecationReason": null,
+                        "description": "A boolean value",
+                        "isDeprecated": false,
+                        "name": "BooleanKind"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "An integer value",
+                        "isDeprecated": false,
+                        "name": "IntegerKind"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "A list of values all having the same type.\n\nAlways paired with a ListTypeDef.",
+                        "isDeprecated": false,
+                        "name": "ListKind"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "A named type defined in the GraphQL schema, with fields and functions.\n\nAlways paired with an ObjectTypeDef.",
+                        "isDeprecated": false,
+                        "name": "ObjectKind"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "A string value",
+                        "isDeprecated": false,
+                        "name": "StringKind"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "A special kind used to signify that no value is returned.\n\nThis is used for functions that have no return value. The outer TypeDef\nspecifying this Kind is always Optional, as the Void is never actually\nrepresented.",
+                        "isDeprecated": false,
+                        "name": "VoidKind"
+                    }
+                ],
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "ENUM",
+                "name": "TypeDefKind",
+                "possibleTypes": null
+            },
+            {
+                "description": "The absense of a value.\n\nA Null Void is used as a placeholder for resolvers that do not return anything.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "Void",
+                "possibleTypes": null
+            },
+            {
+                "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document. \n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "args",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__InputValue",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "locations",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "ENUM",
+                                        "name": "__DirectiveLocation",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": "Use `locations`.",
+                        "description": "",
+                        "isDeprecated": true,
+                        "name": "onField",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": "Use `locations`.",
+                        "description": "",
+                        "isDeprecated": true,
+                        "name": "onFragment",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": "Use `locations`.",
+                        "description": "",
+                        "isDeprecated": true,
+                        "name": "onOperation",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "__Directive",
+                "possibleTypes": null
+            },
+            {
+                "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+                "enumValues": [
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to an argument definition.",
+                        "isDeprecated": false,
+                        "name": "ARGUMENT_DEFINITION"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to an enum definition.",
+                        "isDeprecated": false,
+                        "name": "ENUM"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to an enum value definition.",
+                        "isDeprecated": false,
+                        "name": "ENUM_VALUE"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to a field.",
+                        "isDeprecated": false,
+                        "name": "FIELD"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to a field definition.",
+                        "isDeprecated": false,
+                        "name": "FIELD_DEFINITION"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to a fragment definition.",
+                        "isDeprecated": false,
+                        "name": "FRAGMENT_DEFINITION"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to a fragment spread.",
+                        "isDeprecated": false,
+                        "name": "FRAGMENT_SPREAD"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to an inline fragment.",
+                        "isDeprecated": false,
+                        "name": "INLINE_FRAGMENT"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to an input object field definition.",
+                        "isDeprecated": false,
+                        "name": "INPUT_FIELD_DEFINITION"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to an input object type definition.",
+                        "isDeprecated": false,
+                        "name": "INPUT_OBJECT"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to an interface definition.",
+                        "isDeprecated": false,
+                        "name": "INTERFACE"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to a mutation operation.",
+                        "isDeprecated": false,
+                        "name": "MUTATION"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to a object definition.",
+                        "isDeprecated": false,
+                        "name": "OBJECT"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to a query operation.",
+                        "isDeprecated": false,
+                        "name": "QUERY"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to a scalar definition.",
+                        "isDeprecated": false,
+                        "name": "SCALAR"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to a schema definition.",
+                        "isDeprecated": false,
+                        "name": "SCHEMA"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to a subscription operation.",
+                        "isDeprecated": false,
+                        "name": "SUBSCRIPTION"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to a union definition.",
+                        "isDeprecated": false,
+                        "name": "UNION"
+                    }
+                ],
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "ENUM",
+                "name": "__DirectiveLocation",
+                "possibleTypes": null
+            },
+            {
+                "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "deprecationReason",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "isDeprecated",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "__EnumValue",
+                "possibleTypes": null
+            },
+            {
+                "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "args",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__InputValue",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "deprecationReason",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "isDeprecated",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "type",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "__Type",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "__Field",
+                "possibleTypes": null
+            },
+            {
+                "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "A GraphQL-formatted string representing the default value for this input value.",
+                        "isDeprecated": false,
+                        "name": "defaultValue",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "type",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "__Type",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "__InputValue",
+                "possibleTypes": null
+            },
+            {
+                "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "A list of all directives supported by this server.",
+                        "isDeprecated": false,
+                        "name": "directives",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__Directive",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
+                        "isDeprecated": false,
+                        "name": "mutationType",
+                        "type": {
+                            "kind": "OBJECT",
+                            "name": "__Type",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The type that query operations will be rooted at.",
+                        "isDeprecated": false,
+                        "name": "queryType",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "__Type",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "If this server supports subscription, the type that subscription operations will be rooted at.",
+                        "isDeprecated": false,
+                        "name": "subscriptionType",
+                        "type": {
+                            "kind": "OBJECT",
+                            "name": "__Type",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "A list of all types supported by this server.",
+                        "isDeprecated": false,
+                        "name": "types",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__Type",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "__Schema",
+                "possibleTypes": null
+            },
+            {
+                "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": "false",
+                                "description": "",
+                                "name": "includeDeprecated",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "enumValues",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__EnumValue",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": "false",
+                                "description": "",
+                                "name": "includeDeprecated",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "fields",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__Field",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "inputFields",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__InputValue",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "interfaces",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__Type",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "kind",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "ENUM",
+                                "name": "__TypeKind",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "ofType",
+                        "type": {
+                            "kind": "OBJECT",
+                            "name": "__Type",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "possibleTypes",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__Type",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "__Type",
+                "possibleTypes": null
+            },
+            {
+                "description": "An enum describing what kind of type a given `__Type` is",
+                "enumValues": [
+                    {
+                        "deprecationReason": null,
+                        "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+                        "isDeprecated": false,
+                        "name": "ENUM"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+                        "isDeprecated": false,
+                        "name": "INPUT_OBJECT"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+                        "isDeprecated": false,
+                        "name": "INTERFACE"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Indicates this type is a list. `ofType` is a valid field.",
+                        "isDeprecated": false,
+                        "name": "LIST"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+                        "isDeprecated": false,
+                        "name": "NON_NULL"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+                        "isDeprecated": false,
+                        "name": "OBJECT"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Indicates this type is a scalar.",
+                        "isDeprecated": false,
+                        "name": "SCALAR"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+                        "isDeprecated": false,
+                        "name": "UNION"
+                    }
+                ],
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "ENUM",
+                "name": "__TypeKind",
+                "possibleTypes": null
+            }
+        ]
+    }
+}

--- a/sdk/java/dagger-codegen-maven-plugin/src/main/resources/schemas/schema-0.9.5.json
+++ b/sdk/java/dagger-codegen-maven-plugin/src/main/resources/schemas/schema-0.9.5.json
@@ -1,0 +1,8022 @@
+{
+    "__schema": {
+        "directives": [
+            {
+                "args": [
+                    {
+                        "defaultValue": "\"No longer supported\"",
+                        "description": "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formattedin [Markdown](https://daringfireball.net/projects/markdown/).",
+                        "name": "reason",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    }
+                ],
+                "description": "Marks an element of a GraphQL schema as no longer supported.",
+                "locations": [
+                    "FIELD_DEFINITION",
+                    "ENUM_VALUE"
+                ],
+                "name": "deprecated"
+            },
+            {
+                "args": [],
+                "description": "Hide a field, useful when generating types from the AST where the backend type has more fields than the graphql type",
+                "locations": [
+                    "FIELD_DEFINITION"
+                ],
+                "name": "hide"
+            },
+            {
+                "args": [
+                    {
+                        "defaultValue": null,
+                        "description": "Included when true.",
+                        "name": "if",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
+                "locations": [
+                    "FIELD",
+                    "FRAGMENT_SPREAD",
+                    "INLINE_FRAGMENT"
+                ],
+                "name": "include"
+            },
+            {
+                "args": [
+                    {
+                        "defaultValue": null,
+                        "description": "Skipped when true.",
+                        "name": "if",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
+                "locations": [
+                    "FIELD",
+                    "FRAGMENT_SPREAD",
+                    "INLINE_FRAGMENT"
+                ],
+                "name": "skip"
+            }
+        ],
+        "mutationType": null,
+        "queryType": {
+            "name": "Query"
+        },
+        "subscriptionType": null,
+        "types": [
+            {
+                "description": "The `Boolean` scalar type represents `true` or `false`.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "possibleTypes": null
+            },
+            {
+                "description": "Key value object that represents a build argument.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": [
+                    {
+                        "defaultValue": null,
+                        "description": "The build argument name.",
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "defaultValue": null,
+                        "description": "The build argument value.",
+                        "name": "value",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "interfaces": null,
+                "kind": "INPUT_OBJECT",
+                "name": "BuildArg",
+                "possibleTypes": null
+            },
+            {
+                "description": "Sharing mode of the cache volume.",
+                "enumValues": [
+                    {
+                        "deprecationReason": null,
+                        "description": "Shares the cache volume amongst many build pipelines,\nbut will serialize the writes",
+                        "isDeprecated": false,
+                        "name": "LOCKED"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Keeps a cache volume for a single build pipeline",
+                        "isDeprecated": false,
+                        "name": "PRIVATE"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Shares the cache volume amongst many build pipelines",
+                        "isDeprecated": false,
+                        "name": "SHARED"
+                    }
+                ],
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "ENUM",
+                "name": "CacheSharingMode",
+                "possibleTypes": null
+            },
+            {
+                "description": "A directory whose contents persist across runs.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "CacheVolumeID",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "CacheVolume",
+                "possibleTypes": null
+            },
+            {
+                "description": "A global cache volume identifier.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "CacheVolumeID",
+                "possibleTypes": null
+            },
+            {
+                "description": "An OCI-compatible container, also known as a docker container.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Turn the container into a Service.\n\nBe sure to set any exposed ports before this conversion.",
+                        "isDeprecated": false,
+                        "name": "asService",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Service",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Identifiers for other platform specific containers.\nUsed for multi-platform image.",
+                                "name": "platformVariants",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "ContainerID",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Force each layer of the image to use the specified compression algorithm.\nIf this is unset, then if a layer already has a compressed blob in the engine's\ncache, that will be used (this can result in a mix of compression algorithms for\ndifferent layers). If this is unset and a layer has no compressed blob in the\nengine's cache, then it will be compressed using Gzip.",
+                                "name": "forcedCompression",
+                                "type": {
+                                    "kind": "ENUM",
+                                    "name": "ImageLayerCompression",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": "\"OCIMediaTypes\"",
+                                "description": "Use the specified media types for the image's layers. Defaults to OCI, which\nis largely compatible with most recent container runtimes, but Docker may be needed\nfor older runtimes without OCI support.",
+                                "name": "mediaTypes",
+                                "type": {
+                                    "kind": "ENUM",
+                                    "name": "ImageMediaTypes",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Returns a File representing the container serialized to a tarball.",
+                        "isDeprecated": false,
+                        "name": "asTarball",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "File",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Directory context used by the Dockerfile.",
+                                "name": "context",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "DirectoryID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Path to the Dockerfile to use.\n\nDefault: './Dockerfile'.",
+                                "name": "dockerfile",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Additional build arguments.",
+                                "name": "buildArgs",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "BuildArg",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Target build stage to build.",
+                                "name": "target",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Secrets to pass to the build.\n\nThey will be mounted at /run/secrets/[secret-name] in the build container\n\nThey can be accessed in the Dockerfile using the \"secret\" mount type\nand mount path /run/secrets/[secret-name]\ne.g. RUN --mount=type=secret,id=my-secret curl url?token=$(cat /run/secrets/my-secret)\"",
+                                "name": "secrets",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "SecretID",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Initializes this container from a Dockerfile build.",
+                        "isDeprecated": false,
+                        "name": "build",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves default arguments for future commands.",
+                        "isDeprecated": false,
+                        "name": "defaultArgs",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The path of the directory to retrieve (e.g., \"./src\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves a directory at the given path.\n\nMounts are included.",
+                        "isDeprecated": false,
+                        "name": "directory",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves entrypoint to be prepended to the arguments of all commands.",
+                        "isDeprecated": false,
+                        "name": "entrypoint",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The name of the environment variable to retrieve (e.g., \"PATH\").",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves the value of the specified environment variable.",
+                        "isDeprecated": false,
+                        "name": "envVariable",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves the list of environment variables passed to commands.",
+                        "isDeprecated": false,
+                        "name": "envVariables",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "EnvVariable",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "EXPERIMENTAL API! Subject to change/removal at any time.\n\nexperimentalWithAllGPUs configures all available GPUs on the host to be accessible to this container.\nThis currently works for Nvidia devices only.",
+                        "isDeprecated": false,
+                        "name": "experimentalWithAllGPUs",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "devices",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "LIST",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "NON_NULL",
+                                            "name": null,
+                                            "ofType": {
+                                                "kind": "SCALAR",
+                                                "name": "String",
+                                                "ofType": null
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "EXPERIMENTAL API! Subject to change/removal at any time.\n\nexperimentalWithGPU configures the provided list of devices to be accesible to this container.\nThis currently works for Nvidia devices only.",
+                        "isDeprecated": false,
+                        "name": "experimentalWithGPU",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Host's destination path (e.g., \"./tarball\").\nPath can be relative to the engine's workdir or absolute.",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifiers for other platform specific containers.\nUsed for multi-platform image.",
+                                "name": "platformVariants",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "ContainerID",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Force each layer of the exported image to use the specified compression algorithm.\nIf this is unset, then if a layer already has a compressed blob in the engine's\ncache, that will be used (this can result in a mix of compression algorithms for\ndifferent layers). If this is unset and a layer has no compressed blob in the\nengine's cache, then it will be compressed using Gzip.",
+                                "name": "forcedCompression",
+                                "type": {
+                                    "kind": "ENUM",
+                                    "name": "ImageLayerCompression",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": "\"OCIMediaTypes\"",
+                                "description": "Use the specified media types for the exported image's layers. Defaults to OCI, which\nis largely compatible with most recent container runtimes, but Docker may be needed\nfor older runtimes without OCI support.",
+                                "name": "mediaTypes",
+                                "type": {
+                                    "kind": "ENUM",
+                                    "name": "ImageMediaTypes",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Writes the container as an OCI tarball to the destination file path on the host for the specified platform variants.\n\nReturn true on success.\nIt can also publishes platform variants.",
+                        "isDeprecated": false,
+                        "name": "export",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves the list of exposed ports.\n\nThis includes ports already exposed by the image, even if not\nexplicitly added with dagger.",
+                        "isDeprecated": false,
+                        "name": "exposedPorts",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "Port",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The path of the file to retrieve (e.g., \"./README.md\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves a file at the given path.\n\nMounts are included.",
+                        "isDeprecated": false,
+                        "name": "file",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "File",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Image's address from its registry.\n\nFormatted as [host]/[user]/[repo]:[tag] (e.g., \"docker.io/dagger/dagger:main\").",
+                                "name": "address",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Initializes this container from a pulled base image.",
+                        "isDeprecated": false,
+                        "name": "from",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "A unique identifier for this container.",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "ContainerID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The unique image reference which can only be retrieved immediately after the 'Container.From' call.",
+                        "isDeprecated": false,
+                        "name": "imageRef",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "File to read the container from.",
+                                "name": "source",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "FileID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifies the tag to import from the archive, if the archive bundles\nmultiple tags.",
+                                "name": "tag",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Reads the container from an OCI tarball.\n\nNOTE: this involves unpacking the tarball to an OCI store on the host at\n$XDG_CACHE_DIR/dagger/oci. This directory can be removed whenever you like.",
+                        "isDeprecated": false,
+                        "name": "import",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves the value of the specified label.",
+                        "isDeprecated": false,
+                        "name": "label",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves the list of labels passed to container.",
+                        "isDeprecated": false,
+                        "name": "labels",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "Label",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves the list of paths where a directory is mounted.",
+                        "isDeprecated": false,
+                        "name": "mounts",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Pipeline name.",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Pipeline description.",
+                                "name": "description",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Pipeline labels.",
+                                "name": "labels",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "PipelineLabel",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Creates a named sub-pipeline",
+                        "isDeprecated": false,
+                        "name": "pipeline",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The platform this container executes and publishes as.",
+                        "isDeprecated": false,
+                        "name": "platform",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Platform",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Registry's address to publish the image to.\n\nFormatted as [host]/[user]/[repo]:[tag] (e.g. \"docker.io/dagger/dagger:main\").",
+                                "name": "address",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifiers for other platform specific containers.\nUsed for multi-platform image.",
+                                "name": "platformVariants",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "ContainerID",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Force each layer of the published image to use the specified compression algorithm.\nIf this is unset, then if a layer already has a compressed blob in the engine's\ncache, that will be used (this can result in a mix of compression algorithms for\ndifferent layers). If this is unset and a layer has no compressed blob in the\nengine's cache, then it will be compressed using Gzip.",
+                                "name": "forcedCompression",
+                                "type": {
+                                    "kind": "ENUM",
+                                    "name": "ImageLayerCompression",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": "\"OCIMediaTypes\"",
+                                "description": "Use the specified media types for the published image's layers. Defaults to OCI, which\nis largely compatible with most recent registries, but Docker may be needed for older\nregistries without OCI support.",
+                                "name": "mediaTypes",
+                                "type": {
+                                    "kind": "ENUM",
+                                    "name": "ImageMediaTypes",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Publishes this container as a new image to the specified address.\n\nPublish returns a fully qualified ref.\nIt can also publish platform variants.",
+                        "isDeprecated": false,
+                        "name": "publish",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container's root filesystem. Mounts are not included.",
+                        "isDeprecated": false,
+                        "name": "rootfs",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Return a websocket endpoint that, if connected to, will start the container with a TTY streamed\nover the websocket.\n\nPrimarily intended for internal use with the dagger CLI.",
+                        "isDeprecated": false,
+                        "name": "shellEndpoint",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The error stream of the last executed command.\n\nWill execute default command if none is set, or error if there's no default.",
+                        "isDeprecated": false,
+                        "name": "stderr",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The output stream of the last executed command.\n\nWill execute default command if none is set, or error if there's no default.",
+                        "isDeprecated": false,
+                        "name": "stdout",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Forces evaluation of the pipeline in the engine.\n\nIt doesn't run the default command if no exec has been set.",
+                        "isDeprecated": false,
+                        "name": "sync",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "ContainerID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves the user to be set for all commands.",
+                        "isDeprecated": false,
+                        "name": "user",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Arguments to prepend to future executions (e.g., [\"-v\", \"--no-cache\"]).",
+                                "name": "args",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "String",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Configures default arguments for future commands.",
+                        "isDeprecated": false,
+                        "name": "withDefaultArgs",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the written directory (e.g., \"/tmp/directory\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the directory to write",
+                                "name": "directory",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "DirectoryID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Patterns to exclude in the written directory (e.g., [\"node_modules/**\", \".gitignore\", \".git/\"]).",
+                                "name": "exclude",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "String",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Patterns to include in the written directory (e.g., [\"*.go\", \"go.mod\", \"go.sum\"]).",
+                                "name": "include",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "String",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A user:group to set for the directory and its contents.\n\nThe user and group can either be an ID (1000:1000) or a name (foo:bar).\n\nIf the group is omitted, it defaults to the same as the user.",
+                                "name": "owner",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container plus a directory written at the given path.",
+                        "isDeprecated": false,
+                        "name": "withDirectory",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Entrypoint to use for future executions (e.g., [\"go\", \"run\"]).",
+                                "name": "args",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "LIST",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "NON_NULL",
+                                            "name": null,
+                                            "ofType": {
+                                                "kind": "SCALAR",
+                                                "name": "String",
+                                                "ofType": null
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": "false",
+                                "description": "Don't remove the default arguments when setting the entrypoint.",
+                                "name": "keepDefaultArgs",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container but with a different command entrypoint.",
+                        "isDeprecated": false,
+                        "name": "withEntrypoint",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The name of the environment variable (e.g., \"HOST\").",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "The value of the environment variable. (e.g., \"localhost\").",
+                                "name": "value",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Replace `${VAR}` or $VAR in the value according to the current environment\nvariables defined in the container (e.g., \"/opt/bin:$PATH\").",
+                                "name": "expand",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container plus the given environment variable.",
+                        "isDeprecated": false,
+                        "name": "withEnvVariable",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Command to run instead of the container's default command (e.g., [\"run\", \"main.go\"]).\n\nIf empty, the container's default command is used.",
+                                "name": "args",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "LIST",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "NON_NULL",
+                                            "name": null,
+                                            "ofType": {
+                                                "kind": "SCALAR",
+                                                "name": "String",
+                                                "ofType": null
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "If the container has an entrypoint, ignore it for args rather than using it to wrap them.",
+                                "name": "skipEntrypoint",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Content to write to the command's standard input before closing (e.g., \"Hello world\").",
+                                "name": "stdin",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Redirect the command's standard output to a file in the container (e.g., \"/tmp/stdout\").",
+                                "name": "redirectStdout",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Redirect the command's standard error to a file in the container (e.g., \"/tmp/stderr\").",
+                                "name": "redirectStderr",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Provides dagger access to the executed command.\n\nDo not use this option unless you trust the command being executed.\nThe command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.",
+                                "name": "experimentalPrivilegedNesting",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Execute the command with all root capabilities. This is similar to running a command\nwith \"sudo\" or executing `docker run` with the `--privileged` flag. Containerization\ndoes not provide any security guarantees when using this option. It should only be used\nwhen absolutely necessary and only with trusted commands.",
+                                "name": "insecureRootCapabilities",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container after executing the specified command inside it.",
+                        "isDeprecated": false,
+                        "name": "withExec",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Port number to expose",
+                                "name": "port",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "Int",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": "\"TCP\"",
+                                "description": "Transport layer network protocol",
+                                "name": "protocol",
+                                "type": {
+                                    "kind": "ENUM",
+                                    "name": "NetworkProtocol",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Optional port description",
+                                "name": "description",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Expose a network port.\n\nExposed ports serve two purposes:\n\n- For health checks and introspection, when running services\n- For setting the EXPOSE OCI field when publishing the container",
+                        "isDeprecated": false,
+                        "name": "withExposedPort",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the copied file (e.g., \"/tmp/file.txt\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the file to copy.",
+                                "name": "source",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "FileID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Permission given to the copied file (e.g., 0600).\n\nDefault: 0644.",
+                                "name": "permissions",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Int",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A user:group to set for the file.\n\nThe user and group can either be an ID (1000:1000) or a name (foo:bar).\n\nIf the group is omitted, it defaults to the same as the user.",
+                                "name": "owner",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container plus the contents of the given file copied to the given path.",
+                        "isDeprecated": false,
+                        "name": "withFile",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Indicate that subsequent operations should be featured more prominently in\nthe UI.",
+                        "isDeprecated": false,
+                        "name": "withFocus",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The name of the label (e.g., \"org.opencontainers.artifact.created\").",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "The value of the label (e.g., \"2023-01-01T00:00:00Z\").",
+                                "name": "value",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container plus the given label.",
+                        "isDeprecated": false,
+                        "name": "withLabel",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the cache directory (e.g., \"/cache/node_modules\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the cache volume to mount.",
+                                "name": "cache",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "CacheVolumeID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the directory to use as the cache volume's root.",
+                                "name": "source",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "DirectoryID",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Sharing mode of the cache volume.",
+                                "name": "sharing",
+                                "type": {
+                                    "kind": "ENUM",
+                                    "name": "CacheSharingMode",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A user:group to set for the mounted cache directory.\n\nNote that this changes the ownership of the specified mount along with the\ninitial filesystem provided by source (if any). It does not have any effect\nif/when the cache has already been created.\n\nThe user and group can either be an ID (1000:1000) or a name (foo:bar).\n\nIf the group is omitted, it defaults to the same as the user.",
+                                "name": "owner",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container plus a cache volume mounted at the given path.",
+                        "isDeprecated": false,
+                        "name": "withMountedCache",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the mounted directory (e.g., \"/mnt/directory\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the mounted directory.",
+                                "name": "source",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "DirectoryID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A user:group to set for the mounted directory and its contents.\n\nThe user and group can either be an ID (1000:1000) or a name (foo:bar).\n\nIf the group is omitted, it defaults to the same as the user.",
+                                "name": "owner",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container plus a directory mounted at the given path.",
+                        "isDeprecated": false,
+                        "name": "withMountedDirectory",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the mounted file (e.g., \"/tmp/file.txt\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the mounted file.",
+                                "name": "source",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "FileID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A user or user:group to set for the mounted file.\n\nThe user and group can either be an ID (1000:1000) or a name (foo:bar).\n\nIf the group is omitted, it defaults to the same as the user.",
+                                "name": "owner",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container plus a file mounted at the given path.",
+                        "isDeprecated": false,
+                        "name": "withMountedFile",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the secret file (e.g., \"/tmp/secret.txt\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the secret to mount.",
+                                "name": "source",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "SecretID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A user:group to set for the mounted secret.\n\nThe user and group can either be an ID (1000:1000) or a name (foo:bar).\n\nIf the group is omitted, it defaults to the same as the user.",
+                                "name": "owner",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Permission given to the mounted secret (e.g., 0600).\nThis option requires an owner to be set to be active.\n\nDefault: 0400.",
+                                "name": "mode",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Int",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container plus a secret mounted into a file at the given path.",
+                        "isDeprecated": false,
+                        "name": "withMountedSecret",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the temporary directory (e.g., \"/tmp/temp_dir\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container plus a temporary directory mounted at the given path.",
+                        "isDeprecated": false,
+                        "name": "withMountedTemp",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the written file (e.g., \"/tmp/file.txt\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Content of the file to write (e.g., \"Hello world!\").",
+                                "name": "contents",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Permission given to the written file (e.g., 0600).\n\nDefault: 0644.",
+                                "name": "permissions",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Int",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A user:group to set for the file.\n\nThe user and group can either be an ID (1000:1000) or a name (foo:bar).\n\nIf the group is omitted, it defaults to the same as the user.",
+                                "name": "owner",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container plus a new file written at the given path.",
+                        "isDeprecated": false,
+                        "name": "withNewFile",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Registry's address to bind the authentication to.\nFormatted as [host]/[user]/[repo]:[tag] (e.g. docker.io/dagger/dagger:main).",
+                                "name": "address",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "The username of the registry's account (e.g., \"Dagger\").",
+                                "name": "username",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "The API key, password or token to authenticate to this registry.",
+                                "name": "secret",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "SecretID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container with a registry authentication for a given address.",
+                        "isDeprecated": false,
+                        "name": "withRegistryAuth",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "directory",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "DirectoryID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Initializes this container from this DirectoryID.",
+                        "isDeprecated": false,
+                        "name": "withRootfs",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The name of the secret variable (e.g., \"API_SECRET\").",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "The identifier of the secret value.",
+                                "name": "secret",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "SecretID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container plus an env variable containing the given secret.",
+                        "isDeprecated": false,
+                        "name": "withSecretVariable",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "A name that can be used to reach the service from the container",
+                                "name": "alias",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the service container",
+                                "name": "service",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "ServiceID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Establish a runtime dependency on a service.\n\nThe service will be started automatically when needed and detached when it is\nno longer needed, executing the default command if none is set.\n\nThe service will be reachable from the container via the provided hostname alias.\n\nThe service dependency will also convey to any files or directories produced by the container.",
+                        "isDeprecated": false,
+                        "name": "withServiceBinding",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the forwarded Unix socket (e.g., \"/tmp/socket\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the socket to forward.",
+                                "name": "source",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "SocketID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A user:group to set for the mounted socket.\n\nThe user and group can either be an ID (1000:1000) or a name (foo:bar).\n\nIf the group is omitted, it defaults to the same as the user.",
+                                "name": "owner",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container plus a socket forwarded to the given Unix socket path.",
+                        "isDeprecated": false,
+                        "name": "withUnixSocket",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The user to set (e.g., \"root\").",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container with a different command user.",
+                        "isDeprecated": false,
+                        "name": "withUser",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The path to set as the working directory (e.g., \"/app\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container with a different working directory.",
+                        "isDeprecated": false,
+                        "name": "withWorkdir",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container with unset default arguments for future commands.",
+                        "isDeprecated": false,
+                        "name": "withoutDefaultArgs",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": "false",
+                                "description": "Don't remove the default arguments when unsetting the entrypoint.",
+                                "name": "keepDefaultArgs",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container with an unset command entrypoint.",
+                        "isDeprecated": false,
+                        "name": "withoutEntrypoint",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The name of the environment variable (e.g., \"HOST\").",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container minus the given environment variable.",
+                        "isDeprecated": false,
+                        "name": "withoutEnvVariable",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Port number to unexpose",
+                                "name": "port",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "Int",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": "\"TCP\"",
+                                "description": "Port protocol to unexpose",
+                                "name": "protocol",
+                                "type": {
+                                    "kind": "ENUM",
+                                    "name": "NetworkProtocol",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Unexpose a previously exposed port.",
+                        "isDeprecated": false,
+                        "name": "withoutExposedPort",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Indicate that subsequent operations should not be featured more prominently\nin the UI.\n\nThis is the initial state of all containers.",
+                        "isDeprecated": false,
+                        "name": "withoutFocus",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The name of the label to remove (e.g., \"org.opencontainers.artifact.created\").",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container minus the given environment label.",
+                        "isDeprecated": false,
+                        "name": "withoutLabel",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the cache directory (e.g., \"/cache/node_modules\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container after unmounting everything at the given path.",
+                        "isDeprecated": false,
+                        "name": "withoutMount",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Registry's address to remove the authentication from.\nFormatted as [host]/[user]/[repo]:[tag] (e.g. docker.io/dagger/dagger:main).",
+                                "name": "address",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container without the registry authentication of a given address.",
+                        "isDeprecated": false,
+                        "name": "withoutRegistryAuth",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the socket to remove (e.g., \"/tmp/socket\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container with a previously added Unix socket removed.",
+                        "isDeprecated": false,
+                        "name": "withoutUnixSocket",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container with an unset command user.\n\nShould default to root.",
+                        "isDeprecated": false,
+                        "name": "withoutUser",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves this container with an unset working directory.\n\nShould default to \"/\".",
+                        "isDeprecated": false,
+                        "name": "withoutWorkdir",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves the working directory for all commands.",
+                        "isDeprecated": false,
+                        "name": "workdir",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "Container",
+                "possibleTypes": null
+            },
+            {
+                "description": "A unique container identifier. Null designates an empty container (scratch).",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "ContainerID",
+                "possibleTypes": null
+            },
+            {
+                "description": "The `DateTime` scalar type represents a DateTime. The DateTime is serialized as an RFC 3339 quoted string",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "possibleTypes": null
+            },
+            {
+                "description": "A directory.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "An optional subpath of the directory which contains the module's source\ncode.\n\nThis is needed when the module code is in a subdirectory but requires\nparent directories to be loaded in order to execute. For example, the\nmodule source code may need a go.mod, project.toml, package.json, etc. file\nfrom a parent directory.\n\nIf not set, the module source code is loaded from the root of the\ndirectory.",
+                                "name": "sourceSubpath",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load the directory as a Dagger module",
+                        "isDeprecated": false,
+                        "name": "asModule",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Module",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the directory to compare.",
+                                "name": "other",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "DirectoryID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Gets the difference between this directory and an another directory.",
+                        "isDeprecated": false,
+                        "name": "diff",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the directory to retrieve (e.g., \"/src\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves a directory at the given path.",
+                        "isDeprecated": false,
+                        "name": "directory",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Path to the Dockerfile to use (e.g., \"frontend.Dockerfile\").\n\nDefaults: './Dockerfile'.",
+                                "name": "dockerfile",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "The platform to build.",
+                                "name": "platform",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Platform",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Build arguments to use in the build.",
+                                "name": "buildArgs",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "BuildArg",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Target build stage to build.",
+                                "name": "target",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Secrets to pass to the build.\n\nThey will be mounted at /run/secrets/[secret-name].",
+                                "name": "secrets",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "SecretID",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Builds a new Docker container from this directory.",
+                        "isDeprecated": false,
+                        "name": "dockerBuild",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the directory to look at (e.g., \"/src\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Returns a list of files and directories at the given path.",
+                        "isDeprecated": false,
+                        "name": "entries",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the copied directory (e.g., \"logs/\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Writes the contents of the directory to a path on the host.",
+                        "isDeprecated": false,
+                        "name": "export",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the file to retrieve (e.g., \"README.md\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves a file at the given path.",
+                        "isDeprecated": false,
+                        "name": "file",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "File",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Pattern to match (e.g., \"*.md\").",
+                                "name": "pattern",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Returns a list of files and directories that matche the given pattern.",
+                        "isDeprecated": false,
+                        "name": "glob",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The content-addressed identifier of the directory.",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "DirectoryID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Pipeline name.",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Pipeline description.",
+                                "name": "description",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Pipeline labels.",
+                                "name": "labels",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "PipelineLabel",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Creates a named sub-pipeline",
+                        "isDeprecated": false,
+                        "name": "pipeline",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Force evaluation in the engine.",
+                        "isDeprecated": false,
+                        "name": "sync",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "DirectoryID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the written directory (e.g., \"/src/\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the directory to copy.",
+                                "name": "directory",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "DirectoryID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Exclude artifacts that match the given pattern (e.g., [\"node_modules/\", \".git*\"]).",
+                                "name": "exclude",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "String",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Include only artifacts that match the given pattern (e.g., [\"app/\", \"package.*\"]).",
+                                "name": "include",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "String",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this directory plus a directory written at the given path.",
+                        "isDeprecated": false,
+                        "name": "withDirectory",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the copied file (e.g., \"/file.txt\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the file to copy.",
+                                "name": "source",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "FileID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Permission given to the copied file (e.g., 0600).\n\nDefault: 0644.",
+                                "name": "permissions",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Int",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this directory plus the contents of the given file copied to the given path.",
+                        "isDeprecated": false,
+                        "name": "withFile",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the directory created (e.g., \"/logs\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Permission granted to the created directory (e.g., 0777).\n\nDefault: 0755.",
+                                "name": "permissions",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Int",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this directory plus a new directory created at the given path.",
+                        "isDeprecated": false,
+                        "name": "withNewDirectory",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the written file (e.g., \"/file.txt\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Content of the written file (e.g., \"Hello world!\").",
+                                "name": "contents",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Permission given to the copied file (e.g., 0600).\n\nDefault: 0644.",
+                                "name": "permissions",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Int",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this directory plus a new file written at the given path.",
+                        "isDeprecated": false,
+                        "name": "withNewFile",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Timestamp to set dir/files in.\n\nFormatted in seconds following Unix epoch (e.g., 1672531199).",
+                                "name": "timestamp",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "Int",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this directory with all file/dir timestamps set to the given time.",
+                        "isDeprecated": false,
+                        "name": "withTimestamps",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the directory to remove (e.g., \".github/\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this directory with the directory at the given path removed.",
+                        "isDeprecated": false,
+                        "name": "withoutDirectory",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the file to remove (e.g., \"/file.txt\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this directory with the file at the given path removed.",
+                        "isDeprecated": false,
+                        "name": "withoutFile",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "Directory",
+                "possibleTypes": null
+            },
+            {
+                "description": "A content-addressed directory identifier.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "DirectoryID",
+                "possibleTypes": null
+            },
+            {
+                "description": "A simple key value object that represents an environment variable.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The environment variable name.",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The environment variable value.",
+                        "isDeprecated": false,
+                        "name": "value",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "EnvVariable",
+                "possibleTypes": null
+            },
+            {
+                "description": "A definition of a field on a custom object defined in a Module.\nA field on an object has a static value, as opposed to a function on an\nobject whose value is computed by invoking code (and can accept arguments).",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "A doc string for the field, if any",
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The name of the field in the object",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The type of the field",
+                        "isDeprecated": false,
+                        "name": "typeDef",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "FieldTypeDef",
+                "possibleTypes": null
+            },
+            {
+                "description": "A file.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves the contents of the file.",
+                        "isDeprecated": false,
+                        "name": "contents",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the written directory (e.g., \"output.txt\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "If allowParentDirPath is true, the path argument can be a directory path, in which case\nthe file will be created in that directory.",
+                                "name": "allowParentDirPath",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Writes the file to a file path on the host.",
+                        "isDeprecated": false,
+                        "name": "export",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves the content-addressed identifier of the file.",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "FileID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Gets the size of the file, in bytes.",
+                        "isDeprecated": false,
+                        "name": "size",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Force evaluation in the engine.",
+                        "isDeprecated": false,
+                        "name": "sync",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "FileID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Timestamp to set dir/files in.\n\nFormatted in seconds following Unix epoch (e.g., 1672531199).",
+                                "name": "timestamp",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "Int",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves this file with its created/modified timestamps set to the given time.",
+                        "isDeprecated": false,
+                        "name": "withTimestamps",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "File",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "File",
+                "possibleTypes": null
+            },
+            {
+                "description": "A file identifier.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "FileID",
+                "possibleTypes": null
+            },
+            {
+                "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point). ",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "Float",
+                "possibleTypes": null
+            },
+            {
+                "description": "Function represents a resolver provided by a Module.\n\nA function always evaluates against a parent object and is given a set of\nnamed arguments.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Arguments accepted by this function, if any",
+                        "isDeprecated": false,
+                        "name": "args",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "FunctionArg",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "A doc string for the function, if any",
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The ID of the function",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "FunctionID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The name of the function",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The type returned by this function",
+                        "isDeprecated": false,
+                        "name": "returnType",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The name of the argument",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "The type of the argument",
+                                "name": "typeDef",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "TypeDefID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A doc string for the argument, if any",
+                                "name": "description",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A default value to use for this argument if not explicitly set by the caller, if any",
+                                "name": "defaultValue",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "JSON",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Returns the function with the provided argument",
+                        "isDeprecated": false,
+                        "name": "withArg",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Function",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "description",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Returns the function with the doc string",
+                        "isDeprecated": false,
+                        "name": "withDescription",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Function",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "Function",
+                "possibleTypes": null
+            },
+            {
+                "description": "An argument accepted by a function.\n\nThis is a specification for an argument at function definition time, not an\nargument passed at function call time.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "A default value to use for this argument when not explicitly set by the caller, if any",
+                        "isDeprecated": false,
+                        "name": "defaultValue",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "JSON",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "A doc string for the argument, if any",
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The ID of the argument",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "FunctionArgID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The name of the argument",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The type of the argument",
+                        "isDeprecated": false,
+                        "name": "typeDef",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "FunctionArg",
+                "possibleTypes": null
+            },
+            {
+                "description": "A reference to a FunctionArg.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "FunctionArgID",
+                "possibleTypes": null
+            },
+            {
+                "description": "",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The argument values the function is being invoked with.",
+                        "isDeprecated": false,
+                        "name": "inputArgs",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "FunctionCallArgValue",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The name of the function being called.",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The value of the parent object of the function being called.\nIf the function is \"top-level\" to the module, this is always an empty object.",
+                        "isDeprecated": false,
+                        "name": "parent",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The name of the parent object of the function being called.\nIf the function is \"top-level\" to the module, this is the name of the module.",
+                        "isDeprecated": false,
+                        "name": "parentName",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "value",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "JSON",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Set the return value of the function call to the provided value.\nThe value should be a string of the JSON serialization of the return value.",
+                        "isDeprecated": false,
+                        "name": "returnValue",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "Void",
+                            "ofType": null
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "FunctionCall",
+                "possibleTypes": null
+            },
+            {
+                "description": "",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The name of the argument.",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The value of the argument represented as a string of the JSON serialization.",
+                        "isDeprecated": false,
+                        "name": "value",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "FunctionCallArgValue",
+                "possibleTypes": null
+            },
+            {
+                "description": "A reference to a Function.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "FunctionID",
+                "possibleTypes": null
+            },
+            {
+                "description": "",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The directory containing the generated code",
+                        "isDeprecated": false,
+                        "name": "code",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "GeneratedCodeID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "List of paths to mark generated in version control (i.e. .gitattributes)",
+                        "isDeprecated": false,
+                        "name": "vcsGeneratedPaths",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "List of paths to ignore in version control (i.e. .gitignore)",
+                        "isDeprecated": false,
+                        "name": "vcsIgnoredPaths",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "paths",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "LIST",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "NON_NULL",
+                                            "name": null,
+                                            "ofType": {
+                                                "kind": "SCALAR",
+                                                "name": "String",
+                                                "ofType": null
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Set the list of paths to mark generated in version control",
+                        "isDeprecated": false,
+                        "name": "withVCSGeneratedPaths",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "GeneratedCode",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "paths",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "LIST",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "NON_NULL",
+                                            "name": null,
+                                            "ofType": {
+                                                "kind": "SCALAR",
+                                                "name": "String",
+                                                "ofType": null
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Set the list of paths to ignore in version control",
+                        "isDeprecated": false,
+                        "name": "withVCSIgnoredPaths",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "GeneratedCode",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "GeneratedCode",
+                "possibleTypes": null
+            },
+            {
+                "description": "A reference to GeneratedCode.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "GeneratedCodeID",
+                "possibleTypes": null
+            },
+            {
+                "description": "A git ref (tag, branch or commit).",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The resolved commit id at this ref.",
+                        "isDeprecated": false,
+                        "name": "commit",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves the content-addressed identifier of the git ref.",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "GitRefID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "sshKnownHosts",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "sshAuthSocket",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "SocketID",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "The filesystem tree at this ref.",
+                        "isDeprecated": false,
+                        "name": "tree",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "GitRef",
+                "possibleTypes": null
+            },
+            {
+                "description": "A git reference identifier.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "GitRefID",
+                "possibleTypes": null
+            },
+            {
+                "description": "A git repository.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Branch's name (e.g., \"main\").",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Returns details on one branch.",
+                        "isDeprecated": false,
+                        "name": "branch",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "GitRef",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Identifier of the commit (e.g., \"b6315d8f2810962c601af73f86831f6866ea798b\").",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Returns details on one commit.",
+                        "isDeprecated": false,
+                        "name": "commit",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "GitRef",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves the content-addressed identifier of the git repository.",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "GitRepositoryID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Tag's name (e.g., \"v0.3.9\").",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Returns details on one tag.",
+                        "isDeprecated": false,
+                        "name": "tag",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "GitRef",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "GitRepository",
+                "possibleTypes": null
+            },
+            {
+                "description": "A git repository identifier.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "GitRepositoryID",
+                "possibleTypes": null
+            },
+            {
+                "description": "Information about the host execution environment.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the directory to access (e.g., \".\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Exclude artifacts that match the given pattern (e.g., [\"node_modules/\", \".git*\"]).",
+                                "name": "exclude",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "String",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Include only artifacts that match the given pattern (e.g., [\"app/\", \"package.*\"]).",
+                                "name": "include",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "String",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Accesses a directory on the host.",
+                        "isDeprecated": false,
+                        "name": "directory",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the file to retrieve (e.g., \"README.md\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Accesses a file on the host.",
+                        "isDeprecated": false,
+                        "name": "file",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "File",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Ports to expose via the service, forwarding through the host network.\n\nIf a port's frontend is unspecified or 0, it defaults to the same as the\nbackend port.\n\nAn empty set of ports is not valid; an error will be returned.",
+                                "name": "ports",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "LIST",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "NON_NULL",
+                                            "name": null,
+                                            "ofType": {
+                                                "kind": "INPUT_OBJECT",
+                                                "name": "PortForward",
+                                                "ofType": null
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": "\"localhost\"",
+                                "description": "Upstream host to forward traffic to.",
+                                "name": "host",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Creates a service that forwards traffic to a specified address via the host.",
+                        "isDeprecated": false,
+                        "name": "service",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Service",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The user defined name for this secret.",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the file to set as a secret.",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Sets a secret given a user-defined name and the file path on the host, and returns the secret.\nThe file is limited to a size of 512000 bytes.",
+                        "isDeprecated": false,
+                        "name": "setSecretFile",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Secret",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Service to send traffic from the tunnel.",
+                                "name": "service",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "ServiceID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": "false",
+                                "description": "Map each service port to the same port on the host, as if the service were\nrunning natively.\n\nNote: enabling may result in port conflicts.",
+                                "name": "native",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Configure explicit port forwarding rules for the tunnel.\n\nIf a port's frontend is unspecified or 0, a random port will be chosen by\nthe host.\n\nIf no ports are given, all of the service's ports are forwarded. If native\nis true, each port maps to the same port on the host. If native is false,\neach port maps to a random port chosen by the host.\n\nIf ports are given and native is true, the ports are additive.",
+                                "name": "ports",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "PortForward",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Creates a tunnel that forwards traffic from the host to a service.",
+                        "isDeprecated": false,
+                        "name": "tunnel",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Service",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Location of the Unix socket (e.g., \"/var/run/docker.sock\").",
+                                "name": "path",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Accesses a Unix socket on the host.",
+                        "isDeprecated": false,
+                        "name": "unixSocket",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Socket",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "Host",
+                "possibleTypes": null
+            },
+            {
+                "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "ID",
+                "possibleTypes": null
+            },
+            {
+                "description": "Compression algorithm to use for image layers.",
+                "enumValues": [
+                    {
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "EStarGZ"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "Gzip"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "Uncompressed"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "Zstd"
+                    }
+                ],
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "ENUM",
+                "name": "ImageLayerCompression",
+                "possibleTypes": null
+            },
+            {
+                "description": "Mediatypes to use in published or exported image metadata.",
+                "enumValues": [
+                    {
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "DockerMediaTypes"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "OCIMediaTypes"
+                    }
+                ],
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "ENUM",
+                "name": "ImageMediaTypes",
+                "possibleTypes": null
+            },
+            {
+                "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "Int",
+                "possibleTypes": null
+            },
+            {
+                "description": "An arbitrary JSON-encoded value.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "JSON",
+                "possibleTypes": null
+            },
+            {
+                "description": "A simple key value object that represents a label.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The label name.",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The label value.",
+                        "isDeprecated": false,
+                        "name": "value",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "Label",
+                "possibleTypes": null
+            },
+            {
+                "description": "A definition of a list type in a Module.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The type of the elements in the list",
+                        "isDeprecated": false,
+                        "name": "elementTypeDef",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "ListTypeDef",
+                "possibleTypes": null
+            },
+            {
+                "description": "",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Modules used by this module",
+                        "isDeprecated": false,
+                        "name": "dependencies",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "Module",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The dependencies as configured by the module",
+                        "isDeprecated": false,
+                        "name": "dependencyConfig",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The doc string of the module, if any",
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The code generated by the SDK's runtime",
+                        "isDeprecated": false,
+                        "name": "generatedCode",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "GeneratedCode",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The ID of the module",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "ModuleID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The name of the module",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Objects served by this module",
+                        "isDeprecated": false,
+                        "name": "objects",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "TypeDef",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The SDK used by this module. Either a name of a builtin SDK or a module ref pointing to the SDK's implementation.",
+                        "isDeprecated": false,
+                        "name": "sdk",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Serve a module's API in the current session.\n    Note: this can only be called once per session.\n    In the future, it could return a stream or service to remove the side effect.",
+                        "isDeprecated": false,
+                        "name": "serve",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "Void",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The directory containing the module's source code",
+                        "isDeprecated": false,
+                        "name": "sourceDirectory",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The module's subpath within the source directory",
+                        "isDeprecated": false,
+                        "name": "sourceDirectorySubPath",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "object",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "TypeDefID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "This module plus the given Object type and associated functions",
+                        "isDeprecated": false,
+                        "name": "withObject",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Module",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "Module",
+                "possibleTypes": null
+            },
+            {
+                "description": "Static configuration for a module (e.g. parsed contents of dagger.json)",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Modules that this module depends on.",
+                        "isDeprecated": false,
+                        "name": "dependencies",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Exclude these file globs when loading the module root.",
+                        "isDeprecated": false,
+                        "name": "exclude",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Include only these file globs when loading the module root.",
+                        "isDeprecated": false,
+                        "name": "include",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The name of the module.",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The root directory of the module's project, which may be above the module source code.",
+                        "isDeprecated": false,
+                        "name": "root",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Either the name of a built-in SDK ('go', 'python', etc.) OR a module reference pointing to the SDK's module implementation.",
+                        "isDeprecated": false,
+                        "name": "sdk",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "ModuleConfig",
+                "possibleTypes": null
+            },
+            {
+                "description": "A reference to a Module.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "ModuleID",
+                "possibleTypes": null
+            },
+            {
+                "description": "Transport layer network protocol associated to a port.",
+                "enumValues": [
+                    {
+                        "deprecationReason": null,
+                        "description": "TCP (Transmission Control Protocol)",
+                        "isDeprecated": false,
+                        "name": "TCP"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "UDP (User Datagram Protocol)",
+                        "isDeprecated": false,
+                        "name": "UDP"
+                    }
+                ],
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "ENUM",
+                "name": "NetworkProtocol",
+                "possibleTypes": null
+            },
+            {
+                "description": "A definition of a custom object defined in a Module.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The function used to construct new instances of this object, if any",
+                        "isDeprecated": false,
+                        "name": "constructor",
+                        "type": {
+                            "kind": "OBJECT",
+                            "name": "Function",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The doc string for the object, if any",
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Static fields defined on this object, if any",
+                        "isDeprecated": false,
+                        "name": "fields",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "FieldTypeDef",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Functions defined on this object, if any",
+                        "isDeprecated": false,
+                        "name": "functions",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "Function",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The name of the object",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "ObjectTypeDef",
+                "possibleTypes": null
+            },
+            {
+                "description": "Key value object that represents a Pipeline label.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": [
+                    {
+                        "defaultValue": null,
+                        "description": "Label name.",
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "defaultValue": null,
+                        "description": "Label value.",
+                        "name": "value",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "interfaces": null,
+                "kind": "INPUT_OBJECT",
+                "name": "PipelineLabel",
+                "possibleTypes": null
+            },
+            {
+                "description": "The platform config OS and architecture in a Container.\n\nThe format is [os]/[platform]/[version] (e.g., \"darwin/arm64/v7\", \"windows/amd64\", \"linux/arm64\").",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "Platform",
+                "possibleTypes": null
+            },
+            {
+                "description": "A port exposed by a container.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The port description.",
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The port number.",
+                        "isDeprecated": false,
+                        "name": "port",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The transport layer network protocol.",
+                        "isDeprecated": false,
+                        "name": "protocol",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "ENUM",
+                                "name": "NetworkProtocol",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "Port",
+                "possibleTypes": null
+            },
+            {
+                "description": "Port forwarding rules for tunneling network traffic.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": [
+                    {
+                        "defaultValue": null,
+                        "description": "Destination port for traffic.",
+                        "name": "backend",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "defaultValue": null,
+                        "description": "Port to expose to clients. If unspecified, a default will be chosen.",
+                        "name": "frontend",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "Int",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "defaultValue": "\"TCP\"",
+                        "description": "Protocol to use for traffic.",
+                        "name": "protocol",
+                        "type": {
+                            "kind": "ENUM",
+                            "name": "NetworkProtocol",
+                            "ofType": null
+                        }
+                    }
+                ],
+                "interfaces": null,
+                "kind": "INPUT_OBJECT",
+                "name": "PortForward",
+                "possibleTypes": null
+            },
+            {
+                "description": "",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "A string identifier to target this cache volume (e.g., \"modules-cache\").",
+                                "name": "key",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Constructs a cache volume for a given cache key.",
+                        "isDeprecated": false,
+                        "name": "cacheVolume",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "CacheVolume",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The SDK's required version.",
+                                "name": "version",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Checks if the current Dagger Engine is compatible with an SDK's required version.",
+                        "isDeprecated": false,
+                        "name": "checkVersionCompatibility",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "ContainerID",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "platform",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Platform",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Creates a scratch container or loads one by ID.\n\nOptional platform argument initializes new containers to execute and publish\nas that platform. Platform defaults to that of the builder's host.",
+                        "isDeprecated": false,
+                        "name": "container",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The FunctionCall context that the SDK caller is currently executing in.\nIf the caller is not currently executing in a function, this will return\nan error.",
+                        "isDeprecated": false,
+                        "name": "currentFunctionCall",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "FunctionCall",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The module currently being served in the session, if any.",
+                        "isDeprecated": false,
+                        "name": "currentModule",
+                        "type": {
+                            "kind": "OBJECT",
+                            "name": "Module",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The default platform of the builder.",
+                        "isDeprecated": false,
+                        "name": "defaultPlatform",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Platform",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "DirectoryID",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Creates an empty directory or loads one by ID.",
+                        "isDeprecated": false,
+                        "name": "directory",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "FileID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": "Use `loadFileFromID` instead.",
+                        "description": "Loads a file by ID.",
+                        "isDeprecated": true,
+                        "name": "file",
+                        "type": {
+                            "kind": "OBJECT",
+                            "name": "File",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "returnType",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "TypeDefID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Create a function.",
+                        "isDeprecated": false,
+                        "name": "function",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Function",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "code",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "DirectoryID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Create a code generation result, given a directory containing the generated\ncode.",
+                        "isDeprecated": false,
+                        "name": "generatedCode",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "GeneratedCode",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Url of the git repository.\nCan be formatted as `https://{host}/{owner}/{repo}`, `git@{host}:{owner}/{repo}`\nSuffix \".git\" is optional.",
+                                "name": "url",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Set to true to keep .git directory.",
+                                "name": "keepGitDir",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Set SSH known hosts",
+                                "name": "sshKnownHosts",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Set SSH auth socket",
+                                "name": "sshAuthSocket",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "SocketID",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A service which must be started before the repo is fetched.",
+                                "name": "experimentalServiceHost",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "ServiceID",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Queries a git repository.",
+                        "isDeprecated": false,
+                        "name": "git",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "GitRepository",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Queries the host environment.",
+                        "isDeprecated": false,
+                        "name": "host",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Host",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "HTTP url to get the content from (e.g., \"https://docs.dagger.io\").",
+                                "name": "url",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A service which must be started before the URL is fetched.",
+                                "name": "experimentalServiceHost",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "ServiceID",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Returns a file containing an http remote url content.",
+                        "isDeprecated": false,
+                        "name": "http",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "File",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "CacheVolumeID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load a CacheVolume from its ID.",
+                        "isDeprecated": false,
+                        "name": "loadCacheVolumeFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "CacheVolume",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "ContainerID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Loads a container from an ID.",
+                        "isDeprecated": false,
+                        "name": "loadContainerFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Container",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "DirectoryID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load a Directory from its ID.",
+                        "isDeprecated": false,
+                        "name": "loadDirectoryFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Directory",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "FileID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load a File from its ID.",
+                        "isDeprecated": false,
+                        "name": "loadFileFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "File",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "FunctionArgID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load a function argument by ID.",
+                        "isDeprecated": false,
+                        "name": "loadFunctionArgFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "FunctionArg",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "FunctionID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load a function by ID.",
+                        "isDeprecated": false,
+                        "name": "loadFunctionFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Function",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "GeneratedCodeID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load a GeneratedCode by ID.",
+                        "isDeprecated": false,
+                        "name": "loadGeneratedCodeFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "GeneratedCode",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "GitRefID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load a git ref from its ID.",
+                        "isDeprecated": false,
+                        "name": "loadGitRefFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "GitRef",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "GitRepositoryID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load a git repository from its ID.",
+                        "isDeprecated": false,
+                        "name": "loadGitRepositoryFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "GitRepository",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "ModuleID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load a module by ID.",
+                        "isDeprecated": false,
+                        "name": "loadModuleFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Module",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "SecretID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load a Secret from its ID.",
+                        "isDeprecated": false,
+                        "name": "loadSecretFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Secret",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "ServiceID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Loads a service from ID.",
+                        "isDeprecated": false,
+                        "name": "loadServiceFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Service",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "SocketID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load a Socket from its ID.",
+                        "isDeprecated": false,
+                        "name": "loadSocketFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Socket",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "TypeDefID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load a TypeDef by ID.",
+                        "isDeprecated": false,
+                        "name": "loadTypeDefFromID",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Create a new module.",
+                        "isDeprecated": false,
+                        "name": "module",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Module",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "sourceDirectory",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "DirectoryID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "subpath",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Load the static configuration for a module from the given source directory and optional subpath.",
+                        "isDeprecated": false,
+                        "name": "moduleConfig",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "ModuleConfig",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "Pipeline name.",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Pipeline description.",
+                                "name": "description",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Pipeline labels.",
+                                "name": "labels",
+                                "type": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "PipelineLabel",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Creates a named sub-pipeline.",
+                        "isDeprecated": false,
+                        "name": "pipeline",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Query",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "SecretID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": "Use `loadSecretFromID` instead",
+                        "description": "Loads a secret from its ID.",
+                        "isDeprecated": true,
+                        "name": "secret",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Secret",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The user defined name for this secret",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "The plaintext of the secret",
+                                "name": "plaintext",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Sets a secret given a user defined name to its plaintext and returns the secret.\nThe plaintext value is limited to a size of 128000 bytes.",
+                        "isDeprecated": false,
+                        "name": "setSecret",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Secret",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "id",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "SocketID",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": "Use `loadSocketFromID` instead.",
+                        "description": "Loads a socket by its ID.",
+                        "isDeprecated": true,
+                        "name": "socket",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "Socket",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Create a new TypeDef.",
+                        "isDeprecated": false,
+                        "name": "typeDef",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "Query",
+                "possibleTypes": null
+            },
+            {
+                "description": "A reference to a secret value, which can be handled more safely than the value itself.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The identifier for this secret.",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "SecretID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The value of this secret.",
+                        "isDeprecated": false,
+                        "name": "plaintext",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "Secret",
+                "possibleTypes": null
+            },
+            {
+                "description": "A unique identifier for a secret.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "SecretID",
+                "possibleTypes": null
+            },
+            {
+                "description": "",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The exposed port number for the endpoint",
+                                "name": "port",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Int",
+                                    "ofType": null
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "Return a URL with the given scheme, eg. http for http://",
+                                "name": "scheme",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Retrieves an endpoint that clients can use to reach this container.\n\nIf no port is specified, the first exposed port is used. If none exist an error is returned.\n\nIf a scheme is specified, a URL is returned. Otherwise, a host:port pair is returned.",
+                        "isDeprecated": false,
+                        "name": "endpoint",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves a hostname which can be used by clients to reach this container.",
+                        "isDeprecated": false,
+                        "name": "hostname",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "A unique identifier for this service.",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "ServiceID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Retrieves the list of ports provided by the service.",
+                        "isDeprecated": false,
+                        "name": "ports",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "Port",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Start the service and wait for its health checks to succeed.\n\nServices bound to a Container do not need to be manually started.",
+                        "isDeprecated": false,
+                        "name": "start",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "ServiceID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Stop the service.",
+                        "isDeprecated": false,
+                        "name": "stop",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "ServiceID",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "Service",
+                "possibleTypes": null
+            },
+            {
+                "description": "A unique service identifier.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "ServiceID",
+                "possibleTypes": null
+            },
+            {
+                "description": "",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The content-addressed identifier of the socket.",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "SocketID",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "Socket",
+                "possibleTypes": null
+            },
+            {
+                "description": "A content-addressed socket identifier.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "SocketID",
+                "possibleTypes": null
+            },
+            {
+                "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "String",
+                "possibleTypes": null
+            },
+            {
+                "description": "A definition of a parameter or return type in a Module.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "If kind is LIST, the list-specific type definition.\nIf kind is not LIST, this will be null.",
+                        "isDeprecated": false,
+                        "name": "asList",
+                        "type": {
+                            "kind": "OBJECT",
+                            "name": "ListTypeDef",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "If kind is OBJECT, the object-specific type definition.\nIf kind is not OBJECT, this will be null.",
+                        "isDeprecated": false,
+                        "name": "asObject",
+                        "type": {
+                            "kind": "OBJECT",
+                            "name": "ObjectTypeDef",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "id",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "TypeDefID",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The kind of type this is (e.g. primitive, list, object)",
+                        "isDeprecated": false,
+                        "name": "kind",
+                        "type": {
+                            "kind": "ENUM",
+                            "name": "TypeDefKind",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "Whether this type can be set to null. Defaults to false.",
+                        "isDeprecated": false,
+                        "name": "optional",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "function",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "FunctionID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Adds a function for constructing a new instance of an Object TypeDef, failing if the type is not an object.",
+                        "isDeprecated": false,
+                        "name": "withConstructor",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "The name of the field in the object",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "The type of the field",
+                                "name": "typeDef",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "TypeDefID",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "A doc string for the field, if any",
+                                "name": "description",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Adds a static field for an Object TypeDef, failing if the type is not an object.",
+                        "isDeprecated": false,
+                        "name": "withField",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "function",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "FunctionID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Adds a function for an Object TypeDef, failing if the type is not an object.",
+                        "isDeprecated": false,
+                        "name": "withFunction",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "kind",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "ENUM",
+                                        "name": "TypeDefKind",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Sets the kind of the type.",
+                        "isDeprecated": false,
+                        "name": "withKind",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "elementType",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "TypeDefID",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Returns a TypeDef of kind List with the provided type for its elements.",
+                        "isDeprecated": false,
+                        "name": "withListOf",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "name",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "description",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Returns a TypeDef of kind Object with the provided name.\n\nNote that an object's fields and functions may be omitted if the intent is\nonly to refer to an object. This is how functions are able to return their\nown object, or any other circular reference.",
+                        "isDeprecated": false,
+                        "name": "withObject",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": null,
+                                "description": "",
+                                "name": "optional",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "Boolean",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "Sets whether this type can be set to null.",
+                        "isDeprecated": false,
+                        "name": "withOptional",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "TypeDef",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "TypeDef",
+                "possibleTypes": null
+            },
+            {
+                "description": "A reference to a TypeDef.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "TypeDefID",
+                "possibleTypes": null
+            },
+            {
+                "description": "Distinguishes the different kinds of TypeDefs.",
+                "enumValues": [
+                    {
+                        "deprecationReason": null,
+                        "description": "A boolean value",
+                        "isDeprecated": false,
+                        "name": "BooleanKind"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "An integer value",
+                        "isDeprecated": false,
+                        "name": "IntegerKind"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "A list of values all having the same type.\n\nAlways paired with a ListTypeDef.",
+                        "isDeprecated": false,
+                        "name": "ListKind"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "A named type defined in the GraphQL schema, with fields and functions.\n\nAlways paired with an ObjectTypeDef.",
+                        "isDeprecated": false,
+                        "name": "ObjectKind"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "A string value",
+                        "isDeprecated": false,
+                        "name": "StringKind"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "A special kind used to signify that no value is returned.\n\nThis is used for functions that have no return value. The outer TypeDef\nspecifying this Kind is always Optional, as the Void is never actually\nrepresented.",
+                        "isDeprecated": false,
+                        "name": "VoidKind"
+                    }
+                ],
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "ENUM",
+                "name": "TypeDefKind",
+                "possibleTypes": null
+            },
+            {
+                "description": "The absense of a value.\n\nA Null Void is used as a placeholder for resolvers that do not return anything.",
+                "enumValues": null,
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "SCALAR",
+                "name": "Void",
+                "possibleTypes": null
+            },
+            {
+                "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document. \n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "args",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__InputValue",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "locations",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "ENUM",
+                                        "name": "__DirectiveLocation",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": "Use `locations`.",
+                        "description": "",
+                        "isDeprecated": true,
+                        "name": "onField",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": "Use `locations`.",
+                        "description": "",
+                        "isDeprecated": true,
+                        "name": "onFragment",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": "Use `locations`.",
+                        "description": "",
+                        "isDeprecated": true,
+                        "name": "onOperation",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "__Directive",
+                "possibleTypes": null
+            },
+            {
+                "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+                "enumValues": [
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to an argument definition.",
+                        "isDeprecated": false,
+                        "name": "ARGUMENT_DEFINITION"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to an enum definition.",
+                        "isDeprecated": false,
+                        "name": "ENUM"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to an enum value definition.",
+                        "isDeprecated": false,
+                        "name": "ENUM_VALUE"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to a field.",
+                        "isDeprecated": false,
+                        "name": "FIELD"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to a field definition.",
+                        "isDeprecated": false,
+                        "name": "FIELD_DEFINITION"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to a fragment definition.",
+                        "isDeprecated": false,
+                        "name": "FRAGMENT_DEFINITION"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to a fragment spread.",
+                        "isDeprecated": false,
+                        "name": "FRAGMENT_SPREAD"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to an inline fragment.",
+                        "isDeprecated": false,
+                        "name": "INLINE_FRAGMENT"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to an input object field definition.",
+                        "isDeprecated": false,
+                        "name": "INPUT_FIELD_DEFINITION"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to an input object type definition.",
+                        "isDeprecated": false,
+                        "name": "INPUT_OBJECT"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to an interface definition.",
+                        "isDeprecated": false,
+                        "name": "INTERFACE"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to a mutation operation.",
+                        "isDeprecated": false,
+                        "name": "MUTATION"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to a object definition.",
+                        "isDeprecated": false,
+                        "name": "OBJECT"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to a query operation.",
+                        "isDeprecated": false,
+                        "name": "QUERY"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to a scalar definition.",
+                        "isDeprecated": false,
+                        "name": "SCALAR"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to a schema definition.",
+                        "isDeprecated": false,
+                        "name": "SCHEMA"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to a subscription operation.",
+                        "isDeprecated": false,
+                        "name": "SUBSCRIPTION"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Location adjacent to a union definition.",
+                        "isDeprecated": false,
+                        "name": "UNION"
+                    }
+                ],
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "ENUM",
+                "name": "__DirectiveLocation",
+                "possibleTypes": null
+            },
+            {
+                "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "deprecationReason",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "isDeprecated",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "__EnumValue",
+                "possibleTypes": null
+            },
+            {
+                "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "args",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__InputValue",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "deprecationReason",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "isDeprecated",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "type",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "__Type",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "__Field",
+                "possibleTypes": null
+            },
+            {
+                "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "A GraphQL-formatted string representing the default value for this input value.",
+                        "isDeprecated": false,
+                        "name": "defaultValue",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "type",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "__Type",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "__InputValue",
+                "possibleTypes": null
+            },
+            {
+                "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "A list of all directives supported by this server.",
+                        "isDeprecated": false,
+                        "name": "directives",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__Directive",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
+                        "isDeprecated": false,
+                        "name": "mutationType",
+                        "type": {
+                            "kind": "OBJECT",
+                            "name": "__Type",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "The type that query operations will be rooted at.",
+                        "isDeprecated": false,
+                        "name": "queryType",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "__Type",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "If this server supports subscription, the type that subscription operations will be rooted at.",
+                        "isDeprecated": false,
+                        "name": "subscriptionType",
+                        "type": {
+                            "kind": "OBJECT",
+                            "name": "__Type",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "A list of all types supported by this server.",
+                        "isDeprecated": false,
+                        "name": "types",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__Type",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "__Schema",
+                "possibleTypes": null
+            },
+            {
+                "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+                "enumValues": null,
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": "false",
+                                "description": "",
+                                "name": "includeDeprecated",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "enumValues",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__EnumValue",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "defaultValue": "false",
+                                "description": "",
+                                "name": "includeDeprecated",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "fields",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__Field",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "inputFields",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__InputValue",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "interfaces",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__Type",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "kind",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "ENUM",
+                                "name": "__TypeKind",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "ofType",
+                        "type": {
+                            "kind": "OBJECT",
+                            "name": "__Type",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "description": "",
+                        "isDeprecated": false,
+                        "name": "possibleTypes",
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__Type",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "__Type",
+                "possibleTypes": null
+            },
+            {
+                "description": "An enum describing what kind of type a given `__Type` is",
+                "enumValues": [
+                    {
+                        "deprecationReason": null,
+                        "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+                        "isDeprecated": false,
+                        "name": "ENUM"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+                        "isDeprecated": false,
+                        "name": "INPUT_OBJECT"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+                        "isDeprecated": false,
+                        "name": "INTERFACE"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Indicates this type is a list. `ofType` is a valid field.",
+                        "isDeprecated": false,
+                        "name": "LIST"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+                        "isDeprecated": false,
+                        "name": "NON_NULL"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+                        "isDeprecated": false,
+                        "name": "OBJECT"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Indicates this type is a scalar.",
+                        "isDeprecated": false,
+                        "name": "SCALAR"
+                    },
+                    {
+                        "deprecationReason": null,
+                        "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+                        "isDeprecated": false,
+                        "name": "UNION"
+                    }
+                ],
+                "fields": null,
+                "inputFields": null,
+                "interfaces": null,
+                "kind": "ENUM",
+                "name": "__TypeKind",
+                "possibleTypes": null
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Add generated java sdk schema for engine versions 0.9.4 and 0.9.5.