### PR TITLE
CLI: remove experimental annotations and old commands

### DIFF
--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -12,50 +12,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// TODO: remove these ghost commands after next release (v0.9.8)
-var downloadCmd = &cobra.Command{
-	Use:                "download",
-	Short:              "Download an asset from module function",
-	Aliases:            []string{"export", "dl"},
-	Hidden:             true,
-	SilenceUsage:       true,
-	DisableFlagParsing: true,
-	Args: func(cmd *cobra.Command, args []string) error {
-		return fmt.Errorf(`%q has been replaced by "dagger call COMMANDS... --output=PATH"`, cmd.CommandPath())
-	},
-	Run: func(cmd *cobra.Command, args []string) {
-		// do nothing
-	},
-}
-
-var upCmd = &cobra.Command{
-	Use:                "up",
-	Short:              "Start a service and expose its ports to the host",
-	Hidden:             true,
-	SilenceUsage:       true,
-	DisableFlagParsing: true,
-	Args: func(cmd *cobra.Command, args []string) error {
-		return fmt.Errorf(`%q has been replaced by "dagger call COMMANDS... up"`, cmd.CommandPath())
-	},
-	Run: func(cmd *cobra.Command, args []string) {
-		// do nothing
-	},
-}
-
-var shellCmd = &cobra.Command{
-	Use:                "shell",
-	Short:              "Open a shell in a container",
-	Hidden:             true,
-	SilenceUsage:       true,
-	DisableFlagParsing: true,
-	Args: func(cmd *cobra.Command, args []string) error {
-		return fmt.Errorf(`%q has been replaced by "dagger call COMMANDS... shell"`, cmd.CommandPath())
-	},
-	Run: func(cmd *cobra.Command, args []string) {
-		// do nothing
-	},
-}
-
 var outputPath string
 var jsonOutput bool
 

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -204,9 +204,6 @@ func (fc *FuncCommand) Command() *cobra.Command {
 			Long:    fc.Long,
 			Example: fc.Example,
 			GroupID: moduleGroup.ID,
-			Annotations: map[string]string{
-				"experimental": "",
-			},
 
 			// We need to disable flag parsing because it'll act on --help
 			// and validate the args before we have a chance to add the

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -62,9 +62,6 @@ func init() {
 		modulePublishCmd,
 		sessionCmd(),
 		newGenCmd(),
-		downloadCmd,
-		upCmd,
-		shellCmd,
 	)
 
 	funcCmds.AddParent(rootCmd)

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -28,7 +28,7 @@ import (
 var (
 	moduleGroup = &cobra.Group{
 		ID:    "module",
-		Title: "Dagger Module Commands (Experimental)",
+		Title: "Dagger Module Commands",
 	}
 
 	moduleURL   string
@@ -78,74 +78,19 @@ func init() {
 	moduleDevelopCmd.PersistentFlags().AddFlagSet(moduleFlags)
 
 	configCmd.PersistentFlags().AddFlagSet(moduleFlags)
-	configCmd.AddCommand(oldInitCmd, oldInstallCmd, oldSyncCmd)
 	configCmd.AddGroup(moduleGroup)
 }
 
-var oldInitCmd = &cobra.Command{
-	Use:                "init",
-	Short:              "Initialize a new Dagger module",
-	Hidden:             true,
-	SilenceUsage:       true,
-	DisableFlagParsing: true,
-	Args: func(cmd *cobra.Command, args []string) error {
-		return fmt.Errorf(`"dagger mod init" has been replaced by "dagger init"`)
-	},
-	Run: func(cmd *cobra.Command, args []string) {
-		// do nothing
-	},
-}
-
-var oldInstallCmd = &cobra.Command{
-	Use:                "install",
-	Short:              "Add a new dependency to a Dagger module",
-	Hidden:             true,
-	SilenceUsage:       true,
-	DisableFlagParsing: true,
-	GroupID:            moduleGroup.ID,
-	Annotations: map[string]string{
-		"experimental": "true",
-	},
-	Args: func(cmd *cobra.Command, args []string) error {
-		return fmt.Errorf(`"dagger mod install" has been replaced by "dagger install"`)
-	},
-	Run: func(cmd *cobra.Command, args []string) {
-		// do nothing
-	},
-}
-
-var oldSyncCmd = &cobra.Command{
-	Use:          "sync",
-	Short:        "Setup or update all the resources needed to develop on a module locally",
-	Hidden:       true,
-	SilenceUsage: true,
-	GroupID:      moduleGroup.ID,
-	Annotations: map[string]string{
-		"experimental": "true",
-	},
-	DisableFlagParsing: true,
-	Args: func(cmd *cobra.Command, args []string) error {
-		return fmt.Errorf(`"dagger mod sync" has been replaced by "dagger develop"`)
-	},
-	Run: func(cmd *cobra.Command, args []string) {
-		// do nothing
-	},
-}
-
 var configCmd = &cobra.Command{
-	Use:     "config",
-	Aliases: []string{"mod"},
-	Short:   "Get or set the configuration of a Dagger module",
-	Long:    "Get or set the configuration of a Dagger module. By default, print the configuration of the specified module.",
+	Use:   "config",
+	Short: "Get or set the configuration of a Dagger module",
+	Long:  "Get or set the configuration of a Dagger module. By default, print the configuration of the specified module.",
 	Example: strings.TrimSpace(`
 dagger config -m /path/to/some/dir
 dagger config -m github.com/dagger/hello-dagger
 `,
 	),
 	GroupID: moduleGroup.ID,
-	Annotations: map[string]string{
-		"experimental": "true",
-	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 
@@ -213,10 +158,7 @@ The "--source" flag allows controlling the directory in which the actual module 
 `,
 	Example: "dagger init --name=hello --sdk=python --source=some/subdir",
 	GroupID: moduleGroup.ID,
-	Annotations: map[string]string{
-		"experimental": "true",
-	},
-	Args: cobra.MaximumNArgs(1),
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, extraArgs []string) (rerr error) {
 		ctx := cmd.Context()
 
@@ -307,10 +249,7 @@ var moduleInstallCmd = &cobra.Command{
 	// TODO: use example from a reference module, using a tag instead of commit
 	Example: "dagger install github.com/shykes/daggerverse/ttlsh@16e40ec244966e55e36a13cb6e1ff8023e1e1473",
 	GroupID: moduleGroup.ID,
-	Annotations: map[string]string{
-		"experimental": "true",
-	},
-	Args: cobra.ExactArgs(1),
+	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, extraArgs []string) (rerr error) {
 		ctx := cmd.Context()
 		return withEngineAndTUI(ctx, client.Params{}, func(ctx context.Context, engineClient *client.Client) (err error) {
@@ -435,9 +374,6 @@ If not updating source or SDK, this is only required for IDE auto-completion/LSP
 :::
 `,
 	GroupID: moduleGroup.ID,
-	Annotations: map[string]string{
-		"experimental": "true",
-	},
 	RunE: func(cmd *cobra.Command, extraArgs []string) (rerr error) {
 		ctx := cmd.Context()
 		return withEngineAndTUI(ctx, client.Params{}, func(ctx context.Context, engineClient *client.Client) (err error) {
@@ -528,9 +464,6 @@ forced), to avoid mistakingly depending on uncommitted files.
 		daDaggerverse,
 	),
 	GroupID: moduleGroup.ID,
-	Annotations: map[string]string{
-		"experimental": "true",
-	},
 	RunE: func(cmd *cobra.Command, extraArgs []string) (rerr error) {
 		ctx := cmd.Context()
 		return withEngineAndTUI(ctx, client.Params{}, func(ctx context.Context, engineClient *client.Client) (err error) {


### PR DESCRIPTION
In preparation for v0.10.0, we want to open up zenith commands.