### PR TITLE
CLI: Improve display of core API in `--help`

### DIFF
--- a/cmd/dagger/cloud.go
+++ b/cmd/dagger/cloud.go
@@ -15,17 +15,25 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cloud.API, "api", "https://api.dagger.cloud", "Dagger Cloud API URL")
 	rootCmd.PersistentFlags().MarkHidden("api")
 
+	group := &cobra.Group{
+		ID:    "cloud",
+		Title: "Dagger Cloud Commands",
+	}
+	rootCmd.AddGroup(group)
+
 	loginCmd := &cobra.Command{
-		Use:   "login",
-		Short: "Log in to Dagger Cloud",
-		RunE:  cloud.Login,
+		Use:     "login",
+		Short:   "Log in to Dagger Cloud",
+		GroupID: group.ID,
+		RunE:    cloud.Login,
 	}
 	rootCmd.AddCommand(loginCmd)
 
 	logoutCmd := &cobra.Command{
-		Use:   "logout",
-		Short: "Log out from Dagger Cloud",
-		RunE:  cloud.Logout,
+		Use:     "logout",
+		Short:   "Log out from Dagger Cloud",
+		GroupID: group.ID,
+		RunE:    cloud.Logout,
 	}
 	rootCmd.AddCommand(logoutCmd)
 }

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -30,6 +30,11 @@ const (
 	CacheVolume string = "CacheVolume"
 )
 
+var funcGroup = &cobra.Group{
+	ID:    "functions",
+	Title: "Function Commands",
+}
+
 var funcCmds = FuncCommands{
 	funcListCmd,
 	callCmd,
@@ -470,6 +475,7 @@ func (fc *FuncCommand) traverse(c *cobra.Command) (*cobra.Command, []string, err
 
 func (fc *FuncCommand) addSubCommands(cmd *cobra.Command, dag *dagger.Client, fnProvider functionProvider) {
 	if fnProvider != nil {
+		cmd.AddGroup(funcGroup)
 		for _, fn := range fnProvider.GetFunctions() {
 			subCmd := fc.makeSubCmd(dag, fn)
 			cmd.AddCommand(subCmd)
@@ -479,8 +485,9 @@ func (fc *FuncCommand) addSubCommands(cmd *cobra.Command, dag *dagger.Client, fn
 
 func (fc *FuncCommand) makeSubCmd(dag *dagger.Client, fn *modFunction) *cobra.Command {
 	newCmd := &cobra.Command{
-		Use:   cliName(fn.Name),
-		Short: fn.Description,
+		Use:     cliName(fn.Name),
+		Short:   fn.Description,
+		GroupID: funcGroup.ID,
 		PreRunE: func(cmd *cobra.Command, args []string) (err error) {
 			if err := fc.addArgsForFunction(cmd, args, fn, dag); err != nil {
 				return err

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -486,7 +486,8 @@ func (fc *FuncCommand) addSubCommands(cmd *cobra.Command, dag *dagger.Client, fn
 func (fc *FuncCommand) makeSubCmd(dag *dagger.Client, fn *modFunction) *cobra.Command {
 	newCmd := &cobra.Command{
 		Use:     cliName(fn.Name),
-		Short:   fn.Description,
+		Short:   strings.SplitN(fn.Description, "\n", 2)[0],
+		Long:    fn.Description,
 		GroupID: funcGroup.ID,
 		PreRunE: func(cmd *cobra.Command, args []string) (err error) {
 			if err := fc.addArgsForFunction(cmd, args, fn, dag); err != nil {

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -236,6 +236,13 @@ Examples:
 
 {{- end}}
 
+{{- if .HasAvailableLocalFlags}}
+
+Flags:
+{{ flagUsagesWrapped .LocalFlags | trimTrailingWhitespaces}}
+
+{{- end}}
+
 {{- if .HasAvailableSubCommands}}{{$cmds := .Commands}}
 {{- if eq (len .Groups) 0}}
 
@@ -268,13 +275,6 @@ Additional Commands:
 {{- end}}{{/* if not .AllChildCommandsHaveGroup */}}
 {{- end}}{{/* if eq (len .Groups) 0 */}}
 {{- end}}{{/* if .HasAvailableSubCommands */}}
-
-{{- if .HasAvailableLocalFlags}}
-
-Flags:
-{{ flagUsagesWrapped .LocalFlags | trimTrailingWhitespaces}}
-
-{{- end}}
 
 {{- if .HasAvailableInheritedFlags}}
 

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -14,6 +14,11 @@ import (
 )
 
 var (
+	execGroup = &cobra.Group{
+		ID:    "exec",
+		Title: "Execution Commands",
+	}
+
 	workdir string
 
 	cpuprofile string
@@ -47,10 +52,11 @@ func init() {
 
 	funcCmds.AddParent(rootCmd)
 
-	cobra.AddTemplateFunc("isExperimental", isExperimental)
-
-	rootCmd.SetUsageTemplate(usageTemplate)
 	rootCmd.AddGroup(moduleGroup)
+	rootCmd.AddGroup(execGroup)
+
+	cobra.AddTemplateFunc("isExperimental", isExperimental)
+	rootCmd.SetUsageTemplate(usageTemplate)
 }
 
 var rootCmd = &cobra.Command{

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -65,6 +65,11 @@ func init() {
 	cobra.AddTemplateFunc("flagUsagesWrapped", flagUsagesWrapped)
 	cobra.AddTemplateFunc("cmdShortWrapped", cmdShortWrapped)
 	rootCmd.SetUsageTemplate(usageTemplate)
+
+	// hide the help flag as it's ubiquitous and thus noisy
+	// we'll add it in the last line of the usage template
+	rootCmd.PersistentFlags().BoolP("help", "h", false, "Print usage")
+	rootCmd.PersistentFlags().Lookup("help").Hidden = true
 }
 
 var rootCmd = &cobra.Command{

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -26,7 +26,7 @@ import (
 var (
 	moduleGroup = &cobra.Group{
 		ID:    "module",
-		Title: "Dagger Modules (Experimental)",
+		Title: "Dagger Module Commands (Experimental)",
 	}
 
 	moduleURL   string

--- a/cmd/dagger/query.go
+++ b/cmd/dagger/query.go
@@ -44,7 +44,8 @@ queries in the document.
 }
 EOF
 `,
-	Args: cobra.MaximumNArgs(1), // operation can be specified
+	GroupID: execGroup.ID,
+	Args:    cobra.MaximumNArgs(1), // operation can be specified
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return optionalModCmdWrapper(Query, "")(cmd, args)
 	},

--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -47,6 +47,7 @@ dagger run node index.mjs
 dagger run python main.py
 `,
 	),
+	GroupID:      execGroup.ID,
 	Run:          Run,
 	Args:         cobra.MinimumNArgs(1),
 	SilenceUsage: true,


### PR DESCRIPTION
Fixes #6358

Putting individual improvements in separate commits.

Notice in the example below that if we follow #6516 and keep the first line of API descriptions up to 50 chars, that'll be short of the end of the line below "EXPERIMENTAL". Meaning that it won't wrap on this screen size.

## Todo

Not all of these are focused on the core API, most impactful is the wrapping on flags and commands. I’m submitting what I have now to be cut in next release but will continue in a separate PR for general `--help` improvements.

- [x] Group commands in `dagger` root (modules, execution, cloud, additional)
- [x] Group function commands in `dagger call`
- [x] Wrapping on flag usages
- [x] Wrapping on available command descriptions
- [x] Only use first line of a function’s description for cmd.Short 
- [x] Move flags before sub commands
- [ ] https://github.com/dagger/dagger/issues/6516
- [ ] Conventionalize on `<command>` syntax instead of `COMMAND` in `cmd.Use`
- [ ] Global flags only on root command and top level commands
    - [ ] Traverse children
    - [ ] Remove persistent flags from child commands after being parsed
        - [ ] TUI (`--silent`, `--focus`)
        - [ ] Modules (`-m`)
- [ ] Add line break between error and usage
- [ ] Style headings in **BOLD UPPERCASE** to help break sections visually
- [ ] Help topics for `dagger call` to keep `--help` lean while still providing more documentation

## Example

Taking an example of a function returning a `dagger.Container` which has a lot of functions.

- **Before:** https://app.warp.dev/block/1W5uEInSvPgnwJ4dN9iC9f
- **After:** https://app.warp.dev/block/KwLaq1XtV6T19lA8M2UQle
