### PR TITLE
ci: use docker-fix runner for testdev job

### DIFF
--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -38,7 +38,7 @@ jobs:
     secrets: inherit
     with:
       mage-targets: engine:testimportant
-      size: dagger-runner-16c-64g
+      size: dagger-runner-docker-fix
       dev-engine: true
 
 


### PR DESCRIPTION
This new worker has a second nvme drive, and mounts it to `/var/lib/docker`, so we get better performance.

Based off of the findings in #6563.