### PR TITLE
ci: fix typescript version for test provision job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -297,7 +297,7 @@ jobs:
         shell: bash
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 18
       - name: "Test TypeScript SDK"
         run: |
           cd sdk/typescript


### PR DESCRIPTION
Follow-up to https://github.com/dagger/dagger/pull/6819

We also need this version update for `test-provision-typescript-linux`.