### PR TITLE
fix resolution of local dep from git module

### DIFF
--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -961,3 +961,22 @@ func (m *Test) Fn() ([]string, error) {
 	require.NoError(t, err)
 	require.Contains(t, strings.TrimSpace(out), "random-file")
 }
+
+func TestModuleDaggerInstallGit(t *testing.T) {
+	/*
+		TODO: this is a stopgap test to get some basic coverage of installing modules
+		from git refs. Ideally it would rely on our own repo for of test fixtures but
+		those have not been setup yet: https://github.com/dagger/dagger/issues/6623
+	*/
+	t.Parallel()
+
+	c, ctx := connect(t)
+
+	_, err := goGitBase(t, c).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithWorkdir("/work").
+		With(daggerExec("init", "--name=test", "--sdk=go")).
+		With(daggerExec("install", "github.com/sagikazarmark/daggerverse/archivist@bedfa0c8bdba7192c65c21b5e88a48b600666fcc")).
+		Sync(ctx)
+	require.NoError(t, err)
+}

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -344,8 +344,9 @@ func (src *GitModuleSource) PBDefinitions(ctx context.Context) ([]*pb.Definition
 
 func (src *GitModuleSource) RefString() string {
 	refPath := src.URLParent
-	if src.RootSubpath != "/" {
-		refPath += src.RootSubpath
+	subPath := filepath.Join("/", src.RootSubpath)
+	if subPath != "/" {
+		refPath += subPath
 	}
 	return fmt.Sprintf("%s@%s", refPath, src.Commit)
 }

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -119,11 +119,12 @@ func (s *moduleSchema) moduleSource(ctx context.Context, query *core.Query, args
 		}
 		src.AsGitSource.Value.Commit = gitCommit
 
+		subPath = filepath.Clean(subPath)
 		if !filepath.IsAbs(subPath) && !filepath.IsLocal(subPath) {
 			return nil, fmt.Errorf("git module source subpath points out of root: %q", subPath)
 		}
-		if !filepath.IsAbs(subPath) {
-			subPath = filepath.Join("/", subPath)
+		if filepath.IsAbs(subPath) {
+			subPath = strings.TrimPrefix(subPath, "/")
 		}
 
 		// TODO:(sipsma) support sparse loading of git repos similar to how local dirs are loaded.


### PR DESCRIPTION
The source root subpath of git refs were being turned into absolute paths (as opposed to local refs which always stored the source root subpath as relative). This broke the resolve dependency logic and resulted in errors when installing modules from a git ref that had a relative local dep.