### PR TITLE
chore: remove old zenith directory

### DIFF
--- a/zenith/README.md
+++ b/zenith/README.md
@@ -1,4 +1,0 @@
-# Project Zenith
-
-For information on Zenith and getting started with it see
-<https://docs.dagger.io/labs/project-zenith/>.


### PR DESCRIPTION
https://github.com/dagger/dagger/pull/6503 removed most of the content of the `zenith/` top-level directory, but we kept the `README.md` around to keep pointing users to the docs.

However, I don't think we're linking to this from anywhere anymore, and now that functions/modules have launched and have a permanent home in the docs, it doesn't really make sense to keep this folder anymore.