### PR TITLE
docs: Improves Go builder example in quickstart

### DIFF
--- a/docs/current_docs/quickstart/292472-arguments.mdx
+++ b/docs/current_docs/quickstart/292472-arguments.mdx
@@ -24,7 +24,7 @@ dagger -m github.com/shykes/daggerverse/hello@v0.1.2 call hello --help
 
 You should see output that looks like this:
 
-```shell
+```
 Say hello to the world!
 
 Usage:
@@ -51,7 +51,7 @@ dagger -m github.com/shykes/daggerverse/hello@v0.1.2 call hello --greeting=bonjo
 
 You should see the following output:
 
-```shell
+```
 bonjour, daggernaut!
 ```
 
@@ -70,7 +70,7 @@ dagger -m github.com/shykes/daggerverse/hello@v0.1.2 call hello --greeting=bonjo
 
 You should see the same output as before, but in giant letters!
 
-```shell
+```
  _                  _
 | |__   ___  _ __  (_) ___  _   _ _ __
 | '_ \ / _ \| '_ \ | |/ _ \| | | | '__|
@@ -105,7 +105,7 @@ dagger -m github.com/shykes/daggerverse/hello@v0.1.2 call hello --greeting=bonjo
 
 You should see the image being pulled, then the following output:
 
-```shell
+```
  _                  _
 | |__   ___  _ __  (_) ___  _   _ _ __
 | '_ \ / _ \| '_ \ | |/ _ \| | | | '__|
@@ -128,7 +128,7 @@ dagger -m github.com/shykes/daggerverse/hello@v0.1.2 call hello --giant --greeti
 
 You should see an error telling you that `figlet` could not be found:
 
-```shell
+```
 ...
   ✘ Container.stdout: String! 0.7s
     ✘ exec figlet bonjour, daggernaut! 0.3s
@@ -145,7 +145,7 @@ dagger -m github.com/vikram-dagger/daggerverse/fileutils call tree --dir=.
 
 This example uses a file utility module and calls its `Tree()` function. The `Tree()` function accepts a directory (here, the current working directory) as argument and returns a tree representation of that directory. An abbreviated example of the output is shown below:
 
-```shell
+```
 .
 ├── README.md
 ├── cli
@@ -168,7 +168,7 @@ dagger -m github.com/vikram-dagger/daggerverse/fileutils call tree --dir='https:
 
 You should see the same file listing as [this GitHub page](https://github.com/dagger/dagger/tree/main/cmd/dagger):
 
-```shell
+```
 .
 ├── call.go
 ├── cloud.go

--- a/docs/current_docs/quickstart/562821-hello.mdx
+++ b/docs/current_docs/quickstart/562821-hello.mdx
@@ -23,7 +23,7 @@ dagger -m github.com/shykes/daggerverse/hello@v0.1.2 call hello
 
 Here's what you should see:
 
-```shell
+```
 hello, world!
 ```
 

--- a/docs/current_docs/quickstart/822194-daggerize.mdx
+++ b/docs/current_docs/quickstart/822194-daggerize.mdx
@@ -114,7 +114,7 @@ dagger -m hello functions
 
 You should see a familiar result:
 
-```shell
+```
 Name    Description
 hello   Say hello to the world!
 ```
@@ -127,7 +127,7 @@ dagger -m hello call hello
 
 Again, the output should be familiar:
 
-```shell
+```
 hello, world!
 ```
 
@@ -149,7 +149,7 @@ dagger -m golang call \
 
 Once the container image is built, you should see the address at which it was published, as in the example below:
 
-```shell
+```
 ttl.sh/my-hello-container-20124@sha256:15eb8379e1ab6f6746ccbcbf531aef23882381c29a8d09a8682fafa7b1adf467
 ```
 
@@ -164,7 +164,7 @@ docker run \
 
 You should see the following output:
 
-```shell
+```
 Hello, world!
 ```
 

--- a/docs/current_docs/quickstart/853930-directories.mdx
+++ b/docs/current_docs/quickstart/853930-directories.mdx
@@ -29,7 +29,7 @@ By default, the Go builder Dagger Function builds a binary based on information 
 
 Once the command completes, you should see this output:
 
-```shell
+```
 Directory evaluated. Use "dagger call build --help" to see available sub-commands.
 ```
 
@@ -59,7 +59,7 @@ dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project
 
 The result should look like this:
 
-```shell
+```
 .changes
 .changie.yaml
 .dockerignore
@@ -101,40 +101,25 @@ tracing
 zenith
 ```
 
-This does look like the contents of the Dagger repository after build. Great! Next, export the directory to the local filesystem by chaining a call to the `Export()` function:
+This does look like the contents of the Dagger repository after build. Great!
+
+Next, export the compiled binary to the local filesystem. You can do this by chaining a call to the `File()` function, which returns a specific file (the compiled binary) from the directory, and then using the global `--output` flag to export that file to the host:
 
 ```shell
-dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=https://github.com/dagger/dagger --args=./cmd/dagger export --path=./my-dagger-build
-```
-
-This revised command builds the Go binary and exports the returned directory to the Dagger host. A new `my-dagger-build` directory is created in the current working directory on the Dagger host. This directory contains the contents of the Dagger repository, plus the compiled Go binary.
-
-Validate the compiled binary by executing the following commands on the Dagger host:
-
-```shell
-cd my-dagger-build
-./dagger version
-```
-
-You should see output similar to the following, which confirms that you've just remotely built a development version of the Dagger CLI:
-
-```shell
-dagger (registry.dagger.io/engine) linux/amd64
-```
-
-Instead of exporting the entire directory to the Dagger host, you can export just the compiled binary. This involves chaining calls to two functions: first, call the `File()` function to return a specific file from the directory and then, call the `Export()` function to export that file to the host:
-
-```shell
-dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=https://github.com/dagger/dagger --args=./cmd/dagger file --path=dagger export --path=./my-dagger-cli
+dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=https://github.com/dagger/dagger --args=./cmd/dagger --os=$(uname -s | awk '{print tolower($0)}') file --path=dagger --output=./my-dagger-cli
 ```
 
 Validate the exported binary by calling it:
 
-```shell
+```
 ./my-dagger-cli version
 ```
 
-You should see the same output as before.
+You should see output similar to the following, which confirms that you've just remotely built a development version of the Dagger CLI:
+
+```
+dagger (registry.dagger.io/engine) linux/amd64
+```
 
 :::tip
 As you've seen in the previous examples, Dagger modules can contain one or more functions, each with different arguments and return values. You can list all the functions available in a module with the `dagger functions` command, or append `--help` to any `dagger call` command to see a context-sensitive list of supported arguments and sub-commands. Try it with the Go builder module:

--- a/docs/current_docs/quickstart/853930-directories.mdx
+++ b/docs/current_docs/quickstart/853930-directories.mdx
@@ -65,10 +65,10 @@ dagger
 
 This does look like a compiled binary. Great!
 
-Next, export the directory to the host filesystem. You can do this by using the global `--output` flag to export the directory to a custom path (`./my-dagger-build`) on the host:
+Next, export the directory to the host filesystem. You can do this by using the global `-o` (shorthand for `--output`) flag to export the directory to a custom path (`./my-dagger-build`) on the host:
 
 ```shell
-dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.10 call build --source=https://github.com/dagger/dagger --args=./cmd/dagger --os=$(uname -s | awk '{print tolower($0)}') --output=./my-dagger-build
+dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.10 call build --source=https://github.com/dagger/dagger --args=./cmd/dagger --os=$(uname -s | awk '{print tolower($0)}') -o=./my-dagger-build
 ```
 
 Validate the exported binary by calling it:

--- a/docs/current_docs/quickstart/853930-directories.mdx
+++ b/docs/current_docs/quickstart/853930-directories.mdx
@@ -18,10 +18,10 @@ This opens powerful applications to Dagger Functions. For example, a function th
 Try calling this Go builder Dagger Function, which builds the Dagger CLI:
 
 ```shell
-dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=https://github.com/dagger/dagger --args=./cmd/dagger --os=$(uname -s | awk '{print tolower($0)}')
+dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.10 call build --source=https://github.com/dagger/dagger --args=./cmd/dagger --os=$(uname -s | awk '{print tolower($0)}')
 ```
 
-This function takes a `project` argument of type `Directory`. Similar to how the CLI can pass a `Container` from a remote OCI address, it can also pass a `Directory` from a local path or remote Git address. Here, you're passing the address of Dagger's open-source repository.
+This function takes a `source` argument of type `Directory`. Similar to how the CLI can pass a `Container` from a remote OCI address, it can also pass a `Directory` from a local path or remote Git address. Here, you're passing the address of Dagger's open-source repository.
 
 :::note
 By default, the Go builder Dagger Function builds a binary based on information derived from the runtime container. Since the runtime container uses Linux, this usually means that the compiled binary will be a `linux/amd64` binary. This can be overridden by passing additional `--os` and `--arch` arguments to the Go builder Dagger Function. The previous example uses `uname` to dynamically derive the host operating system type, and passes that to the Dagger Function via the `--os` argument.
@@ -54,65 +54,27 @@ Using this knowledge of function chaining, call the builder function again and c
 Begin by listing the directory's contents:
 
 ```shell
-dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=https://github.com/dagger/dagger --args=./cmd/dagger --os=$(uname -s | awk '{print tolower($0)}') entries
+dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.10 call build --source=https://github.com/dagger/dagger --args=./cmd/dagger --os=$(uname -s | awk '{print tolower($0)}') entries
 ```
 
 The result should look like this:
 
 ```
-.changes
-.changie.yaml
-.dockerignore
-.git
-.github
-.gitignore
-.golangci.yml
-.goreleaser.common.yml
-.goreleaser.nightly.yml
-.goreleaser.yml
-.markdownlint.yaml
-.readthedocs.yaml
-CHANGELOG.md
-CODE_OF_CONDUCT.md
-CONTRIBUTING.md
-LICENSE
-NOTICE
-README.md
-RELEASING.md
-auth
-ci
-cmd
-core
 dagger
-dagql
-docs
-engine
-examples
-go.mod
-go.sum
-hack
-helm
-install.sh
-internal
-network
-sdk
-telemetry
-tracing
-zenith
 ```
 
-This does look like the contents of the Dagger repository after build. Great!
+This does look like the returned directory contains a compiled binary. Great!
 
-Next, export the compiled binary to the local filesystem. You can do this by chaining a call to the `File()` function, which returns a specific file (the compiled Go binary) from the directory, and then using the global `--output` flag to export that file to the host:
+Next, export the directory to the host filesystem. You can do this by using the global `--output` flag to export the directory to a custom path (`./my-dagger-build`) on the host:
 
 ```shell
-dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=https://github.com/dagger/dagger --args=./cmd/dagger --os=$(uname -s | awk '{print tolower($0)}') file --path=dagger --output=./my-dagger-cli
+dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.10 call build --source=https://github.com/dagger/dagger --args=./cmd/dagger --os=$(uname -s | awk '{print tolower($0)}') --output=./my-dagger-build
 ```
 
 Validate the exported binary by calling it:
 
 ```
-./my-dagger-cli version
+./my-dagger-build/dagger version
 ```
 
 You should see output similar to the following, which confirms that you've just remotely built a development version of the Dagger CLI:
@@ -125,7 +87,7 @@ dagger (registry.dagger.io/engine) linux/amd64
 As you've seen in the previous examples, Dagger modules can contain one or more functions, each with different arguments and return values. You can list all the functions available in a module with the `dagger functions` command, or append `--help` to any `dagger call` command to see a context-sensitive list of supported arguments and sub-commands. Try it with the Go builder module:
 
 ```shell
-dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 functions
-dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call --help
+dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.10 functions
+dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.10 call --help
 ```
 :::

--- a/docs/current_docs/quickstart/853930-directories.mdx
+++ b/docs/current_docs/quickstart/853930-directories.mdx
@@ -15,13 +15,17 @@ This opens powerful applications to Dagger Functions. For example, a function th
 
 ### Call a builder function
 
-Try calling this Go builder function:
+Try calling this Go builder Dagger Function, which builds the Dagger CLI:
 
 ```shell
-dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project https://github.com/dagger/dagger --args ./cmd/dagger
+dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=https://github.com/dagger/dagger --args=./cmd/dagger --os=$(uname -s | awk '{print tolower($0)}')
 ```
 
-This function takes a `proj` argument of type `Directory`. Similar to how the CLI can pass a `Container` from a remote OCI address, it can also pass a `Directory` from a local path or remote Git address. Here, you're passing the address of Dagger's open-source repository.
+This function takes a `project` argument of type `Directory`. Similar to how the CLI can pass a `Container` from a remote OCI address, it can also pass a `Directory` from a local path or remote Git address. Here, you're passing the address of Dagger's open-source repository.
+
+:::note
+By default, the Go builder Dagger Function builds a binary based on information derived from the runtime container. Since the runtime container uses Linux, this usually means that the compiled binary will be a `linux/amd64` binary. This can be overridden by passing additional `--os` and `--arch` arguments to the Go builder Dagger Function. The previous example uses `uname` to dynamically derive the host operating system type, and passes that to the Dagger Function via the `--os` argument.
+:::
 
 Once the command completes, you should see this output:
 
@@ -29,7 +33,7 @@ Once the command completes, you should see this output:
 Directory evaluated. Use "dagger call build --help" to see available sub-commands.
 ```
 
-This means that the build succeeded, and the build directory was returned. But how do you use it?
+This means that the build succeeded, and a directory was returned. But how do you use it?
 
 :::tip
 It's important to realize that even though you're building a Go application in this example, you don't need to have Go, Git or any other local dependencies installed on the Dagger host. You only need the Dagger CLI and the ability to run containers. This is a very powerful feature of Dagger, because it allows development teams to create standardized tooling and eliminates all the variables and dependencies related to the host environment and/or configuration.
@@ -43,14 +47,14 @@ Dagger's core types (`Container`, `Directory`, `Service`, `Secret`, ...) are all
 
 When a function returns a core type - for example, a directory - the caller typically continues the chain by calling a function from that directory - for example, export it to the local filesystem, modify it, mount it into a container, etc.
 
-### Export the build directory
+### Export the returned directory
 
 Using this knowledge of function chaining, call the builder function again and continue the chain by interacting with the resulting directory.
 
 Begin by listing the directory's contents:
 
 ```shell
-dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project https://github.com/dagger/dagger --args ./cmd/dagger entries
+dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=https://github.com/dagger/dagger --args=./cmd/dagger --os=$(uname -s | awk '{print tolower($0)}') entries
 ```
 
 The result should look like this:
@@ -97,13 +101,13 @@ tracing
 zenith
 ```
 
-This does look like the contents of the Dagger repository after build. Great! Next, export its contents to the local filesystem:
+This does look like the contents of the Dagger repository after build. Great! Next, export the directory to the local filesystem:
 
 ```shell
-dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project https://github.com/dagger/dagger --args ./cmd/dagger export --path ./my-dagger-build
+dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=https://github.com/dagger/dagger --args=./cmd/dagger export --path=./my-dagger-build
 ```
 
-This revised command builds the Go binary and exports the build output directory to the Dagger host. Once the command completes execution, a new `my-dagger-build` directory is created in the current working directory on the Dagger host. This directory contains the compiled Go binary.
+This revised command builds the Go binary and exports the returned directory to the Dagger host. A new `my-dagger-build` directory is created in the current working directory on the Dagger host. This directory contains the contents of the Dagger repository, plus the compiled Go binary.
 
 Validate the compiled binary by executing the following commands on the Dagger host:
 
@@ -117,6 +121,20 @@ You should see output similar to the following, which confirms that you've just 
 ```shell
 dagger (registry.dagger.io/engine) linux/amd64
 ```
+
+Instead of exporting the entire directory to the Dagger host, you can export just the compiled binary:
+
+```shell
+dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=https://github.com/dagger/dagger --args=./cmd/dagger file --path=dagger export --path=./my-dagger-cli
+```
+
+Validate the exported binary by calling it:
+
+```shell
+./my-dagger-cli version
+```
+
+You should see the same output as before.
 
 :::tip
 As you've seen in the previous examples, Dagger modules can contain one or more functions, each with different arguments and return values. You can list all the functions available in a module with the `dagger functions` command, or append `--help` to any `dagger call` command to see a context-sensitive list of supported arguments and sub-commands. Try it with the Go builder module:

--- a/docs/current_docs/quickstart/853930-directories.mdx
+++ b/docs/current_docs/quickstart/853930-directories.mdx
@@ -63,7 +63,7 @@ The result should look like this:
 dagger
 ```
 
-This does look like the returned directory contains a compiled binary. Great!
+This does look like a compiled binary. Great!
 
 Next, export the directory to the host filesystem. You can do this by using the global `--output` flag to export the directory to a custom path (`./my-dagger-build`) on the host:
 

--- a/docs/current_docs/quickstart/853930-directories.mdx
+++ b/docs/current_docs/quickstart/853930-directories.mdx
@@ -47,7 +47,7 @@ Dagger's core types (`Container`, `Directory`, `Service`, `Secret`, ...) are all
 
 When a function returns a core type - for example, a directory - the caller typically continues the chain by calling a function from that directory - for example, export it to the local filesystem, modify it, mount it into a container, etc.
 
-### Export the returned directory
+### Export the built binary
 
 Using this knowledge of function chaining, call the builder function again and continue the chain by interacting with the resulting directory.
 
@@ -103,7 +103,7 @@ zenith
 
 This does look like the contents of the Dagger repository after build. Great!
 
-Next, export the compiled binary to the local filesystem. You can do this by chaining a call to the `File()` function, which returns a specific file (the compiled binary) from the directory, and then using the global `--output` flag to export that file to the host:
+Next, export the compiled binary to the local filesystem. You can do this by chaining a call to the `File()` function, which returns a specific file (the compiled Go binary) from the directory, and then using the global `--output` flag to export that file to the host:
 
 ```shell
 dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=https://github.com/dagger/dagger --args=./cmd/dagger --os=$(uname -s | awk '{print tolower($0)}') file --path=dagger --output=./my-dagger-cli

--- a/docs/current_docs/quickstart/853930-directories.mdx
+++ b/docs/current_docs/quickstart/853930-directories.mdx
@@ -101,7 +101,7 @@ tracing
 zenith
 ```
 
-This does look like the contents of the Dagger repository after build. Great! Next, export the directory to the local filesystem:
+This does look like the contents of the Dagger repository after build. Great! Next, export the directory to the local filesystem by chaining a call to the `Export()` function:
 
 ```shell
 dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=https://github.com/dagger/dagger --args=./cmd/dagger export --path=./my-dagger-build
@@ -122,7 +122,7 @@ You should see output similar to the following, which confirms that you've just 
 dagger (registry.dagger.io/engine) linux/amd64
 ```
 
-Instead of exporting the entire directory to the Dagger host, you can export just the compiled binary:
+Instead of exporting the entire directory to the Dagger host, you can export just the compiled binary. This involves chaining calls to two functions: first, call the `File()` function to return a specific file from the directory and then, call the `Export()` function to export that file to the host:
 
 ```shell
 dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=https://github.com/dagger/dagger --args=./cmd/dagger file --path=dagger export --path=./my-dagger-cli

--- a/docs/current_docs/quickstart/883939-containers.mdx
+++ b/docs/current_docs/quickstart/883939-containers.mdx
@@ -22,7 +22,7 @@ This Wolfi container builder module exposes a `Container()` function that return
 
 You can use this function to build and return a Wolfi container image containing specific packages - in this example, the `cowsay` package. You should see the container being built and the packages being added, as shown below:
 
-```shell
+```
 Container evaluated. Use "dagger call base with-package container --help" to see available sub-commands.
 ```
 
@@ -48,7 +48,7 @@ cowsay "dagger"
 
 You should see output similar to the following:
 
-```shell
+```
  ________
 < dagger >
  --------
@@ -83,7 +83,7 @@ dagger -m github.com/shykes/daggerverse/wolfi@v0.1.2 \
 
 The output will be a container image reference on the [ttl.sh container registry](https://ttl.sh), as shown below:
 
-```shell
+```
 ttl.sh/dagger-cowsay-10939@sha256:57c15999fdc59df452161f648aaa9b9a1ea9dbda710a0a0242f509966a286b4b
 ```
 
@@ -95,7 +95,7 @@ docker run --rm -it ttl.sh/dagger-cowsay-10939 cowsay "dagger"
 
 You should see the output below:
 
-```shell
+```
  ________
 < dagger >
  --------


### PR DESCRIPTION
This commit improves the Go builder example in the quickstart based on the discussion at https://discord.com/channels/707636530424053791/1223010377097547857

It also fixes the shell output snippets, which in some cases were being automatically colorized by the syntax highlighter, even though the actual output seen by the user would not be colorized.