### PR TITLE
fix: ensure common capitalization for go type generation

### DIFF
--- a/cmd/codegen/generator/go/templates/format.go
+++ b/cmd/codegen/generator/go/templates/format.go
@@ -47,10 +47,10 @@ func (f *FormatTypeFunc) FormatKindScalarBoolean(representation string) string {
 }
 
 func (f *FormatTypeFunc) FormatKindScalarDefault(representation string, refName string, input bool) string {
-	if obj, rest, ok := strings.Cut(refName, "ID"); input && ok && rest == "" {
-		representation += "*" + f.scope + obj
+	if obj, ok := strings.CutSuffix(refName, "ID"); input && ok {
+		representation += "*" + f.scope + formatName(obj)
 	} else {
-		representation += f.scope + refName
+		representation += f.scope + formatName(refName)
 	}
 
 	return representation


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/6669.

Previously, FormatOutputType and FormatInputType wouldn't use the same capitalization as formatName. The solution is to have these functions also format the underlying names, which means we get *consistent* caps!