### PR TITLE
fix(sdk/elixir): fix SDK crash when downloading the dagger binary

### DIFF
--- a/sdk/elixir/mix.exs
+++ b/sdk/elixir/mix.exs
@@ -19,7 +19,7 @@ defmodule Dagger.MixProject do
 
   def application do
     [
-      extra_applications: [:logger, :public_key]
+      extra_applications: [:logger, :public_key, :ssl]
     ]
   end
 


### PR DESCRIPTION
Start `:ssl` application to make it work during download Dagger binary from https site. Tested by remove Dagger binary out of cache directory (`~/.cache/dagger/dagger-<version>`) then run mix test under `sdk/elixir` again.