### PR TITLE
Hide debug and soon-to-be-deprecated flags

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -43,6 +43,13 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cpuprofile, "cpuprofile", "", "collect CPU profile to path, and trace at path.trace")
 	rootCmd.PersistentFlags().StringVar(&pprofAddr, "pprof", "", "serve HTTP pprof at this address")
 
+	for _, fl := range []string{"workdir", "cpuprofile", "pprof"} {
+		if err := rootCmd.PersistentFlags().MarkHidden(fl); err != nil {
+			fmt.Println("Error hiding flag: "+fl, err)
+			os.Exit(1)
+		}
+	}
+
 	rootCmd.AddCommand(
 		listenCmd,
 		versionCmd,


### PR DESCRIPTION
--pprof: useful for debugging dagger itself, but not for regular usage
--cpuprofile: same as above
--workdir: may be deprecated soon, hide it in the meantime

I also wanted to hide the `dagger completion`, but didn't find how. Will open a separate PR once I do.
