### PR TITLE
Upgrade to go 1.22

### DIFF
--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           cache-dependency-path: "internal/mage/go.sum"
       - name: Waiting for Dagger Engine to be ready...
         run: |
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           cache-dependency-path: "internal/mage/go.sum"
       - name: Waiting for Dagger Engine to be ready...
         run: |

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           cache-dependency-path: "internal/mage/go.sum"
       - name: "Build Dev Engine"
         run: |

--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
       - name: "Publish Helm Chart"
         run: ./hack/make helm:publish ${{ github.ref_name }}

--- a/.github/workflows/publish-sdk-elixir.yml
+++ b/.github/workflows/publish-sdk-elixir.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - run: ./hack/make sdk:elixir:publish ${{ github.ref_name }}
         env:
           GITHUB_PAT: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}

--- a/.github/workflows/publish-sdk-go.yml
+++ b/.github/workflows/publish-sdk-go.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - run: ./hack/make sdk:go:publish ${{ github.ref_name }}
         env:
           GITHUB_PAT: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}

--- a/.github/workflows/publish-sdk-php.yml
+++ b/.github/workflows/publish-sdk-php.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - run: ./hack/make sdk:php:publish ${{ github.ref_name }}
         env:
           GITHUB_PAT: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}

--- a/.github/workflows/publish-sdk-python.yml
+++ b/.github/workflows/publish-sdk-python.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - run: ./hack/make sdk:python:publish ${{ github.ref_name }}
         env:
           PYPI_REPO: ${{ secrets.RELEASE_PYPI_REPO }}

--- a/.github/workflows/publish-sdk-rust.yml
+++ b/.github/workflows/publish-sdk-rust.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - run: ./hack/make sdk:rust:publish ${{ github.ref_name }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-sdk-typescript.yml
+++ b/.github/workflows/publish-sdk-typescript.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - run: ./hack/make sdk:typescript:publish ${{ github.ref_name }}
         env:
           NPM_TOKEN: ${{ secrets.RELEASE_NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           cache-dependency-path: "internal/mage/go.sum"
       - name: "Publish Engine & CLI"
         run: |
@@ -127,7 +127,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
       - name: "Test Go SDK"
         run: |
@@ -198,7 +198,7 @@ jobs:
         shell: bash
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: "Test Go SDK"
         run: |
           cd sdk/go

--- a/ci/go.mod
+++ b/ci/go.mod
@@ -1,6 +1,6 @@
 module dagger
 
-go 1.21.1
+go 1.22.0
 
 require (
 	github.com/99designs/gqlgen v0.17.31

--- a/core/integration/images.go
+++ b/core/integration/images.go
@@ -2,7 +2,7 @@ package core
 
 const (
 	alpineImage = "alpine:3.18.2"
-	golangImage = "golang:1.21.3-alpine"
+	golangImage = "golang:1.22.0-alpine"
 
 	// TODO: use these
 	// registryImage   = "registry:2"

--- a/core/integration/testdata/modules/go/basic/go.mod
+++ b/core/integration/testdata/modules/go/basic/go.mod
@@ -1,6 +1,6 @@
 module basic
 
-go 1.21.0
+go 1.22.0
 
 require (
 	github.com/99designs/gqlgen v0.17.37

--- a/core/integration/testdata/modules/go/broken/go.mod
+++ b/core/integration/testdata/modules/go/broken/go.mod
@@ -1,6 +1,6 @@
 module broken
 
-go 1.21.0
+go 1.22.0
 
 require (
 	github.com/99designs/gqlgen v0.17.37

--- a/core/integration/testdata/modules/go/ifaces/go.mod
+++ b/core/integration/testdata/modules/go/ifaces/go.mod
@@ -1,6 +1,6 @@
 module test
 
-go 1.21.3
+go 1.22.0
 
 require (
 	github.com/99designs/gqlgen v0.17.31

--- a/core/integration/testdata/modules/go/ifaces/impl/go.mod
+++ b/core/integration/testdata/modules/go/ifaces/impl/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.21.3
+go 1.22.0
 
 require (
 	github.com/99designs/gqlgen v0.17.31

--- a/core/integration/testdata/modules/go/ifaces/test/go.mod
+++ b/core/integration/testdata/modules/go/ifaces/test/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.21.3
+go 1.22.0
 
 require (
 	github.com/99designs/gqlgen v0.17.31

--- a/core/integration/testdata/modules/go/namespacing/go.mod
+++ b/core/integration/testdata/modules/go/namespacing/go.mod
@@ -1,6 +1,6 @@
 module test
 
-go 1.21.2
+go 1.22.0
 
 require (
 	github.com/99designs/gqlgen v0.17.31

--- a/core/integration/testdata/modules/go/namespacing/sub1/go.mod
+++ b/core/integration/testdata/modules/go/namespacing/sub1/go.mod
@@ -1,6 +1,6 @@
 module sub-1
 
-go 1.21.2
+go 1.22.0
 
 require (
 	github.com/99designs/gqlgen v0.17.31

--- a/core/integration/testdata/modules/go/namespacing/sub2/go.mod
+++ b/core/integration/testdata/modules/go/namespacing/sub2/go.mod
@@ -1,6 +1,6 @@
 module sub-2
 
-go 1.21.2
+go 1.22.0
 
 require (
 	github.com/99designs/gqlgen v0.17.31

--- a/docs/versioned_docs/version-zenith/developer/go/snippets/advanced-programming/constructor/go.mod
+++ b/docs/versioned_docs/version-zenith/developer/go/snippets/advanced-programming/constructor/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.21.3
+go 1.22.0
 
 require (
 	github.com/99designs/gqlgen v0.17.31

--- a/docs/versioned_docs/version-zenith/developer/go/snippets/quickstart/step3a/go.mod
+++ b/docs/versioned_docs/version-zenith/developer/go/snippets/quickstart/step3a/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.21.3
+go 1.22.0
 
 require (
 	github.com/99designs/gqlgen v0.17.31

--- a/docs/versioned_docs/version-zenith/developer/go/snippets/quickstart/trivy/go.mod
+++ b/docs/versioned_docs/version-zenith/developer/go/snippets/quickstart/trivy/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.21.3
+go 1.22.0
 
 require (
 	github.com/99designs/gqlgen v0.17.31

--- a/docs/versioned_docs/version-zenith/developer/go/snippets/test-build-publish/step6/go.mod
+++ b/docs/versioned_docs/version-zenith/developer/go/snippets/test-build-publish/step6/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.21.3
+go 1.22.0
 
 require (
 	github.com/99designs/gqlgen v0.17.31

--- a/docs/versioned_docs/version-zenith/quickstart/snippets/create/go/go.mod
+++ b/docs/versioned_docs/version-zenith/quickstart/snippets/create/go/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.21.3
+go 1.22.0
 
 require (
 	github.com/99designs/gqlgen v0.17.31

--- a/examples/sdk/go/multiplatform/main.go
+++ b/examples/sdk/go/multiplatform/main.go
@@ -28,7 +28,7 @@ func main() {
 
 	for _, platform := range platforms {
 		build := client.Container(dagger.ContainerOpts{Platform: platform}).
-			From("golang:1.21.3-bullseye").
+			From("golang:1.22.0-bullseye").
 			WithDirectory("/src", project).
 			WithWorkdir("/src").
 			WithMountedCache("/cache", cache).

--- a/examples/sdk/nodejs/multiplatform/build.js
+++ b/examples/sdk/nodejs/multiplatform/build.js
@@ -14,7 +14,7 @@ connect(async (client) => {
 
   for (let i = 0; i < platforms.length; i++) {
     const build = client.container({platform: platforms[i]})
-    .from("golang:1.21.3-bullseye")
+    .from("golang:1.22.0-bullseye")
     .withDirectory("/src", project)
     .withWorkdir("/src")
     .withMountedCache("/cache", cache)

--- a/examples/sdk/python/multiplatform/pipeline.py
+++ b/examples/sdk/python/multiplatform/pipeline.py
@@ -17,7 +17,7 @@ async def pipeline():
         for platform in platforms:
             build = (
             client.container(platform=dagger.Platform(platform))
-            .from_("golang:1.21.3-bullseye")
+            .from_("golang:1.22.0-bullseye")
             .with_directory("/src", project)
             .with_workdir("/src")
             .with_mounted_cache("/cache", cache)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dagger/dagger
 
-go 1.21
+go 1.22
 
 replace dagger.io/dagger => ./sdk/go
 

--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -50,7 +50,7 @@ func (t Engine) Lint(ctx context.Context) error {
 	repo := util.RepositoryGoCodeOnly(c)
 
 	_, err = c.Container().
-		From("golangci/golangci-lint:v1.55-alpine").
+		From("golangci/golangci-lint:v1.56-alpine").
 		WithMountedDirectory("/app", repo).
 		WithWorkdir("/app").
 		WithExec([]string{"golangci-lint", "run", "-v", "--timeout", "5m"}).

--- a/internal/mage/go.mod
+++ b/internal/mage/go.mod
@@ -1,6 +1,6 @@
 module github.com/dagger/dagger/internal/mage
 
-go 1.21.3
+go 1.22
 
 require (
 	dagger.io/dagger v0.9.8

--- a/internal/mage/sdk/go.go
+++ b/internal/mage/sdk/go.go
@@ -34,7 +34,7 @@ func (t Go) Lint(ctx context.Context) error {
 	c = c.Pipeline("sdk").Pipeline("go").Pipeline("lint")
 
 	_, err = c.Container().
-		From("golangci/golangci-lint:v1.54-alpine").
+		From("golangci/golangci-lint:v1.56-alpine").
 		WithMountedDirectory("/app", util.RepositoryGoCodeOnly(c)).
 		WithWorkdir("/app/sdk/go").
 		WithExec([]string{"golangci-lint", "run", "-v", "--timeout", "5m"}).

--- a/internal/mage/util/engine.go
+++ b/internal/mage/util/engine.go
@@ -24,7 +24,7 @@ const (
 	engineDialStdioPath = "/usr/local/bin/dial-stdio"
 	engineShimPath      = distconsts.EngineShimPath
 
-	golangVersion = "1.21.3"
+	golangVersion = "1.22.0"
 	alpineVersion = "3.18"
 	ubuntuVersion = "22.04"
 	runcVersion   = "v1.1.12"

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -1,6 +1,6 @@
 module dagger.io/dagger
 
-go 1.21
+go 1.22
 
 // retract engine releases from SDK releases
 retract [v0.0.0, v0.2.36]

--- a/sdk/php/docker/dev.Dockerfile
+++ b/sdk/php/docker/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine3.19 AS golang-base
+FROM golang:1.22-alpine3.19 AS golang-base
 FROM php:8.2-zts-bookworm AS php-base
 FROM composer/composer:2-bin AS composer_upstream
 FROM docker:20.10.17-cli-alpine3.16 AS docker-cli
@@ -32,10 +32,10 @@ RUN apt-get update && \
 
 RUN set -eux; \
     install-php-extensions \
-        apcu \
-		intl \
-		opcache \
-		zip \
+    apcu \
+    intl \
+    opcache \
+    zip \
     ;
 
 ARG UID=1000

--- a/sdk/python/runtime/go.mod
+++ b/sdk/python/runtime/go.mod
@@ -1,6 +1,6 @@
 module python-sdk
 
-go 1.21
+go 1.22
 
 require (
 	github.com/99designs/gqlgen v0.17.31

--- a/sdk/typescript/runtime/go.mod
+++ b/sdk/typescript/runtime/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.21.3
+go 1.22.0
 
 require (
 	github.com/99designs/gqlgen v0.17.31


### PR DESCRIPTION
See https://go.dev/doc/go1.22. Worth reading, but in particular:

> - Previously, the variables declared by a "for" loop were created once and updated by each iteration. In Go 1.22, each iteration of the loop creates new variables, to avoid accidental sharing bugs. The [transition support tooling](https://go.dev/wiki/LoopvarExperiment#my-test-fails-with-the-change-how-can-i-debug-it) described in the proposal continues to work in the same way it did in Go 1.21.
> - "For" loops may now range over integers.
>   ...
>   See the spec for [details](https://go.dev/ref/spec#For_range).

Also need to bump to 1.56 of golangci-lint for these changes.