### PR TITLE
core: add support for wipe arg to Directory.export

### DIFF
--- a/core/directory.go
+++ b/core/directory.go
@@ -702,7 +702,7 @@ func (dir *Directory) Without(ctx context.Context, path string) (*Directory, err
 	return dir, nil
 }
 
-func (dir *Directory) Export(ctx context.Context, destPath string) (rerr error) {
+func (dir *Directory) Export(ctx context.Context, destPath string, merge bool) (rerr error) {
 	svcs := dir.Query.Services
 	bk := dir.Query.Buildkit
 
@@ -735,7 +735,7 @@ func (dir *Directory) Export(ctx context.Context, destPath string) (rerr error) 
 	}
 	defer detach()
 
-	return bk.LocalDirExport(ctx, defPB, destPath)
+	return bk.LocalDirExport(ctx, defPB, destPath, merge)
 }
 
 // Root removes any relative path from the directory.

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -678,6 +678,26 @@ func TestDirectoryExport(t *testing.T) {
 		entries, err := ls(wd)
 		require.NoError(t, err)
 		require.Equal(t, []string{"20locale.sh", "README", "color_prompt.sh.disabled"}, entries)
+
+		t.Run("wipe flag", func(t *testing.T) {
+			dir := dir.WithoutFile("README")
+
+			// by default a delete in the source dir won't overwrite the destination on the host
+			ok, err := dir.Export(ctx, ".")
+			require.NoError(t, err)
+			require.True(t, ok)
+			entries, err = ls(wd)
+			require.NoError(t, err)
+			require.Equal(t, []string{"20locale.sh", "README", "color_prompt.sh.disabled"}, entries)
+
+			// wipe results in the destination being replaced with the source entirely, including deletes
+			ok, err = dir.Export(ctx, ".", dagger.DirectoryExportOpts{Wipe: true})
+			require.NoError(t, err)
+			require.True(t, ok)
+			entries, err = ls(wd)
+			require.NoError(t, err)
+			require.Equal(t, []string{"20locale.sh", "color_prompt.sh.disabled"}, entries)
+		})
 	})
 
 	t.Run("to outer dir", func(t *testing.T) {

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -81,7 +81,7 @@ func (s *directorySchema) Install() {
 			Impure("Writes to the local host.").
 			Doc(`Writes the contents of the directory to a path on the host.`).
 			ArgDoc("path", `Location of the copied directory (e.g., "logs/").`).
-			ArgDoc("wipe", `If true, then the host directory will be wiped clean such that it exactly matches the directory being exported, including deleting any files on the host that aren't in the exported dir. If false (the default), the contents of the directory will be merged with any existing contents of the host directory, leaving any existing files on the host that aren't in the exported directory alone.`),
+			ArgDoc("wipe", `If true, then the host directory will be wiped clean before exporting so that it exactly matches the directory being exported; this means it will delete any files on the host that aren't in the exported dir. If false (the default), the contents of the directory will be merged with any existing contents of the host directory, leaving any existing files on the host that aren't in the exported directory alone.`),
 		dagql.Func("dockerBuild", s.dockerBuild).
 			Doc(`Builds a new Docker container from this directory.`).
 			ArgDoc("dockerfile", `Path to the Dockerfile to use (e.g., "frontend.Dockerfile").`).

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -80,7 +80,8 @@ func (s *directorySchema) Install() {
 		dagql.Func("export", s.export).
 			Impure("Writes to the local host.").
 			Doc(`Writes the contents of the directory to a path on the host.`).
-			ArgDoc("path", `Location of the copied directory (e.g., "logs/").`),
+			ArgDoc("path", `Location of the copied directory (e.g., "logs/").`).
+			ArgDoc("wipe", `If true, then the host directory will be wiped clean such that it exactly matches the directory being exported, including deleting any files on the host that aren't in the exported dir. If false (the default), the contents of the directory will be merged with any existing contents of the host directory, leaving any existing files on the host that aren't in the exported directory alone.`),
 		dagql.Func("dockerBuild", s.dockerBuild).
 			Doc(`Builds a new Docker container from this directory.`).
 			ArgDoc("dockerfile", `Path to the Dockerfile to use (e.g., "frontend.Dockerfile").`).
@@ -262,10 +263,11 @@ func (s *directorySchema) diff(ctx context.Context, parent *core.Directory, args
 
 type dirExportArgs struct {
 	Path string
+	Wipe bool `default:"false"`
 }
 
 func (s *directorySchema) export(ctx context.Context, parent *core.Directory, args dirExportArgs) (dagql.Boolean, error) {
-	err := parent.Export(ctx, args.Path)
+	err := parent.Export(ctx, args.Path, !args.Wipe)
 	if err != nil {
 		return false, err
 	}

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -995,12 +995,12 @@ type Directory {
     path: String!
 
     """
-    If true, then the host directory will be wiped clean such that it exactly
-    matches the directory being exported, including deleting any files on the
-    host that aren't in the exported dir. If false (the default), the contents
-    of the directory will be merged with any existing contents of the host
-    directory, leaving any existing files on the host that aren't in the
-    exported directory alone.
+    If true, then the host directory will be wiped clean before exporting so
+    that it exactly matches the directory being exported; this means it will
+    delete any files on the host that aren't in the exported dir. If false (the
+    default), the contents of the directory will be merged with any existing
+    contents of the host directory, leaving any existing files on the host that
+    aren't in the exported directory alone.
     """
     wipe: Boolean = false
   ): Boolean!

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -993,6 +993,16 @@ type Directory {
   export(
     """Location of the copied directory (e.g., "logs/")."""
     path: String!
+
+    """
+    If true, then the host directory will be wiped clean such that it exactly
+    matches the directory being exported, including deleting any files on the
+    host that aren't in the exported dir. If false (the default), the contents
+    of the directory will be merged with any existing contents of the host
+    directory, leaving any existing files on the host that aren't in the
+    exported directory alone.
+    """
+    wipe: Boolean = false
   ): Boolean!
 
   """Retrieves a file at the given path."""

--- a/engine/buildkit/filesync.go
+++ b/engine/buildkit/filesync.go
@@ -179,6 +179,7 @@ func (c *Client) LocalDirExport(
 	ctx context.Context,
 	def *bksolverpb.Definition,
 	destPath string,
+	merge bool,
 ) (rerr error) {
 	ctx = bklog.WithLogger(ctx, bklog.G(ctx).WithField("export_path", destPath))
 	bklog.G(ctx).Debug("exporting local dir")
@@ -226,7 +227,8 @@ func (c *Client) LocalDirExport(
 	}
 
 	ctx = engine.LocalExportOpts{
-		Path: destPath,
+		Path:  destPath,
+		Merge: merge,
 	}.AppendToOutgoingContext(ctx)
 
 	_, descRef, err := expInstance.Export(ctx, cacheRes, nil, clientMetadata.ClientID)

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -763,7 +763,7 @@ func (AnyDirTarget) DiffCopy(stream filesync.FileSend_DiffCopyServer) (rerr erro
 		}
 
 		err := fsutil.Receive(stream.Context(), stream, opts.Path, fsutil.ReceiveOpt{
-			Merge: true,
+			Merge: opts.Merge,
 			Filter: func(path string, stat *fstypes.Stat) bool {
 				stat.Uid = uint32(os.Getuid())
 				stat.Gid = uint32(os.Getgid())

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -178,6 +178,10 @@ type LocalExportOpts struct {
 	FileOriginalName   string      `json:"file_original_name"`
 	AllowParentDirPath bool        `json:"allow_parent_dir_path"`
 	FileMode           os.FileMode `json:"file_mode"`
+	// whether to just merge in contents of a directory to the target on the host
+	// or to replace the target entirely such that it matches the source directory,
+	// which includes deleting any files that are not in the source directory
+	Merge bool
 }
 
 func (o LocalExportOpts) ToGRPCMD() metadata.MD {

--- a/sdk/elixir/lib/dagger/gen/directory.ex
+++ b/sdk/elixir/lib/dagger/gen/directory.ex
@@ -118,7 +118,7 @@ defmodule Dagger.Directory do
   )
 
   (
-    @doc "Writes the contents of the directory to a path on the host.\n\n## Required Arguments\n\n* `path` - Location of the copied directory (e.g., \"logs/\").\n\n## Optional Arguments\n\n* `wipe` - If true, then the host directory will be wiped clean such that it exactly matches the directory being exported, including deleting any files on the host that aren't in the exported dir. If false (the default), the contents of the directory will be merged with any existing contents of the host directory, leaving any existing files on the host that aren't in the exported directory alone."
+    @doc "Writes the contents of the directory to a path on the host.\n\n## Required Arguments\n\n* `path` - Location of the copied directory (e.g., \"logs/\").\n\n## Optional Arguments\n\n* `wipe` - If true, then the host directory will be wiped clean before exporting so that it exactly matches the directory being exported; this means it will delete any files on the host that aren't in the exported dir. If false (the default), the contents of the directory will be merged with any existing contents of the host directory, leaving any existing files on the host that aren't in the exported directory alone."
     @spec export(t(), Dagger.String.t(), keyword()) ::
             {:ok, Dagger.Boolean.t()} | {:error, term()}
     def export(%__MODULE__{} = directory, path, optional_args \\ []) do

--- a/sdk/elixir/lib/dagger/gen/directory.ex
+++ b/sdk/elixir/lib/dagger/gen/directory.ex
@@ -118,11 +118,20 @@ defmodule Dagger.Directory do
   )
 
   (
-    @doc "Writes the contents of the directory to a path on the host.\n\n## Required Arguments\n\n* `path` - Location of the copied directory (e.g., \"logs/\")."
-    @spec export(t(), Dagger.String.t()) :: {:ok, Dagger.Boolean.t()} | {:error, term()}
-    def export(%__MODULE__{} = directory, path) do
+    @doc "Writes the contents of the directory to a path on the host.\n\n## Required Arguments\n\n* `path` - Location of the copied directory (e.g., \"logs/\").\n\n## Optional Arguments\n\n* `wipe` - If true, then the host directory will be wiped clean such that it exactly matches the directory being exported, including deleting any files on the host that aren't in the exported dir. If false (the default), the contents of the directory will be merged with any existing contents of the host directory, leaving any existing files on the host that aren't in the exported directory alone."
+    @spec export(t(), Dagger.String.t(), keyword()) ::
+            {:ok, Dagger.Boolean.t()} | {:error, term()}
+    def export(%__MODULE__{} = directory, path, optional_args \\ []) do
       selection = select(directory.selection, "export")
       selection = arg(selection, "path", path)
+
+      selection =
+        if is_nil(optional_args[:wipe]) do
+          selection
+        else
+          arg(selection, "wipe", optional_args[:wipe])
+        end
+
       execute(selection, directory.client)
     end
   )

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -1938,12 +1938,24 @@ func (r *Directory) Entries(ctx context.Context, opts ...DirectoryEntriesOpts) (
 	return response, q.Execute(ctx)
 }
 
+// DirectoryExportOpts contains options for Directory.Export
+type DirectoryExportOpts struct {
+	// If true, then the host directory will be wiped clean such that it exactly matches the directory being exported, including deleting any files on the host that aren't in the exported dir. If false (the default), the contents of the directory will be merged with any existing contents of the host directory, leaving any existing files on the host that aren't in the exported directory alone.
+	Wipe bool
+}
+
 // Writes the contents of the directory to a path on the host.
-func (r *Directory) Export(ctx context.Context, path string) (bool, error) {
+func (r *Directory) Export(ctx context.Context, path string, opts ...DirectoryExportOpts) (bool, error) {
 	if r.export != nil {
 		return *r.export, nil
 	}
 	q := r.query.Select("export")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `wipe` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Wipe) {
+			q = q.Arg("wipe", opts[i].Wipe)
+		}
+	}
 	q = q.Arg("path", path)
 
 	var response bool

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -1940,7 +1940,7 @@ func (r *Directory) Entries(ctx context.Context, opts ...DirectoryEntriesOpts) (
 
 // DirectoryExportOpts contains options for Directory.Export
 type DirectoryExportOpts struct {
-	// If true, then the host directory will be wiped clean such that it exactly matches the directory being exported, including deleting any files on the host that aren't in the exported dir. If false (the default), the contents of the directory will be merged with any existing contents of the host directory, leaving any existing files on the host that aren't in the exported directory alone.
+	// If true, then the host directory will be wiped clean before exporting so that it exactly matches the directory being exported; this means it will delete any files on the host that aren't in the exported dir. If false (the default), the contents of the directory will be merged with any existing contents of the host directory, leaving any existing files on the host that aren't in the exported directory alone.
 	Wipe bool
 }
 

--- a/sdk/php/generated/Directory.php
+++ b/sdk/php/generated/Directory.php
@@ -90,10 +90,13 @@ class Directory extends Client\AbstractObject implements Client\IdAble
     /**
      * Writes the contents of the directory to a path on the host.
      */
-    public function export(string $path): bool
+    public function export(string $path, ?bool $wipe = false): bool
     {
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('export');
         $leafQueryBuilder->setArgument('path', $path);
+        if (null !== $wipe) {
+        $leafQueryBuilder->setArgument('wipe', $wipe);
+        }
         return (bool)$this->queryLeaf($leafQueryBuilder, 'export');
     }
 

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -2210,12 +2210,13 @@ class Directory(Type):
         path:
             Location of the copied directory (e.g., "logs/").
         wipe:
-            If true, then the host directory will be wiped clean such that it
-            exactly matches the directory being exported, including deleting
-            any files on the host that aren't in the exported dir. If false
-            (the default), the contents of the directory will be merged with
-            any existing contents of the host directory, leaving any existing
-            files on the host that aren't in the exported directory alone.
+            If true, then the host directory will be wiped clean before
+            exporting so that it exactly matches the directory being exported;
+            this means it will delete any files on the host that aren't in the
+            exported dir. If false (the default), the contents of the
+            directory will be merged with any existing contents of the host
+            directory, leaving any existing files on the host that aren't in
+            the exported directory alone.
 
         Returns
         -------

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -2197,13 +2197,25 @@ class Directory(Type):
         return await _ctx.execute(list[str])
 
     @typecheck
-    async def export(self, path: str) -> bool:
+    async def export(
+        self,
+        path: str,
+        *,
+        wipe: bool | None = False,
+    ) -> bool:
         """Writes the contents of the directory to a path on the host.
 
         Parameters
         ----------
         path:
             Location of the copied directory (e.g., "logs/").
+        wipe:
+            If true, then the host directory will be wiped clean such that it
+            exactly matches the directory being exported, including deleting
+            any files on the host that aren't in the exported dir. If false
+            (the default), the contents of the directory will be merged with
+            any existing contents of the host directory, leaving any existing
+            files on the host that aren't in the exported directory alone.
 
         Returns
         -------
@@ -2219,6 +2231,7 @@ class Directory(Type):
         """
         _args = [
             Arg("path", path),
+            Arg("wipe", wipe, False),
         ]
         _ctx = self._select("export", _args)
         return await _ctx.execute(bool)

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -2625,7 +2625,7 @@ pub struct DirectoryEntriesOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryExportOpts {
-    /// If true, then the host directory will be wiped clean such that it exactly matches the directory being exported, including deleting any files on the host that aren't in the exported dir. If false (the default), the contents of the directory will be merged with any existing contents of the host directory, leaving any existing files on the host that aren't in the exported directory alone.
+    /// If true, then the host directory will be wiped clean before exporting so that it exactly matches the directory being exported; this means it will delete any files on the host that aren't in the exported dir. If false (the default), the contents of the directory will be merged with any existing contents of the host directory, leaving any existing files on the host that aren't in the exported directory alone.
     #[builder(setter(into, strip_option), default)]
     pub wipe: Option<bool>,
 }

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -2624,6 +2624,12 @@ pub struct DirectoryEntriesOpts<'a> {
     pub path: Option<&'a str>,
 }
 #[derive(Builder, Debug, PartialEq)]
+pub struct DirectoryExportOpts {
+    /// If true, then the host directory will be wiped clean such that it exactly matches the directory being exported, including deleting any files on the host that aren't in the exported dir. If false (the default), the contents of the directory will be merged with any existing contents of the host directory, leaving any existing files on the host that aren't in the exported directory alone.
+    #[builder(setter(into, strip_option), default)]
+    pub wipe: Option<bool>,
+}
+#[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryPipelineOpts<'a> {
     /// Description of the sub-pipeline.
     #[builder(setter(into, strip_option), default)]
@@ -2799,9 +2805,28 @@ impl Directory {
     /// # Arguments
     ///
     /// * `path` - Location of the copied directory (e.g., "logs/").
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn export(&self, path: impl Into<String>) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
         query = query.arg("path", path.into());
+        query.execute(self.graphql_client.clone()).await
+    }
+    /// Writes the contents of the directory to a path on the host.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Location of the copied directory (e.g., "logs/").
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub async fn export_opts(
+        &self,
+        path: impl Into<String>,
+        opts: DirectoryExportOpts,
+    ) -> Result<bool, DaggerError> {
+        let mut query = self.selection.select("export");
+        query = query.arg("path", path.into());
+        if let Some(wipe) = opts.wipe {
+            query = query.arg("wipe", wipe);
+        }
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves a file at the given path.

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -526,6 +526,13 @@ export type DirectoryEntriesOpts = {
   path?: string
 }
 
+export type DirectoryExportOpts = {
+  /**
+   * If true, then the host directory will be wiped clean such that it exactly matches the directory being exported, including deleting any files on the host that aren't in the exported dir. If false (the default), the contents of the directory will be merged with any existing contents of the host directory, leaving any existing files on the host that aren't in the exported directory alone.
+   */
+  wipe?: boolean
+}
+
 export type DirectoryPipelineOpts = {
   /**
    * Description of the sub-pipeline.
@@ -2916,8 +2923,12 @@ export class Directory extends BaseClient {
   /**
    * Writes the contents of the directory to a path on the host.
    * @param path Location of the copied directory (e.g., "logs/").
+   * @param opts.wipe If true, then the host directory will be wiped clean such that it exactly matches the directory being exported, including deleting any files on the host that aren't in the exported dir. If false (the default), the contents of the directory will be merged with any existing contents of the host directory, leaving any existing files on the host that aren't in the exported directory alone.
    */
-  export = async (path: string): Promise<boolean> => {
+  export = async (
+    path: string,
+    opts?: DirectoryExportOpts,
+  ): Promise<boolean> => {
     if (this._export) {
       return this._export
     }
@@ -2927,7 +2938,7 @@ export class Directory extends BaseClient {
         ...this._queryTree,
         {
           operation: "export",
-          args: { path },
+          args: { path, ...opts },
         },
       ],
       await this._ctx.connection(),

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -528,7 +528,7 @@ export type DirectoryEntriesOpts = {
 
 export type DirectoryExportOpts = {
   /**
-   * If true, then the host directory will be wiped clean such that it exactly matches the directory being exported, including deleting any files on the host that aren't in the exported dir. If false (the default), the contents of the directory will be merged with any existing contents of the host directory, leaving any existing files on the host that aren't in the exported directory alone.
+   * If true, then the host directory will be wiped clean before exporting so that it exactly matches the directory being exported; this means it will delete any files on the host that aren't in the exported dir. If false (the default), the contents of the directory will be merged with any existing contents of the host directory, leaving any existing files on the host that aren't in the exported directory alone.
    */
   wipe?: boolean
 }
@@ -2923,7 +2923,7 @@ export class Directory extends BaseClient {
   /**
    * Writes the contents of the directory to a path on the host.
    * @param path Location of the copied directory (e.g., "logs/").
-   * @param opts.wipe If true, then the host directory will be wiped clean such that it exactly matches the directory being exported, including deleting any files on the host that aren't in the exported dir. If false (the default), the contents of the directory will be merged with any existing contents of the host directory, leaving any existing files on the host that aren't in the exported directory alone.
+   * @param opts.wipe If true, then the host directory will be wiped clean before exporting so that it exactly matches the directory being exported; this means it will delete any files on the host that aren't in the exported dir. If false (the default), the contents of the directory will be merged with any existing contents of the host directory, leaving any existing files on the host that aren't in the exported directory alone.
    */
   export = async (
     path: string,


### PR DESCRIPTION
Related discord thread: https://discord.com/channels/707636530424053791/1220078037542895617/1220078037542895617

By default, exporting a directory resulted in its contents being merged into the target directory on the host, with any files that existed on the host but not in the source dir being untouched during the export.

More often than not, this is the behavior you want, but there are use cases where you'd instead like to replace the contents of the host directory entirely such that it exactly matches the source dir being exported. This enables you to e.g. load a dir from the host, delete some files from it and then export that back to the host with those deletes being reflected.

This change adds an arg to `Directory.export` to enable that behavior.

I really wanted to name the arg `merge` and default it to `true`, but it turns out that doesn't really work for optional args since at least the Go SDK can't distinguish between an explicit `false` value on an optional arg and an implicitly set `false` zero-value, so it wasn't possible to ever get anything but the `merge: true` behavior. Didn't check other SDKs but I would imagine at least a few of them have the same sort of problem.

~~So I fell back to just naming the arg `replaceAll` and making it trigger the non-default behavior only when set to true. I don't especially love the name; open to suggestions.~~
EDIT: changed name to `wipe` as suggested in comments