### PR TITLE
Don't print the full env var name in error message.

### DIFF
--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -290,7 +290,14 @@ func (v *secretValue) Get(ctx context.Context, c *dagger.Client) (any, error) {
 	case envSecretSource:
 		envPlaintext, ok := os.LookupEnv(v.sourceVal)
 		if !ok {
-			return nil, fmt.Errorf("secret env var not found %q", v.sourceVal)
+			// Don't show the entire env var name, in case the user accidentally passed the value instead...
+			// This is important because users originally *did* have to pass the value, before we changed to
+			// passing by name instead.
+			key := v.sourceVal
+			if len(key) >= 4 {
+				key = key[:3] + "..."
+			}
+			return nil, fmt.Errorf("secret env var not found: %q", key)
 		}
 		plaintext = envPlaintext
 

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -277,7 +277,7 @@ func (m *Test) Insecure(ctx context.Context, token *Secret) (string, error) {
 			t.Run("sad", func(t *testing.T) {
 				t.Parallel()
 				_, err := modGen.With(daggerCall("insecure", "--token", "env:NOWHERETOBEFOUND")).Stdout(ctx)
-				require.ErrorContains(t, err, `secret env var not found "NOWHERETOBEFOUND"`)
+				require.ErrorContains(t, err, `secret env var not found: "NOW..."`)
 			})
 		})
 
@@ -292,7 +292,7 @@ func (m *Test) Insecure(ctx context.Context, token *Secret) (string, error) {
 			t.Run("sad", func(t *testing.T) {
 				t.Parallel()
 				_, err := modGen.With(daggerCall("insecure", "--token", "NOWHERETOBEFOUND")).Stdout(ctx)
-				require.ErrorContains(t, err, `secret env var not found "NOWHERETOBEFOUND"`)
+				require.ErrorContains(t, err, `secret env var not found: "NOW..."`)
 			})
 		})
 


### PR DESCRIPTION
This avoids a possible credential leak, in case the user accidentally passes the env variable instead of its name. This is particularly likely because until very recently, that's exactly what we told users to do. So there is a real risk of leaks for early adopters, which this change mitigates.