### PR TITLE
feat: add llb to progress output

### DIFF
--- a/engine/buildkit/progrock.go
+++ b/engine/buildkit/progrock.go
@@ -169,7 +169,7 @@ func (g *recordingGateway) ConvertStatus(event *bkclient.SolveStatus) *progrock.
 				g.records[v.Digest] = nil // don't write out a record again
 
 				if a, err := types.MarshalAny(op); err == nil {
-					status.Metas = append(status.Metas, &progrock.VertexMeta{Vertex: vtx.Id, Data: &anypb.Any{TypeUrl: a.TypeUrl, Value: a.Value}})
+					status.Metas = append(status.Metas, &progrock.VertexMeta{Name: "op", Vertex: vtx.Id, Data: &anypb.Any{TypeUrl: a.TypeUrl, Value: a.Value}})
 				}
 			}
 		}

--- a/engine/buildkit/progrock.go
+++ b/engine/buildkit/progrock.go
@@ -1,14 +1,17 @@
 package buildkit
 
 import (
+	"bytes"
 	"context"
-	"fmt"
 	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/containerd/containerd/platforms"
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
 	bkclient "github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/frontend"
@@ -22,13 +25,24 @@ import (
 const FocusPrefix = "[focus] "
 const InternalPrefix = "[internal] "
 
+type BK2Progrock interface {
+	ConvertStatus(*bkclient.SolveStatus) *progrock.StatusUpdate
+}
+
 type recordingGateway struct {
 	llbBridge frontend.FrontendLLBBridge
+
+	records   map[digest.Digest]proto.Message
+	recordsMu sync.Mutex
 }
+
+var _ frontend.FrontendLLBBridge = &recordingGateway{}
+
+var _ BK2Progrock = &recordingGateway{}
 
 // ResolveImageConfig records the image config resolution vertex as a member of
 // the current progress group, and calls the inner ResolveImageConfig.
-func (g recordingGateway) ResolveImageConfig(ctx context.Context, ref string, opt llb.ResolveImageConfigOpt) (string, digest.Digest, []byte, error) {
+func (g *recordingGateway) ResolveImageConfig(ctx context.Context, ref string, opt llb.ResolveImageConfigOpt) (string, digest.Digest, []byte, error) {
 	rec := progrock.FromContext(ctx)
 
 	// HACK(vito): this is how Buildkit determines the vertex digest. Keep this
@@ -48,11 +62,52 @@ func (g recordingGateway) ResolveImageConfig(ctx context.Context, ref string, op
 
 // Solve records the vertexes of the definition and frontend inputs as members
 // of the current progress group, and calls the inner Solve.
-func (g recordingGateway) Solve(ctx context.Context, req frontend.SolveRequest, sessionID string) (*frontend.Result, error) {
+func (g *recordingGateway) Solve(ctx context.Context, req frontend.SolveRequest, sessionID string) (*frontend.Result, error) {
 	rec := progrock.FromContext(ctx)
 
 	if req.Definition != nil {
 		RecordVertexes(rec, req.Definition)
+
+		g.recordsMu.Lock()
+		if g.records == nil {
+			g.records = make(map[digest.Digest]proto.Message)
+		}
+		for _, dt := range req.Definition.Def {
+			dgst := digest.FromBytes(dt)
+			if _, ok := g.records[dgst]; ok {
+				continue
+			}
+			var op pb.Op
+			if err := (&op).Unmarshal(dt); err != nil {
+				g.recordsMu.Unlock()
+				return nil, err
+			}
+
+			// remove raw file contents (these can be kinda large)
+			if fileOp := op.GetFile(); fileOp != nil {
+				for _, action := range fileOp.Actions {
+					if mkfile := action.GetMkfile(); mkfile != nil {
+						mkfile.Data = nil
+					}
+				}
+			}
+
+			switch op := op.Op.(type) {
+			case *pb.Op_Exec:
+				g.records[dgst] = op.Exec
+			case *pb.Op_Source:
+				g.records[dgst] = op.Source
+			case *pb.Op_File:
+				g.records[dgst] = op.File
+			case *pb.Op_Build:
+				g.records[dgst] = op.Build
+			case *pb.Op_Merge:
+				g.records[dgst] = op.Merge
+			case *pb.Op_Diff:
+				g.records[dgst] = op.Diff
+			}
+		}
+		g.recordsMu.Unlock()
 	}
 
 	for _, input := range req.FrontendInputs {
@@ -68,8 +123,87 @@ func (g recordingGateway) Solve(ctx context.Context, req frontend.SolveRequest, 
 	return g.llbBridge.Solve(ctx, req, sessionID)
 }
 
-func (g recordingGateway) Warn(ctx context.Context, dgst digest.Digest, msg string, opts frontend.WarnOpts) error {
+func (g *recordingGateway) Warn(ctx context.Context, dgst digest.Digest, msg string, opts frontend.WarnOpts) error {
 	return g.llbBridge.Warn(ctx, dgst, msg, opts)
+}
+
+func (g *recordingGateway) ConvertStatus(event *bkclient.SolveStatus) *progrock.StatusUpdate {
+	var status progrock.StatusUpdate
+	for _, v := range event.Vertexes {
+		vtx := &progrock.Vertex{
+			Id:     v.Digest.String(),
+			Name:   v.Name,
+			Cached: v.Cached,
+		}
+		if strings.HasPrefix(v.Name, InternalPrefix) {
+			vtx.Internal = true
+			vtx.Name = strings.TrimPrefix(v.Name, InternalPrefix)
+		}
+		if strings.HasPrefix(v.Name, FocusPrefix) {
+			vtx.Focused = true
+			vtx.Name = strings.TrimPrefix(v.Name, FocusPrefix)
+		}
+		for _, input := range v.Inputs {
+			vtx.Inputs = append(vtx.Inputs, input.String())
+		}
+		if v.Started != nil {
+			vtx.Started = timestamppb.New(*v.Started)
+		}
+		if v.Completed != nil {
+			vtx.Completed = timestamppb.New(*v.Completed)
+		}
+		if v.Error != "" {
+			if strings.HasSuffix(v.Error, context.Canceled.Error()) {
+				vtx.Canceled = true
+			} else {
+				msg := v.Error
+				vtx.Error = &msg
+			}
+		}
+
+		g.recordsMu.Lock()
+		if op, ok := g.records[v.Digest]; ok {
+			if op != nil {
+				g.records[v.Digest] = nil // don't write out a record again
+
+				marshal := jsonpb.Marshaler{}
+				var buf bytes.Buffer
+				if err := marshal.Marshal(&buf, op); err == nil {
+					vtx.Labels = append(vtx.Labels, progrock.Labelf("llb", buf.String()))
+				}
+			}
+		}
+		g.recordsMu.Unlock()
+
+		status.Vertexes = append(status.Vertexes, vtx)
+	}
+
+	for _, s := range event.Statuses {
+		task := &progrock.VertexTask{
+			Vertex:  s.Vertex.String(),
+			Name:    s.ID, // remap
+			Total:   s.Total,
+			Current: s.Current,
+		}
+		if s.Started != nil {
+			task.Started = timestamppb.New(*s.Started)
+		}
+		if s.Completed != nil {
+			task.Completed = timestamppb.New(*s.Completed)
+		}
+		status.Tasks = append(status.Tasks, task)
+	}
+
+	for _, s := range event.Logs {
+		status.Logs = append(status.Logs, &progrock.VertexLog{
+			Vertex:    s.Vertex.String(),
+			Stream:    progrock.LogStream(s.Stream),
+			Data:      s.Data,
+			Timestamp: timestamppb.New(s.Timestamp),
+		})
+	}
+
+	return &status
 }
 
 type ProgrockLogrusWriter struct{}
@@ -113,7 +247,6 @@ func ProgrockForwarder(sockPath string, w progrock.Writer) (progrock.Writer, fun
 func RecordVertexes(recorder *progrock.Recorder, def *pb.Definition) {
 	dgsts := []digest.Digest{}
 	for dgst, meta := range def.Metadata {
-		_ = meta
 		if meta.ProgressGroup != nil {
 			// Regular progress group, i.e. from Dockerfile; record it as a subgroup,
 			// with 'weak' annotation so it's distinct from user-configured
@@ -125,77 +258,4 @@ func RecordVertexes(recorder *progrock.Recorder, def *pb.Definition) {
 	}
 
 	recorder.Join(dgsts...)
-}
-
-func RecordBuildkitStatus(rec *progrock.Recorder, solveCh <-chan *bkclient.SolveStatus) error {
-	for ev := range solveCh {
-		if err := rec.Record(BK2Progrock(ev)); err != nil {
-			return fmt.Errorf("record: %w", err)
-		}
-	}
-	return nil
-}
-
-func BK2Progrock(event *bkclient.SolveStatus) *progrock.StatusUpdate {
-	var status progrock.StatusUpdate
-	for _, v := range event.Vertexes {
-		vtx := &progrock.Vertex{
-			Id:     v.Digest.String(),
-			Name:   v.Name,
-			Cached: v.Cached,
-		}
-		if strings.HasPrefix(v.Name, InternalPrefix) {
-			vtx.Internal = true
-			vtx.Name = strings.TrimPrefix(v.Name, InternalPrefix)
-		}
-		if strings.HasPrefix(v.Name, FocusPrefix) {
-			vtx.Focused = true
-			vtx.Name = strings.TrimPrefix(v.Name, FocusPrefix)
-		}
-		for _, input := range v.Inputs {
-			vtx.Inputs = append(vtx.Inputs, input.String())
-		}
-		if v.Started != nil {
-			vtx.Started = timestamppb.New(*v.Started)
-		}
-		if v.Completed != nil {
-			vtx.Completed = timestamppb.New(*v.Completed)
-		}
-		if v.Error != "" {
-			if strings.HasSuffix(v.Error, context.Canceled.Error()) {
-				vtx.Canceled = true
-			} else {
-				msg := v.Error
-				vtx.Error = &msg
-			}
-		}
-		status.Vertexes = append(status.Vertexes, vtx)
-	}
-
-	for _, s := range event.Statuses {
-		task := &progrock.VertexTask{
-			Vertex:  s.Vertex.String(),
-			Name:    s.ID, // remap
-			Total:   s.Total,
-			Current: s.Current,
-		}
-		if s.Started != nil {
-			task.Started = timestamppb.New(*s.Started)
-		}
-		if s.Completed != nil {
-			task.Completed = timestamppb.New(*s.Completed)
-		}
-		status.Tasks = append(status.Tasks, task)
-	}
-
-	for _, s := range event.Logs {
-		status.Logs = append(status.Logs, &progrock.VertexLog{
-			Vertex:    s.Vertex.String(),
-			Stream:    progrock.LogStream(s.Stream),
-			Data:      s.Data,
-			Timestamp: timestamppb.New(s.Timestamp),
-		})
-	}
-
-	return &status
 }


### PR DESCRIPTION
The idea behind this PR is to attach the JSON representation of the underlying LLB to each vertex in the progress output. This data should be available to be ingested by the cloud service, so it can be used for better visualizations.

This piece is just the client-side part. To see an example, you can use `_EXPERIMENTAL_DAGGER_PROGROCK_JOURNAL`:

```
$ _EXPERIMENTAL_DAGGER_PROGROCK_JOURNAL=/tmp/progrock.json dagger call -m github.com/jedevc/daggerverse/hugo build --target git@github.com:gohugoio/hugoBasicExample#master
$ cat /tmp/progrock.json | grep "exec hugo" | jq
```
```json
...
    {
      "id": "sha256:2efaca543d1aae0cbfa350f05d048d9f3ed9149cb11482cc09cf5c73af2a7da8",
      "name": "exec hugo --gc --cacheDir /cache --destination /dest",
      "inputs": [
        "sha256:4d909dfc6a84e0f9285063eae4d36672b0f5c358be8fe91b80faabf4283cf19e",
        "sha256:d992cee8196052d190c4e3ab98c46199d4fbf1f5cc301c778732bde899deddfd"
      ],
      "labels": [
        {
          "name": "llb",
          "value": "{\"meta\":{\"args\":[\"hugo\",\"--gc\",\"--cacheDir\",\"/cache\",\"--destination\",\"/dest\"],\"env\":[\"PATH=/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\",\"GOLANG_VERSION=1.21.5\",\"GOTOOLCHAIN=local\",\"GOPATH=/go\"],\"cwd\":\"/src\",\"proxyEnv\":{\"ftpProxy\":\"{\\\"parentClientIDs\\\":[\\\"2x9fqd1jevoyr3kcffwptzt1n\\\",\\\"p7xe3ub52s74lwgq4rx0wgk8y\\\"],\\\"serverID\\\":\\\"z9f4o3lx4ie0j0z8ln5hyaq5f\\\",\\\"progSockPath\\\":\\\"/run/dagger/server-progrock-pvifkmx7r35ri8670uiu1nguv.sock\\\"}\"},\"removeMountStubsRecursive\":true},\"mounts\":[{\"dest\":\"/\"},{\"input\":\"1\",\"selector\":\"meta\",\"dest\":\"/.dagger_meta_mount\",\"output\":\"1\"},{\"input\":\"-1\",\"dest\":\"/cache\",\"output\":\"-1\",\"mountType\":\"CACHE\",\"cacheOpt\":{\"ID\":\"5buA7PiVeYHo/GgWBlI4tuKXOZ2VTFxRIQpSRNg5POI=\"}}]}"
        }
      ]
    },
...
```

This data can be used to get:
- The exact command run, and the contents of the environment
- All paths used during copying
- The location cache mounts are mounted to
- Links to git repos / http downloads
- Secrets used
- Essentially any info as directly represented in https://github.com/moby/buildkit/blob/master/solver/pb/ops.proto.