### PR TITLE
Various interface fixes

### DIFF
--- a/cmd/codegen/generator/go/templates/module_interfaces.go
+++ b/cmd/codegen/generator/go/templates/module_interfaces.go
@@ -403,7 +403,7 @@ func (spec *parsedIfaceType) concreteMethodCode(method *funcTypeSpec) (*Statemen
 	for _, argSpec := range method.argSpecs {
 		if argSpec.isContext {
 			// ctx context.Context case
-			methodArgs = append(methodArgs, Id(argSpec.name).Qual("context", "Context"))
+			methodArgs = append(methodArgs, Id("ctx").Qual("context", "Context"))
 			continue
 		}
 

--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -103,7 +103,9 @@ func (funcs goTemplateFuncs) moduleMainSrc() (string, error) {
 			continue
 		}
 
-		tps = append(tps, obj.Type())
+		if ps.isMainModuleObject(obj.Name()) || ps.isDaggerGenerated(obj) {
+			tps = append(tps, obj.Type())
+		}
 	}
 
 	if ps.daggerObjectIfaceType == nil {
@@ -111,7 +113,6 @@ func (funcs goTemplateFuncs) moduleMainSrc() (string, error) {
 	}
 
 	added := map[string]struct{}{}
-	topLevel := true
 
 	implementationCode := Empty()
 	for len(tps) != 0 {
@@ -129,10 +130,7 @@ func (funcs goTemplateFuncs) moduleMainSrc() (string, error) {
 			}
 			if !obj.Exported() {
 				// the type must be exported
-				if !topLevel {
-					return "", fmt.Errorf("cannot code-generate unexported type %s", obj.Name())
-				}
-				continue
+				return "", fmt.Errorf("cannot code-generate unexported type %s", obj.Name())
 			}
 
 			// avoid adding a struct definition twice (if it's referenced in two function signatures)
@@ -157,11 +155,6 @@ func (funcs goTemplateFuncs) moduleMainSrc() (string, error) {
 					return "", fmt.Errorf("failed to generate function cases for %s: %w", obj.Name(), err)
 				}
 
-				if topLevel && !ps.isMainModuleObject(obj.Name()) {
-					// don't add a non-main object at the top-level (wait till it comes up as a sub-object)
-					continue
-				}
-
 				// Add the object to the module
 				objTypeDefCode, err := objTypeSpec.TypeDefCode()
 				if err != nil {
@@ -182,11 +175,6 @@ func (funcs goTemplateFuncs) moduleMainSrc() (string, error) {
 
 			case *types.Interface:
 				iface := underlyingObj
-				if topLevel {
-					// refrain from adding interfaces to the module typedefs unless it's referenced by a object/function in the module
-					continue
-				}
-
 				ifaceTypeSpec, err := ps.parseGoIface(iface, named)
 				if err != nil {
 					return "", err
@@ -217,7 +205,6 @@ func (funcs goTemplateFuncs) moduleMainSrc() (string, error) {
 		}
 
 		tps, nextTps = nextTps, nil
-		topLevel = false
 	}
 
 	return strings.Join([]string{


### PR DESCRIPTION
Fixes I wrote while playing around with interfaces introduced in #6213.

The first patch makes sure that the context name is fixed to `ctx` regardless of what the interface specifies it as - this is because the context is special, and the code in the defined function below requires it to be set to `ctx`.

The second patch is a rework of https://github.com/dagger/dagger/pull/6282, to ensure that it also works with interfaces (there's a weird case we can get where we generate the function cases, but don't do the struct codegen so we reference but don't actually create the concrete `impl`). Essentially, we should traverse the tree starting *only* at the top-level and work down from there. See https://github.com/dagger/dagger/pull/6282#discussion_r1446200476 for why the previous patch is insufficient.