### PR TITLE
Add field to populate a module's description

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -1736,7 +1736,6 @@ class Minimal:
 				"Minimal object, short description",
 				mod.Get("objects.0.asObject.description").String(),
 			)
-
 		})
 	}
 }

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -1275,6 +1275,7 @@ query {
   host {
     directory(path: ".") {
       asModule {
+        description
         objects {
           asObject {
             name
@@ -1683,6 +1684,63 @@ func (m *Minimal) IsEmpty() bool {
 	require.JSONEq(t, `{"minimal": {"isEmpty": true}}`, out)
 }
 
+func TestModuleDescription(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := connect(t)
+
+	for _, tc := range []struct {
+		sdk    string
+		source string
+	}{
+		{
+			sdk: "python",
+			source: `"""Minimal module, short description
+
+Long description, with full sentences.
+"""
+
+from dagger import field, function, object_type
+
+@object_type
+class Minimal:
+    """Minimal object, short description"""
+
+    foo: str = field(default="foo")
+`,
+		},
+	} {
+		tc := tc
+
+		t.Run(tc.sdk, func(t *testing.T) {
+			t.Parallel()
+
+			modGen := c.Container().From(golangImage).
+				WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+				WithWorkdir("/work").
+				With(daggerExec("mod", "init", "--name=minimal", "--sdk="+tc.sdk)).
+				With(sdkSource(tc.sdk, tc.source))
+
+			if tc.sdk == "go" {
+				logGen(ctx, t, modGen.Directory("."))
+			}
+
+			out, err := modGen.With(inspectModule).Stdout(ctx)
+			require.NoError(t, err)
+			mod := gjson.Get(out, "host.directory.asModule")
+			require.Equal(t,
+				"Minimal module, short description\n\nLong description, with full sentences.",
+				mod.Get("description").String(),
+			)
+			require.Equal(t,
+				"Minimal object, short description",
+				mod.Get("objects.0.asObject.description").String(),
+			)
+
+		})
+	}
+}
+
 func TestModulePrivateField(t *testing.T) {
 	t.Parallel()
 
@@ -1915,7 +1973,7 @@ class Test {
   repeater(msg: string, times: number): Repeater {
     return new Repeater(msg, times)
   }
-}			
+}
 `,
 		},
 	} {
@@ -2081,7 +2139,7 @@ import { object, func, field } from "@dagger.io/dagger"
 
 @object
 class X {
-  @field 
+  @field
   message: string
 
   @field
@@ -2578,7 +2636,7 @@ class Foo {
   async fn(): Promise<string> {
     return someDefault.withExec(["echo", "foo"]).stdout()
   }
-}			
+}
 `,
 		},
 	} {
@@ -3823,46 +3881,46 @@ import { Directory, object, func, field } from '@dagger.io/dagger';
 class Test {
 	@field
 	foo: string
-				
+
 	@field
 	dir: Directory
-				
+
 	@field
 	bar: number
-				
+
 	@field
 	baz: string[]
-				
+
 	@field
 	neverSetDir?: Directory
-				
+
 	constructor(foo: string, dir: Directory, bar = 42, baz: string[] = []) {
 		this.foo = foo;
 		this.dir = dir;
 		this.bar = bar;
 		this.baz = baz;
 	}
-				
+
 	@func
 	gimmeFoo(): string {
 		return this.foo;
 	}
-				
+
 	@func
 	gimmeBar(): number {
 		return this.bar;
 	}
-				
+
 	@func
 	gimmeBaz(): string[] {
 		return this.baz;
 	}
-				
+
 	@func
 	async gimmeDirEnts(): Promise<string[]> {
 		return this.dir.entries();
 	}
-}					
+}
 `,
 			},
 		} {
@@ -3980,7 +4038,7 @@ class Test {
       return this; // Return the newly-created instance
     })();
   }
-}				
+}
 `,
 			},
 		} {
@@ -4048,7 +4106,7 @@ class Test {
   constructor() {
     throw new Error("too bad")
   }
-}				
+}
 `,
 			},
 		} {
@@ -4440,7 +4498,7 @@ func TestModuleTypescriptInit(t *testing.T) {
 					return dag.container().from("alpine:latest").withExec(["echo", stringArg])
 				  }
 				}
-					
+
 				`,
 			}).
 			With(daggerExec("mod", "init", "--name=existingSource", "--sdk=typescript"))
@@ -4562,7 +4620,7 @@ class PotatoSack {
   @func
   potato_%d(): string {
     return "potato #%d"
-  }			
+  }
 			`, i, i)
 		}
 

--- a/core/module.go
+++ b/core/module.go
@@ -23,7 +23,7 @@ type Module struct {
 	NameField string `field:"true" name:"name" doc:"The name of the module"`
 
 	// The doc string of the module, if any
-	Description *string `field:"true" doc:"The doc string of the module, if any"`
+	Description string `field:"true" doc:"The doc string of the module, if any"`
 
 	// The module's SDKConfig, as set in the module config file
 	SDKConfig string `field:"true" name:"sdk" doc:"The SDK used by this module. Either a name of a builtin SDK or a module ref pointing to the SDK's implementation."`
@@ -572,6 +572,12 @@ func (mod Module) Clone() *Module {
 		cp.InterfaceDefs[i] = def.Clone()
 	}
 	return &cp
+}
+
+func (mod *Module) WithDescription(desc string) *Module {
+	mod = mod.Clone()
+	mod.Description = strings.TrimSpace(desc)
+	return mod
 }
 
 func (mod *Module) WithObject(ctx context.Context, def *TypeDef) (*Module, error) {

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -89,6 +89,10 @@ func (s *moduleSchema) Install() {
 		dagql.NodeFunc("initialize", s.moduleInitialize).
 			Doc(`Retrieves the module with the objects loaded via its SDK.`),
 
+		dagql.Func("withDescription", s.moduleWithDescription).
+			Doc(`Retrieves the module with the given description`).
+			ArgDoc("description", `The description to set`),
+
 		dagql.Func("withObject", s.moduleWithObject).
 			Doc(`This module plus the given Object type and associated functions.`),
 
@@ -469,6 +473,12 @@ func (s *moduleSchema) functionCallReturnValue(ctx context.Context, fnCall *core
 }) (dagql.Nullable[core.Void], error) {
 	// TODO: error out if caller is not coming from a module
 	return dagql.Null[core.Void](), fnCall.ReturnValue(ctx, args.Value)
+}
+
+func (s *moduleSchema) moduleWithDescription(ctx context.Context, modMeta *core.Module, args struct {
+	Description string
+}) (*core.Module, error) {
+	return modMeta.WithDescription(args.Description), nil
 }
 
 func (s *moduleSchema) moduleWithObject(ctx context.Context, modMeta *core.Module, args struct {

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -1432,7 +1432,7 @@ scalar ListTypeDefID
 type Module {
   dependencies: [Module!]!
   dependencyConfig: [String!]!
-  description: String
+  description: String!
   generatedCode: GeneratedCode!
 
   """A unique identifier for this Module."""
@@ -1454,6 +1454,12 @@ type Module {
   serve: Void
   sourceDirectory: Directory!
   sourceDirectorySubpath: String!
+
+  """Retrieves the module with the given description"""
+  withDescription(
+    """The description to set"""
+    description: String!
+  ): Module!
 
   """This module plus the given Interface type and associated functions"""
   withInterface(iface: TypeDefID!): Module!

--- a/sdk/elixir/lib/dagger/gen/module.ex
+++ b/sdk/elixir/lib/dagger/gen/module.ex
@@ -14,7 +14,7 @@ defmodule Dagger.Module do
       selection =
         select(
           selection,
-          "dependencies dependencyConfig description generatedCode id initialize interfaces name objects sdk serve sourceDirectory sourceDirectorySubpath withInterface withObject withSource"
+          "dependencies dependencyConfig description generatedCode id initialize interfaces name objects sdk serve sourceDirectory sourceDirectorySubpath withDescription withInterface withObject withSource"
         )
 
       with {:ok, data} <- execute(selection, module.client) do
@@ -41,7 +41,7 @@ defmodule Dagger.Module do
 
   (
     @doc ""
-    @spec description(t()) :: {:ok, Dagger.String.t() | nil} | {:error, term()}
+    @spec description(t()) :: {:ok, Dagger.String.t()} | {:error, term()}
     def description(%__MODULE__{} = module) do
       selection = select(module.selection, "description")
       execute(selection, module.client)
@@ -167,6 +167,16 @@ defmodule Dagger.Module do
     def source_directory_subpath(%__MODULE__{} = module) do
       selection = select(module.selection, "sourceDirectorySubpath")
       execute(selection, module.client)
+    end
+  )
+
+  (
+    @doc "Retrieves the module with the given description\n\n## Required Arguments\n\n* `description` - The description to set"
+    @spec with_description(t(), Dagger.String.t()) :: Dagger.Module.t()
+    def with_description(%__MODULE__{} = module, description) do
+      selection = select(module.selection, "withDescription")
+      selection = arg(selection, "description", description)
+      %Dagger.Module{selection: selection, client: module.client}
     end
   )
 

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -3932,6 +3932,17 @@ func (r *Module) SourceDirectorySubpath(ctx context.Context) (string, error) {
 	return response, q.Execute(ctx, r.c)
 }
 
+// Retrieves the module with the given description
+func (r *Module) WithDescription(description string) *Module {
+	q := r.q.Select("withDescription")
+	q = q.Arg("description", description)
+
+	return &Module{
+		q: q,
+		c: r.c,
+	}
+}
+
 // This module plus the given Interface type and associated functions
 func (r *Module) WithInterface(iface *TypeDef) *Module {
 	assertNotNil("iface", iface)

--- a/sdk/php/generated/Module.php
+++ b/sdk/php/generated/Module.php
@@ -103,6 +103,16 @@ class Module extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * Retrieves the module with the given description
+     */
+    public function withDescription(string $description): Module
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withDescription');
+        $innerQueryBuilder->setArgument('description', $description);
+        return new \Dagger\Module($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
      * This module plus the given Interface type and associated functions
      */
     public function withInterface(TypeDefId|TypeDef $iface): Module

--- a/sdk/python/dev/src/main/__init__.py
+++ b/sdk/python/dev/src/main/__init__.py
@@ -1,3 +1,4 @@
+"""The Python SDK's development module."""
 import logging
 import uuid
 from collections.abc import Sequence

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -3829,10 +3829,10 @@ class Module(Type):
         return await _ctx.execute(list[str])
 
     @typecheck
-    async def description(self) -> str | None:
+    async def description(self) -> str:
         """Returns
         -------
-        str | None
+        str
             The `String` scalar type represents textual data, represented as
             UTF-8 character sequences. The String type is most often used by
             GraphQL to represent free-form human-readable text.
@@ -3848,7 +3848,7 @@ class Module(Type):
             return self._description
         _args: list[Arg] = []
         _ctx = self._select("description", _args)
-        return await _ctx.execute(str | None)
+        return await _ctx.execute(str)
 
     @typecheck
     def generated_code(self) -> GeneratedCode:
@@ -4005,6 +4005,21 @@ class Module(Type):
         _args: list[Arg] = []
         _ctx = self._select("sourceDirectorySubpath", _args)
         return await _ctx.execute(str)
+
+    @typecheck
+    def with_description(self, description: str) -> "Module":
+        """Retrieves the module with the given description
+
+        Parameters
+        ----------
+        description:
+            The description to set
+        """
+        _args = [
+            Arg("description", description),
+        ]
+        _ctx = self._select("withDescription", _args)
+        return Module(_ctx)
 
     @typecheck
     def with_interface(self, iface: "TypeDef") -> "Module":

--- a/sdk/python/src/dagger/mod/_module.py
+++ b/sdk/python/src/dagger/mod/_module.py
@@ -9,7 +9,7 @@ import types
 import typing
 from collections import Counter, defaultdict
 from collections.abc import Callable, Mapping, MutableMapping
-from typing import Any, TypeAlias, TypeVar
+from typing import Any, Self, TypeAlias, TypeVar
 
 import anyio
 import cattrs
@@ -76,6 +76,11 @@ class Module:
         self._resolvers: list[Resolver] = []
         self._fn_call = dag.current_function_call()
         self._mod = dag.current_module()
+
+    def with_description(self, description: str | None) -> Self:
+        if description:
+            self._mod = self._mod.with_description(description)
+        return self
 
     def add_resolver(self, resolver: Resolver):
         self._resolvers.append(resolver)

--- a/sdk/python/src/dagger/mod/_module.py
+++ b/sdk/python/src/dagger/mod/_module.py
@@ -9,13 +9,13 @@ import types
 import typing
 from collections import Counter, defaultdict
 from collections.abc import Callable, Mapping, MutableMapping
-from typing import Any, Self, TypeAlias, TypeVar
+from typing import Any, TypeAlias, TypeVar
 
 import anyio
 import cattrs
 import cattrs.gen
 from rich.console import Console
-from typing_extensions import dataclass_transform, overload
+from typing_extensions import Self, dataclass_transform, overload
 
 import dagger
 from dagger import dag

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -3745,6 +3745,20 @@ impl Module {
         let query = self.selection.select("sourceDirectorySubpath");
         query.execute(self.graphql_client.clone()).await
     }
+    /// Retrieves the module with the given description
+    ///
+    /// # Arguments
+    ///
+    /// * `description` - The description to set
+    pub fn with_description(&self, description: impl Into<String>) -> Module {
+        let mut query = self.selection.select("withDescription");
+        query = query.arg("description", description.into());
+        return Module {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        };
+    }
     /// This module plus the given Interface type and associated functions
     pub fn with_interface(&self, iface: TypeDef) -> Module {
         let mut query = self.selection.select("withInterface");

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -4892,6 +4892,23 @@ export class Module_ extends BaseClient {
   }
 
   /**
+   * Retrieves the module with the given description
+   * @param description The description to set
+   */
+  withDescription = (description: string): Module_ => {
+    return new Module_({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "withDescription",
+          args: { description },
+        },
+      ],
+      ctx: this._ctx,
+    })
+  }
+
+  /**
    * This module plus the given Interface type and associated functions
    */
   withInterface = (iface: TypeDef): Module_ => {


### PR DESCRIPTION
We had a `Module.description` field in the schema but no way of populating it. Rather than make the main object's description the module description, we can cleanly separate those two in the SDKs. The consumer can, for example, default to the main object's description if there's no module description.

Only Python supports this for now.

Module authors simply add a [docstring to the top](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) of their `src/main.py` module (or `src/main/__init__.py` package):

```python
"""My Foo module's description."""

from dagger import object_type

@object_type
class Foo:
    """My Foo object's description."""
```

Now, from a module dir we can inspect the description from the API:

![image](https://github.com/dagger/dagger/assets/174525/b12025cd-b8e6-4aee-be38-2058610e4719)


\cc @grouville @jpadams