### PR TITLE
Zenith: Update dagger init module for Go SDK

### DIFF
--- a/cmd/codegen/generator/go/generator.go
+++ b/cmd/codegen/generator/go/generator.go
@@ -333,9 +333,9 @@ func loadPackage(ctx context.Context, dir string) (*packages.Package, *token.Fil
 func (g *GoGenerator) baseModuleSource() string {
 	moduleStructName := strcase.ToCamel(g.Config.ModuleName)
 
-	return fmt.Sprintf(`// The %s module's short description
+	return fmt.Sprintf(`// The %[1]s module's short description
 //
-// The %s module's long description is here. It can span multiple lines and
+// The %[1]s module's long description is here. It can span multiple lines and
 // provides more detail about your module's usage.
 
 package main
@@ -344,16 +344,16 @@ import (
 	"context"
 )
 
-// Functions for working with %s
-type %s struct{}
+// Functions for working with %[1]s
+type %[1]s struct{}
 
 // Returns a container that echoes whatever string argument is provided
-func (m *%s) ContainerEcho(stringArg string) *Container {
+func (m *%[1]s) ContainerEcho(stringArg string) *Container {
 	return dag.Container().From("alpine:latest").WithExec([]string{"echo", stringArg})
 }
 
 // Returns lines that match a pattern in the files of the provided Directory
-func (m *%s) GrepDir(ctx context.Context, directoryArg *Directory, pattern string) (string, error) {
+func (m *%[1]s) GrepDir(ctx context.Context, directoryArg *Directory, pattern string) (string, error) {
 	return dag.Container().
 		From("alpine:latest").
 		WithMountedDirectory("/mnt", directoryArg).
@@ -361,5 +361,5 @@ func (m *%s) GrepDir(ctx context.Context, directoryArg *Directory, pattern strin
 		WithExec([]string{"grep", "-R", pattern, "."}).
 		Stdout(ctx)
 }
-`, moduleStructName, moduleStructName, moduleStructName, moduleStructName, moduleStructName, moduleStructName)
+`, moduleStructName)
 }

--- a/cmd/codegen/generator/go/generator.go
+++ b/cmd/codegen/generator/go/generator.go
@@ -333,20 +333,26 @@ func loadPackage(ctx context.Context, dir string) (*packages.Package, *token.Fil
 func (g *GoGenerator) baseModuleSource() string {
 	moduleStructName := strcase.ToCamel(g.Config.ModuleName)
 
-	return fmt.Sprintf(`package main
+	return fmt.Sprintf(`// The %s module's short description
+//
+// The %s module's long description is here. It can span multiple lines and
+// provides more detail about your module's usage.
+
+package main
 
 import (
 	"context"
 )
 
-type %s struct {}
+// Functions for working with %s
+type %s struct{}
 
-// example usage: "dagger call container-echo --string-arg yo stdout"
+// Returns a container that echoes whatever string argument is provided
 func (m *%s) ContainerEcho(stringArg string) *Container {
 	return dag.Container().From("alpine:latest").WithExec([]string{"echo", stringArg})
 }
 
-// example usage: "dagger call grep-dir --directory-arg . --pattern GrepDir"
+// Returns lines that match a pattern in the files of the provided Directory
 func (m *%s) GrepDir(ctx context.Context, directoryArg *Directory, pattern string) (string, error) {
 	return dag.Container().
 		From("alpine:latest").
@@ -355,6 +361,5 @@ func (m *%s) GrepDir(ctx context.Context, directoryArg *Directory, pattern strin
 		WithExec([]string{"grep", "-R", pattern, "."}).
 		Stdout(ctx)
 }
-
-`, moduleStructName, moduleStructName, moduleStructName)
+`, moduleStructName, moduleStructName, moduleStructName, moduleStructName, moduleStructName, moduleStructName)
 }

--- a/cmd/codegen/generator/go/generator.go
+++ b/cmd/codegen/generator/go/generator.go
@@ -333,10 +333,19 @@ func loadPackage(ctx context.Context, dir string) (*packages.Package, *token.Fil
 func (g *GoGenerator) baseModuleSource() string {
 	moduleStructName := strcase.ToCamel(g.Config.ModuleName)
 
-	return fmt.Sprintf(`// The %[1]s module's short description
+	return fmt.Sprintf(`// A generated module for %[1]s functions
 //
-// The %[1]s module's long description is here. It can span multiple lines and
-// provides more detail about your module's usage.
+// This module has been generated via dagger init and serves as a reference to
+// basic module structure as you get started with Dagger.
+//
+// Two functions have been pre-created. You can modify, delete, or add to them,
+// as needed. They demonstrate usage of arguments and return types using simple
+// echo and grep commands. The functions can be called from the dagger CLI or
+// from one of the SDKs.
+//
+// The first line in this comment block is a short description line and the
+// rest is a long description with more detail on the module's purpose or usage,
+// if appropriate. All modules should have a short description.
 
 package main
 
@@ -344,7 +353,6 @@ import (
 	"context"
 )
 
-// Functions for working with %[1]s
 type %[1]s struct{}
 
 // Returns a container that echoes whatever string argument is provided


### PR DESCRIPTION
Just focused on keeping function signatures the same for now (as they're used in docs and smoke tests) and adding short and long descriptions and appropriate comments.

The generated code in the `main.go` is unaltered after running `go fmt` on it, so it's got that going for it :)
