### PR TITLE
Update zenith dev guides with incoming breaking changes.

### DIFF
--- a/docs/versioned_docs/version-zenith/developer/go/191108-advanced-programming.mdx
+++ b/docs/versioned_docs/version-zenith/developer/go/191108-advanced-programming.mdx
@@ -26,10 +26,10 @@ This guide assumes that:
 
 ## Use modules in other modules
 
-Modules can call each other. To add a dependency to your module, you can use `dagger install`, as in the following example:
+Modules can call each other. To add a dependency to your module, you can use `dagger mod install`, as in the following example:
 
 ```sh
-dagger install github.com/shykes/daggerverse/helloWorld@26f8ed9f1748ec8c9345281add850fd392441990
+dagger mod install github.com/shykes/daggerverse/helloWorld@26f8ed9f1748ec8c9345281add850fd392441990
 ```
 
 This module will be added to your `dagger.json`:
@@ -43,7 +43,7 @@ This module will be added to your `dagger.json`:
 You can also use local modules as dependencies. However, they must be stored in a sub-directory of your module. For example:
 
 ```sh
-dagger install ./path/to/module
+dagger mod install ./path/to/module
 ```
 
 The dependent module will be added to your code-generation routines, so you can access it from your own module's code, as shown below:

--- a/docs/versioned_docs/version-zenith/developer/go/191108-advanced-programming.mdx
+++ b/docs/versioned_docs/version-zenith/developer/go/191108-advanced-programming.mdx
@@ -26,10 +26,10 @@ This guide assumes that:
 
 ## Use modules in other modules
 
-Modules can call each other. To add a dependency to your module, you can use `dagger mod install`, as in the following example:
+Modules can call each other. To add a dependency to your module, you can use `dagger install`, as in the following example:
 
 ```sh
-dagger mod install github.com/shykes/daggerverse/helloWorld@26f8ed9f1748ec8c9345281add850fd392441990
+dagger install github.com/shykes/daggerverse/helloWorld@26f8ed9f1748ec8c9345281add850fd392441990
 ```
 
 This module will be added to your `dagger.json`:
@@ -43,7 +43,7 @@ This module will be added to your `dagger.json`:
 You can also use local modules as dependencies. However, they must be stored in a sub-directory of your module. For example:
 
 ```sh
-dagger mod install ./path/to/module
+dagger install ./path/to/module
 ```
 
 The dependent module will be added to your code-generation routines, so you can access it from your own module's code, as shown below:
@@ -70,34 +70,16 @@ Here is an example module using the Go SDK:
 
 ```
 
-And here is an example query for this module:
+And here is an example call for this module:
 
-```graphql
-{
-  helloWorld {
-    message
-    withName(name: "Monde") {
-      withGreeting(greeting: "Bonjour") {
-        message
-      }
-    }
-  }
-}
+```console
+dagger call with-name --name=Monde with-greeting --greeting=Bonjour message
 ```
 
 The result will be:
 
-```json
-{
-  "helloWorld": {
-    "message": "Hello, World!",
-    "withName": {
-      "withGreeting": {
-        "message": "Bonjour, Monde!"
-      }
-    }
-  }
-}
+```console
+Bonjour, Monde!
 ```
 
 ## Write a module constructor function

--- a/docs/versioned_docs/version-zenith/developer/go/457202-test-build-publish.mdx
+++ b/docs/versioned_docs/version-zenith/developer/go/457202-test-build-publish.mdx
@@ -251,7 +251,7 @@ The `shell` API on `Container` types can be used to open an interactive shell se
 Try it with the command below:
 
 ```shell
-dagger call package --args sh shell
+dagger call package shell --args sh
 ```
 
 This command drops you into an interactive shell, allowing you to directly execute commands in the container returned by the `package` function, as in the example below:
@@ -275,7 +275,7 @@ func (m *MyMod) PackageService(
   // +optional
   nodeVersion string,
 ) *Service {
-  return m.Package().
+  return m.Package(nodeVersion).
     AsService()
 }
 ```
@@ -283,7 +283,7 @@ func (m *MyMod) PackageService(
 Then, use the `up` API to build the application and serve it with NGINX, mapping container port 80 to host port 8080:
 
 ```shell
-dagger call package-service up --port 8080:80
+dagger call package-service up --ports 8080:80
 ```
 
 You should now be able to access the application by browsing to `http://localhost:8080` on the host (replace `localhost` with your Docker host's network name if accessing it remotely).

--- a/docs/versioned_docs/version-zenith/developer/go/457202-test-build-publish.mdx
+++ b/docs/versioned_docs/version-zenith/developer/go/457202-test-build-publish.mdx
@@ -32,10 +32,10 @@ This guide assumes that:
 
 The example module used in this guide builds, tests and publishes a Node.js application.
 
-Begin by running `dagger mod init` in your application directory to bootstrap a new module:
+Begin by running `dagger init` in your application directory to bootstrap a new module:
 
 ```sh
-dagger mod init --name=mymod --sdk=go
+dagger init --name=my-mod --sdk=go
 ```
 
 This will generate a `dagger.json` module file, an initial `main.go` source file, as well as a generated `dagger.gen.go` and `internal` folder for the generated module code.
@@ -49,7 +49,7 @@ Since the application is a Node.js application, it's convenient to use the [`nod
 1. Add the `node` module as a dependency:
 
     ```shell
-    dagger mod install github.com/quartz-technology/daggerverse/node@9ce087b83aa8b85f828d7d92ce39bd7c055cfc0f
+    dagger install github.com/quartz-technology/daggerverse/node@9ce087b83aa8b85f828d7d92ce39bd7c055cfc0f
     ```
 
 1. Update the generated `main.go` file with the following code:
@@ -57,17 +57,18 @@ Since the application is a Node.js application, it's convenient to use the [`nod
     ```go
     package main
 
-    type Mymod struct {}
+    type MyMod struct {}
 
     const defaultNodeVersion = "16"
 
-    func (m *Mymod) buildBase(nodeVersion Optional[string]) *Node {
+    func (m *MyMod) buildBase(nodeVersion string) *Node {
+      if nodeVersion == "" {
+        nodeVersion = defaultNodeVersion
+      }
       return dag.Node().
-        WithVersion(nodeVersion.GetOr(defaultNodeVersion)).
+        WithVersion(nodeVersion).
         WithNpm().
-        WithSource(dag.Host().Directory(".", HostDirectoryOpts{
-          Exclude: []string{".git", "**/node_modules"},
-        })).
+        WithSource(dag.CurrentModule().Source()).
         Install(nil)
     }
     ```
@@ -97,7 +98,11 @@ import (
 
 // ...
 
-func (m *Mymod) Test(ctx context.Context, nodeVersion Optional[string]) (string, error) {
+func (m *MyMod) Test(
+  ctx context.Context, 
+  // +optional
+  nodeVersion string,
+) (string, error) {
   return m.buildBase(nodeVersion).
     Run([]string{"test", "--", "--watchAll=false"}).
     Stderr(ctx)
@@ -145,7 +150,10 @@ If your application passes all its tests, the typical next step is to build it.
 Add a new `Build()` function that creates a production build of the example application:
 
 ```go
-func (m *Mymod) Build(nodeVersion Optional[string]) *Directory {
+func (m *MyMod) Build(
+  // +optional
+  nodeVersion string,
+) *Directory {
   return m.buildBase(nodeVersion).Build().Container().Directory("./build")
 }
 ```
@@ -189,19 +197,26 @@ One such registry is [ttl.sh](https://ttl.sh), an ephemeral Docker registry. The
 1. Add the `ttlsh` module as a dependency in your module:
 
     ```shell
-    dagger mod install github.com/shykes/daggerverse/ttlsh@16e40ec244966e55e36a13cb6e1ff8023e1e1473
+    dagger install github.com/shykes/daggerverse/ttlsh@16e40ec244966e55e36a13cb6e1ff8023e1e1473
     ```
 
 1. Update the module and add new `Package()` and `Publish()` functions to copy the built application into an NGINX web server container image and deliver the result to the registry:
 
     ```go
-    func (m *Mymod) Package(nodeVersion Optional[string]) *Container {
+    func (m *MyMod) Package(
+      // +optional
+      nodeVersion string,
+    ) *Container {
       return dag.Container().From("nginx:1.23-alpine").
         WithDirectory("/usr/share/nginx/html", m.Build(nodeVersion)).
         WithExposedPort(80)
     }
 
-    func (m *Mymod) Publish(ctx context.Context, nodeVersion Optional[string]) (string, error) {
+    func (m *MyMod) Publish(
+      ctx context.Context, 
+      // +optional
+      nodeVersion string,
+    ) (string, error) {
       return dag.Ttlsh().Publish(ctx, m.Package(nodeVersion))
     }
     ```
@@ -258,7 +273,10 @@ The `dagger up` command allows `Service` and `Container` types returned by a fun
 In order for this to work, the service/container returned by the function must have the `Container.withExposedPort` field defining one or more exposed ports. This is already implemented in the `Package()` function shown in the previous section. So, all that's needed is a new `PackageService()` function, as shown below:
 
 ```go
-func (m *Mymod) PackageService(nodeVersion Optional[string]) *Service {
+func (m *MyMod) PackageService(
+  // +optional
+  nodeVersion string,
+) *Service {
   return m.Package().
     AsService()
 }
@@ -267,7 +285,7 @@ func (m *Mymod) PackageService(nodeVersion Optional[string]) *Service {
 Then, use the `dagger up` command to build the application and serve it with NGINX, mapping container port 80 to host port 8080:
 
 ```shell
-dagger up --port 8080:80 package-service
+dagger package-service up --port 8080:80
 ```
 
 You should now be able to access the application by browsing to `http://localhost:8080` on the host (replace `localhost` with your Docker host's network name if accessing it remotely).

--- a/docs/versioned_docs/version-zenith/developer/go/457202-test-build-publish.mdx
+++ b/docs/versioned_docs/version-zenith/developer/go/457202-test-build-publish.mdx
@@ -32,10 +32,10 @@ This guide assumes that:
 
 The example module used in this guide builds, tests and publishes a Node.js application.
 
-Begin by running `dagger init` in your application directory to bootstrap a new module:
+Begin by running `dagger mod init` in your application directory to bootstrap a new module:
 
 ```sh
-dagger init --name=my-mod --sdk=go
+dagger mod init --name=my-mod --sdk=go
 ```
 
 This will generate a `dagger.json` module file, an initial `main.go` source file, as well as a generated `dagger.gen.go` and `internal` folder for the generated module code.
@@ -49,7 +49,7 @@ Since the application is a Node.js application, it's convenient to use the [`nod
 1. Add the `node` module as a dependency:
 
     ```shell
-    dagger install github.com/quartz-technology/daggerverse/node@9ce087b83aa8b85f828d7d92ce39bd7c055cfc0f
+    dagger mod install github.com/quartz-technology/daggerverse/node@9ce087b83aa8b85f828d7d92ce39bd7c055cfc0f
     ```
 
 1. Update the generated `main.go` file with the following code:
@@ -197,7 +197,7 @@ One such registry is [ttl.sh](https://ttl.sh), an ephemeral Docker registry. The
 1. Add the `ttlsh` module as a dependency in your module:
 
     ```shell
-    dagger install github.com/shykes/daggerverse/ttlsh@16e40ec244966e55e36a13cb6e1ff8023e1e1473
+    dagger mod install github.com/shykes/daggerverse/ttlsh@16e40ec244966e55e36a13cb6e1ff8023e1e1473
     ```
 
 1. Update the module and add new `Package()` and `Publish()` functions to copy the built application into an NGINX web server container image and deliver the result to the registry:
@@ -244,16 +244,14 @@ Here's an example of the output you will see:
 
 Apart from the usual debugging techniques, Dagger provides two commands that come in very handy when debugging modules.
 
-### dagger shell
+### Interactive shells
 
-The `dagger shell` command can be used to open an interactive shell session with any `Container` type returned by a function. This is very useful for debugging and experimenting since it allows you to interact with containers directly.
-
-By default, `dagger shell` will execute the container's entrypoint, but you can override this with the `--entrypoint` flag.
+The `shell` API on `Container` types can be used to open an interactive shell session with any `Container` returned by a function. This is very useful for debugging and experimenting since it allows you to interact with containers directly.
 
 Try it with the command below:
 
 ```shell
-dagger shell package --entrypoint /bin/sh
+dagger call package --args sh shell
 ```
 
 This command drops you into an interactive shell, allowing you to directly execute commands in the container returned by the `package` function, as in the example below:
@@ -266,9 +264,9 @@ asset-manifest.json  index.html           logo512.png          robots.txt
 /usr/share/nginx/html #
 ```
 
-### dagger up
+### Connecting to Services from your machine
 
-The `dagger up` command allows `Service` and `Container` types returned by a function to be executed and have any exposed ports forwarded to the host machine. This has many potential use cases, such as manually testing web servers or databases directly from the host browser or host system.
+The `up` API allows `Service` types returned by a function to be executed and have any exposed ports forwarded to the host machine. This has many potential use cases, such as manually testing web servers or databases directly from the host browser or host system.
 
 In order for this to work, the service/container returned by the function must have the `Container.withExposedPort` field defining one or more exposed ports. This is already implemented in the `Package()` function shown in the previous section. So, all that's needed is a new `PackageService()` function, as shown below:
 
@@ -282,10 +280,10 @@ func (m *MyMod) PackageService(
 }
 ```
 
-Then, use the `dagger up` command to build the application and serve it with NGINX, mapping container port 80 to host port 8080:
+Then, use the `up` API to build the application and serve it with NGINX, mapping container port 80 to host port 8080:
 
 ```shell
-dagger package-service up --port 8080:80
+dagger call package-service up --port 8080:80
 ```
 
 You should now be able to access the application by browsing to `http://localhost:8080` on the host (replace `localhost` with your Docker host's network name if accessing it remotely).

--- a/docs/versioned_docs/version-zenith/developer/go/525021-quickstart.mdx
+++ b/docs/versioned_docs/version-zenith/developer/go/525021-quickstart.mdx
@@ -29,14 +29,14 @@ This quickstart assumes that:
 
 ## Step 1: Initialize a new module
 
-1. Create a new directory on your filesystem and run `dagger init` to bootstrap your first module. We'll call it `potato` here, but you can choose your favorite food.
+1. Create a new directory on your filesystem and run `dagger mod init` to bootstrap your first module. We'll call it `potato` here, but you can choose your favorite food.
 
     ```sh
     mkdir potato/
     cd potato/
 
     # initialize Dagger module
-    dagger init --name=potato --sdk=go
+    dagger mod init --name=potato --sdk=go
     ```
 
     This will generate a `dagger.json` module file, an initial `main.go` source file, as well as a generated `dagger.gen.go` and library folders for the generated module code.
@@ -123,7 +123,7 @@ The example module in the previous sections was just that - an example. Next, le
     ```shell
     mkdir trivy/
     cd trivy/
-    dagger init --name=trivy --sdk=go
+    dagger mod init --name=trivy --sdk=go
     ```
 
 1. Replace the generated `main.go` file with the following code:

--- a/docs/versioned_docs/version-zenith/developer/go/525021-quickstart.mdx
+++ b/docs/versioned_docs/version-zenith/developer/go/525021-quickstart.mdx
@@ -29,17 +29,17 @@ This quickstart assumes that:
 
 ## Step 1: Initialize a new module
 
-1. Create a new directory on your filesystem and run `dagger mod init` to bootstrap your first module. We'll call it `potato` here, but you can choose your favorite food.
+1. Create a new directory on your filesystem and run `dagger init` to bootstrap your first module. We'll call it `potato` here, but you can choose your favorite food.
 
     ```sh
     mkdir potato/
     cd potato/
 
     # initialize Dagger module
-    dagger mod init --name=potato --sdk=go
+    dagger init --name=potato --sdk=go
     ```
 
-    This will generate a `dagger.json` module file, an initial `main.go` source file, as well as a generated `dagger.gen.go` and `internal` folder for the generated module code.
+    This will generate a `dagger.json` module file, an initial `main.go` source file, as well as a generated `dagger.gen.go` and library folders for the generated module code.
 
 1. Test the module. Run the generated `main.go` with the `dagger call` command:
 
@@ -51,16 +51,8 @@ This quickstart assumes that:
     When using `dagger call` to call module functions, do not explicitly use the name of the module.
     :::
 
-    An alternative approach is to run the module using a GraphQL query piped through the `dagger query` command:
-
-    ```sh
-    echo '{potato{containerEcho(stringArg:"Hello daggernauts!"){stdout}}}' | dagger query
-    ```
-
 :::note
 When using `dagger call`, all names (functions, arguments, struct fields, etc) are converted into a shell-friendly "kebab-case" style.
-
-When using `dagger query` and GraphQL, all names are converted into a language-agnostic "camelCase" style.
 :::
 
 ## Step 2: Add a function
@@ -83,26 +75,10 @@ Let's try changing the `main.go` file.
     func (m *Potato) HelloWorld(ctx context.Context) (string, error)
     ```
 
-1. Run `dagger mod sync` to regenerate the module code:
-
-    ```sh
-    dagger mod sync
-    ```
-
-    :::important
-    You must run `dagger mod sync` after every change to your module's interface (when you add/remove functions or change their parameters and return types).
-    :::
-
-1. Test the new function, once again using `dagger call` or `dagger query`:
+1. Test the new function, once again using `dagger call`:
 
     ```sh
     dagger call hello-world
-    ```
-
-    or
-
-    ```sh
-    echo '{potato{helloWorld}}' | dagger query
     ```
 
 ## Step 3: Use input parameters and return types
@@ -116,18 +92,10 @@ Your module functions can accept and return multiple different types, not just b
 
     The optional parameters are specified using the special `// +optional` comment, which dagger uses to set these as optional in the generated API. These comments must appear in the comment block before the parameter.
 
-    You can also use the `Optional` generic helper type, which has helper methods, like `GetOr` to easily get the underlying value.
-
     Here's an example of calling the function with optional parameters:
 
     ```sh
     dagger call hello-world --count 10 --mashed true
-    ```
-
-    or
-
-    ```sh
-    echo '{potato{helloWorld(count:10, mashed:true)}}' | dagger query
     ```
 
 1. Update the function to return a custom `PotatoMessage` type:
@@ -135,17 +103,11 @@ Your module functions can accept and return multiple different types, not just b
     ```go file=./snippets/quickstart/step3b/main.go
     ```
 
-    Test it using `dagger call` or `dagger query`:
+    Test it using `dagger call`:
 
     ```sh
     dagger call hello-world --message "I am a potato" message
     dagger call hello-world --message "I am a potato" from
-    ```
-
-    or
-
-    ```sh
-    echo '{potato{helloWorld(message: "I am a potato"){message, from}}}' | dagger query
     ```
 
 :::tip
@@ -161,7 +123,7 @@ The example module in the previous sections was just that - an example. Next, le
     ```shell
     mkdir trivy/
     cd trivy/
-    dagger mod init --name=trivy --sdk=go
+    dagger init --name=trivy --sdk=go
     ```
 
 1. Replace the generated `main.go` file with the following code:

--- a/docs/versioned_docs/version-zenith/developer/go/525021-quickstart.mdx
+++ b/docs/versioned_docs/version-zenith/developer/go/525021-quickstart.mdx
@@ -44,7 +44,7 @@ This quickstart assumes that:
 1. Test the module. Run the generated `main.go` with the `dagger call` command:
 
     ```sh
-    dagger call container-echo --string-arg 'Hello daggernauts!'
+    dagger call container-echo --string-arg 'Hello daggernauts!' stdout
     ```
 
     :::tip
@@ -95,7 +95,7 @@ Your module functions can accept and return multiple different types, not just b
     Here's an example of calling the function with optional parameters:
 
     ```sh
-    dagger call hello-world --count 10 --mashed true
+    dagger call hello-world --count 10 --mashed
     ```
 
 1. Update the function to return a custom `PotatoMessage` type:

--- a/docs/versioned_docs/version-zenith/developer/go/snippets/advanced-programming/constructor/main.go
+++ b/docs/versioned_docs/version-zenith/developer/go/snippets/advanced-programming/constructor/main.go
@@ -7,8 +7,10 @@ import (
 )
 
 func New(
+	// +optional
 	// +default=Hello
 	greeting string,
+	// +optional
 	// +default=World
 	name string,
 ) *HelloWorld {

--- a/docs/versioned_docs/version-zenith/developer/go/snippets/advanced-programming/constructor/main.go
+++ b/docs/versioned_docs/version-zenith/developer/go/snippets/advanced-programming/constructor/main.go
@@ -6,10 +6,15 @@ import (
 	"fmt"
 )
 
-func New(greeting Optional[string], name Optional[string]) *HelloWorld {
+func New(
+	// +default=Hello
+	greeting string,
+	// +default=World
+	name string,
+) *HelloWorld {
 	return &HelloWorld{
-		Greeting: greeting.GetOr("Hello"),
-		Name:     name.GetOr("World"),
+		Greeting: greeting,
+		Name:     name,
 	}
 }
 

--- a/docs/versioned_docs/version-zenith/developer/go/snippets/quickstart/trivy/main.go
+++ b/docs/versioned_docs/version-zenith/developer/go/snippets/quickstart/trivy/main.go
@@ -12,10 +12,12 @@ type Trivy struct{}
 func (t *Trivy) ScanImage(
 	ctx context.Context,
 	imageRef string,
+	// +optional
 	// +default=UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
 	severity string,
 	// +optional
 	exitCode int,
+	// +optional
 	// +default=table
 	format string,
 ) (string, error) {
@@ -26,7 +28,7 @@ func (t *Trivy) ScanImage(
 			"image",
 			"--quiet",
 			"--severity", severity,
-			"--exit-code", exitCode,
+			"--exit-code", strconv.Itoa(exitCode),
 			"--format", format,
 			imageRef,
 		}).

--- a/docs/versioned_docs/version-zenith/developer/go/snippets/quickstart/trivy/main.go
+++ b/docs/versioned_docs/version-zenith/developer/go/snippets/quickstart/trivy/main.go
@@ -12,15 +12,23 @@ type Trivy struct{}
 func (t *Trivy) ScanImage(
 	ctx context.Context,
 	imageRef string,
-	severity Optional[string],
-	exitCode Optional[int],
-	format Optional[string],
+	// +default=UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+	severity string,
+	// +optional
+	exitCode int,
+	// +default=table
+	format string,
 ) (string, error) {
-	sv := severity.GetOr("UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL")
-	ec := exitCode.GetOr(0)
-	ft := format.GetOr("table")
 	return dag.
 		Container().
 		From("aquasec/trivy:latest").
-		WithExec([]string{"image", "--quiet", "--severity", sv, "--exit-code", strconv.Itoa(ec), "--format", ft, imageRef}).Stdout(ctx)
+		WithExec([]string{
+			"image",
+			"--quiet",
+			"--severity", severity,
+			"--exit-code", exitCode,
+			"--format", format,
+			imageRef,
+		}).
+		Stdout(ctx)
 }

--- a/docs/versioned_docs/version-zenith/developer/go/snippets/test-build-publish/step6/main.go
+++ b/docs/versioned_docs/version-zenith/developer/go/snippets/test-build-publish/step6/main.go
@@ -13,7 +13,7 @@ func (m *MyMod) buildBase(nodeVersion string) *Node {
 		nodeVersion = defaultNodeVersion
 	}
 	return dag.Node().
-		WithVersion(nodeVersion.GetOr(defaultNodeVersion)).
+		WithVersion(nodeVersion).
 		WithNpm().
 		WithSource(dag.CurrentModule().Source()).
 		Install(nil)

--- a/docs/versioned_docs/version-zenith/developer/go/snippets/test-build-publish/step6/main.go
+++ b/docs/versioned_docs/version-zenith/developer/go/snippets/test-build-publish/step6/main.go
@@ -4,41 +4,59 @@ import (
 	"context"
 )
 
-type Mymod struct{}
+type MyMod struct{}
 
 const defaultNodeVersion = "16"
 
-func (m *Mymod) buildBase(nodeVersion Optional[string]) *Node {
+func (m *MyMod) buildBase(nodeVersion string) *Node {
+	if nodeVersion == "" {
+		nodeVersion = defaultNodeVersion
+	}
 	return dag.Node().
 		WithVersion(nodeVersion.GetOr(defaultNodeVersion)).
 		WithNpm().
-		WithSource(dag.Host().Directory(".", HostDirectoryOpts{
-			Exclude: []string{".git", "**/node_modules"},
-		})).
+		WithSource(dag.CurrentModule().Source()).
 		Install(nil)
 }
 
-func (m *Mymod) Test(ctx context.Context, nodeVersion Optional[string]) (string, error) {
+func (m *MyMod) Test(
+	ctx context.Context,
+	// +optional
+	nodeVersion string,
+) (string, error) {
 	return m.buildBase(nodeVersion).
 		Run([]string{"test", "--", "--watchAll=false"}).
 		Stderr(ctx)
 }
 
-func (m *Mymod) Build(nodeVersion Optional[string]) *Directory {
+func (m *MyMod) Build(
+	// +optional
+	nodeVersion string,
+) *Directory {
 	return m.buildBase(nodeVersion).Build().Container().Directory("./build")
 }
 
-func (m *Mymod) Package(nodeVersion Optional[string]) *Container {
+func (m *MyMod) Package(
+	// +optional
+	nodeVersion string,
+) *Container {
 	return dag.Container().From("nginx:1.23-alpine").
 		WithDirectory("/usr/share/nginx/html", m.Build(nodeVersion)).
 		WithExposedPort(80)
 }
 
-func (m *Mymod) PackageService(nodeVersion Optional[string]) *Service {
+func (m *MyMod) PackageService(
+	// +optional
+	nodeVersion string,
+) *Service {
 	return m.Package(nodeVersion).
 		AsService()
 }
 
-func (m *Mymod) Publish(ctx context.Context, nodeVersion Optional[string]) (string, error) {
+func (m *MyMod) Publish(
+	ctx context.Context,
+	// +optional
+	nodeVersion string,
+) (string, error) {
 	return dag.Ttlsh().Publish(ctx, m.Package(nodeVersion))
 }

--- a/docs/versioned_docs/version-zenith/developer/python/419481-quickstart.mdx
+++ b/docs/versioned_docs/version-zenith/developer/python/419481-quickstart.mdx
@@ -29,14 +29,14 @@ This quickstart assumes that:
 
 ## Step 1: Initialize a new module
 
-1. Create a new directory on your filesystem and run `dagger mod init` to bootstrap your first module. We'll call it `potato` here, but you can choose your favorite food.
+1. Create a new directory on your filesystem and run `dagger init` to bootstrap your first module. We'll call it `potato` here, but you can choose your favorite food.
 
     ```sh
     mkdir potato/
     cd potato/
 
     # initialize Dagger module
-    dagger mod init --name=potato --sdk=python
+    dagger init --name=potato --sdk=python
     ```
 
     This will generate a `dagger.json` module file, initial `src/main.py` and `pyproject.toml` files, as well as a generated `sdk` folder for local development.
@@ -51,16 +51,8 @@ This quickstart assumes that:
     When using `dagger call` to call module functions, do not explicitly use the name of the module.
     :::
 
-    An alternative approach is to run the module using a GraphQL query piped through the `dagger query` command:
-
-    ```sh
-    echo '{potato{containerEcho(stringArg:"Hello daggernauts!"){stdout}}}' | dagger query
-    ```
-
 :::note
 When using `dagger call`, all names (functions, arguments, struct fields, etc) are converted into a shell-friendly "kebab-case" style.
-
-When using `dagger query` and GraphQL, all names are converted into a language-agnostic "camelCase" style.
 :::
 
 ## Step 2: Prepare the development environment
@@ -80,7 +72,7 @@ pip install -e ./sdk
 :::tip
 As always, you can use any virtual environment manager, including [Poetry](https://python-poetry.org) and others. Just make sure you add `./sdk` as a development dependency. If you place the virtual environment inside the module, don't forget to add it to `.gitignore` and to `"exclude"` in `dagger.json`.
 
-It's also important to install the SDK in **editable mode** (the `-e` in the `pip install` command) so you don't have to reinstall it after a `dagger mod sync`. However, it's always recommended to reinstall the SDK after upgrading Dagger to cover possible dependency changes.
+It's also important to install the SDK in **editable mode** (the `-e` in the `pip install` command) so you don't have to reinstall it after a `dagger develop`. However, it's always recommended to reinstall the SDK after upgrading Dagger to cover possible dependency changes.
 :::
 
 ## Step 3: Add a function
@@ -92,16 +84,10 @@ Let's try changing the `src/main.py` file.
     ```python file=./snippets/quickstart/step2/main.py
     ```
 
-1. Test the new function, once again using `dagger call` or `dagger query`:
+1. Test the new function, once again using `dagger call`:
 
     ```sh
     dagger call hello-world
-    ```
-
-    or
-
-    ```sh
-    echo '{potato{helloWorld}}' | dagger query
     ```
 
 ## Step 4: Use input parameters and return types
@@ -121,30 +107,18 @@ Your module functions can accept and return multiple different types, not just b
     dagger call hello-world --count 10 --mashed
     ```
 
-    or
-
-    ```sh
-    echo '{potato{helloWorld(count:10, mashed:true)}}' | dagger query
-    ```
-
 1. Update the function to return a custom `PotatoMessage` type:
 
     ```python file=./snippets/quickstart/step3b/main.py
     ```
 
-    Test it using `dagger call` or `dagger query`:
+    Test it using `dagger call`:
 
     ```sh
     dagger call hello-world --message "I am a potato" message
     dagger call hello-world --message "I am a potato" from
+
     ```
-
-    or
-
-    ```sh
-    echo '{potato{helloWorld(message: "I am a potato"){message, from}}}' | dagger query
-    ```
-
     [dagger.mod.field](https://dagger-io.readthedocs.io/en/latest/module.html#dagger.mod.field)
     is only needed to allow accessing the field directly via the API. Otherwise,
     it will still be used during serialization/deserialization when passing the
@@ -163,7 +137,7 @@ The example module in the previous sections was just that - an example. Next, le
     ```shell
     mkdir trivy/
     cd trivy/
-    dagger mod init --name=trivy --sdk=python
+    dagger init --name=trivy --sdk=python
     ```
 
 1. Replace the generated `main.py` file with the following code:

--- a/docs/versioned_docs/version-zenith/developer/python/419481-quickstart.mdx
+++ b/docs/versioned_docs/version-zenith/developer/python/419481-quickstart.mdx
@@ -29,14 +29,14 @@ This quickstart assumes that:
 
 ## Step 1: Initialize a new module
 
-1. Create a new directory on your filesystem and run `dagger init` to bootstrap your first module. We'll call it `potato` here, but you can choose your favorite food.
+1. Create a new directory on your filesystem and run `dagger mod init` to bootstrap your first module. We'll call it `potato` here, but you can choose your favorite food.
 
     ```sh
     mkdir potato/
     cd potato/
 
     # initialize Dagger module
-    dagger init --name=potato --sdk=python
+    dagger mod init --name=potato --sdk=python
     ```
 
     This will generate a `dagger.json` module file, initial `src/main.py` and `pyproject.toml` files, as well as a generated `sdk` folder for local development.
@@ -72,7 +72,7 @@ pip install -e ./sdk
 :::tip
 As always, you can use any virtual environment manager, including [Poetry](https://python-poetry.org) and others. Just make sure you add `./sdk` as a development dependency. If you place the virtual environment inside the module, don't forget to add it to `.gitignore` and to `"exclude"` in `dagger.json`.
 
-It's also important to install the SDK in **editable mode** (the `-e` in the `pip install` command) so you don't have to reinstall it after a `dagger develop`. However, it's always recommended to reinstall the SDK after upgrading Dagger to cover possible dependency changes.
+It's also important to install the SDK in **editable mode** (the `-e` in the `pip install` command) so you don't have to reinstall it after a `dagger mod sync`. However, it's always recommended to reinstall the SDK after upgrading Dagger to cover possible dependency changes.
 :::
 
 ## Step 3: Add a function
@@ -137,7 +137,7 @@ The example module in the previous sections was just that - an example. Next, le
     ```shell
     mkdir trivy/
     cd trivy/
-    dagger init --name=trivy --sdk=python
+    dagger mod init --name=trivy --sdk=python
     ```
 
 1. Replace the generated `main.py` file with the following code:

--- a/docs/versioned_docs/version-zenith/developer/python/419481-quickstart.mdx
+++ b/docs/versioned_docs/version-zenith/developer/python/419481-quickstart.mdx
@@ -44,7 +44,7 @@ This quickstart assumes that:
 1. Test the module. Run the generated `main.py` with the `dagger call` command:
 
     ```sh
-    dagger call container-echo --string-arg 'Hello daggernauts!'
+    dagger call container-echo --string-arg 'Hello daggernauts!' stdout
     ```
 
     :::tip
@@ -140,7 +140,7 @@ The example module in the previous sections was just that - an example. Next, le
     dagger mod init --name=trivy --sdk=python
     ```
 
-1. Replace the generated `main.py` file with the following code:
+1. Replace the generated `src/main.py` file with the following code:
 
     ```python file=./snippets/quickstart/trivy/main.py
     ```

--- a/docs/versioned_docs/version-zenith/developer/python/539756-advanced-programming.mdx
+++ b/docs/versioned_docs/version-zenith/developer/python/539756-advanced-programming.mdx
@@ -25,10 +25,10 @@ This guide assumes that:
 
 ## Use modules in other modules
 
-Modules can call each other. To add a dependency to your module, you can use `dagger mod install`, as in the following example:
+Modules can call each other. To add a dependency to your module, you can use `dagger install`, as in the following example:
 
 ```sh
-dagger mod install github.com/shykes/daggerverse/helloWorld@26f8ed9f1748ec8c9345281add850fd392441990
+dagger install github.com/shykes/daggerverse/helloWorld@26f8ed9f1748ec8c9345281add850fd392441990
 ```
 
 This module will be added to your `dagger.json`:
@@ -42,7 +42,7 @@ This module will be added to your `dagger.json`:
 You can also use local modules as dependencies. However, they must be stored in a sub-directory of your module. For example:
 
 ```sh
-dagger mod install ./path/to/module
+dagger install ./path/to/module
 ```
 
 The dependent module will be added to your code-generation routines, so you can access it from your own module's code, as shown below:
@@ -70,34 +70,16 @@ Here is an example module using the Python SDK:
 
 ```
 
-And here is an example query for this module:
+And here is an example call for this module:
 
-```graphql
-{
-  helloWorld {
-    message
-    withName(name: "Monde") {
-      withGreeting(greeting: "Bonjour") {
-        message
-      }
-    }
-  }
-}
+```console
+dagger call with-name --name=Monde with-greeting --greeting=Bonjour message
 ```
 
 The result will be:
 
-```json
-{
-  "helloWorld": {
-    "message": "Hello, World!",
-    "withName": {
-      "withGreeting": {
-        "message": "Bonjour, Monde!"
-      }
-    }
-  }
-}
+```console
+Bonjour, Monde!
 ```
 
 ## Write an asynchronous module constructor function

--- a/docs/versioned_docs/version-zenith/developer/python/539756-advanced-programming.mdx
+++ b/docs/versioned_docs/version-zenith/developer/python/539756-advanced-programming.mdx
@@ -25,10 +25,10 @@ This guide assumes that:
 
 ## Use modules in other modules
 
-Modules can call each other. To add a dependency to your module, you can use `dagger install`, as in the following example:
+Modules can call each other. To add a dependency to your module, you can use `dagger mod install`, as in the following example:
 
 ```sh
-dagger install github.com/shykes/daggerverse/helloWorld@26f8ed9f1748ec8c9345281add850fd392441990
+dagger mod install github.com/shykes/daggerverse/helloWorld@26f8ed9f1748ec8c9345281add850fd392441990
 ```
 
 This module will be added to your `dagger.json`:
@@ -42,7 +42,7 @@ This module will be added to your `dagger.json`:
 You can also use local modules as dependencies. However, they must be stored in a sub-directory of your module. For example:
 
 ```sh
-dagger install ./path/to/module
+dagger mod install ./path/to/module
 ```
 
 The dependent module will be added to your code-generation routines, so you can access it from your own module's code, as shown below:

--- a/docs/versioned_docs/version-zenith/developer/typescript/506316-quickstart.mdx
+++ b/docs/versioned_docs/version-zenith/developer/typescript/506316-quickstart.mdx
@@ -44,7 +44,7 @@ This quickstart assumes that:
 2. Test the module. Run the generated `index.ts` with the `dagger call` command:
 
     ```sh
-    dagger call container-echo --string-arg 'Hello daggernauts!'
+    dagger call container-echo --string-arg 'Hello daggernauts!' stdout
     ```
 
     :::tip
@@ -118,7 +118,7 @@ The example module in the previous sections was just that - an example. Next, le
 
     cd trivy/
 
-    dagger mod init --name=trivy --sdk=python
+    dagger mod init --name=trivy --sdk=typescript
     ```
 
 2. Replace the generated `index.ts` file with the following code:

--- a/docs/versioned_docs/version-zenith/developer/typescript/506316-quickstart.mdx
+++ b/docs/versioned_docs/version-zenith/developer/typescript/506316-quickstart.mdx
@@ -29,14 +29,14 @@ This quickstart assumes that:
 
 ## Step 1: Initialize a new module
 
-1. Create a new directory on your filesystem and run `dagger init` to bootstrap your first module. We'll call it `potato` here, but you can choose your favorite food.
+1. Create a new directory on your filesystem and run `dagger mod init` to bootstrap your first module. We'll call it `potato` here, but you can choose your favorite food.
 
     ```sh
     mkdir potato/
     cd potato/
 
     # initialize Dagger module
-    dagger init --name=potato --sdk=typescript
+    dagger mod init --name=potato --sdk=typescript
     ```
 
     This will generate a `dagger.json` module file, initial `src/index.ts` and typescript basic setup with a `package.json`, a `tsconfig.json` and a `yarn.lock`, as well as a generated `sdk` folder for local development.
@@ -118,7 +118,7 @@ The example module in the previous sections was just that - an example. Next, le
 
     cd trivy/
 
-    dagger init --name=trivy --sdk=python
+    dagger mod init --name=trivy --sdk=python
     ```
 
 2. Replace the generated `index.ts` file with the following code:

--- a/docs/versioned_docs/version-zenith/developer/typescript/506316-quickstart.mdx
+++ b/docs/versioned_docs/version-zenith/developer/typescript/506316-quickstart.mdx
@@ -29,14 +29,14 @@ This quickstart assumes that:
 
 ## Step 1: Initialize a new module
 
-1. Create a new directory on your filesystem and run `dagger mod init` to bootstrap your first module. We'll call it `potato` here, but you can choose your favorite food.
+1. Create a new directory on your filesystem and run `dagger init` to bootstrap your first module. We'll call it `potato` here, but you can choose your favorite food.
 
     ```sh
     mkdir potato/
     cd potato/
 
     # initialize Dagger module
-    dagger mod init --name=potato --sdk=typescript
+    dagger init --name=potato --sdk=typescript
     ```
 
     This will generate a `dagger.json` module file, initial `src/index.ts` and typescript basic setup with a `package.json`, a `tsconfig.json` and a `yarn.lock`, as well as a generated `sdk` folder for local development.
@@ -51,16 +51,8 @@ This quickstart assumes that:
     When using `dagger call` to call module functions, do not explicitly use the name of the module.
     :::
 
-    An alternative approach is to run the module using a GraphQL query piped through the `dagger query` command:
-
-    ```sh
-    echo '{potato{containerEcho(stringArg:"Hello daggernauts!"){stdout}}}' | dagger query
-    ```
-
 :::note
 When using `dagger call`, all names (functions, arguments, struct fields, etc) are converted into a shell-friendly "kebab-case" style.
-
-When using `dagger query` and GraphQL, all names are converted into a language-agnostic "camelCase" style.
 :::
 
 ## Step 2: Add a function
@@ -74,16 +66,10 @@ Let's try changing the `src/index.ts` file.
 
     The `@object` decorator expose the class to the Dagger API and allow calling its methods decorator by `@func` from the Dagger CLI.
 
-2. Test the new function, once again using `dagger call` or `dagger query`:
+2. Test the new function, once again using `dagger call`:
 
     ```sh
     dagger call hello-world
-    ```
-
-    or
-
-    ```sh
-    echo '{potato{helloWorld}}' | dagger query
     ```
 
 ## Step 3: Use input parameters and return types
@@ -103,28 +89,16 @@ Your module functions can accept and return multiple different types, not just b
     dagger call hello-world --count 10 --mashed
     ```
 
-    or
-
-    ```sh
-    echo '{potato{helloWorld(count:10, mashed:true)}}' | dagger query
-    ```
-
 2. Update the function to return a custom `PotatoMessage` type:
 
     ```typescript file=./snippets/quickstart/step3b/index.ts
     ```
 
-    Test it using `dagger call` or `dagger query`:
+    Test it using `dagger call`:
 
     ```sh
     dagger call hello-world --message "I am a potato" message
     dagger call hello-world --message "I am a potato" from
-    ```
-
-    or
-
-    ```sh
-    echo '{potato{helloWorld(message: "I am a potato"){message, from}}}' | dagger query
     ```
 
     Using the `@field` decorator is only needed to allow accessing the field directly via the Dagger API. Otherwise, it will still be used during serialization/deserialization when passing the object instance to other functions.
@@ -144,7 +118,7 @@ The example module in the previous sections was just that - an example. Next, le
 
     cd trivy/
 
-    dagger mod init --name=trivy --sdk=python
+    dagger init --name=trivy --sdk=python
     ```
 
 2. Replace the generated `index.ts` file with the following code:


### PR DESCRIPTION
The most important updates here are in anticipation of breaking changes in the next release. There are also some more opinionated cleanups, but for now just leaving the overall structure the same.

The big breaking changes to adapt for are:
1. `dagger mod init/install/etc.` moving to be right under `dagger`
2. `dagger up` replaced by chainable `dagger call ... up`
3. `dag.Host()` being replaced with `dag.CurrentModule().Source()`

The more opinionated tweaks are:
1. Don't use raw graphql queries, only use `dagger call`
2. In Go, avoid use of `Optional` and instead center on `//+optional` and `//+default` pragmas.

One important note: the moving of `dagger mod init/install/etc.` has not been merged yet ([PR here](https://github.com/dagger/dagger/pull/6533)), so depending on how the timing works out may or may not need to modify this update before merging.

---

Let me know what you think about the opinionated tweaks. If we need more discussion about them but need to release, I can update this PR to only cover the breaking changes and save the rest for later.

Draft until:
- [ ] I run through all the commands to double check
- [ ] https://github.com/dagger/dagger/pull/6533 is finalized (since it impacts the command updates in here)