### PR TITLE
docs: fixup module template suggested command

### DIFF
--- a/cmd/codegen/generator/go/generator.go
+++ b/cmd/codegen/generator/go/generator.go
@@ -325,7 +325,7 @@ import (
 
 type %s struct {}
 
-// example usage: "dagger call container-echo --string-arg yo"
+// example usage: "dagger call container-echo --string-arg yo stdout"
 func (m *%s) ContainerEcho(stringArg string) *Container {
 	return dag.Container().From("alpine:latest").WithExec([]string{"echo", stringArg})
 }

--- a/sdk/python/runtime/template/src/main.py
+++ b/sdk/python/runtime/template/src/main.py
@@ -4,7 +4,7 @@ from dagger import dag, function
 
 @function
 def container_echo(string_arg: str) -> dagger.Container:
-    # Example usage: "dagger call container-echo --string-arg hello"
+    # Example usage: "dagger call container-echo --string-arg hello stdout"
     return dag.container().from_("alpine:latest").with_exec(["echo", string_arg])
 
 

--- a/sdk/typescript/runtime/template/src/index.ts
+++ b/sdk/typescript/runtime/template/src/index.ts
@@ -4,7 +4,7 @@ import { dag, Container, Directory, object, func } from "@dagger.io/dagger"
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 class QuickStart {
   /**
-   * example usage: "dagger call container-echo --string-arg yo"
+   * example usage: "dagger call container-echo --string-arg yo stdout"
    */
   @func()
   containerEcho(stringArg: string): Container {


### PR DESCRIPTION
The listed command in the previous examples didn't really help users:

	$ dagger call container-echo --string-arg yo
	Container evaluated. Use "dagger call container-echo --help" to see available sub-commands.

We should amend the default template command to actually print the result:

	$ dagger call container-echo --string-arg yo stdout
	yo