### PR TITLE
chore: avoid panic in CI scripts

### DIFF
--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -87,10 +87,14 @@ func (t Engine) Publish(ctx context.Context, version string) error {
 		gpuRef      = fmt.Sprintf("%s:%s-gpu", engineImage, versionInfo.EngineVersion())
 	)
 
+	targets, err := util.DevEngineContainer(ctx, c, publishedEngineArches, versionInfo.EngineVersion())
+	if err != nil {
+		return err
+	}
 	digest, err := c.Container().
 		WithRegistryAuth(registry, username, password).
 		Publish(ctx, ref, dagger.ContainerPublishOpts{
-			PlatformVariants: util.DevEngineContainer(ctx, c, publishedEngineArches, versionInfo.EngineVersion()),
+			PlatformVariants: targets,
 			// use gzip to avoid incompatibility w/ older docker versions
 			ForcedCompression: dagger.Gzip,
 		})
@@ -111,8 +115,12 @@ func (t Engine) Publish(ctx context.Context, version string) error {
 	fmt.Println("PUBLISHED IMAGE REF:", digest)
 
 	// gpu is experimental, not fatal if publish fails
+	targets, err = util.DevEngineContainerWithGPUSupport(ctx, c, publishedGPUEngineArches, versionInfo.EngineVersion())
+	if err != nil {
+		return err
+	}
 	gpuDigest, err := c.Container().Publish(ctx, gpuRef, dagger.ContainerPublishOpts{
-		PlatformVariants: util.DevEngineContainerWithGPUSupport(ctx, c, publishedGPUEngineArches, versionInfo.EngineVersion()),
+		PlatformVariants: targets,
 	})
 	if err == nil {
 		fmt.Println("PUBLISHED GPU IMAGE REF:", gpuDigest)
@@ -139,15 +147,23 @@ func (t Engine) TestPublish(ctx context.Context) error {
 
 	c = c.Pipeline("engine").Pipeline("test-publish")
 
+	targets, err := util.DevEngineContainer(ctx, c, publishedEngineArches, versionInfo.EngineVersion())
+	if err != nil {
+		return err
+	}
 	_, err = c.Container().Export(ctx, "./engine.tar", dagger.ContainerExportOpts{
-		PlatformVariants: util.DevEngineContainer(ctx, c, publishedEngineArches, versionInfo.EngineVersion()),
+		PlatformVariants: targets,
 	})
 	if err != nil {
 		return err
 	}
 
+	targets, err = util.DevEngineContainerWithGPUSupport(ctx, c, publishedGPUEngineArches, versionInfo.EngineVersion())
+	if err != nil {
+		return err
+	}
 	_, err = c.Container().Export(ctx, "./engine-gpu.tar", dagger.ContainerExportOpts{
-		PlatformVariants: util.DevEngineContainerWithGPUSupport(ctx, c, publishedGPUEngineArches, versionInfo.EngineVersion()),
+		PlatformVariants: targets,
 	})
 	if err != nil {
 		return err
@@ -245,9 +261,15 @@ func (t Engine) Dev(ctx context.Context) error {
 	// Conditionally load GPU enabled image for dev environment if the flag is set:
 	var platformVariants []*dagger.Container
 	if gpuSupportEnabled {
-		platformVariants = util.DevEngineContainerWithGPUSupport(ctx, c, arches, versionInfo.EngineVersion())
+		platformVariants, err = util.DevEngineContainerWithGPUSupport(ctx, c, arches, versionInfo.EngineVersion())
+		if err != nil {
+			return err
+		}
 	} else {
-		platformVariants = util.DevEngineContainer(ctx, c, arches, versionInfo.EngineVersion())
+		platformVariants, err = util.DevEngineContainer(ctx, c, arches, versionInfo.EngineVersion())
+		if err != nil {
+			return err
+		}
 	}
 
 	_, err = c.Container().Export(ctx, tarPath, dagger.ContainerExportOpts{
@@ -388,14 +410,18 @@ func (t Engine) testCmd(ctx context.Context, c *dagger.Client) (*dagger.Containe
 			`registry."privateregistry:5000"`: "http = true",
 		},
 	}
-	devEngine := util.DevEngineContainer(
+	devEngines, err := util.DevEngineContainer(
 		ctx,
 		c.Pipeline("dev-engine"),
 		[]string{runtime.GOARCH},
 		versionInfo.EngineVersion(),
 		util.DefaultDevEngineOpts,
 		opts,
-	)[0]
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	devEngine := devEngines[0]
 
 	// This creates an engine.tar container file that can be used by the integration tests.
 	// In particular, it is used by core/integration/remotecache_test.go to create a

--- a/internal/mage/sdk/elixir.go
+++ b/internal/mage/sdk/elixir.go
@@ -51,12 +51,16 @@ func (Elixir) Lint(ctx context.Context) error {
 		return err
 	}
 
+	cliBinary, err := util.DevelDaggerBinary(ctx, c)
+	if err != nil {
+		return err
+	}
 	cliBinPath := "/.dagger-cli"
 
 	_, err = elixirBase(c, elixirVersions[1]).
 		WithServiceBinding("dagger-engine", devEngine).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint).
-		WithMountedFile(cliBinPath, util.DevelDaggerBinary(ctx, c)).
+		WithMountedFile(cliBinPath, cliBinary).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
 		WithExec([]string{"mix", "lint"}).
 		Sync(ctx)
@@ -86,13 +90,17 @@ func (Elixir) Test(ctx context.Context) error {
 		return err
 	}
 
+	cliBinary, err := util.DevelDaggerBinary(ctx, c)
+	if err != nil {
+		return err
+	}
 	cliBinPath := "/.dagger-cli"
 
 	for _, elixirVersion := range elixirVersions {
 		_, err := elixirBase(c.Pipeline(elixirVersion), elixirVersion).
 			WithServiceBinding("dagger-engine", devEngine).
 			WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint).
-			WithMountedFile(cliBinPath, util.DevelDaggerBinary(ctx, c)).
+			WithMountedFile(cliBinPath, cliBinary).
 			WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
 			WithExec([]string{"mix", "test"}).
 			Sync(ctx)
@@ -122,12 +130,16 @@ func (Elixir) Generate(ctx context.Context) error {
 		return err
 	}
 
+	cliBinary, err := util.DevelDaggerBinary(ctx, c)
+	if err != nil {
+		return err
+	}
 	cliBinPath := "/.dagger-cli"
 
 	generated := elixirBase(c, elixirVersions[1]).
 		WithServiceBinding("dagger-engine", devEngine).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint).
-		WithMountedFile(cliBinPath, util.DevelDaggerBinary(ctx, c)).
+		WithMountedFile(cliBinPath, cliBinary).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
 		WithExec([]string{"mix", "dagger.gen"})
 

--- a/internal/mage/sdk/go.go
+++ b/internal/mage/sdk/go.go
@@ -62,13 +62,18 @@ func (t Go) Test(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	cliBinary, err := util.DevelDaggerBinary(ctx, c)
+	if err != nil {
+		return err
+	}
 	cliBinPath := "/.dagger-cli"
 
 	output, err := util.GoBase(c).
 		WithWorkdir("sdk/go").
 		WithServiceBinding("dagger-engine", devEngine).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint).
-		WithMountedFile(cliBinPath, util.DevelDaggerBinary(ctx, c)).
+		WithMountedFile(cliBinPath, cliBinary).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
 		WithExec([]string{"go", "test", "-v", "./..."}).
 		Stdout(ctx)
@@ -92,13 +97,18 @@ func (t Go) Generate(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	cliBinary, err := util.DevelDaggerBinary(ctx, c)
+	if err != nil {
+		return err
+	}
 	cliBinPath := "/.dagger-cli"
 
 	generated := util.GoBase(c).
 		WithServiceBinding("dagger-engine", devEngine).
-		WithMountedFile("/usr/local/bin/dagger", util.DevelDaggerBinary(ctx, c)).
+		WithMountedFile("/usr/local/bin/dagger", cliBinary).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint).
-		WithMountedFile(cliBinPath, util.DevelDaggerBinary(ctx, c)).
+		WithMountedFile(cliBinPath, cliBinary).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
 		WithWorkdir("sdk/go").
 		WithExec([]string{"go", "generate", "-v", "./..."}).

--- a/internal/mage/sdk/java.go
+++ b/internal/mage/sdk/java.go
@@ -62,12 +62,16 @@ func (Java) Test(ctx context.Context) error {
 		return err
 	}
 
+	cliBinary, err := util.DevelDaggerBinary(ctx, c)
+	if err != nil {
+		return err
+	}
 	cliBinPath := "/.dagger-cli"
 
 	_, err = javaBase(c).
 		WithServiceBinding("dagger-engine", devEngine).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint).
-		WithMountedFile(cliBinPath, util.DevelDaggerBinary(ctx, c)).
+		WithMountedFile(cliBinPath, cliBinary).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
 		WithExec([]string{"mvn", "clean", "verify", "-Ddaggerengine.version=local"}).
 		Sync(ctx)
@@ -96,12 +100,16 @@ func (Java) Generate(ctx context.Context) error {
 		return err
 	}
 
+	cliBinary, err := util.DevelDaggerBinary(ctx, c)
+	if err != nil {
+		return err
+	}
 	cliBinPath := "/.dagger-cli"
 
 	generatedSchema, err := javaBase(c).
 		WithServiceBinding("dagger-engine", devEngine).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint).
-		WithMountedFile(cliBinPath, util.DevelDaggerBinary(ctx, c)).
+		WithMountedFile(cliBinPath, cliBinary).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
 		WithExec([]string{"mvn", "clean", "install", "-pl", "dagger-codegen-maven-plugin"}).
 		WithExec([]string{"mvn", "-N", "dagger-codegen:generateSchema"}).
@@ -115,7 +123,7 @@ func (Java) Generate(ctx context.Context) error {
 	engineVersion, err := javaBase(c).
 		WithServiceBinding("dagger-engine", devEngine).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint).
-		WithMountedFile(cliBinPath, util.DevelDaggerBinary(ctx, c)).
+		WithMountedFile(cliBinPath, cliBinary).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
 		WithExec([]string{cliBinPath, "version"}).
 		Stdout(ctx)

--- a/internal/mage/sdk/php.go
+++ b/internal/mage/sdk/php.go
@@ -62,11 +62,16 @@ func (t PHP) Generate(ctx context.Context) error {
 		return err
 	}
 
+	cliBinary, err := util.DevelDaggerBinary(ctx, c)
+	if err != nil {
+		return err
+	}
 	cliBinPath := "/.dagger-cli"
+
 	ok, err := phpBase(c).
 		WithServiceBinding("dagger-engine", devEngine).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint).
-		WithMountedFile(cliBinPath, util.DevelDaggerBinary(ctx, c)).
+		WithMountedFile(cliBinPath, cliBinary).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
 		With(util.ShellCmds(
 			fmt.Sprintf("rm -f %s/*.php", phpSDKGeneratedDir),

--- a/internal/mage/sdk/python.go
+++ b/internal/mage/sdk/python.go
@@ -82,7 +82,12 @@ func (t Python) Test(ctx context.Context) error {
 		return err
 	}
 
+	cliBinary, err := util.DevelDaggerBinary(ctx, c)
+	if err != nil {
+		return err
+	}
 	cliBinPath := "/.dagger-cli"
+
 	eg, gctx := errgroup.WithContext(ctx)
 	for _, version := range versions {
 		version := version
@@ -93,7 +98,7 @@ func (t Python) Test(ctx context.Context) error {
 			_, err := base.
 				WithServiceBinding("dagger-engine", devEngine).
 				WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint).
-				WithMountedFile(cliBinPath, util.DevelDaggerBinary(ctx, c)).
+				WithMountedFile(cliBinPath, cliBinary).
 				WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
 				WithExec([]string{"pytest", "-Wd", "--exitfirst"}).
 				Sync(gctx)
@@ -140,12 +145,17 @@ func (t Python) Generate(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	cliBinary, err := util.DevelDaggerBinary(ctx, c)
+	if err != nil {
+		return err
+	}
 	cliBinPath := "/.dagger-cli"
 
 	generated, err := pythonBase(c, pythonDefaultVersion).
 		WithServiceBinding("dagger-engine", devEngine).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint).
-		WithMountedFile(cliBinPath, util.DevelDaggerBinary(ctx, c)).
+		WithMountedFile(cliBinPath, cliBinary).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
 		WithWorkdir("/").
 		WithExec([]string{cliBinPath, "run", "python", "-m", "dagger", "codegen", "-o", pythonGeneratedAPIPath}).

--- a/internal/mage/sdk/rust.go
+++ b/internal/mage/sdk/rust.go
@@ -76,12 +76,16 @@ func (r Rust) Generate(ctx context.Context) error {
 		return err
 	}
 
+	cliBinary, err := util.DevelDaggerBinary(ctx, c)
+	if err != nil {
+		return err
+	}
 	cliBinPath := "/.dagger-cli"
 
 	generated := r.rustBase(ctx, c.Pipeline(rustDockerStable), rustDockerStable).
 		WithServiceBinding("dagger-engine", devEngine).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint).
-		WithMountedFile(cliBinPath, util.DevelDaggerBinary(ctx, c)).
+		WithMountedFile(cliBinPath, cliBinary).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
 		WithExec([]string{"cargo", "run", "-p", "dagger-bootstrap", "generate", "--output", fmt.Sprintf("/%s", rustGeneratedAPIPath)}).
 		WithExec([]string{"cargo", "fix", "--all", "--allow-no-vcs"}).
@@ -199,12 +203,16 @@ func (r Rust) Test(ctx context.Context) error {
 		return err
 	}
 
+	cliBinary, err := util.DevelDaggerBinary(ctx, c)
+	if err != nil {
+		return err
+	}
 	cliBinPath := "/.dagger-cli"
 
 	_, err = r.rustBase(ctx, c.Pipeline(rustDockerStable), rustDockerStable).
 		WithServiceBinding("dagger-engine", devEngine).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint).
-		WithMountedFile(cliBinPath, util.DevelDaggerBinary(ctx, c)).
+		WithMountedFile(cliBinPath, cliBinary).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
 		WithExec([]string{"rustc", "--version"}).
 		WithExec([]string{"cargo", "test", "--release", "--all"}).

--- a/internal/mage/sdk/typescript.go
+++ b/internal/mage/sdk/typescript.go
@@ -85,12 +85,17 @@ func (t TypeScript) Test(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	cliBinary, err := util.DevelDaggerBinary(ctx, c)
+	if err != nil {
+		return err
+	}
 	cliBinPath := "/.dagger-cli"
 
 	_, err = nodeJsBase(c).
 		WithServiceBinding("dagger-engine", devEngine).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint).
-		WithMountedFile(cliBinPath, util.DevelDaggerBinary(ctx, c)).
+		WithMountedFile(cliBinPath, cliBinary).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
 		WithExec([]string{"yarn", "test"}).
 		Sync(ctx)
@@ -111,12 +116,17 @@ func (t TypeScript) Generate(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	cliBinary, err := util.DevelDaggerBinary(ctx, c)
+	if err != nil {
+		return err
+	}
 	cliBinPath := "/.dagger-cli"
 
 	generated, err := nodeJsBase(c).
 		WithServiceBinding("dagger-engine", devEngine).
 		WithMountedFile("/usr/local/bin/codegen", util.CodegenBinary(c)).
-		WithMountedFile(cliBinPath, util.DevelDaggerBinary(ctx, c)).
+		WithMountedFile(cliBinPath, cliBinary).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
 		WithExec([]string{"codegen", "--lang", "typescript", "-o", path.Dir(typescriptGeneratedAPIPath)}).

--- a/internal/mage/util/util.go
+++ b/internal/mage/util/util.go
@@ -155,12 +155,12 @@ func DaggerBinary(c *dagger.Client, version string) *dagger.File {
 }
 
 // DevelDaggerBinary returns a compiled dagger binary with the devel version
-func DevelDaggerBinary(ctx context.Context, c *dagger.Client) *dagger.File {
+func DevelDaggerBinary(ctx context.Context, c *dagger.Client) (*dagger.File, error) {
 	info, err := DevelVersionInfo(ctx, c)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	return PlatformDaggerBinary(c, "", "", "", info.EngineVersion())
+	return PlatformDaggerBinary(c, "", "", "", info.EngineVersion()), nil
 }
 
 // HostDaggerBinary returns a dagger binary compiled to target the host's OS+arch


### PR DESCRIPTION
panics can result in some bizarre error reports - for example:

	failed to check version compatibility: Post "http://dagger/query": context canceled
	panic: get tree hash: Post "http://dagger/query": context canceled

	goroutine 51 [running]:
	github.com/dagger/dagger/internal/mage/util.CIDevEngineContainer({0x90a140, 0xc0002be000}, 0xc00011a9c0, {0xc0000efb00, 0x1, 0xc00011e1d0?})
		/home/jedevc/Documents/Projects/dagger/dagger/internal/mage/util/engine.go:163 +0x5db
	github.com/dagger/dagger/internal/mage/util.CIDevEngineContainerAndEndpoint({0x90a140, 0xc0002be000}, 0xa?, {0xc0000efb00?, 0x0?, 0xc000285a30?})
		/home/jedevc/Documents/Projects/dagger/dagger/internal/mage/util/engine.go:140 +0x2c
	github.com/dagger/dagger/internal/mage/sdk.Python.Generate({}, {0x90a140, 0xc0002be000})
		/home/jedevc/Documents/Projects/dagger/dagger/internal/mage/sdk/python.go:143 +0x1db
	github.com/dagger/dagger/internal/mage/sdk.Python.Lint.func2.1()
		/home/jedevc/Documents/Projects/dagger/dagger/internal/mage/sdk/python.go:65 +0x1b
	github.com/dagger/dagger/internal/mage/util.LintGeneratedCode({0x860c84, 0x13}, 0xc000285f50, {0xc000285f40, 0x1, 0x0?})
		/home/jedevc/Documents/Projects/dagger/dagger/internal/mage/util/generated.go:54 +0x349
	github.com/dagger/dagger/internal/mage/sdk.Python.Lint.func2()
		/home/jedevc/Documents/Projects/dagger/dagger/internal/mage/sdk/python.go:64 +0x7c
	golang.org/x/sync/errgroup.(*Group).Go.func1()
		/home/jedevc/go/pkg/mod/golang.org/x/sync@v0.6.0/errgroup/errgroup.go:78 +0x56
	created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 6
		/home/jedevc/go/pkg/mod/golang.org/x/sync@v0.6.0/errgroup/errgroup.go:75 +0x96
	exit status 2

This is really unhelpful, and is caused because an error group context got cancelled, because another job there failed - but this original error gets obscured by the panic, and so the user doesn't see the full error.

As part of converting this to zenith, we'd need to clean this up anyways, so just pulling in that change here!

I've removed as many panics as seems feasible (`WithContainerFunc` is a pain though, since it can't return an error :cry:) - but getting functions to return errors requires a fair bit of refactoring around.