### PR TITLE
Introduce better versioning compatibility guarantees

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -113,12 +113,29 @@ to read more about this, see [this (private) Discord
 thread](https://discord.com/channels/707636530424053791/1101242942267601038/1101508879671623780).
 
 - [ ] If doing a minor release, determine if there are any deprecations that
-      can be removed
+      can be removed.
 
 > [!NOTE]
 >
 > Once you know what type of release we are producing - patch vs minor -
 > remember to edit the `?` in the Discord thread.
+
+### Backwards compatibility
+
+Where possible, we try to ensure backwards compatibility between mismatched cli
+and engine versions. However, for technical reasons, this isn't always possible:
+sometime the communication protocol changes, or a bug fix or new feature
+requires changes on both the CLI and the engine.
+
+Before releasing, make sure to sanity check the backwards compatibility of a
+release. If you enounter issues, then:
+
+- [ ] Add a release note using `changie new` (or add it later manually).
+- [ ] Bump the minimum version numbers in [engine/version.go](https://github.com/dagger/dagger/blob/mainengine/version.go).
+
+If unsure, bump both the client and engine minimum version numbers, but if
+the backwards compatibility is only an issue in one direction, you only need
+to bump that one.
 
 ## Improve this doc while releasing 改善
 

--- a/cmd/engine/telemetry.go
+++ b/cmd/engine/telemetry.go
@@ -34,7 +34,7 @@ var (
 
 func init() {
 	var ok bool
-	engineName, ok = os.LookupEnv("_EXPERIMENTAL_DAGGER_ENGINE_NAME")
+	engineName, ok = os.LookupEnv(engine.DaggerNameEnv)
 	if !ok {
 		// use the hostname
 		hostname, err := os.Hostname()

--- a/engine/consts.go
+++ b/engine/consts.go
@@ -1,12 +1,44 @@
 package engine
 
+import (
+	"fmt"
+	"os"
+)
+
+const (
+	EngineImageRepo = "registry.dagger.io/engine"
+	Package         = "github.com/dagger/dagger"
+
+	DaggerNameEnv = "_EXPERIMENTAL_DAGGER_ENGINE_NAME"
+
+	DaggerVersionEnv        = "_EXPERIMENTAL_DAGGER_VERSION"
+	DaggerMinimumVersionEnv = "_EXPERIMENTAL_DAGGER_MIN_VERSION"
+
+	GPUSupportEnv = "_EXPERIMENTAL_DAGGER_GPU_SUPPORT"
+	RunnerHostEnv = "_EXPERIMENTAL_DAGGER_RUNNER_HOST"
+)
+
+func RunnerHost() (string, error) {
+	if v, ok := os.LookupEnv(RunnerHostEnv); ok {
+		return v, nil
+	}
+
+	tag := Version
+	if os.Getenv(GPUSupportEnv) != "" {
+		tag += "-gpu"
+	}
+	return fmt.Sprintf("docker-image://%s:%s", EngineImageRepo, tag), nil
+}
+
 const (
 	StdinPrefix  = "\x00,"
 	StdoutPrefix = "\x01,"
 	StderrPrefix = "\x02,"
 	ResizePrefix = "resize,"
 	ExitPrefix   = "exit,"
+)
 
+const (
 	HTTPProxyEnvName  = "HTTP_PROXY"
 	HTTPSProxyEnvName = "HTTPS_PROXY"
 	FTPProxyEnvName   = "FTP_PROXY"

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -57,6 +57,9 @@ type ClientMetadata struct {
 	// matches.
 	ClientHostname string `json:"client_hostname"`
 
+	// ClientVersion is the version string of the client that make the request.
+	ClientVersion string `json:"client_version"`
+
 	// (Optional) Pipeline labels for e.g. vcs info like branch, commit, etc.
 	Labels map[string]string `json:"labels"`
 
@@ -105,6 +108,10 @@ func ClientMetadataFromContext(ctx context.Context) (*ClientMetadata, error) {
 	clientMetadata := &ClientMetadata{}
 	if err := decodeMeta(md, ClientMetadataMetaKey, clientMetadata); err != nil {
 		return nil, err
+	}
+	if clientMetadata.ClientVersion == "" {
+		// fallback for old clients that don't send a client version!
+		clientMetadata.ClientVersion = clientMetadata.Labels["dagger.io/client.version"]
 	}
 	return clientMetadata, nil
 }

--- a/engine/server/buildkitcontroller.go
+++ b/engine/server/buildkitcontroller.go
@@ -153,6 +153,10 @@ func (e *BuildkitController) Session(stream controlapi.Control_SessionServer) (r
 		WithField("client_hostname", opts.ClientHostname).
 		WithField("server_id", opts.ServerID))
 
+	if err := engine.CheckVersionCompatibility(opts.ClientVersion, engine.MinimumClientVersion); err != nil {
+		return fmt.Errorf("incompatible client version: %w", err)
+	}
+
 	{
 		lg := bklog.G(ctx).WithField("register_client", opts.RegisterClient)
 		lgLevel := lg.Trace

--- a/engine/telemetry/labels.go
+++ b/engine/telemetry/labels.go
@@ -3,8 +3,10 @@ package telemetry
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net/url"
 	"os"
 	"os/exec"
@@ -36,6 +38,40 @@ func LoadDefaultLabels(workdir, clientEngineVersion string) Labels {
 			WithVCSLabels(workdir)
 	})
 	return defaultLabels
+}
+
+func (labels *Labels) UnmarshalJSON(dt []byte) error {
+	// HACK: this custom Unmarshaller allows for old clients to pass labels in
+	// the legacy pre-v0.11 format without immediately erroring out (we can
+	// easily convert them) ...but we should eventually remove this.
+
+	var err error
+
+	current := map[string]string{}
+	if err = json.Unmarshal(dt, &current); err == nil {
+		if *labels == nil {
+			*labels = current
+		} else {
+			maps.Copy(*labels, current)
+		}
+		return nil
+	}
+
+	legacy := []struct {
+		Name  string `json:"name"`
+		Value string `json:"value"`
+	}{}
+	if err = json.Unmarshal(dt, &legacy); err == nil {
+		if *labels == nil {
+			*labels = Labels{}
+		}
+		for _, label := range legacy {
+			(*labels)[label.Name] = label.Value
+		}
+		return nil
+	}
+
+	return err
 }
 
 func (labels Labels) UserAgent() string {


### PR DESCRIPTION
See the rationale in https://github.com/dagger/dagger/pull/7013, https://github.com/dagger/dagger/pull/7001#discussion_r1549487821. TL;DR, during the release of v0.11.0, we broke compatibility with older clients, but didn't really have the tooling to make sure that this *errored* cleanly out.

This PR ensures that this doesn't happen again - both the client and the server are able to specify a minimum version, defined in `engine/version.go`. If a client/server doesn't satisfy these constraints, an appropriate error is printed out. These checks are introduced into the client/server code *directly*, instead of into each SDK, which don't trigger in dagger module code (see commit messages for more detailed description of the exact logic used).

For example, during the release of v0.11.0, if we'd had this, we would've bumped both the version compats to v0.11.0:
- Clients <=0.10.3 connecting to >v0.11.0 would be rejected by the server
- Servers <=0.10.3 being connected to by >=v0.11.0 would be rejected by the client

Even though we can't add this for v0.11.0, we *can* for v0.11.1 (or later) - it's designed to work with client/servers of as far back as possible (it *should* even work for v0.9, when all compat was deliberately broken in #5892).

If we take this, I wonder if we should think about deprecating/removing `checkVersionCompatibility` call? This new approach enforces constraints on both the client/server instead of just the server, and allows a more find-grained approach (so we can choose specific compatibility with each release on an ad-hoc basis, instead of using [hardcoded rules](https://github.com/dagger/dagger/blob/95b4ce550a2dcd1fa73f8b55199c7e9ed0ef1fc3/core/schema/query.go#L94-L115)).

I have *no* idea how to test this relatively fragile logic - since the version numbers come from hardcoded numbers in the binaries, it might be relatively fiddly. Will do some brainstorming and try and come up with something.

Note: at some point, the compute drivers to be added in #5583 should resolve this issue entirely, by making sure that the client/engine *always* match - but that may be some way off, and this is a relatively simple fix to prevent user issues until then. 

Related:
- #5315 
- #7029 (kept getting frustrated this didn't exist while working on this PR)
