### PR TITLE
core: fix native always true for up even when ports are set

### DIFF
--- a/core/schema/service.go
+++ b/core/schema/service.go
@@ -121,6 +121,7 @@ type upArgs struct {
 func (s *serviceSchema) up(ctx context.Context, svc dagql.Instance[*core.Service], args upArgs) (dagql.Nullable[core.Void], error) {
 	void := dagql.Null[core.Void]()
 
+	useNative := !args.Random && len(args.Ports) == 0
 	var hostSvc dagql.Instance[*core.Service]
 	err := s.srv.Select(ctx, s.srv.Root(), &hostSvc,
 		dagql.Selector{
@@ -131,7 +132,7 @@ func (s *serviceSchema) up(ctx context.Context, svc dagql.Instance[*core.Service
 			Args: []dagql.NamedInput{
 				{Name: "service", Value: dagql.NewID[*core.Service](svc.ID())},
 				{Name: "ports", Value: dagql.ArrayInput[dagql.InputObject[core.PortForward]](args.Ports)},
-				{Name: "native", Value: dagql.Boolean(!args.Random)},
+				{Name: "native", Value: dagql.Boolean(useNative)},
 			},
 		},
 	)


### PR DESCRIPTION
Think this happened when switch up to default to `native`.

The logic was accidentally setting native to true even when ports were manually specified which resulted in each port being applied twice. In the case where the same values of frontend and backend were specified (i.e. 5000:5000) this resulted in an error since you'd try to listen on the same port twice.

Should (re-) fix https://github.com/dagger/dagger/issues/6303, though this is definitely a different root cause than the previous one because this can only happen if you use the same frontend+backend (whereas previously it happened with any use of --port)