### PR TITLE
fix: no panic on missing defaultTerminalCmd

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -95,7 +95,7 @@ type Container struct {
 	Focused bool `json:"focused"`
 
 	// The args to invoke when using the terminal api on this container.
-	DefaultTerminalCmd *DefaultTerminalCmdOpts `json:"defaultTerminalCmd,omitempty"`
+	DefaultTerminalCmd DefaultTerminalCmdOpts `json:"defaultTerminalCmd,omitempty"`
 }
 
 func (*Container) Type() *ast.Type {

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -1349,7 +1349,7 @@ func (s *containerSchema) withDefaultTerminalCmd(
 	args containerWithDefaultTerminalCmdArgs,
 ) (*core.Container, error) {
 	ctr = ctr.Clone()
-	ctr.DefaultTerminalCmd = &args.DefaultTerminalCmdOpts
+	ctr.DefaultTerminalCmd = args.DefaultTerminalCmdOpts
 	return ctr, nil
 }
 
@@ -1366,7 +1366,7 @@ func (s *containerSchema) terminal(
 		args.Cmd = ctr.Self.DefaultTerminalCmd.Args
 	}
 
-	if args.ExperimentalPrivilegedNesting == nil {
+	if args.ExperimentalPrivilegedNesting == nil{
 		args.ExperimentalPrivilegedNesting = &ctr.Self.DefaultTerminalCmd.ExperimentalPrivilegedNesting
 	}
 


### PR DESCRIPTION
Fixes #6828 