### PR TITLE
hack: send SIGQUIT to testdev if we run too long

### DIFF
--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -39,6 +39,9 @@ jobs:
             export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev
           fi
           ./hack/make ${{ inputs.mage-targets }}
+      - name: "ALWAYS print engine logs - if available"
+        if: always() && inputs.dev-engine
+        run: docker logs $(docker ps -q --filter name=dagger-engine)
       - name: "ALWAYS print kernel logs - especialy useful on failure"
         if: always()
         run: sudo dmesg
@@ -66,6 +69,9 @@ jobs:
         env:
           _EXPERIMENTAL_DAGGER_RUNNER_HOST: "unix:///var/run/buildkit/buildkitd.sock"
           _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
+      - name: "ALWAYS print engine logs - if available"
+        if: always() && inputs.dev-engine
+        run: docker logs $(docker ps -q --filter name=dagger-engine)
       - name: "ALWAYS print kernel logs - especialy useful on failure"
         if: always()
         run: sudo dmesg

--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -37,6 +37,10 @@ jobs:
             export _EXPERIMENTAL_DAGGER_CLI_BIN="$PWD/bin/dagger"
             chmod +x $_EXPERIMENTAL_DAGGER_CLI_BIN
             export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev
+
+            # if we're stillaround after a *long* while, we've probably
+            # deadlocked - so send SIGQUIT to the dagger engine
+            (sleep 55m && docker exec $(docker ps -q --filter name=dagger-engine) sh -c 'set -x; ps aux; pstree -p; kill -QUIT $(pgrep -n dagger-engine)') &
           fi
           ./hack/make ${{ inputs.mage-targets }}
       - name: "ALWAYS print engine logs - if available"
@@ -64,6 +68,10 @@ jobs:
             export _EXPERIMENTAL_DAGGER_CLI_BIN="$PWD/bin/dagger"
             chmod +x $_EXPERIMENTAL_DAGGER_CLI_BIN
             export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev
+
+            # if we're stillaround after a *long* while, we've probably
+            # deadlocked - so send SIGQUIT to the dagger engine
+            (sleep 55m && docker exec $(docker ps -q --filter name=dagger-engine) sh -c 'set -x; ps aux; pstree -p; kill -QUIT $(pgrep -n dagger-engine)') &
           fi
           ./hack/make ${{ inputs.mage-targets }}
         env:


### PR DESCRIPTION
:scream: we're still seeing the weird deadlocks from the buildkit upgrade, *even after* pulling in https://github.com/dagger/dagger/pull/6479 (it looks like other non-blocked tests keep running now, but the blocked tests are still an issue).

This PR tries to dump a ton more information in these scenarios.

The weird sleep and "docker exec" to send SIGQUIT *should* be removed once the source of the deadlock is resolved, since it's very very hacky, but should work to at least grab some info for this - I can't repro this locally easily.