### PR TITLE
docs: Add missing class in Python reference docs

### DIFF
--- a/sdk/python/docs/module.rst
+++ b/sdk/python/docs/module.rst
@@ -13,3 +13,5 @@ Experimental Dagger modules support.
 
 .. autoclass:: Arg
 
+.. autoclass:: Doc
+


### PR DESCRIPTION
Tiny fix for a broken link in zenith docs.