### PR TITLE
fix: update test-publish to node 18 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -155,7 +155,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 18
 
       - name: "Test TypeScript SDK"
         run: |


### PR DESCRIPTION
Following of #6685 to update the test publish job.

It's weird but some test are not run on push and so we didn't caught this erorr.
 https://github.com/dagger/dagger/blob/1759f47a7c6bc8cc13380e193f6f7a1248ca6e0d/.github/workflows/publish.yml#L93

Normally this fixes works and fixes:

<img width="1114" alt="Screenshot 2024-03-05 at 10 39 36" src="https://github.com/dagger/dagger/assets/61683879/fbb1ea9e-2272-40f0-b6e2-6a5bd79c1f57">

Btw, do we actually need these tests? Since we are using Dagger modules now, we don't have use that provisioning feature anymore. 