### PR TITLE
feat: go module default arg values must all be valid JSON

### DIFF
--- a/cmd/codegen/generator/go/templates/module_funcs.go
+++ b/cmd/codegen/generator/go/templates/module_funcs.go
@@ -128,17 +128,11 @@ func (spec *funcTypeSpec) TypeDefCode() (*Statement, error) {
 			argOptsCode = append(argOptsCode, Id("Description").Op(":").Lit(argSpec.description))
 		}
 		if argSpec.defaultValue != "" {
-			var jsonEnc string
-			if argSpec.typeSpec.GoType().String() == "string" {
-				enc, err := json.Marshal(argSpec.defaultValue)
-				if err != nil {
-					return nil, fmt.Errorf("failed to marshal default value: %w", err)
-				}
-				jsonEnc = string(enc)
-			} else {
-				jsonEnc = argSpec.defaultValue
+			var v any
+			if err := json.Unmarshal([]byte(argSpec.defaultValue), &v); err != nil {
+				return nil, fmt.Errorf("default value %q must be valid JSON: %w", argSpec.defaultValue, err)
 			}
-			argOptsCode = append(argOptsCode, Id("DefaultValue").Op(":").Id("JSON").Call(Lit(jsonEnc)))
+			argOptsCode = append(argOptsCode, Id("DefaultValue").Op(":").Id("JSON").Call(Lit(argSpec.defaultValue)))
 		}
 
 		// arguments to WithArg (args to arg... ugh, at least the name of the variable is honest?)

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -1217,7 +1217,7 @@ package main
 
 // Test object, short description
 type Test struct {
-	// +default=foo
+	// +default="foo"
 	Foo string
 }
 `,

--- a/core/integration/testdata/modules/go/minimal/main.go
+++ b/core/integration/testdata/modules/go/minimal/main.go
@@ -158,7 +158,7 @@ func (m *Minimal) EchoOptsPragmas(
 
 	// String to append to the echoed message
 	// +optional=true
-	// +default=...
+	// +default="..."
 	suffix string,
 	// Number of times to repeat the message
 	// +optional

--- a/docs/versioned_docs/version-zenith/developer/go/snippets/advanced-programming/constructor/main.go
+++ b/docs/versioned_docs/version-zenith/developer/go/snippets/advanced-programming/constructor/main.go
@@ -8,10 +8,10 @@ import (
 
 func New(
 	// +optional
-	// +default=Hello
+	// +default="Hello"
 	greeting string,
 	// +optional
-	// +default=World
+	// +default="World"
 	name string,
 ) *HelloWorld {
 	return &HelloWorld{

--- a/docs/versioned_docs/version-zenith/developer/go/snippets/quickstart/trivy/main.go
+++ b/docs/versioned_docs/version-zenith/developer/go/snippets/quickstart/trivy/main.go
@@ -13,12 +13,12 @@ func (t *Trivy) ScanImage(
 	ctx context.Context,
 	imageRef string,
 	// +optional
-	// +default=UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+	// +default="UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
 	severity string,
 	// +optional
 	exitCode int,
 	// +optional
-	// +default=table
+	// +default="table"
 	format string,
 ) (string, error) {
 	return dag.


### PR DESCRIPTION
Reference: https://discord.com/channels/707636530424053791/1150156410462679180/1207824903458398258

Also see #6651.

No more `// +default=foo` which is unclear, now we require `// +default="foo"`.

This is a zenith breaking change! cc @vikram-dagger, I've updated the docs as well.

---

Chucking this onto the v0.9.11 milestone, sooner > later. We should do another announcement in #project-zenith when we do this.