### PR TITLE
Remove Host API from module SDK codegen.

### DIFF
--- a/.changes/unreleased/Breaking-20240131-225025.yaml
+++ b/.changes/unreleased/Breaking-20240131-225025.yaml
@@ -1,7 +1,0 @@
-kind: Breaking
-body: Remove Host API from module SDKs. See linked PR for descriptions on how to update
-  if impacted.
-time: 2024-01-31T22:50:25.44606116-08:00
-custom:
-  Author: sipsma
-  PR: "6535"

--- a/.changes/unreleased/Breaking-20240131-225025.yaml
+++ b/.changes/unreleased/Breaking-20240131-225025.yaml
@@ -1,0 +1,7 @@
+kind: Breaking
+body: Remove Host API from module SDKs. See linked PR for descriptions on how to update
+  if impacted.
+time: 2024-01-31T22:50:25.44606116-08:00
+custom:
+  Author: sipsma
+  PR: "6535"

--- a/cmd/codegen/introspection/introspection.go
+++ b/cmd/codegen/introspection/introspection.go
@@ -45,6 +45,19 @@ func (s *Schema) Visit() []*Type {
 	return v.Run()
 }
 
+// Remove all occurrences of a type from the schema, including
+// any fields, input fields, and enum values that reference it.
+func (s *Schema) ScrubType(typeName string) {
+	filteredTypes := make(Types, 0, len(s.Types))
+	for _, t := range s.Types {
+		if t.ScrubType(typeName) {
+			continue
+		}
+		filteredTypes = append(filteredTypes, t)
+	}
+	s.Types = filteredTypes
+}
+
 type TypeKind string
 
 const (
@@ -76,6 +89,52 @@ type Type struct {
 	EnumValues  []EnumValue  `json:"enumValues,omitempty"`
 }
 
+// Remove all occurrences of a type from the schema, including
+// any fields, input fields, and enum values that reference it.
+// Returns true if this type should be removed, whether because
+// it is the type being scrubbed, or because it is now empty after
+// scrubbing its references.
+func (t *Type) ScrubType(typeName string) bool {
+	if t.Kind == TypeKindScalar {
+		return t.Name == typeName
+	}
+
+	filteredFields := make([]*Field, 0, len(t.Fields))
+	for _, f := range t.Fields {
+		if f.TypeRef.ReferencesType(typeName) {
+			continue
+		}
+		filteredFields = append(filteredFields, f)
+	}
+	t.Fields = filteredFields
+
+	filteredInputFields := make([]InputValue, 0, len(t.InputFields))
+	for _, f := range t.InputFields {
+		if f.Name == typeName {
+			continue
+		}
+		if f.TypeRef.ReferencesType(typeName) {
+			continue
+		}
+		filteredInputFields = append(filteredInputFields, f)
+	}
+	t.InputFields = filteredInputFields
+
+	filteredEnumValues := make([]EnumValue, 0, len(t.EnumValues))
+	for _, e := range t.EnumValues {
+		if e.Name == typeName {
+			continue
+		}
+		filteredEnumValues = append(filteredEnumValues, e)
+	}
+	t.EnumValues = filteredEnumValues
+
+	// check if we removed everything from it, in which case it should
+	// be removed itself
+	isEmpty := len(t.Fields) == 0 && len(t.InputFields) == 0 && len(t.EnumValues) == 0
+	return t.Name == typeName || isEmpty
+}
+
 type Types []*Type
 
 func (t Types) Get(name string) *Type {
@@ -96,6 +155,20 @@ type Field struct {
 	DeprecationReason string      `json:"deprecationReason"`
 
 	ParentObject *Type `json:"-"`
+}
+
+func (f *Field) ReferencesType(typeName string) bool {
+	// check return
+	if f.TypeRef.ReferencesType(typeName) {
+		return true
+	}
+	// check args
+	for _, arg := range f.Args {
+		if arg.TypeRef.ReferencesType(typeName) {
+			return true
+		}
+	}
+	return false
 }
 
 type TypeRef struct {
@@ -142,6 +215,13 @@ func (r TypeRef) IsList() bool {
 		return true
 	}
 	return false
+}
+
+func (r TypeRef) ReferencesType(typeName string) bool {
+	if r.OfType != nil {
+		return r.OfType.ReferencesType(typeName)
+	}
+	return r.Name == typeName
 }
 
 type InputValues []InputValue

--- a/cmd/codegen/introspection/introspection.go
+++ b/cmd/codegen/introspection/introspection.go
@@ -16,14 +16,14 @@ type Response struct {
 
 type Schema struct {
 	QueryType struct {
-		Name string `json:"name"`
-	} `json:"queryType"`
-	MutationType struct {
-		Name string `json:"name"`
-	} `json:"mutationType"`
-	SubscriptionType struct {
-		Name string `json:"name"`
-	} `json:"subscriptionType"`
+		Name string `json:"name,omitempty"`
+	} `json:"queryType,omitempty"`
+	MutationType *struct {
+		Name string `json:"name,omitempty"`
+	} `json:"mutationType,omitempty"`
+	SubscriptionType *struct {
+		Name string `json:"name,omitempty"`
+	} `json:"subscriptionType,omitempty"`
 
 	Types Types `json:"types"`
 }
@@ -33,10 +33,16 @@ func (s *Schema) Query() *Type {
 }
 
 func (s *Schema) Mutation() *Type {
+	if s.MutationType == nil {
+		return nil
+	}
 	return s.Types.Get(s.MutationType.Name)
 }
 
 func (s *Schema) Subscription() *Type {
+	if s.SubscriptionType == nil {
+		return nil
+	}
 	return s.Types.Get(s.SubscriptionType.Name)
 }
 
@@ -87,6 +93,7 @@ type Type struct {
 	Fields      []*Field     `json:"fields,omitempty"`
 	InputFields []InputValue `json:"inputFields,omitempty"`
 	EnumValues  []EnumValue  `json:"enumValues,omitempty"`
+	Interfaces  []*Type      `json:"interfaces"`
 }
 
 // Remove all occurrences of a type from the schema, including

--- a/core/module.go
+++ b/core/module.go
@@ -428,8 +428,8 @@ func (mod *Module) TypeDefs(ctx context.Context) ([]*TypeDef, error) {
 	return typeDefs, nil
 }
 
-func (mod *Module) DependencySchemaIntrospectionJSON(ctx context.Context) (string, error) {
-	return mod.Deps.SchemaIntrospectionJSON(ctx)
+func (mod *Module) DependencySchemaIntrospectionJSON(ctx context.Context, forModule bool) (string, error) {
+	return mod.Deps.SchemaIntrospectionJSON(ctx, forModule)
 }
 
 func (mod *Module) ModTypeFor(ctx context.Context, typeDef *TypeDef, checkDirectDeps bool) (ModType, bool, error) {

--- a/core/schema/schema.go
+++ b/core/schema/schema.go
@@ -183,7 +183,7 @@ func (s *APIServer) CurrentServedDeps(ctx context.Context) (*core.ModDeps, error
 }
 
 func (s *APIServer) Introspect(ctx context.Context) (string, error) {
-	return s.root.DefaultDeps.SchemaIntrospectionJSON(ctx)
+	return s.root.DefaultDeps.SchemaIntrospectionJSON(ctx, false)
 }
 
 type SchemaResolvers interface {

--- a/core/schema/sdk.go
+++ b/core/schema/sdk.go
@@ -119,7 +119,7 @@ func (s *moduleSchema) newModuleSDK(
 
 // Codegen calls the Codegen function on the SDK Module
 func (sdk *moduleSDK) Codegen(ctx context.Context, mod *core.Module, source dagql.Instance[*core.ModuleSource]) (*core.GeneratedCode, error) {
-	introspectionJSON, err := mod.DependencySchemaIntrospectionJSON(ctx)
+	introspectionJSON, err := mod.DependencySchemaIntrospectionJSON(ctx, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get schema introspection json during %s module sdk codegen: %w", sdk.mod.Self.Name(), err)
 	}
@@ -146,7 +146,7 @@ func (sdk *moduleSDK) Codegen(ctx context.Context, mod *core.Module, source dagq
 
 // Runtime calls the Runtime function on the SDK Module
 func (sdk *moduleSDK) Runtime(ctx context.Context, mod *core.Module, source dagql.Instance[*core.ModuleSource]) (*core.Container, error) {
-	introspectionJSON, err := mod.DependencySchemaIntrospectionJSON(ctx)
+	introspectionJSON, err := mod.DependencySchemaIntrospectionJSON(ctx, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get schema introspection json during %s module sdk runtime: %w", sdk.mod.Self.Name(), err)
 	}
@@ -366,7 +366,7 @@ func (sdk *goSDK) baseWithCodegen(
 ) (dagql.Instance[*core.Container], error) {
 	var ctr dagql.Instance[*core.Container]
 
-	introspectionJSON, err := mod.DependencySchemaIntrospectionJSON(ctx)
+	introspectionJSON, err := mod.DependencySchemaIntrospectionJSON(ctx, true)
 	if err != nil {
 		return ctr, fmt.Errorf("failed to get schema introspection json during %s module sdk codegen: %w", mod.Name(), err)
 	}

--- a/dagql/types.go
+++ b/dagql/types.go
@@ -505,9 +505,13 @@ func NewDynamicID[T Typed](id *idproto.ID, typed T) ID[T] {
 	}
 }
 
+func IDTypeNameFor(t Typed) string {
+	return t.Type().Name() + "ID"
+}
+
 // TypeName returns the name of the type with "ID" appended, e.g. `FooID`.
 func (i ID[T]) TypeName() string {
-	return i.inner.Type().Name() + "ID"
+	return IDTypeNameFor(i.inner)
 }
 
 var _ Typed = ID[Typed]{}


### PR DESCRIPTION
# 🔥 Update Instructions for Breaking Changes
## Modules that use the Host API to read source files
(using go syntax below, but same idea applies to all SDKs)

Previously, module containers set their working directory to the directory containing the module's source code. You could then read files from that directory with calls like `dag.Host().File("./some/file.txt")`.

Now, module containers are set to an initially empty scratch directory, so those calls will not work anymore.

To use files/directories from the module source code, you can instead:
1. Directories - `dag.CurrentModule().Source().Directory("some/subdir")`
2. Files - `dag.CurrentModule().Source().File("some/file.txt")`

Additionally, it used to technically be possible to use files/directories from anywhere in the root dir loaded for a module in the case where `"root"` was configured in `dagger.json`. This is no longer possible; instead anything you need to use from outside the module's source code directory should be accepted as an argument to a function or the module constructor.

One final use case to mention: if you need to create new files/directories and then load them into the dagger API during module execution, this is still possible.
1. Directories - `dag.CurrentModule().Workdir("./some/dir")`
2. Files - `dag.CurrentModule().WorkdirFile("./some/file.txt")`


---

The new dag.CurrentModule() API replaces the need for the Host API and gives more controlled functionality that is specific to modules.

Fixes https://github.com/dagger/dagger/issues/6312

More details on the new API in [this PR](https://github.com/dagger/dagger/pull/6386) description (specifically `CurrentModule API`).

TODO:
- [x] Update release notes with details on breaking change