### PR TITLE
ci: add linting for go.mod

### DIFF
--- a/internal/mage/engine.go
+++ b/internal/mage/engine.go
@@ -49,6 +49,22 @@ func (t Engine) Lint(ctx context.Context) error {
 
 	repo := util.RepositoryGoCodeOnly(c)
 
+	err = util.LintGeneratedCode("go mod tidy", func() error {
+		_, err := c.Directory().
+			WithDirectory("/",
+				util.GoBase(c).
+					WithExec([]string{"go", "mod", "tidy"}).
+					Directory("."),
+				dagger.DirectoryWithDirectoryOpts{
+					Include: []string{"go.mod", "go.sum"},
+				}).
+			Export(ctx, ".")
+		return err
+	}, "go.mod", "go.sum")
+	if err != nil {
+		return err
+	}
+
 	_, err = c.Container().
 		From("golangci/golangci-lint:v1.55-alpine").
 		WithMountedDirectory("/app", repo).

--- a/internal/mage/sdk/go.go
+++ b/internal/mage/sdk/go.go
@@ -102,6 +102,7 @@ func (t Go) Generate(ctx context.Context) error {
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", cliBinPath).
 		WithWorkdir("sdk/go").
 		WithExec([]string{"go", "generate", "-v", "./..."}).
+		WithExec([]string{"go", "mod", "tidy"}).
 		Directory(".")
 	_, err = generated.Export(ctx, goGeneratedAPIPath)
 	if err != nil {


### PR DESCRIPTION
Thanks @vito for the suggestion: https://github.com/dagger/dagger/pull/6759#discussion_r1504696242

This now adds linting to the engine and the go sdk for `go.mod` consistency. An error looks something like this:

```
Error: Generated code mismatch. Please run `go mod tidy`:
--- go.mod
+++ go.mod
@@ -4,12 +4,9 @@
 
 replace dagger.io/dagger => ./sdk/go
 
-require (
-	dagger.io/dagger v0.10.0
-)
+require dagger.io/dagger v0.10.0
 
 require (
-	dagger.io/dagger v0.10.0
 	github.com/99designs/gqlgen v0.17.41
 	github.com/Khan/genqlient v0.6.0
 	github.com/MakeNowJust/heredoc/v2 v2.0.1

exit status 1
```