### PR TITLE
Zenith: Fix short names for remote refs

### DIFF
--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -732,7 +732,11 @@ func getModuleConfigurationForSourceRef(
 				return nil, fmt.Errorf("failed to unmarshal %s: %s", configPath, err)
 			}
 			if namedDep, ok := modCfg.DependencyByName(srcRefStr); ok {
-				return getModuleConfigurationForSourceRef(ctx, dag, namedDep.Source, resolveFromCaller)
+				if strings.HasPrefix(namedDep.Source, "github.com/") {
+					return getModuleConfigurationForSourceRef(ctx, dag, namedDep.Source, resolveFromCaller)
+				}
+				depPath := filepath.Join(defaultConfigDir, namedDep.Source)
+				srcRefStr = depPath
 			}
 		}
 

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -209,7 +209,7 @@ Any module can be installed to via "dagger install".
 
 A module can only be called once it has been initialized with an SDK though. The "--sdk" flag can be provided to init here, but if it's not the configuration can be updated later via "dagger develop".
 
-The "--source" flag allows controlling the directory in which the actual module source code is stored. By default, it will be stored in a directory named "dagger". 
+The "--source" flag allows controlling the directory in which the actual module source code is stored. By default, it will be stored in a directory named "dagger".
 `,
 	Example: "dagger init --name=hello --sdk=python --source=some/subdir",
 	GroupID: moduleGroup.ID,
@@ -732,8 +732,7 @@ func getModuleConfigurationForSourceRef(
 				return nil, fmt.Errorf("failed to unmarshal %s: %s", configPath, err)
 			}
 			if namedDep, ok := modCfg.DependencyByName(srcRefStr); ok {
-				depPath := filepath.Join(defaultConfigDir, namedDep.Source)
-				srcRefStr = depPath
+				return getModuleConfigurationForSourceRef(ctx, dag, namedDep.Source, resolveFromCaller)
 			}
 		}
 

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -732,7 +732,12 @@ func getModuleConfigurationForSourceRef(
 				return nil, fmt.Errorf("failed to unmarshal %s: %s", configPath, err)
 			}
 			if namedDep, ok := modCfg.DependencyByName(srcRefStr); ok {
-				if strings.HasPrefix(namedDep.Source, "github.com/") {
+				src := dag.ModuleSource(namedDep.Source)
+				kind, err := src.Kind(ctx)
+				if err != nil {
+					return nil, err
+				}
+				if kind == dagger.GitSource {
 					return getModuleConfigurationForSourceRef(ctx, dag, namedDep.Source, resolveFromCaller)
 				}
 				depPath := filepath.Join(defaultConfigDir, namedDep.Source)

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -980,3 +980,25 @@ func TestModuleDaggerInstallGit(t *testing.T) {
 		Sync(ctx)
 	require.NoError(t, err)
 }
+
+func TestModuleDaggerCallGit(t *testing.T) {
+	/*
+		TODO: this is a stopgap test to get some basic coverage of installing modules
+		from git refs. Ideally it would rely on our own repo for of test fixtures but
+		those have not been setup yet: https://github.com/dagger/dagger/issues/6623
+	*/
+	t.Parallel()
+
+	c, ctx := connect(t)
+
+	out, err := goGitBase(t, c).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithWorkdir("/work").
+		With(daggerExec("init", "--name=test", "--sdk=go")).
+		With(daggerExec("install", "github.com/jedevc/shykes-daggerverse/hello@06e224b789a9c339e10e9fc46833ba96397dcc63")).
+		With(daggerExec("-m", "hello", "functions")).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Contains(t, out, "hello")
+	require.Contains(t, out, "Say hello to the world!")
+}


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/6664

Based on my testing, `DependencyByName` would return the git URL from the config, and we'd assume this was a local path. `Source.Kind` check happens earlier in this function, so recursively calling the function with the un-short-named ref felt right. There may be a case I'm missing here.