### PR TITLE
namespace services by server, not by client

### DIFF
--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -501,11 +501,8 @@ func setupBundle() (returnExitCode int) {
 	}
 
 	var searchDomains []string
-	for _, parentClientID := range execMetadata.ParentClientIDs {
-		searchDomains = append(searchDomains, network.ClientDomain(parentClientID))
-	}
-	if len(searchDomains) > 0 {
-		spec.Process.Env = append(spec.Process.Env, "_DAGGER_PARENT_CLIENT_IDS="+strings.Join(execMetadata.ParentClientIDs, " "))
+	if ns := execMetadata.ServerID; ns != "" {
+		searchDomains = append(searchDomains, network.ClientDomain(ns))
 	}
 
 	var hostsFilePath string
@@ -733,12 +730,9 @@ func runWithNesting(ctx context.Context, cmd *exec.Cmd) error {
 	}
 	sessionPort := l.Addr().(*net.TCPAddr).Port
 
-	parentClientIDsVal, _ := internalEnv("_DAGGER_PARENT_CLIENT_IDS")
-
 	clientParams := client.Params{
-		SecretToken:     sessionToken.String(),
-		RunnerHost:      "unix:///.runner.sock",
-		ParentClientIDs: strings.Fields(parentClientIDsVal),
+		SecretToken: sessionToken.String(),
+		RunnerHost:  "unix:///.runner.sock",
 	}
 
 	if _, ok := internalEnv("_DAGGER_ENABLE_NESTING_IN_SAME_SESSION"); ok {

--- a/core/container.go
+++ b/core/container.go
@@ -1190,8 +1190,7 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 		return nil, err
 	}
 	execMeta := buildkit.ContainerExecUncachedMetadata{
-		ParentClientIDs: clientMetadata.ClientIDs(),
-		ServerID:        clientMetadata.ServerID,
+		ServerID: clientMetadata.ServerID,
 	}
 	proxyVal, err := execMeta.ToPBFtpProxyVal()
 	if err != nil {

--- a/core/service.go
+++ b/core/service.go
@@ -260,7 +260,7 @@ func (svc *Service) startContainer(
 		}
 	}()
 
-	fullHost := host + "." + network.ClientDomain(clientMetadata.ClientID)
+	fullHost := host + "." + network.ClientDomain(clientMetadata.ServerID)
 
 	bk := svc.Query.Buildkit
 
@@ -328,8 +328,7 @@ func (svc *Service) startContainer(
 	}
 
 	execMeta := buildkit.ContainerExecUncachedMetadata{
-		ParentClientIDs: clientMetadata.ClientIDs(),
-		ServerID:        clientMetadata.ServerID,
+		ServerID: clientMetadata.ServerID,
 	}
 	execOp.Meta.ProxyEnv.FtpProxy, err = execMeta.ToPBFtpProxyVal()
 	if err != nil {
@@ -596,7 +595,7 @@ func (svc *Service) startReverseTunnel(ctx context.Context, id *call.ID) (runnin
 		return nil, err
 	}
 
-	fullHost := host + "." + network.ClientDomain(clientMetadata.ClientID)
+	fullHost := host + "." + network.ClientDomain(clientMetadata.ServerID)
 
 	bk := svc.Query.Buildkit
 

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -722,8 +722,7 @@ func withOutgoingContext(ctx context.Context) context.Context {
 // the "real" ftp proxy setting in here too and have the shim handle
 // leaving only that set in the actual env var.
 type ContainerExecUncachedMetadata struct {
-	ParentClientIDs []string `json:"parentClientIDs,omitempty"`
-	ServerID        string   `json:"serverID,omitempty"`
+	ServerID string `json:"serverID,omitempty"`
 }
 
 func (md ContainerExecUncachedMetadata) ToPBFtpProxyVal() (string, error) {

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -57,12 +57,6 @@ type Params struct {
 	// should be started.
 	ServerID string
 
-	// Parent client IDs of this Dagger client.
-	//
-	// Used by Dagger-in-Dagger so that nested sessions can resolve addresses
-	// passed from the parent.
-	ParentClientIDs []string
-
 	SecretToken string
 
 	RunnerHost string // host of dagger engine runner serving buildkit apis
@@ -325,7 +319,6 @@ func (c *Client) startSession(ctx context.Context) (rerr error) {
 		ServerID:           c.ServerID,
 		ClientHostname:     c.hostname,
 		Labels:             c.labels,
-		ParentClientIDs:    c.ParentClientIDs,
 		ModuleCallerDigest: c.ModuleCallerDigest,
 	})
 
@@ -355,7 +348,6 @@ func (c *Client) startSession(ctx context.Context) (rerr error) {
 				ClientID:                  c.ID(),
 				ClientSecretToken:         c.SecretToken,
 				ServerID:                  c.ServerID,
-				ParentClientIDs:           c.ParentClientIDs,
 				ClientHostname:            hostname,
 				UpstreamCacheImportConfig: c.upstreamCacheImportOptions,
 				UpstreamCacheExportConfig: c.upstreamCacheExportOptions,
@@ -633,7 +625,6 @@ func (c *Client) DialContext(ctx context.Context, _, _ string) (conn net.Conn, e
 			ClientSecretToken:  c.SecretToken,
 			ServerID:           c.ServerID,
 			ClientHostname:     c.hostname,
-			ParentClientIDs:    c.ParentClientIDs,
 			Labels:             c.labels,
 			ModuleCallerDigest: c.ModuleCallerDigest,
 		}.ToGRPCMD())

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -61,11 +61,6 @@ type ClientMetadata struct {
 	// (Optional) Pipeline labels for e.g. vcs info like branch, commit, etc.
 	Labels telemetry.Labels `json:"labels"`
 
-	// ParentClientIDs is a list of session ids that are parents of the current
-	// session. The first element is the direct parent, the second element is the
-	// parent of the parent, and so on.
-	ParentClientIDs []string `json:"parent_client_ids"`
-
 	// If this client is for a module function, this digest will be set in the
 	// grpc context metadata for any api requests back to the engine. It's used by the API
 	// server to determine which schema to serve and other module context metadata.
@@ -82,11 +77,6 @@ type ClientMetadata struct {
 
 	// Disable analytics
 	DoNotTrack bool
-}
-
-// ClientIDs returns the ClientID followed by ParentClientIDs.
-func (m ClientMetadata) ClientIDs() []string {
-	return append([]string{m.ClientID}, m.ParentClientIDs...)
 }
 
 func (m ClientMetadata) ToGRPCMD() metadata.MD {

--- a/engine/sources/gitdns/identifier.go
+++ b/engine/sources/gitdns/identifier.go
@@ -4,10 +4,10 @@ import (
 	bkgit "github.com/moby/buildkit/source/git"
 )
 
-const AttrGitClientIDs = "dagger.git.clientids"
+const AttrDNSNamespace = "dagger.dns.namespace"
 
 type GitIdentifier struct {
 	bkgit.GitIdentifier
 
-	ClientIDs []string
+	Namespace string
 }

--- a/engine/sources/gitdns/source.go
+++ b/engine/sources/gitdns/source.go
@@ -78,8 +78,8 @@ func (gs *gitSource) Identifier(scheme, ref string, attrs map[string]string, pla
 		GitIdentifier: *(srcid.(*srcgit.GitIdentifier)),
 	}
 
-	if v, ok := attrs[AttrGitClientIDs]; ok {
-		id.ClientIDs = strings.Split(v, ",")
+	if v, ok := attrs[AttrDNSNamespace]; ok {
+		id.Namespace = v
 	}
 
 	return id, nil
@@ -322,10 +322,9 @@ func (gs *gitSourceHandler) mountKnownHosts() (string, func() error, error) {
 
 func (gs *gitSourceHandler) dnsConfig() *oci.DNSConfig {
 	clientDomains := []string{}
-	for _, clientID := range gs.src.ClientIDs {
-		clientDomains = append(clientDomains, network.ClientDomain(clientID))
+	if gs.src.Namespace != "" {
+		clientDomains = append(clientDomains, network.ClientDomain(gs.src.Namespace))
 	}
-
 	dns := *gs.dns
 	dns.SearchDomains = append(clientDomains, dns.SearchDomains...)
 	return &dns

--- a/engine/sources/gitdns/state.go
+++ b/engine/sources/gitdns/state.go
@@ -2,7 +2,6 @@ package gitdns
 
 import (
 	"path"
-	"strings"
 
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/solver/pb"
@@ -11,11 +10,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-const AttrNetConfig = "gitdns.netconfig"
-
 // Git is a helper mimicking the llb.Git function, but with the ability to
 // set additional attributes.
-func Git(url, ref string, clientIDs []string, opts ...llb.GitOption) llb.State {
+func Git(url, ref string, namespace string, opts ...llb.GitOption) llb.State {
 	remote, err := gitutil.ParseURL(url)
 	if errors.Is(err, gitutil.ErrUnknownProtocol) {
 		url = "https://" + url
@@ -78,7 +75,7 @@ func Git(url, ref string, clientIDs []string, opts ...llb.GitOption) llb.State {
 		}
 	}
 
-	attrs[AttrGitClientIDs] = strings.Join(clientIDs, ",")
+	attrs[AttrDNSNamespace] = namespace
 
 	source := llb.NewSource("git://"+id, attrs, gi.Constraints)
 	return llb.NewState(source.Output())

--- a/engine/sources/httpdns/identifier.go
+++ b/engine/sources/httpdns/identifier.go
@@ -4,10 +4,10 @@ import (
 	bkhttp "github.com/moby/buildkit/source/http"
 )
 
-const AttrHTTPClientIDs = "dagger.http.clientids"
+const AttrDNSNamespace = "dagger.dns.namespace"
 
 type HTTPIdentifier struct {
 	bkhttp.HTTPIdentifier
 
-	ClientIDs []string
+	Namespace string
 }

--- a/engine/sources/httpdns/source.go
+++ b/engine/sources/httpdns/source.go
@@ -76,8 +76,8 @@ func (hs *httpSource) Identifier(scheme, ref string, attrs map[string]string, pl
 		HTTPIdentifier: *(srcid.(*srchttp.HTTPIdentifier)),
 	}
 
-	if v, ok := attrs[AttrHTTPClientIDs]; ok {
-		id.ClientIDs = strings.Split(v, ",")
+	if v, ok := attrs[AttrDNSNamespace]; ok {
+		id.Namespace = v
 	}
 
 	return id, nil
@@ -106,8 +106,8 @@ type httpSourceHandler struct {
 
 func (hs *httpSourceHandler) client(g session.Group) *http.Client {
 	clientDomains := []string{}
-	for _, clientID := range hs.src.ClientIDs {
-		clientDomains = append(clientDomains, network.ClientDomain(clientID))
+	if ns := hs.src.Namespace; ns != "" {
+		clientDomains = append(clientDomains, network.ClientDomain(ns))
 	}
 
 	dns := *hs.dns

--- a/engine/sources/httpdns/state.go
+++ b/engine/sources/httpdns/state.go
@@ -2,17 +2,14 @@ package httpdns
 
 import (
 	"strconv"
-	"strings"
 
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/solver/pb"
 )
 
-const AttrNetConfig = "httpdns.netconfig"
-
 // HTTP is a helper mimicking the llb.HTTP function, but with the ability to
 // set additional attributes.
-func HTTP(url string, clientIDs []string, opts ...llb.HTTPOption) llb.State {
+func HTTP(url string, namespace string, opts ...llb.HTTPOption) llb.State {
 	hi := &llb.HTTPInfo{}
 	for _, o := range opts {
 		o.SetHTTPOption(hi)
@@ -34,7 +31,7 @@ func HTTP(url string, clientIDs []string, opts ...llb.HTTPOption) llb.State {
 		attrs[pb.AttrHTTPGID] = strconv.Itoa(hi.GID)
 	}
 
-	attrs[AttrHTTPClientIDs] = strings.Join(clientIDs, ",")
+	attrs[AttrDNSNamespace] = namespace
 
 	source := llb.NewSource(url, attrs, hi.Constraints)
 	return llb.NewState(source.Output())


### PR DESCRIPTION
Previously it was possible to start a dependent service in one module API call, and then use it again in a later call, only to have it fail because it cannot resolve the service address, even though it's still running. This happened because each invocation has its own client ID, and client IDs were used to build service addresses. ([Repro](https://github.com/camptocamp/daggerverse/blob/95e15b1c7931c4072e0255791902fe293b0e06df/presentation/main.go))

This change brings service addresses into alignment with the recent change to uniq them by service ID instead of client ID. The overall effect is that services are deduped within a Dagger invocation, even across module calls. So with this change, the service will just stay running and be re-used by a later call, thanks to the grace period.