### PR TITLE
chore: disable debug=true for published/tested image

### DIFF
--- a/internal/mage/util/engine.go
+++ b/internal/mage/util/engine.go
@@ -60,7 +60,6 @@ exec {{.EngineBin}} --config {{.EngineConfig}} {{ range $key := .EntrypointArgKe
 `
 
 const engineConfigTmpl = `
-debug = true
 insecure-entitlements = ["security.insecure"]
 {{ range $key := .ConfigKeys }}
 [{{ $key }}]


### PR DESCRIPTION
There's not a huge reason to include debug=true in tests - these logs add huge amounts of extra logging, that is often not particularly helpful during debugging.

For local development, with `./hack/dev`, these were already enabled with the `--debug` flag - it's just with the engine for tests.

Note - I also removed it for the images we push to `registry.dagger.io` - it can be added back, but I'm actually not convinced adding `debug` logging by default is the right call.