### PR TITLE
fix: skip nil cache result

### DIFF
--- a/engine/cache/manager.go
+++ b/engine/cache/manager.go
@@ -199,6 +199,10 @@ func (m *manager) Export(ctx context.Context) error {
 				return nil
 			}
 			cacheRef := workerRef.ImmutableRef
+			if cacheRef == nil {
+				bklog.G(ctx).Debugf("skipping cache result %s for %s: nil", cacheResult.ID, id)
+				return nil
+			}
 			cacheKey.Results = append(cacheKey.Results, Result{
 				ID:          cacheRef.ID(),
 				CreatedAt:   cacheResult.CreatedAt,


### PR DESCRIPTION
Somehow ImmutableRefs can be nil - not 100% sure how this happens, but upstream buildkit does include checks in appropriate places for this case. We should probably do the same as well.

Should hopefully mitigate https://github.com/dagger/dagger/issues/6379.