### PR TITLE
docs: Clarifies section dependency and module naming in quickstart

### DIFF
--- a/docs/current_docs/quickstart/428201-custom-function.mdx
+++ b/docs/current_docs/quickstart/428201-custom-function.mdx
@@ -20,6 +20,10 @@ By creating your own Dagger Module and installing other modules into it, you can
 
 To see this in action, create a custom Dagger Module that uses two other Dagger Modules to build your project, add it to a custom container image of your choice, and publish the result to a registry.
 
+:::note
+The steps below assume that you have already [Daggerized the example Go project repository](./822194-daggerize.mdx) by initializing a new Dagger Module and installing the Go builder module as a dependency. If not, complete those steps before proceeding.
+:::
+
 ### Bootstrap a module template
 
 Begin by running `dagger develop` to bootstrap a module template in one of the supported programming languages:
@@ -31,7 +35,7 @@ Begin by running `dagger develop` to bootstrap a module template in one of the s
 dagger develop --sdk=go
 ```
 
-This will generate a `dagger.json` module file, an initial `dagger/main.go` source file, as well as a generated `dagger/dagger.gen.go` and `dagger/querybuilder` directory for the generated module code.
+This will generate a `dagger.json` module file, an initial `dagger/main.go` source file, as well as a generated `dagger/dagger.gen.go` and `dagger/internal` directory for the generated module code.
 
 </TabItem>
 <TabItem value="Python">
@@ -53,6 +57,10 @@ This will generate a `dagger.json` module file, initial `dagger/src/index.ts`, `
 
 </TabItem>
 </Tabs>
+
+:::note
+The class/type definitions in the generated module code are derived from the module name.
+:::
 
 ### Install another dependency
 

--- a/docs/current_docs/quickstart/822194-daggerize.mdx
+++ b/docs/current_docs/quickstart/822194-daggerize.mdx
@@ -48,10 +48,14 @@ You should see the following:
 
 ```json
 {
-  "name": "greetings-api",
-  "engineVersion": "v0.10.0"
+  "name": "example",
+  "engineVersion": "v0.10.1"
 }
 ```
+
+:::note
+By default, the module name is derived from the name of the directory in which it is initialized. To use a different name, add the `--name` argument to the `dagger init` call - for example, `dagger init --name=my-module`.
+:::
 
 Finally, commit the file to your repository:
 
@@ -74,14 +78,16 @@ Once the command completes, look at the `dagger.json` file again. You should see
 
 ```json
 {
-  "name": "greetings-api",
+  "name": "example",
+  "sdk": "go",
   "dependencies": [
     {
       "name": "hello",
-      "source": "github.com/shykes/daggerverse/hello@7884cbc1941f85a7c714fc7f1bcc5c148842c21e"
+      "source": "github.com/shykes/daggerverse/hello@3d608cb5e6b4b18036a471400bc4e6c753f229d7"
     }
   ],
-  "engineVersion": "v0.10.0"
+  "source": "dagger",
+  "engineVersion": "v0.10.1"
 }
 ```
 


### PR DESCRIPTION
This commit adds notes to the quickstart based on the user feedback in https://discord.com/channels/707636530424053791/1215318377329983519