### PR TITLE
fix: repair dagger.gen.go access to Client

### DIFF
--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -4962,8 +4962,7 @@ func (r *Client) BuiltinContainer(digest string) *Container {
 	q = q.Arg("digest", digest)
 
 	return &Container{
-		Query:  q,
-		Client: r.Client,
+		Query: q,
 	}
 }
 


### PR DESCRIPTION
Due to an undetected conflict, we added a new method BuiltinContainer, which accessed the old Client property.

This fixes the CI failure on main: https://github.com/dagger/dagger/commit/62ced562b1bdd69f35b5112d0d2736a2d2189c7a