### PR TITLE
feat(tsSDK): fix constructor registration

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -958,6 +958,12 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 		out, err = modGen.With(daggerQuery(`{minimal{echoOpts(msg: "hi", suffix: "!", times: 2)}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoOpts":"hi!hi!"}}`, out)
+
+		t.Run("execute with unordered args", func(t *testing.T) {
+			out, err = modGen.With(daggerQuery(`{minimal{echoOpts(times: 2, msg: "order", suffix: "?")}}`)).Stdout(ctx)
+			require.NoError(t, err)
+			require.JSONEq(t, `{"minimal":{"echoOpts":"order?order?"}}`, out)
+		})
 	})
 
 	t.Run("echoMaybe(msg: string, isQuestion = false): string", func(t *testing.T) {
@@ -970,6 +976,12 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 		out, err = modGen.With(daggerQuery(`{minimal{echoMaybe(msg: "hi", isQuestion: true)}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoMaybe":"hi?...hi?...hi?..."}}`, out)
+
+		t.Run("execute with unordered args", func(t *testing.T) {
+			out, err = modGen.With(daggerQuery(`{minimal{echoMaybe(isQuestion: false, msg: "hi")}}`)).Stdout(ctx)
+			require.NoError(t, err)
+			require.JSONEq(t, `{"minimal":{"echoMaybe":"hi...hi...hi..."}}`, out)
+		})
 	})
 }
 

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -3444,6 +3444,57 @@ class Test:
         return await self.dir.entries()
 `,
 			},
+			{
+				sdk: "typescript",
+				source: `
+import { Directory, object, func, field } from '@dagger.io/dagger';
+
+@object
+class Test {
+	@field
+	foo: string
+				
+	@field
+	dir: Directory
+				
+	@field
+	bar: number
+				
+	@field
+	baz: string[]
+				
+	@field
+	neverSetDir?: Directory = undefined
+				
+	constructor(foo: string, dir: Directory, bar = 42, baz: string[] = []) {
+		this.foo = foo;
+		this.dir = dir;
+		this.bar = bar;
+		this.baz = baz;
+	}
+				
+	@func
+	gimmeFoo(): string {
+		return this.foo;
+	}
+				
+	@func
+	gimmeBar(): number {
+		return this.bar;
+	}
+				
+	@func
+	gimmeBaz(): string[] {
+		return this.baz;
+	}
+				
+	@func
+	async gimmeDirEnts(): Promise<string[]> {
+		return this.dir.entries();
+	}
+}					
+`,
+			},
 		} {
 			tc := tc
 
@@ -4449,6 +4500,8 @@ func sdkSource(sdk, contents string) dagger.WithContainerFunc {
 			sourcePath = "main.go"
 		case "python":
 			sourcePath = "src/main.py"
+		case "typescript":
+			sourcePath = "src/index.ts"
 		default:
 			return c
 		}

--- a/sdk/typescript/api/test/api.spec.ts
+++ b/sdk/typescript/api/test/api.spec.ts
@@ -354,7 +354,6 @@ describe("TypeScript SDK api", function () {
           const result = await ctr.stdout()
           assert.strictEqual(result.trim(), name)
 
-          console.log(result)
           seededPlatformVariants.push(ctr)
         }
 

--- a/sdk/typescript/entrypoint/entrypoint.ts
+++ b/sdk/typescript/entrypoint/entrypoint.ts
@@ -50,7 +50,7 @@ export async function entrypoint() {
           const name = await arg.name()
 
           args[name] = await loadArg(
-            await arg.value(),
+            JSON.parse(await arg.value()),
             loadArgType(scanResult, parentName, fnName, name)
           )
         }
@@ -58,7 +58,7 @@ export async function entrypoint() {
         if (parentJson) {
           for (const [key, value] of Object.entries(parentJson)) {
             parentArgs[key] = await loadArg(
-              value as string,
+              value,
               loadPropertyType(scanResult, parentName, key)
             )
           }

--- a/sdk/typescript/entrypoint/invoke.ts
+++ b/sdk/typescript/entrypoint/invoke.ts
@@ -1,19 +1,56 @@
-import { Args, registry, State } from "../introspector/registry/registry.js"
+import { Args, registry } from "../introspector/registry/registry.js"
+import { ScanResult } from "../introspector/scanner/scan.js"
+import {
+  loadArgOrder,
+  loadArg,
+  loadArgType,
+  loadPropertyType,
+  loadResult,
+} from "./load.js"
+
+export type InvokeCtx = {
+  parentName: string
+  fnName: string
+  parentArgs: Args
+  fnArgs: Args
+}
 
 /**
  * A wrapper around the registry to invoke a function.
  *
- * @param objectName – The class to look for
- * @param methodName – The method to call in the class
- * @param state – The current state of the class
- * @param inputs – The input to send to the method to call
+ * @param scanResult The result of the scan.
+ * @param parentName The name of the parent object.
+ * @param fnName The name of the function to call.
+ * @param parentArgs The arguments of the parent object.
+ * @param fnArgs The arguments of the function to call.
  */
 export async function invoke(
-  objectName: string,
-  methodName: string,
-  state: State,
-  inputs: Args
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): Promise<any> {
-  return await registry.getResult(objectName, methodName, state, inputs)
+  scanResult: ScanResult,
+  { parentName, fnName, parentArgs, fnArgs }: InvokeCtx
+): // eslint-disable-next-line @typescript-eslint/no-explicit-any
+Promise<any> {
+  const args: Args = {}
+
+  // Load function arguments in the right order
+  for (const argName of loadArgOrder(scanResult, parentName, fnName)) {
+    args[argName] = await loadArg(
+      fnArgs[argName],
+      loadArgType(scanResult, parentName, fnName, argName)
+    )
+  }
+
+  // Load parent state
+  for (const [key, value] of Object.entries(parentArgs)) {
+    parentArgs[key] = await loadArg(
+      value,
+      loadPropertyType(scanResult, parentName, key)
+    )
+  }
+
+  let result = await registry.getResult(parentName, fnName, parentArgs, args)
+  if (result) {
+    result = await loadResult(result)
+  }
+
+  return result
 }

--- a/sdk/typescript/entrypoint/load.ts
+++ b/sdk/typescript/entrypoint/load.ts
@@ -99,9 +99,12 @@ export async function loadArg(
 ): Promise<any> {
   switch (type.kind) {
     case TypeDefKind.ListKind:
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return value.map((v: any) =>
-        loadArg(v, (type as TypeDef<TypeDefKind.ListKind>).typeDef)
+      return Promise.all(
+        value.map(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          async (v: any) =>
+            await loadArg(v, (type as TypeDef<TypeDefKind.ListKind>).typeDef)
+        )
       )
     case TypeDefKind.ObjectKind: {
       const objectType = (type as TypeDef<TypeDefKind.ObjectKind>).name

--- a/sdk/typescript/entrypoint/register.ts
+++ b/sdk/typescript/entrypoint/register.ts
@@ -46,7 +46,9 @@ export async function register(
     })
 
     if (modClass.constructor) {
-      typeDef.withConstructor(addConstructor(modClass.constructor, typeDef))
+      typeDef = typeDef.withConstructor(
+        addConstructor(modClass.constructor, typeDef)
+      )
     }
 
     // Add it to the module object

--- a/sdk/typescript/introspector/registry/registry.ts
+++ b/sdk/typescript/introspector/registry/registry.ts
@@ -127,9 +127,7 @@ export class Registry {
 
     // If method is nil, apply the constructor.
     if (method === "") {
-      return new resolver.class_(
-        ...this.getArgOrder(resolver.class_).map((arg) => inputs[arg])
-      )
+      return new resolver.class_(...Object.values(inputs))
     }
 
     // Safety check to make sure the method called exist in the class
@@ -148,31 +146,8 @@ export class Registry {
     // Apply state to the class
     r = Object.assign(r, state)
 
-    // Order argument following the arg order and picking argument from the inputs map
-    const args = this.getArgOrder(r[method]).map((arg) => inputs[arg])
-
     // Execute and return the result
-    return await r[method](...args)
-  }
-
-  /**
-   * Get the order of argument by reading its content and create an array of its argument
-   * We cannot use r[method].prototype because it can be empty depending on the loading.
-   * Note(TomChv): This is a workaround until we find something more accurate.
-   * @param fct
-   * @private
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private getArgOrder(fct: any): string[] {
-    const fnStr = fct
-      .toString()
-      .replace(/((\/\/.*$)|(\/\*[\s\S]*?\*\/))/gm, "") as string
-
-    return (
-      fnStr
-        .slice(fnStr.indexOf("(") + 1, fnStr.indexOf(")"))
-        .match(/\b(\w+)\b(?:(?=\s*[:=?]|,\s*|$))/g) ?? []
-    )
+    return await r[method](...Object.values(inputs))
   }
 }
 

--- a/sdk/typescript/introspector/scanner/typeDefs.ts
+++ b/sdk/typescript/introspector/scanner/typeDefs.ts
@@ -44,6 +44,7 @@ export type FieldTypeDef = {
   name: string
   description: string
   typeDef: TypeDef<TypeDefKind>
+  isExposed: boolean
 }
 
 /**
@@ -63,12 +64,12 @@ export type FunctionArg = {
 export type FunctionTypedef = {
   name: string
   description: string
-  args: FunctionArg[]
+  args: { [name: string]: FunctionArg }
   returnType: TypeDef<TypeDefKind>
 }
 
 export type ConstructorTypeDef = {
-  args: FunctionArg[]
+  args: { [name: string]: FunctionArg }
 }
 
 /**
@@ -77,7 +78,7 @@ export type ConstructorTypeDef = {
 export type ClassTypeDef = {
   name: string
   description: string
-  fields: FieldTypeDef[]
+  fields: { [name: string]: FieldTypeDef }
   constructor?: ConstructorTypeDef
-  methods: FunctionTypedef[]
+  methods: { [name: string]: FunctionTypedef }
 }

--- a/sdk/typescript/introspector/test/invoke.spec.ts
+++ b/sdk/typescript/introspector/test/invoke.spec.ts
@@ -1,10 +1,12 @@
 import assert from "assert"
+import { describe, it } from "mocha"
 import * as path from "path"
 import { fileURLToPath } from "url"
 
 import { connection } from "../../connect.js"
 import { invoke } from "../../entrypoint/invoke.js"
 import { load } from "../../entrypoint/load.js"
+import { scan } from "../scanner/scan.js"
 import { listFiles } from "../utils/files.js"
 
 const __filename = fileURLToPath(import.meta.url)
@@ -24,20 +26,17 @@ describe("Invoke typescript function", function () {
     // Load function
     await load(files)
 
+    const scanResult = scan(files)
+
     // Mocking the fetch from the dagger API
     const input = {
-      objectName: "HelloWorld",
-      methodName: "helloWorld",
-      state: {},
-      inputs: { name: "world" },
+      parentName: "HelloWorld",
+      fnName: "helloWorld",
+      parentArgs: {},
+      fnArgs: { name: "world" },
     }
 
-    const result = await invoke(
-      input.objectName,
-      input.methodName,
-      input.state,
-      input.inputs
-    )
+    const result = await invoke(scanResult, input)
 
     // We verify the result, this could be serialized and set using `dag.ReturnValue` as a response
     assert.equal(result, "hello world")
@@ -51,12 +50,14 @@ describe("Invoke typescript function", function () {
     // Load function
     await load(files)
 
+    const scanResult = scan(files)
+
     // Mocking the fetch from the dagger API
     const input = {
-      objectName: "Bar",
-      methodName: "exec",
-      state: {},
-      inputs: {
+      parentName: "Bar",
+      fnName: "exec",
+      parentArgs: {},
+      fnArgs: {
         // string[]
         cmd: ["echo", "-n", "hello world"],
       },
@@ -64,15 +65,41 @@ describe("Invoke typescript function", function () {
 
     // We wrap the execution into a Dagger connection
     await connection(async () => {
-      const result = await invoke(
-        input.objectName,
-        input.methodName,
-        input.state,
-        input.inputs
-      )
+      const result = await invoke(scanResult, input)
 
       // We verify the result, this could be serialized and set using `dag.ReturnValue` as a response
       assert.equal(result, "hello world")
+    })
+  })
+
+  it("Should correctly order arguments", async function () {
+    this.timeout(60000)
+
+    const files = await listFiles(`${rootDirectory}/multiArgs`)
+
+    // Load function
+    await load(files)
+
+    const scanResult = scan(files)
+
+    // Mocking the fetch from the dagger API
+    const input = {
+      parentName: "HelloWorld",
+      fnName: "compute",
+      parentArgs: {},
+      fnArgs: {
+        b: 2,
+        a: 4,
+        c: 3,
+      },
+    }
+
+    // We wrap the execution into a Dagger connection
+    await connection(async () => {
+      const result = await invoke(scanResult, input)
+
+      // We verify the result
+      assert.equal(result, 11)
     })
   })
 
@@ -84,58 +111,56 @@ describe("Invoke typescript function", function () {
     // Load function
     await load(files)
 
+    const scanResult = scan(files)
+
     // We wrap the execution into a Dagger connection
     await connection(
       async () => {
         // Mocking the fetch from the dagger API
         const inputBase = {
-          objectName: "Alpine",
-          methodName: "base",
-          state: {},
-          inputs: { version: ["3.16.0"] },
+          parentName: "Alpine",
+          fnName: "base",
+          parentArgs: {},
+          fnArgs: { version: "3.16.0" },
         }
 
-        const inputBaseResult = await invoke(
-          inputBase.objectName,
-          inputBase.methodName,
-          inputBase.state,
-          inputBase.inputs
-        )
+        const inputBaseResult = await invoke(scanResult, inputBase)
+
+        // Assert state has been updated by the function
+        assert.equal("3.16.0", inputBaseResult.version)
+        assert.equal("root", inputBaseResult.user)
+        assert.deepEqual([], inputBaseResult.packages)
+        assert.notEqual(undefined, inputBaseResult.ctr)
 
         const inputInstall = {
-          objectName: "Alpine",
-          methodName: "install",
-          // Would be fetched from dagger and loaded from the container ID
-          state: inputBaseResult,
-          inputs: {
+          parentName: "Alpine",
+          fnName: "install",
+          // Would be fetched from dagger and parsed from dagger entrypoint
+          parentArgs: JSON.parse(JSON.stringify(inputBaseResult)),
+          fnArgs: {
             pkgs: ["jq"],
           },
         }
 
-        const inputInstallResult = await invoke(
-          inputInstall.objectName,
-          inputInstall.methodName,
-          // Would be fetched from dagger and loaded from the container ID
-          inputInstall.state,
-          inputInstall.inputs
-        )
+        const inputInstallResult = await invoke(scanResult, inputInstall)
+
+        // Verify state conservation
+        assert.equal("3.16.0", inputInstallResult.version)
+        assert.equal("root", inputInstallResult.user)
+        assert.deepEqual(["jq"], inputInstallResult.packages)
+        assert.notEqual(undefined, inputInstallResult.ctr)
 
         const inputExec = {
-          objectName: "Alpine",
-          methodName: "exec",
-          // Would be fetched from dagger and loaded from the container ID
-          state: inputInstallResult,
-          inputs: {
+          parentName: "Alpine",
+          fnName: "exec",
+          // Would be fetched from dagger and parsed from dagger entrypoint
+          parentArgs: JSON.parse(JSON.stringify(inputInstallResult)),
+          fnArgs: {
             cmd: ["jq", "-h"],
           },
         }
 
-        const result = await invoke(
-          inputExec.objectName,
-          inputExec.methodName,
-          inputExec.state,
-          inputExec.inputs
-        )
+        const result = await invoke(scanResult, inputExec)
 
         // We verify the result, this could be serialized and set using `dag.ReturnValue` as a response
         // In that case, we verify it's not failing and that it returned a value

--- a/sdk/typescript/introspector/test/registry.spec.ts
+++ b/sdk/typescript/introspector/test/registry.spec.ts
@@ -223,9 +223,9 @@ describe("Registry", function () {
       {},
       {
         // Send argument in disorder to ensure we order them back
-        c: 3,
-        b: 2,
         a: 1,
+        b: 2,
+        c: 3,
       }
     )
 

--- a/sdk/typescript/introspector/test/scan.spec.ts
+++ b/sdk/typescript/introspector/test/scan.spec.ts
@@ -1,4 +1,5 @@
 import assert from "assert"
+import { describe, it } from "mocha"
 import * as path from "path"
 import { fileURLToPath } from "url"
 
@@ -16,33 +17,33 @@ describe("scan static TypeScript", function () {
 
     const result = scan(files)
     const expected: ScanResult = {
-      classes: [
-        {
+      classes: {
+        HelloWorld: {
           name: "HelloWorld",
           description: "HelloWorld class",
-          fields: [],
+          fields: {},
           constructor: undefined,
-          methods: [
-            {
+          methods: {
+            helloWorld: {
               name: "helloWorld",
               returnType: {
                 kind: TypeDefKind.StringKind,
               },
               description: "",
-              args: [
-                {
+              args: {
+                name: {
                   name: "name",
                   typeDef: { kind: TypeDefKind.StringKind },
                   description: "",
                   optional: false,
                   defaultValue: undefined,
                 },
-              ],
+              },
             },
-          ],
+          },
         },
-      ],
-      functions: [],
+      },
+      functions: {},
     }
 
     assert.deepEqual(result, expected)
@@ -53,8 +54,8 @@ describe("scan static TypeScript", function () {
 
     const result = scan(files)
     const expected: ScanResult = {
-      classes: [],
-      functions: [],
+      classes: {},
+      functions: {},
     }
 
     assert.deepEqual(result, expected)
@@ -65,19 +66,19 @@ describe("scan static TypeScript", function () {
 
     const result = scan(files)
     const expected: ScanResult = {
-      classes: [
-        {
+      classes: {
+        Bar: {
           name: "Bar",
           description: "Bar class",
           constructor: undefined,
-          fields: [],
-          methods: [
-            {
+          fields: {},
+          methods: {
+            exec: {
               name: "exec",
               description: "Execute the command and return its result",
               returnType: { kind: TypeDefKind.StringKind },
-              args: [
-                {
+              args: {
+                cmd: {
                   name: "cmd",
                   typeDef: {
                     kind: TypeDefKind.ListKind,
@@ -89,29 +90,29 @@ describe("scan static TypeScript", function () {
                   optional: false,
                   defaultValue: undefined,
                 },
-              ],
+              },
             },
-          ],
+          },
         },
-        {
+        Foo: {
           name: "Foo",
           description: "Foo class",
           constructor: undefined,
-          fields: [],
-          methods: [
-            {
+          fields: {},
+          methods: {
+            bar: {
               name: "bar",
               description: "Return Bar object",
               returnType: {
                 kind: TypeDefKind.ObjectKind,
                 name: "Bar",
               },
-              args: [],
+              args: {},
             },
-          ],
+          },
         },
-      ],
-      functions: [],
+      },
+      functions: {},
     }
 
     assert.deepEqual(result, expected)
@@ -122,45 +123,45 @@ describe("scan static TypeScript", function () {
 
     const result = scan(files)
     const expected: ScanResult = {
-      classes: [
-        {
+      classes: {
+        HelloWorld: {
           name: "HelloWorld",
           description: "HelloWorld class",
           constructor: undefined,
-          fields: [],
-          methods: [
-            {
+          fields: {},
+          methods: {
+            greeting: {
               name: "greeting",
               returnType: { kind: TypeDefKind.StringKind },
               description: "",
-              args: [
-                {
+              args: {
+                name: {
                   name: "name",
                   typeDef: { kind: TypeDefKind.StringKind },
                   description: "",
                   optional: false,
                   defaultValue: undefined,
                 },
-              ],
+              },
             },
-            {
+            helloWorld: {
               name: "helloWorld",
               returnType: { kind: TypeDefKind.StringKind },
               description: "",
-              args: [
-                {
+              args: {
+                name: {
                   name: "name",
                   typeDef: { kind: TypeDefKind.StringKind },
                   description: "",
                   optional: false,
                   defaultValue: undefined,
                 },
-              ],
+              },
             },
-          ],
+          },
         },
-      ],
-      functions: [],
+      },
+      functions: {},
     }
 
     assert.deepEqual(result, expected)
@@ -171,13 +172,13 @@ describe("scan static TypeScript", function () {
 
     const result = scan(files)
     const expected: ScanResult = {
-      classes: [
-        {
+      classes: {
+        Alpine: {
           name: "Alpine",
           description: "Alpine module",
           constructor: undefined,
-          fields: [
-            {
+          fields: {
+            packages: {
               name: "packages",
               typeDef: {
                 kind: TypeDefKind.ListKind,
@@ -186,43 +187,57 @@ describe("scan static TypeScript", function () {
                 },
               },
               description: "packages to install",
+              isExposed: true,
             },
-            {
+            ctr: {
               name: "ctr",
               typeDef: {
                 kind: TypeDefKind.ObjectKind,
                 name: "Container",
               },
               description: "",
+              isExposed: true,
             },
-          ],
-          methods: [
-            {
+            version: {
+              name: "version",
+              typeDef: { kind: TypeDefKind.StringKind },
+              description: "",
+              isExposed: false,
+            },
+            user: {
+              name: "user",
+              typeDef: { kind: TypeDefKind.StringKind },
+              description: "",
+              isExposed: false,
+            },
+          },
+          methods: {
+            base: {
               name: "base",
               returnType: {
                 kind: TypeDefKind.ObjectKind,
                 name: "Alpine",
               },
               description: "Returns a base Alpine container",
-              args: [
-                {
+              args: {
+                version: {
                   name: "version",
                   typeDef: { kind: TypeDefKind.StringKind },
                   description: "version to use (default to: 3.16.2)",
                   optional: true,
                   defaultValue: undefined,
                 },
-              ],
+              },
             },
-            {
+            install: {
               name: "install",
               returnType: {
                 kind: TypeDefKind.ObjectKind,
                 name: "Alpine",
               },
               description: "",
-              args: [
-                {
+              args: {
+                pkgs: {
                   name: "pkgs",
                   typeDef: {
                     kind: TypeDefKind.ListKind,
@@ -234,14 +249,14 @@ describe("scan static TypeScript", function () {
                   optional: false,
                   defaultValue: undefined,
                 },
-              ],
+              },
             },
-            {
+            exec: {
               name: "exec",
               returnType: { kind: TypeDefKind.StringKind },
               description: "",
-              args: [
-                {
+              args: {
+                cmd: {
                   name: "cmd",
                   typeDef: {
                     kind: TypeDefKind.ListKind,
@@ -253,12 +268,12 @@ describe("scan static TypeScript", function () {
                   optional: false,
                   defaultValue: undefined,
                 },
-              ],
+              },
             },
-          ],
+          },
         },
-      ],
-      functions: [],
+      },
+      functions: {},
     }
 
     assert.deepEqual(result, expected)
@@ -269,80 +284,80 @@ describe("scan static TypeScript", function () {
 
     const result = scan(files)
     const expected: ScanResult = {
-      classes: [
-        {
+      classes: {
+        HelloWorld: {
           name: "HelloWorld",
           description: "HelloWorld class",
-          fields: [],
+          fields: {},
           constructor: undefined,
-          methods: [
-            {
+          methods: {
+            helloWorld: {
               name: "helloWorld",
               returnType: { kind: TypeDefKind.StringKind },
               description: "",
-              args: [
-                {
+              args: {
+                name: {
                   name: "name",
                   typeDef: { kind: TypeDefKind.StringKind },
                   description: "",
                   optional: true,
                   defaultValue: undefined,
                 },
-              ],
+              },
             },
-            {
+            isTrue: {
               name: "isTrue",
               returnType: { kind: TypeDefKind.BooleanKind },
               description: "",
-              args: [
-                {
+              args: {
+                value: {
                   name: "value",
                   typeDef: { kind: TypeDefKind.BooleanKind },
                   description: "",
                   optional: false,
                   defaultValue: undefined,
                 },
-              ],
+              },
             },
-            {
+            add: {
               name: "add",
               returnType: { kind: TypeDefKind.IntegerKind },
               description: "",
-              args: [
-                {
+              args: {
+                a: {
                   name: "a",
                   typeDef: { kind: TypeDefKind.IntegerKind },
                   description: "",
                   optional: true,
                   defaultValue: "0",
                 },
-                {
+                b: {
                   name: "b",
                   typeDef: { kind: TypeDefKind.IntegerKind },
                   description: "",
                   optional: true,
                   defaultValue: "0",
                 },
-              ],
+              },
             },
-            {
+            sayBool: {
               name: "sayBool",
               returnType: { kind: TypeDefKind.BooleanKind },
               description: "",
-              args: [
-                {
+              args: {
+                value: {
                   name: "value",
                   typeDef: { kind: TypeDefKind.BooleanKind },
                   description: "",
                   optional: true,
                   defaultValue: "false",
                 },
-              ],
+              },
             },
-          ],
+          },
         },
-      ],
-      functions: [],
+      },
+      functions: {},
     }
 
     assert.deepEqual(result, expected)
@@ -353,45 +368,45 @@ describe("scan static TypeScript", function () {
 
     const result = scan(files)
     const expected: ScanResult = {
-      classes: [
-        {
+      classes: {
+        HelloWorld: {
           name: "HelloWorld",
           description: "HelloWorld class",
           constructor: undefined,
-          fields: [],
-          methods: [
-            {
+          fields: {},
+          methods: {
+            helloWorld: {
               name: "helloWorld",
               returnType: { kind: TypeDefKind.VoidKind },
               description: "",
-              args: [
-                {
+              args: {
+                name: {
                   name: "name",
                   typeDef: { kind: TypeDefKind.StringKind },
                   description: "",
                   optional: false,
                   defaultValue: undefined,
                 },
-              ],
+              },
             },
-            {
+            asyncHelloWorld: {
               name: "asyncHelloWorld",
               returnType: { kind: TypeDefKind.VoidKind },
               description: "",
-              args: [
-                {
+              args: {
+                name: {
                   name: "name",
                   typeDef: { kind: TypeDefKind.StringKind },
                   description: "",
                   optional: true,
                   defaultValue: undefined,
                 },
-              ],
+              },
             },
-          ],
+          },
         },
-      ],
-      functions: [],
+      },
+      functions: {},
     }
 
     assert.deepEqual(result, expected)
@@ -402,43 +417,52 @@ describe("scan static TypeScript", function () {
 
     const result = scan(files)
     const expected: ScanResult = {
-      classes: [
-        {
+      classes: {
+        HelloWorld: {
           name: "HelloWorld",
           description: "HelloWorld class",
-          fields: [],
+          fields: {
+            name: {
+              description: "",
+              isExposed: false,
+              name: "name",
+              typeDef: {
+                kind: TypeDefKind.StringKind,
+              },
+            },
+          },
           constructor: {
-            args: [
-              {
+            args: {
+              name: {
                 name: "name",
                 typeDef: { kind: TypeDefKind.StringKind },
                 description: "",
                 defaultValue: '"world"',
                 optional: true,
               },
-            ],
+            },
           },
-          methods: [
-            {
+          methods: {
+            sayHello: {
               name: "sayHello",
               returnType: {
                 kind: TypeDefKind.StringKind,
               },
               description: "",
-              args: [
-                {
+              args: {
+                name: {
                   name: "name",
                   typeDef: { kind: TypeDefKind.StringKind },
                   description: "",
                   optional: false,
                   defaultValue: undefined,
                 },
-              ],
+              },
             },
-          ],
+          },
         },
-      ],
-      functions: [],
+      },
+      functions: {},
     }
 
     assert.deepEqual(result, expected)

--- a/sdk/typescript/introspector/test/testdata/multiArgs/index.ts
+++ b/sdk/typescript/introspector/test/testdata/multiArgs/index.ts
@@ -1,0 +1,10 @@
+import { func, object } from '../../../decorators/decorators.js'
+
+@object
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+class HelloWorld {
+  @func
+  compute(a: number, b: number, c: number): number {
+    return a * b + c
+  }
+}

--- a/sdk/typescript/introspector/test/testdata/state/state.ts
+++ b/sdk/typescript/introspector/test/testdata/state/state.ts
@@ -20,19 +20,17 @@ export class Alpine {
     @field
     ctr?: Container = undefined
 
-    ignored: string = ""
-
     /**
      * Returns a base Alpine container
      * @param version version to use (default to: 3.16.2)
      */
     @func
     base(version?: string): Alpine {
-        if (version === undefined) {
-            version = this.version
+        if (version) {
+            this.version = version
         }
 
-        this.ctr = dag.container().from(`alpine:${version}`)
+        this.ctr = dag.container().from(`alpine:${this.version}`)
 
         return this
     }


### PR DESCRIPTION
Updates entrypoint loading by:
- Loading args type in constructor

Fixes argument loading by:
- Correctly serializing input and parentJSON
- Fixing loadArg to correctly supports list
- Fixing loadArg to load object with ID only
- Refactor load to avoid repetition

Update invoke to:
- Order argument
- Load values, state and result

Update loader to:
- Load arguments order
- Load result
- Adapt to new scanResult data structure

Update scanner to:
- Use a new data structure based on object instead of arrays to increase
performances and maintainability on `ScanResult`.
- Scan non-exposed field
- Add `isExposed` property to `FieldTypeDef`

Update register to:
- Only register exposed field to Dagger API
- Use new data structure scanResult
- Correctly assigning constructor if there's

*Additional notes* 
- Registry is no longer in charge of ordering arguments.
- Update and improve unit tests and integration tests
- Updates entrypoint to no longer loads values but send them 
raw JSON to invoke.

Fixes DEV-3309
Fixes DEV-3314
Fixes DEV-3313