### PR TITLE
ci: Only notify on new releases when there is a new tag

### DIFF
--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -1,6 +1,5 @@
 name: Publish Helm Chart
 on:
-  workflow_dispatch:
   push:
     tags: ["helm/chart/v**"]
 

--- a/.github/workflows/publish-sdk-go.yml
+++ b/.github/workflows/publish-sdk-go.yml
@@ -18,6 +18,7 @@ jobs:
           DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
 
   notify:
+    if: github.ref_type == 'tag'
     needs: publish
     uses: ./.github/workflows/_new_release_notification.yml
     secrets: inherit

--- a/.github/workflows/publish-sdk-php.yml
+++ b/.github/workflows/publish-sdk-php.yml
@@ -18,6 +18,7 @@ jobs:
           DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
 
   notify:
+    if: github.ref_type == 'tag'
     needs: publish
     uses: ./.github/workflows/_new_release_notification.yml
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,6 +69,7 @@ jobs:
           draft: true
 
   notify:
+    if: github.ref_type == 'tag'
     needs: publish
     uses: ./.github/workflows/_new_release_notification.yml
     secrets: inherit


### PR DESCRIPTION
Otherwise this will trigger every time there is push to `main`

Follow-up to:
- https://github.com/dagger/dagger/pull/6665

---
![Dagger Releases Fix](https://github.com/dagger/dagger/assets/3342/9c52bc32-6464-4883-9c52-6f751c572921)
