### PR TITLE
core: only allow Host.unixSocket to be used from main client

### DIFF
--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -58,9 +58,10 @@ type Opts struct {
 	// client. It is special in that when it shuts down, the client will be closed and
 	// that registry auth and sockets are currently only ever sourced from this caller,
 	// not any nested clients (may change in future).
-	MainClientCaller bksession.Caller
-	DNSConfig        *oci.DNSConfig
-	Frontends        map[string]bkfrontend.Frontend
+	MainClientCaller   bksession.Caller
+	MainClientCallerID string
+	DNSConfig          *oci.DNSConfig
+	Frontends          map[string]bkfrontend.Frontend
 }
 
 type ResolveCacheExporterFunc func(ctx context.Context, g bksession.Group) (remotecache.Exporter, error)

--- a/engine/server/buildkitcontroller.go
+++ b/engine/server/buildkitcontroller.go
@@ -263,6 +263,7 @@ func (e *BuildkitController) Session(stream controlapi.Control_SessionServer) (r
 			UpstreamCacheImports:  cacheImporterCfgs,
 			ProgSockPath:          progSockPath,
 			MainClientCaller:      caller,
+			MainClientCallerID:    opts.ClientID,
 			DNSConfig:             e.DNSConfig,
 			Frontends:             e.Frontends,
 		})


### PR DESCRIPTION
Before this, it was technically possible for a module to make a raw graphql query to the Host.unixSocket API and gain access to any unix socket on the main client caller's host (i.e. where the CLI is running). This is due to the fact that the socket attachable currently has to be hardcoded to always refer to the main client caller (which in turn is due to relevant grpc metadata not being forwarded by buildkit yet in those codepaths).

Now we just enforce that this API can only ever be called from the main client caller. This is okay for now because we don't yet support passing unix sockets around modules. We do want to support that in the near future, but it will require some tweaks upstream in buildkit and more plumbing in our own code to carefully track which module has access to a given socket based on being explicitly passed it as an arg (or embedded in the DAG of some arg like a Container). This change just blocks that backdoor in the meantime.

Support for the above is tracked here: https://github.com/dagger/dagger/issues/6747

---

Adding to `v0.10.0` since this is quite trivial and very nice-to-have for general security+sandboxing. However, similar to https://github.com/dagger/dagger/pull/6601 I wouldn't consider this a total blocker since we haven't exactly hardened against every possible malicious module yet.