### PR TITLE
fix: protect against concurrent map access in APIServer

### DIFF
--- a/.changes/unreleased/Fixed-20240111-113705.yaml
+++ b/.changes/unreleased/Fixed-20240111-113705.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fix concurrent map access in api server
+time: 2024-01-11T11:37:05.30634086Z
+custom:
+  Author: jedevc
+  PR: "6388"


### PR DESCRIPTION
Fixes a potential concurrency issue introduced in https://github.com/dagger/dagger/pull/6167 - it looks like during the lock refactors, we missed a couple cases.

In a past testdev run (https://github.com/dagger/dagger/actions/runs/7459047868/job/20294230186), the tests failed with:

	fatal error: concurrent map read and map write

	goroutine 569315 [running]:
	github.com/dagger/dagger/core/schema.(*APIServer).ServeHTTP(0xc0197f3900, {0x1f9c9a0, 0xc0100aa460}, 0xc00eed5800)
		/app/core/schema/schema.go:171 +0x119
	github.com/dagger/dagger/engine/server.(*DaggerServer).ServeClientConn.(*DaggerServer).HTTPHandlerForClient.func4({0x1f9c9a0, 0xc0100aa460}, 0xc0348b3660?)
		/app/engine/server/server.go:211 +0x219
	net/http.HandlerFunc.ServeHTTP(0x410805?, {0x1f9c9a0?, 0xc0100aa460?}, 0xc0100aa401?)
		/usr/local/go/src/net/http/server.go:2136 +0x29
	net/http.serverHandler.ServeHTTP({0x1f912f8?}, {0x1f9c9a0?, 0xc0100aa460?}, 0x6?)
		/usr/local/go/src/net/http/server.go:2938 +0x8e
	net/http.(*conn).serve(0xc003f73b00, {0x1fa3018, 0xc034a38bd0})
		/usr/local/go/src/net/http/server.go:2009 +0x5f4
	created by net/http.(*Server).Serve in goroutine 568703
		/usr/local/go/src/net/http/server.go:3086 +0x5cb

The map in question, `clientCallContext` is usually accessed behing the `clientCallMu` lock. There were a few instances where reads of this map were *not* behind this lock, so I've added these in.