### PR TITLE
fix: traceExec in docker driver should capture stderr

### DIFF
--- a/engine/client/drivers/docker.go
+++ b/engine/client/drivers/docker.go
@@ -202,7 +202,7 @@ func traceExec(ctx context.Context, cmd *exec.Cmd) (out string, rerr error) {
 	_, stdout, stderr := telemetry.WithStdioToOtel(ctx, "")
 	outBuf := new(bytes.Buffer)
 	cmd.Stdout = io.MultiWriter(stdout, outBuf)
-	cmd.Stdout = stderr
+	cmd.Stderr = io.MultiWriter(stderr, outBuf)
 	if err := cmd.Run(); err != nil {
 		return outBuf.String(), errors.Wrap(err, "failed to run command")
 	}


### PR DESCRIPTION
Should fix the currently failing provision tests on `main`: https://github.com/dagger/dagger/actions/runs/8536672759/job/23386879376

The new `traceExec` function introduced in #6835 was discarding all stdout/stderr - we need to capture this so that we can detect the case of multiple engines being spun up in parallel with each other.