### PR TITLE
update container.shell to container.terminal

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -81,8 +81,8 @@ type Container struct {
 	// focused, i.e. shown more prominently in the UI.
 	Focused bool `json:"focused"`
 
-	// The args to invoke when using the "shell" api on this container.
-	DefaultShell []string `json:"defaultShell,omitempty"`
+	// The args to invoke when using the terminal api on this container.
+	DefaultTerminalCmd []string `json:"defaultTerminalCmd,omitempty"`
 }
 
 func (*Container) Type() *ast.Type {

--- a/core/integration/module_shell_test.go
+++ b/core/integration/module_shell_test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Shells tests are run directly on the host rather than in exec containers because we want to
+// Terminal tests are run directly on the host rather than in exec containers because we want to
 // directly interact with the dagger shell tui without resorting to embedding more go code
 // into a container for driving it.
 
-func TestModuleDaggerShell(t *testing.T) {
+func TestModuleDaggerTerminal(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -65,7 +65,7 @@ type Test struct {
 		err = pty.Setsize(tty, &pty.Winsize{Rows: 6, Cols: 16})
 		require.NoError(t, err)
 
-		cmd := hostDaggerCommand(ctx, t, modDir, "call", "ctr", "shell")
+		cmd := hostDaggerCommand(ctx, t, modDir, "call", "ctr", "terminal")
 		cmd.Stdin = tty
 		cmd.Stdout = tty
 		cmd.Stderr = tty
@@ -132,7 +132,7 @@ type Test struct {
 		err = pty.Setsize(tty, &pty.Winsize{Rows: 5, Cols: 22})
 		require.NoError(t, err)
 
-		cmd := hostDaggerCommand(ctx, t, modDir, "call", "ctr", "shell", "--args=python")
+		cmd := hostDaggerCommand(ctx, t, modDir, "call", "ctr", "terminal", "--cmd=python")
 		cmd.Stdin = tty
 		cmd.Stdout = tty
 		cmd.Stderr = tty

--- a/core/integration/module_shell_test.go
+++ b/core/integration/module_shell_test.go
@@ -35,7 +35,7 @@ func New(ctx context.Context) *Test {
 			From("mirror.gcr.io/alpine:3.18").
 			WithEnvVariable("COOLENV", "woo").
 			WithWorkdir("/coolworkdir").
-			WithDefaultShell([]string{"/bin/sh"}),
+			WithDefaultTerminalCmd([]string{"/bin/sh"}),
 	}
 }
 
@@ -106,7 +106,7 @@ func New(ctx context.Context) *Test {
 			WithEnvVariable("COOLENV", "woo").
 			WithWorkdir("/coolworkdir").
 			WithExec([]string{"apk", "add", "python3"}).
-			WithDefaultShell([]string{"/bin/sh"}),
+			WithDefaultTerminalCmd([]string{"/bin/sh"}),
 	}
 }
 

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -433,8 +433,8 @@ func (s *containerSchema) Install() {
 			ArgDoc("args", `The args of the command.`),
 
 		dagql.NodeFunc("terminal", s.terminal).
-			Doc(`Return an interactive terminal for this container using its configured shell if not overridden by args (or sh as a fallback default).`).
-			ArgDoc("cmd", `If set, override the container's default shell command and invoke these command arguments instead.`),
+			Doc(`Return an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).`).
+			ArgDoc("cmd", `If set, override the container's default terminal command and invoke these command arguments instead.`),
 
 		dagql.Func("experimentalWithGPU", s.withGPU).
 			Doc(`EXPERIMENTAL API! Subject to change/removal at any time.`,
@@ -1304,12 +1304,12 @@ func (s *containerSchema) terminal(
 	ctx context.Context,
 	ctr dagql.Instance[*core.Container],
 	args struct {
-		Cmd dagql.Optional[dagql.ArrayInput[dagql.String]]
+		Cmd *[]string
 	},
 ) (*core.Terminal, error) {
 	var shellArgs []string
-	if args.Cmd.Valid {
-		shellArgs = collectArrayInput(args.Cmd.Value, dagql.String.String)
+	if args.Cmd != nil {
+		shellArgs = *args.Cmd
 	} else {
 		// if no override args specified, use default shell
 		shellArgs = ctr.Self.DefaultTerminalCmd

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -432,9 +432,9 @@ func (s *containerSchema) Install() {
 			Doc(`Set the default command to invoke for the "shell" API.`).
 			ArgDoc("args", `The args of the command to set the default shell to.`),
 
-		dagql.NodeFunc("shell", s.shell).
+		dagql.NodeFunc("terminal", s.terminal).
 			Doc(`Return an interactive terminal for this container using its configured shell if not overridden by args (or sh as a fallback default).`).
-			ArgDoc("args", `If set, override the container's default shell and invoke these arguments instead.`),
+			ArgDoc("cmd", `If set, override the container's default shell command and invoke these command arguments instead.`),
 
 		dagql.Func("experimentalWithGPU", s.withGPU).
 			Doc(`EXPERIMENTAL API! Subject to change/removal at any time.`,
@@ -1300,16 +1300,16 @@ func (s *containerSchema) withDefaultShell(
 	return ctr, nil
 }
 
-func (s *containerSchema) shell(
+func (s *containerSchema) terminal(
 	ctx context.Context,
 	ctr dagql.Instance[*core.Container],
 	args struct {
-		Args dagql.Optional[dagql.ArrayInput[dagql.String]]
+		Cmd dagql.Optional[dagql.ArrayInput[dagql.String]]
 	},
 ) (*core.Terminal, error) {
 	var shellArgs []string
-	if args.Args.Valid {
-		shellArgs = collectArrayInput(args.Args.Value, dagql.String.String)
+	if args.Cmd.Valid {
+		shellArgs = collectArrayInput(args.Cmd.Value, dagql.String.String)
 	} else {
 		// if no override args specified, use default shell
 		shellArgs = ctr.Self.DefaultShell

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -428,9 +428,9 @@ func (s *containerSchema) Install() {
 			Doc(`Indicate that subsequent operations should not be featured more prominently in the UI.`,
 				`This is the initial state of all containers.`),
 
-		dagql.Func("withDefaultShell", s.withDefaultShell).
-			Doc(`Set the default command to invoke for the "shell" API.`).
-			ArgDoc("args", `The args of the command to set the default shell to.`),
+		dagql.Func("withDefaultTerminalCmd", s.withDefaultTerminalCmd).
+			Doc(`Set the default command to invoke for the container's terminal API.`).
+			ArgDoc("args", `The args of the command.`),
 
 		dagql.NodeFunc("terminal", s.terminal).
 			Doc(`Return an interactive terminal for this container using its configured shell if not overridden by args (or sh as a fallback default).`).
@@ -1288,7 +1288,7 @@ func (s *containerSchema) withoutFocus(ctx context.Context, parent *core.Contain
 	return child, nil
 }
 
-func (s *containerSchema) withDefaultShell(
+func (s *containerSchema) withDefaultTerminalCmd(
 	ctx context.Context,
 	ctr *core.Container,
 	args struct {
@@ -1296,7 +1296,7 @@ func (s *containerSchema) withDefaultShell(
 	},
 ) (*core.Container, error) {
 	ctr = ctr.Clone()
-	ctr.DefaultShell = args.Args
+	ctr.DefaultTerminalCmd = args.Args
 	return ctr, nil
 }
 
@@ -1312,7 +1312,7 @@ func (s *containerSchema) terminal(
 		shellArgs = collectArrayInput(args.Cmd.Value, dagql.String.String)
 	} else {
 		// if no override args specified, use default shell
-		shellArgs = ctr.Self.DefaultShell
+		shellArgs = ctr.Self.DefaultTerminalCmd
 	}
 
 	// if still no args, default to sh

--- a/core/schema/util.go
+++ b/core/schema/util.go
@@ -42,14 +42,6 @@ func collectInputsSlice[T dagql.Type](inputs []dagql.InputObject[T]) []T {
 	return ts
 }
 
-func collectArrayInput[T any, I dagql.Input](in dagql.ArrayInput[I], conv func(I) T) []T {
-	ts := make([]T, len(in))
-	for i, v := range in {
-		ts[i] = conv(v)
-	}
-	return ts
-}
-
 func collectIDObjects[T dagql.Typed](ctx context.Context, srv *dagql.Server, ids []dagql.ID[T]) ([]T, error) {
 	ts := make([]T, len(ids))
 	for i, id := range ids {

--- a/docs/current_docs/cli/979595-reference.mdx
+++ b/docs/current_docs/cli/979595-reference.mdx
@@ -13,115 +13,18 @@ The Dagger CLI provides a command-line interface to Dagger.
 ### Options
 
 ```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
+      --debug             Show more information for debugging
+      --progress string   progress output format (auto, plain, tty) (default "auto")
+  -s, --silent            disable terminal UI and progress output
 ```
 
 ### SEE ALSO
 
-* [dagger call](#dagger-call)	 - Call a module function
-* [dagger completion](#dagger-completion)	 - Generate the autocompletion script for the specified shell
-* [dagger functions](#dagger-functions)	 - List available functions
 * [dagger login](#dagger-login)	 - Log in to Dagger Cloud
 * [dagger logout](#dagger-logout)	 - Log out from Dagger Cloud
-* [dagger module](#dagger-module)	 - Manage Dagger modules
 * [dagger query](#dagger-query)	 - Send API queries to a dagger engine
 * [dagger run](#dagger-run)	 - Run a command in a Dagger session
 * [dagger version](#dagger-version)	 - Print dagger version
-
-## dagger call
-
-Call a module function
-
-### Synopsis
-
-Call a module function and print the result.
-
-If the last argument is either a Container, Directory, or File, the pipeline
-will be evaluated (the result of calling `sync`) without presenting any output.
-Providing the `--output` option (shorthand: `-o`) is equivalent to calling
-`export` instead. To print a property of these core objects, continue chaining
-by appending it to the end of the command (for example, `stdout`, `entries`, or
-`contents`).
-
-
-```
-dagger call [flags] [FUNCTION]...
-```
-
-### Examples
-
-```
-dagger call test
-dagger call build -o ./bin/myapp
-dagger call lint stdout
-```
-
-### Options
-
-```
-      --focus           Only show output for focused commands (default true)
-      --json            Present result as JSON
-  -m, --mod string      Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
-  -o, --output string   Path in the host to save the result to
-```
-
-### Options inherited from parent commands
-
-```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
-```
-
-### SEE ALSO
-
-* [dagger](#dagger)	 - The Dagger CLI provides a command-line interface to Dagger.
-
-## dagger functions
-
-List available functions
-
-### Synopsis
-
-List available functions in a module.
-
-This is similar to `dagger call --help`, but only focused on showing the
-available functions.
-
-
-```
-dagger functions [flags] [FUNCTION]...
-```
-
-### Options
-
-```
-      --focus        Only show output for focused commands (default true)
-  -m, --mod string   Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
-```
-
-### Options inherited from parent commands
-
-```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
-```
-
-### SEE ALSO
-
-* [dagger](#dagger)	 - The Dagger CLI provides a command-line interface to Dagger.
 
 ## dagger login
 
@@ -134,12 +37,9 @@ dagger login [flags]
 ### Options inherited from parent commands
 
 ```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
+      --debug             Show more information for debugging
+      --progress string   progress output format (auto, plain, tty) (default "auto")
+  -s, --silent            disable terminal UI and progress output
 ```
 
 ### SEE ALSO
@@ -157,223 +57,14 @@ dagger logout [flags]
 ### Options inherited from parent commands
 
 ```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
+      --debug             Show more information for debugging
+      --progress string   progress output format (auto, plain, tty) (default "auto")
+  -s, --silent            disable terminal UI and progress output
 ```
 
 ### SEE ALSO
 
 * [dagger](#dagger)	 - The Dagger CLI provides a command-line interface to Dagger.
-
-## dagger module
-
-Manage Dagger modules
-
-### Synopsis
-
-Manage Dagger modules. By default, print the configuration of the specified module in json format.
-
-```
-dagger module [flags]
-```
-
-### Examples
-
-```
-dagger mod -m /path/to/some/dir
-dagger mod -m github.com/dagger/hello-dagger
-```
-
-### Options
-
-```
-      --focus        Only show output for focused commands (default true)
-  -m, --mod string   Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
-```
-
-### Options inherited from parent commands
-
-```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
-```
-
-### SEE ALSO
-
-* [dagger](#dagger)	 - The Dagger CLI provides a command-line interface to Dagger.
-* [dagger module init](#dagger-module-init)	 - Initialize a new Dagger module
-* [dagger module install](#dagger-module-install)	 - Add a new dependency to a Dagger module
-* [dagger module publish](#dagger-module-publish)	 - Publish a Dagger module to the Daggerverse
-* [dagger module sync](#dagger-module-sync)	 - Synchronize a Dagger module
-
-## dagger module init
-
-Initialize a new Dagger module
-
-### Synopsis
-
-Initialize a new Dagger module in a local directory.
-
-```
-dagger module init [--sdk string --name string] [flags]
-```
-
-### Examples
-
-```
-dagger mod init --name=hello --sdk=python
-```
-
-### Options
-
-```
-      --license string   License identifier to generate - see https://spdx.org/licenses/
-      --name string      Name of the new module
-      --sdk string       SDK name or image ref to use for the module
-```
-
-### Options inherited from parent commands
-
-```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --focus               Only show output for focused commands (default true)
-  -m, --mod string          Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
-```
-
-### SEE ALSO
-
-* [dagger module](#dagger-module)	 - Manage Dagger modules
-
-## dagger module install
-
-Add a new dependency to a Dagger module
-
-### Synopsis
-
-Add a Dagger module as a dependency of a local module.
-
-```
-dagger module install [flags] MODULE
-```
-
-### Examples
-
-```
-dagger mod install github.com/shykes/daggerverse/ttlsh@16e40ec244966e55e36a13cb6e1ff8023e1e1473
-```
-
-### Options
-
-```
-  -n, --name string   Name to use for the dependency in the module. Defaults to the name of the module being installed.
-```
-
-### Options inherited from parent commands
-
-```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --focus               Only show output for focused commands (default true)
-  -m, --mod string          Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
-```
-
-### SEE ALSO
-
-* [dagger module](#dagger-module)	 - Manage Dagger modules
-
-## dagger module publish
-
-Publish a Dagger module to the Daggerverse
-
-### Synopsis
-
-Publish a local module to the Daggerverse (https://daggerverse.dev).
-
-The module needs to be committed to a git repository and have a remote
-configured with name "origin". The git repository must be clean (unless
-forced), to avoid mistakingly depending on uncommitted files.
-
-
-```
-dagger module publish [flags]
-```
-
-### Options
-
-```
-  -f, --force   Force publish even if the git repository is not clean
-```
-
-### Options inherited from parent commands
-
-```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --focus               Only show output for focused commands (default true)
-  -m, --mod string          Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
-```
-
-### SEE ALSO
-
-* [dagger module](#dagger-module)	 - Manage Dagger modules
-
-## dagger module sync
-
-Synchronize a Dagger module
-
-### Synopsis
-
-Synchronize a Dagger module with the latest version of its extensions.
-
-:::note
-This is only required for IDE auto-completion/LSP purposes.
-:::
-
-This command re-regerates the module's generated code based on dependencies
-and the current state of the module's source code.
-
-
-```
-dagger module sync [flags]
-```
-
-### Options inherited from parent commands
-
-```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --focus               Only show output for focused commands (default true)
-  -m, --mod string          Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
-```
-
-### SEE ALSO
-
-* [dagger module](#dagger-module)	 - Manage Dagger modules
 
 ## dagger query
 
@@ -423,12 +114,9 @@ EOF
 ### Options inherited from parent commands
 
 ```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
+      --debug             Show more information for debugging
+      --progress string   progress output format (auto, plain, tty) (default "auto")
+  -s, --silent            disable terminal UI and progress output
 ```
 
 ### SEE ALSO
@@ -479,12 +167,9 @@ dagger run python main.py
 ### Options inherited from parent commands
 
 ```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
+      --debug             Show more information for debugging
+      --progress string   progress output format (auto, plain, tty) (default "auto")
+  -s, --silent            disable terminal UI and progress output
 ```
 
 ### SEE ALSO
@@ -502,14 +187,12 @@ dagger version [flags]
 ### Options inherited from parent commands
 
 ```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
+      --debug             Show more information for debugging
+      --progress string   progress output format (auto, plain, tty) (default "auto")
+  -s, --silent            disable terminal UI and progress output
 ```
 
 ### SEE ALSO
 
 * [dagger](#dagger)	 - The Dagger CLI provides a command-line interface to Dagger.
+

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -340,12 +340,12 @@ type Container {
   sync: ContainerID!
 
   """
-  Return an interactive terminal for this container using its configured shell
-  if not overridden by args (or sh as a fallback default).
+  Return an interactive terminal for this container using its configured default
+  terminal command if not overridden by args (or sh as a fallback default).
   """
   terminal(
     """
-    If set, override the container's default shell command and invoke these command arguments instead.
+    If set, override the container's default terminal command and invoke these command arguments instead.
     """
     cmd: [String!]
   ): Terminal!

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -361,9 +361,9 @@ type Container {
     args: [String!]!
   ): Container!
 
-  """Set the default command to invoke for the "shell" API."""
-  withDefaultShell(
-    """The args of the command to set the default shell to."""
+  """Set the default command to invoke for the container's terminal API."""
+  withDefaultTerminalCmd(
+    """The args of the command."""
     args: [String!]!
   ): Container!
 

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -319,17 +319,6 @@ type Container {
   rootfs: Directory!
 
   """
-  Return an interactive terminal for this container using its configured shell
-  if not overridden by args (or sh as a fallback default).
-  """
-  shell(
-    """
-    If set, override the container's default shell and invoke these arguments instead.
-    """
-    args: [String!]
-  ): Terminal!
-
-  """
   The error stream of the last executed command.
   
   Will execute default command if none is set, or error if there's no default.
@@ -349,6 +338,17 @@ type Container {
   It doesn't run the default command if no exec has been set.
   """
   sync: ContainerID!
+
+  """
+  Return an interactive terminal for this container using its configured shell
+  if not overridden by args (or sh as a fallback default).
+  """
+  terminal(
+    """
+    If set, override the container's default shell command and invoke these command arguments instead.
+    """
+    cmd: [String!]
+  ): Terminal!
 
   """Retrieves the user to be set for all commands."""
   user: String!

--- a/docs/versioned_docs/version-zenith/reference/979596-cli.mdx
+++ b/docs/versioned_docs/version-zenith/reference/979596-cli.mdx
@@ -17,12 +17,9 @@ The Dagger CLI provides a command-line interface to Dagger.
 ### Options
 
 ```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
+      --debug             Show more information for debugging
+      --progress string   progress output format (auto, plain, tty) (default "auto")
+  -s, --silent            disable terminal UI and progress output
 ```
 
 ### SEE ALSO
@@ -76,12 +73,9 @@ dagger call lint stdout
 ### Options inherited from parent commands
 
 ```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
+      --debug             Show more information for debugging
+      --progress string   progress output format (auto, plain, tty) (default "auto")
+  -s, --silent            disable terminal UI and progress output
 ```
 
 ### SEE ALSO
@@ -114,12 +108,9 @@ dagger functions [flags] [FUNCTION]...
 ### Options inherited from parent commands
 
 ```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
+      --debug             Show more information for debugging
+      --progress string   progress output format (auto, plain, tty) (default "auto")
+  -s, --silent            disable terminal UI and progress output
 ```
 
 ### SEE ALSO
@@ -137,12 +128,9 @@ dagger login [flags]
 ### Options inherited from parent commands
 
 ```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
+      --debug             Show more information for debugging
+      --progress string   progress output format (auto, plain, tty) (default "auto")
+  -s, --silent            disable terminal UI and progress output
 ```
 
 ### SEE ALSO
@@ -160,12 +148,9 @@ dagger logout [flags]
 ### Options inherited from parent commands
 
 ```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
+      --debug             Show more information for debugging
+      --progress string   progress output format (auto, plain, tty) (default "auto")
+  -s, --silent            disable terminal UI and progress output
 ```
 
 ### SEE ALSO
@@ -201,12 +186,9 @@ dagger mod -m github.com/dagger/hello-dagger
 ### Options inherited from parent commands
 
 ```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
+      --debug             Show more information for debugging
+      --progress string   progress output format (auto, plain, tty) (default "auto")
+  -s, --silent            disable terminal UI and progress output
 ```
 
 ### SEE ALSO
@@ -246,14 +228,11 @@ dagger mod init --name=hello --sdk=python
 ### Options inherited from parent commands
 
 ```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --focus               Only show output for focused commands (default true)
-  -m, --mod string          Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
+      --debug             Show more information for debugging
+      --focus             Only show output for focused commands (default true)
+  -m, --mod string        Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
+      --progress string   progress output format (auto, plain, tty) (default "auto")
+  -s, --silent            disable terminal UI and progress output
 ```
 
 ### SEE ALSO
@@ -287,14 +266,11 @@ dagger mod install github.com/shykes/daggerverse/ttlsh@16e40ec244966e55e36a13cb6
 ### Options inherited from parent commands
 
 ```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --focus               Only show output for focused commands (default true)
-  -m, --mod string          Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
+      --debug             Show more information for debugging
+      --focus             Only show output for focused commands (default true)
+  -m, --mod string        Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
+      --progress string   progress output format (auto, plain, tty) (default "auto")
+  -s, --silent            disable terminal UI and progress output
 ```
 
 ### SEE ALSO
@@ -327,14 +303,11 @@ dagger module publish [flags]
 ### Options inherited from parent commands
 
 ```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --focus               Only show output for focused commands (default true)
-  -m, --mod string          Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
+      --debug             Show more information for debugging
+      --focus             Only show output for focused commands (default true)
+  -m, --mod string        Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
+      --progress string   progress output format (auto, plain, tty) (default "auto")
+  -s, --silent            disable terminal UI and progress output
 ```
 
 ### SEE ALSO
@@ -364,14 +337,11 @@ dagger module sync [flags]
 ### Options inherited from parent commands
 
 ```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --focus               Only show output for focused commands (default true)
-  -m, --mod string          Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
+      --debug             Show more information for debugging
+      --focus             Only show output for focused commands (default true)
+  -m, --mod string        Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
+      --progress string   progress output format (auto, plain, tty) (default "auto")
+  -s, --silent            disable terminal UI and progress output
 ```
 
 ### SEE ALSO
@@ -426,12 +396,9 @@ EOF
 ### Options inherited from parent commands
 
 ```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
+      --debug             Show more information for debugging
+      --progress string   progress output format (auto, plain, tty) (default "auto")
+  -s, --silent            disable terminal UI and progress output
 ```
 
 ### SEE ALSO
@@ -482,12 +449,9 @@ dagger run python main.py
 ### Options inherited from parent commands
 
 ```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
+      --debug             Show more information for debugging
+      --progress string   progress output format (auto, plain, tty) (default "auto")
+  -s, --silent            disable terminal UI and progress output
 ```
 
 ### SEE ALSO
@@ -505,12 +469,9 @@ dagger version [flags]
 ### Options inherited from parent commands
 
 ```
-      --cpuprofile string   collect CPU profile to path, and trace at path.trace
-      --debug               Show more information for debugging
-      --pprof string        serve HTTP pprof at this address
-      --progress string     progress output format (auto, plain, tty) (default "auto")
-  -s, --silent              disable terminal UI and progress output
-      --workdir string      The host workdir loaded into dagger (default ".")
+      --debug             Show more information for debugging
+      --progress string   progress output format (auto, plain, tty) (default "auto")
+  -s, --silent            disable terminal UI and progress output
 ```
 
 ### SEE ALSO

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -487,10 +487,10 @@ defmodule Dagger.Container do
   )
 
   (
-    @doc "Set the default command to invoke for the \"shell\" API.\n\n## Required Arguments\n\n* `args` - The args of the command to set the default shell to."
-    @spec with_default_shell(t(), [Dagger.String.t()]) :: Dagger.Container.t()
-    def with_default_shell(%__MODULE__{} = container, args) do
-      selection = select(container.selection, "withDefaultShell")
+    @doc "Set the default command to invoke for the container's terminal API.\n\n## Required Arguments\n\n* `args` - The args of the command."
+    @spec with_default_terminal_cmd(t(), [Dagger.String.t()]) :: Dagger.Container.t()
+    def with_default_terminal_cmd(%__MODULE__{} = container, args) do
+      selection = select(container.selection, "withDefaultTerminalCmd")
       selection = arg(selection, "args", args)
       %Dagger.Container{selection: selection, client: container.client}
     end

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -424,23 +424,6 @@ defmodule Dagger.Container do
   )
 
   (
-    @doc "Return an interactive terminal for this container using its configured shell if not overridden by args (or sh as a fallback default).\n\n\n\n## Optional Arguments\n\n* `args` - If set, override the container's default shell and invoke these arguments instead."
-    @spec shell(t(), keyword()) :: Dagger.Terminal.t()
-    def shell(%__MODULE__{} = container, optional_args \\ []) do
-      selection = select(container.selection, "shell")
-
-      selection =
-        if is_nil(optional_args[:args]) do
-          selection
-        else
-          arg(selection, "args", optional_args[:args])
-        end
-
-      %Dagger.Terminal{selection: selection, client: container.client}
-    end
-  )
-
-  (
     @doc "The error stream of the last executed command.\n\nWill execute default command if none is set, or error if there's no default."
     @spec stderr(t()) :: {:ok, Dagger.String.t()} | {:error, term()}
     def stderr(%__MODULE__{} = container) do
@@ -464,6 +447,23 @@ defmodule Dagger.Container do
     def sync(%__MODULE__{} = container) do
       selection = select(container.selection, "sync")
       execute(selection, container.client)
+    end
+  )
+
+  (
+    @doc "Return an interactive terminal for this container using its configured shell if not overridden by args (or sh as a fallback default).\n\n\n\n## Optional Arguments\n\n* `cmd` - If set, override the container's default shell command and invoke these command arguments instead."
+    @spec terminal(t(), keyword()) :: Dagger.Terminal.t()
+    def terminal(%__MODULE__{} = container, optional_args \\ []) do
+      selection = select(container.selection, "terminal")
+
+      selection =
+        if is_nil(optional_args[:cmd]) do
+          selection
+        else
+          arg(selection, "cmd", optional_args[:cmd])
+        end
+
+      %Dagger.Terminal{selection: selection, client: container.client}
     end
   )
 

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -451,7 +451,7 @@ defmodule Dagger.Container do
   )
 
   (
-    @doc "Return an interactive terminal for this container using its configured shell if not overridden by args (or sh as a fallback default).\n\n\n\n## Optional Arguments\n\n* `cmd` - If set, override the container's default shell command and invoke these command arguments instead."
+    @doc "Return an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).\n\n\n\n## Optional Arguments\n\n* `cmd` - If set, override the container's default terminal command and invoke these command arguments instead."
     @spec terminal(t(), keyword()) :: Dagger.Terminal.t()
     def terminal(%__MODULE__{} = container, optional_args \\ []) do
       selection = select(container.selection, "terminal")

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -930,28 +930,6 @@ func (r *Container) Rootfs() *Directory {
 	}
 }
 
-// ContainerShellOpts contains options for Container.Shell
-type ContainerShellOpts struct {
-	// If set, override the container's default shell and invoke these arguments instead.
-	Args []string
-}
-
-// Return an interactive terminal for this container using its configured shell if not overridden by args (or sh as a fallback default).
-func (r *Container) Shell(opts ...ContainerShellOpts) *Terminal {
-	q := r.q.Select("shell")
-	for i := len(opts) - 1; i >= 0; i-- {
-		// `args` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Args) {
-			q = q.Arg("args", opts[i].Args)
-		}
-	}
-
-	return &Terminal{
-		q: q,
-		c: r.c,
-	}
-}
-
 // The error stream of the last executed command.
 //
 // Will execute default command if none is set, or error if there's no default.
@@ -989,6 +967,28 @@ func (r *Container) Sync(ctx context.Context) (*Container, error) {
 	q := r.q.Select("sync")
 
 	return r, q.Execute(ctx, r.c)
+}
+
+// ContainerTerminalOpts contains options for Container.Terminal
+type ContainerTerminalOpts struct {
+	// If set, override the container's default shell command and invoke these command arguments instead.
+	Cmd []string
+}
+
+// Return an interactive terminal for this container using its configured shell if not overridden by args (or sh as a fallback default).
+func (r *Container) Terminal(opts ...ContainerTerminalOpts) *Terminal {
+	q := r.q.Select("terminal")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `cmd` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Cmd) {
+			q = q.Arg("cmd", opts[i].Cmd)
+		}
+	}
+
+	return &Terminal{
+		q: q,
+		c: r.c,
+	}
 }
 
 // Retrieves the user to be set for all commands.

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -971,11 +971,11 @@ func (r *Container) Sync(ctx context.Context) (*Container, error) {
 
 // ContainerTerminalOpts contains options for Container.Terminal
 type ContainerTerminalOpts struct {
-	// If set, override the container's default shell command and invoke these command arguments instead.
+	// If set, override the container's default terminal command and invoke these command arguments instead.
 	Cmd []string
 }
 
-// Return an interactive terminal for this container using its configured shell if not overridden by args (or sh as a fallback default).
+// Return an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).
 func (r *Container) Terminal(opts ...ContainerTerminalOpts) *Terminal {
 	q := r.q.Select("terminal")
 	for i := len(opts) - 1; i >= 0; i-- {

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -1015,9 +1015,9 @@ func (r *Container) WithDefaultArgs(args []string) *Container {
 	}
 }
 
-// Set the default command to invoke for the "shell" API.
-func (r *Container) WithDefaultShell(args []string) *Container {
-	q := r.q.Select("withDefaultShell")
+// Set the default command to invoke for the container's terminal API.
+func (r *Container) WithDefaultTerminalCmd(args []string) *Container {
+	q := r.q.Select("withDefaultTerminalCmd")
 	q = q.Arg("args", args)
 
 	return &Container{

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -397,11 +397,11 @@ class Container extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
-     * Set the default command to invoke for the "shell" API.
+     * Set the default command to invoke for the container's terminal API.
      */
-    public function withDefaultShell(array $args): Container
+    public function withDefaultTerminalCmd(array $args): Container
     {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withDefaultShell');
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withDefaultTerminalCmd');
         $innerQueryBuilder->setArgument('args', $args);
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -333,18 +333,6 @@ class Container extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
-     * Return an interactive terminal for this container using its configured shell if not overridden by args (or sh as a fallback default).
-     */
-    public function shell(?array $args = null): Terminal
-    {
-        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('shell');
-        if (null !== $args) {
-        $innerQueryBuilder->setArgument('args', $args);
-        }
-        return new \Dagger\Terminal($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
-    }
-
-    /**
      * The error stream of the last executed command.
      *
      * Will execute default command if none is set, or error if there's no default.
@@ -375,6 +363,18 @@ class Container extends Client\AbstractObject implements Client\IdAble
     {
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('sync');
         return new \Dagger\ContainerId((string)$this->queryLeaf($leafQueryBuilder, 'sync'));
+    }
+
+    /**
+     * Return an interactive terminal for this container using its configured shell if not overridden by args (or sh as a fallback default).
+     */
+    public function terminal(?array $cmd = null): Terminal
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('terminal');
+        if (null !== $cmd) {
+        $innerQueryBuilder->setArgument('cmd', $cmd);
+        }
+        return new \Dagger\Terminal($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 
     /**

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -366,7 +366,7 @@ class Container extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
-     * Return an interactive terminal for this container using its configured shell if not overridden by args (or sh as a fallback default).
+     * Return an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).
      */
     public function terminal(?array $cmd = null): Terminal
     {

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -1001,13 +1001,14 @@ class Container(Type):
         cmd: Sequence[str] | None = None,
     ) -> "Terminal":
         """Return an interactive terminal for this container using its configured
-        shell if not overridden by args (or sh as a fallback default).
+        default terminal command if not overridden by args (or sh as a
+        fallback default).
 
         Parameters
         ----------
         cmd:
-            If set, override the container's default shell command and invoke
-            these command arguments instead.
+            If set, override the container's default terminal command and
+            invoke these command arguments instead.
         """
         _args = [
             Arg("cmd", cmd, None),

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -1054,18 +1054,18 @@ class Container(Type):
         return Container(_ctx)
 
     @typecheck
-    def with_default_shell(self, args: Sequence[str]) -> "Container":
-        """Set the default command to invoke for the "shell" API.
+    def with_default_terminal_cmd(self, args: Sequence[str]) -> "Container":
+        """Set the default command to invoke for the container's terminal API.
 
         Parameters
         ----------
         args:
-            The args of the command to set the default shell to.
+            The args of the command.
         """
         _args = [
             Arg("args", args),
         ]
-        _ctx = self._select("withDefaultShell", _args)
+        _ctx = self._select("withDefaultTerminalCmd", _args)
         return Container(_ctx)
 
     @typecheck

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -921,27 +921,6 @@ class Container(Type):
         return Directory(_ctx)
 
     @typecheck
-    def shell(
-        self,
-        *,
-        args: Sequence[str] | None = None,
-    ) -> "Terminal":
-        """Return an interactive terminal for this container using its configured
-        shell if not overridden by args (or sh as a fallback default).
-
-        Parameters
-        ----------
-        args:
-            If set, override the container's default shell and invoke these
-            arguments instead.
-        """
-        _args = [
-            Arg("args", args, None),
-        ]
-        _ctx = self._select("shell", _args)
-        return Terminal(_ctx)
-
-    @typecheck
     async def stderr(self) -> str:
         """The error stream of the last executed command.
 
@@ -1014,6 +993,27 @@ class Container(Type):
 
     def __await__(self):
         return self.sync().__await__()
+
+    @typecheck
+    def terminal(
+        self,
+        *,
+        cmd: Sequence[str] | None = None,
+    ) -> "Terminal":
+        """Return an interactive terminal for this container using its configured
+        shell if not overridden by args (or sh as a fallback default).
+
+        Parameters
+        ----------
+        cmd:
+            If set, override the container's default shell command and invoke
+            these command arguments instead.
+        """
+        _args = [
+            Arg("cmd", cmd, None),
+        ]
+        _ctx = self._select("terminal", _args)
+        return Terminal(_ctx)
 
     @typecheck
     async def user(self) -> str:

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -698,7 +698,7 @@ pub struct ContainerPublishOpts {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerTerminalOpts<'a> {
-    /// If set, override the container's default shell command and invoke these command arguments instead.
+    /// If set, override the container's default terminal command and invoke these command arguments instead.
     #[builder(setter(into, strip_option), default)]
     pub cmd: Option<Vec<&'a str>>,
 }
@@ -1305,7 +1305,7 @@ impl Container {
         let query = self.selection.select("sync");
         query.execute(self.graphql_client.clone()).await
     }
-    /// Return an interactive terminal for this container using its configured shell if not overridden by args (or sh as a fallback default).
+    /// Return an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).
     ///
     /// # Arguments
     ///
@@ -1318,7 +1318,7 @@ impl Container {
             graphql_client: self.graphql_client.clone(),
         };
     }
-    /// Return an interactive terminal for this container using its configured shell if not overridden by args (or sh as a fallback default).
+    /// Return an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).
     ///
     /// # Arguments
     ///

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -1356,13 +1356,13 @@ impl Container {
             graphql_client: self.graphql_client.clone(),
         };
     }
-    /// Set the default command to invoke for the "shell" API.
+    /// Set the default command to invoke for the container's terminal API.
     ///
     /// # Arguments
     ///
-    /// * `args` - The args of the command to set the default shell to.
-    pub fn with_default_shell(&self, args: Vec<impl Into<String>>) -> Container {
-        let mut query = self.selection.select("withDefaultShell");
+    /// * `args` - The args of the command.
+    pub fn with_default_terminal_cmd(&self, args: Vec<impl Into<String>>) -> Container {
+        let mut query = self.selection.select("withDefaultTerminalCmd");
         query = query.arg(
             "args",
             args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -697,10 +697,10 @@ pub struct ContainerPublishOpts {
     pub platform_variants: Option<Vec<ContainerId>>,
 }
 #[derive(Builder, Debug, PartialEq)]
-pub struct ContainerShellOpts<'a> {
-    /// If set, override the container's default shell and invoke these arguments instead.
+pub struct ContainerTerminalOpts<'a> {
+    /// If set, override the container's default shell command and invoke these command arguments instead.
     #[builder(setter(into, strip_option), default)]
-    pub args: Option<Vec<&'a str>>,
+    pub cmd: Option<Vec<&'a str>>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithDirectoryOpts<'a> {
@@ -1287,35 +1287,6 @@ impl Container {
             graphql_client: self.graphql_client.clone(),
         };
     }
-    /// Return an interactive terminal for this container using its configured shell if not overridden by args (or sh as a fallback default).
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn shell(&self) -> Terminal {
-        let query = self.selection.select("shell");
-        return Terminal {
-            proc: self.proc.clone(),
-            selection: query,
-            graphql_client: self.graphql_client.clone(),
-        };
-    }
-    /// Return an interactive terminal for this container using its configured shell if not overridden by args (or sh as a fallback default).
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn shell_opts<'a>(&self, opts: ContainerShellOpts<'a>) -> Terminal {
-        let mut query = self.selection.select("shell");
-        if let Some(args) = opts.args {
-            query = query.arg("args", args);
-        }
-        return Terminal {
-            proc: self.proc.clone(),
-            selection: query,
-            graphql_client: self.graphql_client.clone(),
-        };
-    }
     /// The error stream of the last executed command.
     /// Will execute default command if none is set, or error if there's no default.
     pub async fn stderr(&self) -> Result<String, DaggerError> {
@@ -1333,6 +1304,35 @@ impl Container {
     pub async fn sync(&self) -> Result<ContainerId, DaggerError> {
         let query = self.selection.select("sync");
         query.execute(self.graphql_client.clone()).await
+    }
+    /// Return an interactive terminal for this container using its configured shell if not overridden by args (or sh as a fallback default).
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub fn terminal(&self) -> Terminal {
+        let query = self.selection.select("terminal");
+        return Terminal {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        };
+    }
+    /// Return an interactive terminal for this container using its configured shell if not overridden by args (or sh as a fallback default).
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub fn terminal_opts<'a>(&self, opts: ContainerTerminalOpts<'a>) -> Terminal {
+        let mut query = self.selection.select("terminal");
+        if let Some(cmd) = opts.cmd {
+            query = query.arg("cmd", cmd);
+        }
+        return Terminal {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        };
     }
     /// Retrieves the user to be set for all commands.
     pub async fn user(&self) -> Result<String, DaggerError> {

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -199,7 +199,7 @@ export type ContainerPublishOpts = {
 
 export type ContainerTerminalOpts = {
   /**
-   * If set, override the container's default shell command and invoke these command arguments instead.
+   * If set, override the container's default terminal command and invoke these command arguments instead.
    */
   cmd?: string[]
 }
@@ -1761,8 +1761,8 @@ export class Container extends BaseClient {
   }
 
   /**
-   * Return an interactive terminal for this container using its configured shell if not overridden by args (or sh as a fallback default).
-   * @param opts.cmd If set, override the container's default shell command and invoke these command arguments instead.
+   * Return an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).
+   * @param opts.cmd If set, override the container's default terminal command and invoke these command arguments instead.
    */
   terminal = (opts?: ContainerTerminalOpts): Terminal => {
     return new Terminal({

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -197,11 +197,11 @@ export type ContainerPublishOpts = {
   mediaTypes?: ImageMediaTypes
 }
 
-export type ContainerShellOpts = {
+export type ContainerTerminalOpts = {
   /**
-   * If set, override the container's default shell and invoke these arguments instead.
+   * If set, override the container's default shell command and invoke these command arguments instead.
    */
-  args?: string[]
+  cmd?: string[]
 }
 
 export type ContainerWithDirectoryOpts = {
@@ -1696,23 +1696,6 @@ export class Container extends BaseClient {
   }
 
   /**
-   * Return an interactive terminal for this container using its configured shell if not overridden by args (or sh as a fallback default).
-   * @param opts.args If set, override the container's default shell and invoke these arguments instead.
-   */
-  shell = (opts?: ContainerShellOpts): Terminal => {
-    return new Terminal({
-      queryTree: [
-        ...this._queryTree,
-        {
-          operation: "shell",
-          args: { ...opts },
-        },
-      ],
-      ctx: this._ctx,
-    })
-  }
-
-  /**
    * The error stream of the last executed command.
    *
    * Will execute default command if none is set, or error if there's no default.
@@ -1775,6 +1758,23 @@ export class Container extends BaseClient {
     )
 
     return this
+  }
+
+  /**
+   * Return an interactive terminal for this container using its configured shell if not overridden by args (or sh as a fallback default).
+   * @param opts.cmd If set, override the container's default shell command and invoke these command arguments instead.
+   */
+  terminal = (opts?: ContainerTerminalOpts): Terminal => {
+    return new Terminal({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "terminal",
+          args: { ...opts },
+        },
+      ],
+      ctx: this._ctx,
+    })
   }
 
   /**

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -1816,15 +1816,15 @@ export class Container extends BaseClient {
   }
 
   /**
-   * Set the default command to invoke for the "shell" API.
-   * @param args The args of the command to set the default shell to.
+   * Set the default command to invoke for the container's terminal API.
+   * @param args The args of the command.
    */
-  withDefaultShell = (args: string[]): Container => {
+  withDefaultTerminalCmd = (args: string[]): Container => {
     return new Container({
       queryTree: [
         ...this._queryTree,
         {
-          operation: "withDefaultShell",
+          operation: "withDefaultTerminalCmd",
           args: { args },
         },
       ],


### PR DESCRIPTION
Prior discussion on GH: https://github.com/dagger/dagger/pull/6390
Recent Discord discussion: https://discord.com/channels/707636530424053791/1120503349599543376/1202998900223647804

Changes current in this PR:
* `Container.shell` is renamed to `Container.terminal`
* `--args` renamed to `--cmd`

So from the CLI you'd now do e.g.
```console
dagger call my-devenv terminal --cmd neovim
```

We also discussed some alternatives to `terminal` in the zenith call a bit ago:
* `tty`
* `open-terminal`
* `console`
* `attach`
* (more I am probably forgetting already, please chime in)

Overall, `terminal` is fine with me in that it avoids:
* some of the weirdness around `withDefaultShell` and `shell` not actually corresponding to "set value" and "get value"
* it's more generic and technically accurate than shell 

The main downside is verbosity, which `tty` could avoid. But `tty` might be overly technical depending on the audience.

---

TODO:
- [ ] update docs once this is settled