### PR TITLE
Fix goroutine and memory leaks in engine

### DIFF
--- a/engine/server/buildkitcontroller.go
+++ b/engine/server/buildkitcontroller.go
@@ -172,13 +172,7 @@ func (e *BuildkitController) Session(stream controlapi.Control_SessionServer) (r
 		}
 	}()
 
-	conn, closeCh, hijackmd := grpchijack.Hijack(stream)
-	// TODO: this blocks if opts.RegisterClient and an error happens
-	// TODO: ? defer conn.Close()
-	go func() {
-		<-closeCh
-		cancel()
-	}()
+	conn, _, hijackmd := grpchijack.Hijack(stream)
 
 	if !opts.RegisterClient {
 		e.serverMu.RLock()


### PR DESCRIPTION
Fixes: https://github.com/dagger/dagger/issues/6719

See individual commit messages for explanations.

Running the full `TestModule` suite locally now shows RSS maxing out around 1GB (still high-ish but much more reasonable than 6GB). And most importantly, whereas previously the engine's RSS *stayed* high after the test suite ended (it stuck around 2-3 GB RSS), now the RSS drops down to reasonable 600MB afterwards, with `pprof` showing reasonable usage mostly from buildkit's in memory cache metadata:
```
File: dagger-engine
Type: inuse_space
Time: Feb 27, 2024 at 10:00am (PST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 38.15MB, 58.54% of 65.17MB total
Showing top 10 nodes out of 306
      flat  flat%   sum%        cum   cum%
      11MB 16.88% 16.88%    12.50MB 19.18%  github.com/moby/buildkit/cache/metadata.newStorageItem.func1
    5.50MB  8.44% 25.32%     5.50MB  8.44%  github.com/moby/buildkit/cache.(*cacheRecord).ref
       5MB  7.67% 33.00%        5MB  7.67%  github.com/moby/buildkit/cache/metadata.(*StorageItem).setValue
    3.50MB  5.37% 38.37%     3.50MB  5.37%  github.com/moby/buildkit/cache.(*cacheRecord).layerDigestChain
       3MB  4.60% 42.97%        3MB  4.60%  runtime.malg
    2.55MB  3.92% 46.89%    20.06MB 30.77%  github.com/moby/buildkit/cache.(*cacheManager).getRecord
    2.29MB  3.52% 50.41%     2.29MB  3.52%  github.com/moby/buildkit/solver/pb.(*Op).Marshal
       2MB  3.07% 53.48%     2.50MB  3.84%  github.com/moby/buildkit/cache/metadata.NewValue
    1.75MB  2.69% 56.16%     1.75MB  2.69%  github.com/moby/buildkit/util/tracing/detect.(*TraceRecorder).ExportSpans
    1.55MB  2.37% 58.54%     1.55MB  2.37%  google.golang.org/grpc/internal/transport.newBufWriter
```

Also, previously there were 20000+ goroutines laying around after the test suite was done. Now there's only 21.