### PR TITLE
fix: add generated go modules to go.work

### DIFF
--- a/cmd/codegen/generator/go/generator.go
+++ b/cmd/codegen/generator/go/generator.go
@@ -55,6 +55,10 @@ func (g *GoGenerator) Generate(ctx context.Context, schema *introspection.Schema
 			exec.Command("go", "mod", "tidy"),
 		},
 	}
+	if _, err := os.Stat("go.work"); err != nil {
+		// run "go work use ." after generating if we had a go.work at the root
+		genSt.PostCommands = append(genSt.PostCommands, exec.Command("go", "work", "use", "."))
+	}
 
 	pkgInfo, partial, err := g.bootstrapMod(ctx, mfs)
 	if err != nil {

--- a/cmd/codegen/generator/go/generator.go
+++ b/cmd/codegen/generator/go/generator.go
@@ -308,7 +308,9 @@ func loadPackage(ctx context.Context, dir string) (*packages.Package, *token.Fil
 		return nil, nil, fmt.Errorf("no packages found in %s", dir)
 	case 1:
 		if pkgs[0].Name == "" {
-			// this happens when loading an empty dir within an existing Go module
+			// this can happen when:
+			// - loading an empty dir within an existing Go module
+			// - loading a dir that is not included in a parent go.work
 			return nil, nil, fmt.Errorf("package name is empty")
 		}
 		return pkgs[0], fset, nil


### PR DESCRIPTION
*Should* fix https://github.com/dagger/dagger/issues/6659 (cc @nipuna-perera).

This is a pretty common use case - we have a `go.work` at the root of a repo, and we want to create a dagger module for it with `dagger init`.

However, naively, this will actually create a dagger module that can't be called (because `go.work` doesn't include it). To resolve this, we need to add it to `go.work`.

(bleh, this took way too long to track down and work out how to fix)