### PR TITLE
docs: fix minor output error in quickstart

### DIFF
--- a/docs/versioned_docs/version-zenith/quickstart/883939-containers.mdx
+++ b/docs/versioned_docs/version-zenith/quickstart/883939-containers.mdx
@@ -103,9 +103,9 @@ docker run --rm -it ttl.sh/my-wolfi cowsay "dagger"
 You should see the output below:
 
 ```shell
- _______
-< hello >
- -------
+ ________
+< dagger >
+ --------
         \   ^__^
          \  (oo)\_______
             (__)\       )\/\


### PR DESCRIPTION
This commit fixes an output error in the Zenith quickstart