### PR TITLE
fix: remove global Client property on generated structs

### DIFF
--- a/cmd/codegen/generator/go/templates/module_interfaces.go
+++ b/cmd/codegen/generator/go/templates/module_interfaces.go
@@ -202,7 +202,6 @@ The struct definition for the concrete implementation of the interface. e.g.:
 
 	type customIfaceImpl struct {
 		Query  *querybuilder.Selection
-		Client graphql.Client
 		id     *CustomIfaceID
 		str    *string
 		int    *int
@@ -212,7 +211,6 @@ The struct definition for the concrete implementation of the interface. e.g.:
 func (spec *parsedIfaceType) concreteStructDefCode() *Statement {
 	return Type().Id(spec.concreteStructName()).StructFunc(func(g *Group) {
 		g.Id("Query").Op("*").Qual("querybuilder", "Selection")
-		g.Id("Client").Qual("graphql", "Client")
 		g.Id("id").Op("*").Id(spec.idTypeName())
 
 		for _, method := range spec.methods {
@@ -231,12 +229,11 @@ func (spec *parsedIfaceType) concreteStructDefCode() *Statement {
 /*
 The Load*FromID method attached to the top-level Client struct for this interface. e.g.:
 
-	func (r *Client) LoadCustomIfaceFromID(id CustomIfaceID) CustomIface {
+	func LoadCustomIfaceFromID(r *Client, id CustomIfaceID) CustomIface {
 		q := r.Query.Select("loadTestCustomIfaceFromID")
 		q = q.Arg("id", id)
 		return &customIfaceImpl{
 			Query:  q,
-			Client: r.Client,
 		}
 	}
 */
@@ -249,8 +246,7 @@ func (spec *parsedIfaceType) loadFromIDMethodCode() *Statement {
 			g.Id("q").Op(":=").Id("r").Dot("Query").Dot("Select").Call(Lit(loadFromIDGQLFieldName(spec)))
 			g.Id("q").Op("=").Id("q").Dot("Arg").Call(Lit("id"), Id("id"))
 			g.Return(Op("&").Id(spec.concreteStructName()).Values(Dict{
-				Id("Query"):  Id("q"),
-				Id("Client"): Id("r").Dot("Client"),
+				Id("Query"): Id("q"),
 			}))
 		})
 }
@@ -465,7 +461,7 @@ func (spec *parsedIfaceType) concreteMethodExecuteQueryCode(method *funcTypeSpec
 				q := r.Query.Select("void")
 				var response Void
 				q = q.Bind(&response)
-				return q.Execute(ctx, r.Client)
+				return q.Execute(ctx)
 		*/
 
 		implTypeCode, err := spec.concreteMethodImplTypeCode(method.returnSpec)
@@ -475,7 +471,7 @@ func (spec *parsedIfaceType) concreteMethodExecuteQueryCode(method *funcTypeSpec
 		s.Var().Id("response").Add(implTypeCode).Line()
 		s.Id("q").Op("=").Id("q").Dot("Bind").Call(Op("&").Id("response")).Line()
 		s.Return(
-			Id("q").Dot("Execute").Call(Id("ctx"), Id("r").Dot("Client")),
+			Id("q").Dot("Execute").Call(Id("ctx")),
 		)
 
 	case *parsedPrimitiveType:
@@ -485,7 +481,7 @@ func (spec *parsedIfaceType) concreteMethodExecuteQueryCode(method *funcTypeSpec
 				q := r.Query.Select("str")
 				var response string
 				q = q.Bind(&response)
-				return response, q.Execute(ctx, r.Client)
+				return response, q.Execute(ctx)
 		*/
 
 		implTypeCode, err := spec.concreteMethodImplTypeCode(method.returnSpec)
@@ -496,7 +492,7 @@ func (spec *parsedIfaceType) concreteMethodExecuteQueryCode(method *funcTypeSpec
 		s.Id("q").Op("=").Id("q").Dot("Bind").Call(Op("&").Id("response")).Line()
 		s.Return(
 			Id("response"),
-			Id("q").Dot("Execute").Call(Id("ctx"), Id("r").Dot("Client")),
+			Id("q").Dot("Execute").Call(Id("ctx")),
 		)
 
 	case *parsedIfaceTypeReference, *parsedObjectTypeReference:
@@ -504,7 +500,6 @@ func (spec *parsedIfaceType) concreteMethodExecuteQueryCode(method *funcTypeSpec
 			Just object type with chained query (no error). e.g.:
 
 				return &customIfaceImpl{
-					Client: r.Client,
 					Query:  q,
 				}
 		*/
@@ -514,8 +509,7 @@ func (spec *parsedIfaceType) concreteMethodExecuteQueryCode(method *funcTypeSpec
 			return nil, fmt.Errorf("failed to generate return type code: %w", err)
 		}
 		s.Return(Op("&").Add(implTypeCode).Values(Dict{
-			Id("Query"):  Id("q"),
-			Id("Client"): Id("r").Dot("Client"),
+			Id("Query"): Id("q"),
 		}))
 
 	case *parsedSliceType:
@@ -530,7 +524,7 @@ func (spec *parsedIfaceType) concreteMethodExecuteQueryCode(method *funcTypeSpec
 						Id DirectoryID
 					}
 					q = q.Bind(&idResults)
-					err := q.Execute(ctx, r.Client)
+					err := q.Execute(ctx)
 					if err != nil {
 						return nil, err
 					}
@@ -539,8 +533,7 @@ func (spec *parsedIfaceType) concreteMethodExecuteQueryCode(method *funcTypeSpec
 						id := idResult.Id
 
 						results = append(results, &Directory{
-							Query:  querybuilder.Query().Select("loadDirectoryFromID").Arg("id", id),
-							Client: r.Client,
+							Query:  q.Query.Root().Select("loadDirectoryFromID").Arg("id", id),
 						})
 					}
 					return results, nil
@@ -554,7 +547,7 @@ func (spec *parsedIfaceType) concreteMethodExecuteQueryCode(method *funcTypeSpec
 			s.Var().Id("idResults").Index().Struct(Id("Id").Id(idScalarName)).Line()
 			s.Id("q").Op("=").Id("q").Dot("Bind").Call(Op("&").Id("idResults")).Line()
 
-			s.Id("err").Op(":=").Id("q").Dot("Execute").Call(Id("ctx"), Id("r").Dot("Client")).Line()
+			s.Id("err").Op(":=").Id("q").Dot("Execute").Call(Id("ctx")).Line()
 			s.If(Id("err").Op("!=").Nil()).Block(Return(Nil(), Id("err"))).Line()
 
 			underlyingReturnTypeCode, err := spec.concreteMethodSigTypeCode(returnType.underlying)
@@ -569,8 +562,7 @@ func (spec *parsedIfaceType) concreteMethodExecuteQueryCode(method *funcTypeSpec
 			s.For(List(Id("_"), Id("idResult")).Op(":=").Range().Id("idResults")).BlockFunc(func(g *Group) {
 				g.Id("id").Op(":=").Id("idResult").Dot("Id").Line()
 				d := Dict{
-					Id("Query"):  Id("querybuilder").Dot("Query").Call().Dot("Select").Call(Lit(loadFromIDQueryName)).Dot("Arg").Call(Lit("id"), Id("id")),
-					Id("Client"): Id("r").Dot("Client"),
+					Id("Query"): Id("r").Dot("Query").Dot("Root").Call().Dot("Select").Call(Lit(loadFromIDQueryName)).Dot("Arg").Call(Lit("id"), Id("id")),
 					// FIXME: this is a nice optimization, but we can't enable
 					// it since the private "id" field can only be accessed on
 					// local structs
@@ -587,7 +579,7 @@ func (spec *parsedIfaceType) concreteMethodExecuteQueryCode(method *funcTypeSpec
 
 					var response []string
 					q = q.Bind(&response)
-					return response, q.Execute(ctx, r.Client)
+					return response, q.Execute(ctx)
 			*/
 
 			implTypeCode, err := spec.concreteMethodImplTypeCode(method.returnSpec)
@@ -598,7 +590,7 @@ func (spec *parsedIfaceType) concreteMethodExecuteQueryCode(method *funcTypeSpec
 			s.Id("q").Op("=").Id("q").Dot("Bind").Call(Op("&").Id("response")).Line()
 			s.Return(
 				Id("response"),
-				Id("q").Dot("Execute").Call(Id("ctx"), Id("r").Dot("Client")),
+				Id("q").Dot("Execute").Call(Id("ctx")),
 			)
 
 		default:

--- a/cmd/codegen/generator/go/templates/src/_dagger.gen.go/defs.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_dagger.gen.go/defs.go.tmpl
@@ -111,7 +111,6 @@ func (e *ExecError) Unwrap() error {
 
 {{ if IsModuleCode }}
 type Client struct {
-	Client graphql.Client
 	Query *querybuilder.Selection
 }
 
@@ -120,8 +119,7 @@ var dag *Client
 func init() {
 	gqlClient, q := getClientParams()
 	dag = &Client{
-		Client: gqlClient,
-		Query: q,
+		Query: q.Client(gqlClient),
 	}
 }
 

--- a/cmd/codegen/generator/go/templates/src/_dagger.gen.go/defs.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_dagger.gen.go/defs.go.tmpl
@@ -112,6 +112,7 @@ func (e *ExecError) Unwrap() error {
 {{ if IsModuleCode }}
 type Client struct {
 	Query *querybuilder.Selection
+	client graphql.Client
 }
 
 var dag *Client
@@ -120,11 +121,17 @@ func init() {
 	gqlClient, q := getClientParams()
 	dag = &Client{
 		Query: q.Client(gqlClient),
+		client: gqlClient,
 	}
 }
 
 func Connect() *Client {
 	return dag
+}
+
+// GraphQLClient returns the underlying graphql.Client
+func (c *Client) GraphQLClient() graphql.Client {
+	return c.client
 }
 
 func getClientParams() (graphql.Client, *querybuilder.Selection) {

--- a/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
@@ -2,7 +2,6 @@
 {{ .Description | Comment }}
 type {{ .Name | FormatName }} struct {
 	Query *querybuilder.Selection
-	Client graphql.Client
 
     {{ range $field := .Fields }}
         {{- if $field.TypeRef.IsScalar }}
@@ -83,13 +82,12 @@ type {{ $field | FieldOptionsStructName }} struct {
 	{{- end }}
 	{{- end }}
     {{ if $convertID }}
-	return r, q.Execute(ctx, r.Client)
+	return r, q.Execute(ctx)
 
 	{{- else if $field.TypeRef.IsObject }}
 	{{ $typeName := $field.TypeRef | FormatOutputType }}
 	return &{{ $field.TypeRef | FormatOutputType }} {
 		Query: q,
-		Client: r.Client,
 	}
 
 	{{- else if or $field.TypeRef.IsScalar $field.TypeRef.IsList }}
@@ -109,8 +107,7 @@ type {{ $field | FieldOptionsStructName }} struct {
         for i := range fields {
             val := {{ $field.TypeRef | FormatOutputType | FormatArrayToSingleType }}{{"{"}}{{ $field | GetArrayField | FormatArrayField }}{{"}"}}
             {{- if $eleType | IsIDableObject }}
-              val.Query = querybuilder.Query().Select("load{{$eleType | ObjectName}}FromID").Arg("id", fields[i].Id)
-              val.Client = r.Client
+              val.Query = q.Root().Select("load{{$eleType | ObjectName}}FromID").Arg("id", fields[i].Id)
             {{- end }}
             out = append(out, val)
         }
@@ -130,14 +127,14 @@ type {{ $field | FieldOptionsStructName }} struct {
 	{{- if ne $typeName "Client" }}
 	    {{- if and $field.TypeRef.IsList (IsListOfObject $field.TypeRef) }}
 
-	err := q.Execute(ctx, r.Client)
+	err := q.Execute(ctx)
 	if err != nil {
 	    return nil, err
 	}
 
 	return convert(response), nil
 	    {{- else }}
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 	    {{- end }}
 	{{- else }}
 	return response, q.Execute(ctx, r.gql)

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -525,9 +525,9 @@ func (fc *FuncCommand) makeSubCmd(dag *dagger.Client, fn *modFunction) *cobra.Co
 
 			var response any
 
-			q := fc.q.Bind(&response)
+			q := fc.q.Bind(&response).Client(dag.GraphQLClient())
 
-			if err := q.Execute(ctx, dag.Client); err != nil {
+			if err := q.Execute(ctx); err != nil {
 				return fmt.Errorf("response from query: %w", err)
 			}
 

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -2762,7 +2762,7 @@ type Test struct{}
 
 func (m *Test) FnA(ctx context.Context) (string, error) {
 	resp := &graphql.Response{}
-	err := dag.Client.MakeRequest(ctx, &graphql.Request{
+	err := dag.GraphQLClient().MakeRequest(ctx, &graphql.Request{
 		Query: "{test{fnB}}",
 	}, resp)
 	if err != nil {

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -17,8 +17,8 @@ import (
 type Client struct {
 	conn engineconn.EngineConn
 
-	Client graphql.Client
 	Query  *querybuilder.Selection
+	client graphql.Client
 }
 
 // ClientOpt holds a client option
@@ -75,8 +75,8 @@ func Connect(ctx context.Context, opts ...ClientOpt) (*Client, error) {
 	gql := errorWrappedClient{graphql.NewClient("http://"+conn.Host()+"/query", conn)}
 
 	c := &Client{
-		Client: gql,
-		Query:  querybuilder.Query(),
+		Query:  querybuilder.Query().Client(gql),
+		client: gql,
 		conn:   conn,
 	}
 
@@ -93,7 +93,7 @@ func Connect(ctx context.Context, opts ...ClientOpt) (*Client, error) {
 
 // GraphQLClient returns the underlying graphql.Client
 func (c *Client) GraphQLClient() graphql.Client {
-	return c.Client
+	return c.client
 }
 
 // Close the engine connection
@@ -112,7 +112,7 @@ func (c *Client) Do(ctx context.Context, req *Request, resp *Response) error {
 		r.Errors = resp.Errors
 		r.Extensions = resp.Extensions
 	}
-	return c.Client.MakeRequest(ctx, &graphql.Request{
+	return c.client.MakeRequest(ctx, &graphql.Request{
 		Query:     req.Query,
 		Variables: req.Variables,
 		OpName:    req.OpName,

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/Khan/genqlient/graphql"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 
 	"dagger.io/dagger/querybuilder"
@@ -239,8 +238,7 @@ type PortForward struct {
 
 // A directory whose contents persist across runs.
 type CacheVolume struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	id *CacheVolumeID
 }
@@ -255,7 +253,7 @@ func (r *CacheVolume) ID(ctx context.Context) (CacheVolumeID, error) {
 	var response CacheVolumeID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -287,8 +285,7 @@ func (r *CacheVolume) MarshalJSON() ([]byte, error) {
 
 // An OCI-compatible container, also known as a Docker container.
 type Container struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	envVariable *string
 	export      *bool
@@ -319,8 +316,7 @@ func (r *Container) AsService() *Service {
 	q := r.Query.Select("asService")
 
 	return &Service{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -359,8 +355,7 @@ func (r *Container) AsTarball(opts ...ContainerAsTarballOpts) *File {
 	}
 
 	return &File{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -405,8 +400,7 @@ func (r *Container) Build(context *Directory, opts ...ContainerBuildOpts) *Conta
 	q = q.Arg("context", context)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -417,7 +411,7 @@ func (r *Container) DefaultArgs(ctx context.Context) ([]string, error) {
 	var response []string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Retrieves a directory at the given path.
@@ -428,8 +422,7 @@ func (r *Container) Directory(path string) *Directory {
 	q = q.Arg("path", path)
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -440,7 +433,7 @@ func (r *Container) Entrypoint(ctx context.Context) ([]string, error) {
 	var response []string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Retrieves the value of the specified environment variable.
@@ -454,7 +447,7 @@ func (r *Container) EnvVariable(ctx context.Context, name string) (string, error
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Retrieves the list of environment variables passed to commands.
@@ -472,8 +465,7 @@ func (r *Container) EnvVariables(ctx context.Context) ([]EnvVariable, error) {
 
 		for i := range fields {
 			val := EnvVariable{id: &fields[i].Id}
-			val.Query = querybuilder.Query().Select("loadEnvVariableFromID").Arg("id", fields[i].Id)
-			val.Client = r.Client
+			val.Query = q.Root().Select("loadEnvVariableFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -483,7 +475,7 @@ func (r *Container) EnvVariables(ctx context.Context) ([]EnvVariable, error) {
 
 	q = q.Bind(&response)
 
-	err := q.Execute(ctx, r.Client)
+	err := q.Execute(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -500,8 +492,7 @@ func (r *Container) ExperimentalWithAllGPUs() *Container {
 	q := r.Query.Select("experimentalWithAllGPUs")
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -515,8 +506,7 @@ func (r *Container) ExperimentalWithGPU(devices []string) *Container {
 	q = q.Arg("devices", devices)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -565,7 +555,7 @@ func (r *Container) Export(ctx context.Context, path string, opts ...ContainerEx
 	var response bool
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Retrieves the list of exposed ports.
@@ -585,8 +575,7 @@ func (r *Container) ExposedPorts(ctx context.Context) ([]Port, error) {
 
 		for i := range fields {
 			val := Port{id: &fields[i].Id}
-			val.Query = querybuilder.Query().Select("loadPortFromID").Arg("id", fields[i].Id)
-			val.Client = r.Client
+			val.Query = q.Root().Select("loadPortFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -596,7 +585,7 @@ func (r *Container) ExposedPorts(ctx context.Context) ([]Port, error) {
 
 	q = q.Bind(&response)
 
-	err := q.Execute(ctx, r.Client)
+	err := q.Execute(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -612,8 +601,7 @@ func (r *Container) File(path string) *File {
 	q = q.Arg("path", path)
 
 	return &File{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -623,8 +611,7 @@ func (r *Container) From(address string) *Container {
 	q = q.Arg("address", address)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -638,7 +625,7 @@ func (r *Container) ID(ctx context.Context) (ContainerID, error) {
 	var response ContainerID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -678,7 +665,7 @@ func (r *Container) ImageRef(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // ContainerImportOpts contains options for Container.Import
@@ -700,8 +687,7 @@ func (r *Container) Import(source *File, opts ...ContainerImportOpts) *Container
 	q = q.Arg("source", source)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -716,7 +702,7 @@ func (r *Container) Label(ctx context.Context, name string) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Retrieves the list of labels passed to container.
@@ -734,8 +720,7 @@ func (r *Container) Labels(ctx context.Context) ([]Label, error) {
 
 		for i := range fields {
 			val := Label{id: &fields[i].Id}
-			val.Query = querybuilder.Query().Select("loadLabelFromID").Arg("id", fields[i].Id)
-			val.Client = r.Client
+			val.Query = q.Root().Select("loadLabelFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -745,7 +730,7 @@ func (r *Container) Labels(ctx context.Context) ([]Label, error) {
 
 	q = q.Bind(&response)
 
-	err := q.Execute(ctx, r.Client)
+	err := q.Execute(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -760,7 +745,7 @@ func (r *Container) Mounts(ctx context.Context) ([]string, error) {
 	var response []string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // ContainerPipelineOpts contains options for Container.Pipeline
@@ -787,8 +772,7 @@ func (r *Container) Pipeline(name string, opts ...ContainerPipelineOpts) *Contai
 	q = q.Arg("name", name)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -802,7 +786,7 @@ func (r *Container) Platform(ctx context.Context) (Platform, error) {
 	var response Platform
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // ContainerPublishOpts contains options for Container.Publish
@@ -850,7 +834,7 @@ func (r *Container) Publish(ctx context.Context, address string, opts ...Contain
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Retrieves this container's root filesystem. Mounts are not included.
@@ -858,8 +842,7 @@ func (r *Container) Rootfs() *Directory {
 	q := r.Query.Select("rootfs")
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -875,7 +858,7 @@ func (r *Container) Stderr(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // The output stream of the last executed command.
@@ -890,7 +873,7 @@ func (r *Container) Stdout(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Forces evaluation of the pipeline in the engine.
@@ -899,7 +882,7 @@ func (r *Container) Stdout(ctx context.Context) (string, error) {
 func (r *Container) Sync(ctx context.Context) (*Container, error) {
 	q := r.Query.Select("sync")
 
-	return r, q.Execute(ctx, r.Client)
+	return r, q.Execute(ctx)
 }
 
 // ContainerTerminalOpts contains options for Container.Terminal
@@ -919,8 +902,7 @@ func (r *Container) Terminal(opts ...ContainerTerminalOpts) *Terminal {
 	}
 
 	return &Terminal{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -934,7 +916,7 @@ func (r *Container) User(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Configures default arguments for future commands.
@@ -943,8 +925,7 @@ func (r *Container) WithDefaultArgs(args []string) *Container {
 	q = q.Arg("args", args)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -954,8 +935,7 @@ func (r *Container) WithDefaultTerminalCmd(args []string) *Container {
 	q = q.Arg("args", args)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -995,8 +975,7 @@ func (r *Container) WithDirectory(path string, directory *Directory, opts ...Con
 	q = q.Arg("directory", directory)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1018,8 +997,7 @@ func (r *Container) WithEntrypoint(args []string, opts ...ContainerWithEntrypoin
 	q = q.Arg("args", args)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1042,8 +1020,7 @@ func (r *Container) WithEnvVariable(name string, value string, opts ...Container
 	q = q.Arg("value", value)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1097,8 +1074,7 @@ func (r *Container) WithExec(args []string, opts ...ContainerWithExecOpts) *Cont
 	q = q.Arg("args", args)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1138,8 +1114,7 @@ func (r *Container) WithExposedPort(port int, opts ...ContainerWithExposedPortOp
 	q = q.Arg("port", port)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1173,8 +1148,7 @@ func (r *Container) WithFile(path string, source *File, opts ...ContainerWithFil
 	q = q.Arg("source", source)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1207,8 +1181,7 @@ func (r *Container) WithFiles(path string, sources []*File, opts ...ContainerWit
 	q = q.Arg("sources", sources)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1217,8 +1190,7 @@ func (r *Container) WithFocus() *Container {
 	q := r.Query.Select("withFocus")
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1229,8 +1201,7 @@ func (r *Container) WithLabel(name string, value string) *Container {
 	q = q.Arg("value", value)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1272,8 +1243,7 @@ func (r *Container) WithMountedCache(path string, cache *CacheVolume, opts ...Co
 	q = q.Arg("cache", cache)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1301,8 +1271,7 @@ func (r *Container) WithMountedDirectory(path string, source *Directory, opts ..
 	q = q.Arg("source", source)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1330,8 +1299,7 @@ func (r *Container) WithMountedFile(path string, source *File, opts ...Container
 	q = q.Arg("source", source)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1367,8 +1335,7 @@ func (r *Container) WithMountedSecret(path string, source *Secret, opts ...Conta
 	q = q.Arg("source", source)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1378,8 +1345,7 @@ func (r *Container) WithMountedTemp(path string) *Container {
 	q = q.Arg("path", path)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1417,8 +1383,7 @@ func (r *Container) WithNewFile(path string, opts ...ContainerWithNewFileOpts) *
 	q = q.Arg("path", path)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1431,8 +1396,7 @@ func (r *Container) WithRegistryAuth(address string, username string, secret *Se
 	q = q.Arg("secret", secret)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1443,8 +1407,7 @@ func (r *Container) WithRootfs(directory *Directory) *Container {
 	q = q.Arg("directory", directory)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1456,8 +1419,7 @@ func (r *Container) WithSecretVariable(name string, secret *Secret) *Container {
 	q = q.Arg("secret", secret)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1475,8 +1437,7 @@ func (r *Container) WithServiceBinding(alias string, service *Service) *Containe
 	q = q.Arg("service", service)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1504,8 +1465,7 @@ func (r *Container) WithUnixSocket(path string, source *Socket, opts ...Containe
 	q = q.Arg("source", source)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1515,8 +1475,7 @@ func (r *Container) WithUser(name string) *Container {
 	q = q.Arg("name", name)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1526,8 +1485,7 @@ func (r *Container) WithWorkdir(path string) *Container {
 	q = q.Arg("path", path)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1536,8 +1494,7 @@ func (r *Container) WithoutDefaultArgs() *Container {
 	q := r.Query.Select("withoutDefaultArgs")
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1558,8 +1515,7 @@ func (r *Container) WithoutEntrypoint(opts ...ContainerWithoutEntrypointOpts) *C
 	}
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1569,8 +1525,7 @@ func (r *Container) WithoutEnvVariable(name string) *Container {
 	q = q.Arg("name", name)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1592,8 +1547,7 @@ func (r *Container) WithoutExposedPort(port int, opts ...ContainerWithoutExposed
 	q = q.Arg("port", port)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1604,8 +1558,7 @@ func (r *Container) WithoutFocus() *Container {
 	q := r.Query.Select("withoutFocus")
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1615,8 +1568,7 @@ func (r *Container) WithoutLabel(name string) *Container {
 	q = q.Arg("name", name)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1626,8 +1578,7 @@ func (r *Container) WithoutMount(path string) *Container {
 	q = q.Arg("path", path)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1637,8 +1588,7 @@ func (r *Container) WithoutRegistryAuth(address string) *Container {
 	q = q.Arg("address", address)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1648,8 +1598,7 @@ func (r *Container) WithoutUnixSocket(path string) *Container {
 	q = q.Arg("path", path)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1660,8 +1609,7 @@ func (r *Container) WithoutUser() *Container {
 	q := r.Query.Select("withoutUser")
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1672,8 +1620,7 @@ func (r *Container) WithoutWorkdir() *Container {
 	q := r.Query.Select("withoutWorkdir")
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1687,13 +1634,12 @@ func (r *Container) Workdir(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Reflective module API provided to functions at runtime.
 type CurrentModule struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	id   *CurrentModuleID
 	name *string
@@ -1709,7 +1655,7 @@ func (r *CurrentModule) ID(ctx context.Context) (CurrentModuleID, error) {
 	var response CurrentModuleID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -1749,7 +1695,7 @@ func (r *CurrentModule) Name(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // The directory containing the module's source code loaded into the engine (plus any generated code that may have been created).
@@ -1757,8 +1703,7 @@ func (r *CurrentModule) Source() *Directory {
 	q := r.Query.Select("source")
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1786,8 +1731,7 @@ func (r *CurrentModule) Workdir(path string, opts ...CurrentModuleWorkdirOpts) *
 	q = q.Arg("path", path)
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1797,15 +1741,13 @@ func (r *CurrentModule) WorkdirFile(path string) *File {
 	q = q.Arg("path", path)
 
 	return &File{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
 // A directory.
 type Directory struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	export *bool
 	id     *DirectoryID
@@ -1841,8 +1783,7 @@ func (r *Directory) AsModule(opts ...DirectoryAsModuleOpts) *Module {
 	}
 
 	return &Module{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1853,8 +1794,7 @@ func (r *Directory) Diff(other *Directory) *Directory {
 	q = q.Arg("other", other)
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1864,8 +1804,7 @@ func (r *Directory) Directory(path string) *Directory {
 	q = q.Arg("path", path)
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1912,8 +1851,7 @@ func (r *Directory) DockerBuild(opts ...DirectoryDockerBuildOpts) *Container {
 	}
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1936,7 +1874,7 @@ func (r *Directory) Entries(ctx context.Context, opts ...DirectoryEntriesOpts) (
 	var response []string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Writes the contents of the directory to a path on the host.
@@ -1950,7 +1888,7 @@ func (r *Directory) Export(ctx context.Context, path string) (bool, error) {
 	var response bool
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Retrieves a file at the given path.
@@ -1959,8 +1897,7 @@ func (r *Directory) File(path string) *File {
 	q = q.Arg("path", path)
 
 	return &File{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -1972,7 +1909,7 @@ func (r *Directory) Glob(ctx context.Context, pattern string) ([]string, error) 
 	var response []string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // A unique identifier for this Directory.
@@ -1985,7 +1922,7 @@ func (r *Directory) ID(ctx context.Context) (DirectoryID, error) {
 	var response DirectoryID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -2039,8 +1976,7 @@ func (r *Directory) Pipeline(name string, opts ...DirectoryPipelineOpts) *Direct
 	q = q.Arg("name", name)
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -2048,7 +1984,7 @@ func (r *Directory) Pipeline(name string, opts ...DirectoryPipelineOpts) *Direct
 func (r *Directory) Sync(ctx context.Context) (*Directory, error) {
 	q := r.Query.Select("sync")
 
-	return r, q.Execute(ctx, r.Client)
+	return r, q.Execute(ctx)
 }
 
 // DirectoryWithDirectoryOpts contains options for Directory.WithDirectory
@@ -2077,8 +2013,7 @@ func (r *Directory) WithDirectory(path string, directory *Directory, opts ...Dir
 	q = q.Arg("directory", directory)
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -2102,8 +2037,7 @@ func (r *Directory) WithFile(path string, source *File, opts ...DirectoryWithFil
 	q = q.Arg("source", source)
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -2126,8 +2060,7 @@ func (r *Directory) WithFiles(path string, sources []*File, opts ...DirectoryWit
 	q = q.Arg("sources", sources)
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -2149,8 +2082,7 @@ func (r *Directory) WithNewDirectory(path string, opts ...DirectoryWithNewDirect
 	q = q.Arg("path", path)
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -2173,8 +2105,7 @@ func (r *Directory) WithNewFile(path string, contents string, opts ...DirectoryW
 	q = q.Arg("contents", contents)
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -2184,8 +2115,7 @@ func (r *Directory) WithTimestamps(timestamp int) *Directory {
 	q = q.Arg("timestamp", timestamp)
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -2195,8 +2125,7 @@ func (r *Directory) WithoutDirectory(path string) *Directory {
 	q = q.Arg("path", path)
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -2206,15 +2135,13 @@ func (r *Directory) WithoutFile(path string) *Directory {
 	q = q.Arg("path", path)
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
 // An environment variable name and value.
 type EnvVariable struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	id    *EnvVariableID
 	name  *string
@@ -2231,7 +2158,7 @@ func (r *EnvVariable) ID(ctx context.Context) (EnvVariableID, error) {
 	var response EnvVariableID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -2271,7 +2198,7 @@ func (r *EnvVariable) Name(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // The environment variable value.
@@ -2284,15 +2211,14 @@ func (r *EnvVariable) Value(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // A definition of a field on a custom object defined in a Module.
 //
 // A field on an object has a static value, as opposed to a function on an object whose value is computed by invoking code (and can accept arguments).
 type FieldTypeDef struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	description *string
 	id          *FieldTypeDefID
@@ -2309,7 +2235,7 @@ func (r *FieldTypeDef) Description(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // A unique identifier for this FieldTypeDef.
@@ -2322,7 +2248,7 @@ func (r *FieldTypeDef) ID(ctx context.Context) (FieldTypeDefID, error) {
 	var response FieldTypeDefID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -2362,7 +2288,7 @@ func (r *FieldTypeDef) Name(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // The type of the field.
@@ -2370,15 +2296,13 @@ func (r *FieldTypeDef) TypeDef() *TypeDef {
 	q := r.Query.Select("typeDef")
 
 	return &TypeDef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
 // A file.
 type File struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	contents *string
 	export   *bool
@@ -2406,7 +2330,7 @@ func (r *File) Contents(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // FileExportOpts contains options for File.Export
@@ -2432,7 +2356,7 @@ func (r *File) Export(ctx context.Context, path string, opts ...FileExportOpts) 
 	var response bool
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // A unique identifier for this File.
@@ -2445,7 +2369,7 @@ func (r *File) ID(ctx context.Context) (FileID, error) {
 	var response FileID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -2485,7 +2409,7 @@ func (r *File) Name(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Retrieves the size of the file, in bytes.
@@ -2498,14 +2422,14 @@ func (r *File) Size(ctx context.Context) (int, error) {
 	var response int
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Force evaluation in the engine.
 func (r *File) Sync(ctx context.Context) (*File, error) {
 	q := r.Query.Select("sync")
 
-	return r, q.Execute(ctx, r.Client)
+	return r, q.Execute(ctx)
 }
 
 // Retrieves this file with its created/modified timestamps set to the given time.
@@ -2514,8 +2438,7 @@ func (r *File) WithTimestamps(timestamp int) *File {
 	q = q.Arg("timestamp", timestamp)
 
 	return &File{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -2523,8 +2446,7 @@ func (r *File) WithTimestamps(timestamp int) *File {
 //
 // A function always evaluates against a parent object and is given a set of named arguments.
 type Function struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	description *string
 	id          *FunctionID
@@ -2554,8 +2476,7 @@ func (r *Function) Args(ctx context.Context) ([]FunctionArg, error) {
 
 		for i := range fields {
 			val := FunctionArg{id: &fields[i].Id}
-			val.Query = querybuilder.Query().Select("loadFunctionArgFromID").Arg("id", fields[i].Id)
-			val.Client = r.Client
+			val.Query = q.Root().Select("loadFunctionArgFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -2565,7 +2486,7 @@ func (r *Function) Args(ctx context.Context) ([]FunctionArg, error) {
 
 	q = q.Bind(&response)
 
-	err := q.Execute(ctx, r.Client)
+	err := q.Execute(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2583,7 +2504,7 @@ func (r *Function) Description(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // A unique identifier for this Function.
@@ -2596,7 +2517,7 @@ func (r *Function) ID(ctx context.Context) (FunctionID, error) {
 	var response FunctionID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -2636,7 +2557,7 @@ func (r *Function) Name(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // The type returned by the function.
@@ -2644,8 +2565,7 @@ func (r *Function) ReturnType() *TypeDef {
 	q := r.Query.Select("returnType")
 
 	return &TypeDef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -2675,8 +2595,7 @@ func (r *Function) WithArg(name string, typeDef *TypeDef, opts ...FunctionWithAr
 	q = q.Arg("typeDef", typeDef)
 
 	return &Function{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -2686,8 +2605,7 @@ func (r *Function) WithDescription(description string) *Function {
 	q = q.Arg("description", description)
 
 	return &Function{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -2695,8 +2613,7 @@ func (r *Function) WithDescription(description string) *Function {
 //
 // This is a specification for an argument at function definition time, not an argument passed at function call time.
 type FunctionArg struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	defaultValue *JSON
 	description  *string
@@ -2714,7 +2631,7 @@ func (r *FunctionArg) DefaultValue(ctx context.Context) (JSON, error) {
 	var response JSON
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // A doc string for the argument, if any.
@@ -2727,7 +2644,7 @@ func (r *FunctionArg) Description(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // A unique identifier for this FunctionArg.
@@ -2740,7 +2657,7 @@ func (r *FunctionArg) ID(ctx context.Context) (FunctionArgID, error) {
 	var response FunctionArgID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -2780,7 +2697,7 @@ func (r *FunctionArg) Name(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // The type of the argument.
@@ -2788,15 +2705,13 @@ func (r *FunctionArg) TypeDef() *TypeDef {
 	q := r.Query.Select("typeDef")
 
 	return &TypeDef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
 // An active function call.
 type FunctionCall struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	id          *FunctionCallID
 	name        *string
@@ -2815,7 +2730,7 @@ func (r *FunctionCall) ID(ctx context.Context) (FunctionCallID, error) {
 	var response FunctionCallID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -2860,8 +2775,7 @@ func (r *FunctionCall) InputArgs(ctx context.Context) ([]FunctionCallArgValue, e
 
 		for i := range fields {
 			val := FunctionCallArgValue{id: &fields[i].Id}
-			val.Query = querybuilder.Query().Select("loadFunctionCallArgValueFromID").Arg("id", fields[i].Id)
-			val.Client = r.Client
+			val.Query = q.Root().Select("loadFunctionCallArgValueFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -2871,7 +2785,7 @@ func (r *FunctionCall) InputArgs(ctx context.Context) ([]FunctionCallArgValue, e
 
 	q = q.Bind(&response)
 
-	err := q.Execute(ctx, r.Client)
+	err := q.Execute(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2889,7 +2803,7 @@ func (r *FunctionCall) Name(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // The value of the parent object of the function being called. If the function is top-level to the module, this is always an empty object.
@@ -2902,7 +2816,7 @@ func (r *FunctionCall) Parent(ctx context.Context) (JSON, error) {
 	var response JSON
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // The name of the parent object of the function being called. If the function is top-level to the module, this is the name of the module.
@@ -2915,7 +2829,7 @@ func (r *FunctionCall) ParentName(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Set the return value of the function call to the provided value.
@@ -2929,13 +2843,12 @@ func (r *FunctionCall) ReturnValue(ctx context.Context, value JSON) (Void, error
 	var response Void
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // A value passed as a named argument to a function call.
 type FunctionCallArgValue struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	id    *FunctionCallArgValueID
 	name  *string
@@ -2952,7 +2865,7 @@ func (r *FunctionCallArgValue) ID(ctx context.Context) (FunctionCallArgValueID, 
 	var response FunctionCallArgValueID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -2992,7 +2905,7 @@ func (r *FunctionCallArgValue) Name(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // The value of the argument represented as a JSON serialized string.
@@ -3005,13 +2918,12 @@ func (r *FunctionCallArgValue) Value(ctx context.Context) (JSON, error) {
 	var response JSON
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // The result of running an SDK's codegen.
 type GeneratedCode struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	id *GeneratedCodeID
 }
@@ -3029,8 +2941,7 @@ func (r *GeneratedCode) Code() *Directory {
 	q := r.Query.Select("code")
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -3044,7 +2955,7 @@ func (r *GeneratedCode) ID(ctx context.Context) (GeneratedCodeID, error) {
 	var response GeneratedCodeID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -3081,7 +2992,7 @@ func (r *GeneratedCode) VcsGeneratedPaths(ctx context.Context) ([]string, error)
 	var response []string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // List of paths to ignore in version control (i.e. .gitignore).
@@ -3091,7 +3002,7 @@ func (r *GeneratedCode) VcsIgnoredPaths(ctx context.Context) ([]string, error) {
 	var response []string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Set the list of paths to mark generated in version control.
@@ -3100,8 +3011,7 @@ func (r *GeneratedCode) WithVCSGeneratedPaths(paths []string) *GeneratedCode {
 	q = q.Arg("paths", paths)
 
 	return &GeneratedCode{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -3111,15 +3021,13 @@ func (r *GeneratedCode) WithVCSIgnoredPaths(paths []string) *GeneratedCode {
 	q = q.Arg("paths", paths)
 
 	return &GeneratedCode{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
 // Module source originating from a git repo.
 type GitModuleSource struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	cloneURL    *string
 	commit      *string
@@ -3139,7 +3047,7 @@ func (r *GitModuleSource) CloneURL(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // The resolved commit of the git repo this source points to.
@@ -3152,7 +3060,7 @@ func (r *GitModuleSource) Commit(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // The directory containing everything needed to load load and use the module.
@@ -3160,8 +3068,7 @@ func (r *GitModuleSource) ContextDirectory() *Directory {
 	q := r.Query.Select("contextDirectory")
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -3175,7 +3082,7 @@ func (r *GitModuleSource) HTMLURL(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // A unique identifier for this GitModuleSource.
@@ -3188,7 +3095,7 @@ func (r *GitModuleSource) ID(ctx context.Context) (GitModuleSourceID, error) {
 	var response GitModuleSourceID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -3228,7 +3135,7 @@ func (r *GitModuleSource) RootSubpath(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // The specified version of the git repo this source points to.
@@ -3241,13 +3148,12 @@ func (r *GitModuleSource) Version(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // A git ref (tag, branch, or commit).
 type GitRef struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	commit *string
 	id     *GitRefID
@@ -3263,7 +3169,7 @@ func (r *GitRef) Commit(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // A unique identifier for this GitRef.
@@ -3276,7 +3182,7 @@ func (r *GitRef) ID(ctx context.Context) (GitRefID, error) {
 	var response GitRefID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -3329,15 +3235,13 @@ func (r *GitRef) Tree(opts ...GitRefTreeOpts) *Directory {
 	}
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
 // A git repository.
 type GitRepository struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	id *GitRepositoryID
 }
@@ -3348,8 +3252,7 @@ func (r *GitRepository) Branch(name string) *GitRef {
 	q = q.Arg("name", name)
 
 	return &GitRef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -3359,8 +3262,7 @@ func (r *GitRepository) Commit(id string) *GitRef {
 	q = q.Arg("id", id)
 
 	return &GitRef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -3374,7 +3276,7 @@ func (r *GitRepository) ID(ctx context.Context) (GitRepositoryID, error) {
 	var response GitRepositoryID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -3410,8 +3312,7 @@ func (r *GitRepository) Ref(name string) *GitRef {
 	q = q.Arg("name", name)
 
 	return &GitRef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -3421,15 +3322,13 @@ func (r *GitRepository) Tag(name string) *GitRef {
 	q = q.Arg("name", name)
 
 	return &GitRef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
 // Information about the host environment.
 type Host struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	id *HostID
 }
@@ -3458,8 +3357,7 @@ func (r *Host) Directory(path string, opts ...HostDirectoryOpts) *Directory {
 	q = q.Arg("path", path)
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -3469,8 +3367,7 @@ func (r *Host) File(path string) *File {
 	q = q.Arg("path", path)
 
 	return &File{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -3484,7 +3381,7 @@ func (r *Host) ID(ctx context.Context) (HostID, error) {
 	var response HostID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -3532,8 +3429,7 @@ func (r *Host) Service(ports []PortForward, opts ...HostServiceOpts) *Service {
 	q = q.Arg("ports", ports)
 
 	return &Service{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -3546,8 +3442,7 @@ func (r *Host) SetSecretFile(name string, path string) *Secret {
 	q = q.Arg("path", path)
 
 	return &Secret{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -3584,8 +3479,7 @@ func (r *Host) Tunnel(service *Service, opts ...HostTunnelOpts) *Service {
 	q = q.Arg("service", service)
 
 	return &Service{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -3595,8 +3489,7 @@ func (r *Host) UnixSocket(path string) *Socket {
 	q = q.Arg("path", path)
 
 	return &Socket{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -3605,8 +3498,7 @@ func (r *Host) UnixSocket(path string) *Socket {
 // in the core API. It is not used by user modules and shouldn't ever be as user
 // module accept input objects via their id rather than graphql input types.
 type InputTypeDef struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	id   *InputTypeDefID
 	name *string
@@ -3627,8 +3519,7 @@ func (r *InputTypeDef) Fields(ctx context.Context) ([]FieldTypeDef, error) {
 
 		for i := range fields {
 			val := FieldTypeDef{id: &fields[i].Id}
-			val.Query = querybuilder.Query().Select("loadFieldTypeDefFromID").Arg("id", fields[i].Id)
-			val.Client = r.Client
+			val.Query = q.Root().Select("loadFieldTypeDefFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -3638,7 +3529,7 @@ func (r *InputTypeDef) Fields(ctx context.Context) ([]FieldTypeDef, error) {
 
 	q = q.Bind(&response)
 
-	err := q.Execute(ctx, r.Client)
+	err := q.Execute(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -3656,7 +3547,7 @@ func (r *InputTypeDef) ID(ctx context.Context) (InputTypeDefID, error) {
 	var response InputTypeDefID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -3696,13 +3587,12 @@ func (r *InputTypeDef) Name(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // A definition of a custom interface defined in a Module.
 type InterfaceTypeDef struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	description      *string
 	id               *InterfaceTypeDefID
@@ -3720,7 +3610,7 @@ func (r *InterfaceTypeDef) Description(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Functions defined on this interface, if any.
@@ -3738,8 +3628,7 @@ func (r *InterfaceTypeDef) Functions(ctx context.Context) ([]Function, error) {
 
 		for i := range fields {
 			val := Function{id: &fields[i].Id}
-			val.Query = querybuilder.Query().Select("loadFunctionFromID").Arg("id", fields[i].Id)
-			val.Client = r.Client
+			val.Query = q.Root().Select("loadFunctionFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -3749,7 +3638,7 @@ func (r *InterfaceTypeDef) Functions(ctx context.Context) ([]Function, error) {
 
 	q = q.Bind(&response)
 
-	err := q.Execute(ctx, r.Client)
+	err := q.Execute(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -3767,7 +3656,7 @@ func (r *InterfaceTypeDef) ID(ctx context.Context) (InterfaceTypeDefID, error) {
 	var response InterfaceTypeDefID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -3807,7 +3696,7 @@ func (r *InterfaceTypeDef) Name(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // If this InterfaceTypeDef is associated with a Module, the name of the module. Unset otherwise.
@@ -3820,13 +3709,12 @@ func (r *InterfaceTypeDef) SourceModuleName(ctx context.Context) (string, error)
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // A simple key value object that represents a label.
 type Label struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	id    *LabelID
 	name  *string
@@ -3843,7 +3731,7 @@ func (r *Label) ID(ctx context.Context) (LabelID, error) {
 	var response LabelID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -3883,7 +3771,7 @@ func (r *Label) Name(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // The label value.
@@ -3896,13 +3784,12 @@ func (r *Label) Value(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // A definition of a list type in a Module.
 type ListTypeDef struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	id *ListTypeDefID
 }
@@ -3912,8 +3799,7 @@ func (r *ListTypeDef) ElementTypeDef() *TypeDef {
 	q := r.Query.Select("elementTypeDef")
 
 	return &TypeDef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -3927,7 +3813,7 @@ func (r *ListTypeDef) ID(ctx context.Context) (ListTypeDefID, error) {
 	var response ListTypeDefID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -3959,8 +3845,7 @@ func (r *ListTypeDef) MarshalJSON() ([]byte, error) {
 
 // Module source that that originates from a path locally relative to an arbitrary directory.
 type LocalModuleSource struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	id          *LocalModuleSourceID
 	rootSubpath *string
@@ -3971,8 +3856,7 @@ func (r *LocalModuleSource) ContextDirectory() *Directory {
 	q := r.Query.Select("contextDirectory")
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -3986,7 +3870,7 @@ func (r *LocalModuleSource) ID(ctx context.Context) (LocalModuleSourceID, error)
 	var response LocalModuleSourceID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -4026,13 +3910,12 @@ func (r *LocalModuleSource) RootSubpath(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // A Dagger module.
 type Module struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	description *string
 	id          *ModuleID
@@ -4064,8 +3947,7 @@ func (r *Module) Dependencies(ctx context.Context) ([]Module, error) {
 
 		for i := range fields {
 			val := Module{id: &fields[i].Id}
-			val.Query = querybuilder.Query().Select("loadModuleFromID").Arg("id", fields[i].Id)
-			val.Client = r.Client
+			val.Query = q.Root().Select("loadModuleFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -4075,7 +3957,7 @@ func (r *Module) Dependencies(ctx context.Context) ([]Module, error) {
 
 	q = q.Bind(&response)
 
-	err := q.Execute(ctx, r.Client)
+	err := q.Execute(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -4098,8 +3980,7 @@ func (r *Module) DependencyConfig(ctx context.Context) ([]ModuleDependency, erro
 
 		for i := range fields {
 			val := ModuleDependency{id: &fields[i].Id}
-			val.Query = querybuilder.Query().Select("loadModuleDependencyFromID").Arg("id", fields[i].Id)
-			val.Client = r.Client
+			val.Query = q.Root().Select("loadModuleDependencyFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -4109,7 +3990,7 @@ func (r *Module) DependencyConfig(ctx context.Context) ([]ModuleDependency, erro
 
 	q = q.Bind(&response)
 
-	err := q.Execute(ctx, r.Client)
+	err := q.Execute(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -4127,7 +4008,7 @@ func (r *Module) Description(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // The generated files and directories made on top of the module source's context directory.
@@ -4135,8 +4016,7 @@ func (r *Module) GeneratedContextDiff() *Directory {
 	q := r.Query.Select("generatedContextDiff")
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -4145,8 +4025,7 @@ func (r *Module) GeneratedContextDirectory() *Directory {
 	q := r.Query.Select("generatedContextDirectory")
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -4160,7 +4039,7 @@ func (r *Module) ID(ctx context.Context) (ModuleID, error) {
 	var response ModuleID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -4195,8 +4074,7 @@ func (r *Module) Initialize() *Module {
 	q := r.Query.Select("initialize")
 
 	return &Module{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -4215,8 +4093,7 @@ func (r *Module) Interfaces(ctx context.Context) ([]TypeDef, error) {
 
 		for i := range fields {
 			val := TypeDef{id: &fields[i].Id}
-			val.Query = querybuilder.Query().Select("loadTypeDefFromID").Arg("id", fields[i].Id)
-			val.Client = r.Client
+			val.Query = q.Root().Select("loadTypeDefFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -4226,7 +4103,7 @@ func (r *Module) Interfaces(ctx context.Context) ([]TypeDef, error) {
 
 	q = q.Bind(&response)
 
-	err := q.Execute(ctx, r.Client)
+	err := q.Execute(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -4244,7 +4121,7 @@ func (r *Module) Name(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Objects served by this module.
@@ -4262,8 +4139,7 @@ func (r *Module) Objects(ctx context.Context) ([]TypeDef, error) {
 
 		for i := range fields {
 			val := TypeDef{id: &fields[i].Id}
-			val.Query = querybuilder.Query().Select("loadTypeDefFromID").Arg("id", fields[i].Id)
-			val.Client = r.Client
+			val.Query = q.Root().Select("loadTypeDefFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -4273,7 +4149,7 @@ func (r *Module) Objects(ctx context.Context) ([]TypeDef, error) {
 
 	q = q.Bind(&response)
 
-	err := q.Execute(ctx, r.Client)
+	err := q.Execute(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -4286,8 +4162,7 @@ func (r *Module) Runtime() *Container {
 	q := r.Query.Select("runtime")
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -4301,7 +4176,7 @@ func (r *Module) SDK(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Serve a module's API in the current session.
@@ -4316,7 +4191,7 @@ func (r *Module) Serve(ctx context.Context) (Void, error) {
 	var response Void
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // The source for the module.
@@ -4324,8 +4199,7 @@ func (r *Module) Source() *ModuleSource {
 	q := r.Query.Select("source")
 
 	return &ModuleSource{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -4335,8 +4209,7 @@ func (r *Module) WithDescription(description string) *Module {
 	q = q.Arg("description", description)
 
 	return &Module{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -4347,8 +4220,7 @@ func (r *Module) WithInterface(iface *TypeDef) *Module {
 	q = q.Arg("iface", iface)
 
 	return &Module{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -4359,8 +4231,7 @@ func (r *Module) WithObject(object *TypeDef) *Module {
 	q = q.Arg("object", object)
 
 	return &Module{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -4371,15 +4242,13 @@ func (r *Module) WithSource(source *ModuleSource) *Module {
 	q = q.Arg("source", source)
 
 	return &Module{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
 // The configuration of dependency of a module.
 type ModuleDependency struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	id   *ModuleDependencyID
 	name *string
@@ -4395,7 +4264,7 @@ func (r *ModuleDependency) ID(ctx context.Context) (ModuleDependencyID, error) {
 	var response ModuleDependencyID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -4435,7 +4304,7 @@ func (r *ModuleDependency) Name(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // The source for the dependency module.
@@ -4443,15 +4312,13 @@ func (r *ModuleDependency) Source() *ModuleSource {
 	q := r.Query.Select("source")
 
 	return &ModuleSource{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
 // The source needed to load and run a module, along with any metadata about the source such as versions/urls/etc.
 type ModuleSource struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	asString                     *string
 	configExists                 *bool
@@ -4477,8 +4344,7 @@ func (r *ModuleSource) AsGitSource() *GitModuleSource {
 	q := r.Query.Select("asGitSource")
 
 	return &GitModuleSource{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -4487,8 +4353,7 @@ func (r *ModuleSource) AsLocalSource() *LocalModuleSource {
 	q := r.Query.Select("asLocalSource")
 
 	return &LocalModuleSource{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -4497,8 +4362,7 @@ func (r *ModuleSource) AsModule() *Module {
 	q := r.Query.Select("asModule")
 
 	return &Module{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -4512,7 +4376,7 @@ func (r *ModuleSource) AsString(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Returns whether the module source has a configuration file.
@@ -4525,7 +4389,7 @@ func (r *ModuleSource) ConfigExists(ctx context.Context) (bool, error) {
 	var response bool
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // The directory containing everything needed to load load and use the module.
@@ -4533,8 +4397,7 @@ func (r *ModuleSource) ContextDirectory() *Directory {
 	q := r.Query.Select("contextDirectory")
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -4553,8 +4416,7 @@ func (r *ModuleSource) Dependencies(ctx context.Context) ([]ModuleDependency, er
 
 		for i := range fields {
 			val := ModuleDependency{id: &fields[i].Id}
-			val.Query = querybuilder.Query().Select("loadModuleDependencyFromID").Arg("id", fields[i].Id)
-			val.Client = r.Client
+			val.Query = q.Root().Select("loadModuleDependencyFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -4564,7 +4426,7 @@ func (r *ModuleSource) Dependencies(ctx context.Context) ([]ModuleDependency, er
 
 	q = q.Bind(&response)
 
-	err := q.Execute(ctx, r.Client)
+	err := q.Execute(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -4578,8 +4440,7 @@ func (r *ModuleSource) Directory(path string) *Directory {
 	q = q.Arg("path", path)
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -4593,7 +4454,7 @@ func (r *ModuleSource) ID(ctx context.Context) (ModuleSourceID, error) {
 	var response ModuleSourceID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -4633,7 +4494,7 @@ func (r *ModuleSource) Kind(ctx context.Context) (ModuleSourceKind, error) {
 	var response ModuleSourceKind
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // If set, the name of the module this source references, including any overrides at runtime by callers.
@@ -4646,7 +4507,7 @@ func (r *ModuleSource) ModuleName(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // The original name of the module this source references, as defined in the module configuration.
@@ -4659,7 +4520,7 @@ func (r *ModuleSource) ModuleOriginalName(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // The path to the module source's context directory on the caller's filesystem. Only valid for local sources.
@@ -4672,7 +4533,7 @@ func (r *ModuleSource) ResolveContextPathFromCaller(ctx context.Context) (string
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Resolve the provided module source arg as a dependency relative to this module source.
@@ -4682,8 +4543,7 @@ func (r *ModuleSource) ResolveDependency(dep *ModuleSource) *ModuleSource {
 	q = q.Arg("dep", dep)
 
 	return &ModuleSource{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -4692,8 +4552,7 @@ func (r *ModuleSource) ResolveFromCaller() *ModuleSource {
 	q := r.Query.Select("resolveFromCaller")
 
 	return &ModuleSource{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -4707,7 +4566,7 @@ func (r *ModuleSource) SourceRootSubpath(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // The path relative to context of the module implementation source code.
@@ -4720,7 +4579,7 @@ func (r *ModuleSource) SourceSubpath(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Update the module source with a new context directory. Only valid for local sources.
@@ -4730,8 +4589,7 @@ func (r *ModuleSource) WithContextDirectory(dir *Directory) *ModuleSource {
 	q = q.Arg("dir", dir)
 
 	return &ModuleSource{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -4741,8 +4599,7 @@ func (r *ModuleSource) WithDependencies(dependencies []*ModuleDependency) *Modul
 	q = q.Arg("dependencies", dependencies)
 
 	return &ModuleSource{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -4752,8 +4609,7 @@ func (r *ModuleSource) WithName(name string) *ModuleSource {
 	q = q.Arg("name", name)
 
 	return &ModuleSource{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -4763,8 +4619,7 @@ func (r *ModuleSource) WithSDK(sdk string) *ModuleSource {
 	q = q.Arg("sdk", sdk)
 
 	return &ModuleSource{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -4774,15 +4629,13 @@ func (r *ModuleSource) WithSourceSubpath(path string) *ModuleSource {
 	q = q.Arg("path", path)
 
 	return &ModuleSource{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
 // A definition of a custom object defined in a Module.
 type ObjectTypeDef struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	description      *string
 	id               *ObjectTypeDefID
@@ -4795,8 +4648,7 @@ func (r *ObjectTypeDef) Constructor() *Function {
 	q := r.Query.Select("constructor")
 
 	return &Function{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -4810,7 +4662,7 @@ func (r *ObjectTypeDef) Description(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Static fields defined on this object, if any.
@@ -4828,8 +4680,7 @@ func (r *ObjectTypeDef) Fields(ctx context.Context) ([]FieldTypeDef, error) {
 
 		for i := range fields {
 			val := FieldTypeDef{id: &fields[i].Id}
-			val.Query = querybuilder.Query().Select("loadFieldTypeDefFromID").Arg("id", fields[i].Id)
-			val.Client = r.Client
+			val.Query = q.Root().Select("loadFieldTypeDefFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -4839,7 +4690,7 @@ func (r *ObjectTypeDef) Fields(ctx context.Context) ([]FieldTypeDef, error) {
 
 	q = q.Bind(&response)
 
-	err := q.Execute(ctx, r.Client)
+	err := q.Execute(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -4862,8 +4713,7 @@ func (r *ObjectTypeDef) Functions(ctx context.Context) ([]Function, error) {
 
 		for i := range fields {
 			val := Function{id: &fields[i].Id}
-			val.Query = querybuilder.Query().Select("loadFunctionFromID").Arg("id", fields[i].Id)
-			val.Client = r.Client
+			val.Query = q.Root().Select("loadFunctionFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -4873,7 +4723,7 @@ func (r *ObjectTypeDef) Functions(ctx context.Context) ([]Function, error) {
 
 	q = q.Bind(&response)
 
-	err := q.Execute(ctx, r.Client)
+	err := q.Execute(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -4891,7 +4741,7 @@ func (r *ObjectTypeDef) ID(ctx context.Context) (ObjectTypeDefID, error) {
 	var response ObjectTypeDefID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -4931,7 +4781,7 @@ func (r *ObjectTypeDef) Name(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // If this ObjectTypeDef is associated with a Module, the name of the module. Unset otherwise.
@@ -4944,13 +4794,12 @@ func (r *ObjectTypeDef) SourceModuleName(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // A port exposed by a container.
 type Port struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	description                 *string
 	experimentalSkipHealthcheck *bool
@@ -4969,7 +4818,7 @@ func (r *Port) Description(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Skip the health check when run as a service.
@@ -4982,7 +4831,7 @@ func (r *Port) ExperimentalSkipHealthcheck(ctx context.Context) (bool, error) {
 	var response bool
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // A unique identifier for this Port.
@@ -4995,7 +4844,7 @@ func (r *Port) ID(ctx context.Context) (PortID, error) {
 	var response PortID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -5035,7 +4884,7 @@ func (r *Port) Port(ctx context.Context) (int, error) {
 	var response int
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // The transport layer protocol.
@@ -5048,7 +4897,7 @@ func (r *Port) Protocol(ctx context.Context) (NetworkProtocol, error) {
 	var response NetworkProtocol
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 type WithClientFunc func(r *Client) *Client
@@ -5069,8 +4918,7 @@ func (r *Client) Blob(digest string, size int, mediaType string, uncompressed st
 	q = q.Arg("uncompressed", uncompressed)
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5080,8 +4928,7 @@ func (r *Client) CacheVolume(key string) *CacheVolume {
 	q = q.Arg("key", key)
 
 	return &CacheVolume{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5093,7 +4940,7 @@ func (r *Client) CheckVersionCompatibility(ctx context.Context, version string) 
 	var response bool
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // ContainerOpts contains options for Client.Container
@@ -5121,8 +4968,7 @@ func (r *Client) Container(opts ...ContainerOpts) *Container {
 	}
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5133,8 +4979,7 @@ func (r *Client) CurrentFunctionCall() *FunctionCall {
 	q := r.Query.Select("currentFunctionCall")
 
 	return &FunctionCall{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5143,8 +4988,7 @@ func (r *Client) CurrentModule() *CurrentModule {
 	q := r.Query.Select("currentModule")
 
 	return &CurrentModule{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5163,8 +5007,7 @@ func (r *Client) CurrentTypeDefs(ctx context.Context) ([]TypeDef, error) {
 
 		for i := range fields {
 			val := TypeDef{id: &fields[i].Id}
-			val.Query = querybuilder.Query().Select("loadTypeDefFromID").Arg("id", fields[i].Id)
-			val.Client = r.Client
+			val.Query = q.Root().Select("loadTypeDefFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -5174,7 +5017,7 @@ func (r *Client) CurrentTypeDefs(ctx context.Context) ([]TypeDef, error) {
 
 	q = q.Bind(&response)
 
-	err := q.Execute(ctx, r.Client)
+	err := q.Execute(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -5189,7 +5032,7 @@ func (r *Client) DefaultPlatform(ctx context.Context) (Platform, error) {
 	var response Platform
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // DirectoryOpts contains options for Client.Directory
@@ -5209,8 +5052,7 @@ func (r *Client) Directory(opts ...DirectoryOpts) *Directory {
 	}
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5220,8 +5062,7 @@ func (r *Client) File(id FileID) *File {
 	q = q.Arg("id", id)
 
 	return &File{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5233,8 +5074,7 @@ func (r *Client) Function(name string, returnType *TypeDef) *Function {
 	q = q.Arg("returnType", returnType)
 
 	return &Function{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5245,8 +5085,7 @@ func (r *Client) GeneratedCode(code *Directory) *GeneratedCode {
 	q = q.Arg("code", code)
 
 	return &GeneratedCode{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5286,8 +5125,7 @@ func (r *Client) Git(url string, opts ...GitOpts) *GitRepository {
 	q = q.Arg("url", url)
 
 	return &GitRepository{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5296,8 +5134,7 @@ func (r *Client) Host() *Host {
 	q := r.Query.Select("host")
 
 	return &Host{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5319,8 +5156,7 @@ func (r *Client) HTTP(url string, opts ...HTTPOpts) *File {
 	q = q.Arg("url", url)
 
 	return &File{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5330,8 +5166,7 @@ func (r *Client) LoadCacheVolumeFromID(id CacheVolumeID) *CacheVolume {
 	q = q.Arg("id", id)
 
 	return &CacheVolume{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5341,8 +5176,7 @@ func (r *Client) LoadContainerFromID(id ContainerID) *Container {
 	q = q.Arg("id", id)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5352,8 +5186,7 @@ func (r *Client) LoadCurrentModuleFromID(id CurrentModuleID) *CurrentModule {
 	q = q.Arg("id", id)
 
 	return &CurrentModule{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5363,8 +5196,7 @@ func (r *Client) LoadDirectoryFromID(id DirectoryID) *Directory {
 	q = q.Arg("id", id)
 
 	return &Directory{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5374,8 +5206,7 @@ func (r *Client) LoadEnvVariableFromID(id EnvVariableID) *EnvVariable {
 	q = q.Arg("id", id)
 
 	return &EnvVariable{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5385,8 +5216,7 @@ func (r *Client) LoadFieldTypeDefFromID(id FieldTypeDefID) *FieldTypeDef {
 	q = q.Arg("id", id)
 
 	return &FieldTypeDef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5396,8 +5226,7 @@ func (r *Client) LoadFileFromID(id FileID) *File {
 	q = q.Arg("id", id)
 
 	return &File{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5407,8 +5236,7 @@ func (r *Client) LoadFunctionArgFromID(id FunctionArgID) *FunctionArg {
 	q = q.Arg("id", id)
 
 	return &FunctionArg{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5418,8 +5246,7 @@ func (r *Client) LoadFunctionCallArgValueFromID(id FunctionCallArgValueID) *Func
 	q = q.Arg("id", id)
 
 	return &FunctionCallArgValue{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5429,8 +5256,7 @@ func (r *Client) LoadFunctionCallFromID(id FunctionCallID) *FunctionCall {
 	q = q.Arg("id", id)
 
 	return &FunctionCall{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5440,8 +5266,7 @@ func (r *Client) LoadFunctionFromID(id FunctionID) *Function {
 	q = q.Arg("id", id)
 
 	return &Function{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5451,8 +5276,7 @@ func (r *Client) LoadGeneratedCodeFromID(id GeneratedCodeID) *GeneratedCode {
 	q = q.Arg("id", id)
 
 	return &GeneratedCode{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5462,8 +5286,7 @@ func (r *Client) LoadGitModuleSourceFromID(id GitModuleSourceID) *GitModuleSourc
 	q = q.Arg("id", id)
 
 	return &GitModuleSource{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5473,8 +5296,7 @@ func (r *Client) LoadGitRefFromID(id GitRefID) *GitRef {
 	q = q.Arg("id", id)
 
 	return &GitRef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5484,8 +5306,7 @@ func (r *Client) LoadGitRepositoryFromID(id GitRepositoryID) *GitRepository {
 	q = q.Arg("id", id)
 
 	return &GitRepository{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5495,8 +5316,7 @@ func (r *Client) LoadHostFromID(id HostID) *Host {
 	q = q.Arg("id", id)
 
 	return &Host{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5506,8 +5326,7 @@ func (r *Client) LoadInputTypeDefFromID(id InputTypeDefID) *InputTypeDef {
 	q = q.Arg("id", id)
 
 	return &InputTypeDef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5517,8 +5336,7 @@ func (r *Client) LoadInterfaceTypeDefFromID(id InterfaceTypeDefID) *InterfaceTyp
 	q = q.Arg("id", id)
 
 	return &InterfaceTypeDef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5528,8 +5346,7 @@ func (r *Client) LoadLabelFromID(id LabelID) *Label {
 	q = q.Arg("id", id)
 
 	return &Label{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5539,8 +5356,7 @@ func (r *Client) LoadListTypeDefFromID(id ListTypeDefID) *ListTypeDef {
 	q = q.Arg("id", id)
 
 	return &ListTypeDef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5550,8 +5366,7 @@ func (r *Client) LoadLocalModuleSourceFromID(id LocalModuleSourceID) *LocalModul
 	q = q.Arg("id", id)
 
 	return &LocalModuleSource{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5561,8 +5376,7 @@ func (r *Client) LoadModuleDependencyFromID(id ModuleDependencyID) *ModuleDepend
 	q = q.Arg("id", id)
 
 	return &ModuleDependency{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5572,8 +5386,7 @@ func (r *Client) LoadModuleFromID(id ModuleID) *Module {
 	q = q.Arg("id", id)
 
 	return &Module{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5583,8 +5396,7 @@ func (r *Client) LoadModuleSourceFromID(id ModuleSourceID) *ModuleSource {
 	q = q.Arg("id", id)
 
 	return &ModuleSource{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5594,8 +5406,7 @@ func (r *Client) LoadObjectTypeDefFromID(id ObjectTypeDefID) *ObjectTypeDef {
 	q = q.Arg("id", id)
 
 	return &ObjectTypeDef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5605,8 +5416,7 @@ func (r *Client) LoadPortFromID(id PortID) *Port {
 	q = q.Arg("id", id)
 
 	return &Port{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5616,8 +5426,7 @@ func (r *Client) LoadSecretFromID(id SecretID) *Secret {
 	q = q.Arg("id", id)
 
 	return &Secret{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5627,8 +5436,7 @@ func (r *Client) LoadServiceFromID(id ServiceID) *Service {
 	q = q.Arg("id", id)
 
 	return &Service{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5638,8 +5446,7 @@ func (r *Client) LoadSocketFromID(id SocketID) *Socket {
 	q = q.Arg("id", id)
 
 	return &Socket{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5649,8 +5456,7 @@ func (r *Client) LoadTerminalFromID(id TerminalID) *Terminal {
 	q = q.Arg("id", id)
 
 	return &Terminal{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5660,8 +5466,7 @@ func (r *Client) LoadTypeDefFromID(id TypeDefID) *TypeDef {
 	q = q.Arg("id", id)
 
 	return &TypeDef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5670,8 +5475,7 @@ func (r *Client) Module() *Module {
 	q := r.Query.Select("module")
 
 	return &Module{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5694,8 +5498,7 @@ func (r *Client) ModuleDependency(source *ModuleSource, opts ...ModuleDependency
 	q = q.Arg("source", source)
 
 	return &ModuleDependency{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5717,8 +5520,7 @@ func (r *Client) ModuleSource(refString string, opts ...ModuleSourceOpts) *Modul
 	q = q.Arg("refString", refString)
 
 	return &ModuleSource{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5746,8 +5548,7 @@ func (r *Client) Pipeline(name string, opts ...PipelineOpts) *Client {
 	q = q.Arg("name", name)
 
 	return &Client{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5757,8 +5558,7 @@ func (r *Client) Secret(name string) *Secret {
 	q = q.Arg("name", name)
 
 	return &Secret{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5771,8 +5571,7 @@ func (r *Client) SetSecret(name string, plaintext string) *Secret {
 	q = q.Arg("plaintext", plaintext)
 
 	return &Secret{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5784,8 +5583,7 @@ func (r *Client) Socket(id SocketID) *Socket {
 	q = q.Arg("id", id)
 
 	return &Socket{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -5794,15 +5592,13 @@ func (r *Client) TypeDef() *TypeDef {
 	q := r.Query.Select("typeDef")
 
 	return &TypeDef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
 // A reference to a secret value, which can be handled more safely than the value itself.
 type Secret struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	id        *SecretID
 	plaintext *string
@@ -5818,7 +5614,7 @@ func (r *Secret) ID(ctx context.Context) (SecretID, error) {
 	var response SecretID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -5858,13 +5654,12 @@ func (r *Secret) Plaintext(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // A content-addressed service providing TCP connectivity.
 type Service struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	endpoint *string
 	hostname *string
@@ -5906,7 +5701,7 @@ func (r *Service) Endpoint(ctx context.Context, opts ...ServiceEndpointOpts) (st
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Retrieves a hostname which can be used by clients to reach this container.
@@ -5919,7 +5714,7 @@ func (r *Service) Hostname(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // A unique identifier for this Service.
@@ -5932,7 +5727,7 @@ func (r *Service) ID(ctx context.Context) (ServiceID, error) {
 	var response ServiceID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -5977,8 +5772,7 @@ func (r *Service) Ports(ctx context.Context) ([]Port, error) {
 
 		for i := range fields {
 			val := Port{id: &fields[i].Id}
-			val.Query = querybuilder.Query().Select("loadPortFromID").Arg("id", fields[i].Id)
-			val.Client = r.Client
+			val.Query = q.Root().Select("loadPortFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -5988,7 +5782,7 @@ func (r *Service) Ports(ctx context.Context) ([]Port, error) {
 
 	q = q.Bind(&response)
 
-	err := q.Execute(ctx, r.Client)
+	err := q.Execute(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -6002,7 +5796,7 @@ func (r *Service) Ports(ctx context.Context) ([]Port, error) {
 func (r *Service) Start(ctx context.Context) (*Service, error) {
 	q := r.Query.Select("start")
 
-	return r, q.Execute(ctx, r.Client)
+	return r, q.Execute(ctx)
 }
 
 // ServiceStopOpts contains options for Service.Stop
@@ -6021,7 +5815,7 @@ func (r *Service) Stop(ctx context.Context, opts ...ServiceStopOpts) (*Service, 
 		}
 	}
 
-	return r, q.Execute(ctx, r.Client)
+	return r, q.Execute(ctx)
 }
 
 // ServiceUpOpts contains options for Service.Up
@@ -6054,13 +5848,12 @@ func (r *Service) Up(ctx context.Context, opts ...ServiceUpOpts) (Void, error) {
 	var response Void
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // A Unix or TCP/IP socket that can be mounted into a container.
 type Socket struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	id *SocketID
 }
@@ -6075,7 +5868,7 @@ func (r *Socket) ID(ctx context.Context) (SocketID, error) {
 	var response SocketID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -6107,8 +5900,7 @@ func (r *Socket) MarshalJSON() ([]byte, error) {
 
 // An interactive terminal that clients can connect to.
 type Terminal struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	id                *TerminalID
 	websocketEndpoint *string
@@ -6124,7 +5916,7 @@ func (r *Terminal) ID(ctx context.Context) (TerminalID, error) {
 	var response TerminalID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -6164,13 +5956,12 @@ func (r *Terminal) WebsocketEndpoint(ctx context.Context) (string, error) {
 	var response string
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // A definition of a parameter or return type in a Module.
 type TypeDef struct {
-	Query  *querybuilder.Selection
-	Client graphql.Client
+	Query *querybuilder.Selection
 
 	id       *TypeDefID
 	kind     *TypeDefKind
@@ -6190,8 +5981,7 @@ func (r *TypeDef) AsInput() *InputTypeDef {
 	q := r.Query.Select("asInput")
 
 	return &InputTypeDef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -6200,8 +5990,7 @@ func (r *TypeDef) AsInterface() *InterfaceTypeDef {
 	q := r.Query.Select("asInterface")
 
 	return &InterfaceTypeDef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -6210,8 +5999,7 @@ func (r *TypeDef) AsList() *ListTypeDef {
 	q := r.Query.Select("asList")
 
 	return &ListTypeDef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -6220,8 +6008,7 @@ func (r *TypeDef) AsObject() *ObjectTypeDef {
 	q := r.Query.Select("asObject")
 
 	return &ObjectTypeDef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -6235,7 +6022,7 @@ func (r *TypeDef) ID(ctx context.Context) (TypeDefID, error) {
 	var response TypeDefID
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // XXX_GraphQLType is an internal function. It returns the native GraphQL type name
@@ -6275,7 +6062,7 @@ func (r *TypeDef) Kind(ctx context.Context) (TypeDefKind, error) {
 	var response TypeDefKind
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Whether this type can be set to null. Defaults to false.
@@ -6288,7 +6075,7 @@ func (r *TypeDef) Optional(ctx context.Context) (bool, error) {
 	var response bool
 
 	q = q.Bind(&response)
-	return response, q.Execute(ctx, r.Client)
+	return response, q.Execute(ctx)
 }
 
 // Adds a function for constructing a new instance of an Object TypeDef, failing if the type is not an object.
@@ -6298,8 +6085,7 @@ func (r *TypeDef) WithConstructor(function *Function) *TypeDef {
 	q = q.Arg("function", function)
 
 	return &TypeDef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -6323,8 +6109,7 @@ func (r *TypeDef) WithField(name string, typeDef *TypeDef, opts ...TypeDefWithFi
 	q = q.Arg("typeDef", typeDef)
 
 	return &TypeDef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -6335,8 +6120,7 @@ func (r *TypeDef) WithFunction(function *Function) *TypeDef {
 	q = q.Arg("function", function)
 
 	return &TypeDef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -6357,8 +6141,7 @@ func (r *TypeDef) WithInterface(name string, opts ...TypeDefWithInterfaceOpts) *
 	q = q.Arg("name", name)
 
 	return &TypeDef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -6368,8 +6151,7 @@ func (r *TypeDef) WithKind(kind TypeDefKind) *TypeDef {
 	q = q.Arg("kind", kind)
 
 	return &TypeDef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -6380,8 +6162,7 @@ func (r *TypeDef) WithListOf(elementType *TypeDef) *TypeDef {
 	q = q.Arg("elementType", elementType)
 
 	return &TypeDef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -6404,8 +6185,7 @@ func (r *TypeDef) WithObject(name string, opts ...TypeDefWithObjectOpts) *TypeDe
 	q = q.Arg("name", name)
 
 	return &TypeDef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 
@@ -6415,8 +6195,7 @@ func (r *TypeDef) WithOptional(optional bool) *TypeDef {
 	q = q.Arg("optional", optional)
 
 	return &TypeDef{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 

--- a/sdk/go/querybuilder/querybuilder.go
+++ b/sdk/go/querybuilder/querybuilder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"runtime/debug"
 	"strings"
 	"sync"
 
@@ -22,6 +23,8 @@ type Selection struct {
 	bind  interface{}
 
 	prev *Selection
+
+	client graphql.Client
 }
 
 func (s *Selection) path() []*Selection {
@@ -33,11 +36,18 @@ func (s *Selection) path() []*Selection {
 	return selections
 }
 
+func (s *Selection) Root() *Selection {
+	return &Selection{
+		client: s.client,
+	}
+}
+
 func (s *Selection) SelectWithAlias(alias, name string) *Selection {
 	sel := &Selection{
-		name:  name,
-		prev:  s,
-		alias: alias,
+		name:   name,
+		prev:   s,
+		alias:  alias,
+		client: s.client,
 	}
 	return sel
 }
@@ -147,14 +157,25 @@ func (s *Selection) unpack(data interface{}) error {
 	return nil
 }
 
-func (s *Selection) Execute(ctx context.Context, c graphql.Client) error {
+func (s *Selection) Client(c graphql.Client) *Selection {
+	sel := *s
+	sel.client = c
+	return &sel
+}
+
+func (s *Selection) Execute(ctx context.Context) error {
+	if s.client == nil {
+		debug.PrintStack()
+		return fmt.Errorf("no client configured for selection")
+	}
+
 	query, err := s.Build(ctx)
 	if err != nil {
 		return err
 	}
 
 	var response any
-	err = c.MakeRequest(ctx,
+	err = s.client.MakeRequest(ctx,
 		&graphql.Request{
 			Query: query,
 		},


### PR DESCRIPTION
See discussion in discord: https://discord.com/channels/707636530424053791/1120503349599543376/1209815200023191662

https://github.com/dagger/dagger/pull/6680 made `Client` and `Query` reserved fields on all objects - but it's quite common to define `Client` on objects.

This patch is a little bit of a refactoring I've wanted to do for a while - it essentially allows binding clients to `querybuilder.Selection`s, which means we can pretty much do away with `Client`+`Query` combinations, now we only need to track `Query` (and the client gets automagically inherited).

We still have this issue for `Query`. Gonna keep thinking about this one.