### PR TITLE
fix: prevent variable shadow in TestModuleDaggerDevelop

### DIFF
--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -539,7 +539,7 @@ func TestModuleDaggerDevelop(t *testing.T) {
 					})
 
 				// should be able to invoke it directly now
-				out, err = ctr.With(daggerCall("fn")).Stdout(ctx)
+				out, err := ctr.With(daggerCall("fn")).Stdout(ctx)
 				require.NoError(t, err)
 				require.Equal(t, "hi from work hi from dep", strings.TrimSpace(out))
 


### PR DESCRIPTION
Introduced in https://github.com/dagger/dagger/pull/6860, causing some additional test flake.

This manifested as additional flakiness in the test, causing `out` to be written to in a racey way:

	WARNING: DATA RACE
	Write at 0x00c00189a6c0 by goroutine 20341:
	  github.com/dagger/dagger/core/integration.TestModuleDaggerDevelop.func1.1()
	      /app/core/integration/module_config_test.go:542 +0x9bd
	  testing.tRunner()
	      /usr/local/go/src/testing/testing.go:1595 +0x261
	  testing.(*T).Run.func1()
	      /usr/local/go/src/testing/testing.go:1648 +0x44

	Previous write at 0x00c00189a6c0 by goroutine 20342:
	  github.com/dagger/dagger/core/integration.TestModuleDaggerDevelop.func1.1()
	      /app/core/integration/module_config_test.go:542 +0x9bd
	  testing.tRunner()
	      /usr/local/go/src/testing/testing.go:1595 +0x261
	  testing.(*T).Run.func1()
	      /usr/local/go/src/testing/testing.go:1648 +0x44