### PR TITLE
fix: only run one test for typescript provision tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -157,11 +157,16 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: 1.0.x
-      - name: "Test TypeScript SDK"
+      - name: "Test TypeScript SDK (Node)"
         run: |
           cd sdk/typescript
           yarn install
-          yarn test -g 'Automatic Provisioned CLI Binary'
+          yarn test:node -g 'Automatic Provisioned CLI Binary'
+      - name: "Test TypeScript SDK (Bun)"
+        run: |
+          cd sdk/typescript
+          yarn install
+          yarn test:bun -g 'Automatic Provisioned CLI Binary'
 
       - name: "ALWAYS print engine logs - especially useful on failure"
         if: always()
@@ -298,11 +303,16 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: 1.0.x
-      - name: "Test TypeScript SDK"
+      - name: "Test TypeScript SDK (Node)"
         run: |
           cd sdk/typescript
           yarn install
-          yarn test -g 'Automatic Provisioned CLI Binary'
+          yarn test:node -g 'Automatic Provisioned CLI Binary'
+      - name: "Test TypeScript SDK (Bun)"
+        run: |
+          cd sdk/typescript
+          yarn install
+          yarn test:bun -g 'Automatic Provisioned CLI Binary'
       - name: "ALWAYS print engine logs - especially useful on failure"
         if: always()
         run: docker logs $(docker ps -q --filter name=dagger-engine)

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "yarn run test:node && yarn run test:bun",
+    "test": "yarn run test:node",
     "test:bun": "bun run --bun mocha",
     "test:node": "mocha",
     "test:generate-scan": "tsx ./introspector/test/testdata/generate_expected_scan.ts",


### PR DESCRIPTION
This fixes the currently failing typescript tests on `main`: https://github.com/dagger/dagger/actions/runs/8549788696/job/23425690833

This was the intention - but with the node/bun split, we were running *all* the tests for node, and only one of the tests for bun:

	 $ yarn run test:node && yarn run test:bun -g 'Automatic Provisioned CLI Binary'

The other tests aren't designed to run in this environment, so should be skipped.