### PR TITLE
Isolate secrets to each module

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -340,6 +340,7 @@ func (container *Container) Build(
 	container.Services.Merge(contextDir.Services)
 
 	for _, secret := range secrets {
+		// ??? what - how does this work?
 		container.Secrets = append(container.Secrets, ContainerSecret{
 			Secret:    secret,
 			MountPath: fmt.Sprintf("/run/secrets/%s", secret.Name),
@@ -1076,7 +1077,7 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 
 	secretsToScrub := SecretToScrubInfo{}
 	for i, secret := range container.Secrets {
-		secretOpts := []llb.SecretOption{llb.SecretID(secret.Secret.Name)}
+		secretOpts := []llb.SecretOption{llb.SecretID(secret.Secret.Scope + "/" + secret.Secret.Name)}
 
 		var secretDest string
 		switch {

--- a/core/container.go
+++ b/core/container.go
@@ -1077,7 +1077,7 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 
 	secretsToScrub := SecretToScrubInfo{}
 	for i, secret := range container.Secrets {
-		secretOpts := []llb.SecretOption{llb.SecretID(secret.Secret.Scope + "/" + secret.Secret.Name)}
+		secretOpts := []llb.SecretOption{llb.SecretID(secret.Secret.Accessor)}
 
 		var secretDest string
 		switch {

--- a/core/container.go
+++ b/core/container.go
@@ -387,6 +387,8 @@ func (container *Container) Build(
 		dockerui.DefaultLocalNameDockerfile: contextDir.LLB,
 	}
 
+	// FIXME: ew, this is a terrible way to pass this around
+	//nolint:staticcheck
 	solveCtx := context.WithValue(ctx, "secret-translator", func(name string) (string, error) {
 		m, err := container.Query.CurrentModule(ctx)
 		if err != nil && !errors.Is(err, ErrNoCurrentModule) {

--- a/core/container.go
+++ b/core/container.go
@@ -390,18 +390,7 @@ func (container *Container) Build(
 	// FIXME: ew, this is a terrible way to pass this around
 	//nolint:staticcheck
 	solveCtx := context.WithValue(ctx, "secret-translator", func(name string) (string, error) {
-		m, err := container.Query.CurrentModule(ctx)
-		if err != nil && !errors.Is(err, ErrNoCurrentModule) {
-			return "", err
-		}
-		var d digest.Digest
-		if m != nil {
-			d, err = m.InstanceID.Digest()
-			if err != nil {
-				return "", err
-			}
-		}
-		return NewSecretAccessor(name, d.String()), nil
+		return GetLocalSecretAccessor(ctx, container.Query, name)
 	})
 
 	res, err := bk.Solve(solveCtx, bkgw.SolveRequest{

--- a/core/host.go
+++ b/core/host.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/containerd/containerd/labels"
 	"github.com/dagger/dagger/dagql"
-	"github.com/dagger/dagger/engine"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/vektah/gqlparser/v2/ast"
 	"github.com/vito/progrock"
@@ -121,16 +120,16 @@ func (host *Host) File(ctx context.Context, srv *dagql.Server, filePath string) 
 }
 
 func (host *Host) SetSecretFile(ctx context.Context, srv *dagql.Server, secretName string, path string) (i dagql.Instance[*Secret], err error) {
-	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+	accessor, err := GetLocalSecretAccessor(ctx, host.Query, secretName)
 	if err != nil {
 		return i, err
 	}
-	accessor := NewSecretAccessor(secretName, clientMetadata.ClientID)
 
 	secretFileContent, err := host.Query.Buildkit.ReadCallerHostFile(ctx, path)
 	if err != nil {
 		return i, fmt.Errorf("read secret file: %w", err)
 	}
+
 	if err := host.Query.Secrets.AddSecret(ctx, accessor, secretFileContent); err != nil {
 		return i, err
 	}

--- a/core/host.go
+++ b/core/host.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containerd/containerd/labels"
 	"github.com/dagger/dagger/dagql"
+	"github.com/dagger/dagger/engine"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/vektah/gqlparser/v2/ast"
 	"github.com/vito/progrock"
@@ -120,11 +121,16 @@ func (host *Host) File(ctx context.Context, srv *dagql.Server, filePath string) 
 }
 
 func (host *Host) SetSecretFile(ctx context.Context, srv *dagql.Server, secretName string, path string) (i dagql.Instance[*Secret], err error) {
+	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+	if err != nil {
+		return i, err
+	}
+
 	secretFileContent, err := host.Query.Buildkit.ReadCallerHostFile(ctx, path)
 	if err != nil {
 		return i, fmt.Errorf("read secret file: %w", err)
 	}
-	if err := host.Query.Secrets.AddSecret(ctx, secretName, secretFileContent); err != nil {
+	if err := host.Query.Secrets.AddSecret(ctx, clientMetadata.ClientID, secretName, secretFileContent); err != nil {
 		return i, err
 	}
 	err = srv.Select(ctx, srv.Root(), &i, dagql.Selector{

--- a/core/host.go
+++ b/core/host.go
@@ -125,12 +125,13 @@ func (host *Host) SetSecretFile(ctx context.Context, srv *dagql.Server, secretNa
 	if err != nil {
 		return i, err
 	}
+	accessor := NewSecretAccessor(secretName, clientMetadata.ClientID)
 
 	secretFileContent, err := host.Query.Buildkit.ReadCallerHostFile(ctx, path)
 	if err != nil {
 		return i, fmt.Errorf("read secret file: %w", err)
 	}
-	if err := host.Query.Secrets.AddSecret(ctx, clientMetadata.ClientID, secretName, secretFileContent); err != nil {
+	if err := host.Query.Secrets.AddSecret(ctx, accessor, secretFileContent); err != nil {
 		return i, err
 	}
 	err = srv.Select(ctx, srv.Root(), &i, dagql.Selector{
@@ -139,6 +140,10 @@ func (host *Host) SetSecretFile(ctx context.Context, srv *dagql.Server, secretNa
 			{
 				Name:  "name",
 				Value: dagql.NewString(secretName),
+			},
+			{
+				Name:  "accessor",
+				Value: dagql.NewString(accessor),
 			},
 		},
 	})

--- a/core/host.go
+++ b/core/host.go
@@ -142,7 +142,7 @@ func (host *Host) SetSecretFile(ctx context.Context, srv *dagql.Server, secretNa
 			},
 			{
 				Name:  "accessor",
-				Value: dagql.NewString(accessor),
+				Value: dagql.Opt(dagql.NewString(accessor)),
 			},
 		},
 	})

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -223,8 +223,8 @@ CMD echo "stage2"
 			WithNewFile("Dockerfile",
 				`FROM golang:1.18.2-alpine
 WORKDIR /src
-RUN --mount=type=secret,id=my-secret test "$(cat /run/secrets/my-secret)" = "barbar"
-RUN --mount=type=secret,id=my-secret cp /run/secrets/my-secret  /secret
+RUN --mount=type=secret,id=my-secret,required=true test "$(cat /run/secrets/my-secret)" = "barbar"
+RUN --mount=type=secret,id=my-secret,required=true cp /run/secrets/my-secret  /secret
 CMD cat /secret
 `)
 

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -3004,7 +3004,7 @@ func TestModuleGoUtilsPkg(t *testing.T) {
 		With(daggerExec("init", "--source=.", "--name=minimal", "--sdk=go")).
 		WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 			Contents: `package main
-			
+
 import (
 	"context"
 	"main/utils"
@@ -5195,7 +5195,7 @@ func diffSecret(ctx context.Context, first, second *Secret) error {
 	if err != nil {
 		return err
 	}
-	
+
 	if firstOut != secondOut {
 		return fmt.Errorf("%q != %q", firstOut, secondOut)
 	}

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5033,7 +5033,7 @@ func (t *Toplevel) Attempt(ctx context.Context) error {
 		require.NoError(t, c.Close())
 	})
 
-	t.Run("seperate secret stores", func(t *testing.T) {
+	t.Run("separate secret stores", func(t *testing.T) {
 		// check that modules can't access each other's global secret stores,
 		// by attempting to leak from each other
 		t.Parallel()

--- a/core/query.go
+++ b/core/query.go
@@ -58,6 +58,8 @@ type Query struct {
 	endpointMu *sync.RWMutex
 }
 
+var ErrNoCurrentModule = fmt.Errorf("no current module")
+
 func NewRoot() *Query {
 	return &Query{
 		clientCallContext: map[digest.Digest]*ClientCallContext{},
@@ -180,7 +182,7 @@ func (q *Query) CurrentModule(ctx context.Context) (*Module, error) {
 		return nil, err
 	}
 	if clientMetadata.ModuleCallerDigest == "" {
-		return nil, fmt.Errorf("no current module for main client caller")
+		return nil, fmt.Errorf("%w: main client caller has no module", ErrNoCurrentModule)
 	}
 
 	q.clientCallMu.RLock()
@@ -198,7 +200,7 @@ func (q *Query) CurrentFunctionCall(ctx context.Context) (*FunctionCall, error) 
 		return nil, err
 	}
 	if clientMetadata.ModuleCallerDigest == "" {
-		return nil, fmt.Errorf("no current function call for main client caller")
+		return nil, fmt.Errorf("%w: main client caller has no function", ErrNoCurrentModule)
 	}
 
 	q.clientCallMu.RLock()

--- a/core/query.go
+++ b/core/query.go
@@ -240,11 +240,10 @@ func (q *Query) NewContainer(platform Platform) *Container {
 	}
 }
 
-func (q *Query) NewSecret(name string, scope string) *Secret {
+func (q *Query) NewSecret(accessor string) *Secret {
 	return &Secret{
-		Query: q,
-		Name:  name,
-		Scope: scope,
+		Query:    q,
+		Accessor: accessor,
 	}
 }
 

--- a/core/query.go
+++ b/core/query.go
@@ -242,9 +242,10 @@ func (q *Query) NewContainer(platform Platform) *Container {
 	}
 }
 
-func (q *Query) NewSecret(accessor string) *Secret {
+func (q *Query) NewSecret(name string, accessor string) *Secret {
 	return &Secret{
 		Query:    q,
+		Name:     name,
 		Accessor: accessor,
 	}
 }

--- a/core/query.go
+++ b/core/query.go
@@ -240,10 +240,11 @@ func (q *Query) NewContainer(platform Platform) *Container {
 	}
 }
 
-func (q *Query) NewSecret(name string) *Secret {
+func (q *Query) NewSecret(name string, scope string) *Secret {
 	return &Secret{
 		Query: q,
 		Name:  name,
+		Scope: scope,
 	}
 }
 

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -1200,7 +1200,7 @@ func (s *containerSchema) withRegistryAuth(ctx context.Context, parent *core.Con
 		return nil, err
 	}
 
-	secretBytes, err := parent.Query.Secrets.GetSecret(ctx, secret.Self.Name)
+	secretBytes, err := parent.Query.Secrets.GetSecret(ctx, secret.Self.Scope+"/"+secret.Self.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -1200,7 +1200,7 @@ func (s *containerSchema) withRegistryAuth(ctx context.Context, parent *core.Con
 		return nil, err
 	}
 
-	secretBytes, err := parent.Query.Secrets.GetSecret(ctx, secret.Self.Scope+"/"+secret.Self.Name)
+	secretBytes, err := parent.Query.Secrets.GetSecret(ctx, secret.Self.Accessor)
 	if err != nil {
 		return nil, err
 	}

--- a/core/schema/secret.go
+++ b/core/schema/secret.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/dagql"
-	"github.com/dagger/dagger/engine"
 	"github.com/moby/buildkit/session/secrets"
 	"github.com/pkg/errors"
 )
@@ -46,11 +45,15 @@ type secretArgs struct {
 func (s *secretSchema) secret(ctx context.Context, parent *core.Query, args secretArgs) (*core.Secret, error) {
 	accessor := string(args.Accessor.GetOr(""))
 	if accessor == "" {
-		clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+		m, err := parent.CurrentModule(ctx)
 		if err != nil {
 			return nil, err
 		}
-		accessor = core.NewSecretAccessor(args.Name, clientMetadata.ClientID)
+		d, err := m.InstanceID.Digest()
+		if err != nil {
+			return nil, err
+		}
+		accessor = core.NewSecretAccessor(args.Name, d.String())
 	}
 
 	return parent.NewSecret(accessor), nil
@@ -64,11 +67,15 @@ type setSecretArgs struct {
 func (s *secretSchema) setSecret(ctx context.Context, parent *core.Query, args setSecretArgs) (dagql.Instance[*core.Secret], error) {
 	var inst dagql.Instance[*core.Secret]
 
-	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+	m, err := parent.CurrentModule(ctx)
 	if err != nil {
 		return inst, err
 	}
-	accessor := core.NewSecretAccessor(args.Name, clientMetadata.ClientID)
+	d, err := m.InstanceID.Digest()
+	if err != nil {
+		return inst, err
+	}
+	accessor := core.NewSecretAccessor(args.Name, d.String())
 
 	if err := parent.Secrets.AddSecret(ctx, accessor, []byte(args.Plaintext)); err != nil {
 		return inst, err
@@ -90,6 +97,7 @@ func (s *secretSchema) setSecret(ctx context.Context, parent *core.Query, args s
 	}); err != nil {
 		return inst, err
 	}
+
 	return inst, nil
 }
 

--- a/core/secret.go
+++ b/core/secret.go
@@ -23,6 +23,21 @@ type Secret struct {
 	Accessor string `json:"accessor,omitempty"`
 }
 
+func GetLocalSecretAccessor(ctx context.Context, parent *Query, name string) (string, error) {
+	m, err := parent.CurrentModule(ctx)
+	if err != nil && !errors.Is(err, ErrNoCurrentModule) {
+		return "", err
+	}
+	var d digest.Digest
+	if m != nil {
+		d, err = m.InstanceID.Digest()
+		if err != nil {
+			return "", err
+		}
+	}
+	return NewSecretAccessor(name, d.String()), nil
+}
+
 func NewSecretAccessor(name string, scope string) string {
 	// Use an HMAC, which allows us to keep the scope secret
 	// This also protects from length-extension attacks (where if we had

--- a/core/secret.go
+++ b/core/secret.go
@@ -30,7 +30,7 @@ func GetLocalSecretAccessor(ctx context.Context, parent *Query, name string) (st
 	}
 	var d digest.Digest
 	if m != nil {
-		d, err = m.InstanceID.Digest()
+		d, err = m.Source.ID().Digest()
 		if err != nil {
 			return "", err
 		}

--- a/core/secret.go
+++ b/core/secret.go
@@ -14,6 +14,8 @@ type Secret struct {
 	Query *Query
 	// Name specifies the name of the secret.
 	Name string `json:"name,omitempty"`
+	// Scope specifes the origin of the secret.
+	Scope string `json:"scope,omitempty"`
 }
 
 func (*Secret) Type() *ast.Type {
@@ -32,10 +34,6 @@ func (secret *Secret) Clone() *Secret {
 	return &cp
 }
 
-func (secret *Secret) Plaintext(ctx context.Context) ([]byte, error) {
-	return secret.Query.Secrets.GetSecret(ctx, secret.Name)
-}
-
 func NewSecretStore() *SecretStore {
 	return &SecretStore{
 		secrets: map[string][]byte{},
@@ -49,12 +47,14 @@ type SecretStore struct {
 	secrets map[string][]byte
 }
 
+// XXX: add secret scoping util
+
 // AddSecret adds the secret identified by user defined name with its plaintext
 // value to the secret store.
-func (store *SecretStore) AddSecret(_ context.Context, name string, plaintext []byte) error {
+func (store *SecretStore) AddSecret(ctx context.Context, scope string, name string, plaintext []byte) error {
 	store.mu.Lock()
 	defer store.mu.Unlock()
-	store.secrets[name] = plaintext
+	store.secrets[scope+"/"+name] = plaintext
 	return nil
 }
 

--- a/core/secret.go
+++ b/core/secret.go
@@ -15,7 +15,7 @@ type Secret struct {
 	// Name specifies the name of the secret.
 	Name string `json:"name,omitempty"`
 	// Scope specifes the origin of the secret.
-	Scope string `json:"scope,omitempty"`
+	Scope string `json:"scope,omitempty"` // XXX: make sure this can't be accessed as part of the ID
 }
 
 func (*Secret) Type() *ast.Type {

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -2233,7 +2233,7 @@ type Query {
   ): Query!
 
   """Reference a secret by name."""
-  secret(name: String!): Secret!
+  secret(accessor: String, name: String!): Secret!
 
   """
   Sets a secret given a user defined name to its plaintext and returns the secret.

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -433,7 +433,7 @@ func (c *Client) NewContainer(ctx context.Context, req bkgw.NewContainerRequest)
 	ctr, err := bkcontainer.NewContainer(
 		context.Background(),
 		c.Worker.CacheManager(),
-		c.Worker.Executor(),
+		c.llbExec,
 		c.SessionManager,
 		bksession.NewGroup(c.ID()),
 		ctrReq,

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -244,7 +244,8 @@ func (c *Client) Solve(ctx context.Context, req bkgw.SolveRequest) (_ *Result, r
 
 	// include exec metadata that isn't included in the cache key
 	var llbRes *bkfrontend.Result
-	if req.Definition != nil && req.Definition.Def != nil {
+	switch {
+	case req.Definition != nil && req.Definition.Def != nil:
 		clientMetadata, err := engine.ClientMetadataFromContext(ctx)
 		if err != nil {
 			return nil, err
@@ -302,7 +303,7 @@ func (c *Client) Solve(ctx context.Context, req bkgw.SolveRequest) (_ *Result, r
 		if err != nil {
 			return nil, wrapError(ctx, err, c.ID())
 		}
-	} else if req.Frontend != "" {
+	case req.Frontend != "":
 		// HACK: don't force evaluation like this, we can write custom frontend
 		// wrappers (for dockerfile.v0 and gateway.v0) that read from ctx to
 		// replace the llbBridge it knows about.
@@ -327,7 +328,7 @@ func (c *Client) Solve(ctx context.Context, req bkgw.SolveRequest) (_ *Result, r
 		if err != nil {
 			return nil, err
 		}
-	} else {
+	default:
 		return nil, fmt.Errorf("invalid request")
 	}
 

--- a/engine/server/buildkitcontroller.go
+++ b/engine/server/buildkitcontroller.go
@@ -264,6 +264,7 @@ func (e *BuildkitController) Session(stream controlapi.Control_SessionServer) (r
 			ProgSockPath:          progSockPath,
 			MainClientCaller:      caller,
 			DNSConfig:             e.DNSConfig,
+			Frontends:             e.Frontends,
 		})
 		if err != nil {
 			e.perServerMu.Unlock(opts.ServerID)

--- a/sdk/elixir/lib/dagger/gen/client.ex
+++ b/sdk/elixir/lib/dagger/gen/client.ex
@@ -643,11 +643,19 @@ defmodule Dagger.Client do
   )
 
   (
-    @doc "Reference a secret by name.\n\n## Required Arguments\n\n* `name` -"
-    @spec secret(t(), Dagger.String.t()) :: Dagger.Secret.t()
-    def secret(%__MODULE__{} = query, name) do
+    @doc "Reference a secret by name.\n\n## Required Arguments\n\n* `name` - \n\n## Optional Arguments\n\n* `accessor` -"
+    @spec secret(t(), Dagger.String.t(), keyword()) :: Dagger.Secret.t()
+    def secret(%__MODULE__{} = query, name, optional_args \\ []) do
       selection = select(query.selection, "secret")
       selection = arg(selection, "name", name)
+
+      selection =
+        if is_nil(optional_args[:accessor]) do
+          selection
+        else
+          arg(selection, "accessor", optional_args[:accessor])
+        end
+
       %Dagger.Secret{selection: selection, client: query.client}
     end
   )

--- a/sdk/go/dag/dag.gen.go
+++ b/sdk/go/dag/dag.gen.go
@@ -351,9 +351,9 @@ func Pipeline(name string, opts ...dagger.PipelineOpts) *dagger.Client {
 }
 
 // Reference a secret by name.
-func Secret(name string) *dagger.Secret {
+func Secret(name string, opts ...dagger.SecretOpts) *dagger.Secret {
 	client := initClient()
-	return client.Secret(name)
+	return client.Secret(name, opts...)
 }
 
 // Sets a secret given a user defined name to its plaintext and returns the secret.

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -5762,9 +5762,20 @@ func (r *Client) Pipeline(name string, opts ...PipelineOpts) *Client {
 	}
 }
 
+// SecretOpts contains options for Client.Secret
+type SecretOpts struct {
+	Accessor string
+}
+
 // Reference a secret by name.
-func (r *Client) Secret(name string) *Secret {
+func (r *Client) Secret(name string, opts ...SecretOpts) *Secret {
 	q := r.Query.Select("secret")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `accessor` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Accessor) {
+			q = q.Arg("accessor", opts[i].Accessor)
+		}
+	}
 	q = q.Arg("name", name)
 
 	return &Secret{

--- a/sdk/php/generated/Client.php
+++ b/sdk/php/generated/Client.php
@@ -567,10 +567,13 @@ class Client extends Client\AbstractClient
     /**
      * Reference a secret by name.
      */
-    public function secret(string $name): Secret
+    public function secret(string $name, ?string $accessor = null): Secret
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('secret');
         $innerQueryBuilder->setArgument('name', $name);
+        if (null !== $accessor) {
+        $innerQueryBuilder->setArgument('accessor', $accessor);
+        }
         return new \Dagger\Secret($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -5963,10 +5963,16 @@ class Client(Root):
         return Client(_ctx)
 
     @typecheck
-    def secret(self, name: str) -> "Secret":
+    def secret(
+        self,
+        name: str,
+        *,
+        accessor: str | None = None,
+    ) -> "Secret":
         """Reference a secret by name."""
         _args = [
             Arg("name", name),
+            Arg("accessor", accessor, None),
         ]
         _ctx = self._select("secret", _args)
         return Secret(_ctx)

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -4607,6 +4607,11 @@ pub struct QueryPipelineOpts<'a> {
     #[builder(setter(into, strip_option), default)]
     pub labels: Option<Vec<PipelineLabel>>,
 }
+#[derive(Builder, Debug, PartialEq)]
+pub struct QuerySecretOpts<'a> {
+    #[builder(setter(into, strip_option), default)]
+    pub accessor: Option<&'a str>,
+}
 impl Query {
     /// Retrieves a content-addressed blob.
     ///
@@ -5547,9 +5552,30 @@ impl Query {
         };
     }
     /// Reference a secret by name.
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn secret(&self, name: impl Into<String>) -> Secret {
         let mut query = self.selection.select("secret");
         query = query.arg("name", name.into());
+        return Secret {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        };
+    }
+    /// Reference a secret by name.
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub fn secret_opts<'a>(&self, name: impl Into<String>, opts: QuerySecretOpts<'a>) -> Secret {
+        let mut query = self.selection.select("secret");
+        query = query.arg("name", name.into());
+        if let Some(accessor) = opts.accessor {
+            query = query.arg("accessor", accessor);
+        }
         return Secret {
             proc: self.proc.clone(),
             selection: query,

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -893,6 +893,10 @@ export type ClientPipelineOpts = {
   labels?: PipelineLabel[]
 }
 
+export type ClientSecretOpts = {
+  accessor?: string
+}
+
 /**
  * The `SecretID` scalar type represents an identifier for an object of type Secret.
  */
@@ -7473,13 +7477,13 @@ export class Client extends BaseClient {
   /**
    * Reference a secret by name.
    */
-  secret = (name: string): Secret => {
+  secret = (name: string, opts?: ClientSecretOpts): Secret => {
     return new Secret({
       queryTree: [
         ...this._queryTree,
         {
           operation: "secret",
-          args: { name },
+          args: { name, ...opts },
         },
       ],
       ctx: this._ctx,


### PR DESCRIPTION
[Original feature request](https://linear.app/dagger/issue/DEV-3204):

> Right now the in-memory secret store is shared across a whole dagger session, which includes the original client caller and all the modules it invokes (including transitively).
>
> Instead secrets should be passable as inputs/outputs of Functions but only accessible that explicit way, not accessible via the "ambient secret store".

To achieve this isolation, we keep the same global secret store, but ensure that each secret has a "scope" - this scope split the global secret store into lots of smaller stores.

Note, this is really quite a tricky puzzle, and the requirements become more fiddly as you lay them out:
- Secrets across different sessions/modules should be allowed the same name
- Secrets shouldn't affect caching (any more than they do today)
- Direct access to the secret store using the "feature" where they can be pulled directly using the `DockerBuild` API without explicit passing
- What should the "lifetime" of a "module-scoped ambient secret store" be? If I create a secret in a `Foo` function call, but then try and access it in `Bar`, is it still there or is it only valid per-call? If it's still there, then does it matter which module called me - and does that make for weird dependency state?

We can tick all these boxes by doing the prefixing trick - we also need to explicitly handle the `DockerBuild` frontend case, so we protect against reading directly from there. The only question really, is what prefix to use. A couple ideas I had:
- Client ID - but this is very bad for caching, so probably not
- Hash of the secret ID - this doesn't work, since there is no real parent (beyond the root query object)
- Unique ID of the current module (git hash + subpath for git modules, contenthash for a directory module) - quite good, maybe work to calculate, but also not an option for generic privileged nesting
	- Could avoid some weird lifetime issues if we extended this and also included the unique IDs of all the parents as well (so `A->X` and `B->X` calls would have two separately scoped `X` secret stores)
- Generate a unique buildkit secret for every *use* of a secret and base the prefix off a hash of everything prior to the use - also *potentially* possible, but now we need to make sure we don't accidentally cause a buildkit edge merge here!
- ...something else I'm not thinking of?

TODO:
- [x] Prefix secrets with the client ID that created them (which isolates them). Update all secret access logic with this.
- [x] Intercept dockerfile builds, and rewrite secrets with the client prefix.
	- This is needed, since frontends have the ability to directly access secrets from the secret store (via `ExecOp`/etc). We can use a custom gateway/frontend to protect against this.
- [x] Use a "stable" ID for prefixing (instead of client IDs). Every time we change a secret ID we invalidate cache, so we have to avoid doing this.
	- [x] Ensure this is tested as well