### PR TITLE
fix(sdk/elixir): fix backslash didn't get escape

### DIFF
--- a/sdk/elixir/.changes/unreleased/Fixed-20240227-224706.yaml
+++ b/sdk/elixir/.changes/unreleased/Fixed-20240227-224706.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: Fix \ didn't get escape, cause APIs that accept string can get GraphQL parse
+  error.
+time: 2024-02-27T22:47:06.02558+07:00
+custom:
+  Author: wingyplus
+  PR: "6757"

--- a/sdk/elixir/lib/dagger/core/query_builder.ex
+++ b/sdk/elixir/lib/dagger/core/query_builder.ex
@@ -54,6 +54,8 @@ defmodule Dagger.Core.QueryBuilder.Selection do
   defp encode_value(value) when is_binary(value) do
     string =
       value
+      |> String.replace("\\", "\\\\")
+      |> String.replace("\r", "\\r")
       |> String.replace("\n", "\\n")
       |> String.replace("\t", "\\t")
       |> String.replace("\"", "\\\"")
@@ -105,7 +107,7 @@ defmodule Dagger.Core.QueryBuilder do
     q = Selection.build(selection)
 
     case Client.query(client, q) do
-      {:ok, %{status: 200, body: %{"data" => nil, "errors" => errors}}} ->
+      {:ok, %{body: %{"data" => nil, "errors" => errors}}} ->
         {:error, %Dagger.QueryError{errors: errors}}
 
       {:ok, %{status: 200, body: %{"data" => data}}} ->

--- a/sdk/elixir/test/dagger/client_test.exs
+++ b/sdk/elixir/test/dagger/client_test.exs
@@ -17,7 +17,7 @@ defmodule Dagger.ClientTest do
   }
 
   setup do
-    client = Dagger.connect!()
+    client = Dagger.connect!(connect_timeout: :timer.seconds(60))
     on_exit(fn -> Dagger.close(client) end)
 
     %{client: client}
@@ -289,5 +289,22 @@ defmodule Dagger.ClientTest do
              |> Container.stdout()
 
     assert out =~ ~r/Welcome to nginx/
+  end
+
+  test "string escape", %{client: client} do
+    assert {:ok, _} =
+             client
+             |> Client.container()
+             |> Container.from("nginx:1.25-alpine3.18")
+             |> Container.with_new_file("/a.txt",
+               contents: """
+                 \\  /       Partly cloudy
+               _ /\"\".-.     +29(31) °C
+                 \\_(   ).   ↑ 13 km/h
+                 /(___(__)  10 km
+                            0.0 mm
+               """
+             )
+             |> Sync.sync()
   end
 end


### PR DESCRIPTION
This issue found during work on `wttr` module [1] that is a prototype of the Elixir for Dagger Module, the error is silent when send the output from `wttr` back to the function call. After investigate it, it has 2 issues:

1. The `execute` function silent the error. It returns ok tuple with error result, cause a function process incorrectly.
2. The graphql builder didn't escape `\` got graphql server returns 403 parse error to the client.

This patch fix those issues above.

[1] https://github.com/wingyplus/daggerverse/tree/main/wttr.