### PR TITLE
engine: only sync seen cachemounts on engine shutdown

### DIFF
--- a/engine/cache/mountsync.go
+++ b/engine/cache/mountsync.go
@@ -88,17 +88,13 @@ func (m *manager) StartCacheMountSynchronization(ctx context.Context) error {
 	m.stopCacheMountSync = func(ctx context.Context) error {
 		var eg errgroup.Group
 
-		allCacheMounts := map[string]struct{}{}
+		seenCacheMounts := map[string]struct{}{}
 		core.SeenCacheKeys.Range(func(k any, v any) bool {
-			allCacheMounts[k.(string)] = struct{}{}
+			seenCacheMounts[k.(string)] = struct{}{}
 			return true
 		})
 
-		for _, syncedCacheMount := range syncedCacheMounts {
-			allCacheMounts[syncedCacheMount.Name] = struct{}{}
-		}
-
-		for cacheMountName := range allCacheMounts {
+		for cacheMountName := range seenCacheMounts {
 			cacheMountName := cacheMountName
 			eg.Go(func() error {
 				bklog.G(ctx).Debugf("syncing cache mount remotely %s", cacheMountName)


### PR DESCRIPTION
to avoid unnecessarily long shutdown times when using the remote cache
service, we should only sync the cachemounts that have been seen by the engine
previously. This helps in the specific scenario were pipelines are
cached and cache mount re-uplodas are unnecessary.

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
