### PR TITLE
docs: Changes logo URL

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -119,6 +119,7 @@ const config = {
           alt: "Dagger Logo",
           src: "img/dagger-logo-white.svg",
           height: "50px",
+          href: "https://dagger.io/"
         },
         items: [
           {


### PR DESCRIPTION
This commit changes the target URL to dagger.io for clicks on the navbar logo on docs.dagger.io. 