### PR TITLE
core: fix Directory.withoutFile to account for subdir

### DIFF
--- a/core/directory.go
+++ b/core/directory.go
@@ -666,6 +666,7 @@ func (dir *Directory) Without(ctx context.Context, path string) (*Directory, err
 		return nil, err
 	}
 
+	path = filepath.Join(dir.Dir, path)
 	err = dir.SetState(ctx, st.File(llb.Rm(path, llb.WithAllowWildcard(true), llb.WithAllowNotFound(true))))
 	if err != nil {
 		return nil, err

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -518,6 +518,18 @@ func TestDirectoryWithoutDirectoryWithoutFile(t *testing.T) {
 	entries, err = filesDir.Entries(ctx)
 	require.NoError(t, err)
 	require.Equal(t, []string{"some-dir"}, entries)
+
+	// verify WithoutFile works when dir has be selected to a subdir
+	subdirWithout := c.Directory().
+		WithDirectory("subdir", c.Directory().
+			WithNewFile("some-file", "delete me").
+			WithNewFile("some-other-file", "keep me"),
+		).
+		Directory("subdir").
+		WithoutFile("some-file")
+	entries, err = subdirWithout.Entries(ctx)
+	require.NoError(t, err)
+	require.Equal(t, []string{"some-other-file"}, entries)
 }
 
 func TestDirectoryDiff(t *testing.T) {


### PR DESCRIPTION
Hit a case where files weren't being deleted while working on dagger.json changes and thought I had completely lost my mind for a bit, but turns out it's just a bug that's existed since the beginning of time apparently 😮‍💨