### PR TITLE
Revert "chore: cleanup grpchijacked connections"

### DIFF
--- a/engine/server/buildkitcontroller.go
+++ b/engine/server/buildkitcontroller.go
@@ -173,7 +173,8 @@ func (e *BuildkitController) Session(stream controlapi.Control_SessionServer) (r
 	}()
 
 	conn, closeCh, hijackmd := grpchijack.Hijack(stream)
-	defer conn.Close()
+	// TODO: this blocks if opts.RegisterClient and an error happens
+	// TODO: ? defer conn.Close()
 	go func() {
 		<-closeCh
 		cancel()


### PR DESCRIPTION
Reverts #6597.

See https://github.com/dagger/dagger/pull/6597#issuecomment-1930527937. I don't have the bandwidth to investigate this properly, and the leaking threads (while annoying, at least doesn't break every test run).

If we merge this, I'll open an issue and pick it up later.