### PR TITLE
support passing cache volumes as flag

### DIFF
--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -98,48 +98,53 @@ appending it to the end of the command (for example, *stdout*, *entries*, or
 			// to get the name from modType.
 			// You can't select `id`, but you can select `sync`, and there
 			// may be others.
-			writer := cmd.OutOrStdout()
-
-			if outputPath != "" {
-				file, err := openOutputFile(outputPath)
-				if err != nil {
-					return fmt.Errorf("couldn't write output to file: %w", err)
-				}
-
-				defer func() {
-					file.Close()
-					logOutputSuccess(cmd, outputPath)
-				}()
-
-				writer = io.MultiWriter(writer, file)
-			}
+			buf := new(bytes.Buffer)
 
 			// especially useful for lists and maps
 			if jsonOutput {
 				// disable HTML escaping to improve readability
-				var buf bytes.Buffer
-				encoder := json.NewEncoder(&buf)
+				encoder := json.NewEncoder(buf)
 				encoder.SetEscapeHTML(false)
 				encoder.SetIndent("", "    ")
-
 				if err := encoder.Encode(response); err != nil {
 					return err
 				}
-				fmt.Fprintf(writer, "%s\n", buf.String())
-				return nil
+			} else {
+				if err := printFunctionResult(buf, response); err != nil {
+					return err
+				}
 			}
 
-			return printFunctionResult(writer, response)
+			if outputPath != "" {
+				if err := writeOutputFile(outputPath, buf); err != nil {
+					return fmt.Errorf("couldn't write output to file: %w", err)
+				}
+				logOutputSuccess(cmd, outputPath)
+			}
+
+			writer := cmd.OutOrStdout()
+			buf.WriteTo(writer)
+
+			// TODO(vito) right now when stdoutIsTTY we'll be printing to a Progrock
+			// vertex, which currently adds its own linebreak (as well as all the
+			// other UI clutter), so there's no point doing this. consider adding
+			// back when we switch to printing "clean" output on exit.
+			// if stdoutIsTTY && !strings.HasSuffix(buf.String(), "\n") {
+			// 	fmt.Fprintln(writer, "⏎")
+			// }
+
+			return nil
 		}
 	},
 }
 
-// openOutputFile opens a file for writing, creating the parent directories if needed.
-func openOutputFile(path string) (*os.File, error) {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return nil, err
+// writeOutputFile writes the buffer to a file, creating the parent directories
+// if needed.
+func writeOutputFile(path string, buf *bytes.Buffer) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil { // nolint: gosec
+		return err
 	}
-	return os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
+	return os.WriteFile(path, buf.Bytes(), 0o644) // nolint: gosec
 }
 
 // logOutputSuccess prints to stderr the the output path to the user.
@@ -161,18 +166,22 @@ func printFunctionResult(w io.Writer, r any) error {
 			if err := printFunctionResult(w, v); err != nil {
 				return err
 			}
+			fmt.Fprintln(w)
 		}
 		return nil
 	case map[string]any:
-		// TODO: group in progrock
+		// NB: we're only interested in values because this is where we unwrap
+		// things like {"container":{"from":{"withExec":{"stdout":"foo"}}}}.
 		for _, v := range t {
 			if err := printFunctionResult(w, v); err != nil {
 				return err
 			}
 		}
 		return nil
+	case string:
+		fmt.Fprint(w, t)
 	default:
-		fmt.Fprintf(w, "%+v\n", t)
+		fmt.Fprintf(w, "%+v", t)
 	}
 	return nil
 }

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -27,6 +27,7 @@ const (
 	Service     string = "Service"
 	Terminal    string = "Terminal"
 	PortForward string = "PortForward"
+	CacheVolume string = "CacheVolume"
 )
 
 var funcGroup = &cobra.Group{

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -52,7 +52,7 @@ func (m *Test) Fn(ctx context.Context, svc *Service) (string, error) {
 				WithServiceBinding("testserver", httpServer).
 				With(daggerCall("fn", "--svc", "tcp://"+endpoint)).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, strings.TrimSpace(out), "im up")
+			require.Equal(t, "im up", out)
 		})
 
 		t.Run("used directly", func(t *testing.T) {
@@ -103,7 +103,7 @@ func (m *Test) Fn(ctx context.Context, svc *Service) (string, error) {
 				WithServiceBinding("testserver", httpServer).
 				With(daggerCall("fn", "--svc", "tcp://"+endpoint)).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, strings.TrimSpace(out), "1 exposed ports:\n- TCP/8000")
+			require.Equal(t, "1 exposed ports:\n- TCP/8000", out)
 		})
 	})
 
@@ -150,11 +150,11 @@ func (m *Minimal) Reads(ctx context.Context, files []File) (string, error) {
 
 		out, err := modGen.With(daggerCall("hello", "--msgs", "yo", "--msgs", "my", "--msgs", "friend")).Stdout(ctx)
 		require.NoError(t, err)
-		require.Equal(t, strings.TrimSpace(out), "yo+my+friend")
+		require.Equal(t, "yo+my+friend", out)
 
 		out, err = modGen.With(daggerCall("reads", "--files=foo.txt", "--files=foo.txt")).Stdout(ctx)
 		require.NoError(t, err)
-		require.Equal(t, strings.TrimSpace(out), "bar+bar")
+		require.Equal(t, "bar+bar", out)
 	})
 
 	t.Run("directory arg inputs", func(t *testing.T) {
@@ -186,11 +186,11 @@ func (m *Test) Fn(dir *Directory) *Directory {
 
 			out, err := modGen.With(daggerCall("fn", "--dir", "/dir/subdir", "entries")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, strings.TrimSpace(out), "bar.txt\nfoo.txt")
+			require.Equal(t, "bar.txt\nfoo.txt\n", out)
 
 			out, err = modGen.With(daggerCall("fn", "--dir", "file:///dir/subdir", "entries")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, strings.TrimSpace(out), "bar.txt\nfoo.txt")
+			require.Equal(t, "bar.txt\nfoo.txt\n", out)
 		})
 
 		t.Run("git dir", func(t *testing.T) {
@@ -279,7 +279,7 @@ func (m *Test) Insecure(ctx context.Context, token *Secret) (string, error) {
 			t.Run("happy", func(t *testing.T) {
 				out, err := modGen.With(daggerCall("insecure", "--token", "env:TOPSECRET")).Stdout(ctx)
 				require.NoError(t, err)
-				require.Equal(t, "shhh", strings.TrimSpace(out))
+				require.Equal(t, "shhh", out)
 			})
 			t.Run("sad", func(t *testing.T) {
 				_, err := modGen.With(daggerCall("insecure", "--token", "env:NOWHERETOBEFOUND")).Stdout(ctx)
@@ -292,7 +292,7 @@ func (m *Test) Insecure(ctx context.Context, token *Secret) (string, error) {
 			t.Run("happy", func(t *testing.T) {
 				out, err := modGen.With(daggerCall("insecure", "--token", "TOPSECRET")).Stdout(ctx)
 				require.NoError(t, err)
-				require.Equal(t, "shhh", strings.TrimSpace(out))
+				require.Equal(t, "shhh", out)
 			})
 			t.Run("sad", func(t *testing.T) {
 				_, err := modGen.With(daggerCall("insecure", "--token", "NOWHERETOBEFOUND")).Stdout(ctx)
@@ -304,7 +304,7 @@ func (m *Test) Insecure(ctx context.Context, token *Secret) (string, error) {
 			t.Run("happy", func(t *testing.T) {
 				out, err := modGen.With(daggerCall("insecure", "--token", "file:/mysupersecret")).Stdout(ctx)
 				require.NoError(t, err)
-				require.Equal(t, "file shhh", strings.TrimSpace(out))
+				require.Equal(t, "file shhh", out)
 			})
 			t.Run("sad", func(t *testing.T) {
 				_, err := modGen.With(daggerCall("insecure", "--token", "file:/nowheretobefound")).Stdout(ctx)
@@ -316,7 +316,7 @@ func (m *Test) Insecure(ctx context.Context, token *Secret) (string, error) {
 			t.Run("happy", func(t *testing.T) {
 				out, err := modGen.With(daggerCall("insecure", "--token", "cmd:echo -n cmd shhh")).Stdout(ctx)
 				require.NoError(t, err)
-				require.Equal(t, "cmd shhh", strings.TrimSpace(out))
+				require.Equal(t, "cmd shhh", out)
 			})
 			t.Run("sad", func(t *testing.T) {
 				_, err := modGen.With(daggerCall("insecure", "--token", "cmd:exit 1")).Stdout(ctx)
@@ -332,6 +332,8 @@ func (m *Test) Insecure(ctx context.Context, token *Secret) (string, error) {
 
 	t.Run("cache volume args", func(t *testing.T) {
 		t.Parallel()
+
+		c, ctx := connect(t)
 
 		volName := identity.NewID()
 
@@ -361,10 +363,10 @@ func (m *Test) Cacher(ctx context.Context, cache *CacheVolume, val string) (stri
 
 		out, err := modGen.With(daggerCall("cacher", "--cache", volName, "--val", "foo")).Stdout(ctx)
 		require.NoError(t, err)
-		require.Equal(t, "foo\n\n", out) // TODO: extra linebreak from 'dagger call'
+		require.Equal(t, "foo\n", out)
 		out, err = modGen.With(daggerCall("cacher", "--cache", volName, "--val", "bar")).Stdout(ctx)
 		require.NoError(t, err)
-		require.Equal(t, "foo\nbar\n\n", out) // TODO: extra linebreak from 'dagger call'
+		require.Equal(t, "foo\nbar\n", out)
 	})
 }
 
@@ -399,12 +401,12 @@ func (m *Minimal) Fn() []*Foo {
 			})
 
 		logGen(ctx, t, modGen.Directory("."))
-		expected := "0\n1\n2"
+		expected := "0\n1\n2\n"
 
 		t.Run("print", func(t *testing.T) {
 			out, err := modGen.With(daggerCall("fn", "bar")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, expected, strings.TrimSpace(out))
+			require.Equal(t, expected, out)
 		})
 
 		t.Run("output", func(t *testing.T) {
@@ -413,7 +415,7 @@ func (m *Minimal) Fn() []*Foo {
 				File("./outfile").
 				Contents(ctx)
 			require.NoError(t, err)
-			require.Equal(t, expected, strings.TrimSpace(out))
+			require.Equal(t, expected, out)
 		})
 
 		t.Run("json", func(t *testing.T) {
@@ -514,11 +516,11 @@ type Test struct {
 
 			foo, err := modGen.Directory("./outdir").File("foo.txt").Contents(ctx)
 			require.NoError(t, err)
-			require.Equal(t, "foo", strings.TrimSpace(foo))
+			require.Equal(t, "foo", foo)
 
 			bar, err := modGen.Directory("./outdir").File("bar.txt").Contents(ctx)
 			require.NoError(t, err)
-			require.Equal(t, "bar", strings.TrimSpace(bar))
+			require.Equal(t, "bar", bar)
 		})
 	})
 
@@ -563,7 +565,7 @@ type Test struct {
 				File("./outfile").
 				Contents(ctx)
 			require.NoError(t, err)
-			require.Equal(t, "foo", strings.TrimSpace(out))
+			require.Equal(t, "foo", out)
 		})
 	})
 
@@ -622,7 +624,7 @@ type Test struct {
 		t.Run("file", func(t *testing.T) {
 			out, err := modGen.With(daggerCall("ctr", "file", "--path=/etc/alpine-release", "contents")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, "3.18.5", strings.TrimSpace(out))
+			require.Equal(t, "3.18.5\n", out)
 		})
 
 		t.Run("export", func(t *testing.T) {
@@ -660,7 +662,7 @@ type Test struct {
 		t.Run("file", func(t *testing.T) {
 			out, err := modGen.With(daggerCall("dir", "file", "--path=foo.txt", "contents")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, "foo", strings.TrimSpace(out))
+			require.Equal(t, "foo", out)
 		})
 
 		t.Run("export", func(t *testing.T) {
@@ -698,7 +700,7 @@ type Test struct {
 		t.Run("size", func(t *testing.T) {
 			out, err := modGen.With(daggerCall("file", "size")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, "3", strings.TrimSpace(out))
+			require.Equal(t, "3", out)
 		})
 
 		t.Run("export", func(t *testing.T) {
@@ -706,7 +708,7 @@ type Test struct {
 			require.NoError(t, err)
 			contents, err := modGen.File("./outfile").Contents(ctx)
 			require.NoError(t, err)
-			require.Equal(t, "foo", strings.TrimSpace(contents))
+			require.Equal(t, "foo", contents)
 		})
 	})
 }
@@ -749,7 +751,7 @@ func (t *Test) File() *File {
 			File("foo.txt").
 			Contents(ctx)
 		require.NoError(t, err)
-		require.Equal(t, "hello", strings.TrimSpace(out))
+		require.Equal(t, "hello", out)
 	})
 
 	t.Run("not a file", func(t *testing.T) {
@@ -763,7 +765,7 @@ func (t *Test) File() *File {
 			File("foo.txt").
 			Contents(ctx)
 		require.NoError(t, err)
-		require.Equal(t, "foo", strings.TrimSpace(out))
+		require.Equal(t, "foo", out)
 	})
 
 	t.Run("create parent dirs", func(t *testing.T) {
@@ -780,13 +782,13 @@ func (t *Test) File() *File {
 		t.Run("check directory permissions", func(t *testing.T) {
 			out, err := ctr.WithExec([]string{"stat", "-c", "%a", "foo"}).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, "755", strings.TrimSpace(out))
+			require.Equal(t, "755\n", out)
 		})
 
 		t.Run("check file permissions", func(t *testing.T) {
 			out, err := ctr.WithExec([]string{"stat", "-c", "%a", "foo/bar.txt"}).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, "644", strings.TrimSpace(out))
+			require.Equal(t, "644\n", out)
 		})
 	})
 
@@ -807,13 +809,13 @@ exec "$@"
 		t.Run("directory", func(t *testing.T) {
 			out, err := ctr.WithExec([]string{"stat", "-c", "%a", "/tmp/foo"}).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, "750", strings.TrimSpace(out))
+			require.Equal(t, "750\n", out)
 		})
 
 		t.Run("file", func(t *testing.T) {
 			out, err := ctr.WithExec([]string{"stat", "-c", "%a", "/tmp/foo/bar.txt"}).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, "640", strings.TrimSpace(out))
+			require.Equal(t, "640\n", out)
 		})
 	})
 }


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/6409

Prior to this PR, attempting to run a module that takes a CacheVolume in its constructor (or likely also any function) would fail with this:

```
Error: unsupported object type "CacheVolume" for flag: mod-cache 
```

The flag value is just the cache volume name. Can't think of an immediate reason for it to be any more complicated than that.

* [x] test