### PR TITLE
add integ test for mod init --name and --sdk required together

### DIFF
--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -534,3 +534,26 @@ func TestModuleCustomDepNames(t *testing.T) {
 		require.Equal(t, "hi from dep1 hi from dep2", strings.TrimSpace(out))
 	})
 }
+
+func TestModuleDaggerInit(t *testing.T) {
+	t.Parallel()
+	t.Run("name and sdk must be set together", func(t *testing.T) {
+		t.Parallel()
+		c, ctx := connect(t)
+		_, err := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work").
+			With(daggerExec("mod", "init", "--name=test")).
+			Stdout(ctx)
+		require.Error(t, err)
+		require.ErrorContains(t, err, `if any flags in the group [sdk name] are set they must all be set; missing [sdk]`)
+
+		_, err = c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work").
+			With(daggerExec("mod", "init", "--sdk=go")).
+			Stdout(ctx)
+		require.Error(t, err)
+		require.ErrorContains(t, err, `if any flags in the group [sdk name] are set they must all be set; missing [name]`)
+	})
+}


### PR DESCRIPTION
Coverage for this was missing. I expected going into this that it would actually not work as expected yet based on user reports but I haven't been able to repro the behavior they saw yet. Will update if any bugs are found. But in the meantime obviously need to have coverage of this either way.