### PR TITLE
fix: close service in pipeline test

### DIFF
--- a/core/integration/pipeline_test.go
+++ b/core/integration/pipeline_test.go
@@ -77,7 +77,7 @@ func TestPipeline(t *testing.T) {
 		_, err = client.Sync(ctx)
 		require.NoError(t, err)
 
-		_, err = srv.Stop(ctx)
+		_, err = srv.Stop(ctx) // FIXME: shouldn't need this, but test is flaking
 		require.NoError(t, err)
 
 		require.NoError(t, c.Close()) // close + flush logs

--- a/core/integration/pipeline_test.go
+++ b/core/integration/pipeline_test.go
@@ -77,6 +77,9 @@ func TestPipeline(t *testing.T) {
 		_, err = client.Sync(ctx)
 		require.NoError(t, err)
 
+		_, err = srv.Stop(ctx)
+		require.NoError(t, err)
+
 		require.NoError(t, c.Close()) // close + flush logs
 
 		t.Log(logs.String())


### PR DESCRIPTION
This test is super annoyingly flaky :( Potentially fixes #6697.

It seems like calling Close is racy, and sometimes we don't get the fully progress logs - to work around this for now, we can try and call service close explicitly, which should *hopefully* make this failure a bit more unlikely.

Yes, we should fix the underlying issue at some point - cc @grouville, I know you were also working on this.