### PR TITLE
docs(command order)

### DIFF
--- a/docs/versioned_docs/version-zenith/user/quickstart/623939-call.mdx
+++ b/docs/versioned_docs/version-zenith/user/quickstart/623939-call.mdx
@@ -87,19 +87,19 @@ dagger call test --node-version 18
 Modules don't need to be installed locally. Dagger lets you consume modules from remote sources as well. For example, you can `dagger call` a function from a module using its GitHub URL:
 
 ```shell
-dagger call test -m "github.com/sipsma/daggerverse@main"
+dagger call -m "github.com/sipsma/daggerverse@main" test
 ```
 
 Or, if the target module is in a subdirectory of the repository:
 
 ```shell
-dagger call test -m "github.com/sipsma/daggerverse/example@main"
+dagger call -m "github.com/sipsma/daggerverse/example@main" test
 ```
 
 You can also use modules from the local filesystem, without needing to push them to GitHub. For example:
 
 ```shell
-dagger call test -m "./path/to/module"
+dagger call -m "./path/to/module" test
 ```
 
 :::tip


### PR DESCRIPTION
I think the command has to come after the `-m` flag.  When it comes before dagger can't find the module... most other places (for instance in the bottom tip)  the command is after the module flag.

>This is a tiny update, but it cost me at least 10 minutes before I found another example with them flipped and then mine started working locally.  Hope it saves someone else a few minutes!