### PR TITLE
fix bug with extra space

### DIFF
--- a/docs/current_docs/developer-guide/typescript/292372-functions.mdx
+++ b/docs/current_docs/developer-guide/typescript/292372-functions.mdx
@@ -203,7 +203,7 @@ Here's an example of a Dagger Function that accepts a `Directory` containing a G
 Here is an example call for this Dagger Function:
 
 ```shell
-dagger call build --source=https://github.com/golang/example/#master:hello --os=linux --architecture =amd64 terminal
+dagger call build --source=https://github.com/golang/example/#master:hello --os=linux --architecture=amd64 terminal
 ```
 
 This example chains two functions calls:


### PR DESCRIPTION
There is an extra space in the CLI snippet that causes the command to fail with the following error: 

```
levlaz@Levs-MacBook-Pro ts % dagger call build --source=https://github.com/golang/example/#master:hello --os=linux --architecture =amd64 terminal
zsh: amd64 not found
```

Removing this space fixes it.