### PR TITLE
feat: Java SDK upgrade maven to 3.9.6

### DIFF
--- a/sdk/java/.mvn/wrapper/maven-wrapper.properties
+++ b/sdk/java/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.2/apache-maven-3.9.2-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar


### PR DESCRIPTION
Upgrade Maven to get rid of validation issues from an old maven version.

```bash
[WARNING]  Plugin validation issues were detected in 1 plugin(s)
[WARNING] 
[WARNING]  * org.apache.maven.plugins:maven-plugin-plugin:3.7.1
[WARNING]   Declared at location(s):
[WARNING]    * org.apache.maven:maven-core:3.9.2:default-lifecycle-bindings @ line -1
[WARNING]   Used in module(s):
[WARNING]    * io.dagger:dagger-codegen-maven-plugin:1.0.0-SNAPSHOT (dagger-codegen-maven-plugin/pom.xml)
```