### PR TITLE
propagate progrock parents

### DIFF
--- a/cmd/codegen/codegen.go
+++ b/cmd/codegen/codegen.go
@@ -4,33 +4,25 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
-	"time"
-
-	"github.com/opencontainers/go-digest"
-	"github.com/vito/progrock"
 
 	"dagger.io/dagger"
 	"github.com/dagger/dagger/cmd/codegen/generator"
 	gogenerator "github.com/dagger/dagger/cmd/codegen/generator/go"
 	typescriptgenerator "github.com/dagger/dagger/cmd/codegen/generator/typescript"
 	"github.com/dagger/dagger/cmd/codegen/introspection"
+	"github.com/koron-go/prefixw"
 )
 
 func Generate(ctx context.Context, cfg generator.Config, dag *dagger.Client) (err error) {
-	rec := progrock.FromContext(ctx)
+	logsW := os.Stdout
 
-	var vtxName string
 	if cfg.ModuleConfig != nil {
-		vtxName = fmt.Sprintf("generating %s module: %s", cfg.Lang, cfg.ModuleConfig.Name)
+		fmt.Fprintf(logsW, "generating %s module: %s\n", cfg.Lang, cfg.ModuleConfig.Name)
 	} else {
-		vtxName = fmt.Sprintf("generating %s SDK client", cfg.Lang)
+		fmt.Fprintf(logsW, "generating %s SDK client\n", cfg.Lang)
 	}
-
-	vtx := rec.Vertex(digest.FromString(time.Now().String()), vtxName)
-	defer func() { vtx.Done(err) }()
-
-	logsW := vtx.Stdout()
 
 	var introspectionSchema *introspection.Schema
 	if cfg.IntrospectionJSON != "" {
@@ -57,10 +49,14 @@ func Generate(ctx context.Context, cfg generator.Config, dag *dagger.Client) (er
 		}
 
 		for _, cmd := range generated.PostCommands {
+			pw := prefixw.New(logsW, strings.Join(cmd.Args, " ")+" | ")
 			cmd.Dir = cfg.OutputDir
-			cmd.Stdout = vtx.Stdout()
-			cmd.Stderr = vtx.Stderr()
-			vtx.Task(strings.Join(cmd.Args, " ")).Done(cmd.Run())
+			cmd.Stdout = pw
+			cmd.Stderr = pw
+			if err := cmd.Run(); err != nil {
+				fmt.Fprintf(pw, "error: %s\n", err)
+				return fmt.Errorf("failed to run post command: %w", err)
+			}
 		}
 
 		if !generated.NeedRegenerate {

--- a/cmd/codegen/main.go
+++ b/cmd/codegen/main.go
@@ -5,8 +5,6 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/vito/progrock"
-	"github.com/vito/progrock/console"
 
 	"dagger.io/dagger"
 	"github.com/dagger/dagger/cmd/codegen/generator"
@@ -17,7 +15,6 @@ var (
 	outputDir             string
 	moduleRef             string
 	lang                  string
-	propagateLogs         bool
 	introspectionJSONPath string
 )
 
@@ -35,11 +32,8 @@ func init() {
 	rootCmd.Flags().StringVar(&lang, "lang", "go", "language to generate")
 	rootCmd.Flags().StringVarP(&outputDir, "output", "o", ".", "output directory")
 	rootCmd.Flags().StringVar(&moduleRef, "module", "", "module to load and codegen dependency code")
-	rootCmd.Flags().BoolVar(&propagateLogs, "propagate-logs", false, "propagate logs directly to progrock.sock")
 	rootCmd.Flags().StringVar(&introspectionJSONPath, "introspection-json-path", "", "optional path to file containing pre-computed graphql introspection JSON")
 }
-
-const nestedSock = "/.progrock.sock"
 
 func ClientGen(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
@@ -47,28 +41,6 @@ func ClientGen(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
-	var progW progrock.Writer
-	var dialErr error
-	if propagateLogs {
-		progW, dialErr = progrock.DialRPC(ctx, "unix://"+nestedSock)
-		if dialErr != nil {
-			return fmt.Errorf("error connecting to progrock: %w; falling back to console output", dialErr)
-		}
-	} else {
-		progW = console.NewWriter(os.Stderr, console.WithMessageLevel(progrock.MessageLevel_DEBUG))
-	}
-
-	var rec *progrock.Recorder
-	if parent := os.Getenv("_DAGGER_PROGROCK_PARENT"); parent != "" {
-		rec = progrock.NewSubRecorder(progW, parent)
-	} else {
-		rec = progrock.NewRecorder(progW)
-	}
-	defer rec.Complete()
-	defer rec.Close()
-
-	ctx = progrock.ToContext(ctx, rec)
 
 	cfg := generator.Config{
 		Lang: generator.SDKLang(lang),

--- a/cmd/codegen/main.go
+++ b/cmd/codegen/main.go
@@ -37,7 +37,7 @@ func init() {
 
 func ClientGen(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-	dag, err := dagger.Connect(ctx)
+	dag, err := dagger.Connect(ctx, dagger.WithSkipCompatibilityCheck())
 	if err != nil {
 		return err
 	}

--- a/cmd/codegen/main.go
+++ b/cmd/codegen/main.go
@@ -59,7 +59,12 @@ func ClientGen(cmd *cobra.Command, args []string) error {
 		progW = console.NewWriter(os.Stderr, console.WithMessageLevel(progrock.MessageLevel_DEBUG))
 	}
 
-	rec := progrock.NewRecorder(progW)
+	var rec *progrock.Recorder
+	if parent := os.Getenv("_DAGGER_PROGROCK_PARENT"); parent != "" {
+		rec = progrock.NewSubRecorder(progW, parent)
+	} else {
+		rec = progrock.NewRecorder(progW)
+	}
 	defer rec.Complete()
 	defer rec.Close()
 

--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -86,7 +86,13 @@ func withEngineAndTUI(
 			opts = append(opts, console.WithMessageLevel(progrock.MessageLevel_DEBUG))
 		}
 
-		params.ProgrockWriter = console.NewWriter(os.Stderr, opts...)
+		progW := console.NewWriter(os.Stderr, opts...)
+		progW, engineErr := progrockTee(progW)
+		if engineErr != nil {
+			return engineErr
+		}
+
+		params.ProgrockWriter = progW
 
 		params.EngineNameCallback = func(name string) {
 			fmt.Fprintln(os.Stderr, "Connected to engine", name)

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -489,9 +489,6 @@ func loadMod(ctx context.Context, c *dagger.Client) (*dagger.Module, error) {
 // loadModTypeDefs loads the objects defined by the given module in an easier to use data structure.
 func loadModTypeDefs(ctx context.Context, dag *dagger.Client, mod *dagger.Module) (*moduleDef, error) {
 	var res struct {
-		Mod struct {
-			Name string
-		}
 		TypeDefs []*modTypeDef
 	}
 
@@ -549,9 +546,6 @@ fragment FieldParts on FieldTypeDef {
 }
 
 query TypeDefs($module: ModuleID!) {
-	mod: loadModuleFromID(id: $module) {
-		name
-	}
 	typeDefs: currentTypeDefs {
 		kind
 		optional
@@ -597,7 +591,12 @@ query TypeDefs($module: ModuleID!) {
 		return nil, fmt.Errorf("query module objects: %w", err)
 	}
 
-	modDef := &moduleDef{Name: res.Mod.Name}
+	name, err := mod.Name(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get module name: %w", err)
+	}
+
+	modDef := &moduleDef{Name: name}
 	for _, typeDef := range res.TypeDefs {
 		switch typeDef.Kind {
 		case dagger.ObjectKind:

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -883,7 +883,7 @@ func TestDirectoryDirectMerge(t *testing.T) {
 	for fileName, inode := range fileNameToInode {
 		out, err := ctr.WithExec([]string{"stat", "-c", "%i", fileName}).Stdout(ctx)
 		require.NoError(t, err)
-		require.Equal(t, strings.TrimSpace(out), inode)
+		require.Equal(t, inode, strings.TrimSpace(out))
 	}
 }
 

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/vito/progrock"
 )
 
 type ModuleFunction struct {
@@ -212,7 +213,8 @@ func (fn *ModuleFunction) Call(ctx context.Context, caller *idproto.ID, opts *Ca
 		deps = mod.Deps.Prepend(mod)
 	}
 
-	err = mod.Query.RegisterFunctionCall(callerDigest, deps, fn.modID, callMeta)
+	err = mod.Query.RegisterFunctionCall(callerDigest, deps, fn.modID, callMeta,
+		progrock.FromContext(ctx).Parent)
 	if err != nil {
 		return nil, fmt.Errorf("failed to register function call: %w", err)
 	}

--- a/core/query.go
+++ b/core/query.go
@@ -105,6 +105,8 @@ type ClientCallContext struct {
 	// metadata of that ongoing function call
 	ModID  *idproto.ID
 	FnCall *FunctionCall
+
+	ProgrockParent string
 }
 
 func (q *Query) ClientCallContext(clientDigest digest.Digest) (*ClientCallContext, bool) {
@@ -146,7 +148,13 @@ func (q *Query) ServeModuleToMainClient(ctx context.Context, modMeta dagql.Insta
 	return nil
 }
 
-func (q *Query) RegisterFunctionCall(dgst digest.Digest, deps *ModDeps, modID *idproto.ID, call *FunctionCall) error {
+func (q *Query) RegisterFunctionCall(
+	dgst digest.Digest,
+	deps *ModDeps,
+	modID *idproto.ID,
+	call *FunctionCall,
+	progrockParent string,
+) error {
 	if dgst == "" {
 		return fmt.Errorf("cannot register function call with empty digest")
 	}
@@ -158,9 +166,10 @@ func (q *Query) RegisterFunctionCall(dgst digest.Digest, deps *ModDeps, modID *i
 		return nil
 	}
 	q.clientCallContext[dgst] = &ClientCallContext{
-		Deps:   deps,
-		ModID:  modID,
-		FnCall: call,
+		Deps:           deps,
+		ModID:          modID,
+		FnCall:         call,
+		ProgrockParent: progrockParent,
 	}
 	return nil
 }

--- a/core/schema/schema.go
+++ b/core/schema/schema.go
@@ -29,7 +29,6 @@ import (
 type InitializeArgs struct {
 	BuildkitClient *buildkit.Client
 	Platform       specs.Platform
-	ProgSockPath   string
 	OCIStore       content.Store
 	LeaseManager   *leaseutil.Manager
 	Auth           *auth.RegistryAuthProvider
@@ -48,7 +47,6 @@ func New(ctx context.Context, params InitializeArgs) (*APIServer, error) {
 	root := core.NewRoot()
 	root.Buildkit = params.BuildkitClient
 	root.Services = svcs
-	root.ProgrockSocketPath = params.ProgSockPath
 	root.Platform = core.Platform(params.Platform)
 	root.Secrets = params.Secrets
 	root.OCIStore = params.OCIStore

--- a/core/schema/sdk.go
+++ b/core/schema/sdk.go
@@ -385,7 +385,6 @@ func (sdk *goSDK) baseWithCodegen(ctx context.Context, mod *core.Module, sourceD
 				Name: "args",
 				Value: dagql.ArrayInput[dagql.String]{
 					"--module", ".",
-					"--propagate-logs=true",
 					"--introspection-json-path", goSDKIntrospectionJSONPath,
 				},
 			},

--- a/core/service.go
+++ b/core/service.go
@@ -339,8 +339,6 @@ func (svc *Service) startContainer(
 	execMeta := buildkit.ContainerExecUncachedMetadata{
 		ParentClientIDs: clientMetadata.ClientIDs(),
 		ServerID:        clientMetadata.ServerID,
-		ProgSockPath:    bk.ProgSockPath,
-		ProgParent:      rec.Parent,
 	}
 	execOp.Meta.ProxyEnv.FtpProxy, err = execMeta.ToPBFtpProxyVal()
 	if err != nil {

--- a/core/service.go
+++ b/core/service.go
@@ -336,11 +336,13 @@ func (svc *Service) startContainer(
 		execOp.Meta.ProxyEnv = &pb.ProxyEnv{}
 	}
 
-	execOp.Meta.ProxyEnv.FtpProxy, err = buildkit.ContainerExecUncachedMetadata{
+	execMeta := buildkit.ContainerExecUncachedMetadata{
 		ParentClientIDs: clientMetadata.ClientIDs(),
 		ServerID:        clientMetadata.ServerID,
 		ProgSockPath:    bk.ProgSockPath,
-	}.ToPBFtpProxyVal()
+		ProgParent:      rec.Parent,
+	}
+	execOp.Meta.ProxyEnv.FtpProxy, err = execMeta.ToPBFtpProxyVal()
 	if err != nil {
 		return nil, err
 	}

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -33,7 +33,6 @@ import (
 	"github.com/moby/buildkit/util/entitlements"
 	bkworker "github.com/moby/buildkit/worker"
 	"github.com/opencontainers/go-digest"
-	"github.com/vito/progrock"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/metadata"
 )
@@ -52,7 +51,6 @@ type Opts struct {
 	AuthProvider          *auth.RegistryAuthProvider
 	PrivilegedExecEnabled bool
 	UpstreamCacheImports  []bkgw.CacheOptionsEntry
-	ProgSockPath          string
 	// MainClientCaller is the caller who initialized the server associated with this
 	// client. It is special in that when it shuts down, the client will be closed and
 	// that registry auth and sockets are currently only ever sourced from this caller,
@@ -252,8 +250,6 @@ func (c *Client) Solve(ctx context.Context, req bkgw.SolveRequest) (_ *Result, r
 			execMeta := ContainerExecUncachedMetadata{
 				ParentClientIDs: clientMetadata.ClientIDs(),
 				ServerID:        clientMetadata.ServerID,
-				ProgSockPath:    c.ProgSockPath,
-				ProgParent:      progrock.FromContext(ctx).Parent,
 			}
 			var err error
 			execOp.Meta.ProxyEnv.FtpProxy, err = execMeta.ToPBFtpProxyVal()
@@ -689,9 +685,6 @@ func withOutgoingContext(ctx context.Context) context.Context {
 type ContainerExecUncachedMetadata struct {
 	ParentClientIDs []string `json:"parentClientIDs,omitempty"`
 	ServerID        string   `json:"serverID,omitempty"`
-	// Progrock propagation
-	ProgSockPath string `json:"progSockPath,omitempty"`
-	ProgParent   string `json:"progParent,omitempty"`
 }
 
 func (md ContainerExecUncachedMetadata) ToPBFtpProxyVal() (string, error) {

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -13,7 +13,6 @@ import (
 	"github.com/dagger/dagger/auth"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/session"
-	"github.com/dagger/dagger/tracing"
 	bkcache "github.com/moby/buildkit/cache"
 	bkcacheconfig "github.com/moby/buildkit/cache/config"
 	"github.com/moby/buildkit/cache/remotecache"

--- a/engine/buildkit/progrock.go
+++ b/engine/buildkit/progrock.go
@@ -3,9 +3,6 @@ package buildkit
 import (
 	"context"
 	"fmt"
-	"net"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/containerd/containerd/platforms"
@@ -91,23 +88,6 @@ func (w ProgrockLogrusWriter) WriteStatus(ev *progrock.StatusUpdate) error {
 
 func (w ProgrockLogrusWriter) Close() error {
 	return nil
-}
-
-func ProgrockForwarder(sockPath string, w progrock.Writer) (progrock.Writer, func() error, error) {
-	if err := os.MkdirAll(filepath.Dir(sockPath), 0700); err != nil {
-		return nil, nil, err
-	}
-	l, err := net.Listen("unix", sockPath)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	progW, err := progrock.ServeRPC(l, w)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return progW, l.Close, nil
 }
 
 func RecordVertexes(recorder *progrock.Recorder, def *pb.Definition) {

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -66,7 +66,6 @@ type Params struct {
 
 	JournalFile        string
 	ProgrockWriter     progrock.Writer
-	ProgrockParent     string
 	EngineNameCallback func(string)
 	CloudURLCallback   func(string)
 
@@ -144,11 +143,7 @@ func Connect(ctx context.Context, params Params) (_ *Client, _ context.Context, 
 		cloudURL = tel.URL()
 		progMultiW = append(progMultiW, telemetry.NewWriter(tel))
 	}
-	if c.ProgrockParent != "" {
-		c.Recorder = progrock.NewSubRecorder(progMultiW, c.ProgrockParent)
-	} else {
-		c.Recorder = progrock.NewRecorder(progMultiW)
-	}
+	c.Recorder = progrock.NewRecorder(progMultiW)
 	ctx = progrock.ToContext(ctx, c.Recorder)
 
 	nestedSessionPortVal, isNestedSession := os.LookupEnv("DAGGER_SESSION_PORT")

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -272,11 +272,6 @@ func Connect(ctx context.Context, params Params) (_ *Client, _ context.Context, 
 	bkSession.Allow(authprovider.NewDockerAuthProvider(config.LoadDefaultConfigFile(os.Stderr), nil))
 
 	// host=>container networking
-	if c.ProgrockParent != "" {
-		c.Recorder = progrock.NewSubRecorder(progMultiW, c.ProgrockParent)
-	} else {
-		c.Recorder = progrock.NewRecorder(progMultiW)
-	}
 	bkSession.Allow(session.NewTunnelListenerAttachable(c.Recorder))
 	ctx = progrock.ToContext(ctx, c.Recorder)
 

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -44,7 +44,6 @@ import (
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/session"
 	"github.com/dagger/dagger/telemetry"
-	"github.com/dagger/dagger/tracing"
 )
 
 type Params struct {
@@ -172,9 +171,15 @@ func Connect(ctx context.Context, params Params) (_ *Client, _ context.Context, 
 		return c, ctx, nil
 	}
 
-	initGroup := progrock.FromContext(ctx).WithGroup("init", progrock.Weak())
+	// sneakily using ModuleCallerDigest here because it seems nicer than just
+	// making something up, and should be pretty much 1:1 I think (even
+	// non-cached things will have a different caller digest each time)
+	connectDigest := params.ModuleCallerDigest
+	if connectDigest == "" {
+		connectDigest = digest.FromString("_root") // arbitrary
+	}
 
-	loader := initGroup.Vertex("starting-engine", "connect")
+	loader := c.Recorder.Vertex(connectDigest, "connect")
 	defer func() {
 		loader.Done(rerr)
 	}()

--- a/engine/server/buildkitcontroller.go
+++ b/engine/server/buildkitcontroller.go
@@ -23,7 +23,6 @@ import (
 	"github.com/moby/buildkit/executor/oci"
 	"github.com/moby/buildkit/frontend"
 	bkgw "github.com/moby/buildkit/frontend/gateway/client"
-	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/grpchijack"
 	containerdsnapshot "github.com/moby/buildkit/snapshot/containerd"
@@ -245,10 +244,6 @@ func (e *BuildkitController) Session(stream controlapi.Control_SessionServer) (r
 			})
 		}
 
-		// using a new random ID rather than server ID to squash any nefarious attempts to set
-		// a server id that has e.g. ../../.. or similar in it
-		progSockPath := fmt.Sprintf("/run/dagger/server-progrock-%s.sock", identity.NewID())
-
 		bkClient, err := buildkit.NewClient(ctx, buildkit.Opts{
 			Worker:                e.worker,
 			SessionManager:        e.SessionManager,
@@ -258,7 +253,6 @@ func (e *BuildkitController) Session(stream controlapi.Control_SessionServer) (r
 			AuthProvider:          authProvider,
 			PrivilegedExecEnabled: e.privilegedExecEnabled,
 			UpstreamCacheImports:  cacheImporterCfgs,
-			ProgSockPath:          progSockPath,
 			MainClientCaller:      caller,
 			DNSConfig:             e.DNSConfig,
 		})

--- a/go.mod
+++ b/go.mod
@@ -101,6 +101,8 @@ require (
 	oss.terrastruct.com/util-go v0.0.0-20231101220827-55b3812542c2
 )
 
+require github.com/koron-go/prefixw v1.0.0
+
 require (
 	cdr.dev/slog v1.4.2 // indirect
 	dario.cat/mergo v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/urfave/cli v1.22.14
 	github.com/vektah/gqlparser/v2 v2.5.10
 	github.com/vito/midterm v0.1.4
-	github.com/vito/progrock v0.10.2-0.20240112170756-062394b3e4ae
+	github.com/vito/progrock v0.10.2-0.20240119030128-52ef9ee1a291
 	github.com/weaveworks/common v0.0.0-20230119144549-0aaa5abd1e63
 	github.com/zeebo/xxh3 v1.0.2
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.0

--- a/go.sum
+++ b/go.sum
@@ -978,6 +978,8 @@ github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa02
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/koron-go/prefixw v1.0.0 h1:p7OC1ffZ/z+Miz0j/Ddt4fVYr8g4W9BKWkViAZ+1LmI=
+github.com/koron-go/prefixw v1.0.0/go.mod h1:WZvD0yrbCrkJD23tq03BhCu1ucn5ZenktcXt39QbPyk=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/go.sum
+++ b/go.sum
@@ -1471,8 +1471,8 @@ github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f h1:p4VB7kIXpOQvV
 github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vito/midterm v0.1.4 h1:SALq5mQ+AgzeZxjL4loB6Uk5TZc9JMyX2ELA/NVH65c=
 github.com/vito/midterm v0.1.4/go.mod h1:Mm3u6lrpzo2EFSJbwksKOdottTJzYePK8c1KJy4aRbk=
-github.com/vito/progrock v0.10.2-0.20240112170756-062394b3e4ae h1:l5+peCyvBr937ywBwKfsPiCm9hFJwTKlShUNLwWr6BQ=
-github.com/vito/progrock v0.10.2-0.20240112170756-062394b3e4ae/go.mod h1:Q8hxIUXZW8vkezLwH4TnRmXv+XdRb4KfLtS9t5RtH9g=
+github.com/vito/progrock v0.10.2-0.20240119030128-52ef9ee1a291 h1:VcLECqiOXx4PTEzsV0QlWVubUeE+k0ZclAlKpUuejo8=
+github.com/vito/progrock v0.10.2-0.20240119030128-52ef9ee1a291/go.mod h1:Q8hxIUXZW8vkezLwH4TnRmXv+XdRb4KfLtS9t5RtH9g=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/weaveworks/common v0.0.0-20230119144549-0aaa5abd1e63 h1:qZcnPZbiX8gGs3VmipVc3ft29vPYBZzlox/04Von6+k=
 github.com/weaveworks/common v0.0.0-20230119144549-0aaa5abd1e63/go.mod h1:KoQ+3z63GUJzQ7AhU0AWQNU+LPda2EwL/cx1PlbDzVQ=

--- a/internal/mage/docs.go
+++ b/internal/mage/docs.go
@@ -50,7 +50,7 @@ func (d Docs) Lint(ctx context.Context) error {
 	})
 
 	eg.Go(func() error {
-		return util.LintGeneratedCode(func() error {
+		return util.LintGeneratedCode("docs:generate", func() error {
 			return d.Generate(ctx)
 		}, generatedSchemaPath)
 	})

--- a/internal/mage/sdk/go.go
+++ b/internal/mage/sdk/go.go
@@ -43,7 +43,7 @@ func (t Go) Lint(ctx context.Context) error {
 		return err
 	}
 
-	return util.LintGeneratedCode(func() error {
+	return util.LintGeneratedCode("sdk:go:generate", func() error {
 		return t.Generate(ctx)
 	}, goGeneratedAPIPath)
 }

--- a/internal/mage/sdk/python.go
+++ b/internal/mage/sdk/python.go
@@ -57,7 +57,7 @@ func (t Python) Lint(ctx context.Context) error {
 	})
 
 	eg.Go(func() error {
-		return util.LintGeneratedCode(func() error {
+		return util.LintGeneratedCode("sdk:python:generate", func() error {
 			return t.Generate(gctx)
 		}, pythonGeneratedAPIPath)
 	})

--- a/internal/mage/sdk/rust.go
+++ b/internal/mage/sdk/rust.go
@@ -127,7 +127,7 @@ func (r Rust) Lint(ctx context.Context) error {
 	})
 
 	eg.Go(func() error {
-		return util.LintGeneratedCode(func() error {
+		return util.LintGeneratedCode("sdk:rust:generate", func() error {
 			return r.Generate(gctx)
 		}, rustGeneratedAPIPath)
 	})

--- a/internal/mage/sdk/typescript.go
+++ b/internal/mage/sdk/typescript.go
@@ -62,7 +62,7 @@ func (t TypeScript) Lint(ctx context.Context) error {
 	})
 
 	eg.Go(func() error {
-		return util.LintGeneratedCode(func() error {
+		return util.LintGeneratedCode("sdk:typescript:generate", func() error {
 			return t.Generate(gctx)
 		}, typescriptGeneratedAPIPath)
 	})

--- a/internal/mage/util/generated.go
+++ b/internal/mage/util/generated.go
@@ -17,7 +17,7 @@ import (
 // 2) Generate again
 // 3) Compare
 // 4) Restore original generated code.
-func LintGeneratedCode(fn func() error, files ...string) error {
+func LintGeneratedCode(target string, fn func() error, files ...string) error {
 	newFiles := make([]string, 0, len(files))
 	for _, file := range files {
 		err := filepath.WalkDir(file, func(path string, d fs.DirEntry, err error) error {
@@ -65,7 +65,7 @@ func LintGeneratedCode(fn func() error, files ...string) error {
 		if original != string(updated) {
 			edits := myers.ComputeEdits(span.URIFromPath(f), original, string(updated))
 			diff := fmt.Sprint(gotextdiff.ToUnified(f, f, original, edits))
-			return fmt.Errorf("generated api mismatch. please run `mage sdk:all:generate`:\n%s", diff)
+			return fmt.Errorf("Generated code mismatch. Please run `%s`:\n%s", target, diff)
 		}
 	}
 

--- a/tracing/graphql.go
+++ b/tracing/graphql.go
@@ -62,15 +62,26 @@ func ProgrockAroundFunc(ctx context.Context, self dagql.Object, id *idproto.ID, 
 			slog.Warn("failed to digest id", "id", id.Display(), "err", err)
 			return next(ctx)
 		}
-		payload, resolveErr := anypb.New(id)
-		if resolveErr != nil {
-			slog.Warn("failed to anypb.New(id)", "id", id.Display(), "err", resolveErr)
-			return next(ctx)
-		}
-		vtx := rec.Vertex(dig, id.Field, progrock.Internal())
+		// TODO: we don't need this for anything yet
+		// inputs, err := id.Inputs()
+		// if err != nil {
+		// 	slog.Warn("failed to digest inputs", "id", id.Display(), "err", err)
+		// 	return next(ctx)
+		// }
+		vtx := rec.Vertex(dig, id.Field,
+			// progrock.WithInputs(inputs...),
+			// TODO: these really shouldn't be internal, but for backwards
+			// compatibility we don't want to overwhelm the TUI with a bunch of
+			// vertices.
+			progrock.Internal())
 		ctx = ioctx.WithStdout(ctx, vtx.Stdout())
 		ctx = ioctx.WithStderr(ctx, vtx.Stderr())
 
+		payload, err := anypb.New(id)
+		if err != nil {
+			slog.Warn("failed to anypb.New(id)", "id", id.Display(), "err", err)
+			return next(ctx)
+		}
 		// send ID payload to the frontend
 		vtx.Meta("id", payload)
 


### PR DESCRIPTION
These are the necessary changes for the Zenith visualization experiments I've been working on. I figure we can sneak these out even if we don't have anything that uses them yet, just to have the ability to record a journal file and test the new UI/TUI against it.

The only real change is that Progrock now supports parent/child vertex relationships, which are analogous to parent/child spans in OpenTelemetry. The DagQL telemetry now uses this instead of the weird group-that's-really-a-vertex from before, which was also contributing to a lot of noisy output. Now when a resolver performs a self-call or runs something with Buildkit, the resulting vertices will be children of the calling vertex.

Most of the effort is just getting the parent vertex ID plumbed through all the right places for nesting/modules. If/when we want to add support for OpenTelemetry, this is a good breadcrumb trail to follow. I took a swing at it but couldn't quite get it to work how I wanted to so I backed out for now.