### PR TITLE
fix(ts): correctly return alias state

### DIFF
--- a/sdk/typescript/introspector/test/invoke.spec.ts
+++ b/sdk/typescript/introspector/test/invoke.spec.ts
@@ -262,17 +262,68 @@ describe("Invoke typescript function", function () {
 
       const scanResult = scan(files)
 
-      // Mocking the fetch from the dagger API
-      const input = {
-        parentName: "HelloWorld", // HelloWorld
-        fnName: "greet", // helloWorld
-        parentArgs: {},
-        fnArgs: { name: "Dagger" },
-      }
+      // We wrap the execution into a Dagger connection
+      await connection(async () => {
+        const constructorInput = {
+          parentName: "HelloWorld", // HelloWorld
+          fnName: "", // call constructor
+          parentArgs: {
+            prefix: "test",
+          },
+          fnArgs: {},
+        }
 
-      const result = await invoke(scanResult, input)
+        const constructorResult = await invoke(scanResult, constructorInput)
 
-      assert.equal("hello Dagger", result)
+        assert.equal("test", constructorResult.prefix)
+        assert.notStrictEqual(undefined, constructorResult.container)
+
+        // Mocking the fetch from the dagger API
+        const input = {
+          parentName: "HelloWorld", // HelloWorld
+          fnName: "greet", // helloWorld
+          parentArgs: JSON.parse(JSON.stringify(constructorResult)),
+          fnArgs: { name: "Dagger" },
+        }
+
+        const result = await invoke(scanResult, input)
+        assert.equal("hello Dagger", result)
+      })
+    })
+
+    it("Should correctly invoke hello world with custom prefix", async function () {
+      const files = await listFiles(`${rootDirectory}/alias`)
+
+      // Load function
+      await load(files)
+
+      const scanResult = scan(files)
+      await connection(async () => {
+        const constructorInput = {
+          parentName: "HelloWorld", // HelloWorld
+          fnName: "", // call constructor
+          parentArgs: {
+            prefix: "test",
+          },
+          fnArgs: {},
+        }
+
+        const constructorResult = await invoke(scanResult, constructorInput)
+
+        assert.equal("test", constructorResult.prefix)
+        assert.notStrictEqual(undefined, constructorResult.container)
+
+        // Mocking the fetch from the dagger API
+        const input = {
+          parentName: "HelloWorld", // HelloWorld
+          fnName: "customGreet", // helloWorld
+          parentArgs: JSON.parse(JSON.stringify(constructorResult)),
+          fnArgs: { name: "Dagger" },
+        }
+
+        const result = await invoke(scanResult, input)
+        assert.equal("test Dagger", result)
+      })
     })
   })
 })

--- a/sdk/typescript/introspector/test/scan.spec.ts
+++ b/sdk/typescript/introspector/test/scan.spec.ts
@@ -664,8 +664,40 @@ describe("scan static TypeScript", function () {
         HelloWorld: {
           name: "HelloWorld",
           description: "",
-          fields: {},
-          constructor: undefined,
+          fields: {
+            prefix: {
+              name: "gretingPrefix",
+              alias: "prefix",
+              typeDef: { kind: TypeDefKind.StringKind },
+              description: "",
+              isExposed: true,
+            },
+            container: {
+              name: "ctr",
+              alias: "container",
+              typeDef: {
+                kind: TypeDefKind.ObjectKind,
+                name: "Container",
+              },
+              description: "",
+              isExposed: true,
+            },
+          },
+          constructor: {
+            args: {
+              ctr: {
+                defaultValue: undefined,
+                description: "",
+                isVariadic: false,
+                name: "ctr",
+                optional: true,
+                typeDef: {
+                  kind: TypeDefKind.ObjectKind,
+                  name: "Container",
+                },
+              },
+            },
+          },
           methods: {
             testBar: {
               name: "bar",
@@ -721,6 +753,33 @@ describe("scan static TypeScript", function () {
                   isVariadic: false,
                 },
               },
+            },
+            customGreet: {
+              name: "customHelloWorld",
+              alias: "customGreet",
+              returnType: {
+                kind: TypeDefKind.StringKind,
+              },
+              description: "",
+              args: {
+                name: {
+                  name: "name",
+                  typeDef: { kind: TypeDefKind.StringKind },
+                  description: "",
+                  optional: false,
+                  defaultValue: undefined,
+                  isVariadic: false,
+                },
+              },
+            },
+            version: {
+              name: "displayVersion",
+              alias: "version",
+              returnType: {
+                kind: TypeDefKind.StringKind,
+              },
+              description: "",
+              args: {},
             },
           },
         },

--- a/sdk/typescript/introspector/test/testdata/alias/index.ts
+++ b/sdk/typescript/introspector/test/testdata/alias/index.ts
@@ -1,4 +1,5 @@
 import { func, object, field } from '../../../decorators/decorators.js'
+import { dag, Container } from '../../../../api/client.gen.js'
 
 @object()
 export class Bar {
@@ -21,6 +22,16 @@ export class Bar {
 
 @object()
 export class HelloWorld {
+    @field("prefix")
+    gretingPrefix = "test"
+
+    @field("container")
+    ctr: Container
+  
+    constructor(ctr?: Container) {
+      this.ctr = ctr ?? dag.container().from("alpine:3.14.0")
+    }
+
     @func('testBar')
     bar(): Bar {
         return new Bar()
@@ -30,9 +41,19 @@ export class HelloWorld {
     customBar(baz: string, foo: number): Bar {
         return new Bar(baz, foo)
     }
+  
+    @func("version")
+    async displayVersion(): Promise<string> {
+      return await this.ctr.withExec(["/bin/sh", "-c", "cat /etc/os-release | grep VERSION_ID"]).stdout()
+    }
 
     @func('greet')
     helloWorld(name: string): string {
         return `hello ${name}`
+    }
+
+    @func("customGreet")
+    customHelloWorld(name: string): string {
+        return `${this.gretingPrefix} ${name}`
     }
 }


### PR DESCRIPTION
There was an issue of serialization when the object has aliases in this state.
This PR fixes this and improve the alias testing with more cases.
Also fixes an issue with object state being serialized with non useful data.

*Note*:
- Correctly support array's result loading 
