### PR TITLE
cli: Use more generic default output for core types in dagger call

### DIFF
--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -150,6 +150,7 @@ func logOutputSuccess(cmd *cobra.Command, path string) {
 func printFunctionResult(w io.Writer, r any) error {
 	switch t := r.(type) {
 	case []any:
+		// TODO: group in progrock
 		for _, v := range t {
 			if err := printFunctionResult(w, v); err != nil {
 				return err
@@ -157,6 +158,7 @@ func printFunctionResult(w io.Writer, r any) error {
 		}
 		return nil
 	case map[string]any:
+		// TODO: group in progrock
 		for _, v := range t {
 			if err := printFunctionResult(w, v); err != nil {
 				return err

--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -80,10 +80,23 @@ appending it to the end of the command (for example, *stdout*, *entries*, or
 				logOutputSuccess(cmd, outputPath)
 				return nil
 			}
+
 			// Just `sync`, don't print the result (id), but let user know.
+
+			// TODO: This is only "needed" when there's no output because
+			// you're left wondering if the command did anything. Otherwise,
+			// the output is sent only to progrock (TUI), so we'd need to check
+			// there if possible. Decide whether this message is ok in all cases,
+			// better to not print it, or to conditionally check.
 			cmd.PrintErrf("%s evaluated. Use \"%s --help\" to see available sub-commands.\n", modType.Name(), cmd.CommandPath())
 			return nil
 		default:
+			// TODO: Since IDs aren't stable to be used in the CLI, we should
+			// silence all ID results (or present in a compact way like
+			// ´<ContainerID:etpdi9gue9l5>`), but need a KindScalar TypeDef
+			// to get the name from modType.
+			// You can't select `id`, but you can select `sync`, and there
+			// may be others.
 			writer := cmd.OutOrStdout()
 
 			if outputPath != "" {
@@ -100,6 +113,7 @@ appending it to the end of the command (for example, *stdout*, *entries*, or
 				writer = io.MultiWriter(writer, file)
 			}
 
+			// especially useful for lists and maps
 			if jsonOutput {
 				jb, err := json.MarshalIndent(response, "", "    ")
 				if err != nil {

--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -115,11 +116,16 @@ appending it to the end of the command (for example, *stdout*, *entries*, or
 
 			// especially useful for lists and maps
 			if jsonOutput {
-				jb, err := json.MarshalIndent(response, "", "    ")
-				if err != nil {
+				// disable HTML escaping to improve readability
+				var buf bytes.Buffer
+				encoder := json.NewEncoder(&buf)
+				encoder.SetEscapeHTML(false)
+				encoder.SetIndent("", "    ")
+
+				if err := encoder.Encode(response); err != nil {
 					return err
 				}
-				fmt.Fprintf(writer, "%s\n", jb)
+				fmt.Fprintf(writer, "%s\n", buf.String())
 				return nil
 			}
 

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -4157,11 +4157,11 @@ class Test:
 `, content),
 			))
 
-		out, err := ctr.With(daggerCall("foo")).Stdout(ctx)
+		out, err := ctr.With(daggerCall("foo", "contents")).Stdout(ctx)
 		require.NoError(t, err)
-		require.Equal(t, strings.TrimSpace(out), content)
+		require.Equal(t, content, strings.TrimSpace(out))
 
-		out, err = ctr.With(daggerCall("--foo=dagger.json", "foo")).Stdout(ctx)
+		out, err = ctr.With(daggerCall("--foo=dagger.json", "foo", "contents")).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, `"sdk": "python"`)
 
@@ -4199,11 +4199,11 @@ class Test {
 `, content),
 			))
 
-		out, err := ctr.With(daggerCall("foo")).Stdout(ctx)
+		out, err := ctr.With(daggerCall("foo", "contents")).Stdout(ctx)
 		require.NoError(t, err)
-		require.Equal(t, strings.TrimSpace(out), content)
+		require.Equal(t, content, strings.TrimSpace(out))
 
-		out, err = ctr.With(daggerCall("--foo=dagger.json", "foo")).Stdout(ctx)
+		out, err = ctr.With(daggerCall("--foo=dagger.json", "foo", "contents")).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, `"sdk": "typescript"`)
 
@@ -4743,7 +4743,7 @@ s += depS
 	}
 	addModulesWithDeps(1, curDeps)
 
-	_, err := modGen.With(daggerCall("fn")).Stdout(ctx)
+	_, err := modGen.With(daggerCall("fn")).Sync(ctx)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
Fixes #6359 

Added `--json` option.

Need to detect a scalar typedef, to exclude printing any ID. To limit that just to sync, an alternative is to check last selection in the query builder, but need to expose `q.name()`. Another alternative is to disallow selecting `sync` explicitly in favor of ending the chain in the core type. Could also generalize by activating the convenience to all types that support `sync` instead of explicitly the 3 mages.

I suggest splitting the arbitrary user objects in another issue/PR. We need changes in the query builder to allow selecting siblings.