### PR TITLE
docs: Adds note about module viz in Cloud get started

### DIFF
--- a/docs/current_docs/user-guide/cloud/572923-get-started.mdx
+++ b/docs/current_docs/user-guide/cloud/572923-get-started.mdx
@@ -266,6 +266,10 @@ The **All Runs** page provides an overview of all runs. You can drill down into 
 
 The **Run Details** page includes detailed status and duration metadata about the pipeline steps. The tree view shows Dagger pipelines and steps within those pipelines. If there are any errors in the run, Dagger Cloud automatically brings you to the first error in the list. You see detailed logs and output of each step, making it easy for you to debug your pipelines and collaborate with your teammates.
 
+:::note
+Dagger 0.10.0 introduced Dagger Functions. Full visualization of Dagger Functions in Dagger Cloud will be available shortly.
+:::
+
 When the run is performed in a Git context, the Dagger Cloud UI shows the VCS Git metadata associated with the commit.
 
 ![Run with metadata](/img/current_docs/user-guide/cloud/get-started/run-git-metadata.png)


### PR DESCRIPTION
This commit adds a note to the Dagger Cloud get started.