### PR TITLE
fix: propagate graphql client to child clients

### DIFF
--- a/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
@@ -88,6 +88,9 @@ type {{ $field | FieldOptionsStructName }} struct {
 	{{ $typeName := $field.TypeRef | FormatOutputType }}
 	return &{{ $field.TypeRef | FormatOutputType }} {
 		Query: q,
+		{{- if eq $typeName "Client" }}
+		client: r.client,
+		{{ end }}
 	}
 
 	{{- else if or $field.TypeRef.IsScalar $field.TypeRef.IsList }}

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -5592,7 +5592,8 @@ func (r *Client) Pipeline(name string, opts ...PipelineOpts) *Client {
 	q = q.Arg("name", name)
 
 	return &Client{
-		Query: q,
+		Query:  q,
+		client: r.client,
 	}
 }
 


### PR DESCRIPTION
Should fix https://github.com/dagger/dagger/issues/6850 (cc @morlay)

This regressed in https://github.com/dagger/dagger/pull/6716, and meant that child clients were invalid, and couldn't be called with `Do()`, as well as causing `GraphQLClient()` to return an invalid nil value.

This only previously worked because the GraphQL client and the dagger client shared the same name `client`. When this property was removed, the propagation stopped working. Now, we make this special case explicit.

---

@morlay if you have a more specific stack trace from the panic, or can somehow confirm that this fixes your issue that would be super helpful.