### PR TITLE
fix(ts): add `node_modules` to ignored files

### DIFF
--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -75,6 +75,7 @@ func (t *TypeScriptSdk) Codegen(ctx context.Context, modSource *ModuleSource, in
 		}).
 		WithVCSIgnoredPaths([]string{
 			genDir,
+			"node_modules/**",
 		}), nil
 }
 


### PR DESCRIPTION
The generated `.gitignore` did not include `node_modules` in the ignored files:

```txt
/sdk
```

This PR fixes it by including it in the module runtime:

```txt
/sdk
/node_modules/**
```