### PR TITLE
cli: do findup of dagger.json for all relevant commands

### DIFF
--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -547,7 +547,7 @@ func (v *moduleValue) Get(ctx context.Context, dag *dagger.Client) (any, error) 
 	if v.ref == "" {
 		return nil, fmt.Errorf("module ref cannot be empty")
 	}
-	modConf, err := getModuleConfigurationForSourceRef(ctx, dag, v.ref, true)
+	modConf, err := getModuleConfigurationForSourceRef(ctx, dag, v.ref, true, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get module configuration: %w", err)
 	}
@@ -578,7 +578,7 @@ func (v *moduleSourceValue) Get(ctx context.Context, dag *dagger.Client) (any, e
 	if v.ref == "" {
 		return nil, fmt.Errorf("module source ref cannot be empty")
 	}
-	modConf, err := getModuleConfigurationForSourceRef(ctx, dag, v.ref, true)
+	modConf, err := getModuleConfigurationForSourceRef(ctx, dag, v.ref, true, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get module configuration: %w", err)
 	}

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -366,7 +366,7 @@ func (fc *FuncCommand) load(c *cobra.Command, a []string) (cmd *cobra.Command, _
 	ctx, vtx := progrock.Span(ctx, idtui.InitVertex, "initialize")
 	defer func() { vtx.Done(rerr) }()
 
-	modConf, err := getDefaultModuleConfiguration(ctx, dag, true)
+	modConf, err := getDefaultModuleConfiguration(ctx, dag, true, true)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get configured module: %w", err)
 	}

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -1080,3 +1080,18 @@ func TestModuleCallGitMod(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "hi from top level hi from dep hi from dep2", strings.TrimSpace(out))
 }
+
+func TestModuleCallFindup(t *testing.T) {
+	t.Parallel()
+	c, ctx := connect(t)
+
+	out, err := c.Container().From(golangImage).
+		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+		WithWorkdir("/work").
+		With(daggerExec("init", "--name=foo", "--sdk=go")).
+		WithWorkdir("/work/some/subdir").
+		With(daggerCall("container-echo", "--string-arg", "yo", "stdout")).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "yo", strings.TrimSpace(out))
+}

--- a/core/integration/module_functions_test.go
+++ b/core/integration/module_functions_test.go
@@ -97,6 +97,20 @@ func (m *OtherObj) FnE() *Container {
 		require.Contains(t, lines, "prim   doc for Prim")
 	})
 
+	t.Run("top-level from subdir", func(t *testing.T) {
+		// find-up should kick in
+		out, err := ctr.
+			WithWorkdir("/work/some/subdir").
+			With(daggerFunctions()).
+			Stdout(ctx)
+		require.NoError(t, err)
+		lines := strings.Split(out, "\n")
+		require.Contains(t, lines, "fn-a   doc for FnA")
+		require.Contains(t, lines, "fn-b   doc for FnB")
+		require.Contains(t, lines, "fn-c   doc for FnC")
+		require.Contains(t, lines, "prim   doc for Prim")
+	})
+
 	t.Run("return core object", func(t *testing.T) {
 		out, err := ctr.With(daggerFunctions("fn-a")).Stdout(ctx)
 		require.NoError(t, err)


### PR DESCRIPTION
`dagger call/install/develop/publish/functions/config` all now take into account the find-up we do of `dagger.json` so they can work from subdirs.

`dagger init` is a special case where we don't findup since it would prevent you from initializing a module from a subdir of another.