### PR TITLE
fix(gosdk): gracefully handle contexts in weird places

### DIFF
--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -126,7 +126,7 @@ func (funcs goTemplateFuncs) moduleMainSrc() (string, error) {
 			obj := named.Obj()
 			if obj.Pkg() != funcs.modulePkg.Types {
 				// the type must be created in the target package
-				continue
+				return "", fmt.Errorf("cannot code-generate for foreign type %s", obj.Name())
 			}
 			if !obj.Exported() {
 				// the type must be exported

--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -509,8 +509,8 @@ func (ps *parseState) fillObjectFunctionCase(
 	}
 
 	vars := map[string]struct{}{}
-	for i, spec := range paramSpecs {
-		if i == 0 && spec.paramType.String() == contextTypename {
+	for _, spec := range paramSpecs {
+		if spec.isContext {
 			fnCallArgs = append(fnCallArgs, Id("ctx"))
 			continue
 		}


### PR DESCRIPTION
Fixes #6532 :tada:

We should explicitly check for weird contexts, instead of just charging ahead and panicking.

Also, while I was in the area, I threw in an explicit failure for foreign types (since we don't currently have anything for https://github.com/dagger/dagger/pull/6185). The code generated was completely invalid, so better to fail early with a good error message.