### PR TITLE
chore: cleanup grpchijacked connections

### DIFF
--- a/engine/server/buildkitcontroller.go
+++ b/engine/server/buildkitcontroller.go
@@ -173,8 +173,7 @@ func (e *BuildkitController) Session(stream controlapi.Control_SessionServer) (r
 	}()
 
 	conn, closeCh, hijackmd := grpchijack.Hijack(stream)
-	// TODO: this blocks if opts.RegisterClient and an error happens
-	// TODO: ? defer conn.Close()
+	defer conn.Close()
 	go func() {
 		<-closeCh
 		cancel()


### PR DESCRIPTION
There is a comment suggesting this? I'm not quite sure why it's not turned on, it definitely feels important.

This also clogs up every stack dump, with literally thousands of copies, since it never closes.

@sipsma is there a good reason to not do this? The stream connection can never outlive this `Session` call, so we should just be able to call this.