### PR TITLE
feat: set GOTOOLCHAIN to auto for go module sdk

### DIFF
--- a/internal/mage/util/engine.go
+++ b/internal/mage/util/engine.go
@@ -390,6 +390,7 @@ func goSDKImageTarBall(c *dagger.Client, arch string) *dagger.File {
 
 	_, err = c.Container(dagger.ContainerOpts{Platform: dagger.Platform("linux/" + arch)}).
 		From(fmt.Sprintf("golang:%s-alpine%s", golangVersion, alpineVersion)).
+		WithEnvVariable("GOTOOLCHAIN", "auto").
 		WithFile("/usr/local/bin/codegen", goSDKCodegenBin(c, arch)).
 		WithEntrypoint([]string{"/usr/local/bin/codegen"}).
 		Export(ctx, tarballPath)


### PR DESCRIPTION
Without this, the Go module SDK would only ever be able to build modules with the single go version that our CI had permitted - this made for a really confusing and frustrating experience when running a newer go version locally (e.g. being on a bleeding edge distro :smile).

I noticed this when using a `go.work` in my own daggerverse repo:

```
$ dagger call get-latest-release --repo="dagger/dagger" body
✘ ModuleSource.asModule: Module! 1.8s
  ✘ Module.withSource(
      source: ✔ ModuleSource.resolveFromCaller: ModuleSource! 0.0s
    ): Module! 1.8s
    ✔ Container.import(
        source: ✔ Directory.file(path: "go-module-sdk-image.tar"): File! 0.0s
      ): Container! 0.7s
    ✘ Container.directory(path: "/src"): Directory! 0.8s
      ✘ exec /usr/local/bin/codegen --module-context /src --module-name github --propagate-logs=true --introspection-json-path /schema.json 0.7s
      ┃ Error: load package ".": err: exit status 1: stderr: go: ../go.work requires go >= 1.22.0 (running go 1.21.3; GOTOOLCHAIN=local)                                      
      ┃                                                                                                                                                                       
      ✘ generating go module: github 0.1s
      ┃ writing dagger.gen.go                                                                                                                                                 
      ┃ writing go.mod                                                                                                                                                        
      ┃ writing go.sum                                                                                                                                                        
      ┃ needs another pass...                                                                                                                                                 

Error: input: resolve: moduleSource: resolveFromCaller: asModule: failed to create module: failed to update codegen and runtime: failed to generate code: failed to get modified source directory for go module sdk codegen: process "/usr/local/bin/codegen --module-context /src --module-name github --propagate-logs=true --introspection-json-path /schema.json" did not complete successfully: exit code: 1

Stderr:
Error: load package ".": err: exit status 1: stderr: go: ../go.work requires go >= 1.22.0 (running go 1.21.3; GOTOOLCHAIN=local)
```

With this change though, the go tooling automatically downloads the version I need.