### PR TITLE
Fix `Container.withFiles` not respecting absolute paths

### DIFF
--- a/.changes/unreleased/Fixed-20240313-155031.yaml
+++ b/.changes/unreleased/Fixed-20240313-155031.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fix `Container.withFiles` not respecting absolute paths
+time: 2024-03-13T15:50:31.465015-01:00
+custom:
+  Author: helderco
+  PR: "6879"

--- a/core/container.go
+++ b/core/container.go
@@ -521,7 +521,7 @@ func (container *Container) WithFiles(ctx context.Context, destDir string, src [
 			return nil, err
 		}
 
-		return dir.WithFiles(ctx, destDir, src, permissions, ownership)
+		return dir.WithFiles(ctx, path.Base(destDir), src, permissions, ownership)
 	})
 }
 

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -1815,6 +1815,37 @@ func TestContainerWithFiles(t *testing.T) {
 	require.Equal(t, "file2 content", contents)
 }
 
+func TestContainerWithFilesAbsolute(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := connect(t)
+
+	file1 := c.Directory().
+		WithNewFile("first-file", "file1 content").
+		File("first-file")
+	file2 := c.Directory().
+		WithNewFile("second-file", "file2 content").
+		File("second-file")
+	files := []*dagger.File{file1, file2}
+
+	ctr := c.Container().
+		From(alpineImage).
+		WithWorkdir("/work").
+		WithFiles("/opt/myfiles", files)
+
+	contents, err := ctr.
+		WithExec([]string{"cat", "/opt/myfiles/first-file"}).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "file1 content", contents)
+
+	contents, err = ctr.
+		WithExec([]string{"cat", "/opt/myfiles/second-file"}).
+		Stdout(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "file2 content", contents)
+}
+
 func TestContainerWithNewFile(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Reported by user in [Discord](https://discord.com/channels/707636530424053791/1217212533354533036/1217453431229386793).

When the path to `Container.withFiles` is absolute:

```go
ctr := c.Container().
    From("alpine").
    WithWorkdir("/work").
    WithFiles("/opt/myfiles", files)
```

The files were being copied incorrectly:
```
copy /file1 /opt/opt/myfiles/file1
copy /file2 /opt/opt/myfiles/file2
```

With this PR:
```
copy /file1 /opt/myfiles/file1
copy /file2 /opt/myfiles/file2
```