### PR TITLE
elixir: update sdk version file path in mage

### DIFF
--- a/internal/mage/sdk/elixir.go
+++ b/internal/mage/sdk/elixir.go
@@ -17,7 +17,7 @@ import (
 const (
 	elixirSDKPath            = "sdk/elixir"
 	elixirSDKGeneratedPath   = elixirSDKPath + "/lib/dagger/gen"
-	elixirSDKVersionFilePath = elixirSDKPath + "/lib/dagger/engine_conn.ex"
+	elixirSDKVersionFilePath = elixirSDKPath + "/lib/dagger/core/engine_conn.ex"
 )
 
 // https://hub.docker.com/r/hexpm/elixir/tags?page=1&name=debian-buster


### PR DESCRIPTION
This path changed the other day: https://github.com/dagger/dagger/commit/01268a5fe62067f7d5dddfb5f5d90ecf4909eac4

But it's only used in mage during engine bump PR, which only runs at release, so wouldn't have been caught til then. Noticed it because I was testing publish workflows in my fork.