### PR TITLE
chore: bump go to 1.21.7

### DIFF
--- a/core/integration/images.go
+++ b/core/integration/images.go
@@ -2,7 +2,7 @@ package core
 
 const (
 	alpineImage = "alpine:3.18.2"
-	golangImage = "golang:1.21.3-alpine"
+	golangImage = "golang:1.21.7-alpine"
 
 	// TODO: use these
 	// registryImage   = "registry:2"

--- a/core/integration/testdata/modules/go/basic/go.mod
+++ b/core/integration/testdata/modules/go/basic/go.mod
@@ -1,6 +1,6 @@
 module basic
 
-go 1.21.0
+go 1.21.7
 
 require (
 	github.com/99designs/gqlgen v0.17.37

--- a/core/integration/testdata/modules/go/broken/go.mod
+++ b/core/integration/testdata/modules/go/broken/go.mod
@@ -1,6 +1,6 @@
 module broken
 
-go 1.21.0
+go 1.21.7
 
 require (
 	github.com/99designs/gqlgen v0.17.37

--- a/core/integration/testdata/modules/go/ifaces/go.mod
+++ b/core/integration/testdata/modules/go/ifaces/go.mod
@@ -1,6 +1,6 @@
 module test
 
-go 1.21.3
+go 1.21.7
 
 require (
 	github.com/99designs/gqlgen v0.17.31

--- a/core/integration/testdata/modules/go/ifaces/impl/go.mod
+++ b/core/integration/testdata/modules/go/ifaces/impl/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.21.3
+go 1.21.7
 
 require (
 	github.com/99designs/gqlgen v0.17.31

--- a/core/integration/testdata/modules/go/ifaces/test/go.mod
+++ b/core/integration/testdata/modules/go/ifaces/test/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.21.3
+go 1.21.7
 
 require (
 	github.com/99designs/gqlgen v0.17.31

--- a/core/integration/testdata/modules/go/namespacing/go.mod
+++ b/core/integration/testdata/modules/go/namespacing/go.mod
@@ -1,6 +1,6 @@
 module test
 
-go 1.21.2
+go 1.21.7
 
 require (
 	github.com/99designs/gqlgen v0.17.31

--- a/core/integration/testdata/modules/go/namespacing/sub1/go.mod
+++ b/core/integration/testdata/modules/go/namespacing/sub1/go.mod
@@ -1,6 +1,6 @@
 module sub-1
 
-go 1.21.2
+go 1.21.7
 
 require (
 	github.com/99designs/gqlgen v0.17.31

--- a/core/integration/testdata/modules/go/namespacing/sub2/go.mod
+++ b/core/integration/testdata/modules/go/namespacing/sub2/go.mod
@@ -1,6 +1,6 @@
 module sub-2
 
-go 1.21.2
+go 1.21.7
 
 require (
 	github.com/99designs/gqlgen v0.17.31

--- a/core/integration/testdata/nested-c2c/main.go
+++ b/core/integration/testdata/nested-c2c/main.go
@@ -85,7 +85,7 @@ func weHaveToGoDeeper(ctx context.Context, c *dagger.Client, depth int, mode str
 	args = append(args, mirrorURL)
 
 	out, err := c.Container().
-		From("golang:1.20.6-alpine").
+		From("golang:1.21.7-alpine").
 		WithMountedCache("/go/pkg/mod", c.CacheVolume("go-mod")).
 		WithEnvVariable("GOMODCACHE", "/go/pkg/mod").
 		WithMountedCache("/go/build-cache", c.CacheVolume("go-build")).

--- a/docs/versioned_docs/version-zenith/developer/go/snippets/advanced-programming/constructor/go.mod
+++ b/docs/versioned_docs/version-zenith/developer/go/snippets/advanced-programming/constructor/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.21.3
+go 1.21.7
 
 require (
 	github.com/99designs/gqlgen v0.17.31

--- a/docs/versioned_docs/version-zenith/developer/go/snippets/quickstart/step3a/go.mod
+++ b/docs/versioned_docs/version-zenith/developer/go/snippets/quickstart/step3a/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.21.3
+go 1.21.7
 
 require (
 	github.com/99designs/gqlgen v0.17.31

--- a/docs/versioned_docs/version-zenith/developer/go/snippets/quickstart/trivy/go.mod
+++ b/docs/versioned_docs/version-zenith/developer/go/snippets/quickstart/trivy/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.21.3
+go 1.21.7
 
 require (
 	github.com/99designs/gqlgen v0.17.31

--- a/docs/versioned_docs/version-zenith/developer/go/snippets/test-build-publish/step6/go.mod
+++ b/docs/versioned_docs/version-zenith/developer/go/snippets/test-build-publish/step6/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.21.3
+go 1.21.7
 
 require (
 	github.com/99designs/gqlgen v0.17.31

--- a/docs/versioned_docs/version-zenith/quickstart/snippets/create/go/go.mod
+++ b/docs/versioned_docs/version-zenith/quickstart/snippets/create/go/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.21.3
+go 1.21.7
 
 require (
 	github.com/99designs/gqlgen v0.17.31

--- a/internal/mage/go.mod
+++ b/internal/mage/go.mod
@@ -1,6 +1,6 @@
 module github.com/dagger/dagger/internal/mage
 
-go 1.21.3
+go 1.21
 
 require (
 	dagger.io/dagger v0.9.10

--- a/internal/mage/util/engine.go
+++ b/internal/mage/util/engine.go
@@ -24,7 +24,7 @@ const (
 	engineDialStdioPath = "/usr/local/bin/dial-stdio"
 	engineShimPath      = distconsts.EngineShimPath
 
-	golangVersion = "1.21.3"
+	golangVersion = "1.21.7"
 	alpineVersion = "3.18"
 	ubuntuVersion = "22.04"
 	runcVersion   = "v1.1.12"

--- a/sdk/typescript/runtime/go.mod
+++ b/sdk/typescript/runtime/go.mod
@@ -1,6 +1,6 @@
 module main
 
-go 1.21.3
+go 1.21.7
 
 require (
 	github.com/99designs/gqlgen v0.17.31


### PR DESCRIPTION
Hopefully fix https://github.com/dagger/dagger/pull/6636#issuecomment-1935917443.

This is a nice intermediate until we can bump to go 1.22: https://github.com/dagger/dagger/pull/6637 (blocked due to an upstream go/glibc issue).

See also discord conversation: https://discord.com/channels/707636530424053791/1003718839739105300/1209830653051412490.