### PR TITLE
fix: avoid duplicate secret accessor conversion

### DIFF
--- a/.changes/unreleased/Fixed-20240304-124800.yaml
+++ b/.changes/unreleased/Fixed-20240304-124800.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fix a regression where secrets used with dockerBuild could error out
+time: 2024-03-04T12:48:00.847879836Z
+custom:
+  Author: jedevc
+  PR: "6809"

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -224,7 +224,7 @@ CMD echo "stage2"
 				`FROM golang:1.18.2-alpine
 WORKDIR /src
 RUN --mount=type=secret,id=my-secret,required=true test "$(cat /run/secrets/my-secret)" = "barbar"
-RUN --mount=type=secret,id=my-secret,required=true cp /run/secrets/my-secret  /secret
+RUN --mount=type=secret,id=my-secret,required=true cp /run/secrets/my-secret /secret
 CMD cat /secret
 `)
 
@@ -233,6 +233,25 @@ CMD cat /secret
 		}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, stdout, "***")
+	})
+
+	t.Run("with input build secrets", func(t *testing.T) {
+		sec := c.SetSecret("my-secret", "barbar")
+
+		// src is a directory that has a secret dependency in it's build graph
+		src := c.Container().
+			From(alpineImage).
+			WithExec([]string{"apk", "add", "git"}).
+			WithDirectory("/src", c.Directory()).
+			WithWorkdir("/src").
+			WithMountedSecret("/run/my-secret", sec).
+			WithExec([]string{`sh`, `-c`, `echo "FROM alpine" > Dockerfile`}).
+			Directory("/src")
+
+		// building src should only transform the secrets from the raw
+		// Dockerfile, not from the src input
+		_, err := src.DockerBuild().Sync(ctx)
+		require.NoError(t, err)
 	})
 
 	t.Run("just build, don't execute", func(t *testing.T) {

--- a/engine/buildkit/llbdefinition.go
+++ b/engine/buildkit/llbdefinition.go
@@ -136,9 +136,15 @@ func (dag *OpDAG) walk(f func(*OpDAG) error, memo map[*OpDAG]struct{}) error {
 		return nil
 	}
 	memo[dag] = struct{}{}
-	if err := f(dag); err != nil {
+
+	err := f(dag)
+	if err == SkipInputs {
+		return nil
+	}
+	if err != nil {
 		return err
 	}
+
 	for _, input := range dag.Inputs {
 		if err := input.walk(f, memo); err != nil {
 			return err
@@ -146,6 +152,8 @@ func (dag *OpDAG) walk(f func(*OpDAG) error, memo map[*OpDAG]struct{}) error {
 	}
 	return nil
 }
+
+var SkipInputs = fmt.Errorf("skip inputs") //nolint:stylecheck // Err prefix isn't convention for Walk control errors
 
 // Marshal will convert the dag back to a flat pb.Definition, updating all digests
 // based on any modifications made to the dag.


### PR DESCRIPTION
Fixes regression from #6601, see [discord discussion](https://discord.com/channels/707636530424053791/1212602528890363955). 

Essentially, it became possible to construct an input which would apply the secret accessor translation twice. If one of the frontend inputs was constructed from dagger, it could already have an accessor secret ID as part of it's build graph (if `WithExec` was used alongside a secret).

However, this input could appear inside the frontend request - which would result in double-wrapping the secret accessor to a secret that definitely can't exist, which presents the weird error.

The easiest solution to this is to just track the inputs for dagger calls to buildkit's Solve request, and to ensure that we avoid secret filtering for those inputs.