### PR TITLE
Python: Improve error message when using unsupported scalar or enums as arguments

### DIFF
--- a/core/integration/module_python_test.go
+++ b/core/integration/module_python_test.go
@@ -343,7 +343,7 @@ func TestModulePythonDocs(t *testing.T) {
 		modGen := pythonModInit(ctx, t, c, `
             from typing import Annotated
 
-            from dagger.mod import Doc, function, object_type
+            from dagger import Doc, function, object_type
 
             @object_type
             class Test:
@@ -402,7 +402,7 @@ func TestModulePythonDocs(t *testing.T) {
             from dataclasses import field as datafield
             from typing import Annotated
 
-            from dagger.mod import Doc, function, object_type, field
+            from dagger import Doc, function, object_type, field
 
             @object_type
             class Test:
@@ -446,7 +446,7 @@ func TestModulePythonDocs(t *testing.T) {
 		modGen := pythonModInit(ctx, t, c, `
             from typing import Annotated, Self
 
-            from dagger.mod import Doc, function, object_type
+            from dagger import Doc, function, object_type
 
             @object_type
             class Test:
@@ -474,7 +474,7 @@ func TestModulePythonDocs(t *testing.T) {
 		modGen := pythonModInit(ctx, t, c, `
             from typing import Annotated, Self
 
-            from dagger.mod import Doc, function, object_type
+            from dagger import Doc, function, object_type
 
             @object_type
             class External:
@@ -514,7 +514,7 @@ func TestModulePythonDocs(t *testing.T) {
 		modGen := pythonModInit(ctx, t, c, `
             from typing import Annotated, Self
 
-            from dagger.mod import Doc, function, object_type
+            from dagger import Doc, function, object_type
 
             @object_type
             class External:
@@ -543,7 +543,7 @@ func TestModulePythonDocs(t *testing.T) {
 		modGen := pythonModInit(ctx, t, c, `
             from typing import Annotated, Self
 
-            from dagger.mod import Doc, function, object_type
+            from dagger import Doc, function, object_type
 
             class Base:
                 """What's the object-oriented way to become wealthy?"""
@@ -572,7 +572,7 @@ func TestModulePythonNameOverrides(t *testing.T) {
 	modGen := pythonModInit(ctx, t, c, `
         from typing import Annotated
 
-        from dagger.mod import Arg, Doc, field, function, object_type
+        from dagger import Arg, Doc, field, function, object_type
 
         @object_type
         class Test:
@@ -775,6 +775,48 @@ func TestModulePythonWithOtherModuleTypes(t *testing.T) {
 			))
 		})
 	})
+}
+
+func TestModulePythonScalarKind(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := connect(t)
+
+	_, err := pythonModInit(ctx, t, c, `
+        import dagger
+        from dagger import dag, function, object_type
+
+        @object_type
+        class Test:
+            @function
+            def foo(self, platform: dagger.Platform) -> dagger.Container:
+                return dag.container(platform=platform)
+        `).
+		With(daggerCall("foo", "--platform", "linux/arm64")).
+		Sync(ctx)
+
+	require.ErrorContains(t, err, "not supported yet")
+}
+
+func TestModulePythonEnumKind(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := connect(t)
+
+	_, err := pythonModInit(ctx, t, c, `
+        import dagger
+        from dagger import dag, function, object_type
+
+        @object_type
+        class Test:
+            @function
+            def foo(self, protocol: dagger.NetworkProtocol) -> dagger.Container:
+                return dag.container().with_exposed_port(8000, protocol=protocol)
+        `).
+		With(daggerCall("foo", "--protocol", "UDP")).
+		Sync(ctx)
+
+	require.ErrorContains(t, err, "not supported yet")
 }
 
 func pythonSource(contents string) dagger.WithContainerFunc {


### PR DESCRIPTION
The previous error message was actually erroneous. Scalars are subtypes of strings. After handling built-in strings, this failed in validating Sequence types (lists). However, strings are sequences of characters, so it failed in a particular case for lists which is to define one without a subtype (`args: list` when it must be `args: list[str]`). 

Thus the error message wasn't correct. The fact is we don't support a ScalarKind or EnumKind in TypeDefs yet, so might as well fail early with a helpful error message.

**Before:**

```
TypeError: Expected collection type to be subscripted with 1 subtype, got 0: <class 'dagger.Platform'>
```
```
TypeError: Expected collection type to be subscripted with 1 subtype, got 0: <enum 'NetworkProtocol'>
```

**After:**

```
NotImplementedError: Scalar types are not supported yet. Define argument as a string and convert to the desired scalar type in the function body.
```
```
NotImplementedError: Enum types are not supported yet. Define argument as a string and convert to the desired enum type in the function body.
```