### PR TITLE
test(tsSDK): add integration test

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -2303,7 +2303,7 @@ class Foo {
   con: Container
 
   @field
-  usetFile?: File
+  unsetFile?: File
 
   constructor(con: Container, usetFile?: File) {
     this.con = con
@@ -3977,12 +3977,11 @@ class Test {
     return (async () => {
       this.alpineVersion = await dag.container().from("alpine:3.18.4").file("/etc/alpine-release").contents()
 
-
       return this; // Return the newly-created instance
-  })();
+    })();
   }
 }				
-				`,
+`,
 			},
 		} {
 			tc := tc
@@ -4050,7 +4049,7 @@ class Test {
     throw new Error("too bad")
   }
 }				
-				`,
+`,
 			},
 		} {
 			tc := tc
@@ -4141,7 +4140,7 @@ class Test {
   }
 }
 `, content),
-			))
+		))
 
 		out, err := ctr.With(daggerCall("foo")).Stdout(ctx)
 		require.NoError(t, err)

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -2314,14 +2314,14 @@ class Foo {
 @object
 class Playground {
   @func
-  async mySlice(): Promise<Container[]> {
+  mySlice(): Container[] {
     return [
       dag.container().from("alpine:latest").withExec(["echo", "hello world"])
     ]
   }
 
   @func
-  async myStruct(): Promise<Foo> {
+  myStruct(): Foo {
     return new Foo(
       dag.container().from("alpine:latest").withExec(["echo", "hello world"])
     )

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -4140,7 +4140,7 @@ class Test {
   }
 }
 `, content),
-		))
+			))
 
 		out, err := ctr.With(daggerCall("foo")).Stdout(ctx)
 		require.NoError(t, err)

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -2395,6 +2395,28 @@ class Foo:
         return self.data
 `,
 		},
+		{
+			sdk: "typescript",
+			source: `
+import { object, func } from "@dagger.io/dagger"
+
+@object
+class Foo {
+  data: string = ""
+
+  @func
+  set(data: string): Foo {
+    this.data = data
+    return this
+  }
+
+  @func
+  get(): string {
+    return this.data
+  }
+}
+`,
+		},
 	} {
 		tc := tc
 

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -1733,6 +1733,37 @@ class Minimal:
         return self.foo + self.bar
 `,
 		},
+		{
+			sdk: "typescript",
+			source: `
+import { object, func, field } from "@dagger.io/dagger"
+
+@object
+class Minimal {
+  @field
+  foo: string
+
+  bar?: string
+
+  constructor(foo?: string, bar?: string) {
+    this.foo = foo
+    this.bar = bar
+  }
+
+  @func
+  set(foo: string, bar: string): Minimal {
+    this.foo = foo
+    this.bar = bar
+    return this
+  }
+
+  @func
+  hello(): string {
+    return this.foo + this.bar
+  }
+}
+`,
+		},
 	} {
 		tc := tc
 
@@ -1854,6 +1885,39 @@ def repeater(msg: str, times: int) -> Repeater:
     return Repeater(message=msg, times=times)
 `,
 		},
+		{
+			sdk: "typescript",
+			source: `
+import { object, func, field } from "@dagger.io/dagger"
+
+@object
+class Repeater {
+  @field
+  message: string
+
+  @field
+  times: number
+
+  constructor(message: string, times: number) {
+    this.message = message
+    this.times = times
+  }
+
+  @func
+  render(): string {
+    return this.message.repeat(this.times)
+  }
+}
+
+@object
+class Test {
+  @func
+  repeater(msg: string, times: number): Repeater {
+    return new Repeater(msg, times)
+  }
+}			
+`,
+		},
 	} {
 		tc := tc
 
@@ -1914,6 +1978,30 @@ class X:
 @function
 def my_function() -> X:
     return X(message="foo")
+`,
+		},
+		{
+			sdk: "typescript",
+			source: `
+import { object, func, field } from "@dagger.io/dagger"
+
+@object
+class X {
+  @field
+  message: string
+
+  constructor(message: string) {
+    this.message = message;
+  }
+}
+
+@object
+class Foo {
+  @func
+  myFunction(): X {
+    return new X("foo");
+  }
+}
 `,
 		},
 	} {
@@ -1986,6 +2074,42 @@ class Foo:
         return X(message="foo", when="now", to="user", from_="admin")
 `,
 		},
+		{
+			sdk: "typescript",
+			source: `
+import { object, func, field } from "@dagger.io/dagger"
+
+@object
+class X {
+  @field 
+  message: string
+
+  @field
+  timestamp: string
+
+  @field
+  recipient: string
+
+  @field
+  from: string
+
+  constructor(message: string, timestamp: string, recipient: string, from: string) {
+    this.message = message;
+    this.timestamp = timestamp;
+    this.recipient = recipient;
+    this.from = from;
+  }
+}
+
+@object
+class Foo {
+  @func
+  myFunction(): X {
+    return new X("foo", "now", "user", "admin");
+  }
+}
+`,
+		},
 	} {
 		tc := tc
 
@@ -2056,6 +2180,40 @@ class Playground:
     @function
     def my_function(self) -> Foo:
         return Foo(msg_container=Bar(msg="hello world"))
+`,
+		},
+		{
+			sdk: "typescript",
+			source: `
+import { object, func, field } from "@dagger.io/dagger"
+
+@object
+class Bar {
+  @field
+  msg: string;
+
+  constructor(msg: string) {
+    this.msg = msg;
+  }
+}
+
+@object
+class Foo {
+  @field
+  msgContainer: Bar;
+
+  constructor(msgContainer: Bar) {
+    this.msgContainer = msgContainer;
+  }
+}
+
+@object
+class Playground {
+  @func
+  myFunction(): Foo {
+    return new Foo(new Bar("hello world"));
+  }
+}
 `,
 		},
 	} {

--- a/core/integration/testdata/modules/typescript/id/arg/index.ts
+++ b/core/integration/testdata/modules/typescript/id/arg/index.ts
@@ -1,0 +1,9 @@
+import { object, func } from "@dagger.io/dagger"
+
+@object
+class Test {
+  @func
+  fn(id: string): string {
+    return "NOOOO!!!!"
+  } 
+}

--- a/core/integration/testdata/modules/typescript/id/field/index.ts
+++ b/core/integration/testdata/modules/typescript/id/field/index.ts
@@ -1,0 +1,19 @@
+import { object, func, field } from "@dagger.io/dagger"
+
+@object
+class Test {
+  @func
+  fn(): CustomObject {
+    return new CustomObject("NOOOO!!!!")
+  }
+}
+
+@object
+class CustomObject {
+  @field
+  ID: string
+
+  constructor(id: string) {
+    this.ID = id
+  }
+}

--- a/core/integration/testdata/modules/typescript/id/fn/index.ts
+++ b/core/integration/testdata/modules/typescript/id/fn/index.ts
@@ -1,0 +1,9 @@
+import { object, func } from "@dagger.io/dagger"
+
+@object
+class Test {
+  @func
+  id(): string {
+    return "NOOOO!!!!"
+  }
+}

--- a/sdk/typescript/entrypoint/load.ts
+++ b/sdk/typescript/entrypoint/load.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { dag, TypeDefKind } from "../api/client.gen.js"
 import { ScanResult } from "../introspector/scanner/scan.js"
 import { TypeDef } from "../introspector/scanner/typeDefs.js"
@@ -119,16 +120,18 @@ export function loadPropertyType(
  * Note: The JSON.parse() is required to remove extra quotes
  */
 export async function loadArg(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   value: any,
   type: TypeDef<TypeDefKind>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any> {
+  // If value is undefinied, return it directly.
+  if (value === undefined) {
+    return value
+  }
+
   switch (type.kind) {
     case TypeDefKind.ListKind:
       return Promise.all(
         value.map(
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           async (v: any) =>
             await loadArg(v, (type as TypeDef<TypeDefKind.ListKind>).typeDef)
         )
@@ -165,7 +168,6 @@ export async function loadArg(
  * @param result The result of the invocation.
  * @returns Loaded result.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function loadResult(result: any): Promise<any> {
   if (result && typeof result?.id === "function") {
     result = await result.id()

--- a/sdk/typescript/introspector/registry/registry.ts
+++ b/sdk/typescript/introspector/registry/registry.ts
@@ -1,11 +1,12 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import "reflect-metadata"
 
 import { UnknownDaggerError } from "../../common/errors/UnknownDaggerError.js"
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Class = { new (...args: any[]): any }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type State = { [property: string]: any }
 
 export type Args = Record<string, unknown>
@@ -76,7 +77,6 @@ export class Registry {
    * The definition of @field decorator that should be on top of any
    * class' property that must be exposed to the Dagger API.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   field = (target: object, propertyKey: string) => {
     // A placeholder to declare fields
   }
@@ -86,11 +86,8 @@ export class Registry {
    * class' method that must be exposed to the Dagger API.
    */
   func = (
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     target: object,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     propertyKey: string | symbol,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     descriptor: PropertyDescriptor
   ) => {
     // The logic is done in the object constructor since it's not possible to
@@ -114,7 +111,6 @@ export class Registry {
     method: string,
     state: State,
     inputs: Args
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<any> {
     // Retrieve the resolver class from its key
     const resolver = Reflect.getMetadata(object, this) as RegistryClass
@@ -140,7 +136,6 @@ export class Registry {
     }
 
     // Instantiate the class
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let r = new resolver.class_() as any
 
     // Apply state to the class

--- a/sdk/typescript/introspector/test/registry.spec.ts
+++ b/sdk/typescript/introspector/test/registry.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import assert from "assert"
 
 import { dag, Container } from "../../api/client.gen.js"
@@ -9,7 +10,6 @@ describe("Registry", function () {
     const registry = new Registry()
 
     @registry.object
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     class HelloWorld {
       @registry.func
       greeting(name: string): string {
@@ -32,7 +32,6 @@ describe("Registry", function () {
     const registry = new Registry()
 
     @registry.object
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     class HelloWorld {
       @registry.func
       async asyncGreeting(name: string): Promise<string> {
@@ -55,7 +54,6 @@ describe("Registry", function () {
     const registry = new Registry()
 
     @registry.object
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     class HelloWorld {
       @registry.func
       async asyncGreeting(name: string): Promise<string> {
@@ -93,7 +91,6 @@ describe("Registry", function () {
     const registry = new Registry()
 
     @registry.object
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     class HelloWorld {
       prefix = "Hello"
 
@@ -119,7 +116,6 @@ describe("Registry", function () {
     const registry = new Registry()
 
     @registry.object
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     class HelloWorld {
       @registry.field
       prefix = "placeholder"
@@ -148,7 +144,6 @@ describe("Registry", function () {
     const registry = new Registry()
 
     @registry.object
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     class HelloWorld {
       @registry.field
       prefix = "placeholder"
@@ -180,7 +175,6 @@ describe("Registry", function () {
     const registry = new Registry()
 
     @registry.object
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     class HelloWorld {
       @registry.field
       ctr?: Ctr = undefined
@@ -209,7 +203,6 @@ describe("Registry", function () {
     const registry = new Registry()
 
     @registry.object
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     class HelloWorld {
       @registry.func
       compute(a: number, b: number, c: number): number {
@@ -254,7 +247,6 @@ describe("Registry", function () {
     }
 
     @registry.object
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     class Foo {
       @registry.field
       foo(): Bar {
@@ -282,7 +274,6 @@ describe("Registry", function () {
     const registry = new Registry()
 
     @registry.object
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     class HelloWorld {
       @registry.field
       msg: string
@@ -322,7 +313,6 @@ describe("Registry", function () {
     const registry = new Registry()
 
     @registry.object
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     class HelloWorld {
       @registry.func
       sayHi(msg = ["foobar"]): string {


### PR DESCRIPTION
- Add integration tests for constructors
- Add `Unwrap` test case
- Add `lotOfFunction` test case
- Add `ReservedWord` test case
- Add `TestModuleArgOwnType` case
- Add `IDableType` case
- Add dependencies cases
- Add `ReturnCompositeCore` case
- Add `ReturnComplexThing` case
- Add `GlobalVarDAG` case
- Add `PrivateField` case
- Add `CustomTypes` case
- Add `ReturnTypeDetection` case
- Add `ReturnObject` case
- Add `NestedObject` case

*Additional notes*
- Remove inline Eslint nolint instruction in favor of file's scope instruction
- Fixes an issue with `loadArg` when `value` is `undefined`.

Fixes DEV-3323
Fixes DEV-3324