### PR TITLE
ci: skip some test jobs on pull requests

### DIFF
--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -9,6 +9,8 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+    paths-ignore:
+      - docs/**
   # Enable manual trigger for easy debugging
   workflow_dispatch:
 

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -9,6 +9,8 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+    paths-ignore:
+      - docs/**
   # Enable manual trigger for easier debugging
   workflow_dispatch:
 


### PR DESCRIPTION
cc @d3rp3tt3 @vikram-dagger 

We don't need to run `helm` or `engine-and-cli` (the very long ones, `test`+`testdev`) on every single docs PR.

The SDK jobs still should run on every PR, since the linting jobs can also lint the contents of the `docs/` directory I think?