### PR TITLE
distinguish internal module calls from user calls

### DIFF
--- a/analytics/internal.go
+++ b/analytics/internal.go
@@ -1,0 +1,21 @@
+package analytics
+
+import "context"
+
+type internalKey struct{}
+
+// Internal returns a new context with the internal flag set.
+//
+// This is used for analytics so that we can distinguish between calls made by
+// an end user and calls made within the engine, for example to SDK modules.
+func WithInternal(ctx context.Context) context.Context {
+	return context.WithValue(ctx, internalKey{}, true)
+}
+
+// IsInternal returns whether the internal flag is set in the context.
+func IsInternal(ctx context.Context) bool {
+	if val := ctx.Value(internalKey{}); val != nil {
+		return val.(bool)
+	}
+	return false
+}

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -110,6 +110,8 @@ func (fn *ModuleFunction) Call(ctx context.Context, caller *idproto.ID, opts *Ca
 		if caller, err := mod.Query.CurrentModule(ctx); err == nil {
 			props["caller_type"] = "module"
 			moduleAnalyticsProps(caller, "caller_", props)
+		} else if analytics.IsInternal(ctx) {
+			props["caller_type"] = "internal"
 		} else {
 			props["caller_type"] = "direct"
 		}

--- a/core/object.go
+++ b/core/object.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"sort"
 
+	"github.com/dagger/dagger/analytics"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/idproto"
 	"github.com/moby/buildkit/solver/pb"
@@ -334,7 +335,10 @@ func objFun(ctx context.Context, mod *Module, objDef *ObjectTypeDef, fun *Functi
 		Func: func(ctx context.Context, obj dagql.Instance[*ModuleObject], args map[string]dagql.Input) (dagql.Typed, error) {
 			opts := &CallOpts{
 				ParentVal: obj.Self.Fields,
-				Cache:     false, // TODO
+				// TODO: there may be a more elegant way to do this, but the desired
+				// effect is to cache SDK module calls, which we used to do pre-DagQL.
+				// We should figure out how user modules can opt in to caching, too.
+				Cache: analytics.IsInternal(ctx),
 				// Pipeline:  _, // TODO
 				SkipSelfSchema: false, // TODO?
 			}

--- a/core/schema/sdk.go
+++ b/core/schema/sdk.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/dagger/dagger/analytics"
 	"github.com/dagger/dagger/dagql"
 	"github.com/vito/progrock"
 
@@ -103,6 +104,8 @@ func (s *moduleSchema) newModuleSDK(
 	sdkModMeta dagql.Instance[*core.Module],
 	optionalFullSDKSourceDir dagql.Instance[*core.Directory],
 ) (*moduleSDK, error) {
+	ctx = analytics.WithInternal(ctx)
+
 	dag := dagql.NewServer(root)
 	dag.Cache = root.Cache
 	if err := sdkModMeta.Self.Install(ctx, dag); err != nil {
@@ -135,6 +138,8 @@ func (s *moduleSchema) newModuleSDK(
 
 // Codegen calls the Codegen function on the SDK Module
 func (sdk *moduleSDK) Codegen(ctx context.Context, deps *core.ModDeps, source dagql.Instance[*core.ModuleSource]) (*core.GeneratedCode, error) {
+	ctx = analytics.WithInternal(ctx)
+
 	introspectionJSON, err := deps.SchemaIntrospectionJSON(ctx, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get schema introspection json during %s module sdk codegen: %w", sdk.mod.Self.Name(), err)
@@ -162,6 +167,8 @@ func (sdk *moduleSDK) Codegen(ctx context.Context, deps *core.ModDeps, source da
 
 // Runtime calls the Runtime function on the SDK Module
 func (sdk *moduleSDK) Runtime(ctx context.Context, deps *core.ModDeps, source dagql.Instance[*core.ModuleSource]) (*core.Container, error) {
+	ctx = analytics.WithInternal(ctx)
+
 	introspectionJSON, err := deps.SchemaIntrospectionJSON(ctx, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get schema introspection json during %s module sdk runtime: %w", sdk.mod.Self.Name(), err)
@@ -199,6 +206,8 @@ func (sdk *moduleSDK) Runtime(ctx context.Context, deps *core.ModDeps, source da
 }
 
 func (sdk *moduleSDK) RequiredPaths(ctx context.Context) ([]string, error) {
+	ctx = analytics.WithInternal(ctx)
+
 	var paths []string
 	err := sdk.dag.Select(ctx, sdk.sdk, &paths,
 		dagql.Selector{


### PR DESCRIPTION
This uses a little bit of `ctx` trickery to propagate a flag through intra-engine calls to SDK modules so we can set a different caller (`internal` instead of `direct`) on module analytics.

It also uses that same flag to re-enable caching for SDK modules, which was lost with #6297.