### PR TITLE
core: fix support for custom SDK modules

### DIFF
--- a/core/module.go
+++ b/core/module.go
@@ -59,7 +59,7 @@ type Module struct {
 	DirectoryExcludeConfig []string
 
 	// Runtime is the container that runs the module's entrypoint. It will fail to execute if the module doesn't compile.
-	Runtime *Container
+	Runtime *Container `field:"true" name:"runtime" doc:"The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile."`
 
 	// The following are populated while initializing the module
 

--- a/core/schema/sdk.go
+++ b/core/schema/sdk.go
@@ -34,11 +34,17 @@ func (s *moduleSchema) sdkForModule(
 	var sdkMod dagql.Instance[*core.Module]
 	err = s.dag.Select(ctx, s.dag.Root(), &sdkMod,
 		dagql.Selector{
-			Field: "moduleRef",
+			Field: "moduleSource",
 			Args: []dagql.NamedInput{
 				{Name: "refString", Value: dagql.String(sdk)},
-				{Name: "parentDirectory", Value: dagql.NewID[*core.Directory](parentDir.ID())},
+				{Name: "rootDirectory", Value: dagql.Opt(dagql.NewID[*core.Directory](parentDir.ID()))},
 			},
+		},
+		dagql.Selector{
+			Field: "asModule",
+		},
+		dagql.Selector{
+			Field: "initialize",
 		},
 	)
 	if err != nil {

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -1534,6 +1534,7 @@ type Module {
   interfaces: [TypeDef!]!
   name: String!
   objects: [TypeDef!]!
+  runtime: Container!
   sdk: String!
 
   """

--- a/sdk/elixir/lib/dagger/gen/module.ex
+++ b/sdk/elixir/lib/dagger/gen/module.ex
@@ -14,7 +14,7 @@ defmodule Dagger.Module do
       selection =
         select(
           selection,
-          "dependencies dependencyConfig description generatedSourceRootDirectory id initialize interfaces name objects sdk serve source withDependencies withDescription withInterface withName withObject withSDK withSource"
+          "dependencies dependencyConfig description generatedSourceRootDirectory id initialize interfaces name objects runtime sdk serve source withDependencies withDescription withInterface withName withObject withSDK withSource"
         )
 
       with {:ok, data} <- execute(selection, module.client) do
@@ -142,6 +142,15 @@ defmodule Dagger.Module do
            %Dagger.TypeDef{selection: elem_selection, client: module.client}
          end)}
       end
+    end
+  )
+
+  (
+    @doc ""
+    @spec runtime(t()) :: Dagger.Container.t()
+    def runtime(%__MODULE__{} = module) do
+      selection = select(module.selection, "runtime")
+      %Dagger.Container{selection: selection, client: module.client}
     end
   )
 

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -4208,6 +4208,15 @@ func (r *Module) Objects(ctx context.Context) ([]TypeDef, error) {
 	return convert(response), nil
 }
 
+func (r *Module) Runtime() *Container {
+	q := r.q.Select("runtime")
+
+	return &Container{
+		q: q,
+		c: r.c,
+	}
+}
+
 func (r *Module) SDK(ctx context.Context) (string, error) {
 	if r.sdk != nil {
 		return *r.sdk, nil

--- a/sdk/php/generated/Module.php
+++ b/sdk/php/generated/Module.php
@@ -76,6 +76,12 @@ class Module extends Client\AbstractObject implements Client\IdAble
         return (array)$this->queryLeaf($leafQueryBuilder, 'objects');
     }
 
+    public function runtime(): Container
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('runtime');
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
     public function sdk(): string
     {
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('sdk');

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -4242,6 +4242,12 @@ class Module(Type):
         return await _ctx.execute(list[TypeDef])
 
     @typecheck
+    def runtime(self) -> Container:
+        _args: list[Arg] = []
+        _ctx = self._select("runtime", _args)
+        return Container(_ctx)
+
+    @typecheck
     async def sdk(self) -> str:
         """Returns
         -------

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -3930,6 +3930,14 @@ impl Module {
             graphql_client: self.graphql_client.clone(),
         }];
     }
+    pub fn runtime(&self) -> Container {
+        let query = self.selection.select("runtime");
+        return Container {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        };
+    }
     pub async fn sdk(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("sdk");
         query.execute(self.graphql_client.clone()).await

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -5217,6 +5217,17 @@ export class Module_ extends BaseClient {
         )
     )
   }
+  runtime = (): Container => {
+    return new Container({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "runtime",
+        },
+      ],
+      ctx: this._ctx,
+    })
+  }
   sdk = async (): Promise<string> => {
     if (this._sdk) {
       return this._sdk


### PR DESCRIPTION
The recent updates accidentally left in dag.Select calls that referred to old APIs in the codepath for custom (i.e. 3rd party) SDKs. We didn't catch this because we didn't have any integ tests for this feature.

This fixes the bug and adds an integ test. It also required exposing Module.Runtime as a graphql field in order to write the test case, but that seems like it will only be beneficial in general to any other SDK authors trying to do something similar to this.