### PR TITLE
feat: custom flag parser for `Platform` args

### DIFF
--- a/cmd/codegen/generator/go/templates/module_types.go
+++ b/cmd/codegen/generator/go/templates/module_types.go
@@ -144,6 +144,9 @@ func (spec *parsedPrimitiveType) TypeDefCode() (*Statement, error) {
 	if spec.isPtr {
 		def = def.Dot("WithOptional").Call(Lit(true))
 	}
+	if spec.alias != "" {
+		def = def.Dot("WithAlias").Call(Lit(spec.alias))
+	}
 	return def, nil
 }
 

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -27,6 +27,7 @@ const (
 	Terminal    string = "Terminal"
 	PortForward string = "PortForward"
 	CacheVolume string = "CacheVolume"
+	Platform    string = "Platform"
 )
 
 var funcGroup = &cobra.Group{

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -798,6 +798,7 @@ func loadModTypeDefs(ctx context.Context, dag *dagger.Client, mod *dagger.Module
 fragment TypeDefRefParts on TypeDef {
 	kind
 	optional
+	alias
 	asObject {
 			name
 	}
@@ -851,6 +852,7 @@ query TypeDefs($module: ModuleID!) {
 	typeDefs: currentTypeDefs {
 		kind
 		optional
+		alias
 		asObject {
 			name
 			sourceModuleName
@@ -1041,6 +1043,7 @@ func (m *moduleDef) LoadTypeDef(typeDef *modTypeDef) {
 type modTypeDef struct {
 	Kind        dagger.TypeDefKind
 	Optional    bool
+	Alias       string
 	AsObject    *modObject
 	AsInterface *modInterface
 	AsInput     *modInput

--- a/core/schema/coremod.go
+++ b/core/schema/coremod.go
@@ -110,6 +110,11 @@ func (m *CoreMod) TypeDefs(ctx context.Context) ([]*core.TypeDef, error) {
 	typeDefs := make([]*core.TypeDef, 0, len(schema.Types))
 	for _, introspectionType := range schema.Types {
 		switch introspectionType.Kind {
+		case introspection.TypeKindScalar:
+			typeDefs = append(typeDefs, &core.TypeDef{
+				Kind:  core.TypeDefKindString,
+				Alias: introspectionType.Name,
+			})
 		case introspection.TypeKindObject:
 			typeDef := &core.ObjectTypeDef{
 				Name:        introspectionType.Name,
@@ -293,6 +298,8 @@ func introspectionRefToTypeDef(introspectionType *introspection.TypeRef, nonNull
 		default:
 			// default to saying it's a string for now
 			typeDef.Kind = core.TypeDefKindString
+			typeDef.Alias = introspectionType.Name
+			fmt.Println("thinking", typeDef.Kind, typeDef.Alias)
 		}
 
 		return typeDef, true, nil

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -225,6 +225,9 @@ func (s *moduleSchema) Install() {
 		dagql.Func("withOptional", s.typeDefWithOptional).
 			Doc(`Sets whether this type can be set to null.`),
 
+		dagql.Func("withAlias", s.typeDefWithAlias).
+			Doc(),
+
 		dagql.Func("withKind", s.typeDefWithKind).
 			Doc(`Sets the kind of the type.`),
 
@@ -281,6 +284,12 @@ func (s *moduleSchema) typeDefWithKind(ctx context.Context, def *core.TypeDef, a
 	Kind core.TypeDefKind
 }) (*core.TypeDef, error) {
 	return def.WithKind(args.Kind), nil
+}
+
+func (s *moduleSchema) typeDefWithAlias(ctx context.Context, def *core.TypeDef, args struct {
+	Name string
+}) (*core.TypeDef, error) {
+	return def.WithAlias(args.Name), nil
 }
 
 func (s *moduleSchema) typeDefWithListOf(ctx context.Context, def *core.TypeDef, args struct {

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -277,6 +277,7 @@ func (d DynamicID) MarshalJSON() ([]byte, error) {
 type TypeDef struct {
 	Kind        TypeDefKind                       `field:"true" doc:"The kind of type this is (e.g. primitive, list, object)."`
 	Optional    bool                              `field:"true" doc:"Whether this type can be set to null. Defaults to false."`
+	Alias       string                            `field:"true"`
 	AsList      dagql.Nullable[*ListTypeDef]      `field:"true" doc:"If kind is LIST, the list-specific type definition. If kind is not LIST, this will be null."`
 	AsObject    dagql.Nullable[*ObjectTypeDef]    `field:"true" doc:"If kind is OBJECT, the object-specific type definition. If kind is not OBJECT, this will be null."`
 	AsInterface dagql.Nullable[*InterfaceTypeDef] `field:"true" doc:"If kind is INTERFACE, the interface-specific type definition. If kind is not INTERFACE, this will be null."`
@@ -409,6 +410,12 @@ func (typeDef *TypeDef) WithInterface(name, desc string) *TypeDef {
 func (typeDef *TypeDef) WithOptional(optional bool) *TypeDef {
 	typeDef = typeDef.Clone()
 	typeDef.Optional = optional
+	return typeDef
+}
+
+func (typeDef *TypeDef) WithAlias(name string) *TypeDef {
+	typeDef = typeDef.Clone()
+	typeDef.Alias = name
 	return typeDef
 }
 


### PR DESCRIPTION
This is tricky, since the scalar aliases were getting lost in our `TypeDef` code. We can preserve these, and then provide a custom parser.

With this, we can add validation that the target platform is valid, as well as allow a special `current` platform, which allows this use case:

```go
package main

import (
	"fmt"
)

type Playground struct{}

func (m *Playground) Hello(platform Platform) string {
	return fmt.Sprintf("hello i am platform %q", platform)
}
```

```
❯ dagger call hello --platform=current
hello i am platform "linux/amd64"
```