### PR TITLE
docs: Adds troubleshooting page

### DIFF
--- a/docs/current_docs/user-guide/932727-troubleshooting.mdx
+++ b/docs/current_docs/user-guide/932727-troubleshooting.mdx
@@ -1,0 +1,64 @@
+---
+slug: /user-guide/932727-troubleshooting
+---
+
+# Troubleshooting Dagger
+
+This page describes problems you may encounter when using Dagger, and their solutions.
+
+## Dagger is unresponsive with a BuildKit error
+
+A Dagger Function may hang or become unresponsive, eventually generating a BuildKit error such as `buildkit failed to respond` or `container state improper`.
+
+To resolve this error, you must stop and remove the Dagger Engine container and (optionally) clear the container state.
+
+1. Stop and remove the Dagger Engine container:
+
+    ```shell
+    DAGGER_ENGINE_DOCKER_CONTAINER="$(docker container list --all --filter 'name=^dagger-engine-*' --format '{{.Names}}')"
+    docker container stop "$DAGGER_ENGINE_DOCKER_CONTAINER"
+    docker container rm "$DAGGER_ENGINE_DOCKER_CONTAINER"
+    ```
+
+1. Clear unused volumes and data:
+
+    :::info
+    This step is optional. It will remove the cache and result in a slow first run when the container is re-provisioned.
+    :::
+
+    ```shell
+    docker volume prune
+    docker system prune
+    ```
+
+You should now be able to run your Dagger Function successfully.
+
+:::note
+If you have custom-provisioned the Dagger Engine, please adjust the above commands to your environment.
+:::
+
+## Dagger is unable to resolve host names after network configuration changes
+
+If the network configuration of the host changes after the Dagger Engine container starts, Docker does not notify the Dagger Engine of the change. This may cause Dagger to fail with network-related errors.
+
+As an example, if the nameserver configuration of the host changes after switching to a different network connection or connecting/disconnecting a VPN result, Dagger may fail with DNS resolution errors.
+
+To resolve this error, you must restart the Dagger Engine container after the host network configuration changes.
+
+```shell
+DAGGER_ENGINE_DOCKER_CONTAINER="$(docker container list --all --filter 'name=^dagger-engine-*' --format '{{.Names}}')"
+docker restart "$DAGGER_ENGINE_DOCKER_CONTAINER"
+```
+
+You should now be able to re-run your Dagger Function successfully.
+
+## Calling a Dagger Function fails when `DOCKER_DEFAULT_PLATFORM` is set
+
+A Dagger Function may fail with an error like `unable to start container process` and/or cause the Dagger Engine to crash. This can occur when you have the `DOCKER_DEFAULT_PLATFORM` environment variable set.
+
+To resolve this error, remove the `DOCKER_DEFAULT_PLATFORM` variable, restart the shell, and recreate the Dagger Engine container with the commands below:
+
+```shell
+DAGGER_ENGINE_DOCKER_CONTAINER="$(docker container list --all --filter 'name=^dagger-engine-*' --format '{{.Names}}')"
+docker restart "$DAGGER_ENGINE_DOCKER_CONTAINER"
+```

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -104,6 +104,11 @@ module.exports = {
               "id": "user-guide/cloud/org-administration"
             }
           ]
+        },
+        {
+          "type": "doc",
+          "id": "user-guide/troubleshooting",
+          "label": "Troubleshooting"
         }
       ]
     },


### PR DESCRIPTION
Transfer of content from https://archive.docs.dagger.io/0.9/235290/troubleshooting with additional information from https://discord.com/channels/707636530424053791/1213529490525917265