### PR TITLE
ci: split out starting engine step

### DIFF
--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -29,15 +29,22 @@ jobs:
         with:
           go-version: "1.21"
           cache-dependency-path: "internal/mage/go.sum"
-      - name: ${{ inputs.mage-targets }}
+      - name: Waiting for engine to be ready
         run: |
           if [ "${{ inputs.dev-engine }}" == "true" ]
           then
             ./hack/dev
+
             export _EXPERIMENTAL_DAGGER_CLI_BIN="$PWD/bin/dagger"
-            chmod +x $_EXPERIMENTAL_DAGGER_CLI_BIN
+            echo "_EXPERIMENTAL_DAGGER_CLI_BIN=${_EXPERIMENTAL_DAGGER_CLI_BIN}" >> "$GITHUB_ENV"
             export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev
+            echo "_EXPERIMENTAL_DAGGER_RUNNER_HOST=${_EXPERIMENTAL_DAGGER_RUNNER_HOST}" >> "$GITHUB_ENV"
+
+            chmod +x $_EXPERIMENTAL_DAGGER_CLI_BIN
           fi
+          ./hack/make engine:connect
+      - name: ${{ inputs.mage-targets }}
+        run: |
           ./hack/make ${{ inputs.mage-targets }}
       - name: "ALWAYS print kernel logs - especialy useful on failure"
         if: always()
@@ -53,18 +60,29 @@ jobs:
         with:
           go-version: "1.21"
           cache-dependency-path: "internal/mage/go.sum"
-      - name: ${{ inputs.mage-targets }}
+      - name: Waiting for engine to be ready
         run: |
           if [ "${{ inputs.dev-engine }}" == "true" ]
           then
             ./hack/dev
+
             export _EXPERIMENTAL_DAGGER_CLI_BIN="$PWD/bin/dagger"
             chmod +x $_EXPERIMENTAL_DAGGER_CLI_BIN
+            echo "_EXPERIMENTAL_DAGGER_CLI_BIN=${_EXPERIMENTAL_DAGGER_CLI_BIN}" >> "$GITHUB_ENV"
+
             export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev
           fi
-          ./hack/make ${{ inputs.mage-targets }}
+
+          echo "_EXPERIMENTAL_DAGGER_RUNNER_HOST=${_EXPERIMENTAL_DAGGER_RUNNER_HOST}" >> "$GITHUB_ENV"
+
+          ./hack/make engine:connect
         env:
           _EXPERIMENTAL_DAGGER_RUNNER_HOST: "unix:///var/run/buildkit/buildkitd.sock"
+          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
+      - name: ${{ inputs.mage-targets }}
+        run: |
+          ./hack/make ${{ inputs.mage-targets }}
+        env:
           _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
       - name: "ALWAYS print kernel logs - especialy useful on failure"
         if: always()

--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -18,8 +18,7 @@ on:
         required: false
 
 jobs:
-  # Use a free GitHub Actions runner when
-  # NOT running in the dagger/dagger repo
+  # Use a free GitHub Actions runner when NOT running in the dagger/dagger repo
   github-free-runner:
     if: ${{ github.repository != 'dagger/dagger' }}
     runs-on: ubuntu-latest
@@ -29,7 +28,7 @@ jobs:
         with:
           go-version: "1.21"
           cache-dependency-path: "internal/mage/go.sum"
-      - name: Waiting for engine to be ready
+      - name: Waiting for Dagger Engine to be ready...
         run: |
           if [ "${{ inputs.dev-engine }}" == "true" ]
           then
@@ -60,7 +59,7 @@ jobs:
         with:
           go-version: "1.21"
           cache-dependency-path: "internal/mage/go.sum"
-      - name: Waiting for engine to be ready
+      - name: Waiting for Dagger Engine to be ready...
         run: |
           if [ "${{ inputs.dev-engine }}" == "true" ]
           then

--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -37,7 +37,7 @@ func parseRef(tag string) error {
 
 type Engine mg.Namespace
 
-// Connect tests a connection to a dagger engine
+// Connect tests a connection to a Dagger Engine
 func (t Engine) Connect(ctx context.Context) error {
 	c, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
 	if err != nil {
@@ -47,7 +47,7 @@ func (t Engine) Connect(ctx context.Context) error {
 	return nil
 }
 
-// Build builds the dagger cli binary
+// Build builds the Dagger CLI binary
 func (t Engine) Build(ctx context.Context) error {
 	c, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
 	if err != nil {
@@ -61,7 +61,7 @@ func (t Engine) Build(ctx context.Context) error {
 	return err
 }
 
-// Lint lints the engine
+// Lint lints the Engine
 func (t Engine) Lint(ctx context.Context) error {
 	c, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
 	if err != nil {
@@ -141,7 +141,7 @@ func (t Engine) Publish(ctx context.Context, version string) error {
 	return nil
 }
 
-// Verify that all arches for the engine can be built. Just do a local export to avoid setting up
+// Verify that all arches for the Engine can be built. Just do a local export to avoid setting up
 // a registry
 func (t Engine) TestPublish(ctx context.Context) error {
 	c, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
@@ -231,6 +231,7 @@ func (t Engine) TestCustom(ctx context.Context) error {
 	return err
 }
 
+// Dev builds and starts an Engine & CLI from local source code
 func (t Engine) Dev(ctx context.Context) error {
 	c, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
 	if err != nil {
@@ -323,7 +324,7 @@ func (t Engine) Dev(ctx context.Context) error {
 		return fmt.Errorf("docker run: %w: %s", err, output)
 	}
 
-	// build the CLI and export locally so it can be used to connect to the engine
+	// build the CLI and export locally so it can be used to connect to the Engine
 	binDest := filepath.Join(os.Getenv("DAGGER_SRC_ROOT"), "bin", "dagger")
 	_ = os.Remove(binDest) // HACK(vito): avoid 'text file busy'.
 	_, err = util.HostDaggerBinary(c).Export(ctx, binDest)

--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -37,6 +37,16 @@ func parseRef(tag string) error {
 
 type Engine mg.Namespace
 
+// Connect tests a connection to a dagger engine
+func (t Engine) Connect(ctx context.Context) error {
+	c, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+	return nil
+}
+
 // Build builds the dagger cli binary
 func (t Engine) Build(ctx context.Context) error {
 	c, err := dagger.Connect(ctx, dagger.WithLogOutput(os.Stderr))


### PR DESCRIPTION
As discussed this morning :tada:

We can have a dedicated starting engine step, which will connect to the engine, start a session, and immediately disconnect.

If the engine isn't already started, this starts it! In the future, we can use honeycomb and more quickly identify issues with too many cache volumes, etc.