### PR TITLE
fix: avoid duplicate secret accessor for all frontend inputs

### DIFF
--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -241,11 +241,13 @@ CMD cat /secret
 		// src is a directory that has a secret dependency in it's build graph
 		src := c.Container().
 			From(alpineImage).
-			WithExec([]string{"apk", "add", "git"}).
-			WithDirectory("/src", c.Directory()).
 			WithWorkdir("/src").
-			WithMountedSecret("/run/my-secret", sec).
-			WithExec([]string{`sh`, `-c`, `echo "FROM alpine" > Dockerfile`}).
+			WithMountedSecret("/run/secret", sec).
+			WithExec([]string{"cat", "/run/secret"}).
+			WithNewFile("Dockerfile", dagger.ContainerWithNewFileOpts{Contents: `
+			FROM alpine
+			COPY / /
+			`}).
 			Directory("/src")
 
 		// building src should only transform the secrets from the raw

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -806,7 +806,9 @@ type filteringGateway struct {
 func newFilterGateway(bridge bkfrontend.FrontendLLBBridge, req bkgw.SolveRequest) *filteringGateway {
 	inputs := map[digest.Digest]struct{}{}
 	for _, inp := range req.FrontendInputs {
-		inputs[digest.FromBytes(inp.Def[len(inp.Def)-1])] = struct{}{}
+		for _, def := range inp.Def {
+			inputs[digest.FromBytes(def)] = struct{}{}
+		}
 	}
 
 	return &filteringGateway{


### PR DESCRIPTION
...not just the last one. Not quite sure why I missed this before, but this occurs in some test cases (that are really annoying to add test cases for some reason).

This fixes up the logic from #6809 - see the discord conversation in https://discord.com/channels/707636530424053791/1212602528890363955/1214748356472213504.

Not 100% sure why the previous fix wasn't right, but this *definitely* works, and I don't really have the time to dive into exactly what I'm misunderstanding.
