### PR TITLE
Fix empty Secret default in CLI

### DIFF
--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -331,6 +331,9 @@ func (v *secretValue) Set(s string) error {
 }
 
 func (v *secretValue) String() string {
+	if v.sourceVal == "" {
+		return ""
+	}
 	return fmt.Sprintf("%s:%s", v.secretSource, v.sourceVal)
 }
 

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -568,7 +568,7 @@ func (fc *FuncCommand) addArgsForFunction(cmd *cobra.Command, cmdArgs []string, 
 		if err != nil {
 			return err
 		}
-		if !arg.TypeDef.Optional && arg.DefaultValue == "" {
+		if arg.IsRequired() {
 			cmd.MarkFlagRequired(arg.FlagName())
 		}
 	}

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -1206,6 +1206,10 @@ func (r *modFunctionArg) FlagName() string {
 	return r.flagName
 }
 
+func (r *modFunctionArg) IsRequired() bool {
+	return !r.TypeDef.Optional && r.DefaultValue == ""
+}
+
 func getDefaultValue[T any](r *modFunctionArg) (T, error) {
 	var val T
 	err := json.Unmarshal([]byte(r.DefaultValue), &val)


### PR DESCRIPTION
Fixes #6897

An empty secret value produced a non-empty `":"` string representation:

```diff
Flags:
-      --access-token Secret    mastodon access token (default :)
+      --access-token Secret    mastodon access token
```
