### PR TITLE
Service.up: make `native` the default, add `random`

### DIFF
--- a/core/integration/module_shell_test.go
+++ b/core/integration/module_shell_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -52,7 +53,7 @@ type Test struct {
 		require.NoError(t, err)
 
 		// timeout for waiting for each expected line is very generous in case CI is under heavy load or something
-		console, err := newShellTestConsole(60 * time.Second)
+		console, err := newTUIConsole(t, 60*time.Second)
 		require.NoError(t, err)
 		defer console.Close()
 
@@ -122,7 +123,7 @@ type Test struct {
 		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "call", "ctr", "sync")
 		require.NoError(t, err)
 
-		console, err := newShellTestConsole(60 * time.Second)
+		console, err := newTUIConsole(t, 60*time.Second)
 		require.NoError(t, err)
 		defer console.Close()
 
@@ -164,32 +165,43 @@ type Test struct {
 	})
 }
 
-// shellTestConsole wraps expect.Console with methods that allow us to enforce timeouts despite
-// the fact that the TUI is constantly writing more data (which invalidates the expect lib's builtin
-// read timeout mechanisms).
-type shellTestConsole struct {
+// tuiConsole wraps expect.Console with methods that allow us to enforce
+// timeouts despite the fact that the TUI is constantly writing more data
+// (which invalidates the expect lib's builtin read timeout mechanisms).
+type tuiConsole struct {
 	*expect.Console
 	expectLineTimeout time.Duration
 	output            *bytes.Buffer
 }
 
-func newShellTestConsole(expectLineTimeout time.Duration) (*shellTestConsole, error) {
+func newTUIConsole(t *testing.T, expectLineTimeout time.Duration) (*tuiConsole, error) {
 	output := bytes.NewBuffer(nil)
-	console, err := expect.NewConsole(expect.WithStdout(output), expect.WithDefaultTimeout(expectLineTimeout))
+	console, err := expect.NewConsole(
+		expect.WithStdout(io.MultiWriter(newTWriter(t), output)),
+		expect.WithDefaultTimeout(expectLineTimeout),
+	)
 	if err != nil {
 		return nil, err
 	}
-	return &shellTestConsole{
+	t.Cleanup(func() {
+		console.Close()
+	})
+	return &tuiConsole{
 		Console:           console,
 		expectLineTimeout: expectLineTimeout,
 		output:            output,
 	}, nil
 }
 
-func (e *shellTestConsole) ExpectLineRegex(ctx context.Context, pattern string) error {
+func (e *tuiConsole) ExpectLineRegex(ctx context.Context, pattern string) error {
+	_, _, err := e.MatchLine(ctx, pattern)
+	return err
+}
+
+func (e *tuiConsole) MatchLine(ctx context.Context, pattern string) (string, []string, error) {
 	re, err := regexp.Compile(pattern)
 	if err != nil {
-		return err
+		return "", nil, err
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, e.expectLineTimeout)
@@ -198,16 +210,16 @@ func (e *shellTestConsole) ExpectLineRegex(ctx context.Context, pattern string) 
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("timed out waiting for line matching %q, most recent output:\n%s", pattern, e.output.String())
+			return "", nil, fmt.Errorf("timed out waiting for line matching %q, most recent output:\n%s", pattern, e.output.String())
 		default:
 		}
 
 		line, err := e.Expect(lineMatcher)
 		if err != nil {
-			return err
+			return "", nil, err
 		}
-		if re.MatchString(line) {
-			return nil
+		if matches := re.FindStringSubmatch(line); matches != nil {
+			return line, matches, nil
 		}
 	}
 }

--- a/core/schema/host.go
+++ b/core/schema/host.go
@@ -81,6 +81,8 @@ func (s *hostSchema) Install() {
 		dagql.Func("tunnel", s.tunnel).
 			Doc(`Creates a tunnel that forwards traffic from the host to a service.`).
 			ArgDoc("service", `Service to send traffic from the tunnel.`).
+			ArgDoc("ports", `List of frontend/backend port mappings to forward.`,
+				`Frontend is the port accepting traffic on the host, backend is the service port.`).
 			ArgDoc("native",
 				`Map each service port to the same port on the host, as if the service were running natively.`,
 				`Note: enabling may result in port conflicts.`).

--- a/core/schema/service.go
+++ b/core/schema/service.go
@@ -49,7 +49,10 @@ func (s *serviceSchema) Install() {
 
 		dagql.NodeFunc("up", s.up).
 			Impure("Starts a host tunnel, possibly with ports that change each time it's started.").
-			Doc(`Creates a tunnel that forwards traffic from the caller's network to this service.`),
+			Doc(`Creates a tunnel that forwards traffic from the caller's network to this service.`).
+			ArgDoc("random", `Bind each tunnel port to a random port on the host.`).
+			ArgDoc("ports", `List of frontend/backend port mappings to forward.`,
+				`Frontend is the port accepting traffic on the host, backend is the service port.`),
 
 		dagql.NodeFunc("stop", s.stop).
 			Impure("Imperatively mutates runtime state.").
@@ -115,7 +118,7 @@ func (s *serviceSchema) stop(ctx context.Context, parent dagql.Instance[*core.Se
 
 type upArgs struct {
 	Ports  []dagql.InputObject[core.PortForward] `default:"[]"`
-	Native bool                                  `default:"false"`
+	Random bool                                  `default:"false"`
 }
 
 func (s *serviceSchema) up(ctx context.Context, svc dagql.Instance[*core.Service], args upArgs) (dagql.Nullable[core.Void], error) {
@@ -131,7 +134,7 @@ func (s *serviceSchema) up(ctx context.Context, svc dagql.Instance[*core.Service
 			Args: []dagql.NamedInput{
 				{Name: "service", Value: dagql.NewID[*core.Service](svc.ID())},
 				{Name: "ports", Value: dagql.ArrayInput[dagql.InputObject[core.PortForward]](args.Ports)},
-				{Name: "native", Value: dagql.Boolean(args.Native)},
+				{Name: "native", Value: dagql.Boolean(!args.Random)},
 			},
 		},
 	)

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -2214,7 +2214,17 @@ type Service {
   """
   Creates a tunnel that forwards traffic from the caller's network to this service.
   """
-  up(native: Boolean = false, ports: [PortForward!] = []): Void
+  up(
+    """
+    List of frontend/backend port mappings to forward.
+    
+    Frontend is the port accepting traffic on the host, backend is the service port.
+    """
+    ports: [PortForward!] = []
+
+    """Bind each tunnel port to a random port on the host."""
+    random: Boolean = false
+  ): Void
 }
 
 """

--- a/sdk/elixir/lib/dagger/gen/service.ex
+++ b/sdk/elixir/lib/dagger/gen/service.ex
@@ -94,7 +94,7 @@ defmodule Dagger.Service do
   )
 
   (
-    @doc "Creates a tunnel that forwards traffic from the caller's network to this service.\n\n\n\n## Optional Arguments\n\n* `ports` - \n* `native` -"
+    @doc "Creates a tunnel that forwards traffic from the caller's network to this service.\n\n\n\n## Optional Arguments\n\n* `ports` - List of frontend/backend port mappings to forward.\n\nFrontend is the port accepting traffic on the host, backend is the service port.\n* `random` - Bind each tunnel port to a random port on the host."
     @spec up(t(), keyword()) :: {:ok, Dagger.Void.t() | nil} | {:error, term()}
     def up(%__MODULE__{} = service, optional_args \\ []) do
       selection = select(service.selection, "up")
@@ -107,10 +107,10 @@ defmodule Dagger.Service do
         end
 
       selection =
-        if is_nil(optional_args[:native]) do
+        if is_nil(optional_args[:random]) do
           selection
         else
-          arg(selection, "native", optional_args[:native])
+          arg(selection, "random", optional_args[:random])
         end
 
       execute(selection, service.client)

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -5888,9 +5888,12 @@ func (r *Service) Stop(ctx context.Context, opts ...ServiceStopOpts) (*Service, 
 
 // ServiceUpOpts contains options for Service.Up
 type ServiceUpOpts struct {
+	// List of frontend/backend port mappings to forward.
+	//
+	// Frontend is the port accepting traffic on the host, backend is the service port.
 	Ports []PortForward
-
-	Native bool
+	// Bind each tunnel port to a random port on the host.
+	Random bool
 }
 
 // Creates a tunnel that forwards traffic from the caller's network to this service.
@@ -5904,9 +5907,9 @@ func (r *Service) Up(ctx context.Context, opts ...ServiceUpOpts) (Void, error) {
 		if !querybuilder.IsZeroValue(opts[i].Ports) {
 			q = q.Arg("ports", opts[i].Ports)
 		}
-		// `native` optional argument
-		if !querybuilder.IsZeroValue(opts[i].Native) {
-			q = q.Arg("native", opts[i].Native)
+		// `random` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Random) {
+			q = q.Arg("random", opts[i].Random)
 		}
 	}
 

--- a/sdk/php/generated/Service.php
+++ b/sdk/php/generated/Service.php
@@ -85,14 +85,14 @@ class Service extends Client\AbstractObject implements Client\IdAble
     /**
      * Creates a tunnel that forwards traffic from the caller's network to this service.
      */
-    public function up(?array $ports = null, ?bool $native = false): void
+    public function up(?array $ports = null, ?bool $random = false): void
     {
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('up');
         if (null !== $ports) {
         $leafQueryBuilder->setArgument('ports', $ports);
         }
-        if (null !== $native) {
-        $leafQueryBuilder->setArgument('native', $native);
+        if (null !== $random) {
+        $leafQueryBuilder->setArgument('random', $random);
         }
         $this->queryLeaf($leafQueryBuilder, 'up');
     }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -5948,10 +5948,19 @@ class Service(Type):
         self,
         *,
         ports: Sequence[PortForward] | None = [],
-        native: bool | None = False,
+        random: bool | None = False,
     ) -> Void | None:
         """Creates a tunnel that forwards traffic from the caller's network to
         this service.
+
+        Parameters
+        ----------
+        ports:
+            List of frontend/backend port mappings to forward.
+            Frontend is the port accepting traffic on the host, backend is the
+            service port.
+        random:
+            Bind each tunnel port to a random port on the host.
 
         Returns
         -------
@@ -5968,7 +5977,7 @@ class Service(Type):
         """
         _args = [
             Arg("ports", ports, []),
-            Arg("native", native, False),
+            Arg("random", random, False),
         ]
         _ctx = self._select("up", _args)
         return await _ctx.execute(Void | None)

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -5429,10 +5429,13 @@ pub struct ServiceStopOpts {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ServiceUpOpts {
-    #[builder(setter(into, strip_option), default)]
-    pub native: Option<bool>,
+    /// List of frontend/backend port mappings to forward.
+    /// Frontend is the port accepting traffic on the host, backend is the service port.
     #[builder(setter(into, strip_option), default)]
     pub ports: Option<Vec<PortForward>>,
+    /// Bind each tunnel port to a random port on the host.
+    #[builder(setter(into, strip_option), default)]
+    pub random: Option<bool>,
 }
 impl Service {
     /// Retrieves an endpoint that clients can use to reach this container.
@@ -5531,8 +5534,8 @@ impl Service {
         if let Some(ports) = opts.ports {
             query = query.arg("ports", ports);
         }
-        if let Some(native) = opts.native {
-            query = query.arg("native", native);
+        if let Some(random) = opts.random {
+            query = query.arg("random", random);
         }
         query.execute(self.graphql_client.clone()).await
     }

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -900,8 +900,17 @@ export type ServiceStopOpts = {
 }
 
 export type ServiceUpOpts = {
+  /**
+   * List of frontend/backend port mappings to forward.
+   *
+   * Frontend is the port accepting traffic on the host, backend is the service port.
+   */
   ports?: PortForward[]
-  native?: boolean
+
+  /**
+   * Bind each tunnel port to a random port on the host.
+   */
+  random?: boolean
 }
 
 /**
@@ -7471,6 +7480,10 @@ export class Service extends BaseClient {
 
   /**
    * Creates a tunnel that forwards traffic from the caller's network to this service.
+   * @param opts.ports List of frontend/backend port mappings to forward.
+   *
+   * Frontend is the port accepting traffic on the host, backend is the service port.
+   * @param opts.random Bind each tunnel port to a random port on the host.
    */
   up = async (opts?: ServiceUpOpts): Promise<Void> => {
     if (this._up) {


### PR DESCRIPTION
It seems in most cases we want `--native` to be the default. So this makes it the default and adds `--random` for the old behavior (choose random ports).
