### PR TITLE
fix nullable input object fields

### DIFF
--- a/dagql/nullables.go
+++ b/dagql/nullables.go
@@ -150,9 +150,13 @@ var _ InputDecoder = DynamicOptional{}
 func (o DynamicOptional) DecodeInput(val any) (Input, error) {
 	if val == nil {
 		return DynamicOptional{
-			Elem:  o,
+			Elem:  o.Elem,
 			Valid: false,
 		}, nil
+	}
+	valV := reflect.ValueOf(val)
+	if valV.Kind() == reflect.Ptr {
+		val = valV.Elem().Interface()
 	}
 	input, err := o.Elem.Decoder().DecodeInput(val)
 	if err != nil {
@@ -283,5 +287,17 @@ func (n *DynamicNullable) UnmarshalJSON(p []byte) error {
 	if err := json.Unmarshal(p, &n.Value); err != nil {
 		return err
 	}
+	if n.Value != nil {
+		n.Valid = true
+	}
 	return nil
 }
+
+// var _ call.Literate = DynamicNullable{}
+
+// func (n DynamicNullable) ToLiteral() call.Literal {
+// 	if !o.Valid {
+// 		return call.NewLiteralNull()
+// 	}
+// 	return o.Value.ToLiteral()
+// }

--- a/dagql/objects.go
+++ b/dagql/objects.go
@@ -675,7 +675,9 @@ func inputSpecsForType(obj any, optIn bool) (InputSpecs, error) {
 			}
 			if input.Type().NonNull {
 				input = DynamicOptional{
-					Elem: input,
+					Elem:  input,
+					Value: inputDef,
+					Valid: true,
 				}
 			}
 		}


### PR DESCRIPTION
wip, need unit tests, just don't want to lose track of this rabbit hole

To no one's surprise, the tricky reflect handling around input objects isn't working properly, resulting in this ID for `up --ports 9090:8080`:

```
Service.up(ports: [{frontend: null, backend: 8080, protocol: TCP}])
```

instead of this:

```
Service.up(ports: [{frontend: 9090, backend: 8080, protocol: TCP}]):
```

The actual behavior is correct - the resolver gets `9090`, not `null` - but the serialization into the ID is ending up with `null`.

The changes here fix it but I'm not happy with it yet.