### PR TITLE
Zenith: Adds descriptions & comments for Python SDK init

### DIFF
--- a/sdk/python/runtime/template/src/main.py
+++ b/sdk/python/runtime/template/src/main.py
@@ -1,3 +1,17 @@
+"""A generated module for __NAME__ functions
+
+This module has been generated via dagger init and serves as a reference to
+basic module structure as you get started with Dagger.
+
+Two functions have been pre-created. You can modify, delete, or add to them,
+as needed. They demonstrate usage of arguments and return types using simple
+echo and grep commands. The functions can be called from the dagger CLI or
+from one of the SDKs.
+
+The first line in this comment block is a short description line and the
+rest is a long description with more detail on the module's purpose or usage,
+if appropriate. All modules should have a short description."""
+
 import dagger
 from dagger import dag, function, object_type
 
@@ -6,12 +20,12 @@ from dagger import dag, function, object_type
 class __NAME__:
     @function
     def container_echo(self, string_arg: str) -> dagger.Container:
-        """Example usage: `dagger call container-echo --string-arg hello stdout`"""
+        """Returns a container that echoes whatever string argument is provided"""
         return dag.container().from_("alpine:latest").with_exec(["echo", string_arg])
 
     @function
     async def grep_dir(self, directory_arg: dagger.Directory, pattern: str) -> str:
-        """Example usage: `dagger call grep-dir --directory-arg . --patern grep_dir`"""
+        """Returns lines that match a pattern in the files of the provided Directory"""
         return await (
             dag.container()
             .from_("alpine:latest")

--- a/sdk/python/runtime/template/src/main.py
+++ b/sdk/python/runtime/template/src/main.py
@@ -10,7 +10,8 @@ from one of the SDKs.
 
 The first line in this comment block is a short description line and the
 rest is a long description with more detail on the module's purpose or usage,
-if appropriate. All modules should have a short description."""
+if appropriate. All modules should have a short description.
+"""
 
 import dagger
 from dagger import dag, function, object_type


### PR DESCRIPTION
To match https://github.com/dagger/dagger/pull/6720 and #6742 

Builds on  https://github.com/dagger/dagger/pull/6729

`ruff format` seems happy.

Similar to Go and TS, I'm not putting a comment on the Class.
With `pylint` that throws

```
src/main.py:19:0: C0115: Missing class docstring (missing-class-docstring)
```

which someone could quiet down with something like this in their `.pylintrc`:
```
[MASTER]
disable=
    C0115, #missing-class-docstring
```