### PR TITLE
feat: add version graphql call to get engine version

### DIFF
--- a/.changes/unreleased/Added-20240423-103802.yaml
+++ b/.changes/unreleased/Added-20240423-103802.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: New version field to get engine version details
+time: 2024-04-23T10:38:02.356725015+01:00
+custom:
+  Author: jedevc
+  PR: "7029"

--- a/core/schema/query.go
+++ b/core/schema/query.go
@@ -50,6 +50,9 @@ func (s *querySchema) Install() {
 			ArgDoc("description", "Description of the sub-pipeline.").
 			ArgDoc("labels", "Labels to apply to the sub-pipeline."),
 
+		dagql.Func("version", s.version).
+			Doc(`Get the current Dagger Engine version.`),
+
 		dagql.Func("checkVersionCompatibility", s.checkVersionCompatibility).
 			Doc(`Checks if the current Dagger Engine is compatible with an SDK's required version.`).
 			ArgDoc("version", "Version required by the SDK."),
@@ -64,6 +67,10 @@ type pipelineArgs struct {
 
 func (s *querySchema) pipeline(ctx context.Context, parent *core.Query, args pipelineArgs) (*core.Query, error) {
 	return parent.WithPipeline(args.Name, args.Description), nil
+}
+
+func (s *querySchema) version(_ context.Context, _ *core.Query, args struct{}) (string, error) {
+	return engine.Version, nil
 }
 
 type checkVersionCompatibilityArgs struct {

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -2365,6 +2365,9 @@ type Query {
 
   """Create a new TypeDef."""
   typeDef: TypeDef!
+
+  """Get the current Dagger Engine version."""
+  version: String!
 }
 
 """

--- a/sdk/elixir/lib/dagger/gen/client.ex
+++ b/sdk/elixir/lib/dagger/gen/client.ex
@@ -750,4 +750,13 @@ defmodule Dagger.Client do
       client: client.client
     }
   end
+
+  @doc "Get the current Dagger Engine version."
+  @spec version(t()) :: {:ok, String.t()} | {:error, term()}
+  def version(%__MODULE__{} = client) do
+    selection =
+      client.selection |> select("version")
+
+    execute(selection, client.client)
+  end
 end

--- a/sdk/go/dag/dag.gen.go
+++ b/sdk/go/dag/dag.gen.go
@@ -383,3 +383,9 @@ func TypeDef() *dagger.TypeDef {
 	client := initClient()
 	return client.TypeDef()
 }
+
+// Get the current Dagger Engine version.
+func Version(ctx context.Context) (string, error) {
+	client := initClient()
+	return client.Version(ctx)
+}

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -6041,6 +6041,16 @@ func (r *Client) TypeDef() *TypeDef {
 	}
 }
 
+// Get the current Dagger Engine version.
+func (r *Client) Version(ctx context.Context) (string, error) {
+	q := r.query.Select("version")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
 // A reference to a secret value, which can be handled more safely than the value itself.
 type Secret struct {
 	query *querybuilder.Selection

--- a/sdk/php/generated/Client.php
+++ b/sdk/php/generated/Client.php
@@ -618,4 +618,13 @@ class Client extends Client\AbstractClient
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('typeDef');
         return new \Dagger\TypeDef($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }
+
+    /**
+     * Get the current Dagger Engine version.
+     */
+    public function version(): string
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('version');
+        return (string)$this->queryLeaf($leafQueryBuilder, 'version');
+    }
 }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -6046,6 +6046,27 @@ class Client(Root):
         _ctx = self._select("typeDef", _args)
         return TypeDef(_ctx)
 
+    async def version(self) -> str:
+        """Get the current Dagger Engine version.
+
+        Returns
+        -------
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("version", _args)
+        return await _ctx.execute(str)
+
     def with_(self, cb: Callable[["Client"], "Client"]) -> "Client":
         """Call the provided callable with current Client.
 

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -5904,6 +5904,11 @@ impl Query {
             graphql_client: self.graphql_client.clone(),
         }
     }
+    /// Get the current Dagger Engine version.
+    pub async fn version(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("version");
+        query.execute(self.graphql_client.clone()).await
+    }
 }
 #[derive(Clone)]
 pub struct Secret {

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -6866,6 +6866,7 @@ export class Port extends BaseClient {
 export class Client extends BaseClient {
   private readonly _checkVersionCompatibility?: boolean = undefined
   private readonly _defaultPlatform?: Platform = undefined
+  private readonly _version?: string = undefined
 
   /**
    * Constructor is used for internal usage only, do not create object from it.
@@ -6874,11 +6875,13 @@ export class Client extends BaseClient {
     parent?: { queryTree?: QueryTree[]; ctx: Context },
     _checkVersionCompatibility?: boolean,
     _defaultPlatform?: Platform,
+    _version?: string,
   ) {
     super(parent)
 
     this._checkVersionCompatibility = _checkVersionCompatibility
     this._defaultPlatform = _defaultPlatform
+    this._version = _version
   }
 
   /**
@@ -7849,6 +7852,23 @@ export class Client extends BaseClient {
       ],
       ctx: this._ctx,
     })
+  }
+
+  /**
+   * Get the current Dagger Engine version.
+   */
+  version = async (): Promise<string> => {
+    const response: Awaited<string> = await computeQuery(
+      [
+        ...this._queryTree,
+        {
+          operation: "version",
+        },
+      ],
+      await this._ctx.connection(),
+    )
+
+    return response
   }
 
   /**


### PR DESCRIPTION
Before this, there was no way to get the version of an engine - this is *really* useful if the engine is running remotely, and you want to make a query for it to get it programatically (it's always been possible by analyzing logs, etc).

One of my main use cases is for working out what version of dagger the playground is using: https://play.dagger.cloud/playground - there's actually no way to do that right now (this PR would let you).

What feels frustrating is that `checkVersionCompatibility` is *almost* the right method call, but doesn't actually give you the raw data.