### PR TITLE
fix: translate elixir codegen http req

### DIFF
--- a/sdk/elixir/lib/dagger/codegen/generator.ex
+++ b/sdk/elixir/lib/dagger/codegen/generator.ex
@@ -4,9 +4,9 @@ defmodule Dagger.Codegen.Generator do
   def generate() do
     {:ok, client} = Dagger.Core.Client.connect()
 
-    {:ok, %{status: 200, body: resp}} =
+    {:ok, %{"data" => data}} =
       Dagger.Core.Client.query(client, Dagger.Codegen.Introspection.query())
 
-    Dagger.Codegen.Compiler.compile(resp["data"])
+    Dagger.Codegen.Compiler.compile(data)
   end
 end


### PR DESCRIPTION
In https://github.com/dagger/dagger/pull/6905, we changed the HTTP client.

However, we also need to update the HTTP client usage for generate - this ensures that `./hack/make sdk:elixir:generate` can now run again.