### PR TITLE
engine: fix git module source symbolic URL

### DIFF
--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"strings"
 
@@ -364,7 +365,9 @@ func (src *GitModuleSource) RefString() string {
 }
 
 func (src *GitModuleSource) Symbolic() string {
-	return filepath.Join(src.CloneURL(), src.RootSubpath)
+	// ignore error since ref is validated upon module initialization
+	p, _ := url.JoinPath(src.CloneURL(), src.RootSubpath)
+	return p
 }
 
 func (src *GitModuleSource) CloneURL() string {


### PR DESCRIPTION
since we were using filepath.Join instead of url.JoinPath, the symbolic
URL was not being generated correctly. It was prefixing `https:/`
instead of `https://`

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
