### PR TITLE
Fix typescript sdk docs

### DIFF
--- a/docs/current_docs/developer-guide/typescript/629502-ide-integration.mdx
+++ b/docs/current_docs/developer-guide/typescript/629502-ide-integration.mdx
@@ -9,7 +9,7 @@ title: "IDE Integration"
 # IDE Integration
 
 
-When opening the generated `dagger/src/main.py` in an IDE, most IDEs will automatically recognize the `@dagger.io/dagger` package, so long as the `tsconfig.json` file has a path configured on it.
+When opening the generated `dagger/src/index.ts` in an IDE, most IDEs will automatically recognize the `@dagger.io/dagger` package, so long as the `tsconfig.json` file has a path configured on it.
 
 For Dagger Modules initialized using `dagger init`, the default template is already configured this way:
 


### PR DESCRIPTION
In this page
https://docs.dagger.io/developer-guide/typescript/629502/ide-integration

change from 
When opening the generated `dagger/src/main.py` in an IDE to
When opening the generated `dagger/src/index.ts` in an IDE