### PR TITLE
Pin images by digest for performance

### DIFF
--- a/core/modules/resolver.go
+++ b/core/modules/resolver.go
@@ -14,6 +14,12 @@ import (
 	"github.com/moby/buildkit/identity"
 )
 
+var (
+	// The digest-pinned ref of an address that can run 'git'
+	// FIXME: make this image smaller
+	gitImageRef = "index.docker.io/alpine/git@sha256:1031f50b5bdda7eee6167e362cff09b8c809889cd43e5306abc5bf6438e68890"
+)
+
 // Ref contains all of the information we're able to learn about a provided
 // module ref.
 type Ref struct {
@@ -305,7 +311,7 @@ func ResolveModuleDependency(ctx context.Context, dag *dagger.Client, parent *Re
 
 func defaultBranch(ctx context.Context, dag *dagger.Client, repo string) (string, error) {
 	output, err := dag.Container().
-		From("alpine/git").
+		From(gitImageRef).
 		WithEnvVariable("CACHEBUSTER", identity.NewID()). // force this to always run so we don't get stale data
 		WithExec([]string{"git", "ls-remote", "--symref", repo, "HEAD"}, dagger.ContainerWithExecOpts{
 			SkipEntrypoint: true,

--- a/sdk/python/runtime/main.go
+++ b/sdk/python/runtime/main.go
@@ -17,6 +17,8 @@ const (
 	genDir                = "sdk"
 	genPath               = "src/dagger/client/gen.py"
 	schemaPath            = "/schema.json"
+	defaultPythonVersion  = "3.11-slim"
+	defaultPythonDigest   = "sha256:8f64a67710f3d981cf3008d6f9f1dbe61accd7927f165f4e37ea3f8b883ccc3f"
 )
 
 //go:embed scripts/runtime.py
@@ -78,7 +80,7 @@ func (m *PythonSdk) CodegenBase(modSource *Directory, subPath string, introspect
 
 func (m *PythonSdk) Base(version string) *Container {
 	if version == "" {
-		version = "3.11-slim"
+		version = defaultPythonVersion + "@" + defaultPythonDigest
 	}
 	return dag.Container().
 		From("python:"+version).


### PR DESCRIPTION
By specifying the digest of images pulled by the core, we save network back-and-forth, which helps with performance especially on slow internet links.