### PR TITLE
chore: error out with too new go tooling

### DIFF
--- a/cmd/codegen/generator/go/generator.go
+++ b/cmd/codegen/generator/go/generator.go
@@ -37,6 +37,8 @@ const (
 	StarterTemplateFile = "main.go"
 )
 
+var goVersion = semver.MustParse(strings.TrimPrefix(runtime.Version(), "go"))
+
 type GoGenerator struct {
 	Config generator.Config
 }
@@ -151,7 +153,17 @@ func (g *GoGenerator) bootstrapMod(ctx context.Context, mfs *memfs.FS) (*Package
 		if err != nil {
 			return nil, false, fmt.Errorf("parse go.mod: %w", err)
 		}
-
+		currentModGoVersion, err := semver.Parse(currentMod.Go.Version)
+		if err != nil {
+			var err2 error
+			currentModGoVersion, err2 = semver.Parse(currentMod.Go.Version + ".0")
+			if err2 != nil {
+				return nil, false, fmt.Errorf("parse go.mod version %q: %w", currentMod.Go.Version, err)
+			}
+		}
+		if currentModGoVersion.GT(goVersion) {
+			return nil, false, fmt.Errorf("existing go.mod has unsupported version %v (highest supported version is %v)", currentMod.Go.Version, goVersion)
+		}
 		newMod = currentMod
 
 		for _, req := range sdkMod.Require {
@@ -189,9 +201,7 @@ func (g *GoGenerator) bootstrapMod(ctx context.Context, mfs *memfs.FS) (*Package
 			newModName := "main" // use a safe default, not going to be a reserved word. User is free to modify
 
 			newMod.AddModuleStmt(newModName)
-			if v, err := semver.Parse(strings.TrimPrefix(runtime.Version(), "go")); err == nil {
-				newMod.AddGoStmt(v.String())
-			}
+			newMod.AddGoStmt(goVersion.String())
 			newMod.SetRequire(sdkMod.Require)
 
 			info.PackageImport = newModName


### PR DESCRIPTION
Another fix for https://github.com/dagger/dagger/issues/6706 - we're not gonna get any full compete solution that happily manages all the go versions before v0.10, but this at least can warn users when a weird case happens.

We've already got protections for the case of making a new module from scratch (the most common case), but this adds a similar protection for creating using an existing go.mod file.
