### PR TITLE
typescript: Re-enable CLI binary test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,6 @@ on:
       - sdk/go/internal/engineconn/version.gen.go
       - sdk/python/src/dagger/_engine/_version.py
       - sdk/typescript/provisioning/default.ts
-      - sdk/rust/src/crates/dagger-sdk/src/core/mod.rs
 
 jobs:
   publish:
@@ -162,9 +161,6 @@ jobs:
           cd sdk/typescript
           yarn install
           yarn test -g 'Automatic Provisioned CLI Binary'
-
-      - name: "Setup Rust"
-        uses: dtolnay/rust-toolchain@stable
 
       - name: "ALWAYS print engine logs - especially useful on failure"
         if: always()

--- a/sdk/typescript/test/connect.spec.ts
+++ b/sdk/typescript/test/connect.spec.ts
@@ -149,7 +149,7 @@ describe("TypeScript sdk Connect", function () {
     }
   })
 
-  describe.skip("Automatic Provisioned CLI Binary", function () {
+  describe("Automatic Provisioned CLI Binary", function () {
     let oldEnv: string
     let tempDir: string
     let cacheDir: string


### PR DESCRIPTION
This is used by the `publish.yaml` workflow on the main branch.

If this spec does not run, that workflow fails.

Follow-up to:
- https://github.com/dagger/dagger/pull/6831