### PR TITLE
backfill changie with breaking changes from module config updates

### DIFF
--- a/.changes/unreleased/Breaking-20240131-220847.yaml
+++ b/.changes/unreleased/Breaking-20240131-220847.yaml
@@ -1,0 +1,6 @@
+kind: Breaking
+body: Refactor module configuration + loading. This breaks modules currently using "root" in dagger.json and changes the working directory of modules. See the linked PR for update instructions if impacted.
+time: 2024-01-31T22:08:47.229427944-08:00
+custom:
+  Author: sipsma
+  PR: "6386"


### PR DESCRIPTION
These are worth mentioning in the release notes I think since a decent chunk of users will be impacted (though not the majority). I kept the breaking change log itself short but updated the PR it links to with a Description that details the steps for updating if impacted: https://github.com/dagger/dagger/pull/6386