### PR TITLE
Docs - fix typo on the Daggerverse modules publish page

### DIFF
--- a/docs/current_docs/guides/821742-publish-modules.mdx
+++ b/docs/current_docs/guides/821742-publish-modules.mdx
@@ -39,7 +39,7 @@ To manually publish a module to the Daggerverse, follow the steps below:
     git push origin main
     ```
 
-    Dagger is agnostic to repository layout, and any number of Dagger Modules can peacefully coexist in a rpeository. It’s up to you how to organize your module’s source code in Git. Some like to publish each module as a dedicated repository; others like to organize all their modules together, with the git repository acting as a "catalog". These repositories are often named "daggerverse" by convention.
+    Dagger is agnostic to repository layout, and any number of Dagger Modules can peacefully coexist in a repository. It’s up to you how to organize your module’s source code in Git. Some like to publish each module as a dedicated repository; others like to organize all their modules together, with the git repository acting as a "catalog". These repositories are often named "daggerverse" by convention.
 
 1. Navigate to the [Daggerverse](https://daggerverse.dev) and click the `Publish` button. On the resulting page, paste the URL to the GitHub repository containing your module in the format `github.com/USERNAME/REPOSITORY[/SUBPATH][@VERSION]`.
 
@@ -49,18 +49,18 @@ To manually publish a module to the Daggerverse, follow the steps below:
 
 1. Click "Publish" to have your Dagger Module published to the Daggerverse. This process may take a few minutes. Once complete, your Dagger Module will appear in the Daggerverse module listing.
 
-#### Notes
-
+:::important
 - Currently, only URLs beginning with `github.com` are supported.
 - The Daggerverse only fetches publicly available information from GitHub. Modules are not hosted on the Daggerverse. If you need a module removed from the Daggerverse for some reason, let the Dagger team know in [Discord](https://discord.gg/dagger-io).
+:::
 
 ### Publishing on use
 
 Every time that a user executes `dagger call`, if any of the Dagger Functions which are invoked in the execution come from a remote Dagger Module (here, a remote module is defined as a module whose location is specified by a URL like `github.com/USERNAME/daggerverse/...`), that Dagger Module will automatically be published to the Daggerverse.
 
-#### Notes
-
+:::note
 Under this process, it is possible for some Dagger Modules to appear in the Daggerverse even when they're not fully ready. An example of this is when the module developer is developing the module in a local development environment and pushing work-in-progress to the Git repository. In this case, as soon as the module developer tags the module with a [valid semantic version number](#semantic-versioning), the module will be considered released and the latest version will be published to the Daggerverse.
+:::
 
 ## Semantic versioning
 


### PR DESCRIPTION
The `Notes` update is a suggestion since they are not visible enough IMO. 
I'm using the Admonition from Docusaurus.
Let me know if you rather roll back to the original style @vikram-dagger. Thanks 🙏 
