### PR TITLE
ci: remove `ready_for_review` trigger for prs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,6 @@ on:
       - opened
       - synchronize
       - reopened
-      - ready_for_review
   # Enable manual trigger for easy debugging
   workflow_dispatch:
 

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -8,7 +8,6 @@ on:
       - opened
       - synchronize
       - reopened
-      - ready_for_review
   # Enable manual trigger for easy debugging
   workflow_dispatch:
 

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -8,7 +8,6 @@ on:
       - opened
       - synchronize
       - reopened
-      - ready_for_review
   # Enable manual trigger for easier debugging
   workflow_dispatch:
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,6 @@ on:
       - opened
       - synchronize
       - reopened
-      - ready_for_review
     paths:
       - sdk/go/internal/engineconn/version.gen.go
       - sdk/python/src/dagger/_engine/_version.py

--- a/.github/workflows/sdk-elixir.yml
+++ b/.github/workflows/sdk-elixir.yml
@@ -8,7 +8,6 @@ on:
       - opened
       - synchronize
       - reopened
-      - ready_for_review
   # Enable manual trigger for easier debugging
   workflow_dispatch:
 

--- a/.github/workflows/sdk-go.yml
+++ b/.github/workflows/sdk-go.yml
@@ -8,7 +8,6 @@ on:
       - opened
       - synchronize
       - reopened
-      - ready_for_review
   # Enable manual trigger for easier debugging
   workflow_dispatch:
 

--- a/.github/workflows/sdk-java.yml
+++ b/.github/workflows/sdk-java.yml
@@ -8,7 +8,6 @@ on:
       - opened
       - synchronize
       - reopened
-      - ready_for_review
   # Enable manual trigger for easier debugging
   workflow_dispatch:
 

--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -8,7 +8,6 @@ on:
       - opened
       - synchronize
       - reopened
-      - ready_for_review
   # Enable manual trigger for easier debugging
   workflow_dispatch:
 

--- a/.github/workflows/sdk-rust.yml
+++ b/.github/workflows/sdk-rust.yml
@@ -8,7 +8,6 @@ on:
       - opened
       - synchronize
       - reopened
-      - ready_for_review
   # Enable manual trigger for easier debugging
   workflow_dispatch:
 

--- a/.github/workflows/sdk-typescript.yml
+++ b/.github/workflows/sdk-typescript.yml
@@ -8,7 +8,6 @@ on:
       - opened
       - synchronize
       - reopened
-      - ready_for_review
   # Enable manual trigger for easier debugging
   workflow_dispatch:
 


### PR DESCRIPTION
These were added in https://github.com/dagger/dagger/commit/e4e5fa65ac5ebc0ed58b92f6cd9d29156a63e132.

`opened`, `synchronize` and `reopened` make sense to me - these are all cases when changes are made to the PR (and re-opened is quite rare, but given that main may have moved on since then, it can be useful to re-run).

However, `ready_for_review` often doesn't mean any actual changes to the content of the PR, and happens much more frequently, so it makes sense to skip this.