### PR TITLE
sdk/java: pass --silent to dagger query

### DIFF
--- a/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/DaggerCLIUtils.java
+++ b/sdk/java/dagger-codegen-maven-plugin/src/main/java/io/dagger/codegen/DaggerCLIUtils.java
@@ -26,7 +26,7 @@ public class DaggerCLIUtils {
 
   public static InputStream query(InputStream query, String binPath) {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
-    FluentProcess.start(binPath, "query")
+    FluentProcess.start(binPath, "query", "--silent")
         .withTimeout(Duration.of(60, ChronoUnit.SECONDS))
         .inputStream(query)
         .writeToOutputStream(out);


### PR DESCRIPTION
otherwise it hangs the moment it tries to write to os.Stderr