### PR TITLE
post-OpenTelemetry clean-ups/fixes

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -172,6 +172,7 @@ func installGlobalFlags(flags *pflag.FlagSet) {
 
 func parseGlobalFlags() {
 	flags := pflag.NewFlagSet("global", pflag.ContinueOnError)
+	flags.Usage = func() {}
 	flags.ParseErrorsWhitelist.UnknownFlags = true
 	installGlobalFlags(flags)
 	if err := flags.Parse(os.Args[1:]); err != nil && !errors.Is(err, pflag.ErrHelp) {

--- a/cmd/engine/logger.go
+++ b/cmd/engine/logger.go
@@ -1,35 +1,14 @@
 package main
 
 import (
-	"os"
+	"fmt"
 	"strings"
+	"time"
 
-	"github.com/moby/buildkit/identity"
 	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/trace"
 )
-
-var (
-	engineName string
-)
-
-func init() {
-	var ok bool
-	engineName, ok = os.LookupEnv("_EXPERIMENTAL_DAGGER_ENGINE_NAME")
-	if !ok {
-		// use the hostname
-		hostname, err := os.Hostname()
-		if err != nil {
-			engineName = "rand-" + identity.NewID() // random ID as a fallback
-		} else {
-			engineName = hostname
-		}
-	}
-
-	// TODO(vito): send engine logs over OTLP
-	// tel = telemetry.New()
-
-	// logrus.AddHook(&cloudHook{})
-}
 
 // some logs from buildkit/containerd libs are not useful even at debug level,
 // this hook ignores them
@@ -90,44 +69,98 @@ func (h *noiseReductionHook) Fire(entry *logrus.Entry) error {
 	return nil
 }
 
-// type cloudHook struct{}
+type otelLogrusHook struct {
+	rootSpan trace.Span
+	logger   log.Logger
+}
 
-// var _ logrus.Hook = (*cloudHook)(nil)
+var _ logrus.Hook = (*otelLogrusHook)(nil)
 
-// func (h *cloudHook) Levels() []logrus.Level {
-// 	return logrus.AllLevels
-// }
+func (h *otelLogrusHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
 
-// func (h *cloudHook) Fire(entry *logrus.Entry) error {
-// 	payload := &engineLogPayload{
-// 		Engine: engineMetadata{
-// 			Name: engineName,
-// 		},
-// 		Message: entry.Message,
-// 		Level:   entry.Level.String(),
-// 		Fields:  entry.Data,
-// 	}
+func (h *otelLogrusHook) Fire(entry *logrus.Entry) error {
+	var rec log.Record
+	rec.SetBody(log.StringValue(entry.Message))
+	switch entry.Level {
+	case logrus.PanicLevel:
+		rec.SetSeverity(log.SeverityFatal)
+	case logrus.FatalLevel:
+		rec.SetSeverity(log.SeverityFatal)
+	case logrus.ErrorLevel:
+		rec.SetSeverity(log.SeverityError)
+	case logrus.WarnLevel:
+		rec.SetSeverity(log.SeverityWarn)
+	case logrus.InfoLevel:
+		rec.SetSeverity(log.SeverityInfo)
+	case logrus.DebugLevel:
+		rec.SetSeverity(log.SeverityDebug)
+	case logrus.TraceLevel:
+		rec.SetSeverity(log.SeverityTrace)
+	}
+	kvs := make([]log.KeyValue, 0, len(entry.Data))
+	for key, val := range entry.Data {
+		kvs = append(kvs, log.KeyValue{
+			Key:   key,
+			Value: logValue(val),
+		})
+	}
+	rec.AddAttributes(kvs...)
+	rec.SetTimestamp(entry.Time)
 
-// 	tel.Push(payload, entry.Time)
-// 	return nil
-// }
+	// TODO revive if/when we want engine logs to correlate to a trace
+	// ctx := entry.Context
+	// if trace.SpanFromContext(entry.Context).SpanContext().IsValid() {
+	// 	ctx = trace.ContextWithSpan(ctx, h.rootSpan)
+	// }
 
-// type engineLogPayload struct {
-// 	Engine  engineMetadata `json:"engine"`
-// 	Message string         `json:"message"`
-// 	Level   string         `json:"level"`
-// 	// NOTE: fields includes traceID and spanID, can we use that to correlate with clients?
-// 	Fields map[string]any `json:"fields"`
-// }
+	h.logger.Emit(entry.Context, rec)
 
-// func (engineLogPayload) Type() telemetry.EventType {
-// 	return telemetry.EventType("engine_log")
-// }
+	return nil
+}
 
-// func (engineLogPayload) Scope() telemetry.EventScope {
-// 	return telemetry.EventScopeSystem
-// }
-
-// type engineMetadata struct {
-// 	Name string `json:"name"`
-// }
+func logValue(v any) log.Value {
+	switch x := v.(type) {
+	case string:
+		return log.StringValue(x)
+	case []byte:
+		return log.BytesValue(x)
+	case float64:
+		return log.Float64Value(x)
+	case int:
+		return log.IntValue(x)
+	case int32:
+		return log.Int64Value(int64(x))
+	case int64:
+		return log.Int64Value(x)
+	case uint:
+		return log.IntValue(int(x))
+	case uint32:
+		return log.Int64Value(int64(x))
+	case uint64:
+		return log.Int64Value(int64(x))
+	case time.Duration:
+		return log.Int64Value(x.Nanoseconds())
+	case bool:
+		return log.BoolValue(x)
+	case map[string]any:
+		kvs := make([]log.KeyValue, len(x))
+		for key, val := range x {
+			kvs = append(kvs, log.KeyValue{
+				Key:   key,
+				Value: logValue(val),
+			})
+		}
+		return log.MapValue(kvs...)
+	case []any:
+		vals := make([]log.Value, len(x))
+		for _, v := range x {
+			vals = append(vals, logValue(v))
+		}
+		return log.SliceValue(vals...)
+	default:
+		// sane default fallback, don't want to panic
+		return log.StringValue(fmt.Sprintf("%v", x))
+	}
+}

--- a/cmd/engine/telemetry.go
+++ b/cmd/engine/telemetry.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/dagger/dagger/engine"
+	"github.com/dagger/dagger/telemetry"
+	"github.com/dagger/dagger/telemetry/sdklog"
+	"github.com/moby/buildkit/identity"
+	"github.com/moby/buildkit/util/bklog"
+	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	InstrumentationScopeName = "dagger.io/engine"
+)
+
+var (
+	engineName string
+
+	rootSpan trace.Span
+
+	engineTraceProvider  *sdktrace.TracerProvider
+	engineLoggerProvider *sdklog.LoggerProvider
+)
+
+func init() {
+	var ok bool
+	engineName, ok = os.LookupEnv("_EXPERIMENTAL_DAGGER_ENGINE_NAME")
+	if !ok {
+		// use the hostname
+		hostname, err := os.Hostname()
+		if err != nil {
+			engineName = "rand-" + identity.NewID() // random ID as a fallback
+		} else {
+			engineName = hostname
+		}
+	}
+}
+
+func InitTelemetry(ctx context.Context) (context.Context, *telemetry.PubSub) {
+	pubsub := telemetry.NewPubSub()
+
+	otelResource := resource.NewWithAttributes(
+		semconv.SchemaURL,
+		semconv.ServiceNameKey.String("dagger-engine"),
+		semconv.ServiceVersionKey.String(engine.Version),
+		semconv.HostNameKey.String(engineName),
+	)
+
+	// Send engine telemetry to Cloud if configured.
+	if _, logs, ok := telemetry.ConfiguredCloudExporters(ctx); ok {
+		// TODO revive if/when we want engine logs to correlate to a trace
+		// spanProcessor := sdktrace.NewBatchSpanProcessor(spans)
+		// engineTraceProvider = sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanProcessor))
+
+		// ctx, rootSpan = engineTraceProvider.Tracer(InstrumentationScopeName).Start(ctx, "dagger engine")
+
+		engineLoggerProvider = sdklog.NewLoggerProvider(otelResource)
+		engineLoggerProvider.RegisterLogProcessor(
+			sdklog.NewBatchLogProcessor(logs),
+		)
+		logrus.AddHook(&otelLogrusHook{
+			rootSpan: rootSpan,
+			logger:   engineLoggerProvider.Logger(InstrumentationScopeName),
+		})
+	}
+
+	ctx = telemetry.Init(ctx, telemetry.Config{
+		Resource: otelResource,
+
+		// Detect is false because we don't want to forward user-initiated
+		// telemetry to Cloud or OTEL_* - only Engine-specific telemetry.
+		Detect: false,
+
+		// Send everything to the pub/sub, which distributes telemetry to
+		// individual clients.
+		LiveTraceExporters: []sdktrace.SpanExporter{pubsub},
+		LiveLogExporters:   []sdklog.LogExporter{pubsub},
+	})
+
+	return ctx, pubsub
+}
+
+func CloseTelemetry() {
+	telemetry.Close()
+
+	if rootSpan != nil {
+		rootSpan.End()
+	}
+
+	type shutdowner interface {
+		Shutdown(context.Context) error
+	}
+
+	shutdown := func(shutdowner shutdowner) {
+		timeout := 30 * time.Second
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		bklog.G(shutdownCtx).Debugf("Shutting down %T (timeout=%s)", shutdowner, timeout)
+		shutdowner.Shutdown(shutdownCtx)
+	}
+
+	if engineTraceProvider != nil {
+		shutdown(engineTraceProvider)
+	}
+
+	if engineLoggerProvider != nil {
+		shutdown(engineLoggerProvider)
+	}
+}

--- a/telemetry/sdklog/logger.go
+++ b/telemetry/sdklog/logger.go
@@ -24,10 +24,11 @@ func (l logger) Emit(ctx context.Context, r log.Record) {
 	span := otrace.SpanFromContext(ctx)
 
 	log := &LogData{
-		Record:   r,
-		TraceID:  span.SpanContext().TraceID(),
-		SpanID:   span.SpanContext().SpanID(),
-		Resource: l.resource,
+		Record:               r,
+		TraceID:              span.SpanContext().TraceID(),
+		SpanID:               span.SpanContext().SpanID(),
+		Resource:             l.resource,
+		InstrumentationScope: l.instrumentationScope,
 	}
 
 	for _, proc := range l.provider.getLogProcessors() {

--- a/telemetry/sdklog/otlploghttp/transform/transform.go
+++ b/telemetry/sdklog/otlploghttp/transform/transform.go
@@ -119,7 +119,16 @@ func logValue(v olog.Value) *commonpb.AnyValue {
 			ArrayValue: array,
 		}
 	case olog.KindMap:
-		panic("not supported")
+		kvList := &commonpb.KeyValueList{}
+		for _, e := range v.AsMap() {
+			kvList.Values = append(kvList.Values, &commonpb.KeyValue{
+				Key:   e.Key,
+				Value: logValue(e.Value),
+			})
+		}
+		av.Value = &commonpb.AnyValue_KvlistValue{
+			KvlistValue: kvList,
+		}
 	default:
 		av.Value = &commonpb.AnyValue_StringValue{
 			StringValue: "INVALID",

--- a/telemetry/servers.go
+++ b/telemetry/servers.go
@@ -197,7 +197,8 @@ func attrValue(v *otlpcommonv1.AnyValue) attribute.Value {
 		return attribute.BoolValue(v.GetBoolValue())
 	default:
 		// TODO slices, bleh
-		return attribute.StringValue(fmt.Sprintf("UNHANDLED ATTR TYPE: %v", x))
+		slog.Error("unhandled otlpcommonv1.AnyValue -> attribute.Value conversion", "type", fmt.Sprintf("%T", x))
+		return attribute.StringValue(fmt.Sprintf("UNHANDLED ATTR TYPE: %v (%T)", x, x))
 	}
 }
 
@@ -226,6 +227,7 @@ func logValue(v *otlpcommonv1.AnyValue) log.Value {
 	case *otlpcommonv1.AnyValue_BytesValue:
 		return log.BytesValue(x.BytesValue)
 	default:
-		panic(fmt.Sprintf("unknown value type: %T", x))
+		slog.Error("unhandled otlpcommonv1.AnyValue -> log.Value conversion", "type", fmt.Sprintf("%T", x))
+		return log.StringValue(fmt.Sprintf("UNHANDLED LOG VALUE TYPE: %v (%T)", x, x))
 	}
 }


### PR DESCRIPTION
follow-up to #6835 

* fix extra `--help` output caused by two-pass flag parsing
* fix engine inheriting `DAGGER_CLOUD_TOKEN` and sending redundant data to Cloud
* send engine logs to Cloud over OTLP