### PR TITLE
core: speed up loading of builtin SDKs

### DIFF
--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -1986,6 +1986,12 @@ type Query {
     uncompressed: String!
   ): Directory!
 
+  """Retrieves a container builtin to the engine."""
+  builtinContainer(
+    """Digest of the image manifest"""
+    digest: String!
+  ): Container!
+
   """Constructs a cache volume for a given cache key."""
   cacheVolume(
     """

--- a/docs/versioned_docs/version-zenith/reference/979596-cli.mdx
+++ b/docs/versioned_docs/version-zenith/reference/979596-cli.mdx
@@ -32,7 +32,6 @@ The Dagger CLI provides a command-line interface to Dagger.
 * [dagger install](#dagger-install)	 - Add a new dependency to a Dagger module
 * [dagger login](#dagger-login)	 - Log in to Dagger Cloud
 * [dagger logout](#dagger-logout)	 - Log out from Dagger Cloud
-* [dagger publish](#dagger-publish)	 - Publish a Dagger module to the Daggerverse
 * [dagger query](#dagger-query)	 - Send API queries to a dagger engine
 * [dagger run](#dagger-run)	 - Run a command in a Dagger session
 * [dagger version](#dagger-version)	 - Print dagger version
@@ -219,7 +218,7 @@ Any module can be installed to via "dagger install".
 
 A module can only be called once it has been initialized with an SDK though. The "--sdk" flag can be provided to init here, but if it's not the configuration can be updated later via "dagger develop".
 
-The "--source" flag allows controlling the directory in which the actual module source code is stored. By default, it will be stored in a directory named "dagger". 
+The "--source" flag allows controlling the directory in which the actual module source code is stored. By default, it will be stored in a directory named "dagger".
 
 
 ```
@@ -229,7 +228,7 @@ dagger init [flags] [PATH]
 ### Examples
 
 ```
-dagger mod init --name=hello --sdk=python --source=some/subdir
+dagger init --name=hello --sdk=python --source=some/subdir
 ```
 
 ### Options
@@ -268,7 +267,7 @@ dagger install [flags] MODULE
 ### Examples
 
 ```
-dagger mod install github.com/shykes/daggerverse/ttlsh@16e40ec244966e55e36a13cb6e1ff8023e1e1473
+dagger install github.com/shykes/daggerverse/ttlsh@16e40ec244966e55e36a13cb6e1ff8023e1e1473
 ```
 
 ### Options
@@ -317,43 +316,6 @@ Log out from Dagger Cloud
 
 ```
 dagger logout [flags]
-```
-
-### Options inherited from parent commands
-
-```
-      --debug             Show more information for debugging
-      --progress string   progress output format (auto, plain, tty) (default "auto")
-  -s, --silent            disable terminal UI and progress output
-```
-
-### SEE ALSO
-
-* [dagger](#dagger)	 - The Dagger CLI provides a command-line interface to Dagger.
-
-## dagger publish
-
-Publish a Dagger module to the Daggerverse
-
-### Synopsis
-
-Publish a local module to the Daggerverse (https://daggerverse.dev).
-
-The module needs to be committed to a git repository and have a remote
-configured with name "origin". The git repository must be clean (unless
-forced), to avoid mistakingly depending on uncommitted files.
-
-
-```
-dagger publish [flags]
-```
-
-### Options
-
-```
-      --focus        Only show output for focused commands (default true)
-  -f, --force        Force publish even if the git repository is not clean
-  -m, --mod string   Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
 ```
 
 ### Options inherited from parent commands

--- a/go.mod
+++ b/go.mod
@@ -106,6 +106,8 @@ require (
 	oss.terrastruct.com/util-go v0.0.0-20231101220827-55b3812542c2
 )
 
+require github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81
+
 require (
 	cdr.dev/slog v1.4.2 // indirect
 	dario.cat/mergo v1.0.0 // indirect

--- a/internal/distconsts/consts.go
+++ b/internal/distconsts/consts.go
@@ -11,7 +11,8 @@ const (
 
 	EngineDefaultStateDir = "/var/lib/dagger"
 
-	GoSDKEngineContainerTarballPath        = "/usr/local/share/dagger/go-module-sdk-image.tar"
-	PythonSDKEngineContainerModulePath     = "/usr/local/share/dagger/python-sdk/runtime"
-	TypescriptSDKEngineContainerModulePath = "/usr/local/share/dagger/typescript-sdk/runtime"
+	EngineContainerBuiltinContentDir   = "/usr/local/share/dagger/content"
+	GoSDKManifestDigestEnvName         = "DAGGER_GO_SDK_MANIFEST_DIGEST"
+	PythonSDKManifestDigestEnvName     = "DAGGER_PYTHON_SDK_MANIFEST_DIGEST"
+	TypescriptSDKManifestDigestEnvName = "DAGGER_TYPESCRIPT_SDK_MANIFEST_DIGEST"
 )

--- a/internal/mage/go.mod
+++ b/internal/mage/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/magefile/mage v1.15.0
 	github.com/moby/buildkit v0.13.0-beta3
+	github.com/opencontainers/image-spec v1.1.0-rc5
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa
 	golang.org/x/mod v0.14.0
 	golang.org/x/sync v0.6.0
@@ -20,6 +21,7 @@ require (
 	github.com/adrg/xdg v0.4.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sosodev/duration v1.1.0 // indirect
 	github.com/vektah/gqlparser/v2 v2.5.10 // indirect

--- a/internal/mage/go.sum
+++ b/internal/mage/go.sum
@@ -23,6 +23,10 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/moby/buildkit v0.13.0-beta3 h1:eefOGE6SsWYHFfymc09Q7VU5i3L9vUs8ZCZVCDXWNOo=
 github.com/moby/buildkit v0.13.0-beta3/go.mod h1:tSWWhq1EDM0eB3ngMNDiH2hOOW9fXTyn2uXuOraCLlE=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/opencontainers/image-spec v1.1.0-rc5 h1:Ygwkfw9bpDvs+c9E34SdgGOj41dX/cbdlwvlWt0pnFI=
+github.com/opencontainers/image-spec v1.1.0-rc5/go.mod h1:X4pATf0uXsnn3g5aiGIsVnJBR4mxhKzfwmvK/B2NTm8=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/mage/util/engine.go
+++ b/internal/mage/util/engine.go
@@ -370,22 +370,7 @@ func pythonSDKContent(ctx context.Context, c *dagger.Client, arch string) dagger
 			WithExec([]string{"tar", "xf", "/sdk.tar", "-C", "/out"}).
 			Directory("/out")
 
-		var index ocispecs.Index
-		indexContents, err := sdkDir.File("index.json").Contents(ctx)
-		if err != nil {
-			panic(err)
-		}
-		if err := json.Unmarshal([]byte(indexContents), &index); err != nil {
-			panic(err)
-		}
-		manifest := index.Manifests[0]
-		manifestDgst := manifest.Digest.String()
-
-		return ctr.
-			WithEnvVariable(distconsts.PythonSDKManifestDigestEnvName, manifestDgst).
-			WithDirectory(distconsts.EngineContainerBuiltinContentDir, sdkDir, dagger.ContainerWithDirectoryOpts{
-				Include: []string{"blobs/"},
-			})
+		return sdkContent(ctx, ctr, sdkDir, distconsts.PythonSDKManifestDigestEnvName)
 	}
 }
 
@@ -420,22 +405,7 @@ func typescriptSDKContent(ctx context.Context, c *dagger.Client, arch string) da
 			WithExec([]string{"tar", "xf", "/sdk.tar", "-C", "/out"}).
 			Directory("/out")
 
-		var index ocispecs.Index
-		indexContents, err := sdkDir.File("index.json").Contents(ctx)
-		if err != nil {
-			panic(err)
-		}
-		if err := json.Unmarshal([]byte(indexContents), &index); err != nil {
-			panic(err)
-		}
-		manifest := index.Manifests[0]
-		manifestDgst := manifest.Digest.String()
-
-		return ctr.
-			WithEnvVariable(distconsts.TypescriptSDKManifestDigestEnvName, manifestDgst).
-			WithDirectory(distconsts.EngineContainerBuiltinContentDir, sdkDir, dagger.ContainerWithDirectoryOpts{
-				Include: []string{"blobs/"},
-			})
+		return sdkContent(ctx, ctr, sdkDir, distconsts.TypescriptSDKManifestDigestEnvName)
 	}
 }
 
@@ -458,23 +428,27 @@ func goSDKContent(ctx context.Context, c *dagger.Client, arch string) dagger.Wit
 			WithExec([]string{"tar", "xf", "/sdk.tar", "-C", "/out"}).
 			Directory("/out")
 
-		var index ocispecs.Index
-		indexContents, err := sdkDir.File("index.json").Contents(ctx)
-		if err != nil {
-			panic(err)
-		}
-		if err := json.Unmarshal([]byte(indexContents), &index); err != nil {
-			panic(err)
-		}
-		manifest := index.Manifests[0]
-		manifestDgst := manifest.Digest.String()
-
-		return ctr.
-			WithEnvVariable(distconsts.GoSDKManifestDigestEnvName, manifestDgst).
-			WithDirectory(distconsts.EngineContainerBuiltinContentDir, sdkDir, dagger.ContainerWithDirectoryOpts{
-				Include: []string{"blobs/"},
-			})
+		return sdkContent(ctx, ctr, sdkDir, distconsts.GoSDKManifestDigestEnvName)
 	}
+}
+
+func sdkContent(ctx context.Context, ctr *dagger.Container, sdkDir *dagger.Directory, envName string) *dagger.Container {
+	var index ocispecs.Index
+	indexContents, err := sdkDir.File("index.json").Contents(ctx)
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal([]byte(indexContents), &index); err != nil {
+		panic(err)
+	}
+	manifest := index.Manifests[0]
+	manifestDgst := manifest.Digest.String()
+
+	return ctr.
+		WithEnvVariable(envName, manifestDgst).
+		WithDirectory(distconsts.EngineContainerBuiltinContentDir, sdkDir, dagger.ContainerWithDirectoryOpts{
+			Include: []string{"blobs/"},
+		})
 }
 
 func goSDKCodegenBin(c *dagger.Client, arch string) *dagger.File {

--- a/internal/mage/util/engine.go
+++ b/internal/mage/util/engine.go
@@ -3,8 +3,8 @@ package util
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -14,6 +14,7 @@ import (
 
 	"dagger.io/dagger"
 	"github.com/moby/buildkit/identity"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/exp/maps"
 
 	"github.com/dagger/dagger/internal/distconsts"
@@ -243,9 +244,9 @@ func devEngineContainer(ctx context.Context, c *dagger.Client, arch string, vers
 		}).
 		WithFile(engineShimPath, shimBin(c, arch, version)).
 		WithFile(engineServerPath, engineBin(c, arch, version)).
-		WithFile(distconsts.GoSDKEngineContainerTarballPath, goSDKImageTarBall(c, arch)).
-		WithDirectory(filepath.Dir(distconsts.PythonSDKEngineContainerModulePath), pythonSDK(c)).
-		WithDirectory(filepath.Dir(distconsts.TypescriptSDKEngineContainerModulePath), typescriptSDK(c, arch)).
+		With(goSDKContent(ctx, c, arch)).
+		With(pythonSDKContent(ctx, c, arch)).
+		With(typescriptSDKContent(ctx, c, arch)).
 		WithDirectory("/usr/local/bin", qemuBins(c, arch)).
 		WithDirectory("/", cniPlugins(c, arch, false)).
 		WithDirectory("/", dialstdioFiles(c, arch)).
@@ -292,9 +293,9 @@ func devEngineContainerWithGPUSupport(ctx context.Context, c *dagger.Client, arc
 		}).
 		WithFile(engineShimPath, shimBin(c, arch, version)).
 		WithFile(engineServerPath, engineBin(c, arch, version)).
-		WithFile(distconsts.GoSDKEngineContainerTarballPath, goSDKImageTarBall(c, arch)).
-		WithDirectory(filepath.Dir(distconsts.PythonSDKEngineContainerModulePath), pythonSDK(c)).
-		WithDirectory(filepath.Dir(distconsts.TypescriptSDKEngineContainerModulePath), typescriptSDK(c, arch)).
+		With(goSDKContent(ctx, c, arch)).
+		With(pythonSDKContent(ctx, c, arch)).
+		With(typescriptSDKContent(ctx, c, arch)).
 		WithDirectory("/usr/local/bin", qemuBins(c, arch)).
 		WithDirectory("/", cniPlugins(c, arch, true)).
 		WithDirectory("/", dialstdioFiles(c, arch)).
@@ -344,65 +345,136 @@ func devEngineContainersWithGPUSupport(ctx context.Context, c *dagger.Client, ar
 
 // helper functions for building the dev engine container
 
-func pythonSDK(c *dagger.Client) *dagger.Directory {
-	return c.Host().Directory("sdk/python", dagger.HostDirectoryOpts{
-		Include: []string{
-			"pyproject.toml",
-			"src/**/*.py",
-			"src/**/*.typed",
-			"runtime/",
-			"LICENSE",
-			"README.md",
-			"dagger.json",
-		},
-	})
+func pythonSDKContent(ctx context.Context, c *dagger.Client, arch string) dagger.WithContainerFunc {
+	return func(ctr *dagger.Container) *dagger.Container {
+		sdkCtrTarball := c.Container().
+			WithRootfs(c.Host().Directory("sdk/python", dagger.HostDirectoryOpts{
+				Include: []string{
+					"pyproject.toml",
+					"src/**/*.py",
+					"src/**/*.typed",
+					"runtime/",
+					"LICENSE",
+					"README.md",
+					"dagger.json",
+				},
+			})).
+			WithFile("/codegen", goSDKCodegenBin(c, arch)).
+			AsTarball(dagger.ContainerAsTarballOpts{
+				ForcedCompression: dagger.Uncompressed,
+			})
+
+		sdkDir := c.Container().From("alpine:"+alpineVersion).
+			WithMountedDirectory("/out", c.Directory()).
+			WithMountedFile("/sdk.tar", sdkCtrTarball).
+			WithExec([]string{"tar", "xf", "/sdk.tar", "-C", "/out"}).
+			Directory("/out")
+
+		var index ocispecs.Index
+		indexContents, err := sdkDir.File("index.json").Contents(ctx)
+		if err != nil {
+			panic(err)
+		}
+		if err := json.Unmarshal([]byte(indexContents), &index); err != nil {
+			panic(err)
+		}
+		manifest := index.Manifests[0]
+		manifestDgst := manifest.Digest.String()
+
+		return ctr.
+			WithEnvVariable(distconsts.PythonSDKManifestDigestEnvName, manifestDgst).
+			WithDirectory(distconsts.EngineContainerBuiltinContentDir, sdkDir, dagger.ContainerWithDirectoryOpts{
+				Include: []string{"blobs/"},
+			})
+	}
 }
 
-func typescriptSDK(c *dagger.Client, arch string) *dagger.Directory {
-	return c.Host().Directory("sdk/typescript", dagger.HostDirectoryOpts{
-		Include: []string{
-			"**/*.ts",
-			"LICENSE",
-			"README.md",
-			"runtime",
-			"package.json",
-			"dagger.json",
-		},
-		Exclude: []string{
-			"node_modules",
-			"dist",
-			"**/test",
-			"**/*.spec.ts",
-			"dev",
-		},
-	}).WithFile("/codegen", goSDKCodegenBin(c, arch))
+func typescriptSDKContent(ctx context.Context, c *dagger.Client, arch string) dagger.WithContainerFunc {
+	return func(ctr *dagger.Container) *dagger.Container {
+		sdkCtrTarball := c.Container().
+			WithRootfs(c.Host().Directory("sdk/typescript", dagger.HostDirectoryOpts{
+				Include: []string{
+					"**/*.ts",
+					"LICENSE",
+					"README.md",
+					"runtime",
+					"package.json",
+					"dagger.json",
+				},
+				Exclude: []string{
+					"node_modules",
+					"dist",
+					"**/test",
+					"**/*.spec.ts",
+					"dev",
+				},
+			})).
+			WithFile("/codegen", goSDKCodegenBin(c, arch)).
+			AsTarball(dagger.ContainerAsTarballOpts{
+				ForcedCompression: dagger.Uncompressed,
+			})
+
+		sdkDir := c.Container().From("alpine:"+alpineVersion).
+			WithMountedDirectory("/out", c.Directory()).
+			WithMountedFile("/sdk.tar", sdkCtrTarball).
+			WithExec([]string{"tar", "xf", "/sdk.tar", "-C", "/out"}).
+			Directory("/out")
+
+		var index ocispecs.Index
+		indexContents, err := sdkDir.File("index.json").Contents(ctx)
+		if err != nil {
+			panic(err)
+		}
+		if err := json.Unmarshal([]byte(indexContents), &index); err != nil {
+			panic(err)
+		}
+		manifest := index.Manifests[0]
+		manifestDgst := manifest.Digest.String()
+
+		return ctr.
+			WithEnvVariable(distconsts.TypescriptSDKManifestDigestEnvName, manifestDgst).
+			WithDirectory(distconsts.EngineContainerBuiltinContentDir, sdkDir, dagger.ContainerWithDirectoryOpts{
+				Include: []string{"blobs/"},
+			})
+	}
 }
 
-func goSDKImageTarBall(c *dagger.Client, arch string) *dagger.File {
-	// TODO: update this to use Container.AsTarball once released
-	ctx := context.Background()
-	tmpDir, err := os.MkdirTemp("", "dagger-go-sdk")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(tmpDir)
-	tarballPath := filepath.Join(tmpDir, filepath.Base(distconsts.GoSDKEngineContainerTarballPath))
+func goSDKContent(ctx context.Context, c *dagger.Client, arch string) dagger.WithContainerFunc {
+	return func(ctr *dagger.Container) *dagger.Container {
+		base := c.Container(dagger.ContainerOpts{Platform: dagger.Platform("linux/" + arch)}).
+			From(fmt.Sprintf("golang:%s-alpine%s", golangVersion, alpineVersion))
 
-	_, err = c.Container(dagger.ContainerOpts{Platform: dagger.Platform("linux/" + arch)}).
-		From(fmt.Sprintf("golang:%s-alpine%s", golangVersion, alpineVersion)).
-		WithEnvVariable("GOTOOLCHAIN", "auto").
-		WithFile("/usr/local/bin/codegen", goSDKCodegenBin(c, arch)).
-		WithEntrypoint([]string{"/usr/local/bin/codegen"}).
-		Export(ctx, tarballPath)
-	if err != nil {
-		panic(err)
-	}
+		sdkCtrTarball := base.
+			WithEnvVariable("GOTOOLCHAIN", "auto").
+			WithFile("/usr/local/bin/codegen", goSDKCodegenBin(c, arch)).
+			WithEntrypoint([]string{"/usr/local/bin/codegen"}).
+			AsTarball(dagger.ContainerAsTarballOpts{
+				ForcedCompression: dagger.Uncompressed,
+			})
 
-	f, err := c.Host().File(tarballPath).Sync(ctx)
-	if err != nil {
-		panic(err)
+		sdkDir := base.
+			WithMountedDirectory("/out", c.Directory()).
+			WithMountedFile("/sdk.tar", sdkCtrTarball).
+			WithExec([]string{"tar", "xf", "/sdk.tar", "-C", "/out"}).
+			Directory("/out")
+
+		var index ocispecs.Index
+		indexContents, err := sdkDir.File("index.json").Contents(ctx)
+		if err != nil {
+			panic(err)
+		}
+		if err := json.Unmarshal([]byte(indexContents), &index); err != nil {
+			panic(err)
+		}
+		manifest := index.Manifests[0]
+		manifestDgst := manifest.Digest.String()
+
+		return ctr.
+			WithEnvVariable(distconsts.GoSDKManifestDigestEnvName, manifestDgst).
+			WithDirectory(distconsts.EngineContainerBuiltinContentDir, sdkDir, dagger.ContainerWithDirectoryOpts{
+				Include: []string{"blobs/"},
+			})
 	}
-	return f
 }
 
 func goSDKCodegenBin(c *dagger.Client, arch string) *dagger.File {

--- a/sdk/elixir/lib/dagger/gen/client.ex
+++ b/sdk/elixir/lib/dagger/gen/client.ex
@@ -20,6 +20,16 @@ defmodule Dagger.Client do
   )
 
   (
+    @doc "Retrieves a container builtin to the engine.\n\n## Required Arguments\n\n* `digest` - Digest of the image manifest"
+    @spec builtin_container(t(), Dagger.String.t()) :: Dagger.Container.t()
+    def builtin_container(%__MODULE__{} = query, digest) do
+      selection = select(query.selection, "builtinContainer")
+      selection = arg(selection, "digest", digest)
+      %Dagger.Container{selection: selection, client: query.client}
+    end
+  )
+
+  (
     @doc "Constructs a cache volume for a given cache key.\n\n## Required Arguments\n\n* `key` - A string identifier to target this cache volume (e.g., \"modules-cache\")."
     @spec cache_volume(t(), Dagger.String.t()) :: Dagger.CacheVolume.t()
     def cache_volume(%__MODULE__{} = query, key) do

--- a/sdk/go/dag/dag.gen.go
+++ b/sdk/go/dag/dag.gen.go
@@ -46,6 +46,12 @@ func Blob(digest string, size int, mediaType string, uncompressed string) *dagge
 	return client.Blob(digest, size, mediaType, uncompressed)
 }
 
+// Retrieves a container builtin to the engine.
+func BuiltinContainer(digest string) *dagger.Container {
+	client := initClient()
+	return client.BuiltinContainer(digest)
+}
+
 // Constructs a cache volume for a given cache key.
 func CacheVolume(key string) *dagger.CacheVolume {
 	client := initClient()

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -5074,6 +5074,17 @@ func (r *Client) Blob(digest string, size int, mediaType string, uncompressed st
 	}
 }
 
+// Retrieves a container builtin to the engine.
+func (r *Client) BuiltinContainer(digest string) *Container {
+	q := r.Query.Select("builtinContainer")
+	q = q.Arg("digest", digest)
+
+	return &Container{
+		Query:  q,
+		Client: r.Client,
+	}
+}
+
 // Constructs a cache volume for a given cache key.
 func (r *Client) CacheVolume(key string) *CacheVolume {
 	q := r.Query.Select("cacheVolume")

--- a/sdk/php/generated/Client.php
+++ b/sdk/php/generated/Client.php
@@ -27,6 +27,16 @@ class Client extends Client\AbstractClient
     }
 
     /**
+     * Retrieves a container builtin to the engine.
+     */
+    public function builtinContainer(string $digest): Container
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('builtinContainer');
+        $innerQueryBuilder->setArgument('digest', $digest);
+        return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
      * Constructs a cache volume for a given cache key.
      */
     public function cacheVolume(string $key): CacheVolume

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -5312,6 +5312,21 @@ class Client(Root):
         return Directory(_ctx)
 
     @typecheck
+    def builtin_container(self, digest: str) -> Container:
+        """Retrieves a container builtin to the engine.
+
+        Parameters
+        ----------
+        digest:
+            Digest of the image manifest
+        """
+        _args = [
+            Arg("digest", digest),
+        ]
+        _ctx = self._select("builtinContainer", _args)
+        return Container(_ctx)
+
+    @typecheck
     def cache_volume(self, key: str) -> CacheVolume:
         """Constructs a cache volume for a given cache key.
 

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -4634,6 +4634,20 @@ impl Query {
             graphql_client: self.graphql_client.clone(),
         };
     }
+    /// Retrieves a container builtin to the engine.
+    ///
+    /// # Arguments
+    ///
+    /// * `digest` - Digest of the image manifest
+    pub fn builtin_container(&self, digest: impl Into<String>) -> Container {
+        let mut query = self.selection.select("builtinContainer");
+        query = query.arg("digest", digest.into());
+        return Container {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        };
+    }
     /// Constructs a cache volume for a given cache key.
     ///
     /// # Arguments

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -6610,6 +6610,23 @@ export class Client extends BaseClient {
   }
 
   /**
+   * Retrieves a container builtin to the engine.
+   * @param digest Digest of the image manifest
+   */
+  builtinContainer = (digest: string): Container => {
+    return new Container({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "builtinContainer",
+          args: { digest },
+        },
+      ],
+      ctx: this._ctx,
+    })
+  }
+
+  /**
    * Constructs a cache volume for a given cache key.
    * @param key A string identifier to target this cache volume (e.g., "modules-cache").
    */


### PR DESCRIPTION
@vito noticed a while back that we were spending a lot of time loading the builtin Go SDK tarball. This fixes that bottleneck by avoiding use of local imports for built-in SDKs and instead using OCI store sources, which avoid the various problems with local sources (re-importing when used in parallel, need to always re-read tarball when importing containers, etc.).