### PR TITLE
fix(sdk/elixir): fix auto-provision mode cannot running on Windows

### DIFF
--- a/sdk/elixir/.changes/unreleased/Fixed-20240203-105721.yaml
+++ b/sdk/elixir/.changes/unreleased/Fixed-20240203-105721.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fix auto-provision not working on Windows
+time: 2024-02-03T10:57:21.881275+07:00
+custom:
+  Author: wingyplus
+  PR: "6579"


### PR DESCRIPTION
Change how to detect os and architectue on Windows. For the architecture. For the architecture, it needs to strict with `amd64` since `:erlang.system_info(:system_architecture)` returns `:win32`, which not helping us to determine os architecture on Windows.

Fixes: #6540