### PR TITLE
docs: Fixes to current docs in preparation for archival

### DIFF
--- a/docs/current_docs/cli/389936-run-pipelines-cli.mdx
+++ b/docs/current_docs/cli/389936-run-pipelines-cli.mdx
@@ -104,4 +104,4 @@ tree
 
 This tutorial introduced you to the Dagger CLI and its `dagger query` and `dagger run` sub-commands. It explained how to install the CLI and how to use it to execute Dagger GraphQL API queries. It also provided a working example of how to run a Dagger pipeline from the command line using a Bash shell script.
 
-Use the [API Reference](https://docs.dagger.io/api/reference) and the [CLI Reference](/cli/979595/reference) to learn more about the Dagger GraphQL API and the Dagger CLI respectively.
+Use the [API Reference](https://docs.dagger.io/api/reference) and the [CLI Reference](./979595/reference.mdx) to learn more about the Dagger GraphQL API and the Dagger CLI respectively.

--- a/docs/current_docs/cli/389936-run-pipelines-cli.mdx
+++ b/docs/current_docs/cli/389936-run-pipelines-cli.mdx
@@ -104,4 +104,4 @@ tree
 
 This tutorial introduced you to the Dagger CLI and its `dagger query` and `dagger run` sub-commands. It explained how to install the CLI and how to use it to execute Dagger GraphQL API queries. It also provided a working example of how to run a Dagger pipeline from the command line using a Bash shell script.
 
-Use the [API Reference](https://docs.dagger.io/api/reference) and the [CLI Reference](./979595/reference.mdx) to learn more about the Dagger GraphQL API and the Dagger CLI respectively.
+Use the [API Reference](https://docs.dagger.io/api/reference) and the [CLI Reference](./979595-reference.mdx) to learn more about the Dagger GraphQL API and the Dagger CLI respectively.

--- a/docs/current_docs/faq.mdx
+++ b/docs/current_docs/faq.mdx
@@ -235,7 +235,7 @@ Refer to our [getting started guide](./cloud/572923-get-started.mdx) for detaile
 
 ### What language SDKs are available for Dagger?
 
-We currently offer a [Go SDK](./sdk/go/index.mdx), a [Node.js SDK](./sdk/nodejs/index.mdx) and a [Python SDK](./sdk/python/index.mdx). Waiting for your favorite language to be supported? [Let us know which one](https://airtable.com/shrzABOn1wCk5yBF4), and we'll notify you when it's ready.
+We currently offer a [Go SDK](./sdk/go/index.mdx), a [Node.js SDK](./sdk/nodejs/index.md) and a [Python SDK](./sdk/python/index.mdx). Waiting for your favorite language to be supported? [Let us know which one](https://airtable.com/shrzABOn1wCk5yBF4), and we'll notify you when it's ready.
 
 ### How do I log in to a container registry using a Dagger SDK?
 

--- a/docs/current_docs/faq.mdx
+++ b/docs/current_docs/faq.mdx
@@ -235,7 +235,7 @@ Refer to our [getting started guide](./cloud/572923-get-started.mdx) for detaile
 
 ### What language SDKs are available for Dagger?
 
-We currently offer a [Go SDK](/sdk/go), a [Node.js SDK](/sdk/nodejs) and a [Python SDK](/sdk/python). Waiting for your favorite language to be supported? [Let us know which one](https://airtable.com/shrzABOn1wCk5yBF4), and we'll notify you when it's ready.
+We currently offer a [Go SDK](./sdk/go/index.mdx), a [Node.js SDK](./sdk/nodejs/index.mdx) and a [Python SDK](./sdk/python/index.mdx). Waiting for your favorite language to be supported? [Let us know which one](https://airtable.com/shrzABOn1wCk5yBF4), and we'll notify you when it's ready.
 
 ### How do I log in to a container registry using a Dagger SDK?
 

--- a/docs/current_docs/guides/128409-build-test-publish-php.mdx
+++ b/docs/current_docs/guides/128409-build-test-publish-php.mdx
@@ -13,7 +13,7 @@ import PartialRunApiClient from '../partials/_run_api_client.mdx';
 
 ## Introduction
 
-Dagger SDKs are currently available for [Go](../sdk/go/index.mdx), [Node.js](../sdk/nodejs/index.mdx) and [Python](../sdk/python/index.mdx) and make it easy to develop CI/CD pipelines in those languages. However, even if you're using a different language, you can still use Dagger via the [Dagger GraphQL API](../api/index.mdx). The Dagger GraphQL API is a unified interface for programming the Dagger Engine that can be accessed and used by any standards-compliant GraphQL client.
+Dagger SDKs are currently available for [Go](../sdk/go/index.mdx), [Node.js](../sdk/nodejs/index.md) and [Python](../sdk/python/index.mdx) and make it easy to develop CI/CD pipelines in those languages. However, even if you're using a different language, you can still use Dagger via the [Dagger GraphQL API](../api/index.mdx). The Dagger GraphQL API is a unified interface for programming the Dagger Engine that can be accessed and used by any standards-compliant GraphQL client.
 
 This tutorial demonstrates the above by using PHP with a PHP-based GraphQL client to continuously build, test and publish a Laravel Web application using Dagger. You will learn how to:
 

--- a/docs/current_docs/guides/128409-build-test-publish-php.mdx
+++ b/docs/current_docs/guides/128409-build-test-publish-php.mdx
@@ -13,7 +13,7 @@ import PartialRunApiClient from '../partials/_run_api_client.mdx';
 
 ## Introduction
 
-Dagger SDKs are currently available for [Go](../sdk/go/), [Node.js](../sdk/nodejs/) and [Python](../sdk/python/) and make it easy to develop CI/CD pipelines in those languages. However, even if you're using a different language, you can still use Dagger via the [Dagger GraphQL API](../api/). The Dagger GraphQL API is a unified interface for programming the Dagger Engine that can be accessed and used by any standards-compliant GraphQL client.
+Dagger SDKs are currently available for [Go](../sdk/go/index.mdx), [Node.js](../sdk/nodejs/index.mdx) and [Python](../sdk/python/index.mdx) and make it easy to develop CI/CD pipelines in those languages. However, even if you're using a different language, you can still use Dagger via the [Dagger GraphQL API](../api/index.mdx). The Dagger GraphQL API is a unified interface for programming the Dagger Engine that can be accessed and used by any standards-compliant GraphQL client.
 
 This tutorial demonstrates the above by using PHP with a PHP-based GraphQL client to continuously build, test and publish a Laravel Web application using Dagger. You will learn how to:
 


### PR DESCRIPTION
Absolute URL links create a problem when archiving the website, because the base URL is no longer the same on the archive website. This fixes such links to be filesystem links instead.