### PR TITLE
feat: support new options in terminal

### DIFF
--- a/.changes/unreleased/Added-20240304-224513.yaml
+++ b/.changes/unreleased/Added-20240304-224513.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Support privileges and nesting in default terminal command
+time: 2024-03-04T22:45:13.122651+01:00
+custom:
+  Author: TomChv
+  PR: "6805"

--- a/core/container.go
+++ b/core/container.go
@@ -41,6 +41,18 @@ import (
 
 var ErrContainerNoExec = errors.New("no command has been executed")
 
+type DefaultTerminalCmdOpts struct {
+	Args []string
+		
+	// Provide dagger access to the executed command
+	// Do not use this option unless you trust the command being executed.
+	// The command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM
+	ExperimentalPrivilegedNesting bool `default:"false"`
+
+	// Grant the process all root capabilities
+	InsecureRootCapabilities bool `default:"false"`
+}
+
 // Container is a content-addressed container.
 type Container struct {
 	Query *Query
@@ -83,7 +95,7 @@ type Container struct {
 	Focused bool `json:"focused"`
 
 	// The args to invoke when using the terminal api on this container.
-	DefaultTerminalCmd []string `json:"defaultTerminalCmd,omitempty"`
+	DefaultTerminalCmd *DefaultTerminalCmdOpts `json:"defaultTerminalCmd,omitempty"`
 }
 
 func (*Container) Type() *ast.Type {

--- a/core/container.go
+++ b/core/container.go
@@ -43,7 +43,7 @@ var ErrContainerNoExec = errors.New("no command has been executed")
 
 type DefaultTerminalCmdOpts struct {
 	Args []string
-		
+
 	// Provide dagger access to the executed command
 	// Do not use this option unless you trust the command being executed.
 	// The command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -294,7 +294,7 @@ func (s *containerSchema) Install() {
 				`Redirect the command's standard error to a file in the container (e.g.,
 			"/tmp/stderr").`).
 			ArgDoc("experimentalPrivilegedNesting",
-				`Provides dagger access to the executed command.`,
+				`Provides Dagger access to the executed command.`,
 				`Do not use this option unless you trust the command being executed;
 				the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST
 				FILESYSTEM.`).
@@ -443,7 +443,7 @@ func (s *containerSchema) Install() {
 			Doc(`Set the default command to invoke for the container's terminal API.`).
 			ArgDoc("args", `The args of the command.`).
 			ArgDoc("experimentalPrivilegedNesting",
-				`Provides dagger access to the executed command.`,
+				`Provides Dagger access to the executed command.`,
 				`Do not use this option unless you trust the command being executed;
 			the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST
 			FILESYSTEM.`).
@@ -458,7 +458,7 @@ func (s *containerSchema) Install() {
 			Doc(`Return an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).`).
 			ArgDoc("cmd", `If set, override the container's default terminal command and invoke these command arguments instead.`).
 			ArgDoc("experimentalPrivilegedNesting",
-				`Provides dagger access to the executed command.`,
+				`Provides Dagger access to the executed command.`,
 				`Do not use this option unless you trust the command being executed;
 		the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST
 		FILESYSTEM.`).

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -441,11 +441,33 @@ func (s *containerSchema) Install() {
 
 		dagql.Func("withDefaultTerminalCmd", s.withDefaultTerminalCmd).
 			Doc(`Set the default command to invoke for the container's terminal API.`).
-			ArgDoc("args", `The args of the command.`),
+			ArgDoc("args", `The args of the command.`).
+			ArgDoc("experimentalPrivilegedNesting",
+				`Provides dagger access to the executed command.`,
+				`Do not use this option unless you trust the command being executed;
+			the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST
+			FILESYSTEM.`).
+			ArgDoc("insecureRootCapabilities",
+				`Execute the command with all root capabilities. This is similar to
+			running a command with "sudo" or executing "docker run" with the
+			"--privileged" flag. Containerization does not provide any security
+			guarantees when using this option. It should only be used when
+			absolutely necessary and only with trusted commands.`),
 
 		dagql.NodeFunc("terminal", s.terminal).
 			Doc(`Return an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).`).
-			ArgDoc("cmd", `If set, override the container's default terminal command and invoke these command arguments instead.`),
+			ArgDoc("cmd", `If set, override the container's default terminal command and invoke these command arguments instead.`).
+			ArgDoc("experimentalPrivilegedNesting",
+				`Provides dagger access to the executed command.`,
+				`Do not use this option unless you trust the command being executed;
+		the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST
+		FILESYSTEM.`).
+			ArgDoc("insecureRootCapabilities",
+				`Execute the command with all root capabilities. This is similar to
+		running a command with "sudo" or executing "docker run" with the
+		"--privileged" flag. Containerization does not provide any security
+		guarantees when using this option. It should only be used when
+		absolutely necessary and only with trusted commands.`),
 
 		dagql.Func("experimentalWithGPU", s.withGPU).
 			Doc(`EXPERIMENTAL API! Subject to change/removal at any time.`,
@@ -1317,39 +1339,47 @@ func (s *containerSchema) withoutFocus(ctx context.Context, parent *core.Contain
 	return child, nil
 }
 
+type containerWithDefaultTerminalCmdArgs struct {
+	core.DefaultTerminalCmdOpts
+}
+
 func (s *containerSchema) withDefaultTerminalCmd(
 	ctx context.Context,
 	ctr *core.Container,
-	args struct {
-		Args []string
-	},
+	args containerWithDefaultTerminalCmdArgs,
 ) (*core.Container, error) {
 	ctr = ctr.Clone()
-	ctr.DefaultTerminalCmd = args.Args
+	ctr.DefaultTerminalCmd = &args.DefaultTerminalCmdOpts
 	return ctr, nil
+}
+
+type containerTerminalArgs struct {
+	core.TerminalArgs
 }
 
 func (s *containerSchema) terminal(
 	ctx context.Context,
 	ctr dagql.Instance[*core.Container],
-	args struct {
-		Cmd *[]string
-	},
+	args containerTerminalArgs,
 ) (*core.Terminal, error) {
-	var shellArgs []string
-	if args.Cmd != nil {
-		shellArgs = *args.Cmd
-	} else {
-		// if no override args specified, use default shell
-		shellArgs = ctr.Self.DefaultTerminalCmd
+	if args.Cmd == nil || len(args.Cmd) == 0 {
+		args.Cmd = ctr.Self.DefaultTerminalCmd.Args
+	}
+
+	if args.ExperimentalPrivilegedNesting == nil {
+		args.ExperimentalPrivilegedNesting = &ctr.Self.DefaultTerminalCmd.ExperimentalPrivilegedNesting
+	}
+
+	if args.InsecureRootCapabilities == nil {
+		args.InsecureRootCapabilities = &ctr.Self.DefaultTerminalCmd.InsecureRootCapabilities
 	}
 
 	// if still no args, default to sh
-	if len(shellArgs) == 0 {
-		shellArgs = []string{"sh"}
+	if len(args.Cmd) == 0 {
+		args.Cmd = []string{"sh"}
 	}
 
-	term, handler, err := ctr.Self.Terminal(ctr.ID(), shellArgs)
+	term, handler, err := ctr.Self.Terminal(ctr.ID(), &args.TerminalArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -351,7 +351,7 @@ type Container {
     cmd: [String!] = []
 
     """
-    Provides dagger access to the executed command.
+    Provides Dagger access to the executed command.
     
     Do not use this option unless you trust the command being executed; the
     command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
@@ -385,7 +385,7 @@ type Container {
     args: [String!]!
 
     """
-    Provides dagger access to the executed command.
+    Provides Dagger access to the executed command.
     
     Do not use this option unless you trust the command being executed; the
     command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
@@ -466,7 +466,7 @@ type Container {
     args: [String!]!
 
     """
-    Provides dagger access to the executed command.
+    Provides Dagger access to the executed command.
     
     Do not use this option unless you trust the command being executed; the
     command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -348,7 +348,24 @@ type Container {
     """
     If set, override the container's default terminal command and invoke these command arguments instead.
     """
-    cmd: [String!]
+    cmd: [String!] = []
+
+    """
+    Provides dagger access to the executed command.
+    
+    Do not use this option unless you trust the command being executed; the
+    command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
+    """
+    experimentalPrivilegedNesting: Boolean = false
+
+    """
+    Execute the command with all root capabilities. This is similar to running a
+    command with "sudo" or executing "docker run" with the "--privileged" flag.
+    Containerization does not provide any security guarantees when using this
+    option. It should only be used when absolutely necessary and only with
+    trusted commands.
+    """
+    insecureRootCapabilities: Boolean = false
   ): Terminal!
 
   """Retrieves the user to be set for all commands."""
@@ -366,6 +383,23 @@ type Container {
   withDefaultTerminalCmd(
     """The args of the command."""
     args: [String!]!
+
+    """
+    Provides dagger access to the executed command.
+    
+    Do not use this option unless you trust the command being executed; the
+    command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
+    """
+    experimentalPrivilegedNesting: Boolean = false
+
+    """
+    Execute the command with all root capabilities. This is similar to running a
+    command with "sudo" or executing "docker run" with the "--privileged" flag.
+    Containerization does not provide any security guarantees when using this
+    option. It should only be used when absolutely necessary and only with
+    trusted commands.
+    """
+    insecureRootCapabilities: Boolean = false
   ): Container!
 
   """Retrieves this container plus a directory written at the given path."""

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -451,7 +451,7 @@ defmodule Dagger.Container do
   )
 
   (
-    @doc "Return an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).\n\n\n\n## Optional Arguments\n\n* `cmd` - If set, override the container's default terminal command and invoke these command arguments instead."
+    @doc "Return an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).\n\n\n\n## Optional Arguments\n\n* `cmd` - If set, override the container's default terminal command and invoke these command arguments instead.\n* `experimental_privileged_nesting` - Provides Dagger access to the executed command.\n\nDo not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.\n* `insecure_root_capabilities` - Execute the command with all root capabilities. This is similar to running a command with \"sudo\" or executing \"docker run\" with the \"--privileged\" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands."
     @spec terminal(t(), keyword()) :: Dagger.Terminal.t()
     def terminal(%__MODULE__{} = container, optional_args \\ []) do
       selection = select(container.selection, "terminal")
@@ -461,6 +461,24 @@ defmodule Dagger.Container do
           selection
         else
           arg(selection, "cmd", optional_args[:cmd])
+        end
+
+      selection =
+        if is_nil(optional_args[:experimental_privileged_nesting]) do
+          selection
+        else
+          arg(
+            selection,
+            "experimentalPrivilegedNesting",
+            optional_args[:experimental_privileged_nesting]
+          )
+        end
+
+      selection =
+        if is_nil(optional_args[:insecure_root_capabilities]) do
+          selection
+        else
+          arg(selection, "insecureRootCapabilities", optional_args[:insecure_root_capabilities])
         end
 
       %Dagger.Terminal{selection: selection, client: container.client}
@@ -487,11 +505,30 @@ defmodule Dagger.Container do
   )
 
   (
-    @doc "Set the default command to invoke for the container's terminal API.\n\n## Required Arguments\n\n* `args` - The args of the command."
-    @spec with_default_terminal_cmd(t(), [Dagger.String.t()]) :: Dagger.Container.t()
-    def with_default_terminal_cmd(%__MODULE__{} = container, args) do
+    @doc "Set the default command to invoke for the container's terminal API.\n\n## Required Arguments\n\n* `args` - The args of the command.\n\n## Optional Arguments\n\n* `experimental_privileged_nesting` - Provides Dagger access to the executed command.\n\nDo not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.\n* `insecure_root_capabilities` - Execute the command with all root capabilities. This is similar to running a command with \"sudo\" or executing \"docker run\" with the \"--privileged\" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands."
+    @spec with_default_terminal_cmd(t(), [Dagger.String.t()], keyword()) :: Dagger.Container.t()
+    def with_default_terminal_cmd(%__MODULE__{} = container, args, optional_args \\ []) do
       selection = select(container.selection, "withDefaultTerminalCmd")
       selection = arg(selection, "args", args)
+
+      selection =
+        if is_nil(optional_args[:experimental_privileged_nesting]) do
+          selection
+        else
+          arg(
+            selection,
+            "experimentalPrivilegedNesting",
+            optional_args[:experimental_privileged_nesting]
+          )
+        end
+
+      selection =
+        if is_nil(optional_args[:insecure_root_capabilities]) do
+          selection
+        else
+          arg(selection, "insecureRootCapabilities", optional_args[:insecure_root_capabilities])
+        end
+
       %Dagger.Container{selection: selection, client: container.client}
     end
   )
@@ -573,7 +610,7 @@ defmodule Dagger.Container do
   )
 
   (
-    @doc "Retrieves this container after executing the specified command inside it.\n\n## Required Arguments\n\n* `args` - Command to run instead of the container's default command (e.g., [\"run\", \"main.go\"]).\n\nIf empty, the container's default command is used.\n\n## Optional Arguments\n\n* `skip_entrypoint` - If the container has an entrypoint, ignore it for args rather than using it to wrap them.\n* `stdin` - Content to write to the command's standard input before closing (e.g., \"Hello world\").\n* `redirect_stdout` - Redirect the command's standard output to a file in the container (e.g., \"/tmp/stdout\").\n* `redirect_stderr` - Redirect the command's standard error to a file in the container (e.g., \"/tmp/stderr\").\n* `experimental_privileged_nesting` - Provides dagger access to the executed command.\n\nDo not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.\n* `insecure_root_capabilities` - Execute the command with all root capabilities. This is similar to running a command with \"sudo\" or executing \"docker run\" with the \"--privileged\" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands."
+    @doc "Retrieves this container after executing the specified command inside it.\n\n## Required Arguments\n\n* `args` - Command to run instead of the container's default command (e.g., [\"run\", \"main.go\"]).\n\nIf empty, the container's default command is used.\n\n## Optional Arguments\n\n* `skip_entrypoint` - If the container has an entrypoint, ignore it for args rather than using it to wrap them.\n* `stdin` - Content to write to the command's standard input before closing (e.g., \"Hello world\").\n* `redirect_stdout` - Redirect the command's standard output to a file in the container (e.g., \"/tmp/stdout\").\n* `redirect_stderr` - Redirect the command's standard error to a file in the container (e.g., \"/tmp/stderr\").\n* `experimental_privileged_nesting` - Provides Dagger access to the executed command.\n\nDo not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.\n* `insecure_root_capabilities` - Execute the command with all root capabilities. This is similar to running a command with \"sudo\" or executing \"docker run\" with the \"--privileged\" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands."
     @spec with_exec(t(), [Dagger.String.t()], keyword()) :: Dagger.Container.t()
     def with_exec(%__MODULE__{} = container, args, optional_args \\ []) do
       selection = select(container.selection, "withExec")

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -906,7 +906,7 @@ func (r *Container) Sync(ctx context.Context) (*Container, error) {
 type ContainerTerminalOpts struct {
 	// If set, override the container's default terminal command and invoke these command arguments instead.
 	Cmd []string
-	// Provides dagger access to the executed command.
+	// Provides Dagger access to the executed command.
 	//
 	// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
 	ExperimentalPrivilegedNesting bool
@@ -964,7 +964,7 @@ func (r *Container) WithDefaultArgs(args []string) *Container {
 
 // ContainerWithDefaultTerminalCmdOpts contains options for Container.WithDefaultTerminalCmd
 type ContainerWithDefaultTerminalCmdOpts struct {
-	// Provides dagger access to the executed command.
+	// Provides Dagger access to the executed command.
 	//
 	// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
 	ExperimentalPrivilegedNesting bool
@@ -1091,7 +1091,7 @@ type ContainerWithExecOpts struct {
 	RedirectStdout string
 	// Redirect the command's standard error to a file in the container (e.g., "/tmp/stderr").
 	RedirectStderr string
-	// Provides dagger access to the executed command.
+	// Provides Dagger access to the executed command.
 	//
 	// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
 	ExperimentalPrivilegedNesting bool

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -906,6 +906,12 @@ func (r *Container) Sync(ctx context.Context) (*Container, error) {
 type ContainerTerminalOpts struct {
 	// If set, override the container's default terminal command and invoke these command arguments instead.
 	Cmd []string
+	// Provides dagger access to the executed command.
+	//
+	// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
+	ExperimentalPrivilegedNesting bool
+	// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
+	InsecureRootCapabilities bool
 }
 
 // Return an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).
@@ -915,6 +921,14 @@ func (r *Container) Terminal(opts ...ContainerTerminalOpts) *Terminal {
 		// `cmd` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Cmd) {
 			q = q.Arg("cmd", opts[i].Cmd)
+		}
+		// `experimentalPrivilegedNesting` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ExperimentalPrivilegedNesting) {
+			q = q.Arg("experimentalPrivilegedNesting", opts[i].ExperimentalPrivilegedNesting)
+		}
+		// `insecureRootCapabilities` optional argument
+		if !querybuilder.IsZeroValue(opts[i].InsecureRootCapabilities) {
+			q = q.Arg("insecureRootCapabilities", opts[i].InsecureRootCapabilities)
 		}
 	}
 
@@ -948,9 +962,29 @@ func (r *Container) WithDefaultArgs(args []string) *Container {
 	}
 }
 
+// ContainerWithDefaultTerminalCmdOpts contains options for Container.WithDefaultTerminalCmd
+type ContainerWithDefaultTerminalCmdOpts struct {
+	// Provides dagger access to the executed command.
+	//
+	// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
+	ExperimentalPrivilegedNesting bool
+	// Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
+	InsecureRootCapabilities bool
+}
+
 // Set the default command to invoke for the container's terminal API.
-func (r *Container) WithDefaultTerminalCmd(args []string) *Container {
+func (r *Container) WithDefaultTerminalCmd(args []string, opts ...ContainerWithDefaultTerminalCmdOpts) *Container {
 	q := r.Query.Select("withDefaultTerminalCmd")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `experimentalPrivilegedNesting` optional argument
+		if !querybuilder.IsZeroValue(opts[i].ExperimentalPrivilegedNesting) {
+			q = q.Arg("experimentalPrivilegedNesting", opts[i].ExperimentalPrivilegedNesting)
+		}
+		// `insecureRootCapabilities` optional argument
+		if !querybuilder.IsZeroValue(opts[i].InsecureRootCapabilities) {
+			q = q.Arg("insecureRootCapabilities", opts[i].InsecureRootCapabilities)
+		}
+	}
 	q = q.Arg("args", args)
 
 	return &Container{

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -368,11 +368,21 @@ class Container extends Client\AbstractObject implements Client\IdAble
     /**
      * Return an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).
      */
-    public function terminal(?array $cmd = null): Terminal
+    public function terminal(
+        ?array $cmd = null,
+        ?bool $experimentalPrivilegedNesting = false,
+        ?bool $insecureRootCapabilities = false,
+    ): Terminal
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('terminal');
         if (null !== $cmd) {
         $innerQueryBuilder->setArgument('cmd', $cmd);
+        }
+        if (null !== $experimentalPrivilegedNesting) {
+        $innerQueryBuilder->setArgument('experimentalPrivilegedNesting', $experimentalPrivilegedNesting);
+        }
+        if (null !== $insecureRootCapabilities) {
+        $innerQueryBuilder->setArgument('insecureRootCapabilities', $insecureRootCapabilities);
         }
         return new \Dagger\Terminal($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
@@ -399,10 +409,20 @@ class Container extends Client\AbstractObject implements Client\IdAble
     /**
      * Set the default command to invoke for the container's terminal API.
      */
-    public function withDefaultTerminalCmd(array $args): Container
+    public function withDefaultTerminalCmd(
+        array $args,
+        ?bool $experimentalPrivilegedNesting = false,
+        ?bool $insecureRootCapabilities = false,
+    ): Container
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withDefaultTerminalCmd');
         $innerQueryBuilder->setArgument('args', $args);
+        if (null !== $experimentalPrivilegedNesting) {
+        $innerQueryBuilder->setArgument('experimentalPrivilegedNesting', $experimentalPrivilegedNesting);
+        }
+        if (null !== $insecureRootCapabilities) {
+        $innerQueryBuilder->setArgument('insecureRootCapabilities', $insecureRootCapabilities);
+        }
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
 

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -1030,7 +1030,9 @@ class Container(Type):
     def terminal(
         self,
         *,
-        cmd: Sequence[str] | None = None,
+        cmd: Sequence[str] | None = [],
+        experimental_privileged_nesting: bool | None = False,
+        insecure_root_capabilities: bool | None = False,
     ) -> "Terminal":
         """Return an interactive terminal for this container using its configured
         default terminal command if not overridden by args (or sh as a
@@ -1041,9 +1043,24 @@ class Container(Type):
         cmd:
             If set, override the container's default terminal command and
             invoke these command arguments instead.
+        experimental_privileged_nesting:
+            Provides dagger access to the executed command.
+            Do not use this option unless you trust the command being
+            executed; the command being executed WILL BE GRANTED FULL ACCESS
+            TO YOUR HOST FILESYSTEM.
+        insecure_root_capabilities:
+            Execute the command with all root capabilities. This is similar to
+            running a command with "sudo" or executing "docker run" with the "
+            --privileged" flag. Containerization does not provide any security
+            guarantees when using this option. It should only be used when
+            absolutely necessary and only with trusted commands.
         """
         _args = [
-            Arg("cmd", cmd, None),
+            Arg("cmd", cmd, []),
+            Arg(
+                "experimentalPrivilegedNesting", experimental_privileged_nesting, False
+            ),
+            Arg("insecureRootCapabilities", insecure_root_capabilities, False),
         ]
         _ctx = self._select("terminal", _args)
         return Terminal(_ctx)
@@ -1087,16 +1104,37 @@ class Container(Type):
         return Container(_ctx)
 
     @typecheck
-    def with_default_terminal_cmd(self, args: Sequence[str]) -> "Container":
+    def with_default_terminal_cmd(
+        self,
+        args: Sequence[str],
+        *,
+        experimental_privileged_nesting: bool | None = False,
+        insecure_root_capabilities: bool | None = False,
+    ) -> "Container":
         """Set the default command to invoke for the container's terminal API.
 
         Parameters
         ----------
         args:
             The args of the command.
+        experimental_privileged_nesting:
+            Provides dagger access to the executed command.
+            Do not use this option unless you trust the command being
+            executed; the command being executed WILL BE GRANTED FULL ACCESS
+            TO YOUR HOST FILESYSTEM.
+        insecure_root_capabilities:
+            Execute the command with all root capabilities. This is similar to
+            running a command with "sudo" or executing "docker run" with the "
+            --privileged" flag. Containerization does not provide any security
+            guarantees when using this option. It should only be used when
+            absolutely necessary and only with trusted commands.
         """
         _args = [
             Arg("args", args),
+            Arg(
+                "experimentalPrivilegedNesting", experimental_privileged_nesting, False
+            ),
+            Arg("insecureRootCapabilities", insecure_root_capabilities, False),
         ]
         _ctx = self._select("withDefaultTerminalCmd", _args)
         return Container(_ctx)

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -1044,7 +1044,7 @@ class Container(Type):
             If set, override the container's default terminal command and
             invoke these command arguments instead.
         experimental_privileged_nesting:
-            Provides dagger access to the executed command.
+            Provides Dagger access to the executed command.
             Do not use this option unless you trust the command being
             executed; the command being executed WILL BE GRANTED FULL ACCESS
             TO YOUR HOST FILESYSTEM.
@@ -1118,7 +1118,7 @@ class Container(Type):
         args:
             The args of the command.
         experimental_privileged_nesting:
-            Provides dagger access to the executed command.
+            Provides Dagger access to the executed command.
             Do not use this option unless you trust the command being
             executed; the command being executed WILL BE GRANTED FULL ACCESS
             TO YOUR HOST FILESYSTEM.
@@ -1265,7 +1265,7 @@ class Container(Type):
             Redirect the command's standard error to a file in the container
             (e.g., "/tmp/stderr").
         experimental_privileged_nesting:
-            Provides dagger access to the executed command.
+            Provides Dagger access to the executed command.
             Do not use this option unless you trust the command being
             executed; the command being executed WILL BE GRANTED FULL ACCESS
             TO YOUR HOST FILESYSTEM.

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -701,7 +701,7 @@ pub struct ContainerTerminalOpts<'a> {
     /// If set, override the container's default terminal command and invoke these command arguments instead.
     #[builder(setter(into, strip_option), default)]
     pub cmd: Option<Vec<&'a str>>,
-    /// Provides dagger access to the executed command.
+    /// Provides Dagger access to the executed command.
     /// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
     #[builder(setter(into, strip_option), default)]
     pub experimental_privileged_nesting: Option<bool>,
@@ -711,7 +711,7 @@ pub struct ContainerTerminalOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithDefaultTerminalCmdOpts {
-    /// Provides dagger access to the executed command.
+    /// Provides Dagger access to the executed command.
     /// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
     #[builder(setter(into, strip_option), default)]
     pub experimental_privileged_nesting: Option<bool>,
@@ -747,7 +747,7 @@ pub struct ContainerWithEnvVariableOpts {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithExecOpts<'a> {
-    /// Provides dagger access to the executed command.
+    /// Provides Dagger access to the executed command.
     /// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
     #[builder(setter(into, strip_option), default)]
     pub experimental_privileged_nesting: Option<bool>,

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -202,6 +202,32 @@ export type ContainerTerminalOpts = {
    * If set, override the container's default terminal command and invoke these command arguments instead.
    */
   cmd?: string[]
+
+  /**
+   * Provides dagger access to the executed command.
+   *
+   * Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
+   */
+  experimentalPrivilegedNesting?: boolean
+
+  /**
+   * Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
+   */
+  insecureRootCapabilities?: boolean
+}
+
+export type ContainerWithDefaultTerminalCmdOpts = {
+  /**
+   * Provides dagger access to the executed command.
+   *
+   * Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
+   */
+  experimentalPrivilegedNesting?: boolean
+
+  /**
+   * Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
+   */
+  insecureRootCapabilities?: boolean
 }
 
 export type ContainerWithDirectoryOpts = {
@@ -1785,6 +1811,10 @@ export class Container extends BaseClient {
   /**
    * Return an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).
    * @param opts.cmd If set, override the container's default terminal command and invoke these command arguments instead.
+   * @param opts.experimentalPrivilegedNesting Provides dagger access to the executed command.
+   *
+   * Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
+   * @param opts.insecureRootCapabilities Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
    */
   terminal = (opts?: ContainerTerminalOpts): Terminal => {
     return new Terminal({
@@ -1840,14 +1870,21 @@ export class Container extends BaseClient {
   /**
    * Set the default command to invoke for the container's terminal API.
    * @param args The args of the command.
+   * @param opts.experimentalPrivilegedNesting Provides dagger access to the executed command.
+   *
+   * Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
+   * @param opts.insecureRootCapabilities Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
    */
-  withDefaultTerminalCmd = (args: string[]): Container => {
+  withDefaultTerminalCmd = (
+    args: string[],
+    opts?: ContainerWithDefaultTerminalCmdOpts,
+  ): Container => {
     return new Container({
       queryTree: [
         ...this._queryTree,
         {
           operation: "withDefaultTerminalCmd",
-          args: { args },
+          args: { args, ...opts },
         },
       ],
       ctx: this._ctx,

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -204,7 +204,7 @@ export type ContainerTerminalOpts = {
   cmd?: string[]
 
   /**
-   * Provides dagger access to the executed command.
+   * Provides Dagger access to the executed command.
    *
    * Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
    */
@@ -218,7 +218,7 @@ export type ContainerTerminalOpts = {
 
 export type ContainerWithDefaultTerminalCmdOpts = {
   /**
-   * Provides dagger access to the executed command.
+   * Provides Dagger access to the executed command.
    *
    * Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
    */
@@ -287,7 +287,7 @@ export type ContainerWithExecOpts = {
   redirectStderr?: string
 
   /**
-   * Provides dagger access to the executed command.
+   * Provides Dagger access to the executed command.
    *
    * Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
    */
@@ -1811,7 +1811,7 @@ export class Container extends BaseClient {
   /**
    * Return an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).
    * @param opts.cmd If set, override the container's default terminal command and invoke these command arguments instead.
-   * @param opts.experimentalPrivilegedNesting Provides dagger access to the executed command.
+   * @param opts.experimentalPrivilegedNesting Provides Dagger access to the executed command.
    *
    * Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
    * @param opts.insecureRootCapabilities Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
@@ -1870,7 +1870,7 @@ export class Container extends BaseClient {
   /**
    * Set the default command to invoke for the container's terminal API.
    * @param args The args of the command.
-   * @param opts.experimentalPrivilegedNesting Provides dagger access to the executed command.
+   * @param opts.experimentalPrivilegedNesting Provides Dagger access to the executed command.
    *
    * Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
    * @param opts.insecureRootCapabilities Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.
@@ -1973,7 +1973,7 @@ export class Container extends BaseClient {
    * @param opts.stdin Content to write to the command's standard input before closing (e.g., "Hello world").
    * @param opts.redirectStdout Redirect the command's standard output to a file in the container (e.g., "/tmp/stdout").
    * @param opts.redirectStderr Redirect the command's standard error to a file in the container (e.g., "/tmp/stderr").
-   * @param opts.experimentalPrivilegedNesting Provides dagger access to the executed command.
+   * @param opts.experimentalPrivilegedNesting Provides Dagger access to the executed command.
    *
    * Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
    * @param opts.insecureRootCapabilities Execute the command with all root capabilities. This is similar to running a command with "sudo" or executing "docker run" with the "--privileged" flag. Containerization does not provide any security guarantees when using this option. It should only be used when absolutely necessary and only with trusted commands.


### PR DESCRIPTION
Add `ExperimentalPrivilegedNesting` args in `DefaultTerminalCmdOpts` and `TerminalOpts`.
Add `InsecureRootCapabilities` args in `DefaultTerminalCmdOpts` and `TerminalOpts`.

I did some test with a local module I made but I struggle figuring out how to test it in our integration's test.
I know we have `module_terminal_test.go` for terminal tests and `container_test.go` for inscure and nesting params but I cannot figure out a nice way to combine both because this requires extra installation and sending lines/checking return etc...

I would love to have some ideas

/cc @sipsma @vito 

Fixes #6712 