### PR TITLE
fix: new engine drivers should allow multiple connection attempts

### DIFF
--- a/engine/client/drivers/driver.go
+++ b/engine/client/drivers/driver.go
@@ -9,13 +9,19 @@ import (
 	"github.com/vito/progrock"
 )
 
-// Driver allows dialing to a dagger backend.
-//
-// It's slightly similar to the docker connhelpers, however, the function
-// signatures are slightly different.
 type Driver interface {
-	// Connect creates a buildkit client to a dagger instance from the given URL
-	Connect(ctx context.Context, rec *progrock.VertexRecorder, url *url.URL, opts *DriverOpts) (net.Conn, error)
+	// Provision creates any underlying resources for a driver, and returns a
+	// Connector that can connect to it.
+	Provision(ctx context.Context, rec *progrock.VertexRecorder, url *url.URL, opts *DriverOpts) (Connector, error)
+}
+
+type Connector interface {
+	// Connect creates a connection to a dagger instance.
+	//
+	// Connect can be called multiple times during attempts to establish a
+	// connection - but a connector can choose to block this call until
+	// previously returned connections have been closed.
+	Connect(ctx context.Context) (net.Conn, error)
 }
 
 type DriverOpts struct {


### PR DESCRIPTION
See https://github.com/dagger/dagger/pull/6288#issuecomment-1931971234 - this fixes the borked provision job: https://github.com/dagger/dagger/actions/runs/7814283652/job/21315752098.

Previously, we would only connect once. However, when calling buildkit's client.Wait we might attempt multiple connections over and over. If we only have one connection, this isn't possible. Ideally, we should have some better error messages in buildkit, since this was annoying to debug.

The right call here is to clearly split up Provision and Connect steps for a driver. This separation allows us to ensure that we Provision once, but can Connect multiple times.

I've also noted that Connect can be called multiple times, but we don't need to support multiple concurrent connections. While this isn't really important now, it would be if we added CLI plugins, where trying to require that users support *multiple concurrent connections* would be very annoying actually!