### PR TITLE
fix(typescriptSDK): fix loading type argument

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -960,7 +960,7 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 		require.JSONEq(t, `{"minimal":{"echoOpts":"hi!hi!"}}`, out)
 	})
 
-	t.Run("echoMaybe(msg: string, isQuestion = false): string", func (t *testing.T) {
+	t.Run("echoMaybe(msg: string, isQuestion = false): string", func(t *testing.T) {
 		t.Parallel()
 
 		out, err := modGen.With(daggerQuery(`{minimal{echoMaybe(msg: "hi")}}`)).Stdout(ctx)

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -959,6 +959,18 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoOpts":"hi!hi!"}}`, out)
 	})
+
+	t.Run("echoMaybe(msg: string, isQuestion = false): string", func (t *testing.T) {
+		t.Parallel()
+
+		out, err := modGen.With(daggerQuery(`{minimal{echoMaybe(msg: "hi")}}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"minimal":{"echoMaybe":"hi...hi...hi..."}}`, out)
+
+		out, err = modGen.With(daggerQuery(`{minimal{echoMaybe(msg: "hi", isQuestion: true)}}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"minimal":{"echoMaybe":"hi?...hi?...hi?..."}}`, out)
+	})
 }
 
 func TestModuleGoSignaturesBuiltinTypes(t *testing.T) {

--- a/core/integration/testdata/modules/typescript/minimal/index.ts
+++ b/core/integration/testdata/modules/typescript/minimal/index.ts
@@ -20,6 +20,15 @@ class Minimal {
 	}
 
 	@func
+	echoMaybe(msg: string, isQuestion = false): string {
+		if (isQuestion) {
+			return this.echo(msg + "?")
+		}
+
+		return this.echo(msg)
+	}
+
+	@func
 	echoOptional(msg = "default"): string {
 		return this.echo(msg)
 	}

--- a/sdk/typescript/entrypoint/load.ts
+++ b/sdk/typescript/entrypoint/load.ts
@@ -1,4 +1,6 @@
-import { dag } from "../api/client.gen.js"
+import { dag, TypeDefKind } from "../api/client.gen.js"
+import { ScanResult } from "../introspector/scanner/scan.js"
+import { TypeDef } from "../introspector/scanner/typeDefs.js"
 
 /**
  * Import all given typescript files so that trigger their decorators
@@ -11,41 +13,102 @@ export async function load(files: string[]): Promise<void> {
 }
 
 /**
- * Load argument as Dagger type.
+ * Load the argument type from the scan result.
  *
- * This function remove the quote from the identifier and checks
- * if it's a Dagger type, if it is, it loads it according to
- * its type.
+ * @param scanResult Result of the scan
+ * @param parentName Class called
+ * @param fnName Function called
+ * @param argName Argument name
+ * @returns The type of the argument
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function loadArg(value: string): Promise<any> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let parsedValue: any
-
-  const isString = (): boolean =>
-    (value.startsWith('"') && value.endsWith('"')) ||
-    (value.startsWith(`'`) && value.endsWith(`'`))
-  const isArray = (): boolean => value.startsWith("[") && value.endsWith("]")
-
-  // Apply JSON parse to parse array or string if the value is wrapped into a string or array
-  if (isString() || isArray()) {
-    parsedValue = JSON.parse(value)
-  } else {
-    parsedValue = value
+export function loadArgType(
+  scanResult: ScanResult,
+  parentName: string,
+  fnName: string,
+  argName: string
+): TypeDef<TypeDefKind> {
+  const classTypeDef = scanResult.classes.find((c) => c.name === parentName)
+  if (!classTypeDef) {
+    throw new Error(`could not find class ${parentName}`)
   }
 
-  // If it's a string, it might contain an identifier to load, or it might be a hidden array
-  if (typeof parsedValue === "string") {
-    const [source] = parsedValue.split(":")
+  const methodTypeDef = classTypeDef.methods.find((m) => m.name === fnName)
+  if (!methodTypeDef) {
+    throw new Error(`could not find method ${fnName}`)
+  }
 
-    const [origin, type] = source.split(".")
-    if (origin === "core") {
+  const argTypeDef = methodTypeDef.args.find((a) => a.name === argName)
+  if (!argTypeDef) {
+    throw new Error(`could not find argument ${argName} type`)
+  }
+
+  return argTypeDef.typeDef
+}
+
+/**
+ * Load the property type from the scan result.
+ *
+ * @param scanResult Result of the scan
+ * @param parentName Class called
+ * @param propertyName property of the class
+ * @returns the type of the property
+ */
+export function loadPropertyType(
+  scanResult: ScanResult,
+  parentName: string,
+  propertyName: string
+): TypeDef<TypeDefKind> {
+  const classTypeDef = scanResult.classes.find((c) => c.name === parentName)
+  if (!classTypeDef) {
+    throw new Error(`could not find class ${parentName}`)
+  }
+
+  const propertyTypeDef = classTypeDef.fields.find(
+    (p) => p.name === propertyName
+  )
+  if (!propertyTypeDef) {
+    throw new Error(`could not find property ${propertyName} type`)
+  }
+
+  return propertyTypeDef.typeDef
+}
+
+/**
+ * This function load the argument as a Dagger type.
+ *
+ * Note: The JSON.parse() is required to remove extra quotes
+ */
+export async function loadArg(
+  value: string,
+  type: TypeDef<TypeDefKind>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<any> {
+  switch (type.kind) {
+    case TypeDefKind.ListKind:
+      return JSON.parse(value)
+    case TypeDefKind.ObjectKind: {
+      const objectType = (type as TypeDef<TypeDefKind.ObjectKind>).name
+
+      // This ID might be wrapped in quotes depending on the source.
+      // We need to remove them to be able to call the loading function.
+      if (value.startsWith('"') && value.endsWith('"')) {
+        value = JSON.parse(value)
+      }
+
       // Workaround to call get any object that has an id
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      return dag[`load${type}FromID`](parsedValue)
+      return dag[`load${objectType}FromID`](value)
     }
+    case TypeDefKind.StringKind:
+      return JSON.parse(value)
+    case TypeDefKind.IntegerKind:
+      return Number(value)
+    case TypeDefKind.BooleanKind:
+      return value === "true" // Return false if string is different than true
+    case TypeDefKind.InterfaceKind:
+      throw new Error("interface not supported")
+    case TypeDefKind.VoidKind:
+      return null
   }
-
-  return parsedValue
 }

--- a/sdk/typescript/entrypoint/register.ts
+++ b/sdk/typescript/entrypoint/register.ts
@@ -6,7 +6,7 @@ import {
   TypeDef,
   TypeDefKind,
 } from "../api/client.gen"
-import { scan } from "../introspector/scanner/scan.js"
+import { ScanResult } from "../introspector/scanner/scan.js"
 import {
   ConstructorTypeDef,
   FunctionArg,
@@ -19,10 +19,10 @@ import {
 /**
  * Register the module files and returns its ID
  */
-export async function register(files: string[]): Promise<ModuleID> {
-  // Scan all files
-  const scanResult = await scan(files)
-
+export async function register(
+  files: string[],
+  scanResult: ScanResult
+): Promise<ModuleID> {
   // Get the current module
   let mod = dag.currentModule()
 

--- a/sdk/typescript/introspector/test/scan.spec.ts
+++ b/sdk/typescript/introspector/test/scan.spec.ts
@@ -325,6 +325,20 @@ describe("scan static TypeScript", function () {
                 },
               ],
             },
+            {
+              name: "sayBool",
+              returnType: { kind: TypeDefKind.BooleanKind },
+              description: "",
+              args: [
+                {
+                  name: "value",
+                  typeDef: { kind: TypeDefKind.BooleanKind },
+                  description: "",
+                  optional: true,
+                  defaultValue: "false",
+                },
+              ],
+            },
           ],
         },
       ],

--- a/sdk/typescript/introspector/test/testdata/optionalParameter/optionalParameter.ts
+++ b/sdk/typescript/introspector/test/testdata/optionalParameter/optionalParameter.ts
@@ -19,4 +19,9 @@ export class HelloWorld {
     add(a = 0, b = 0): number {
         return a + b
     }
+
+    @func
+    sayBool(value = false): boolean {
+        return value
+    }
 }


### PR DESCRIPTION
Correctly load type argument prior to value to correctly serialize it. 
Fix Quickstart issue found by @d3rp3tt3 (https://discord.com/channels/707636530424053791/1120503349599543376/1195178137101799474).

```shell
➜  ci git:(main) ✗ dagger call hello-world --count 10 --mashed
✔ dagger call hello-world [2.34s]
┃ Hello world, I have mashed 10 potatoes                                                                                                         
• Engine: c7de3eb13d57 (version devel ())
⧗ 27.72s ✔ 309 ∅ 39
```

```shell
➜  ci git:(main) ✗ dagger call hello-world --count 10         
✔ dagger call hello-world [2.42s]
┃ Hello world, I have 10 potatoes                                                                                                                
• Engine: c7de3eb13d57 (version devel ())
⧗ 11.55s ✔ 280 ∅ 47
```

Related to DEV-3029

/cc @sipsma @jpadams 