### PR TITLE
fix: include typescript in pkg dependencies

### DIFF
--- a/sdk/typescript/.changes/unreleased/Fixed-20240122-140126.yaml
+++ b/sdk/typescript/.changes/unreleased/Fixed-20240122-140126.yaml
@@ -1,5 +1,5 @@
 kind: Fixed
-body: Add typescript to required dependencies
+body: Fixes missing production dependencies in SDK package.json.
 time: 2024-01-22T14:01:26.169943+01:00
 custom:
   Author: TomChv

--- a/sdk/typescript/.changes/unreleased/Fixed-20240122-140126.yaml
+++ b/sdk/typescript/.changes/unreleased/Fixed-20240122-140126.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Add typescript to required dependencies
+time: 2024-01-22T14:01:26.169943+01:00
+custom:
+  Author: TomChv
+  PR: "6467"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -26,7 +26,8 @@
     "node-color-log": "^10.0.2",
     "node-fetch": "^3.3.1",
     "reflect-metadata": "^0.2.1",
-    "tar": "^6.1.13"
+    "tar": "^6.1.13",
+    "typescript": "^5.3.3"
   },
   "scripts": {
     "build": "tsc",
@@ -50,7 +51,6 @@
     "eslint-plugin-prettier": "^4.2.1",
     "mocha": "^10.2.0",
     "prettier": "^2.8.7",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.3.3"
+    "ts-node": "^10.9.1"
   }
 }


### PR DESCRIPTION
Javascript projects were broken because `typescript` became a required import from [0.9.6](https://github.com/dagger/dagger/releases/tag/sdk%2Ftypescript%2Fv0.9.6) with `scan.js` importing it.

Currently, if you try to run a JS project, you'll get the following error:
```shell
┃ node:internal/modules/esm/resolve:844                                                                                                              
┃   throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);                                                                          
┃         ^                                                                                                                                          
┃                                                                                                                                                    
┃ Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'typescript' imported from /Users/tomchauveau/Documents/Quartz/playground/js-repro/node_modules/@
┃ dagger.io/dagger/dist/introspector/scanner/scan.js                                                                                                 
┃     at packageResolve (node:internal/modules/esm/resolve:844:9)                                                                                    
┃     at moduleResolve (node:internal/modules/esm/resolve:901:20)                                                                                    
┃     at defaultResolve (node:internal/modules/esm/resolve:1121:11)                                                                                  
┃     at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:396:12)                                                                       
┃     at ModuleLoader.resolve (node:internal/modules/esm/loader:365:25)                                                                              
┃     at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:240:38)                                                                         
┃     at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:85:39)                                                                         
┃     at link (node:internal/modules/esm/module_job:84:36) {                                                                                         
┃   code: 'ERR_MODULE_NOT_FOUND'  
```

This commit moves `typescript` from `devDependencies` to `dependencies` so it will be part of the deps installed when you installed `@dagger.io/dagger`