### PR TITLE
Change Logo URL

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -123,7 +123,7 @@ const config: Config = {
         alt: "Dagger Logo",
         src: "img/dagger-logo-white.svg",
         height: "50px",
-        href: "https://dagger.io/",
+        href: "https://docs.dagger.io/",
       },
       items: [
         {


### PR DESCRIPTION
Right now the experience is a bit strange on the docs page because clicking the logo takes you back to the marketing page. We should have this go to the home page of the docs page and perhaps add a new link to go to the marketing site.