### PR TITLE
feat: remove Optional from go modules

### DIFF
--- a/cmd/codegen/generator/go/templates/module_interfaces.go
+++ b/cmd/codegen/generator/go/templates/module_interfaces.go
@@ -411,9 +411,6 @@ func (spec *parsedIfaceType) concreteMethodCode(method *funcTypeSpec) (*Statemen
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate arg type code: %w", err)
 		}
-		if argSpec.hasOptionalWrapper {
-			argTypeCode = Id("Optional").Types(argTypeCode.Clone())
-		}
 		methodArgs = append(methodArgs, Id(argSpec.name).Add(argTypeCode))
 	}
 
@@ -449,14 +446,7 @@ func (spec *parsedIfaceType) concreteMethodCode(method *funcTypeSpec) (*Statemen
 				}
 				gqlArgName := strcase.ToLowerCamel(argSpec.name)
 				setCode := Id("q").Op("=").Id("q").Dot("Arg").Call(Lit(gqlArgName), Id(argSpec.name))
-				if argSpec.hasOptionalWrapper {
-					g.If(
-						List(Id(argSpec.name), Id("ok")).Op(":=").Id(argSpec.name).Dot("Get").Call(),
-						Id("ok"),
-					).Block(setCode)
-				} else {
-					g.Add(setCode).Line()
-				}
+				g.Add(setCode).Line()
 			}
 
 			g.Add(executeQueryCode)

--- a/cmd/codegen/generator/go/templates/module_objects.go
+++ b/cmd/codegen/generator/go/templates/module_objects.go
@@ -91,11 +91,6 @@ func (ps *parseState) parseGoStruct(t *types.Struct, named *types.Named) (*parse
 		}
 
 		fieldSpec := &fieldSpec{goType: field.Type()}
-		if _, optional, err := ps.isOptionalWrapper(fieldSpec.goType); err != nil {
-			return nil, err
-		} else if optional {
-			return nil, fmt.Errorf("optional type wrapper not allowed in struct field %s", field.Name())
-		}
 		fieldSpec.typeSpec, err = ps.parseGoTypeReference(fieldSpec.goType, nil, false)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse field type: %w", err)

--- a/cmd/codegen/generator/go/templates/src/dagger.gen.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/dagger.gen.go.tmpl
@@ -38,56 +38,6 @@ func ptr[T any](v T) *T {
 	return &v
 }
 
-// Optional is a helper type to represent optional values. Any method arguments
-// that use this wrapper type will be set as optional in the generated API.
-//
-// To construct an Optional from within a module, use the Opt helper function.
-type Optional[T any] struct {
-	value T
-	isSet bool
-}
-
-// Opt is a helper function to construct an Optional with the given value set.
-func Opt[T any](v T) Optional[T] {
-	return Optional[T]{value: v, isSet: true}
-}
-
-// OptEmpty is a helper function to construct an empty Optional.
-func OptEmpty[T any]() Optional[T] {
-	return Optional[T]{}
-}
-
-// Get returns the internal value of the optional and a boolean indicating if
-// the value was set explicitly by the caller.
-func (o *Optional[T]) Get() (T, bool) {
-	if o == nil {
-		var empty T
-		return empty, false
-	}
-	return o.value, o.isSet
-}
-
-// GetOr returns the internal value of the optional or the given default value
-// if the value was not explicitly set by the caller.
-func (o *Optional[T]) GetOr(defaultValue T) T {
-	if o == nil {
-		return defaultValue
-	}
-	if o.isSet {
-		return o.value
-	}
-	return defaultValue
-}
-
-func (o *Optional[T]) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&o.value)
-}
-
-func (o *Optional[T]) UnmarshalJSON(dt []byte) error {
-	o.isSet = true
-	return json.Unmarshal(dt, &o.value)
-}
-
 type DaggerObject querybuilder.GraphQLMarshaller
 
 func convertSlice[I any, O any](in []I, f func(I) O) []O {
@@ -96,13 +46,6 @@ func convertSlice[I any, O any](in []I, f func(I) O) []O {
     out[i] = f(v)
   }
   return out
-}
-
-func convertOptionalVal[I any, O any](opt Optional[I], f func(I) O) Optional[O] {
-	if !opt.isSet {
-		return Optional[O]{}
-	}
-	return Optional[O]{value: f(opt.value), isSet: true}
 }
 
 // getCustomError parses a GraphQL error into a more specific error type.

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -205,8 +205,14 @@ func (m *Test) Fn(dir *Directory) *Directory {
 					Contents: `package main
 type Test struct {}
 
-func (m *Test) Fn(dir *Directory, subpath Optional[string]) *Directory {
-	return dir.Directory(subpath.GetOr("."))
+func (m *Test) Fn(
+	dir *Directory,
+	subpath string, // +optional
+) *Directory {
+	if subpath == "" {
+		subpath = "."
+	}
+	return dir.Directory(subpath)
 }
 	`,
 				})

--- a/core/integration/testdata/modules/go/ifaces/impl/main.go
+++ b/core/integration/testdata/modules/go/ifaces/impl/main.go
@@ -50,13 +50,6 @@ func (m Impl) WithStr(strArg string) *Impl {
 	return &m
 }
 
-func (m Impl) WithOptionalTypeStr(strArg Optional[string]) *Impl {
-	if str, ok := strArg.Get(); ok {
-		m.Str = str
-	}
-	return &m
-}
-
 func (m Impl) WithOptionalPragmaStr(
 	// +optional
 	strArg string,
@@ -97,12 +90,6 @@ func (m Impl) WithObj(objArg *Directory) *Impl {
 	return &m
 }
 
-func (m Impl) WithOptionalTypeObj(objArg Optional[*Directory]) *Impl {
-	if obj, ok := objArg.Get(); ok {
-		m.Obj = obj
-	}
-	return &m
-}
 func (m Impl) WithOptionalPragmaObj(
 	// +optional
 	objArg *Directory,

--- a/core/integration/testdata/modules/go/ifaces/main_test.go
+++ b/core/integration/testdata/modules/go/ifaces/main_test.go
@@ -40,17 +40,6 @@ func TestIface(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "c", str)
 	})
-	t.Run("withOptionalTypeStr", func(t *testing.T) {
-		t.Parallel()
-		str, err := test.WithOptionalTypeStr(impl.AsTestCustomIface(), TestWithOptionalTypeStrOpts{
-			StrArg: "d",
-		}).Str(ctx)
-		require.NoError(t, err)
-		require.Equal(t, "d", str)
-		str, err = test.WithOptionalTypeStr(impl.AsTestCustomIface()).Str(ctx)
-		require.NoError(t, err)
-		require.Equal(t, "a", str)
-	})
 	t.Run("withOptionalPragmaStr", func(t *testing.T) {
 		t.Parallel()
 		str, err := test.WithOptionalPragmaStr(impl.AsTestCustomIface(), TestWithOptionalPragmaStrOpts{
@@ -138,20 +127,6 @@ func TestIface(t *testing.T) {
 		dirEnts, err := dir.Entries(ctx)
 		require.NoError(t, err)
 		require.Contains(t, dirEnts, "file2")
-	})
-	t.Run("withOptionalTypeObj", func(t *testing.T) {
-		t.Parallel()
-		obj := test.WithOptionalTypeObj(impl.AsTestCustomIface(), TestWithOptionalTypeObjOpts{
-			ObjArg: dag.Directory().WithNewFile("/file3", "file3"),
-		}).Obj()
-		dirEnts, err := obj.Entries(ctx)
-		require.NoError(t, err)
-		require.Contains(t, dirEnts, "file3")
-
-		obj = test.WithOptionalTypeObj(impl.AsTestCustomIface()).Obj()
-		dirEnts, err = obj.Entries(ctx)
-		require.NoError(t, err)
-		require.Contains(t, dirEnts, "file1")
 	})
 	t.Run("objList", func(t *testing.T) {
 		t.Parallel()
@@ -307,13 +282,6 @@ func TestIface(t *testing.T) {
 		t.Run("optionals", func(t *testing.T) {
 			t.Parallel()
 			strs, err := test.
-				WithOptionalTypeIface().
-				WithOptionalTypeIface(TestWithOptionalTypeIfaceOpts{Iface: impl.AsTestCustomIface()}).
-				WithOptionalTypeIface().
-				ParentIfaceFields(ctx)
-			require.NoError(t, err)
-			require.Equal(t, []string{"a"}, strs)
-			strs, err = test.
 				WithOptionalPragmaIface().
 				WithOptionalPragmaIface(TestWithOptionalPragmaIfaceOpts{Iface: impl.AsTestCustomIface()}).
 				WithOptionalPragmaIface().

--- a/core/integration/testdata/modules/go/ifaces/test/main.go
+++ b/core/integration/testdata/modules/go/ifaces/test/main.go
@@ -23,7 +23,6 @@ type CustomIface interface {
 
 	Str(ctx context.Context) (string, error)
 	WithStr(ctx context.Context, strArg string) CustomIface
-	WithOptionalTypeStr(ctx context.Context, strArg Optional[string]) CustomIface
 	WithOptionalPragmaStr(
 		ctx context.Context,
 		// +optional
@@ -44,7 +43,6 @@ type CustomIface interface {
 
 	Obj() *Directory
 	WithObj(objArg *Directory) CustomIface
-	WithOptionalTypeObj(objArg Optional[*Directory]) CustomIface
 	WithOptionalPragmaObj(
 		// +optional
 		objArg *Directory,
@@ -80,10 +78,6 @@ func (m *Test) Str(ctx context.Context, ifaceArg CustomIface) (string, error) {
 
 func (m *Test) WithStr(ctx context.Context, ifaceArg CustomIface, strArg string) CustomIface {
 	return ifaceArg.WithStr(ctx, strArg)
-}
-
-func (m *Test) WithOptionalTypeStr(ctx context.Context, ifaceArg CustomIface, strArg Optional[string]) CustomIface {
-	return ifaceArg.WithOptionalTypeStr(ctx, strArg)
 }
 
 func (m *Test) WithOptionalPragmaStr(
@@ -141,10 +135,6 @@ func (m *Test) Obj(ifaceArg CustomIface) *Directory {
 
 func (m *Test) WithObj(ifaceArg CustomIface, objArg *Directory) CustomIface {
 	return ifaceArg.WithObj(objArg)
-}
-
-func (m *Test) WithOptionalTypeObj(ifaceArg CustomIface, objArg Optional[*Directory]) CustomIface {
-	return ifaceArg.WithOptionalTypeObj(objArg)
 }
 
 func (m *Test) WithOptionalPragmaObj(
@@ -216,13 +206,6 @@ func (m *Test) IfaceListArgs(ctx context.Context, ifaces []CustomIface, otherIfa
 
 func (m *Test) WithIface(iface CustomIface) *Test {
 	m.IfaceField = iface
-	return m
-}
-
-func (m *Test) WithOptionalTypeIface(iface Optional[CustomIface]) *Test {
-	if iface, ok := iface.Get(); ok {
-		m.IfaceField = iface
-	}
 	return m
 }
 

--- a/core/integration/testdata/modules/go/minimal/main.go
+++ b/core/integration/testdata/modules/go/minimal/main.go
@@ -12,7 +12,7 @@ func (m *Minimal) Hello() string {
 }
 
 func (m *Minimal) Echo(msg string) string {
-	return m.EchoOpts(msg, Opt("..."), Opt(3))
+	return m.EchoOpts(msg, "...", 3)
 }
 
 func (m *Minimal) EchoPointer(msg *string) *string {
@@ -26,25 +26,34 @@ func (m *Minimal) EchoPointerPointer(msg **string) **string {
 	return &v2
 }
 
-func (m *Minimal) EchoOptional(msg Optional[string]) string {
-	v, ok := msg.Get()
-	if !ok {
-		v = "default"
+func (m *Minimal) EchoOptional(
+	// +optional
+	msg string,
+) string {
+	if msg == "" {
+		return m.Echo("default")
 	}
-	return m.Echo(v)
+	return m.Echo(msg)
 }
 
-func (m *Minimal) EchoOptionalPointer(msg **Optional[**string]) string {
-	v, ok := (*msg).Get()
-	if !ok {
-		v = ptr(ptr("default"))
+func (m *Minimal) EchoOptionalPointer(
+	// +optional
+	msg *string,
+) string {
+	if msg == nil {
+		return m.Echo("default")
 	}
-	return m.Echo(**v)
+	return m.Echo(*msg)
 }
 
-func (m *Minimal) EchoOptionalSlice(msg Optional[[]string]) string {
-	v := msg.GetOr([]string{"foobar"})
-	return m.Echo(strings.Join(v, "+"))
+func (m *Minimal) EchoOptionalSlice(
+	// +optional
+	msg []string,
+) string {
+	if msg == nil {
+		msg = []string{"foobar"}
+	}
+	return m.Echo(strings.Join(msg, "+"))
 }
 
 func (m *Minimal) Echoes(msgs []string) []string {
@@ -78,12 +87,17 @@ func (m *Minimal) EchoOpts(
 	msg string, // the message to echo
 
 	// String to append to the echoed message
-	suffix Optional[string],
+	// +optional
+	suffix string,
 	// Number of times to repeat the message
-	times Optional[int],
+	// +optional
+	times int,
 ) string {
-	msg += suffix.GetOr("")
-	return strings.Repeat(msg, times.GetOr(1))
+	msg += suffix
+	if times == 0 {
+		times = 1
+	}
+	return strings.Repeat(msg, times)
 }
 
 // EchoOptsInline does some opts things
@@ -91,9 +105,11 @@ func (m *Minimal) EchoOptsInline(opts struct {
 	Msg string // the message to echo
 
 	// String to append to the echoed message
-	Suffix Optional[string]
+	// +optional
+	Suffix string
 	// Number of times to repeat the message
-	Times Optional[int]
+	// +optional
+	Times int
 }) string {
 	return m.EchoOpts(opts.Msg, opts.Suffix, opts.Times)
 }
@@ -102,9 +118,11 @@ func (m *Minimal) EchoOptsInlinePointer(opts *struct {
 	Msg string
 
 	// String to append to the echoed message
-	Suffix Optional[string]
+	// +optional
+	Suffix string
 	// Number of times to repeat the message
-	Times Optional[int]
+	// +optional
+	Times int
 }) string {
 	return m.EchoOptsInline(*opts)
 }
@@ -113,9 +131,11 @@ func (m *Minimal) EchoOptsInlineCtx(ctx context.Context, opts struct {
 	Msg string
 
 	// String to append to the echoed message
-	Suffix Optional[string]
+	// +optional
+	Suffix string
 	// Number of times to repeat the message
-	Times Optional[int]
+	// +optional
+	Times int
 }) string {
 	return m.EchoOpts(opts.Msg, opts.Suffix, opts.Times)
 }
@@ -124,9 +144,11 @@ func (m *Minimal) EchoOptsInlineTags(ctx context.Context, opts struct {
 	Msg string
 
 	// String to append to the echoed message
-	Suffix Optional[string] `tag:"hello"`
+	// +optional
+	Suffix string `tag:"hello"`
 	// Number of times to repeat the message
-	Times Optional[int] `tag:"hello again"`
+	// +optional
+	Times int `tag:"hello again"`
 }) string {
 	return m.EchoOpts(opts.Msg, opts.Suffix, opts.Times)
 }

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -32,56 +32,6 @@ func ptr[T any](v T) *T {
 	return &v
 }
 
-// Optional is a helper type to represent optional values. Any method arguments
-// that use this wrapper type will be set as optional in the generated API.
-//
-// To construct an Optional from within a module, use the Opt helper function.
-type Optional[T any] struct {
-	value T
-	isSet bool
-}
-
-// Opt is a helper function to construct an Optional with the given value set.
-func Opt[T any](v T) Optional[T] {
-	return Optional[T]{value: v, isSet: true}
-}
-
-// OptEmpty is a helper function to construct an empty Optional.
-func OptEmpty[T any]() Optional[T] {
-	return Optional[T]{}
-}
-
-// Get returns the internal value of the optional and a boolean indicating if
-// the value was set explicitly by the caller.
-func (o *Optional[T]) Get() (T, bool) {
-	if o == nil {
-		var empty T
-		return empty, false
-	}
-	return o.value, o.isSet
-}
-
-// GetOr returns the internal value of the optional or the given default value
-// if the value was not explicitly set by the caller.
-func (o *Optional[T]) GetOr(defaultValue T) T {
-	if o == nil {
-		return defaultValue
-	}
-	if o.isSet {
-		return o.value
-	}
-	return defaultValue
-}
-
-func (o *Optional[T]) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&o.value)
-}
-
-func (o *Optional[T]) UnmarshalJSON(dt []byte) error {
-	o.isSet = true
-	return json.Unmarshal(dt, &o.value)
-}
-
 type DaggerObject querybuilder.GraphQLMarshaller
 
 func convertSlice[I any, O any](in []I, f func(I) O) []O {
@@ -90,13 +40,6 @@ func convertSlice[I any, O any](in []I, f func(I) O) []O {
 		out[i] = f(v)
 	}
 	return out
-}
-
-func convertOptionalVal[I any, O any](opt Optional[I], f func(I) O) Optional[O] {
-	if !opt.isSet {
-		return Optional[O]{}
-	}
-	return Optional[O]{value: f(opt.value), isSet: true}
 }
 
 // getCustomError parses a GraphQL error into a more specific error type.


### PR DESCRIPTION
This PR just removes `Optional`. Very simple, very neat. Based on the discussion in https://discord.com/channels/707636530424053791/1203102934901071882/1203134907677675630 (and probably in other places). There's also some additional context in https://github.com/dagger/dagger/pull/6370.

I think we should try and get this in for v0.9.9:
- We shouldn't ship two mechanisms of doing optionals in v0.10.0 - breaking earlier is better, and gives us more time for feedback.
- Our docs haven't described this for a while (since https://github.com/dagger/dagger/pull/6225). We've made other breaking changes since then (including the removal of `dag.Host`), so it's likely that users who wrote modules using these docs as references will need to make other updates as well.

We could *potentially* deprecate this in v0.9.9, and remove in v0.10.0, but:
1. I couldn't easily think of a nice way of doing this that would alert users helpfully
2. I ran out of time, and this is nice and easy :tada:

We could also just reschedule this for v0.10.0 if there's too much missing.