### PR TITLE
helm: Add `priorityClassName` to Helm Chart

### DIFF
--- a/helm/dagger/templates/engine-daemonset.yaml
+++ b/helm/dagger/templates/engine-daemonset.yaml
@@ -38,6 +38,9 @@ spec:
         fsGroup: 1001
         fsGroupChangePolicy: "OnRootMismatch"
       serviceAccountName: {{ include "dagger.serviceAccountName" . }}
+      {{- if .Values.engine.priorityClassName }}
+      priorityClassName: {{ .Values.engine.priorityClassName }}
+      {{- end }}
       containers:
         - name: dagger-engine
           image: {{ .Values.engine.image.repository }}:{{ if .Values.engine.image.tag }}{{ .Values.engine.image.tag }}{{ else }}{{ .Chart.AppVersion }}{{ end }}

--- a/helm/dagger/values.yaml
+++ b/helm/dagger/values.yaml
@@ -40,6 +40,8 @@ engine:
   #       - matchExpressions:
   #         - key: actions-runner
   #           operator: Exists
+  ### Set priorityClassName to avoid eviction
+  priorityClassName: ""
   readinessProbeSettings: 
     initialDelaySeconds: 5
     timeoutSeconds: 30


### PR DESCRIPTION
Allows the user to set the `priorityClassName` in the Helm Chart to avoid eviction and ensure that the Dagger engine is always present on the node.