### PR TITLE
chore: enable nolintlint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
     - ineffassign
     - misspell
     - nakedret
+    - nolintlint
     - prealloc
     - revive
     - rowserrcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,3 @@
-run:
-  skip-dirs:
-    # progressui is a modified 3rd party library from buildkit
-    - util/progressui
-
 linters:
   disable-all: true
   enable:

--- a/ci/main.go
+++ b/ci/main.go
@@ -20,7 +20,7 @@ const (
 	alpineVersion = "3.18"
 	runcVersion   = "v1.1.5"
 	cniVersion    = "v1.2.0"
-	qemuBinImage  = "tonistiigi/binfmt:buildkit-v7.1.0-30@sha256:45dd57b4ba2f24e2354f71f1e4e51f073cb7a28fd848ce6f5f2a7701142a6bf0" // nolint:gosec
+	qemuBinImage  = "tonistiigi/binfmt:buildkit-v7.1.0-30@sha256:45dd57b4ba2f24e2354f71f1e4e51f073cb7a28fd848ce6f5f2a7701142a6bf0" //nolint:gosec
 
 	engineDefaultStateDir = "/var/lib/dagger"
 	engineTomlPath        = "/etc/dagger/engine.toml"

--- a/cmd/codegen/generator/go/templates/module_funcs.go
+++ b/cmd/codegen/generator/go/templates/module_funcs.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	. "github.com/dave/jennifer/jen" // nolint:revive,stylecheck
+	. "github.com/dave/jennifer/jen" //nolint:stylecheck
 )
 
 const errorTypeName = "error"

--- a/cmd/codegen/generator/go/templates/module_interfaces.go
+++ b/cmd/codegen/generator/go/templates/module_interfaces.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	. "github.com/dave/jennifer/jen" // nolint:revive,stylecheck
+	. "github.com/dave/jennifer/jen" //nolint:stylecheck
 	"github.com/iancoleman/strcase"
 )
 

--- a/cmd/codegen/generator/go/templates/module_objects.go
+++ b/cmd/codegen/generator/go/templates/module_objects.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	. "github.com/dave/jennifer/jen" // nolint:revive,stylecheck
+	. "github.com/dave/jennifer/jen" //nolint:stylecheck
 )
 
 func (ps *parseState) parseGoStruct(t *types.Struct, named *types.Named) (*parsedObjectType, error) {

--- a/cmd/codegen/generator/go/templates/module_types.go
+++ b/cmd/codegen/generator/go/templates/module_types.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"go/types"
 
-	. "github.com/dave/jennifer/jen" // nolint:revive,stylecheck
+	. "github.com/dave/jennifer/jen" //nolint:stylecheck
 )
 
 // A Go type that has been parsed and can be registered with the dagger API

--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -12,7 +12,7 @@ import (
 	"sort"
 	"strings"
 
-	. "github.com/dave/jennifer/jen" // nolint:revive,stylecheck
+	. "github.com/dave/jennifer/jen" //nolint:stylecheck
 	"github.com/iancoleman/strcase"
 	"golang.org/x/tools/go/packages"
 )

--- a/cmd/dagger/debug.go
+++ b/cmd/dagger/debug.go
@@ -40,6 +40,6 @@ func setupDebugHandlers(addr string) error {
 		return err
 	}
 	fmt.Fprintln(os.Stderr, "debug handlers listening at", addr)
-	go http.Serve(l, m) // nolint:gosec
+	go http.Serve(l, m) //nolint:gosec
 	return nil
 }

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -349,7 +349,7 @@ var modulePublishCmd = &cobra.Command{
 
 			data := url.Values{}
 			data.Add("ref", refStr)
-			req, err := http.NewRequest(http.MethodPut, crawlURL, strings.NewReader(data.Encode())) // nolint: gosec
+			req, err := http.NewRequest(http.MethodPut, crawlURL, strings.NewReader(data.Encode()))
 			if err != nil {
 				return fmt.Errorf("failed to create request: %w", err)
 			}

--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -113,7 +113,7 @@ func run(ctx context.Context, args []string) error {
 		// shell because Ctrl+C sends to the process group.)
 		ensureChildProcessesAreKilled(subCmd)
 
-		go http.Serve(sessionL, engineClient) // nolint:gosec
+		go http.Serve(sessionL, engineClient) //nolint:gosec
 
 		var cmdErr error
 		if !silent {

--- a/cmd/dnsname/main.go
+++ b/cmd/dnsname/main.go
@@ -153,7 +153,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 
 type podname struct {
 	types.CommonArgs
-	K8S_POD_NAME types.UnmarshallableString `json:"podname,omitempty"` //nolint:revive,stylecheck
+	K8S_POD_NAME types.UnmarshallableString `json:"podname,omitempty"` //nolint:stylecheck
 }
 
 // parseConfig parses the supplied configuration (and prevResult) from stdin.

--- a/cmd/engine/debug.go
+++ b/cmd/engine/debug.go
@@ -53,7 +53,7 @@ func setupDebugHandlers(addr string) error {
 		return err
 	}
 	logrus.Debugf("debug handlers listening at %s", addr)
-	go http.Serve(l, m) // nolint:gosec
+	go http.Serve(l, m) //nolint:gosec
 	return nil
 }
 

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -568,7 +568,7 @@ func appendHostAlias(hostsFilePath string, env string, searchDomains []string) e
 	return hostsFile.Close()
 }
 
-// nolint: unparam
+//nolint:unparam
 func execRunc() int {
 	args := []string{runcPath}
 	args = append(args, os.Args[1:]...)

--- a/core/integration/secret_test.go
+++ b/core/integration/secret_test.go
@@ -164,6 +164,5 @@ func TestSecretBigScrubbed(t *testing.T) {
 	require.Equal(t, "***", stdout)
 }
 
-//nolint:typecheck
 //go:embed testdata/secretkey.txt
 var secretKeyBytes []byte

--- a/core/interface.go
+++ b/core/interface.go
@@ -112,7 +112,6 @@ func (iface *InterfaceType) TypeDef() *TypeDef {
 	}
 }
 
-// nolint:gocyclo
 func (iface *InterfaceType) Install(ctx context.Context, dag *dagql.Server) error {
 	ctx = bklog.WithLogger(ctx, bklog.G(ctx).WithField("interface", iface.typeDef.Name))
 	bklog.G(ctx).Debug("installing interface")

--- a/core/modules/config.go
+++ b/core/modules/config.go
@@ -40,7 +40,7 @@ type ModuleConfig struct {
 func (modCfg *ModuleConfig) Validate() error {
 	if modCfg.Root != "" {
 		// this is too hard to handle automatically, just tell the user they need to update via error message
-		// nolint:stylecheck // we're okay with an error message formated as full sentences in this case
+		//nolint:stylecheck // we're okay with an error message formated as full sentences in this case
 		return fmt.Errorf(legacyRootUsageMessage, modCfg.Root)
 	}
 	return nil

--- a/core/pipeline/label.go
+++ b/core/pipeline/label.go
@@ -311,7 +311,7 @@ func LoadGitLabels(workdir string) ([]Label, error) {
 }
 
 func LoadCircleCILabels() ([]Label, error) {
-	if os.Getenv("CIRCLECI") != "true" { // nolint:goconst
+	if os.Getenv("CIRCLECI") != "true" { //nolint:goconst
 		return []Label{}, nil
 	}
 
@@ -398,7 +398,7 @@ func LoadCircleCILabels() ([]Label, error) {
 }
 
 func LoadGitLabLabels() ([]Label, error) {
-	if os.Getenv("GITLAB_CI") != "true" { // nolint:goconst
+	if os.Getenv("GITLAB_CI") != "true" { //nolint:goconst
 		return []Label{}, nil
 	}
 
@@ -490,7 +490,7 @@ func LoadGitLabLabels() ([]Label, error) {
 }
 
 func LoadGitHubLabels() ([]Label, error) {
-	if os.Getenv("GITHUB_ACTIONS") != "true" { // nolint:goconst
+	if os.Getenv("GITHUB_ACTIONS") != "true" { //nolint:goconst
 		return []Label{}, nil
 	}
 

--- a/core/pipeline/label_test.go
+++ b/core/pipeline/label_test.go
@@ -460,7 +460,7 @@ func TestLoadCircleCILabels(t *testing.T) {
 	}
 }
 
-func run(t *testing.T, exe string, args ...string) string { // nolint: unparam
+func run(t *testing.T, exe string, args ...string) string { //nolint: unparam
 	t.Helper()
 	cmd := exec.Command(exe, args...)
 	cmd.Stderr = os.Stderr

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -1143,7 +1143,7 @@ type containerImportArgs struct {
 	Tag    string `default:""`
 }
 
-func (s *containerSchema) import_(ctx context.Context, parent *core.Container, args containerImportArgs) (*core.Container, error) { // nolint:revive
+func (s *containerSchema) import_(ctx context.Context, parent *core.Container, args containerImportArgs) (*core.Container, error) {
 	start := time.Now()
 	slog.Debug("importing container", "source", args.Source.Display(), "tag", args.Tag)
 	defer func() {

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -1008,7 +1008,7 @@ func (s *moduleSchema) updateCodegenAndRuntime(ctx context.Context, mod *core.Mo
 
 	// update .gitattributes
 	// (linter thinks this chunk of code is too similar to the below, but not clear abstraction is worth it)
-	// nolint: dupl
+	//nolint:dupl
 	if len(generatedCode.VCSGeneratedPaths) > 0 {
 		gitAttrsPath := filepath.Join(sourceSubpath, ".gitattributes")
 		var gitAttrsContents []byte
@@ -1049,7 +1049,7 @@ func (s *moduleSchema) updateCodegenAndRuntime(ctx context.Context, mod *core.Mo
 
 	// update .gitignore
 	// (linter thinks this chunk of code is too similar to the above, but not clear abstraction is worth it)
-	// nolint: dupl
+	//nolint:dupl
 	if len(generatedCode.VCSIgnoredPaths) > 0 {
 		gitIgnorePath := filepath.Join(sourceSubpath, ".gitignore")
 		var gitIgnoreContents []byte

--- a/core/schema/sdk.go
+++ b/core/schema/sdk.go
@@ -112,8 +112,6 @@ func (s *moduleSchema) newModuleSDK(
 }
 
 // Codegen calls the Codegen function on the SDK Module
-//
-//nolint:dupl
 func (sdk *moduleSDK) Codegen(ctx context.Context, mod *core.Module, source dagql.Instance[*core.ModuleSource]) (*core.GeneratedCode, error) {
 	introspectionJSON, err := mod.DependencySchemaIntrospectionJSON(ctx)
 	if err != nil {
@@ -141,8 +139,6 @@ func (sdk *moduleSDK) Codegen(ctx context.Context, mod *core.Module, source dagq
 }
 
 // Runtime calls the Runtime function on the SDK Module
-//
-//nolint:dupl
 func (sdk *moduleSDK) Runtime(ctx context.Context, mod *core.Module, source dagql.Instance[*core.ModuleSource]) (*core.Container, error) {
 	introspectionJSON, err := mod.DependencySchemaIntrospectionJSON(ctx)
 	if err != nil {

--- a/core/schema/socket.go
+++ b/core/schema/socket.go
@@ -27,7 +27,6 @@ type socketArgs struct {
 	ID core.SocketID
 }
 
-// nolint: unparam
 func (s *socketSchema) socket(ctx context.Context, parent *core.Query, args socketArgs) (dagql.Instance[*core.Socket], error) {
 	return args.ID.Load(ctx, s.srv)
 }

--- a/core/service.go
+++ b/core/service.go
@@ -202,7 +202,7 @@ func (svc *Service) Start(
 	}
 }
 
-// nolint: gocyclo
+//nolint:gocyclo
 func (svc *Service) startContainer(
 	ctx context.Context,
 	id *idproto.ID,

--- a/dagql/demo/main.go
+++ b/dagql/demo/main.go
@@ -71,7 +71,7 @@ func main() {
 			<-ctx.Done()
 			l.Close()
 		}()
-		return http.Serve(l, nil) // nolint: gosec
+		return http.Serve(l, nil) //nolint: gosec
 	}); err != nil {
 		panic(err)
 	}

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -76,7 +76,7 @@ func (*Frontend) Close() error {
 var _ progrock.Frontend = (*Frontend)(nil)
 
 func (f *Frontend) Render(tape *progrock.Tape, w io.Writer, u *progrock.UI) error {
-	var ids []vertexAndID // nolint:prealloc
+	var ids []vertexAndID //nolint:prealloc
 	for vid, id := range f.leafIDs {
 		vtx := tape.Vertices[vid]
 		if vtx == nil {
@@ -314,7 +314,7 @@ func renderID(tape *progrock.Tape, out *termenv.Output, u *progrock.UI, vtx *pro
 }
 
 func collectTransitiveChildren(tape *progrock.Tape, groupID string) []*progrock.Vertex {
-	var children []*progrock.Vertex // nolint:prealloc
+	var children []*progrock.Vertex //nolint:prealloc
 	for id := range tape.GroupVertices[groupID] {
 		child := tape.Vertices[id]
 		if child == nil {

--- a/engine/buildkit/session.go
+++ b/engine/buildkit/session.go
@@ -36,7 +36,7 @@ func (c *Client) newSession(ctx context.Context) (*bksession.Session, error) {
 	}))
 
 	clientConn, serverConn := net.Pipe()
-	dialer := func(ctx context.Context, proto string, meta map[string][]string) (net.Conn, error) { // nolint: unparam
+	dialer := func(ctx context.Context, proto string, meta map[string][]string) (net.Conn, error) { //nolint: unparam
 		go func() {
 			defer serverConn.Close()
 			err := c.SessionManager.HandleConn(ctx, serverConn, meta)

--- a/engine/cache/service.go
+++ b/engine/cache/service.go
@@ -109,7 +109,6 @@ func (r UpdateCacheRecordsRequest) String() string {
 	return string(b)
 }
 
-//nolint:revive
 type CacheKey struct {
 	ID      string
 	Results []Result
@@ -319,7 +318,6 @@ func (c *client) UpdateCacheRecords(
 	return resp, nil
 }
 
-//nolint:dupl
 func (c *client) UpdateCacheLayers(
 	ctx context.Context,
 	req UpdateCacheLayersRequest,
@@ -354,7 +352,6 @@ func (c *client) UpdateCacheLayers(
 	return nil
 }
 
-//nolint:dupl
 func (c *client) ImportCache(ctx context.Context) (*remotecache.CacheConfig, error) {
 	httpReq, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/import", nil)
 	if err != nil {

--- a/engine/sources/gitdns/gitsource.go
+++ b/engine/sources/gitdns/gitsource.go
@@ -451,7 +451,7 @@ func (gs *gitSourceHandler) CacheKey(ctx context.Context, g session.Group, index
 	return cacheKey, sha, nil, true, nil
 }
 
-func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out cache.ImmutableRef, retErr error) { // nolint: gocyclo
+func (gs *gitSourceHandler) Snapshot(ctx context.Context, g session.Group) (out cache.ImmutableRef, retErr error) { //nolint: gocyclo
 	cacheKey := gs.cacheKey
 	if cacheKey == "" {
 		var err error

--- a/engine/sources/httpdns/httpsource.go
+++ b/engine/sources/httpdns/httpsource.go
@@ -196,7 +196,7 @@ func (hs *httpSourceHandler) formatCacheKey(filename string, dgst digest.Digest,
 	return digest.FromBytes(dt)
 }
 
-func (hs *httpSourceHandler) CacheKey(ctx context.Context, g session.Group, index int) (string, string, solver.CacheOpts, bool, error) { // nolint: gocyclo
+func (hs *httpSourceHandler) CacheKey(ctx context.Context, g session.Group, index int) (string, string, solver.CacheOpts, bool, error) {
 	if hs.src.Checksum != "" {
 		hs.cacheKey = hs.src.Checksum
 		return hs.formatCacheKey(getFileName(hs.src.URL, hs.src.Filename, nil), hs.src.Checksum, "").String(), hs.src.Checksum.String(), nil, true, nil

--- a/internal/cloud/auth/auth.go
+++ b/internal/cloud/auth/auth.go
@@ -73,7 +73,7 @@ func Login(ctx context.Context) error {
 		requestCh <- r
 	})
 
-	srv := &http.Server{ // nolint: gosec
+	srv := &http.Server{ //nolint: gosec
 		Addr:    fmt.Sprintf("localhost:%d", callbackPort),
 		Handler: m,
 	}

--- a/internal/tui/editor.go
+++ b/internal/tui/editor.go
@@ -57,7 +57,7 @@ func openEditor(filePath string) tea.Cmd {
 	}
 	editorArgs = append(editorArgs, filePath)
 
-	cmd := exec.Command(editorArgs[0], editorArgs[1:]...) // nolint:gosec
+	cmd := exec.Command(editorArgs[0], editorArgs[1:]...) //nolint:gosec
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/sdk/go/provision_test.go
+++ b/sdk/go/provision_test.go
@@ -82,7 +82,7 @@ func TestProvision(t *testing.T) {
 		checksumFileContents := fmt.Sprintf("%x  %s\n", checksum, archiveName)
 		checksumPath := path.Join(basePath, "checksums.txt")
 
-		go http.Serve(l, http.FileServer(http.FS(fstest.MapFS{ //nolint:gosec
+		go http.Serve(l, http.FileServer(http.FS(fstest.MapFS{
 			checksumPath: &fstest.MapFile{
 				Data:    []byte(checksumFileContents),
 				Mode:    0o644,

--- a/sdk/go/querybuilder/marshal.go
+++ b/sdk/go/querybuilder/marshal.go
@@ -65,7 +65,7 @@ func marshalValue(ctx context.Context, v reflect.Value) (string, error) {
 		// https://github.com/graphql/graphql-spec/blob/main/spec/Section%202%20--%20Language.md#string-value
 		var buf bytes.Buffer
 		gqlgen.MarshalString(v.String()).MarshalGQL(&buf)
-		return buf.String(), nil //nolint:gosimple,staticcheck
+		return buf.String(), nil
 	case reflect.Pointer, reflect.Interface:
 		if v.IsNil() {
 			return "null", nil

--- a/sdk/go/querybuilder/marshal_test.go
+++ b/sdk/go/querybuilder/marshal_test.go
@@ -106,23 +106,22 @@ type customMarshaller struct {
 	count int
 }
 
-// nolint
+//nolint:stylecheck
 func (m *customMarshaller) XXX_GraphQLType() string { return "idTest" }
 
-// nolint
+//nolint:stylecheck
 func (m *customMarshaller) XXX_GraphQLIDType() string { return "idTypeTest" }
 
-// nolint
+//nolint:stylecheck
 func (m *customMarshaller) XXX_GraphQLID(context.Context) (string, error) {
 	m.count++
 	return m.v, nil
 }
 
-// nolint
 func (m *customMarshaller) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
-		v     string
-		count int
+		V     string `json:"v"`
+		Count int    `json:"count"`
 	}{m.v, m.count})
 }
 


### PR DESCRIPTION
There were a few uses of nolint where we didn't need them - it's often difficult to discern their intended purpose when cleaning them up later, so we should enforce them as soon as they aren't required.