### PR TITLE
fix: move gitattributes/gitignore files into source directory

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -490,7 +490,7 @@ func TestModuleGit(t *testing.T) {
 			require.JSONEq(t, `{"bare":{"containerEcho":{"stdout":"hello\n"}}}`, out)
 
 			t.Run("configures .gitattributes", func(t *testing.T) {
-				ignore, err := modGen.File(".gitattributes").Contents(ctx)
+				ignore, err := modGen.File("dagger/.gitattributes").Contents(ctx)
 				require.NoError(t, err)
 				for _, fileName := range tc.gitGeneratedFiles {
 					require.Contains(t, ignore, fmt.Sprintf("%s linguist-generated\n", fileName))
@@ -498,7 +498,7 @@ func TestModuleGit(t *testing.T) {
 			})
 			if len(tc.gitIgnoredFiles) > 0 {
 				t.Run("configures .gitignore", func(t *testing.T) {
-					ignore, err := modGen.File(".gitignore").Contents(ctx)
+					ignore, err := modGen.File("dagger/.gitignore").Contents(ctx)
 					require.NoError(t, err)
 					for _, fileName := range tc.gitIgnoredFiles {
 						require.Contains(t, ignore, fileName)

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -755,7 +755,7 @@ func (s *moduleSchema) updateCodegenAndRuntime(
 	}
 	mod.GeneratedContextDirectory = baseContext
 
-	rootSubpath, err := src.Self.SourceRootSubpath()
+	sourceSubpath, err := src.Self.SourceSubpathWithDefault(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get source root subpath: %w", err)
 	}
@@ -800,7 +800,7 @@ func (s *moduleSchema) updateCodegenAndRuntime(
 	// (linter thinks this chunk of code is too similar to the below, but not clear abstraction is worth it)
 	//nolint:dupl
 	if len(generatedCode.VCSGeneratedPaths) > 0 {
-		gitAttrsPath := filepath.Join(rootSubpath, ".gitattributes")
+		gitAttrsPath := filepath.Join(sourceSubpath, ".gitattributes")
 		var gitAttrsContents []byte
 		gitAttrsFile, err := baseContext.Self.File(ctx, gitAttrsPath)
 		if err == nil {
@@ -841,7 +841,7 @@ func (s *moduleSchema) updateCodegenAndRuntime(
 	// (linter thinks this chunk of code is too similar to the above, but not clear abstraction is worth it)
 	//nolint:dupl
 	if len(generatedCode.VCSIgnoredPaths) > 0 {
-		gitIgnorePath := filepath.Join(rootSubpath, ".gitignore")
+		gitIgnorePath := filepath.Join(sourceSubpath, ".gitignore")
 		var gitIgnoreContents []byte
 		gitIgnoreFile, err := baseContext.Self.File(ctx, gitIgnorePath)
 		if err == nil {


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/6625.

We just need to switch from putting them into the `SourceRootSubpath` to putting them in `SourceSubpath`.