### PR TITLE
backfill integ test coverage for git ref modules

### DIFF
--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -278,44 +280,81 @@ func TestModuleConfigs(t *testing.T) {
 		t.Run("source points out of root", func(t *testing.T) {
 			t.Parallel()
 
-			base := base.
-				With(configFile(".", &modules.ModuleConfig{
-					Name:   "evil",
-					SDK:    "go",
-					Source: "..",
-				}))
+			t.Run("local", func(t *testing.T) {
+				t.Parallel()
+				base := base.
+					With(configFile(".", &modules.ModuleConfig{
+						Name:   "evil",
+						SDK:    "go",
+						Source: "..",
+					}))
 
-			_, err := base.With(daggerCall("container-echo", "--string-arg", "plz fail")).Sync(ctx)
-			require.ErrorContains(t, err, `local module source path ".." escapes context "/work"`)
+				_, err := base.With(daggerCall("container-echo", "--string-arg", "plz fail")).Sync(ctx)
+				require.ErrorContains(t, err, `local module source path ".." escapes context "/work"`)
 
-			_, err = base.With(daggerExec("develop")).Sync(ctx)
-			require.ErrorContains(t, err, `local module source path ".." escapes context "/work"`)
+				_, err = base.With(daggerExec("develop")).Sync(ctx)
+				require.ErrorContains(t, err, `local module source path ".." escapes context "/work"`)
 
-			_, err = base.With(daggerExec("install", "./dep")).Sync(ctx)
-			require.ErrorContains(t, err, `local module source path ".." escapes context "/work"`)
+				_, err = base.With(daggerExec("install", "./dep")).Sync(ctx)
+				require.ErrorContains(t, err, `local module source path ".." escapes context "/work"`)
+			})
+
+			t.Run("git", func(t *testing.T) {
+				t.Parallel()
+				_, err := base.With(daggerCallAt(testGitModuleRef("invalid/bad-source"), "container-echo", "--string-arg", "plz fail")).Sync(ctx)
+				require.ErrorContains(t, err, `source path "../../../" contains parent directory components`)
+			})
 		})
 
 		t.Run("dep points out of root", func(t *testing.T) {
 			t.Parallel()
 
-			base := base.
-				With(configFile(".", &modules.ModuleConfig{
-					Name: "evil",
-					SDK:  "go",
-					Dependencies: []*modules.ModuleConfigDependency{{
-						Name:   "escape",
-						Source: "..",
-					}},
-				}))
+			t.Run("local", func(t *testing.T) {
+				t.Parallel()
+				base := base.
+					With(configFile(".", &modules.ModuleConfig{
+						Name: "evil",
+						SDK:  "go",
+						Dependencies: []*modules.ModuleConfigDependency{{
+							Name:   "escape",
+							Source: "..",
+						}},
+					}))
 
-			_, err := base.With(daggerCall("container-echo", "--string-arg", "plz fail")).Sync(ctx)
-			require.ErrorContains(t, err, `local module dep source path ".." escapes context "/work"`)
+				_, err := base.With(daggerCall("container-echo", "--string-arg", "plz fail")).Sync(ctx)
+				require.ErrorContains(t, err, `local module dep source path ".." escapes context "/work"`)
 
-			_, err = base.With(daggerExec("develop")).Sync(ctx)
-			require.ErrorContains(t, err, `local module dep source path ".." escapes context "/work"`)
+				_, err = base.With(daggerExec("develop")).Sync(ctx)
+				require.ErrorContains(t, err, `local module dep source path ".." escapes context "/work"`)
 
-			_, err = base.With(daggerExec("install", "./dep")).Sync(ctx)
-			require.ErrorContains(t, err, `local module dep source path ".." escapes context "/work"`)
+				_, err = base.With(daggerExec("install", "./dep")).Sync(ctx)
+				require.ErrorContains(t, err, `local module dep source path ".." escapes context "/work"`)
+
+				base = base.
+					With(configFile(".", &modules.ModuleConfig{
+						Name: "evil",
+						SDK:  "go",
+						Dependencies: []*modules.ModuleConfigDependency{{
+							Name:   "escape",
+							Source: "../work/dep",
+						}},
+					}))
+
+				_, err = base.With(daggerCall("container-echo", "--string-arg", "plz fail")).Sync(ctx)
+				require.ErrorContains(t, err, `module dep source root path "../work/dep" escapes root`)
+
+				_, err = base.With(daggerExec("develop")).Sync(ctx)
+				require.ErrorContains(t, err, `module dep source root path "../work/dep" escapes root`)
+
+				_, err = base.With(daggerExec("install", "./dep")).Sync(ctx)
+				require.ErrorContains(t, err, `module dep source root path "../work/dep" escapes root`)
+			})
+
+			t.Run("git", func(t *testing.T) {
+				t.Parallel()
+				_, err := base.With(daggerCallAt(testGitModuleRef("invalid/bad-dep"), "container-echo", "--string-arg", "plz fail")).Sync(ctx)
+				require.ErrorContains(t, err, `module dep source root path "../../../foo" escapes root`)
+			})
 		})
 	})
 }
@@ -717,6 +756,16 @@ func TestModuleDaggerDevelop(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, ents, "main.go")
 	})
+
+	t.Run("fails on git", func(t *testing.T) {
+		t.Parallel()
+		c, ctx := connect(t)
+
+		_, err := goGitBase(t, c).
+			With(daggerExec("develop", "-m", testGitModuleRef("top-level"))).
+			Sync(ctx)
+		require.ErrorContains(t, err, `module must be local`)
+	})
 }
 
 func TestModuleDaggerConfig(t *testing.T) {
@@ -962,64 +1011,221 @@ func (m *Test) Fn() ([]string, error) {
 	require.Contains(t, strings.TrimSpace(out), "random-file")
 }
 
+const (
+	// TODO: update to use repo in dagger org
+	gitTestRepoURL    = "github.com/sipsma/dagger-module-tests"
+	gitTestRepoCommit = "7ef471e24f56ff2dc902ca9feae24836b8f2e7e4"
+)
+
+func testGitModuleRef(subpath string) string {
+	url := gitTestRepoURL
+	if subpath != "" {
+		if !strings.HasPrefix(subpath, "/") {
+			subpath = "/" + subpath
+		}
+		url += subpath
+	}
+	return fmt.Sprintf("%s@%s", url, gitTestRepoCommit)
+}
+
 func TestModuleDaggerInstallGit(t *testing.T) {
-	/*
-		TODO: this is a stopgap test to get some basic coverage of installing modules
-		from git refs. Ideally it would rely on our own repo for of test fixtures but
-		those have not been setup yet: https://github.com/dagger/dagger/issues/6623
-	*/
 	t.Parallel()
 
-	c, ctx := connect(t)
+	t.Run("happy", func(t *testing.T) {
+		t.Parallel()
+		c, ctx := connect(t)
 
-	_, err := goGitBase(t, c).
-		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
-		WithWorkdir("/work").
-		With(daggerExec("init", "--name=test", "--sdk=go")).
-		With(daggerExec("install", "github.com/sagikazarmark/daggerverse/archivist@bedfa0c8bdba7192c65c21b5e88a48b600666fcc")).
-		Sync(ctx)
-	require.NoError(t, err)
+		out, err := goGitBase(t, c).
+			WithWorkdir("/work").
+			With(daggerExec("init", "--name=test", "--sdk=go", "--source=.")).
+			With(daggerExec("install", testGitModuleRef("top-level"))).
+			WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
+				Contents: `package main
 
-	c.ModuleSource("github.com/sagikazarmark/daggerverse/archivist@bedfa0c8bdba7192c65c21b5e88a48b600666fcc").
-		AsGitSource().
-		HTMLURL(ctx)
+import "context"
+
+type Test struct {}
+
+func (m *Test) Fn(ctx context.Context) (string, error) {
+	return dag.TopLevel().Fn(ctx)
+}
+`,
+			}).
+			With(daggerCall("fn")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "hi from top level hi from dep hi from dep2", strings.TrimSpace(out))
+	})
+
+	t.Run("sad", func(t *testing.T) {
+		t.Parallel()
+		c, ctx := connect(t)
+
+		_, err := goGitBase(t, c).
+			WithWorkdir("/work").
+			With(daggerExec("init", "--name=test", "--sdk=go", "--source=.")).
+			With(daggerExec("install", testGitModuleRef("../../"))).
+			Sync(ctx)
+		require.ErrorContains(t, err, `git module source subpath points out of root: "../.."`)
+
+		_, err = goGitBase(t, c).
+			WithWorkdir("/work").
+			With(daggerExec("init", "--name=test", "--sdk=go", "--source=.")).
+			With(daggerExec("install", testGitModuleRef("this/just/does/not/exist"))).
+			Sync(ctx)
+		require.ErrorContains(t, err, `module "test" dependency "" with source root path "this/just/does/not/exist" does not exist or does not have a configuration file`)
+	})
+
+	t.Run("unpinned gets pinned", func(t *testing.T) {
+		t.Parallel()
+		c, ctx := connect(t)
+
+		out, err := goGitBase(t, c).
+			WithWorkdir("/work").
+			With(daggerExec("init", "--name=test", "--sdk=go", "--source=.")).
+			With(daggerExec("install", gitTestRepoURL)).
+			File("/work/dagger.json").
+			Contents(ctx)
+		require.NoError(t, err)
+		var modCfg modules.ModuleConfig
+		require.NoError(t, json.Unmarshal([]byte(out), &modCfg))
+		require.Len(t, modCfg.Dependencies, 1)
+		url, commit, ok := strings.Cut(modCfg.Dependencies[0].Source, "@")
+		require.True(t, ok)
+		require.Equal(t, gitTestRepoURL, url)
+		require.NotEmpty(t, commit)
+	})
 }
 
 func TestModuleDaggerGitRefs(t *testing.T) {
-	/*
-		TODO: this is a stopgap test to get some basic coverage of installing modules
-		from git refs. Ideally it would rely on our own repo for of test fixtures but
-		those have not been setup yet: https://github.com/dagger/dagger/issues/6623
-	*/
 	t.Parallel()
-
 	c, ctx := connect(t)
 
-	htmlURL, err := c.ModuleSource("github.com/sagikazarmark/daggerverse/archivist@bedfa0c8bdba7192c65c21b5e88a48b600666fcc").
-		AsGitSource().
-		HTMLURL(ctx)
-	require.NoError(t, err)
-	require.Equal(t, "https://github.com/sagikazarmark/daggerverse/tree/bedfa0c8bdba7192c65c21b5e88a48b600666fcc/archivist", htmlURL)
+	t.Run("root module", func(t *testing.T) {
+		t.Parallel()
+		rootModSrc := c.ModuleSource(testGitModuleRef(""))
+
+		htmlURL, err := rootModSrc.AsGitSource().HTMLURL(ctx)
+		require.NoError(t, err)
+		require.Equal(t, fmt.Sprintf("https://%s/tree/%s", gitTestRepoURL, gitTestRepoCommit), htmlURL)
+		resp, err := http.Get(htmlURL)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		cloneURL, err := rootModSrc.AsGitSource().CloneURL(ctx)
+		require.NoError(t, err)
+		require.Equal(t, fmt.Sprintf("https://%s", gitTestRepoURL), cloneURL)
+
+		commit, err := rootModSrc.AsGitSource().Commit(ctx)
+		require.NoError(t, err)
+		require.Equal(t, gitTestRepoCommit, commit)
+
+		refStr, err := rootModSrc.AsString(ctx)
+		require.NoError(t, err)
+		require.Equal(t, testGitModuleRef(""), refStr)
+	})
+
+	t.Run("top-level module", func(t *testing.T) {
+		t.Parallel()
+		topLevelModSrc := c.ModuleSource(testGitModuleRef("top-level"))
+		htmlURL, err := topLevelModSrc.AsGitSource().HTMLURL(ctx)
+		require.NoError(t, err)
+		require.Equal(t, fmt.Sprintf("https://%s/tree/%s/top-level", gitTestRepoURL, gitTestRepoCommit), htmlURL)
+		resp, err := http.Get(htmlURL)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		cloneURL, err := topLevelModSrc.AsGitSource().CloneURL(ctx)
+		require.NoError(t, err)
+		require.Equal(t, fmt.Sprintf("https://%s", gitTestRepoURL), cloneURL)
+
+		commit, err := topLevelModSrc.AsGitSource().Commit(ctx)
+		require.NoError(t, err)
+		require.Equal(t, gitTestRepoCommit, commit)
+
+		refStr, err := topLevelModSrc.AsString(ctx)
+		require.NoError(t, err)
+		require.Equal(t, testGitModuleRef("top-level"), refStr)
+	})
+
+	t.Run("subdir dep2 module", func(t *testing.T) {
+		t.Parallel()
+		subdirDepModSrc := c.ModuleSource(testGitModuleRef("subdir/dep2"))
+		htmlURL, err := subdirDepModSrc.AsGitSource().HTMLURL(ctx)
+		require.NoError(t, err)
+		require.Equal(t, fmt.Sprintf("https://%s/tree/%s/subdir/dep2", gitTestRepoURL, gitTestRepoCommit), htmlURL)
+		resp, err := http.Get(htmlURL)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		cloneURL, err := subdirDepModSrc.AsGitSource().CloneURL(ctx)
+		require.NoError(t, err)
+		require.Equal(t, fmt.Sprintf("https://%s", gitTestRepoURL), cloneURL)
+
+		commit, err := subdirDepModSrc.AsGitSource().Commit(ctx)
+		require.NoError(t, err)
+		require.Equal(t, gitTestRepoCommit, commit)
+
+		refStr, err := subdirDepModSrc.AsString(ctx)
+		require.NoError(t, err)
+		require.Equal(t, testGitModuleRef("subdir/dep2"), refStr)
+	})
+
+	t.Run("stable arg", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := c.ModuleSource(gitTestRepoURL, dagger.ModuleSourceOpts{
+			Stable: true,
+		}).AsString(ctx)
+		require.ErrorContains(t, err, fmt.Sprintf(`no version provided for stable remote ref: %s`, gitTestRepoURL))
+
+		_, err = c.ModuleSource(testGitModuleRef("top-level"), dagger.ModuleSourceOpts{
+			Stable: true,
+		}).AsString(ctx)
+		require.NoError(t, err)
+	})
 }
 
-func TestModuleDaggerCallGit(t *testing.T) {
-	/*
-		TODO: this is a stopgap test to get some basic coverage of installing modules
-		from git refs. Ideally it would rely on our own repo for of test fixtures but
-		those have not been setup yet: https://github.com/dagger/dagger/issues/6623
-	*/
+func TestModuleDaggerGitWithSources(t *testing.T) {
 	t.Parallel()
 
-	c, ctx := connect(t)
+	for _, modSubpath := range []string{"samedir", "subdir"} {
+		modSubpath := modSubpath
+		t.Run(modSubpath, func(t *testing.T) {
+			t.Parallel()
+			c, ctx := connect(t)
+			ctr := goGitBase(t, c).
+				WithWorkdir("/work").
+				With(daggerExec("init")).
+				With(daggerExec("install", "--name", "foo", testGitModuleRef("various-source-values/"+modSubpath)))
 
-	out, err := goGitBase(t, c).
-		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
-		WithWorkdir("/work").
-		With(daggerExec("init", "--name=test", "--sdk=go")).
-		With(daggerExec("install", "github.com/jedevc/shykes-daggerverse/hello@06e224b789a9c339e10e9fc46833ba96397dcc63")).
-		With(daggerExec("-m", "hello", "functions")).
-		Stdout(ctx)
-	require.NoError(t, err)
-	require.Contains(t, out, "hello")
-	require.Contains(t, out, "Say hello to the world!")
+			out, err := ctr.With(daggerCallAt("foo", "container-echo", "--string-arg", "hi", "stdout")).Stdout(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "hi", strings.TrimSpace(out))
+
+			ctr = ctr.With(daggerExec("develop", "--sdk=go", "--source=.")).
+				WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
+					Contents: `package main
+
+import "context"
+
+type Work struct {}
+
+func (m *Work) Fn(ctx context.Context) (string, error) {
+	return dag.Foo().ContainerEcho("hi").Stdout(ctx)
+}
+`})
+
+			out, err = ctr.With(daggerCall("fn")).Stdout(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "hi", strings.TrimSpace(out))
+
+			out, err = ctr.With(daggerCallAt(testGitModuleRef("various-source-values/"+modSubpath), "container-echo", "--string-arg", "hi", "stdout")).Stdout(ctx)
+			require.NoError(t, err)
+			require.Equal(t, "hi", strings.TrimSpace(out))
+		})
+	}
 }

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -143,6 +143,9 @@ func (src *ModuleSource) SourceSubpath(ctx context.Context) (string, error) {
 	}
 
 	if src.WithSourceSubpath != "" {
+		if !filepath.IsLocal(src.WithSourceSubpath) {
+			return "", fmt.Errorf("source path %q contains parent directory components", src.WithSourceSubpath)
+		}
 		return filepath.Join(rootSubpath, src.WithSourceSubpath), nil
 	}
 
@@ -157,6 +160,9 @@ func (src *ModuleSource) SourceSubpath(ctx context.Context) (string, error) {
 		return "", nil
 	}
 
+	if !filepath.IsLocal(cfg.Source) {
+		return "", fmt.Errorf("source path %q contains parent directory components", cfg.Source)
+	}
 	return filepath.Join(rootSubpath, cfg.Source), nil
 }
 
@@ -164,7 +170,7 @@ func (src *ModuleSource) SourceSubpath(ctx context.Context) (string, error) {
 func (src *ModuleSource) SourceSubpathWithDefault(ctx context.Context) (string, error) {
 	sourceSubpath, err := src.SourceSubpath(ctx)
 	if err != nil {
-		return "", fmt.Errorf("source subpath: %w", err)
+		return "", err
 	}
 	if sourceSubpath == "" {
 		return src.SourceRootSubpath()

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -689,6 +689,16 @@ func (s *moduleSchema) updateDeps(
 	}
 	mod.DependencyConfig = make([]*core.ModuleDependency, len(deps))
 	for i, dep := range deps {
+		// verify that the dependency config actually exists
+		_, cfgExists, err := dep.Self.Source.Self.ModuleConfig(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to load module %q dependency %q config: %w", mod.NameField, dep.Self.Name, err)
+		}
+		if !cfgExists {
+			// best effort for err message, ignore err
+			sourceRootPath, _ := dep.Self.Source.Self.SourceRootSubpath()
+			return fmt.Errorf("module %q dependency %q with source root path %q does not exist or does not have a configuration file", mod.NameField, dep.Self.Name, sourceRootPath)
+		}
 		mod.DependencyConfig[i] = dep.Self
 	}
 

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -470,7 +470,7 @@ func (s *moduleSchema) moduleSourceResolveDependency(
 	depSubpath := filepath.Join(srcRootSubpath, depRootSubpath)
 
 	if !filepath.IsLocal(depSubpath) {
-		return inst, fmt.Errorf("module dep source path %q escapes root", depSubpath)
+		return inst, fmt.Errorf("module dep source root path %q escapes root", depRootSubpath)
 	}
 
 	switch src.Kind {
@@ -1011,7 +1011,6 @@ func (s *moduleSchema) collectCallerLocalDeps(
 				localDep.sdkKey = sdkPath
 
 			case core.ModuleSourceKindGit:
-				// TODO: this codepath is completely untested atm
 				localDep.sdk, err = s.sdkForModule(ctx, query, modCfg.SDK, dagql.Instance[*core.ModuleSource]{})
 				if err != nil {
 					return nil, fmt.Errorf("failed to get git module sdk: %w", err)


### PR DESCRIPTION
fixes https://github.com/dagger/dagger/issues/6623

Most of the recent bugs from the last week ended up being simple things related to using git module refs, which was due to the fact that we didn't have integ test coverage of those.

We didn't have coverage previously because it's slightly less obvious than it seems due to the limitation around git modules only being allowed to be from `github.com/`. That essentially rules out authoring the tests in the repo itself (there's various shenanigans that might be possible but it gets way too complicated to be worth it).

So, until we have support for non-github module refs, we can just maintain a separate git repo that has "test fixture" modules. I created one in my org [here](https://github.com/sipsma/dagger-module-tests) for now (should be moved to be under the dagger org asap).

It's a bit annoying to maintain since you need to update the separate repo and then update the commit to use in the test code, but it's much better than not having this coverage at this point.

---

There's a few changes to actual code here too:
- Better error messages, more robust handling of invalid paths: https://github.com/dagger/dagger/commit/1e5e89ae6df8d1544031c72c0baf749e2eb25d69
- Fix panic when using custom SDK specified via git ref: https://github.com/dagger/dagger/commit/8fbced63ad4e9c2706564190105b8900fba578b6

Due to the fix for the panic, I will provisionally add this to v0.9.11, but if @jedevc or others would prefer to save this for later it's an obscure enough case that it can wait.

---

TODO (can be now or follow-up)
- [ ] Move https://github.com/sipsma/dagger-module-tests to be under the dagger org 