### PR TITLE
fix listen disable-host-read-write with modules

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -4710,6 +4710,116 @@ func TestModuleHostError(t *testing.T) {
 	require.ErrorContains(t, err, "dag.Host undefined")
 }
 
+func TestModuleDaggerListen(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with mod", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		modDir := t.TempDir()
+		_, err := hostDaggerExec(ctx, t, modDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")
+		require.NoError(t, err)
+
+		listenCmd := hostDaggerCommand(ctx, t, modDir, "--debug", "listen", "--listen", "127.0.0.1:12456")
+		listenCmd.Env = append(listenCmd.Env, os.Environ()...)
+		listenCmd.Env = append(listenCmd.Env, "DAGGER_SESSION_TOKEN=lol")
+
+		go func() {
+			out, _ := listenCmd.CombinedOutput()
+			t.Logf("listen output: %s", string(out))
+		}()
+		var out []byte
+		for range limitTicker(time.Second, 60) {
+			callCmd := hostDaggerCommand(ctx, t, modDir, "--debug", "call", "container-echo", "--string-arg=hi", "stdout")
+			copy(callCmd.Env, os.Environ())
+			callCmd.Env = append(callCmd.Env, "DAGGER_SESSION_PORT=12456", "DAGGER_SESSION_TOKEN=lol")
+			out, err = callCmd.CombinedOutput()
+			if err == nil {
+				lines := strings.Split(string(out), "\n")
+				lastLine := lines[len(lines)-2]
+				require.Equal(t, "hi", lastLine)
+				return
+			}
+			time.Sleep(1 * time.Second)
+		}
+		t.Fatalf("failed to call container-echo: %s err: %v", string(out), err)
+	})
+
+	t.Run("disable read write", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("with mod", func(t *testing.T) {
+			// mod load fails but should still be able to query base api
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+
+			modDir := t.TempDir()
+			_, err := hostDaggerExec(ctx, t, modDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")
+			require.NoError(t, err)
+
+			listenCmd := hostDaggerCommand(ctx, t, modDir, "--debug", "listen", "--disable-host-read-write", "--listen", "127.0.0.1:12457")
+			listenCmd.Env = append(listenCmd.Env, os.Environ()...)
+			listenCmd.Env = append(listenCmd.Env, "DAGGER_SESSION_TOKEN=lol")
+
+			go func() {
+				out, _ := listenCmd.CombinedOutput()
+				t.Logf("listen output: %s", string(out))
+			}()
+			var out []byte
+			for range limitTicker(time.Second, 60) {
+				callCmd := hostDaggerCommand(ctx, t, modDir, "--debug", "query")
+				callCmd.Stdin = strings.NewReader(`query{container{from(address:"alpine:3.18.6"){file(path:"/etc/alpine-release"){contents}}}}`)
+				callCmd.Env = append(callCmd.Env, os.Environ()...)
+				callCmd.Env = append(callCmd.Env, "DAGGER_SESSION_PORT=12457", "DAGGER_SESSION_TOKEN=lol")
+				out, err = callCmd.CombinedOutput()
+				if err == nil {
+					require.Contains(t, string(out), "3.18.6")
+					return
+				}
+				time.Sleep(1 * time.Second)
+			}
+			t.Fatalf("failed to call query: %s err: %v", string(out), err)
+		})
+
+		t.Run("without mod", func(t *testing.T) {
+			t.Parallel()
+
+			tmpdir := t.TempDir()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+
+			listenCmd := hostDaggerCommand(ctx, t, tmpdir, "--debug", "listen", "--disable-host-read-write", "--listen", "127.0.0.1:12458")
+			listenCmd.Env = append(listenCmd.Env, os.Environ()...)
+			listenCmd.Env = append(listenCmd.Env, "DAGGER_SESSION_TOKEN=lol")
+			go func() {
+				out, _ := listenCmd.CombinedOutput()
+				t.Logf("listen output: %s", string(out))
+			}()
+			var out []byte
+			var err error
+			for range limitTicker(time.Second, 60) {
+				callCmd := hostDaggerCommand(ctx, t, tmpdir, "--debug", "query")
+				callCmd.Stdin = strings.NewReader(`query{container{from(address:"alpine:3.18.6"){file(path:"/etc/alpine-release"){contents}}}}`)
+				callCmd.Env = append(callCmd.Env, os.Environ()...)
+				callCmd.Env = append(callCmd.Env, "DAGGER_SESSION_PORT=12458", "DAGGER_SESSION_TOKEN=lol")
+				out, err = callCmd.CombinedOutput()
+				if err == nil {
+					require.Contains(t, string(out), "3.18.6")
+					return
+				}
+				time.Sleep(1 * time.Second)
+			}
+			t.Fatalf("failed to call query: %s err: %v", string(out), err)
+		})
+	})
+}
+
 func daggerExec(args ...string) dagger.WithContainerFunc {
 	return func(c *dagger.Container) *dagger.Container {
 		return c.WithExec(append([]string{"dagger", "--debug"}, args...), dagger.ContainerWithExecOpts{

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"dagger.io/dagger"
 	"github.com/dagger/dagger/core"
@@ -285,4 +286,17 @@ func (s *safeBuffer) String() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.bu.String()
+}
+
+func limitTicker(interval time.Duration, limit int) <-chan time.Time {
+	ch := make(chan time.Time, limit)
+	ticker := time.NewTicker(interval)
+	go func() {
+		defer ticker.Stop()
+		defer close(ch)
+		for i := 0; i < limit; i++ {
+			ch <- <-ticker.C
+		}
+	}()
+	return ch
 }


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/6640

The behavior of dagger listen is supposed to be that it tries to load a local module if it exists but ignores any error and just operates without the module if it can't load one. This just fixes error handling in the case where `--disable-host-read-write` is enabled.