### PR TITLE
Revert "rip out progrock socket plumbing"

### DIFF
--- a/cmd/codegen/main.go
+++ b/cmd/codegen/main.go
@@ -5,6 +5,8 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/vito/progrock"
+	"github.com/vito/progrock/console"
 
 	"dagger.io/dagger"
 	"github.com/dagger/dagger/cmd/codegen/generator"
@@ -13,6 +15,7 @@ import (
 var (
 	outputDir             string
 	lang                  string
+	propagateLogs         bool
 	introspectionJSONPath string
 
 	moduleSourceRootPath string
@@ -32,11 +35,14 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.Flags().StringVar(&lang, "lang", "go", "language to generate")
 	rootCmd.Flags().StringVarP(&outputDir, "output", "o", ".", "output directory")
+	rootCmd.Flags().BoolVar(&propagateLogs, "propagate-logs", false, "propagate logs directly to progrock.sock")
 	rootCmd.Flags().StringVar(&introspectionJSONPath, "introspection-json-path", "", "optional path to file containing pre-computed graphql introspection JSON")
 
 	rootCmd.Flags().StringVar(&moduleSourceRootPath, "module-source-root", "", "path to root directory of module source (i.e. where its dagger.json is located)")
 	rootCmd.Flags().StringVar(&moduleName, "module-name", "", "name of module to generate code for")
 }
+
+const nestedSock = "/.progrock.sock"
 
 func ClientGen(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
@@ -44,6 +50,28 @@ func ClientGen(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	var progW progrock.Writer
+	var dialErr error
+	if propagateLogs {
+		progW, dialErr = progrock.DialRPC(ctx, "unix://"+nestedSock)
+		if dialErr != nil {
+			return fmt.Errorf("error connecting to progrock: %w; falling back to console output", dialErr)
+		}
+	} else {
+		progW = console.NewWriter(os.Stderr, console.WithMessageLevel(progrock.MessageLevel_DEBUG))
+	}
+
+	var rec *progrock.Recorder
+	if parent := os.Getenv("_DAGGER_PROGROCK_PARENT"); parent != "" {
+		rec = progrock.NewSubRecorder(progW, parent)
+	} else {
+		rec = progrock.NewRecorder(progW)
+	}
+	defer rec.Complete()
+	defer rec.Close()
+
+	ctx = progrock.ToContext(ctx, rec)
 
 	cfg := generator.Config{
 		Lang: generator.SDKLang(lang),

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/vito/progrock"
 	"golang.org/x/sys/unix"
 )
 
@@ -450,6 +451,9 @@ func setupBundle() int {
 			}
 			keepEnv = append(keepEnv, "_DAGGER_SERVER_ID="+execMetadata.ServerID)
 
+			// propagate parent vertex ID
+			keepEnv = append(keepEnv, "_DAGGER_PROGROCK_PARENT="+execMetadata.ProgParent)
+
 			// mount buildkit sock since it's nesting
 			spec.Mounts = append(spec.Mounts, specs.Mount{
 				Destination: "/.runner.sock",
@@ -463,6 +467,17 @@ func setupBundle() int {
 				Type:        "bind",
 				Options:     []string{"rbind", "ro"},
 				Source:      "/usr/local/bin/dagger",
+			})
+			// also need the progsock path for forwarding progress
+			if execMetadata.ProgSockPath == "" {
+				fmt.Fprintln(os.Stderr, "missing progsock path")
+				return errorExitCode
+			}
+			spec.Mounts = append(spec.Mounts, specs.Mount{
+				Destination: "/.progrock.sock",
+				Type:        "bind",
+				Options:     []string{"rbind"},
+				Source:      execMetadata.ProgSockPath,
 			})
 		case strings.HasPrefix(env, "_DAGGER_SERVER_ID="):
 		case strings.HasPrefix(env, aliasPrefix):
@@ -628,6 +643,16 @@ func runWithNesting(ctx context.Context, cmd *exec.Cmd) error {
 	moduleCallerDigest, ok := internalEnv("_DAGGER_MODULE_CALLER_DIGEST")
 	if ok {
 		clientParams.ModuleCallerDigest = digest.Digest(moduleCallerDigest)
+	}
+
+	progW, err := progrock.DialRPC(ctx, "unix:///.progrock.sock")
+	if err != nil {
+		return fmt.Errorf("error connecting to progrock: %w", err)
+	}
+	clientParams.ProgrockWriter = progW
+
+	if parentID := os.Getenv("_DAGGER_PROGROCK_PARENT"); parentID != "" {
+		clientParams.ProgrockParent = parentID
 	}
 
 	sess, ctx, err := client.Connect(ctx, clientParams)

--- a/core/schema/schema.go
+++ b/core/schema/schema.go
@@ -29,6 +29,7 @@ import (
 type InitializeArgs struct {
 	BuildkitClient *buildkit.Client
 	Platform       specs.Platform
+	ProgSockPath   string
 	OCIStore       content.Store
 	LeaseManager   *leaseutil.Manager
 	Auth           *auth.RegistryAuthProvider
@@ -47,6 +48,7 @@ func New(ctx context.Context, params InitializeArgs) (*APIServer, error) {
 	root := core.NewRoot()
 	root.Buildkit = params.BuildkitClient
 	root.Services = svcs
+	root.ProgrockSocketPath = params.ProgSockPath
 	root.Platform = core.Platform(params.Platform)
 	root.Secrets = params.Secrets
 	root.OCIStore = params.OCIStore

--- a/core/schema/sdk.go
+++ b/core/schema/sdk.go
@@ -434,6 +434,7 @@ func (sdk *goSDK) baseWithCodegen(
 				Value: dagql.ArrayInput[dagql.String]{
 					"--module-source-root", goSDKUserModSourceDirPath,
 					"--module-name", dagql.String(mod.OriginalName),
+					"--propagate-logs=true",
 					"--introspection-json-path", goSDKIntrospectionJSONPath,
 				},
 			},

--- a/core/service.go
+++ b/core/service.go
@@ -339,6 +339,8 @@ func (svc *Service) startContainer(
 	execMeta := buildkit.ContainerExecUncachedMetadata{
 		ParentClientIDs: clientMetadata.ClientIDs(),
 		ServerID:        clientMetadata.ServerID,
+		ProgSockPath:    bk.ProgSockPath,
+		ProgParent:      rec.Parent,
 	}
 	execOp.Meta.ProxyEnv.FtpProxy, err = execMeta.ToPBFtpProxyVal()
 	if err != nil {

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -33,6 +33,7 @@ import (
 	"github.com/moby/buildkit/util/entitlements"
 	bkworker "github.com/moby/buildkit/worker"
 	"github.com/opencontainers/go-digest"
+	"github.com/vito/progrock"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/metadata"
 )
@@ -51,6 +52,7 @@ type Opts struct {
 	AuthProvider          *auth.RegistryAuthProvider
 	PrivilegedExecEnabled bool
 	UpstreamCacheImports  []bkgw.CacheOptionsEntry
+	ProgSockPath          string
 	// MainClientCaller is the caller who initialized the server associated with this
 	// client. It is special in that when it shuts down, the client will be closed and
 	// that registry auth and sockets are currently only ever sourced from this caller,
@@ -262,6 +264,8 @@ func (c *Client) Solve(ctx context.Context, req bkgw.SolveRequest) (_ *Result, r
 				execMeta = ContainerExecUncachedMetadata{
 					ParentClientIDs: clientMetadata.ClientIDs(),
 					ServerID:        clientMetadata.ServerID,
+					ProgSockPath:    c.ProgSockPath,
+					ProgParent:      progrock.FromContext(ctx).Parent,
 				}
 				c.execMetadata[*execOp.OpDigest] = execMeta
 			}
@@ -707,6 +711,9 @@ func withOutgoingContext(ctx context.Context) context.Context {
 type ContainerExecUncachedMetadata struct {
 	ParentClientIDs []string `json:"parentClientIDs,omitempty"`
 	ServerID        string   `json:"serverID,omitempty"`
+	// Progrock propagation
+	ProgSockPath string `json:"progSockPath,omitempty"`
+	ProgParent   string `json:"progParent,omitempty"`
 }
 
 func (md ContainerExecUncachedMetadata) ToPBFtpProxyVal() (string, error) {

--- a/engine/buildkit/progrock.go
+++ b/engine/buildkit/progrock.go
@@ -3,6 +3,9 @@ package buildkit
 import (
 	"context"
 	"fmt"
+	"net"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/containerd/containerd/platforms"
@@ -88,6 +91,23 @@ func (w ProgrockLogrusWriter) WriteStatus(ev *progrock.StatusUpdate) error {
 
 func (w ProgrockLogrusWriter) Close() error {
 	return nil
+}
+
+func ProgrockForwarder(sockPath string, w progrock.Writer) (progrock.Writer, func() error, error) {
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0700); err != nil {
+		return nil, nil, err
+	}
+	l, err := net.Listen("unix", sockPath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	progW, err := progrock.ServeRPC(l, w)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return progW, l.Close, nil
 }
 
 func RecordVertexes(recorder *progrock.Recorder, def *pb.Definition) {

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -66,6 +66,7 @@ type Params struct {
 
 	JournalFile        string
 	ProgrockWriter     progrock.Writer
+	ProgrockParent     string
 	EngineNameCallback func(string)
 	CloudURLCallback   func(string)
 
@@ -143,7 +144,11 @@ func Connect(ctx context.Context, params Params) (_ *Client, _ context.Context, 
 		cloudURL = tel.URL()
 		progMultiW = append(progMultiW, telemetry.NewWriter(tel))
 	}
-	c.Recorder = progrock.NewRecorder(progMultiW)
+	if c.ProgrockParent != "" {
+		c.Recorder = progrock.NewSubRecorder(progMultiW, c.ProgrockParent)
+	} else {
+		c.Recorder = progrock.NewRecorder(progMultiW)
+	}
 	ctx = progrock.ToContext(ctx, c.Recorder)
 
 	nestedSessionPortVal, isNestedSession := os.LookupEnv("DAGGER_SESSION_PORT")

--- a/engine/server/buildkitcontroller.go
+++ b/engine/server/buildkitcontroller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/moby/buildkit/executor/oci"
 	"github.com/moby/buildkit/frontend"
 	bkgw "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/grpchijack"
 	containerdsnapshot "github.com/moby/buildkit/snapshot/containerd"
@@ -244,6 +245,10 @@ func (e *BuildkitController) Session(stream controlapi.Control_SessionServer) (r
 			})
 		}
 
+		// using a new random ID rather than server ID to squash any nefarious attempts to set
+		// a server id that has e.g. ../../.. or similar in it
+		progSockPath := fmt.Sprintf("/run/dagger/server-progrock-%s.sock", identity.NewID())
+
 		bkClient, err := buildkit.NewClient(ctx, buildkit.Opts{
 			Worker:                e.worker,
 			SessionManager:        e.SessionManager,
@@ -253,6 +258,7 @@ func (e *BuildkitController) Session(stream controlapi.Control_SessionServer) (r
 			AuthProvider:          authProvider,
 			PrivilegedExecEnabled: e.privilegedExecEnabled,
 			UpstreamCacheImports:  cacheImporterCfgs,
+			ProgSockPath:          progSockPath,
 			MainClientCaller:      caller,
 			DNSConfig:             e.DNSConfig,
 		})

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -31,8 +31,9 @@ type DaggerServer struct {
 	bkClient *buildkit.Client
 	worker   bkworker.Worker
 
-	schema   *schema.APIServer
-	recorder *progrock.Recorder
+	schema      *schema.APIServer
+	recorder    *progrock.Recorder
+	progCleanup func() error
 
 	doneCh    chan struct{}
 	closeOnce sync.Once
@@ -65,10 +66,14 @@ func NewDaggerServer(
 		return nil, err
 	}
 
-	progWriter := progrock.MultiWriter{
+	progWriter, progCleanup, err := buildkit.ProgrockForwarder(bkClient.ProgSockPath, progrock.MultiWriter{
 		progrock.NewRPCWriter(clientConn, progUpdates),
 		buildkit.ProgrockLogrusWriter{},
+	})
+	if err != nil {
+		return nil, err
 	}
+	srv.progCleanup = progCleanup
 
 	progrockLabels := []*progrock.Label{}
 	for _, label := range rootLabels {
@@ -110,6 +115,7 @@ func NewDaggerServer(
 	apiSchema, err := schema.New(ctx, schema.InitializeArgs{
 		BuildkitClient: srv.bkClient,
 		Platform:       srv.worker.Platforms(true)[0],
+		ProgSockPath:   bkClient.ProgSockPath,
 		OCIStore:       srv.worker.ContentStore(),
 		LeaseManager:   srv.worker.LeaseManager(),
 		Secrets:        secretStore,
@@ -137,6 +143,8 @@ func (srv *DaggerServer) Close() {
 	srv.recorder.Complete()
 	// close the recorder so the UI exits
 	srv.recorder.Close()
+
+	srv.progCleanup()
 }
 
 func (srv *DaggerServer) Wait(ctx context.Context) error {

--- a/go.mod
+++ b/go.mod
@@ -101,8 +101,6 @@ require (
 	oss.terrastruct.com/util-go v0.0.0-20231101220827-55b3812542c2
 )
 
-require github.com/koron-go/prefixw v1.0.0
-
 require (
 	cdr.dev/slog v1.4.2 // indirect
 	dario.cat/mergo v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -983,8 +983,6 @@ github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa02
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/koron-go/prefixw v1.0.0 h1:p7OC1ffZ/z+Miz0j/Ddt4fVYr8g4W9BKWkViAZ+1LmI=
-github.com/koron-go/prefixw v1.0.0/go.mod h1:WZvD0yrbCrkJD23tq03BhCu1ucn5ZenktcXt39QbPyk=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=


### PR DESCRIPTION
Reverts part of #6456 

Turns out this is still needed by legacy Dagger (`dagger run`, `go run` + auto-started `dagger session`, etc).

It's unfortunate to bring all this plumbing back but we obviously can't break that yet.

Kept everything as-is, including propagating parents, because #6505 prevents the cache-busting issue that we originally ripped all this out to avoid.

This reverts commit 3309a8e799e1f4d66506bdc5e540613ae4bab90a.