### PR TITLE
docs: fix incorrect init module path

### DIFF
--- a/docs/versioned_docs/version-zenith/quickstart/428201-custom-modules.mdx
+++ b/docs/versioned_docs/version-zenith/quickstart/428201-custom-modules.mdx
@@ -29,8 +29,7 @@ To see this in action, create a custom Dagger module to build a Go binary, add i
     <TabItem value="Go">
 
     ```shell
-    mkdir my-module
-    dagger init --name=my-module --sdk=go
+    dagger init --sdk=go my-module
     ```
 
     This will generate a `dagger.json` module file, an initial `dagger/main.go` source file, as well as a generated `dagger/dagger.gen.go` and `dagger/querybuilder` directory for the generated module code.
@@ -39,8 +38,7 @@ To see this in action, create a custom Dagger module to build a Go binary, add i
     <TabItem value="Python">
 
     ```shell
-    mkdir my-module
-    dagger init --name=my-module --sdk=python
+    dagger init --sdk=python my-module
     ```
 
     This will generate a `dagger.json` module file, initial `dagger/src/main.py` and `dagger/pyproject.toml` files, as well as a generated `dagger/sdk` folder for local development.
@@ -49,8 +47,7 @@ To see this in action, create a custom Dagger module to build a Go binary, add i
     <TabItem value="TypeScript">
 
     ```shell
-    mkdir my-module
-    dagger init --name=my-module --sdk=typescript
+    dagger init --sdk=typescript my-module
     ```
 
     This will generate a `dagger.json` module file, initial `dagger/src/index.ts`, `dagger/package.json` and `dagger/tsconfig.json` files, as well as a generated `dagger/sdk` folder for local development.


### PR DESCRIPTION
In Zenith documentation, it need to change directory to `my-module` before initiate the module to create module to correct location.