### PR TITLE
ci: add dry-run targets for SDK publishing

### DIFF
--- a/internal/mage/sdk/go.go
+++ b/internal/mage/sdk/go.go
@@ -3,9 +3,9 @@ package sdk
 import (
 	"context"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/dagger/dagger/internal/mage/util"
@@ -122,16 +122,12 @@ func (t Go) Publish(ctx context.Context, tag string) error {
 
 	var targetTag = strings.TrimPrefix(tag, "sdk/go/")
 
+	dryRun, _ := strconv.ParseBool(os.Getenv("DRY_RUN"))
+
 	var targetRepo = os.Getenv("TARGET_REPO")
 	if targetRepo == "" {
 		targetRepo = "https://github.com/dagger/dagger-go-sdk.git"
 	}
-
-	var pat = os.Getenv("GITHUB_PAT")
-	if pat == "" {
-		return errors.New("GITHUB_PAT environment variable must be set")
-	}
-	encodedPAT := base64.URLEncoding.EncodeToString([]byte("pat:" + pat))
 
 	var gitUserName = os.Getenv("GIT_USER_NAME")
 	if gitUserName == "" {
@@ -143,13 +139,20 @@ func (t Go) Publish(ctx context.Context, tag string) error {
 		gitUserEmail = "hello@dagger.io"
 	}
 
-	_, err = util.GoBase(c).
+	git := util.GoBase(c).
 		WithExec([]string{"apk", "add", "-U", "--no-cache", "git"}).
 		WithExec([]string{"git", "config", "--global", "user.name", gitUserName}).
-		WithExec([]string{"git", "config", "--global", "user.email", gitUserEmail}).
-		WithEnvVariable("GIT_CONFIG_COUNT", "1").
-		WithEnvVariable("GIT_CONFIG_KEY_0", "http.https://github.com/.extraheader").
-		WithSecretVariable("GIT_CONFIG_VALUE_0", c.SetSecret("GITHUB_HEADER", fmt.Sprintf("AUTHORIZATION: Basic %s", encodedPAT))).
+		WithExec([]string{"git", "config", "--global", "user.email", gitUserEmail})
+	if !dryRun {
+		pat := util.GetHostEnv("GITHUB_PAT")
+		encodedPAT := base64.URLEncoding.EncodeToString([]byte("pat:" + pat))
+		git = git.
+			WithEnvVariable("GIT_CONFIG_COUNT", "1").
+			WithEnvVariable("GIT_CONFIG_KEY_0", "http.https://github.com/.extraheader").
+			WithSecretVariable("GIT_CONFIG_VALUE_0", c.SetSecret("GITHUB_HEADER", fmt.Sprintf("AUTHORIZATION: Basic %s", encodedPAT)))
+	}
+
+	result := git.
 		WithEnvVariable("CACHEBUSTER", identity.NewID()).
 		WithExec([]string{"git", "clone", "https://github.com/dagger/dagger.git", "/src/dagger"}).
 		WithWorkdir("/src/dagger").
@@ -159,16 +162,17 @@ func (t Go) Publish(ctx context.Context, tag string) error {
 			"--subdirectory-filter", "sdk/go",
 			"--tree-filter", "if [ -f go.mod ]; then go mod edit -dropreplace github.com/dagger/dagger; fi",
 			"--", tag,
-		}).
-		WithExec([]string{
+		})
+	if !dryRun {
+		result = result.WithExec([]string{
 			"git",
 			"push",
 			"-f",
 			targetRepo,
 			fmt.Sprintf("%s:%s", tag, targetTag),
-		}).
-		Sync(ctx)
-
+		})
+	}
+	_, err = result.Sync(ctx)
 	return err
 }
 

--- a/internal/mage/sdk/java.go
+++ b/internal/mage/sdk/java.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"dagger.io/dagger"
@@ -136,13 +137,12 @@ func (Java) Publish(ctx context.Context, tag string) error {
 	}
 	defer c.Close()
 
-	var (
-		version = strings.TrimPrefix(tag, "sdk/java/v")
-		dryRun  = os.Getenv("MVN_DEPLOY_DRY_RUN")
-	)
+	version := strings.TrimPrefix(tag, "sdk/java/v")
+
+	dryRun, _ := strconv.ParseBool(os.Getenv("DRY_RUN"))
 
 	skipDeploy := "true" // FIXME: Always set to true as long as the maven central deployment is not configured
-	if dryRun != "" {
+	if dryRun {
 		skipDeploy = "true"
 	}
 

--- a/internal/mage/sdk/typescript.go
+++ b/internal/mage/sdk/typescript.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 
 	"dagger.io/dagger"
@@ -142,25 +143,31 @@ func (t TypeScript) Publish(ctx context.Context, tag string) error {
 
 	c = c.Pipeline("sdk").Pipeline("typescript").Pipeline("publish")
 
-	var (
-		version = strings.TrimPrefix(tag, "sdk/typescript/v")
-		token   = os.Getenv("NPM_TOKEN")
-	)
+	version := strings.TrimPrefix(tag, "sdk/typescript/v")
 
-	build := nodeJsBase(c).WithExec([]string{"npm", "run", "build"})
+	dryRun, _ := strconv.ParseBool(os.Getenv("DRY_RUN"))
+
+	// build and set version
+	build := nodeJsBase(c).
+		WithExec([]string{"npm", "run", "build"}).
+		WithExec([]string{"npm", "version", version})
 
 	// configure .npmrc
-	npmrc := fmt.Sprintf(`//registry.npmjs.org/:_authToken=%s
+	if !dryRun {
+		token := util.GetHostEnv("NPM_TOKEN")
+		npmrc := fmt.Sprintf(`//registry.npmjs.org/:_authToken=%s
 registry=https://registry.npmjs.org/
 always-auth=true`, token)
+		build = build.WithMountedSecret(".npmrc", c.SetSecret("npmrc", npmrc))
+	}
 
-	// set version & publish
-	_, err = build.
-		WithMountedSecret(".npmrc", c.SetSecret("npmrc", npmrc)).
-		WithExec([]string{"npm", "version", version}).
-		WithExec([]string{"npm", "publish", "--access", "public"}).
-		Sync(ctx)
+	// publish
+	publish := build.WithExec([]string{"npm", "publish", "--access", "public"})
+	if dryRun {
+		publish = build.WithExec([]string{"npm", "publish", "--access", "public", "--dry-run"})
+	}
 
+	_, err = publish.Sync(ctx)
 	return err
 }
 


### PR DESCRIPTION
Follow-up to #6463 (and related to #6488)

This PR introduces `DRY_RUN` to all SDK publish mage jobs, allowing any of them to be run and tested locally.
- Adds `DRY_RUN` to python, go, typescript and php
- Renames `HEX_DRY_RUN` to `DRY_RUN` for elixir
- Renames `CARGO_PUBLISH_DRYRUN` to `DRY_RUN` for rust
- Renames `MVN_DEPLOY_DRY_RUN` to `DRY_RUN` for java

The idea is to prevent issues like #6464 from appearing only during the release process, and instead to show up as soon as possible.