### PR TITLE
Add npm ignore for typescript

### DIFF
--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -6,7 +6,7 @@
     "./**/*.spec.ts",
     "./dist/**/*",
     "./**/testdata/*",
-    "runtime/template"
+    "./runtime/"
   ],
   "compilerOptions": {
     "target": "ES2022",


### PR DESCRIPTION
It seems like https://github.com/dagger/dagger/actions/runs/7586336084/job/20664474209 was broken, due to changes in https://github.com/dagger/dagger/pull/6433/files#diff-dd39eea8d6cc5b9f8f7a2c9645c31136dbef40ad6f79b5d3860fac8bbae44ce9.

See https://docs.npmjs.com/cli/v10/commands/npm-publish#files-included-in-package for more info.