### PR TITLE
helm: Bump default Dagger Engine version to v0.9.10

### DIFF
--- a/helm/dagger/Chart.yaml
+++ b/helm/dagger/Chart.yaml
@@ -3,5 +3,5 @@ name: dagger-helm
 description: Dagger Helm chart
 
 type: application
-version: 0.1.0
-appVersion: v0.9.3
+version: 0.1.1
+appVersion: v0.9.10


### PR DESCRIPTION
Follow-up to:
- https://github.com/dagger/dagger/pull/6665