### PR TITLE
feat: allow passing git files on dagger cli

### DIFF
--- a/.changes/unreleased/Added-20240304-100326.yaml
+++ b/.changes/unreleased/Added-20240304-100326.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Allow passing git URLs to `dagger call` file type args
+time: 2024-03-04T10:03:26.553024737Z
+custom:
+  Author: jedevc
+  PR: "6769"


### PR DESCRIPTION
As suggested by @helderco in https://github.com/dagger/dagger/pull/6744#pullrequestreview-1902308392.

This brings it inline with how you can currently pass git directories.

Usage:

	dagger call thing --file https://github.com/dagger/dagger.git#main:README.md

Or with an implicit branch:

	dagger call thing --file https://github.com/dagger/dagger.git#:README.md