### PR TITLE
chore: ensure git clone step in sdk publish always runs

### DIFF
--- a/internal/mage/sdk/go.go
+++ b/internal/mage/sdk/go.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/dagger/dagger/internal/mage/util"
+	"github.com/moby/buildkit/identity"
 
 	"dagger.io/dagger"
 	"github.com/magefile/mage/mg"
@@ -152,6 +153,7 @@ func (t Go) Publish(ctx context.Context, tag string) error {
 		})
 
 	repository := git.
+		WithEnvVariable("CACHEBUSTER", identity.NewID()).
 		WithExec([]string{"git", "clone", "https://github.com/dagger/dagger.git", "/src/dagger"}).
 		WithWorkdir("/src/dagger")
 

--- a/internal/mage/sdk/php.go
+++ b/internal/mage/sdk/php.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/dagger/dagger/internal/mage/util"
+	"github.com/moby/buildkit/identity"
 
 	"dagger.io/dagger"
 	"github.com/magefile/mage/mg"
@@ -78,6 +79,7 @@ func (t PHP) Publish(ctx context.Context, tag string) error {
 			"sh", "-c",
 			`git config --global http.https://github.com/.extraheader "AUTHORIZATION: Basic $GITHUB_PAT"`,
 		}).
+		WithEnvVariable("CACHEBUSTER", identity.NewID()).
 		WithExec([]string{"git", "clone", "https://github.com/dagger/dagger.git", "/src/dagger"}).
 		WithWorkdir("/src/dagger").
 		WithEnvVariable("FILTER_BRANCH_SQUELCH_WARNING", "1").


### PR DESCRIPTION
Found this during the release of v0.9.6.

This step should *always* run - otherwise, it can accidentally cache, and we wouldn't run the rest of the pipeline, even when we would have new tags/branches/commits.

The "correct" solution long term is to ensure that we use the top-level `client.Git` method here - however, due to a weird upstream bug, we end up confusing tags and branches when cloning, which causes the filter-branch command we use to fail. (I'm following up with this upstream).