### PR TITLE
fix: ensure typescript provision tests work

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -135,7 +135,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.21"
-
       - name: "Test Go SDK"
         run: |
           cd sdk/go
@@ -155,7 +154,9 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 18
-
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.0.x
       - name: "Test TypeScript SDK"
         run: |
           cd sdk/typescript
@@ -294,6 +295,9 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 18
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.0.x
       - name: "Test TypeScript SDK"
         run: |
           cd sdk/typescript

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -32,6 +32,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
+    "test": "yarn run test:node && yarn run test:bun",
     "test:bun": "bun run --bun mocha",
     "test:node": "mocha",
     "test:generate-scan": "tsx ./introspector/test/testdata/generate_expected_scan.ts",


### PR DESCRIPTION
After merging https://github.com/dagger/dagger/pull/6615, various provision tests that run on `main` started failing: https://github.com/dagger/dagger/actions/runs/8433279441/job/23094090218.

We should run our bun tests in CI - to do this we need to install bun dependencies in our GitHub provision test workflows.

Additionally, we restore the old `test` script to run both the bun and nodejs tests, so that `yarn test` continues to work.