### PR TITLE
chore: fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ Contributions to this project must be accompanied by a Developer Certificate of
 Origin (DCO).
 
 All commit messages must contain the Signed-off-by line with an email address
-that matches the commit author. When commiting, use the `--signoff` flag:
+that matches the commit author. When committing, use the `--signoff` flag:
 
 ```shell
 git commit -s

--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -35,7 +35,7 @@ The overall idea is that users just need to create a struct with the same name a
 add methods to that struct to implement their Module. Methods on that struct become Functions.
 
 They are also free to return custom objects from Functions, which themselves may have methods that become
-Functions too. However, only the "top-level" Module struct's Functions will be directly invokable.
+Functions too. However, only the "top-level" Module struct's Functions will be directly invocable.
 
 This is essentially just the GraphQL execution model.
 

--- a/cmd/codegen/generator/typescript/templates/functions.go
+++ b/cmd/codegen/generator/typescript/templates/functions.go
@@ -52,7 +52,7 @@ func pascalCase(name string) string {
 	return strcase.ToCamel(name)
 }
 
-// solve checks if a field is solveable.
+// solve checks if a field is solvable.
 func solve(field introspection.Field) bool {
 	if field.TypeRef == nil {
 		return false

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -396,7 +396,7 @@ var modulePublishCmd = &cobra.Command{
 
 The module needs to be committed to a git repository and have a remote
 configured with name "origin". The git repository must be clean (unless
-forced), to avoid mistakingly depending on uncommitted files.
+forced), to avoid mistakenly depending on uncommitted files.
 `,
 		daDaggerverse,
 	),

--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -26,7 +26,7 @@ var runCmd = &cobra.Command{
 		`Executes the specified command in a Dagger Session and displays
 live progress in a TUI.
 
-´DAGGER_SESSION_PORT´ and ´DAGGER_SESSION_TOKEN´ will be convieniently
+´DAGGER_SESSION_PORT´ and ´DAGGER_SESSION_TOKEN´ will be conveniently
 injected automatically.
 
 For example:

--- a/cmd/engine/main_oci_worker.go
+++ b/cmd/engine/main_oci_worker.go
@@ -526,13 +526,13 @@ const (
 	// the target image.
 	targetImageLayersLabel = "containerd.io/snapshot/remote/stargz.layers"
 
-	// targetSessionLabel is a labeld which contains session IDs usable for
+	// targetSessionLabel is a label which contains session IDs usable for
 	// authenticating the target snapshot.
 	targetSessionLabel = "containerd.io/snapshot/remote/stargz.session"
 )
 
 // sourceWithSession returns a callback which implements a converter from labels to the
-// typed snapshot source info. This callback is called everytime the snapshotter resolves a
+// typed snapshot source info. This callback is called every time the snapshotter resolves a
 // snapshot. This callback returns configuration that is based on buildkitd's registry config
 // and utilizes the session-based authorizer.
 func sourceWithSession(hosts docker.RegistryHosts, sm *session.Manager) sgzsource.GetSources {

--- a/cmd/shim/secret_scrub.go
+++ b/cmd/shim/secret_scrub.go
@@ -117,7 +117,7 @@ type censor struct {
 //
 // Unlike some other secret scrubbing implementations, this aims to sanitize
 // bytes *as soon as possible*. The moment that we know a byte is not part of a
-// secret, we should ouput it into dst - even if this would break up a provided
+// secret, we should output it into dst - even if this would break up a provided
 // src into multiple dsts over multiple calls to Transform.
 func (c *censor) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err error) {
 	for {

--- a/core/docs/extension_implementation.md
+++ b/core/docs/extension_implementation.md
@@ -22,7 +22,7 @@ An Extension Runtime is the bridge between the Dagger GraphQL server and executa
 
 The above process (described in greater detail below) is what's called the "runtime protocol". It's what enables the otherwise highly-generic, language-agnostic Dagger server to dynamically plug in resolver implementations written in arbitrary languages and/or frameworks.
 
-The protocol could thus be thought of as a way of "proxying" resolver calls out from the server to these dynamically loaded pieces of user code. It is optimized to maximize re-usability of BuildKit caching, with each resolver call being cached based exactly on its relevent inputs.
+The protocol could thus be thought of as a way of "proxying" resolver calls out from the server to these dynamically loaded pieces of user code. It is optimized to maximize re-usability of BuildKit caching, with each resolver call being cached based exactly on its relevant inputs.
 
 There are currently two runtime implementations:
 1. Go
@@ -124,13 +124,13 @@ The rest of the doc will use this terminology:
 It's only valid to invoke a full hierarchy of commands to a leaf.
 * e.g. if a user invokes `dagger do sdk:go` only the `--help` output will be shown, no commands actually executed
 
-All arguments on every command in the hierarchy are coallesced together as flags available on the leaf.
+All arguments on every command in the hierarchy are coalesced together as flags available on the leaf.
 * e.g. There is a `foo` arg on `sdk` and a `bar` arg on `build`, so `sdk:go:build` has flags for `--foo` and `--bar`
 * As a result, there must be no overlap in names in a hierarchy. Doing so should result in an error.
 
 Command hierarchies are helpful for organization, but they also enable common work and configuration to be down in parent commands and then passed down to subcommands, including leafs.
 * This is just the graphql resolver model. More background and examples of the general idea are available in most graphql framework docs, e.g. [these Apollo docs](https://www.apollographql.com/docs/apollo-server/data/resolvers/#example)
-* Parent commands pass information to subcommands by returning "structs" (or similar concept), which are then made available to the subcommands. More details in the Type restrictions section of Requirements below. 
+* Parent commands pass information to subcommands by returning "structs" (or similar concept), which are then made available to the subcommands. More details in the Type restrictions section of Requirements below.
 * Importantly, every execution of parent commands are cached individually, so any expensive work that runs as part of them can be cached even if the execution of the subcommands is not cached.
 
 ## Requirements

--- a/core/integration/gpu_test.go
+++ b/core/integration/gpu_test.go
@@ -159,7 +159,7 @@ func TestGPUAccessWithPython(t *testing.T) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	t.Run("pytorch CUDA availibility check", func(t *testing.T) {
+	t.Run("pytorch CUDA availability check", func(t *testing.T) {
 		ctr := c.Container().From("pytorch/pytorch:latest")
 		contents, err := ctr.
 			ExperimentalWithAllGPUs().

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -471,7 +471,7 @@ func (s *containerSchema) Install() {
 
 		dagql.Func("experimentalWithGPU", s.withGPU).
 			Doc(`EXPERIMENTAL API! Subject to change/removal at any time.`,
-				`Configures the provided list of devices to be accesible to this container.`,
+				`Configures the provided list of devices to be accessible to this container.`,
 				`This currently works for Nvidia devices only.`).
 			ArgDoc("devices", `List of devices to be accessible to this container.`),
 

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -20,7 +20,7 @@ func (s *directorySchema) Install() {
 	dagql.Fields[*core.Query]{
 		dagql.Func("directory", s.directory).
 			Doc(`Creates an empty directory.`).
-			ArgDeprecated("id", "Use `loadDirectoryFromID` isntead."),
+			ArgDeprecated("id", "Use `loadDirectoryFromID` instead."),
 	}.Install(s.srv)
 
 	dagql.Fields[*core.Directory]{

--- a/dagql/README.md
+++ b/dagql/README.md
@@ -22,7 +22,7 @@ Below are a set of assertions that build on one another.
 * An *impure* query or ID may return an Object with a *pure* ID.
 * All data may be kept in-memory with LRU-like caching semantics.
 * All Arrays returned by Objects have deterministic order.
-* An ID may refer to an Object returned in an Array by specifing the *nth* index (starting at 1).
+* An ID may refer to an Object returned in an Array by specifying the *nth* index (starting at 1).
 * All Objects in Arrays have IDs: either an ID of their own, or the field's ID with *nth* set.
 * At the GraphQL API layer, Objects are passed to each other by ID.
 * At the code layer, Objects received as arguments are automatically loaded from a given ID.

--- a/docs/current_docs/cli/979595-reference.mdx
+++ b/docs/current_docs/cli/979595-reference.mdx
@@ -392,7 +392,7 @@ Run a command in a Dagger session
 Executes the specified command in a Dagger Session and displays
 live progress in a TUI.
 
-`DAGGER_SESSION_PORT` and `DAGGER_SESSION_TOKEN` will be convieniently
+`DAGGER_SESSION_PORT` and `DAGGER_SESSION_TOKEN` will be conveniently
 injected automatically.
 
 For example:

--- a/docs/current_docs/faq.mdx
+++ b/docs/current_docs/faq.mdx
@@ -127,7 +127,7 @@ Dagger is able to cache:
 - Operations, such as copying files or directories to a container, running tests, compiling code, etc.
 - Volumes, such as data caches or package manager caches
 
-Operations are automatically cached every time a Dagger pipeline runs. Cache volumes must be explicity defined and used in your Dagger pipeline code.
+Operations are automatically cached every time a Dagger pipeline runs. Cache volumes must be explicitly defined and used in your Dagger pipeline code.
 
 ### Can I run the Dagger Engine as a "rootless" container?
 

--- a/docs/current_docs/guides/snippets/create-app-ci-module/base/go/dagger.gen.go
+++ b/docs/current_docs/guides/snippets/create-app-ci-module/base/go/dagger.gen.go
@@ -587,7 +587,7 @@ func (r *Container) ExperimentalWithAllGPUs() *Container {
 
 // EXPERIMENTAL API! Subject to change/removal at any time.
 //
-// Configures the provided list of devices to be accesible to this container.
+// Configures the provided list of devices to be accessible to this container.
 //
 // This currently works for Nvidia devices only.
 func (r *Container) ExperimentalWithGPU(devices []string) *Container {
@@ -5285,7 +5285,7 @@ func (r *Client) DefaultPlatform(ctx context.Context) (Platform, error) {
 
 // DirectoryOpts contains options for Client.Directory
 type DirectoryOpts struct {
-	// DEPRECATED: Use `loadDirectoryFromID` isntead.
+	// DEPRECATED: Use `loadDirectoryFromID` instead.
 	ID DirectoryID
 }
 

--- a/docs/current_docs/guides/snippets/create-app-ci-module/build/go/dagger.gen.go
+++ b/docs/current_docs/guides/snippets/create-app-ci-module/build/go/dagger.gen.go
@@ -587,7 +587,7 @@ func (r *Container) ExperimentalWithAllGPUs() *Container {
 
 // EXPERIMENTAL API! Subject to change/removal at any time.
 //
-// Configures the provided list of devices to be accesible to this container.
+// Configures the provided list of devices to be accessible to this container.
 //
 // This currently works for Nvidia devices only.
 func (r *Container) ExperimentalWithGPU(devices []string) *Container {
@@ -5285,7 +5285,7 @@ func (r *Client) DefaultPlatform(ctx context.Context) (Platform, error) {
 
 // DirectoryOpts contains options for Client.Directory
 type DirectoryOpts struct {
-	// DEPRECATED: Use `loadDirectoryFromID` isntead.
+	// DEPRECATED: Use `loadDirectoryFromID` instead.
 	ID DirectoryID
 }
 

--- a/docs/current_docs/guides/snippets/create-app-ci-module/publish/go/dagger.gen.go
+++ b/docs/current_docs/guides/snippets/create-app-ci-module/publish/go/dagger.gen.go
@@ -587,7 +587,7 @@ func (r *Container) ExperimentalWithAllGPUs() *Container {
 
 // EXPERIMENTAL API! Subject to change/removal at any time.
 //
-// Configures the provided list of devices to be accesible to this container.
+// Configures the provided list of devices to be accessible to this container.
 //
 // This currently works for Nvidia devices only.
 func (r *Container) ExperimentalWithGPU(devices []string) *Container {
@@ -5285,7 +5285,7 @@ func (r *Client) DefaultPlatform(ctx context.Context) (Platform, error) {
 
 // DirectoryOpts contains options for Client.Directory
 type DirectoryOpts struct {
-	// DEPRECATED: Use `loadDirectoryFromID` isntead.
+	// DEPRECATED: Use `loadDirectoryFromID` instead.
 	ID DirectoryID
 }
 

--- a/docs/current_docs/guides/snippets/create-app-ci-module/serve/go/dagger.gen.go
+++ b/docs/current_docs/guides/snippets/create-app-ci-module/serve/go/dagger.gen.go
@@ -587,7 +587,7 @@ func (r *Container) ExperimentalWithAllGPUs() *Container {
 
 // EXPERIMENTAL API! Subject to change/removal at any time.
 //
-// Configures the provided list of devices to be accesible to this container.
+// Configures the provided list of devices to be accessible to this container.
 //
 // This currently works for Nvidia devices only.
 func (r *Container) ExperimentalWithGPU(devices []string) *Container {
@@ -5285,7 +5285,7 @@ func (r *Client) DefaultPlatform(ctx context.Context) (Platform, error) {
 
 // DirectoryOpts contains options for Client.Directory
 type DirectoryOpts struct {
-	// DEPRECATED: Use `loadDirectoryFromID` isntead.
+	// DEPRECATED: Use `loadDirectoryFromID` instead.
 	ID DirectoryID
 }
 

--- a/docs/current_docs/guides/snippets/create-app-ci-module/test/go/dagger.gen.go
+++ b/docs/current_docs/guides/snippets/create-app-ci-module/test/go/dagger.gen.go
@@ -587,7 +587,7 @@ func (r *Container) ExperimentalWithAllGPUs() *Container {
 
 // EXPERIMENTAL API! Subject to change/removal at any time.
 //
-// Configures the provided list of devices to be accesible to this container.
+// Configures the provided list of devices to be accessible to this container.
 //
 // This currently works for Nvidia devices only.
 func (r *Container) ExperimentalWithGPU(devices []string) *Container {
@@ -5285,7 +5285,7 @@ func (r *Client) DefaultPlatform(ctx context.Context) (Platform, error) {
 
 // DirectoryOpts contains options for Client.Directory
 type DirectoryOpts struct {
-	// DEPRECATED: Use `loadDirectoryFromID` isntead.
+	// DEPRECATED: Use `loadDirectoryFromID` instead.
 	ID DirectoryID
 }
 

--- a/docs/current_docs/guides/snippets/github-google-cloud/go/dagger.gen.go
+++ b/docs/current_docs/guides/snippets/github-google-cloud/go/dagger.gen.go
@@ -584,7 +584,7 @@ func (r *Container) ExperimentalWithAllGPUs() *Container {
 
 // EXPERIMENTAL API! Subject to change/removal at any time.
 //
-// Configures the provided list of devices to be accesible to this container.
+// Configures the provided list of devices to be accessible to this container.
 //
 // This currently works for Nvidia devices only.
 func (r *Container) ExperimentalWithGPU(devices []string) *Container {
@@ -5031,7 +5031,7 @@ func (r *Client) DefaultPlatform(ctx context.Context) (Platform, error) {
 
 // DirectoryOpts contains options for Client.Directory
 type DirectoryOpts struct {
-	// DEPRECATED: Use `loadDirectoryFromID` isntead.
+	// DEPRECATED: Use `loadDirectoryFromID` instead.
 	ID DirectoryID
 }
 

--- a/docs/current_docs/manuals/developer/go/882081-module-structure.mdx
+++ b/docs/current_docs/manuals/developer/go/882081-module-structure.mdx
@@ -13,7 +13,7 @@ It's essential to understand a few key concepts about Dagger Modules created for
 
 ## Runtime container with Go 1.21
 
-Dagger Modules run in a runtime container that's bootstrapped by the Dagger Engine, with the neccessary environment to run the Dagger Module's code. It's currently hardcoded to run in Go 1.21  (although this may be configurable in future).
+Dagger Modules run in a runtime container that's bootstrapped by the Dagger Engine, with the necessary environment to run the Dagger Module's code. It's currently hardcoded to run in Go 1.21  (although this may be configurable in future).
 
 ## Go modules
 

--- a/docs/current_docs/manuals/developer/go/snippets/custom-types/internal/dagger/dagger.gen.go
+++ b/docs/current_docs/manuals/developer/go/snippets/custom-types/internal/dagger/dagger.gen.go
@@ -517,7 +517,7 @@ func (r *Container) ExperimentalWithAllGPUs() *Container {
 
 // EXPERIMENTAL API! Subject to change/removal at any time.
 //
-// Configures the provided list of devices to be accesible to this container.
+// Configures the provided list of devices to be accessible to this container.
 //
 // This currently works for Nvidia devices only.
 func (r *Container) ExperimentalWithGPU(devices []string) *Container {
@@ -5257,7 +5257,7 @@ func (r *Client) DefaultPlatform(ctx context.Context) (Platform, error) {
 
 // DirectoryOpts contains options for Client.Directory
 type DirectoryOpts struct {
-	// DEPRECATED: Use `loadDirectoryFromID` isntead.
+	// DEPRECATED: Use `loadDirectoryFromID` instead.
 	ID DirectoryID
 }
 

--- a/docs/current_docs/manuals/developer/go/snippets/documentation/module/internal/dagger/dagger.gen.go
+++ b/docs/current_docs/manuals/developer/go/snippets/documentation/module/internal/dagger/dagger.gen.go
@@ -517,7 +517,7 @@ func (r *Container) ExperimentalWithAllGPUs() *Container {
 
 // EXPERIMENTAL API! Subject to change/removal at any time.
 //
-// Configures the provided list of devices to be accesible to this container.
+// Configures the provided list of devices to be accessible to this container.
 //
 // This currently works for Nvidia devices only.
 func (r *Container) ExperimentalWithGPU(devices []string) *Container {
@@ -5257,7 +5257,7 @@ func (r *Client) DefaultPlatform(ctx context.Context) (Platform, error) {
 
 // DirectoryOpts contains options for Client.Directory
 type DirectoryOpts struct {
-	// DEPRECATED: Use `loadDirectoryFromID` isntead.
+	// DEPRECATED: Use `loadDirectoryFromID` instead.
 	ID DirectoryID
 }
 

--- a/docs/current_docs/manuals/developer/go/snippets/first-module/trivy/internal/dagger/dagger.gen.go
+++ b/docs/current_docs/manuals/developer/go/snippets/first-module/trivy/internal/dagger/dagger.gen.go
@@ -517,7 +517,7 @@ func (r *Container) ExperimentalWithAllGPUs() *Container {
 
 // EXPERIMENTAL API! Subject to change/removal at any time.
 //
-// Configures the provided list of devices to be accesible to this container.
+// Configures the provided list of devices to be accessible to this container.
 //
 // This currently works for Nvidia devices only.
 func (r *Container) ExperimentalWithGPU(devices []string) *Container {
@@ -5257,7 +5257,7 @@ func (r *Client) DefaultPlatform(ctx context.Context) (Platform, error) {
 
 // DirectoryOpts contains options for Client.Directory
 type DirectoryOpts struct {
-	// DEPRECATED: Use `loadDirectoryFromID` isntead.
+	// DEPRECATED: Use `loadDirectoryFromID` instead.
 	ID DirectoryID
 }
 

--- a/docs/current_docs/manuals/developer/go/snippets/functions/arguments-directory/internal/dagger/dagger.gen.go
+++ b/docs/current_docs/manuals/developer/go/snippets/functions/arguments-directory/internal/dagger/dagger.gen.go
@@ -517,7 +517,7 @@ func (r *Container) ExperimentalWithAllGPUs() *Container {
 
 // EXPERIMENTAL API! Subject to change/removal at any time.
 //
-// Configures the provided list of devices to be accesible to this container.
+// Configures the provided list of devices to be accessible to this container.
 //
 // This currently works for Nvidia devices only.
 func (r *Container) ExperimentalWithGPU(devices []string) *Container {
@@ -5257,7 +5257,7 @@ func (r *Client) DefaultPlatform(ctx context.Context) (Platform, error) {
 
 // DirectoryOpts contains options for Client.Directory
 type DirectoryOpts struct {
-	// DEPRECATED: Use `loadDirectoryFromID` isntead.
+	// DEPRECATED: Use `loadDirectoryFromID` instead.
 	ID DirectoryID
 }
 

--- a/docs/current_docs/manuals/developer/go/snippets/functions/arguments-string/internal/dagger/dagger.gen.go
+++ b/docs/current_docs/manuals/developer/go/snippets/functions/arguments-string/internal/dagger/dagger.gen.go
@@ -517,7 +517,7 @@ func (r *Container) ExperimentalWithAllGPUs() *Container {
 
 // EXPERIMENTAL API! Subject to change/removal at any time.
 //
-// Configures the provided list of devices to be accesible to this container.
+// Configures the provided list of devices to be accessible to this container.
 //
 // This currently works for Nvidia devices only.
 func (r *Container) ExperimentalWithGPU(devices []string) *Container {
@@ -5257,7 +5257,7 @@ func (r *Client) DefaultPlatform(ctx context.Context) (Platform, error) {
 
 // DirectoryOpts contains options for Client.Directory
 type DirectoryOpts struct {
-	// DEPRECATED: Use `loadDirectoryFromID` isntead.
+	// DEPRECATED: Use `loadDirectoryFromID` instead.
 	ID DirectoryID
 }
 

--- a/docs/current_docs/manuals/developer/go/snippets/functions/functions-complex/internal/dagger/dagger.gen.go
+++ b/docs/current_docs/manuals/developer/go/snippets/functions/functions-complex/internal/dagger/dagger.gen.go
@@ -517,7 +517,7 @@ func (r *Container) ExperimentalWithAllGPUs() *Container {
 
 // EXPERIMENTAL API! Subject to change/removal at any time.
 //
-// Configures the provided list of devices to be accesible to this container.
+// Configures the provided list of devices to be accessible to this container.
 //
 // This currently works for Nvidia devices only.
 func (r *Container) ExperimentalWithGPU(devices []string) *Container {
@@ -5257,7 +5257,7 @@ func (r *Client) DefaultPlatform(ctx context.Context) (Platform, error) {
 
 // DirectoryOpts contains options for Client.Directory
 type DirectoryOpts struct {
-	// DEPRECATED: Use `loadDirectoryFromID` isntead.
+	// DEPRECATED: Use `loadDirectoryFromID` instead.
 	ID DirectoryID
 }
 

--- a/docs/current_docs/manuals/developer/go/snippets/functions/return-values-container/internal/dagger/dagger.gen.go
+++ b/docs/current_docs/manuals/developer/go/snippets/functions/return-values-container/internal/dagger/dagger.gen.go
@@ -517,7 +517,7 @@ func (r *Container) ExperimentalWithAllGPUs() *Container {
 
 // EXPERIMENTAL API! Subject to change/removal at any time.
 //
-// Configures the provided list of devices to be accesible to this container.
+// Configures the provided list of devices to be accessible to this container.
 //
 // This currently works for Nvidia devices only.
 func (r *Container) ExperimentalWithGPU(devices []string) *Container {
@@ -5257,7 +5257,7 @@ func (r *Client) DefaultPlatform(ctx context.Context) (Platform, error) {
 
 // DirectoryOpts contains options for Client.Directory
 type DirectoryOpts struct {
-	// DEPRECATED: Use `loadDirectoryFromID` isntead.
+	// DEPRECATED: Use `loadDirectoryFromID` instead.
 	ID DirectoryID
 }
 

--- a/docs/current_docs/manuals/developer/go/snippets/interfaces/internal/dagger/dagger.gen.go
+++ b/docs/current_docs/manuals/developer/go/snippets/interfaces/internal/dagger/dagger.gen.go
@@ -517,7 +517,7 @@ func (r *Container) ExperimentalWithAllGPUs() *Container {
 
 // EXPERIMENTAL API! Subject to change/removal at any time.
 //
-// Configures the provided list of devices to be accesible to this container.
+// Configures the provided list of devices to be accessible to this container.
 //
 // This currently works for Nvidia devices only.
 func (r *Container) ExperimentalWithGPU(devices []string) *Container {
@@ -5257,7 +5257,7 @@ func (r *Client) DefaultPlatform(ctx context.Context) (Platform, error) {
 
 // DirectoryOpts contains options for Client.Directory
 type DirectoryOpts struct {
-	// DEPRECATED: Use `loadDirectoryFromID` isntead.
+	// DEPRECATED: Use `loadDirectoryFromID` instead.
 	ID DirectoryID
 }
 

--- a/docs/current_docs/manuals/developer/go/snippets/secrets/internal/dagger/dagger.gen.go
+++ b/docs/current_docs/manuals/developer/go/snippets/secrets/internal/dagger/dagger.gen.go
@@ -517,7 +517,7 @@ func (r *Container) ExperimentalWithAllGPUs() *Container {
 
 // EXPERIMENTAL API! Subject to change/removal at any time.
 //
-// Configures the provided list of devices to be accesible to this container.
+// Configures the provided list of devices to be accessible to this container.
 //
 // This currently works for Nvidia devices only.
 func (r *Container) ExperimentalWithGPU(devices []string) *Container {
@@ -5257,7 +5257,7 @@ func (r *Client) DefaultPlatform(ctx context.Context) (Platform, error) {
 
 // DirectoryOpts contains options for Client.Directory
 type DirectoryOpts struct {
-	// DEPRECATED: Use `loadDirectoryFromID` isntead.
+	// DEPRECATED: Use `loadDirectoryFromID` instead.
 	ID DirectoryID
 }
 

--- a/docs/current_docs/manuals/developer/python/820256-module-structure.mdx
+++ b/docs/current_docs/manuals/developer/python/820256-module-structure.mdx
@@ -92,7 +92,7 @@ packages = [{ include = "main.py", from = "src" }]
 
 ## Default project layout
 
-The default template from `dagger init` creates a `main.py` file inside a `src` directory. This follows a [Python convention](https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/) that requires a project to be installed in order to run its code, which prevents accidental usage of development code since the Python interpreter includes the current working directory as the first item on the import path (more information is available in this [blog post on Python pakaging](https://blog.ionelmc.ro/2014/05/25/python-packaging/)).
+The default template from `dagger init` creates a `main.py` file inside a `src` directory. This follows a [Python convention](https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/) that requires a project to be installed in order to run its code, which prevents accidental usage of development code since the Python interpreter includes the current working directory as the first item on the import path (more information is available in this [blog post on Python packaging](https://blog.ionelmc.ro/2014/05/25/python-packaging/)).
 
 Tools like [build](https://build.pypa.io/en/latest/) (default), [Hatch](https://hatch.pypa.io/latest/), and [Poetry](https://python-poetry.org/docs/) already detect this project layout by default, but it's not required and can be overridden as long as `main` is installed correctly in `site-packages`, or is at least importable with `import main`.
 

--- a/docs/current_docs/manuals/developer/python/924959-debugging.mdx
+++ b/docs/current_docs/manuals/developer/python/924959-debugging.mdx
@@ -16,7 +16,7 @@ The Dagger CLI tries to keep its output concise by default. If you're running
 into issues and want to debug with more detailed output, you can run any `dagger`
 subcommand with the `--debug` flag to have it reveal all available information.
 
-## Enable Pyton debug logs
+## Enable Python debug logs
 
 The Python SDK prints debugging information at various steps of the execution
 flow of a module, which can be very useful in understanding what's being

--- a/docs/current_docs/manuals/developer/python/snippets/constructor/async/main.py
+++ b/docs/current_docs/manuals/developer/python/snippets/constructor/async/main.py
@@ -8,22 +8,22 @@ from dagger import Doc, dag, function, object_type
 class MyModule:
     """Functions for testing a project"""
 
-    paralelize: int
+    parallelize: int
 
     @classmethod
     async def create(
         cls,
-        paralelize: Annotated[
+        parallelize: Annotated[
             int | None, Doc("Number of parallel processes to run")
         ] = None,
     ):
-        if paralelize is None:
-            paralelize = int(
+        if parallelize is None:
+            parallelize = int(
                 await dag.container().from_("alpine").with_exec(["nproc"]).stdout()
             )
-        return cls(paralelize=paralelize)
+        return cls(parallelize=parallelize)
 
     @function
     def debug(self) -> str:
         """Check the number of parallel processes"""
-        return f"Number of parallel processes: {self.paralelize}"
+        return f"Number of parallel processes: {self.parallelize}"

--- a/docs/current_docs/manuals/developer/python/snippets/constructor/initvar/main.py
+++ b/docs/current_docs/manuals/developer/python/snippets/constructor/initvar/main.py
@@ -1,4 +1,4 @@
-"""An example module controling contructor parameters."""
+"""An example module controlling constructor parameters."""
 import dataclasses
 
 import dagger

--- a/docs/current_docs/reference/979596-cli.mdx
+++ b/docs/current_docs/reference/979596-cli.mdx
@@ -392,7 +392,7 @@ Run a command in a Dagger session
 Executes the specified command in a Dagger Session and displays
 live progress in a TUI.
 
-`DAGGER_SESSION_PORT` and `DAGGER_SESSION_TOKEN` will be convieniently
+`DAGGER_SESSION_PORT` and `DAGGER_SESSION_TOKEN` will be conveniently
 injected automatically.
 
 For example:

--- a/docs/docs-graphql/custom-theme/stylesheets/custom.scss
+++ b/docs/docs-graphql/custom-theme/stylesheets/custom.scss
@@ -1,6 +1,6 @@
 // The default theme will put nothing in here, but it will be imported in
 // "main.scss", allowing users to specify it in their custom theme to adjust the
-// deafult theme without losing updates to the "core" SCSS.
+// default theme without losing updates to the "core" SCSS.
 
 // You can override variables and styles in your custom.scss file. All support
 // variables are shown below.

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -152,7 +152,7 @@ type Container {
   """
   EXPERIMENTAL API! Subject to change/removal at any time.
   
-  Configures the provided list of devices to be accesible to this container.
+  Configures the provided list of devices to be accessible to this container.
   
   This currently works for Nvidia devices only.
   """
@@ -2136,7 +2136,7 @@ type Query {
 
   """Creates an empty directory."""
   directory(
-    """DEPRECATED: Use `loadDirectoryFromID` isntead."""
+    """DEPRECATED: Use `loadDirectoryFromID` instead."""
     id: DirectoryID
   ): Directory!
   file(id: FileID!): File! @deprecated(reason: "Use `loadFileFromID` instead.")

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -659,7 +659,7 @@
                         <td>
                           <span class="property-name"><code>id</code></span> - <span class="property-type"><a href="#definition-DirectoryID"><code>DirectoryID</code></a></span>
                         </td>
-                        <td> DEPRECATED: Use <code>loadDirectoryFromID</code> isntead. </td>
+                        <td> DEPRECATED: Use <code>loadDirectoryFromID</code> instead. </td>
                       </tr>
                     </tbody>
                   </table>
@@ -3485,7 +3485,7 @@
                         <td data-property-name=""><a class="property-name" id="Container-experimentalWithGPU" href="#Container-experimentalWithGPU"><code>experimentalWithGPU</code></a> - <span class="property-type"><a href="#definition-Container"><code>Container!</code></a></span> </td>
                         <td>
                           <p>EXPERIMENTAL API! Subject to change/removal at any time.</p>
-                          <p>Configures the provided list of devices to be accesible to this container.</p>
+                          <p>Configures the provided list of devices to be accessible to this container.</p>
                           <p>This currently works for Nvidia devices only.</p>
                         </td>
                       </tr>

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -47,7 +47,7 @@ type ClientMetadata struct {
 	RegisterClient bool `json:"register_client"`
 
 	// ClientHostname is the hostname of the client that made the request. It's
-	// used opportunisticly as a best-effort, semi-stable identifier for the
+	// used opportunistically as a best-effort, semi-stable identifier for the
 	// client across multiple sessions, which can be useful for debugging and for
 	// minimizing occurrences of both excessive cache misses and excessive cache
 	// matches.

--- a/hack/README.md
+++ b/hack/README.md
@@ -14,7 +14,7 @@ _Example:_ `./hack/make engine:test`
 
 _Example:_ `./hack/dev bash`
 
-`dev` will first boostrap an engine from local code and then execute whatever command you specify with environment variables set so that dagger SDKs will connect to the dev engine.
+`dev` will first bootstrap an engine from local code and then execute whatever command you specify with environment variables set so that dagger SDKs will connect to the dev engine.
 
 # Examples
 

--- a/sdk/elixir/lib/dagger/gen/client.ex
+++ b/sdk/elixir/lib/dagger/gen/client.ex
@@ -128,7 +128,7 @@ defmodule Dagger.Client do
   )
 
   (
-    @doc "Creates an empty directory.\n\n\n\n## Optional Arguments\n\n* `id` - DEPRECATED: Use `loadDirectoryFromID` isntead."
+    @doc "Creates an empty directory.\n\n\n\n## Optional Arguments\n\n* `id` - DEPRECATED: Use `loadDirectoryFromID` instead."
     @spec directory(t(), keyword()) :: Dagger.Directory.t()
     def directory(%__MODULE__{} = query, optional_args \\ []) do
       selection = select(query.selection, "directory")

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -172,7 +172,7 @@ defmodule Dagger.Container do
   )
 
   (
-    @doc "EXPERIMENTAL API! Subject to change/removal at any time.\n\nConfigures the provided list of devices to be accesible to this container.\n\nThis currently works for Nvidia devices only.\n\n## Required Arguments\n\n* `devices` - List of devices to be accessible to this container."
+    @doc "EXPERIMENTAL API! Subject to change/removal at any time.\n\nConfigures the provided list of devices to be accessible to this container.\n\nThis currently works for Nvidia devices only.\n\n## Required Arguments\n\n* `devices` - List of devices to be accessible to this container."
     @spec experimental_with_gpu(t(), [Dagger.String.t()]) :: Dagger.Container.t()
     def experimental_with_gpu(%__MODULE__{} = container, devices) do
       selection = select(container.selection, "experimentalWithGPU")

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -513,7 +513,7 @@ func (r *Container) ExperimentalWithAllGPUs() *Container {
 
 // EXPERIMENTAL API! Subject to change/removal at any time.
 //
-// Configures the provided list of devices to be accesible to this container.
+// Configures the provided list of devices to be accessible to this container.
 //
 // This currently works for Nvidia devices only.
 func (r *Container) ExperimentalWithGPU(devices []string) *Container {
@@ -5412,7 +5412,7 @@ func (r *Client) DefaultPlatform(ctx context.Context) (Platform, error) {
 
 // DirectoryOpts contains options for Client.Directory
 type DirectoryOpts struct {
-	// DEPRECATED: Use `loadDirectoryFromID` isntead.
+	// DEPRECATED: Use `loadDirectoryFromID` instead.
 	ID DirectoryID
 }
 

--- a/sdk/java/dagger-codegen-maven-plugin/src/main/resources/schemas/schema-0.9.3.json
+++ b/sdk/java/dagger-codegen-maven-plugin/src/main/resources/schemas/schema-0.9.3.json
@@ -527,7 +527,7 @@
                             }
                         ],
                         "deprecationReason": null,
-                        "description": "EXPERIMENTAL API! Subject to change/removal at any time.\n\nexperimentalWithGPU configures the provided list of devices to be accessible to this container.\nThis currently works for Nvidia devices only.",
+                        "description": "EXPERIMENTAL API! Subject to change/removal at any time.\n\nexperimentalWithGPU configures the provided list of devices to be accesible to this container.\nThis currently works for Nvidia devices only.",
                         "isDeprecated": false,
                         "name": "experimentalWithGPU",
                         "type": {

--- a/sdk/java/dagger-codegen-maven-plugin/src/main/resources/schemas/schema-0.9.3.json
+++ b/sdk/java/dagger-codegen-maven-plugin/src/main/resources/schemas/schema-0.9.3.json
@@ -527,7 +527,7 @@
                             }
                         ],
                         "deprecationReason": null,
-                        "description": "EXPERIMENTAL API! Subject to change/removal at any time.\n\nexperimentalWithGPU configures the provided list of devices to be accesible to this container.\nThis currently works for Nvidia devices only.",
+                        "description": "EXPERIMENTAL API! Subject to change/removal at any time.\n\nexperimentalWithGPU configures the provided list of devices to be accessible to this container.\nThis currently works for Nvidia devices only.",
                         "isDeprecated": false,
                         "name": "experimentalWithGPU",
                         "type": {

--- a/sdk/java/dagger-codegen-maven-plugin/src/main/resources/schemas/schema-0.9.4.json
+++ b/sdk/java/dagger-codegen-maven-plugin/src/main/resources/schemas/schema-0.9.4.json
@@ -527,7 +527,7 @@
                             }
                         ],
                         "deprecationReason": null,
-                        "description": "EXPERIMENTAL API! Subject to change/removal at any time.\n\nexperimentalWithGPU configures the provided list of devices to be accessible to this container.\nThis currently works for Nvidia devices only.",
+                        "description": "EXPERIMENTAL API! Subject to change/removal at any time.\n\nexperimentalWithGPU configures the provided list of devices to be accesible to this container.\nThis currently works for Nvidia devices only.",
                         "isDeprecated": false,
                         "name": "experimentalWithGPU",
                         "type": {

--- a/sdk/java/dagger-codegen-maven-plugin/src/main/resources/schemas/schema-0.9.4.json
+++ b/sdk/java/dagger-codegen-maven-plugin/src/main/resources/schemas/schema-0.9.4.json
@@ -527,7 +527,7 @@
                             }
                         ],
                         "deprecationReason": null,
-                        "description": "EXPERIMENTAL API! Subject to change/removal at any time.\n\nexperimentalWithGPU configures the provided list of devices to be accesible to this container.\nThis currently works for Nvidia devices only.",
+                        "description": "EXPERIMENTAL API! Subject to change/removal at any time.\n\nexperimentalWithGPU configures the provided list of devices to be accessible to this container.\nThis currently works for Nvidia devices only.",
                         "isDeprecated": false,
                         "name": "experimentalWithGPU",
                         "type": {

--- a/sdk/java/dagger-codegen-maven-plugin/src/main/resources/schemas/schema-0.9.5.json
+++ b/sdk/java/dagger-codegen-maven-plugin/src/main/resources/schemas/schema-0.9.5.json
@@ -527,7 +527,7 @@
                             }
                         ],
                         "deprecationReason": null,
-                        "description": "EXPERIMENTAL API! Subject to change/removal at any time.\n\nexperimentalWithGPU configures the provided list of devices to be accessible to this container.\nThis currently works for Nvidia devices only.",
+                        "description": "EXPERIMENTAL API! Subject to change/removal at any time.\n\nexperimentalWithGPU configures the provided list of devices to be accesible to this container.\nThis currently works for Nvidia devices only.",
                         "isDeprecated": false,
                         "name": "experimentalWithGPU",
                         "type": {

--- a/sdk/java/dagger-codegen-maven-plugin/src/main/resources/schemas/schema-0.9.5.json
+++ b/sdk/java/dagger-codegen-maven-plugin/src/main/resources/schemas/schema-0.9.5.json
@@ -527,7 +527,7 @@
                             }
                         ],
                         "deprecationReason": null,
-                        "description": "EXPERIMENTAL API! Subject to change/removal at any time.\n\nexperimentalWithGPU configures the provided list of devices to be accesible to this container.\nThis currently works for Nvidia devices only.",
+                        "description": "EXPERIMENTAL API! Subject to change/removal at any time.\n\nexperimentalWithGPU configures the provided list of devices to be accessible to this container.\nThis currently works for Nvidia devices only.",
                         "isDeprecated": false,
                         "name": "experimentalWithGPU",
                         "type": {

--- a/sdk/java/dagger-codegen-maven-plugin/src/main/resources/schemas/schema-4b825dc642cb6eb9a060e54bf8d69288fbee4904.json
+++ b/sdk/java/dagger-codegen-maven-plugin/src/main/resources/schemas/schema-4b825dc642cb6eb9a060e54bf8d69288fbee4904.json
@@ -514,7 +514,7 @@
                             }
                         ],
                         "deprecationReason": null,
-                        "description": "EXPERIMENTAL API! Subject to change/removal at any time.\n\nConfigures the provided list of devices to be accessible to this container.\n\nThis currently works for Nvidia devices only.",
+                        "description": "EXPERIMENTAL API! Subject to change/removal at any time.\n\nConfigures the provided list of devices to be accesible to this container.\n\nThis currently works for Nvidia devices only.",
                         "isDeprecated": false,
                         "name": "experimentalWithGPU",
                         "type": {
@@ -7453,7 +7453,7 @@
                         "args": [
                             {
                                 "defaultValue": null,
-                                "description": "DEPRECATED: Use `loadDirectoryFromID` instead.",
+                                "description": "DEPRECATED: Use `loadDirectoryFromID` isntead.",
                                 "name": "id",
                                 "type": {
                                     "kind": "SCALAR",

--- a/sdk/java/dagger-codegen-maven-plugin/src/main/resources/schemas/schema-4b825dc642cb6eb9a060e54bf8d69288fbee4904.json
+++ b/sdk/java/dagger-codegen-maven-plugin/src/main/resources/schemas/schema-4b825dc642cb6eb9a060e54bf8d69288fbee4904.json
@@ -514,7 +514,7 @@
                             }
                         ],
                         "deprecationReason": null,
-                        "description": "EXPERIMENTAL API! Subject to change/removal at any time.\n\nConfigures the provided list of devices to be accesible to this container.\n\nThis currently works for Nvidia devices only.",
+                        "description": "EXPERIMENTAL API! Subject to change/removal at any time.\n\nConfigures the provided list of devices to be accessible to this container.\n\nThis currently works for Nvidia devices only.",
                         "isDeprecated": false,
                         "name": "experimentalWithGPU",
                         "type": {
@@ -7453,7 +7453,7 @@
                         "args": [
                             {
                                 "defaultValue": null,
-                                "description": "DEPRECATED: Use `loadDirectoryFromID` isntead.",
+                                "description": "DEPRECATED: Use `loadDirectoryFromID` instead.",
                                 "name": "id",
                                 "type": {
                                     "kind": "SCALAR",

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -139,7 +139,7 @@ class Container extends Client\AbstractObject implements Client\IdAble
     /**
      * EXPERIMENTAL API! Subject to change/removal at any time.
      *
-     * Configures the provided list of devices to be accesible to this container.
+     * Configures the provided list of devices to be accessible to this container.
      *
      * This currently works for Nvidia devices only.
      */

--- a/sdk/python/src/dagger/_config.py
+++ b/sdk/python/src/dagger/_config.py
@@ -70,7 +70,7 @@ class Config(ConnectConfig):
     console: Console = field(init=False)
 
     def __post_init__(self):
-        # Backwards compability for (expected) use of `timeout` config.
+        # Backwards compatibility for (expected) use of `timeout` config.
         if self.timeout and not isinstance(self.timeout, Timeout):
             # TODO: deprecation warning: Use
             # self.timeout hasn't worked! (unused)
@@ -85,7 +85,7 @@ class Config(ConnectConfig):
 
             self.timeout = Timeout(None, connect=timeout)
 
-        # Backwards compability for `execute_timeout` config.
+        # Backwards compatibility for `execute_timeout` config.
         if self.execute_timeout is not UNSET:
             # TODO: deprecation warning: Use `timeout` instead.
             timeout = self.execute_timeout

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -559,7 +559,7 @@ class Container(Type):
     def experimental_with_gpu(self, devices: Sequence[str]) -> "Container":
         """EXPERIMENTAL API! Subject to change/removal at any time.
 
-        Configures the provided list of devices to be accesible to this
+        Configures the provided list of devices to be accessible to this
         container.
 
         This currently works for Nvidia devices only.
@@ -5682,7 +5682,7 @@ class Client(Root):
         Parameters
         ----------
         id:
-            DEPRECATED: Use `loadDirectoryFromID` isntead.
+            DEPRECATED: Use `loadDirectoryFromID` instead.
         """
         _args = [
             Arg("id", id, None),

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -1051,7 +1051,7 @@ impl Container {
         };
     }
     /// EXPERIMENTAL API! Subject to change/removal at any time.
-    /// Configures the provided list of devices to be accesible to this container.
+    /// Configures the provided list of devices to be accessible to this container.
     /// This currently works for Nvidia devices only.
     ///
     /// # Arguments
@@ -4776,7 +4776,7 @@ pub struct QueryContainerOpts {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct QueryDirectoryOpts {
-    /// DEPRECATED: Use `loadDirectoryFromID` isntead.
+    /// DEPRECATED: Use `loadDirectoryFromID` instead.
     #[builder(setter(into, strip_option), default)]
     pub id: Option<DirectoryId>,
 }

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -878,7 +878,7 @@ export type ClientContainerOpts = {
 
 export type ClientDirectoryOpts = {
   /**
-   * DEPRECATED: Use `loadDirectoryFromID` isntead.
+   * DEPRECATED: Use `loadDirectoryFromID` instead.
    */
   id?: DirectoryID
 }
@@ -1402,7 +1402,7 @@ export class Container extends BaseClient {
   /**
    * EXPERIMENTAL API! Subject to change/removal at any time.
    *
-   * Configures the provided list of devices to be accesible to this container.
+   * Configures the provided list of devices to be accessible to this container.
    *
    * This currently works for Nvidia devices only.
    * @param devices List of devices to be accessible to this container.
@@ -7010,7 +7010,7 @@ export class Client extends BaseClient {
 
   /**
    * Creates an empty directory.
-   * @param opts.id DEPRECATED: Use `loadDirectoryFromID` isntead.
+   * @param opts.id DEPRECATED: Use `loadDirectoryFromID` instead.
    */
   directory = (opts?: ClientDirectoryOpts): Directory => {
     return new Directory({

--- a/sdk/typescript/dev/node/src/index.ts
+++ b/sdk/typescript/dev/node/src/index.ts
@@ -103,7 +103,7 @@ class Node {
   /**
    * Downloads dependencies in the container.
    *
-   * @param pkgs Additonal packages to install in the container.
+   * @param pkgs Additional packages to install in the container.
    */
   @func()
   install(pkgs: string[] = []): Node {

--- a/sdk/typescript/introspector/test/invoke.spec.ts
+++ b/sdk/typescript/introspector/test/invoke.spec.ts
@@ -175,7 +175,7 @@ describe("Invoke typescript function", function () {
     )
   })
 
-  it("Should correctly handle multiple objets as fields", async function () {
+  it("Should correctly handle multiple objects as fields", async function () {
     this.timeout(60000)
 
     const files = await listFiles(`${rootDirectory}/multipleObjectsAsFields`)
@@ -193,7 +193,7 @@ describe("Invoke typescript function", function () {
     }
 
     const constructorResult = await invoke(scanResult, constructorInput)
-    // Verify object instanciation
+    // Verify object instantiation
     assert.notStrictEqual(undefined, constructorResult)
     assert.notStrictEqual(undefined, constructorResult.test)
     assert.notStrictEqual(undefined, constructorResult.lint)


### PR DESCRIPTION
Hello, I found some typos in the documentation and initially wanted to fix just a few of them. I then ran `codespell` on the repo and found a bunch more. Please tell me if some files should not be touched.