### PR TITLE
simplify module config UX via automatic sparse loading of required files

### DIFF
--- a/cmd/codegen/generator/generator.go
+++ b/cmd/codegen/generator/generator.go
@@ -31,8 +31,8 @@ type Config struct {
 	OutputDir string
 
 	// Name of the module to generate code for
-	ModuleName           string
-	ModuleSourceRootPath string
+	ModuleName        string
+	ModuleContextPath string
 
 	// Optional pre-computed introspection json string
 	IntrospectionJSON string

--- a/cmd/codegen/generator/go/generator.go
+++ b/cmd/codegen/generator/go/generator.go
@@ -154,7 +154,7 @@ func (g *GoGenerator) bootstrapMod(ctx context.Context, mfs *memfs.FS) (*Package
 			if err != nil {
 				return nil, false, fmt.Errorf("get absolute path: %w", err)
 			}
-			rootDir := g.Config.ModuleSourceRootPath
+			rootDir := g.Config.ModuleContextPath
 			subdirRelPath, err := filepath.Rel(rootDir, outDir)
 			if err != nil {
 				return nil, false, fmt.Errorf("failed to get output dir rel path: %w", err)

--- a/cmd/codegen/main.go
+++ b/cmd/codegen/main.go
@@ -18,8 +18,8 @@ var (
 	propagateLogs         bool
 	introspectionJSONPath string
 
-	moduleSourceRootPath string
-	moduleName           string
+	moduleContextPath string
+	moduleName        string
 )
 
 var rootCmd = &cobra.Command{
@@ -38,12 +38,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&propagateLogs, "propagate-logs", false, "propagate logs directly to progrock.sock")
 	rootCmd.Flags().StringVar(&introspectionJSONPath, "introspection-json-path", "", "optional path to file containing pre-computed graphql introspection JSON")
 
-	// TODO:
-	// TODO:
-	// TODO:
-	// TODO:
-	// TODO: technically should be renamed to module-context-root
-	rootCmd.Flags().StringVar(&moduleSourceRootPath, "module-source-root", "", "path to root directory of module source (i.e. where its dagger.json is located)")
+	rootCmd.Flags().StringVar(&moduleContextPath, "module-context", "", "path to context directory of the module")
 	rootCmd.Flags().StringVar(&moduleName, "module-name", "", "name of module to generate code for")
 }
 
@@ -87,10 +82,10 @@ func ClientGen(cmd *cobra.Command, args []string) error {
 	if moduleName != "" {
 		cfg.ModuleName = moduleName
 
-		if moduleSourceRootPath == "" {
-			return fmt.Errorf("--module-name requires --module-source-root")
+		if moduleContextPath == "" {
+			return fmt.Errorf("--module-name requires --module-context")
 		}
-		cfg.ModuleSourceRootPath = moduleSourceRootPath
+		cfg.ModuleContextPath = moduleContextPath
 	}
 
 	if introspectionJSONPath != "" {

--- a/cmd/codegen/main.go
+++ b/cmd/codegen/main.go
@@ -38,6 +38,11 @@ func init() {
 	rootCmd.Flags().BoolVar(&propagateLogs, "propagate-logs", false, "propagate logs directly to progrock.sock")
 	rootCmd.Flags().StringVar(&introspectionJSONPath, "introspection-json-path", "", "optional path to file containing pre-computed graphql introspection JSON")
 
+	// TODO:
+	// TODO:
+	// TODO:
+	// TODO:
+	// TODO: technically should be renamed to module-context-root
 	rootCmd.Flags().StringVar(&moduleSourceRootPath, "module-source-root", "", "path to root directory of module source (i.e. where its dagger.json is located)")
 	rootCmd.Flags().StringVar(&moduleName, "module-name", "", "name of module to generate code for")
 }

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -383,14 +383,14 @@ func (fc *FuncCommand) load(c *cobra.Command, a []string, vtx *progrock.VertexRe
 	}()
 
 	load := vtx.Task("loading module")
-	modConf, err := getDefaultModuleConfiguration(ctx, dag, "")
+	modConf, err := getDefaultModuleConfiguration(ctx, dag, true)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get configured module: %w", err)
 	}
 	if !modConf.FullyInitialized() {
 		return nil, nil, fmt.Errorf("module at source dir %q doesn't exist or is invalid", modConf.LocalSourcePath)
 	}
-	mod := modConf.Mod.Initialize()
+	mod := modConf.Source.AsModule().Initialize()
 	_, err = mod.Serve(ctx)
 	load.Done(err)
 	if err != nil {

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -388,7 +388,7 @@ func (fc *FuncCommand) load(c *cobra.Command, a []string, vtx *progrock.VertexRe
 		return nil, nil, fmt.Errorf("failed to get configured module: %w", err)
 	}
 	if !modConf.FullyInitialized() {
-		return nil, nil, fmt.Errorf("module at source dir %q doesn't exist or is invalid", modConf.LocalSourcePath)
+		return nil, nil, fmt.Errorf("module at source dir %q doesn't exist or is invalid", modConf.LocalRootSourcePath)
 	}
 	mod := modConf.Source.AsModule().Initialize()
 	_, err = mod.Serve(ctx)

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -231,8 +231,9 @@ var moduleInitCmd = &cobra.Command{
 			_, err = modConf.Source.
 				WithName(moduleName).
 				WithSDK(sdk).
-				WithSourceSubdir(moduleSourcePath).
+				WithSourceSubpath(moduleSourcePath).
 				ResolveFromCaller().
+				AsModule().
 				GeneratedContextDiff().
 				Export(ctx, modConf.LocalContextPath)
 			if err != nil {
@@ -298,11 +299,10 @@ var moduleInstallCmd = &cobra.Command{
 				Name: installName,
 			})
 
-			modSource := modConf.Source.
+			_, err = modConf.Source.
 				WithDependencies([]*dagger.ModuleDependency{dep}).
-				ResolveFromCaller()
-
-			_, err = modSource.
+				ResolveFromCaller().
+				AsModule().
 				GeneratedContextDiff().
 				Export(ctx, modConf.LocalContextPath)
 			if err != nil {
@@ -319,7 +319,7 @@ var moduleInstallCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			depRootSubpath, err := depSrc.RootSubpath(ctx)
+			depRootSubpath, err := depSrc.SourceRootSubpath(ctx)
 			if err != nil {
 				return err
 			}

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -147,14 +147,14 @@ dagger config -m github.com/dagger/hello-dagger
 		return withEngineAndTUI(ctx, client.Params{}, func(ctx context.Context, engineClient *client.Client) (err error) {
 			cmd.SetContext(ctx)
 
-			modConf, err := getDefaultModuleConfiguration(ctx, engineClient.Dagger(), "")
+			modConf, err := getDefaultModuleConfiguration(ctx, engineClient.Dagger(), true)
 			if err != nil {
 				return fmt.Errorf("failed to load module: %w", err)
 			}
 			if !modConf.FullyInitialized() {
 				return fmt.Errorf("module must be fully initialized")
 			}
-			mod := modConf.Mod
+			mod := modConf.Source.AsModule()
 
 			name, err := mod.Name(ctx)
 			if err != nil {
@@ -176,7 +176,7 @@ dagger config -m github.com/dagger/hello-dagger
 			)
 			fmt.Fprintf(tw, "%s\t%s\n",
 				"Root Directory:",
-				modConf.LocalRootPath,
+				modConf.LocalContextPath,
 			)
 			fmt.Fprintf(tw, "%s\t%s\n",
 				"Source Directory:",
@@ -204,17 +204,12 @@ var moduleInitCmd = &cobra.Command{
 		return withEngineAndTUI(ctx, client.Params{}, func(ctx context.Context, engineClient *client.Client) (err error) {
 			dag := engineClient.Dagger()
 
-			// default the module source root to the current working directory if it doesn't exist yet
-			cwd, err := os.Getwd()
-			if err != nil {
-				return fmt.Errorf("failed to get current working directory: %w", err)
-			}
 			srcRootPath := cwd
 			if len(extraArgs) > 0 {
 				srcRootPath = extraArgs[0]
 			}
 
-			modConf, err := getModuleConfigurationForSourceRef(ctx, dag, srcRootPath, cwd)
+			modConf, err := getModuleConfigurationForSourceRef(ctx, dag, srcRootPath, false)
 			if err != nil {
 				return fmt.Errorf("failed to get configured module: %w", err)
 			}
@@ -231,11 +226,12 @@ var moduleInitCmd = &cobra.Command{
 				moduleName = filepath.Base(modConf.LocalSourcePath)
 			}
 
-			_, err = modConf.Mod.
+			_, err = modConf.Source.
 				WithName(moduleName).
 				WithSDK(sdk).
-				GeneratedSourceRootDirectory().
-				Export(ctx, modConf.LocalRootPath)
+				ResolveFromCaller().
+				GeneratedContextDiff().
+				Export(ctx, modConf.LocalContextPath)
 			if err != nil {
 				return fmt.Errorf("failed to generate code: %w", err)
 			}
@@ -265,7 +261,7 @@ var moduleInstallCmd = &cobra.Command{
 		ctx := cmd.Context()
 		return withEngineAndTUI(ctx, client.Params{}, func(ctx context.Context, engineClient *client.Client) (err error) {
 			dag := engineClient.Dagger()
-			modConf, err := getDefaultModuleConfiguration(ctx, dag, "")
+			modConf, err := getDefaultModuleConfiguration(ctx, dag, false)
 			if err != nil {
 				return fmt.Errorf("failed to get configured module: %w", err)
 			}
@@ -286,22 +282,24 @@ var moduleInstallCmd = &cobra.Command{
 				// need to ensure that local dep paths are relative to the parent root source
 				depAbsPath, err := filepath.Abs(depRefStr)
 				if err != nil {
-					return fmt.Errorf("failed to get absolute path for %s: %w", depRefStr, err)
+					return fmt.Errorf("failed to get dep absolute path for %s: %w", depRefStr, err)
 				}
 				depRelPath, err := filepath.Rel(modConf.LocalSourcePath, depAbsPath)
 				if err != nil {
-					return fmt.Errorf("failed to get relative path: %w", err)
+					return fmt.Errorf("failed to get dep relative path: %w", err)
 				}
+
 				depSrc = dag.ModuleSource(depRelPath)
 			}
 			dep := dag.ModuleDependency(depSrc, dagger.ModuleDependencyOpts{
 				Name: installName,
 			})
 
-			_, err = modConf.Mod.
+			_, err = modConf.Source.
 				WithDependencies([]*dagger.ModuleDependency{dep}).
-				GeneratedSourceRootDirectory().
-				Export(ctx, modConf.LocalRootPath)
+				ResolveFromCaller().
+				GeneratedContextDiff().
+				Export(ctx, modConf.LocalContextPath)
 			if err != nil {
 				return fmt.Errorf("failed to generate code: %w", err)
 			}
@@ -391,7 +389,7 @@ If not updating name or SDK, this is only required for IDE auto-completion/LSP p
 		ctx := cmd.Context()
 		return withEngineAndTUI(ctx, client.Params{}, func(ctx context.Context, engineClient *client.Client) (err error) {
 			dag := engineClient.Dagger()
-			modConf, err := getDefaultModuleConfiguration(ctx, dag, "")
+			modConf, err := getDefaultModuleConfiguration(ctx, dag, true)
 			if err != nil {
 				return fmt.Errorf("failed to get configured module: %w", err)
 			}
@@ -399,15 +397,15 @@ If not updating name or SDK, this is only required for IDE auto-completion/LSP p
 				return fmt.Errorf("module must be local")
 			}
 
-			mod := modConf.Mod
+			src := modConf.Source
 			if developName != "" {
-				mod = mod.WithName(developName)
+				src = src.WithName(developName)
 			}
 			if developSDK != "" {
-				mod = mod.WithSDK(developSDK)
+				src = src.WithSDK(developSDK)
 			}
 
-			_, err = mod.GeneratedSourceRootDirectory().Export(ctx, modConf.LocalRootPath)
+			_, err = src.AsModule().GeneratedContextDiff().Export(ctx, modConf.LocalContextPath)
 			if err != nil {
 				return fmt.Errorf("failed to generate code: %w", err)
 			}
@@ -445,7 +443,7 @@ forced), to avoid mistakingly depending on uncommitted files.
 			cmd.SetErr(vtx.Stderr())
 
 			dag := engineClient.Dagger()
-			modConf, err := getDefaultModuleConfiguration(ctx, dag, "")
+			modConf, err := getDefaultModuleConfiguration(ctx, dag, true)
 			if err != nil {
 				return fmt.Errorf("failed to get configured module: %w", err)
 			}
@@ -558,11 +556,11 @@ func originToPath(origin string) (string, error) {
 }
 
 type configuredModule struct {
-	Mod        *dagger.Module
+	Source     *dagger.ModuleSource
 	SourceKind dagger.ModuleSourceKind
 
-	LocalRootPath   string
-	LocalSourcePath string
+	LocalContextPath string
+	LocalSourcePath  string
 
 	// whether the dagger.json in the module source dir exists yet
 	ModuleSourceConfigExists bool
@@ -572,7 +570,17 @@ func (c *configuredModule) FullyInitialized() bool {
 	return c.ModuleSourceConfigExists
 }
 
-func getDefaultModuleConfiguration(ctx context.Context, dag *dagger.Client, defaultRootPath string) (*configuredModule, error) {
+func getDefaultModuleConfiguration(
+	ctx context.Context,
+	dag *dagger.Client,
+	// if true, will resolve local sources from the caller
+	// before returning the source. This should be set false
+	// if the caller wants to mutate configuration (sdk/dependency/etc.)
+	// since those changes require the source be resolved after
+	// they are made (due to the fact that they may result in more
+	// files needing to be loaded).
+	resolveFromCaller bool,
+) (*configuredModule, error) {
 	srcRefStr := moduleURL
 	if srcRefStr == "" {
 		// it's unset or default value, use mod if present
@@ -586,20 +594,20 @@ func getDefaultModuleConfiguration(ctx context.Context, dag *dagger.Client, defa
 		}
 	}
 
-	return getModuleConfigurationForSourceRef(ctx, dag, srcRefStr, defaultRootPath)
+	return getModuleConfigurationForSourceRef(ctx, dag, srcRefStr, resolveFromCaller)
 }
 
 func getModuleConfigurationForSourceRef(
 	ctx context.Context,
 	dag *dagger.Client,
 	srcRefStr string,
-	defaultRootPath string,
+	resolveFromCaller bool,
 ) (*configuredModule, error) {
 	conf := &configuredModule{}
 
-	src := dag.ModuleSource(srcRefStr)
+	conf.Source = dag.ModuleSource(srcRefStr)
 	var err error
-	conf.SourceKind, err = src.Kind(ctx)
+	conf.SourceKind, err = conf.Source.Kind(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get module ref kind: %w", err)
 	}
@@ -625,11 +633,9 @@ func getModuleConfigurationForSourceRef(
 			if err := json.Unmarshal(contents, &modCfg); err != nil {
 				return nil, fmt.Errorf("failed to unmarshal %s: %s", configPath, err)
 			}
-			if err := modCfg.Validate(); err != nil {
-				return nil, fmt.Errorf("error validating %s: %s", configPath, err)
-			}
 			if namedDep, ok := modCfg.DependencyByName(srcRefStr); ok {
-				srcRefStr = namedDep.Source
+				depPath := filepath.Join(defaultConfigDir, namedDep.Source)
+				srcRefStr = depPath
 			}
 		}
 
@@ -637,24 +643,33 @@ func getModuleConfigurationForSourceRef(
 		if err != nil {
 			return nil, fmt.Errorf("failed to get absolute path for %s: %w", srcRefStr, err)
 		}
-		src = dag.ModuleSource(conf.LocalSourcePath).AsLocalSource().ResolveFromCaller(dagger.LocalModuleSourceResolveFromCallerOpts{
-			DefaultRootPath: defaultRootPath,
-		})
 
-		conf.LocalRootPath, err = src.AsLocalSource().LocalRootPath(ctx)
+		if filepath.IsAbs(srcRefStr) {
+			srcRefStr, err = filepath.Rel(cwd, srcRefStr)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get relative path for %s: %w", srcRefStr, err)
+			}
+		}
+		if err := os.MkdirAll(srcRefStr, 0755); err != nil {
+			return nil, fmt.Errorf("failed to create directory for %s: %w", srcRefStr, err)
+		}
+		conf.Source = dag.ModuleSource(srcRefStr)
+
+		conf.LocalContextPath, err = conf.Source.ResolveContextPathFromCaller(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get local root path: %w", err)
 		}
+		_, err = os.Lstat(filepath.Join(conf.LocalSourcePath, modules.Filename))
+		conf.ModuleSourceConfigExists = err == nil
 
-		conf.ModuleSourceConfigExists, err = src.AsLocalSource().ConfigExists(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to check if module source config exists: %w", err)
+		if resolveFromCaller {
+			conf.Source = conf.Source.ResolveFromCaller()
 		}
-		conf.Mod = src.AsModule()
-
 	} else {
-		conf.Mod = src.AsModule()
-		conf.ModuleSourceConfigExists = true
+		conf.ModuleSourceConfigExists, err = conf.Source.ConfigExists(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check if module config exists: %w", err)
+		}
 	}
 
 	return conf, nil
@@ -711,13 +726,13 @@ func optionalModCmdWrapper(
 			vtx := rec.Vertex("cmd-loader", strings.Join(os.Args, " "))
 			defer func() { vtx.Done(err) }()
 
-			modConf, err := getDefaultModuleConfiguration(ctx, engineClient.Dagger(), "")
+			modConf, err := getDefaultModuleConfiguration(ctx, engineClient.Dagger(), true)
 			if err != nil {
 				return fmt.Errorf("failed to get configured module: %w", err)
 			}
 			var loadedMod *dagger.Module
 			if modConf.FullyInitialized() {
-				loadedMod = modConf.Mod.Initialize()
+				loadedMod = modConf.Source.AsModule().Initialize()
 				load := vtx.Task("loading module")
 				_, err := loadedMod.Serve(ctx)
 				load.Done(err)

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -244,7 +244,7 @@ var moduleInitCmd = &cobra.Command{
 
 			// default source dir
 			if moduleSourcePath == "" && sdk != "" {
-				moduleSourcePath = filepath.Join(defaultModuleSourceDirName, sdk)
+				moduleSourcePath = defaultModuleSourceDirName
 			}
 
 			_, err = modConf.Source.

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -24,7 +24,7 @@ func TestModuleDaggerCallArgTypes(t *testing.T) {
 			modGen := c.Container().From(golangImage).
 				WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 				WithWorkdir("/work").
-				With(daggerExec("init", "--name=test", "--sdk=go")).
+				With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
 				WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 					Contents: `package main
 import (
@@ -63,7 +63,7 @@ func (m *Test) Fn(ctx context.Context, svc *Service) (string, error) {
 			modGen := c.Container().From(golangImage).
 				WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 				WithWorkdir("/work").
-				With(daggerExec("init", "--name=test", "--sdk=go")).
+				With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
 				WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 					Contents: `package main
 import (
@@ -115,7 +115,7 @@ func (m *Test) Fn(ctx context.Context, svc *Service) (string, error) {
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
-			With(daggerExec("init", "--name=minimal", "--sdk=go")).
+			With(daggerExec("init", "--source=.", "--name=minimal", "--sdk=go")).
 			WithNewFile("foo.txt", dagger.ContainerWithNewFileOpts{
 				Contents: "bar",
 			}).
@@ -167,7 +167,7 @@ func (m *Minimal) Reads(ctx context.Context, files []File) (string, error) {
 			modGen := c.Container().From(golangImage).
 				WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 				WithWorkdir("/work").
-				With(daggerExec("init", "--name=test", "--sdk=go")).
+				With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
 				WithNewFile("/dir/subdir/foo.txt", dagger.ContainerWithNewFileOpts{
 					Contents: "foo",
 				}).
@@ -200,7 +200,7 @@ func (m *Test) Fn(dir *Directory) *Directory {
 			modGen := c.Container().From(golangImage).
 				WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 				WithWorkdir("/work").
-				With(daggerExec("init", "--name=test", "--sdk=go")).
+				With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
 				WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 					Contents: `package main
 type Test struct {}
@@ -259,7 +259,7 @@ func (m *Test) Fn(dir *Directory, subpath Optional[string]) *Directory {
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
-			With(daggerExec("init", "--name=test", "--sdk=go")).
+			With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
 			WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 
@@ -340,7 +340,7 @@ func (m *Test) Insecure(ctx context.Context, token *Secret) (string, error) {
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
-			With(daggerExec("init", "--name=test", "--sdk=go")).
+			With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
 			WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 
@@ -381,7 +381,7 @@ func TestModuleDaggerCallReturnTypes(t *testing.T) {
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
-			With(daggerExec("init", "--name=minimal", "--sdk=go")).
+			With(daggerExec("init", "--source=.", "--name=minimal", "--sdk=go")).
 			WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 type Minimal struct {}
@@ -434,7 +434,7 @@ func (m *Minimal) Fn() []*Foo {
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
-			With(daggerExec("init", "--name=test", "--sdk=go")).
+			With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
 			WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 
@@ -478,7 +478,7 @@ type Test struct {
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
-			With(daggerExec("init", "--name=test", "--sdk=go")).
+			With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
 			WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 
@@ -531,7 +531,7 @@ type Test struct {
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
-			With(daggerExec("init", "--name=test", "--sdk=go")).
+			With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
 			WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 
@@ -576,7 +576,7 @@ type Test struct {
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
-			With(daggerExec("init", "--name=test", "--sdk=go")).
+			With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
 			WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 
@@ -607,7 +607,7 @@ func TestModuleDaggerCallCoreChaining(t *testing.T) {
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
-			With(daggerExec("init", "--name=test", "--sdk=go")).
+			With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
 			WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 
@@ -643,7 +643,7 @@ type Test struct {
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
-			With(daggerExec("init", "--name=test", "--sdk=go")).
+			With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
 			WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 
@@ -681,7 +681,7 @@ type Test struct {
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
-			With(daggerExec("init", "--name=test", "--sdk=go")).
+			With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
 			WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 
@@ -723,7 +723,7 @@ func TestModuleDaggerCallSaveOutput(t *testing.T) {
 	modGen := c.Container().From(golangImage).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 		WithWorkdir("/work").
-		With(daggerExec("init", "--name=test", "--sdk=go")).
+		With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
 		WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 			Contents: `package main
 
@@ -827,7 +827,7 @@ func TestModuleCallByName(t *testing.T) {
 	ctr := c.Container().From(golangImage).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 		WithWorkdir("/work/mod-a").
-		With(daggerExec("init", "--name=mod-a", "--sdk=go")).
+		With(daggerExec("init", "--source=.", "--name=mod-a", "--sdk=go")).
 		WithNewFile("/work/mod-a/main.go", dagger.ContainerWithNewFileOpts{
 			Contents: `package main
 
@@ -841,7 +841,7 @@ func TestModuleCallByName(t *testing.T) {
 			`,
 		}).
 		WithWorkdir("/work/mod-b").
-		With(daggerExec("init", "--name=mod-b", "--sdk=go")).
+		With(daggerExec("init", "--source=.", "--name=mod-b", "--sdk=go")).
 		WithNewFile("/work/mod-b/main.go", dagger.ContainerWithNewFileOpts{
 			Contents: `package main
 

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -579,7 +579,7 @@ func TestModuleDaggerInit(t *testing.T) {
 				require.NoError(t, err)
 				require.Contains(t, srcRootEnts, "dagger.json")
 				require.NotContains(t, srcRootEnts, tc.sourceDirEnt)
-				srcDirEnts, err := srcRootDir.Directory("dagger/" + tc.sdk).Entries(ctx)
+				srcDirEnts, err := srcRootDir.Directory("dagger").Entries(ctx)
 				require.NoError(t, err)
 				require.Contains(t, srcDirEnts, tc.sourceDirEnt)
 			})
@@ -774,7 +774,7 @@ func (m *Coolsdk) RequiredPaths() []string {
 
 			if tc.customSDKSource != "" {
 				// TODO: hardcoding that underlying sdk is go right now, could be generalized
-				ctr = ctr.WithNewFile("dagger/"+tc.sdk+"/main.go", dagger.ContainerWithNewFileOpts{
+				ctr = ctr.WithNewFile("dagger/main.go", dagger.ContainerWithNewFileOpts{
 					Contents: tc.mainSource,
 				})
 			} else {
@@ -786,11 +786,11 @@ func (m *Coolsdk) RequiredPaths() []string {
 				With(configFile(".", &modules.ModuleConfig{
 					Name:    "test",
 					SDK:     tc.sdk,
-					Include: []string{"dagger/" + tc.sdk + "/subdir/keepdir"},
-					Exclude: []string{"dagger/" + tc.sdk + "/subdir/keepdir/rmdir"},
-					Source:  "dagger/" + tc.sdk,
+					Include: []string{"dagger/subdir/keepdir"},
+					Exclude: []string{"dagger/subdir/keepdir/rmdir"},
+					Source:  "dagger",
 				})).
-				WithDirectory("dagger/"+tc.sdk+"/subdir/keepdir/rmdir", c.Directory())
+				WithDirectory("dagger/subdir/keepdir/rmdir", c.Directory())
 
 			// call should work even though dagger.json and main source files weren't
 			// explicitly included

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -48,6 +48,7 @@ func TestModuleConfigs(t *testing.T) {
 				Name:   "dep",
 				Source: "foo",
 			}},
+			Source: ".",
 		}
 		expectedConfBytes, err := json.Marshal(expectedConf)
 		require.NoError(t, err)

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -21,9 +21,9 @@ func TestModuleConfigs(t *testing.T) {
 		baseWithOldConfig := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work/foo").
-			With(daggerExec("init", "--name=dep", "--sdk=go")).
+			With(daggerExec("init", "--source=.", "--name=dep", "--sdk=go")).
 			WithWorkdir("/work").
-			With(daggerExec("init", "--name=test", "--sdk=go")).
+			With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
 			WithNewFile("/work/main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 			type Test struct {}
@@ -72,7 +72,7 @@ func TestModuleConfigs(t *testing.T) {
 		base := goGitBase(t, c).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work/subdir/dep").
-			With(daggerExec("init", "--name=dep", "--sdk=go")).
+			With(daggerExec("init", "--source=.", "--name=dep", "--sdk=go")).
 			WithNewFile("/work/subdir/dep/main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 
@@ -84,7 +84,7 @@ func TestModuleConfigs(t *testing.T) {
 			`,
 			}).
 			WithWorkdir("/work").
-			With(daggerExec("init", "--name=test", "--sdk=go", "test")).
+			With(daggerExec("init", "--source=.", "--name=test", "--sdk=go", "test")).
 			With(daggerExec("install", "-m=test", "./subdir/dep")).
 			WithNewFile("/work/test/main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
@@ -142,7 +142,7 @@ func TestModuleConfigs(t *testing.T) {
 		base := goGitBase(t, c).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
-			With(daggerExec("init", "--name=dep", "--sdk=go", "subdir/dep")).
+			With(daggerExec("init", "--source=.", "--name=dep", "--sdk=go", "subdir/dep")).
 			WithNewFile("/work/subdir/dep/main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 
@@ -153,7 +153,7 @@ func TestModuleConfigs(t *testing.T) {
 			func (m *Dep) DepFn(ctx context.Context, str string) string { return str }
 			`,
 			}).
-			With(daggerExec("init", "--name=test", "--sdk=go", "test")).
+			With(daggerExec("init", "--source=.", "--name=test", "--sdk=go", "test")).
 			WithNewFile("/work/test/main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 
@@ -261,7 +261,7 @@ func TestModuleConfigs(t *testing.T) {
 		base := goGitBase(t, c).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work/dep").
-			With(daggerExec("init", "--name=dep", "--sdk=go")).
+			With(daggerExec("init", "--source=.", "--name=dep", "--sdk=go")).
 			WithNewFile("/work/dep/main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 
@@ -275,7 +275,7 @@ func TestModuleConfigs(t *testing.T) {
 			`,
 			}).
 			WithWorkdir("/work").
-			With(daggerExec("init", "--name=test", "--sdk=go"))
+			With(daggerExec("init", "--source=.", "--name=test", "--sdk=go"))
 
 		t.Run("source points out of root", func(t *testing.T) {
 			t.Parallel()
@@ -331,7 +331,7 @@ func TestModuleCustomDepNames(t *testing.T) {
 		ctr := goGitBase(t, c).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work/dep").
-			With(daggerExec("init", "--name=dep", "--sdk=go")).
+			With(daggerExec("init", "--source=.", "--name=dep", "--sdk=go")).
 			WithNewFile("/work/dep/main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 
@@ -361,7 +361,7 @@ func TestModuleCustomDepNames(t *testing.T) {
 			`,
 			}).
 			WithWorkdir("/work").
-			With(daggerExec("init", "--name=test", "--sdk=go")).
+			With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
 			With(daggerExec("install", "--name", "foo", "./dep")).
 			WithNewFile("/work/main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
@@ -420,7 +420,7 @@ func TestModuleCustomDepNames(t *testing.T) {
 		ctr := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work/dep").
-			With(daggerExec("init", "--name=test", "--sdk=go")).
+			With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
 			WithNewFile("/work/dep/main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 
@@ -434,7 +434,7 @@ func TestModuleCustomDepNames(t *testing.T) {
 			`,
 			}).
 			WithWorkdir("/work").
-			With(daggerExec("init", "--name=test", "--sdk=go")).
+			With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
 			With(daggerExec("install", "--name", "foo", "./dep")).
 			WithNewFile("/work/main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
@@ -460,7 +460,7 @@ func TestModuleCustomDepNames(t *testing.T) {
 		ctr := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work/dep1").
-			With(daggerExec("init", "--name=dep", "--sdk=go")).
+			With(daggerExec("init", "--source=.", "--name=dep", "--sdk=go")).
 			WithNewFile("/work/dep1/main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 
@@ -474,7 +474,7 @@ func TestModuleCustomDepNames(t *testing.T) {
 			`,
 			}).
 			WithWorkdir("/work/dep2").
-			With(daggerExec("init", "--name=dep", "--sdk=go")).
+			With(daggerExec("init", "--source=.", "--name=dep", "--sdk=go")).
 			WithNewFile("/work/dep2/main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 
@@ -488,7 +488,7 @@ func TestModuleCustomDepNames(t *testing.T) {
 			`,
 			}).
 			WithWorkdir("/work").
-			With(daggerExec("init", "--name=test", "--sdk=go")).
+			With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
 			With(daggerExec("install", "--name", "foo", "./dep1")).
 			With(daggerExec("install", "--name", "bar", "./dep2")).
 			WithNewFile("/work/main.go", dagger.ContainerWithNewFileOpts{
@@ -526,7 +526,7 @@ func TestModuleDaggerInit(t *testing.T) {
 		out, err := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
-			With(daggerExec("init", "--sdk=go", "coolmod")).
+			With(daggerExec("init", "--source=.", "--sdk=go", "coolmod")).
 			WithNewFile("/work/coolmod/main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 
@@ -596,7 +596,7 @@ func TestModuleDaggerDevelop(t *testing.T) {
 		ctr := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work/dep").
-			With(daggerExec("init", "--name=dep", "--sdk=go")).
+			With(daggerExec("init", "--source=.", "--name=dep", "--sdk=go")).
 			WithNewFile("/work/dep/main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 
@@ -618,10 +618,10 @@ func TestModuleDaggerDevelop(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "hi from dep", strings.TrimSpace(out))
 
-		// now add an sdk+name
+		// now add an sdk+source
 		ctr = ctr.
-			With(daggerExec("develop", "--sdk", "go")).
-			WithNewFile("/work/main.go", dagger.ContainerWithNewFileOpts{
+			With(daggerExec("develop", "--sdk", "go", "--source", "cool/subdir")).
+			WithNewFile("/work/cool/subdir/main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 
 			import "context"
@@ -649,7 +649,10 @@ func TestModuleDaggerDevelop(t *testing.T) {
 		require.ErrorContains(t, err, `cannot update module name that has already been set to "work"`)
 
 		_, err = ctr.With(daggerExec("develop", "--sdk", "python")).Sync(ctx)
-		require.ErrorContains(t, err, `cannot update module sdk that has already been set to "go"`)
+		require.ErrorContains(t, err, `cannot update module SDK that has already been set to "go"`)
+
+		_, err = ctr.With(daggerExec("develop", "--source", "blahblahblaha/blah")).Sync(ctx)
+		require.ErrorContains(t, err, `cannot update module source path that has already been set to "cool/subdir"`)
 	})
 }
 
@@ -706,9 +709,9 @@ class Test:
 			mainSource: `
 import { dag, Directory, object, func } from "@dagger.io/dagger"
 
-@object
+@object()
 class Test {
-  @func
+  @func()
   fn(): Directory {
     return dag.currentModule().source()
   }
@@ -729,7 +732,7 @@ func (m *Test) Fn() *Directory {
 type Coolsdk struct {}
 
 func (m *Coolsdk) ModuleRuntime(modSource *ModuleSource, introspectionJson string) *Container {
-	return modSource.WithSDK("go").AsModule().Initialize().Runtime().WithEnvVariable("COOL", "true")
+	return modSource.WithSDK("go").AsModule().Runtime().WithEnvVariable("COOL", "true")
 }
 
 func (m *Coolsdk) Codegen(modSource *ModuleSource, introspectionJson string) *GeneratedCode {
@@ -754,7 +757,7 @@ func (m *Coolsdk) RequiredPaths() []string {
 			t.Parallel()
 			c, ctx := connect(t)
 
-			ctr := c.Container().From(golangImage).
+			ctr := goGitBase(t, c).
 				WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 				WithWorkdir("/work")
 
@@ -770,7 +773,10 @@ func (m *Coolsdk) RequiredPaths() []string {
 			ctr = ctr.With(daggerExec("init", "--name=test", "--sdk="+tc.sdk))
 
 			if tc.customSDKSource != "" {
-				ctr = ctr.With(sdkSource(tc.customSDKUnderlyingSDK, tc.mainSource))
+				// TODO: hardcoding that underlying sdk is go right now, could be generalized
+				ctr = ctr.WithNewFile("dagger/"+tc.sdk+"/main.go", dagger.ContainerWithNewFileOpts{
+					Contents: tc.mainSource,
+				})
 			} else {
 				ctr = ctr.With(sdkSource(tc.sdk, tc.mainSource))
 			}
@@ -780,10 +786,11 @@ func (m *Coolsdk) RequiredPaths() []string {
 				With(configFile(".", &modules.ModuleConfig{
 					Name:    "test",
 					SDK:     tc.sdk,
-					Include: []string{"subdir/keepdir"},
-					Exclude: []string{"subdir/keepdir/rmdir"},
+					Include: []string{"dagger/" + tc.sdk + "/subdir/keepdir"},
+					Exclude: []string{"dagger/" + tc.sdk + "/subdir/keepdir/rmdir"},
+					Source:  "dagger/" + tc.sdk,
 				})).
-				WithDirectory("subdir/keepdir/rmdir", c.Directory())
+				WithDirectory("dagger/"+tc.sdk+"/subdir/keepdir/rmdir", c.Directory())
 
 			// call should work even though dagger.json and main source files weren't
 			// explicitly included
@@ -833,7 +840,7 @@ func TestModuleContextDefaultsToSourceRoot(t *testing.T) {
 	ctr := c.Container().From(golangImage).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 		WithWorkdir("/work/coolsdk").
-		With(daggerExec("init", "--name=cool-sdk", "--sdk=go")).
+		With(daggerExec("init", "--source=.", "--name=cool-sdk", "--sdk=go")).
 		WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 			Contents: `package main
 
@@ -862,7 +869,7 @@ func (m *CoolSdk) RequiredPaths() []string {
 		}).
 		WithWorkdir("/work").
 		WithNewFile("random-file").
-		With(daggerExec("init", "--name=test", "--sdk=coolsdk")).
+		With(daggerExec("init", "--source=.", "--name=test", "--sdk=coolsdk")).
 		WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 			Contents: `package main
 

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -36,7 +36,7 @@ func TestModuleConfigs(t *testing.T) {
 			})
 
 		// verify develop updates config to new format
-		baseWithNewConfig := baseWithOldConfig.With(daggerExec("mod", "develop"))
+		baseWithNewConfig := baseWithOldConfig.With(daggerExec("develop"))
 		confContents, err := baseWithNewConfig.File("dagger.json").Contents(ctx)
 		require.NoError(t, err)
 		expectedConf := modules.ModuleConfig{
@@ -290,10 +290,10 @@ func TestModuleConfigs(t *testing.T) {
 			_, err := base.With(daggerCall("container-echo", "--string-arg", "plz fail")).Sync(ctx)
 			require.ErrorContains(t, err, `local module source path ".." escapes context "/work"`)
 
-			_, err = base.With(daggerExec("mod", "sync")).Sync(ctx)
+			_, err = base.With(daggerExec("develop")).Sync(ctx)
 			require.ErrorContains(t, err, `local module source path ".." escapes context "/work"`)
 
-			_, err = base.With(daggerExec("mod", "install", "./dep")).Sync(ctx)
+			_, err = base.With(daggerExec("install", "./dep")).Sync(ctx)
 			require.ErrorContains(t, err, `local module source path ".." escapes context "/work"`)
 		})
 
@@ -573,7 +573,7 @@ func TestModuleDaggerInit(t *testing.T) {
 			t.Run(tc.sdk, func(t *testing.T) {
 				t.Parallel()
 				srcRootDir := ctr.
-					With(daggerExec("mod", "init", "--name=test", "--sdk="+tc.sdk)).
+					With(daggerExec("init", "--name=test", "--sdk="+tc.sdk)).
 					Directory(".")
 				srcRootEnts, err := srcRootDir.Entries(ctx)
 				require.NoError(t, err)
@@ -762,12 +762,12 @@ func (m *Coolsdk) RequiredPaths() []string {
 			if tc.customSDKSource != "" {
 				ctr = ctr.
 					WithWorkdir("/work/" + tc.sdk).
-					With(daggerExec("mod", "init", "--name="+tc.sdk, "--sdk="+tc.customSDKUnderlyingSDK)).
+					With(daggerExec("init", "--name="+tc.sdk, "--sdk="+tc.customSDKUnderlyingSDK)).
 					With(sdkSource(tc.customSDKUnderlyingSDK, tc.customSDKSource)).
 					WithWorkdir("/work")
 			}
 
-			ctr = ctr.With(daggerExec("mod", "init", "--name=test", "--sdk="+tc.sdk))
+			ctr = ctr.With(daggerExec("init", "--name=test", "--sdk="+tc.sdk))
 
 			if tc.customSDKSource != "" {
 				ctr = ctr.With(sdkSource(tc.customSDKUnderlyingSDK, tc.mainSource))
@@ -807,8 +807,8 @@ func (m *Coolsdk) RequiredPaths() []string {
 			require.NoError(t, err)
 			require.Equal(t, "keepdir", strings.TrimSpace(out))
 
-			// call should still work after sync
-			ctr = ctr.With(daggerExec("mod", "sync"))
+			// call should still work after develop
+			ctr = ctr.With(daggerExec("develop"))
 
 			out, err = ctr.
 				With(daggerCall("fn", "directory", "--path", "subdir", "entries")).
@@ -833,7 +833,7 @@ func TestModuleContextDefaultsToSourceRoot(t *testing.T) {
 	ctr := c.Container().From(golangImage).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 		WithWorkdir("/work/coolsdk").
-		With(daggerExec("mod", "init", "--name=cool-sdk", "--sdk=go")).
+		With(daggerExec("init", "--name=cool-sdk", "--sdk=go")).
 		WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 			Contents: `package main
 
@@ -862,7 +862,7 @@ func (m *CoolSdk) RequiredPaths() []string {
 		}).
 		WithWorkdir("/work").
 		WithNewFile("random-file").
-		With(daggerExec("mod", "init", "--name=test", "--sdk=coolsdk")).
+		With(daggerExec("init", "--name=test", "--sdk=coolsdk")).
 		WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 			Contents: `package main
 

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -663,9 +663,6 @@ func TestModuleDaggerDevelop(t *testing.T) {
 
 		// currently, we don't support renaming or re-sdking a module, make sure that errors comprehensibly
 
-		_, err = ctr.With(daggerExec("develop", "--name", "foo")).Sync(ctx)
-		require.ErrorContains(t, err, `cannot update module name that has already been set to "work"`)
-
 		_, err = ctr.With(daggerExec("develop", "--sdk", "python")).Sync(ctx)
 		require.ErrorContains(t, err, `cannot update module SDK that has already been set to "go"`)
 

--- a/core/integration/module_functions_test.go
+++ b/core/integration/module_functions_test.go
@@ -16,7 +16,7 @@ func TestModuleDaggerCLIFunctions(t *testing.T) {
 	ctr := c.Container().From(golangImage).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 		WithWorkdir("/work").
-		With(daggerExec("init", "--name=test", "--sdk=go")).
+		With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
 		WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 			Contents: `package main
 

--- a/core/integration/module_iface_test.go
+++ b/core/integration/module_iface_test.go
@@ -33,7 +33,7 @@ func TestModuleIfaceGoSadPaths(t *testing.T) {
 		_, err := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
-			With(daggerExec("init", "--name=test", "--sdk=go")).
+			With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
 			WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 type Test struct {}
@@ -62,7 +62,7 @@ func TestModuleIfaceGoDanglingInterface(t *testing.T) {
 	modGen, err := c.Container().From(golangImage).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 		WithWorkdir("/work").
-		With(daggerExec("init", "--name=test", "--sdk=go")).
+		With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
 		WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 			Contents: `package main
 type Test struct {}
@@ -100,7 +100,7 @@ func TestModuleIfaceDaggerCall(t *testing.T) {
 	out, err := c.Container().From(golangImage).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 		WithWorkdir("/work/mallard").
-		With(daggerExec("init", "--name=mallard", "--sdk=go")).
+		With(daggerExec("init", "--source=.", "--name=mallard", "--sdk=go")).
 		WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 			Contents: `package main
 type Mallard struct {}
@@ -111,7 +111,7 @@ func (m *Mallard) Quack() string {
 	`,
 		}).
 		WithWorkdir("/work").
-		With(daggerExec("init", "--name=test", "--sdk=go")).
+		With(daggerExec("init", "--source=.", "--name=test", "--sdk=go")).
 		WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 			Contents: `package main
 

--- a/core/integration/module_python_test.go
+++ b/core/integration/module_python_test.go
@@ -95,7 +95,7 @@ func TestModulePythonInit(t *testing.T) {
                         return "Hello, world!"
                 `),
 			}).
-			With(daggerExec("init", "--name=hasMainPy", "--sdk=python")).
+			With(daggerExec("init", "--source=.", "--name=hasMainPy", "--sdk=python")).
 			With(daggerQuery(`{hasMainPy{hello}}`)).
 			Stdout(ctx)
 
@@ -622,7 +622,7 @@ func TestModulePythonWithOtherModuleTypes(t *testing.T) {
 
 	c, ctx := connect(t)
 
-	ctr := c.Container().From(golangImage).
+	ctr := goGitBase(t, c).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 		WithWorkdir("/work/dep").
 		With(daggerExec("init", "--name=dep", "--sdk=python")).
@@ -801,7 +801,7 @@ func TestModulePythonPackageDescription(t *testing.T) {
                     foo: str = field(default="foo")
             `),
 		}).
-		With(daggerExec("init", "--name=test", "--sdk=python"))
+		With(daggerExec("init", "--source=.", "--name=test", "--sdk=python"))
 
 	mod := inspectModule(ctx, t, modGen)
 

--- a/core/integration/module_terminal_test.go
+++ b/core/integration/module_terminal_test.go
@@ -45,7 +45,7 @@ type Test struct {
 `), 0644)
 		require.NoError(t, err)
 
-		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--name=test", "--sdk=go")
+		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")
 		require.NoError(t, err)
 
 		// cache the module load itself so there's less to wait for in the shell invocation below
@@ -116,7 +116,7 @@ type Test struct {
 `), 0644)
 		require.NoError(t, err)
 
-		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--name=test", "--sdk=go")
+		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")
 		require.NoError(t, err)
 
 		// cache the returned container so there's less to wait for in the shell invocation below

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -188,7 +188,7 @@ func TestModuleGoInit(t *testing.T) {
 			WithWorkdir("/work/child").
 			WithExec([]string{"go", "mod", "init", "my-mod"}).
 			WithWorkdir("/work").
-			With(daggerExec("init", "--source=.", "--name=child", "--sdk=go", "./child")).
+			With(daggerExec("init", "--source=./child", "--name=child", "--sdk=go", "./child")).
 			WithWorkdir("/work/child").
 			// explicitly develop to see whether it makes a go.mod
 			With(daggerExec("develop")).
@@ -294,7 +294,7 @@ func (m *HasNotMainGo) Hello() string { return "Hello, world!" }
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
-			With(daggerExec("init", "--source=.", "--name=bare", "--sdk=go", "--source=some/subdir"))
+			With(daggerExec("init", "--name=bare", "--sdk=go", "--source=some/subdir"))
 
 		out, err := modGen.
 			With(daggerQuery(`{bare{containerEcho(stringArg:"hello"){stdout}}}`)).
@@ -2475,7 +2475,7 @@ func (m *D) Fn(foo int) Obj {
 
 	ctr = ctr.
 		WithWorkdir("/work").
-		With(daggerExec("init", "--source=.", "--name=c", "--sdk=go", "c")).
+		With(daggerExec("init", "--source=c", "--name=c", "--sdk=go", "c")).
 		WithWorkdir("/work/c").
 		With(daggerExec("install", "../dstr")).
 		WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
@@ -2495,7 +2495,7 @@ func (m *C) Fn(ctx context.Context, foo string) (string, error) {
 
 	ctr = ctr.
 		WithWorkdir("/work").
-		With(daggerExec("init", "--source=.", "--name=b", "--sdk=go", "b")).
+		With(daggerExec("init", "--source=b", "--name=b", "--sdk=go", "b")).
 		With(daggerExec("install", "-m=b", "./dint")).
 		WithNewFile("/work/b/main.go", dagger.ContainerWithNewFileOpts{
 			Contents: `package main
@@ -2514,7 +2514,7 @@ func (m *B) Fn(ctx context.Context, foo int) (int, error) {
 
 	ctr = ctr.
 		WithWorkdir("/work").
-		With(daggerExec("init", "--source=.", "--name=a", "--sdk=go", "a")).
+		With(daggerExec("init", "--source=a", "--name=a", "--sdk=go", "a")).
 		WithWorkdir("/work/a").
 		With(daggerExec("install", "../b")).
 		With(daggerExec("install", "../c")).
@@ -2620,7 +2620,7 @@ func (m *Dep) Fn() Obj {
 `,
 		}).
 		WithWorkdir("/work").
-		With(daggerExec("init", "--source=.", "--name=test", "--sdk=go", "test")).
+		With(daggerExec("init", "--source=test", "--name=test", "--sdk=go", "test")).
 		With(daggerExec("install", "-m=test", "./dep")).
 		WithWorkdir("/work/test")
 

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -4375,6 +4375,10 @@ func (m *CoolSdk) Codegen(modSource *ModuleSource, introspectionJson string) *Ge
 		WithFile("dagger.json", existingConfig),
 	)
 }
+
+func (m *CoolSdk) RequiredPaths() []string {
+	return []string{"main.go"}
+}
 `,
 		}).
 		WithWorkdir("/work").

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -309,7 +309,7 @@ func (m *HasNotMainGo) Hello() string { return "Hello, world!" }
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
-			With(daggerExec("mod", "init", "--name=bare", "--sdk=go", "--source=some/subdir"))
+			With(daggerExec("init", "--name=bare", "--sdk=go", "--source=some/subdir"))
 
 		out, err := modGen.
 			With(daggerQuery(`{bare{containerEcho(stringArg:"hello"){stdout}}}`)).

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -109,7 +109,7 @@ func TestModuleGoInit(t *testing.T) {
 		require.JSONEq(t, `{"beneathGoMod":{"containerEcho":{"stdout":"hello\n"}}}`, out)
 
 		t.Run("names Go module after Dagger module", func(t *testing.T) {
-			generated, err := modGen.Directory("dagger/go").File("go.mod").Contents(ctx)
+			generated, err := modGen.Directory("dagger").File("go.mod").Contents(ctx)
 			require.NoError(t, err)
 			require.Contains(t, generated, "module main")
 		})
@@ -626,7 +626,7 @@ func TestModuleGoSignaturesBuiltinTypes(t *testing.T) {
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 		WithWorkdir("/work").
 		With(daggerExec("init", "--name=minimal", "--sdk=go")).
-		WithNewFile("dagger/go/main.go", dagger.ContainerWithNewFileOpts{
+		WithNewFile("dagger/main.go", dagger.ContainerWithNewFileOpts{
 			Contents: `package main
 
 import "context"
@@ -4443,11 +4443,11 @@ func sdkSource(sdk, contents string) dagger.WithContainerFunc {
 		var sourcePath string
 		switch sdk {
 		case "go":
-			sourcePath = "dagger/go/main.go"
+			sourcePath = "dagger/main.go"
 		case "python":
-			sourcePath = "dagger/python/src/main.py"
+			sourcePath = "dagger/src/main.py"
 		case "typescript":
-			sourcePath = "dagger/typescript/src/index.ts"
+			sourcePath = "dagger/src/index.ts"
 		default:
 			return c
 		}
@@ -4461,11 +4461,11 @@ func sdkCodegenFile(t *testing.T, sdk string) string {
 	t.Helper()
 	switch sdk {
 	case "go":
-		return "dagger/go/dagger.gen.go"
+		return "dagger/dagger.gen.go"
 	case "python":
-		return "dagger/python/sdk/src/dagger/client/gen.py"
+		return "dagger/sdk/src/dagger/client/gen.py"
 	case "typescript":
-		return "dagger/typescript/sdk/api/client.gen.ts"
+		return "dagger/sdk/api/client.gen.ts"
 	default:
 		return ""
 	}

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -4478,9 +4478,6 @@ func modInit(ctx context.Context, t *testing.T, c *dagger.Client, sdk, contents 
 		WithWorkdir("/work").
 		With(daggerExec("init", "--name=test", "--sdk="+sdk)).
 		With(sdkSource(sdk, contents))
-	if sdk == "go" {
-		logGen(ctx, t, modGen.Directory("."))
-	}
 	return modGen
 }
 

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -300,6 +300,31 @@ func (m *HasNotMainGo) Hello() string { return "Hello, world!" }
 		require.NoError(t, err)
 		require.JSONEq(t, `{"hasNotMainGo":{"hello":"Hello, world!"}}`, out)
 	})
+
+	t.Run("with source", func(t *testing.T) {
+		t.Parallel()
+
+		c, ctx := connect(t)
+
+		modGen := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work").
+			With(daggerExec("mod", "init", "--name=bare", "--sdk=go", "--source=some/subdir"))
+
+		out, err := modGen.
+			With(daggerQuery(`{bare{containerEcho(stringArg:"hello"){stdout}}}`)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"bare":{"containerEcho":{"stdout":"hello\n"}}}`, out)
+
+		sourceSubdirEnts, err := modGen.Directory("/work/some/subdir").Entries(ctx)
+		require.NoError(t, err)
+		require.Contains(t, sourceSubdirEnts, "main.go")
+
+		sourceRootEnts, err := modGen.Directory("/work").Entries(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, sourceRootEnts, "main.go")
+	})
 }
 
 func TestModuleInitLICENSE(t *testing.T) {

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -4384,11 +4384,11 @@ func TestModuleCustomSDK(t *testing.T) {
 type CoolSdk struct {}
 
 func (m *CoolSdk) ModuleRuntime(modSource *ModuleSource, introspectionJson string) *Container {
-	return modSource.WithSDK("go").AsModule().Initialize().Runtime().WithEnvVariable("COOL", "true")
+	return modSource.WithSDK("go").AsModule().Runtime().WithEnvVariable("COOL", "true")
 }
 
 func (m *CoolSdk) Codegen(modSource *ModuleSource, introspectionJson string) *GeneratedCode {
-	return dag.GeneratedCode(modSource.WithSDK("go").ContextDirectory())
+	return dag.GeneratedCode(modSource.WithSDK("go").AsModule().GeneratedContextDirectory())
 }
 
 func (m *CoolSdk) RequiredPaths() []string {

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -1462,7 +1462,7 @@ func TestModuleGoBadCtx(t *testing.T) {
 	_, err := c.Container().From(golangImage).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 		WithWorkdir("/work").
-		With(daggerExec("init", "--name=foo", "--sdk=go")).
+		With(daggerExec("init", "--source=.", "--name=foo", "--sdk=go")).
 		WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 			Contents: `package main
 

--- a/core/integration/module_typescript_test.go
+++ b/core/integration/module_typescript_test.go
@@ -128,7 +128,7 @@ func TestModuleTypescriptInit(t *testing.T) {
 		require.JSONEq(t, `{"hasTsConfig":{"containerEcho":{"stdout":"hello\n"}}}`, out)
 
 		t.Run("Add dagger paths to the existing tsconfig.json", func(t *testing.T) {
-			tsConfig, err := modGen.File("/work/dagger/typescript/tsconfig.json").Contents(ctx)
+			tsConfig, err := modGen.File("/work/dagger/tsconfig.json").Contents(ctx)
 			require.NoError(t, err)
 			require.Contains(t, tsConfig, `"@dagger.io/dagger":`)
 		})

--- a/core/integration/module_typescript_test.go
+++ b/core/integration/module_typescript_test.go
@@ -86,7 +86,7 @@ func TestModuleTypescriptInit(t *testing.T) {
   "license": "MIT"
 	}`,
 			}).
-			With(daggerExec("init", "--name=hasPkgJson", "--sdk=typescript"))
+			With(daggerExec("init", "--source=.", "--name=hasPkgJson", "--sdk=typescript"))
 
 		out, err := modGen.
 			With(daggerQuery(`{hasPkgJson{containerEcho(stringArg:"hello"){stdout}}}`)).
@@ -128,7 +128,7 @@ func TestModuleTypescriptInit(t *testing.T) {
 		require.JSONEq(t, `{"hasTsConfig":{"containerEcho":{"stdout":"hello\n"}}}`, out)
 
 		t.Run("Add dagger paths to the existing tsconfig.json", func(t *testing.T) {
-			tsConfig, err := modGen.File("/work/tsconfig.json").Contents(ctx)
+			tsConfig, err := modGen.File("/work/dagger/typescript/tsconfig.json").Contents(ctx)
 			require.NoError(t, err)
 			require.Contains(t, tsConfig, `"@dagger.io/dagger":`)
 		})
@@ -157,7 +157,7 @@ func TestModuleTypescriptInit(t *testing.T) {
 
 				`,
 			}).
-			With(daggerExec("init", "--name=existingSource", "--sdk=typescript"))
+			With(daggerExec("init", "--source=.", "--name=existingSource", "--sdk=typescript"))
 
 		out, err := modGen.
 			With(daggerQuery(`{existingSource{helloWorld(stringArg:"hello"){stdout}}}`)).

--- a/core/integration/module_typescript_test.go
+++ b/core/integration/module_typescript_test.go
@@ -453,7 +453,7 @@ func TestModuleTypescriptWithOtherModuleTypes(t *testing.T) {
 
 	c, ctx := connect(t)
 
-	ctr := c.Container().From(golangImage).
+	ctr := goGitBase(t, c).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 		WithWorkdir("/work/dep").
 		With(daggerExec("init", "--name=dep", "--sdk=typescript")).

--- a/core/integration/module_typescript_test.go
+++ b/core/integration/module_typescript_test.go
@@ -36,7 +36,7 @@ func TestModuleTypescriptInit(t *testing.T) {
 
 		c, ctx := connect(t)
 
-		modGen := c.Container().From(golangImage).
+		modGen := goGitBase(t, c).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
 			With(daggerExec("init", "--name=bare", "--sdk=typescript", "child"))

--- a/core/integration/module_typescript_test.go
+++ b/core/integration/module_typescript_test.go
@@ -174,7 +174,7 @@ func TestModuleTypescriptInit(t *testing.T) {
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
-			With(daggerExec("mod", "init", "--name=bare", "--sdk=typescript", "--source=some/subdir"))
+			With(daggerExec("init", "--name=bare", "--sdk=typescript", "--source=some/subdir"))
 
 		out, err := modGen.
 			With(daggerQuery(`{bare{containerEcho(stringArg:"hello"){stdout}}}`)).

--- a/core/integration/module_up_test.go
+++ b/core/integration/module_up_test.go
@@ -40,7 +40,7 @@ type Test struct {
 `), 0644)
 	require.NoError(t, err)
 
-	_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--name=test", "--sdk=go")
+	_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")
 	require.NoError(t, err)
 
 	// cache the module load itself so there's less to wait for below

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -303,16 +303,23 @@ func moduleAnalyticsProps(mod *Module, prefix string, props map[string]string) {
 	props[prefix+"module_name"] = mod.Name()
 
 	source := mod.Source.Self
+
+	// TODO: go back to symbolic on each subtype
+	symbolic, err := source.Symbolic()
+	if err != nil {
+		symbolic = ""
+	}
+
 	switch source.Kind {
 	case ModuleSourceKindLocal:
 		props[prefix+"source_kind"] = "local"
-		props[prefix+"local_subpath"] = source.AsLocalSource.Value.Subpath
+		props[prefix+"local_subpath"] = source.RootSubpath
 	case ModuleSourceKindGit:
 		git := source.AsGitSource.Value
 		props[prefix+"source_kind"] = "git"
-		props[prefix+"git_symbolic"] = git.Symbolic()
+		props[prefix+"git_symbolic"] = symbolic
 		props[prefix+"git_clone_url"] = git.CloneURL()
-		props[prefix+"git_subpath"] = git.Subpath
+		props[prefix+"git_subpath"] = source.RootSubpath
 		props[prefix+"git_version"] = git.Version
 		props[prefix+"git_commit"] = git.Commit
 	}

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -303,23 +303,17 @@ func moduleAnalyticsProps(mod *Module, prefix string, props map[string]string) {
 	props[prefix+"module_name"] = mod.Name()
 
 	source := mod.Source.Self
-
-	// TODO: go back to symbolic on each subtype
-	symbolic, err := source.Symbolic()
-	if err != nil {
-		symbolic = ""
-	}
-
 	switch source.Kind {
 	case ModuleSourceKindLocal:
+		local := source.AsLocalSource.Value
 		props[prefix+"source_kind"] = "local"
-		props[prefix+"local_subpath"] = source.RootSubpath
+		props[prefix+"local_subpath"] = local.RootSubpath
 	case ModuleSourceKindGit:
 		git := source.AsGitSource.Value
 		props[prefix+"source_kind"] = "git"
-		props[prefix+"git_symbolic"] = symbolic
+		props[prefix+"git_symbolic"] = git.Symbolic()
 		props[prefix+"git_clone_url"] = git.CloneURL()
-		props[prefix+"git_subpath"] = source.RootSubpath
+		props[prefix+"git_subpath"] = git.RootSubpath
 		props[prefix+"git_version"] = git.Version
 		props[prefix+"git_commit"] = git.Commit
 	}

--- a/core/module.go
+++ b/core/module.go
@@ -36,7 +36,7 @@ type Module struct {
 	SDKConfig string `field:"true" name:"sdk" doc:"The SDK used by this module. Either a name of a builtin SDK or a module source ref string pointing to the SDK's implementation."`
 
 	// TODO:
-	GeneratedContextDirectory dagql.Instance[*Directory]
+	GeneratedContextDirectory dagql.Instance[*Directory] `field:"true" name:"generatedContextDirectory" doc:"The module source's context plus any configuration and source files created by codegen."`
 
 	// Dependencies as configured by the module
 	DependencyConfig []*ModuleDependency `field:"true" doc:"The dependencies as configured by the module."`

--- a/core/module.go
+++ b/core/module.go
@@ -786,6 +786,10 @@ type SDK interface {
 	The provided Module is not fully initialized; the Runtime field will not be set yet.
 	*/
 	Runtime(context.Context, *Module, dagql.Instance[*ModuleSource]) (*Container, error)
+
+	// Paths that should always be loaded from module sources using this SDK. Ensures that e.g. main.go
+	// in the Go SDK is always loaded even if dagger.json has include settings that don't include it.
+	RequiredPaths(context.Context) ([]string, error)
 }
 
 var _ HasPBDefinitions = (*Module)(nil)

--- a/core/module.go
+++ b/core/module.go
@@ -35,6 +35,9 @@ type Module struct {
 	// The module's SDKConfig, as set in the module config file
 	SDKConfig string `field:"true" name:"sdk" doc:"The SDK used by this module. Either a name of a builtin SDK or a module source ref string pointing to the SDK's implementation."`
 
+	// TODO:
+	GeneratedContextDirectory dagql.Instance[*Directory]
+
 	// Dependencies as configured by the module
 	DependencyConfig []*ModuleDependency `field:"true" doc:"The dependencies as configured by the module."`
 

--- a/core/module.go
+++ b/core/module.go
@@ -4,17 +4,13 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"sort"
 	"strings"
 	"time"
 
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/idproto"
 	"github.com/moby/buildkit/solver/pb"
-	"github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/v2/ast"
-	"golang.org/x/sync/errgroup"
 )
 
 type Module struct {
@@ -39,16 +35,6 @@ type Module struct {
 	// The module's SDKConfig, as set in the module config file
 	SDKConfig string `field:"true" name:"sdk" doc:"The SDK used by this module. Either a name of a builtin SDK or a module source ref string pointing to the SDK's implementation."`
 
-	// The module's root directory containing the config file for it and its source (possibly as a subdir). It includes any generated code or updated config files created after initial load.
-	GeneratedSourceRootDirectory dagql.Instance[*Directory]
-
-	// The subpath of the GeneratedSourceDirectory that contains the actual source code of the module (which may be a subdir when dagger.json is a parent dir).
-	// This is not always equal to Source.SourceSubpath in the case where the Source is a directory containing
-	// dagger.json as a subdir.
-	// E.g. if the module is in a git repo where dagger.json is at /foo/dagger.json and then module source code is at
-	// /foo/mymod/, then GeneratedSourceSubpath will be "mymod".
-	GeneratedSourceSubpath string
-
 	// Dependencies as configured by the module
 	DependencyConfig []*ModuleDependency `field:"true" doc:"The dependencies as configured by the module."`
 
@@ -57,9 +43,6 @@ type Module struct {
 
 	// Deps contains the module's dependency DAG.
 	Deps *ModDeps
-
-	DirectoryIncludeConfig []string
-	DirectoryExcludeConfig []string
 
 	// Runtime is the container that runs the module's entrypoint. It will fail to execute if the module doesn't compile.
 	Runtime *Container `field:"true" name:"runtime" doc:"The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile."`
@@ -121,200 +104,6 @@ func (mod *Module) Dependencies() []Mod {
 		mods[i] = dep.Self
 	}
 	return mods
-}
-
-func (mod *Module) WithName(ctx context.Context, name string) (*Module, error) {
-	if mod.InstanceID != nil {
-		return nil, fmt.Errorf("cannot update name on initialized module")
-	}
-
-	mod = mod.Clone()
-	mod.NameField = name
-	if mod.OriginalName == "" {
-		mod.OriginalName = name
-	}
-	return mod, nil
-}
-
-func (mod *Module) WithSDK(ctx context.Context, sdk string) (*Module, error) {
-	if mod.InstanceID != nil {
-		return nil, fmt.Errorf("cannot update sdk on initialized module")
-	}
-
-	mod = mod.Clone()
-	mod.SDKConfig = sdk
-	if mod.OriginalSDK == "" {
-		mod.OriginalSDK = sdk
-	}
-
-	return mod, nil
-}
-
-func (mod *Module) WithDependencies(
-	ctx context.Context,
-	srv *dagql.Server,
-	dependencies []*ModuleDependency,
-) (*Module, error) {
-	if mod.InstanceID != nil {
-		return nil, fmt.Errorf("cannot update dependencies on initialized module")
-	}
-	if mod.Source.Self == nil {
-		return nil, fmt.Errorf("cannot update dependencies on module without source")
-	}
-
-	mod = mod.Clone()
-
-	clonedDependencies := make([]*ModuleDependency, len(dependencies))
-	for i, dep := range dependencies {
-		clonedDependencies[i] = dep.Clone()
-	}
-
-	// resolve the dependency relative to this module's source
-	var eg errgroup.Group
-	for i, dep := range dependencies {
-		if dep.Source.Self == nil {
-			return nil, fmt.Errorf("dependency %d has no source", i)
-		}
-		i, dep := i, dep
-
-		eg.Go(func() error {
-			err := srv.Select(ctx, mod.Source, &clonedDependencies[i].Source,
-				dagql.Selector{
-					Field: "resolveDependency",
-					Args: []dagql.NamedInput{
-						{Name: "dep", Value: dagql.NewID[*ModuleSource](dep.Source.ID())},
-					},
-				},
-			)
-			if err != nil {
-				return fmt.Errorf("failed to resolve dependency module: %w", err)
-			}
-
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return nil, err
-	}
-
-	// figure out the set of deps, keyed by their symbolic ref string, which de-dupes
-	// equivalent sources at different versions, preferring the version provided
-	// in the dependencies arg here
-	depSet := make(map[string]*ModuleDependency)
-	for _, dep := range mod.DependencyConfig {
-		symbolic, err := dep.Source.Self.Symbolic()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get symbolic source ref: %w", err)
-		}
-		depSet[symbolic] = dep
-	}
-	for _, newDep := range clonedDependencies {
-		symbolic, err := newDep.Source.Self.Symbolic()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get symbolic source ref: %w", err)
-		}
-		depSet[symbolic] = newDep
-	}
-
-	mod.DependencyConfig = make([]*ModuleDependency, 0, len(depSet))
-	for _, dep := range depSet {
-		mod.DependencyConfig = append(mod.DependencyConfig, dep)
-	}
-
-	refStrs := make([]string, 0, len(mod.DependencyConfig))
-	for _, dep := range mod.DependencyConfig {
-		refStr, err := dep.Source.Self.RefString()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get ref string for dependency: %w", err)
-		}
-		refStrs = append(refStrs, refStr)
-	}
-	sort.Slice(mod.DependencyConfig, func(i, j int) bool {
-		return refStrs[i] < refStrs[j]
-	})
-
-	mod.DependenciesField = make([]dagql.Instance[*Module], len(mod.DependencyConfig))
-	eg = errgroup.Group{}
-	for i, depCfg := range mod.DependencyConfig {
-		i, depCfg := i, depCfg
-		eg.Go(func() error {
-			err := srv.Select(ctx, depCfg.Source, &mod.DependenciesField[i],
-				dagql.Selector{
-					Field: "asModule",
-				},
-				dagql.Selector{
-					Field: "withName",
-					Args: []dagql.NamedInput{
-						{Name: "name", Value: dagql.NewString(depCfg.Name)},
-					},
-				},
-				dagql.Selector{
-					Field: "initialize",
-				},
-			)
-			if err != nil {
-				return fmt.Errorf("failed to initialize dependency module: %w", err)
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		if errors.Is(err, dagql.ErrCacheMapRecursiveCall) {
-			err = fmt.Errorf("module %s has a circular dependency: %w", mod.NameField, err)
-		}
-		return nil, fmt.Errorf("failed to load updated dependencies: %w", err)
-	}
-	// fill in any missing names if needed
-	for i, dep := range mod.DependencyConfig {
-		if dep.Name == "" {
-			dep.Name = mod.DependenciesField[i].Self.Name()
-		}
-	}
-
-	// Check for loops by walking the DAG of deps, seeing if we ever encounter this mod.
-	// Modules are identified here by their *Source's ID*, which is relatively stable and
-	// unique to the module.
-	// Note that this is ultimately best effort, subtle differences in IDs that don't actually
-	// impact the final module will still result in us considering the two modules different.
-	// E.g. if you initialize a module from a source directory that had a no-op file change
-	// made to it, the ID used here will still change.
-	selfDgst, err := mod.Source.ID().Digest()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get digest of module source: %w", err)
-	}
-	memo := make(map[digest.Digest]struct{}) // set of id digests
-	var visit func(dagql.Instance[*Module]) error
-	visit = func(inst dagql.Instance[*Module]) error {
-		instDgst, err := inst.Self.Source.ID().Digest()
-		if err != nil {
-			return fmt.Errorf("failed to get digest of module source: %w", err)
-		}
-		if instDgst == selfDgst {
-			return fmt.Errorf("module %s has a circular dependency", mod.NameField)
-		}
-
-		if _, ok := memo[instDgst]; ok {
-			return nil
-		}
-		memo[instDgst] = struct{}{}
-
-		for _, dep := range inst.Self.DependenciesField {
-			if err := visit(dep); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-	for _, dep := range mod.DependenciesField {
-		if err := visit(dep); err != nil {
-			return nil, err
-		}
-	}
-
-	mod.Deps = NewModDeps(mod.Query, mod.Dependencies()).
-		Append(mod.Query.DefaultDeps.Mods...)
-
-	return mod, nil
 }
 
 func (mod *Module) Initialize(ctx context.Context, oldSelf dagql.Instance[*Module], newID *idproto.ID) (*Module, error) {
@@ -779,13 +568,13 @@ type SDK interface {
 
 	The provided Module is not fully initialized; the Runtime field will not be set yet.
 	*/
-	Codegen(context.Context, *Module, dagql.Instance[*ModuleSource]) (*GeneratedCode, error)
+	Codegen(context.Context, *ModDeps, dagql.Instance[*ModuleSource]) (*GeneratedCode, error)
 
 	/* Runtime returns a container that is used to execute module code at runtime in the Dagger engine.
 
 	The provided Module is not fully initialized; the Runtime field will not be set yet.
 	*/
-	Runtime(context.Context, *Module, dagql.Instance[*ModuleSource]) (*Container, error)
+	Runtime(context.Context, *ModDeps, dagql.Instance[*ModuleSource]) (*Container, error)
 
 	// Paths that should always be loaded from module sources using this SDK. Ensures that e.g. main.go
 	// in the Go SDK is always loaded even if dagger.json has include settings that don't include it.
@@ -796,8 +585,8 @@ var _ HasPBDefinitions = (*Module)(nil)
 
 func (mod *Module) PBDefinitions(ctx context.Context) ([]*pb.Definition, error) {
 	var defs []*pb.Definition
-	if mod.GeneratedSourceRootDirectory.Self != nil {
-		dirDefs, err := mod.GeneratedSourceRootDirectory.Self.PBDefinitions(ctx)
+	if mod.Source.Self != nil {
+		dirDefs, err := mod.Source.Self.PBDefinitions(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -813,10 +602,6 @@ func (mod Module) Clone() *Module {
 		cp.Source.Self = mod.Source.Self.Clone()
 	}
 
-	if mod.GeneratedSourceRootDirectory.Self != nil {
-		cp.GeneratedSourceRootDirectory.Self = mod.GeneratedSourceRootDirectory.Self.Clone()
-	}
-
 	cp.DependencyConfig = make([]*ModuleDependency, len(mod.DependencyConfig))
 	for i, dep := range mod.DependencyConfig {
 		cp.DependencyConfig[i] = dep.Clone()
@@ -825,15 +610,6 @@ func (mod Module) Clone() *Module {
 	cp.DependenciesField = make([]dagql.Instance[*Module], len(mod.DependenciesField))
 	for i, dep := range mod.DependenciesField {
 		cp.DependenciesField[i].Self = dep.Self.Clone()
-	}
-
-	if len(mod.DirectoryIncludeConfig) > 0 {
-		cp.DirectoryIncludeConfig = make([]string, len(mod.DirectoryIncludeConfig))
-		copy(cp.DirectoryIncludeConfig, mod.DirectoryIncludeConfig)
-	}
-	if len(mod.DirectoryExcludeConfig) > 0 {
-		cp.DirectoryExcludeConfig = make([]string, len(mod.DirectoryExcludeConfig))
-		copy(cp.DirectoryExcludeConfig, mod.DirectoryExcludeConfig)
 	}
 
 	cp.ObjectDefs = make([]*TypeDef, len(mod.ObjectDefs))

--- a/core/module.go
+++ b/core/module.go
@@ -35,7 +35,6 @@ type Module struct {
 	// The module's SDKConfig, as set in the module config file
 	SDKConfig string `field:"true" name:"sdk" doc:"The SDK used by this module. Either a name of a builtin SDK or a module source ref string pointing to the SDK's implementation."`
 
-	// TODO:
 	GeneratedContextDirectory dagql.Instance[*Directory] `field:"true" name:"generatedContextDirectory" doc:"The module source's context plus any configuration and source files created by codegen."`
 
 	// Dependencies as configured by the module

--- a/core/modules/config.go
+++ b/core/modules/config.go
@@ -25,7 +25,7 @@ type ModuleConfig struct {
 	// The modules this module depends on.
 	Dependencies []*ModuleConfigDependency `json:"dependencies,omitempty"`
 
-	// TODO:
+	// The path, relative to this config file, to the subdir containing the module's implementation source code.
 	Source string `json:"source,omitempty"`
 }
 

--- a/core/modules/config.go
+++ b/core/modules/config.go
@@ -26,7 +26,7 @@ type ModuleConfig struct {
 	Dependencies []*ModuleConfigDependency `json:"dependencies,omitempty"`
 
 	// TODO:
-	Source string `json:"source,omitempty"`
+	SourceSubdir string `json:"sourceSubdir,omitempty"`
 }
 
 func (modCfg *ModuleConfig) DependencyByName(name string) (*ModuleConfigDependency, bool) {

--- a/core/modules/config.go
+++ b/core/modules/config.go
@@ -26,7 +26,7 @@ type ModuleConfig struct {
 	Dependencies []*ModuleConfigDependency `json:"dependencies,omitempty"`
 
 	// TODO:
-	SourceSubdir string `json:"sourceSubdir,omitempty"`
+	Source string `json:"source,omitempty"`
 }
 
 func (modCfg *ModuleConfig) DependencyByName(name string) (*ModuleConfigDependency, bool) {

--- a/core/modules/config.go
+++ b/core/modules/config.go
@@ -8,10 +8,6 @@ import (
 // Filename is the name of the module config file.
 const Filename = "dagger.json"
 
-// TODO: update message
-const legacyRootUsageMessage = `Cannot load module config with legacy "root" setting %q, manual updates needed. Delete the current dagger.json file and re-initialize the module from the directory where root is pointing, using the -m flag to point to the module's source directory.
-`
-
 // ModuleConfig is the config for a single module as loaded from a dagger.json file.
 type ModuleConfig struct {
 	// The name of the module.
@@ -29,30 +25,8 @@ type ModuleConfig struct {
 	// The modules this module depends on.
 	Dependencies []*ModuleConfigDependency `json:"dependencies,omitempty"`
 
-	// Modules in subdirs that this config is the root for, which impacts those modules'
-	// root directory and possibly other global settings that propagate from the root.
-	RootFor []*ModuleConfigRootFor `json:"root-for,omitempty"`
-
-	// Deprecated: use Source instead, only used to identify legacy config files
-	Root string `json:"root,omitempty"`
-}
-
-func (modCfg *ModuleConfig) Validate() error {
-	if modCfg.Root != "" {
-		// this is too hard to handle automatically, just tell the user they need to update via error message
-		//nolint:stylecheck // we're okay with an error message formated as full sentences in this case
-		return fmt.Errorf(legacyRootUsageMessage, modCfg.Root)
-	}
-	return nil
-}
-
-func (modCfg *ModuleConfig) IsRootFor(source string) bool {
-	for _, rootFor := range modCfg.RootFor {
-		if rootFor.Source == source {
-			return true
-		}
-	}
-	return false
+	// TODO:
+	Source string `json:"source,omitempty"`
 }
 
 func (modCfg *ModuleConfig) DependencyByName(name string) (*ModuleConfigDependency, bool) {
@@ -62,11 +36,6 @@ func (modCfg *ModuleConfig) DependencyByName(name string) (*ModuleConfigDependen
 		}
 	}
 	return nil, false
-}
-
-type ModuleConfigRootFor struct {
-	// The path to the module that this config is the root for, relative to the configuration file.
-	Source string `json:"source"`
 }
 
 type ModuleConfigDependency struct {

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -47,15 +47,15 @@ type ModuleSource struct {
 
 	Kind ModuleSourceKind `field:"true" name:"kind" doc:"The kind of source (e.g. local, git, etc.)"`
 
-	// TODO: doc
+	AsLocalSource dagql.Nullable[*LocalModuleSource] `field:"true" doc:"If the source is of kind local, the local source representation of it."`
+
+	AsGitSource dagql.Nullable[*GitModuleSource] `field:"true" doc:"If the source is a of kind git, the git source representation of it."`
+
+	// Settings that can be used to initialize or override the source's configuration
 	WithName          string
 	WithDependencies  []dagql.Instance[*ModuleDependency]
 	WithSDK           string
 	WithSourceSubpath string
-
-	AsLocalSource dagql.Nullable[*LocalModuleSource] `field:"true" doc:"If the source is of kind local, the local source representation of it."`
-
-	AsGitSource dagql.Nullable[*GitModuleSource] `field:"true" doc:"If the source is a of kind git, the git source representation of it."`
 }
 
 func (src *ModuleSource) Type() *ast.Type {

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -52,6 +52,7 @@ type ModuleSource struct {
 	WithName         string
 	WithDependencies []dagql.Instance[*ModuleDependency]
 	WithSDK          string
+	WithSourceSubdir string
 
 	// the unmodifiied directory the source was was loaded from
 	BaseContextDirectory dagql.Instance[*Directory]
@@ -177,6 +178,10 @@ func (src *ModuleSource) ContextDirectory() (inst dagql.Instance[*Directory], er
 }
 
 func (src *ModuleSource) ModuleSourceSubpath(ctx context.Context) (string, error) {
+	if src.WithSourceSubdir != "" {
+		return filepath.Join(src.RootSubpath, src.WithSourceSubdir), nil
+	}
+
 	cfg, ok, err := src.ModuleConfig(ctx)
 	if err != nil {
 		return "", fmt.Errorf("module config: %w", err)
@@ -186,7 +191,7 @@ func (src *ModuleSource) ModuleSourceSubpath(ctx context.Context) (string, error
 		return src.RootSubpath, nil
 	}
 
-	return filepath.Join(src.RootSubpath, cfg.Source), nil
+	return filepath.Join(src.RootSubpath, cfg.SourceSubdir), nil
 }
 
 func (src *ModuleSource) ModuleSourceRelSubpath(ctx context.Context) (string, error) {

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -151,11 +151,25 @@ func (src *ModuleSource) SourceSubpath(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("module config: %w", err)
 	}
 	if !ok {
-		// default to the root subpath for unintialized modules
-		return rootSubpath, nil
+		return "", nil
+	}
+	if cfg.Source == "" {
+		return "", nil
 	}
 
 	return filepath.Join(rootSubpath, cfg.Source), nil
+}
+
+// SourceSubpathWithDefault is the same as SourceSubpath, but it will default to the root subpath if the module has no configuration.
+func (src *ModuleSource) SourceSubpathWithDefault(ctx context.Context) (string, error) {
+	sourceSubpath, err := src.SourceSubpath(ctx)
+	if err != nil {
+		return "", fmt.Errorf("source subpath: %w", err)
+	}
+	if sourceSubpath == "" {
+		return src.SourceRootSubpath()
+	}
+	return sourceSubpath, nil
 }
 
 func (src *ModuleSource) ModuleName(ctx context.Context) (string, error) {

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -168,7 +168,15 @@ func (src *ModuleSource) ModuleName(ctx context.Context) (string, error) {
 }
 
 type LocalModuleSource struct {
+	Query *Query
+
 	Subpath string `field:"true" name:"sourceSubpath" doc:"The path to the module source code dir specified by this source."`
+
+	// If source was loaded from a caller's filesystem, the path to the root directory on that filesystem.
+	LocalRootPath string `field:"true" doc:"The path to the root directory of the module source on the caller's filesystem."`
+
+	// Whether the module source has a configuration file already.
+	ConfigExists bool `field:"true" doc:"Whether the module source has a configuration file already."`
 }
 
 func (src *LocalModuleSource) Type() *ast.Type {

--- a/core/schema/host.go
+++ b/core/schema/host.go
@@ -51,7 +51,7 @@ func (s *hostSchema) Install() {
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal blob source: %s", err)
 			}
-			return core.NewDirectory(parent, blobDef.ToPB(), "", parent.Platform, nil), nil
+			return core.NewDirectory(parent, blobDef.ToPB(), "/", parent.Platform, nil), nil
 		}).Doc("Retrieves a content-addressed blob."),
 	}.Install(s.srv)
 

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/dagger/dagger/core"
@@ -495,7 +496,7 @@ func (s *moduleSchema) currentModuleSource(
 	curMod *core.CurrentModule,
 	args struct{},
 ) (inst dagql.Instance[*core.Directory], err error) {
-	srcSubpath, err := curMod.Module.Source.Self.SourceSubpath(ctx)
+	srcSubpath, err := curMod.Module.Source.Self.SourceSubpathWithDefault(ctx)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get module source subpath: %w", err)
 	}
@@ -635,6 +636,28 @@ func (s *moduleSchema) moduleWithSource(ctx context.Context, mod *core.Module, a
 	if err != nil {
 		return nil, fmt.Errorf("failed to get module SDK: %w", err)
 	}
+
+	// TODO:
+	// TODO:
+	// TODO:
+	// TODO:
+	// TODO:
+	// TODO:
+	rootSubpath, err := src.Self.SourceRootSubpath()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get source root subpath: %w", err)
+	}
+	srcSubpath, err := src.Self.SourceSubpath(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get source subpath: %w", err)
+	}
+	slog.Debug("moduleWithSource",
+		"mod.NameField", mod.NameField,
+		"mod.OriginalName", mod.OriginalName,
+		"mod.SDKConfig", mod.SDKConfig,
+		"rootSubpath", rootSubpath,
+		"srcSubpath", srcSubpath,
+	)
 
 	if err := s.updateDeps(ctx, mod, src); err != nil {
 		return nil, fmt.Errorf("failed to update module dependencies: %w", err)
@@ -894,7 +917,7 @@ func (s *moduleSchema) updateDaggerConfig(
 	if err != nil {
 		return fmt.Errorf("failed to get source root subpath: %w", err)
 	}
-	sourceSubpath, err := src.Self.SourceSubpath(ctx)
+	sourceSubpath, err := src.Self.SourceSubpathWithDefault(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get source subpath: %w", err)
 	}

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -84,38 +84,43 @@ func (s *moduleSchema) Install() {
 			Doc(`The directory containing everything needed to load load and use the module.`),
 
 		dagql.Func("withContextDirectory", s.moduleSourceWithContextDirectory).
-			Doc(`TODO`),
+			Doc(`Update the module source with a new context directory. Only valid for local sources.`).
+			ArgDoc("dir", `The directory to set as the context directory.`),
 
 		dagql.Func("directory", s.moduleSourceDirectory).
 			Doc(`The directory containing the module configuration and source code (source code may be in a subdir).`).
 			ArgDoc(`path`, `The path from the source directory to select.`),
 
 		dagql.Func("sourceRootSubpath", s.moduleSourceRootSubpath).
-			Doc(`TODO`),
+			Doc(`The path relative to context of the root of the module source, which contains dagger.json. It also contains the module implementation source code, but that may or may not being a subdir of this root.`),
 
 		dagql.Func("sourceSubpath", s.moduleSourceSubpath).
-			Doc(`TODO`),
+			Doc(`The path relative to context of the module implementation source code.`),
 
 		dagql.Func("withSourceSubpath", s.moduleSourceWithSourceSubpath).
-			Doc(`TODO`),
+			Doc(`Update the module source with a new source subpath.`).
+			ArgDoc("path", `The path to set as the source subpath.`),
 
 		dagql.Func("moduleName", s.moduleSourceModuleName).
-			Doc(`If set, the name of the module this source references`),
+			Doc(`If set, the name of the module this source references, including any overrides at runtime by callers.`),
 
 		dagql.Func("moduleOriginalName", s.moduleSourceModuleOriginalName).
-			Doc(`TODO`),
+			Doc(`The original name of the module this source references, as defined in the module configuration.`),
 
 		dagql.Func("withName", s.moduleSourceWithName).
-			Doc(`TODO`),
+			Doc(`Update the module source with a new name.`).
+			ArgDoc("name", `The name to set.`),
 
 		dagql.NodeFunc("dependencies", s.moduleSourceDependencies).
-			Doc(`TODO`),
+			Doc(`The dependencies of the module source. Includes dependencies from the configuration and any extras from withDependencies calls.`),
 
 		dagql.Func("withDependencies", s.moduleSourceWithDependencies).
-			Doc(`TODO`),
+			Doc(`Append the provided dependencies to the module source's dependency list.`).
+			ArgDoc("dependencies", `The dependencies to append.`),
 
 		dagql.Func("withSDK", s.moduleSourceWithSDK).
-			Doc(`TODO`),
+			Doc(`Update the module source with a new SDK.`).
+			ArgDoc("sdk", `The SDK to set.`),
 
 		dagql.Func("configExists", s.moduleSourceConfigExists).
 			Doc(`Returns whether the module source has a configuration file.`),
@@ -132,11 +137,11 @@ func (s *moduleSchema) Install() {
 
 		dagql.Func("resolveFromCaller", s.moduleSourceResolveFromCaller).
 			Impure(`Loads live caller-specific data from their filesystem.`).
-			Doc(`Load the source from its path on the caller's filesystem. Only valid for local sources.`),
+			Doc(`Load the source from its path on the caller's filesystem, including only needed+configured files and directories. Only valid for local sources.`),
 
 		dagql.Func("resolveContextPathFromCaller", s.moduleSourceResolveContextPathFromCaller).
 			Impure(`Queries live caller-specific data from their filesystem.`).
-			Doc(`TODO`),
+			Doc(`The path to the module source's context directory on the caller's filesystem. Only valid for local sources.`),
 	}.Install(s.dag)
 
 	dagql.Fields[*core.LocalModuleSource]{}.Install(s.dag)
@@ -157,7 +162,7 @@ func (s *moduleSchema) Install() {
 			ArgDoc("source", `The module source to initialize from.`),
 
 		dagql.Func("generatedContextDiff", s.moduleGeneratedContextDiff).
-			Doc(`TODO`),
+			Doc(`The generated files and directories made on top of the module source's context directory.`),
 
 		dagql.NodeFunc("initialize", s.moduleInitialize).
 			Doc(`Retrieves the module with the objects loaded via its SDK.`),

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -96,6 +96,9 @@ func (s *moduleSchema) Install() {
 		dagql.Func("withSDK", s.moduleSourceWithSDK).
 			Doc(`TODO`),
 
+		dagql.Func("withSourceSubdir", s.moduleSourceWithSourceSubdir).
+			Doc(`TODO`),
+
 		dagql.NodeFunc("contextDirectory", s.moduleSourceContextDirectory).
 			Doc(`TODO`),
 

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"path/filepath"
 
 	"github.com/dagger/dagger/core"
@@ -636,28 +635,6 @@ func (s *moduleSchema) moduleWithSource(ctx context.Context, mod *core.Module, a
 	if err != nil {
 		return nil, fmt.Errorf("failed to get module SDK: %w", err)
 	}
-
-	// TODO:
-	// TODO:
-	// TODO:
-	// TODO:
-	// TODO:
-	// TODO:
-	rootSubpath, err := src.Self.SourceRootSubpath()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get source root subpath: %w", err)
-	}
-	srcSubpath, err := src.Self.SourceSubpath(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get source subpath: %w", err)
-	}
-	slog.Debug("moduleWithSource",
-		"mod.NameField", mod.NameField,
-		"mod.OriginalName", mod.OriginalName,
-		"mod.SDKConfig", mod.SDKConfig,
-		"rootSubpath", rootSubpath,
-		"srcSubpath", srcSubpath,
-	)
 
 	if err := s.updateDeps(ctx, mod, src); err != nil {
 		return nil, fmt.Errorf("failed to update module dependencies: %w", err)

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -735,6 +734,7 @@ func (s *moduleSchema) moduleSourceResolveFromCaller(
 			return inst, fmt.Errorf("local module source path %q escapes context %q", sourceRelSubpath, contextAbsPath)
 		}
 		includeSet[sourceRelSubpath+"/**/*"] = struct{}{}
+	}
 
 	for _, sdk := range sdkSet {
 		// NOTE: required paths are currently **-style globs that apply to the whole context subtree
@@ -865,7 +865,7 @@ type callerLocalDep struct {
 	sourceRootAbsPath string
 	modCfg            *modules.ModuleConfig
 	sdk               core.SDK
-	// sdkKey is a unique identifer for the SDK, slightly different
+	// sdkKey is a unique identifier for the SDK, slightly different
 	// from the module ref for the SDK because custom local SDKs
 	// use their local path for sdkKey, which allows us to de-dupe
 	// loading them across the dag of local deps.

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -1,0 +1,1387 @@
+package schema
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/core/modules"
+	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine/buildkit"
+	"github.com/vito/progrock"
+	"golang.org/x/sync/errgroup"
+)
+
+type moduleSourceArgs struct {
+	// avoiding name "ref" due to that being a reserved word in some SDKs (e.g. Rust)
+	RefString string
+
+	Stable bool `default:"false"`
+}
+
+func (s *moduleSchema) moduleSource(ctx context.Context, query *core.Query, args moduleSourceArgs) (*core.ModuleSource, error) {
+	parsed := parseRefString(args.RefString)
+	modPath, modVersion, hasVersion, isGitHub := parsed.modPath, parsed.modVersion, parsed.hasVersion, parsed.isGitHub
+
+	if !hasVersion && isGitHub && args.Stable {
+		return nil, fmt.Errorf("no version provided for stable remote ref: %s", args.RefString)
+	}
+
+	src := &core.ModuleSource{
+		Query: query,
+		Kind:  parsed.kind,
+	}
+
+	switch src.Kind {
+	case core.ModuleSourceKindLocal:
+		if filepath.IsAbs(modPath) {
+			return nil, fmt.Errorf("local module source path is absolute: %s", modPath)
+		}
+		src.RootSubpath = modPath
+		src.AsLocalSource = dagql.NonNull(&core.LocalModuleSource{
+			Query: query,
+		})
+
+	case core.ModuleSourceKindGit:
+		if !isGitHub {
+			return nil, fmt.Errorf("for now, only github.com/ paths are supported: %q", args.RefString)
+		}
+
+		src.AsGitSource = dagql.NonNull(&core.GitModuleSource{})
+
+		segments := strings.SplitN(modPath, "/", 4)
+		if len(segments) < 3 {
+			return nil, fmt.Errorf("invalid github.com path: %s", modPath)
+		}
+
+		src.AsGitSource.Value.URLParent = segments[0] + "/" + segments[1] + "/" + segments[2]
+
+		cloneURL := src.AsGitSource.Value.CloneURL()
+
+		if !hasVersion {
+			if args.Stable {
+				return nil, fmt.Errorf("no version provided for stable remote ref: %s", args.RefString)
+			}
+			var err error
+			modVersion, err = defaultBranch(ctx, cloneURL)
+			if err != nil {
+				return nil, fmt.Errorf("determine default branch: %w", err)
+			}
+		}
+		src.AsGitSource.Value.Version = modVersion
+
+		var subPath string
+		if len(segments) == 4 {
+			subPath = segments[3]
+		} else {
+			subPath = "/"
+		}
+		src.RootSubpath = subPath
+
+		commitRef := modVersion
+		if hasVersion && isSemver(modVersion) {
+			allTags, err := gitTags(ctx, cloneURL)
+			if err != nil {
+				return nil, fmt.Errorf("get git tags: %w", err)
+			}
+			matched, err := matchVersion(allTags, modVersion, subPath)
+			if err != nil {
+				return nil, fmt.Errorf("matching version to tags: %w", err)
+			}
+			// reassign modVersion to matched tag which could be subPath/tag
+			commitRef = matched
+		}
+
+		var gitRef dagql.Instance[*core.GitRef]
+		err := s.dag.Select(ctx, s.dag.Root(), &gitRef,
+			dagql.Selector{
+				Field: "git",
+				Args: []dagql.NamedInput{
+					{Name: "url", Value: dagql.String(cloneURL)},
+				},
+			},
+			dagql.Selector{
+				Field: "commit",
+				Args: []dagql.NamedInput{
+					{Name: "id", Value: dagql.String(commitRef)},
+				},
+			},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve git src: %w", err)
+		}
+		gitCommit, err := gitRef.Self.Commit(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve git src to commit: %w", err)
+		}
+		src.AsGitSource.Value.Commit = gitCommit
+
+		if !filepath.IsAbs(subPath) && !filepath.IsLocal(subPath) {
+			return nil, fmt.Errorf("git module source subpath points out of root: %q", subPath)
+		}
+		if !filepath.IsAbs(src.RootSubpath) {
+			var err error
+			src.RootSubpath, err = filepath.Rel("/", src.RootSubpath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get relative path: %w", err)
+			}
+		}
+
+		// TODO:(sipsma) support sparse loading of git repos similar to how local dirs are loaded.
+		// Related: https://github.com/dagger/dagger/issues/6292
+		err = s.dag.Select(ctx, gitRef, &src.BaseContextDirectory,
+			dagql.Selector{Field: "tree"},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load git dir: %w", err)
+		}
+
+		// git source needs rootpath on itself too for constructing urls
+		src.AsGitSource.Value.RootSubpath = src.RootSubpath
+	}
+
+	return src, nil
+}
+
+type parsedRefString struct {
+	modPath    string
+	modVersion string
+	hasVersion bool
+	isGitHub   bool
+	kind       core.ModuleSourceKind
+}
+
+func parseRefString(refString string) parsedRefString {
+	var parsed parsedRefString
+	parsed.modPath, parsed.modVersion, parsed.hasVersion = strings.Cut(refString, "@")
+	parsed.isGitHub = strings.HasPrefix(parsed.modPath, "github.com/")
+
+	if !parsed.hasVersion && !parsed.isGitHub {
+		parsed.kind = core.ModuleSourceKindLocal
+		return parsed
+	}
+	parsed.kind = core.ModuleSourceKindGit
+	return parsed
+}
+
+func (s *moduleSchema) moduleSourceAsModule(
+	ctx context.Context,
+	src dagql.Instance[*core.ModuleSource],
+	args struct{},
+) (inst dagql.Instance[*core.Module], err error) {
+	// TODO:
+	// TODO:
+	// TODO:
+	// TODO:
+	// TODO:
+	name, err := src.Self.ModuleName(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get module name: %w", err)
+	}
+	originalName, err := src.Self.ModuleOriginalName(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get module original name: %w", err)
+	}
+	slog.Debug("MODULESOURCEASMODULE",
+		"name", name,
+		"originalName", originalName,
+		"rootSubpath", src.Self.RootSubpath,
+	)
+
+	// ensure codegen has run
+	err = s.dag.Select(ctx, src, &src,
+		dagql.Selector{
+			Field: "withGeneratedContext",
+		},
+	)
+	if err != nil {
+		return inst, fmt.Errorf("failed to generate context: %w", err)
+	}
+
+	err = s.dag.Select(ctx, s.dag.Root(), &inst,
+		dagql.Selector{
+			Field: "module",
+		},
+		dagql.Selector{
+			Field: "withSource",
+			Args: []dagql.NamedInput{
+				{Name: "source", Value: dagql.NewID[*core.ModuleSource](src.ID())},
+			},
+		},
+	)
+	if err != nil {
+		return inst, fmt.Errorf("failed to create module: %w", err)
+	}
+	return inst, err
+}
+
+func (s *moduleSchema) moduleSourceSubpath(ctx context.Context, src *core.ModuleSource, args struct{}) (string, error) {
+	return src.ModuleSourceSubpath(ctx)
+}
+
+func (s *moduleSchema) moduleSourceAsString(ctx context.Context, src *core.ModuleSource, args struct{}) (string, error) {
+	return src.RefString()
+}
+
+func (s *moduleSchema) gitModuleSourceCloneURL(
+	ctx context.Context,
+	ref *core.GitModuleSource,
+	args struct{},
+) (string, error) {
+	return ref.CloneURL(), nil
+}
+
+func (s *moduleSchema) gitModuleSourceHTMLURL(
+	ctx context.Context,
+	ref *core.GitModuleSource,
+	args struct{},
+) (string, error) {
+	return ref.HTMLURL(), nil
+}
+
+func (s *moduleSchema) moduleSourceConfigExists(
+	ctx context.Context,
+	src *core.ModuleSource,
+	args struct{},
+) (bool, error) {
+	_, ok, err := src.ModuleConfig(ctx)
+	return ok, err
+}
+
+func (s *moduleSchema) moduleSourceModuleName(
+	ctx context.Context,
+	src *core.ModuleSource,
+	args struct{},
+) (string, error) {
+	return src.ModuleName(ctx)
+}
+
+func (s *moduleSchema) moduleSourceModuleOriginalName(
+	ctx context.Context,
+	src *core.ModuleSource,
+	args struct{},
+) (string, error) {
+	return src.ModuleOriginalName(ctx)
+}
+
+func (s *moduleSchema) moduleSourceWithName(
+	ctx context.Context,
+	src *core.ModuleSource,
+	args struct {
+		Name string
+	},
+) (*core.ModuleSource, error) {
+	src = src.Clone()
+
+	// invalidate generated context if set
+	src.GeneratedContextDirectory = dagql.Instance[*core.Directory]{}
+
+	src.WithName = args.Name
+	return src, nil
+}
+
+func (s *moduleSchema) moduleSourceWithDependencies(
+	ctx context.Context,
+	src *core.ModuleSource,
+	args struct {
+		Dependencies []core.ModuleDependencyID
+	},
+) (*core.ModuleSource, error) {
+	src = src.Clone()
+
+	// invalidate generated context if set
+	src.GeneratedContextDirectory = dagql.Instance[*core.Directory]{}
+
+	newDeps, err := collectIDInstances(ctx, s.dag, args.Dependencies)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load module source dependencies from ids: %w", err)
+	}
+	src.WithDependencies = append(src.WithDependencies, newDeps...)
+	return src, nil
+}
+
+func (s *moduleSchema) moduleSourceWithSDK(
+	ctx context.Context,
+	src *core.ModuleSource,
+	args struct {
+		SDK string
+	},
+) (*core.ModuleSource, error) {
+	src = src.Clone()
+
+	// invalidate generated context if set
+	src.GeneratedContextDirectory = dagql.Instance[*core.Directory]{}
+
+	src.WithSDK = args.SDK
+	return src, nil
+}
+
+func (s *moduleSchema) moduleSourceResolveDependency(
+	ctx context.Context,
+	src *core.ModuleSource,
+	args struct {
+		Dep core.ModuleSourceID
+	},
+) (inst dagql.Instance[*core.ModuleSource], err error) {
+	depSrc, err := args.Dep.Load(ctx, s.dag)
+	if err != nil {
+		return inst, fmt.Errorf("failed to decode module source: %w", err)
+	}
+
+	// TODO:
+	// TODO:
+	// TODO:
+	// TODO:
+	// TODO:
+	// TODO:
+	srcName, err := src.ModuleName(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get module name: %w", err)
+	}
+	depName, err := depSrc.Self.ModuleName(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get module name: %w", err)
+	}
+	slog.Debug("MODULESOURCERESOLVEDEPENDENCY",
+		"srcName", srcName,
+		"srcRootSubpath", src.RootSubpath,
+		"depName", depName,
+		"depRootSubpath", depSrc.Self.RootSubpath,
+	)
+
+	if depSrc.Self.Kind == core.ModuleSourceKindGit {
+		// git deps stand on their own, no special handling needed
+		return depSrc, nil
+	}
+
+	// This dep is a local path relative to a src, need to find the src's root
+	// and return a source that points to the full path to this dep
+	if src.BaseContextDirectory.Self == nil {
+		return inst, fmt.Errorf("cannot resolve dependency for module source with no context directory")
+	}
+
+	// depSrc.RootSubpath is relative to the src.RootSubpath, i.e.
+	// if src.RootSubpath is foo/bar and its dagger.json has dep on ../baz, then
+	// depSrc.RootSubpath is ../baz and relative to foo/bar.
+	// depSubpath is the resolved path, i.e. foo/baz.
+	depSubpath := filepath.Join(src.RootSubpath, depSrc.Self.RootSubpath)
+
+	if !filepath.IsLocal(depSubpath) {
+		return inst, fmt.Errorf("module dep source path %q escapes root", depSubpath)
+	}
+
+	switch src.Kind {
+	case core.ModuleSourceKindGit:
+		src = src.Clone()
+		src.RootSubpath = depSubpath
+
+		// preserve the git metadata by just constructing a modified git source ref string
+		// and using that to load the dep
+		newDepRefStr, err := src.RefString()
+		if err != nil {
+			return inst, fmt.Errorf("failed to get module source ref string: %w", err)
+		}
+
+		var newDepSrc dagql.Instance[*core.ModuleSource]
+		err = s.dag.Select(ctx, s.dag.Root(), &newDepSrc,
+			dagql.Selector{
+				Field: "moduleSource",
+				Args: []dagql.NamedInput{
+					{Name: "refString", Value: dagql.String(newDepRefStr)},
+					{Name: "stable", Value: dagql.Boolean(true)},
+				},
+			},
+		)
+		if err != nil {
+			return inst, fmt.Errorf("failed to load git dep: %w", err)
+		}
+		return newDepSrc, nil
+
+	case core.ModuleSourceKindLocal:
+		var newDepSrc dagql.Instance[*core.ModuleSource]
+		err = s.dag.Select(ctx, s.dag.Root(), &newDepSrc,
+			dagql.Selector{
+				Field: "moduleSource",
+				Args: []dagql.NamedInput{
+					{Name: "refString", Value: dagql.String(depSubpath)},
+				},
+			},
+			dagql.Selector{
+				Field: "withContext",
+				Args: []dagql.NamedInput{
+					{Name: "dir", Value: dagql.NewID[*core.Directory](src.BaseContextDirectory.ID())},
+				},
+			},
+		)
+		if err != nil {
+			return inst, fmt.Errorf("failed to load git dep: %w", err)
+		}
+		return newDepSrc, nil
+
+	default:
+		return inst, fmt.Errorf("unsupported module source kind: %q", src.Kind)
+	}
+}
+
+func (s *moduleSchema) moduleSourceDirectory(
+	ctx context.Context,
+	src dagql.Instance[*core.ModuleSource],
+	args struct {
+		Path string
+	},
+) (dir dagql.Instance[*core.Directory], err error) {
+	fullSubpath := filepath.Join("/", src.Self.RootSubpath, args.Path)
+	err = s.dag.Select(ctx, src, &dir,
+		dagql.Selector{
+			Field: "contextDirectory",
+		},
+		dagql.Selector{
+			Field: "directory",
+			Args: []dagql.NamedInput{
+				{Name: "path", Value: dagql.String(fullSubpath)},
+			},
+		},
+	)
+	return dir, err
+}
+
+func (s *moduleSchema) moduleSourceWithContext(
+	ctx context.Context,
+	src *core.ModuleSource,
+	args struct {
+		Dir dagql.ID[*core.Directory]
+	},
+) (*core.ModuleSource, error) {
+	src = src.Clone()
+
+	dest := &src.BaseContextDirectory
+	if dest.Self != nil {
+		// we already loaded the base context, update GeneratedContextDirectory instead
+		if src.GeneratedContextDirectory.Self == nil {
+			// start out at the base context
+			src.GeneratedContextDirectory = src.BaseContextDirectory
+		}
+		dest = &src.GeneratedContextDirectory
+	}
+
+	if dest.Self == nil {
+		err := s.dag.Select(ctx, s.dag.Root(), dest,
+			dagql.Selector{
+				Field: "directory",
+			},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize empty context: %w", err)
+		}
+	}
+
+	additionalContextDir, err := args.Dir.Load(ctx, s.dag)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load directory: %w", err)
+	}
+
+	err = s.dag.Select(ctx, *dest, dest,
+		dagql.Selector{
+			Field: "withDirectory",
+			Args: []dagql.NamedInput{
+				{Name: "directory", Value: dagql.NewID[*core.Directory](additionalContextDir.ID())},
+				{Name: "path", Value: dagql.String("/")},
+			},
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add additional context: %w", err)
+	}
+
+	// TODO:
+	// TODO:
+	// TODO:
+	// TODO:
+	// TODO:
+	/*
+		ents, err := dest.Self.Entries(ctx, "/")
+		if err != nil {
+			return nil, fmt.Errorf("failed to get entries: %w", err)
+		}
+		slog.Debug("MODULESOURCEWITHCONTEXT", "ents", ents, "dest", destStr)
+	*/
+
+	return src, nil
+}
+
+func (s *moduleSchema) moduleSourceBaseContextDirectory(
+	ctx context.Context,
+	src dagql.Instance[*core.ModuleSource],
+	args struct{},
+) (inst dagql.Instance[*core.Directory], err error) {
+	if src.Self.BaseContextDirectory.Self == nil {
+		return inst, fmt.Errorf("base context directory not set")
+	}
+	return src.Self.BaseContextDirectory, nil
+}
+
+func (s *moduleSchema) moduleSourceContextDirectory(
+	ctx context.Context,
+	src dagql.Instance[*core.ModuleSource],
+	args struct{},
+) (inst dagql.Instance[*core.Directory], err error) {
+	return src.Self.ContextDirectory()
+}
+
+func (s *moduleSchema) moduleSourceGeneratedContextDiff(
+	ctx context.Context,
+	src dagql.Instance[*core.ModuleSource],
+	args struct{},
+) (inst dagql.Instance[*core.Directory], err error) {
+	baseContext := src.Self.BaseContextDirectory
+
+	err = s.dag.Select(ctx, src, &src,
+		dagql.Selector{
+			Field: "withGeneratedContext", // no-op if already was generated
+		},
+	)
+	if err != nil {
+		return inst, fmt.Errorf("failed to generate context: %w", err)
+	}
+
+	err = s.dag.Select(ctx, baseContext, &inst,
+		dagql.Selector{
+			Field: "diff",
+			Args: []dagql.NamedInput{
+				{Name: "other", Value: dagql.NewID[*core.Directory](src.Self.GeneratedContextDirectory.ID())},
+			},
+		},
+	)
+	return inst, err
+}
+
+// TODO: this is obviously way too long, break apart
+func (s *moduleSchema) moduleSourceWithGeneratedContext(
+	ctx context.Context,
+	src dagql.Instance[*core.ModuleSource],
+	args struct{},
+) (inst dagql.Instance[*core.ModuleSource], err error) {
+	if src.Self.BaseContextDirectory.Self == nil {
+		return inst, fmt.Errorf("base context directory not set")
+	}
+
+	if src.Self.GeneratedContextDirectory.Self != nil {
+		// already generated, nothing to do. this is invalidated on mutations like withSDK/withName/etc.
+		return src, nil
+	}
+
+	// start out at the loaded context
+	generatedContext := src.Self.BaseContextDirectory
+
+	modCfg, ok, err := src.Self.ModuleConfig(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("module config: %w", err)
+	}
+	if !ok {
+		modCfg = &modules.ModuleConfig{}
+	}
+
+	if src.Self.WithName != "" {
+		modCfg.Name = src.Self.WithName
+	}
+	if src.Self.WithSDK != "" {
+		modCfg.SDK = src.Self.WithSDK
+	}
+
+	existingDeps := make([]*core.ModuleDependency, len(modCfg.Dependencies))
+	var eg errgroup.Group
+	for i, depCfg := range modCfg.Dependencies {
+		i, depCfg := i, depCfg
+		eg.Go(func() error {
+			var depSrc dagql.Instance[*core.ModuleSource]
+			err := s.dag.Select(ctx, s.dag.Root(), &depSrc,
+				dagql.Selector{
+					Field: "moduleSource",
+					Args: []dagql.NamedInput{
+						{Name: "refString", Value: dagql.String(depCfg.Source)},
+					},
+				},
+			)
+			if err != nil {
+				return fmt.Errorf("failed to create module source from dependency: %w", err)
+			}
+
+			var resolvedDepSrc dagql.Instance[*core.ModuleSource]
+			err = s.dag.Select(ctx, src, &resolvedDepSrc,
+				dagql.Selector{
+					Field: "resolveDependency",
+					Args: []dagql.NamedInput{
+						{Name: "dep", Value: dagql.NewID[*core.ModuleSource](depSrc.ID())},
+					},
+				},
+			)
+			if err != nil {
+				return fmt.Errorf("failed to resolve dependency: %w", err)
+			}
+			existingDeps[i] = &core.ModuleDependency{
+				Source: resolvedDepSrc,
+				Name:   depCfg.Name,
+			}
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return inst, fmt.Errorf("failed to load pre-configured dependencies: %w", err)
+	}
+
+	newDeps := make([]*core.ModuleDependency, len(src.Self.WithDependencies))
+	eg = errgroup.Group{}
+	for i, dep := range src.Self.WithDependencies {
+		i, dep := i, dep
+		eg.Go(func() error {
+			var resolvedDepSrc dagql.Instance[*core.ModuleSource]
+			err := s.dag.Select(ctx, src, &resolvedDepSrc,
+				dagql.Selector{
+					Field: "resolveDependency",
+					Args: []dagql.NamedInput{
+						{Name: "dep", Value: dagql.NewID[*core.ModuleSource](dep.Self.Source.ID())},
+					},
+				},
+			)
+			if err != nil {
+				return fmt.Errorf("failed to resolve dependency: %w", err)
+			}
+			newDeps[i] = &core.ModuleDependency{
+				Source: resolvedDepSrc,
+				Name:   dep.Self.Name,
+			}
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return inst, fmt.Errorf("failed to resolve new dependencies: %w", err)
+	}
+
+	// figure out the set of deps, keyed by their symbolic ref string, which de-dupes
+	// equivalent sources at different versions, preferring the version provided
+	// in the dependencies arg here
+	depSet := make(map[string]*core.ModuleDependency)
+	for _, dep := range existingDeps {
+		symbolic, err := dep.Source.Self.Symbolic()
+		if err != nil {
+			return inst, fmt.Errorf("failed to get symbolic source ref: %w", err)
+		}
+		depSet[symbolic] = dep
+	}
+	for _, dep := range newDeps {
+		symbolic, err := dep.Source.Self.Symbolic()
+		if err != nil {
+			return inst, fmt.Errorf("failed to get symbolic source ref: %w", err)
+		}
+		depSet[symbolic] = dep
+	}
+
+	finalDeps := make([]*core.ModuleDependency, 0, len(depSet))
+	modCfg.Dependencies = make([]*modules.ModuleConfigDependency, 0, len(depSet))
+	for _, dep := range depSet {
+		finalDeps = append(finalDeps, dep)
+
+		var refStr string
+		switch dep.Source.Self.Kind {
+		case core.ModuleSourceKindLocal:
+			depRootPath := dep.Source.Self.RootSubpath
+			depRelSubpath, err := filepath.Rel(src.Self.RootSubpath, depRootPath)
+			if err != nil {
+				return inst, fmt.Errorf("failed to get module dep source path relative to source: %w", err)
+			}
+			refStr = depRelSubpath
+
+		default:
+			refStr, err = dep.Source.Self.RefString()
+			if err != nil {
+				return inst, fmt.Errorf("failed to get ref string for dependency: %w", err)
+			}
+		}
+		modCfg.Dependencies = append(modCfg.Dependencies, &modules.ModuleConfigDependency{
+			Name:   dep.Name,
+			Source: refStr,
+		})
+	}
+	sort.Slice(finalDeps, func(i, j int) bool {
+		return modCfg.Dependencies[i].Source < modCfg.Dependencies[j].Source
+	})
+	sort.Slice(modCfg.Dependencies, func(i, j int) bool {
+		return modCfg.Dependencies[i].Source < modCfg.Dependencies[j].Source
+	})
+
+	depMods := make([]*core.Module, len(finalDeps))
+	eg = errgroup.Group{}
+	for i, dep := range finalDeps {
+		i, dep := i, dep
+		eg.Go(func() error {
+			var depMod dagql.Instance[*core.Module]
+			err := s.dag.Select(ctx, dep.Source, &depMod,
+				dagql.Selector{
+					Field: "withName",
+					Args: []dagql.NamedInput{
+						{Name: "name", Value: dagql.String(dep.Name)},
+					},
+				},
+				dagql.Selector{
+					Field: "asModule",
+				},
+				dagql.Selector{
+					Field: "initialize",
+				},
+			)
+			if err != nil {
+				return fmt.Errorf("failed to initialize dependency module: %w", err)
+			}
+			depMods[i] = depMod.Self
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return inst, fmt.Errorf("failed to initialize dependency modules: %w", err)
+	}
+	// fill in any missing names if needed
+	for i, dep := range modCfg.Dependencies {
+		if dep.Name == "" {
+			dep.Name = depMods[i].Name()
+		}
+	}
+
+	rootSubpath := src.Self.RootSubpath
+
+	if modCfg.Name != "" && modCfg.SDK != "" {
+		sdk, err := s.sdkForModule(ctx, src.Self.Query, modCfg.SDK, src)
+		if err != nil {
+			return inst, fmt.Errorf("failed to load sdk for module: %w", err)
+		}
+
+		deps := core.NewModDeps(src.Self.Query, src.Self.Query.DefaultDeps.Mods)
+		for _, dep := range depMods {
+			deps = deps.Append(dep)
+		}
+
+		generatedCode, err := sdk.Codegen(ctx, deps, src)
+		if err != nil {
+			return inst, fmt.Errorf("failed to generate code: %w", err)
+		}
+
+		var diff dagql.Instance[*core.Directory]
+		err = s.dag.Select(ctx, src.Self.BaseContextDirectory, &diff,
+			dagql.Selector{
+				Field: "diff",
+				Args: []dagql.NamedInput{
+					{Name: "other", Value: dagql.NewID[*core.Directory](generatedCode.Code.ID())},
+				},
+			},
+		)
+		if err != nil {
+			return inst, fmt.Errorf("failed to diff generated code: %w", err)
+		}
+
+		err = s.dag.Select(ctx, generatedContext, &generatedContext,
+			dagql.Selector{
+				Field: "withDirectory",
+				Args: []dagql.NamedInput{
+					{Name: "path", Value: dagql.String("/")},
+					{Name: "directory", Value: dagql.NewID[*core.Directory](diff.ID())},
+				},
+			},
+		)
+		if err != nil {
+			return inst, fmt.Errorf("failed to add codegen to module context directory: %w", err)
+		}
+
+		// update .gitattributes
+		// (linter thinks this chunk of code is too similar to the below, but not clear abstraction is worth it)
+		//nolint:dupl
+		if len(generatedCode.VCSGeneratedPaths) > 0 {
+			gitAttrsPath := filepath.Join(rootSubpath, ".gitattributes")
+			var gitAttrsContents []byte
+			gitAttrsFile, err := src.Self.BaseContextDirectory.Self.File(ctx, gitAttrsPath)
+			if err == nil {
+				gitAttrsContents, err = gitAttrsFile.Contents(ctx)
+				if err != nil {
+					return inst, fmt.Errorf("failed to get git attributes file contents: %w", err)
+				}
+				if !bytes.HasSuffix(gitAttrsContents, []byte("\n")) {
+					gitAttrsContents = append(gitAttrsContents, []byte("\n")...)
+				}
+			}
+			for _, fileName := range generatedCode.VCSGeneratedPaths {
+				if bytes.Contains(gitAttrsContents, []byte(fileName)) {
+					// already has some config for the file
+					continue
+				}
+				gitAttrsContents = append(gitAttrsContents,
+					[]byte(fmt.Sprintf("/%s linguist-generated\n", fileName))...,
+				)
+			}
+
+			err = s.dag.Select(ctx, generatedContext, &generatedContext,
+				dagql.Selector{
+					Field: "withNewFile",
+					Args: []dagql.NamedInput{
+						{Name: "path", Value: dagql.String(gitAttrsPath)},
+						{Name: "contents", Value: dagql.String(gitAttrsContents)},
+						{Name: "permissions", Value: dagql.Int(0600)},
+					},
+				},
+			)
+			if err != nil {
+				return inst, fmt.Errorf("failed to add vcs generated file: %w", err)
+			}
+		}
+
+		// update .gitignore
+		// (linter thinks this chunk of code is too similar to the above, but not clear abstraction is worth it)
+		//nolint:dupl
+		if len(generatedCode.VCSIgnoredPaths) > 0 {
+			gitIgnorePath := filepath.Join(rootSubpath, ".gitignore")
+			var gitIgnoreContents []byte
+			gitIgnoreFile, err := src.Self.BaseContextDirectory.Self.File(ctx, gitIgnorePath)
+			if err == nil {
+				gitIgnoreContents, err = gitIgnoreFile.Contents(ctx)
+				if err != nil {
+					return inst, fmt.Errorf("failed to get .gitignore file contents: %w", err)
+				}
+				if !bytes.HasSuffix(gitIgnoreContents, []byte("\n")) {
+					gitIgnoreContents = append(gitIgnoreContents, []byte("\n")...)
+				}
+			}
+			for _, fileName := range generatedCode.VCSIgnoredPaths {
+				if bytes.Contains(gitIgnoreContents, []byte(fileName)) {
+					continue
+				}
+				gitIgnoreContents = append(gitIgnoreContents,
+					[]byte(fmt.Sprintf("/%s\n", fileName))...,
+				)
+			}
+
+			err = s.dag.Select(ctx, generatedContext, &generatedContext,
+				dagql.Selector{
+					Field: "withNewFile",
+					Args: []dagql.NamedInput{
+						{Name: "path", Value: dagql.String(gitIgnorePath)},
+						{Name: "contents", Value: dagql.String(gitIgnoreContents)},
+						{Name: "permissions", Value: dagql.Int(0600)},
+					},
+				},
+			)
+			if err != nil {
+				return inst, fmt.Errorf("failed to add vcs ignore file: %w", err)
+			}
+		}
+	}
+
+	// update dagger.json last so SDKs can't intentionally or unintentionally
+	// modify it during codegen in ways that would be hard to deal with
+	modCfgPath := filepath.Join(rootSubpath, modules.Filename)
+	updatedModCfgBytes, err := json.MarshalIndent(modCfg, "", "  ")
+	if err != nil {
+		return inst, fmt.Errorf("failed to encode module config: %w", err)
+	}
+	updatedModCfgBytes = append(updatedModCfgBytes, '\n')
+	err = s.dag.Select(ctx, generatedContext, &generatedContext,
+		dagql.Selector{
+			Field: "withNewFile",
+			Args: []dagql.NamedInput{
+				{Name: "path", Value: dagql.String(modCfgPath)},
+				{Name: "contents", Value: dagql.String(updatedModCfgBytes)},
+				{Name: "permissions", Value: dagql.Int(0644)},
+			},
+		},
+	)
+	if err != nil {
+		return inst, fmt.Errorf("failed to update module context directory config file: %w", err)
+	}
+
+	err = s.dag.Select(ctx, src, &inst,
+		dagql.Selector{
+			Field: "withContext",
+			Args: []dagql.NamedInput{
+				{Name: "dir", Value: dagql.NewID[*core.Directory](generatedContext.ID())},
+			},
+		},
+	)
+	return inst, err
+}
+
+func (s *moduleSchema) moduleSourceResolveContextPathFromCaller(
+	ctx context.Context,
+	src *core.ModuleSource,
+	args struct{},
+) (string, error) {
+	if src.Kind != core.ModuleSourceKindLocal {
+		return "", fmt.Errorf("cannot resolve non-local module source from caller")
+	}
+
+	sourceRootStat, err := src.Query.Buildkit.StatCallerHostPath(ctx, src.RootSubpath, true)
+	if err != nil {
+		return "", fmt.Errorf("failed to stat source root: %w", err)
+	}
+	sourceRootAbsPath := sourceRootStat.Path
+
+	contextAbsPath, contextFound, err := callerHostFindUpContext(ctx, src.Query.Buildkit, sourceRootAbsPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to find up root: %w", err)
+	}
+
+	if !contextFound {
+		// default to restricting to the source root dir, make it abs though for consistency
+		contextAbsPath = sourceRootAbsPath
+	}
+
+	return contextAbsPath, nil
+}
+
+func (s *moduleSchema) moduleSourceResolveFromCaller(
+	ctx context.Context,
+	src *core.ModuleSource,
+	args struct{},
+) (inst dagql.Instance[*core.ModuleSource], err error) {
+	// TODO: de-dupe with code above
+	if src.Kind != core.ModuleSourceKindLocal {
+		return inst, fmt.Errorf("cannot resolve non-local module source from caller")
+	}
+
+	sourceRootStat, err := src.Query.Buildkit.StatCallerHostPath(ctx, src.RootSubpath, true)
+	if err != nil {
+		return inst, fmt.Errorf("failed to stat source root: %w", err)
+	}
+	sourceRootAbsPath := sourceRootStat.Path
+
+	contextAbsPath, contextFound, err := callerHostFindUpContext(ctx, src.Query.Buildkit, sourceRootAbsPath)
+	if err != nil {
+		return inst, fmt.Errorf("failed to find up root: %w", err)
+	}
+
+	if !contextFound {
+		// default to restricting to the source root dir, make it abs though for consistency
+		contextAbsPath = sourceRootAbsPath
+	}
+
+	sourceRootRelPath, err := filepath.Rel(contextAbsPath, sourceRootAbsPath)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get source root relative path: %s", err)
+	}
+
+	// TODO:
+	// TODO:
+	// TODO:
+	slog.Debug("moduleLocalSourceResolveFromCaller",
+		"contextAbsPath", contextAbsPath,
+		"sourceRootAbsPath", sourceRootAbsPath,
+		"sourceRootRelPath", sourceRootRelPath,
+		"callerRootPath", fmt.Sprintf("%q", src.RootSubpath),
+		"contextFound", contextFound,
+	)
+
+	collectedDeps := dagql.NewCacheMap[string, *callerLocalDep]()
+	if err := s.collectCallerLocalDeps(ctx, src.Query, contextAbsPath, sourceRootAbsPath, true, src, collectedDeps); err != nil {
+		return inst, fmt.Errorf("failed to collect local module source deps: %w", err)
+	}
+
+	includeSet := map[string]struct{}{}
+	excludeSet := map[string]struct{}{
+		// always exclude .git dirs, we don't need them and they tend to invalidate cache a lot
+		"**/.git": {},
+	}
+	sdkSet := map[string]core.SDK{}
+	sourceRootPaths := collectedDeps.Keys()
+	for _, rootPath := range sourceRootPaths {
+		rootRelPath, err := filepath.Rel(contextAbsPath, rootPath)
+		if err != nil {
+			return inst, fmt.Errorf("failed to get source root relative path: %s", err)
+		}
+		if !filepath.IsLocal(rootRelPath) {
+			return inst, fmt.Errorf("local module dep source path %q escapes context %q", rootRelPath, contextAbsPath)
+		}
+
+		localDep, err := collectedDeps.Get(ctx, rootPath)
+		if err != nil {
+			return inst, fmt.Errorf("failed to get collected local dep %s: %w", rootPath, err)
+		}
+
+		if rootPath == sourceRootAbsPath {
+			// only the top-level module source is allowed to be nameless/sdkless
+			if localDep.sdk != nil {
+				sdkSet[localDep.sdkKey] = localDep.sdk
+			}
+			if localDep.modCfg == nil {
+				// uninitialized top-level module source, include it's source root dir (otherwise
+				// we could load everything if no other includes end up being specified)
+				includeSet[sourceRootRelPath] = struct{}{}
+				continue
+			}
+		} else {
+			if localDep.modCfg == nil {
+				return inst, fmt.Errorf("local module source dep %s is not initialized", rootPath)
+			}
+			if localDep.sdk == nil {
+				return inst, fmt.Errorf("local module source dep %s has no sdk", rootPath)
+			}
+			sdkSet[localDep.sdkKey] = localDep.sdk
+		}
+
+		// rebase user defined include/exclude relative to context
+		for _, path := range localDep.modCfg.Include {
+			absPath := filepath.Join(sourceRootAbsPath, path)
+			relPath, err := filepath.Rel(contextAbsPath, absPath)
+			if err != nil {
+				return inst, fmt.Errorf("failed to get relative path of config include: %s", err)
+			}
+			if !filepath.IsLocal(relPath) {
+				return inst, fmt.Errorf("local module dep source include path %q escapes context %q", relPath, contextAbsPath)
+			}
+			includeSet[relPath] = struct{}{}
+		}
+		for _, path := range localDep.modCfg.Exclude {
+			absPath := filepath.Join(sourceRootAbsPath, path)
+			relPath, err := filepath.Rel(contextAbsPath, absPath)
+			if err != nil {
+				return inst, fmt.Errorf("failed to get relative path of config exclude: %s", err)
+			}
+			if !filepath.IsLocal(relPath) {
+				return inst, fmt.Errorf("local module dep source exclude path %q escapes context %q", relPath, contextAbsPath)
+			}
+			excludeSet[relPath] = struct{}{}
+		}
+
+		// always include the config file
+		configRelPath, err := filepath.Rel(contextAbsPath, filepath.Join(rootPath, modules.Filename))
+		if err != nil {
+			return inst, fmt.Errorf("failed to get relative path: %s", err)
+		}
+		includeSet[configRelPath] = struct{}{}
+
+		// always include the source dir
+		source := localDep.modCfg.Source
+		if source == "" {
+			source = "."
+		}
+		sourceAbsSubpath := filepath.Join(rootPath, source)
+		sourceRelSubpath, err := filepath.Rel(contextAbsPath, sourceAbsSubpath)
+		if err != nil {
+			return inst, fmt.Errorf("failed to get relative path: %s", err)
+		}
+		if !filepath.IsLocal(sourceRelSubpath) {
+			return inst, fmt.Errorf("local module source path %q escapes context %q", sourceRelSubpath, contextAbsPath)
+		}
+		includeSet[sourceRelSubpath+"/**/*"] = struct{}{}
+	}
+
+	for _, sdk := range sdkSet {
+		// NOTE: required paths are currently **-style globs that apply to the whole context subtree
+		// This is a bit of a delicate assumption, if need arises for including exact paths, this
+		// will need some adjustment.
+		requiredPaths, err := sdk.RequiredPaths(ctx)
+		if err != nil {
+			return inst, fmt.Errorf("failed to get sdk required paths: %w", err)
+		}
+		for _, path := range requiredPaths {
+			includeSet[path] = struct{}{}
+		}
+	}
+
+	includes := make([]string, 0, len(includeSet))
+	for include := range includeSet {
+		includes = append(includes, include)
+	}
+	excludes := make([]string, 0, len(excludeSet))
+	for exclude := range excludeSet {
+		excludes = append(excludes, exclude)
+	}
+
+	// TODO:
+	// TODO:
+	// TODO:
+	slog.Debug("moduleLocalSourceResolveFromCaller",
+		"contextAbsPath", contextAbsPath,
+		"sourceRootAbsPath", sourceRootAbsPath,
+		"sourceRootRelPath", sourceRootRelPath,
+		"callerRootPath", fmt.Sprintf("%q", src.RootSubpath),
+		"contextFound", contextFound,
+		"includes", includes,
+		"excludes", excludes,
+	)
+
+	pipelineName := fmt.Sprintf("load local module context %s", contextAbsPath)
+	ctx, subRecorder := progrock.WithGroup(ctx, pipelineName, progrock.Weak())
+	_, desc, err := src.Query.Buildkit.LocalImport(
+		ctx, subRecorder, src.Query.Platform.Spec(),
+		contextAbsPath,
+		excludes,
+		includes,
+	)
+	if err != nil {
+		return inst, fmt.Errorf("failed to import local module source: %w", err)
+	}
+	loadedDir, err := core.LoadBlob(ctx, s.dag, desc)
+	if err != nil {
+		return inst, fmt.Errorf("failed to load local module source: %w", err)
+	}
+
+	err = s.dag.Select(ctx, s.dag.Root(), &inst,
+		dagql.Selector{
+			Field: "moduleSource",
+			Args: []dagql.NamedInput{
+				{Name: "refString", Value: dagql.String(sourceRootRelPath)},
+			},
+		},
+		dagql.Selector{
+			Field: "withContext",
+			Args: []dagql.NamedInput{
+				{Name: "dir", Value: dagql.NewID[*core.Directory](loadedDir.ID())},
+			},
+		},
+	)
+
+	if src.WithName != "" {
+		err = s.dag.Select(ctx, inst, &inst,
+			dagql.Selector{
+				Field: "withName",
+				Args: []dagql.NamedInput{
+					{Name: "name", Value: dagql.String(src.WithName)},
+				},
+			},
+		)
+		if err != nil {
+			return inst, fmt.Errorf("failed to set name: %w", err)
+		}
+	}
+	if src.WithSDK != "" {
+		err = s.dag.Select(ctx, inst, &inst,
+			dagql.Selector{
+				Field: "withSDK",
+				Args: []dagql.NamedInput{
+					{Name: "sdk", Value: dagql.String(src.WithSDK)},
+				},
+			},
+		)
+		if err != nil {
+			return inst, fmt.Errorf("failed to set sdk: %w", err)
+		}
+	}
+	if len(src.WithDependencies) > 0 {
+		depIDs := make([]core.ModuleDependencyID, len(src.WithDependencies))
+		for i, dep := range src.WithDependencies {
+			depIDs[i] = dagql.NewID[*core.ModuleDependency](dep.ID())
+		}
+
+		err = s.dag.Select(ctx, inst, &inst,
+			dagql.Selector{
+				Field: "withDependencies",
+				Args: []dagql.NamedInput{
+					{Name: "dependencies", Value: dagql.ArrayInput[core.ModuleDependencyID](depIDs)},
+				},
+			},
+		)
+		if err != nil {
+			return inst, fmt.Errorf("failed to set dependency: %w", err)
+		}
+	}
+	return inst, err
+}
+
+type callerLocalDep struct {
+	sourceRootAbsPath string
+	modCfg            *modules.ModuleConfig
+	sdk               core.SDK
+	sdkKey            string // TODO :explain..
+}
+
+func (s *moduleSchema) collectCallerLocalDeps(
+	ctx context.Context,
+	query *core.Query,
+	contextAbsPath string,
+	sourceRootAbsPath string,
+	topLevel bool, // TODO: doc
+	src *core.ModuleSource,
+	// cache of sourceRootAbsPath -> *callerLocalDep
+	collectedDeps dagql.CacheMap[string, *callerLocalDep],
+) error {
+	_, err := collectedDeps.GetOrInitialize(ctx, sourceRootAbsPath, func(ctx context.Context) (*callerLocalDep, error) {
+		sourceRootRelPath, err := filepath.Rel(contextAbsPath, sourceRootAbsPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get source root relative path: %s", err)
+		}
+		if !filepath.IsLocal(sourceRootRelPath) {
+			return nil, fmt.Errorf("local module dep source path %q escapes context %q", sourceRootRelPath, contextAbsPath)
+		}
+
+		var modCfg modules.ModuleConfig
+		configPath := filepath.Join(sourceRootAbsPath, modules.Filename)
+		configBytes, err := query.Buildkit.ReadCallerHostFile(ctx, configPath)
+		switch {
+		case err == nil:
+			if err := json.Unmarshal(configBytes, &modCfg); err != nil {
+				return nil, fmt.Errorf("error unmarshaling config at %s: %s", configPath, err)
+			}
+
+		case strings.Contains(err.Error(), "no such file or directory"):
+			// This is only allowed for the top-level module (which may be in the process of being newly initialized).
+			// sentinel via nil modCfg unless there's WithSDK/WithDependencies/etc. to be applied
+			if !topLevel {
+				return nil, fmt.Errorf("missing config file %s", configPath)
+			}
+			if src.WithSDK == "" && len(src.WithDependencies) == 0 {
+				return &callerLocalDep{sourceRootAbsPath: sourceRootAbsPath}, nil
+			}
+
+		default:
+			return nil, fmt.Errorf("error reading config %s: %s", configPath, err)
+		}
+
+		if topLevel {
+			modCfg.Name = src.WithName
+			modCfg.SDK = src.WithSDK
+			for _, dep := range src.WithDependencies {
+				refString, err := dep.Self.Source.Self.RefString()
+				if err != nil {
+					return nil, fmt.Errorf("failed to get ref string for dependency: %w", err)
+				}
+				modCfg.Dependencies = append(modCfg.Dependencies, &modules.ModuleConfigDependency{
+					Name:   dep.Self.Name,
+					Source: refString,
+				})
+			}
+		}
+
+		localDep := &callerLocalDep{
+			sourceRootAbsPath: sourceRootAbsPath,
+			modCfg:            &modCfg,
+		}
+
+		for _, depCfg := range modCfg.Dependencies {
+			parsed := parseRefString(depCfg.Source)
+			if parsed.kind != core.ModuleSourceKindLocal {
+				continue
+			}
+			depAbsPath := filepath.Join(sourceRootAbsPath, parsed.modPath)
+			// TODO:
+			// TODO:
+			// TODO:
+			// TODO:
+			// TODO:
+			// TODO:
+			slog.Debug("collectCallerLocalDeps", "dep", parsed.modPath, "depAbsPath", depAbsPath, "sourceRootAbsPath", sourceRootAbsPath)
+
+			err = s.collectCallerLocalDeps(ctx, query, contextAbsPath, depAbsPath, false, src, collectedDeps)
+			if err != nil {
+				return nil, fmt.Errorf("failed to collect local module source dep: %w", err)
+			}
+		}
+
+		if modCfg.SDK == "" {
+			return localDep, nil
+		}
+
+		localDep.sdkKey = modCfg.SDK
+
+		localDep.sdk, err = s.builtinSDK(ctx, query, modCfg.SDK)
+		switch {
+		case err == nil:
+		case errors.Is(err, errUnknownBuiltinSDK):
+			parsed := parseRefString(modCfg.SDK)
+			switch parsed.kind {
+			case core.ModuleSourceKindLocal:
+				// SDK is a local custom one, it needs to be included
+				sdkPath := filepath.Join(sourceRootAbsPath, parsed.modPath)
+				err = s.collectCallerLocalDeps(ctx, query, contextAbsPath, sdkPath, false, src, collectedDeps)
+				if err != nil {
+					return nil, fmt.Errorf("failed to collect local sdk: %w", err)
+				}
+
+				// TODO: this is inefficient, leads to extra local loads, but only for case
+				// of local custom SDK.
+				callerCwdStat, err := query.Buildkit.StatCallerHostPath(ctx, ".", true)
+				if err != nil {
+					return nil, fmt.Errorf("failed to stat caller cwd: %w", err)
+				}
+				callerCwd := callerCwdStat.Path
+				sdkCallerRelPath, err := filepath.Rel(callerCwd, sdkPath)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get relative path of local sdk: %s", err)
+				}
+				var sdkMod dagql.Instance[*core.Module]
+				err = s.dag.Select(ctx, s.dag.Root(), &sdkMod,
+					dagql.Selector{
+						Field: "moduleSource",
+						Args: []dagql.NamedInput{
+							{Name: "refString", Value: dagql.String(sdkCallerRelPath)},
+						},
+					},
+					dagql.Selector{
+						Field: "resolveFromCaller",
+					},
+					dagql.Selector{
+						Field: "asModule",
+					},
+					dagql.Selector{
+						Field: "initialize",
+					},
+				)
+				if err != nil {
+					return nil, fmt.Errorf("failed to load local sdk module source: %w", err)
+				}
+				localDep.sdk, err = s.newModuleSDK(ctx, query, sdkMod, dagql.Instance[*core.Directory]{})
+				if err != nil {
+					return nil, fmt.Errorf("failed to get local sdk: %w", err)
+				}
+				localDep.sdkKey = sdkPath
+
+			case core.ModuleSourceKindGit:
+				// TODO: this codepath is completely untested atm
+				localDep.sdk, err = s.sdkForModule(ctx, query, modCfg.SDK, dagql.Instance[*core.ModuleSource]{})
+				if err != nil {
+					return nil, fmt.Errorf("failed to get git module sdk: %w", err)
+				}
+			}
+		default:
+			return nil, fmt.Errorf("failed to load sdk: %w", err)
+		}
+
+		return localDep, nil
+	})
+	if errors.Is(err, dagql.ErrCacheMapRecursiveCall) {
+		return fmt.Errorf("local module at %q has a circular dependency", sourceRootAbsPath)
+	}
+	return err
+}
+
+// context path is the parent dir containing .git
+func callerHostFindUpContext(
+	ctx context.Context,
+	bk *buildkit.Client,
+	curDirPath string,
+) (string, bool, error) {
+	if !filepath.IsAbs(curDirPath) {
+		return "", false, fmt.Errorf("path is not absolute: %s", curDirPath)
+	}
+	_, err := bk.StatCallerHostPath(ctx, filepath.Join(curDirPath, ".git"), false)
+	if err == nil {
+		return curDirPath, true, nil
+	}
+	if !strings.Contains(err.Error(), "no such file or directory") {
+		return "", false, fmt.Errorf("failed to lstat .git: %s", err)
+	}
+
+	if curDirPath == "/" {
+		return "", false, nil
+	}
+	return callerHostFindUpContext(ctx, bk, filepath.Dir(curDirPath))
+}
+
+func pathEscapes(parentAbsPath, childAbsPath string) bool {
+	relPath, err := filepath.Rel(parentAbsPath, childAbsPath)
+	if err != nil {
+		return true
+	}
+	return !filepath.IsLocal(relPath)
+}

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"runtime/debug"
 	"sort"
 	"strings"
 
@@ -456,29 +457,6 @@ func (s *moduleSchema) moduleSourceResolveDependency(
 		return inst, fmt.Errorf("failed to decode module source: %w", err)
 	}
 
-	// TODO:
-	// TODO:
-	// TODO:
-	// TODO:
-	// TODO:
-	// TODO:
-	/*
-		srcName, err := src.ModuleName(ctx)
-		if err != nil {
-			return inst, fmt.Errorf("failed to get module name: %w", err)
-		}
-		depName, err := depSrc.Self.ModuleName(ctx)
-		if err != nil {
-			return inst, fmt.Errorf("failed to get module name: %w", err)
-		}
-		slog.Debug("MODULESOURCERESOLVEDEPENDENCY",
-			"srcName", srcName,
-			"srcRootSubpath", src.RootSubpath,
-			"depName", depName,
-			"depRootSubpath", depSrc.Self.RootSubpath,
-		)
-	*/
-
 	if depSrc.Self.Kind == core.ModuleSourceKindGit {
 		// git deps stand on their own, no special handling needed
 		return depSrc, nil
@@ -497,9 +475,36 @@ func (s *moduleSchema) moduleSourceResolveDependency(
 		return inst, fmt.Errorf("failed to get source root subpath: %w", err)
 	}
 
+	// TODO:
+	// TODO:
+	// TODO:
+	// TODO:
+	// TODO:
+	// TODO:
+	srcName, err := src.ModuleName(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get module name: %w", err)
+	}
+	depName, err := depSrc.Self.ModuleName(ctx)
+	if err != nil {
+		return inst, fmt.Errorf("failed to get module name: %w", err)
+	}
+	slog.Debug("MODULESOURCERESOLVEDEPENDENCY",
+		"srcName", srcName,
+		"srcRootSubpath", srcRootSubpath,
+		"depName", depName,
+		"depRootSubpath", depRootSubpath,
+	)
+
 	// This dep is a local path relative to a src, need to find the src's root
 	// and return a source that points to the full path to this dep
 	if contextDir.Self == nil {
+		// TODO:
+		// TODO:
+		// TODO:
+		// TODO:
+		debug.PrintStack()
+
 		return inst, fmt.Errorf("cannot resolve dependency for module source with no context directory")
 	}
 
@@ -548,9 +553,6 @@ func (s *moduleSchema) moduleSourceResolveDependency(
 				Args: []dagql.NamedInput{
 					{Name: "refString", Value: dagql.String(depSubpath)},
 				},
-			},
-			dagql.Selector{
-				Field: "asLocalSource",
 			},
 			dagql.Selector{
 				Field: "withContextDirectory",

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -736,19 +736,6 @@ func (s *moduleSchema) moduleSourceResolveFromCaller(
 		}
 		includeSet[sourceRelSubpath+"/**/*"] = struct{}{}
 
-		// TODO:
-		// TODO:
-		// TODO:
-		// TODO:
-		// TODO:
-		slog.Debug("moduleSourceResolveFromCaller",
-			"rootPath", rootPath,
-			"sourceAbsSubpath", sourceAbsSubpath,
-			"configRelPath", configRelPath,
-			"sourceRelSubpath", sourceRelSubpath,
-		)
-	}
-
 	for _, sdk := range sdkSet {
 		// NOTE: required paths are currently **-style globs that apply to the whole context subtree
 		// This is a bit of a delicate assumption, if need arises for including exact paths, this
@@ -878,7 +865,11 @@ type callerLocalDep struct {
 	sourceRootAbsPath string
 	modCfg            *modules.ModuleConfig
 	sdk               core.SDK
-	sdkKey            string // TODO :explain..
+	// sdkKey is a unique identifer for the SDK, slightly different
+	// from the module ref for the SDK because custom local SDKs
+	// use their local path for sdkKey, which allows us to de-dupe
+	// loading them across the dag of local deps.
+	sdkKey string
 }
 
 func (s *moduleSchema) collectCallerLocalDeps(
@@ -886,7 +877,11 @@ func (s *moduleSchema) collectCallerLocalDeps(
 	query *core.Query,
 	contextAbsPath string,
 	sourceRootAbsPath string,
-	topLevel bool, // TODO: doc
+	// topLevel should only be true for the module source being operated on,
+	// everything else we collect is a (transitive) dep. The top level module
+	// is a bit special in that it is allowed to not be initialized yet and/or
+	// not have a name/sdk/etc.
+	topLevel bool,
 	src *core.ModuleSource,
 	// cache of sourceRootAbsPath -> *callerLocalDep
 	collectedDeps dagql.CacheMap[string, *callerLocalDep],

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -233,7 +233,7 @@ func (s *moduleSchema) moduleSourceWithSourceSubpath(
 		return src, nil
 	}
 	if !filepath.IsLocal(args.Path) {
-		return nil, fmt.Errorf("source subdir path escapes parent dir: %q", args.Path)
+		return nil, fmt.Errorf("source subdir path %q escapes context", args.Path)
 	}
 	src = src.Clone()
 	src.WithSourceSubpath = args.Path

--- a/core/schema/sdk.go
+++ b/core/schema/sdk.go
@@ -182,6 +182,19 @@ func (sdk *moduleSDK) Runtime(ctx context.Context, mod *core.Module, source dagq
 	return inst.Self, nil
 }
 
+func (sdk *moduleSDK) RequiredPaths(ctx context.Context) ([]string, error) {
+	var paths []string
+	err := sdk.dag.Select(ctx, sdk.sdk, &paths,
+		dagql.Selector{
+			Field: "requiredPaths",
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call sdk module requiredPaths: %w", err)
+	}
+	return paths, nil
+}
+
 // loadBuiltinSDK loads an SDK implemented as a module that is "builtin" to engine, which means its pre-packaged
 // with the engine container in order to enable use w/out hard dependencies on the internet
 func (s *moduleSchema) loadBuiltinSDK(
@@ -356,6 +369,10 @@ func (sdk *goSDK) Runtime(
 		return nil, fmt.Errorf("failed to exec go build in go module sdk container runtime: %w", err)
 	}
 	return ctr.Self, nil
+}
+
+func (sdk *goSDK) RequiredPaths(_ context.Context) ([]string, error) {
+	return []string{"main.go"}, nil
 }
 
 func (sdk *goSDK) baseWithCodegen(

--- a/core/schema/sdk.go
+++ b/core/schema/sdk.go
@@ -221,13 +221,6 @@ func (s *moduleSchema) loadBuiltinSDK(
 ) (*moduleSDK, error) {
 	ctx, recorder := progrock.WithGroup(ctx, fmt.Sprintf("load builtin module sdk %s", name))
 
-	// TODO:
-	// TODO:
-	// TODO:
-	// TODO:
-	// TODO:
-	// TODO:
-	// TODO: I think the problem of not honoring include/exclude can be fixed now
 	// TODO: currently hardcoding assumption that builtin sdks put *module* source code at
 	// subdir right under the *full* sdk source dir. Can be generalized once we support
 	// default-args/scripts in dagger.json
@@ -278,7 +271,7 @@ func (s *moduleSchema) loadBuiltinSDK(
 }
 
 const (
-	goSDKUserModSourceDirPath  = "/src"
+	goSDKUserModContextDirPath = "/src"
 	goSDKRuntimePath           = "/runtime"
 	goSDKIntrospectionJSONPath = "/schema.json"
 )
@@ -313,7 +306,7 @@ func (sdk *goSDK) Codegen(
 		Args: []dagql.NamedInput{
 			{
 				Name:  "path",
-				Value: dagql.String(goSDKUserModSourceDirPath),
+				Value: dagql.String(goSDKUserModContextDirPath),
 			},
 		},
 	}); err != nil {
@@ -480,7 +473,7 @@ func (sdk *goSDK) baseWithCodegen(
 		Args: []dagql.NamedInput{
 			{
 				Name:  "path",
-				Value: dagql.NewString(goSDKUserModSourceDirPath),
+				Value: dagql.NewString(goSDKUserModContextDirPath),
 			},
 			{
 				Name:  "source",
@@ -492,7 +485,7 @@ func (sdk *goSDK) baseWithCodegen(
 		Args: []dagql.NamedInput{
 			{
 				Name:  "path",
-				Value: dagql.NewString(filepath.Join(goSDKUserModSourceDirPath, srcSubpath)),
+				Value: dagql.NewString(filepath.Join(goSDKUserModContextDirPath, srcSubpath)),
 			},
 		},
 	}, dagql.Selector{
@@ -503,7 +496,7 @@ func (sdk *goSDK) baseWithCodegen(
 			{
 				Name: "args",
 				Value: dagql.ArrayInput[dagql.String]{
-					"--module-source-root", goSDKUserModSourceDirPath,
+					"--module-context", goSDKUserModContextDirPath,
 					"--module-name", dagql.String(modName),
 					"--propagate-logs=true",
 					"--introspection-json-path", goSDKIntrospectionJSONPath,

--- a/core/schema/sdk.go
+++ b/core/schema/sdk.go
@@ -414,18 +414,21 @@ func (sdk *goSDK) baseWithCodegen(
 		return ctr, fmt.Errorf("failed to get module name for go module sdk codegen: %w", err)
 	}
 
+	contextDir, err := src.Self.ContextDirectory()
+	if err != nil {
+		return ctr, fmt.Errorf("failed to get context directory for go module sdk codegen: %w", err)
+	}
+	srcSubpath, err := src.Self.SourceSubpath(ctx)
+	if err != nil {
+		return ctr, fmt.Errorf("failed to get subpath for go module sdk codegen: %w", err)
+	}
+
 	ctr, err = sdk.base(ctx)
 	if err != nil {
 		return ctr, err
 	}
 
-	contextDir := src.Self.BaseContextDirectory
-	srcSubpath, err := src.Self.ModuleSourceSubpath(ctx)
-	if err != nil {
-		return ctr, fmt.Errorf("failed to get subpath for go module sdk codegen: %w", err)
-	}
-
-	// Makethe source subpath if it doesn't exist already.
+	// Make the source subpath if it doesn't exist already.
 	// Also rm dagger.gen.go if it exists, which is going to be overwritten
 	// anyways. If it doesn't exist, we ignore not found in the implementation of
 	// `withoutFile` so it will be a no-op.

--- a/core/schema/sdk.go
+++ b/core/schema/sdk.go
@@ -411,7 +411,7 @@ func (sdk *goSDK) baseWithCodegen(
 	if err != nil {
 		return ctr, fmt.Errorf("failed to get context directory for go module sdk codegen: %w", err)
 	}
-	srcSubpath, err := src.Self.SourceSubpath(ctx)
+	srcSubpath, err := src.Self.SourceSubpathWithDefault(ctx)
 	if err != nil {
 		return ctr, fmt.Errorf("failed to get subpath for go module sdk codegen: %w", err)
 	}

--- a/core/schema/util.go
+++ b/core/schema/util.go
@@ -54,6 +54,18 @@ func collectIDObjects[T dagql.Typed](ctx context.Context, srv *dagql.Server, ids
 	return ts, nil
 }
 
+func collectIDInstances[T dagql.Typed](ctx context.Context, srv *dagql.Server, ids []dagql.ID[T]) ([]dagql.Instance[T], error) {
+	ts := make([]dagql.Instance[T], len(ids))
+	for i, id := range ids {
+		inst, err := id.Load(ctx, srv)
+		if err != nil {
+			return nil, err
+		}
+		ts[i] = inst
+	}
+	return ts, nil
+}
+
 func asArrayInput[T any, I dagql.Input](ts []T, conv func(T) I) dagql.ArrayInput[I] {
 	ins := make(dagql.ArrayInput[I], len(ts))
 	for i, v := range ts {

--- a/core/schema/util.go
+++ b/core/schema/util.go
@@ -42,18 +42,6 @@ func collectInputsSlice[T dagql.Type](inputs []dagql.InputObject[T]) []T {
 	return ts
 }
 
-func collectIDObjects[T dagql.Typed](ctx context.Context, srv *dagql.Server, ids []dagql.ID[T]) ([]T, error) {
-	ts := make([]T, len(ids))
-	for i, id := range ids {
-		inst, err := id.Load(ctx, srv)
-		if err != nil {
-			return nil, err
-		}
-		ts[i] = inst.Self
-	}
-	return ts, nil
-}
-
 func collectIDInstances[T dagql.Typed](ctx context.Context, srv *dagql.Server, ids []dagql.ID[T]) ([]dagql.Instance[T], error) {
 	ts := make([]dagql.Instance[T], len(ids))
 	for i, id := range ids {

--- a/dagql/builtins.go
+++ b/dagql/builtins.go
@@ -105,6 +105,19 @@ func (d DynamicArrayOutput) MarshalJSON() ([]byte, error) {
 	return json.Marshal(d.Values)
 }
 
+func (d DynamicArrayOutput) SetField(val reflect.Value) error {
+	if val.Kind() != reflect.Slice {
+		return fmt.Errorf("expected slice, got %v", val.Kind())
+	}
+	val.Set(reflect.MakeSlice(val.Type(), len(d.Values), len(d.Values)))
+	for i, elem := range d.Values {
+		if err := assign(val.Index(i), elem); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func builtinOrInput(val any) (Input, error) {
 	switch x := val.(type) {
 	case Input:

--- a/dagql/objects.go
+++ b/dagql/objects.go
@@ -868,3 +868,14 @@ func assign(field reflect.Value, val any) error {
 		return fmt.Errorf("cannot assign %T to %s", val, field.Type())
 	}
 }
+
+func appendAssign(slice reflect.Value, val any) error {
+	if reflect.TypeOf(val).AssignableTo(slice.Type().Elem()) {
+		slice.Set(reflect.Append(slice, reflect.ValueOf(val)))
+		return nil
+	} else if setter, ok := val.(Setter); ok {
+		return setter.SetField(slice)
+	} else {
+		return fmt.Errorf("cannot assign %T to %s", val, slice.Type())
+	}
+}

--- a/dagql/objects.go
+++ b/dagql/objects.go
@@ -605,8 +605,7 @@ func (field Field[T]) Impure(reason string, paras ...string) Field[T] {
 	return field
 }
 
-// Impure marks the field as "impure", meaning its result may change over time,
-// or it has side effects.
+// Meta indicates that the field has no impact on the field's result.
 func (field Field[T]) Meta() Field[T] {
 	field.Spec.Meta = true
 	return field

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -880,7 +880,7 @@ type Directory {
   """Load the directory as a Dagger module"""
   asModule(
     """
-    An optional subpath of the directory which contains the module's source code.
+    An optional subpath of the directory which contains the module's configuration file.
     
     This is needed when the module code is in a subdirectory but requires parent
     directories to be loaded in order to execute. For example, the module source
@@ -888,7 +888,7 @@ type Directory {
     
     If not set, the module source code is loaded from the root of the directory.
     """
-    sourceSubpath: String = "."
+    sourceRootPath: String = "."
   ): Module!
 
   """Gets the difference between this directory and an another directory."""

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -1624,8 +1624,15 @@ type Module {
   """The doc string of the module, if any"""
   description: String!
 
-  """TODO"""
+  """
+  The generated files and directories made on top of the module source's context directory.
+  """
   generatedContextDiff: Directory!
+
+  """
+  The module source's context plus any configuration and source files created by codegen.
+  """
+  generatedContextDirectory: Directory!
 
   """A unique identifier for this Module."""
   id: ModuleID!
@@ -1732,7 +1739,10 @@ type ModuleSource {
   """
   contextDirectory: Directory!
 
-  """TODO"""
+  """
+  The dependencies of the module source. Includes dependencies from the
+  configuration and any extras from withDependencies calls.
+  """
   dependencies: [ModuleDependency!]!
 
   """
@@ -1749,13 +1759,19 @@ type ModuleSource {
   """The kind of source (e.g. local, git, etc.)"""
   kind: ModuleSourceKind!
 
-  """If set, the name of the module this source references"""
+  """
+  If set, the name of the module this source references, including any overrides at runtime by callers.
+  """
   moduleName: String!
 
-  """TODO"""
+  """
+  The original name of the module this source references, as defined in the module configuration.
+  """
   moduleOriginalName: String!
 
-  """TODO"""
+  """
+  The path to the module source's context directory on the caller's filesystem. Only valid for local sources.
+  """
   resolveContextPathFromCaller: String!
 
   """
@@ -1767,30 +1783,54 @@ type ModuleSource {
   ): ModuleSource!
 
   """
-  Load the source from its path on the caller's filesystem. Only valid for local sources.
+  Load the source from its path on the caller's filesystem, including only
+  needed+configured files and directories. Only valid for local sources.
   """
   resolveFromCaller: ModuleSource!
 
-  """TODO"""
+  """
+  The path relative to context of the root of the module source, which contains
+  dagger.json. It also contains the module implementation source code, but that
+  may or may not being a subdir of this root.
+  """
   sourceRootSubpath: String!
 
-  """TODO"""
+  """The path relative to context of the module implementation source code."""
   sourceSubpath: String!
 
-  """TODO"""
-  withContextDirectory(dir: DirectoryID!): ModuleSource!
+  """
+  Update the module source with a new context directory. Only valid for local sources.
+  """
+  withContextDirectory(
+    """The directory to set as the context directory."""
+    dir: DirectoryID!
+  ): ModuleSource!
 
-  """TODO"""
-  withDependencies(dependencies: [ModuleDependencyID!]!): ModuleSource!
+  """
+  Append the provided dependencies to the module source's dependency list.
+  """
+  withDependencies(
+    """The dependencies to append."""
+    dependencies: [ModuleDependencyID!]!
+  ): ModuleSource!
 
-  """TODO"""
-  withName(name: String!): ModuleSource!
+  """Update the module source with a new name."""
+  withName(
+    """The name to set."""
+    name: String!
+  ): ModuleSource!
 
-  """TODO"""
-  withSDK(sdk: String!): ModuleSource!
+  """Update the module source with a new SDK."""
+  withSDK(
+    """The SDK to set."""
+    sdk: String!
+  ): ModuleSource!
 
-  """TODO"""
-  withSourceSubpath(path: String!): ModuleSource!
+  """Update the module source with a new source subpath."""
+  withSourceSubpath(
+    """The path to set as the source subpath."""
+    path: String!
+  ): ModuleSource!
 }
 
 """

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -888,7 +888,7 @@ type Directory {
     
     If not set, the module source code is loaded from the root of the directory.
     """
-    sourceSubpath: String = "/"
+    sourceSubpath: String = "."
   ): Module!
 
   """Gets the difference between this directory and an another directory."""
@@ -1315,11 +1315,6 @@ type GitModuleSource {
   """A unique identifier for this GitModuleSource."""
   id: GitModuleSourceID!
 
-  """
-  The path to the module source code dir specified by this source relative to the source's root directory.
-  """
-  sourceSubpath: String!
-
   """The specified version of the git repo this source points to."""
   version: String!
 }
@@ -1587,9 +1582,6 @@ Module source that that originates from a path locally relative to an arbitrary 
 type LocalModuleSource {
   """A unique identifier for this LocalModuleSource."""
   id: LocalModuleSourceID!
-
-  """The path to the module source code dir specified by this source."""
-  sourceSubpath: String!
 }
 
 """
@@ -1607,14 +1599,6 @@ type Module {
 
   """The doc string of the module, if any"""
   description: String!
-
-  """
-  The module's root directory containing the config file for it and its source
-  (possibly as a subdir). It includes any generated code or updated config files
-  created after initial load, but not any files/directories that were unchanged
-  after sdk codegen was run.
-  """
-  generatedSourceRootDirectory: Directory!
 
   """A unique identifier for this Module."""
   id: ModuleID!
@@ -1653,12 +1637,6 @@ type Module {
   """The source for the module."""
   source: ModuleSource!
 
-  """Update the module configuration to use the given dependencies."""
-  withDependencies(
-    """The dependency modules to install."""
-    dependencies: [ModuleDependencyID!]!
-  ): Module!
-
   """Retrieves the module with the given description"""
   withDescription(
     """The description to set"""
@@ -1668,20 +1646,8 @@ type Module {
   """This module plus the given Interface type and associated functions"""
   withInterface(iface: TypeDefID!): Module!
 
-  """Update the module configuration to use the given name."""
-  withName(
-    """The name to use."""
-    name: String!
-  ): Module!
-
   """This module plus the given Object type and associated functions."""
   withObject(object: TypeDefID!): Module!
-
-  """Update the module configuration to use the given SDK."""
-  withSDK(
-    """The SDK to use."""
-    sdk: String!
-  ): Module!
 
   """Retrieves the module with basic configuration loaded if present."""
   withSource(
@@ -1731,13 +1697,19 @@ type ModuleSource {
   """A human readable ref string representation of this module source."""
   asString: String!
 
+  """TODO"""
+  contextDirectory: Directory!
+
   """
-  The directory containing the actual module's source code, as determined from the root directory and subpath.
+  The directory containing the module configuration and source code (source code may be in a subdir).
   """
   directory(
     """The path from the source directory to select."""
     path: String!
   ): Directory!
+
+  """TODO; just the diff"""
+  generatedContextDiff: Directory!
 
   """A unique identifier for this ModuleSource."""
   id: ModuleSourceID!
@@ -1748,6 +1720,9 @@ type ModuleSource {
   """If set, the name of the module this source references"""
   moduleName: String!
 
+  """TODO"""
+  moduleOriginalName: String!
+
   """
   Resolve the provided module source arg as a dependency relative to this module source.
   """
@@ -1757,15 +1732,34 @@ type ModuleSource {
   ): ModuleSource!
 
   """
-  The root directory of the module source that contains its configuration and
-  source code (which may be in a subdirectory of this root).
+  Load the source from its path on the caller's filesystem. Only valid for local sources.
   """
-  rootDirectory: Directory!
+  resolveFromCaller: ModuleSource!
 
   """
-  The path to the module subdirectory containing the actual module's source code.
+  The path to the root of the module source under the context directory. This
+  directory contains its configuration file. It also contains its source code
+  (possibly as a subdirectory).
   """
-  subpath: String!
+  rootSubpath: String!
+
+  """TODO"""
+  sourceSubpath: String!
+
+  """TODO; doc that additive"""
+  withContext(dir: DirectoryID!): ModuleSource!
+
+  """TODO"""
+  withDependencies(dependencies: [ModuleDependencyID!]!): ModuleSource!
+
+  """TODO"""
+  withGeneratedContext: ModuleSource!
+
+  """TODO"""
+  withName(name: String!): ModuleSource!
+
+  """TODO"""
+  withSDK(sdk: String!): ModuleSource!
 }
 
 """
@@ -2105,13 +2099,6 @@ type Query {
   moduleSource(
     """The string ref representation of the module source"""
     refString: String!
-
-    """
-    An explicitly set root directory for the module source. This is required to
-    load local sources as modules; other source types implicitly encode the root
-    directory and do not require this.
-    """
-    rootDirectory: DirectoryID
 
     """
     If true, enforce that the source is a stable version for source kinds that support versioning.

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -1309,11 +1309,23 @@ type GitModuleSource {
   """The resolved commit of the git repo this source points to."""
   commit: String!
 
+  """
+  The directory containing everything needed to load load and use the module.
+  """
+  contextDirectory: Directory!
+
   """The URL to the source's git repo in a web browser"""
   htmlURL: String!
 
   """A unique identifier for this GitModuleSource."""
   id: GitModuleSourceID!
+
+  """
+  The path to the root of the module source under the context directory. This
+  directory contains its configuration file. It also contains its source code
+  (possibly as a subdirectory).
+  """
+  rootSubpath: String!
 
   """The specified version of the git repo this source points to."""
   version: String!
@@ -1580,8 +1592,20 @@ scalar ListTypeDefID
 Module source that that originates from a path locally relative to an arbitrary directory.
 """
 type LocalModuleSource {
+  """
+  The directory containing everything needed to load load and use the module.
+  """
+  contextDirectory: Directory!
+
   """A unique identifier for this LocalModuleSource."""
   id: LocalModuleSourceID!
+
+  """
+  The path to the root of the module source under the context directory. This
+  directory contains its configuration file. It also contains its source code
+  (possibly as a subdirectory).
+  """
+  rootSubpath: String!
 }
 
 """
@@ -1599,6 +1623,9 @@ type Module {
 
   """The doc string of the module, if any"""
   description: String!
+
+  """TODO"""
+  generatedContextDiff: Directory!
 
   """A unique identifier for this Module."""
   id: ModuleID!
@@ -1697,8 +1724,16 @@ type ModuleSource {
   """A human readable ref string representation of this module source."""
   asString: String!
 
-  """TODO"""
+  """Returns whether the module source has a configuration file."""
+  configExists: Boolean!
+
+  """
+  The directory containing everything needed to load load and use the module.
+  """
   contextDirectory: Directory!
+
+  """TODO"""
+  dependencies: [ModuleDependency!]!
 
   """
   The directory containing the module configuration and source code (source code may be in a subdir).
@@ -1707,9 +1742,6 @@ type ModuleSource {
     """The path from the source directory to select."""
     path: String!
   ): Directory!
-
-  """TODO; just the diff"""
-  generatedContextDiff: Directory!
 
   """A unique identifier for this ModuleSource."""
   id: ModuleSourceID!
@@ -1722,6 +1754,9 @@ type ModuleSource {
 
   """TODO"""
   moduleOriginalName: String!
+
+  """TODO"""
+  resolveContextPathFromCaller: String!
 
   """
   Resolve the provided module source arg as a dependency relative to this module source.
@@ -1736,30 +1771,26 @@ type ModuleSource {
   """
   resolveFromCaller: ModuleSource!
 
-  """
-  The path to the root of the module source under the context directory. This
-  directory contains its configuration file. It also contains its source code
-  (possibly as a subdirectory).
-  """
-  rootSubpath: String!
+  """TODO"""
+  sourceRootSubpath: String!
 
   """TODO"""
   sourceSubpath: String!
 
-  """TODO; doc that additive"""
-  withContext(dir: DirectoryID!): ModuleSource!
+  """TODO"""
+  withContextDirectory(dir: DirectoryID!): ModuleSource!
 
   """TODO"""
   withDependencies(dependencies: [ModuleDependencyID!]!): ModuleSource!
-
-  """TODO"""
-  withGeneratedContext: ModuleSource!
 
   """TODO"""
   withName(name: String!): ModuleSource!
 
   """TODO"""
   withSDK(sdk: String!): ModuleSource!
+
+  """TODO"""
+  withSourceSubpath(path: String!): ModuleSource!
 }
 
 """

--- a/docs/versioned_docs/version-zenith/reference/979596-cli.mdx
+++ b/docs/versioned_docs/version-zenith/reference/979596-cli.mdx
@@ -208,7 +208,7 @@ Initialize a new Dagger module
 Initialize a new Dagger module in a local directory.
 
 ```
-dagger module init [--sdk string --name string] [flags]
+dagger module init [--sdk string --name string] [--source string] [flags]
 ```
 
 ### Examples
@@ -223,6 +223,7 @@ dagger mod init --name=hello --sdk=python
       --license string   License identifier to generate - see https://spdx.org/licenses/
       --name string      Name of the new module
       --sdk string       SDK name or image ref to use for the module
+      --source string    Directory to store the module implementation source code in (default ".")
 ```
 
 ### Options inherited from parent commands

--- a/docs/versioned_docs/version-zenith/reference/979596-cli.mdx
+++ b/docs/versioned_docs/version-zenith/reference/979596-cli.mdx
@@ -135,15 +135,17 @@ Setup or update all the resources needed to develop on a module locally.
 This command re-regerates the module's generated code based on dependencies
 and the current state of the module's source code.
 
-If --name and --sdk are set, the config file and generated code will be updated with those values reflected.
+If --sdk is set, the config file and generated code will be updated with those values reflected. It currently can only be used to set the SDK of a module that does not have one already.
+
+--source allows controlling the directory in which the actual module source code is stored. By default, it will be stored in a directory named "dagger".
 
 :::note
-If not updating name or SDK, this is only required for IDE auto-completion/LSP purposes.
+If not updating source or SDK, this is only required for IDE auto-completion/LSP purposes.
 :::
 
 
 ```
-dagger develop [--name string --sdk string] [--source string] [flags]
+dagger develop [flags]
 ```
 
 ### Options
@@ -151,7 +153,6 @@ dagger develop [--name string --sdk string] [--source string] [flags]
 ```
       --focus           Only show output for focused commands (default true)
   -m, --mod string      Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
-      --name string     New name for the module
       --sdk string      New SDK for the module
       --source string   Directory to store the module implementation source code in
 ```
@@ -210,24 +211,34 @@ Initialize a new Dagger module
 ### Synopsis
 
 Initialize a new Dagger module in a local directory.
+By default, create a new dagger.json configuration in the current working directory. If the positional argument PATH is provided, create the module in that directory instead.
+
+The configuration will default the name of the module to the parent directory name, unless specified with --name.
+
+Any module can be installed to via "dagger install".
+
+A module can only be called once it has been initialized with an SDK though. The "--sdk" flag can be provided to init here, but if it's not the configuration can be updated later via "dagger develop".
+
+The "--source" flag allows controlling the directory in which the actual module source code is stored. By default, it will be stored in a directory named "dagger". 
+
 
 ```
-dagger init [--sdk string --name string] [--source string] [PATH] [flags]
+dagger init [flags] [PATH]
 ```
 
 ### Examples
 
 ```
-dagger mod init --name=hello --sdk=python
+dagger mod init --name=hello --sdk=python --source=some/subdir
 ```
 
 ### Options
 
 ```
       --license string   License identifier to generate - see https://spdx.org/licenses/
-      --name string      Name of the new module
-      --sdk string       SDK name or image ref to use for the module
-      --source string    Directory to store the module implementation source code in
+      --name string      Name of the new module (defaults to parent directory name)
+      --sdk string       Optionally initialize module for development in the given SDK
+      --source string    Directory to store the module implementation source code in (defaults to "dagger/ if "--sdk" is provided)
 ```
 
 ### Options inherited from parent commands

--- a/docs/versioned_docs/version-zenith/reference/979596-cli.mdx
+++ b/docs/versioned_docs/version-zenith/reference/979596-cli.mdx
@@ -143,16 +143,17 @@ If not updating name or SDK, this is only required for IDE auto-completion/LSP p
 
 
 ```
-dagger develop [--name string --sdk string] [flags]
+dagger develop [--name string --sdk string] [--source string] [flags]
 ```
 
 ### Options
 
 ```
-      --focus         Only show output for focused commands (default true)
-  -m, --mod string    Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
-      --name string   New name for the module
-      --sdk string    New SDK for the module
+      --focus           Only show output for focused commands (default true)
+  -m, --mod string      Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
+      --name string     New name for the module
+      --sdk string      New SDK for the module
+      --source string   Directory to store the module implementation source code in
 ```
 
 ### Options inherited from parent commands

--- a/docs/versioned_docs/version-zenith/reference/979596-cli.mdx
+++ b/docs/versioned_docs/version-zenith/reference/979596-cli.mdx
@@ -25,10 +25,14 @@ The Dagger CLI provides a command-line interface to Dagger.
 ### SEE ALSO
 
 * [dagger call](#dagger-call)	 - Call a module function
+* [dagger config](#dagger-config)	 - Get or set the configuration of a Dagger module
+* [dagger develop](#dagger-develop)	 - Setup or update all the resources needed to develop on a module locally
 * [dagger functions](#dagger-functions)	 - List available functions
+* [dagger init](#dagger-init)	 - Initialize a new Dagger module
+* [dagger install](#dagger-install)	 - Add a new dependency to a Dagger module
 * [dagger login](#dagger-login)	 - Log in to Dagger Cloud
 * [dagger logout](#dagger-logout)	 - Log out from Dagger Cloud
-* [dagger module](#dagger-module)	 - Manage Dagger modules
+* [dagger publish](#dagger-publish)	 - Publish a Dagger module to the Daggerverse
 * [dagger query](#dagger-query)	 - Send API queries to a dagger engine
 * [dagger run](#dagger-run)	 - Run a command in a Dagger session
 * [dagger version](#dagger-version)	 - Print dagger version
@@ -82,6 +86,87 @@ dagger call lint stdout
 
 * [dagger](#dagger)	 - The Dagger CLI provides a command-line interface to Dagger.
 
+## dagger config
+
+Get or set the configuration of a Dagger module
+
+### Synopsis
+
+Get or set the configuration of a Dagger module. By default, print the configuration of the specified module.
+
+```
+dagger config [flags]
+```
+
+### Examples
+
+```
+dagger config -m /path/to/some/dir
+dagger config -m github.com/dagger/hello-dagger
+```
+
+### Options
+
+```
+      --focus        Only show output for focused commands (default true)
+  -m, --mod string   Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
+```
+
+### Options inherited from parent commands
+
+```
+      --debug             Show more information for debugging
+      --progress string   progress output format (auto, plain, tty) (default "auto")
+  -s, --silent            disable terminal UI and progress output
+```
+
+### SEE ALSO
+
+* [dagger](#dagger)	 - The Dagger CLI provides a command-line interface to Dagger.
+
+## dagger develop
+
+Setup or update all the resources needed to develop on a module locally
+
+### Synopsis
+
+Setup or update all the resources needed to develop on a module locally.
+
+This command re-regerates the module's generated code based on dependencies
+and the current state of the module's source code.
+
+If --name and --sdk are set, the config file and generated code will be updated with those values reflected.
+
+:::note
+If not updating name or SDK, this is only required for IDE auto-completion/LSP purposes.
+:::
+
+
+```
+dagger develop [--name string --sdk string] [flags]
+```
+
+### Options
+
+```
+      --focus         Only show output for focused commands (default true)
+  -m, --mod string    Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
+      --name string   New name for the module
+      --sdk string    New SDK for the module
+```
+
+### Options inherited from parent commands
+
+```
+      --debug             Show more information for debugging
+      --progress string   progress output format (auto, plain, tty) (default "auto")
+  -s, --silent            disable terminal UI and progress output
+```
+
+### SEE ALSO
+
+* [dagger](#dagger)	 - The Dagger CLI provides a command-line interface to Dagger.
+
 ## dagger functions
 
 List available functions
@@ -103,6 +188,83 @@ dagger functions [flags] [FUNCTION]...
 ```
       --focus        Only show output for focused commands (default true)
   -m, --mod string   Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
+```
+
+### Options inherited from parent commands
+
+```
+      --debug             Show more information for debugging
+      --progress string   progress output format (auto, plain, tty) (default "auto")
+  -s, --silent            disable terminal UI and progress output
+```
+
+### SEE ALSO
+
+* [dagger](#dagger)	 - The Dagger CLI provides a command-line interface to Dagger.
+
+## dagger init
+
+Initialize a new Dagger module
+
+### Synopsis
+
+Initialize a new Dagger module in a local directory.
+
+```
+dagger init [--sdk string --name string] [--source string] [PATH] [flags]
+```
+
+### Examples
+
+```
+dagger mod init --name=hello --sdk=python
+```
+
+### Options
+
+```
+      --license string   License identifier to generate - see https://spdx.org/licenses/
+      --name string      Name of the new module
+      --sdk string       SDK name or image ref to use for the module
+      --source string    Directory to store the module implementation source code in
+```
+
+### Options inherited from parent commands
+
+```
+      --debug             Show more information for debugging
+      --progress string   progress output format (auto, plain, tty) (default "auto")
+  -s, --silent            disable terminal UI and progress output
+```
+
+### SEE ALSO
+
+* [dagger](#dagger)	 - The Dagger CLI provides a command-line interface to Dagger.
+
+## dagger install
+
+Add a new dependency to a Dagger module
+
+### Synopsis
+
+Add a Dagger module as a dependency of a local module.
+
+```
+dagger install [flags] MODULE
+```
+
+### Examples
+
+```
+dagger mod install github.com/shykes/daggerverse/ttlsh@16e40ec244966e55e36a13cb6e1ff8023e1e1473
+```
+
+### Options
+
+```
+      --focus         Only show output for focused commands (default true)
+  -m, --mod string    Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
+  -n, --name string   Name to use for the dependency in the module. Defaults to the name of the module being installed.
 ```
 
 ### Options inherited from parent commands
@@ -157,29 +319,28 @@ dagger logout [flags]
 
 * [dagger](#dagger)	 - The Dagger CLI provides a command-line interface to Dagger.
 
-## dagger module
+## dagger publish
 
-Manage Dagger modules
+Publish a Dagger module to the Daggerverse
 
 ### Synopsis
 
-Manage Dagger modules. By default, print the configuration of the specified module in json format.
+Publish a local module to the Daggerverse (https://daggerverse.dev).
+
+The module needs to be committed to a git repository and have a remote
+configured with name "origin". The git repository must be clean (unless
+forced), to avoid mistakingly depending on uncommitted files.
+
 
 ```
-dagger module [flags]
-```
-
-### Examples
-
-```
-dagger mod -m /path/to/some/dir
-dagger mod -m github.com/dagger/hello-dagger
+dagger publish [flags]
 ```
 
 ### Options
 
 ```
       --focus        Only show output for focused commands (default true)
+  -f, --force        Force publish even if the git repository is not clean
   -m, --mod string   Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
 ```
 
@@ -194,160 +355,6 @@ dagger mod -m github.com/dagger/hello-dagger
 ### SEE ALSO
 
 * [dagger](#dagger)	 - The Dagger CLI provides a command-line interface to Dagger.
-* [dagger module init](#dagger-module-init)	 - Initialize a new Dagger module
-* [dagger module install](#dagger-module-install)	 - Add a new dependency to a Dagger module
-* [dagger module publish](#dagger-module-publish)	 - Publish a Dagger module to the Daggerverse
-* [dagger module sync](#dagger-module-sync)	 - Synchronize a Dagger module
-
-## dagger module init
-
-Initialize a new Dagger module
-
-### Synopsis
-
-Initialize a new Dagger module in a local directory.
-
-```
-dagger module init [--sdk string --name string] [--source string] [flags]
-```
-
-### Examples
-
-```
-dagger mod init --name=hello --sdk=python
-```
-
-### Options
-
-```
-      --license string   License identifier to generate - see https://spdx.org/licenses/
-      --name string      Name of the new module
-      --sdk string       SDK name or image ref to use for the module
-      --source string    Directory to store the module implementation source code in (default ".")
-```
-
-### Options inherited from parent commands
-
-```
-      --debug             Show more information for debugging
-      --focus             Only show output for focused commands (default true)
-  -m, --mod string        Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
-      --progress string   progress output format (auto, plain, tty) (default "auto")
-  -s, --silent            disable terminal UI and progress output
-```
-
-### SEE ALSO
-
-* [dagger module](#dagger-module)	 - Manage Dagger modules
-
-## dagger module install
-
-Add a new dependency to a Dagger module
-
-### Synopsis
-
-Add a Dagger module as a dependency of a local module.
-
-```
-dagger module install [flags] MODULE
-```
-
-### Examples
-
-```
-dagger mod install github.com/shykes/daggerverse/ttlsh@16e40ec244966e55e36a13cb6e1ff8023e1e1473
-```
-
-### Options
-
-```
-  -n, --name string   Name to use for the dependency in the module. Defaults to the name of the module being installed.
-```
-
-### Options inherited from parent commands
-
-```
-      --debug             Show more information for debugging
-      --focus             Only show output for focused commands (default true)
-  -m, --mod string        Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
-      --progress string   progress output format (auto, plain, tty) (default "auto")
-  -s, --silent            disable terminal UI and progress output
-```
-
-### SEE ALSO
-
-* [dagger module](#dagger-module)	 - Manage Dagger modules
-
-## dagger module publish
-
-Publish a Dagger module to the Daggerverse
-
-### Synopsis
-
-Publish a local module to the Daggerverse (https://daggerverse.dev).
-
-The module needs to be committed to a git repository and have a remote
-configured with name "origin". The git repository must be clean (unless
-forced), to avoid mistakingly depending on uncommitted files.
-
-
-```
-dagger module publish [flags]
-```
-
-### Options
-
-```
-  -f, --force   Force publish even if the git repository is not clean
-```
-
-### Options inherited from parent commands
-
-```
-      --debug             Show more information for debugging
-      --focus             Only show output for focused commands (default true)
-  -m, --mod string        Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
-      --progress string   progress output format (auto, plain, tty) (default "auto")
-  -s, --silent            disable terminal UI and progress output
-```
-
-### SEE ALSO
-
-* [dagger module](#dagger-module)	 - Manage Dagger modules
-
-## dagger module sync
-
-Synchronize a Dagger module
-
-### Synopsis
-
-Synchronize a Dagger module with the latest version of its extensions.
-
-:::note
-This is only required for IDE auto-completion/LSP purposes.
-:::
-
-This command re-regerates the module's generated code based on dependencies
-and the current state of the module's source code.
-
-
-```
-dagger module sync [flags]
-```
-
-### Options inherited from parent commands
-
-```
-      --debug             Show more information for debugging
-      --focus             Only show output for focused commands (default true)
-  -m, --mod string        Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
-      --progress string   progress output format (auto, plain, tty) (default "auto")
-  -s, --silent            disable terminal UI and progress output
-```
-
-### SEE ALSO
-
-* [dagger module](#dagger-module)	 - Manage Dagger modules
 
 ## dagger query
 

--- a/engine/buildkit/filesync.go
+++ b/engine/buildkit/filesync.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"os"
 	"path"
 	"path/filepath"
@@ -107,8 +106,6 @@ func (c *Client) EngineContainerLocalImport(
 }
 
 func (c *Client) ReadCallerHostFile(ctx context.Context, path string) ([]byte, error) {
-	slog.Debug("ReadCallerHostFile", "path", path)
-
 	ctx, cancel, err := c.withClientCloseCancel(ctx)
 	if err != nil {
 		return nil, err
@@ -145,8 +142,6 @@ func (c *Client) ReadCallerHostFile(ctx context.Context, path string) ([]byte, e
 }
 
 func (c *Client) StatCallerHostPath(ctx context.Context, path string, returnAbsPath bool) (*fsutiltypes.Stat, error) {
-	slog.Debug("StatCallerHostPath", "path", path, "returnAbsPath", returnAbsPath)
-
 	ctx, cancel, err := c.withClientCloseCancel(ctx)
 	if err != nil {
 		return nil, err

--- a/engine/buildkit/filesync.go
+++ b/engine/buildkit/filesync.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path"
 	"path/filepath"
@@ -106,6 +107,8 @@ func (c *Client) EngineContainerLocalImport(
 }
 
 func (c *Client) ReadCallerHostFile(ctx context.Context, path string) ([]byte, error) {
+	slog.Debug("ReadCallerHostFile", "path", path)
+
 	ctx, cancel, err := c.withClientCloseCancel(ctx)
 	if err != nil {
 		return nil, err
@@ -141,7 +144,9 @@ func (c *Client) ReadCallerHostFile(ctx context.Context, path string) ([]byte, e
 	return msg.Data, nil
 }
 
-func (c *Client) StatCallerHostPath(ctx context.Context, path string) (*fsutiltypes.Stat, error) {
+func (c *Client) StatCallerHostPath(ctx context.Context, path string, returnAbsPath bool) (*fsutiltypes.Stat, error) {
+	slog.Debug("StatCallerHostPath", "path", path, "returnAbsPath", returnAbsPath)
+
 	ctx, cancel, err := c.withClientCloseCancel(ctx)
 	if err != nil {
 		return nil, err
@@ -154,9 +159,10 @@ func (c *Client) StatCallerHostPath(ctx context.Context, path string) (*fsutilty
 	}
 
 	ctx = engine.LocalImportOpts{
-		OwnerClientID: clientMetadata.ClientID,
-		Path:          path,
-		StatPathOnly:  true,
+		OwnerClientID:     clientMetadata.ClientID,
+		Path:              path,
+		StatPathOnly:      true,
+		StatReturnAbsPath: returnAbsPath,
 	}.AppendToOutgoingContext(ctx)
 
 	clientCaller, err := c.SessionManager.Get(ctx, clientMetadata.ClientID, false)

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -706,6 +706,14 @@ func (s AnyDirSource) DiffCopy(stream filesync.FileSync_DiffCopyServer) error {
 		return stream.SendMsg(&filesync.BytesMessage{Data: fileContents})
 	}
 
+	if opts.StatPathOnly {
+		stat, err := fsutil.Stat(opts.Path)
+		if err != nil {
+			return fmt.Errorf("stat path: %w", err)
+		}
+		return stream.SendMsg(stat)
+	}
+
 	// otherwise, do the whole directory sync back to the caller
 	fs, err := fsutil.NewFS(opts.Path)
 	if err != nil {

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -711,6 +711,12 @@ func (s AnyDirSource) DiffCopy(stream filesync.FileSync_DiffCopyServer) error {
 		if err != nil {
 			return fmt.Errorf("stat path: %w", err)
 		}
+		if opts.StatReturnAbsPath {
+			stat.Path, err = filepath.Abs(opts.Path)
+			if err != nil {
+				return fmt.Errorf("get abs path: %w", err)
+			}
+		}
 		return stream.SendMsg(stat)
 	}
 

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -115,8 +115,9 @@ type LocalImportOpts struct {
 	ExcludePatterns    []string `json:"exclude_patterns"`
 	FollowPaths        []string `json:"follow_paths"`
 	ReadSingleFileOnly bool     `json:"read_single_file_only"`
-	StatPathOnly       bool     `json:"stat_path_only"`
 	MaxFileSize        int64    `json:"max_file_size"`
+	StatPathOnly       bool     `json:"stat_path_only"`
+	StatReturnAbsPath  bool     `json:"stat_return_abs_path"`
 }
 
 func (o LocalImportOpts) ToGRPCMD() metadata.MD {

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -115,6 +115,7 @@ type LocalImportOpts struct {
 	ExcludePatterns    []string `json:"exclude_patterns"`
 	FollowPaths        []string `json:"follow_paths"`
 	ReadSingleFileOnly bool     `json:"read_single_file_only"`
+	StatPathOnly       bool     `json:"stat_path_only"`
 	MaxFileSize        int64    `json:"max_file_size"`
 }
 

--- a/sdk/elixir/lib/dagger/gen/client.ex
+++ b/sdk/elixir/lib/dagger/gen/client.ex
@@ -590,19 +590,11 @@ defmodule Dagger.Client do
   )
 
   (
-    @doc "Create a new module source instance from a source ref string.\n\n## Required Arguments\n\n* `ref_string` - The string ref representation of the module source\n\n## Optional Arguments\n\n* `root_directory` - An explicitly set root directory for the module source. This is required to load local sources as modules; other source types implicitly encode the root directory and do not require this.\n* `stable` - If true, enforce that the source is a stable version for source kinds that support versioning."
+    @doc "Create a new module source instance from a source ref string.\n\n## Required Arguments\n\n* `ref_string` - The string ref representation of the module source\n\n## Optional Arguments\n\n* `stable` - If true, enforce that the source is a stable version for source kinds that support versioning."
     @spec module_source(t(), Dagger.String.t(), keyword()) :: Dagger.ModuleSource.t()
     def module_source(%__MODULE__{} = query, ref_string, optional_args \\ []) do
       selection = select(query.selection, "moduleSource")
       selection = arg(selection, "refString", ref_string)
-
-      selection =
-        if is_nil(optional_args[:root_directory]) do
-          selection
-        else
-          {:ok, id} = Dagger.Directory.id(optional_args[:root_directory])
-          arg(selection, "rootDirectory", id)
-        end
 
       selection =
         if is_nil(optional_args[:stable]) do

--- a/sdk/elixir/lib/dagger/gen/directory.ex
+++ b/sdk/elixir/lib/dagger/gen/directory.ex
@@ -7,16 +7,16 @@ defmodule Dagger.Directory do
   defstruct [:selection, :client]
 
   (
-    @doc "Load the directory as a Dagger module\n\n\n\n## Optional Arguments\n\n* `source_subpath` - An optional subpath of the directory which contains the module's source code.\n\nThis is needed when the module code is in a subdirectory but requires parent directories to be loaded in order to execute. For example, the module source code may need a go.mod, project.toml, package.json, etc. file from a parent directory.\n\nIf not set, the module source code is loaded from the root of the directory."
+    @doc "Load the directory as a Dagger module\n\n\n\n## Optional Arguments\n\n* `source_root_path` - An optional subpath of the directory which contains the module's configuration file.\n\nThis is needed when the module code is in a subdirectory but requires parent directories to be loaded in order to execute. For example, the module source code may need a go.mod, project.toml, package.json, etc. file from a parent directory.\n\nIf not set, the module source code is loaded from the root of the directory."
     @spec as_module(t(), keyword()) :: Dagger.Module.t()
     def as_module(%__MODULE__{} = directory, optional_args \\ []) do
       selection = select(directory.selection, "asModule")
 
       selection =
-        if is_nil(optional_args[:source_subpath]) do
+        if is_nil(optional_args[:source_root_path]) do
           selection
         else
-          arg(selection, "sourceSubpath", optional_args[:source_subpath])
+          arg(selection, "sourceRootPath", optional_args[:source_root_path])
         end
 
       %Dagger.Module{selection: selection, client: directory.client}

--- a/sdk/elixir/lib/dagger/gen/git_module_source.ex
+++ b/sdk/elixir/lib/dagger/gen/git_module_source.ex
@@ -24,6 +24,15 @@ defmodule Dagger.GitModuleSource do
   )
 
   (
+    @doc "The directory containing everything needed to load load and use the module."
+    @spec context_directory(t()) :: Dagger.Directory.t()
+    def context_directory(%__MODULE__{} = git_module_source) do
+      selection = select(git_module_source.selection, "contextDirectory")
+      %Dagger.Directory{selection: selection, client: git_module_source.client}
+    end
+  )
+
+  (
     @doc "The URL to the source's git repo in a web browser"
     @spec html_url(t()) :: {:ok, Dagger.String.t()} | {:error, term()}
     def html_url(%__MODULE__{} = git_module_source) do
@@ -42,10 +51,10 @@ defmodule Dagger.GitModuleSource do
   )
 
   (
-    @doc "The path to the module source code dir specified by this source relative to the source's root directory."
-    @spec source_subpath(t()) :: {:ok, Dagger.String.t()} | {:error, term()}
-    def source_subpath(%__MODULE__{} = git_module_source) do
-      selection = select(git_module_source.selection, "sourceSubpath")
+    @doc "The path to the root of the module source under the context directory. This directory contains its configuration file. It also contains its source code (possibly as a subdirectory)."
+    @spec root_subpath(t()) :: {:ok, Dagger.String.t()} | {:error, term()}
+    def root_subpath(%__MODULE__{} = git_module_source) do
+      selection = select(git_module_source.selection, "rootSubpath")
       execute(selection, git_module_source.client)
     end
   )

--- a/sdk/elixir/lib/dagger/gen/local_module_source.ex
+++ b/sdk/elixir/lib/dagger/gen/local_module_source.ex
@@ -6,6 +6,15 @@ defmodule Dagger.LocalModuleSource do
   defstruct [:selection, :client]
 
   (
+    @doc "The directory containing everything needed to load load and use the module."
+    @spec context_directory(t()) :: Dagger.Directory.t()
+    def context_directory(%__MODULE__{} = local_module_source) do
+      selection = select(local_module_source.selection, "contextDirectory")
+      %Dagger.Directory{selection: selection, client: local_module_source.client}
+    end
+  )
+
+  (
     @doc "A unique identifier for this LocalModuleSource."
     @spec id(t()) :: {:ok, Dagger.LocalModuleSourceID.t()} | {:error, term()}
     def id(%__MODULE__{} = local_module_source) do
@@ -15,10 +24,10 @@ defmodule Dagger.LocalModuleSource do
   )
 
   (
-    @doc "The path to the module source code dir specified by this source."
-    @spec source_subpath(t()) :: {:ok, Dagger.String.t()} | {:error, term()}
-    def source_subpath(%__MODULE__{} = local_module_source) do
-      selection = select(local_module_source.selection, "sourceSubpath")
+    @doc "The path to the root of the module source under the context directory. This directory contains its configuration file. It also contains its source code (possibly as a subdirectory)."
+    @spec root_subpath(t()) :: {:ok, Dagger.String.t()} | {:error, term()}
+    def root_subpath(%__MODULE__{} = local_module_source) do
+      selection = select(local_module_source.selection, "rootSubpath")
       execute(selection, local_module_source.client)
     end
   )

--- a/sdk/elixir/lib/dagger/gen/module.ex
+++ b/sdk/elixir/lib/dagger/gen/module.ex
@@ -14,7 +14,7 @@ defmodule Dagger.Module do
       selection =
         select(
           selection,
-          "dependencies dependencyConfig description generatedSourceRootDirectory id initialize interfaces name objects runtime sdk serve source withDependencies withDescription withInterface withName withObject withSDK withSource"
+          "dependencies dependencyConfig description generatedContextDiff generatedContextDirectory id initialize interfaces name objects runtime sdk serve source withDescription withInterface withObject withSource"
         )
 
       with {:ok, data} <- execute(selection, module.client) do
@@ -60,10 +60,19 @@ defmodule Dagger.Module do
   )
 
   (
-    @doc "The module's root directory containing the config file for it and its source (possibly as a subdir). It includes any generated code or updated config files created after initial load, but not any files/directories that were unchanged after sdk codegen was run."
-    @spec generated_source_root_directory(t()) :: Dagger.Directory.t()
-    def generated_source_root_directory(%__MODULE__{} = module) do
-      selection = select(module.selection, "generatedSourceRootDirectory")
+    @doc "The generated files and directories made on top of the module source's context directory."
+    @spec generated_context_diff(t()) :: Dagger.Directory.t()
+    def generated_context_diff(%__MODULE__{} = module) do
+      selection = select(module.selection, "generatedContextDiff")
+      %Dagger.Directory{selection: selection, client: module.client}
+    end
+  )
+
+  (
+    @doc "The module source's context plus any configuration and source files created by codegen."
+    @spec generated_context_directory(t()) :: Dagger.Directory.t()
+    def generated_context_directory(%__MODULE__{} = module) do
+      selection = select(module.selection, "generatedContextDirectory")
       %Dagger.Directory{selection: selection, client: module.client}
     end
   )
@@ -182,16 +191,6 @@ defmodule Dagger.Module do
   )
 
   (
-    @doc "Update the module configuration to use the given dependencies.\n\n## Required Arguments\n\n* `dependencies` - The dependency modules to install."
-    @spec with_dependencies(t(), [Dagger.ModuleDependencyID.t()]) :: Dagger.Module.t()
-    def with_dependencies(%__MODULE__{} = module, dependencies) do
-      selection = select(module.selection, "withDependencies")
-      selection = arg(selection, "dependencies", dependencies)
-      %Dagger.Module{selection: selection, client: module.client}
-    end
-  )
-
-  (
     @doc "Retrieves the module with the given description\n\n## Required Arguments\n\n* `description` - The description to set"
     @spec with_description(t(), Dagger.String.t()) :: Dagger.Module.t()
     def with_description(%__MODULE__{} = module, description) do
@@ -217,16 +216,6 @@ defmodule Dagger.Module do
   )
 
   (
-    @doc "Update the module configuration to use the given name.\n\n## Required Arguments\n\n* `name` - The name to use."
-    @spec with_name(t(), Dagger.String.t()) :: Dagger.Module.t()
-    def with_name(%__MODULE__{} = module, name) do
-      selection = select(module.selection, "withName")
-      selection = arg(selection, "name", name)
-      %Dagger.Module{selection: selection, client: module.client}
-    end
-  )
-
-  (
     @doc "This module plus the given Object type and associated functions.\n\n## Required Arguments\n\n* `object` -"
     @spec with_object(t(), Dagger.TypeDef.t()) :: Dagger.Module.t()
     def with_object(%__MODULE__{} = module, object) do
@@ -237,16 +226,6 @@ defmodule Dagger.Module do
         selection = arg(selection, "object", id)
       )
 
-      %Dagger.Module{selection: selection, client: module.client}
-    end
-  )
-
-  (
-    @doc "Update the module configuration to use the given SDK.\n\n## Required Arguments\n\n* `sdk` - The SDK to use."
-    @spec with_sdk(t(), Dagger.String.t()) :: Dagger.Module.t()
-    def with_sdk(%__MODULE__{} = module, sdk) do
-      selection = select(module.selection, "withSDK")
-      selection = arg(selection, "sdk", sdk)
       %Dagger.Module{selection: selection, client: module.client}
     end
   )

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -1855,21 +1855,21 @@ func (r *Directory) With(f WithDirectoryFunc) *Directory {
 
 // DirectoryAsModuleOpts contains options for Directory.AsModule
 type DirectoryAsModuleOpts struct {
-	// An optional subpath of the directory which contains the module's source code.
+	// An optional subpath of the directory which contains the module's configuration file.
 	//
 	// This is needed when the module code is in a subdirectory but requires parent directories to be loaded in order to execute. For example, the module source code may need a go.mod, project.toml, package.json, etc. file from a parent directory.
 	//
 	// If not set, the module source code is loaded from the root of the directory.
-	SourceSubpath string
+	SourceRootPath string
 }
 
 // Load the directory as a Dagger module
 func (r *Directory) AsModule(opts ...DirectoryAsModuleOpts) *Module {
 	q := r.q.Select("asModule")
 	for i := len(opts) - 1; i >= 0; i-- {
-		// `sourceSubpath` optional argument
-		if !querybuilder.IsZeroValue(opts[i].SourceSubpath) {
-			q = q.Arg("sourceSubpath", opts[i].SourceSubpath)
+		// `sourceRootPath` optional argument
+		if !querybuilder.IsZeroValue(opts[i].SourceRootPath) {
+			q = q.Arg("sourceRootPath", opts[i].SourceRootPath)
 		}
 	}
 

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -4139,7 +4139,7 @@ func (r *Module) Description(ctx context.Context) (string, error) {
 	return response, q.Execute(ctx, r.c)
 }
 
-// TODO
+// The generated files and directories made on top of the module source's context directory.
 func (r *Module) GeneratedContextDiff() *Directory {
 	q := r.q.Select("generatedContextDiff")
 
@@ -4547,7 +4547,7 @@ func (r *ModuleSource) ContextDirectory() *Directory {
 	}
 }
 
-// TODO
+// The dependencies of the module source. Includes dependencies from the configuration and any extras from withDependencies calls.
 func (r *ModuleSource) Dependencies(ctx context.Context) ([]ModuleDependency, error) {
 	q := r.q.Select("dependencies")
 
@@ -4645,7 +4645,7 @@ func (r *ModuleSource) Kind(ctx context.Context) (ModuleSourceKind, error) {
 	return response, q.Execute(ctx, r.c)
 }
 
-// If set, the name of the module this source references
+// If set, the name of the module this source references, including any overrides at runtime by callers.
 func (r *ModuleSource) ModuleName(ctx context.Context) (string, error) {
 	if r.moduleName != nil {
 		return *r.moduleName, nil
@@ -4658,7 +4658,7 @@ func (r *ModuleSource) ModuleName(ctx context.Context) (string, error) {
 	return response, q.Execute(ctx, r.c)
 }
 
-// TODO
+// The original name of the module this source references, as defined in the module configuration.
 func (r *ModuleSource) ModuleOriginalName(ctx context.Context) (string, error) {
 	if r.moduleOriginalName != nil {
 		return *r.moduleOriginalName, nil
@@ -4671,7 +4671,7 @@ func (r *ModuleSource) ModuleOriginalName(ctx context.Context) (string, error) {
 	return response, q.Execute(ctx, r.c)
 }
 
-// TODO
+// The path to the module source's context directory on the caller's filesystem. Only valid for local sources.
 func (r *ModuleSource) ResolveContextPathFromCaller(ctx context.Context) (string, error) {
 	if r.resolveContextPathFromCaller != nil {
 		return *r.resolveContextPathFromCaller, nil
@@ -4696,7 +4696,7 @@ func (r *ModuleSource) ResolveDependency(dep *ModuleSource) *ModuleSource {
 	}
 }
 
-// Load the source from its path on the caller's filesystem. Only valid for local sources.
+// Load the source from its path on the caller's filesystem, including only needed+configured files and directories. Only valid for local sources.
 func (r *ModuleSource) ResolveFromCaller() *ModuleSource {
 	q := r.q.Select("resolveFromCaller")
 
@@ -4706,7 +4706,7 @@ func (r *ModuleSource) ResolveFromCaller() *ModuleSource {
 	}
 }
 
-// TODO
+// The path relative to context of the root of the module source, which contains dagger.json. It also contains the module implementation source code, but that may or may not being a subdir of this root.
 func (r *ModuleSource) SourceRootSubpath(ctx context.Context) (string, error) {
 	if r.sourceRootSubpath != nil {
 		return *r.sourceRootSubpath, nil
@@ -4719,7 +4719,7 @@ func (r *ModuleSource) SourceRootSubpath(ctx context.Context) (string, error) {
 	return response, q.Execute(ctx, r.c)
 }
 
-// TODO
+// The path relative to context of the module implementation source code.
 func (r *ModuleSource) SourceSubpath(ctx context.Context) (string, error) {
 	if r.sourceSubpath != nil {
 		return *r.sourceSubpath, nil
@@ -4732,7 +4732,7 @@ func (r *ModuleSource) SourceSubpath(ctx context.Context) (string, error) {
 	return response, q.Execute(ctx, r.c)
 }
 
-// TODO
+// Update the module source with a new context directory. Only valid for local sources.
 func (r *ModuleSource) WithContextDirectory(dir *Directory) *ModuleSource {
 	assertNotNil("dir", dir)
 	q := r.q.Select("withContextDirectory")
@@ -4744,7 +4744,7 @@ func (r *ModuleSource) WithContextDirectory(dir *Directory) *ModuleSource {
 	}
 }
 
-// TODO
+// Append the provided dependencies to the module source's dependency list.
 func (r *ModuleSource) WithDependencies(dependencies []*ModuleDependency) *ModuleSource {
 	q := r.q.Select("withDependencies")
 	q = q.Arg("dependencies", dependencies)
@@ -4755,7 +4755,7 @@ func (r *ModuleSource) WithDependencies(dependencies []*ModuleDependency) *Modul
 	}
 }
 
-// TODO
+// Update the module source with a new name.
 func (r *ModuleSource) WithName(name string) *ModuleSource {
 	q := r.q.Select("withName")
 	q = q.Arg("name", name)
@@ -4766,7 +4766,7 @@ func (r *ModuleSource) WithName(name string) *ModuleSource {
 	}
 }
 
-// TODO
+// Update the module source with a new SDK.
 func (r *ModuleSource) WithSDK(sdk string) *ModuleSource {
 	q := r.q.Select("withSDK")
 	q = q.Arg("sdk", sdk)
@@ -4777,7 +4777,7 @@ func (r *ModuleSource) WithSDK(sdk string) *ModuleSource {
 	}
 }
 
-// TODO
+// Update the module source with a new source subpath.
 func (r *ModuleSource) WithSourceSubpath(path string) *ModuleSource {
 	q := r.q.Select("withSourceSubpath")
 	q = q.Arg("path", path)

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -3961,8 +3961,23 @@ type LocalModuleSource struct {
 	q *querybuilder.Selection
 	c graphql.Client
 
+	configExists  *bool
 	id            *LocalModuleSourceID
+	localRootPath *string
 	sourceSubpath *string
+}
+
+// TODO
+func (r *LocalModuleSource) ConfigExists(ctx context.Context) (bool, error) {
+	if r.configExists != nil {
+		return *r.configExists, nil
+	}
+	q := r.q.Select("configExists")
+
+	var response bool
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx, r.c)
 }
 
 // A unique identifier for this LocalModuleSource.
@@ -4003,6 +4018,40 @@ func (r *LocalModuleSource) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	return json.Marshal(id)
+}
+
+// TODO
+func (r *LocalModuleSource) LocalRootPath(ctx context.Context) (string, error) {
+	if r.localRootPath != nil {
+		return *r.localRootPath, nil
+	}
+	q := r.q.Select("localRootPath")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx, r.c)
+}
+
+// LocalModuleSourceResolveFromCallerOpts contains options for LocalModuleSource.ResolveFromCaller
+type LocalModuleSourceResolveFromCallerOpts struct {
+	DefaultRootPath string
+}
+
+// TODO
+func (r *LocalModuleSource) ResolveFromCaller(opts ...LocalModuleSourceResolveFromCallerOpts) *ModuleSource {
+	q := r.q.Select("resolveFromCaller")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `defaultRootPath` optional argument
+		if !querybuilder.IsZeroValue(opts[i].DefaultRootPath) {
+			q = q.Arg("defaultRootPath", opts[i].DefaultRootPath)
+		}
+	}
+
+	return &ModuleSource{
+		q: q,
+		c: r.c,
+	}
 }
 
 // The path to the module source code dir specified by this source.

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -4149,6 +4149,16 @@ func (r *Module) GeneratedContextDiff() *Directory {
 	}
 }
 
+// The module source's context plus any configuration and source files created by codegen.
+func (r *Module) GeneratedContextDirectory() *Directory {
+	q := r.q.Select("generatedContextDirectory")
+
+	return &Directory{
+		q: q,
+		c: r.c,
+	}
+}
+
 // A unique identifier for this Module.
 func (r *Module) ID(ctx context.Context) (ModuleID, error) {
 	if r.id != nil {

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -4705,6 +4705,17 @@ func (r *ModuleSource) WithSDK(sdk string) *ModuleSource {
 	}
 }
 
+// TODO
+func (r *ModuleSource) WithSourceSubdir(path string) *ModuleSource {
+	q := r.q.Select("withSourceSubdir")
+	q = q.Arg("path", path)
+
+	return &ModuleSource{
+		q: q,
+		c: r.c,
+	}
+}
+
 // A definition of a custom object defined in a Module.
 type ObjectTypeDef struct {
 	q *querybuilder.Selection

--- a/sdk/php/generated/Client.php
+++ b/sdk/php/generated/Client.php
@@ -528,17 +528,10 @@ class Client extends Client\AbstractClient
     /**
      * Create a new module source instance from a source ref string.
      */
-    public function moduleSource(
-        string $refString,
-        DirectoryId|Directory|null $rootDirectory = null,
-        ?bool $stable = false,
-    ): ModuleSource
+    public function moduleSource(string $refString, ?bool $stable = false): ModuleSource
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('moduleSource');
         $innerQueryBuilder->setArgument('refString', $refString);
-        if (null !== $rootDirectory) {
-        $innerQueryBuilder->setArgument('rootDirectory', $rootDirectory);
-        }
         if (null !== $stable) {
         $innerQueryBuilder->setArgument('stable', $stable);
         }

--- a/sdk/php/generated/Directory.php
+++ b/sdk/php/generated/Directory.php
@@ -16,11 +16,11 @@ class Directory extends Client\AbstractObject implements Client\IdAble
     /**
      * Load the directory as a Dagger module
      */
-    public function asModule(?string $sourceSubpath = '.'): Module
+    public function asModule(?string $sourceRootPath = '.'): Module
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('asModule');
-        if (null !== $sourceSubpath) {
-        $innerQueryBuilder->setArgument('sourceSubpath', $sourceSubpath);
+        if (null !== $sourceRootPath) {
+        $innerQueryBuilder->setArgument('sourceRootPath', $sourceRootPath);
         }
         return new \Dagger\Module($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }

--- a/sdk/php/generated/Directory.php
+++ b/sdk/php/generated/Directory.php
@@ -16,7 +16,7 @@ class Directory extends Client\AbstractObject implements Client\IdAble
     /**
      * Load the directory as a Dagger module
      */
-    public function asModule(?string $sourceSubpath = '/'): Module
+    public function asModule(?string $sourceSubpath = '.'): Module
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('asModule');
         if (null !== $sourceSubpath) {

--- a/sdk/php/generated/GitModuleSource.php
+++ b/sdk/php/generated/GitModuleSource.php
@@ -32,6 +32,15 @@ class GitModuleSource extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * The directory containing everything needed to load load and use the module.
+     */
+    public function contextDirectory(): Directory
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('contextDirectory');
+        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
      * The URL to the source's git repo in a web browser
      */
     public function htmlURL(): string
@@ -50,12 +59,12 @@ class GitModuleSource extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
-     * The path to the module source code dir specified by this source relative to the source's root directory.
+     * The path to the root of the module source under the context directory. This directory contains its configuration file. It also contains its source code (possibly as a subdirectory).
      */
-    public function sourceSubpath(): string
+    public function rootSubpath(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('sourceSubpath');
-        return (string)$this->queryLeaf($leafQueryBuilder, 'sourceSubpath');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('rootSubpath');
+        return (string)$this->queryLeaf($leafQueryBuilder, 'rootSubpath');
     }
 
     /**

--- a/sdk/php/generated/LocalModuleSource.php
+++ b/sdk/php/generated/LocalModuleSource.php
@@ -14,6 +14,15 @@ namespace Dagger;
 class LocalModuleSource extends Client\AbstractObject implements Client\IdAble
 {
     /**
+     * The directory containing everything needed to load load and use the module.
+     */
+    public function contextDirectory(): Directory
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('contextDirectory');
+        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
      * A unique identifier for this LocalModuleSource.
      */
     public function id(): LocalModuleSourceId
@@ -23,11 +32,11 @@ class LocalModuleSource extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
-     * The path to the module source code dir specified by this source.
+     * The path to the root of the module source under the context directory. This directory contains its configuration file. It also contains its source code (possibly as a subdirectory).
      */
-    public function sourceSubpath(): string
+    public function rootSubpath(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('sourceSubpath');
-        return (string)$this->queryLeaf($leafQueryBuilder, 'sourceSubpath');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('rootSubpath');
+        return (string)$this->queryLeaf($leafQueryBuilder, 'rootSubpath');
     }
 }

--- a/sdk/php/generated/Module.php
+++ b/sdk/php/generated/Module.php
@@ -41,11 +41,20 @@ class Module extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
-     * The module's root directory containing the config file for it and its source (possibly as a subdir). It includes any generated code or updated config files created after initial load, but not any files/directories that were unchanged after sdk codegen was run.
+     * The generated files and directories made on top of the module source's context directory.
      */
-    public function generatedSourceRootDirectory(): Directory
+    public function generatedContextDiff(): Directory
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('generatedSourceRootDirectory');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('generatedContextDiff');
+        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
+     * The module source's context plus any configuration and source files created by codegen.
+     */
+    public function generatedContextDirectory(): Directory
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('generatedContextDirectory');
         return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
@@ -133,16 +142,6 @@ class Module extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
-     * Update the module configuration to use the given dependencies.
-     */
-    public function withDependencies(array $dependencies): Module
-    {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withDependencies');
-        $innerQueryBuilder->setArgument('dependencies', $dependencies);
-        return new \Dagger\Module($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
-    }
-
-    /**
      * Retrieves the module with the given description
      */
     public function withDescription(string $description): Module
@@ -163,32 +162,12 @@ class Module extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
-     * Update the module configuration to use the given name.
-     */
-    public function withName(string $name): Module
-    {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withName');
-        $innerQueryBuilder->setArgument('name', $name);
-        return new \Dagger\Module($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
-    }
-
-    /**
      * This module plus the given Object type and associated functions.
      */
     public function withObject(TypeDefId|TypeDef $object): Module
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withObject');
         $innerQueryBuilder->setArgument('object', $object);
-        return new \Dagger\Module($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
-    }
-
-    /**
-     * Update the module configuration to use the given SDK.
-     */
-    public function withSDK(string $sdk): Module
-    {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withSDK');
-        $innerQueryBuilder->setArgument('sdk', $sdk);
         return new \Dagger\Module($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 

--- a/sdk/php/generated/ModuleSource.php
+++ b/sdk/php/generated/ModuleSource.php
@@ -50,7 +50,34 @@ class ModuleSource extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
-     * The directory containing the actual module's source code, as determined from the root directory and subpath.
+     * Returns whether the module source has a configuration file.
+     */
+    public function configExists(): bool
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('configExists');
+        return (bool)$this->queryLeaf($leafQueryBuilder, 'configExists');
+    }
+
+    /**
+     * The directory containing everything needed to load load and use the module.
+     */
+    public function contextDirectory(): Directory
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('contextDirectory');
+        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
+     * The dependencies of the module source. Includes dependencies from the configuration and any extras from withDependencies calls.
+     */
+    public function dependencies(): array
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('dependencies');
+        return (array)$this->queryLeaf($leafQueryBuilder, 'dependencies');
+    }
+
+    /**
+     * The directory containing the module configuration and source code (source code may be in a subdir).
      */
     public function directory(string $path): Directory
     {
@@ -78,12 +105,30 @@ class ModuleSource extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
-     * If set, the name of the module this source references
+     * If set, the name of the module this source references, including any overrides at runtime by callers.
      */
     public function moduleName(): string
     {
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('moduleName');
         return (string)$this->queryLeaf($leafQueryBuilder, 'moduleName');
+    }
+
+    /**
+     * The original name of the module this source references, as defined in the module configuration.
+     */
+    public function moduleOriginalName(): string
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('moduleOriginalName');
+        return (string)$this->queryLeaf($leafQueryBuilder, 'moduleOriginalName');
+    }
+
+    /**
+     * The path to the module source's context directory on the caller's filesystem. Only valid for local sources.
+     */
+    public function resolveContextPathFromCaller(): string
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('resolveContextPathFromCaller');
+        return (string)$this->queryLeaf($leafQueryBuilder, 'resolveContextPathFromCaller');
     }
 
     /**
@@ -97,20 +142,79 @@ class ModuleSource extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
-     * The root directory of the module source that contains its configuration and source code (which may be in a subdirectory of this root).
+     * Load the source from its path on the caller's filesystem, including only needed+configured files and directories. Only valid for local sources.
      */
-    public function rootDirectory(): Directory
+    public function resolveFromCaller(): ModuleSource
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('rootDirectory');
-        return new \Dagger\Directory($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('resolveFromCaller');
+        return new \Dagger\ModuleSource($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**
-     * The path to the module subdirectory containing the actual module's source code.
+     * The path relative to context of the root of the module source, which contains dagger.json. It also contains the module implementation source code, but that may or may not being a subdir of this root.
      */
-    public function subpath(): string
+    public function sourceRootSubpath(): string
     {
-        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('subpath');
-        return (string)$this->queryLeaf($leafQueryBuilder, 'subpath');
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('sourceRootSubpath');
+        return (string)$this->queryLeaf($leafQueryBuilder, 'sourceRootSubpath');
+    }
+
+    /**
+     * The path relative to context of the module implementation source code.
+     */
+    public function sourceSubpath(): string
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('sourceSubpath');
+        return (string)$this->queryLeaf($leafQueryBuilder, 'sourceSubpath');
+    }
+
+    /**
+     * Update the module source with a new context directory. Only valid for local sources.
+     */
+    public function withContextDirectory(DirectoryId|Directory $dir): ModuleSource
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withContextDirectory');
+        $innerQueryBuilder->setArgument('dir', $dir);
+        return new \Dagger\ModuleSource($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
+     * Append the provided dependencies to the module source's dependency list.
+     */
+    public function withDependencies(array $dependencies): ModuleSource
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withDependencies');
+        $innerQueryBuilder->setArgument('dependencies', $dependencies);
+        return new \Dagger\ModuleSource($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
+     * Update the module source with a new name.
+     */
+    public function withName(string $name): ModuleSource
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withName');
+        $innerQueryBuilder->setArgument('name', $name);
+        return new \Dagger\ModuleSource($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
+     * Update the module source with a new SDK.
+     */
+    public function withSDK(string $sdk): ModuleSource
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withSDK');
+        $innerQueryBuilder->setArgument('sdk', $sdk);
+        return new \Dagger\ModuleSource($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
+     * Update the module source with a new source subpath.
+     */
+    public function withSourceSubpath(string $path): ModuleSource
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withSourceSubpath');
+        $innerQueryBuilder->setArgument('path', $path);
+        return new \Dagger\ModuleSource($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 }

--- a/sdk/python/runtime/dagger.json
+++ b/sdk/python/runtime/dagger.json
@@ -1,9 +1,4 @@
 {
   "name": "python-sdk",
-  "sdk": "go",
-  "root-for": [
-    {
-      "source": "."
-    }
-  ]
+  "sdk": "go"
 }

--- a/sdk/python/runtime/main.go
+++ b/sdk/python/runtime/main.go
@@ -14,7 +14,7 @@ func New(
 	return &PythonSdk{
 		SDKSourceDir: sdkSourceDir,
 		RequiredPaths: []string{
-			"src/main.py",
+			"**/pyproject.toml",
 		},
 	}
 }
@@ -80,7 +80,7 @@ func (m *PythonSdk) Codegen(ctx context.Context, modSource *ModuleSource, intros
 }
 
 func (m *PythonSdk) CodegenBase(ctx context.Context, modSource *ModuleSource, introspectionJson string) (*Container, error) {
-	subPath, err := modSource.Subpath(ctx)
+	subPath, err := modSource.SourceSubpath(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not load module config: %v", err)
 	}
@@ -89,7 +89,7 @@ func (m *PythonSdk) CodegenBase(ctx context.Context, modSource *ModuleSource, in
 		WithMountedDirectory(sdkSrc, m.SDKSourceDir.WithoutDirectory("runtime")).
 		WithMountedDirectory("/opt", dag.CurrentModule().Source().Directory("./template")).
 		WithExec([]string{"python", "-m", "pip", "install", "-e", sdkSrc}).
-		WithMountedDirectory(ModSourceDirPath, modSource.RootDirectory()).
+		WithMountedDirectory(ModSourceDirPath, modSource.BaseContextDirectory()).
 		WithWorkdir(path.Join(ModSourceDirPath, subPath)).
 		WithNewFile(schemaPath, ContainerWithNewFileOpts{
 			Contents: introspectionJson,

--- a/sdk/python/runtime/main.go
+++ b/sdk/python/runtime/main.go
@@ -13,11 +13,15 @@ func New(
 ) *PythonSdk {
 	return &PythonSdk{
 		SDKSourceDir: sdkSourceDir,
+		RequiredPaths: []string{
+			"src/main.py",
+		},
 	}
 }
 
 type PythonSdk struct {
-	SDKSourceDir *Directory
+	SDKSourceDir  *Directory
+	RequiredPaths []string
 }
 
 const (

--- a/sdk/python/runtime/main.go
+++ b/sdk/python/runtime/main.go
@@ -89,7 +89,7 @@ func (m *PythonSdk) CodegenBase(ctx context.Context, modSource *ModuleSource, in
 		WithMountedDirectory(sdkSrc, m.SDKSourceDir.WithoutDirectory("runtime")).
 		WithMountedDirectory("/opt", dag.CurrentModule().Source().Directory("./template")).
 		WithExec([]string{"python", "-m", "pip", "install", "-e", sdkSrc}).
-		WithMountedDirectory(ModSourceDirPath, modSource.BaseContextDirectory()).
+		WithMountedDirectory(ModSourceDirPath, modSource.ContextDirectory()).
 		WithWorkdir(path.Join(ModSourceDirPath, subPath)).
 		WithNewFile(schemaPath, ContainerWithNewFileOpts{
 			Contents: introspectionJson,

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -1969,7 +1969,7 @@ class Directory(Type):
     def as_module(
         self,
         *,
-        source_subpath: str | None = "/",
+        source_subpath: str | None = ".",
     ) -> "Module":
         """Load the directory as a Dagger module
 
@@ -1986,7 +1986,7 @@ class Directory(Type):
             directory.
         """
         _args = [
-            Arg("sourceSubpath", source_subpath, "/"),
+            Arg("sourceSubpath", source_subpath, "."),
         ]
         _ctx = self._select("asModule", _args)
         return Module(_ctx)
@@ -3406,6 +3406,15 @@ class GitModuleSource(Type):
         return await _ctx.execute(str)
 
     @typecheck
+    def context_directory(self) -> Directory:
+        """The directory containing everything needed to load load and use the
+        module.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("contextDirectory", _args)
+        return Directory(_ctx)
+
+    @typecheck
     async def html_url(self) -> str:
         """The URL to the source's git repo in a web browser
 
@@ -3453,9 +3462,10 @@ class GitModuleSource(Type):
         return await _ctx.execute(GitModuleSourceID)
 
     @typecheck
-    async def source_subpath(self) -> str:
-        """The path to the module source code dir specified by this source
-        relative to the source's root directory.
+    async def root_subpath(self) -> str:
+        """The path to the root of the module source under the context directory.
+        This directory contains its configuration file. It also contains its
+        source code (possibly as a subdirectory).
 
         Returns
         -------
@@ -3472,7 +3482,7 @@ class GitModuleSource(Type):
             If the API returns an error.
         """
         _args: list[Arg] = []
-        _ctx = self._select("sourceSubpath", _args)
+        _ctx = self._select("rootSubpath", _args)
         return await _ctx.execute(str)
 
     @typecheck
@@ -4135,6 +4145,15 @@ class LocalModuleSource(Type):
     an arbitrary directory."""
 
     @typecheck
+    def context_directory(self) -> Directory:
+        """The directory containing everything needed to load load and use the
+        module.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("contextDirectory", _args)
+        return Directory(_ctx)
+
+    @typecheck
     async def id(self) -> LocalModuleSourceID:
         """A unique identifier for this LocalModuleSource.
 
@@ -4160,8 +4179,10 @@ class LocalModuleSource(Type):
         return await _ctx.execute(LocalModuleSourceID)
 
     @typecheck
-    async def source_subpath(self) -> str:
-        """The path to the module source code dir specified by this source.
+    async def root_subpath(self) -> str:
+        """The path to the root of the module source under the context directory.
+        This directory contains its configuration file. It also contains its
+        source code (possibly as a subdirectory).
 
         Returns
         -------
@@ -4178,7 +4199,7 @@ class LocalModuleSource(Type):
             If the API returns an error.
         """
         _args: list[Arg] = []
-        _ctx = self._select("sourceSubpath", _args)
+        _ctx = self._select("rootSubpath", _args)
         return await _ctx.execute(str)
 
 
@@ -4245,14 +4266,21 @@ class Module(Type):
         return await _ctx.execute(str)
 
     @typecheck
-    def generated_source_root_directory(self) -> Directory:
-        """The module's root directory containing the config file for it and its
-        source (possibly as a subdir). It includes any generated code or
-        updated config files created after initial load, but not any
-        files/directories that were unchanged after sdk codegen was run.
+    def generated_context_diff(self) -> Directory:
+        """The generated files and directories made on top of the module source's
+        context directory.
         """
         _args: list[Arg] = []
-        _ctx = self._select("generatedSourceRootDirectory", _args)
+        _ctx = self._select("generatedContextDiff", _args)
+        return Directory(_ctx)
+
+    @typecheck
+    def generated_context_directory(self) -> Directory:
+        """The module source's context plus any configuration and source files
+        created by codegen.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("generatedContextDirectory", _args)
         return Directory(_ctx)
 
     @typecheck
@@ -4401,24 +4429,6 @@ class Module(Type):
         return ModuleSource(_ctx)
 
     @typecheck
-    def with_dependencies(
-        self,
-        dependencies: Sequence["ModuleDependency"],
-    ) -> "Module":
-        """Update the module configuration to use the given dependencies.
-
-        Parameters
-        ----------
-        dependencies:
-            The dependency modules to install.
-        """
-        _args = [
-            Arg("dependencies", dependencies),
-        ]
-        _ctx = self._select("withDependencies", _args)
-        return Module(_ctx)
-
-    @typecheck
     def with_description(self, description: str) -> "Module":
         """Retrieves the module with the given description
 
@@ -4443,42 +4453,12 @@ class Module(Type):
         return Module(_ctx)
 
     @typecheck
-    def with_name(self, name: str) -> "Module":
-        """Update the module configuration to use the given name.
-
-        Parameters
-        ----------
-        name:
-            The name to use.
-        """
-        _args = [
-            Arg("name", name),
-        ]
-        _ctx = self._select("withName", _args)
-        return Module(_ctx)
-
-    @typecheck
     def with_object(self, object: "TypeDef") -> "Module":
         """This module plus the given Object type and associated functions."""
         _args = [
             Arg("object", object),
         ]
         _ctx = self._select("withObject", _args)
-        return Module(_ctx)
-
-    @typecheck
-    def with_sdk(self, sdk: str) -> "Module":
-        """Update the module configuration to use the given SDK.
-
-        Parameters
-        ----------
-        sdk:
-            The SDK to use.
-        """
-        _args = [
-            Arg("sdk", sdk),
-        ]
-        _ctx = self._select("withSDK", _args)
         return Module(_ctx)
 
     @typecheck
@@ -4618,9 +4598,50 @@ class ModuleSource(Type):
         return await _ctx.execute(str)
 
     @typecheck
+    async def config_exists(self) -> bool:
+        """Returns whether the module source has a configuration file.
+
+        Returns
+        -------
+        bool
+            The `Boolean` scalar type represents `true` or `false`.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("configExists", _args)
+        return await _ctx.execute(bool)
+
+    @typecheck
+    def context_directory(self) -> Directory:
+        """The directory containing everything needed to load load and use the
+        module.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("contextDirectory", _args)
+        return Directory(_ctx)
+
+    @typecheck
+    async def dependencies(self) -> list[ModuleDependency]:
+        """The dependencies of the module source. Includes dependencies from the
+        configuration and any extras from withDependencies calls.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("dependencies", _args)
+        _ctx = ModuleDependency(_ctx)._select_multiple(
+            _name="name",
+        )
+        return await _ctx.execute(list[ModuleDependency])
+
+    @typecheck
     def directory(self, path: str) -> Directory:
-        """The directory containing the actual module's source code, as
-        determined from the root directory and subpath.
+        """The directory containing the module configuration and source code
+        (source code may be in a subdir).
 
         Parameters
         ----------
@@ -4680,7 +4701,8 @@ class ModuleSource(Type):
 
     @typecheck
     async def module_name(self) -> str:
-        """If set, the name of the module this source references
+        """If set, the name of the module this source references, including any
+        overrides at runtime by callers.
 
         Returns
         -------
@@ -4701,35 +4723,9 @@ class ModuleSource(Type):
         return await _ctx.execute(str)
 
     @typecheck
-    def resolve_dependency(self, dep: "ModuleSource") -> "ModuleSource":
-        """Resolve the provided module source arg as a dependency relative to
-        this module source.
-
-        Parameters
-        ----------
-        dep:
-            The dependency module source to resolve.
-        """
-        _args = [
-            Arg("dep", dep),
-        ]
-        _ctx = self._select("resolveDependency", _args)
-        return ModuleSource(_ctx)
-
-    @typecheck
-    def root_directory(self) -> Directory:
-        """The root directory of the module source that contains its
-        configuration and source code (which may be in a subdirectory of this
-        root).
-        """
-        _args: list[Arg] = []
-        _ctx = self._select("rootDirectory", _args)
-        return Directory(_ctx)
-
-    @typecheck
-    async def subpath(self) -> str:
-        """The path to the module subdirectory containing the actual module's
-        source code.
+    async def module_original_name(self) -> str:
+        """The original name of the module this source references, as defined in
+        the module configuration.
 
         Returns
         -------
@@ -4746,8 +4742,183 @@ class ModuleSource(Type):
             If the API returns an error.
         """
         _args: list[Arg] = []
-        _ctx = self._select("subpath", _args)
+        _ctx = self._select("moduleOriginalName", _args)
         return await _ctx.execute(str)
+
+    @typecheck
+    async def resolve_context_path_from_caller(self) -> str:
+        """The path to the module source's context directory on the caller's
+        filesystem. Only valid for local sources.
+
+        Returns
+        -------
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("resolveContextPathFromCaller", _args)
+        return await _ctx.execute(str)
+
+    @typecheck
+    def resolve_dependency(self, dep: "ModuleSource") -> "ModuleSource":
+        """Resolve the provided module source arg as a dependency relative to
+        this module source.
+
+        Parameters
+        ----------
+        dep:
+            The dependency module source to resolve.
+        """
+        _args = [
+            Arg("dep", dep),
+        ]
+        _ctx = self._select("resolveDependency", _args)
+        return ModuleSource(_ctx)
+
+    @typecheck
+    def resolve_from_caller(self) -> "ModuleSource":
+        """Load the source from its path on the caller's filesystem, including
+        only needed+configured files and directories. Only valid for local
+        sources.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("resolveFromCaller", _args)
+        return ModuleSource(_ctx)
+
+    @typecheck
+    async def source_root_subpath(self) -> str:
+        """The path relative to context of the root of the module source, which
+        contains dagger.json. It also contains the module implementation
+        source code, but that may or may not being a subdir of this root.
+
+        Returns
+        -------
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("sourceRootSubpath", _args)
+        return await _ctx.execute(str)
+
+    @typecheck
+    async def source_subpath(self) -> str:
+        """The path relative to context of the module implementation source code.
+
+        Returns
+        -------
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("sourceSubpath", _args)
+        return await _ctx.execute(str)
+
+    @typecheck
+    def with_context_directory(self, dir: Directory) -> "ModuleSource":
+        """Update the module source with a new context directory. Only valid for
+        local sources.
+
+        Parameters
+        ----------
+        dir:
+            The directory to set as the context directory.
+        """
+        _args = [
+            Arg("dir", dir),
+        ]
+        _ctx = self._select("withContextDirectory", _args)
+        return ModuleSource(_ctx)
+
+    @typecheck
+    def with_dependencies(
+        self,
+        dependencies: Sequence[ModuleDependency],
+    ) -> "ModuleSource":
+        """Append the provided dependencies to the module source's dependency
+        list.
+
+        Parameters
+        ----------
+        dependencies:
+            The dependencies to append.
+        """
+        _args = [
+            Arg("dependencies", dependencies),
+        ]
+        _ctx = self._select("withDependencies", _args)
+        return ModuleSource(_ctx)
+
+    @typecheck
+    def with_name(self, name: str) -> "ModuleSource":
+        """Update the module source with a new name.
+
+        Parameters
+        ----------
+        name:
+            The name to set.
+        """
+        _args = [
+            Arg("name", name),
+        ]
+        _ctx = self._select("withName", _args)
+        return ModuleSource(_ctx)
+
+    @typecheck
+    def with_sdk(self, sdk: str) -> "ModuleSource":
+        """Update the module source with a new SDK.
+
+        Parameters
+        ----------
+        sdk:
+            The SDK to set.
+        """
+        _args = [
+            Arg("sdk", sdk),
+        ]
+        _ctx = self._select("withSDK", _args)
+        return ModuleSource(_ctx)
+
+    @typecheck
+    def with_source_subpath(self, path: str) -> "ModuleSource":
+        """Update the module source with a new source subpath.
+
+        Parameters
+        ----------
+        path:
+            The path to set as the source subpath.
+        """
+        _args = [
+            Arg("path", path),
+        ]
+        _ctx = self._select("withSourceSubpath", _args)
+        return ModuleSource(_ctx)
 
     def with_(self, cb: Callable[["ModuleSource"], "ModuleSource"]) -> "ModuleSource":
         """Call the provided callable with current ModuleSource.
@@ -5627,7 +5798,6 @@ class Client(Root):
         self,
         ref_string: str,
         *,
-        root_directory: Directory | None = None,
         stable: bool | None = False,
     ) -> ModuleSource:
         """Create a new module source instance from a source ref string.
@@ -5636,17 +5806,12 @@ class Client(Root):
         ----------
         ref_string:
             The string ref representation of the module source
-        root_directory:
-            An explicitly set root directory for the module source. This is
-            required to load local sources as modules; other source types
-            implicitly encode the root directory and do not require this.
         stable:
             If true, enforce that the source is a stable version for source
             kinds that support versioning.
         """
         _args = [
             Arg("refString", ref_string),
-            Arg("rootDirectory", root_directory, None),
             Arg("stable", stable, False),
         ]
         _ctx = self._select("moduleSource", _args)

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -1969,15 +1969,15 @@ class Directory(Type):
     def as_module(
         self,
         *,
-        source_subpath: str | None = ".",
+        source_root_path: str | None = ".",
     ) -> "Module":
         """Load the directory as a Dagger module
 
         Parameters
         ----------
-        source_subpath:
+        source_root_path:
             An optional subpath of the directory which contains the module's
-            source code.
+            configuration file.
             This is needed when the module code is in a subdirectory but
             requires parent directories to be loaded in order to execute. For
             example, the module source code may need a go.mod, project.toml,
@@ -1986,7 +1986,7 @@ class Directory(Type):
             directory.
         """
         _args = [
-            Arg("sourceSubpath", source_subpath, "."),
+            Arg("sourceRootPath", source_root_path, "."),
         ]
         _ctx = self._select("asModule", _args)
         return Module(_ctx)

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -2461,11 +2461,11 @@ pub struct Directory {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryAsModuleOpts<'a> {
-    /// An optional subpath of the directory which contains the module's source code.
+    /// An optional subpath of the directory which contains the module's configuration file.
     /// This is needed when the module code is in a subdirectory but requires parent directories to be loaded in order to execute. For example, the module source code may need a go.mod, project.toml, package.json, etc. file from a parent directory.
     /// If not set, the module source code is loaded from the root of the directory.
     #[builder(setter(into, strip_option), default)]
-    pub source_subpath: Option<&'a str>,
+    pub source_root_path: Option<&'a str>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryDockerBuildOpts<'a> {
@@ -2549,8 +2549,8 @@ impl Directory {
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn as_module_opts<'a>(&self, opts: DirectoryAsModuleOpts<'a>) -> Module {
         let mut query = self.selection.select("asModule");
-        if let Some(source_subpath) = opts.source_subpath {
-            query = query.arg("sourceSubpath", source_subpath);
+        if let Some(source_root_path) = opts.source_root_path {
+            query = query.arg("sourceRootPath", source_root_path);
         }
         return Module {
             proc: self.proc.clone(),

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -853,11 +853,6 @@ export type ClientModuleDependencyOpts = {
 
 export type ClientModuleSourceOpts = {
   /**
-   * An explicitly set root directory for the module source. This is required to load local sources as modules; other source types implicitly encode the root directory and do not require this.
-   */
-  rootDirectory?: Directory
-
-  /**
    * If true, enforce that the source is a stable version for source kinds that support versioning.
    */
   stable?: boolean
@@ -4167,7 +4162,7 @@ export class GitModuleSource extends BaseClient {
   private readonly _cloneURL?: string = undefined
   private readonly _commit?: string = undefined
   private readonly _htmlURL?: string = undefined
-  private readonly _sourceSubpath?: string = undefined
+  private readonly _rootSubpath?: string = undefined
   private readonly _version?: string = undefined
 
   /**
@@ -4179,7 +4174,7 @@ export class GitModuleSource extends BaseClient {
     _cloneURL?: string,
     _commit?: string,
     _htmlURL?: string,
-    _sourceSubpath?: string,
+    _rootSubpath?: string,
     _version?: string
   ) {
     super(parent)
@@ -4188,7 +4183,7 @@ export class GitModuleSource extends BaseClient {
     this._cloneURL = _cloneURL
     this._commit = _commit
     this._htmlURL = _htmlURL
-    this._sourceSubpath = _sourceSubpath
+    this._rootSubpath = _rootSubpath
     this._version = _version
   }
 
@@ -4256,6 +4251,21 @@ export class GitModuleSource extends BaseClient {
   }
 
   /**
+   * The directory containing everything needed to load load and use the module.
+   */
+  contextDirectory = (): Directory => {
+    return new Directory({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "contextDirectory",
+        },
+      ],
+      ctx: this._ctx,
+    })
+  }
+
+  /**
    * The URL to the source's git repo in a web browser
    */
   htmlURL = async (): Promise<string> => {
@@ -4277,18 +4287,18 @@ export class GitModuleSource extends BaseClient {
   }
 
   /**
-   * The path to the module source code dir specified by this source relative to the source's root directory.
+   * The path to the root of the module source under the context directory. This directory contains its configuration file. It also contains its source code (possibly as a subdirectory).
    */
-  sourceSubpath = async (): Promise<string> => {
-    if (this._sourceSubpath) {
-      return this._sourceSubpath
+  rootSubpath = async (): Promise<string> => {
+    if (this._rootSubpath) {
+      return this._rootSubpath
     }
 
     const response: Awaited<string> = await computeQuery(
       [
         ...this._queryTree,
         {
-          operation: "sourceSubpath",
+          operation: "rootSubpath",
         },
       ],
       await this._ctx.connection()
@@ -5074,7 +5084,7 @@ export class ListTypeDef extends BaseClient {
  */
 export class LocalModuleSource extends BaseClient {
   private readonly _id?: LocalModuleSourceID = undefined
-  private readonly _sourceSubpath?: string = undefined
+  private readonly _rootSubpath?: string = undefined
 
   /**
    * Constructor is used for internal usage only, do not create object from it.
@@ -5082,12 +5092,12 @@ export class LocalModuleSource extends BaseClient {
   constructor(
     parent?: { queryTree?: QueryTree[]; ctx: Context },
     _id?: LocalModuleSourceID,
-    _sourceSubpath?: string
+    _rootSubpath?: string
   ) {
     super(parent)
 
     this._id = _id
-    this._sourceSubpath = _sourceSubpath
+    this._rootSubpath = _rootSubpath
   }
 
   /**
@@ -5112,18 +5122,33 @@ export class LocalModuleSource extends BaseClient {
   }
 
   /**
-   * The path to the module source code dir specified by this source.
+   * The directory containing everything needed to load load and use the module.
    */
-  sourceSubpath = async (): Promise<string> => {
-    if (this._sourceSubpath) {
-      return this._sourceSubpath
+  contextDirectory = (): Directory => {
+    return new Directory({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "contextDirectory",
+        },
+      ],
+      ctx: this._ctx,
+    })
+  }
+
+  /**
+   * The path to the root of the module source under the context directory. This directory contains its configuration file. It also contains its source code (possibly as a subdirectory).
+   */
+  rootSubpath = async (): Promise<string> => {
+    if (this._rootSubpath) {
+      return this._rootSubpath
     }
 
     const response: Awaited<string> = await computeQuery(
       [
         ...this._queryTree,
         {
-          operation: "sourceSubpath",
+          operation: "rootSubpath",
         },
       ],
       await this._ctx.connection()
@@ -5282,14 +5307,29 @@ export class Module_ extends BaseClient {
   }
 
   /**
-   * The module's root directory containing the config file for it and its source (possibly as a subdir). It includes any generated code or updated config files created after initial load, but not any files/directories that were unchanged after sdk codegen was run.
+   * The generated files and directories made on top of the module source's context directory.
    */
-  generatedSourceRootDirectory = (): Directory => {
+  generatedContextDiff = (): Directory => {
     return new Directory({
       queryTree: [
         ...this._queryTree,
         {
-          operation: "generatedSourceRootDirectory",
+          operation: "generatedContextDiff",
+        },
+      ],
+      ctx: this._ctx,
+    })
+  }
+
+  /**
+   * The module source's context plus any configuration and source files created by codegen.
+   */
+  generatedContextDirectory = (): Directory => {
+    return new Directory({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "generatedContextDirectory",
         },
       ],
       ctx: this._ctx,
@@ -5483,23 +5523,6 @@ export class Module_ extends BaseClient {
   }
 
   /**
-   * Update the module configuration to use the given dependencies.
-   * @param dependencies The dependency modules to install.
-   */
-  withDependencies = (dependencies: ModuleDependency[]): Module_ => {
-    return new Module_({
-      queryTree: [
-        ...this._queryTree,
-        {
-          operation: "withDependencies",
-          args: { dependencies },
-        },
-      ],
-      ctx: this._ctx,
-    })
-  }
-
-  /**
    * Retrieves the module with the given description
    * @param description The description to set
    */
@@ -5533,23 +5556,6 @@ export class Module_ extends BaseClient {
   }
 
   /**
-   * Update the module configuration to use the given name.
-   * @param name The name to use.
-   */
-  withName = (name: string): Module_ => {
-    return new Module_({
-      queryTree: [
-        ...this._queryTree,
-        {
-          operation: "withName",
-          args: { name },
-        },
-      ],
-      ctx: this._ctx,
-    })
-  }
-
-  /**
    * This module plus the given Object type and associated functions.
    */
   withObject = (object: TypeDef): Module_ => {
@@ -5559,23 +5565,6 @@ export class Module_ extends BaseClient {
         {
           operation: "withObject",
           args: { object },
-        },
-      ],
-      ctx: this._ctx,
-    })
-  }
-
-  /**
-   * Update the module configuration to use the given SDK.
-   * @param sdk The SDK to use.
-   */
-  withSDK = (sdk: string): Module_ => {
-    return new Module_({
-      queryTree: [
-        ...this._queryTree,
-        {
-          operation: "withSDK",
-          args: { sdk },
         },
       ],
       ctx: this._ctx,
@@ -5694,9 +5683,13 @@ export class ModuleDependency extends BaseClient {
 export class ModuleSource extends BaseClient {
   private readonly _id?: ModuleSourceID = undefined
   private readonly _asString?: string = undefined
+  private readonly _configExists?: boolean = undefined
   private readonly _kind?: ModuleSourceKind = undefined
   private readonly _moduleName?: string = undefined
-  private readonly _subpath?: string = undefined
+  private readonly _moduleOriginalName?: string = undefined
+  private readonly _resolveContextPathFromCaller?: string = undefined
+  private readonly _sourceRootSubpath?: string = undefined
+  private readonly _sourceSubpath?: string = undefined
 
   /**
    * Constructor is used for internal usage only, do not create object from it.
@@ -5705,17 +5698,25 @@ export class ModuleSource extends BaseClient {
     parent?: { queryTree?: QueryTree[]; ctx: Context },
     _id?: ModuleSourceID,
     _asString?: string,
+    _configExists?: boolean,
     _kind?: ModuleSourceKind,
     _moduleName?: string,
-    _subpath?: string
+    _moduleOriginalName?: string,
+    _resolveContextPathFromCaller?: string,
+    _sourceRootSubpath?: string,
+    _sourceSubpath?: string
   ) {
     super(parent)
 
     this._id = _id
     this._asString = _asString
+    this._configExists = _configExists
     this._kind = _kind
     this._moduleName = _moduleName
-    this._subpath = _subpath
+    this._moduleOriginalName = _moduleOriginalName
+    this._resolveContextPathFromCaller = _resolveContextPathFromCaller
+    this._sourceRootSubpath = _sourceRootSubpath
+    this._sourceSubpath = _sourceSubpath
   }
 
   /**
@@ -5806,7 +5807,81 @@ export class ModuleSource extends BaseClient {
   }
 
   /**
-   * The directory containing the actual module's source code, as determined from the root directory and subpath.
+   * Returns whether the module source has a configuration file.
+   */
+  configExists = async (): Promise<boolean> => {
+    if (this._configExists) {
+      return this._configExists
+    }
+
+    const response: Awaited<boolean> = await computeQuery(
+      [
+        ...this._queryTree,
+        {
+          operation: "configExists",
+        },
+      ],
+      await this._ctx.connection()
+    )
+
+    return response
+  }
+
+  /**
+   * The directory containing everything needed to load load and use the module.
+   */
+  contextDirectory = (): Directory => {
+    return new Directory({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "contextDirectory",
+        },
+      ],
+      ctx: this._ctx,
+    })
+  }
+
+  /**
+   * The dependencies of the module source. Includes dependencies from the configuration and any extras from withDependencies calls.
+   */
+  dependencies = async (): Promise<ModuleDependency[]> => {
+    type dependencies = {
+      id: ModuleDependencyID
+    }
+
+    const response: Awaited<dependencies[]> = await computeQuery(
+      [
+        ...this._queryTree,
+        {
+          operation: "dependencies",
+        },
+        {
+          operation: "id",
+        },
+      ],
+      await this._ctx.connection()
+    )
+
+    return response.map(
+      (r) =>
+        new ModuleDependency(
+          {
+            queryTree: [
+              {
+                operation: "loadModuleDependencyFromID",
+                args: { id: r.id },
+              },
+            ],
+            ctx: this._ctx,
+          },
+          r.id
+        )
+    )
+  }
+
+  /**
+   * The directory containing the module configuration and source code (source code may be in a subdir).
    * @param path The path from the source directory to select.
    */
   directory = (path: string): Directory => {
@@ -5844,7 +5919,7 @@ export class ModuleSource extends BaseClient {
   }
 
   /**
-   * If set, the name of the module this source references
+   * If set, the name of the module this source references, including any overrides at runtime by callers.
    */
   moduleName = async (): Promise<string> => {
     if (this._moduleName) {
@@ -5856,6 +5931,48 @@ export class ModuleSource extends BaseClient {
         ...this._queryTree,
         {
           operation: "moduleName",
+        },
+      ],
+      await this._ctx.connection()
+    )
+
+    return response
+  }
+
+  /**
+   * The original name of the module this source references, as defined in the module configuration.
+   */
+  moduleOriginalName = async (): Promise<string> => {
+    if (this._moduleOriginalName) {
+      return this._moduleOriginalName
+    }
+
+    const response: Awaited<string> = await computeQuery(
+      [
+        ...this._queryTree,
+        {
+          operation: "moduleOriginalName",
+        },
+      ],
+      await this._ctx.connection()
+    )
+
+    return response
+  }
+
+  /**
+   * The path to the module source's context directory on the caller's filesystem. Only valid for local sources.
+   */
+  resolveContextPathFromCaller = async (): Promise<string> => {
+    if (this._resolveContextPathFromCaller) {
+      return this._resolveContextPathFromCaller
+    }
+
+    const response: Awaited<string> = await computeQuery(
+      [
+        ...this._queryTree,
+        {
+          operation: "resolveContextPathFromCaller",
         },
       ],
       await this._ctx.connection()
@@ -5882,14 +5999,14 @@ export class ModuleSource extends BaseClient {
   }
 
   /**
-   * The root directory of the module source that contains its configuration and source code (which may be in a subdirectory of this root).
+   * Load the source from its path on the caller's filesystem, including only needed+configured files and directories. Only valid for local sources.
    */
-  rootDirectory = (): Directory => {
-    return new Directory({
+  resolveFromCaller = (): ModuleSource => {
+    return new ModuleSource({
       queryTree: [
         ...this._queryTree,
         {
-          operation: "rootDirectory",
+          operation: "resolveFromCaller",
         },
       ],
       ctx: this._ctx,
@@ -5897,24 +6014,130 @@ export class ModuleSource extends BaseClient {
   }
 
   /**
-   * The path to the module subdirectory containing the actual module's source code.
+   * The path relative to context of the root of the module source, which contains dagger.json. It also contains the module implementation source code, but that may or may not being a subdir of this root.
    */
-  subpath = async (): Promise<string> => {
-    if (this._subpath) {
-      return this._subpath
+  sourceRootSubpath = async (): Promise<string> => {
+    if (this._sourceRootSubpath) {
+      return this._sourceRootSubpath
     }
 
     const response: Awaited<string> = await computeQuery(
       [
         ...this._queryTree,
         {
-          operation: "subpath",
+          operation: "sourceRootSubpath",
         },
       ],
       await this._ctx.connection()
     )
 
     return response
+  }
+
+  /**
+   * The path relative to context of the module implementation source code.
+   */
+  sourceSubpath = async (): Promise<string> => {
+    if (this._sourceSubpath) {
+      return this._sourceSubpath
+    }
+
+    const response: Awaited<string> = await computeQuery(
+      [
+        ...this._queryTree,
+        {
+          operation: "sourceSubpath",
+        },
+      ],
+      await this._ctx.connection()
+    )
+
+    return response
+  }
+
+  /**
+   * Update the module source with a new context directory. Only valid for local sources.
+   * @param dir The directory to set as the context directory.
+   */
+  withContextDirectory = (dir: Directory): ModuleSource => {
+    return new ModuleSource({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "withContextDirectory",
+          args: { dir },
+        },
+      ],
+      ctx: this._ctx,
+    })
+  }
+
+  /**
+   * Append the provided dependencies to the module source's dependency list.
+   * @param dependencies The dependencies to append.
+   */
+  withDependencies = (dependencies: ModuleDependency[]): ModuleSource => {
+    return new ModuleSource({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "withDependencies",
+          args: { dependencies },
+        },
+      ],
+      ctx: this._ctx,
+    })
+  }
+
+  /**
+   * Update the module source with a new name.
+   * @param name The name to set.
+   */
+  withName = (name: string): ModuleSource => {
+    return new ModuleSource({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "withName",
+          args: { name },
+        },
+      ],
+      ctx: this._ctx,
+    })
+  }
+
+  /**
+   * Update the module source with a new SDK.
+   * @param sdk The SDK to set.
+   */
+  withSDK = (sdk: string): ModuleSource => {
+    return new ModuleSource({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "withSDK",
+          args: { sdk },
+        },
+      ],
+      ctx: this._ctx,
+    })
+  }
+
+  /**
+   * Update the module source with a new source subpath.
+   * @param path The path to set as the source subpath.
+   */
+  withSourceSubpath = (path: string): ModuleSource => {
+    return new ModuleSource({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "withSourceSubpath",
+          args: { path },
+        },
+      ],
+      ctx: this._ctx,
+    })
   }
 
   /**
@@ -7119,7 +7342,6 @@ export class Client extends BaseClient {
   /**
    * Create a new module source instance from a source ref string.
    * @param refString The string ref representation of the module source
-   * @param opts.rootDirectory An explicitly set root directory for the module source. This is required to load local sources as modules; other source types implicitly encode the root directory and do not require this.
    * @param opts.stable If true, enforce that the source is a stable version for source kinds that support versioning.
    */
   moduleSource = (

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -439,13 +439,13 @@ export type CurrentModuleID = string & { __CurrentModuleID: never }
 
 export type DirectoryAsModuleOpts = {
   /**
-   * An optional subpath of the directory which contains the module's source code.
+   * An optional subpath of the directory which contains the module's configuration file.
    *
    * This is needed when the module code is in a subdirectory but requires parent directories to be loaded in order to execute. For example, the module source code may need a go.mod, project.toml, package.json, etc. file from a parent directory.
    *
    * If not set, the module source code is loaded from the root of the directory.
    */
-  sourceSubpath?: string
+  sourceRootPath?: string
 }
 
 export type DirectoryDockerBuildOpts = {
@@ -2714,7 +2714,7 @@ export class Directory extends BaseClient {
 
   /**
    * Load the directory as a Dagger module
-   * @param opts.sourceSubpath An optional subpath of the directory which contains the module's source code.
+   * @param opts.sourceRootPath An optional subpath of the directory which contains the module's configuration file.
    *
    * This is needed when the module code is in a subdirectory but requires parent directories to be loaded in order to execute. For example, the module source code may need a go.mod, project.toml, package.json, etc. file from a parent directory.
    *

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -14,11 +14,15 @@ func New(
 ) *TypeScriptSdk {
 	return &TypeScriptSdk{
 		SDKSourceDir: sdkSourceDir,
+		RequiredPaths: []string{
+			"src/index.ts",
+		},
 	}
 }
 
 type TypeScriptSdk struct {
-	SDKSourceDir *Directory
+	SDKSourceDir  *Directory
+	RequiredPaths []string
 }
 
 const (

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -100,7 +100,7 @@ func (t *TypeScriptSdk) CodegenBase(ctx context.Context, modSource *ModuleSource
 		// Add template directory
 		WithMountedDirectory("/opt", dag.CurrentModule().Source().Directory(".")).
 		// Mount users' module
-		WithMountedDirectory(ModSourceDirPath, modSource.BaseContextDirectory()).
+		WithMountedDirectory(ModSourceDirPath, modSource.ContextDirectory()).
 		WithWorkdir(path.Join(ModSourceDirPath, subPath)).
 		WithNewFile(schemaPath, ContainerWithNewFileOpts{
 			Contents: introspectionJson,

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -109,7 +109,7 @@ func (t *TypeScriptSdk) CodegenBase(ctx context.Context, modSource *ModuleSource
 		WithExec([]string{
 			codegenBinPath,
 			"--lang", "typescript",
-			"--module-source-root", ModSourceDirPath,
+			"--module-context", ModSourceDirPath,
 			"--output", genPath,
 			"--module-name", name,
 			"--introspection-json-path", schemaPath,


### PR DESCRIPTION
## Goals
- Simplify module loading further by just always defaulting the "context" to the root of the git repo
   - for the local case, we find-up a `.git` and otherwise default to the source root path specified so everything stays sandboxed
   - users no longer need to think about running `dagger init` in the right place, there's no `root`/`root-for`/etc. settings, etc.
   - the tradeoff is we need to be much more intelligent about only sparsely loading exactly the files/dirs we need based on local deps, local custom sdks, files that are required by the SDKs in use and custom include/exclude settings provided by the user. This also needs to apply recursively to any deps/sdks/files needed in the whole context
- Add support for `dagger init --source <path>` and `dagger develop --source <path>` for customizing the subdirs at which actual module source code is located
   - if not specified `--source` defaults to `dagger/`. See [this discord thread](https://discord.com/channels/707636530424053791/1204583515400970260) for discussion on the default value.

## Example Usage
### `--source` usage
One of the primary use cases `--source` as an arg to `init`/`develop` enables is putting `dagger.json` in the root of a repo without necessarily polluting the root with SDK source files, e.g.
1. from root of local git repo clone, run `dagger init --name foo`
   * `dagger.json` is created in your cwd by default, so in this case it's in the root of the repo
3. run `dagger install` to add some deps 
4. decide you want to start writing some code, so run `dagger develop --sdk=go --source=some/subdir`
   * you'll now see `main.go` and other go sdk files at under `some/subdir` in the repo
   * `dagger.json` is also updated to set `"source": "some/subdir"`
   * If `--source` hadn't been specified, it would have defaulted `dagger/go` (with the last element always being set to the name of the sdk)
   * `--source=.` is valid too still, just not the default
5. Your module is still the default one when in the root of repo, so you can do e.g. `dagger call foofunc ...` from the root
   * This also applies to anyone else `git clone`'ing your daggerized repo for the first time
   * It also applies to anyone invoking/installing your module from its remote git ref, e.g. `dagger install github./com/org/repo` is enough since they just need to point to the root of the repo

This is just one use case, generally speaking the goal here is to be flexible while retaining sane defaults and sandboxing everything to the `.git` context.

## Terminology
- `Context`
   - this is the dir that is loaded into the engine and provided to SDKs for codegen. End modules don't get implicit access to the whole context; it's only used to support modules that use `go.mod`/`package.json`/etc. from parent dirs and to load any deps/custom sdks/etc. local to the module
    - For local modules, this is a sparsely loaded directory rooted at the nearest parent dir containing `.git` (or the dir containing `dagger.json` as a fallback)
    - For git modules, this is just the git repo. As noted in the code, support for sparsely loading from git remotes is a TODO and will require https://github.com/dagger/dagger/issues/6292)
- `Source Root Path`
   - this is the dir under `Context` (or the same as it) that contains `dagger.json` for a module.
   - it's important in that if you specify a module ref, it should point to this dir. e.g. `dagger call -m github.com/foo/bar/the/sourceroot ...`
- `Source Path`
   - this is the dir that contains the actual module source implementation (i.e. `main.go`, `src/index.ts`, `src/main.py`, etc.)
   - It can be set via `--source` and defaults to `dagger/` (see above sections for more usage details)

## Implementation notes
- SDKs now have an additional method `RequireFiles` that allows them to specify which files they need in order to load (i.e. `go.mod` is one required by the go SDK)
   - This is currently a bit barebones in that it's just a flat list of glob patterns. Better would be if this method was given the `ModuleSource` arg and used it to determine very precisely what's needed (i.e. right now we require `**/go.mod` but really we only needs ones that are in parent dirs or are referenced by those in parent dirs). But saving that optimization for the future.
- The sparse loading of local dirs uses the filesync API to first walk the whole DAG of local deps and read `dagger.json` from each one. [Code](https://github.com/sipsma/dagger/blob/03a867bfdefebd3a4399287d963e7444c91c1871/core/schema/modulesource.go#L888-L888)
   - Once that's done, we collect all the include/exclude values and invoke all the SDKs encountered to determine which files they strictly require and finally do a single local import of everything we need. [Code](https://github.com/sipsma/dagger/blob/03a867bfdefebd3a4399287d963e7444c91c1871/core/schema/modulesource.go#L658-L658)
   - This required adding an extra method for just stat'ing paths, which enabled the find-up of `.git` from the engine code. [Code](https://github.com/sipsma/dagger/blob/03a867bfdefebd3a4399287d963e7444c91c1871/engine/buildkit/filesync.go#L144-L144)
- This effort required another iteration on the `Module`/`ModuleSource` API, though it amounted to mostly re-arranging rather than anything new besides the sparse loading logic
   - The biggest rearrangement is the `WithName`/`WithSDK`/`WithDependencies` moved from `Module` to `ModuleSource`. This was required because those apis can actually change what is required from the context and trying to later re-load those files from their original source *while also keeping source IDs pure* was practically speaking not really possible.
   - The idea is essentially that all the configuration happens on `ModuleSource` and once `AsModule` is called it's immutable
   - I actually think all the code around this ended up even cleaner than before somehow even though it was only changed to get things working for this feature 🤷‍♂️🎉