### PR TITLE
`asModule` automatically `initialize`s

### DIFF
--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -371,7 +371,7 @@ func (fc *FuncCommand) load(c *cobra.Command, a []string) (cmd *cobra.Command, _
 	if !modConf.FullyInitialized() {
 		return nil, nil, fmt.Errorf("module at source dir %q doesn't exist or is invalid", modConf.LocalRootSourcePath)
 	}
-	mod := modConf.Source.AsModule().Initialize()
+	mod := modConf.Source.AsModule()
 	_, err = mod.Serve(ctx)
 	if err != nil {
 		return nil, nil, err

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -778,7 +778,7 @@ func optionalModCmdWrapper(
 			}
 			var loadedMod *dagger.Module
 			if modConf.FullyInitialized() {
-				loadedMod = modConf.Source.AsModule().Initialize()
+				loadedMod = modConf.Source.AsModule()
 				_, err := loadedMod.Serve(ctx)
 				if err != nil {
 					return fmt.Errorf("failed to serve module: %w", err)

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5440,7 +5440,7 @@ func currentSchema(ctx context.Context, t *testing.T, ctr *dagger.Container) *in
 }
 
 var moduleIntrospection = daggerQuery(`
-query { host { directory(path: ".") { asModule { initialize {
+query { host { directory(path: ".") { asModule {
     description
     objects {
         asObject {
@@ -5469,7 +5469,7 @@ query { host { directory(path: ".") { asModule { initialize {
             }
         }
     }
-} } } } }
+} } } }
 `)
 
 func inspectModule(ctx context.Context, t *testing.T, ctr *dagger.Container) gjson.Result {

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -179,6 +179,9 @@ func (s *moduleSchema) moduleSourceAsModule(
 				{Name: "source", Value: dagql.NewID[*core.ModuleSource](src.ID())},
 			},
 		},
+		dagql.Selector{
+			Field: "initialize",
+		},
 	)
 	if err != nil {
 		return inst, fmt.Errorf("failed to create module: %w", err)


### PR DESCRIPTION
(Pardon the noise, not quite ready yet based on the test failures, this isn't necessarily a breaking change so if it doesn't make it for v0.10.0 that's OK.)

Found myself calling this all over the place; I don't think we really meant to leak this out since it was originally an implementation detail of the DagQL switch. `Directory.asModule` and `ModuleSource.asModule` seem like the two main APIs for loading modules so it seems like they should return a fully instantiated one.

Funnily enough this doesn't seem to be a breaking change, since you can call `initialize.initialize.initialize` just fine. I saw there was a TODO to remove `initialize` entirely, happy to do that if pointed in the right direction, wanted to get this up before looking further in hope of sneaking it in for v0.10.0. :pray: 