### PR TITLE
feat(ts): improve error displaying.

### DIFF
--- a/sdk/typescript/entrypoint/entrypoint.ts
+++ b/sdk/typescript/entrypoint/entrypoint.ts
@@ -52,12 +52,19 @@ export async function entrypoint() {
 
         await load(files)
 
-        result = await invoke(scanResult, {
-          parentName,
-          fnName,
-          parentArgs,
-          fnArgs: args,
-        })
+        try {
+          result = await invoke(scanResult, {
+            parentName,
+            fnName,
+            parentArgs,
+            fnArgs: args,
+          })
+        } catch (e) {
+          if (e instanceof Error) {
+            console.error(`${e.name}: ${e.message}`)
+          }
+          process.exit(1)
+        }
       }
 
       // If result is set, we stringify it

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -58,7 +58,9 @@ func (t *TypeScriptSdk) ModuleRuntime(ctx context.Context, modSource *ModuleSour
 		WithMountedFile(entrypointPath, ctr.Directory("/opt/bin").File(EntrypointExecutableFile)).
 		// need to specify --tsconfig because final runtime container will change working directory to a separate scratch
 		// dir, without this the paths mapped in the tsconfig.json will not be used and js module loading will fail
-		WithEntrypoint([]string{"tsx", "--tsconfig", tsConfigPath, entrypointPath}), nil
+		// need to specify --no-deprecation because the default package.json has no main field which triggers a warning
+		// not useful to display to the user.
+		WithEntrypoint([]string{"tsx", "--no-deprecation", "--tsconfig", tsConfigPath, entrypointPath}), nil
 }
 
 // Codegen returns the generated API client based on user's module


### PR DESCRIPTION
We display the error message instead of the whole stack trace so it's easier for the user to catch the error.

**Before**

```
(node:30) [DEP0128] DeprecationWarning: Invalid 'main' field in '/src/dagger-docs/error-handling/sdk/package.json' of 'dist/index.js'. Please either fix that or report it to the module author
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:30) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
/src/dagger-docs/error-handling/src/index.ts:9
      throw new Error("cannot divide by zero")
            ^


Error: cannot divide by zero
    at HelloWorld.divide (/src/dagger-docs/error-handling/src/index.ts:9:13)
    at Registry.getResult (/src/dagger-docs/error-handling/sdk/introspector/registry/registry.ts:131:26)
    at invoke (/src/dagger-docs/error-handling/sdk/entrypoint/invoke.ts:65:31)
    at LogOutput (/src/dagger-docs/error-handling/sdk/entrypoint/entrypoint.ts:55:18)
    at connection (/src/dagger-docs/error-handling/sdk/connect.ts:31:3)
    at entrypoint (/src/dagger-docs/error-handling/sdk/entrypoint/entrypoint.ts:24:3)

Node.js v21.3.0
```

**After**

```
Error: cannot divide by zero
```