### PR TITLE
Improve releasing during v0.10.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 replace dagger.io/dagger => ./sdk/go
 
 require (
-	dagger.io/dagger v0.10.1
+	dagger.io/dagger v0.10.2
 	github.com/99designs/gqlgen v0.17.41
 	github.com/Khan/genqlient v0.6.0
 	github.com/MakeNowJust/heredoc/v2 v2.0.1

--- a/internal/mage/go.mod
+++ b/internal/mage/go.mod
@@ -3,8 +3,8 @@ module github.com/dagger/dagger/internal/mage
 go 1.21
 
 require (
-	dagger.io/dagger v0.10.1
-	github.com/dagger/dagger v0.10.1
+	dagger.io/dagger v0.10.2
+	github.com/dagger/dagger v0.10.2
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/magefile/mage v1.15.0

--- a/internal/mage/go.sum
+++ b/internal/mage/go.sum
@@ -1,5 +1,5 @@
-dagger.io/dagger v0.10.1 h1:/Gr12SuYAkWAFYMOp7VJdb5D3UXkrvLvmyugeteVonw=
-dagger.io/dagger v0.10.1/go.mod h1:AonAYX6ZXNGsVvro4HhB/Uzsp9FU+aI41YfAEY9f5mI=
+dagger.io/dagger v0.10.2 h1:8q4AwKm48qAWZdY7O2NMZ3FveteDHJeM3WwmcNKZOM0=
+dagger.io/dagger v0.10.2/go.mod h1:AonAYX6ZXNGsVvro4HhB/Uzsp9FU+aI41YfAEY9f5mI=
 github.com/99designs/gqlgen v0.17.41 h1:C1/zYMhGVP5TWNCNpmZ9Mb6CqT1Vr5SHEWoTOEJ3v3I=
 github.com/99designs/gqlgen v0.17.41/go.mod h1:GQ6SyMhwFbgHR0a8r2Wn8fYgEwPxxmndLFPhU63+cJE=
 github.com/Khan/genqlient v0.6.0 h1:Bwb1170ekuNIVIwTJEqvO8y7RxBxXu639VJOkKSrwAk=


### PR DESCRIPTION
I have captured a bunch of things in `RELEASING.md` that we have been missing for too long. That is possibly the most important change, the rest is standard, i.e. `0.10.1` -> `0.10.2` bump.