### PR TITLE
ci: Update Node.js version for the typescript SDK and test LTS and Maintenance versions

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -12,7 +12,7 @@
     ".": "./dist/index.js"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "main": "dist/index.js",
   "dependencies": {


### PR DESCRIPTION
As discussed with @TomChv in #6591.

### Changes:

Our CI would test with
 - `node:18-alpine`
 - `node:20-alpine`
 and not with `node:16-alpine`, which is discontinued and reached EOL.

All other tasks, such as lint, bump, publish, build, utilize the LTS version of node, which is currently 20.

Updated the `package.json` to reflect we only test for `node>=18`.

___

Node 18 is maintained until 30 Apr 2025.
Thats when we should potentially look into upgrading again.