### PR TITLE
Send Discord notifications part of releasing

### DIFF
--- a/.github/workflows/_new_release_notification.yml
+++ b/.github/workflows/_new_release_notification.yml
@@ -1,0 +1,24 @@
+name: "New Release Notification"
+
+on:
+  workflow_call:
+    inputs:
+      message:
+        type: string
+        required: true
+
+jobs:
+  discord:
+    runs-on: ubuntu-latest
+    env:
+      DISCORD_WEBHOOK: ${{ secrets.NEW_RELEASE_DISCORD_WEBHOOK }}
+    steps:
+      - name: Notify Discord
+        run: |
+          export TESTED_WITH_DAGGER_VERSION=0.9.10
+
+          curl --fail --silent --show-error https://dl.dagger.io/dagger/install.sh \
+          | DAGGER_VERSION=$TESTED_WITH_DAGGER_VERSION sh
+
+          ./bin/dagger call --mod github.com/gerhard/daggerverse/notify@2024-02-13 \
+            discord --webhook-url env:DISCORD_WEBHOOK --message '${{ inputs.message }}'

--- a/.github/workflows/_new_release_notification.yml
+++ b/.github/workflows/_new_release_notification.yml
@@ -10,15 +10,12 @@ on:
 jobs:
   discord:
     runs-on: ubuntu-latest
-    env:
-      DISCORD_WEBHOOK: ${{ secrets.NEW_RELEASE_DISCORD_WEBHOOK }}
     steps:
       - name: Notify Discord
-        run: |
-          export TESTED_WITH_DAGGER_VERSION=0.9.10
-
-          curl --fail --silent --show-error https://dl.dagger.io/dagger/install.sh \
-          | DAGGER_VERSION=$TESTED_WITH_DAGGER_VERSION sh
-
-          ./bin/dagger call --mod github.com/gerhard/daggerverse/notify@2024-02-13 \
-            discord --webhook-url env:DISCORD_WEBHOOK --message '${{ inputs.message }}'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.NEW_RELEASE_DISCORD_WEBHOOK }}
+        uses: dagger/dagger-for-github@v5
+        with:
+          version: '0.9.10'
+          module: 'github.com/gerhard/daggerverse/notify@2024-02-13'
+          args: discord --webhook-url env:DISCORD_WEBHOOK --message '${{ inputs.message }}'

--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -21,3 +21,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}
           DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+  notify:
+    needs: publish
+    uses: ./.github/workflows/_new_release_notification.yml
+    secrets: inherit
+    with:
+      message: "🎡 Helm Chart: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}"

--- a/.github/workflows/publish-sdk-elixir.yml
+++ b/.github/workflows/publish-sdk-elixir.yml
@@ -16,3 +16,10 @@ jobs:
           GITHUB_PAT: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}
           HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
           DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+  notify:
+    needs: publish
+    uses: ./.github/workflows/_new_release_notification.yml
+    secrets: inherit
+    with:
+      message: "🧪 Elixir SDK: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}"

--- a/.github/workflows/publish-sdk-go.yml
+++ b/.github/workflows/publish-sdk-go.yml
@@ -16,3 +16,10 @@ jobs:
         env:
           GITHUB_PAT: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}
           DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+  notify:
+    needs: publish
+    uses: ./.github/workflows/_new_release_notification.yml
+    secrets: inherit
+    with:
+      message: "🐹 Go SDK: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}"

--- a/.github/workflows/publish-sdk-php.yml
+++ b/.github/workflows/publish-sdk-php.yml
@@ -17,3 +17,9 @@ jobs:
           GITHUB_PAT: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}
           DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
 
+  notify:
+    needs: publish
+    uses: ./.github/workflows/_new_release_notification.yml
+    secrets: inherit
+    with:
+      message: "🐘 PHP SDK: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}"

--- a/.github/workflows/publish-sdk-python.yml
+++ b/.github/workflows/publish-sdk-python.yml
@@ -15,3 +15,10 @@ jobs:
           PYPI_REPO: ${{ secrets.RELEASE_PYPI_REPO }}
           PYPI_TOKEN: ${{ secrets.RELEASE_PYPI_TOKEN }}
           DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+  notify:
+    needs: publish
+    uses: ./.github/workflows/_new_release_notification.yml
+    secrets: inherit
+    with:
+      message: "🐍 Python SDK: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}"

--- a/.github/workflows/publish-sdk-rust.yml
+++ b/.github/workflows/publish-sdk-rust.yml
@@ -16,3 +16,10 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           CARGO_PUBLISH_DRYRUN: "false"
           DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+  notify:
+    needs: publish
+    uses: ./.github/workflows/_new_release_notification.yml
+    secrets: inherit
+    with:
+      message: "⚙️ Rust SDK: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}"

--- a/.github/workflows/publish-sdk-typescript.yml
+++ b/.github/workflows/publish-sdk-typescript.yml
@@ -14,3 +14,10 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.RELEASE_NPM_TOKEN }}
           DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+  notify:
+    needs: publish
+    uses: ./.github/workflows/_new_release_notification.yml
+    secrets: inherit
+    with:
+      message: "⬢ TypeScript SDK: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,10 +68,17 @@ jobs:
           branch: bump-engine
           draft: true
 
+  notify:
+    needs: publish
+    uses: ./.github/workflows/_new_release_notification.yml
+    secrets: inherit
+    with:
+      message: "🚙 Engine + 🚗 CLI: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}"
+
   scan-engine:
     runs-on: ubuntu-latest
     name: "Scan Engine Image for Vulnerabilities"
-    needs: [publish]
+    needs: publish
     # only run this on push events, not in PRs (since we only publish images during pushes)
     if: github.event_name == 'push' && github.repository == 'dagger/dagger'
     steps:
@@ -88,7 +95,7 @@ jobs:
     # has to be skipped, AND after every push to main/tags, in which case publish
     # must run first. This is unfortunately quite annoying to express in yaml...
     # https://github.com/actions/runner/issues/491#issuecomment-850884422
-    needs: [publish]
+    needs: publish
     if: |
       always() &&
       github.repository == 'dagger/dagger' &&
@@ -168,7 +175,7 @@ jobs:
 
   test-provision-go-linux:
     name: "Test SDK Provision / go / linux"
-    needs: [publish]
+    needs: publish
     if: |
       always() &&
       github.repository == 'dagger/dagger' &&
@@ -212,7 +219,7 @@ jobs:
 
   test-provision-python-linux:
     name: "Test SDK Provision / python / linux"
-    needs: [publish]
+    needs: publish
     if: |
       always() &&
       github.repository == 'dagger/dagger' &&
@@ -259,7 +266,7 @@ jobs:
 
   test-provision-typescript-linux:
     name: "Test SDK Provision / TypeScript / linux"
-    needs: [publish]
+    needs: publish
     if: |
       always() &&
       github.repository == 'dagger/dagger' &&


### PR DESCRIPTION
`TL;DR`

`1/3. GitHub Workflow`
<img width="1440" alt="image" src="https://github.com/dagger/dagger/assets/3342/91cc115b-354f-4397-8483-de3a7c49295b">

`2/3. dagger call in GitHub Workflow Step`
<img width="1440" alt="image" src="https://github.com/dagger/dagger/assets/3342/85700b32-2163-4d17-9dfa-171be59132be">

`3/3. Discord Notification`
![image](https://github.com/dagger/dagger/assets/3342/85c5a10d-7430-45bd-b167-fcec47d2aad3)

---
This adds notifications for the following releases:
1. 🚙 Engine + 🚗 CLI
2. 🐹 Go SDK
3. 🐍 Python SDK
4. ⬢ TypeScript SDK
5. ⚙️ Rust SDK (this is not published part of the regular release cycle)
6. 🧪 Elixir SDK
7. 🐘 PHP SDK
8. 🎡 Helm Chart (this is not published part of the regular release cycle)

We used to have a bot for this purpose: `github-release-towncrier`. It required us to:
- keep the app running all the time
- change the filtering when a new release type was added

A few other issues that we've hit with this setup:
- performing any updates during a release would miss webhooks
- if a webhook was missed, the notification would not go out
- setting up redundant instances would result in multiple notifications for the same webhook

This new approach leverages Dagger Modules and doesn't require any code to run: we simply invoke a remote module just-in-time.

<https://github.com/gerhard/daggerverse/tree/2024-02-13/notify> Dagger
Module was developed part of an internal Dacker Hackathon 🐶

## Action items
- [x] Submit PR
- [x] Configure WebHook - `NEW_RELEASE_DISCORD_WEBHOOK`
  - Discord
![image](https://github.com/dagger/dagger/assets/3342/26de29b5-aa9f-4974-92fc-02b333188080)
  - GitHub Actions Secrets
- [x] Create list of Dagger Zenith issues
  - Ask which are worth submitting as GitHub issues
- [x] Get PR reviewed
- [ ] Record demo video
- [ ] Test with new Helm release
- [ ] Delete `sdk-release-towncrier-bot`
  - Remove Discord integration
- [ ] Merge PR