### PR TITLE
fix(tsSDK): fix object reference on object's fields

### DIFF
--- a/sdk/typescript/.changes/unreleased/Fixed-20240313-092936.yaml
+++ b/sdk/typescript/.changes/unreleased/Fixed-20240313-092936.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fix issue with objects as field not correctly serialiazed
+time: 2024-03-13T09:29:36.920581Z
+custom:
+  Author: TomChv
+  PR: "6877"

--- a/sdk/typescript/entrypoint/load.ts
+++ b/sdk/typescript/entrypoint/load.ts
@@ -227,20 +227,23 @@ export async function loadResult(
         throw new Error(`could not find result property ${key}`)
       }
 
+      let referencedObject: DaggerObject | undefined = undefined
       if (property.type.kind === TypeDefKind.ObjectKind) {
-        const referencedObject =
+        referencedObject =
           module.objects[
             (property.type as TypeDef<TypeDefKind.ObjectKind>).name
           ]
-        if (referencedObject) {
-          object = referencedObject
-        }
+      }
+
+      // If there's no referenced object, we use the current object.
+      if (!referencedObject) {
+        referencedObject = object
       }
 
       state[property.alias ?? property.name] = await loadResult(
         value,
         module,
-        object,
+        referencedObject,
       )
     }
 

--- a/sdk/typescript/introspector/test/invoke.spec.ts
+++ b/sdk/typescript/introspector/test/invoke.spec.ts
@@ -175,6 +175,52 @@ describe("Invoke typescript function", function () {
     )
   })
 
+  it("Should correctly handle multiple objets as fields", async function () {
+    this.timeout(60000)
+
+    const files = await listFiles(`${rootDirectory}/multipleObjectsAsFields`)
+
+    // Load function
+    await load(files)
+
+    const scanResult = scan(files)
+
+    const constructorInput = {
+      parentName: "MultipleObjectsAsFields",
+      fnName: "", // call constructor
+      parentArgs: {},
+      fnArgs: {},
+    }
+
+    const constructorResult = await invoke(scanResult, constructorInput)
+    // Verify object instanciation
+    assert.notStrictEqual(undefined, constructorResult)
+    assert.notStrictEqual(undefined, constructorResult.test)
+    assert.notStrictEqual(undefined, constructorResult.lint)
+
+    // Call echo method
+    const invokeTestEcho = {
+      parentName: "Test",
+      fnName: "echo",
+      parentArgs: {},
+      fnArgs: {},
+    }
+
+    const testEchoResult = await invoke(scanResult, invokeTestEcho)
+    assert.strictEqual("world", testEchoResult)
+
+    // Call echo method
+    const invokeLintEcho = {
+      parentName: "Lint",
+      fnName: "echo",
+      parentArgs: {},
+      fnArgs: {},
+    }
+
+    const lintEchoResult = await invoke(scanResult, invokeLintEcho)
+    assert.strictEqual("world", lintEchoResult)
+  })
+
   describe("Should correctly invoke variadic functions", async function () {
     this.timeout(60000)
 

--- a/sdk/typescript/introspector/test/scan.spec.ts
+++ b/sdk/typescript/introspector/test/scan.spec.ts
@@ -66,6 +66,10 @@ describe("scan static TypeScript", function () {
       name: "Should correctly serialize object param",
       directory: "objectParam",
     },
+    {
+      name: "Should correctly scan multiple objects as fields",
+      directory: "multipleObjectsAsFields",
+    },
   ]
 
   for (const test of testCases) {

--- a/sdk/typescript/introspector/test/testdata/multipleObjectsAsFields/expected.json
+++ b/sdk/typescript/introspector/test/testdata/multipleObjectsAsFields/expected.json
@@ -1,0 +1,63 @@
+{
+  "name": "MultipleObjectsAsFields",
+  "objects": {
+    "Test": {
+      "name": "Test",
+      "description": "",
+      "methods": {
+        "echo": {
+          "name": "echo",
+          "description": "",
+          "arguments": {},
+          "returnType": {
+            "kind": "STRING_KIND"
+          }
+        }
+      },
+      "properties": {}
+    },
+    "Lint": {
+      "name": "Lint",
+      "description": "",
+      "methods": {
+        "echo": {
+          "name": "echo",
+          "description": "",
+          "arguments": {},
+          "returnType": {
+            "kind": "STRING_KIND"
+          }
+        }
+      },
+      "properties": {}
+    },
+    "MultipleObjectsAsFields": {
+      "name": "MultipleObjectsAsFields",
+      "description": "",
+      "constructor": {
+        "args": {}
+      },
+      "methods": {},
+      "properties": {
+        "test": {
+          "name": "test",
+          "description": "",
+          "type": {
+            "kind": "OBJECT_KIND",
+            "name": "Test"
+          },
+          "isExposed": true
+        },
+        "lint": {
+          "name": "lint",
+          "description": "",
+          "type": {
+            "kind": "OBJECT_KIND",
+            "name": "Lint"
+          },
+          "isExposed": true
+        }
+      }
+    }
+  }
+}

--- a/sdk/typescript/introspector/test/testdata/multipleObjectsAsFields/index.ts
+++ b/sdk/typescript/introspector/test/testdata/multipleObjectsAsFields/index.ts
@@ -1,0 +1,14 @@
+import { object, field } from "../../../decorators/decorators.js"
+import { Lint } from './lint.js';
+import { Test } from './test.js'
+
+@object()
+class MultipleObjectsAsFields {
+  @field()
+  test: Test = new Test()
+
+  @field()
+  lint: Lint = new Lint()
+
+  constructor() {}
+}

--- a/sdk/typescript/introspector/test/testdata/multipleObjectsAsFields/lint.ts
+++ b/sdk/typescript/introspector/test/testdata/multipleObjectsAsFields/lint.ts
@@ -1,0 +1,9 @@
+import { func, object } from '../../../decorators/decorators.js'
+
+@object()
+export class Lint {
+    @func()
+    echo(): string {
+        return "world"
+    }
+}

--- a/sdk/typescript/introspector/test/testdata/multipleObjectsAsFields/test.ts
+++ b/sdk/typescript/introspector/test/testdata/multipleObjectsAsFields/test.ts
@@ -1,0 +1,9 @@
+import { func, object } from '../../../decorators/decorators.js'
+
+@object()
+export class Test {
+    @func()
+    echo(): string {
+        return "world"
+    }
+}


### PR DESCRIPTION
Fix https://discord.com/channels/707636530424053791/1215420048865362030

### Explanation

I was overriding the variable `object` in `loadResult` which broke the loop.
Instead, I use a sub variable inside the loop to store the referenced object and everything went back to normal.