### PR TITLE
fix: remove public Query field from go generated types

### DIFF
--- a/cmd/codegen/generator/go/templates/src/_dagger.gen.go/defs.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_dagger.gen.go/defs.go.tmpl
@@ -115,7 +115,7 @@ func (e *ExecError) Unwrap() error {
 
 {{ if IsModuleCode }}
 type Client struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 	client graphql.Client
 }
 
@@ -124,7 +124,7 @@ var dag *Client
 func init() {
 	gqlClient, q := getClientParams()
 	dag = &Client{
-		Query: q.Client(gqlClient),
+		query: q.Client(gqlClient),
 		client: gqlClient,
 	}
 }

--- a/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
@@ -1,7 +1,7 @@
 {{- if ne .Name "Query" }}
 {{ .Description | Comment }}
 type {{ .Name | FormatName }} struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
     {{ range $field := .Fields }}
         {{- if $field.TypeRef.IsScalar }}
@@ -10,7 +10,6 @@ type {{ .Name | FormatName }} struct {
 	{{- end }}
 }
 {{- end }}
-
 
 {{- if . | IsSelfChainable }}
 type With{{ .Name | FormatName }}Func func(r *{{ .Name | FormatName }}) *{{ .Name | FormatName }}
@@ -23,6 +22,11 @@ func (r *{{ $.Name | FormatName }}) With(f With{{ .Name | FormatName }}Func) *{{
 }
 
 {{- end }}
+
+
+func (r *{{ .Name | FormatName }}) WithGraphQLQuery(q *querybuilder.Selection) *{{ $.Name | FormatName }} {
+	return &{{ .Name | FormatName }}{query: q}
+}
 
 {{ range $field := .Fields }}
 {{- if $field.Args.HasOptionals }}
@@ -60,7 +64,7 @@ type {{ $field | FieldOptionsStructName }} struct {
         return *r.{{ $field.Name }}, nil
     }
     {{- end }}
-	q := r.Query.Select("{{ $field.Name }}")
+	q := r.query.Select("{{ $field.Name }}")
 
 	{{- if $field.Args.HasOptionals }}
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -87,7 +91,7 @@ type {{ $field | FieldOptionsStructName }} struct {
 	{{- else if $field.TypeRef.IsObject }}
 	{{ $typeName := $field.TypeRef | FormatOutputType }}
 	return &{{ $field.TypeRef | FormatOutputType }} {
-		Query: q,
+		query: q,
 		{{- if eq $typeName "Client" }}
 		client: r.client,
 		{{ end }}
@@ -110,7 +114,7 @@ type {{ $field | FieldOptionsStructName }} struct {
         for i := range fields {
             val := {{ $field.TypeRef | FormatOutputType | FormatArrayToSingleType }}{{"{"}}{{ $field | GetArrayField | FormatArrayField }}{{"}"}}
             {{- if $eleType | IsIDableObject }}
-              val.Query = q.Root().Select("load{{$eleType | ObjectName}}FromID").Arg("id", fields[i].Id)
+              val.query = q.Root().Select("load{{$eleType | ObjectName}}FromID").Arg("id", fields[i].Id)
             {{- end }}
             out = append(out, val)
         }

--- a/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
@@ -25,7 +25,12 @@ func (r *{{ $.Name | FormatName }}) With(f With{{ .Name | FormatName }}Func) *{{
 
 
 func (r *{{ .Name | FormatName }}) WithGraphQLQuery(q *querybuilder.Selection) *{{ $.Name | FormatName }} {
-	return &{{ .Name | FormatName }}{query: q}
+	return &{{ .Name | FormatName }}{
+		query: q,
+		{{- if eq .Name "Query" }}
+		client: r.client,
+		{{ end }}
+	}
 }
 
 {{ range $field := .Fields }}

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -17,7 +17,7 @@ import (
 type Client struct {
 	conn engineconn.EngineConn
 
-	Query  *querybuilder.Selection
+	query  *querybuilder.Selection
 	client graphql.Client
 }
 
@@ -75,7 +75,7 @@ func Connect(ctx context.Context, opts ...ClientOpt) (*Client, error) {
 	gql := errorWrappedClient{graphql.NewClient("http://"+conn.Host()+"/query", conn)}
 
 	c := &Client{
-		Query:  querybuilder.Query().Client(gql),
+		query:  querybuilder.Query().Client(gql),
 		client: gql,
 		conn:   conn,
 	}

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -238,9 +238,13 @@ type PortForward struct {
 
 // A directory whose contents persist across runs.
 type CacheVolume struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	id *CacheVolumeID
+}
+
+func (r *CacheVolume) WithGraphQLQuery(q *querybuilder.Selection) *CacheVolume {
+	return &CacheVolume{query: q}
 }
 
 // A unique identifier for this CacheVolume.
@@ -248,7 +252,7 @@ func (r *CacheVolume) ID(ctx context.Context) (CacheVolumeID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response CacheVolumeID
 
@@ -285,7 +289,7 @@ func (r *CacheVolume) MarshalJSON() ([]byte, error) {
 
 // An OCI-compatible container, also known as a Docker container.
 type Container struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	envVariable *string
 	export      *bool
@@ -309,14 +313,18 @@ func (r *Container) With(f WithContainerFunc) *Container {
 	return f(r)
 }
 
+func (r *Container) WithGraphQLQuery(q *querybuilder.Selection) *Container {
+	return &Container{query: q}
+}
+
 // Turn the container into a Service.
 //
 // Be sure to set any exposed ports before this conversion.
 func (r *Container) AsService() *Service {
-	q := r.Query.Select("asService")
+	q := r.query.Select("asService")
 
 	return &Service{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -338,7 +346,7 @@ type ContainerAsTarballOpts struct {
 
 // Returns a File representing the container serialized to a tarball.
 func (r *Container) AsTarball(opts ...ContainerAsTarballOpts) *File {
-	q := r.Query.Select("asTarball")
+	q := r.query.Select("asTarball")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `platformVariants` optional argument
 		if !querybuilder.IsZeroValue(opts[i].PlatformVariants) {
@@ -355,7 +363,7 @@ func (r *Container) AsTarball(opts ...ContainerAsTarballOpts) *File {
 	}
 
 	return &File{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -378,7 +386,7 @@ type ContainerBuildOpts struct {
 // Initializes this container from a Dockerfile build.
 func (r *Container) Build(context *Directory, opts ...ContainerBuildOpts) *Container {
 	assertNotNil("context", context)
-	q := r.Query.Select("build")
+	q := r.query.Select("build")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `dockerfile` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Dockerfile) {
@@ -400,13 +408,13 @@ func (r *Container) Build(context *Directory, opts ...ContainerBuildOpts) *Conta
 	q = q.Arg("context", context)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
 // Retrieves default arguments for future commands.
 func (r *Container) DefaultArgs(ctx context.Context) ([]string, error) {
-	q := r.Query.Select("defaultArgs")
+	q := r.query.Select("defaultArgs")
 
 	var response []string
 
@@ -418,17 +426,17 @@ func (r *Container) DefaultArgs(ctx context.Context) ([]string, error) {
 //
 // Mounts are included.
 func (r *Container) Directory(path string) *Directory {
-	q := r.Query.Select("directory")
+	q := r.query.Select("directory")
 	q = q.Arg("path", path)
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
 // Retrieves entrypoint to be prepended to the arguments of all commands.
 func (r *Container) Entrypoint(ctx context.Context) ([]string, error) {
-	q := r.Query.Select("entrypoint")
+	q := r.query.Select("entrypoint")
 
 	var response []string
 
@@ -441,7 +449,7 @@ func (r *Container) EnvVariable(ctx context.Context, name string) (string, error
 	if r.envVariable != nil {
 		return *r.envVariable, nil
 	}
-	q := r.Query.Select("envVariable")
+	q := r.query.Select("envVariable")
 	q = q.Arg("name", name)
 
 	var response string
@@ -452,7 +460,7 @@ func (r *Container) EnvVariable(ctx context.Context, name string) (string, error
 
 // Retrieves the list of environment variables passed to commands.
 func (r *Container) EnvVariables(ctx context.Context) ([]EnvVariable, error) {
-	q := r.Query.Select("envVariables")
+	q := r.query.Select("envVariables")
 
 	q = q.Select("id")
 
@@ -465,7 +473,7 @@ func (r *Container) EnvVariables(ctx context.Context) ([]EnvVariable, error) {
 
 		for i := range fields {
 			val := EnvVariable{id: &fields[i].Id}
-			val.Query = q.Root().Select("loadEnvVariableFromID").Arg("id", fields[i].Id)
+			val.query = q.Root().Select("loadEnvVariableFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -489,10 +497,10 @@ func (r *Container) EnvVariables(ctx context.Context) ([]EnvVariable, error) {
 //
 // This currently works for Nvidia devices only.
 func (r *Container) ExperimentalWithAllGPUs() *Container {
-	q := r.Query.Select("experimentalWithAllGPUs")
+	q := r.query.Select("experimentalWithAllGPUs")
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -502,11 +510,11 @@ func (r *Container) ExperimentalWithAllGPUs() *Container {
 //
 // This currently works for Nvidia devices only.
 func (r *Container) ExperimentalWithGPU(devices []string) *Container {
-	q := r.Query.Select("experimentalWithGPU")
+	q := r.query.Select("experimentalWithGPU")
 	q = q.Arg("devices", devices)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -535,7 +543,7 @@ func (r *Container) Export(ctx context.Context, path string, opts ...ContainerEx
 	if r.export != nil {
 		return *r.export, nil
 	}
-	q := r.Query.Select("export")
+	q := r.query.Select("export")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `platformVariants` optional argument
 		if !querybuilder.IsZeroValue(opts[i].PlatformVariants) {
@@ -562,7 +570,7 @@ func (r *Container) Export(ctx context.Context, path string, opts ...ContainerEx
 //
 // This includes ports already exposed by the image, even if not explicitly added with dagger.
 func (r *Container) ExposedPorts(ctx context.Context) ([]Port, error) {
-	q := r.Query.Select("exposedPorts")
+	q := r.query.Select("exposedPorts")
 
 	q = q.Select("id")
 
@@ -575,7 +583,7 @@ func (r *Container) ExposedPorts(ctx context.Context) ([]Port, error) {
 
 		for i := range fields {
 			val := Port{id: &fields[i].Id}
-			val.Query = q.Root().Select("loadPortFromID").Arg("id", fields[i].Id)
+			val.query = q.Root().Select("loadPortFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -597,21 +605,21 @@ func (r *Container) ExposedPorts(ctx context.Context) ([]Port, error) {
 //
 // Mounts are included.
 func (r *Container) File(path string) *File {
-	q := r.Query.Select("file")
+	q := r.query.Select("file")
 	q = q.Arg("path", path)
 
 	return &File{
-		Query: q,
+		query: q,
 	}
 }
 
 // Initializes this container from a pulled base image.
 func (r *Container) From(address string) *Container {
-	q := r.Query.Select("from")
+	q := r.query.Select("from")
 	q = q.Arg("address", address)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -620,7 +628,7 @@ func (r *Container) ID(ctx context.Context) (ContainerID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response ContainerID
 
@@ -660,7 +668,7 @@ func (r *Container) ImageRef(ctx context.Context) (string, error) {
 	if r.imageRef != nil {
 		return *r.imageRef, nil
 	}
-	q := r.Query.Select("imageRef")
+	q := r.query.Select("imageRef")
 
 	var response string
 
@@ -677,7 +685,7 @@ type ContainerImportOpts struct {
 // Reads the container from an OCI tarball.
 func (r *Container) Import(source *File, opts ...ContainerImportOpts) *Container {
 	assertNotNil("source", source)
-	q := r.Query.Select("import")
+	q := r.query.Select("import")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `tag` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Tag) {
@@ -687,7 +695,7 @@ func (r *Container) Import(source *File, opts ...ContainerImportOpts) *Container
 	q = q.Arg("source", source)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -696,7 +704,7 @@ func (r *Container) Label(ctx context.Context, name string) (string, error) {
 	if r.label != nil {
 		return *r.label, nil
 	}
-	q := r.Query.Select("label")
+	q := r.query.Select("label")
 	q = q.Arg("name", name)
 
 	var response string
@@ -707,7 +715,7 @@ func (r *Container) Label(ctx context.Context, name string) (string, error) {
 
 // Retrieves the list of labels passed to container.
 func (r *Container) Labels(ctx context.Context) ([]Label, error) {
-	q := r.Query.Select("labels")
+	q := r.query.Select("labels")
 
 	q = q.Select("id")
 
@@ -720,7 +728,7 @@ func (r *Container) Labels(ctx context.Context) ([]Label, error) {
 
 		for i := range fields {
 			val := Label{id: &fields[i].Id}
-			val.Query = q.Root().Select("loadLabelFromID").Arg("id", fields[i].Id)
+			val.query = q.Root().Select("loadLabelFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -740,7 +748,7 @@ func (r *Container) Labels(ctx context.Context) ([]Label, error) {
 
 // Retrieves the list of paths where a directory is mounted.
 func (r *Container) Mounts(ctx context.Context) ([]string, error) {
-	q := r.Query.Select("mounts")
+	q := r.query.Select("mounts")
 
 	var response []string
 
@@ -758,7 +766,7 @@ type ContainerPipelineOpts struct {
 
 // Creates a named sub-pipeline.
 func (r *Container) Pipeline(name string, opts ...ContainerPipelineOpts) *Container {
-	q := r.Query.Select("pipeline")
+	q := r.query.Select("pipeline")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `description` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Description) {
@@ -772,7 +780,7 @@ func (r *Container) Pipeline(name string, opts ...ContainerPipelineOpts) *Contai
 	q = q.Arg("name", name)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -781,7 +789,7 @@ func (r *Container) Platform(ctx context.Context) (Platform, error) {
 	if r.platform != nil {
 		return *r.platform, nil
 	}
-	q := r.Query.Select("platform")
+	q := r.query.Select("platform")
 
 	var response Platform
 
@@ -814,7 +822,7 @@ func (r *Container) Publish(ctx context.Context, address string, opts ...Contain
 	if r.publish != nil {
 		return *r.publish, nil
 	}
-	q := r.Query.Select("publish")
+	q := r.query.Select("publish")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `platformVariants` optional argument
 		if !querybuilder.IsZeroValue(opts[i].PlatformVariants) {
@@ -839,10 +847,10 @@ func (r *Container) Publish(ctx context.Context, address string, opts ...Contain
 
 // Retrieves this container's root filesystem. Mounts are not included.
 func (r *Container) Rootfs() *Directory {
-	q := r.Query.Select("rootfs")
+	q := r.query.Select("rootfs")
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -853,7 +861,7 @@ func (r *Container) Stderr(ctx context.Context) (string, error) {
 	if r.stderr != nil {
 		return *r.stderr, nil
 	}
-	q := r.Query.Select("stderr")
+	q := r.query.Select("stderr")
 
 	var response string
 
@@ -868,7 +876,7 @@ func (r *Container) Stdout(ctx context.Context) (string, error) {
 	if r.stdout != nil {
 		return *r.stdout, nil
 	}
-	q := r.Query.Select("stdout")
+	q := r.query.Select("stdout")
 
 	var response string
 
@@ -880,7 +888,7 @@ func (r *Container) Stdout(ctx context.Context) (string, error) {
 //
 // It doesn't run the default command if no exec has been set.
 func (r *Container) Sync(ctx context.Context) (*Container, error) {
-	q := r.Query.Select("sync")
+	q := r.query.Select("sync")
 
 	return r, q.Execute(ctx)
 }
@@ -899,7 +907,7 @@ type ContainerTerminalOpts struct {
 
 // Return an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).
 func (r *Container) Terminal(opts ...ContainerTerminalOpts) *Terminal {
-	q := r.Query.Select("terminal")
+	q := r.query.Select("terminal")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `cmd` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Cmd) {
@@ -916,7 +924,7 @@ func (r *Container) Terminal(opts ...ContainerTerminalOpts) *Terminal {
 	}
 
 	return &Terminal{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -925,7 +933,7 @@ func (r *Container) User(ctx context.Context) (string, error) {
 	if r.user != nil {
 		return *r.user, nil
 	}
-	q := r.Query.Select("user")
+	q := r.query.Select("user")
 
 	var response string
 
@@ -935,11 +943,11 @@ func (r *Container) User(ctx context.Context) (string, error) {
 
 // Configures default arguments for future commands.
 func (r *Container) WithDefaultArgs(args []string) *Container {
-	q := r.Query.Select("withDefaultArgs")
+	q := r.query.Select("withDefaultArgs")
 	q = q.Arg("args", args)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -955,7 +963,7 @@ type ContainerWithDefaultTerminalCmdOpts struct {
 
 // Set the default command to invoke for the container's terminal API.
 func (r *Container) WithDefaultTerminalCmd(args []string, opts ...ContainerWithDefaultTerminalCmdOpts) *Container {
-	q := r.Query.Select("withDefaultTerminalCmd")
+	q := r.query.Select("withDefaultTerminalCmd")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `experimentalPrivilegedNesting` optional argument
 		if !querybuilder.IsZeroValue(opts[i].ExperimentalPrivilegedNesting) {
@@ -969,7 +977,7 @@ func (r *Container) WithDefaultTerminalCmd(args []string, opts ...ContainerWithD
 	q = q.Arg("args", args)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -990,7 +998,7 @@ type ContainerWithDirectoryOpts struct {
 // Retrieves this container plus a directory written at the given path.
 func (r *Container) WithDirectory(path string, directory *Directory, opts ...ContainerWithDirectoryOpts) *Container {
 	assertNotNil("directory", directory)
-	q := r.Query.Select("withDirectory")
+	q := r.query.Select("withDirectory")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `exclude` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Exclude) {
@@ -1009,7 +1017,7 @@ func (r *Container) WithDirectory(path string, directory *Directory, opts ...Con
 	q = q.Arg("directory", directory)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -1021,7 +1029,7 @@ type ContainerWithEntrypointOpts struct {
 
 // Retrieves this container but with a different command entrypoint.
 func (r *Container) WithEntrypoint(args []string, opts ...ContainerWithEntrypointOpts) *Container {
-	q := r.Query.Select("withEntrypoint")
+	q := r.query.Select("withEntrypoint")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `keepDefaultArgs` optional argument
 		if !querybuilder.IsZeroValue(opts[i].KeepDefaultArgs) {
@@ -1031,7 +1039,7 @@ func (r *Container) WithEntrypoint(args []string, opts ...ContainerWithEntrypoin
 	q = q.Arg("args", args)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -1043,7 +1051,7 @@ type ContainerWithEnvVariableOpts struct {
 
 // Retrieves this container plus the given environment variable.
 func (r *Container) WithEnvVariable(name string, value string, opts ...ContainerWithEnvVariableOpts) *Container {
-	q := r.Query.Select("withEnvVariable")
+	q := r.query.Select("withEnvVariable")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `expand` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Expand) {
@@ -1054,7 +1062,7 @@ func (r *Container) WithEnvVariable(name string, value string, opts ...Container
 	q = q.Arg("value", value)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -1078,7 +1086,7 @@ type ContainerWithExecOpts struct {
 
 // Retrieves this container after executing the specified command inside it.
 func (r *Container) WithExec(args []string, opts ...ContainerWithExecOpts) *Container {
-	q := r.Query.Select("withExec")
+	q := r.query.Select("withExec")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `skipEntrypoint` optional argument
 		if !querybuilder.IsZeroValue(opts[i].SkipEntrypoint) {
@@ -1108,7 +1116,7 @@ func (r *Container) WithExec(args []string, opts ...ContainerWithExecOpts) *Cont
 	q = q.Arg("args", args)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -1130,7 +1138,7 @@ type ContainerWithExposedPortOpts struct {
 //
 // - For setting the EXPOSE OCI field when publishing the container
 func (r *Container) WithExposedPort(port int, opts ...ContainerWithExposedPortOpts) *Container {
-	q := r.Query.Select("withExposedPort")
+	q := r.query.Select("withExposedPort")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `protocol` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Protocol) {
@@ -1148,7 +1156,7 @@ func (r *Container) WithExposedPort(port int, opts ...ContainerWithExposedPortOp
 	q = q.Arg("port", port)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -1167,7 +1175,7 @@ type ContainerWithFileOpts struct {
 // Retrieves this container plus the contents of the given file copied to the given path.
 func (r *Container) WithFile(path string, source *File, opts ...ContainerWithFileOpts) *Container {
 	assertNotNil("source", source)
-	q := r.Query.Select("withFile")
+	q := r.query.Select("withFile")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `permissions` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Permissions) {
@@ -1182,7 +1190,7 @@ func (r *Container) WithFile(path string, source *File, opts ...ContainerWithFil
 	q = q.Arg("source", source)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -1200,7 +1208,7 @@ type ContainerWithFilesOpts struct {
 
 // Retrieves this container plus the contents of the given files copied to the given path.
 func (r *Container) WithFiles(path string, sources []*File, opts ...ContainerWithFilesOpts) *Container {
-	q := r.Query.Select("withFiles")
+	q := r.query.Select("withFiles")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `permissions` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Permissions) {
@@ -1215,27 +1223,27 @@ func (r *Container) WithFiles(path string, sources []*File, opts ...ContainerWit
 	q = q.Arg("sources", sources)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
 // Indicate that subsequent operations should be featured more prominently in the UI.
 func (r *Container) WithFocus() *Container {
-	q := r.Query.Select("withFocus")
+	q := r.query.Select("withFocus")
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
 // Retrieves this container plus the given label.
 func (r *Container) WithLabel(name string, value string) *Container {
-	q := r.Query.Select("withLabel")
+	q := r.query.Select("withLabel")
 	q = q.Arg("name", name)
 	q = q.Arg("value", value)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -1258,7 +1266,7 @@ type ContainerWithMountedCacheOpts struct {
 // Retrieves this container plus a cache volume mounted at the given path.
 func (r *Container) WithMountedCache(path string, cache *CacheVolume, opts ...ContainerWithMountedCacheOpts) *Container {
 	assertNotNil("cache", cache)
-	q := r.Query.Select("withMountedCache")
+	q := r.query.Select("withMountedCache")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `source` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Source) {
@@ -1277,7 +1285,7 @@ func (r *Container) WithMountedCache(path string, cache *CacheVolume, opts ...Co
 	q = q.Arg("cache", cache)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -1294,7 +1302,7 @@ type ContainerWithMountedDirectoryOpts struct {
 // Retrieves this container plus a directory mounted at the given path.
 func (r *Container) WithMountedDirectory(path string, source *Directory, opts ...ContainerWithMountedDirectoryOpts) *Container {
 	assertNotNil("source", source)
-	q := r.Query.Select("withMountedDirectory")
+	q := r.query.Select("withMountedDirectory")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `owner` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Owner) {
@@ -1305,7 +1313,7 @@ func (r *Container) WithMountedDirectory(path string, source *Directory, opts ..
 	q = q.Arg("source", source)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -1322,7 +1330,7 @@ type ContainerWithMountedFileOpts struct {
 // Retrieves this container plus a file mounted at the given path.
 func (r *Container) WithMountedFile(path string, source *File, opts ...ContainerWithMountedFileOpts) *Container {
 	assertNotNil("source", source)
-	q := r.Query.Select("withMountedFile")
+	q := r.query.Select("withMountedFile")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `owner` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Owner) {
@@ -1333,7 +1341,7 @@ func (r *Container) WithMountedFile(path string, source *File, opts ...Container
 	q = q.Arg("source", source)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -1354,7 +1362,7 @@ type ContainerWithMountedSecretOpts struct {
 // Retrieves this container plus a secret mounted into a file at the given path.
 func (r *Container) WithMountedSecret(path string, source *Secret, opts ...ContainerWithMountedSecretOpts) *Container {
 	assertNotNil("source", source)
-	q := r.Query.Select("withMountedSecret")
+	q := r.query.Select("withMountedSecret")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `owner` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Owner) {
@@ -1369,17 +1377,17 @@ func (r *Container) WithMountedSecret(path string, source *Secret, opts ...Conta
 	q = q.Arg("source", source)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
 // Retrieves this container plus a temporary directory mounted at the given path.
 func (r *Container) WithMountedTemp(path string) *Container {
-	q := r.Query.Select("withMountedTemp")
+	q := r.query.Select("withMountedTemp")
 	q = q.Arg("path", path)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -1399,7 +1407,7 @@ type ContainerWithNewFileOpts struct {
 
 // Retrieves this container plus a new file written at the given path.
 func (r *Container) WithNewFile(path string, opts ...ContainerWithNewFileOpts) *Container {
-	q := r.Query.Select("withNewFile")
+	q := r.query.Select("withNewFile")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `contents` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Contents) {
@@ -1417,43 +1425,43 @@ func (r *Container) WithNewFile(path string, opts ...ContainerWithNewFileOpts) *
 	q = q.Arg("path", path)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
 // Retrieves this container with a registry authentication for a given address.
 func (r *Container) WithRegistryAuth(address string, username string, secret *Secret) *Container {
 	assertNotNil("secret", secret)
-	q := r.Query.Select("withRegistryAuth")
+	q := r.query.Select("withRegistryAuth")
 	q = q.Arg("address", address)
 	q = q.Arg("username", username)
 	q = q.Arg("secret", secret)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
 // Retrieves the container with the given directory mounted to /.
 func (r *Container) WithRootfs(directory *Directory) *Container {
 	assertNotNil("directory", directory)
-	q := r.Query.Select("withRootfs")
+	q := r.query.Select("withRootfs")
 	q = q.Arg("directory", directory)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
 // Retrieves this container plus an env variable containing the given secret.
 func (r *Container) WithSecretVariable(name string, secret *Secret) *Container {
 	assertNotNil("secret", secret)
-	q := r.Query.Select("withSecretVariable")
+	q := r.query.Select("withSecretVariable")
 	q = q.Arg("name", name)
 	q = q.Arg("secret", secret)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -1466,12 +1474,12 @@ func (r *Container) WithSecretVariable(name string, secret *Secret) *Container {
 // The service dependency will also convey to any files or directories produced by the container.
 func (r *Container) WithServiceBinding(alias string, service *Service) *Container {
 	assertNotNil("service", service)
-	q := r.Query.Select("withServiceBinding")
+	q := r.query.Select("withServiceBinding")
 	q = q.Arg("alias", alias)
 	q = q.Arg("service", service)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -1488,7 +1496,7 @@ type ContainerWithUnixSocketOpts struct {
 // Retrieves this container plus a socket forwarded to the given Unix socket path.
 func (r *Container) WithUnixSocket(path string, source *Socket, opts ...ContainerWithUnixSocketOpts) *Container {
 	assertNotNil("source", source)
-	q := r.Query.Select("withUnixSocket")
+	q := r.query.Select("withUnixSocket")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `owner` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Owner) {
@@ -1499,36 +1507,36 @@ func (r *Container) WithUnixSocket(path string, source *Socket, opts ...Containe
 	q = q.Arg("source", source)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
 // Retrieves this container with a different command user.
 func (r *Container) WithUser(name string) *Container {
-	q := r.Query.Select("withUser")
+	q := r.query.Select("withUser")
 	q = q.Arg("name", name)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
 // Retrieves this container with a different working directory.
 func (r *Container) WithWorkdir(path string) *Container {
-	q := r.Query.Select("withWorkdir")
+	q := r.query.Select("withWorkdir")
 	q = q.Arg("path", path)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
 // Retrieves this container with unset default arguments for future commands.
 func (r *Container) WithoutDefaultArgs() *Container {
-	q := r.Query.Select("withoutDefaultArgs")
+	q := r.query.Select("withoutDefaultArgs")
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -1540,7 +1548,7 @@ type ContainerWithoutEntrypointOpts struct {
 
 // Retrieves this container with an unset command entrypoint.
 func (r *Container) WithoutEntrypoint(opts ...ContainerWithoutEntrypointOpts) *Container {
-	q := r.Query.Select("withoutEntrypoint")
+	q := r.query.Select("withoutEntrypoint")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `keepDefaultArgs` optional argument
 		if !querybuilder.IsZeroValue(opts[i].KeepDefaultArgs) {
@@ -1549,17 +1557,17 @@ func (r *Container) WithoutEntrypoint(opts ...ContainerWithoutEntrypointOpts) *C
 	}
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
 // Retrieves this container minus the given environment variable.
 func (r *Container) WithoutEnvVariable(name string) *Container {
-	q := r.Query.Select("withoutEnvVariable")
+	q := r.query.Select("withoutEnvVariable")
 	q = q.Arg("name", name)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -1571,7 +1579,7 @@ type ContainerWithoutExposedPortOpts struct {
 
 // Unexpose a previously exposed port.
 func (r *Container) WithoutExposedPort(port int, opts ...ContainerWithoutExposedPortOpts) *Container {
-	q := r.Query.Select("withoutExposedPort")
+	q := r.query.Select("withoutExposedPort")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `protocol` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Protocol) {
@@ -1581,7 +1589,7 @@ func (r *Container) WithoutExposedPort(port int, opts ...ContainerWithoutExposed
 	q = q.Arg("port", port)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -1589,50 +1597,50 @@ func (r *Container) WithoutExposedPort(port int, opts ...ContainerWithoutExposed
 //
 // This is the initial state of all containers.
 func (r *Container) WithoutFocus() *Container {
-	q := r.Query.Select("withoutFocus")
+	q := r.query.Select("withoutFocus")
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
 // Retrieves this container minus the given environment label.
 func (r *Container) WithoutLabel(name string) *Container {
-	q := r.Query.Select("withoutLabel")
+	q := r.query.Select("withoutLabel")
 	q = q.Arg("name", name)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
 // Retrieves this container after unmounting everything at the given path.
 func (r *Container) WithoutMount(path string) *Container {
-	q := r.Query.Select("withoutMount")
+	q := r.query.Select("withoutMount")
 	q = q.Arg("path", path)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
 // Retrieves this container without the registry authentication of a given address.
 func (r *Container) WithoutRegistryAuth(address string) *Container {
-	q := r.Query.Select("withoutRegistryAuth")
+	q := r.query.Select("withoutRegistryAuth")
 	q = q.Arg("address", address)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
 // Retrieves this container with a previously added Unix socket removed.
 func (r *Container) WithoutUnixSocket(path string) *Container {
-	q := r.Query.Select("withoutUnixSocket")
+	q := r.query.Select("withoutUnixSocket")
 	q = q.Arg("path", path)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -1640,10 +1648,10 @@ func (r *Container) WithoutUnixSocket(path string) *Container {
 //
 // Should default to root.
 func (r *Container) WithoutUser() *Container {
-	q := r.Query.Select("withoutUser")
+	q := r.query.Select("withoutUser")
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -1651,10 +1659,10 @@ func (r *Container) WithoutUser() *Container {
 //
 // Should default to "/".
 func (r *Container) WithoutWorkdir() *Container {
-	q := r.Query.Select("withoutWorkdir")
+	q := r.query.Select("withoutWorkdir")
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -1663,7 +1671,7 @@ func (r *Container) Workdir(ctx context.Context) (string, error) {
 	if r.workdir != nil {
 		return *r.workdir, nil
 	}
-	q := r.Query.Select("workdir")
+	q := r.query.Select("workdir")
 
 	var response string
 
@@ -1673,10 +1681,14 @@ func (r *Container) Workdir(ctx context.Context) (string, error) {
 
 // Reflective module API provided to functions at runtime.
 type CurrentModule struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	id   *CurrentModuleID
 	name *string
+}
+
+func (r *CurrentModule) WithGraphQLQuery(q *querybuilder.Selection) *CurrentModule {
+	return &CurrentModule{query: q}
 }
 
 // A unique identifier for this CurrentModule.
@@ -1684,7 +1696,7 @@ func (r *CurrentModule) ID(ctx context.Context) (CurrentModuleID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response CurrentModuleID
 
@@ -1724,7 +1736,7 @@ func (r *CurrentModule) Name(ctx context.Context) (string, error) {
 	if r.name != nil {
 		return *r.name, nil
 	}
-	q := r.Query.Select("name")
+	q := r.query.Select("name")
 
 	var response string
 
@@ -1734,10 +1746,10 @@ func (r *CurrentModule) Name(ctx context.Context) (string, error) {
 
 // The directory containing the module's source code loaded into the engine (plus any generated code that may have been created).
 func (r *CurrentModule) Source() *Directory {
-	q := r.Query.Select("source")
+	q := r.query.Select("source")
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -1751,7 +1763,7 @@ type CurrentModuleWorkdirOpts struct {
 
 // Load a directory from the module's scratch working directory, including any changes that may have been made to it during module function execution.
 func (r *CurrentModule) Workdir(path string, opts ...CurrentModuleWorkdirOpts) *Directory {
-	q := r.Query.Select("workdir")
+	q := r.query.Select("workdir")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `exclude` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Exclude) {
@@ -1765,23 +1777,23 @@ func (r *CurrentModule) Workdir(path string, opts ...CurrentModuleWorkdirOpts) *
 	q = q.Arg("path", path)
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a file from the module's scratch working directory, including any changes that may have been made to it during module function execution.Load a file from the module's scratch working directory, including any changes that may have been made to it during module function execution.
 func (r *CurrentModule) WorkdirFile(path string) *File {
-	q := r.Query.Select("workdirFile")
+	q := r.query.Select("workdirFile")
 	q = q.Arg("path", path)
 
 	return &File{
-		Query: q,
+		query: q,
 	}
 }
 
 // A directory.
 type Directory struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	export *bool
 	id     *DirectoryID
@@ -1796,6 +1808,10 @@ func (r *Directory) With(f WithDirectoryFunc) *Directory {
 	return f(r)
 }
 
+func (r *Directory) WithGraphQLQuery(q *querybuilder.Selection) *Directory {
+	return &Directory{query: q}
+}
+
 // DirectoryAsModuleOpts contains options for Directory.AsModule
 type DirectoryAsModuleOpts struct {
 	// An optional subpath of the directory which contains the module's configuration file.
@@ -1808,7 +1824,7 @@ type DirectoryAsModuleOpts struct {
 
 // Load the directory as a Dagger module
 func (r *Directory) AsModule(opts ...DirectoryAsModuleOpts) *Module {
-	q := r.Query.Select("asModule")
+	q := r.query.Select("asModule")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `sourceRootPath` optional argument
 		if !querybuilder.IsZeroValue(opts[i].SourceRootPath) {
@@ -1817,28 +1833,28 @@ func (r *Directory) AsModule(opts ...DirectoryAsModuleOpts) *Module {
 	}
 
 	return &Module{
-		Query: q,
+		query: q,
 	}
 }
 
 // Gets the difference between this directory and an another directory.
 func (r *Directory) Diff(other *Directory) *Directory {
 	assertNotNil("other", other)
-	q := r.Query.Select("diff")
+	q := r.query.Select("diff")
 	q = q.Arg("other", other)
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
 // Retrieves a directory at the given path.
 func (r *Directory) Directory(path string) *Directory {
-	q := r.Query.Select("directory")
+	q := r.query.Select("directory")
 	q = q.Arg("path", path)
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -1860,7 +1876,7 @@ type DirectoryDockerBuildOpts struct {
 
 // Builds a new Docker container from this directory.
 func (r *Directory) DockerBuild(opts ...DirectoryDockerBuildOpts) *Container {
-	q := r.Query.Select("dockerBuild")
+	q := r.query.Select("dockerBuild")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `platform` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Platform) {
@@ -1885,7 +1901,7 @@ func (r *Directory) DockerBuild(opts ...DirectoryDockerBuildOpts) *Container {
 	}
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -1897,7 +1913,7 @@ type DirectoryEntriesOpts struct {
 
 // Returns a list of files and directories at the given path.
 func (r *Directory) Entries(ctx context.Context, opts ...DirectoryEntriesOpts) ([]string, error) {
-	q := r.Query.Select("entries")
+	q := r.query.Select("entries")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `path` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Path) {
@@ -1916,7 +1932,7 @@ func (r *Directory) Export(ctx context.Context, path string) (bool, error) {
 	if r.export != nil {
 		return *r.export, nil
 	}
-	q := r.Query.Select("export")
+	q := r.query.Select("export")
 	q = q.Arg("path", path)
 
 	var response bool
@@ -1927,17 +1943,17 @@ func (r *Directory) Export(ctx context.Context, path string) (bool, error) {
 
 // Retrieves a file at the given path.
 func (r *Directory) File(path string) *File {
-	q := r.Query.Select("file")
+	q := r.query.Select("file")
 	q = q.Arg("path", path)
 
 	return &File{
-		Query: q,
+		query: q,
 	}
 }
 
 // Returns a list of files and directories that matche the given pattern.
 func (r *Directory) Glob(ctx context.Context, pattern string) ([]string, error) {
-	q := r.Query.Select("glob")
+	q := r.query.Select("glob")
 	q = q.Arg("pattern", pattern)
 
 	var response []string
@@ -1951,7 +1967,7 @@ func (r *Directory) ID(ctx context.Context) (DirectoryID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response DirectoryID
 
@@ -1996,7 +2012,7 @@ type DirectoryPipelineOpts struct {
 
 // Creates a named sub-pipeline.
 func (r *Directory) Pipeline(name string, opts ...DirectoryPipelineOpts) *Directory {
-	q := r.Query.Select("pipeline")
+	q := r.query.Select("pipeline")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `description` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Description) {
@@ -2010,13 +2026,13 @@ func (r *Directory) Pipeline(name string, opts ...DirectoryPipelineOpts) *Direct
 	q = q.Arg("name", name)
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
 // Force evaluation in the engine.
 func (r *Directory) Sync(ctx context.Context) (*Directory, error) {
-	q := r.Query.Select("sync")
+	q := r.query.Select("sync")
 
 	return r, q.Execute(ctx)
 }
@@ -2032,7 +2048,7 @@ type DirectoryWithDirectoryOpts struct {
 // Retrieves this directory plus a directory written at the given path.
 func (r *Directory) WithDirectory(path string, directory *Directory, opts ...DirectoryWithDirectoryOpts) *Directory {
 	assertNotNil("directory", directory)
-	q := r.Query.Select("withDirectory")
+	q := r.query.Select("withDirectory")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `exclude` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Exclude) {
@@ -2047,7 +2063,7 @@ func (r *Directory) WithDirectory(path string, directory *Directory, opts ...Dir
 	q = q.Arg("directory", directory)
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -2060,7 +2076,7 @@ type DirectoryWithFileOpts struct {
 // Retrieves this directory plus the contents of the given file copied to the given path.
 func (r *Directory) WithFile(path string, source *File, opts ...DirectoryWithFileOpts) *Directory {
 	assertNotNil("source", source)
-	q := r.Query.Select("withFile")
+	q := r.query.Select("withFile")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `permissions` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Permissions) {
@@ -2071,7 +2087,7 @@ func (r *Directory) WithFile(path string, source *File, opts ...DirectoryWithFil
 	q = q.Arg("source", source)
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -2083,7 +2099,7 @@ type DirectoryWithFilesOpts struct {
 
 // Retrieves this directory plus the contents of the given files copied to the given path.
 func (r *Directory) WithFiles(path string, sources []*File, opts ...DirectoryWithFilesOpts) *Directory {
-	q := r.Query.Select("withFiles")
+	q := r.query.Select("withFiles")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `permissions` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Permissions) {
@@ -2094,7 +2110,7 @@ func (r *Directory) WithFiles(path string, sources []*File, opts ...DirectoryWit
 	q = q.Arg("sources", sources)
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -2106,7 +2122,7 @@ type DirectoryWithNewDirectoryOpts struct {
 
 // Retrieves this directory plus a new directory created at the given path.
 func (r *Directory) WithNewDirectory(path string, opts ...DirectoryWithNewDirectoryOpts) *Directory {
-	q := r.Query.Select("withNewDirectory")
+	q := r.query.Select("withNewDirectory")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `permissions` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Permissions) {
@@ -2116,7 +2132,7 @@ func (r *Directory) WithNewDirectory(path string, opts ...DirectoryWithNewDirect
 	q = q.Arg("path", path)
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -2128,7 +2144,7 @@ type DirectoryWithNewFileOpts struct {
 
 // Retrieves this directory plus a new file written at the given path.
 func (r *Directory) WithNewFile(path string, contents string, opts ...DirectoryWithNewFileOpts) *Directory {
-	q := r.Query.Select("withNewFile")
+	q := r.query.Select("withNewFile")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `permissions` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Permissions) {
@@ -2139,47 +2155,51 @@ func (r *Directory) WithNewFile(path string, contents string, opts ...DirectoryW
 	q = q.Arg("contents", contents)
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
 // Retrieves this directory with all file/dir timestamps set to the given time.
 func (r *Directory) WithTimestamps(timestamp int) *Directory {
-	q := r.Query.Select("withTimestamps")
+	q := r.query.Select("withTimestamps")
 	q = q.Arg("timestamp", timestamp)
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
 // Retrieves this directory with the directory at the given path removed.
 func (r *Directory) WithoutDirectory(path string) *Directory {
-	q := r.Query.Select("withoutDirectory")
+	q := r.query.Select("withoutDirectory")
 	q = q.Arg("path", path)
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
 // Retrieves this directory with the file at the given path removed.
 func (r *Directory) WithoutFile(path string) *Directory {
-	q := r.Query.Select("withoutFile")
+	q := r.query.Select("withoutFile")
 	q = q.Arg("path", path)
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
 // An environment variable name and value.
 type EnvVariable struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	id    *EnvVariableID
 	name  *string
 	value *string
+}
+
+func (r *EnvVariable) WithGraphQLQuery(q *querybuilder.Selection) *EnvVariable {
+	return &EnvVariable{query: q}
 }
 
 // A unique identifier for this EnvVariable.
@@ -2187,7 +2207,7 @@ func (r *EnvVariable) ID(ctx context.Context) (EnvVariableID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response EnvVariableID
 
@@ -2227,7 +2247,7 @@ func (r *EnvVariable) Name(ctx context.Context) (string, error) {
 	if r.name != nil {
 		return *r.name, nil
 	}
-	q := r.Query.Select("name")
+	q := r.query.Select("name")
 
 	var response string
 
@@ -2240,7 +2260,7 @@ func (r *EnvVariable) Value(ctx context.Context) (string, error) {
 	if r.value != nil {
 		return *r.value, nil
 	}
-	q := r.Query.Select("value")
+	q := r.query.Select("value")
 
 	var response string
 
@@ -2252,11 +2272,15 @@ func (r *EnvVariable) Value(ctx context.Context) (string, error) {
 //
 // A field on an object has a static value, as opposed to a function on an object whose value is computed by invoking code (and can accept arguments).
 type FieldTypeDef struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	description *string
 	id          *FieldTypeDefID
 	name        *string
+}
+
+func (r *FieldTypeDef) WithGraphQLQuery(q *querybuilder.Selection) *FieldTypeDef {
+	return &FieldTypeDef{query: q}
 }
 
 // A doc string for the field, if any.
@@ -2264,7 +2288,7 @@ func (r *FieldTypeDef) Description(ctx context.Context) (string, error) {
 	if r.description != nil {
 		return *r.description, nil
 	}
-	q := r.Query.Select("description")
+	q := r.query.Select("description")
 
 	var response string
 
@@ -2277,7 +2301,7 @@ func (r *FieldTypeDef) ID(ctx context.Context) (FieldTypeDefID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response FieldTypeDefID
 
@@ -2317,7 +2341,7 @@ func (r *FieldTypeDef) Name(ctx context.Context) (string, error) {
 	if r.name != nil {
 		return *r.name, nil
 	}
-	q := r.Query.Select("name")
+	q := r.query.Select("name")
 
 	var response string
 
@@ -2327,16 +2351,16 @@ func (r *FieldTypeDef) Name(ctx context.Context) (string, error) {
 
 // The type of the field.
 func (r *FieldTypeDef) TypeDef() *TypeDef {
-	q := r.Query.Select("typeDef")
+	q := r.query.Select("typeDef")
 
 	return &TypeDef{
-		Query: q,
+		query: q,
 	}
 }
 
 // A file.
 type File struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	contents *string
 	export   *bool
@@ -2354,12 +2378,16 @@ func (r *File) With(f WithFileFunc) *File {
 	return f(r)
 }
 
+func (r *File) WithGraphQLQuery(q *querybuilder.Selection) *File {
+	return &File{query: q}
+}
+
 // Retrieves the contents of the file.
 func (r *File) Contents(ctx context.Context) (string, error) {
 	if r.contents != nil {
 		return *r.contents, nil
 	}
-	q := r.Query.Select("contents")
+	q := r.query.Select("contents")
 
 	var response string
 
@@ -2378,7 +2406,7 @@ func (r *File) Export(ctx context.Context, path string, opts ...FileExportOpts) 
 	if r.export != nil {
 		return *r.export, nil
 	}
-	q := r.Query.Select("export")
+	q := r.query.Select("export")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `allowParentDirPath` optional argument
 		if !querybuilder.IsZeroValue(opts[i].AllowParentDirPath) {
@@ -2398,7 +2426,7 @@ func (r *File) ID(ctx context.Context) (FileID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response FileID
 
@@ -2438,7 +2466,7 @@ func (r *File) Name(ctx context.Context) (string, error) {
 	if r.name != nil {
 		return *r.name, nil
 	}
-	q := r.Query.Select("name")
+	q := r.query.Select("name")
 
 	var response string
 
@@ -2451,7 +2479,7 @@ func (r *File) Size(ctx context.Context) (int, error) {
 	if r.size != nil {
 		return *r.size, nil
 	}
-	q := r.Query.Select("size")
+	q := r.query.Select("size")
 
 	var response int
 
@@ -2461,18 +2489,18 @@ func (r *File) Size(ctx context.Context) (int, error) {
 
 // Force evaluation in the engine.
 func (r *File) Sync(ctx context.Context) (*File, error) {
-	q := r.Query.Select("sync")
+	q := r.query.Select("sync")
 
 	return r, q.Execute(ctx)
 }
 
 // Retrieves this file with its created/modified timestamps set to the given time.
 func (r *File) WithTimestamps(timestamp int) *File {
-	q := r.Query.Select("withTimestamps")
+	q := r.query.Select("withTimestamps")
 	q = q.Arg("timestamp", timestamp)
 
 	return &File{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -2480,7 +2508,7 @@ func (r *File) WithTimestamps(timestamp int) *File {
 //
 // A function always evaluates against a parent object and is given a set of named arguments.
 type Function struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	description *string
 	id          *FunctionID
@@ -2495,9 +2523,13 @@ func (r *Function) With(f WithFunctionFunc) *Function {
 	return f(r)
 }
 
+func (r *Function) WithGraphQLQuery(q *querybuilder.Selection) *Function {
+	return &Function{query: q}
+}
+
 // Arguments accepted by the function, if any.
 func (r *Function) Args(ctx context.Context) ([]FunctionArg, error) {
-	q := r.Query.Select("args")
+	q := r.query.Select("args")
 
 	q = q.Select("id")
 
@@ -2510,7 +2542,7 @@ func (r *Function) Args(ctx context.Context) ([]FunctionArg, error) {
 
 		for i := range fields {
 			val := FunctionArg{id: &fields[i].Id}
-			val.Query = q.Root().Select("loadFunctionArgFromID").Arg("id", fields[i].Id)
+			val.query = q.Root().Select("loadFunctionArgFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -2533,7 +2565,7 @@ func (r *Function) Description(ctx context.Context) (string, error) {
 	if r.description != nil {
 		return *r.description, nil
 	}
-	q := r.Query.Select("description")
+	q := r.query.Select("description")
 
 	var response string
 
@@ -2546,7 +2578,7 @@ func (r *Function) ID(ctx context.Context) (FunctionID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response FunctionID
 
@@ -2586,7 +2618,7 @@ func (r *Function) Name(ctx context.Context) (string, error) {
 	if r.name != nil {
 		return *r.name, nil
 	}
-	q := r.Query.Select("name")
+	q := r.query.Select("name")
 
 	var response string
 
@@ -2596,10 +2628,10 @@ func (r *Function) Name(ctx context.Context) (string, error) {
 
 // The type returned by the function.
 func (r *Function) ReturnType() *TypeDef {
-	q := r.Query.Select("returnType")
+	q := r.query.Select("returnType")
 
 	return &TypeDef{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -2614,7 +2646,7 @@ type FunctionWithArgOpts struct {
 // Returns the function with the provided argument
 func (r *Function) WithArg(name string, typeDef *TypeDef, opts ...FunctionWithArgOpts) *Function {
 	assertNotNil("typeDef", typeDef)
-	q := r.Query.Select("withArg")
+	q := r.query.Select("withArg")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `description` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Description) {
@@ -2629,17 +2661,17 @@ func (r *Function) WithArg(name string, typeDef *TypeDef, opts ...FunctionWithAr
 	q = q.Arg("typeDef", typeDef)
 
 	return &Function{
-		Query: q,
+		query: q,
 	}
 }
 
 // Returns the function with the given doc string.
 func (r *Function) WithDescription(description string) *Function {
-	q := r.Query.Select("withDescription")
+	q := r.query.Select("withDescription")
 	q = q.Arg("description", description)
 
 	return &Function{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -2647,7 +2679,7 @@ func (r *Function) WithDescription(description string) *Function {
 //
 // This is a specification for an argument at function definition time, not an argument passed at function call time.
 type FunctionArg struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	defaultValue *JSON
 	description  *string
@@ -2655,12 +2687,16 @@ type FunctionArg struct {
 	name         *string
 }
 
+func (r *FunctionArg) WithGraphQLQuery(q *querybuilder.Selection) *FunctionArg {
+	return &FunctionArg{query: q}
+}
+
 // A default value to use for this argument when not explicitly set by the caller, if any.
 func (r *FunctionArg) DefaultValue(ctx context.Context) (JSON, error) {
 	if r.defaultValue != nil {
 		return *r.defaultValue, nil
 	}
-	q := r.Query.Select("defaultValue")
+	q := r.query.Select("defaultValue")
 
 	var response JSON
 
@@ -2673,7 +2709,7 @@ func (r *FunctionArg) Description(ctx context.Context) (string, error) {
 	if r.description != nil {
 		return *r.description, nil
 	}
-	q := r.Query.Select("description")
+	q := r.query.Select("description")
 
 	var response string
 
@@ -2686,7 +2722,7 @@ func (r *FunctionArg) ID(ctx context.Context) (FunctionArgID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response FunctionArgID
 
@@ -2726,7 +2762,7 @@ func (r *FunctionArg) Name(ctx context.Context) (string, error) {
 	if r.name != nil {
 		return *r.name, nil
 	}
-	q := r.Query.Select("name")
+	q := r.query.Select("name")
 
 	var response string
 
@@ -2736,16 +2772,16 @@ func (r *FunctionArg) Name(ctx context.Context) (string, error) {
 
 // The type of the argument.
 func (r *FunctionArg) TypeDef() *TypeDef {
-	q := r.Query.Select("typeDef")
+	q := r.query.Select("typeDef")
 
 	return &TypeDef{
-		Query: q,
+		query: q,
 	}
 }
 
 // An active function call.
 type FunctionCall struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	id          *FunctionCallID
 	name        *string
@@ -2754,12 +2790,16 @@ type FunctionCall struct {
 	returnValue *Void
 }
 
+func (r *FunctionCall) WithGraphQLQuery(q *querybuilder.Selection) *FunctionCall {
+	return &FunctionCall{query: q}
+}
+
 // A unique identifier for this FunctionCall.
 func (r *FunctionCall) ID(ctx context.Context) (FunctionCallID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response FunctionCallID
 
@@ -2796,7 +2836,7 @@ func (r *FunctionCall) MarshalJSON() ([]byte, error) {
 
 // The argument values the function is being invoked with.
 func (r *FunctionCall) InputArgs(ctx context.Context) ([]FunctionCallArgValue, error) {
-	q := r.Query.Select("inputArgs")
+	q := r.query.Select("inputArgs")
 
 	q = q.Select("id")
 
@@ -2809,7 +2849,7 @@ func (r *FunctionCall) InputArgs(ctx context.Context) ([]FunctionCallArgValue, e
 
 		for i := range fields {
 			val := FunctionCallArgValue{id: &fields[i].Id}
-			val.Query = q.Root().Select("loadFunctionCallArgValueFromID").Arg("id", fields[i].Id)
+			val.query = q.Root().Select("loadFunctionCallArgValueFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -2832,7 +2872,7 @@ func (r *FunctionCall) Name(ctx context.Context) (string, error) {
 	if r.name != nil {
 		return *r.name, nil
 	}
-	q := r.Query.Select("name")
+	q := r.query.Select("name")
 
 	var response string
 
@@ -2845,7 +2885,7 @@ func (r *FunctionCall) Parent(ctx context.Context) (JSON, error) {
 	if r.parent != nil {
 		return *r.parent, nil
 	}
-	q := r.Query.Select("parent")
+	q := r.query.Select("parent")
 
 	var response JSON
 
@@ -2858,7 +2898,7 @@ func (r *FunctionCall) ParentName(ctx context.Context) (string, error) {
 	if r.parentName != nil {
 		return *r.parentName, nil
 	}
-	q := r.Query.Select("parentName")
+	q := r.query.Select("parentName")
 
 	var response string
 
@@ -2871,7 +2911,7 @@ func (r *FunctionCall) ReturnValue(ctx context.Context, value JSON) (Void, error
 	if r.returnValue != nil {
 		return *r.returnValue, nil
 	}
-	q := r.Query.Select("returnValue")
+	q := r.query.Select("returnValue")
 	q = q.Arg("value", value)
 
 	var response Void
@@ -2882,11 +2922,15 @@ func (r *FunctionCall) ReturnValue(ctx context.Context, value JSON) (Void, error
 
 // A value passed as a named argument to a function call.
 type FunctionCallArgValue struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	id    *FunctionCallArgValueID
 	name  *string
 	value *JSON
+}
+
+func (r *FunctionCallArgValue) WithGraphQLQuery(q *querybuilder.Selection) *FunctionCallArgValue {
+	return &FunctionCallArgValue{query: q}
 }
 
 // A unique identifier for this FunctionCallArgValue.
@@ -2894,7 +2938,7 @@ func (r *FunctionCallArgValue) ID(ctx context.Context) (FunctionCallArgValueID, 
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response FunctionCallArgValueID
 
@@ -2934,7 +2978,7 @@ func (r *FunctionCallArgValue) Name(ctx context.Context) (string, error) {
 	if r.name != nil {
 		return *r.name, nil
 	}
-	q := r.Query.Select("name")
+	q := r.query.Select("name")
 
 	var response string
 
@@ -2947,7 +2991,7 @@ func (r *FunctionCallArgValue) Value(ctx context.Context) (JSON, error) {
 	if r.value != nil {
 		return *r.value, nil
 	}
-	q := r.Query.Select("value")
+	q := r.query.Select("value")
 
 	var response JSON
 
@@ -2957,7 +3001,7 @@ func (r *FunctionCallArgValue) Value(ctx context.Context) (JSON, error) {
 
 // The result of running an SDK's codegen.
 type GeneratedCode struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	id *GeneratedCodeID
 }
@@ -2970,12 +3014,16 @@ func (r *GeneratedCode) With(f WithGeneratedCodeFunc) *GeneratedCode {
 	return f(r)
 }
 
+func (r *GeneratedCode) WithGraphQLQuery(q *querybuilder.Selection) *GeneratedCode {
+	return &GeneratedCode{query: q}
+}
+
 // The directory containing the generated code.
 func (r *GeneratedCode) Code() *Directory {
-	q := r.Query.Select("code")
+	q := r.query.Select("code")
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -2984,7 +3032,7 @@ func (r *GeneratedCode) ID(ctx context.Context) (GeneratedCodeID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response GeneratedCodeID
 
@@ -3021,7 +3069,7 @@ func (r *GeneratedCode) MarshalJSON() ([]byte, error) {
 
 // List of paths to mark generated in version control (i.e. .gitattributes).
 func (r *GeneratedCode) VcsGeneratedPaths(ctx context.Context) ([]string, error) {
-	q := r.Query.Select("vcsGeneratedPaths")
+	q := r.query.Select("vcsGeneratedPaths")
 
 	var response []string
 
@@ -3031,7 +3079,7 @@ func (r *GeneratedCode) VcsGeneratedPaths(ctx context.Context) ([]string, error)
 
 // List of paths to ignore in version control (i.e. .gitignore).
 func (r *GeneratedCode) VcsIgnoredPaths(ctx context.Context) ([]string, error) {
-	q := r.Query.Select("vcsIgnoredPaths")
+	q := r.query.Select("vcsIgnoredPaths")
 
 	var response []string
 
@@ -3041,27 +3089,27 @@ func (r *GeneratedCode) VcsIgnoredPaths(ctx context.Context) ([]string, error) {
 
 // Set the list of paths to mark generated in version control.
 func (r *GeneratedCode) WithVCSGeneratedPaths(paths []string) *GeneratedCode {
-	q := r.Query.Select("withVCSGeneratedPaths")
+	q := r.query.Select("withVCSGeneratedPaths")
 	q = q.Arg("paths", paths)
 
 	return &GeneratedCode{
-		Query: q,
+		query: q,
 	}
 }
 
 // Set the list of paths to ignore in version control.
 func (r *GeneratedCode) WithVCSIgnoredPaths(paths []string) *GeneratedCode {
-	q := r.Query.Select("withVCSIgnoredPaths")
+	q := r.query.Select("withVCSIgnoredPaths")
 	q = q.Arg("paths", paths)
 
 	return &GeneratedCode{
-		Query: q,
+		query: q,
 	}
 }
 
 // Module source originating from a git repo.
 type GitModuleSource struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	cloneURL    *string
 	commit      *string
@@ -3071,12 +3119,16 @@ type GitModuleSource struct {
 	version     *string
 }
 
+func (r *GitModuleSource) WithGraphQLQuery(q *querybuilder.Selection) *GitModuleSource {
+	return &GitModuleSource{query: q}
+}
+
 // The URL from which the source's git repo can be cloned.
 func (r *GitModuleSource) CloneURL(ctx context.Context) (string, error) {
 	if r.cloneURL != nil {
 		return *r.cloneURL, nil
 	}
-	q := r.Query.Select("cloneURL")
+	q := r.query.Select("cloneURL")
 
 	var response string
 
@@ -3089,7 +3141,7 @@ func (r *GitModuleSource) Commit(ctx context.Context) (string, error) {
 	if r.commit != nil {
 		return *r.commit, nil
 	}
-	q := r.Query.Select("commit")
+	q := r.query.Select("commit")
 
 	var response string
 
@@ -3099,10 +3151,10 @@ func (r *GitModuleSource) Commit(ctx context.Context) (string, error) {
 
 // The directory containing everything needed to load load and use the module.
 func (r *GitModuleSource) ContextDirectory() *Directory {
-	q := r.Query.Select("contextDirectory")
+	q := r.query.Select("contextDirectory")
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -3111,7 +3163,7 @@ func (r *GitModuleSource) HTMLURL(ctx context.Context) (string, error) {
 	if r.htmlURL != nil {
 		return *r.htmlURL, nil
 	}
-	q := r.Query.Select("htmlURL")
+	q := r.query.Select("htmlURL")
 
 	var response string
 
@@ -3124,7 +3176,7 @@ func (r *GitModuleSource) ID(ctx context.Context) (GitModuleSourceID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response GitModuleSourceID
 
@@ -3164,7 +3216,7 @@ func (r *GitModuleSource) RootSubpath(ctx context.Context) (string, error) {
 	if r.rootSubpath != nil {
 		return *r.rootSubpath, nil
 	}
-	q := r.Query.Select("rootSubpath")
+	q := r.query.Select("rootSubpath")
 
 	var response string
 
@@ -3177,7 +3229,7 @@ func (r *GitModuleSource) Version(ctx context.Context) (string, error) {
 	if r.version != nil {
 		return *r.version, nil
 	}
-	q := r.Query.Select("version")
+	q := r.query.Select("version")
 
 	var response string
 
@@ -3187,10 +3239,14 @@ func (r *GitModuleSource) Version(ctx context.Context) (string, error) {
 
 // A git ref (tag, branch, or commit).
 type GitRef struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	commit *string
 	id     *GitRefID
+}
+
+func (r *GitRef) WithGraphQLQuery(q *querybuilder.Selection) *GitRef {
+	return &GitRef{query: q}
 }
 
 // The resolved commit id at this ref.
@@ -3198,7 +3254,7 @@ func (r *GitRef) Commit(ctx context.Context) (string, error) {
 	if r.commit != nil {
 		return *r.commit, nil
 	}
-	q := r.Query.Select("commit")
+	q := r.query.Select("commit")
 
 	var response string
 
@@ -3211,7 +3267,7 @@ func (r *GitRef) ID(ctx context.Context) (GitRefID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response GitRefID
 
@@ -3256,7 +3312,7 @@ type GitRefTreeOpts struct {
 
 // The filesystem tree at this ref.
 func (r *GitRef) Tree(opts ...GitRefTreeOpts) *Directory {
-	q := r.Query.Select("tree")
+	q := r.query.Select("tree")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `sshKnownHosts` optional argument
 		if !querybuilder.IsZeroValue(opts[i].SSHKnownHosts) {
@@ -3269,34 +3325,38 @@ func (r *GitRef) Tree(opts ...GitRefTreeOpts) *Directory {
 	}
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
 // A git repository.
 type GitRepository struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	id *GitRepositoryID
 }
 
+func (r *GitRepository) WithGraphQLQuery(q *querybuilder.Selection) *GitRepository {
+	return &GitRepository{query: q}
+}
+
 // Returns details of a branch.
 func (r *GitRepository) Branch(name string) *GitRef {
-	q := r.Query.Select("branch")
+	q := r.query.Select("branch")
 	q = q.Arg("name", name)
 
 	return &GitRef{
-		Query: q,
+		query: q,
 	}
 }
 
 // Returns details of a commit.
 func (r *GitRepository) Commit(id string) *GitRef {
-	q := r.Query.Select("commit")
+	q := r.query.Select("commit")
 	q = q.Arg("id", id)
 
 	return &GitRef{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -3305,7 +3365,7 @@ func (r *GitRepository) ID(ctx context.Context) (GitRepositoryID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response GitRepositoryID
 
@@ -3342,29 +3402,33 @@ func (r *GitRepository) MarshalJSON() ([]byte, error) {
 
 // Returns details of a ref.
 func (r *GitRepository) Ref(name string) *GitRef {
-	q := r.Query.Select("ref")
+	q := r.query.Select("ref")
 	q = q.Arg("name", name)
 
 	return &GitRef{
-		Query: q,
+		query: q,
 	}
 }
 
 // Returns details of a tag.
 func (r *GitRepository) Tag(name string) *GitRef {
-	q := r.Query.Select("tag")
+	q := r.query.Select("tag")
 	q = q.Arg("name", name)
 
 	return &GitRef{
-		Query: q,
+		query: q,
 	}
 }
 
 // Information about the host environment.
 type Host struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	id *HostID
+}
+
+func (r *Host) WithGraphQLQuery(q *querybuilder.Selection) *Host {
+	return &Host{query: q}
 }
 
 // HostDirectoryOpts contains options for Host.Directory
@@ -3377,7 +3441,7 @@ type HostDirectoryOpts struct {
 
 // Accesses a directory on the host.
 func (r *Host) Directory(path string, opts ...HostDirectoryOpts) *Directory {
-	q := r.Query.Select("directory")
+	q := r.query.Select("directory")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `exclude` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Exclude) {
@@ -3391,17 +3455,17 @@ func (r *Host) Directory(path string, opts ...HostDirectoryOpts) *Directory {
 	q = q.Arg("path", path)
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
 // Accesses a file on the host.
 func (r *Host) File(path string) *File {
-	q := r.Query.Select("file")
+	q := r.query.Select("file")
 	q = q.Arg("path", path)
 
 	return &File{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -3410,7 +3474,7 @@ func (r *Host) ID(ctx context.Context) (HostID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response HostID
 
@@ -3453,7 +3517,7 @@ type HostServiceOpts struct {
 
 // Creates a service that forwards traffic to a specified address via the host.
 func (r *Host) Service(ports []PortForward, opts ...HostServiceOpts) *Service {
-	q := r.Query.Select("service")
+	q := r.query.Select("service")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `host` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Host) {
@@ -3463,7 +3527,7 @@ func (r *Host) Service(ports []PortForward, opts ...HostServiceOpts) *Service {
 	q = q.Arg("ports", ports)
 
 	return &Service{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -3471,12 +3535,12 @@ func (r *Host) Service(ports []PortForward, opts ...HostServiceOpts) *Service {
 //
 // The file is limited to a size of 512000 bytes.
 func (r *Host) SetSecretFile(name string, path string) *Secret {
-	q := r.Query.Select("setSecretFile")
+	q := r.query.Select("setSecretFile")
 	q = q.Arg("name", name)
 	q = q.Arg("path", path)
 
 	return &Secret{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -3499,7 +3563,7 @@ type HostTunnelOpts struct {
 // Creates a tunnel that forwards traffic from the host to a service.
 func (r *Host) Tunnel(service *Service, opts ...HostTunnelOpts) *Service {
 	assertNotNil("service", service)
-	q := r.Query.Select("tunnel")
+	q := r.query.Select("tunnel")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `ports` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Ports) {
@@ -3513,17 +3577,17 @@ func (r *Host) Tunnel(service *Service, opts ...HostTunnelOpts) *Service {
 	q = q.Arg("service", service)
 
 	return &Service{
-		Query: q,
+		query: q,
 	}
 }
 
 // Accesses a Unix socket on the host.
 func (r *Host) UnixSocket(path string) *Socket {
-	q := r.Query.Select("unixSocket")
+	q := r.query.Select("unixSocket")
 	q = q.Arg("path", path)
 
 	return &Socket{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -3532,15 +3596,19 @@ func (r *Host) UnixSocket(path string) *Socket {
 // in the core API. It is not used by user modules and shouldn't ever be as user
 // module accept input objects via their id rather than graphql input types.
 type InputTypeDef struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	id   *InputTypeDefID
 	name *string
 }
 
+func (r *InputTypeDef) WithGraphQLQuery(q *querybuilder.Selection) *InputTypeDef {
+	return &InputTypeDef{query: q}
+}
+
 // Static fields defined on this input object, if any.
 func (r *InputTypeDef) Fields(ctx context.Context) ([]FieldTypeDef, error) {
-	q := r.Query.Select("fields")
+	q := r.query.Select("fields")
 
 	q = q.Select("id")
 
@@ -3553,7 +3621,7 @@ func (r *InputTypeDef) Fields(ctx context.Context) ([]FieldTypeDef, error) {
 
 		for i := range fields {
 			val := FieldTypeDef{id: &fields[i].Id}
-			val.Query = q.Root().Select("loadFieldTypeDefFromID").Arg("id", fields[i].Id)
+			val.query = q.Root().Select("loadFieldTypeDefFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -3576,7 +3644,7 @@ func (r *InputTypeDef) ID(ctx context.Context) (InputTypeDefID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response InputTypeDefID
 
@@ -3616,7 +3684,7 @@ func (r *InputTypeDef) Name(ctx context.Context) (string, error) {
 	if r.name != nil {
 		return *r.name, nil
 	}
-	q := r.Query.Select("name")
+	q := r.query.Select("name")
 
 	var response string
 
@@ -3626,7 +3694,7 @@ func (r *InputTypeDef) Name(ctx context.Context) (string, error) {
 
 // A definition of a custom interface defined in a Module.
 type InterfaceTypeDef struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	description      *string
 	id               *InterfaceTypeDefID
@@ -3634,12 +3702,16 @@ type InterfaceTypeDef struct {
 	sourceModuleName *string
 }
 
+func (r *InterfaceTypeDef) WithGraphQLQuery(q *querybuilder.Selection) *InterfaceTypeDef {
+	return &InterfaceTypeDef{query: q}
+}
+
 // The doc string for the interface, if any.
 func (r *InterfaceTypeDef) Description(ctx context.Context) (string, error) {
 	if r.description != nil {
 		return *r.description, nil
 	}
-	q := r.Query.Select("description")
+	q := r.query.Select("description")
 
 	var response string
 
@@ -3649,7 +3721,7 @@ func (r *InterfaceTypeDef) Description(ctx context.Context) (string, error) {
 
 // Functions defined on this interface, if any.
 func (r *InterfaceTypeDef) Functions(ctx context.Context) ([]Function, error) {
-	q := r.Query.Select("functions")
+	q := r.query.Select("functions")
 
 	q = q.Select("id")
 
@@ -3662,7 +3734,7 @@ func (r *InterfaceTypeDef) Functions(ctx context.Context) ([]Function, error) {
 
 		for i := range fields {
 			val := Function{id: &fields[i].Id}
-			val.Query = q.Root().Select("loadFunctionFromID").Arg("id", fields[i].Id)
+			val.query = q.Root().Select("loadFunctionFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -3685,7 +3757,7 @@ func (r *InterfaceTypeDef) ID(ctx context.Context) (InterfaceTypeDefID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response InterfaceTypeDefID
 
@@ -3725,7 +3797,7 @@ func (r *InterfaceTypeDef) Name(ctx context.Context) (string, error) {
 	if r.name != nil {
 		return *r.name, nil
 	}
-	q := r.Query.Select("name")
+	q := r.query.Select("name")
 
 	var response string
 
@@ -3738,7 +3810,7 @@ func (r *InterfaceTypeDef) SourceModuleName(ctx context.Context) (string, error)
 	if r.sourceModuleName != nil {
 		return *r.sourceModuleName, nil
 	}
-	q := r.Query.Select("sourceModuleName")
+	q := r.query.Select("sourceModuleName")
 
 	var response string
 
@@ -3748,11 +3820,15 @@ func (r *InterfaceTypeDef) SourceModuleName(ctx context.Context) (string, error)
 
 // A simple key value object that represents a label.
 type Label struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	id    *LabelID
 	name  *string
 	value *string
+}
+
+func (r *Label) WithGraphQLQuery(q *querybuilder.Selection) *Label {
+	return &Label{query: q}
 }
 
 // A unique identifier for this Label.
@@ -3760,7 +3836,7 @@ func (r *Label) ID(ctx context.Context) (LabelID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response LabelID
 
@@ -3800,7 +3876,7 @@ func (r *Label) Name(ctx context.Context) (string, error) {
 	if r.name != nil {
 		return *r.name, nil
 	}
-	q := r.Query.Select("name")
+	q := r.query.Select("name")
 
 	var response string
 
@@ -3813,7 +3889,7 @@ func (r *Label) Value(ctx context.Context) (string, error) {
 	if r.value != nil {
 		return *r.value, nil
 	}
-	q := r.Query.Select("value")
+	q := r.query.Select("value")
 
 	var response string
 
@@ -3823,17 +3899,21 @@ func (r *Label) Value(ctx context.Context) (string, error) {
 
 // A definition of a list type in a Module.
 type ListTypeDef struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	id *ListTypeDefID
 }
 
+func (r *ListTypeDef) WithGraphQLQuery(q *querybuilder.Selection) *ListTypeDef {
+	return &ListTypeDef{query: q}
+}
+
 // The type of the elements in the list.
 func (r *ListTypeDef) ElementTypeDef() *TypeDef {
-	q := r.Query.Select("elementTypeDef")
+	q := r.query.Select("elementTypeDef")
 
 	return &TypeDef{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -3842,7 +3922,7 @@ func (r *ListTypeDef) ID(ctx context.Context) (ListTypeDefID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response ListTypeDefID
 
@@ -3879,18 +3959,22 @@ func (r *ListTypeDef) MarshalJSON() ([]byte, error) {
 
 // Module source that that originates from a path locally relative to an arbitrary directory.
 type LocalModuleSource struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	id          *LocalModuleSourceID
 	rootSubpath *string
 }
 
+func (r *LocalModuleSource) WithGraphQLQuery(q *querybuilder.Selection) *LocalModuleSource {
+	return &LocalModuleSource{query: q}
+}
+
 // The directory containing everything needed to load load and use the module.
 func (r *LocalModuleSource) ContextDirectory() *Directory {
-	q := r.Query.Select("contextDirectory")
+	q := r.query.Select("contextDirectory")
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -3899,7 +3983,7 @@ func (r *LocalModuleSource) ID(ctx context.Context) (LocalModuleSourceID, error)
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response LocalModuleSourceID
 
@@ -3939,7 +4023,7 @@ func (r *LocalModuleSource) RootSubpath(ctx context.Context) (string, error) {
 	if r.rootSubpath != nil {
 		return *r.rootSubpath, nil
 	}
-	q := r.Query.Select("rootSubpath")
+	q := r.query.Select("rootSubpath")
 
 	var response string
 
@@ -3949,7 +4033,7 @@ func (r *LocalModuleSource) RootSubpath(ctx context.Context) (string, error) {
 
 // A Dagger module.
 type Module struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	description *string
 	id          *ModuleID
@@ -3966,9 +4050,13 @@ func (r *Module) With(f WithModuleFunc) *Module {
 	return f(r)
 }
 
+func (r *Module) WithGraphQLQuery(q *querybuilder.Selection) *Module {
+	return &Module{query: q}
+}
+
 // Modules used by this module.
 func (r *Module) Dependencies(ctx context.Context) ([]Module, error) {
-	q := r.Query.Select("dependencies")
+	q := r.query.Select("dependencies")
 
 	q = q.Select("id")
 
@@ -3981,7 +4069,7 @@ func (r *Module) Dependencies(ctx context.Context) ([]Module, error) {
 
 		for i := range fields {
 			val := Module{id: &fields[i].Id}
-			val.Query = q.Root().Select("loadModuleFromID").Arg("id", fields[i].Id)
+			val.query = q.Root().Select("loadModuleFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -4001,7 +4089,7 @@ func (r *Module) Dependencies(ctx context.Context) ([]Module, error) {
 
 // The dependencies as configured by the module.
 func (r *Module) DependencyConfig(ctx context.Context) ([]ModuleDependency, error) {
-	q := r.Query.Select("dependencyConfig")
+	q := r.query.Select("dependencyConfig")
 
 	q = q.Select("id")
 
@@ -4014,7 +4102,7 @@ func (r *Module) DependencyConfig(ctx context.Context) ([]ModuleDependency, erro
 
 		for i := range fields {
 			val := ModuleDependency{id: &fields[i].Id}
-			val.Query = q.Root().Select("loadModuleDependencyFromID").Arg("id", fields[i].Id)
+			val.query = q.Root().Select("loadModuleDependencyFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -4037,7 +4125,7 @@ func (r *Module) Description(ctx context.Context) (string, error) {
 	if r.description != nil {
 		return *r.description, nil
 	}
-	q := r.Query.Select("description")
+	q := r.query.Select("description")
 
 	var response string
 
@@ -4047,19 +4135,19 @@ func (r *Module) Description(ctx context.Context) (string, error) {
 
 // The generated files and directories made on top of the module source's context directory.
 func (r *Module) GeneratedContextDiff() *Directory {
-	q := r.Query.Select("generatedContextDiff")
+	q := r.query.Select("generatedContextDiff")
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
 // The module source's context plus any configuration and source files created by codegen.
 func (r *Module) GeneratedContextDirectory() *Directory {
-	q := r.Query.Select("generatedContextDirectory")
+	q := r.query.Select("generatedContextDirectory")
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -4068,7 +4156,7 @@ func (r *Module) ID(ctx context.Context) (ModuleID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response ModuleID
 
@@ -4105,16 +4193,16 @@ func (r *Module) MarshalJSON() ([]byte, error) {
 
 // Retrieves the module with the objects loaded via its SDK.
 func (r *Module) Initialize() *Module {
-	q := r.Query.Select("initialize")
+	q := r.query.Select("initialize")
 
 	return &Module{
-		Query: q,
+		query: q,
 	}
 }
 
 // Interfaces served by this module.
 func (r *Module) Interfaces(ctx context.Context) ([]TypeDef, error) {
-	q := r.Query.Select("interfaces")
+	q := r.query.Select("interfaces")
 
 	q = q.Select("id")
 
@@ -4127,7 +4215,7 @@ func (r *Module) Interfaces(ctx context.Context) ([]TypeDef, error) {
 
 		for i := range fields {
 			val := TypeDef{id: &fields[i].Id}
-			val.Query = q.Root().Select("loadTypeDefFromID").Arg("id", fields[i].Id)
+			val.query = q.Root().Select("loadTypeDefFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -4150,7 +4238,7 @@ func (r *Module) Name(ctx context.Context) (string, error) {
 	if r.name != nil {
 		return *r.name, nil
 	}
-	q := r.Query.Select("name")
+	q := r.query.Select("name")
 
 	var response string
 
@@ -4160,7 +4248,7 @@ func (r *Module) Name(ctx context.Context) (string, error) {
 
 // Objects served by this module.
 func (r *Module) Objects(ctx context.Context) ([]TypeDef, error) {
-	q := r.Query.Select("objects")
+	q := r.query.Select("objects")
 
 	q = q.Select("id")
 
@@ -4173,7 +4261,7 @@ func (r *Module) Objects(ctx context.Context) ([]TypeDef, error) {
 
 		for i := range fields {
 			val := TypeDef{id: &fields[i].Id}
-			val.Query = q.Root().Select("loadTypeDefFromID").Arg("id", fields[i].Id)
+			val.query = q.Root().Select("loadTypeDefFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -4193,10 +4281,10 @@ func (r *Module) Objects(ctx context.Context) ([]TypeDef, error) {
 
 // The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile.
 func (r *Module) Runtime() *Container {
-	q := r.Query.Select("runtime")
+	q := r.query.Select("runtime")
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -4205,7 +4293,7 @@ func (r *Module) SDK(ctx context.Context) (string, error) {
 	if r.sdk != nil {
 		return *r.sdk, nil
 	}
-	q := r.Query.Select("sdk")
+	q := r.query.Select("sdk")
 
 	var response string
 
@@ -4220,7 +4308,7 @@ func (r *Module) Serve(ctx context.Context) (Void, error) {
 	if r.serve != nil {
 		return *r.serve, nil
 	}
-	q := r.Query.Select("serve")
+	q := r.query.Select("serve")
 
 	var response Void
 
@@ -4230,62 +4318,66 @@ func (r *Module) Serve(ctx context.Context) (Void, error) {
 
 // The source for the module.
 func (r *Module) Source() *ModuleSource {
-	q := r.Query.Select("source")
+	q := r.query.Select("source")
 
 	return &ModuleSource{
-		Query: q,
+		query: q,
 	}
 }
 
 // Retrieves the module with the given description
 func (r *Module) WithDescription(description string) *Module {
-	q := r.Query.Select("withDescription")
+	q := r.query.Select("withDescription")
 	q = q.Arg("description", description)
 
 	return &Module{
-		Query: q,
+		query: q,
 	}
 }
 
 // This module plus the given Interface type and associated functions
 func (r *Module) WithInterface(iface *TypeDef) *Module {
 	assertNotNil("iface", iface)
-	q := r.Query.Select("withInterface")
+	q := r.query.Select("withInterface")
 	q = q.Arg("iface", iface)
 
 	return &Module{
-		Query: q,
+		query: q,
 	}
 }
 
 // This module plus the given Object type and associated functions.
 func (r *Module) WithObject(object *TypeDef) *Module {
 	assertNotNil("object", object)
-	q := r.Query.Select("withObject")
+	q := r.query.Select("withObject")
 	q = q.Arg("object", object)
 
 	return &Module{
-		Query: q,
+		query: q,
 	}
 }
 
 // Retrieves the module with basic configuration loaded if present.
 func (r *Module) WithSource(source *ModuleSource) *Module {
 	assertNotNil("source", source)
-	q := r.Query.Select("withSource")
+	q := r.query.Select("withSource")
 	q = q.Arg("source", source)
 
 	return &Module{
-		Query: q,
+		query: q,
 	}
 }
 
 // The configuration of dependency of a module.
 type ModuleDependency struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	id   *ModuleDependencyID
 	name *string
+}
+
+func (r *ModuleDependency) WithGraphQLQuery(q *querybuilder.Selection) *ModuleDependency {
+	return &ModuleDependency{query: q}
 }
 
 // A unique identifier for this ModuleDependency.
@@ -4293,7 +4385,7 @@ func (r *ModuleDependency) ID(ctx context.Context) (ModuleDependencyID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response ModuleDependencyID
 
@@ -4333,7 +4425,7 @@ func (r *ModuleDependency) Name(ctx context.Context) (string, error) {
 	if r.name != nil {
 		return *r.name, nil
 	}
-	q := r.Query.Select("name")
+	q := r.query.Select("name")
 
 	var response string
 
@@ -4343,16 +4435,16 @@ func (r *ModuleDependency) Name(ctx context.Context) (string, error) {
 
 // The source for the dependency module.
 func (r *ModuleDependency) Source() *ModuleSource {
-	q := r.Query.Select("source")
+	q := r.query.Select("source")
 
 	return &ModuleSource{
-		Query: q,
+		query: q,
 	}
 }
 
 // The source needed to load and run a module, along with any metadata about the source such as versions/urls/etc.
 type ModuleSource struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	asString                     *string
 	configExists                 *bool
@@ -4373,30 +4465,34 @@ func (r *ModuleSource) With(f WithModuleSourceFunc) *ModuleSource {
 	return f(r)
 }
 
+func (r *ModuleSource) WithGraphQLQuery(q *querybuilder.Selection) *ModuleSource {
+	return &ModuleSource{query: q}
+}
+
 // If the source is a of kind git, the git source representation of it.
 func (r *ModuleSource) AsGitSource() *GitModuleSource {
-	q := r.Query.Select("asGitSource")
+	q := r.query.Select("asGitSource")
 
 	return &GitModuleSource{
-		Query: q,
+		query: q,
 	}
 }
 
 // If the source is of kind local, the local source representation of it.
 func (r *ModuleSource) AsLocalSource() *LocalModuleSource {
-	q := r.Query.Select("asLocalSource")
+	q := r.query.Select("asLocalSource")
 
 	return &LocalModuleSource{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load the source as a module. If this is a local source, the parent directory must have been provided during module source creation
 func (r *ModuleSource) AsModule() *Module {
-	q := r.Query.Select("asModule")
+	q := r.query.Select("asModule")
 
 	return &Module{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -4405,7 +4501,7 @@ func (r *ModuleSource) AsString(ctx context.Context) (string, error) {
 	if r.asString != nil {
 		return *r.asString, nil
 	}
-	q := r.Query.Select("asString")
+	q := r.query.Select("asString")
 
 	var response string
 
@@ -4418,7 +4514,7 @@ func (r *ModuleSource) ConfigExists(ctx context.Context) (bool, error) {
 	if r.configExists != nil {
 		return *r.configExists, nil
 	}
-	q := r.Query.Select("configExists")
+	q := r.query.Select("configExists")
 
 	var response bool
 
@@ -4428,16 +4524,16 @@ func (r *ModuleSource) ConfigExists(ctx context.Context) (bool, error) {
 
 // The directory containing everything needed to load load and use the module.
 func (r *ModuleSource) ContextDirectory() *Directory {
-	q := r.Query.Select("contextDirectory")
+	q := r.query.Select("contextDirectory")
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
 // The dependencies of the module source. Includes dependencies from the configuration and any extras from withDependencies calls.
 func (r *ModuleSource) Dependencies(ctx context.Context) ([]ModuleDependency, error) {
-	q := r.Query.Select("dependencies")
+	q := r.query.Select("dependencies")
 
 	q = q.Select("id")
 
@@ -4450,7 +4546,7 @@ func (r *ModuleSource) Dependencies(ctx context.Context) ([]ModuleDependency, er
 
 		for i := range fields {
 			val := ModuleDependency{id: &fields[i].Id}
-			val.Query = q.Root().Select("loadModuleDependencyFromID").Arg("id", fields[i].Id)
+			val.query = q.Root().Select("loadModuleDependencyFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -4470,11 +4566,11 @@ func (r *ModuleSource) Dependencies(ctx context.Context) ([]ModuleDependency, er
 
 // The directory containing the module configuration and source code (source code may be in a subdir).
 func (r *ModuleSource) Directory(path string) *Directory {
-	q := r.Query.Select("directory")
+	q := r.query.Select("directory")
 	q = q.Arg("path", path)
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -4483,7 +4579,7 @@ func (r *ModuleSource) ID(ctx context.Context) (ModuleSourceID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response ModuleSourceID
 
@@ -4523,7 +4619,7 @@ func (r *ModuleSource) Kind(ctx context.Context) (ModuleSourceKind, error) {
 	if r.kind != nil {
 		return *r.kind, nil
 	}
-	q := r.Query.Select("kind")
+	q := r.query.Select("kind")
 
 	var response ModuleSourceKind
 
@@ -4536,7 +4632,7 @@ func (r *ModuleSource) ModuleName(ctx context.Context) (string, error) {
 	if r.moduleName != nil {
 		return *r.moduleName, nil
 	}
-	q := r.Query.Select("moduleName")
+	q := r.query.Select("moduleName")
 
 	var response string
 
@@ -4549,7 +4645,7 @@ func (r *ModuleSource) ModuleOriginalName(ctx context.Context) (string, error) {
 	if r.moduleOriginalName != nil {
 		return *r.moduleOriginalName, nil
 	}
-	q := r.Query.Select("moduleOriginalName")
+	q := r.query.Select("moduleOriginalName")
 
 	var response string
 
@@ -4562,7 +4658,7 @@ func (r *ModuleSource) ResolveContextPathFromCaller(ctx context.Context) (string
 	if r.resolveContextPathFromCaller != nil {
 		return *r.resolveContextPathFromCaller, nil
 	}
-	q := r.Query.Select("resolveContextPathFromCaller")
+	q := r.query.Select("resolveContextPathFromCaller")
 
 	var response string
 
@@ -4573,20 +4669,20 @@ func (r *ModuleSource) ResolveContextPathFromCaller(ctx context.Context) (string
 // Resolve the provided module source arg as a dependency relative to this module source.
 func (r *ModuleSource) ResolveDependency(dep *ModuleSource) *ModuleSource {
 	assertNotNil("dep", dep)
-	q := r.Query.Select("resolveDependency")
+	q := r.query.Select("resolveDependency")
 	q = q.Arg("dep", dep)
 
 	return &ModuleSource{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load the source from its path on the caller's filesystem, including only needed+configured files and directories. Only valid for local sources.
 func (r *ModuleSource) ResolveFromCaller() *ModuleSource {
-	q := r.Query.Select("resolveFromCaller")
+	q := r.query.Select("resolveFromCaller")
 
 	return &ModuleSource{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -4595,7 +4691,7 @@ func (r *ModuleSource) SourceRootSubpath(ctx context.Context) (string, error) {
 	if r.sourceRootSubpath != nil {
 		return *r.sourceRootSubpath, nil
 	}
-	q := r.Query.Select("sourceRootSubpath")
+	q := r.query.Select("sourceRootSubpath")
 
 	var response string
 
@@ -4608,7 +4704,7 @@ func (r *ModuleSource) SourceSubpath(ctx context.Context) (string, error) {
 	if r.sourceSubpath != nil {
 		return *r.sourceSubpath, nil
 	}
-	q := r.Query.Select("sourceSubpath")
+	q := r.query.Select("sourceSubpath")
 
 	var response string
 
@@ -4619,57 +4715,57 @@ func (r *ModuleSource) SourceSubpath(ctx context.Context) (string, error) {
 // Update the module source with a new context directory. Only valid for local sources.
 func (r *ModuleSource) WithContextDirectory(dir *Directory) *ModuleSource {
 	assertNotNil("dir", dir)
-	q := r.Query.Select("withContextDirectory")
+	q := r.query.Select("withContextDirectory")
 	q = q.Arg("dir", dir)
 
 	return &ModuleSource{
-		Query: q,
+		query: q,
 	}
 }
 
 // Append the provided dependencies to the module source's dependency list.
 func (r *ModuleSource) WithDependencies(dependencies []*ModuleDependency) *ModuleSource {
-	q := r.Query.Select("withDependencies")
+	q := r.query.Select("withDependencies")
 	q = q.Arg("dependencies", dependencies)
 
 	return &ModuleSource{
-		Query: q,
+		query: q,
 	}
 }
 
 // Update the module source with a new name.
 func (r *ModuleSource) WithName(name string) *ModuleSource {
-	q := r.Query.Select("withName")
+	q := r.query.Select("withName")
 	q = q.Arg("name", name)
 
 	return &ModuleSource{
-		Query: q,
+		query: q,
 	}
 }
 
 // Update the module source with a new SDK.
 func (r *ModuleSource) WithSDK(sdk string) *ModuleSource {
-	q := r.Query.Select("withSDK")
+	q := r.query.Select("withSDK")
 	q = q.Arg("sdk", sdk)
 
 	return &ModuleSource{
-		Query: q,
+		query: q,
 	}
 }
 
 // Update the module source with a new source subpath.
 func (r *ModuleSource) WithSourceSubpath(path string) *ModuleSource {
-	q := r.Query.Select("withSourceSubpath")
+	q := r.query.Select("withSourceSubpath")
 	q = q.Arg("path", path)
 
 	return &ModuleSource{
-		Query: q,
+		query: q,
 	}
 }
 
 // A definition of a custom object defined in a Module.
 type ObjectTypeDef struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	description      *string
 	id               *ObjectTypeDefID
@@ -4677,12 +4773,16 @@ type ObjectTypeDef struct {
 	sourceModuleName *string
 }
 
+func (r *ObjectTypeDef) WithGraphQLQuery(q *querybuilder.Selection) *ObjectTypeDef {
+	return &ObjectTypeDef{query: q}
+}
+
 // The function used to construct new instances of this object, if any
 func (r *ObjectTypeDef) Constructor() *Function {
-	q := r.Query.Select("constructor")
+	q := r.query.Select("constructor")
 
 	return &Function{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -4691,7 +4791,7 @@ func (r *ObjectTypeDef) Description(ctx context.Context) (string, error) {
 	if r.description != nil {
 		return *r.description, nil
 	}
-	q := r.Query.Select("description")
+	q := r.query.Select("description")
 
 	var response string
 
@@ -4701,7 +4801,7 @@ func (r *ObjectTypeDef) Description(ctx context.Context) (string, error) {
 
 // Static fields defined on this object, if any.
 func (r *ObjectTypeDef) Fields(ctx context.Context) ([]FieldTypeDef, error) {
-	q := r.Query.Select("fields")
+	q := r.query.Select("fields")
 
 	q = q.Select("id")
 
@@ -4714,7 +4814,7 @@ func (r *ObjectTypeDef) Fields(ctx context.Context) ([]FieldTypeDef, error) {
 
 		for i := range fields {
 			val := FieldTypeDef{id: &fields[i].Id}
-			val.Query = q.Root().Select("loadFieldTypeDefFromID").Arg("id", fields[i].Id)
+			val.query = q.Root().Select("loadFieldTypeDefFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -4734,7 +4834,7 @@ func (r *ObjectTypeDef) Fields(ctx context.Context) ([]FieldTypeDef, error) {
 
 // Functions defined on this object, if any.
 func (r *ObjectTypeDef) Functions(ctx context.Context) ([]Function, error) {
-	q := r.Query.Select("functions")
+	q := r.query.Select("functions")
 
 	q = q.Select("id")
 
@@ -4747,7 +4847,7 @@ func (r *ObjectTypeDef) Functions(ctx context.Context) ([]Function, error) {
 
 		for i := range fields {
 			val := Function{id: &fields[i].Id}
-			val.Query = q.Root().Select("loadFunctionFromID").Arg("id", fields[i].Id)
+			val.query = q.Root().Select("loadFunctionFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -4770,7 +4870,7 @@ func (r *ObjectTypeDef) ID(ctx context.Context) (ObjectTypeDefID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response ObjectTypeDefID
 
@@ -4810,7 +4910,7 @@ func (r *ObjectTypeDef) Name(ctx context.Context) (string, error) {
 	if r.name != nil {
 		return *r.name, nil
 	}
-	q := r.Query.Select("name")
+	q := r.query.Select("name")
 
 	var response string
 
@@ -4823,7 +4923,7 @@ func (r *ObjectTypeDef) SourceModuleName(ctx context.Context) (string, error) {
 	if r.sourceModuleName != nil {
 		return *r.sourceModuleName, nil
 	}
-	q := r.Query.Select("sourceModuleName")
+	q := r.query.Select("sourceModuleName")
 
 	var response string
 
@@ -4833,7 +4933,7 @@ func (r *ObjectTypeDef) SourceModuleName(ctx context.Context) (string, error) {
 
 // A port exposed by a container.
 type Port struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	description                 *string
 	experimentalSkipHealthcheck *bool
@@ -4842,12 +4942,16 @@ type Port struct {
 	protocol                    *NetworkProtocol
 }
 
+func (r *Port) WithGraphQLQuery(q *querybuilder.Selection) *Port {
+	return &Port{query: q}
+}
+
 // The port description.
 func (r *Port) Description(ctx context.Context) (string, error) {
 	if r.description != nil {
 		return *r.description, nil
 	}
-	q := r.Query.Select("description")
+	q := r.query.Select("description")
 
 	var response string
 
@@ -4860,7 +4964,7 @@ func (r *Port) ExperimentalSkipHealthcheck(ctx context.Context) (bool, error) {
 	if r.experimentalSkipHealthcheck != nil {
 		return *r.experimentalSkipHealthcheck, nil
 	}
-	q := r.Query.Select("experimentalSkipHealthcheck")
+	q := r.query.Select("experimentalSkipHealthcheck")
 
 	var response bool
 
@@ -4873,7 +4977,7 @@ func (r *Port) ID(ctx context.Context) (PortID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response PortID
 
@@ -4913,7 +5017,7 @@ func (r *Port) Port(ctx context.Context) (int, error) {
 	if r.port != nil {
 		return *r.port, nil
 	}
-	q := r.Query.Select("port")
+	q := r.query.Select("port")
 
 	var response int
 
@@ -4926,7 +5030,7 @@ func (r *Port) Protocol(ctx context.Context) (NetworkProtocol, error) {
 	if r.protocol != nil {
 		return *r.protocol, nil
 	}
-	q := r.Query.Select("protocol")
+	q := r.query.Select("protocol")
 
 	var response NetworkProtocol
 
@@ -4943,42 +5047,46 @@ func (r *Client) With(f WithClientFunc) *Client {
 	return f(r)
 }
 
+func (r *Client) WithGraphQLQuery(q *querybuilder.Selection) *Client {
+	return &Client{query: q}
+}
+
 // Retrieves a content-addressed blob.
 func (r *Client) Blob(digest string, size int, mediaType string, uncompressed string) *Directory {
-	q := r.Query.Select("blob")
+	q := r.query.Select("blob")
 	q = q.Arg("digest", digest)
 	q = q.Arg("size", size)
 	q = q.Arg("mediaType", mediaType)
 	q = q.Arg("uncompressed", uncompressed)
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
 // Retrieves a container builtin to the engine.
 func (r *Client) BuiltinContainer(digest string) *Container {
-	q := r.Query.Select("builtinContainer")
+	q := r.query.Select("builtinContainer")
 	q = q.Arg("digest", digest)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
 // Constructs a cache volume for a given cache key.
 func (r *Client) CacheVolume(key string) *CacheVolume {
-	q := r.Query.Select("cacheVolume")
+	q := r.query.Select("cacheVolume")
 	q = q.Arg("key", key)
 
 	return &CacheVolume{
-		Query: q,
+		query: q,
 	}
 }
 
 // Checks if the current Dagger Engine is compatible with an SDK's required version.
 func (r *Client) CheckVersionCompatibility(ctx context.Context, version string) (bool, error) {
-	q := r.Query.Select("checkVersionCompatibility")
+	q := r.query.Select("checkVersionCompatibility")
 	q = q.Arg("version", version)
 
 	var response bool
@@ -4999,7 +5107,7 @@ type ContainerOpts struct {
 //
 // Optional platform argument initializes new containers to execute and publish as that platform. Platform defaults to that of the builder's host.
 func (r *Client) Container(opts ...ContainerOpts) *Container {
-	q := r.Query.Select("container")
+	q := r.query.Select("container")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `id` optional argument
 		if !querybuilder.IsZeroValue(opts[i].ID) {
@@ -5012,7 +5120,7 @@ func (r *Client) Container(opts ...ContainerOpts) *Container {
 	}
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -5020,25 +5128,25 @@ func (r *Client) Container(opts ...ContainerOpts) *Container {
 //
 // If the caller is not currently executing in a function, this will return an error.
 func (r *Client) CurrentFunctionCall() *FunctionCall {
-	q := r.Query.Select("currentFunctionCall")
+	q := r.query.Select("currentFunctionCall")
 
 	return &FunctionCall{
-		Query: q,
+		query: q,
 	}
 }
 
 // The module currently being served in the session, if any.
 func (r *Client) CurrentModule() *CurrentModule {
-	q := r.Query.Select("currentModule")
+	q := r.query.Select("currentModule")
 
 	return &CurrentModule{
-		Query: q,
+		query: q,
 	}
 }
 
 // The TypeDef representations of the objects currently being served in the session.
 func (r *Client) CurrentTypeDefs(ctx context.Context) ([]TypeDef, error) {
-	q := r.Query.Select("currentTypeDefs")
+	q := r.query.Select("currentTypeDefs")
 
 	q = q.Select("id")
 
@@ -5051,7 +5159,7 @@ func (r *Client) CurrentTypeDefs(ctx context.Context) ([]TypeDef, error) {
 
 		for i := range fields {
 			val := TypeDef{id: &fields[i].Id}
-			val.Query = q.Root().Select("loadTypeDefFromID").Arg("id", fields[i].Id)
+			val.query = q.Root().Select("loadTypeDefFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -5071,7 +5179,7 @@ func (r *Client) CurrentTypeDefs(ctx context.Context) ([]TypeDef, error) {
 
 // The default platform of the engine.
 func (r *Client) DefaultPlatform(ctx context.Context) (Platform, error) {
-	q := r.Query.Select("defaultPlatform")
+	q := r.query.Select("defaultPlatform")
 
 	var response Platform
 
@@ -5087,7 +5195,7 @@ type DirectoryOpts struct {
 
 // Creates an empty directory.
 func (r *Client) Directory(opts ...DirectoryOpts) *Directory {
-	q := r.Query.Select("directory")
+	q := r.query.Select("directory")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `id` optional argument
 		if !querybuilder.IsZeroValue(opts[i].ID) {
@@ -5096,40 +5204,40 @@ func (r *Client) Directory(opts ...DirectoryOpts) *Directory {
 	}
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
 // Deprecated: Use LoadFileFromID instead.
 func (r *Client) File(id FileID) *File {
-	q := r.Query.Select("file")
+	q := r.query.Select("file")
 	q = q.Arg("id", id)
 
 	return &File{
-		Query: q,
+		query: q,
 	}
 }
 
 // Creates a function.
 func (r *Client) Function(name string, returnType *TypeDef) *Function {
 	assertNotNil("returnType", returnType)
-	q := r.Query.Select("function")
+	q := r.query.Select("function")
 	q = q.Arg("name", name)
 	q = q.Arg("returnType", returnType)
 
 	return &Function{
-		Query: q,
+		query: q,
 	}
 }
 
 // Create a code generation result, given a directory containing the generated code.
 func (r *Client) GeneratedCode(code *Directory) *GeneratedCode {
 	assertNotNil("code", code)
-	q := r.Query.Select("generatedCode")
+	q := r.query.Select("generatedCode")
 	q = q.Arg("code", code)
 
 	return &GeneratedCode{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -5147,7 +5255,7 @@ type GitOpts struct {
 
 // Queries a Git repository.
 func (r *Client) Git(url string, opts ...GitOpts) *GitRepository {
-	q := r.Query.Select("git")
+	q := r.query.Select("git")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `keepGitDir` optional argument
 		if !querybuilder.IsZeroValue(opts[i].KeepGitDir) {
@@ -5169,16 +5277,16 @@ func (r *Client) Git(url string, opts ...GitOpts) *GitRepository {
 	q = q.Arg("url", url)
 
 	return &GitRepository{
-		Query: q,
+		query: q,
 	}
 }
 
 // Queries the host environment.
 func (r *Client) Host() *Host {
-	q := r.Query.Select("host")
+	q := r.query.Select("host")
 
 	return &Host{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -5190,7 +5298,7 @@ type HTTPOpts struct {
 
 // Returns a file containing an http remote url content.
 func (r *Client) HTTP(url string, opts ...HTTPOpts) *File {
-	q := r.Query.Select("http")
+	q := r.query.Select("http")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `experimentalServiceHost` optional argument
 		if !querybuilder.IsZeroValue(opts[i].ExperimentalServiceHost) {
@@ -5200,326 +5308,326 @@ func (r *Client) HTTP(url string, opts ...HTTPOpts) *File {
 	q = q.Arg("url", url)
 
 	return &File{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a CacheVolume from its ID.
 func (r *Client) LoadCacheVolumeFromID(id CacheVolumeID) *CacheVolume {
-	q := r.Query.Select("loadCacheVolumeFromID")
+	q := r.query.Select("loadCacheVolumeFromID")
 	q = q.Arg("id", id)
 
 	return &CacheVolume{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a Container from its ID.
 func (r *Client) LoadContainerFromID(id ContainerID) *Container {
-	q := r.Query.Select("loadContainerFromID")
+	q := r.query.Select("loadContainerFromID")
 	q = q.Arg("id", id)
 
 	return &Container{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a CurrentModule from its ID.
 func (r *Client) LoadCurrentModuleFromID(id CurrentModuleID) *CurrentModule {
-	q := r.Query.Select("loadCurrentModuleFromID")
+	q := r.query.Select("loadCurrentModuleFromID")
 	q = q.Arg("id", id)
 
 	return &CurrentModule{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a Directory from its ID.
 func (r *Client) LoadDirectoryFromID(id DirectoryID) *Directory {
-	q := r.Query.Select("loadDirectoryFromID")
+	q := r.query.Select("loadDirectoryFromID")
 	q = q.Arg("id", id)
 
 	return &Directory{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a EnvVariable from its ID.
 func (r *Client) LoadEnvVariableFromID(id EnvVariableID) *EnvVariable {
-	q := r.Query.Select("loadEnvVariableFromID")
+	q := r.query.Select("loadEnvVariableFromID")
 	q = q.Arg("id", id)
 
 	return &EnvVariable{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a FieldTypeDef from its ID.
 func (r *Client) LoadFieldTypeDefFromID(id FieldTypeDefID) *FieldTypeDef {
-	q := r.Query.Select("loadFieldTypeDefFromID")
+	q := r.query.Select("loadFieldTypeDefFromID")
 	q = q.Arg("id", id)
 
 	return &FieldTypeDef{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a File from its ID.
 func (r *Client) LoadFileFromID(id FileID) *File {
-	q := r.Query.Select("loadFileFromID")
+	q := r.query.Select("loadFileFromID")
 	q = q.Arg("id", id)
 
 	return &File{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a FunctionArg from its ID.
 func (r *Client) LoadFunctionArgFromID(id FunctionArgID) *FunctionArg {
-	q := r.Query.Select("loadFunctionArgFromID")
+	q := r.query.Select("loadFunctionArgFromID")
 	q = q.Arg("id", id)
 
 	return &FunctionArg{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a FunctionCallArgValue from its ID.
 func (r *Client) LoadFunctionCallArgValueFromID(id FunctionCallArgValueID) *FunctionCallArgValue {
-	q := r.Query.Select("loadFunctionCallArgValueFromID")
+	q := r.query.Select("loadFunctionCallArgValueFromID")
 	q = q.Arg("id", id)
 
 	return &FunctionCallArgValue{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a FunctionCall from its ID.
 func (r *Client) LoadFunctionCallFromID(id FunctionCallID) *FunctionCall {
-	q := r.Query.Select("loadFunctionCallFromID")
+	q := r.query.Select("loadFunctionCallFromID")
 	q = q.Arg("id", id)
 
 	return &FunctionCall{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a Function from its ID.
 func (r *Client) LoadFunctionFromID(id FunctionID) *Function {
-	q := r.Query.Select("loadFunctionFromID")
+	q := r.query.Select("loadFunctionFromID")
 	q = q.Arg("id", id)
 
 	return &Function{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a GeneratedCode from its ID.
 func (r *Client) LoadGeneratedCodeFromID(id GeneratedCodeID) *GeneratedCode {
-	q := r.Query.Select("loadGeneratedCodeFromID")
+	q := r.query.Select("loadGeneratedCodeFromID")
 	q = q.Arg("id", id)
 
 	return &GeneratedCode{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a GitModuleSource from its ID.
 func (r *Client) LoadGitModuleSourceFromID(id GitModuleSourceID) *GitModuleSource {
-	q := r.Query.Select("loadGitModuleSourceFromID")
+	q := r.query.Select("loadGitModuleSourceFromID")
 	q = q.Arg("id", id)
 
 	return &GitModuleSource{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a GitRef from its ID.
 func (r *Client) LoadGitRefFromID(id GitRefID) *GitRef {
-	q := r.Query.Select("loadGitRefFromID")
+	q := r.query.Select("loadGitRefFromID")
 	q = q.Arg("id", id)
 
 	return &GitRef{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a GitRepository from its ID.
 func (r *Client) LoadGitRepositoryFromID(id GitRepositoryID) *GitRepository {
-	q := r.Query.Select("loadGitRepositoryFromID")
+	q := r.query.Select("loadGitRepositoryFromID")
 	q = q.Arg("id", id)
 
 	return &GitRepository{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a Host from its ID.
 func (r *Client) LoadHostFromID(id HostID) *Host {
-	q := r.Query.Select("loadHostFromID")
+	q := r.query.Select("loadHostFromID")
 	q = q.Arg("id", id)
 
 	return &Host{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a InputTypeDef from its ID.
 func (r *Client) LoadInputTypeDefFromID(id InputTypeDefID) *InputTypeDef {
-	q := r.Query.Select("loadInputTypeDefFromID")
+	q := r.query.Select("loadInputTypeDefFromID")
 	q = q.Arg("id", id)
 
 	return &InputTypeDef{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a InterfaceTypeDef from its ID.
 func (r *Client) LoadInterfaceTypeDefFromID(id InterfaceTypeDefID) *InterfaceTypeDef {
-	q := r.Query.Select("loadInterfaceTypeDefFromID")
+	q := r.query.Select("loadInterfaceTypeDefFromID")
 	q = q.Arg("id", id)
 
 	return &InterfaceTypeDef{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a Label from its ID.
 func (r *Client) LoadLabelFromID(id LabelID) *Label {
-	q := r.Query.Select("loadLabelFromID")
+	q := r.query.Select("loadLabelFromID")
 	q = q.Arg("id", id)
 
 	return &Label{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a ListTypeDef from its ID.
 func (r *Client) LoadListTypeDefFromID(id ListTypeDefID) *ListTypeDef {
-	q := r.Query.Select("loadListTypeDefFromID")
+	q := r.query.Select("loadListTypeDefFromID")
 	q = q.Arg("id", id)
 
 	return &ListTypeDef{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a LocalModuleSource from its ID.
 func (r *Client) LoadLocalModuleSourceFromID(id LocalModuleSourceID) *LocalModuleSource {
-	q := r.Query.Select("loadLocalModuleSourceFromID")
+	q := r.query.Select("loadLocalModuleSourceFromID")
 	q = q.Arg("id", id)
 
 	return &LocalModuleSource{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a ModuleDependency from its ID.
 func (r *Client) LoadModuleDependencyFromID(id ModuleDependencyID) *ModuleDependency {
-	q := r.Query.Select("loadModuleDependencyFromID")
+	q := r.query.Select("loadModuleDependencyFromID")
 	q = q.Arg("id", id)
 
 	return &ModuleDependency{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a Module from its ID.
 func (r *Client) LoadModuleFromID(id ModuleID) *Module {
-	q := r.Query.Select("loadModuleFromID")
+	q := r.query.Select("loadModuleFromID")
 	q = q.Arg("id", id)
 
 	return &Module{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a ModuleSource from its ID.
 func (r *Client) LoadModuleSourceFromID(id ModuleSourceID) *ModuleSource {
-	q := r.Query.Select("loadModuleSourceFromID")
+	q := r.query.Select("loadModuleSourceFromID")
 	q = q.Arg("id", id)
 
 	return &ModuleSource{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a ObjectTypeDef from its ID.
 func (r *Client) LoadObjectTypeDefFromID(id ObjectTypeDefID) *ObjectTypeDef {
-	q := r.Query.Select("loadObjectTypeDefFromID")
+	q := r.query.Select("loadObjectTypeDefFromID")
 	q = q.Arg("id", id)
 
 	return &ObjectTypeDef{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a Port from its ID.
 func (r *Client) LoadPortFromID(id PortID) *Port {
-	q := r.Query.Select("loadPortFromID")
+	q := r.query.Select("loadPortFromID")
 	q = q.Arg("id", id)
 
 	return &Port{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a Secret from its ID.
 func (r *Client) LoadSecretFromID(id SecretID) *Secret {
-	q := r.Query.Select("loadSecretFromID")
+	q := r.query.Select("loadSecretFromID")
 	q = q.Arg("id", id)
 
 	return &Secret{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a Service from its ID.
 func (r *Client) LoadServiceFromID(id ServiceID) *Service {
-	q := r.Query.Select("loadServiceFromID")
+	q := r.query.Select("loadServiceFromID")
 	q = q.Arg("id", id)
 
 	return &Service{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a Socket from its ID.
 func (r *Client) LoadSocketFromID(id SocketID) *Socket {
-	q := r.Query.Select("loadSocketFromID")
+	q := r.query.Select("loadSocketFromID")
 	q = q.Arg("id", id)
 
 	return &Socket{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a Terminal from its ID.
 func (r *Client) LoadTerminalFromID(id TerminalID) *Terminal {
-	q := r.Query.Select("loadTerminalFromID")
+	q := r.query.Select("loadTerminalFromID")
 	q = q.Arg("id", id)
 
 	return &Terminal{
-		Query: q,
+		query: q,
 	}
 }
 
 // Load a TypeDef from its ID.
 func (r *Client) LoadTypeDefFromID(id TypeDefID) *TypeDef {
-	q := r.Query.Select("loadTypeDefFromID")
+	q := r.query.Select("loadTypeDefFromID")
 	q = q.Arg("id", id)
 
 	return &TypeDef{
-		Query: q,
+		query: q,
 	}
 }
 
 // Create a new module.
 func (r *Client) Module() *Module {
-	q := r.Query.Select("module")
+	q := r.query.Select("module")
 
 	return &Module{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -5532,7 +5640,7 @@ type ModuleDependencyOpts struct {
 // Create a new module dependency configuration from a module source and name
 func (r *Client) ModuleDependency(source *ModuleSource, opts ...ModuleDependencyOpts) *ModuleDependency {
 	assertNotNil("source", source)
-	q := r.Query.Select("moduleDependency")
+	q := r.query.Select("moduleDependency")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `name` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Name) {
@@ -5542,7 +5650,7 @@ func (r *Client) ModuleDependency(source *ModuleSource, opts ...ModuleDependency
 	q = q.Arg("source", source)
 
 	return &ModuleDependency{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -5554,7 +5662,7 @@ type ModuleSourceOpts struct {
 
 // Create a new module source instance from a source ref string.
 func (r *Client) ModuleSource(refString string, opts ...ModuleSourceOpts) *ModuleSource {
-	q := r.Query.Select("moduleSource")
+	q := r.query.Select("moduleSource")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `stable` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Stable) {
@@ -5564,7 +5672,7 @@ func (r *Client) ModuleSource(refString string, opts ...ModuleSourceOpts) *Modul
 	q = q.Arg("refString", refString)
 
 	return &ModuleSource{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -5578,7 +5686,7 @@ type PipelineOpts struct {
 
 // Creates a named sub-pipeline.
 func (r *Client) Pipeline(name string, opts ...PipelineOpts) *Client {
-	q := r.Query.Select("pipeline")
+	q := r.query.Select("pipeline")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `description` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Description) {
@@ -5592,7 +5700,7 @@ func (r *Client) Pipeline(name string, opts ...PipelineOpts) *Client {
 	q = q.Arg("name", name)
 
 	return &Client{
-		Query:  q,
+		query:  q,
 		client: r.client,
 	}
 }
@@ -5604,7 +5712,7 @@ type SecretOpts struct {
 
 // Reference a secret by name.
 func (r *Client) Secret(name string, opts ...SecretOpts) *Secret {
-	q := r.Query.Select("secret")
+	q := r.query.Select("secret")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `accessor` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Accessor) {
@@ -5614,7 +5722,7 @@ func (r *Client) Secret(name string, opts ...SecretOpts) *Secret {
 	q = q.Arg("name", name)
 
 	return &Secret{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -5622,12 +5730,12 @@ func (r *Client) Secret(name string, opts ...SecretOpts) *Secret {
 //
 // The plaintext value is limited to a size of 128000 bytes.
 func (r *Client) SetSecret(name string, plaintext string) *Secret {
-	q := r.Query.Select("setSecret")
+	q := r.query.Select("setSecret")
 	q = q.Arg("name", name)
 	q = q.Arg("plaintext", plaintext)
 
 	return &Secret{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -5635,29 +5743,33 @@ func (r *Client) SetSecret(name string, plaintext string) *Secret {
 //
 // Deprecated: Use LoadSocketFromID instead.
 func (r *Client) Socket(id SocketID) *Socket {
-	q := r.Query.Select("socket")
+	q := r.query.Select("socket")
 	q = q.Arg("id", id)
 
 	return &Socket{
-		Query: q,
+		query: q,
 	}
 }
 
 // Create a new TypeDef.
 func (r *Client) TypeDef() *TypeDef {
-	q := r.Query.Select("typeDef")
+	q := r.query.Select("typeDef")
 
 	return &TypeDef{
-		Query: q,
+		query: q,
 	}
 }
 
 // A reference to a secret value, which can be handled more safely than the value itself.
 type Secret struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	id        *SecretID
 	plaintext *string
+}
+
+func (r *Secret) WithGraphQLQuery(q *querybuilder.Selection) *Secret {
+	return &Secret{query: q}
 }
 
 // A unique identifier for this Secret.
@@ -5665,7 +5777,7 @@ func (r *Secret) ID(ctx context.Context) (SecretID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response SecretID
 
@@ -5705,7 +5817,7 @@ func (r *Secret) Plaintext(ctx context.Context) (string, error) {
 	if r.plaintext != nil {
 		return *r.plaintext, nil
 	}
-	q := r.Query.Select("plaintext")
+	q := r.query.Select("plaintext")
 
 	var response string
 
@@ -5715,7 +5827,7 @@ func (r *Secret) Plaintext(ctx context.Context) (string, error) {
 
 // A content-addressed service providing TCP connectivity.
 type Service struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	endpoint *string
 	hostname *string
@@ -5723,6 +5835,10 @@ type Service struct {
 	start    *ServiceID
 	stop     *ServiceID
 	up       *Void
+}
+
+func (r *Service) WithGraphQLQuery(q *querybuilder.Selection) *Service {
+	return &Service{query: q}
 }
 
 // ServiceEndpointOpts contains options for Service.Endpoint
@@ -5742,7 +5858,7 @@ func (r *Service) Endpoint(ctx context.Context, opts ...ServiceEndpointOpts) (st
 	if r.endpoint != nil {
 		return *r.endpoint, nil
 	}
-	q := r.Query.Select("endpoint")
+	q := r.query.Select("endpoint")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `port` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Port) {
@@ -5765,7 +5881,7 @@ func (r *Service) Hostname(ctx context.Context) (string, error) {
 	if r.hostname != nil {
 		return *r.hostname, nil
 	}
-	q := r.Query.Select("hostname")
+	q := r.query.Select("hostname")
 
 	var response string
 
@@ -5778,7 +5894,7 @@ func (r *Service) ID(ctx context.Context) (ServiceID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response ServiceID
 
@@ -5815,7 +5931,7 @@ func (r *Service) MarshalJSON() ([]byte, error) {
 
 // Retrieves the list of ports provided by the service.
 func (r *Service) Ports(ctx context.Context) ([]Port, error) {
-	q := r.Query.Select("ports")
+	q := r.query.Select("ports")
 
 	q = q.Select("id")
 
@@ -5828,7 +5944,7 @@ func (r *Service) Ports(ctx context.Context) ([]Port, error) {
 
 		for i := range fields {
 			val := Port{id: &fields[i].Id}
-			val.Query = q.Root().Select("loadPortFromID").Arg("id", fields[i].Id)
+			val.query = q.Root().Select("loadPortFromID").Arg("id", fields[i].Id)
 			out = append(out, val)
 		}
 
@@ -5850,7 +5966,7 @@ func (r *Service) Ports(ctx context.Context) ([]Port, error) {
 //
 // Services bound to a Container do not need to be manually started.
 func (r *Service) Start(ctx context.Context) (*Service, error) {
-	q := r.Query.Select("start")
+	q := r.query.Select("start")
 
 	return r, q.Execute(ctx)
 }
@@ -5863,7 +5979,7 @@ type ServiceStopOpts struct {
 
 // Stop the service.
 func (r *Service) Stop(ctx context.Context, opts ...ServiceStopOpts) (*Service, error) {
-	q := r.Query.Select("stop")
+	q := r.query.Select("stop")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `kill` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Kill) {
@@ -5889,7 +6005,7 @@ func (r *Service) Up(ctx context.Context, opts ...ServiceUpOpts) (Void, error) {
 	if r.up != nil {
 		return *r.up, nil
 	}
-	q := r.Query.Select("up")
+	q := r.query.Select("up")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `ports` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Ports) {
@@ -5909,9 +6025,13 @@ func (r *Service) Up(ctx context.Context, opts ...ServiceUpOpts) (Void, error) {
 
 // A Unix or TCP/IP socket that can be mounted into a container.
 type Socket struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	id *SocketID
+}
+
+func (r *Socket) WithGraphQLQuery(q *querybuilder.Selection) *Socket {
+	return &Socket{query: q}
 }
 
 // A unique identifier for this Socket.
@@ -5919,7 +6039,7 @@ func (r *Socket) ID(ctx context.Context) (SocketID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response SocketID
 
@@ -5956,10 +6076,14 @@ func (r *Socket) MarshalJSON() ([]byte, error) {
 
 // An interactive terminal that clients can connect to.
 type Terminal struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	id                *TerminalID
 	websocketEndpoint *string
+}
+
+func (r *Terminal) WithGraphQLQuery(q *querybuilder.Selection) *Terminal {
+	return &Terminal{query: q}
 }
 
 // A unique identifier for this Terminal.
@@ -5967,7 +6091,7 @@ func (r *Terminal) ID(ctx context.Context) (TerminalID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response TerminalID
 
@@ -6007,7 +6131,7 @@ func (r *Terminal) WebsocketEndpoint(ctx context.Context) (string, error) {
 	if r.websocketEndpoint != nil {
 		return *r.websocketEndpoint, nil
 	}
-	q := r.Query.Select("websocketEndpoint")
+	q := r.query.Select("websocketEndpoint")
 
 	var response string
 
@@ -6017,7 +6141,7 @@ func (r *Terminal) WebsocketEndpoint(ctx context.Context) (string, error) {
 
 // A definition of a parameter or return type in a Module.
 type TypeDef struct {
-	Query *querybuilder.Selection
+	query *querybuilder.Selection
 
 	id       *TypeDefID
 	kind     *TypeDefKind
@@ -6032,39 +6156,43 @@ func (r *TypeDef) With(f WithTypeDefFunc) *TypeDef {
 	return f(r)
 }
 
+func (r *TypeDef) WithGraphQLQuery(q *querybuilder.Selection) *TypeDef {
+	return &TypeDef{query: q}
+}
+
 // If kind is INPUT, the input-specific type definition. If kind is not INPUT, this will be null.
 func (r *TypeDef) AsInput() *InputTypeDef {
-	q := r.Query.Select("asInput")
+	q := r.query.Select("asInput")
 
 	return &InputTypeDef{
-		Query: q,
+		query: q,
 	}
 }
 
 // If kind is INTERFACE, the interface-specific type definition. If kind is not INTERFACE, this will be null.
 func (r *TypeDef) AsInterface() *InterfaceTypeDef {
-	q := r.Query.Select("asInterface")
+	q := r.query.Select("asInterface")
 
 	return &InterfaceTypeDef{
-		Query: q,
+		query: q,
 	}
 }
 
 // If kind is LIST, the list-specific type definition. If kind is not LIST, this will be null.
 func (r *TypeDef) AsList() *ListTypeDef {
-	q := r.Query.Select("asList")
+	q := r.query.Select("asList")
 
 	return &ListTypeDef{
-		Query: q,
+		query: q,
 	}
 }
 
 // If kind is OBJECT, the object-specific type definition. If kind is not OBJECT, this will be null.
 func (r *TypeDef) AsObject() *ObjectTypeDef {
-	q := r.Query.Select("asObject")
+	q := r.query.Select("asObject")
 
 	return &ObjectTypeDef{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -6073,7 +6201,7 @@ func (r *TypeDef) ID(ctx context.Context) (TypeDefID, error) {
 	if r.id != nil {
 		return *r.id, nil
 	}
-	q := r.Query.Select("id")
+	q := r.query.Select("id")
 
 	var response TypeDefID
 
@@ -6113,7 +6241,7 @@ func (r *TypeDef) Kind(ctx context.Context) (TypeDefKind, error) {
 	if r.kind != nil {
 		return *r.kind, nil
 	}
-	q := r.Query.Select("kind")
+	q := r.query.Select("kind")
 
 	var response TypeDefKind
 
@@ -6126,7 +6254,7 @@ func (r *TypeDef) Optional(ctx context.Context) (bool, error) {
 	if r.optional != nil {
 		return *r.optional, nil
 	}
-	q := r.Query.Select("optional")
+	q := r.query.Select("optional")
 
 	var response bool
 
@@ -6137,11 +6265,11 @@ func (r *TypeDef) Optional(ctx context.Context) (bool, error) {
 // Adds a function for constructing a new instance of an Object TypeDef, failing if the type is not an object.
 func (r *TypeDef) WithConstructor(function *Function) *TypeDef {
 	assertNotNil("function", function)
-	q := r.Query.Select("withConstructor")
+	q := r.query.Select("withConstructor")
 	q = q.Arg("function", function)
 
 	return &TypeDef{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -6154,7 +6282,7 @@ type TypeDefWithFieldOpts struct {
 // Adds a static field for an Object TypeDef, failing if the type is not an object.
 func (r *TypeDef) WithField(name string, typeDef *TypeDef, opts ...TypeDefWithFieldOpts) *TypeDef {
 	assertNotNil("typeDef", typeDef)
-	q := r.Query.Select("withField")
+	q := r.query.Select("withField")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `description` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Description) {
@@ -6165,18 +6293,18 @@ func (r *TypeDef) WithField(name string, typeDef *TypeDef, opts ...TypeDefWithFi
 	q = q.Arg("typeDef", typeDef)
 
 	return &TypeDef{
-		Query: q,
+		query: q,
 	}
 }
 
 // Adds a function for an Object or Interface TypeDef, failing if the type is not one of those kinds.
 func (r *TypeDef) WithFunction(function *Function) *TypeDef {
 	assertNotNil("function", function)
-	q := r.Query.Select("withFunction")
+	q := r.query.Select("withFunction")
 	q = q.Arg("function", function)
 
 	return &TypeDef{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -6187,7 +6315,7 @@ type TypeDefWithInterfaceOpts struct {
 
 // Returns a TypeDef of kind Interface with the provided name.
 func (r *TypeDef) WithInterface(name string, opts ...TypeDefWithInterfaceOpts) *TypeDef {
-	q := r.Query.Select("withInterface")
+	q := r.query.Select("withInterface")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `description` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Description) {
@@ -6197,28 +6325,28 @@ func (r *TypeDef) WithInterface(name string, opts ...TypeDefWithInterfaceOpts) *
 	q = q.Arg("name", name)
 
 	return &TypeDef{
-		Query: q,
+		query: q,
 	}
 }
 
 // Sets the kind of the type.
 func (r *TypeDef) WithKind(kind TypeDefKind) *TypeDef {
-	q := r.Query.Select("withKind")
+	q := r.query.Select("withKind")
 	q = q.Arg("kind", kind)
 
 	return &TypeDef{
-		Query: q,
+		query: q,
 	}
 }
 
 // Returns a TypeDef of kind List with the provided type for its elements.
 func (r *TypeDef) WithListOf(elementType *TypeDef) *TypeDef {
 	assertNotNil("elementType", elementType)
-	q := r.Query.Select("withListOf")
+	q := r.query.Select("withListOf")
 	q = q.Arg("elementType", elementType)
 
 	return &TypeDef{
-		Query: q,
+		query: q,
 	}
 }
 
@@ -6231,7 +6359,7 @@ type TypeDefWithObjectOpts struct {
 //
 // Note that an object's fields and functions may be omitted if the intent is only to refer to an object. This is how functions are able to return their own object, or any other circular reference.
 func (r *TypeDef) WithObject(name string, opts ...TypeDefWithObjectOpts) *TypeDef {
-	q := r.Query.Select("withObject")
+	q := r.query.Select("withObject")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `description` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Description) {
@@ -6241,17 +6369,17 @@ func (r *TypeDef) WithObject(name string, opts ...TypeDefWithObjectOpts) *TypeDe
 	q = q.Arg("name", name)
 
 	return &TypeDef{
-		Query: q,
+		query: q,
 	}
 }
 
 // Sets whether this type can be set to null.
 func (r *TypeDef) WithOptional(optional bool) *TypeDef {
-	q := r.Query.Select("withOptional")
+	q := r.query.Select("withOptional")
 	q = q.Arg("optional", optional)
 
 	return &TypeDef{
-		Query: q,
+		query: q,
 	}
 }
 

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -244,7 +244,9 @@ type CacheVolume struct {
 }
 
 func (r *CacheVolume) WithGraphQLQuery(q *querybuilder.Selection) *CacheVolume {
-	return &CacheVolume{query: q}
+	return &CacheVolume{
+		query: q,
+	}
 }
 
 // A unique identifier for this CacheVolume.
@@ -314,7 +316,9 @@ func (r *Container) With(f WithContainerFunc) *Container {
 }
 
 func (r *Container) WithGraphQLQuery(q *querybuilder.Selection) *Container {
-	return &Container{query: q}
+	return &Container{
+		query: q,
+	}
 }
 
 // Turn the container into a Service.
@@ -1688,7 +1692,9 @@ type CurrentModule struct {
 }
 
 func (r *CurrentModule) WithGraphQLQuery(q *querybuilder.Selection) *CurrentModule {
-	return &CurrentModule{query: q}
+	return &CurrentModule{
+		query: q,
+	}
 }
 
 // A unique identifier for this CurrentModule.
@@ -1809,7 +1815,9 @@ func (r *Directory) With(f WithDirectoryFunc) *Directory {
 }
 
 func (r *Directory) WithGraphQLQuery(q *querybuilder.Selection) *Directory {
-	return &Directory{query: q}
+	return &Directory{
+		query: q,
+	}
 }
 
 // DirectoryAsModuleOpts contains options for Directory.AsModule
@@ -2199,7 +2207,9 @@ type EnvVariable struct {
 }
 
 func (r *EnvVariable) WithGraphQLQuery(q *querybuilder.Selection) *EnvVariable {
-	return &EnvVariable{query: q}
+	return &EnvVariable{
+		query: q,
+	}
 }
 
 // A unique identifier for this EnvVariable.
@@ -2280,7 +2290,9 @@ type FieldTypeDef struct {
 }
 
 func (r *FieldTypeDef) WithGraphQLQuery(q *querybuilder.Selection) *FieldTypeDef {
-	return &FieldTypeDef{query: q}
+	return &FieldTypeDef{
+		query: q,
+	}
 }
 
 // A doc string for the field, if any.
@@ -2379,7 +2391,9 @@ func (r *File) With(f WithFileFunc) *File {
 }
 
 func (r *File) WithGraphQLQuery(q *querybuilder.Selection) *File {
-	return &File{query: q}
+	return &File{
+		query: q,
+	}
 }
 
 // Retrieves the contents of the file.
@@ -2524,7 +2538,9 @@ func (r *Function) With(f WithFunctionFunc) *Function {
 }
 
 func (r *Function) WithGraphQLQuery(q *querybuilder.Selection) *Function {
-	return &Function{query: q}
+	return &Function{
+		query: q,
+	}
 }
 
 // Arguments accepted by the function, if any.
@@ -2688,7 +2704,9 @@ type FunctionArg struct {
 }
 
 func (r *FunctionArg) WithGraphQLQuery(q *querybuilder.Selection) *FunctionArg {
-	return &FunctionArg{query: q}
+	return &FunctionArg{
+		query: q,
+	}
 }
 
 // A default value to use for this argument when not explicitly set by the caller, if any.
@@ -2791,7 +2809,9 @@ type FunctionCall struct {
 }
 
 func (r *FunctionCall) WithGraphQLQuery(q *querybuilder.Selection) *FunctionCall {
-	return &FunctionCall{query: q}
+	return &FunctionCall{
+		query: q,
+	}
 }
 
 // A unique identifier for this FunctionCall.
@@ -2930,7 +2950,9 @@ type FunctionCallArgValue struct {
 }
 
 func (r *FunctionCallArgValue) WithGraphQLQuery(q *querybuilder.Selection) *FunctionCallArgValue {
-	return &FunctionCallArgValue{query: q}
+	return &FunctionCallArgValue{
+		query: q,
+	}
 }
 
 // A unique identifier for this FunctionCallArgValue.
@@ -3015,7 +3037,9 @@ func (r *GeneratedCode) With(f WithGeneratedCodeFunc) *GeneratedCode {
 }
 
 func (r *GeneratedCode) WithGraphQLQuery(q *querybuilder.Selection) *GeneratedCode {
-	return &GeneratedCode{query: q}
+	return &GeneratedCode{
+		query: q,
+	}
 }
 
 // The directory containing the generated code.
@@ -3120,7 +3144,9 @@ type GitModuleSource struct {
 }
 
 func (r *GitModuleSource) WithGraphQLQuery(q *querybuilder.Selection) *GitModuleSource {
-	return &GitModuleSource{query: q}
+	return &GitModuleSource{
+		query: q,
+	}
 }
 
 // The URL from which the source's git repo can be cloned.
@@ -3246,7 +3272,9 @@ type GitRef struct {
 }
 
 func (r *GitRef) WithGraphQLQuery(q *querybuilder.Selection) *GitRef {
-	return &GitRef{query: q}
+	return &GitRef{
+		query: q,
+	}
 }
 
 // The resolved commit id at this ref.
@@ -3337,7 +3365,9 @@ type GitRepository struct {
 }
 
 func (r *GitRepository) WithGraphQLQuery(q *querybuilder.Selection) *GitRepository {
-	return &GitRepository{query: q}
+	return &GitRepository{
+		query: q,
+	}
 }
 
 // Returns details of a branch.
@@ -3428,7 +3458,9 @@ type Host struct {
 }
 
 func (r *Host) WithGraphQLQuery(q *querybuilder.Selection) *Host {
-	return &Host{query: q}
+	return &Host{
+		query: q,
+	}
 }
 
 // HostDirectoryOpts contains options for Host.Directory
@@ -3603,7 +3635,9 @@ type InputTypeDef struct {
 }
 
 func (r *InputTypeDef) WithGraphQLQuery(q *querybuilder.Selection) *InputTypeDef {
-	return &InputTypeDef{query: q}
+	return &InputTypeDef{
+		query: q,
+	}
 }
 
 // Static fields defined on this input object, if any.
@@ -3703,7 +3737,9 @@ type InterfaceTypeDef struct {
 }
 
 func (r *InterfaceTypeDef) WithGraphQLQuery(q *querybuilder.Selection) *InterfaceTypeDef {
-	return &InterfaceTypeDef{query: q}
+	return &InterfaceTypeDef{
+		query: q,
+	}
 }
 
 // The doc string for the interface, if any.
@@ -3828,7 +3864,9 @@ type Label struct {
 }
 
 func (r *Label) WithGraphQLQuery(q *querybuilder.Selection) *Label {
-	return &Label{query: q}
+	return &Label{
+		query: q,
+	}
 }
 
 // A unique identifier for this Label.
@@ -3905,7 +3943,9 @@ type ListTypeDef struct {
 }
 
 func (r *ListTypeDef) WithGraphQLQuery(q *querybuilder.Selection) *ListTypeDef {
-	return &ListTypeDef{query: q}
+	return &ListTypeDef{
+		query: q,
+	}
 }
 
 // The type of the elements in the list.
@@ -3966,7 +4006,9 @@ type LocalModuleSource struct {
 }
 
 func (r *LocalModuleSource) WithGraphQLQuery(q *querybuilder.Selection) *LocalModuleSource {
-	return &LocalModuleSource{query: q}
+	return &LocalModuleSource{
+		query: q,
+	}
 }
 
 // The directory containing everything needed to load load and use the module.
@@ -4051,7 +4093,9 @@ func (r *Module) With(f WithModuleFunc) *Module {
 }
 
 func (r *Module) WithGraphQLQuery(q *querybuilder.Selection) *Module {
-	return &Module{query: q}
+	return &Module{
+		query: q,
+	}
 }
 
 // Modules used by this module.
@@ -4377,7 +4421,9 @@ type ModuleDependency struct {
 }
 
 func (r *ModuleDependency) WithGraphQLQuery(q *querybuilder.Selection) *ModuleDependency {
-	return &ModuleDependency{query: q}
+	return &ModuleDependency{
+		query: q,
+	}
 }
 
 // A unique identifier for this ModuleDependency.
@@ -4466,7 +4512,9 @@ func (r *ModuleSource) With(f WithModuleSourceFunc) *ModuleSource {
 }
 
 func (r *ModuleSource) WithGraphQLQuery(q *querybuilder.Selection) *ModuleSource {
-	return &ModuleSource{query: q}
+	return &ModuleSource{
+		query: q,
+	}
 }
 
 // If the source is a of kind git, the git source representation of it.
@@ -4774,7 +4822,9 @@ type ObjectTypeDef struct {
 }
 
 func (r *ObjectTypeDef) WithGraphQLQuery(q *querybuilder.Selection) *ObjectTypeDef {
-	return &ObjectTypeDef{query: q}
+	return &ObjectTypeDef{
+		query: q,
+	}
 }
 
 // The function used to construct new instances of this object, if any
@@ -4943,7 +4993,9 @@ type Port struct {
 }
 
 func (r *Port) WithGraphQLQuery(q *querybuilder.Selection) *Port {
-	return &Port{query: q}
+	return &Port{
+		query: q,
+	}
 }
 
 // The port description.
@@ -5048,7 +5100,10 @@ func (r *Client) With(f WithClientFunc) *Client {
 }
 
 func (r *Client) WithGraphQLQuery(q *querybuilder.Selection) *Client {
-	return &Client{query: q}
+	return &Client{
+		query:  q,
+		client: r.client,
+	}
 }
 
 // Retrieves a content-addressed blob.
@@ -5769,7 +5824,9 @@ type Secret struct {
 }
 
 func (r *Secret) WithGraphQLQuery(q *querybuilder.Selection) *Secret {
-	return &Secret{query: q}
+	return &Secret{
+		query: q,
+	}
 }
 
 // A unique identifier for this Secret.
@@ -5838,7 +5895,9 @@ type Service struct {
 }
 
 func (r *Service) WithGraphQLQuery(q *querybuilder.Selection) *Service {
-	return &Service{query: q}
+	return &Service{
+		query: q,
+	}
 }
 
 // ServiceEndpointOpts contains options for Service.Endpoint
@@ -6031,7 +6090,9 @@ type Socket struct {
 }
 
 func (r *Socket) WithGraphQLQuery(q *querybuilder.Selection) *Socket {
-	return &Socket{query: q}
+	return &Socket{
+		query: q,
+	}
 }
 
 // A unique identifier for this Socket.
@@ -6083,7 +6144,9 @@ type Terminal struct {
 }
 
 func (r *Terminal) WithGraphQLQuery(q *querybuilder.Selection) *Terminal {
-	return &Terminal{query: q}
+	return &Terminal{
+		query: q,
+	}
 }
 
 // A unique identifier for this Terminal.
@@ -6157,7 +6220,9 @@ func (r *TypeDef) With(f WithTypeDefFunc) *TypeDef {
 }
 
 func (r *TypeDef) WithGraphQLQuery(q *querybuilder.Selection) *TypeDef {
-	return &TypeDef{query: q}
+	return &TypeDef{
+		query: q,
+	}
 }
 
 // If kind is INPUT, the input-specific type definition. If kind is not INPUT, this will be null.


### PR DESCRIPTION
Follow-up to https://github.com/dagger/dagger/pull/6716 - people were using `Query` as a method name, see [discord](https://discord.com/channels/707636530424053791/1120503349599543376/1215103368150917180).

This could cause name clashes and was annoying. Thankfully, there's only one legitimate need for this field to be public - interfaces.

We can provide a workaround for this with the new `WithGraphQLQuery` method on generated types, which resets the underlying type, and sets the query.

---

I did briefly consider the idea of using an `XXX` prefix for `Query`, but I prefer having a method to set the private field since then it's not possible to set the query, but not modify the cached properties, which would definitely result in weird things happening.