### PR TITLE
feat: add git ref graphql field

### DIFF
--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -21,31 +21,28 @@ import (
 func TestGit(t *testing.T) {
 	t.Parallel()
 
+	type result struct {
+		Commit string
+		Tree   struct {
+			File struct {
+				Contents string
+			}
+		}
+	}
+
 	res := struct {
 		Git struct {
-			Branch struct {
-				Commit string
-				Tree   struct {
-					File struct {
-						Contents string
-					}
-				}
-			}
-			Commit struct {
-				Commit string
-				Tree   struct {
-					File struct {
-						Contents string
-					}
-				}
-			}
+			Ref    result
+			Commit result
+			Branch result
+			Tag    result
 		}
 	}{}
 
 	err := testutil.Query(
 		`{
 			git(url: "github.com/dagger/dagger", keepGitDir: true) {
-				branch(name: "main") {
+				ref(name: "refs/heads/main") {
 					commit
 					tree {
 						file(path: "README.md") {
@@ -61,13 +58,44 @@ func TestGit(t *testing.T) {
 						}
 					}
 				}
+				branch(name: "main") {
+					commit
+					tree {
+						file(path: "README.md") {
+							contents
+						}
+					}
+				}
+				tag(name: "v0.9.5") {
+					commit
+					tree {
+						file(path: "README.md") {
+							contents
+						}
+					}
+				}
 			}
 		}`, &res, nil)
 	require.NoError(t, err)
-	require.NotEmpty(t, res.Git.Branch.Commit)
+
+	// refs/heads/main
+	require.NotEmpty(t, res.Git.Ref.Commit)
+	require.Contains(t, res.Git.Ref.Tree.File.Contents, "Dagger")
+
+	// c80ac2c13df7d573a069938e01ca13f7a81f0345
 	require.Equal(t, res.Git.Commit.Commit, "c80ac2c13df7d573a069938e01ca13f7a81f0345")
-	require.Contains(t, res.Git.Branch.Tree.File.Contents, "Dagger")
 	require.Contains(t, res.Git.Commit.Tree.File.Contents, "Dagger")
+
+	// main
+	require.NotEmpty(t, res.Git.Branch.Commit)
+	require.Contains(t, res.Git.Branch.Tree.File.Contents, "Dagger")
+
+	// v0.9.5
+	// FIXME: without moby/buildkit#4473, the wrong commit is selected:
+	//		  we *should* select refs/tags/v0.9.5, but we select
+	//		  refs/tags/sdk/elixir/v0.9.5
+	require.Equal(t, res.Git.Tag.Commit, "037520ed6c8a4ace2f1602fa5277d2cd1ed4ebd4")
+	require.Contains(t, res.Git.Tag.Tree.File.Contents, "Dagger")
 }
 
 func TestGitSSHAuthSock(t *testing.T) {

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -91,10 +91,7 @@ func TestGit(t *testing.T) {
 	require.Contains(t, res.Git.Branch.Tree.File.Contents, "Dagger")
 
 	// v0.9.5
-	// FIXME: without moby/buildkit#4473, the wrong commit is selected:
-	//		  we *should* select refs/tags/v0.9.5, but we select
-	//		  refs/tags/sdk/elixir/v0.9.5
-	require.Equal(t, res.Git.Tag.Commit, "037520ed6c8a4ace2f1602fa5277d2cd1ed4ebd4")
+	require.Equal(t, res.Git.Tag.Commit, "9ea5ea7c848fef2a2c47cce0716d5fcb8d6bedeb")
 	require.Contains(t, res.Git.Tag.Tree.File.Contents, "Dagger")
 }
 

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -34,6 +34,9 @@ func (s *gitSchema) Install() {
 	}.Install(s.srv)
 
 	dagql.Fields[*core.GitRepository]{
+		dagql.Func("ref", s.ref).
+			Doc(`Returns details of a ref.`).
+			ArgDoc("name", `Ref's name (can be a commit identifier, a tag name, a branch name, or a fully-qualified ref).`),
 		dagql.Func("branch", s.branch).
 			Doc(`Returns details of a branch.`).
 			ArgDoc("name", `Branch's name (e.g., "main").`),
@@ -98,6 +101,18 @@ func (s *gitSchema) git(ctx context.Context, parent *core.Query, args gitArgs) (
 		SSHAuthSocket: authSock,
 		Services:      svcs,
 		Platform:      parent.Platform,
+	}, nil
+}
+
+type refArgs struct {
+	Name string
+}
+
+func (s *gitSchema) ref(ctx context.Context, parent *core.GitRepository, args refArgs) (*core.GitRef, error) {
+	return &core.GitRef{
+		Query: parent.Query,
+		Ref:   args.Name,
+		Repo:  parent,
 	}, nil
 }
 

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -1313,6 +1313,14 @@ type GitRepository {
   """A unique identifier for this GitRepository."""
   id: GitRepositoryID!
 
+  """Returns details of a ref."""
+  ref(
+    """
+    Ref's name (can be a commit identifier, a tag name, a branch name, or a fully-qualified ref).
+    """
+    name: String!
+  ): GitRef!
+
   """Returns details of a tag."""
   tag(
     """Tag's name (e.g., "v0.3.9")."""

--- a/engine/sources/gitdns/gitsource.go
+++ b/engine/sources/gitdns/gitsource.go
@@ -438,6 +438,7 @@ func (gs *gitSourceHandler) CacheKey(ctx context.Context, g session.Group, index
 	}
 	lines := strings.Split(buf.String(), "\n")
 
+	// simulate git-checkout semantics, and make sure to select exactly the right ref
 	var (
 		partialRef      = "refs/" + strings.TrimPrefix(ref, "refs/")
 		headRef         = "refs/heads/" + strings.TrimPrefix(ref, "refs/heads/")

--- a/engine/sources/gitdns/gitsource.go
+++ b/engine/sources/gitdns/gitsource.go
@@ -432,20 +432,45 @@ func (gs *gitSourceHandler) CacheKey(ctx context.Context, g session.Group, index
 
 	// TODO: should we assume that remote tag is immutable? add a timer?
 
-	buf, err := git.run(ctx, "ls-remote", "origin", ref)
+	buf, err := git.run(ctx, "ls-remote", "origin", ref, ref+"^{}")
 	if err != nil {
 		return "", "", nil, false, errors.Wrapf(err, "failed to fetch remote %s", urlutil.RedactCredentials(remote))
 	}
-	out := buf.String()
-	idx := strings.Index(out, "\t")
-	if idx == -1 {
-		return "", "", nil, false, errors.Errorf("repository does not contain ref %s, output: %q", ref, out)
+	lines := strings.Split(buf.String(), "\n")
+
+	var (
+		partialRef      = "refs/" + strings.TrimPrefix(ref, "refs/")
+		headRef         = "refs/heads/" + strings.TrimPrefix(ref, "refs/heads/")
+		tagRef          = "refs/tags/" + strings.TrimPrefix(ref, "refs/tags/")
+		annotatedTagRef = tagRef + "^{}"
+	)
+	var sha, headSha, tagSha string
+	for _, line := range lines {
+		lineSha, lineRef, _ := strings.Cut(line, "\t")
+		switch lineRef {
+		case headRef:
+			headSha = lineSha
+		case tagRef, annotatedTagRef:
+			tagSha = lineSha
+		case partialRef:
+			sha = lineSha
+		}
 	}
 
-	sha := out[:idx]
+	// git-checkout prefers branches in case of ambiguity
+	if sha == "" {
+		sha = headSha
+	}
+	if sha == "" {
+		sha = tagSha
+	}
+	if sha == "" {
+		return "", "", nil, false, errors.Errorf("repository does not contain ref %s, output: %q", ref, buf.String())
+	}
 	if !isCommitSHA(sha) {
 		return "", "", nil, false, errors.Errorf("invalid commit sha %q", sha)
 	}
+
 	cacheKey := gs.shaToCacheKey(sha)
 	gs.cacheKey = cacheKey
 	return cacheKey, sha, nil, true, nil

--- a/sdk/elixir/lib/dagger/gen/git_repository.ex
+++ b/sdk/elixir/lib/dagger/gen/git_repository.ex
@@ -35,6 +35,16 @@ defmodule Dagger.GitRepository do
   )
 
   (
+    @doc "Returns details of a ref.\n\n## Required Arguments\n\n* `name` - Ref's name (can be a commit identifier, a tag name, a branch name, or a fully-qualified ref)."
+    @spec ref(t(), Dagger.String.t()) :: Dagger.GitRef.t()
+    def ref(%__MODULE__{} = git_repository, name) do
+      selection = select(git_repository.selection, "ref")
+      selection = arg(selection, "name", name)
+      %Dagger.GitRef{selection: selection, client: git_repository.client}
+    end
+  )
+
+  (
     @doc "Returns details of a tag.\n\n## Required Arguments\n\n* `name` - Tag's name (e.g., \"v0.3.9\")."
     @spec tag(t(), Dagger.String.t()) :: Dagger.GitRef.t()
     def tag(%__MODULE__{} = git_repository, name) do

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -3378,6 +3378,17 @@ func (r *GitRepository) MarshalJSON() ([]byte, error) {
 	return json.Marshal(id)
 }
 
+// Returns details of a ref.
+func (r *GitRepository) Ref(name string) *GitRef {
+	q := r.q.Select("ref")
+	q = q.Arg("name", name)
+
+	return &GitRef{
+		q: q,
+		c: r.c,
+	}
+}
+
 // Returns details of a tag.
 func (r *GitRepository) Tag(name string) *GitRef {
 	q := r.q.Select("tag")

--- a/sdk/php/generated/GitRepository.php
+++ b/sdk/php/generated/GitRepository.php
@@ -43,6 +43,16 @@ class GitRepository extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * Returns details of a ref.
+     */
+    public function ref(string $name): GitRef
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('ref');
+        $innerQueryBuilder->setArgument('name', $name);
+        return new \Dagger\GitRef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
      * Returns details of a tag.
      */
     public function tag(string $name): GitRef

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -3582,6 +3582,22 @@ class GitRepository(Type):
         return await _ctx.execute(GitRepositoryID)
 
     @typecheck
+    def ref(self, name: str) -> GitRef:
+        """Returns details of a ref.
+
+        Parameters
+        ----------
+        name:
+            Ref's name (can be a commit identifier, a tag name, a branch name,
+            or a fully-qualified ref).
+        """
+        _args = [
+            Arg("name", name),
+        ]
+        _ctx = self._select("ref", _args)
+        return GitRef(_ctx)
+
+    @typecheck
     def tag(self, name: str) -> GitRef:
         """Returns details of a tag.
 

--- a/sdk/rust/crates/dagger-codegen/src/rust/functions.rs
+++ b/sdk/rust/crates/dagger-codegen/src/rust/functions.rs
@@ -15,7 +15,11 @@ pub fn format_name(s: &str) -> String {
 }
 
 pub fn format_struct_name(s: &str) -> String {
-    s.to_case(Case::Snake)
+    let s = s.to_case(Case::Snake);
+    match s.as_ref() {
+        "ref" => "r#ref".to_string(),
+        _ => s,
+    }
 }
 
 pub fn field_options_struct_name(field: &FullTypeFields) -> Option<String> {

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -3513,6 +3513,20 @@ impl GitRepository {
         let query = self.selection.select("id");
         query.execute(self.graphql_client.clone()).await
     }
+    /// Returns details of a ref.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Ref's name (can be a commit identifier, a tag name, a branch name, or a fully-qualified ref).
+    pub fn r#ref(&self, name: impl Into<String>) -> GitRef {
+        let mut query = self.selection.select("ref");
+        query = query.arg("name", name.into());
+        return GitRef {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        };
+    }
     /// Returns details of a tag.
     ///
     /// # Arguments

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -4366,6 +4366,23 @@ export class GitRepository extends BaseClient {
   }
 
   /**
+   * Returns details of a ref.
+   * @param name Ref's name (can be a commit identifier, a tag name, a branch name, or a fully-qualified ref).
+   */
+  ref = (name: string): GitRef => {
+    return new GitRef({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "ref",
+          args: { name },
+        },
+      ],
+      ctx: this._ctx,
+    })
+  }
+
+  /**
    * Returns details of a tag.
    * @param name Tag's name (e.g., "v0.3.9").
    */


### PR DESCRIPTION
Fix #6375.

As suggested by @sagikazarmark, it feels odd to put `refs/pull/5/merge` and similar into a `commit`/`branch`/`tag` selection - it's a ref, so we should have a generic `ref` selection.

To handle the rust codegen case, we need to do some magic since `ref` is a [strict keyword](https://doc.rust-lang.org/reference/keywords.html#strict-keywords). We can resolve this using a [raw identifier](https://doc.rust-lang.org/rust-by-example/compatibility/raw_identifiers.html). @dagger/sdk-rust I've hacked something in to get the codegen to work, but let me know if you want to take a different approach.

---

In general, it's a little bit strange that we have so many functions that all have exactly the same underlying implementation - e.g. you can put a commit ID in a `branch` and it works fine. Maybe we should consider prefixing it with `refs/heads` to `branch`, and prefixing with `refs/tags` to `tag` - we could then require that the args to commit be a SHA ID.

Then `ref` would be the only "generic" field that passes directly to buildkit.