### PR TITLE
fix: avoid client panic on ctx cancel

### DIFF
--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -541,7 +541,7 @@ func (c *Client) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(resp.StatusCode)
 	_, err = io.Copy(w, resp.Body)
-	if err != nil {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		panic(err) // don't write header because we already wrote to the body, which isn't allowed
 	}
 }


### PR DESCRIPTION
A super weird find (I think this was introduced recently?)

https://github.com/dagger/dagger.io/actions/runs/7756389308/job/21153589598?pr=3359#step:4:2365

```
24: exec go test ./cmd/ci/ -v -timeout=30m
24: [244.0s] 2024/02/02 13:12:31 http: panic serving 127.0.0.1:42432: context canceled
24: [244.0s] goroutine 863 [running]:
24: [244.0s] net/http.(*conn).serve.func1()
24: [244.0s] 	/usr/local/go/src/net/http/server.go:1868 +0xb9
24: [244.0s] panic({0xfcadc0?, 0x1b79170?})
24: [244.0s] 	/usr/local/go/src/runtime/panic.go:920 +0x270
24: [244.0s] github.com/dagger/dagger/engine/client.(*Client).ServeHTTP(0xc00018c9c0, {0x133ab28, 0xc0004d62a0}, 0xc000554c00)
24: [244.0s] 	/app/engine/client/client.go:545 +0xbf2
24: [244.0s] net/http.serverHandler.ServeHTTP({0x1336c70?}, {0x133ab28?, 0xc0004d62a0?}, 0x6?)
24: [244.0s] 	/usr/local/go/src/net/http/server.go:2938 +0x8e
24: [244.0s] net/http.(*conn).serve(0xc0005999e0, {0x133fea0, 0xc0002abe00})
24: [244.0s] 	/usr/local/go/src/net/http/server.go:2009 +0x5f4
24: [244.0s] created by net/http.(*Server).Serve in goroutine 67
24: [244.0s] 	/usr/local/go/src/net/http/server.go:3086 +0x5cb
```

This comes from inside the client - ideally we really really shouldn't be panicking here. What's weird is that this *appears* to be non-fatal? As in, the test doesn't failed, we fail for unrelated reasons later on.

It seems like this is a mistake? The context defined can definitely be cancelled (by design), and we attach it to the request, so getting `context.Canceled` here is certainly valid. That said, what concerns me a bit is why this looks new? I'm not sure why suddenly we get this when we didn't use to.