### PR TITLE
fix: change go module name to match dagger module name

### DIFF
--- a/.changes/unreleased/Fixed-20240304-100555.yaml
+++ b/.changes/unreleased/Fixed-20240304-100555.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Dagger go modules default to the module name instead of "main"
+time: 2024-03-04T10:05:55.625933343Z
+custom:
+  Author: jedevc
+  PR: "6774"

--- a/cmd/codegen/generator/go/generator.go
+++ b/cmd/codegen/generator/go/generator.go
@@ -198,7 +198,7 @@ func (g *GoGenerator) bootstrapMod(ctx context.Context, mfs *memfs.FS) (*Package
 
 			// bootstrap go.mod using dependencies from the embedded Go SDK
 
-			newModName := "main" // use a safe default, not going to be a reserved word. User is free to modify
+			newModName := fmt.Sprintf("dagger/%s", strcase.ToKebab(g.Config.ModuleName))
 
 			newMod.AddModuleStmt(newModName)
 			newMod.AddGoStmt(goVersion.String())
@@ -249,7 +249,7 @@ func generateCode(
 	tmpls := templates.Templates(funcs)
 
 	for k, tmpl := range tmpls {
-		dt, err := renderFile(ctx, cfg, schema, pkgInfo, tmpl)
+		dt, err := renderFile(cfg, schema, pkgInfo, tmpl)
 		if err != nil {
 			return err
 		}
@@ -269,7 +269,6 @@ func generateCode(
 }
 
 func renderFile(
-	ctx context.Context,
 	cfg generator.Config,
 	schema *introspection.Schema,
 	pkgInfo *PackageInfo,

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -3022,7 +3022,7 @@ type Test struct{}
 
 func (m *Test) Fn(ctx context.Context) string {
 	resp := &graphql.Response{}
-	err := dag.Client.MakeRequest(ctx, &graphql.Request{
+	err := dag.GraphQLClient().MakeRequest(ctx, &graphql.Request{
 		Query: "{host{unixSocket(path:\"/some/sock\"){id}}}",
 	}, resp)
 	if err != nil {


### PR DESCRIPTION
This effectively reverts #5983, since with go.work support we can't have duplicate module names inside a single namespace.

Thankfully though, we can avoid the original issue that this fixed (where `go` is effectively a reserved module name), by prefixing all module names with `dagger/`).

This helps for daggerverse-like repo structures, where the top-level `go.work` would ideally need to contain all the sub-modules.