### PR TITLE
Ensure correct insertion of similar keys to secret scrubber trie

### DIFF
--- a/cmd/shim/secret_scrub.go
+++ b/cmd/shim/secret_scrub.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"io/fs"
@@ -221,7 +222,7 @@ func (t *Trie) Insert(key []byte, value []byte) {
 	node := t
 	for i, ch := range key {
 		if node.children == nil {
-			if node.direct == nil {
+			if node.direct == nil || bytes.Equal(node.direct, key[i:]) {
 				node.direct = key[i:]
 				node.value = value
 				return

--- a/cmd/shim/secret_scrub.go
+++ b/cmd/shim/secret_scrub.go
@@ -206,17 +206,17 @@ func (c *censor) Reset() {
 // Why not an off-the-shelf implementation? Well, most of those don't allow
 // navigating character-by-character through the tree, like we do with Step.
 type Trie struct {
-	Children []*Trie
-	Direct   []byte
+	children []*Trie
+	direct   []byte
 	value    []byte
 }
 
 func (t *Trie) Insert(key []byte, value []byte) {
 	node := t
 	for i, ch := range key {
-		if node.Children == nil {
-			if len(node.Direct) == 0 {
-				node.Direct = key[i:]
+		if node.children == nil {
+			if len(node.direct) == 0 {
+				node.direct = key[i:]
 				break
 			}
 
@@ -225,29 +225,29 @@ func (t *Trie) Insert(key []byte, value []byte) {
 			// doing so on a map is *much* slower - since this is in the
 			// hotpath, it makes sense to waste the memory here (and since the
 			// trie is compressed, it doesn't seem to be that much in practice)
-			node.Children = make([]*Trie, 256)
-			node.Children[node.Direct[0]] = &Trie{
-				Direct: node.Direct[1:],
+			node.children = make([]*Trie, 256)
+			node.children[node.direct[0]] = &Trie{
+				direct: node.direct[1:],
 				value:  node.value,
 			}
-			node.Direct = nil
+			node.direct = nil
 			node.value = nil
 		}
-		if node.Children[ch] == nil {
-			node.Children[ch] = &Trie{}
+		if node.children[ch] == nil {
+			node.children[ch] = &Trie{}
 		}
-		node = node.Children[ch]
+		node = node.children[ch]
 	}
 	node.value = value
 }
 
 func (t *Trie) Step(ch byte) *Trie {
-	if t.Children != nil {
-		return t.Children[ch]
+	if t.children != nil {
+		return t.children[ch]
 	}
-	if len(t.Direct) > 0 && t.Direct[0] == ch {
+	if len(t.direct) > 0 && t.direct[0] == ch {
 		return &Trie{
-			Direct: t.Direct[1:],
+			direct: t.direct[1:],
 			value:  t.value,
 		}
 	}
@@ -255,7 +255,7 @@ func (t *Trie) Step(ch byte) *Trie {
 }
 
 func (t *Trie) Value() []byte {
-	if len(t.Direct) == 0 {
+	if len(t.direct) == 0 {
 		return t.value
 	}
 	return nil

--- a/cmd/shim/secret_scrub.go
+++ b/cmd/shim/secret_scrub.go
@@ -206,46 +206,73 @@ func (c *censor) Reset() {
 // Why not an off-the-shelf implementation? Well, most of those don't allow
 // navigating character-by-character through the tree, like we do with Step.
 type Trie struct {
+	// value is the value stored in this trie node
+	value []byte
+
+	// children is a byte-indexed slice of child nodes
 	children []*Trie
-	direct   []byte
-	value    []byte
+	// direct is an alternative shortcut for a list of children that helps save
+	// us some memory (note, it currently only appears in leaf nodes, and
+	// contains suffixes)
+	direct []byte
 }
 
 func (t *Trie) Insert(key []byte, value []byte) {
 	node := t
 	for i, ch := range key {
 		if node.children == nil {
-			if len(node.direct) == 0 {
+			if node.direct == nil {
 				node.direct = key[i:]
-				break
+				node.value = value
+				return
 			}
-
-			// why a slice instead of a map? surely it uses more space?
-			// well, doing a lookup on a slice like this is *super* quick, but
-			// doing so on a map is *much* slower - since this is in the
-			// hotpath, it makes sense to waste the memory here (and since the
-			// trie is compressed, it doesn't seem to be that much in practice)
-			node.children = make([]*Trie, 256)
-			node.children[node.direct[0]] = &Trie{
-				direct: node.direct[1:],
-				value:  node.value,
-			}
-			node.direct = nil
-			node.value = nil
+			node.branch()
 		}
 		if node.children[ch] == nil {
 			node.children[ch] = &Trie{}
 		}
 		node = node.children[ch]
 	}
+	if node.direct != nil {
+		node.branch()
+	}
 	node.value = value
 }
 
+// branch takes a node in the trie and converts it from a leaf node into a
+// branch node.
+func (t *Trie) branch() {
+	if t.children != nil {
+		return
+	}
+
+	// why a slice instead of a map? surely it uses more space?
+	// well, doing a lookup on a slice like this is *super* quick, but
+	// doing so on a map is *much* slower - since this is in the
+	// hotpath, it makes sense to waste the memory here (and since the
+	// trie is compressed, it doesn't seem to be that much in practice)
+	t.children = make([]*Trie, 256)
+
+	// since we potentially create children here, we have to re-insert the
+	// direct shortcuts to preserve internally consistency
+	if len(t.direct) > 0 {
+		t.children[t.direct[0]] = &Trie{
+			direct: t.direct[1:],
+			value:  t.value,
+		}
+		t.value = nil
+	}
+	t.direct = nil
+}
+
+// Step selects a node that was previously inserted.
 func (t *Trie) Step(ch byte) *Trie {
 	if t.children != nil {
 		return t.children[ch]
 	}
 	if len(t.direct) > 0 && t.direct[0] == ch {
+		// this is a "virtual node" - it doesn't actually exist in the trie,
+		// but can still used for traversal
 		return &Trie{
 			direct: t.direct[1:],
 			value:  t.value,
@@ -254,9 +281,28 @@ func (t *Trie) Step(ch byte) *Trie {
 	return nil
 }
 
+// Value gets the value previously inserted at this node.
 func (t *Trie) Value() []byte {
 	if len(t.direct) == 0 {
 		return t.value
 	}
 	return nil
+}
+
+// String prints a debuggable representation of the trie.
+func (t Trie) String() string {
+	lines := ""
+	if t.value != nil {
+		lines += fmt.Sprintf("%s (%s)\n", t.direct, t.value)
+	}
+
+	for ch, child := range t.children {
+		if child != nil {
+			lines += fmt.Sprintf("%c\n", ch)
+			for _, line := range strings.Split(child.String(), "\n") {
+				lines += "  " + line + "\n"
+			}
+		}
+	}
+	return strings.TrimSpace(lines)
 }

--- a/cmd/shim/secret_scrub_test.go
+++ b/cmd/shim/secret_scrub_test.go
@@ -551,15 +551,34 @@ func TestTrie(t *testing.T) {
 	trie := Trie{}
 
 	trie.Insert([]byte("foo"), []byte("bar"))
+	fmt.Println(trie)
 	require.Equal(t, []byte("bar"), trie.Step('f').Step('o').Step('o').Value())
 	require.Nil(t, trie.Step('f').Step('o').Value())
 
 	trie.Insert([]byte("fox"), []byte("bax"))
+	fmt.Println(trie)
 	require.Equal(t, []byte("bar"), trie.Step('f').Step('o').Step('o').Value())
 	require.Equal(t, []byte("bax"), trie.Step('f').Step('o').Step('x').Value())
 
 	trie.Insert([]byte("fax"), []byte("brx"))
+	fmt.Println(trie)
 	require.Equal(t, []byte("bar"), trie.Step('f').Step('o').Step('o').Value())
 	require.Equal(t, []byte("bax"), trie.Step('f').Step('o').Step('x').Value())
 	require.Equal(t, []byte("brx"), trie.Step('f').Step('a').Step('x').Value())
+}
+
+func TestTrieExtend(t *testing.T) {
+	trie := Trie{}
+	trie.Insert([]byte("foo"), []byte("bar"))
+	trie.Insert([]byte("foob"), []byte("bax"))
+	fmt.Println(trie)
+	require.Equal(t, []byte("bar"), trie.Step('f').Step('o').Step('o').Value())
+	require.Equal(t, []byte("bax"), trie.Step('f').Step('o').Step('o').Step('b').Value())
+
+	trie = Trie{}
+	trie.Insert([]byte("foob"), []byte("bax"))
+	trie.Insert([]byte("foo"), []byte("bar"))
+	fmt.Println(trie)
+	require.Equal(t, []byte("bar"), trie.Step('f').Step('o').Step('o').Value())
+	require.Equal(t, []byte("bax"), trie.Step('f').Step('o').Step('o').Step('b').Value())
 }

--- a/cmd/shim/secret_scrub_test.go
+++ b/cmd/shim/secret_scrub_test.go
@@ -582,3 +582,20 @@ func TestTrieExtend(t *testing.T) {
 	require.Equal(t, []byte("bar"), trie.Step('f').Step('o').Step('o').Value())
 	require.Equal(t, []byte("bax"), trie.Step('f').Step('o').Step('o').Step('b').Value())
 }
+
+func TestTrieReinsert(t *testing.T) {
+	trie := Trie{}
+
+	trie.Insert([]byte("foo"), []byte("bar"))
+	require.Equal(t, []byte("bar"), trie.Step('f').Step('o').Step('o').Value())
+	before := trie.String()
+
+	trie.Insert([]byte("foo"), []byte("bar"))
+	require.Equal(t, []byte("bar"), trie.Step('f').Step('o').Step('o').Value())
+	after := trie.String()
+
+	require.Equal(t, before, after)
+
+	trie.Insert([]byte("foo"), []byte("baz"))
+	require.Equal(t, []byte("baz"), trie.Step('f').Step('o').Step('o').Value())
+}


### PR DESCRIPTION
Fix https://github.com/dagger/dagger/issues/6630.

The issue appeared when attempting to insert two keys that had similar prefixes:
- Inserting `abc`, and then inserting `abcd`,
- Inserting `abcd`, and then inserting `abc`.

This case was being handled poorly, due to the handling of the `direct` suffix value. When inserting to a node that already has a suffix, we need to take care to not just directly write there - if there's a value stored there, we need to make it into a branch node.