### PR TITLE
ci: use dagger secrets during sdk publish steps

### DIFF
--- a/internal/mage/sdk/elixir.go
+++ b/internal/mage/sdk/elixir.go
@@ -3,7 +3,6 @@ package sdk
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -142,7 +141,7 @@ func (Elixir) Generate(ctx context.Context) error {
 		return err
 	}
 	if !ok {
-		return fmt.Errorf("Cannot export generated code to `%s`", elixirSDKGeneratedPath)
+		return fmt.Errorf("cannot export generated code to `%s`", elixirSDKGeneratedPath)
 	}
 	return nil
 }
@@ -156,15 +155,10 @@ func (Elixir) Publish(ctx context.Context, tag string) error {
 	defer c.Close()
 
 	var (
-		version   = strings.TrimPrefix(tag, "sdk/elixir/v")
-		mixFile   = "sdk/elixir/mix.exs"
-		hexAPIKey = os.Getenv("HEX_API_KEY")
-		dryRun    = os.Getenv("HEX_DRY_RUN")
+		version = strings.TrimPrefix(tag, "sdk/elixir/v")
+		mixFile = "sdk/elixir/mix.exs"
+		dryRun  = os.Getenv("HEX_DRY_RUN")
 	)
-
-	if hexAPIKey == "" {
-		return errors.New("HEX_API_KEY environment variable must be set")
-	}
 
 	mixExs, err := os.ReadFile(mixFile)
 	if err != nil {
@@ -184,7 +178,7 @@ func (Elixir) Publish(ctx context.Context, tag string) error {
 	c = c.Pipeline("sdk").Pipeline("elixir").Pipeline("generate")
 
 	_, err = elixirBase(c, elixirVersions[1]).
-		WithEnvVariable("HEX_API_KEY", hexAPIKey).
+		With(util.HostSecretVar(c, "HEX_API_KEY")).
 		WithExec(args).
 		Sync(ctx)
 

--- a/internal/mage/sdk/go.go
+++ b/internal/mage/sdk/go.go
@@ -147,10 +147,9 @@ func (t Go) Publish(ctx context.Context, tag string) error {
 		WithExec([]string{"apk", "add", "-U", "--no-cache", "git"}).
 		WithExec([]string{"git", "config", "--global", "user.name", gitUserName}).
 		WithExec([]string{"git", "config", "--global", "user.email", gitUserEmail}).
-		WithExec([]string{"git", "config", "--global",
-			"http.https://github.com/.extraheader",
-			fmt.Sprintf("AUTHORIZATION: Basic %s", encodedPAT),
-		})
+		WithEnvVariable("GIT_CONFIG_COUNT", "1").
+		WithEnvVariable("GIT_CONFIG_KEY_0", "http.https://github.com/.extraheader").
+		WithSecretVariable("GIT_CONFIG_VALUE_0", c.SetSecret("GITHUB_HEADER", fmt.Sprintf("AUTHORIZATION: Basic %s", encodedPAT)))
 
 	repository := git.
 		WithEnvVariable("CACHEBUSTER", identity.NewID()).

--- a/internal/mage/sdk/php.go
+++ b/internal/mage/sdk/php.go
@@ -116,15 +116,13 @@ func (t PHP) Publish(ctx context.Context, tag string) error {
 		gitUserEmail = "hello@dagger.io"
 	}
 
-	git := util.GoBase(c).
+	_, err = util.GoBase(c).
 		WithExec([]string{"apk", "add", "-U", "--no-cache", "git"}).
 		WithExec([]string{"git", "config", "--global", "user.name", gitUserName}).
 		WithExec([]string{"git", "config", "--global", "user.email", gitUserEmail}).
 		WithEnvVariable("GIT_CONFIG_COUNT", "1").
 		WithEnvVariable("GIT_CONFIG_KEY_0", "http.https://github.com/.extraheader").
-		WithSecretVariable("GIT_CONFIG_VALUE_0", c.SetSecret("GITHUB_HEADER", fmt.Sprintf("AUTHORIZATION: Basic %s", encodedPAT)))
-
-	_, err = git.
+		WithSecretVariable("GIT_CONFIG_VALUE_0", c.SetSecret("GITHUB_HEADER", fmt.Sprintf("AUTHORIZATION: Basic %s", encodedPAT))).
 		WithEnvVariable("CACHEBUSTER", identity.NewID()).
 		WithExec([]string{"git", "clone", "https://github.com/dagger/dagger.git", "/src/dagger"}).
 		WithWorkdir("/src/dagger").

--- a/internal/mage/sdk/typescript.go
+++ b/internal/mage/sdk/typescript.go
@@ -153,12 +153,10 @@ func (t TypeScript) Publish(ctx context.Context, tag string) error {
 	npmrc := fmt.Sprintf(`//registry.npmjs.org/:_authToken=%s
 registry=https://registry.npmjs.org/
 always-auth=true`, token)
-	if err = os.WriteFile("sdk/typescript/.npmrc", []byte(npmrc), 0o600); err != nil {
-		return err
-	}
 
 	// set version & publish
 	_, err = build.
+		WithMountedSecret(".npmrc", c.SetSecret("npmrc", npmrc)).
 		WithExec([]string{"npm", "version", version}).
 		WithExec([]string{"npm", "publish", "--access", "public"}).
 		Sync(ctx)


### PR DESCRIPTION
Use dagger secrets for concealing secrets in SDK publish steps.