### PR TITLE
fix up ModuleSource.asString displaying `//`

### DIFF
--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -228,7 +228,11 @@ func (src GitModuleSource) Clone() *GitModuleSource {
 }
 
 func (src *GitModuleSource) String() string {
-	return fmt.Sprintf("%s/%s@%s", src.URLParent, src.Subpath, src.Version)
+	refPath := src.URLParent
+	if src.Subpath != "/" {
+		refPath += src.Subpath
+	}
+	return fmt.Sprintf("%s@%s", refPath, src.Version)
 }
 
 func (src *GitModuleSource) Symbolic() string {


### PR DESCRIPTION
Since `Subpath` always starts with `/`, and its default value is `/`, we're currently always adding an extra `/` between the source path and the subpath. (Amusingly it looks a lot like v2 refs #6187.)