### PR TITLE
fix: forbid go optional wrapper in struct definition

### DIFF
--- a/cmd/codegen/generator/go/templates/module_objects.go
+++ b/cmd/codegen/generator/go/templates/module_objects.go
@@ -91,7 +91,12 @@ func (ps *parseState) parseGoStruct(t *types.Struct, named *types.Named) (*parse
 		}
 
 		fieldSpec := &fieldSpec{goType: field.Type()}
-		fieldSpec.typeSpec, err = ps.parseGoTypeReference(field.Type(), nil, false)
+		if _, optional, err := ps.isOptionalWrapper(fieldSpec.goType); err != nil {
+			return nil, err
+		} else if optional {
+			return nil, fmt.Errorf("optional type wrapper not allowed in struct field %s", field.Name())
+		}
+		fieldSpec.typeSpec, err = ps.parseGoTypeReference(fieldSpec.goType, nil, false)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse field type: %w", err)
 		}


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/6369.

This is easier than attempting to handle this case, which would make the optional handling logic spill out to even more places (which I'd really like to avoid for now).

---

@sipsma @vito what do you think about removing the `Optional` type and relying entirely on `// +optional` for the RC? If we're going to break some things, feels like this is a good candidate.

