### PR TITLE
[WIP] Finish isolating sessions to each client

### DIFF
--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -635,10 +635,6 @@ func runWithNesting(ctx context.Context, cmd *exec.Cmd) error {
 	if !ok {
 		return errors.New("missing nested client server ID")
 	}
-	if clientID == "" {
-		// if this is a new client, it gets it own isolated server
-		serverID = ""
-	}
 
 	parentClientIDsVal, _ := internalEnv("_DAGGER_PARENT_CLIENT_IDS")
 

--- a/core/container.go
+++ b/core/container.go
@@ -1021,12 +1021,12 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 
 	// this allows executed containers to communicate back to this API
 	if opts.ExperimentalPrivilegedNesting {
-		clientID, err := container.Query.RegisterCaller(ctx, opts.NestedExecFunctionCall)
+		newRoot, err := container.Query.NewRootForCurrentCall(ctx, opts.NestedExecFunctionCall)
 		if err != nil {
 			return nil, fmt.Errorf("register caller: %w", err)
 		}
 		runOpts = append(runOpts,
-			llb.AddEnv("_DAGGER_NESTED_CLIENT_ID", clientID),
+			llb.AddEnv("_DAGGER_NESTED_CLIENT_ID", newRoot.ClientID),
 			// include the engine version so that these execs get invalidated if the engine/API change
 			llb.AddEnv("_DAGGER_ENGINE_VERSION", engine.Version),
 		)

--- a/core/host.go
+++ b/core/host.go
@@ -120,17 +120,12 @@ func (host *Host) File(ctx context.Context, srv *dagql.Server, filePath string) 
 }
 
 func (host *Host) SetSecretFile(ctx context.Context, srv *dagql.Server, secretName string, path string) (i dagql.Instance[*Secret], err error) {
-	accessor, err := GetLocalSecretAccessor(ctx, host.Query, secretName)
-	if err != nil {
-		return i, err
-	}
-
 	secretFileContent, err := host.Query.Buildkit.ReadCallerHostFile(ctx, path)
 	if err != nil {
 		return i, fmt.Errorf("read secret file: %w", err)
 	}
 
-	if err := host.Query.Secrets.AddSecret(ctx, accessor, secretFileContent); err != nil {
+	if err := host.Query.Secrets.AddSecret(ctx, secretName, secretFileContent); err != nil {
 		return i, err
 	}
 	err = srv.Select(ctx, srv.Root(), &i, dagql.Selector{
@@ -139,10 +134,6 @@ func (host *Host) SetSecretFile(ctx context.Context, srv *dagql.Server, secretNa
 			{
 				Name:  "name",
 				Value: dagql.NewString(secretName),
-			},
-			{
-				Name:  "accessor",
-				Value: dagql.Opt(dagql.NewString(accessor)),
 			},
 		},
 	})

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -861,7 +861,7 @@ func (m *Test) Fn(ctx context.Context) (string, error) {
 				With(daggerExec("init", "--name=test", "--sdk=go", "--source=.")).
 				With(daggerExec("install", testGitModuleRef("this/just/does/not/exist"))).
 				Sync(ctx)
-			require.ErrorContains(t, err, `module "test" dependency "" with source root path "this/just/does/not/exist" does not exist or does not have a configuration file`)
+			require.ErrorContains(t, err, `dependency "" with source root path "this/just/does/not/exist" does not exist or does not have a configuration file`)
 		})
 
 		t.Run("unpinned gets pinned", func(t *testing.T) {

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5410,8 +5410,6 @@ func (t *Toplevel) Attempt(ctx context.Context, uniq string) error {
 		// even when we know the underlying IDs
 		t.Parallel()
 
-		t.Skip("this protection is not yet implemented")
-
 		var logs safeBuffer
 		c, ctx := connect(t, dagger.WithLogOutput(io.MultiWriter(os.Stderr, &logs)))
 

--- a/core/interface.go
+++ b/core/interface.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
-	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/vektah/gqlparser/v2/ast"
 )
@@ -351,10 +350,10 @@ func (iface *InterfaceAnnotatedValue) TypeDescription() string {
 	return iface.TypeDef.Description
 }
 
-var _ HasPBDefinitions = (*InterfaceAnnotatedValue)(nil)
+var _ HasFieldValues = (*InterfaceAnnotatedValue)(nil)
 
-func (iface *InterfaceAnnotatedValue) PBDefinitions(ctx context.Context) ([]*pb.Definition, error) {
-	defs := []*pb.Definition{}
+func (iface *InterfaceAnnotatedValue) FieldValues(ctx context.Context) ([]dagql.Typed, error) {
+	values := make([]dagql.Typed, 0, len(iface.Fields))
 	objDef := iface.UnderlyingType.TypeDef().AsObject.Value
 	for name, val := range iface.Fields {
 		fieldDef, ok := objDef.FieldByOriginalName(name)
@@ -373,11 +372,7 @@ func (iface *InterfaceAnnotatedValue) PBDefinitions(ctx context.Context) ([]*pb.
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert arg %q: %w", name, err)
 		}
-		fieldDefs, err := collectPBDefinitions(ctx, converted)
-		if err != nil {
-			return nil, err
-		}
-		defs = append(defs, fieldDefs...)
+		values = append(values, converted)
 	}
-	return defs, nil
+	return values, nil
 }

--- a/core/interface.go
+++ b/core/interface.go
@@ -221,7 +221,7 @@ func (iface *InterfaceType) Install(ctx context.Context, dag *dagql.Server) erro
 					})
 				}
 
-				res, err := callable.Call(ctx, dagql.CurrentID(ctx), &CallOpts{
+				res, err := callable.Call(ctx, &CallOpts{
 					Inputs:    callInputs,
 					ParentVal: runtimeVal.Fields,
 				})

--- a/core/module.go
+++ b/core/module.go
@@ -137,7 +137,7 @@ func (mod *Module) Initialize(ctx context.Context, oldSelf dagql.Instance[*Modul
 		return nil, fmt.Errorf("failed to create module definition function for module %q: %w", mod.Name(), err)
 	}
 
-	result, err := getModDefFn.Call(ctx, newID, &CallOpts{Cache: true, SkipSelfSchema: true})
+	result, err := getModDefFn.Call(ctx, &CallOpts{Cache: true, SkipSelfSchema: true})
 	if err != nil {
 		return nil, fmt.Errorf("failed to call module %q to get functions: %w", mod.Name(), err)
 	}

--- a/core/object.go
+++ b/core/object.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 
 	"github.com/dagger/dagger/dagql"
-	"github.com/moby/buildkit/solver/pb"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
@@ -127,10 +126,10 @@ func (obj *ModuleObject) Type() *ast.Type {
 	}
 }
 
-var _ HasPBDefinitions = (*ModuleObject)(nil)
+var _ HasFieldValues = (*ModuleObject)(nil)
 
-func (obj *ModuleObject) PBDefinitions(ctx context.Context) ([]*pb.Definition, error) {
-	defs := []*pb.Definition{}
+func (obj *ModuleObject) FieldValues(ctx context.Context) ([]dagql.Typed, error) {
+	values := []dagql.Typed{}
 	objDef := obj.TypeDef
 	for name, val := range obj.Fields {
 		fieldDef, ok := objDef.FieldByOriginalName(name)
@@ -150,13 +149,9 @@ func (obj *ModuleObject) PBDefinitions(ctx context.Context) ([]*pb.Definition, e
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert field %q: %w", name, err)
 		}
-		fieldDefs, err := collectPBDefinitions(ctx, converted)
-		if err != nil {
-			return nil, err
-		}
-		defs = append(defs, fieldDefs...)
+		values = append(values, converted)
 	}
-	return defs, nil
+	return values, nil
 }
 
 func (obj *ModuleObject) TypeDescription() string {

--- a/core/object.go
+++ b/core/object.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 
 	"github.com/dagger/dagger/dagql"
-	"github.com/dagger/dagger/dagql/call"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/vektah/gqlparser/v2/ast"
 )
@@ -84,7 +83,7 @@ func (t *ModuleObjectType) TypeDef() *TypeDef {
 }
 
 type Callable interface {
-	Call(context.Context, *call.ID, *CallOpts) (dagql.Typed, error)
+	Call(context.Context, *CallOpts) (dagql.Typed, error)
 	ReturnType() (ModType, error)
 	ArgType(argName string) (ModType, error)
 }
@@ -254,7 +253,7 @@ func (obj *ModuleObject) installConstructor(ctx context.Context, dag *dagql.Serv
 					Value: v,
 				})
 			}
-			return fn.Call(ctx, dagql.CurrentID(ctx), &CallOpts{
+			return fn.Call(ctx, &CallOpts{
 				Inputs:    callInput,
 				ParentVal: nil,
 			})
@@ -351,7 +350,7 @@ func objFun(ctx context.Context, mod *Module, objDef *ObjectTypeDef, fun *Functi
 			sort.Slice(opts.Inputs, func(i, j int) bool {
 				return opts.Inputs[i].Name < opts.Inputs[j].Name
 			})
-			return modFun.Call(ctx, dagql.CurrentID(ctx), opts)
+			return modFun.Call(ctx, opts)
 		},
 	}, nil
 }
@@ -362,7 +361,7 @@ type CallableField struct {
 	Return ModType
 }
 
-func (f *CallableField) Call(ctx context.Context, id *call.ID, opts *CallOpts) (dagql.Typed, error) {
+func (f *CallableField) Call(ctx context.Context, opts *CallOpts) (dagql.Typed, error) {
 	val, ok := opts.ParentVal[f.Field.OriginalName]
 	if !ok {
 		return nil, fmt.Errorf("field %q not found on object %q", f.Field.Name, opts.ParentVal)

--- a/core/query.go
+++ b/core/query.go
@@ -4,27 +4,35 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
-	"sync"
 
 	"github.com/containerd/containerd/content"
 	"github.com/dagger/dagger/auth"
 	"github.com/dagger/dagger/core/pipeline"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
-	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/buildkit"
 	"github.com/moby/buildkit/util/leaseutil"
-	"github.com/opencontainers/go-digest"
 	"github.com/vektah/gqlparser/v2/ast"
-	"github.com/vito/progrock"
 )
 
 // Query forms the root of the DAG and houses all necessary state and
 // dependencies for evaluating queries.
 type Query struct {
 	QueryOpts
+
+	Dag *dagql.Server
+
 	Buildkit *buildkit.Client
+
+	ClientID string
+
+	SecretToken string
+
+	Deps *ModDeps
+
+	FnCall *FunctionCall
+
+	ProgrockParent string
 
 	// The current pipeline.
 	Pipeline pipeline.Path
@@ -34,6 +42,8 @@ var ErrNoCurrentModule = fmt.Errorf("no current module")
 
 // Settings for Query that are shared across all instances for a given DaggerServer
 type QueryOpts struct {
+	DaggerServer
+
 	ProgrockSocketPath string
 
 	Services *Services
@@ -48,42 +58,17 @@ type QueryOpts struct {
 	// The default platform.
 	Platform Platform
 
-	// The default deps of every user module (currently just core)
-	DefaultDeps *ModDeps
-
-	// The DagQL query cache.
-	Cache dagql.Cache
-
-	BuildkitOpts *buildkit.Opts
-	Recorder     *progrock.Recorder
-
-	// The metadata of client calls.
-	// For the special case of the main client caller, the key is just empty string.
-	// This is never explicitly deleted from; instead it will just be garbage collected
-	// when this server for the session shuts down
-	ClientCallContext  map[string]*ClientCallContext
-	ClientCallMu       *sync.RWMutex
 	MainClientCallerID string
-
-	// the http endpoints being served (as a map since APIs like shellEndpoint can add more)
-	Endpoints  map[string]http.Handler
-	EndpointMu *sync.RWMutex
 }
 
-func NewRoot(ctx context.Context, opts QueryOpts) (*Query, error) {
-	bk, err := buildkit.NewClient(ctx, opts.BuildkitOpts)
-	if err != nil {
-		return nil, fmt.Errorf("buildkit client: %w", err)
-	}
-
-	// NOTE: context.WithoutCancel is used because if the provided context is canceled, buildkit can
-	// leave internal progress contexts open and leak goroutines.
-	bk.WriteStatusesTo(context.WithoutCancel(ctx), opts.Recorder)
-
-	return &Query{
-		QueryOpts: opts,
-		Buildkit:  bk,
-	}, nil
+// Methods that Query needs from the over-arching DaggerServer which involve mutating and/or creating
+// Query instances
+type DaggerServer interface {
+	MuxEndpoint(ctx context.Context, path string, handler http.Handler) error
+	ServeModule(ctx context.Context, mod *Module) error
+	NewRootForCurrentCall(ctx context.Context, call *FunctionCall) (*Query, error)
+	NewRootForDependencies(ctx context.Context, deps *ModDeps) (*Query, error)
+	NewRootForDynamicID(ctx context.Context, id *call.ID) (*Query, error)
 }
 
 func (*Query) Type() *ast.Type {
@@ -101,149 +86,20 @@ func (q Query) Clone() *Query {
 	return &q
 }
 
-func (q *Query) MuxEndpoint(ctx context.Context, path string, handler http.Handler) error {
-	q.EndpointMu.Lock()
-	defer q.EndpointMu.Unlock()
-	q.Endpoints[path] = handler
-	return nil
-}
-
-type ClientCallContext struct {
-	Root *Query
-
-	// the DAG of modules being served to this client
-	Deps *ModDeps
-
-	// If the client is itself from a function call in a user module, these are set with the
-	// metadata of that ongoing function call
-	FnCall *FunctionCall
-
-	ProgrockParent string
-}
-
-func (q *Query) ServeModule(ctx context.Context, mod *Module) error {
-	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
-	if err != nil {
-		return err
-	}
-
-	q.ClientCallMu.Lock()
-	defer q.ClientCallMu.Unlock()
-	callCtx, ok := q.ClientCallContext[clientMetadata.ClientID]
-	if !ok {
-		return fmt.Errorf("client call not found")
-	}
-	callCtx.Deps = callCtx.Deps.Append(mod)
-	return nil
-}
-
-func (q *Query) RegisterCaller(ctx context.Context, call *FunctionCall) (string, error) {
-	if call == nil {
-		call = &FunctionCall{}
-	}
-	callCtx := &ClientCallContext{
-		FnCall:         call,
-		ProgrockParent: progrock.FromContext(ctx).Parent,
-	}
-
-	currentID := dagql.CurrentID(ctx)
-	clientIDInputs := []string{currentID.Digest().String()}
-	if !call.Cache {
-		// use the ServerID so that we bust cache once-per-session
-		clientMetadata, err := engine.ClientMetadataFromContext(ctx)
-		if err != nil {
-			return "", err
-		}
-		clientIDInputs = append(clientIDInputs, clientMetadata.ServerID)
-	}
-	clientIDDigest := digest.FromString(strings.Join(clientIDInputs, " "))
-
-	// only use encoded part of digest because this ID ends up becoming a buildkit Session ID
-	// and buildkit has some ancient internal logic that splits on a colon to support some
-	// dev mode logic: https://github.com/moby/buildkit/pull/290
-	// also trim it to 25 chars as it ends up becoming part of service URLs
-	clientID := clientIDDigest.Encoded()[:25]
-
-	// break glass for debugging which client is which operation
-	// bklog.G(ctx).Debugf("CLIENT ID %s = %s", clientID, currentID.Display())
-
-	if call.Module == nil {
-		callCtx.Deps = q.DefaultDeps
-	} else {
-		callCtx.Deps = call.Module.Deps
-		// By default, serve both deps and the module's own API to itself. But if SkipSelfSchema is set,
-		// only serve the APIs of the deps of this module. This is currently only needed for the special
-		// case of the function used to get the definition of the module itself (which can't obviously
-		// be served the API its returning the definition of).
-		if !call.SkipSelfSchema {
-			callCtx.Deps = callCtx.Deps.Append(call.Module)
-		}
-	}
-
-	q.ClientCallMu.Lock()
-	defer q.ClientCallMu.Unlock()
-	_, ok := q.ClientCallContext[clientID]
-	if ok {
-		return clientID, nil
-	}
-
-	var err error
-	callCtx.Root, err = NewRoot(ctx, q.QueryOpts)
-	if err != nil {
-		return "", err
-	}
-
-	q.ClientCallContext[clientID] = callCtx
-	return clientID, nil
-}
-
 func (q *Query) CurrentModule(ctx context.Context) (*Module, error) {
-	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	q.ClientCallMu.RLock()
-	defer q.ClientCallMu.RUnlock()
-	callCtx, ok := q.ClientCallContext[clientMetadata.ClientID]
-	if !ok {
-		return nil, fmt.Errorf("client call %s not found", clientMetadata.ClientID)
-	}
-	if callCtx.FnCall.Module == nil {
+	mod := q.FnCall.Module
+	if mod == nil {
 		return nil, ErrNoCurrentModule
 	}
-	return callCtx.FnCall.Module, nil
+	return mod, nil
 }
 
 func (q *Query) CurrentFunctionCall(ctx context.Context) (*FunctionCall, error) {
-	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
-	if err != nil {
-		return nil, err
+	fnCall := q.FnCall
+	if fnCall == nil {
+		return nil, ErrNoCurrentModule
 	}
-	if clientMetadata.ClientID == q.MainClientCallerID {
-		return nil, fmt.Errorf("%w: main client caller has no function", ErrNoCurrentModule)
-	}
-
-	q.ClientCallMu.RLock()
-	defer q.ClientCallMu.RUnlock()
-	callCtx, ok := q.ClientCallContext[clientMetadata.ClientID]
-	if !ok {
-		return nil, fmt.Errorf("client call %s not found", clientMetadata.ClientID)
-	}
-
-	return callCtx.FnCall, nil
-}
-
-func (q *Query) CurrentServedDeps(ctx context.Context) (*ModDeps, error) {
-	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-	callCtx, ok := q.ClientCallContext[clientMetadata.ClientID]
-	if !ok {
-		return nil, fmt.Errorf("client call %s not found", clientMetadata.ClientID)
-	}
-	return callCtx.Deps, nil
+	return fnCall, nil
 }
 
 func (q *Query) WithPipeline(name, desc string, labels []pipeline.Label) *Query {
@@ -304,24 +160,4 @@ func (q *Query) NewHostService(upstream string, ports []PortForward) *Service {
 		HostUpstream: upstream,
 		HostPorts:    ports,
 	}
-}
-
-// IDDeps loads the module dependencies of a given ID.
-//
-// The returned ModDeps extends the inner DefaultDeps with all modules found in
-// the ID, loaded by using the DefaultDeps schema.
-func (q *Query) IDDeps(ctx context.Context, id *call.ID) (*ModDeps, error) {
-	bootstrap, err := q.DefaultDeps.Schema(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("bootstrap schema: %w", err)
-	}
-	deps := q.DefaultDeps
-	for _, modID := range id.Modules() {
-		mod, err := dagql.NewID[*Module](modID.ID()).Load(ctx, bootstrap)
-		if err != nil {
-			return nil, fmt.Errorf("load source mod: %w", err)
-		}
-		deps = deps.Append(mod.Self)
-	}
-	return deps, nil
 }

--- a/core/query.go
+++ b/core/query.go
@@ -28,6 +28,8 @@ type Query struct {
 
 	SecretToken string
 
+	Secrets *SecretStore
+
 	Deps *ModDeps
 
 	FnCall *FunctionCall
@@ -48,8 +50,6 @@ type QueryOpts struct {
 
 	Services *Services
 
-	Secrets *SecretStore
-
 	Auth *auth.RegistryAuthProvider
 
 	OCIStore     content.Store
@@ -69,6 +69,11 @@ type DaggerServer interface {
 	NewRootForCurrentCall(ctx context.Context, call *FunctionCall) (*Query, error)
 	NewRootForDependencies(ctx context.Context, deps *ModDeps) (*Query, error)
 	NewRootForDynamicID(ctx context.Context, id *call.ID) (*Query, error)
+}
+
+func CurrentQuery(ctx context.Context) *Query {
+	srv := dagql.CurrentServer(ctx)
+	return srv.Root().(dagql.Instance[*Query]).Self
 }
 
 func (*Query) Type() *ast.Type {
@@ -114,16 +119,14 @@ func (q *Query) WithPipeline(name, desc string, labels []pipeline.Label) *Query 
 
 func (q *Query) NewContainer(platform Platform) *Container {
 	return &Container{
-		Query:    q,
 		Platform: platform,
 	}
 }
 
-func (q *Query) NewSecret(name string, accessor string) *Secret {
+func (q *Query) NewSecret(name string) *Secret {
 	return &Secret{
-		Query:    q,
-		Name:     name,
-		Accessor: accessor,
+		Query: q,
+		Name:  name,
 	}
 }
 

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -1223,12 +1223,12 @@ func (s *containerSchema) withRegistryAuth(ctx context.Context, parent *core.Con
 		return nil, err
 	}
 
-	secretBytes, err := parent.Query.Secrets.GetSecret(ctx, secret.Self.Accessor)
+	secretBytes, err := core.CurrentQuery(ctx).Secrets.GetSecret(ctx, secret.Self.Name)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := parent.Query.Auth.AddCredential(args.Address, args.Username, string(secretBytes)); err != nil {
+	if err := core.CurrentQuery(ctx).Auth.AddCredential(args.Address, args.Username, string(secretBytes)); err != nil {
 		return nil, err
 	}
 
@@ -1239,8 +1239,8 @@ type containerWithoutRegistryAuthArgs struct {
 	Address string
 }
 
-func (s *containerSchema) withoutRegistryAuth(_ context.Context, parent *core.Container, args containerWithoutRegistryAuthArgs) (*core.Container, error) {
-	if err := parent.Query.Auth.RemoveCredential(args.Address); err != nil {
+func (s *containerSchema) withoutRegistryAuth(ctx context.Context, parent *core.Container, args containerWithoutRegistryAuthArgs) (*core.Container, error) {
+	if err := core.CurrentQuery(ctx).Auth.RemoveCredential(args.Address); err != nil {
 		return nil, err
 	}
 
@@ -1384,7 +1384,7 @@ func (s *containerSchema) terminal(
 		return nil, err
 	}
 
-	if err := ctr.Self.Query.MuxEndpoint(ctx, path.Join("/", term.Endpoint), handler); err != nil {
+	if err := core.CurrentQuery(ctx).MuxEndpoint(ctx, path.Join("/", term.Endpoint), handler); err != nil {
 		return nil, err
 	}
 

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -286,7 +286,7 @@ func (s *directorySchema) dockerBuild(ctx context.Context, parent *core.Director
 	if args.Platform.Valid {
 		platform = args.Platform.Value
 	}
-	ctr, err := core.NewContainer(parent.Query, platform)
+	ctr, err := core.NewContainer(platform)
 	if err != nil {
 		return nil, err
 	}

--- a/core/schema/host.go
+++ b/core/schema/host.go
@@ -76,7 +76,7 @@ func (s *hostSchema) Install() {
 				return nil, fmt.Errorf("marshal root: %w", err)
 			}
 
-			container, err := core.NewContainer(parent, parent.Platform)
+			container, err := core.NewContainer(parent.Platform)
 			if err != nil {
 				return nil, fmt.Errorf("new container: %w", err)
 			}

--- a/core/schema/host.go
+++ b/core/schema/host.go
@@ -206,7 +206,7 @@ func (s *hostSchema) socket(ctx context.Context, host *core.Host, args hostSocke
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client metadata: %w", err)
 	}
-	if clientMetadata.ClientID != host.Query.Buildkit.MainClientCallerID {
+	if clientMetadata.ClientID != host.Query.MainClientCallerID {
 		return nil, fmt.Errorf("only the main client can access the host's unix sockets")
 	}
 

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -464,7 +464,7 @@ func (s *moduleSchema) currentFunctionCall(ctx context.Context, self *core.Query
 }
 
 func (s *moduleSchema) moduleServe(ctx context.Context, modMeta dagql.Instance[*core.Module], _ struct{}) (dagql.Nullable[core.Void], error) {
-	return dagql.Null[core.Void](), modMeta.Self.Query.ServeModuleToMainClient(ctx, modMeta)
+	return dagql.Null[core.Void](), modMeta.Self.Query.ServeModule(ctx, modMeta.Self)
 }
 
 func (s *moduleSchema) currentTypeDefs(ctx context.Context, self *core.Query, _ struct{}) ([]*core.TypeDef, error) {

--- a/core/schema/util.go
+++ b/core/schema/util.go
@@ -2,11 +2,8 @@ package schema
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 
 	"github.com/dagger/dagger/dagql"
-	"github.com/dagger/dagger/dagql/introspection"
 	"github.com/dagger/dagger/engine/buildkit"
 	"github.com/iancoleman/strcase"
 )
@@ -68,18 +65,6 @@ func asArrayInput[T any, I dagql.Input](ts []T, conv func(T) I) dagql.ArrayInput
 		ins[i] = conv(v)
 	}
 	return ins
-}
-
-func schemaIntrospectionJSON(ctx context.Context, dag *dagql.Server) (json.RawMessage, error) {
-	data, err := dag.Query(ctx, introspection.Query, nil)
-	if err != nil {
-		return nil, fmt.Errorf("introspection query failed: %w", err)
-	}
-	jsonBytes, err := json.Marshal(data)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal introspection result: %w", err)
-	}
-	return json.RawMessage(jsonBytes), nil
 }
 
 func gqlFieldName(name string) string {

--- a/core/secret.go
+++ b/core/secret.go
@@ -2,12 +2,9 @@ package core
 
 import (
 	"context"
-	"crypto/hmac"
-	"encoding/hex"
 	"sync"
 
 	"github.com/moby/buildkit/session/secrets"
-	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/v2/ast"
 )
@@ -18,30 +15,6 @@ type Secret struct {
 
 	// Name specifies the name of the secret.
 	Name string `json:"name,omitempty"`
-
-	// Accessor specifies the accessor key for the secret.
-	Accessor string `json:"accessor,omitempty"`
-}
-
-func GetLocalSecretAccessor(ctx context.Context, parent *Query, name string) (string, error) {
-	m, err := parent.CurrentModule(ctx)
-	if err != nil && !errors.Is(err, ErrNoCurrentModule) {
-		return "", err
-	}
-	var d digest.Digest
-	if m != nil {
-		d = m.Source.ID().Digest()
-	}
-	return NewSecretAccessor(name, d.String()), nil
-}
-
-func NewSecretAccessor(name string, scope string) string {
-	// Use an HMAC, which allows us to keep the scope secret
-	// This also protects from length-extension attacks (where if we had
-	// access to secret FOO in scope X, we could derive access to FOOBAR).
-	h := hmac.New(digest.SHA256.Hash, []byte(scope))
-	dt := h.Sum([]byte(name))
-	return hex.EncodeToString(dt)
 }
 
 func (*Secret) Type() *ast.Type {

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -376,6 +376,20 @@ func (typeDef *TypeDef) Underlying() *TypeDef {
 	}
 }
 
+// if the type is an object, input or interface, returns the name of the type
+func (typeDef *TypeDef) Name() string {
+	switch typeDef.Kind {
+	case TypeDefKindObject:
+		return typeDef.AsObject.Value.Name
+	case TypeDefKindInterface:
+		return typeDef.AsInterface.Value.Name
+	case TypeDefKindInput:
+		return typeDef.AsInput.Value.Name
+	default:
+		return ""
+	}
+}
+
 func (typeDef *TypeDef) WithKind(kind TypeDefKind) *TypeDef {
 	typeDef = typeDef.Clone()
 	typeDef.Kind = kind

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -842,6 +842,17 @@ type FunctionCall struct {
 	ParentName string                  `field:"true" doc:"The name of the parent object of the function being called. If the function is top-level to the module, this is the name of the module."`
 	Parent     JSON                    `field:"true" doc:"The value of the parent object of the function being called. If the function is top-level to the module, this is always an empty object."`
 	InputArgs  []*FunctionCallArgValue `field:"true" doc:"The argument values the function is being invoked with."`
+
+	// Below are not in public API
+
+	// The module that the function is being called from
+	Module *Module
+
+	// Whether the function call should be cached across different servers
+	Cache bool
+
+	// Whether to serve the schema for the function's own module to it or not
+	SkipSelfSchema bool
 }
 
 func (*FunctionCall) Type() *ast.Type {

--- a/dagql/referencedTypes.go
+++ b/dagql/referencedTypes.go
@@ -1,0 +1,106 @@
+package dagql
+
+import (
+	"context"
+
+	"github.com/dagger/dagger/dagql/call"
+	"github.com/opencontainers/go-digest"
+)
+
+// TODO: doc, note that it excludes return of ID itself
+func ReferencedTypes[T Typed](ctx context.Context, id *call.ID, srv *Server, includeSelf bool) ([]T, error) {
+	ids := idWalker{
+		typeNameToIDs: map[string][]*call.ID{},
+		memo:          map[digest.Digest]struct{}{},
+	}
+	if err := ids.walkID(id); err != nil {
+		return nil, err
+	}
+
+	var implementingTypes []T
+	srv.installLock.Lock()
+	for _, objType := range srv.objects {
+		innerType := objType.Typed()
+		if t, ok := innerType.(T); ok {
+			implementingTypes = append(implementingTypes, t)
+		}
+	}
+	srv.installLock.Unlock()
+
+	if len(implementingTypes) == 0 {
+		return nil, nil
+	}
+
+	var typedIDs []ID[T]
+	for _, t := range implementingTypes {
+		typeName := t.Type().Name()
+		idProtos, ok := ids.typeNameToIDs[typeName]
+		if !ok {
+			return nil, nil
+		}
+		for _, idProto := range idProtos {
+			if !includeSelf && idProto.Digest() == id.Digest() {
+				// skip self
+				continue
+			}
+			typedIDs = append(typedIDs, NewID[T](idProto))
+		}
+	}
+
+	return LoadIDs[T](ctx, srv, typedIDs)
+}
+
+type idWalker struct {
+	typeNameToIDs map[string][]*call.ID
+	memo          map[digest.Digest]struct{}
+}
+
+func (idWalker *idWalker) walkID(id *call.ID) error {
+	dgst := id.Digest()
+	if _, ok := idWalker.memo[dgst]; ok {
+		return nil
+	}
+	idWalker.memo[dgst] = struct{}{}
+
+	namedType := id.Type().NamedType()
+	if namedType != "" {
+		idWalker.typeNameToIDs[namedType] = append(idWalker.typeNameToIDs[namedType], id)
+	}
+
+	if id.Base != nil {
+		if err := idWalker.walkID(id); err != nil {
+			return err
+		}
+	}
+
+	for _, arg := range id.Args() {
+		if err := idWalker.walkLiteral(arg.Value()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (idWalker *idWalker) walkLiteral(lit call.Literal) error {
+	switch x := lit.(type) {
+	case *call.LiteralID:
+		return idWalker.walkID(x.Value())
+	case *call.LiteralList:
+		if err := x.Range(func(_ int, v call.Literal) error {
+			return idWalker.walkLiteral(v)
+		}); err != nil {
+			return err
+		}
+	case *call.LiteralObject:
+		if err := x.Range(func(_ int, _ string, v call.Literal) error {
+			return idWalker.walkLiteral(v)
+		}); err != nil {
+			return err
+		}
+	default:
+		// NOTE: not handling any primitive types right now, could be added
+		// if needed for some reason
+	}
+	return nil
+}

--- a/dagql/server.go
+++ b/dagql/server.go
@@ -244,6 +244,16 @@ func (s *Server) ObjectType(name string) (ObjectType, bool) {
 	return t, ok
 }
 
+func (s *Server) ObjectTypes() []ObjectType {
+	s.installLock.Lock()
+	defer s.installLock.Unlock()
+	types := make([]ObjectType, 0, len(s.objects))
+	for _, t := range s.objects {
+		types = append(types, t)
+	}
+	return types
+}
+
 // ScalarType returns the ScalarType with the given name, if it exists.
 func (s *Server) ScalarType(name string) (ScalarType, bool) {
 	s.installLock.Lock()
@@ -252,12 +262,32 @@ func (s *Server) ScalarType(name string) (ScalarType, bool) {
 	return t, ok
 }
 
+func (s *Server) ScalarTypes() []ScalarType {
+	s.installLock.Lock()
+	defer s.installLock.Unlock()
+	types := make([]ScalarType, 0, len(s.scalars))
+	for _, t := range s.scalars {
+		types = append(types, t)
+	}
+	return types
+}
+
 // InputType returns the InputType with the given name, if it exists.
 func (s *Server) TypeDef(name string) (TypeDef, bool) {
 	s.installLock.Lock()
 	defer s.installLock.Unlock()
 	t, ok := s.typeDefs[name]
 	return t, ok
+}
+
+func (s *Server) TypeDefs() []TypeDef {
+	s.installLock.Lock()
+	defer s.installLock.Unlock()
+	types := make([]TypeDef, 0, len(s.typeDefs))
+	for _, t := range s.typeDefs {
+		types = append(types, t)
+	}
+	return types
 }
 
 // Around installs a function to be called around every non-cached selection.

--- a/dagql/types.go
+++ b/dagql/types.go
@@ -47,6 +47,10 @@ type ObjectType interface {
 	// Unlike natively added fields, the extended func is limited to the external
 	// Object interface.
 	Extend(FieldSpec, FieldFunc)
+	// If this object is defined by a user module, that module. Otherwise nil.
+	SourceModule() *call.Module
+	// The underlying ast definition for the object.
+	TypeDefinition() *ast.Definition
 }
 
 type IDType interface {

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -615,13 +615,7 @@ func (c *Client) ListenHostToContainer(
 		return nil, nil, err
 	}
 
-	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
-	if err != nil {
-		cancel()
-		return nil, nil, fmt.Errorf("failed to get requester session ID: %s", err)
-	}
-
-	clientCaller, err := c.SessionManager.Get(ctx, clientMetadata.ClientID, false)
+	clientCaller, err := c.GetSessionCaller(ctx, false)
 	if err != nil {
 		cancel()
 		return nil, nil, fmt.Errorf("failed to get requester session: %s", err)

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -59,10 +59,9 @@ type Opts struct {
 	// client. It is special in that when it shuts down, the client will be closed and
 	// that registry auth and sockets are currently only ever sourced from this caller,
 	// not any nested clients (may change in future).
-	MainClientCaller   bksession.Caller
-	MainClientCallerID string
-	DNSConfig          *oci.DNSConfig
-	Frontends          map[string]bkfrontend.Frontend
+	MainClientCaller bksession.Caller
+	DNSConfig        *oci.DNSConfig
+	Frontends        map[string]bkfrontend.Frontend
 	sharedClientState
 }
 

--- a/engine/buildkit/containerimage.go
+++ b/engine/buildkit/containerimage.go
@@ -108,7 +108,7 @@ func (c *Client) ExportContainerImage(
 		IsFileStream: true,
 	}.AppendToOutgoingContext(ctx)
 
-	resp, descRef, err := expInstance.Export(ctx, combinedResult, nil, clientMetadata.ClientID)
+	resp, descRef, err := expInstance.Export(ctx, combinedResult, nil, clientMetadata.BuildkitSessionID())
 	if err != nil {
 		return nil, fmt.Errorf("failed to export: %s", err)
 	}

--- a/engine/buildkit/session.go
+++ b/engine/buildkit/session.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moby/buildkit/identity"
 	bksession "github.com/moby/buildkit/session"
 	sessioncontent "github.com/moby/buildkit/session/content"
+	bksecrets "github.com/moby/buildkit/session/secrets"
 	"github.com/moby/buildkit/session/secrets/secretsprovider"
 	"github.com/moby/buildkit/util/bklog"
 )
@@ -30,7 +31,7 @@ const (
 	BuiltinContentOCIStoreName = "dagger-builtin-content"
 )
 
-func (c *Client) newSession() (*bksession.Session, error) {
+func (c *Client) newSession(secretStore bksecrets.SecretStore) (*bksession.Session, error) {
 	sess, err := bksession.NewSession(c.closeCtx, identity.NewID(), "")
 	if err != nil {
 		return nil, err
@@ -41,7 +42,7 @@ func (c *Client) newSession() (*bksession.Session, error) {
 		return nil, fmt.Errorf("failed to create go sdk content store: %w", err)
 	}
 
-	sess.Allow(secretsprovider.NewSecretProvider(c.SecretStore))
+	sess.Allow(secretsprovider.NewSecretProvider(secretStore))
 	sess.Allow(&socketProxy{c})
 	sess.Allow(&authProxy{c})
 	sess.Allow(&client.AnyDirSource{})

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -290,15 +290,6 @@ func Connect(ctx context.Context, params Params) (_ *Client, _ context.Context, 
 	// already started
 	c.eg.Go(func() error {
 		return bkSession.Run(c.internalCtx, func(ctx context.Context, proto string, meta map[string][]string) (net.Conn, error) {
-			// overwrite the session ID to be our client ID
-			const sessionIDHeader = "X-Docker-Expose-Session-Uuid"
-			if _, ok := meta[sessionIDHeader]; !ok {
-				// should never happen unless upstream changes the value of the header key,
-				// in which case we want to know
-				return nil, fmt.Errorf("missing header %s", sessionIDHeader)
-			}
-			meta[sessionIDHeader] = []string{c.ID}
-
 			return grpchijack.Dialer(c.bkClient.ControlClient())(ctx, proto, engine.ClientMetadata{
 				RegisterClient:            true,
 				ClientID:                  c.ID,

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/dagger/dagger/core/pipeline"
 	controlapi "github.com/moby/buildkit/api/services/control"
-	"github.com/opencontainers/go-digest"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -28,11 +27,12 @@ const (
 )
 
 type ClientMetadata struct {
-	// ClientID is unique to every session created by every client
+	// ClientID is unique to each client. The main client's ID is the empty string,
+	// any module and/or nested exec client's ID is a unique digest.
 	ClientID string `json:"client_id"`
 
 	// ClientSecretToken is a secret token that is unique to every client. It's
-	// initially provided to the server in the controller.Solve request. Every
+	// initially provided to the server in the controller.Session request. Every
 	// other request w/ that client ID must also include the same token.
 	ClientSecretToken string `json:"client_secret_token"`
 
@@ -60,11 +60,6 @@ type ClientMetadata struct {
 	// session. The first element is the direct parent, the second element is the
 	// parent of the parent, and so on.
 	ParentClientIDs []string `json:"parent_client_ids"`
-
-	// If this client is for a module function, this digest will be set in the
-	// grpc context metadata for any api requests back to the engine. It's used by the API
-	// server to determine which schema to serve and other module context metadata.
-	ModuleCallerDigest digest.Digest `json:"module_caller_digest"`
 
 	// Import configuration for Buildkit's remote cache
 	UpstreamCacheImportConfig []*controlapi.CacheOptionsEntry

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/dagger/dagger/core/pipeline"
 	controlapi "github.com/moby/buildkit/api/services/control"
@@ -88,6 +89,15 @@ func (m ClientMetadata) AppendToMD(md metadata.MD) metadata.MD {
 		md[k] = append(md[k], v...)
 	}
 	return md
+}
+
+// The ID to use for this client's buildkit session. It's a combination of both
+// the client and the server IDs to account for the fact that the client ID is
+// a content digest for functions/nested-execs, meaning it can reoccur across
+// different servers; that doesn't work because buildkit's SessionManager is
+// global to the whole process.
+func (m ClientMetadata) BuildkitSessionID() string {
+	return strings.Join([]string{m.ClientID, m.ServerID}, "-")
 }
 
 func ContextWithClientMetadata(ctx context.Context, clientMetadata *ClientMetadata) context.Context {

--- a/engine/server/buildkitcontroller.go
+++ b/engine/server/buildkitcontroller.go
@@ -153,7 +153,6 @@ func (e *BuildkitController) Session(stream controlapi.Control_SessionServer) (r
 	ctx = bklog.WithLogger(ctx, bklog.G(ctx).
 		WithField("client_id", opts.ClientID).
 		WithField("client_hostname", opts.ClientHostname).
-		WithField("client_call_digest", opts.ModuleCallerDigest).
 		WithField("server_id", opts.ServerID))
 	bklog.G(ctx).WithField("register_client", opts.RegisterClient).Debug("handling session call")
 	defer func() {


### PR DESCRIPTION
This is the last part of the saga around https://github.com/dagger/dagger/issues/6747 that fully isolates sessions to each client and thus enables support for passing host unix sockets to modules, plugging some existing holes in our secret isolation, etc.

This PR doesn't have all that yet, been in the process of rebuilding it cleanly after an initial messy prototype. Sending it out anyways because what I have here seems to fix the problem in https://github.com/dagger/dagger/pull/6914, so may want to merge a minimum safe changeset here early.
* The only extra thing strictly needed to safely merge is isolating the secret store to each client; in the current state of things nested execs end up with a shared secret store from their parent caller, which is *probably* a breaking change (though it's complicated, not 100% sure)
* Brief description of changes so far:
   * Consolidate module caller digest to just be the client ID. This is a pretty nice simplification from before since we less IDs to think about and pass around, but especially simplifies the rest of the pending changes
   * Share the server with nested execs, whereas previously they got their own. This is again just a generally nice simplification made possible by the fact that we can now isolate their session attachables.

@vito unfortunately these are the changes I was referring to that may cause rebase headaches with your OTEL PR (and there's more coming on top of the commits already here), so we'll have to sort that out if we merge this soon.