### PR TITLE
docs: update zenith guides for new top-level init/install commands

### DIFF
--- a/docs/versioned_docs/version-zenith/developer/go/191108-advanced-programming.mdx
+++ b/docs/versioned_docs/version-zenith/developer/go/191108-advanced-programming.mdx
@@ -26,24 +26,27 @@ This guide assumes that:
 
 ## Use modules in other modules
 
-Modules can call each other. To add a dependency to your module, you can use `dagger mod install`, as in the following example:
+Modules can call each other. To add a dependency to your module, you can use `dagger install`, as in the following example:
 
 ```sh
-dagger mod install github.com/shykes/daggerverse/helloWorld@26f8ed9f1748ec8c9345281add850fd392441990
+dagger install github.com/shykes/daggerverse/helloWorld@26f8ed9f1748ec8c9345281add850fd392441990
 ```
 
 This module will be added to your `dagger.json`:
 
 ```json
 "dependencies": [
-  "github.com/shykes/daggerverse/helloWorld@26f8ed9f1748ec8c9345281add850fd392441990"
+  {
+    "name": "helloWorld",
+    "source": "github.com/shykes/daggerverse/helloWorld@26f8ed9f1748ec8c9345281add850fd392441990"
+  }
 ]
 ```
 
 You can also use local modules as dependencies. However, they must be stored in a sub-directory of your module. For example:
 
 ```sh
-dagger mod install ./path/to/module
+dagger install ./path/to/module
 ```
 
 The dependent module will be added to your code-generation routines, so you can access it from your own module's code, as shown below:

--- a/docs/versioned_docs/version-zenith/developer/go/457202-test-build-publish.mdx
+++ b/docs/versioned_docs/version-zenith/developer/go/457202-test-build-publish.mdx
@@ -32,13 +32,13 @@ This guide assumes that:
 
 The example module used in this guide builds, tests and publishes a Node.js application.
 
-Begin by running `dagger mod init` in your application directory to bootstrap a new module:
+Begin by running `dagger init` in your application directory to bootstrap a new module:
 
 ```sh
-dagger mod init --name=my-mod --sdk=go
+dagger init --name=my-mod --sdk=go
 ```
 
-This will generate a `dagger.json` module file, an initial `main.go` source file, as well as a generated `dagger.gen.go` and `querybuilder` folder for the generated module code.
+This will generate a `dagger.json` module file, an initial `dagger/main.go` source file, as well as a generated `dagger/dagger.gen.go` and `dagger/querybuilder` folder for the generated module code.
 
 ## Step 2: Add a function to build the application base image
 
@@ -49,7 +49,7 @@ Since the application is a Node.js application, it's convenient to use the [`nod
 1. Add the `node` module as a dependency:
 
     ```shell
-    dagger mod install github.com/quartz-technology/daggerverse/node/go
+    dagger install github.com/quartz-technology/daggerverse/node/go
     ```
 
 1. Update the generated `main.go` file with the following code:
@@ -197,7 +197,7 @@ One such registry is [ttl.sh](https://ttl.sh), an ephemeral Docker registry. The
 1. Add the `ttlsh` module as a dependency in your module:
 
     ```shell
-    dagger mod install github.com/shykes/daggerverse/ttlsh
+    dagger install github.com/shykes/daggerverse/ttlsh
     ```
 
 1. Update the module and add new `Package()` and `Publish()` functions to copy the built application into an NGINX web server container image and deliver the result to the registry:

--- a/docs/versioned_docs/version-zenith/developer/go/525021-quickstart.mdx
+++ b/docs/versioned_docs/version-zenith/developer/go/525021-quickstart.mdx
@@ -29,17 +29,17 @@ This quickstart assumes that:
 
 ## Step 1: Initialize a new module
 
-1. Create a new directory on your filesystem and run `dagger mod init` to bootstrap your first module. We'll call it `potato` here, but you can choose your favorite food.
+1. Create a new directory on your filesystem and run `dagger init` to bootstrap your first module. We'll call it `potato` here, but you can choose your favorite food.
 
     ```sh
     mkdir potato/
     cd potato/
 
     # initialize Dagger module
-    dagger mod init --name=potato --sdk=go
+    dagger init --name=potato --sdk=go
     ```
 
-    This will generate a `dagger.json` module file, an initial `main.go` source file, as well as a generated `dagger.gen.go` and library folders for the generated module code.
+    This will generate a `dagger.json` module file, an initial `dagger/main.go` source file, as well as a generated `dagger/dagger.gen.go` and library folders for the generated module code.
 
 1. Test the module. Run the generated `main.go` with the `dagger call` command:
 
@@ -123,7 +123,7 @@ The example module in the previous sections was just that - an example. Next, le
     ```shell
     mkdir trivy/
     cd trivy/
-    dagger mod init --name=trivy --sdk=go
+    dagger init --name=trivy --sdk=go
     ```
 
 1. Replace the generated `main.go` file with the following code:

--- a/docs/versioned_docs/version-zenith/developer/python/419481-quickstart.mdx
+++ b/docs/versioned_docs/version-zenith/developer/python/419481-quickstart.mdx
@@ -29,17 +29,17 @@ This quickstart assumes that:
 
 ## Step 1: Initialize a new module
 
-1. Create a new directory on your filesystem and run `dagger mod init` to bootstrap your first module. We'll call it `potato` here, but you can choose your favorite food.
+1. Create a new directory on your filesystem and run `dagger init` to bootstrap your first module. We'll call it `potato` here, but you can choose your favorite food.
 
     ```sh
     mkdir potato/
     cd potato/
 
     # initialize Dagger module
-    dagger mod init --name=potato --sdk=python
+    dagger init --name=potato --sdk=python
     ```
 
-    This will generate a `dagger.json` module file, initial `src/main.py` and `pyproject.toml` files, as well as a generated `sdk` folder for local development.
+    This will generate a `dagger.json` module file, initial `dagger/src/main.py` and `dagger/pyproject.toml` files, as well as a generated `dagger/sdk` folder for local development.
 
 1. Test the module. Run the generated `main.py` with the `dagger call` command:
 
@@ -72,7 +72,7 @@ pip install -e ./sdk
 :::tip
 As always, you can use any virtual environment manager, including [Poetry](https://python-poetry.org) and others. Just make sure you add `./sdk` as a development dependency. If you place the virtual environment inside the module, don't forget to add it to `.gitignore` and to `"exclude"` in `dagger.json`.
 
-It's also important to install the SDK in **editable mode** (the `-e` in the `pip install` command) so you don't have to reinstall it after a `dagger mod sync`. However, it's always recommended to reinstall the SDK after upgrading Dagger to cover possible dependency changes.
+It's also important to install the SDK in **editable mode** (the `-e` in the `pip install` command) so you don't have to reinstall it after a `dagger develop`. However, it's always recommended to reinstall the SDK after upgrading Dagger to cover possible dependency changes.
 :::
 
 ## Step 3: Add a function
@@ -137,7 +137,7 @@ The example module in the previous sections was just that - an example. Next, le
     ```shell
     mkdir trivy/
     cd trivy/
-    dagger mod init --name=trivy --sdk=python
+    dagger init --name=trivy --sdk=python
     ```
 
 1. Replace the generated `src/main.py` file with the following code:

--- a/docs/versioned_docs/version-zenith/developer/python/539756-advanced-programming.mdx
+++ b/docs/versioned_docs/version-zenith/developer/python/539756-advanced-programming.mdx
@@ -25,24 +25,27 @@ This guide assumes that:
 
 ## Use modules in other modules
 
-Modules can call each other. To add a dependency to your module, you can use `dagger mod install`, as in the following example:
+Modules can call each other. To add a dependency to your module, you can use `dagger install`, as in the following example:
 
 ```sh
-dagger mod install github.com/shykes/daggerverse/helloWorld@26f8ed9f1748ec8c9345281add850fd392441990
+dagger install github.com/shykes/daggerverse/helloWorld@26f8ed9f1748ec8c9345281add850fd392441990
 ```
 
 This module will be added to your `dagger.json`:
 
 ```json
 "dependencies": [
-  "github.com/shykes/daggerverse/helloWorld@26f8ed9f1748ec8c9345281add850fd392441990"
+  {
+    "name": "helloWorld",
+    "source": "github.com/shykes/daggerverse/helloWorld@26f8ed9f1748ec8c9345281add850fd392441990"
+  }
 ]
 ```
 
 You can also use local modules as dependencies. However, they must be stored in a sub-directory of your module. For example:
 
 ```sh
-dagger mod install ./path/to/module
+dagger install ./path/to/module
 ```
 
 The dependent module will be added to your code-generation routines, so you can access it from your own module's code, as shown below:

--- a/docs/versioned_docs/version-zenith/developer/typescript/506316-quickstart.mdx
+++ b/docs/versioned_docs/version-zenith/developer/typescript/506316-quickstart.mdx
@@ -29,17 +29,17 @@ This quickstart assumes that:
 
 ## Step 1: Initialize a new module
 
-1. Create a new directory on your filesystem and run `dagger mod init` to bootstrap your first module. We'll call it `potato` here, but you can choose your favorite food.
+1. Create a new directory on your filesystem and run `dagger init` to bootstrap your first module. We'll call it `potato` here, but you can choose your favorite food.
 
     ```sh
     mkdir potato/
     cd potato/
 
     # initialize Dagger module
-    dagger mod init --name=potato --sdk=typescript
+    dagger init --name=potato --sdk=typescript
     ```
 
-    This will generate a `dagger.json` module file, initial `src/index.ts` and typescript basic setup with a `package.json`, a `tsconfig.json` and a `yarn.lock`, as well as a generated `sdk` folder for local development.
+    This will generate a `dagger.json` module file, initial `dagger/src/index.ts` and typescript basic setup with a `dagger/package.json`, a `dagger/tsconfig.json` and a `dagger/yarn.lock`, as well as a generated `dagger/sdk` folder for local development.
 
 2. Test the module. Run the generated `index.ts` with the `dagger call` command:
 
@@ -118,7 +118,7 @@ The example module in the previous sections was just that - an example. Next, le
 
     cd trivy/
 
-    dagger mod init --name=trivy --sdk=typescript
+    dagger init --name=trivy --sdk=typescript
     ```
 
 2. Replace the generated `index.ts` file with the following code:

--- a/docs/versioned_docs/version-zenith/quickstart/428201-custom-modules.mdx
+++ b/docs/versioned_docs/version-zenith/quickstart/428201-custom-modules.mdx
@@ -23,46 +23,46 @@ A better approach is to create a programmable Dagger module, which can then call
 
 To see this in action, create a custom Dagger module to build a Go binary, add it to a container image and publish the container image to a registry.
 
-1. Begin by creating a new directory for your Dagger module and running `dagger mod init` to bootstrap a new module:
+1. Begin by creating a new directory for your Dagger module and running `dagger init` to bootstrap a new module:
 
     <Tabs groupId="language">
     <TabItem value="Go">
 
     ```shell
     mkdir my-module
-    dagger mod init --name=my-module --sdk=go
+    dagger init --name=my-module --sdk=go
     ```
 
-    This will generate a `dagger.json` module file, an initial `main.go` source file, as well as a generated `dagger.gen.go` and `querybuilder` directory for the generated module code.
+    This will generate a `dagger.json` module file, an initial `dagger/main.go` source file, as well as a generated `dagger/dagger.gen.go` and `dagger/querybuilder` directory for the generated module code.
 
     </TabItem>
     <TabItem value="Python">
 
     ```shell
     mkdir my-module
-    dagger mod init --name=my-module --sdk=python
+    dagger init --name=my-module --sdk=python
     ```
 
-    This will generate a `dagger.json` module file, initial `src/main.py` and `pyproject.toml` files, as well as a generated `sdk` folder for local development.
+    This will generate a `dagger.json` module file, initial `dagger/src/main.py` and `dagger/pyproject.toml` files, as well as a generated `dagger/sdk` folder for local development.
 
     </TabItem>
     <TabItem value="TypeScript">
 
     ```shell
     mkdir my-module
-    dagger mod init --name=my-module --sdk=typescript
+    dagger init --name=my-module --sdk=typescript
     ```
 
-    This will generate a `dagger.json` module file, initial `src/index.ts`, `package.json` and `tsconfig.json` files, as well as a generated `sdk` folder for local development.
+    This will generate a `dagger.json` module file, initial `dagger/src/index.ts`, `dagger/package.json` and `dagger/tsconfig.json` files, as well as a generated `dagger/sdk` folder for local development.
 
     </TabItem>
     </Tabs>
 
-1. Dagger lets you add dependencies to your modules, so that you can build on modules created by others. Add the `golang` and `wolfi` modules as dependencies in your new module using `dagger mod install`:
+1. Dagger lets you add dependencies to your modules, so that you can build on modules created by others. Add the `golang` and `wolfi` modules as dependencies in your new module using `dagger install`:
 
     ```shell
-    dagger mod install github.com/kpenfound/dagger-modules/golang
-    dagger mod install github.com/shykes/daggerverse/wolfi
+    dagger install github.com/kpenfound/dagger-modules/golang
+    dagger install github.com/shykes/daggerverse/wolfi
     ```
 
 1. Update the generated module template:


### PR DESCRIPTION
These changed in https://github.com/dagger/dagger/pull/6533

Just making the bare minimum changes to keep docs aligned with reality here rather than documenting any of the new features yet.

Not adding to the v0.9.9 milestone since it's not technically a blocker, just should be merged soon after that's done.