### PR TITLE
make dagger -m examples consistent

### DIFF
--- a/docs/current_docs/quickstart/883939-containers.mdx
+++ b/docs/current_docs/quickstart/883939-containers.mdx
@@ -15,7 +15,7 @@ Just as you can chain and return `Directory` types, you can also chain and retur
 Try calling this function:
 
 ```shell
-dagger call -m github.com/shykes/daggerverse/wolfi@v0.1.2 container --packages=cowsay
+dagger -m github.com/shykes/daggerverse/wolfi@v0.1.2 call container --packages=cowsay
 ```
 
 This Wolfi container builder module exposes a `Container()` function that returns a base Wolfi container image, and accepts arguments to additional packages in the base image;
@@ -35,7 +35,7 @@ One of the most interesting `Container` functions is `Terminal()`, which can be 
 To see this in action, call the previous function again, this time chaining an additional function call to `Terminal()` on the returned `Container`:
 
 ```shell
-dagger call -m github.com/shykes/daggerverse/wolfi@v0.1.2 container --packages=cowsay terminal
+dagger -m github.com/shykes/daggerverse/wolfi@v0.1.2 call container --packages=cowsay terminal
 ```
 
 This revised command builds the container image and then drops you into an interactive terminal, allowing you to directly execute commands in the running container.
@@ -68,7 +68,7 @@ While most terminal programs such as `htop` or `vim` work with `dagger ... termi
 The `Container` type has a `withExec()` function, which returns the container after executing a specific command inside it. So, you could achieve the same result as before (although non-interactively) by chaining a function call to `withExec()` on the `Container` returned previously, as shown in the following command:
 
 ```shell
-dagger call -m github.com/shykes/daggerverse/wolfi@v0.1.2 container --packages=cowsay with-exec --args cowsay,dagger stdout
+dagger -m github.com/shykes/daggerverse/wolfi@v0.1.2 call container --packages=cowsay with-exec --args cowsay,dagger stdout
 ```
 
 ### Publish the container image to a registry
@@ -76,8 +76,8 @@ dagger call -m github.com/shykes/daggerverse/wolfi@v0.1.2 container --packages=c
 The `Container` type also has a `Publish()` function, which publishes the container to a registry. To see this in action, call the previous function again, this time chaining an additional function call to `Publish()` on the returned `Container`:
 
 ```shell
-dagger call -m github.com/shykes/daggerverse/wolfi@v0.1.2 \
-  container --packages=cowsay \
+dagger -m github.com/shykes/daggerverse/wolfi@v0.1.2 \
+  call container --packages=cowsay \
   publish --address ttl.sh/dagger-cowsay-$RANDOM
 ```
 


### PR DESCRIPTION
This commit makes our examples consistent with the rest of the docs by changing the examples to use the `dagger -m $MODUDLE call` pattern.