### PR TITLE
feat: add git `Head`

### DIFF
--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -32,6 +32,7 @@ func TestGit(t *testing.T) {
 
 	res := struct {
 		Git struct {
+			Head   result
 			Ref    result
 			Commit result
 			Branch result
@@ -42,6 +43,14 @@ func TestGit(t *testing.T) {
 	err := testutil.Query(
 		`{
 			git(url: "github.com/dagger/dagger", keepGitDir: true) {
+				head {
+					commit
+					tree {
+						file(path: "README.md") {
+							contents
+						}
+					}
+				}
 				ref(name: "refs/heads/main") {
 					commit
 					tree {
@@ -78,8 +87,13 @@ func TestGit(t *testing.T) {
 		}`, &res, nil)
 	require.NoError(t, err)
 
+	// head
+	require.NotEmpty(t, res.Git.Head.Commit)
+	require.Contains(t, res.Git.Head.Tree.File.Contents, "Dagger")
+	mainCommit := res.Git.Head.Commit
+
 	// refs/heads/main
-	require.NotEmpty(t, res.Git.Ref.Commit)
+	require.Equal(t, mainCommit, res.Git.Ref.Commit)
 	require.Contains(t, res.Git.Ref.Tree.File.Contents, "Dagger")
 
 	// c80ac2c13df7d573a069938e01ca13f7a81f0345
@@ -87,7 +101,7 @@ func TestGit(t *testing.T) {
 	require.Contains(t, res.Git.Commit.Tree.File.Contents, "Dagger")
 
 	// main
-	require.NotEmpty(t, res.Git.Branch.Commit)
+	require.NotEmpty(t, mainCommit, res.Git.Branch.Commit)
 	require.Contains(t, res.Git.Branch.Tree.File.Contents, "Dagger")
 
 	// v0.9.5

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -34,6 +34,8 @@ func (s *gitSchema) Install() {
 	}.Install(s.srv)
 
 	dagql.Fields[*core.GitRepository]{
+		dagql.Func("head", s.head).
+			Doc(`Returns details for HEAD.`),
 		dagql.Func("ref", s.ref).
 			Doc(`Returns details of a ref.`).
 			ArgDoc("name", `Ref's name (can be a commit identifier, a tag name, a branch name, or a fully-qualified ref).`),
@@ -101,6 +103,13 @@ func (s *gitSchema) git(ctx context.Context, parent *core.Query, args gitArgs) (
 		SSHAuthSocket: authSock,
 		Services:      svcs,
 		Platform:      parent.Platform,
+	}, nil
+}
+
+func (s *gitSchema) head(ctx context.Context, parent *core.GitRepository, args struct{}) (*core.GitRef, error) {
+	return &core.GitRef{
+		Query: parent.Query,
+		Repo:  parent,
 	}, nil
 }
 

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -1457,6 +1457,9 @@ type GitRepository {
     id: String!
   ): GitRef!
 
+  """Returns details for HEAD."""
+  head: GitRef!
+
   """A unique identifier for this GitRepository."""
   id: GitRepositoryID!
 

--- a/sdk/elixir/lib/dagger/gen/git_repository.ex
+++ b/sdk/elixir/lib/dagger/gen/git_repository.ex
@@ -34,6 +34,18 @@ defmodule Dagger.GitRepository do
     }
   end
 
+  @doc "Returns details for HEAD."
+  @spec head(t()) :: Dagger.GitRef.t()
+  def head(%__MODULE__{} = git_repository) do
+    selection =
+      git_repository.selection |> select("head")
+
+    %Dagger.GitRef{
+      selection: selection,
+      client: git_repository.client
+    }
+  end
+
   @doc "A unique identifier for this GitRepository."
   @spec id(t()) :: {:ok, Dagger.GitRepositoryID.t()} | {:error, term()}
   def id(%__MODULE__{} = git_repository) do

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -3405,6 +3405,15 @@ func (r *GitRepository) Commit(id string) *GitRef {
 	}
 }
 
+// Returns details for HEAD.
+func (r *GitRepository) Head() *GitRef {
+	q := r.query.Select("head")
+
+	return &GitRef{
+		query: q,
+	}
+}
+
 // A unique identifier for this GitRepository.
 func (r *GitRepository) ID(ctx context.Context) (GitRepositoryID, error) {
 	if r.id != nil {

--- a/sdk/php/generated/GitRepository.php
+++ b/sdk/php/generated/GitRepository.php
@@ -34,6 +34,15 @@ class GitRepository extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * Returns details for HEAD.
+     */
+    public function head(): GitRef
+    {
+        $innerQueryBuilder = new \Dagger\Client\QueryBuilder('head');
+        return new \Dagger\GitRef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
+    }
+
+    /**
      * A unique identifier for this GitRepository.
      */
     public function id(): GitRepositoryId

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -3726,6 +3726,13 @@ class GitRepository(Type):
         return GitRef(_ctx)
 
     @typecheck
+    def head(self) -> GitRef:
+        """Returns details for HEAD."""
+        _args: list[Arg] = []
+        _ctx = self._select("head", _args)
+        return GitRef(_ctx)
+
+    @typecheck
     async def id(self) -> GitRepositoryID:
         """A unique identifier for this GitRepository.
 

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -3746,6 +3746,15 @@ impl GitRepository {
             graphql_client: self.graphql_client.clone(),
         }
     }
+    /// Returns details for HEAD.
+    pub fn head(&self) -> GitRef {
+        let query = self.selection.select("head");
+        GitRef {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
     /// A unique identifier for this GitRepository.
     pub async fn id(&self) -> Result<GitRepositoryId, DaggerError> {
         let query = self.selection.select("id");

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -4623,6 +4623,21 @@ export class GitRepository extends BaseClient {
   }
 
   /**
+   * Returns details for HEAD.
+   */
+  head = (): GitRef => {
+    return new GitRef({
+      queryTree: [
+        ...this._queryTree,
+        {
+          operation: "head",
+        },
+      ],
+      ctx: this._ctx,
+    })
+  }
+
+  /**
    * Returns details of a ref.
    * @param name Ref's name (can be a commit identifier, a tag name, a branch name, or a fully-qualified ref).
    */


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/3670

This allows for grabbing the default branch, according to point 1 in https://github.com/dagger/dagger/issues/3670#issuecomment-2022321233.

Potentially, we could rework the git API a bit more in the future, but that feels out-of-scope for this issue right now.