### PR TITLE
fix(cmd/shim): fix panic when exec-ing an unknown command

### DIFF
--- a/.changes/unreleased/Fixed-20240104-003032.yaml
+++ b/.changes/unreleased/Fixed-20240104-003032.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fix shim panic when exec-ing an unknown command
+time: 2024-01-04T00:30:32.476564652+08:00
+custom:
+  Author: Juneezee
+  PR: "6356"

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -284,11 +284,11 @@ func shim() (returnExitCode int) {
 
 	exitCode := 0
 	if err := runWithNesting(ctx, cmd); err != nil {
-		exitCode = errorExitCode
 		if exiterr, ok := err.(*exec.ExitError); ok {
 			exitCode = exiterr.ExitCode()
 		} else {
-			panic(err)
+			exitCode = errorExitCode
+			fmt.Fprintln(os.Stderr, err.Error())
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/6266.

When an unknown command is executed, the returned error is `*exec.Error`.

Example code (Go playground: https://go.dev/play/p/ybni3fJpo46): 

```go
package main

import (
	"log"
	"os/exec"
)

func main() {
	if err := exec.Command("foobar").Run(); err != nil {
		log.Printf("%T: %+v", err, err)
	}

	if err := exec.Command("false").Run(); err != nil {
		log.Printf("%T: %+v", err, err)
	}
}
```

Output:

```
2009/11/10 23:00:00 *exec.Error: exec: "foobar": executable file not found in $PATH
2009/11/10 23:00:00 *exec.ExitError: exit status 1
```

#### Before:

```
./bin/dagger run --focus go run ./cmd/6266/main.go
✘ sync ERROR [1.02s]
✘ exec foobar ERROR [0.13s]
┃ panic: exec: "foobar": executable file not found in $PATH goroutine 1 [running, locked to thread]:
┃ runtime/debug.Stack()
┃         /usr/local/go/src/runtime/debug/stack.go:24 +0x5e
┃ main.main.func1()
┃         /app/cmd/shim/main.go:63 +0x38
┃ panic({0xf2e560?, 0xc0003a6900?})
┃         /usr/local/go/src/runtime/panic.go:914 +0x21f
┃ main.shim()
┃         /app/cmd/shim/main.go:291 +0x105f
┃ main.main()
┃         /app/cmd/shim/main.go:76 +0x74
• Engine: 477dc7d49db5 (version devel ())
⧗ 32.38s ✔ 12 ✘ 3
```

#### After:

```
./bin/dagger run --focus go run ./cmd/6266/main.go
✘ sync ERROR [0.12s]
✘ exec foobar ERROR [0.11s]
┃ exec: "foobar": executable file not found in $PATH
• Engine: ce3e879de096 (version devel ())
⧗ 2.47s ✔ 12 ✘ 2
```