### PR TITLE
remove experimental from two quickstart pages

### DIFF
--- a/docs/current_docs/quickstart/428201-custom-function.mdx
+++ b/docs/current_docs/quickstart/428201-custom-function.mdx
@@ -3,13 +3,10 @@ slug: /quickstart/428201/custom-function
 hide_table_of_contents: true
 title: "Write your first function"
 ---
-import PartialExperimentalDocs from '../partials/_experimental.mdx';
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
 # Quickstart
-
-<PartialExperimentalDocs />
 
 ## Write your first function
 

--- a/docs/current_docs/quickstart/822194-daggerize.mdx
+++ b/docs/current_docs/quickstart/822194-daggerize.mdx
@@ -3,13 +3,10 @@ slug: /quickstart/822194/daggerize
 hide_table_of_contents: true
 title: "Daggerize a project"
 ---
-import PartialExperimentalDocs from '../partials/_experimental.mdx';
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
 # Quickstart
-
-<PartialExperimentalDocs />
 
 ## Daggerize a project
 


### PR DESCRIPTION
There are 2 pages in the current quickstart that contain the experimental note

"Daggerize A Project" and "Write your first function"

This removes that note from those two pages

<img width="1198" alt="Screen Shot 2024-03-04 at 4 04 11 PM" src="https://github.com/dagger/dagger/assets/1865460/2983d055-0517-488f-b7d0-f6a6c060a55d">
