### PR TITLE
Feat/sdk php namespace

### DIFF
--- a/sdk/php/codegen
+++ b/sdk/php/codegen
@@ -1,9 +1,9 @@
 #!/usr/bin/env php
 <?php declare(strict_types=1);
 
-use Dagger\Command\DaggerSchemaGeneratorCommand;
 use Symfony\Component\Console\Application;
-use Dagger\Command\DaggerCodegenCommand;
+use Dagger\Command\CodegenCommand;
+use Dagger\Command\SchemaGeneratorCommand;
 
 if (file_exists(__DIR__.'/../../autoload.php')) {
     // The usual location, since this file will reside in vendor/bin
@@ -15,8 +15,8 @@ if (file_exists(__DIR__.'/../../autoload.php')) {
 
 $console = new Application();
 
-$console->add(new DaggerCodegenCommand());
+$console->add(new CodegenCommand());
 $console->setDefaultCommand('dagger:codegen');
-$console->add(new DaggerSchemaGeneratorCommand());
+$console->add(new SchemaGeneratorCommand());
 
 $console->run();

--- a/sdk/php/composer.json
+++ b/sdk/php/composer.json
@@ -12,8 +12,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Dagger\\": "src/",
-            "Dagger\\Dagger\\": "generated/"
+            "Dagger\\": ["src/", "generated/"]
         }
     },
     "autoload-dev": {

--- a/sdk/php/generated/BuildArg.php
+++ b/sdk/php/generated/BuildArg.php
@@ -6,12 +6,12 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * Key value object that represents a build argument.
  */
-class BuildArg extends \Dagger\Client\AbstractDaggerInputObject
+class BuildArg extends Client\AbstractInputObject
 {
     public function __construct(
         public string $name,

--- a/sdk/php/generated/CacheSharingMode.php
+++ b/sdk/php/generated/CacheSharingMode.php
@@ -6,7 +6,7 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * Sharing mode of the cache volume.

--- a/sdk/php/generated/CacheVolume.php
+++ b/sdk/php/generated/CacheVolume.php
@@ -6,16 +6,16 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A directory whose contents persist across runs.
  */
-class CacheVolume extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Client\IdAble
+class CacheVolume extends Client\AbstractObject implements Client\IdAble
 {
     public function id(): CacheVolumeId
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('id');
-        return new \Dagger\Dagger\CacheVolumeId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('id');
+        return new \Dagger\CacheVolumeId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
     }
 }

--- a/sdk/php/generated/CacheVolumeId.php
+++ b/sdk/php/generated/CacheVolumeId.php
@@ -11,6 +11,6 @@ namespace Dagger;
 /**
  * A global cache volume identifier.
  */
-readonly class CacheVolumeId extends Client\DaggerId
+readonly class CacheVolumeId extends Client\AbstractId
 {
 }

--- a/sdk/php/generated/CacheVolumeId.php
+++ b/sdk/php/generated/CacheVolumeId.php
@@ -6,11 +6,11 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A global cache volume identifier.
  */
-readonly class CacheVolumeId extends \Dagger\Client\DaggerId
+readonly class CacheVolumeId extends Client\DaggerId
 {
 }

--- a/sdk/php/generated/Client.php
+++ b/sdk/php/generated/Client.php
@@ -6,18 +6,18 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
-class DaggerClient extends \Dagger\Client\AbstractDaggerClient
+class Client extends Client\AbstractClient
 {
     /**
      * Constructs a cache volume for a given cache key.
      */
     public function cacheVolume(string $key): CacheVolume
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('cacheVolume');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('cacheVolume');
         $innerQueryBuilder->setArgument('key', $key);
-        return new \Dagger\Dagger\CacheVolume($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\CacheVolume($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -25,7 +25,7 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function checkVersionCompatibility(string $version): bool
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('checkVersionCompatibility');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('checkVersionCompatibility');
         $leafQueryBuilder->setArgument('version', $version);
         return (bool)$this->queryLeaf($leafQueryBuilder, 'checkVersionCompatibility');
     }
@@ -38,14 +38,14 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function container(ContainerId|Container|null $id = null, ?Platform $platform = null): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('container');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('container');
         if (null !== $id) {
         $innerQueryBuilder->setArgument('id', $id);
         }
         if (null !== $platform) {
         $innerQueryBuilder->setArgument('platform', $platform);
         }
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -55,8 +55,8 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function currentFunctionCall(): FunctionCall
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('currentFunctionCall');
-        return new \Dagger\Dagger\FunctionCall($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('currentFunctionCall');
+        return new \Dagger\FunctionCall($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -64,8 +64,8 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function currentModule(): Module
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('currentModule');
-        return new \Dagger\Dagger\Module($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('currentModule');
+        return new \Dagger\Module($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -73,8 +73,8 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function defaultPlatform(): Platform
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('defaultPlatform');
-        return new \Dagger\Dagger\Platform((string)$this->queryLeaf($leafQueryBuilder, 'defaultPlatform'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('defaultPlatform');
+        return new \Dagger\Platform((string)$this->queryLeaf($leafQueryBuilder, 'defaultPlatform'));
     }
 
     /**
@@ -82,11 +82,11 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function directory(DirectoryId|Directory|null $id = null): Directory
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('directory');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('directory');
         if (null !== $id) {
         $innerQueryBuilder->setArgument('id', $id);
         }
-        return new \Dagger\Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -94,9 +94,9 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function file(FileId|File $id): File
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('file');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('file');
         $innerQueryBuilder->setArgument('id', $id);
-        return new \Dagger\Dagger\File($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\File($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -104,10 +104,10 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function function(string $name, TypeDefId|TypeDef $returnType): Function_
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('function');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('function');
         $innerQueryBuilder->setArgument('name', $name);
         $innerQueryBuilder->setArgument('returnType', $returnType);
-        return new \Dagger\Dagger\Function_($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Function_($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -116,9 +116,9 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function generatedCode(DirectoryId|Directory $code): GeneratedCode
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('generatedCode');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('generatedCode');
         $innerQueryBuilder->setArgument('code', $code);
-        return new \Dagger\Dagger\GeneratedCode($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\GeneratedCode($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -132,7 +132,7 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
         ServiceId|Service|null $experimentalServiceHost = null,
     ): GitRepository
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('git');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('git');
         $innerQueryBuilder->setArgument('url', $url);
         if (null !== $keepGitDir) {
         $innerQueryBuilder->setArgument('keepGitDir', $keepGitDir);
@@ -146,7 +146,7 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
         if (null !== $experimentalServiceHost) {
         $innerQueryBuilder->setArgument('experimentalServiceHost', $experimentalServiceHost);
         }
-        return new \Dagger\Dagger\GitRepository($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\GitRepository($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -154,8 +154,8 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function host(): Host
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('host');
-        return new \Dagger\Dagger\Host($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('host');
+        return new \Dagger\Host($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -163,12 +163,12 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function http(string $url, ServiceId|Service|null $experimentalServiceHost = null): File
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('http');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('http');
         $innerQueryBuilder->setArgument('url', $url);
         if (null !== $experimentalServiceHost) {
         $innerQueryBuilder->setArgument('experimentalServiceHost', $experimentalServiceHost);
         }
-        return new \Dagger\Dagger\File($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\File($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -176,9 +176,9 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function loadCacheVolumeFromID(CacheVolumeId|CacheVolume $id): CacheVolume
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('loadCacheVolumeFromID');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('loadCacheVolumeFromID');
         $innerQueryBuilder->setArgument('id', $id);
-        return new \Dagger\Dagger\CacheVolume($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\CacheVolume($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -186,9 +186,9 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function loadContainerFromID(ContainerId|Container $id): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('loadContainerFromID');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('loadContainerFromID');
         $innerQueryBuilder->setArgument('id', $id);
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -196,9 +196,9 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function loadDirectoryFromID(DirectoryId|Directory $id): Directory
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('loadDirectoryFromID');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('loadDirectoryFromID');
         $innerQueryBuilder->setArgument('id', $id);
-        return new \Dagger\Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -206,9 +206,9 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function loadFileFromID(FileId|File $id): File
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('loadFileFromID');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('loadFileFromID');
         $innerQueryBuilder->setArgument('id', $id);
-        return new \Dagger\Dagger\File($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\File($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -216,9 +216,9 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function loadFunctionArgFromID(FunctionArgId|FunctionArg $id): FunctionArg
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('loadFunctionArgFromID');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('loadFunctionArgFromID');
         $innerQueryBuilder->setArgument('id', $id);
-        return new \Dagger\Dagger\FunctionArg($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\FunctionArg($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -226,9 +226,9 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function loadFunctionFromID(FunctionId|Function_ $id): Function_
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('loadFunctionFromID');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('loadFunctionFromID');
         $innerQueryBuilder->setArgument('id', $id);
-        return new \Dagger\Dagger\Function_($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Function_($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -236,9 +236,9 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function loadGeneratedCodeFromID(GeneratedCodeId|GeneratedCode $id): GeneratedCode
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('loadGeneratedCodeFromID');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('loadGeneratedCodeFromID');
         $innerQueryBuilder->setArgument('id', $id);
-        return new \Dagger\Dagger\GeneratedCode($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\GeneratedCode($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -246,9 +246,9 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function loadGitRefFromID(GitRefId|GitRef $id): GitRef
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('loadGitRefFromID');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('loadGitRefFromID');
         $innerQueryBuilder->setArgument('id', $id);
-        return new \Dagger\Dagger\GitRef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\GitRef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -256,9 +256,9 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function loadGitRepositoryFromID(GitRepositoryId|GitRepository $id): GitRepository
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('loadGitRepositoryFromID');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('loadGitRepositoryFromID');
         $innerQueryBuilder->setArgument('id', $id);
-        return new \Dagger\Dagger\GitRepository($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\GitRepository($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -266,9 +266,9 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function loadModuleFromID(ModuleId|Module $id): Module
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('loadModuleFromID');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('loadModuleFromID');
         $innerQueryBuilder->setArgument('id', $id);
-        return new \Dagger\Dagger\Module($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Module($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -276,9 +276,9 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function loadSecretFromID(SecretId|Secret $id): Secret
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('loadSecretFromID');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('loadSecretFromID');
         $innerQueryBuilder->setArgument('id', $id);
-        return new \Dagger\Dagger\Secret($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Secret($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -286,9 +286,9 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function loadServiceFromID(ServiceId|Service $id): Service
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('loadServiceFromID');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('loadServiceFromID');
         $innerQueryBuilder->setArgument('id', $id);
-        return new \Dagger\Dagger\Service($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Service($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -296,9 +296,9 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function loadSocketFromID(SocketId|Socket $id): Socket
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('loadSocketFromID');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('loadSocketFromID');
         $innerQueryBuilder->setArgument('id', $id);
-        return new \Dagger\Dagger\Socket($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Socket($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -306,9 +306,9 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function loadTypeDefFromID(TypeDefId|TypeDef $id): TypeDef
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('loadTypeDefFromID');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('loadTypeDefFromID');
         $innerQueryBuilder->setArgument('id', $id);
-        return new \Dagger\Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -316,8 +316,8 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function module(): Module
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('module');
-        return new \Dagger\Dagger\Module($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('module');
+        return new \Dagger\Module($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -325,20 +325,20 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function moduleConfig(DirectoryId|Directory $sourceDirectory, ?string $subpath = null): ModuleConfig
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('moduleConfig');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('moduleConfig');
         $innerQueryBuilder->setArgument('sourceDirectory', $sourceDirectory);
         if (null !== $subpath) {
         $innerQueryBuilder->setArgument('subpath', $subpath);
         }
-        return new \Dagger\Dagger\ModuleConfig($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\ModuleConfig($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
      * Creates a named sub-pipeline.
      */
-    public function pipeline(string $name, ?string $description = null, ?array $labels = null): DaggerClient
+    public function pipeline(string $name, ?string $description = null, ?array $labels = null): Client
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('pipeline');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('pipeline');
         $innerQueryBuilder->setArgument('name', $name);
         if (null !== $description) {
         $innerQueryBuilder->setArgument('description', $description);
@@ -346,7 +346,7 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
         if (null !== $labels) {
         $innerQueryBuilder->setArgument('labels', $labels);
         }
-        return new \Dagger\Dagger\DaggerClient($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Client($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -354,9 +354,9 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function secret(SecretId|Secret $id): Secret
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('secret');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('secret');
         $innerQueryBuilder->setArgument('id', $id);
-        return new \Dagger\Dagger\Secret($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Secret($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -365,10 +365,10 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function setSecret(string $name, string $plaintext): Secret
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('setSecret');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('setSecret');
         $innerQueryBuilder->setArgument('name', $name);
         $innerQueryBuilder->setArgument('plaintext', $plaintext);
-        return new \Dagger\Dagger\Secret($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Secret($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -376,11 +376,11 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function socket(SocketId|Socket|null $id = null): Socket
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('socket');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('socket');
         if (null !== $id) {
         $innerQueryBuilder->setArgument('id', $id);
         }
-        return new \Dagger\Dagger\Socket($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Socket($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -388,7 +388,7 @@ class DaggerClient extends \Dagger\Client\AbstractDaggerClient
      */
     public function typeDef(): TypeDef
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('typeDef');
-        return new \Dagger\Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('typeDef');
+        return new \Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 }

--- a/sdk/php/generated/Client.php
+++ b/sdk/php/generated/Client.php
@@ -69,6 +69,15 @@ class Client extends Client\AbstractClient
     }
 
     /**
+     * The TypeDef representations of the objects currently being served in the session.
+     */
+    public function currentTypeDefs(): array
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('currentTypeDefs');
+        return (array)$this->queryLeaf($leafQueryBuilder, 'currentTypeDefs');
+    }
+
+    /**
      * The default platform of the builder.
      */
     public function defaultPlatform(): Platform

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -6,12 +6,12 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * An OCI-compatible container, also known as a docker container.
  */
-class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Client\IdAble
+class Container extends Client\AbstractObject implements Client\IdAble
 {
     /**
      * Turn the container into a Service.
@@ -20,8 +20,8 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function asService(): Service
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('asService');
-        return new \Dagger\Dagger\Service($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('asService');
+        return new \Dagger\Service($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -33,7 +33,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         ?ImageMediaTypes $mediaTypes = null,
     ): File
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('asTarball');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('asTarball');
         if (null !== $platformVariants) {
         $innerQueryBuilder->setArgument('platformVariants', $platformVariants);
         }
@@ -43,7 +43,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         if (null !== $mediaTypes) {
         $innerQueryBuilder->setArgument('mediaTypes', $mediaTypes);
         }
-        return new \Dagger\Dagger\File($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\File($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -57,7 +57,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         ?array $secrets = null,
     ): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('build');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('build');
         $innerQueryBuilder->setArgument('context', $context);
         if (null !== $dockerfile) {
         $innerQueryBuilder->setArgument('dockerfile', $dockerfile);
@@ -71,7 +71,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         if (null !== $secrets) {
         $innerQueryBuilder->setArgument('secrets', $secrets);
         }
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -79,7 +79,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function defaultArgs(): array
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('defaultArgs');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('defaultArgs');
         return (array)$this->queryLeaf($leafQueryBuilder, 'defaultArgs');
     }
 
@@ -90,9 +90,9 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function directory(string $path): Directory
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('directory');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('directory');
         $innerQueryBuilder->setArgument('path', $path);
-        return new \Dagger\Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -100,7 +100,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function entrypoint(): array
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('entrypoint');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('entrypoint');
         return (array)$this->queryLeaf($leafQueryBuilder, 'entrypoint');
     }
 
@@ -109,7 +109,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function envVariable(string $name): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('envVariable');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('envVariable');
         $leafQueryBuilder->setArgument('name', $name);
         return (string)$this->queryLeaf($leafQueryBuilder, 'envVariable');
     }
@@ -119,7 +119,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function envVariables(): array
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('envVariables');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('envVariables');
         return (array)$this->queryLeaf($leafQueryBuilder, 'envVariables');
     }
 
@@ -131,8 +131,8 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function experimentalWithAllGPUs(): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('experimentalWithAllGPUs');
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('experimentalWithAllGPUs');
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -143,9 +143,9 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function experimentalWithGPU(array $devices): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('experimentalWithGPU');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('experimentalWithGPU');
         $innerQueryBuilder->setArgument('devices', $devices);
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -161,7 +161,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         ?ImageMediaTypes $mediaTypes = null,
     ): bool
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('export');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('export');
         $leafQueryBuilder->setArgument('path', $path);
         if (null !== $platformVariants) {
         $leafQueryBuilder->setArgument('platformVariants', $platformVariants);
@@ -183,7 +183,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function exposedPorts(): array
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('exposedPorts');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('exposedPorts');
         return (array)$this->queryLeaf($leafQueryBuilder, 'exposedPorts');
     }
 
@@ -194,9 +194,9 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function file(string $path): File
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('file');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('file');
         $innerQueryBuilder->setArgument('path', $path);
-        return new \Dagger\Dagger\File($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\File($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -204,9 +204,9 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function from(string $address): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('from');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('from');
         $innerQueryBuilder->setArgument('address', $address);
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -214,8 +214,8 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function id(): ContainerId
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('id');
-        return new \Dagger\Dagger\ContainerId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('id');
+        return new \Dagger\ContainerId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
     }
 
     /**
@@ -223,7 +223,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function imageRef(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('imageRef');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('imageRef');
         return (string)$this->queryLeaf($leafQueryBuilder, 'imageRef');
     }
 
@@ -235,12 +235,12 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function import(FileId|File $source, ?string $tag = null): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('import');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('import');
         $innerQueryBuilder->setArgument('source', $source);
         if (null !== $tag) {
         $innerQueryBuilder->setArgument('tag', $tag);
         }
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -248,7 +248,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function label(string $name): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('label');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('label');
         $leafQueryBuilder->setArgument('name', $name);
         return (string)$this->queryLeaf($leafQueryBuilder, 'label');
     }
@@ -258,7 +258,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function labels(): array
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('labels');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('labels');
         return (array)$this->queryLeaf($leafQueryBuilder, 'labels');
     }
 
@@ -267,7 +267,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function mounts(): array
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('mounts');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('mounts');
         return (array)$this->queryLeaf($leafQueryBuilder, 'mounts');
     }
 
@@ -276,7 +276,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function pipeline(string $name, ?string $description = null, ?array $labels = null): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('pipeline');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('pipeline');
         $innerQueryBuilder->setArgument('name', $name);
         if (null !== $description) {
         $innerQueryBuilder->setArgument('description', $description);
@@ -284,7 +284,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         if (null !== $labels) {
         $innerQueryBuilder->setArgument('labels', $labels);
         }
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -292,8 +292,8 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function platform(): Platform
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('platform');
-        return new \Dagger\Dagger\Platform((string)$this->queryLeaf($leafQueryBuilder, 'platform'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('platform');
+        return new \Dagger\Platform((string)$this->queryLeaf($leafQueryBuilder, 'platform'));
     }
 
     /**
@@ -309,7 +309,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         ?ImageMediaTypes $mediaTypes = null,
     ): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('publish');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('publish');
         $leafQueryBuilder->setArgument('address', $address);
         if (null !== $platformVariants) {
         $leafQueryBuilder->setArgument('platformVariants', $platformVariants);
@@ -328,8 +328,8 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function rootfs(): Directory
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('rootfs');
-        return new \Dagger\Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('rootfs');
+        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -340,7 +340,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function shellEndpoint(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('shellEndpoint');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('shellEndpoint');
         return (string)$this->queryLeaf($leafQueryBuilder, 'shellEndpoint');
     }
 
@@ -351,7 +351,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function stderr(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('stderr');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('stderr');
         return (string)$this->queryLeaf($leafQueryBuilder, 'stderr');
     }
 
@@ -362,7 +362,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function stdout(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('stdout');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('stdout');
         return (string)$this->queryLeaf($leafQueryBuilder, 'stdout');
     }
 
@@ -373,8 +373,8 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function sync(): ContainerId
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('sync');
-        return new \Dagger\Dagger\ContainerId((string)$this->queryLeaf($leafQueryBuilder, 'sync'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('sync');
+        return new \Dagger\ContainerId((string)$this->queryLeaf($leafQueryBuilder, 'sync'));
     }
 
     /**
@@ -382,7 +382,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function user(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('user');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('user');
         return (string)$this->queryLeaf($leafQueryBuilder, 'user');
     }
 
@@ -391,11 +391,11 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withDefaultArgs(?array $args = null): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withDefaultArgs');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withDefaultArgs');
         if (null !== $args) {
         $innerQueryBuilder->setArgument('args', $args);
         }
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -409,7 +409,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         ?string $owner = null,
     ): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withDirectory');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withDirectory');
         $innerQueryBuilder->setArgument('path', $path);
         $innerQueryBuilder->setArgument('directory', $directory);
         if (null !== $exclude) {
@@ -421,7 +421,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         if (null !== $owner) {
         $innerQueryBuilder->setArgument('owner', $owner);
         }
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -429,12 +429,12 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withEntrypoint(array $args, ?bool $keepDefaultArgs = false): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withEntrypoint');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withEntrypoint');
         $innerQueryBuilder->setArgument('args', $args);
         if (null !== $keepDefaultArgs) {
         $innerQueryBuilder->setArgument('keepDefaultArgs', $keepDefaultArgs);
         }
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -442,13 +442,13 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withEnvVariable(string $name, string $value, ?bool $expand = null): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withEnvVariable');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withEnvVariable');
         $innerQueryBuilder->setArgument('name', $name);
         $innerQueryBuilder->setArgument('value', $value);
         if (null !== $expand) {
         $innerQueryBuilder->setArgument('expand', $expand);
         }
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -464,7 +464,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         ?bool $insecureRootCapabilities = null,
     ): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withExec');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withExec');
         $innerQueryBuilder->setArgument('args', $args);
         if (null !== $skipEntrypoint) {
         $innerQueryBuilder->setArgument('skipEntrypoint', $skipEntrypoint);
@@ -484,7 +484,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         if (null !== $insecureRootCapabilities) {
         $innerQueryBuilder->setArgument('insecureRootCapabilities', $insecureRootCapabilities);
         }
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -501,7 +501,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         ?string $description = null,
     ): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withExposedPort');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withExposedPort');
         $innerQueryBuilder->setArgument('port', $port);
         if (null !== $protocol) {
         $innerQueryBuilder->setArgument('protocol', $protocol);
@@ -509,7 +509,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         if (null !== $description) {
         $innerQueryBuilder->setArgument('description', $description);
         }
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -522,7 +522,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         ?string $owner = null,
     ): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withFile');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withFile');
         $innerQueryBuilder->setArgument('path', $path);
         $innerQueryBuilder->setArgument('source', $source);
         if (null !== $permissions) {
@@ -531,7 +531,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         if (null !== $owner) {
         $innerQueryBuilder->setArgument('owner', $owner);
         }
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -540,8 +540,8 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withFocus(): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withFocus');
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withFocus');
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -549,10 +549,10 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withLabel(string $name, string $value): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withLabel');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withLabel');
         $innerQueryBuilder->setArgument('name', $name);
         $innerQueryBuilder->setArgument('value', $value);
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -566,7 +566,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         ?string $owner = null,
     ): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withMountedCache');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withMountedCache');
         $innerQueryBuilder->setArgument('path', $path);
         $innerQueryBuilder->setArgument('cache', $cache);
         if (null !== $source) {
@@ -578,7 +578,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         if (null !== $owner) {
         $innerQueryBuilder->setArgument('owner', $owner);
         }
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -590,13 +590,13 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         ?string $owner = null,
     ): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withMountedDirectory');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withMountedDirectory');
         $innerQueryBuilder->setArgument('path', $path);
         $innerQueryBuilder->setArgument('source', $source);
         if (null !== $owner) {
         $innerQueryBuilder->setArgument('owner', $owner);
         }
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -604,13 +604,13 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withMountedFile(string $path, FileId|File $source, ?string $owner = null): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withMountedFile');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withMountedFile');
         $innerQueryBuilder->setArgument('path', $path);
         $innerQueryBuilder->setArgument('source', $source);
         if (null !== $owner) {
         $innerQueryBuilder->setArgument('owner', $owner);
         }
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -623,7 +623,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         ?int $mode = null,
     ): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withMountedSecret');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withMountedSecret');
         $innerQueryBuilder->setArgument('path', $path);
         $innerQueryBuilder->setArgument('source', $source);
         if (null !== $owner) {
@@ -632,7 +632,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         if (null !== $mode) {
         $innerQueryBuilder->setArgument('mode', $mode);
         }
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -640,9 +640,9 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withMountedTemp(string $path): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withMountedTemp');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withMountedTemp');
         $innerQueryBuilder->setArgument('path', $path);
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -655,7 +655,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         ?string $owner = null,
     ): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withNewFile');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withNewFile');
         $innerQueryBuilder->setArgument('path', $path);
         if (null !== $contents) {
         $innerQueryBuilder->setArgument('contents', $contents);
@@ -666,7 +666,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         if (null !== $owner) {
         $innerQueryBuilder->setArgument('owner', $owner);
         }
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -674,11 +674,11 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withRegistryAuth(string $address, string $username, SecretId|Secret $secret): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withRegistryAuth');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withRegistryAuth');
         $innerQueryBuilder->setArgument('address', $address);
         $innerQueryBuilder->setArgument('username', $username);
         $innerQueryBuilder->setArgument('secret', $secret);
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -686,9 +686,9 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withRootfs(DirectoryId|Directory $directory): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withRootfs');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withRootfs');
         $innerQueryBuilder->setArgument('directory', $directory);
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -696,10 +696,10 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withSecretVariable(string $name, SecretId|Secret $secret): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withSecretVariable');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withSecretVariable');
         $innerQueryBuilder->setArgument('name', $name);
         $innerQueryBuilder->setArgument('secret', $secret);
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -714,10 +714,10 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withServiceBinding(string $alias, ServiceId|Service $service): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withServiceBinding');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withServiceBinding');
         $innerQueryBuilder->setArgument('alias', $alias);
         $innerQueryBuilder->setArgument('service', $service);
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -725,13 +725,13 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withUnixSocket(string $path, SocketId|Socket $source, ?string $owner = null): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withUnixSocket');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withUnixSocket');
         $innerQueryBuilder->setArgument('path', $path);
         $innerQueryBuilder->setArgument('source', $source);
         if (null !== $owner) {
         $innerQueryBuilder->setArgument('owner', $owner);
         }
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -739,9 +739,9 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withUser(string $name): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withUser');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withUser');
         $innerQueryBuilder->setArgument('name', $name);
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -749,9 +749,9 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withWorkdir(string $path): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withWorkdir');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withWorkdir');
         $innerQueryBuilder->setArgument('path', $path);
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -759,8 +759,8 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withoutDefaultArgs(): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withoutDefaultArgs');
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withoutDefaultArgs');
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -768,11 +768,11 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withoutEntrypoint(?bool $keepDefaultArgs = false): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withoutEntrypoint');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withoutEntrypoint');
         if (null !== $keepDefaultArgs) {
         $innerQueryBuilder->setArgument('keepDefaultArgs', $keepDefaultArgs);
         }
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -780,9 +780,9 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withoutEnvVariable(string $name): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withoutEnvVariable');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withoutEnvVariable');
         $innerQueryBuilder->setArgument('name', $name);
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -790,12 +790,12 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withoutExposedPort(int $port, ?NetworkProtocol $protocol = null): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withoutExposedPort');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withoutExposedPort');
         $innerQueryBuilder->setArgument('port', $port);
         if (null !== $protocol) {
         $innerQueryBuilder->setArgument('protocol', $protocol);
         }
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -806,8 +806,8 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withoutFocus(): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withoutFocus');
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withoutFocus');
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -815,9 +815,9 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withoutLabel(string $name): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withoutLabel');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withoutLabel');
         $innerQueryBuilder->setArgument('name', $name);
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -825,9 +825,9 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withoutMount(string $path): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withoutMount');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withoutMount');
         $innerQueryBuilder->setArgument('path', $path);
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -835,9 +835,9 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withoutRegistryAuth(string $address): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withoutRegistryAuth');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withoutRegistryAuth');
         $innerQueryBuilder->setArgument('address', $address);
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -845,9 +845,9 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withoutUnixSocket(string $path): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withoutUnixSocket');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withoutUnixSocket');
         $innerQueryBuilder->setArgument('path', $path);
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -857,8 +857,8 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withoutUser(): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withoutUser');
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withoutUser');
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -868,8 +868,8 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withoutWorkdir(): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withoutWorkdir');
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withoutWorkdir');
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -877,7 +877,7 @@ class Container extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function workdir(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('workdir');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('workdir');
         return (string)$this->queryLeaf($leafQueryBuilder, 'workdir');
     }
 }

--- a/sdk/php/generated/ContainerId.php
+++ b/sdk/php/generated/ContainerId.php
@@ -6,11 +6,11 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A unique container identifier. Null designates an empty container (scratch).
  */
-readonly class ContainerId extends \Dagger\Client\DaggerId
+readonly class ContainerId extends Client\DaggerId
 {
 }

--- a/sdk/php/generated/ContainerId.php
+++ b/sdk/php/generated/ContainerId.php
@@ -11,6 +11,6 @@ namespace Dagger;
 /**
  * A unique container identifier. Null designates an empty container (scratch).
  */
-readonly class ContainerId extends Client\DaggerId
+readonly class ContainerId extends Client\AbstractId
 {
 }

--- a/sdk/php/generated/Directory.php
+++ b/sdk/php/generated/Directory.php
@@ -6,23 +6,23 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A directory.
  */
-class Directory extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Client\IdAble
+class Directory extends Client\AbstractObject implements Client\IdAble
 {
     /**
      * Load the directory as a Dagger module
      */
     public function asModule(?string $sourceSubpath = null): Module
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('asModule');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('asModule');
         if (null !== $sourceSubpath) {
         $innerQueryBuilder->setArgument('sourceSubpath', $sourceSubpath);
         }
-        return new \Dagger\Dagger\Module($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Module($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -30,9 +30,9 @@ class Directory extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function diff(DirectoryId|Directory $other): Directory
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('diff');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('diff');
         $innerQueryBuilder->setArgument('other', $other);
-        return new \Dagger\Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -40,9 +40,9 @@ class Directory extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function directory(string $path): Directory
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('directory');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('directory');
         $innerQueryBuilder->setArgument('path', $path);
-        return new \Dagger\Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -56,7 +56,7 @@ class Directory extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         ?array $secrets = null,
     ): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('dockerBuild');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('dockerBuild');
         if (null !== $dockerfile) {
         $innerQueryBuilder->setArgument('dockerfile', $dockerfile);
         }
@@ -72,7 +72,7 @@ class Directory extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         if (null !== $secrets) {
         $innerQueryBuilder->setArgument('secrets', $secrets);
         }
-        return new \Dagger\Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -80,7 +80,7 @@ class Directory extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function entries(?string $path = null): array
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('entries');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('entries');
         if (null !== $path) {
         $leafQueryBuilder->setArgument('path', $path);
         }
@@ -92,7 +92,7 @@ class Directory extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function export(string $path): bool
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('export');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('export');
         $leafQueryBuilder->setArgument('path', $path);
         return (bool)$this->queryLeaf($leafQueryBuilder, 'export');
     }
@@ -102,9 +102,9 @@ class Directory extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function file(string $path): File
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('file');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('file');
         $innerQueryBuilder->setArgument('path', $path);
-        return new \Dagger\Dagger\File($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\File($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -112,7 +112,7 @@ class Directory extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function glob(string $pattern): array
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('glob');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('glob');
         $leafQueryBuilder->setArgument('pattern', $pattern);
         return (array)$this->queryLeaf($leafQueryBuilder, 'glob');
     }
@@ -122,8 +122,8 @@ class Directory extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function id(): DirectoryId
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('id');
-        return new \Dagger\Dagger\DirectoryId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('id');
+        return new \Dagger\DirectoryId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
     }
 
     /**
@@ -131,7 +131,7 @@ class Directory extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function pipeline(string $name, ?string $description = null, ?array $labels = null): Directory
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('pipeline');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('pipeline');
         $innerQueryBuilder->setArgument('name', $name);
         if (null !== $description) {
         $innerQueryBuilder->setArgument('description', $description);
@@ -139,7 +139,7 @@ class Directory extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         if (null !== $labels) {
         $innerQueryBuilder->setArgument('labels', $labels);
         }
-        return new \Dagger\Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -147,8 +147,8 @@ class Directory extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function sync(): DirectoryId
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('sync');
-        return new \Dagger\Dagger\DirectoryId((string)$this->queryLeaf($leafQueryBuilder, 'sync'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('sync');
+        return new \Dagger\DirectoryId((string)$this->queryLeaf($leafQueryBuilder, 'sync'));
     }
 
     /**
@@ -161,7 +161,7 @@ class Directory extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         ?array $include = null,
     ): Directory
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withDirectory');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withDirectory');
         $innerQueryBuilder->setArgument('path', $path);
         $innerQueryBuilder->setArgument('directory', $directory);
         if (null !== $exclude) {
@@ -170,7 +170,7 @@ class Directory extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         if (null !== $include) {
         $innerQueryBuilder->setArgument('include', $include);
         }
-        return new \Dagger\Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -178,13 +178,13 @@ class Directory extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withFile(string $path, FileId|File $source, ?int $permissions = null): Directory
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withFile');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withFile');
         $innerQueryBuilder->setArgument('path', $path);
         $innerQueryBuilder->setArgument('source', $source);
         if (null !== $permissions) {
         $innerQueryBuilder->setArgument('permissions', $permissions);
         }
-        return new \Dagger\Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -192,12 +192,12 @@ class Directory extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withNewDirectory(string $path, ?int $permissions = null): Directory
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withNewDirectory');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withNewDirectory');
         $innerQueryBuilder->setArgument('path', $path);
         if (null !== $permissions) {
         $innerQueryBuilder->setArgument('permissions', $permissions);
         }
-        return new \Dagger\Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -205,13 +205,13 @@ class Directory extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withNewFile(string $path, string $contents, ?int $permissions = null): Directory
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withNewFile');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withNewFile');
         $innerQueryBuilder->setArgument('path', $path);
         $innerQueryBuilder->setArgument('contents', $contents);
         if (null !== $permissions) {
         $innerQueryBuilder->setArgument('permissions', $permissions);
         }
-        return new \Dagger\Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -219,9 +219,9 @@ class Directory extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withTimestamps(int $timestamp): Directory
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withTimestamps');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withTimestamps');
         $innerQueryBuilder->setArgument('timestamp', $timestamp);
-        return new \Dagger\Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -229,9 +229,9 @@ class Directory extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withoutDirectory(string $path): Directory
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withoutDirectory');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withoutDirectory');
         $innerQueryBuilder->setArgument('path', $path);
-        return new \Dagger\Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -239,8 +239,8 @@ class Directory extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withoutFile(string $path): Directory
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withoutFile');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withoutFile');
         $innerQueryBuilder->setArgument('path', $path);
-        return new \Dagger\Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 }

--- a/sdk/php/generated/DirectoryId.php
+++ b/sdk/php/generated/DirectoryId.php
@@ -6,11 +6,11 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A content-addressed directory identifier.
  */
-readonly class DirectoryId extends \Dagger\Client\DaggerId
+readonly class DirectoryId extends Client\DaggerId
 {
 }

--- a/sdk/php/generated/DirectoryId.php
+++ b/sdk/php/generated/DirectoryId.php
@@ -11,6 +11,6 @@ namespace Dagger;
 /**
  * A content-addressed directory identifier.
  */
-readonly class DirectoryId extends Client\DaggerId
+readonly class DirectoryId extends Client\AbstractId
 {
 }

--- a/sdk/php/generated/EnvVariable.php
+++ b/sdk/php/generated/EnvVariable.php
@@ -6,19 +6,19 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A simple key value object that represents an environment variable.
  */
-class EnvVariable extends \Dagger\Client\AbstractDaggerObject
+class EnvVariable extends Client\AbstractObject
 {
     /**
      * The environment variable name.
      */
     public function name(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('name');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('name');
         return (string)$this->queryLeaf($leafQueryBuilder, 'name');
     }
 
@@ -27,7 +27,7 @@ class EnvVariable extends \Dagger\Client\AbstractDaggerObject
      */
     public function value(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('value');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('value');
         return (string)$this->queryLeaf($leafQueryBuilder, 'value');
     }
 }

--- a/sdk/php/generated/FieldTypeDef.php
+++ b/sdk/php/generated/FieldTypeDef.php
@@ -6,21 +6,21 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A definition of a field on a custom object defined in a Module.
  * A field on an object has a static value, as opposed to a function on an
  * object whose value is computed by invoking code (and can accept arguments).
  */
-class FieldTypeDef extends \Dagger\Client\AbstractDaggerObject
+class FieldTypeDef extends Client\AbstractObject
 {
     /**
      * A doc string for the field, if any
      */
     public function description(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('description');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('description');
         return (string)$this->queryLeaf($leafQueryBuilder, 'description');
     }
 
@@ -29,7 +29,7 @@ class FieldTypeDef extends \Dagger\Client\AbstractDaggerObject
      */
     public function name(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('name');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('name');
         return (string)$this->queryLeaf($leafQueryBuilder, 'name');
     }
 
@@ -38,7 +38,7 @@ class FieldTypeDef extends \Dagger\Client\AbstractDaggerObject
      */
     public function typeDef(): TypeDef
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('typeDef');
-        return new \Dagger\Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('typeDef');
+        return new \Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 }

--- a/sdk/php/generated/File.php
+++ b/sdk/php/generated/File.php
@@ -6,19 +6,19 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A file.
  */
-class File extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Client\IdAble
+class File extends Client\AbstractObject implements Client\IdAble
 {
     /**
      * Retrieves the contents of the file.
      */
     public function contents(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('contents');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('contents');
         return (string)$this->queryLeaf($leafQueryBuilder, 'contents');
     }
 
@@ -27,7 +27,7 @@ class File extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Client
      */
     public function export(string $path, ?bool $allowParentDirPath = null): bool
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('export');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('export');
         $leafQueryBuilder->setArgument('path', $path);
         if (null !== $allowParentDirPath) {
         $leafQueryBuilder->setArgument('allowParentDirPath', $allowParentDirPath);
@@ -40,8 +40,8 @@ class File extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Client
      */
     public function id(): FileId
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('id');
-        return new \Dagger\Dagger\FileId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('id');
+        return new \Dagger\FileId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
     }
 
     /**
@@ -49,7 +49,7 @@ class File extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Client
      */
     public function size(): int
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('size');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('size');
         return (int)$this->queryLeaf($leafQueryBuilder, 'size');
     }
 
@@ -58,8 +58,8 @@ class File extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Client
      */
     public function sync(): FileId
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('sync');
-        return new \Dagger\Dagger\FileId((string)$this->queryLeaf($leafQueryBuilder, 'sync'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('sync');
+        return new \Dagger\FileId((string)$this->queryLeaf($leafQueryBuilder, 'sync'));
     }
 
     /**
@@ -67,8 +67,8 @@ class File extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Client
      */
     public function withTimestamps(int $timestamp): File
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withTimestamps');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withTimestamps');
         $innerQueryBuilder->setArgument('timestamp', $timestamp);
-        return new \Dagger\Dagger\File($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\File($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 }

--- a/sdk/php/generated/FileId.php
+++ b/sdk/php/generated/FileId.php
@@ -11,6 +11,6 @@ namespace Dagger;
 /**
  * A file identifier.
  */
-readonly class FileId extends Client\DaggerId
+readonly class FileId extends Client\AbstractId
 {
 }

--- a/sdk/php/generated/FileId.php
+++ b/sdk/php/generated/FileId.php
@@ -6,11 +6,11 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A file identifier.
  */
-readonly class FileId extends \Dagger\Client\DaggerId
+readonly class FileId extends Client\DaggerId
 {
 }

--- a/sdk/php/generated/FunctionArg.php
+++ b/sdk/php/generated/FunctionArg.php
@@ -6,7 +6,7 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * An argument accepted by a function.
@@ -14,15 +14,15 @@ namespace Dagger\Dagger;
  * This is a specification for an argument at function definition time, not an
  * argument passed at function call time.
  */
-class FunctionArg extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Client\IdAble
+class FunctionArg extends Client\AbstractObject implements Client\IdAble
 {
     /**
      * A default value to use for this argument when not explicitly set by the caller, if any
      */
     public function defaultValue(): Json
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('defaultValue');
-        return new \Dagger\Dagger\Json((string)$this->queryLeaf($leafQueryBuilder, 'defaultValue'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('defaultValue');
+        return new \Dagger\Json((string)$this->queryLeaf($leafQueryBuilder, 'defaultValue'));
     }
 
     /**
@@ -30,7 +30,7 @@ class FunctionArg extends \Dagger\Client\AbstractDaggerObject implements \Dagger
      */
     public function description(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('description');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('description');
         return (string)$this->queryLeaf($leafQueryBuilder, 'description');
     }
 
@@ -39,8 +39,8 @@ class FunctionArg extends \Dagger\Client\AbstractDaggerObject implements \Dagger
      */
     public function id(): FunctionArgId
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('id');
-        return new \Dagger\Dagger\FunctionArgId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('id');
+        return new \Dagger\FunctionArgId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
     }
 
     /**
@@ -48,7 +48,7 @@ class FunctionArg extends \Dagger\Client\AbstractDaggerObject implements \Dagger
      */
     public function name(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('name');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('name');
         return (string)$this->queryLeaf($leafQueryBuilder, 'name');
     }
 
@@ -57,7 +57,7 @@ class FunctionArg extends \Dagger\Client\AbstractDaggerObject implements \Dagger
      */
     public function typeDef(): TypeDef
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('typeDef');
-        return new \Dagger\Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('typeDef');
+        return new \Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 }

--- a/sdk/php/generated/FunctionArgId.php
+++ b/sdk/php/generated/FunctionArgId.php
@@ -11,6 +11,6 @@ namespace Dagger;
 /**
  * A reference to a FunctionArg.
  */
-readonly class FunctionArgId extends Client\DaggerId
+readonly class FunctionArgId extends Client\AbstractId
 {
 }

--- a/sdk/php/generated/FunctionArgId.php
+++ b/sdk/php/generated/FunctionArgId.php
@@ -6,11 +6,11 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A reference to a FunctionArg.
  */
-readonly class FunctionArgId extends \Dagger\Client\DaggerId
+readonly class FunctionArgId extends Client\DaggerId
 {
 }

--- a/sdk/php/generated/FunctionCall.php
+++ b/sdk/php/generated/FunctionCall.php
@@ -6,16 +6,16 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
-class FunctionCall extends \Dagger\Client\AbstractDaggerObject
+class FunctionCall extends Client\AbstractObject
 {
     /**
      * The argument values the function is being invoked with.
      */
     public function inputArgs(): array
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('inputArgs');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('inputArgs');
         return (array)$this->queryLeaf($leafQueryBuilder, 'inputArgs');
     }
 
@@ -24,7 +24,7 @@ class FunctionCall extends \Dagger\Client\AbstractDaggerObject
      */
     public function name(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('name');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('name');
         return (string)$this->queryLeaf($leafQueryBuilder, 'name');
     }
 
@@ -34,8 +34,8 @@ class FunctionCall extends \Dagger\Client\AbstractDaggerObject
      */
     public function parent(): Json
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('parent');
-        return new \Dagger\Dagger\Json((string)$this->queryLeaf($leafQueryBuilder, 'parent'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('parent');
+        return new \Dagger\Json((string)$this->queryLeaf($leafQueryBuilder, 'parent'));
     }
 
     /**
@@ -44,7 +44,7 @@ class FunctionCall extends \Dagger\Client\AbstractDaggerObject
      */
     public function parentName(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('parentName');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('parentName');
         return (string)$this->queryLeaf($leafQueryBuilder, 'parentName');
     }
 
@@ -54,7 +54,7 @@ class FunctionCall extends \Dagger\Client\AbstractDaggerObject
      */
     public function returnValue(Json $value): void
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('returnValue');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('returnValue');
         $leafQueryBuilder->setArgument('value', $value);
         $this->queryLeaf($leafQueryBuilder, 'returnValue');
     }

--- a/sdk/php/generated/FunctionCallArgValue.php
+++ b/sdk/php/generated/FunctionCallArgValue.php
@@ -6,16 +6,16 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
-class FunctionCallArgValue extends \Dagger\Client\AbstractDaggerObject
+class FunctionCallArgValue extends Client\AbstractObject
 {
     /**
      * The name of the argument.
      */
     public function name(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('name');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('name');
         return (string)$this->queryLeaf($leafQueryBuilder, 'name');
     }
 
@@ -24,7 +24,7 @@ class FunctionCallArgValue extends \Dagger\Client\AbstractDaggerObject
      */
     public function value(): Json
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('value');
-        return new \Dagger\Dagger\Json((string)$this->queryLeaf($leafQueryBuilder, 'value'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('value');
+        return new \Dagger\Json((string)$this->queryLeaf($leafQueryBuilder, 'value'));
     }
 }

--- a/sdk/php/generated/FunctionId.php
+++ b/sdk/php/generated/FunctionId.php
@@ -6,11 +6,11 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A reference to a Function.
  */
-readonly class FunctionId extends \Dagger\Client\DaggerId
+readonly class FunctionId extends Client\DaggerId
 {
 }

--- a/sdk/php/generated/FunctionId.php
+++ b/sdk/php/generated/FunctionId.php
@@ -11,6 +11,6 @@ namespace Dagger;
 /**
  * A reference to a Function.
  */
-readonly class FunctionId extends Client\DaggerId
+readonly class FunctionId extends Client\AbstractId
 {
 }

--- a/sdk/php/generated/Function_.php
+++ b/sdk/php/generated/Function_.php
@@ -6,7 +6,7 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * Function represents a resolver provided by a Module.
@@ -14,14 +14,14 @@ namespace Dagger\Dagger;
  * A function always evaluates against a parent object and is given a set of
  * named arguments.
  */
-class Function_ extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Client\IdAble
+class Function_ extends Client\AbstractObject implements Client\IdAble
 {
     /**
      * Arguments accepted by this function, if any
      */
     public function args(): array
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('args');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('args');
         return (array)$this->queryLeaf($leafQueryBuilder, 'args');
     }
 
@@ -30,7 +30,7 @@ class Function_ extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function description(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('description');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('description');
         return (string)$this->queryLeaf($leafQueryBuilder, 'description');
     }
 
@@ -39,8 +39,8 @@ class Function_ extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function id(): FunctionId
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('id');
-        return new \Dagger\Dagger\FunctionId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('id');
+        return new \Dagger\FunctionId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
     }
 
     /**
@@ -48,7 +48,7 @@ class Function_ extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function name(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('name');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('name');
         return (string)$this->queryLeaf($leafQueryBuilder, 'name');
     }
 
@@ -57,8 +57,8 @@ class Function_ extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function returnType(): TypeDef
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('returnType');
-        return new \Dagger\Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('returnType');
+        return new \Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -71,7 +71,7 @@ class Function_ extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         ?Json $defaultValue = null,
     ): Function_
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withArg');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withArg');
         $innerQueryBuilder->setArgument('name', $name);
         $innerQueryBuilder->setArgument('typeDef', $typeDef);
         if (null !== $description) {
@@ -80,7 +80,7 @@ class Function_ extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
         if (null !== $defaultValue) {
         $innerQueryBuilder->setArgument('defaultValue', $defaultValue);
         }
-        return new \Dagger\Dagger\Function_($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Function_($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -88,8 +88,8 @@ class Function_ extends \Dagger\Client\AbstractDaggerObject implements \Dagger\C
      */
     public function withDescription(string $description): Function_
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withDescription');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withDescription');
         $innerQueryBuilder->setArgument('description', $description);
-        return new \Dagger\Dagger\Function_($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Function_($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 }

--- a/sdk/php/generated/GeneratedCode.php
+++ b/sdk/php/generated/GeneratedCode.php
@@ -6,23 +6,23 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
-class GeneratedCode extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Client\IdAble
+class GeneratedCode extends Client\AbstractObject implements Client\IdAble
 {
     /**
      * The directory containing the generated code
      */
     public function code(): Directory
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('code');
-        return new \Dagger\Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('code');
+        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     public function id(): GeneratedCodeId
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('id');
-        return new \Dagger\Dagger\GeneratedCodeId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('id');
+        return new \Dagger\GeneratedCodeId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
     }
 
     /**
@@ -30,7 +30,7 @@ class GeneratedCode extends \Dagger\Client\AbstractDaggerObject implements \Dagg
      */
     public function vcsGeneratedPaths(): array
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('vcsGeneratedPaths');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('vcsGeneratedPaths');
         return (array)$this->queryLeaf($leafQueryBuilder, 'vcsGeneratedPaths');
     }
 
@@ -39,7 +39,7 @@ class GeneratedCode extends \Dagger\Client\AbstractDaggerObject implements \Dagg
      */
     public function vcsIgnoredPaths(): array
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('vcsIgnoredPaths');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('vcsIgnoredPaths');
         return (array)$this->queryLeaf($leafQueryBuilder, 'vcsIgnoredPaths');
     }
 
@@ -48,9 +48,9 @@ class GeneratedCode extends \Dagger\Client\AbstractDaggerObject implements \Dagg
      */
     public function withVCSGeneratedPaths(array $paths): GeneratedCode
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withVCSGeneratedPaths');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withVCSGeneratedPaths');
         $innerQueryBuilder->setArgument('paths', $paths);
-        return new \Dagger\Dagger\GeneratedCode($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\GeneratedCode($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -58,8 +58,8 @@ class GeneratedCode extends \Dagger\Client\AbstractDaggerObject implements \Dagg
      */
     public function withVCSIgnoredPaths(array $paths): GeneratedCode
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withVCSIgnoredPaths');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withVCSIgnoredPaths');
         $innerQueryBuilder->setArgument('paths', $paths);
-        return new \Dagger\Dagger\GeneratedCode($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\GeneratedCode($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 }

--- a/sdk/php/generated/GeneratedCodeId.php
+++ b/sdk/php/generated/GeneratedCodeId.php
@@ -6,11 +6,11 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A reference to GeneratedCode.
  */
-readonly class GeneratedCodeId extends \Dagger\Client\DaggerId
+readonly class GeneratedCodeId extends Client\DaggerId
 {
 }

--- a/sdk/php/generated/GeneratedCodeId.php
+++ b/sdk/php/generated/GeneratedCodeId.php
@@ -11,6 +11,6 @@ namespace Dagger;
 /**
  * A reference to GeneratedCode.
  */
-readonly class GeneratedCodeId extends Client\DaggerId
+readonly class GeneratedCodeId extends Client\AbstractId
 {
 }

--- a/sdk/php/generated/GitRef.php
+++ b/sdk/php/generated/GitRef.php
@@ -6,19 +6,19 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A git ref (tag, branch or commit).
  */
-class GitRef extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Client\IdAble
+class GitRef extends Client\AbstractObject implements Client\IdAble
 {
     /**
      * The resolved commit id at this ref.
      */
     public function commit(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('commit');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('commit');
         return (string)$this->queryLeaf($leafQueryBuilder, 'commit');
     }
 
@@ -27,8 +27,8 @@ class GitRef extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Clie
      */
     public function id(): GitRefId
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('id');
-        return new \Dagger\Dagger\GitRefId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('id');
+        return new \Dagger\GitRefId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
     }
 
     /**
@@ -36,13 +36,13 @@ class GitRef extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Clie
      */
     public function tree(?string $sshKnownHosts = null, SocketId|Socket|null $sshAuthSocket = null): Directory
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('tree');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('tree');
         if (null !== $sshKnownHosts) {
         $innerQueryBuilder->setArgument('sshKnownHosts', $sshKnownHosts);
         }
         if (null !== $sshAuthSocket) {
         $innerQueryBuilder->setArgument('sshAuthSocket', $sshAuthSocket);
         }
-        return new \Dagger\Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 }

--- a/sdk/php/generated/GitRefId.php
+++ b/sdk/php/generated/GitRefId.php
@@ -11,6 +11,6 @@ namespace Dagger;
 /**
  * A git reference identifier.
  */
-readonly class GitRefId extends Client\DaggerId
+readonly class GitRefId extends Client\AbstractId
 {
 }

--- a/sdk/php/generated/GitRefId.php
+++ b/sdk/php/generated/GitRefId.php
@@ -6,11 +6,11 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A git reference identifier.
  */
-readonly class GitRefId extends \Dagger\Client\DaggerId
+readonly class GitRefId extends Client\DaggerId
 {
 }

--- a/sdk/php/generated/GitRepository.php
+++ b/sdk/php/generated/GitRepository.php
@@ -6,21 +6,21 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A git repository.
  */
-class GitRepository extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Client\IdAble
+class GitRepository extends Client\AbstractObject implements Client\IdAble
 {
     /**
      * Returns details on one branch.
      */
     public function branch(string $name): GitRef
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('branch');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('branch');
         $innerQueryBuilder->setArgument('name', $name);
-        return new \Dagger\Dagger\GitRef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\GitRef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -28,9 +28,9 @@ class GitRepository extends \Dagger\Client\AbstractDaggerObject implements \Dagg
      */
     public function commit(string $id): GitRef
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('commit');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('commit');
         $innerQueryBuilder->setArgument('id', $id);
-        return new \Dagger\Dagger\GitRef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\GitRef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -38,8 +38,8 @@ class GitRepository extends \Dagger\Client\AbstractDaggerObject implements \Dagg
      */
     public function id(): GitRepositoryId
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('id');
-        return new \Dagger\Dagger\GitRepositoryId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('id');
+        return new \Dagger\GitRepositoryId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
     }
 
     /**
@@ -47,8 +47,8 @@ class GitRepository extends \Dagger\Client\AbstractDaggerObject implements \Dagg
      */
     public function tag(string $name): GitRef
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('tag');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('tag');
         $innerQueryBuilder->setArgument('name', $name);
-        return new \Dagger\Dagger\GitRef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\GitRef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 }

--- a/sdk/php/generated/GitRepositoryId.php
+++ b/sdk/php/generated/GitRepositoryId.php
@@ -6,11 +6,11 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A git repository identifier.
  */
-readonly class GitRepositoryId extends \Dagger\Client\DaggerId
+readonly class GitRepositoryId extends Client\DaggerId
 {
 }

--- a/sdk/php/generated/GitRepositoryId.php
+++ b/sdk/php/generated/GitRepositoryId.php
@@ -11,6 +11,6 @@ namespace Dagger;
 /**
  * A git repository identifier.
  */
-readonly class GitRepositoryId extends Client\DaggerId
+readonly class GitRepositoryId extends Client\AbstractId
 {
 }

--- a/sdk/php/generated/Host.php
+++ b/sdk/php/generated/Host.php
@@ -6,19 +6,19 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * Information about the host execution environment.
  */
-class Host extends \Dagger\Client\AbstractDaggerObject
+class Host extends Client\AbstractObject
 {
     /**
      * Accesses a directory on the host.
      */
     public function directory(string $path, ?array $exclude = null, ?array $include = null): Directory
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('directory');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('directory');
         $innerQueryBuilder->setArgument('path', $path);
         if (null !== $exclude) {
         $innerQueryBuilder->setArgument('exclude', $exclude);
@@ -26,7 +26,7 @@ class Host extends \Dagger\Client\AbstractDaggerObject
         if (null !== $include) {
         $innerQueryBuilder->setArgument('include', $include);
         }
-        return new \Dagger\Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -34,9 +34,9 @@ class Host extends \Dagger\Client\AbstractDaggerObject
      */
     public function file(string $path): File
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('file');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('file');
         $innerQueryBuilder->setArgument('path', $path);
-        return new \Dagger\Dagger\File($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\File($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -44,12 +44,12 @@ class Host extends \Dagger\Client\AbstractDaggerObject
      */
     public function service(array $ports, ?string $host = 'localhost'): Service
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('service');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('service');
         $innerQueryBuilder->setArgument('ports', $ports);
         if (null !== $host) {
         $innerQueryBuilder->setArgument('host', $host);
         }
-        return new \Dagger\Dagger\Service($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Service($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -58,10 +58,10 @@ class Host extends \Dagger\Client\AbstractDaggerObject
      */
     public function setSecretFile(string $name, string $path): Secret
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('setSecretFile');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('setSecretFile');
         $innerQueryBuilder->setArgument('name', $name);
         $innerQueryBuilder->setArgument('path', $path);
-        return new \Dagger\Dagger\Secret($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Secret($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -69,7 +69,7 @@ class Host extends \Dagger\Client\AbstractDaggerObject
      */
     public function tunnel(ServiceId|Service $service, ?bool $native = false, ?array $ports = null): Service
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('tunnel');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('tunnel');
         $innerQueryBuilder->setArgument('service', $service);
         if (null !== $native) {
         $innerQueryBuilder->setArgument('native', $native);
@@ -77,7 +77,7 @@ class Host extends \Dagger\Client\AbstractDaggerObject
         if (null !== $ports) {
         $innerQueryBuilder->setArgument('ports', $ports);
         }
-        return new \Dagger\Dagger\Service($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Service($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -85,8 +85,8 @@ class Host extends \Dagger\Client\AbstractDaggerObject
      */
     public function unixSocket(string $path): Socket
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('unixSocket');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('unixSocket');
         $innerQueryBuilder->setArgument('path', $path);
-        return new \Dagger\Dagger\Socket($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Socket($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 }

--- a/sdk/php/generated/ImageLayerCompression.php
+++ b/sdk/php/generated/ImageLayerCompression.php
@@ -6,7 +6,7 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * Compression algorithm to use for image layers.

--- a/sdk/php/generated/ImageMediaTypes.php
+++ b/sdk/php/generated/ImageMediaTypes.php
@@ -6,7 +6,7 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * Mediatypes to use in published or exported image metadata.

--- a/sdk/php/generated/Json.php
+++ b/sdk/php/generated/Json.php
@@ -6,11 +6,11 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * An arbitrary JSON-encoded value.
  */
-readonly class Json extends \Dagger\Client\DaggerScalar
+readonly class Json extends Client\DaggerScalar
 {
 }

--- a/sdk/php/generated/Json.php
+++ b/sdk/php/generated/Json.php
@@ -11,6 +11,6 @@ namespace Dagger;
 /**
  * An arbitrary JSON-encoded value.
  */
-readonly class Json extends Client\DaggerScalar
+readonly class Json extends Client\AbstractScalar
 {
 }

--- a/sdk/php/generated/Label.php
+++ b/sdk/php/generated/Label.php
@@ -6,19 +6,19 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A simple key value object that represents a label.
  */
-class Label extends \Dagger\Client\AbstractDaggerObject
+class Label extends Client\AbstractObject
 {
     /**
      * The label name.
      */
     public function name(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('name');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('name');
         return (string)$this->queryLeaf($leafQueryBuilder, 'name');
     }
 
@@ -27,7 +27,7 @@ class Label extends \Dagger\Client\AbstractDaggerObject
      */
     public function value(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('value');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('value');
         return (string)$this->queryLeaf($leafQueryBuilder, 'value');
     }
 }

--- a/sdk/php/generated/ListTypeDef.php
+++ b/sdk/php/generated/ListTypeDef.php
@@ -6,19 +6,19 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A definition of a list type in a Module.
  */
-class ListTypeDef extends \Dagger\Client\AbstractDaggerObject
+class ListTypeDef extends Client\AbstractObject
 {
     /**
      * The type of the elements in the list
      */
     public function elementTypeDef(): TypeDef
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('elementTypeDef');
-        return new \Dagger\Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('elementTypeDef');
+        return new \Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 }

--- a/sdk/php/generated/Module.php
+++ b/sdk/php/generated/Module.php
@@ -6,16 +6,16 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
-class Module extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Client\IdAble
+class Module extends Client\AbstractObject implements Client\IdAble
 {
     /**
      * Modules used by this module
      */
     public function dependencies(): array
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('dependencies');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('dependencies');
         return (array)$this->queryLeaf($leafQueryBuilder, 'dependencies');
     }
 
@@ -24,7 +24,7 @@ class Module extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Clie
      */
     public function dependencyConfig(): array
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('dependencyConfig');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('dependencyConfig');
         return (array)$this->queryLeaf($leafQueryBuilder, 'dependencyConfig');
     }
 
@@ -33,7 +33,7 @@ class Module extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Clie
      */
     public function description(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('description');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('description');
         return (string)$this->queryLeaf($leafQueryBuilder, 'description');
     }
 
@@ -42,8 +42,8 @@ class Module extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Clie
      */
     public function generatedCode(): GeneratedCode
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('generatedCode');
-        return new \Dagger\Dagger\GeneratedCode($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('generatedCode');
+        return new \Dagger\GeneratedCode($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -51,8 +51,8 @@ class Module extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Clie
      */
     public function id(): ModuleId
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('id');
-        return new \Dagger\Dagger\ModuleId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('id');
+        return new \Dagger\ModuleId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
     }
 
     /**
@@ -60,7 +60,7 @@ class Module extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Clie
      */
     public function name(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('name');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('name');
         return (string)$this->queryLeaf($leafQueryBuilder, 'name');
     }
 
@@ -69,7 +69,7 @@ class Module extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Clie
      */
     public function objects(): array
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('objects');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('objects');
         return (array)$this->queryLeaf($leafQueryBuilder, 'objects');
     }
 
@@ -78,7 +78,7 @@ class Module extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Clie
      */
     public function sdk(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('sdk');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('sdk');
         return (string)$this->queryLeaf($leafQueryBuilder, 'sdk');
     }
 
@@ -89,7 +89,7 @@ class Module extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Clie
      */
     public function serve(): void
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('serve');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('serve');
         $this->queryLeaf($leafQueryBuilder, 'serve');
     }
 
@@ -98,8 +98,8 @@ class Module extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Clie
      */
     public function sourceDirectory(): Directory
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('sourceDirectory');
-        return new \Dagger\Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('sourceDirectory');
+        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -107,7 +107,7 @@ class Module extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Clie
      */
     public function sourceDirectorySubPath(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('sourceDirectorySubPath');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('sourceDirectorySubPath');
         return (string)$this->queryLeaf($leafQueryBuilder, 'sourceDirectorySubPath');
     }
 
@@ -116,8 +116,8 @@ class Module extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Clie
      */
     public function withObject(TypeDefId|TypeDef $object): Module
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withObject');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withObject');
         $innerQueryBuilder->setArgument('object', $object);
-        return new \Dagger\Dagger\Module($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\Module($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 }

--- a/sdk/php/generated/ModuleConfig.php
+++ b/sdk/php/generated/ModuleConfig.php
@@ -6,19 +6,19 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * Static configuration for a module (e.g. parsed contents of dagger.json)
  */
-class ModuleConfig extends \Dagger\Client\AbstractDaggerObject
+class ModuleConfig extends Client\AbstractObject
 {
     /**
      * Modules that this module depends on.
      */
     public function dependencies(): array
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('dependencies');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('dependencies');
         return (array)$this->queryLeaf($leafQueryBuilder, 'dependencies');
     }
 
@@ -27,7 +27,7 @@ class ModuleConfig extends \Dagger\Client\AbstractDaggerObject
      */
     public function exclude(): array
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('exclude');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('exclude');
         return (array)$this->queryLeaf($leafQueryBuilder, 'exclude');
     }
 
@@ -36,7 +36,7 @@ class ModuleConfig extends \Dagger\Client\AbstractDaggerObject
      */
     public function include(): array
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('include');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('include');
         return (array)$this->queryLeaf($leafQueryBuilder, 'include');
     }
 
@@ -45,7 +45,7 @@ class ModuleConfig extends \Dagger\Client\AbstractDaggerObject
      */
     public function name(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('name');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('name');
         return (string)$this->queryLeaf($leafQueryBuilder, 'name');
     }
 
@@ -54,7 +54,7 @@ class ModuleConfig extends \Dagger\Client\AbstractDaggerObject
      */
     public function root(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('root');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('root');
         return (string)$this->queryLeaf($leafQueryBuilder, 'root');
     }
 
@@ -63,7 +63,7 @@ class ModuleConfig extends \Dagger\Client\AbstractDaggerObject
      */
     public function sdk(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('sdk');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('sdk');
         return (string)$this->queryLeaf($leafQueryBuilder, 'sdk');
     }
 }

--- a/sdk/php/generated/ModuleId.php
+++ b/sdk/php/generated/ModuleId.php
@@ -11,6 +11,6 @@ namespace Dagger;
 /**
  * A reference to a Module.
  */
-readonly class ModuleId extends Client\DaggerId
+readonly class ModuleId extends Client\AbstractId
 {
 }

--- a/sdk/php/generated/ModuleId.php
+++ b/sdk/php/generated/ModuleId.php
@@ -6,11 +6,11 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A reference to a Module.
  */
-readonly class ModuleId extends \Dagger\Client\DaggerId
+readonly class ModuleId extends Client\DaggerId
 {
 }

--- a/sdk/php/generated/NetworkProtocol.php
+++ b/sdk/php/generated/NetworkProtocol.php
@@ -6,7 +6,7 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * Transport layer network protocol associated to a port.

--- a/sdk/php/generated/ObjectTypeDef.php
+++ b/sdk/php/generated/ObjectTypeDef.php
@@ -6,20 +6,20 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A definition of a custom object defined in a Module.
  */
-class ObjectTypeDef extends \Dagger\Client\AbstractDaggerObject
+class ObjectTypeDef extends Client\AbstractObject
 {
     /**
      * The function used to construct new instances of this object, if any
      */
     public function constructor(): Function_
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('constructor');
-        return new \Dagger\Dagger\Function_($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('constructor');
+        return new \Dagger\Function_($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -27,7 +27,7 @@ class ObjectTypeDef extends \Dagger\Client\AbstractDaggerObject
      */
     public function description(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('description');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('description');
         return (string)$this->queryLeaf($leafQueryBuilder, 'description');
     }
 
@@ -36,7 +36,7 @@ class ObjectTypeDef extends \Dagger\Client\AbstractDaggerObject
      */
     public function fields(): array
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('fields');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('fields');
         return (array)$this->queryLeaf($leafQueryBuilder, 'fields');
     }
 
@@ -45,7 +45,7 @@ class ObjectTypeDef extends \Dagger\Client\AbstractDaggerObject
      */
     public function functions(): array
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('functions');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('functions');
         return (array)$this->queryLeaf($leafQueryBuilder, 'functions');
     }
 
@@ -54,7 +54,7 @@ class ObjectTypeDef extends \Dagger\Client\AbstractDaggerObject
      */
     public function name(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('name');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('name');
         return (string)$this->queryLeaf($leafQueryBuilder, 'name');
     }
 }

--- a/sdk/php/generated/ObjectTypeDef.php
+++ b/sdk/php/generated/ObjectTypeDef.php
@@ -57,4 +57,13 @@ class ObjectTypeDef extends Client\AbstractObject
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('name');
         return (string)$this->queryLeaf($leafQueryBuilder, 'name');
     }
+
+    /**
+     * If this ObjectTypeDef is associated with a Module, the name of the module. Unset otherwise.
+     */
+    public function sourceModuleName(): string
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('sourceModuleName');
+        return (string)$this->queryLeaf($leafQueryBuilder, 'sourceModuleName');
+    }
 }

--- a/sdk/php/generated/PipelineLabel.php
+++ b/sdk/php/generated/PipelineLabel.php
@@ -6,12 +6,12 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * Key value object that represents a Pipeline label.
  */
-class PipelineLabel extends \Dagger\Client\AbstractDaggerInputObject
+class PipelineLabel extends Client\AbstractInputObject
 {
     public function __construct(
         public string $name,

--- a/sdk/php/generated/Platform.php
+++ b/sdk/php/generated/Platform.php
@@ -13,6 +13,6 @@ namespace Dagger;
  *
  * The format is [os]/[platform]/[version] (e.g., "darwin/arm64/v7", "windows/amd64", "linux/arm64").
  */
-readonly class Platform extends Client\DaggerScalar
+readonly class Platform extends Client\AbstractScalar
 {
 }

--- a/sdk/php/generated/Platform.php
+++ b/sdk/php/generated/Platform.php
@@ -6,13 +6,13 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * The platform config OS and architecture in a Container.
  *
  * The format is [os]/[platform]/[version] (e.g., "darwin/arm64/v7", "windows/amd64", "linux/arm64").
  */
-readonly class Platform extends \Dagger\Client\DaggerScalar
+readonly class Platform extends Client\DaggerScalar
 {
 }

--- a/sdk/php/generated/Port.php
+++ b/sdk/php/generated/Port.php
@@ -6,19 +6,19 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A port exposed by a container.
  */
-class Port extends \Dagger\Client\AbstractDaggerObject
+class Port extends Client\AbstractObject
 {
     /**
      * The port description.
      */
     public function description(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('description');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('description');
         return (string)$this->queryLeaf($leafQueryBuilder, 'description');
     }
 
@@ -27,7 +27,7 @@ class Port extends \Dagger\Client\AbstractDaggerObject
      */
     public function port(): int
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('port');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('port');
         return (int)$this->queryLeaf($leafQueryBuilder, 'port');
     }
 
@@ -36,7 +36,7 @@ class Port extends \Dagger\Client\AbstractDaggerObject
      */
     public function protocol(): NetworkProtocol
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('protocol');
-        return \Dagger\Dagger\NetworkProtocol::from((string)$this->queryLeaf($leafQueryBuilder, 'protocol'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('protocol');
+        return \Dagger\NetworkProtocol::from((string)$this->queryLeaf($leafQueryBuilder, 'protocol'));
     }
 }

--- a/sdk/php/generated/PortForward.php
+++ b/sdk/php/generated/PortForward.php
@@ -6,12 +6,12 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * Port forwarding rules for tunneling network traffic.
  */
-class PortForward extends \Dagger\Client\AbstractDaggerInputObject
+class PortForward extends Client\AbstractInputObject
 {
     public function __construct(
         public int $backend,

--- a/sdk/php/generated/Secret.php
+++ b/sdk/php/generated/Secret.php
@@ -6,20 +6,20 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A reference to a secret value, which can be handled more safely than the value itself.
  */
-class Secret extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Client\IdAble
+class Secret extends Client\AbstractObject implements Client\IdAble
 {
     /**
      * The identifier for this secret.
      */
     public function id(): SecretId
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('id');
-        return new \Dagger\Dagger\SecretId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('id');
+        return new \Dagger\SecretId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
     }
 
     /**
@@ -27,7 +27,7 @@ class Secret extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Clie
      */
     public function plaintext(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('plaintext');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('plaintext');
         return (string)$this->queryLeaf($leafQueryBuilder, 'plaintext');
     }
 }

--- a/sdk/php/generated/SecretId.php
+++ b/sdk/php/generated/SecretId.php
@@ -11,6 +11,6 @@ namespace Dagger;
 /**
  * A unique identifier for a secret.
  */
-readonly class SecretId extends Client\DaggerId
+readonly class SecretId extends Client\AbstractId
 {
 }

--- a/sdk/php/generated/SecretId.php
+++ b/sdk/php/generated/SecretId.php
@@ -6,11 +6,11 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A unique identifier for a secret.
  */
-readonly class SecretId extends \Dagger\Client\DaggerId
+readonly class SecretId extends Client\DaggerId
 {
 }

--- a/sdk/php/generated/Service.php
+++ b/sdk/php/generated/Service.php
@@ -6,9 +6,9 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
-class Service extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Client\IdAble
+class Service extends Client\AbstractObject implements Client\IdAble
 {
     /**
      * Retrieves an endpoint that clients can use to reach this container.
@@ -19,7 +19,7 @@ class Service extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Cli
      */
     public function endpoint(?int $port = null, ?string $scheme = null): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('endpoint');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('endpoint');
         if (null !== $port) {
         $leafQueryBuilder->setArgument('port', $port);
         }
@@ -34,7 +34,7 @@ class Service extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Cli
      */
     public function hostname(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('hostname');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('hostname');
         return (string)$this->queryLeaf($leafQueryBuilder, 'hostname');
     }
 
@@ -43,8 +43,8 @@ class Service extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Cli
      */
     public function id(): ServiceId
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('id');
-        return new \Dagger\Dagger\ServiceId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('id');
+        return new \Dagger\ServiceId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
     }
 
     /**
@@ -52,7 +52,7 @@ class Service extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Cli
      */
     public function ports(): array
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('ports');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('ports');
         return (array)$this->queryLeaf($leafQueryBuilder, 'ports');
     }
 
@@ -63,8 +63,8 @@ class Service extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Cli
      */
     public function start(): ServiceId
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('start');
-        return new \Dagger\Dagger\ServiceId((string)$this->queryLeaf($leafQueryBuilder, 'start'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('start');
+        return new \Dagger\ServiceId((string)$this->queryLeaf($leafQueryBuilder, 'start'));
     }
 
     /**
@@ -72,7 +72,7 @@ class Service extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Cli
      */
     public function stop(): ServiceId
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('stop');
-        return new \Dagger\Dagger\ServiceId((string)$this->queryLeaf($leafQueryBuilder, 'stop'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('stop');
+        return new \Dagger\ServiceId((string)$this->queryLeaf($leafQueryBuilder, 'stop'));
     }
 }

--- a/sdk/php/generated/ServiceId.php
+++ b/sdk/php/generated/ServiceId.php
@@ -6,11 +6,11 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A unique service identifier.
  */
-readonly class ServiceId extends \Dagger\Client\DaggerId
+readonly class ServiceId extends Client\DaggerId
 {
 }

--- a/sdk/php/generated/ServiceId.php
+++ b/sdk/php/generated/ServiceId.php
@@ -11,6 +11,6 @@ namespace Dagger;
 /**
  * A unique service identifier.
  */
-readonly class ServiceId extends Client\DaggerId
+readonly class ServiceId extends Client\AbstractId
 {
 }

--- a/sdk/php/generated/Socket.php
+++ b/sdk/php/generated/Socket.php
@@ -6,16 +6,16 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
-class Socket extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Client\IdAble
+class Socket extends Client\AbstractObject implements Client\IdAble
 {
     /**
      * The content-addressed identifier of the socket.
      */
     public function id(): SocketId
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('id');
-        return new \Dagger\Dagger\SocketId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('id');
+        return new \Dagger\SocketId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
     }
 }

--- a/sdk/php/generated/SocketId.php
+++ b/sdk/php/generated/SocketId.php
@@ -6,11 +6,11 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A content-addressed socket identifier.
  */
-readonly class SocketId extends \Dagger\Client\DaggerId
+readonly class SocketId extends Client\DaggerId
 {
 }

--- a/sdk/php/generated/SocketId.php
+++ b/sdk/php/generated/SocketId.php
@@ -11,6 +11,6 @@ namespace Dagger;
 /**
  * A content-addressed socket identifier.
  */
-readonly class SocketId extends Client\DaggerId
+readonly class SocketId extends Client\AbstractId
 {
 }

--- a/sdk/php/generated/TypeDef.php
+++ b/sdk/php/generated/TypeDef.php
@@ -6,12 +6,12 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A definition of a parameter or return type in a Module.
  */
-class TypeDef extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Client\IdAble
+class TypeDef extends Client\AbstractObject implements Client\IdAble
 {
     /**
      * If kind is LIST, the list-specific type definition.
@@ -19,8 +19,8 @@ class TypeDef extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Cli
      */
     public function asList(): ListTypeDef
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('asList');
-        return new \Dagger\Dagger\ListTypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('asList');
+        return new \Dagger\ListTypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -29,14 +29,14 @@ class TypeDef extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Cli
      */
     public function asObject(): ObjectTypeDef
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('asObject');
-        return new \Dagger\Dagger\ObjectTypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('asObject');
+        return new \Dagger\ObjectTypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     public function id(): TypeDefId
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('id');
-        return new \Dagger\Dagger\TypeDefId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('id');
+        return new \Dagger\TypeDefId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
     }
 
     /**
@@ -44,8 +44,8 @@ class TypeDef extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Cli
      */
     public function kind(): TypeDefKind
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('kind');
-        return \Dagger\Dagger\TypeDefKind::from((string)$this->queryLeaf($leafQueryBuilder, 'kind'));
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('kind');
+        return \Dagger\TypeDefKind::from((string)$this->queryLeaf($leafQueryBuilder, 'kind'));
     }
 
     /**
@@ -53,7 +53,7 @@ class TypeDef extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Cli
      */
     public function optional(): bool
     {
-        $leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('optional');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('optional');
         return (bool)$this->queryLeaf($leafQueryBuilder, 'optional');
     }
 
@@ -62,9 +62,9 @@ class TypeDef extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Cli
      */
     public function withConstructor(FunctionId|Function_ $function): TypeDef
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withConstructor');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withConstructor');
         $innerQueryBuilder->setArgument('function', $function);
-        return new \Dagger\Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -72,13 +72,13 @@ class TypeDef extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Cli
      */
     public function withField(string $name, TypeDefId|TypeDef $typeDef, ?string $description = null): TypeDef
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withField');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withField');
         $innerQueryBuilder->setArgument('name', $name);
         $innerQueryBuilder->setArgument('typeDef', $typeDef);
         if (null !== $description) {
         $innerQueryBuilder->setArgument('description', $description);
         }
-        return new \Dagger\Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -86,9 +86,9 @@ class TypeDef extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Cli
      */
     public function withFunction(FunctionId|Function_ $function): TypeDef
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withFunction');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withFunction');
         $innerQueryBuilder->setArgument('function', $function);
-        return new \Dagger\Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -96,9 +96,9 @@ class TypeDef extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Cli
      */
     public function withKind(TypeDefKind $kind): TypeDef
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withKind');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withKind');
         $innerQueryBuilder->setArgument('kind', $kind);
-        return new \Dagger\Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -106,9 +106,9 @@ class TypeDef extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Cli
      */
     public function withListOf(TypeDefId|TypeDef $elementType): TypeDef
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withListOf');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withListOf');
         $innerQueryBuilder->setArgument('elementType', $elementType);
-        return new \Dagger\Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -120,12 +120,12 @@ class TypeDef extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Cli
      */
     public function withObject(string $name, ?string $description = null): TypeDef
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withObject');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withObject');
         $innerQueryBuilder->setArgument('name', $name);
         if (null !== $description) {
         $innerQueryBuilder->setArgument('description', $description);
         }
-        return new \Dagger\Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
@@ -133,8 +133,8 @@ class TypeDef extends \Dagger\Client\AbstractDaggerObject implements \Dagger\Cli
      */
     public function withOptional(bool $optional): TypeDef
     {
-        $innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder('withOptional');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withOptional');
         $innerQueryBuilder->setArgument('optional', $optional);
-        return new \Dagger\Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        return new \Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 }

--- a/sdk/php/generated/TypeDefId.php
+++ b/sdk/php/generated/TypeDefId.php
@@ -11,6 +11,6 @@ namespace Dagger;
 /**
  * A reference to a TypeDef.
  */
-readonly class TypeDefId extends Client\DaggerId
+readonly class TypeDefId extends Client\AbstractId
 {
 }

--- a/sdk/php/generated/TypeDefId.php
+++ b/sdk/php/generated/TypeDefId.php
@@ -6,11 +6,11 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * A reference to a TypeDef.
  */
-readonly class TypeDefId extends \Dagger\Client\DaggerId
+readonly class TypeDefId extends Client\DaggerId
 {
 }

--- a/sdk/php/generated/TypeDefKind.php
+++ b/sdk/php/generated/TypeDefKind.php
@@ -6,7 +6,7 @@
 
 declare(strict_types=1);
 
-namespace Dagger\Dagger;
+namespace Dagger;
 
 /**
  * Distinguishes the different kinds of TypeDefs.

--- a/sdk/php/graphql.config.yml
+++ b/sdk/php/graphql.config.yml
@@ -1,5 +1,0 @@
-schema:
-  - http://localhost:8080/query:
-      headers:
-        Authorization: "Basic ZGV2Og=="
-      introspect: true

--- a/sdk/php/src/Client/AbstractClient.php
+++ b/sdk/php/src/Client/AbstractClient.php
@@ -2,23 +2,23 @@
 
 namespace Dagger\Client;
 
+use Dagger\Client;
 use Dagger\Connection;
-use Dagger\Dagger\DaggerClient;
 use Dagger\GraphQl\QueryBuilderChain;
-use GraphQL\Client;
+use GraphQL\Client as GqlClient;
 use GraphQL\Query;
 use GraphQL\QueryBuilder\QueryBuilder;
 use GraphQL\Results;
 use RecursiveArrayIterator;
 use RecursiveIteratorIterator;
 
-abstract class AbstractDaggerClient
+abstract class AbstractClient
 {
-    protected AbstractDaggerClient $client;
-    protected Client $graphQlClient;
+    protected AbstractClient $client;
+    protected GqlClient $graphQlClient;
 
     public function __construct(
-        Connection|DaggerClient $clientOrConnection,
+        Connection|Client $clientOrConnection,
         protected readonly QueryBuilderChain $queryBuilderChain = new QueryBuilderChain()
     ) {
         if ($clientOrConnection instanceof Connection) {

--- a/sdk/php/src/Client/AbstractId.php
+++ b/sdk/php/src/Client/AbstractId.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Dagger\Client;
+
+abstract readonly class AbstractId extends AbstractScalar
+{
+}

--- a/sdk/php/src/Client/AbstractInputObject.php
+++ b/sdk/php/src/Client/AbstractInputObject.php
@@ -2,7 +2,7 @@
 
 namespace Dagger\Client;
 
-abstract class AbstractDaggerInputObject
+abstract class AbstractInputObject
 {
     public function toArray(): array
     {

--- a/sdk/php/src/Client/AbstractObject.php
+++ b/sdk/php/src/Client/AbstractObject.php
@@ -5,10 +5,10 @@ namespace Dagger\Client;
 use Dagger\GraphQl\QueryBuilderChain;
 use GraphQL\QueryBuilder\QueryBuilder;
 
-abstract class AbstractDaggerObject
+abstract class AbstractObject
 {
     public function __construct(
-        protected readonly AbstractDaggerClient $client,
+        protected readonly AbstractClient $client,
         protected readonly QueryBuilderChain $queryBuilderChain
     ) {
     }

--- a/sdk/php/src/Client/AbstractScalar.php
+++ b/sdk/php/src/Client/AbstractScalar.php
@@ -4,7 +4,7 @@ namespace Dagger\Client;
 
 use Stringable;
 
-readonly class DaggerScalar implements Stringable
+abstract readonly class AbstractScalar implements Stringable
 {
     public function __construct(private string $value)
     {

--- a/sdk/php/src/Client/DaggerId.php
+++ b/sdk/php/src/Client/DaggerId.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Dagger\Client;
-
-readonly class DaggerId extends DaggerScalar
-{
-}

--- a/sdk/php/src/Client/IdAble.php
+++ b/sdk/php/src/Client/IdAble.php
@@ -4,5 +4,5 @@ namespace Dagger\Client;
 
 interface IdAble
 {
-    public function id(): DaggerId;
+    public function id(): AbstractId;
 }

--- a/sdk/php/src/Client/QueryBuilder.php
+++ b/sdk/php/src/Client/QueryBuilder.php
@@ -18,7 +18,7 @@ class QueryBuilder extends GqlQueryBuilder
             $value = $argumentValue;
         }
 
-        if ($value instanceof DaggerScalar) {
+        if ($value instanceof AbstractScalar) {
             $value = $value->getValue();
         }
 

--- a/sdk/php/src/Client/QueryBuilder.php
+++ b/sdk/php/src/Client/QueryBuilder.php
@@ -3,11 +3,12 @@
 namespace Dagger\Client;
 
 use BackedEnum;
-use GraphQL\QueryBuilder\QueryBuilder;
+use GraphQL\QueryBuilder\AbstractQueryBuilder;
+use GraphQL\QueryBuilder\QueryBuilder as GqlQueryBuilder;
 
-class DaggerQueryBuilder extends QueryBuilder
+class QueryBuilder extends GqlQueryBuilder
 {
-    public function setArgument(string $argumentName, $argumentValue): QueryBuilder|\GraphQL\QueryBuilder\AbstractQueryBuilder
+    public function setArgument(string $argumentName, $argumentValue): QueryBuilder|AbstractQueryBuilder
     {
         if ($argumentValue instanceof BackedEnum) {
             $value = $argumentValue->value;

--- a/sdk/php/src/Codegen/CodeWriter.php
+++ b/sdk/php/src/Codegen/CodeWriter.php
@@ -9,7 +9,7 @@ use Nette\PhpGenerator\PsrPrinter;
 
 class CodeWriter
 {
-    public const NAMESPACE = 'Dagger\\Dagger';
+    public const NAMESPACE = 'Dagger';
 
     public function __construct(private readonly string $targetDirectory)
     {

--- a/sdk/php/src/Codegen/Codegen.php
+++ b/sdk/php/src/Codegen/Codegen.php
@@ -11,7 +11,7 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Schema;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-class DaggerCodegen
+class Codegen
 {
     public function __construct(
         private readonly Schema $schema,

--- a/sdk/php/src/Codegen/Introspection/Helpers.php
+++ b/sdk/php/src/Codegen/Introspection/Helpers.php
@@ -75,7 +75,7 @@ class Helpers
 
         if ($type instanceof ObjectType) {
             if ('Query' === $typeName) {
-                return 'DaggerClient';
+                return 'Client';
             }
 
             return Helpers::formatPhpClassName($typeName);

--- a/sdk/php/src/Codegen/Introspection/InputVisitor.php
+++ b/sdk/php/src/Codegen/Introspection/InputVisitor.php
@@ -2,7 +2,7 @@
 
 namespace Dagger\Codegen\Introspection;
 
-use Dagger\Client\AbstractDaggerInputObject;
+use Dagger\Client\AbstractInputObject;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\Type;
 use Nette\PhpGenerator\ClassType;
@@ -22,7 +22,7 @@ class InputVisitor extends AbstractVisitor
         $phpClassName = Helpers::formatPhpClassName($typeName);
 
         $inputObjectClass = new ClassType($phpClassName);
-        $inputObjectClass->setExtends(AbstractDaggerInputObject::class);
+        $inputObjectClass->setExtends(AbstractInputObject::class);
         $inputObjectClass->addComment($type->description);
 
         $constructor = $inputObjectClass->addMethod('__construct');

--- a/sdk/php/src/Codegen/Introspection/ObjectVisitor.php
+++ b/sdk/php/src/Codegen/Introspection/ObjectVisitor.php
@@ -2,8 +2,8 @@
 
 namespace Dagger\Codegen\Introspection;
 
-use Dagger\Client\AbstractDaggerClient;
-use Dagger\Client\AbstractDaggerObject;
+use Dagger\Client\AbstractClient;
+use Dagger\Client\AbstractObject;
 use Dagger\Client\IdAble;
 use GraphQL\Type\Definition\Argument;
 use GraphQL\Type\Definition\FieldDefinition;
@@ -24,8 +24,8 @@ class ObjectVisitor extends AbstractVisitor
             throw new TypeError('ObjectVisitor can only generate from ObjectType');
         }
 
-        $parentClass = 'Query' === $type->name ? AbstractDaggerClient::class : AbstractDaggerObject::class;
-        $className = 'Query' === $type->name ? 'DaggerClient' : $type->name;
+        $parentClass = 'Query' === $type->name ? AbstractClient::class : AbstractObject::class;
+        $className = 'Query' === $type->name ? 'Client' : $type->name;
 
         $objectClass = new ClassType(Helpers::formatPhpClassName($className));
         $objectClass->setExtends($parentClass);
@@ -60,7 +60,7 @@ class ObjectVisitor extends AbstractVisitor
             // @TODO refactor
 
             if (Helpers::isScalar($returnType) || Helpers::isList($returnType) || Helpers::isEnumType($returnType)) {
-                $method->addBody('$leafQueryBuilder = new \Dagger\Client\DaggerQueryBuilder(?);', [$fieldName]);
+                $method->addBody('$leafQueryBuilder = new \Dagger\Client\QueryBuilder(?);', [$fieldName]);
                 $this->generateMethodArgumentsBody($method, $field->args, 'leafQueryBuilder');
                 if (Helpers::isCustomScalar($returnType) && !Helpers::isVoidType($returnType)) {
                     $method->addBody(
@@ -85,7 +85,7 @@ class ObjectVisitor extends AbstractVisitor
                     );
                 }
             } else {
-                $method->addBody('$innerQueryBuilder = new \Dagger\Client\DaggerQueryBuilder(?);', [$fieldName]);
+                $method->addBody('$innerQueryBuilder = new \Dagger\Client\QueryBuilder(?);', [$fieldName]);
                 $this->generateMethodArgumentsBody($method, $field->args, 'innerQueryBuilder');
                 $method->addBody(
                     'return new '.

--- a/sdk/php/src/Codegen/Introspection/ScalarVisitor.php
+++ b/sdk/php/src/Codegen/Introspection/ScalarVisitor.php
@@ -2,8 +2,8 @@
 
 namespace Dagger\Codegen\Introspection;
 
-use Dagger\Client\DaggerId;
-use Dagger\Client\DaggerScalar;
+use Dagger\Client\AbstractId;
+use Dagger\Client\AbstractScalar;
 use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Type\Definition\Type;
 use Nette\PhpGenerator\ClassType;
@@ -26,9 +26,9 @@ class ScalarVisitor extends AbstractVisitor
         $scalarClass->addComment($type->description);
 
         if (str_ends_with($typeName, 'ID')) {
-            $scalarClass->setExtends(DaggerId::class);
+            $scalarClass->setExtends(AbstractId::class);
         } else {
-            $scalarClass->setExtends(DaggerScalar::class);
+            $scalarClass->setExtends(AbstractScalar::class);
         }
 
         return $scalarClass;

--- a/sdk/php/src/Command/CodegenCommand.php
+++ b/sdk/php/src/Command/CodegenCommand.php
@@ -2,7 +2,7 @@
 
 namespace Dagger\Command;
 
-use Dagger\Codegen\DaggerCodegen;
+use Dagger\Codegen\Codegen;
 use Dagger\Codegen\SchemaGenerator;
 use Dagger\Connection;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand('dagger:codegen')]
-class DaggerCodegenCommand extends Command
+class CodegenCommand extends Command
 {
     private const WRITE_DIR =
         __DIR__.DIRECTORY_SEPARATOR.
@@ -36,7 +36,7 @@ class DaggerCodegenCommand extends Command
         $client = $this->daggerConnection->connect();
 
         $schema = (new SchemaGenerator($client))->getSchema();
-        $codegen = new DaggerCodegen($schema, self::WRITE_DIR, $io);
+        $codegen = new Codegen($schema, self::WRITE_DIR, $io);
         $codegen->generate();
 
         return Command::SUCCESS;

--- a/sdk/php/src/Command/SchemaGeneratorCommand.php
+++ b/sdk/php/src/Command/SchemaGeneratorCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand('dagger:schema')]
-class DaggerSchemaGeneratorCommand extends Command
+class SchemaGeneratorCommand extends Command
 {
     private const WRITE_DIR =
         __DIR__.DIRECTORY_SEPARATOR.

--- a/sdk/php/src/Dagger.php
+++ b/sdk/php/src/Dagger.php
@@ -3,18 +3,17 @@
 namespace Dagger;
 
 use CompileError;
-use Dagger\Dagger\DaggerClient;
 
 class Dagger
 {
-    public static function connect(string $workingDir = ''): DaggerClient
+    public static function connect(string $workingDir = ''): Client
     {
-        if (!class_exists('Dagger\\Dagger\\DaggerClient')) {
+        if (!class_exists('Dagger\\Client')) {
             throw new CompileError('Missing code generated dagger client');
         }
 
         $connection = Connection::get($workingDir);
 
-        return new DaggerClient($connection);
+        return new Client($connection);
     }
 }

--- a/sdk/php/tests/ClientTest.php
+++ b/sdk/php/tests/ClientTest.php
@@ -2,14 +2,14 @@
 
 namespace Dagger\Tests;
 
+use Dagger\Client;
 use Dagger\Dagger;
-use Dagger\Dagger\DaggerClient;
 use GraphQL\QueryBuilder\QueryBuilder;
 use PHPUnit\Framework\TestCase;
 
-class DaggerClientTest extends TestCase
+class ClientTest extends TestCase
 {
-    public function newClient(): DaggerClient
+    public function newClient(): Client
     {
         return Dagger::connect();
     }


### PR DESCRIPTION
As discussed in https://github.com/dagger/dagger/pull/6165

I removed the `Dagger\Dagger` namespace and most of `Dagger` prefix in class names.

Should we keep `DaggerScalar` and `DaggerId` ?

