### PR TITLE
fix file and cmd secret source inputs

### DIFF
--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -357,7 +357,7 @@ func (v *secretValue) Get(ctx context.Context, c *dagger.Client) (any, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to read secret file %q: %w", v.sourceVal, err)
 		}
-		plaintext = string(filePlaintext)
+		plaintext = strings.TrimSpace(string(filePlaintext))
 
 	case commandSecretSource:
 		// #nosec G204
@@ -365,7 +365,7 @@ func (v *secretValue) Get(ctx context.Context, c *dagger.Client) (any, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to run secret command %q: %w", v.sourceVal, err)
 		}
-		plaintext = string(stdoutBytes)
+		plaintext = strings.TrimSpace(string(stdoutBytes))
 
 	default:
 		return nil, fmt.Errorf("unsupported secret arg source: %q", v.secretSource)


### PR DESCRIPTION
Reported here: https://github.com/dagger/dagger/pull/6829#discussion_r1513464630

Based on my testing, the following did not work:

```
dagger call foo --token env:TOKEN
echo $TOKEN > token.txt
dagger call foo --token file:./token.txt
```

Breaking out the file parsing code, the `token.txt` would be parsed with a newline character at the end.

This adds `TrimSpace()` to file and cmd secret inputs. `TrimSpace()` trims leading and trailing unicode whitespace characters. I can't think of any cases where this would have unintended consequences for secrets.