### PR TITLE
doc(sdk/elixir): update version in doc when bump a new version

### DIFF
--- a/docs/current_docs/partials/_install-sdk-elixir.mdx
+++ b/docs/current_docs/partials/_install-sdk-elixir.mdx
@@ -2,7 +2,7 @@
 This Dagger Elixir SDK requires [Elixir 1.14 or later](https://elixir-lang.org/install.html) with [Erlang OTP 23 or later](https://www.erlang.org/downloads). Using Erlang OTP version 25 is recommended.
 :::
 
-In your project directory, open `mix.exs` and add `:dagger` dependency to the list in the `deps` function:
+In your project directory, open `mix.exs` and add `:dagger` as a dependency to the list in the `deps` function:
 
 ```elixir
 def deps do

--- a/docs/current_docs/partials/_install-sdk-elixir.mdx
+++ b/docs/current_docs/partials/_install-sdk-elixir.mdx
@@ -2,12 +2,12 @@
 This Dagger Elixir SDK requires [Elixir 1.14 or later](https://elixir-lang.org/install.html) with [Erlang OTP 23 or later](https://www.erlang.org/downloads). Using Erlang OTP version 25 is recommended.
 :::
 
-In your project directory, open `mix.exs` and add `{:dagger, "~> 0.8"}` to the list in the `deps` function:
+In your project directory, open `mix.exs` and add `:dagger` dependency to the list in the `deps` function:
 
 ```elixir
 def deps do
   [
-    {:dagger, "~> 0.8", only: [:dev, :test]}
+    {:dagger, "~> 0.9.10", only: [:dev, :test]}
   ]
 end
 ```

--- a/internal/mage/sdk/elixir.go
+++ b/internal/mage/sdk/elixir.go
@@ -18,6 +18,7 @@ const (
 	elixirSDKPath            = "sdk/elixir"
 	elixirSDKGeneratedPath   = elixirSDKPath + "/lib/dagger/gen"
 	elixirSDKVersionFilePath = elixirSDKPath + "/lib/dagger/core/engine_conn.ex"
+	elixirSDKInstallDocPath  = "docs/current_docs/partials/_install-sdk-elixir.mdx"
 )
 
 // https://hub.docker.com/r/hexpm/elixir/tags?page=1&name=debian-buster
@@ -202,7 +203,20 @@ func (Elixir) Bump(ctx context.Context, engineVersion string) error {
 		return err
 	}
 	newContents := versionRe.ReplaceAll(contents, []byte(newVersion))
-	return os.WriteFile(elixirSDKVersionFilePath, newContents, 0o600)
+	if err := os.WriteFile(elixirSDKVersionFilePath, newContents, 0o600); err != nil {
+		return err
+	}
+
+	installDoc, err := os.ReadFile(elixirSDKInstallDocPath)
+
+	newVersion = fmt.Sprintf(`~> %s`, strings.TrimPrefix(engineVersion, "v"))
+	versionRe, err = regexp.Compile(`~> (\d+\.\d+\.\d+)`)
+	if err != nil {
+		return err
+	}
+
+	newDoc := versionRe.ReplaceAll(installDoc, []byte(newVersion))
+	return os.WriteFile(elixirSDKInstallDocPath, newDoc, 0o644)
 }
 
 func elixirBase(c *dagger.Client, elixirVersion string) *dagger.Container {


### PR DESCRIPTION
This follows up from
https://github.com/dagger/dagger/pull/5530#discussion_r1321896711, bump a `:dagger` version in the install sdk section to the latest version when calling `sdk:elixir:bump` is called.

This change already bumps to the latest version by running `./hack/make sdk:elixir:bump 0.9.10`.

[Rendered](https://deploy-preview-6684--devel-docs-dagger-io.netlify.app/sdk/elixir/043817/install)