### PR TITLE
[WIP] Change `Host` to more clear name

### DIFF
--- a/core/host.go
+++ b/core/host.go
@@ -12,9 +12,22 @@ import (
 	"github.com/vito/progrock"
 )
 
-type Host struct {
+type Local struct {
 	Query *Query
 }
+
+func (*Local) Type() *ast.Type {
+	return &ast.Type{
+		NamedType: "Local",
+		NonNull:   true,
+	}
+}
+
+func (*Local) TypeDescription() string {
+	return "Information about the host environment."
+}
+
+type Host Local
 
 func (*Host) Type() *ast.Type {
 	return &ast.Type{
@@ -24,7 +37,7 @@ func (*Host) Type() *ast.Type {
 }
 
 func (*Host) TypeDescription() string {
-	return "Information about the host environment."
+	return "TODO"
 }
 
 type CopyFilter struct {
@@ -60,7 +73,7 @@ func LoadBlob(ctx context.Context, srv *dagql.Server, desc specs.Descriptor) (i 
 	return
 }
 
-func (host *Host) Directory(
+func (host *Local) Directory(
 	ctx context.Context,
 	srv *dagql.Server,
 	dirPath string,
@@ -88,7 +101,7 @@ func (host *Host) Directory(
 	return LoadBlob(ctx, srv, desc)
 }
 
-func (host *Host) File(ctx context.Context, srv *dagql.Server, filePath string) (dagql.Instance[*File], error) {
+func (host *Local) File(ctx context.Context, srv *dagql.Server, filePath string) (dagql.Instance[*File], error) {
 	fileDir, fileName := filepath.Split(filePath)
 	var i dagql.Instance[*File]
 	if err := srv.Select(ctx, srv.Root(), &i, dagql.Selector{
@@ -119,7 +132,7 @@ func (host *Host) File(ctx context.Context, srv *dagql.Server, filePath string) 
 	return i, nil
 }
 
-func (host *Host) SetSecretFile(ctx context.Context, srv *dagql.Server, secretName string, path string) (i dagql.Instance[*Secret], err error) {
+func (host *Local) SetSecretFile(ctx context.Context, srv *dagql.Server, secretName string, path string) (i dagql.Instance[*Secret], err error) {
 	secretFileContent, err := host.Query.Buildkit.ReadCallerHostFile(ctx, path)
 	if err != nil {
 		return i, fmt.Errorf("read secret file: %w", err)
@@ -139,6 +152,6 @@ func (host *Host) SetSecretFile(ctx context.Context, srv *dagql.Server, secretNa
 	return
 }
 
-func (host *Host) Socket(sockPath string) *Socket {
+func (host *Local) Socket(sockPath string) *Socket {
 	return NewHostUnixSocket(sockPath)
 }

--- a/core/query.go
+++ b/core/query.go
@@ -239,8 +239,8 @@ func (q *Query) NewSecret(name string) *Secret {
 	}
 }
 
-func (q *Query) NewHost() *Host {
-	return &Host{
+func (q *Query) NewLocal() *Local {
+	return &Local{
 		Query: q,
 	}
 }

--- a/sdk/go/dag/dag.gen.go
+++ b/sdk/go/dag/dag.gen.go
@@ -122,7 +122,9 @@ func Git(url string, opts ...dagger.GitOpts) *dagger.GitRepository {
 	return client.Git(url, opts...)
 }
 
-// Queries the host environment.
+// TODO
+//
+// Deprecated: TODO
 func Host() *dagger.Host {
 	client := initClient()
 	return client.Host()
@@ -236,6 +238,12 @@ func LoadListTypeDefFromID(id dagger.ListTypeDefID) *dagger.ListTypeDef {
 	return client.LoadListTypeDefFromID(id)
 }
 
+// Load a Local from its ID.
+func LoadLocalFromID(id dagger.LocalID) *dagger.Local {
+	client := initClient()
+	return client.LoadLocalFromID(id)
+}
+
 // Load a ModuleConfig from its ID.
 func LoadModuleConfigFromID(id dagger.ModuleConfigID) *dagger.ModuleConfig {
 	client := initClient()
@@ -282,6 +290,12 @@ func LoadSocketFromID(id dagger.SocketID) *dagger.Socket {
 func LoadTypeDefFromID(id dagger.TypeDefID) *dagger.TypeDef {
 	client := initClient()
 	return client.LoadTypeDefFromID(id)
+}
+
+// Queries the host environment.
+func Local() *dagger.Local {
+	client := initClient()
+	return client.Local()
 }
 
 // Create a new module.


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/6312

Opening this purely to have a discussion right now, the changes amount to find+replace on the `host` name right now, but not even entirely yet (need to update tests, etc.)

# Background
The name `Host` has become extremely confusing in the context of modules. So far, it seems that more often than not users very reasonably assume that in a module when they use `dag.Host` they are interacting with the original "host" where the module was invoked from.

However, that's not the case. They are actually interacting with the local execution environment of the module, which is the container the module is executing in.

We do want to retain this ability; being able to interact with the local execution environment of a module supports use cases like:
1. Writing a local file and then importing it to dagger
   * e.g. maybe your module is using a library that insists on writing a file to the local filesystem, but you then want to use it in other dagger api calls
2. Starting a service from within a module function and then interacting with it directly from your module code (in which case you'd want to setup a tunnel)

Whether we want to *additionally* support a module reading files/env vars/etc. from the caller's environment (i.e. read a file from the filesystem local to the actual CLI call) is still an open question ([see discussion here](https://github.com/dagger/dagger/issues/6112)), but for now we are going to continue not supporting it and just leave it open as a possibility.

# Possible new names
## `Local` (current state of this PR)
Examples of usage:
```go
dag.Local().File("./some/file")

dag.Local().Directory("./some/dir")

dag.Local().UnixSocket("/some/sock")

dag.Local().Tunnel(someService)

dag.Local().Service([]dagger.PortForward{
    {Frontend: 80, Backend: port},
})

dag.Local().SetSecretFile("topsecret", "/some/secret/file")
```

Users will still need to have some understanding that modules execute in a container, not directly on the CLI's host, in order to fully grok this name and intuitively guess its behavior. However, once they know that, I think `Local` makes *much* more sense than `Host`. 
* The problem today is that even if you know that modules execute in a container, it's still entirely reasonable+intuitive to assume that `dag.Host()` is going back to the "host" of the CLI caller. It feels very unnatural to call a containerized execution environment "host".
* I *think* that is largely alleviated with `Local`, in which case it feels much more natural to think of `Local` as referring to the local execution environment (which in the case of modules, is their container)

I also like that `Local` is still relatively succinct (i.e. not something even clearer but overly verbose like `CurrentExecutionEnvironment`).

I was concerned that `local` might be a reserved word in too many languages and thus require too much special casing everywhere, but to my surprise it doesn't appear to be a reserved word in our current SDKs.
* This is from a *very* hasty search though, worth a double check; please chime in if I'm missing something.

## Other possible names
Some others that came to mind but I didn't go with for now are:
* `ExecutionEnvironment`
   * While potentially more obvious than `Local`, felt too verbose to be worth it
* `Caller`
   * Felt like it would have the same problems of `Host` in that it would be reasonable to assume that `Caller` is referring to the CLI caller of the module (as opposed to the module itself)
* `CurrentModule`
   * See "C) Add new APIs to `CurrentModule`, remove `Host` from module clients" section below

# Renaming approaches
There's a few different ways we can go about renaming the API.

<details>
  <summary>Expand</summary>

## A) Just rename `Host` (current state of this PR)
The most straightforward is to just rename the `Host` type to something that is more clear.

This is what this PR is currently doing, specifically renaming `Host` to `Local` (see "Possible new names" section above for discussion on this choice and alternatives).

Pros:
1. Keeps module and non-module clients aligned

Cons:
1. Big breaking change for non-module clients (everyone is going to be doing a lot of find+replace)
   * This could be somewhat alleviated by deprecating `Host` but leaving it in for a few more releases and making lots of noise about the need to update to use `Local`

## B) Rename `Host` only for module clients
Another possibility would be to keep the name `Host` for clients that are not executing in a module, but use a different name like `Local` only for clients executing in modules.

In terms of implementing this, it would be *somewhat* annoying but could be done entirely server-side and not require every SDK to update itself to handle this (since the server tells SDKs what schema to run codegen for). So the annoyance would be entirely internal and not so bad as to rule this out.

Pros:
1. Doesn't break existing non-module SDK users
2. For users transitioning from non-module SDK code to module code, makes the fact that their code should no longer assume it can read anything from the original caller's host more obvious (since they need to explicitly update the api in their code)

Cons:
1. Diverges non-module client sdks from module client sdks, may require unnecessary updates in some cases
   * To explain, there actually are plenty of cases where `dag.Host()` would incidentally have the same behavior when run outside a module and inside a module.
   * Specifically, if the non-module code was reading local files that now become files loaded into the module container (i.e. [the directory under the module's dagger.json](https://github.com/dagger/dagger/pull/6386)), then they technically wouldn't have had to make any updates to their code.

## C) Add new APIs to `CurrentModule`, remove `Host` from module clients
Another variant would be to:
1. Remove `Host` from being callable from from module sdks (but leave non-module SDKs alone)
2. Add methods to the existing `CurrentModule` API that allow equivalent functionality (reading files, tunneling, etc.)

`CurrentModule` already exists and returns the `Module` object that the current caller is executing in (error otherwise).

Though I haven't worked out exactly how, _in theory_ we could probably adjust that API such that it has the fields current present under `Host` are exposed under `CurrentModule`, so module code would make calls like:
```go
dag.CurrentModule().File("./some/file")

dag.CurrentModule().Tunnel(someService)

// etc.
```

Pros (same as option B):
1. Doesn't break existing non-module SDK users
2. For users transitioning from non-module SDK code to module code, makes the fact that their code should no longer assume it can read anything from the original caller's host more obvious (since they need to explicitly update the api in their code)

Cons:
1. (same as option B) Diverges non-module client sdks from module client sdks, may require unnecessary updates in some cases
2. Not entirely clear how to adjust the API in such a way that `CurrentModule` still returns a `Module` type but also doesn't create a bunch of cases where non-module code tries to call i.e. `dag.Directory("./whatever").AsModule().File("./some/file")` and we either error out or have some sort of very confusing behavior
   * Basically, not sure yet if there's a way of doing this that results in a comprehensible `Module` api

</details>

# My opinion
For the sake of having a concrete starting place amongst the many possibilities, my current preference is to:
1. Add `Local` api for all clients, both module and non-module. Same fields as `Host`, just a new name.
2. Remove `Host` from module sdk codegen entirely (since backwards incompatible changes there are less painful right now)
3. Keep `Host` in for non-module client sdks at first but marked as deprecated. Make noise about users needing to update to `Local`. Remove `Host` in a few releases.

That feels like a good balance of not creating too much short-term pain for existing users, creating a more clear name for module users and not being overly burdensome in terms of the implementation.