### PR TITLE
fix: actually add generated go modules to go.work

### DIFF
--- a/cmd/codegen/generator/go/generator.go
+++ b/cmd/codegen/generator/go/generator.go
@@ -55,7 +55,7 @@ func (g *GoGenerator) Generate(ctx context.Context, schema *introspection.Schema
 			exec.Command("go", "mod", "tidy"),
 		},
 	}
-	if _, err := os.Stat("go.work"); err != nil {
+	if _, err := os.Stat(filepath.Join(g.Config.ModuleContextPath, "go.work")); err == nil {
 		// run "go work use ." after generating if we had a go.work at the root
 		genSt.PostCommands = append(genSt.PostCommands, exec.Command("go", "work", "use", "."))
 	}


### PR DESCRIPTION
Follow-up to #6678.

I was missing an important test case that reveals I was doing this *entirely* wrong.

The condition should check for the existence of `go.work`, not it's absence, and we should actually look in the root, which is found in a configuration option.