### PR TITLE
docs: Add missing self in python step2 snippet

### DIFF
--- a/docs/current_docs/developer-guide/python/snippets/first-module/step2/main.py
+++ b/docs/current_docs/developer-guide/python/snippets/first-module/step2/main.py
@@ -4,5 +4,5 @@ from dagger import function, object_type
 @object_type
 class Potato:
     @function
-    def hello_world() -> str:
+    def hello_world(self) -> str:
         return "Hello Daggernauts!"


### PR DESCRIPTION
Trying out the python dev guide and think there is a `self` missing [here](https://docs.dagger.io/developer-guide/python/419481/first-module#step-2-create-a-simple-dagger-function).

Output without `self`:
```
 dagger call hello-world       
✔ daggerPotato: DaggerPotato! 0.5s
  ✔ exec /runtime 0.5s
✘ DaggerPotato.helloWorld: String! 0.6s
  ✘ exec /runtime 0.6s
  ┃ ╭─ Error ──────────────────────────────────────────────────────────────────────╮                                                                   
  ┃ │ Function execution error: invalid method signature                           │                                                                   
  ┃ ╰──────────────────────────────────────────────────────────────────────────────╯                                                                   

Error: response from query: input: daggerPotato.helloWorld call function "hello_world": process "/runtime" did not complete successfully: exit code: 1

Stderr:
╭─ Error ──────────────────────────────────────────────────────────────────────╮
│ Function execution error: invalid method signature                           │
╰──────────────────────────────────────────────────────────────────────────────╯
```

Output with `self`:
```
dagger call hello-world   
Hello Daggernauts!
```
