### PR TITLE
chore: update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,24 +12,13 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
 
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    labels:
-      - "kind/dependencies"
-      - "area/tooling"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
-
   - package-ecosystem: "gomod"
     directory: "/internal/mage"
     schedule:
       interval: "monthly"
     labels:
       - "kind/dependencies"
-      - "area/tooling"
+      - "area/ci"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
This patch updates the labels added to internal/mage PRs to include the `area/ci` tag (and not the `area/tooling` tag which no longer exists).

Additionally, we can remove the docker package, the only dockerfiles we have in-tree our docs/examples related (see also https://github.com/dagger/dagger/pull/6350).