### PR TITLE
fix: allow non-root users to use withExec with stdin

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -1723,7 +1723,7 @@ func metaMount(stdin string) (llb.State, string) {
 	// TODO(vito): have the shim exec as the other user instead?
 	meta := llb.Mkdir(buildkit.MetaSourcePath, 0o777)
 	if stdin != "" {
-		meta = meta.Mkfile(path.Join(buildkit.MetaSourcePath, "stdin"), 0o600, []byte(stdin))
+		meta = meta.Mkfile(path.Join(buildkit.MetaSourcePath, "stdin"), 0o666, []byte(stdin))
 	}
 
 	return llb.Scratch().File(

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -609,6 +609,23 @@ func TestContainerExecWithUser(t *testing.T) {
 		require.Equal(t, "2:11", res.Container.From.WithUser.User)
 		require.Equal(t, "daemon\nfloppy\n", res.Container.From.WithUser.WithExec.Stdout)
 	})
+
+	t.Run("stdin", func(t *testing.T) {
+		err := testutil.Query(
+			`{
+			container {
+				from(address: "`+alpineImage+`") {
+					withUser(name: "daemon") {
+						withExec(args: ["sh"], stdin: "whoami") {
+							stdout
+						}
+					}
+				}
+			}
+		}`, &res, nil)
+		require.NoError(t, err)
+		require.Equal(t, "daemon\n", res.Container.From.WithUser.WithExec.Stdout)
+	})
 }
 
 func TestContainerExecWithoutUser(t *testing.T) {


### PR DESCRIPTION
Previously, 0o600 was to narrow to allow non-root users to use withExec with stdin. The command silently exited without being executed.

Fixes #6510