### PR TITLE
docs: Adds telemetry FAQ

### DIFF
--- a/docs/current_docs/faq.mdx
+++ b/docs/current_docs/faq.mdx
@@ -162,7 +162,7 @@ Follow these steps:
 
 ### Does Dagger send telemetry?
 
-By default, the Dagger CLI sends anonymized telemetry to dagger.io. This allows us to improve Dagger by understanding how it is used. Telemetry is optional and can be disabled at any time by setting the environment variable `DO_NOT_TRACK=1` before running the Dagger CLI. Our telemetry implementation is open-source and implements the [Console Do Not Track (DNT) standard](https://consoledonottrack.com/) standard. [Learn more about what is included in Dagger telemetry data and how we use it](../guides/294022-telemetry.mdx).
+By default, the Dagger CLI sends anonymized telemetry to dagger.io. This allows us to improve Dagger by understanding how it is used. Telemetry is optional and can be disabled at any time by setting the environment variable `DO_NOT_TRACK=1` before running the Dagger CLI. Our telemetry implementation is open-source and implements the [Console Do Not Track (DNT) standard](https://consoledonottrack.com/) standard. [Learn more about what is included in Dagger telemetry data and how we use it](./guides/294022-telemetry.mdx).
 
 ### What are Dagger's caching features?
 

--- a/docs/current_docs/faq.mdx
+++ b/docs/current_docs/faq.mdx
@@ -160,6 +160,25 @@ Follow these steps:
       - Python: [https://github.com/platformdirs/platformdirs](https://github.com/platformdirs/platformdirs)
     :::
 
+### Does Dagger send telemetry?
+
+By default, the Dagger CLI sends anonymized telemetry to dagger.io. This allows us to improve Dagger by understanding how it is used. Telemetry is optional and can be disabled at any time. If you are willing and able to leave telemetry enabled: thank you! This will help us better understand how Dagger is used, and will allow us to improve your experience.
+
+### What telemetry does Dagger send?
+
+The following information is included in telemetry:
+
+- Dagger version
+- Platform information
+- Command run
+- Anonymous device ID
+
+We use telemetry for aggregate analysis, and do not tie telemetry events to a specific identity. Our telemetry implementation is open-source and can be reviewed in our [GitHub repository](https://github.com/dagger/dagger).
+
+### Can Dagger telemetry be disabled?
+
+Dagger implements the [Console Do Not Track (DNT) standard](https://consoledonottrack.com/). As a result, you can disable the telemetry by setting the environment variable `DO_NOT_TRACK=1` before running the Dagger CLI.
+
 ### What are Dagger's caching features?
 
 Dagger is able to cache:

--- a/docs/current_docs/faq.mdx
+++ b/docs/current_docs/faq.mdx
@@ -162,22 +162,7 @@ Follow these steps:
 
 ### Does Dagger send telemetry?
 
-By default, the Dagger CLI sends anonymized telemetry to dagger.io. This allows us to improve Dagger by understanding how it is used. Telemetry is optional and can be disabled at any time. If you are willing and able to leave telemetry enabled: thank you! This will help us better understand how Dagger is used, and will allow us to improve your experience.
-
-### What telemetry does Dagger send?
-
-The following information is included in telemetry:
-
-- Dagger version
-- Platform information
-- Command run
-- Anonymous device ID
-
-We use telemetry for aggregate analysis, and do not tie telemetry events to a specific identity. Our telemetry implementation is open-source and can be reviewed in our [GitHub repository](https://github.com/dagger/dagger).
-
-### Can Dagger telemetry be disabled?
-
-Dagger implements the [Console Do Not Track (DNT) standard](https://consoledonottrack.com/). As a result, you can disable the telemetry by setting the environment variable `DO_NOT_TRACK=1` before running the Dagger CLI.
+By default, the Dagger CLI sends anonymized telemetry to dagger.io. This allows us to improve Dagger by understanding how it is used. Telemetry is optional and can be disabled at any time by setting the environment variable `DO_NOT_TRACK=1` before running the Dagger CLI. Our telemetry implementation is open-source and implements the [Console Do Not Track (DNT) standard](https://consoledonottrack.com/) standard. [Learn more about what is included in Dagger telemetry data and how we use it](../guides/294022-telemetry.mdx).
 
 ### What are Dagger's caching features?
 

--- a/docs/current_docs/guides/294022-telemetry.mdx
+++ b/docs/current_docs/guides/294022-telemetry.mdx
@@ -1,0 +1,25 @@
+---
+slug: /294022/telemetry
+displayed_sidebar: "current"
+category: "guides"
+tags: ["go"]
+authors: ["Andrea Luzzzardi"]
+date: "2024-02-01"
+---
+
+# Understand Dagger CLI Telemetry
+
+By default, the Dagger CLI sends anonymized telemetry to dagger.io. This allows us to improve Dagger by understanding how it is used.
+
+Dagger implements the [Console Do Not Track (DNT) standard](https://consoledonottrack.com/) standard. As a result, you can disable the telemetry by setting the environment variable `DO_NOT_TRACK=1` before running the Dagger CLI.
+
+If you are willing and able to leave telemetry enabled: thank you! This will help us better understand how Dagger is used, and will allow us to improve your experience.
+
+The following information is included in telemetry:
+
+- Dagger version
+- Platform information
+- Command run
+- Anonymous device ID
+
+We use telemetry for aggregate analysis, and do not tie telemetry events to a specific identity. Our telemetry implementation is open-source and can be reviewed in our [GitHub repository](https://github.com/dagger/dagger).

--- a/docs/versioned_docs/version-zenith/faq.mdx
+++ b/docs/versioned_docs/version-zenith/faq.mdx
@@ -163,6 +163,25 @@ Follow these steps:
       - Python: [https://github.com/platformdirs/platformdirs](https://github.com/platformdirs/platformdirs)
     :::
 
+### Does Dagger send telemetry?
+
+By default, the Dagger CLI sends anonymized telemetry to dagger.io. This allows us to improve Dagger by understanding how it is used. Telemetry is optional and can be disabled at any time. If you are willing and able to leave telemetry enabled: thank you! This will help us better understand how Dagger is used, and will allow us to improve your experience.
+
+### What telemetry does Dagger send?
+
+The following information is included in telemetry:
+
+- Dagger version
+- Platform information
+- Command run
+- Anonymous device ID
+
+We use telemetry for aggregate analysis, and do not tie telemetry events to a specific identity. Our telemetry implementation is open-source and can be reviewed in our [GitHub repository](https://github.com/dagger/dagger).
+
+### Can Dagger telemetry be disabled?
+
+Dagger implements the [Console Do Not Track (DNT) standard](https://consoledonottrack.com/). As a result, you can disable the telemetry by setting the environment variable `DO_NOT_TRACK=1` before running the Dagger CLI.
+
 ### What are Dagger's caching features?
 
 Dagger is able to cache:


### PR DESCRIPTION
This commit adds FAQ entries/a guide for Dagger telemetry. 

Note: For `zenith` version docs, all the relevant information is placed in the FAQ since we don't yet have a "Guides" section for that version (will be added in #6504)