### PR TITLE
chore: tidy up wrapping nil error in session call

### DIFF
--- a/engine/server/buildkitcontroller.go
+++ b/engine/server/buildkitcontroller.go
@@ -206,7 +206,10 @@ func (e *BuildkitController) Session(stream controlapi.Control_SessionServer) (r
 		bklog.G(ctx).Debug("session manager handling conn")
 		err := e.SessionManager.HandleConn(egctx, conn, hijackmd)
 		bklog.G(ctx).WithError(err).Debug("session manager handle conn done")
-		return fmt.Errorf("handleConn: %w", err)
+		if err != nil {
+			return fmt.Errorf("handleConn: %w", err)
+		}
+		return nil
 	})
 
 	// NOTE: the perServerMu here is used to ensure that we hold a lock


### PR DESCRIPTION
Hm, I didn't catch this in https://github.com/dagger/dagger/pull/6499.

It looks like I fixed it for `srv.Wait`, not actually for `handleConn` :scream: 