### PR TITLE
Fix linguist mark in php in elixir codegen

### DIFF
--- a/sdk/elixir/.gitattributes
+++ b/sdk/elixir/.gitattributes
@@ -1,1 +1,1 @@
-/lib/dagger/gen/ linguist-generated=true
+lib/dagger/gen/** linguist-generated

--- a/sdk/php/.gitattributes
+++ b/sdk/php/.gitattributes
@@ -1,1 +1,1 @@
-/generated/ linguist-generated=true
+generated/** linguist-generated


### PR DESCRIPTION
Follow up to #6447 as I've noticed PHP and Elixir generated files still show in diffs.

Tested with [linguist](https://daggerverse.dev/mod/github.com/helderco/daggerverse/linguist@2b3439af53ac0232a39b3589dc65bf3fb171c2e4#Linguist.run):

<img width="1167" alt="Screenshot 2024-01-24 at 12 36 00" src="https://github.com/dagger/dagger/assets/174525/cfb8ea6b-83bb-4451-94d9-b43a1b1978f9">
