### PR TITLE
core: separate service start vertex

### DIFF
--- a/core/service.go
+++ b/core/service.go
@@ -262,7 +262,7 @@ func (svc *Service) startContainer(
 		}
 	}()
 
-	vtx := rec.Vertex(dig, "start "+strings.Join(execOp.Meta.Args, " "))
+	vtx := rec.Vertex(dig+".start", "start "+strings.Join(execOp.Meta.Args, " "))
 	defer func() {
 		if err != nil {
 			vtx.Error(err)


### PR DESCRIPTION
Following dagql integration, the service start operation was not relying on a unique ID as digest anymore. This led the Cloud not showing the service start as a step in Dagger Cloud. By appending the ".start" to the id, we isolate it

We now have back: 
<img width="493" alt="image" src="https://github.com/dagger/dagger/assets/31691250/6853a679-247c-4854-bf67-f8cf9fe3f594">

