### PR TITLE
chore: improve dependabot config publish weekly with groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,83 +2,78 @@ version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
-    schedule:
-      interval: "monthly"
+    schedule: &schedule-weekly
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "UTC"
     labels:
       - "kind/dependencies"
       - "area/engine"
       - "area/cli"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+    groups:
+      engine:
 
   - package-ecosystem: "gomod"
     directory: "/internal/mage"
-    schedule:
-      interval: "monthly"
+    schedule: *schedule-weekly
     labels:
       - "kind/dependencies"
       - "area/ci"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+    groups:
+      engine-tools:
 
   - package-ecosystem: "npm"
     directory: "/sdk/typescript"
-    schedule:
-      interval: "monthly"
+    schedule: *schedule-weekly
     labels:
       - "kind/dependencies"
       - "sdk/typescript"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+    groups:
+      sdk-typescript:
 
   - package-ecosystem: "npm"
     directory: "/website"
-    schedule:
-      interval: "monthly"
+    schedule: *schedule-weekly
     labels:
       - "kind/dependencies"
       - "area/docs"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+    groups:
+      website:
 
   - package-ecosystem: "gomod"
     directory: "/sdk/go"
-    schedule:
-      interval: "monthly"
+    schedule: *schedule-weekly
     labels:
       - "kind/dependencies"
       - "sdk/go"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+    groups:
+      sdk-go:
 
   - package-ecosystem: "pip"
     directory: "/sdk/python"
-    schedule:
-      interval: "monthly"
+    schedule: *schedule-weekly
     labels:
       - "kind/dependencies"
       - "sdk/python"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
-
-  # ignore all npm dependencies in sdk/rust
-  - package-ecosystem: "npm"
-    directory: "/sdk/rust"
-    schedule:
-      interval: "monthly"
-    ignore:
-      - dependency-name: "*"
+    groups:
+      sdk-python:
 
   - package-ecosystem: "maven"
     directory: "/sdk/java"
-    schedule:
-      interval: "monthly"
+    schedule: *schedule-weekly
     labels:
       - "kind/dependencies"
       - "sdk/java"
@@ -87,3 +82,11 @@ updates:
         update-types: ["version-update:semver-patch"]
       # ignore maven dependencies (API, plugins, etc)
       - dependency-name: "org.apache.maven*"
+    groups:
+      sdk-java:
+
+  # ignore all npm dependencies in sdk/rust
+  - package-ecosystem: "npm"
+    directory: "/sdk/rust"
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
Follow-up on comments from https://github.com/dagger/dagger/pull/6352#discussion_r1439349557.

Getting kinda annoyed with all the dependabot spam :cry:

- By moving from once-a-month to once-a-week, we stay more on top of changes, which means there should be fewer to address all at once. Additionally, I've set the time to trigger on Monday morning - that way, we can hopefully review and merge before the next release.
- I've also used `group`s to try and ensure that each set of updates is all combined, so we don't get a complete overflow of updates. Unfortunately, we don't seem to be able to combine all the go updates together (see https://github.com/dependabot/dependabot-core/issues/7547) - so we may still get invalid PRs, since the `go.mod`s interact with each other in fun ways.
- Finally, I've removed the `version-update:semver-patch` from Go - at least for the core engine+components, I'd like to try following patch updates as well. Some projects follow semver a little differently (even though ideally they wouldn't :laughing:), and I'd like to make sure we don't fall behind.