### PR TITLE
feat/with graphql input

### DIFF
--- a/ci/sdk_rust.go
+++ b/ci/sdk_rust.go
@@ -16,7 +16,7 @@ const (
 	rustVersionFilePath  = "sdk/rust/crates/dagger-sdk/src/core/mod.rs"
 
 	// https://hub.docker.com/_/rust
-	rustDockerStable = "rust:1.71-bookworm"
+	rustDockerStable = "rust:1.77-bookworm"
 	cargoChefVersion = "0.1.62"
 )
 

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -19,18 +19,18 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anstream"
-version = "0.6.11"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
@@ -75,6 +75,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+
+[[package]]
 name = "ascii"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,26 +88,26 @@ checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -126,9 +132,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "block-buffer"
@@ -141,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "byteorder"
@@ -153,18 +159,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 
 [[package]]
 name = "cfg-if"
@@ -174,36 +177,36 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "color-eyre"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
+checksum = "55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5"
 dependencies = [
  "backtrace",
  "color-spantrace",
@@ -281,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
@@ -323,6 +326,7 @@ dependencies = [
  "itertools",
  "pretty_assertions",
  "serde",
+ "serde_graphql_input",
  "serde_json",
 ]
 
@@ -345,6 +349,7 @@ dependencies = [
  "rand",
  "reqwest",
  "serde",
+ "serde_graphql_input",
  "serde_json",
  "sha2",
  "tar",
@@ -376,7 +381,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 1.0.109",
 ]
 
@@ -461,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "encoding_rs"
@@ -502,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "filetime"
@@ -599,7 +604,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -651,7 +656,7 @@ checksum = "d4cf186fea4af17825116f72932fe52cce9a13bae39ff63b4dc0cfdb3fb4bde1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -666,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "a06fddc2749e0528d2813f95e050e87e52c8cbbae56223b9babf73b3e53b0cc6"
 dependencies = [
  "cfg-if",
  "libc",
@@ -742,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -773,9 +778,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.4"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -791,9 +796,9 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "http"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -885,9 +890,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -910,15 +915,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.67"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -937,13 +942,12 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libredox"
-version = "0.0.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "libc",
- "redox_syscall",
 ]
 
 [[package]]
@@ -964,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "matchers"
@@ -979,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "mime"
@@ -991,18 +995,18 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",
@@ -1093,9 +1097,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -1131,9 +1135,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1188,9 +1192,9 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
  "getrandom",
  "libredox",
@@ -1199,14 +1203,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.5",
- "regex-syntax 0.8.2",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -1220,13 +1224,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -1237,9 +1241,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "relative-path"
@@ -1249,9 +1253,9 @@ checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
 
 [[package]]
 name = "reqwest"
-version = "0.11.24"
+version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
  "base64",
  "bytes",
@@ -1292,16 +1296,17 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if",
  "getrandom",
  "libc",
  "spin",
  "untrusted",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1312,11 +1317,11 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1356,9 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "scopeguard"
@@ -1378,29 +1383,42 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "serde_graphql_input"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74edfdf4ee65b0f820a6ea6eb131af9fc59fe741ac54954734dbef33b75ed638"
+dependencies = [
+ "anyhow",
+ "itoa",
+ "serde",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -1459,18 +1477,18 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1486,6 +1504,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,9 +1522,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1547,42 +1571,41 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.9.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
  "rustix",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1605,9 +1628,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.1"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1630,7 +1653,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1683,7 +1706,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1784,18 +1807,18 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unreachable"
@@ -1864,9 +1887,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1874,24 +1897,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.58",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.40"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1901,9 +1924,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1911,22 +1934,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.58",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-streams"
@@ -1943,9 +1966,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.67"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1953,9 +1976,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.3"
+version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "winapi"
@@ -1994,7 +2017,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -2014,17 +2037,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -2035,9 +2058,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2047,9 +2070,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2059,9 +2082,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2071,9 +2094,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2083,9 +2106,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2095,9 +2118,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2107,9 +2130,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winreg"

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -17,6 +17,7 @@ eyre = "0.6.9"
 color-eyre = "0.6.2"
 serde = { version = "1.0.195", features = ["derive"] }
 serde_json = "1.0.111"
+serde_graphql_input = { version = "0.1.1" }
 tokio = { version = "1.35.1", features = ["full"] }
 tracing = { version = "0.1.40", features = ["log"] }
 tracing-subscriber = { version = "0.3.18", features = [

--- a/sdk/rust/crates/dagger-codegen/Cargo.toml
+++ b/sdk/rust/crates/dagger-codegen/Cargo.toml
@@ -16,6 +16,7 @@ dagger-sdk = { workspace = true }
 eyre = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_graphql_input = { workspace = true }
 
 genco.workspace = true
 convert_case.workspace = true

--- a/sdk/rust/crates/dagger-codegen/src/functions.rs
+++ b/sdk/rust/crates/dagger-codegen/src/functions.rs
@@ -193,22 +193,6 @@ pub fn type_ref_is_scalar(type_ref: &TypeRef) -> bool {
         .unwrap_or(false)
 }
 
-pub fn type_ref_is_enum(type_ref: &TypeRef) -> bool {
-    let mut type_ref = type_ref.clone();
-    if type_ref
-        .kind
-        .pipe(|k| *k == __TypeKind::NON_NULL)
-        .unwrap_or(false)
-    {
-        type_ref = *type_ref.of_type.unwrap().clone();
-    }
-
-    type_ref
-        .kind
-        .pipe(|k| *k == __TypeKind::ENUM)
-        .unwrap_or(false)
-}
-
 pub fn type_ref_is_object(type_ref: &TypeRef) -> bool {
     let mut type_ref = type_ref.clone();
     if type_ref

--- a/sdk/rust/crates/dagger-codegen/src/generator.rs
+++ b/sdk/rust/crates/dagger-codegen/src/generator.rs
@@ -7,15 +7,3 @@ pub trait Generator {
 }
 
 pub type DynGenerator = Arc<dyn Generator + Send + Sync>;
-
-pub trait FormatTypeRefs {
-    fn format_kind_list(representation: &str) -> String;
-    fn format_kind_scalar_string(representation: &str) -> String;
-    fn format_kind_scalar_int(representation: &str) -> String;
-    fn format_kind_scalar_float(representation: &str) -> String;
-    fn format_kind_scalar_boolean(representation: &str) -> String;
-    fn format_kind_scalar_default(representation: &str, ref_name: &str, input: bool) -> String;
-    fn format_kind_object(representation: &str, ref_name: &str) -> String;
-    fn format_kind_input_object(representation: &str, ref_name: &str) -> String;
-    fn format_kind_enum(representation: &str, ref_name: &str) -> String;
-}

--- a/sdk/rust/crates/dagger-codegen/src/rust/functions.rs
+++ b/sdk/rust/crates/dagger-codegen/src/rust/functions.rs
@@ -135,11 +135,6 @@ fn render_required_args(_funcs: &CommonFunctions, field: &FullTypeFields) -> Opt
                         }
                     }
 
-                    if type_ref_is_enum(&s.input_value.type_) {
-                        return Some(quote! {
-                            query = query.arg_enum($(quoted(name)), $(n));
-                        })
-                    }
 
                     if type_ref_is_list(&s.input_value.type_) {
                         let inner = *s
@@ -206,14 +201,6 @@ fn render_optional_args(_funcs: &CommonFunctions, field: &FullTypeFields) -> Opt
 
                     let n = format_struct_name(&s.input_value.name);
                     let name = &s.input_value.name;
-
-                    if type_ref_is_enum(&s.input_value.type_) {
-                        return Some(quote! {
-                            if let Some($(&n)) = opts.$(&n) {
-                                query = query.arg_enum($(quoted(name)), $(n));
-                            }
-                        });
-                    }
 
                     Some(quote! {
                         if let Some($(&n)) = opts.$(&n) {

--- a/sdk/rust/crates/dagger-sdk/Cargo.toml
+++ b/sdk/rust/crates/dagger-sdk/Cargo.toml
@@ -15,6 +15,7 @@ eyre = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_graphql_input = { workspace = true }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 thiserror.workspace = true

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -8,19 +8,16 @@ use tokio::process::Child;
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct CacheVolumeId(pub String);
-
 impl Into<CacheVolumeId> for &str {
     fn into(self) -> CacheVolumeId {
         CacheVolumeId(self.to_string())
     }
 }
-
 impl Into<CacheVolumeId> for String {
     fn into(self) -> CacheVolumeId {
         CacheVolumeId(self.clone())
     }
 }
-
 impl CacheVolumeId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -28,19 +25,16 @@ impl CacheVolumeId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct ContainerId(pub String);
-
 impl Into<ContainerId> for &str {
     fn into(self) -> ContainerId {
         ContainerId(self.to_string())
     }
 }
-
 impl Into<ContainerId> for String {
     fn into(self) -> ContainerId {
         ContainerId(self.clone())
     }
 }
-
 impl ContainerId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -48,19 +42,16 @@ impl ContainerId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct CurrentModuleId(pub String);
-
 impl Into<CurrentModuleId> for &str {
     fn into(self) -> CurrentModuleId {
         CurrentModuleId(self.to_string())
     }
 }
-
 impl Into<CurrentModuleId> for String {
     fn into(self) -> CurrentModuleId {
         CurrentModuleId(self.clone())
     }
 }
-
 impl CurrentModuleId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -68,19 +59,16 @@ impl CurrentModuleId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct DirectoryId(pub String);
-
 impl Into<DirectoryId> for &str {
     fn into(self) -> DirectoryId {
         DirectoryId(self.to_string())
     }
 }
-
 impl Into<DirectoryId> for String {
     fn into(self) -> DirectoryId {
         DirectoryId(self.clone())
     }
 }
-
 impl DirectoryId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -88,19 +76,16 @@ impl DirectoryId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct EnvVariableId(pub String);
-
 impl Into<EnvVariableId> for &str {
     fn into(self) -> EnvVariableId {
         EnvVariableId(self.to_string())
     }
 }
-
 impl Into<EnvVariableId> for String {
     fn into(self) -> EnvVariableId {
         EnvVariableId(self.clone())
     }
 }
-
 impl EnvVariableId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -108,19 +93,16 @@ impl EnvVariableId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct FieldTypeDefId(pub String);
-
 impl Into<FieldTypeDefId> for &str {
     fn into(self) -> FieldTypeDefId {
         FieldTypeDefId(self.to_string())
     }
 }
-
 impl Into<FieldTypeDefId> for String {
     fn into(self) -> FieldTypeDefId {
         FieldTypeDefId(self.clone())
     }
 }
-
 impl FieldTypeDefId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -128,19 +110,16 @@ impl FieldTypeDefId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct FileId(pub String);
-
 impl Into<FileId> for &str {
     fn into(self) -> FileId {
         FileId(self.to_string())
     }
 }
-
 impl Into<FileId> for String {
     fn into(self) -> FileId {
         FileId(self.clone())
     }
 }
-
 impl FileId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -148,19 +127,16 @@ impl FileId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct FunctionArgId(pub String);
-
 impl Into<FunctionArgId> for &str {
     fn into(self) -> FunctionArgId {
         FunctionArgId(self.to_string())
     }
 }
-
 impl Into<FunctionArgId> for String {
     fn into(self) -> FunctionArgId {
         FunctionArgId(self.clone())
     }
 }
-
 impl FunctionArgId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -168,19 +144,16 @@ impl FunctionArgId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct FunctionCallArgValueId(pub String);
-
 impl Into<FunctionCallArgValueId> for &str {
     fn into(self) -> FunctionCallArgValueId {
         FunctionCallArgValueId(self.to_string())
     }
 }
-
 impl Into<FunctionCallArgValueId> for String {
     fn into(self) -> FunctionCallArgValueId {
         FunctionCallArgValueId(self.clone())
     }
 }
-
 impl FunctionCallArgValueId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -188,19 +161,16 @@ impl FunctionCallArgValueId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct FunctionCallId(pub String);
-
 impl Into<FunctionCallId> for &str {
     fn into(self) -> FunctionCallId {
         FunctionCallId(self.to_string())
     }
 }
-
 impl Into<FunctionCallId> for String {
     fn into(self) -> FunctionCallId {
         FunctionCallId(self.clone())
     }
 }
-
 impl FunctionCallId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -208,19 +178,16 @@ impl FunctionCallId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct FunctionId(pub String);
-
 impl Into<FunctionId> for &str {
     fn into(self) -> FunctionId {
         FunctionId(self.to_string())
     }
 }
-
 impl Into<FunctionId> for String {
     fn into(self) -> FunctionId {
         FunctionId(self.clone())
     }
 }
-
 impl FunctionId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -228,19 +195,16 @@ impl FunctionId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct GeneratedCodeId(pub String);
-
 impl Into<GeneratedCodeId> for &str {
     fn into(self) -> GeneratedCodeId {
         GeneratedCodeId(self.to_string())
     }
 }
-
 impl Into<GeneratedCodeId> for String {
     fn into(self) -> GeneratedCodeId {
         GeneratedCodeId(self.clone())
     }
 }
-
 impl GeneratedCodeId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -248,19 +212,16 @@ impl GeneratedCodeId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct GitModuleSourceId(pub String);
-
 impl Into<GitModuleSourceId> for &str {
     fn into(self) -> GitModuleSourceId {
         GitModuleSourceId(self.to_string())
     }
 }
-
 impl Into<GitModuleSourceId> for String {
     fn into(self) -> GitModuleSourceId {
         GitModuleSourceId(self.clone())
     }
 }
-
 impl GitModuleSourceId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -268,19 +229,16 @@ impl GitModuleSourceId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct GitRefId(pub String);
-
 impl Into<GitRefId> for &str {
     fn into(self) -> GitRefId {
         GitRefId(self.to_string())
     }
 }
-
 impl Into<GitRefId> for String {
     fn into(self) -> GitRefId {
         GitRefId(self.clone())
     }
 }
-
 impl GitRefId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -288,19 +246,16 @@ impl GitRefId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct GitRepositoryId(pub String);
-
 impl Into<GitRepositoryId> for &str {
     fn into(self) -> GitRepositoryId {
         GitRepositoryId(self.to_string())
     }
 }
-
 impl Into<GitRepositoryId> for String {
     fn into(self) -> GitRepositoryId {
         GitRepositoryId(self.clone())
     }
 }
-
 impl GitRepositoryId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -308,19 +263,16 @@ impl GitRepositoryId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct HostId(pub String);
-
 impl Into<HostId> for &str {
     fn into(self) -> HostId {
         HostId(self.to_string())
     }
 }
-
 impl Into<HostId> for String {
     fn into(self) -> HostId {
         HostId(self.clone())
     }
 }
-
 impl HostId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -328,19 +280,16 @@ impl HostId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct InputTypeDefId(pub String);
-
 impl Into<InputTypeDefId> for &str {
     fn into(self) -> InputTypeDefId {
         InputTypeDefId(self.to_string())
     }
 }
-
 impl Into<InputTypeDefId> for String {
     fn into(self) -> InputTypeDefId {
         InputTypeDefId(self.clone())
     }
 }
-
 impl InputTypeDefId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -348,19 +297,16 @@ impl InputTypeDefId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct InterfaceTypeDefId(pub String);
-
 impl Into<InterfaceTypeDefId> for &str {
     fn into(self) -> InterfaceTypeDefId {
         InterfaceTypeDefId(self.to_string())
     }
 }
-
 impl Into<InterfaceTypeDefId> for String {
     fn into(self) -> InterfaceTypeDefId {
         InterfaceTypeDefId(self.clone())
     }
 }
-
 impl InterfaceTypeDefId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -368,19 +314,16 @@ impl InterfaceTypeDefId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct Json(pub String);
-
 impl Into<Json> for &str {
     fn into(self) -> Json {
         Json(self.to_string())
     }
 }
-
 impl Into<Json> for String {
     fn into(self) -> Json {
         Json(self.clone())
     }
 }
-
 impl Json {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -388,19 +331,16 @@ impl Json {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct LabelId(pub String);
-
 impl Into<LabelId> for &str {
     fn into(self) -> LabelId {
         LabelId(self.to_string())
     }
 }
-
 impl Into<LabelId> for String {
     fn into(self) -> LabelId {
         LabelId(self.clone())
     }
 }
-
 impl LabelId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -408,19 +348,16 @@ impl LabelId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct ListTypeDefId(pub String);
-
 impl Into<ListTypeDefId> for &str {
     fn into(self) -> ListTypeDefId {
         ListTypeDefId(self.to_string())
     }
 }
-
 impl Into<ListTypeDefId> for String {
     fn into(self) -> ListTypeDefId {
         ListTypeDefId(self.clone())
     }
 }
-
 impl ListTypeDefId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -428,19 +365,16 @@ impl ListTypeDefId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct LocalModuleSourceId(pub String);
-
 impl Into<LocalModuleSourceId> for &str {
     fn into(self) -> LocalModuleSourceId {
         LocalModuleSourceId(self.to_string())
     }
 }
-
 impl Into<LocalModuleSourceId> for String {
     fn into(self) -> LocalModuleSourceId {
         LocalModuleSourceId(self.clone())
     }
 }
-
 impl LocalModuleSourceId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -448,19 +382,16 @@ impl LocalModuleSourceId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct ModuleDependencyId(pub String);
-
 impl Into<ModuleDependencyId> for &str {
     fn into(self) -> ModuleDependencyId {
         ModuleDependencyId(self.to_string())
     }
 }
-
 impl Into<ModuleDependencyId> for String {
     fn into(self) -> ModuleDependencyId {
         ModuleDependencyId(self.clone())
     }
 }
-
 impl ModuleDependencyId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -468,19 +399,16 @@ impl ModuleDependencyId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct ModuleId(pub String);
-
 impl Into<ModuleId> for &str {
     fn into(self) -> ModuleId {
         ModuleId(self.to_string())
     }
 }
-
 impl Into<ModuleId> for String {
     fn into(self) -> ModuleId {
         ModuleId(self.clone())
     }
 }
-
 impl ModuleId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -488,19 +416,16 @@ impl ModuleId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct ModuleSourceId(pub String);
-
 impl Into<ModuleSourceId> for &str {
     fn into(self) -> ModuleSourceId {
         ModuleSourceId(self.to_string())
     }
 }
-
 impl Into<ModuleSourceId> for String {
     fn into(self) -> ModuleSourceId {
         ModuleSourceId(self.clone())
     }
 }
-
 impl ModuleSourceId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -508,19 +433,16 @@ impl ModuleSourceId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct ModuleSourceViewId(pub String);
-
 impl Into<ModuleSourceViewId> for &str {
     fn into(self) -> ModuleSourceViewId {
         ModuleSourceViewId(self.to_string())
     }
 }
-
 impl Into<ModuleSourceViewId> for String {
     fn into(self) -> ModuleSourceViewId {
         ModuleSourceViewId(self.clone())
     }
 }
-
 impl ModuleSourceViewId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -528,19 +450,16 @@ impl ModuleSourceViewId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct ObjectTypeDefId(pub String);
-
 impl Into<ObjectTypeDefId> for &str {
     fn into(self) -> ObjectTypeDefId {
         ObjectTypeDefId(self.to_string())
     }
 }
-
 impl Into<ObjectTypeDefId> for String {
     fn into(self) -> ObjectTypeDefId {
         ObjectTypeDefId(self.clone())
     }
 }
-
 impl ObjectTypeDefId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -548,19 +467,16 @@ impl ObjectTypeDefId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct Platform(pub String);
-
 impl Into<Platform> for &str {
     fn into(self) -> Platform {
         Platform(self.to_string())
     }
 }
-
 impl Into<Platform> for String {
     fn into(self) -> Platform {
         Platform(self.clone())
     }
 }
-
 impl Platform {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -568,19 +484,16 @@ impl Platform {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct PortId(pub String);
-
 impl Into<PortId> for &str {
     fn into(self) -> PortId {
         PortId(self.to_string())
     }
 }
-
 impl Into<PortId> for String {
     fn into(self) -> PortId {
         PortId(self.clone())
     }
 }
-
 impl PortId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -588,19 +501,16 @@ impl PortId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct SecretId(pub String);
-
 impl Into<SecretId> for &str {
     fn into(self) -> SecretId {
         SecretId(self.to_string())
     }
 }
-
 impl Into<SecretId> for String {
     fn into(self) -> SecretId {
         SecretId(self.clone())
     }
 }
-
 impl SecretId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -608,19 +518,16 @@ impl SecretId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct ServiceId(pub String);
-
 impl Into<ServiceId> for &str {
     fn into(self) -> ServiceId {
         ServiceId(self.to_string())
     }
 }
-
 impl Into<ServiceId> for String {
     fn into(self) -> ServiceId {
         ServiceId(self.clone())
     }
 }
-
 impl ServiceId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -628,19 +535,16 @@ impl ServiceId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct SocketId(pub String);
-
 impl Into<SocketId> for &str {
     fn into(self) -> SocketId {
         SocketId(self.to_string())
     }
 }
-
 impl Into<SocketId> for String {
     fn into(self) -> SocketId {
         SocketId(self.clone())
     }
 }
-
 impl SocketId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -648,19 +552,16 @@ impl SocketId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct TerminalId(pub String);
-
 impl Into<TerminalId> for &str {
     fn into(self) -> TerminalId {
         TerminalId(self.to_string())
     }
 }
-
 impl Into<TerminalId> for String {
     fn into(self) -> TerminalId {
         TerminalId(self.clone())
     }
 }
-
 impl TerminalId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -668,19 +569,16 @@ impl TerminalId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct TypeDefId(pub String);
-
 impl Into<TypeDefId> for &str {
     fn into(self) -> TypeDefId {
         TypeDefId(self.to_string())
     }
 }
-
 impl Into<TypeDefId> for String {
     fn into(self) -> TypeDefId {
         TypeDefId(self.clone())
     }
 }
-
 impl TypeDefId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -688,19 +586,16 @@ impl TypeDefId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct Void(pub String);
-
 impl Into<Void> for &str {
     fn into(self) -> Void {
         Void(self.to_string())
     }
 }
-
 impl Into<Void> for String {
     fn into(self) -> Void {
         Void(self.clone())
     }
 }
-
 impl Void {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -728,12 +623,10 @@ pub struct CacheVolume {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl CacheVolume {
     /// A unique identifier for this CacheVolume.
     pub async fn id(&self) -> Result<CacheVolumeId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -743,7 +636,6 @@ pub struct Container {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerAsTarballOpts {
     /// Force each layer of the image to use the specified compression algorithm.
@@ -1003,13 +895,11 @@ pub struct ContainerWithoutExposedPortOpts {
     #[builder(setter(into, strip_option), default)]
     pub protocol: Option<NetworkProtocol>,
 }
-
 impl Container {
     /// Turn the container into a Service.
     /// Be sure to set any exposed ports before this conversion.
     pub fn as_service(&self) -> Service {
         let query = self.selection.select("asService");
-
         Service {
             proc: self.proc.clone(),
             selection: query,
@@ -1018,33 +908,24 @@ impl Container {
     }
     /// Returns a File representing the container serialized to a tarball.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn as_tarball(&self) -> File {
         let query = self.selection.select("asTarball");
-
         File {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Returns a File representing the container serialized to a tarball.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn as_tarball_opts(&self, opts: ContainerAsTarballOpts) -> File {
         let mut query = self.selection.select("asTarball");
-
         if let Some(platform_variants) = opts.platform_variants {
             query = query.arg("platformVariants", platform_variants);
         }
@@ -1054,7 +935,6 @@ impl Container {
         if let Some(media_types) = opts.media_types {
             query = query.arg("mediaTypes", media_types);
         }
-
         File {
             proc: self.proc.clone(),
             selection: query,
@@ -1063,16 +943,12 @@ impl Container {
     }
     /// Initializes this container from a Dockerfile build.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `context` - Directory context used by the Dockerfile.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn build(&self, context: Directory) -> Container {
         let mut query = self.selection.select("build");
-
         query = query.arg_lazy(
             "context",
             Box::new(move || {
@@ -1080,26 +956,20 @@ impl Container {
                 Box::pin(async move { context.id().await.unwrap().quote() })
             }),
         );
-
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Initializes this container from a Dockerfile build.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `context` - Directory context used by the Dockerfile.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn build_opts<'a>(&self, context: Directory, opts: ContainerBuildOpts<'a>) -> Container {
         let mut query = self.selection.select("build");
-
         query = query.arg_lazy(
             "context",
             Box::new(move || {
@@ -1119,7 +989,6 @@ impl Container {
         if let Some(secrets) = opts.secrets {
             query = query.arg("secrets", secrets);
         }
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1129,23 +998,17 @@ impl Container {
     /// Retrieves default arguments for future commands.
     pub async fn default_args(&self) -> Result<Vec<String>, DaggerError> {
         let query = self.selection.select("defaultArgs");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves a directory at the given path.
     /// Mounts are included.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - The path of the directory to retrieve (e.g., "./src").
     pub fn directory(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("directory");
-
         query = query.arg("path", path.into());
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -1155,28 +1018,21 @@ impl Container {
     /// Retrieves entrypoint to be prepended to the arguments of all commands.
     pub async fn entrypoint(&self) -> Result<Vec<String>, DaggerError> {
         let query = self.selection.select("entrypoint");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the value of the specified environment variable.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - The name of the environment variable to retrieve (e.g., "PATH").
     pub async fn env_variable(&self, name: impl Into<String>) -> Result<String, DaggerError> {
         let mut query = self.selection.select("envVariable");
-
         query = query.arg("name", name.into());
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the list of environment variables passed to commands.
     pub fn env_variables(&self) -> Vec<EnvVariable> {
         let query = self.selection.select("envVariables");
-
         return vec![EnvVariable {
             proc: self.proc.clone(),
             selection: query,
@@ -1188,7 +1044,6 @@ impl Container {
     /// This currently works for Nvidia devices only.
     pub fn experimental_with_all_gp_us(&self) -> Container {
         let query = self.selection.select("experimentalWithAllGPUs");
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1199,15 +1054,11 @@ impl Container {
     /// Configures the provided list of devices to be accessible to this container.
     /// This currently works for Nvidia devices only.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `devices` - List of devices to be accessible to this container.
     pub fn experimental_with_gpu(&self, devices: Vec<impl Into<String>>) -> Container {
         let mut query = self.selection.select("experimentalWithGPU");
-
         query = query.arg(
             "devices",
             devices
@@ -1215,7 +1066,6 @@ impl Container {
                 .map(|i| i.into())
                 .collect::<Vec<String>>(),
         );
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1226,32 +1076,23 @@ impl Container {
     /// Return true on success.
     /// It can also export platform variants.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Host's destination path (e.g., "./tarball").
     ///
     /// Path can be relative to the engine's workdir or absolute.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn export(&self, path: impl Into<String>) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
-
         query = query.arg("path", path.into());
-
         query.execute(self.graphql_client.clone()).await
     }
-
     /// Writes the container as an OCI tarball to the destination file path on the host.
     /// Return true on success.
     /// It can also export platform variants.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Host's destination path (e.g., "./tarball").
     ///
     /// Path can be relative to the engine's workdir or absolute.
@@ -1262,7 +1103,6 @@ impl Container {
         opts: ContainerExportOpts,
     ) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
-
         query = query.arg("path", path.into());
         if let Some(platform_variants) = opts.platform_variants {
             query = query.arg("platformVariants", platform_variants);
@@ -1273,14 +1113,12 @@ impl Container {
         if let Some(media_types) = opts.media_types {
             query = query.arg("mediaTypes", media_types);
         }
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the list of exposed ports.
     /// This includes ports already exposed by the image, even if not explicitly added with dagger.
     pub fn exposed_ports(&self) -> Vec<Port> {
         let query = self.selection.select("exposedPorts");
-
         return vec![Port {
             proc: self.proc.clone(),
             selection: query,
@@ -1290,17 +1128,12 @@ impl Container {
     /// Retrieves a file at the given path.
     /// Mounts are included.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - The path of the file to retrieve (e.g., "./README.md").
     pub fn file(&self, path: impl Into<String>) -> File {
         let mut query = self.selection.select("file");
-
         query = query.arg("path", path.into());
-
         File {
             proc: self.proc.clone(),
             selection: query,
@@ -1309,19 +1142,14 @@ impl Container {
     }
     /// Initializes this container from a pulled base image.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `address` - Image's address from its registry.
     ///
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g., "docker.io/dagger/dagger:main").
     pub fn from(&self, address: impl Into<String>) -> Container {
         let mut query = self.selection.select("from");
-
         query = query.arg("address", address.into());
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1331,27 +1159,21 @@ impl Container {
     /// A unique identifier for this Container.
     pub async fn id(&self) -> Result<ContainerId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The unique image reference which can only be retrieved immediately after the 'Container.From' call.
     pub async fn image_ref(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("imageRef");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Reads the container from an OCI tarball.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `source` - File to read the container from.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn import(&self, source: File) -> Container {
         let mut query = self.selection.select("import");
-
         query = query.arg_lazy(
             "source",
             Box::new(move || {
@@ -1359,26 +1181,20 @@ impl Container {
                 Box::pin(async move { source.id().await.unwrap().quote() })
             }),
         );
-
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Reads the container from an OCI tarball.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `source` - File to read the container from.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn import_opts<'a>(&self, source: File, opts: ContainerImportOpts<'a>) -> Container {
         let mut query = self.selection.select("import");
-
         query = query.arg_lazy(
             "source",
             Box::new(move || {
@@ -1389,7 +1205,6 @@ impl Container {
         if let Some(tag) = opts.tag {
             query = query.arg("tag", tag);
         }
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1398,23 +1213,17 @@ impl Container {
     }
     /// Retrieves the value of the specified label.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - The name of the label (e.g., "org.opencontainers.artifact.created").
     pub async fn label(&self, name: impl Into<String>) -> Result<String, DaggerError> {
         let mut query = self.selection.select("label");
-
         query = query.arg("name", name.into());
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the list of labels passed to container.
     pub fn labels(&self) -> Vec<Label> {
         let query = self.selection.select("labels");
-
         return vec![Label {
             proc: self.proc.clone(),
             selection: query,
@@ -1424,37 +1233,27 @@ impl Container {
     /// Retrieves the list of paths where a directory is mounted.
     pub async fn mounts(&self) -> Result<Vec<String>, DaggerError> {
         let query = self.selection.select("mounts");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Creates a named sub-pipeline.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - Name of the sub-pipeline.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn pipeline(&self, name: impl Into<String>) -> Container {
         let mut query = self.selection.select("pipeline");
-
         query = query.arg("name", name.into());
-
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Creates a named sub-pipeline.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - Name of the sub-pipeline.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn pipeline_opts<'a>(
@@ -1463,7 +1262,6 @@ impl Container {
         opts: ContainerPipelineOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("pipeline");
-
         query = query.arg("name", name.into());
         if let Some(description) = opts.description {
             query = query.arg("description", description);
@@ -1471,7 +1269,6 @@ impl Container {
         if let Some(labels) = opts.labels {
             query = query.arg("labels", labels);
         }
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1481,39 +1278,29 @@ impl Container {
     /// The platform this container executes and publishes as.
     pub async fn platform(&self) -> Result<Platform, DaggerError> {
         let query = self.selection.select("platform");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Publishes this container as a new image to the specified address.
     /// Publish returns a fully qualified ref.
     /// It can also publish platform variants.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `address` - Registry's address to publish the image to.
     ///
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g. "docker.io/dagger/dagger:main").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn publish(&self, address: impl Into<String>) -> Result<String, DaggerError> {
         let mut query = self.selection.select("publish");
-
         query = query.arg("address", address.into());
-
         query.execute(self.graphql_client.clone()).await
     }
-
     /// Publishes this container as a new image to the specified address.
     /// Publish returns a fully qualified ref.
     /// It can also publish platform variants.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `address` - Registry's address to publish the image to.
     ///
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g. "docker.io/dagger/dagger:main").
@@ -1524,7 +1311,6 @@ impl Container {
         opts: ContainerPublishOpts,
     ) -> Result<String, DaggerError> {
         let mut query = self.selection.select("publish");
-
         query = query.arg("address", address.into());
         if let Some(platform_variants) = opts.platform_variants {
             query = query.arg("platformVariants", platform_variants);
@@ -1535,13 +1321,11 @@ impl Container {
         if let Some(media_types) = opts.media_types {
             query = query.arg("mediaTypes", media_types);
         }
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves this container's root filesystem. Mounts are not included.
     pub fn rootfs(&self) -> Directory {
         let query = self.selection.select("rootfs");
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -1552,52 +1336,40 @@ impl Container {
     /// Will execute default command if none is set, or error if there's no default.
     pub async fn stderr(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("stderr");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The output stream of the last executed command.
     /// Will execute default command if none is set, or error if there's no default.
     pub async fn stdout(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("stdout");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Forces evaluation of the pipeline in the engine.
     /// It doesn't run the default command if no exec has been set.
     pub async fn sync(&self) -> Result<ContainerId, DaggerError> {
         let query = self.selection.select("sync");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Return an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn terminal(&self) -> Terminal {
         let query = self.selection.select("terminal");
-
         Terminal {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Return an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn terminal_opts<'a>(&self, opts: ContainerTerminalOpts<'a>) -> Terminal {
         let mut query = self.selection.select("terminal");
-
         if let Some(cmd) = opts.cmd {
             query = query.arg("cmd", cmd);
         }
@@ -1610,7 +1382,6 @@ impl Container {
         if let Some(insecure_root_capabilities) = opts.insecure_root_capabilities {
             query = query.arg("insecureRootCapabilities", insecure_root_capabilities);
         }
-
         Terminal {
             proc: self.proc.clone(),
             selection: query,
@@ -1620,25 +1391,19 @@ impl Container {
     /// Retrieves the user to be set for all commands.
     pub async fn user(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("user");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Configures default arguments for future commands.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `args` - Arguments to prepend to future executions (e.g., ["-v", "--no-cache"]).
     pub fn with_default_args(&self, args: Vec<impl Into<String>>) -> Container {
         let mut query = self.selection.select("withDefaultArgs");
-
         query = query.arg(
             "args",
             args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
         );
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1647,35 +1412,26 @@ impl Container {
     }
     /// Set the default command to invoke for the container's terminal API.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `args` - The args of the command.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_default_terminal_cmd(&self, args: Vec<impl Into<String>>) -> Container {
         let mut query = self.selection.select("withDefaultTerminalCmd");
-
         query = query.arg(
             "args",
             args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
         );
-
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Set the default command to invoke for the container's terminal API.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `args` - The args of the command.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_default_terminal_cmd_opts(
@@ -1684,7 +1440,6 @@ impl Container {
         opts: ContainerWithDefaultTerminalCmdOpts,
     ) -> Container {
         let mut query = self.selection.select("withDefaultTerminalCmd");
-
         query = query.arg(
             "args",
             args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
@@ -1698,7 +1453,6 @@ impl Container {
         if let Some(insecure_root_capabilities) = opts.insecure_root_capabilities {
             query = query.arg("insecureRootCapabilities", insecure_root_capabilities);
         }
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1707,17 +1461,13 @@ impl Container {
     }
     /// Retrieves this container plus a directory written at the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the written directory (e.g., "/tmp/directory").
     /// * `directory` - Identifier of the directory to write
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_directory(&self, path: impl Into<String>, directory: Directory) -> Container {
         let mut query = self.selection.select("withDirectory");
-
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "directory",
@@ -1726,21 +1476,16 @@ impl Container {
                 Box::pin(async move { directory.id().await.unwrap().quote() })
             }),
         );
-
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Retrieves this container plus a directory written at the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the written directory (e.g., "/tmp/directory").
     /// * `directory` - Identifier of the directory to write
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -1751,7 +1496,6 @@ impl Container {
         opts: ContainerWithDirectoryOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withDirectory");
-
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "directory",
@@ -1769,7 +1513,6 @@ impl Container {
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1778,35 +1521,26 @@ impl Container {
     }
     /// Retrieves this container but with a different command entrypoint.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `args` - Entrypoint to use for future executions (e.g., ["go", "run"]).
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_entrypoint(&self, args: Vec<impl Into<String>>) -> Container {
         let mut query = self.selection.select("withEntrypoint");
-
         query = query.arg(
             "args",
             args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
         );
-
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Retrieves this container but with a different command entrypoint.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `args` - Entrypoint to use for future executions (e.g., ["go", "run"]).
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_entrypoint_opts(
@@ -1815,7 +1549,6 @@ impl Container {
         opts: ContainerWithEntrypointOpts,
     ) -> Container {
         let mut query = self.selection.select("withEntrypoint");
-
         query = query.arg(
             "args",
             args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
@@ -1823,7 +1556,6 @@ impl Container {
         if let Some(keep_default_args) = opts.keep_default_args {
             query = query.arg("keepDefaultArgs", keep_default_args);
         }
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1832,11 +1564,8 @@ impl Container {
     }
     /// Retrieves this container plus the given environment variable.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - The name of the environment variable (e.g., "HOST").
     /// * `value` - The value of the environment variable. (e.g., "localhost").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -1846,24 +1575,18 @@ impl Container {
         value: impl Into<String>,
     ) -> Container {
         let mut query = self.selection.select("withEnvVariable");
-
         query = query.arg("name", name.into());
         query = query.arg("value", value.into());
-
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Retrieves this container plus the given environment variable.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - The name of the environment variable (e.g., "HOST").
     /// * `value` - The value of the environment variable. (e.g., "localhost").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -1874,13 +1597,11 @@ impl Container {
         opts: ContainerWithEnvVariableOpts,
     ) -> Container {
         let mut query = self.selection.select("withEnvVariable");
-
         query = query.arg("name", name.into());
         query = query.arg("value", value.into());
         if let Some(expand) = opts.expand {
             query = query.arg("expand", expand);
         }
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1889,37 +1610,28 @@ impl Container {
     }
     /// Retrieves this container after executing the specified command inside it.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `args` - Command to run instead of the container's default command (e.g., ["run", "main.go"]).
     ///
     /// If empty, the container's default command is used.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_exec(&self, args: Vec<impl Into<String>>) -> Container {
         let mut query = self.selection.select("withExec");
-
         query = query.arg(
             "args",
             args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
         );
-
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Retrieves this container after executing the specified command inside it.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `args` - Command to run instead of the container's default command (e.g., ["run", "main.go"]).
     ///
     /// If empty, the container's default command is used.
@@ -1930,7 +1642,6 @@ impl Container {
         opts: ContainerWithExecOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withExec");
-
         query = query.arg(
             "args",
             args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
@@ -1956,7 +1667,6 @@ impl Container {
         if let Some(insecure_root_capabilities) = opts.insecure_root_capabilities {
             query = query.arg("insecureRootCapabilities", insecure_root_capabilities);
         }
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1968,35 +1678,26 @@ impl Container {
     /// - For health checks and introspection, when running services
     /// - For setting the EXPOSE OCI field when publishing the container
     ///
-
     /// # Arguments
-
     ///
-
     /// * `port` - Port number to expose
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_exposed_port(&self, port: isize) -> Container {
         let mut query = self.selection.select("withExposedPort");
-
         query = query.arg("port", port);
-
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Expose a network port.
     /// Exposed ports serve two purposes:
     /// - For health checks and introspection, when running services
     /// - For setting the EXPOSE OCI field when publishing the container
     ///
-
     /// # Arguments
-
     ///
-
     /// * `port` - Port number to expose
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_exposed_port_opts<'a>(
@@ -2005,7 +1706,6 @@ impl Container {
         opts: ContainerWithExposedPortOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withExposedPort");
-
         query = query.arg("port", port);
         if let Some(protocol) = opts.protocol {
             query = query.arg("protocol", protocol);
@@ -2016,7 +1716,6 @@ impl Container {
         if let Some(experimental_skip_healthcheck) = opts.experimental_skip_healthcheck {
             query = query.arg("experimentalSkipHealthcheck", experimental_skip_healthcheck);
         }
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2025,17 +1724,13 @@ impl Container {
     }
     /// Retrieves this container plus the contents of the given file copied to the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the copied file (e.g., "/tmp/file.txt").
     /// * `source` - Identifier of the file to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_file(&self, path: impl Into<String>, source: File) -> Container {
         let mut query = self.selection.select("withFile");
-
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "source",
@@ -2044,21 +1739,16 @@ impl Container {
                 Box::pin(async move { source.id().await.unwrap().quote() })
             }),
         );
-
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Retrieves this container plus the contents of the given file copied to the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the copied file (e.g., "/tmp/file.txt").
     /// * `source` - Identifier of the file to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -2069,7 +1759,6 @@ impl Container {
         opts: ContainerWithFileOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withFile");
-
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "source",
@@ -2084,7 +1773,6 @@ impl Container {
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2093,34 +1781,25 @@ impl Container {
     }
     /// Retrieves this container plus the contents of the given files copied to the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location where copied files should be placed (e.g., "/src").
     /// * `sources` - Identifiers of the files to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_files(&self, path: impl Into<String>, sources: Vec<FileId>) -> Container {
         let mut query = self.selection.select("withFiles");
-
         query = query.arg("path", path.into());
         query = query.arg("sources", sources);
-
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Retrieves this container plus the contents of the given files copied to the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location where copied files should be placed (e.g., "/src").
     /// * `sources` - Identifiers of the files to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -2131,7 +1810,6 @@ impl Container {
         opts: ContainerWithFilesOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withFiles");
-
         query = query.arg("path", path.into());
         query = query.arg("sources", sources);
         if let Some(permissions) = opts.permissions {
@@ -2140,7 +1818,6 @@ impl Container {
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2150,7 +1827,6 @@ impl Container {
     /// Indicate that subsequent operations should be featured more prominently in the UI.
     pub fn with_focus(&self) -> Container {
         let query = self.selection.select("withFocus");
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2159,19 +1835,14 @@ impl Container {
     }
     /// Retrieves this container plus the given label.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - The name of the label (e.g., "org.opencontainers.artifact.created").
     /// * `value` - The value of the label (e.g., "2023-01-01T00:00:00Z").
     pub fn with_label(&self, name: impl Into<String>, value: impl Into<String>) -> Container {
         let mut query = self.selection.select("withLabel");
-
         query = query.arg("name", name.into());
         query = query.arg("value", value.into());
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2180,17 +1851,13 @@ impl Container {
     }
     /// Retrieves this container plus a cache volume mounted at the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the cache directory (e.g., "/cache/node_modules").
     /// * `cache` - Identifier of the cache volume to mount.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_mounted_cache(&self, path: impl Into<String>, cache: CacheVolume) -> Container {
         let mut query = self.selection.select("withMountedCache");
-
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "cache",
@@ -2199,21 +1866,16 @@ impl Container {
                 Box::pin(async move { cache.id().await.unwrap().quote() })
             }),
         );
-
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Retrieves this container plus a cache volume mounted at the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the cache directory (e.g., "/cache/node_modules").
     /// * `cache` - Identifier of the cache volume to mount.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -2224,7 +1886,6 @@ impl Container {
         opts: ContainerWithMountedCacheOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withMountedCache");
-
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "cache",
@@ -2242,7 +1903,6 @@ impl Container {
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2251,17 +1911,13 @@ impl Container {
     }
     /// Retrieves this container plus a directory mounted at the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the mounted directory (e.g., "/mnt/directory").
     /// * `source` - Identifier of the mounted directory.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_mounted_directory(&self, path: impl Into<String>, source: Directory) -> Container {
         let mut query = self.selection.select("withMountedDirectory");
-
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "source",
@@ -2270,21 +1926,16 @@ impl Container {
                 Box::pin(async move { source.id().await.unwrap().quote() })
             }),
         );
-
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Retrieves this container plus a directory mounted at the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the mounted directory (e.g., "/mnt/directory").
     /// * `source` - Identifier of the mounted directory.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -2295,7 +1946,6 @@ impl Container {
         opts: ContainerWithMountedDirectoryOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withMountedDirectory");
-
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "source",
@@ -2307,7 +1957,6 @@ impl Container {
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2316,17 +1965,13 @@ impl Container {
     }
     /// Retrieves this container plus a file mounted at the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the mounted file (e.g., "/tmp/file.txt").
     /// * `source` - Identifier of the mounted file.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_mounted_file(&self, path: impl Into<String>, source: File) -> Container {
         let mut query = self.selection.select("withMountedFile");
-
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "source",
@@ -2335,21 +1980,16 @@ impl Container {
                 Box::pin(async move { source.id().await.unwrap().quote() })
             }),
         );
-
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Retrieves this container plus a file mounted at the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the mounted file (e.g., "/tmp/file.txt").
     /// * `source` - Identifier of the mounted file.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -2360,7 +2000,6 @@ impl Container {
         opts: ContainerWithMountedFileOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withMountedFile");
-
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "source",
@@ -2372,7 +2011,6 @@ impl Container {
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2381,17 +2019,13 @@ impl Container {
     }
     /// Retrieves this container plus a secret mounted into a file at the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the secret file (e.g., "/tmp/secret.txt").
     /// * `source` - Identifier of the secret to mount.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_mounted_secret(&self, path: impl Into<String>, source: Secret) -> Container {
         let mut query = self.selection.select("withMountedSecret");
-
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "source",
@@ -2400,21 +2034,16 @@ impl Container {
                 Box::pin(async move { source.id().await.unwrap().quote() })
             }),
         );
-
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Retrieves this container plus a secret mounted into a file at the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the secret file (e.g., "/tmp/secret.txt").
     /// * `source` - Identifier of the secret to mount.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -2425,7 +2054,6 @@ impl Container {
         opts: ContainerWithMountedSecretOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withMountedSecret");
-
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "source",
@@ -2440,7 +2068,6 @@ impl Container {
         if let Some(mode) = opts.mode {
             query = query.arg("mode", mode);
         }
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2449,17 +2076,12 @@ impl Container {
     }
     /// Retrieves this container plus a temporary directory mounted at the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the temporary directory (e.g., "/tmp/temp_dir").
     pub fn with_mounted_temp(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withMountedTemp");
-
         query = query.arg("path", path.into());
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2468,32 +2090,23 @@ impl Container {
     }
     /// Retrieves this container plus a new file written at the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the written file (e.g., "/tmp/file.txt").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_new_file(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withNewFile");
-
         query = query.arg("path", path.into());
-
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Retrieves this container plus a new file written at the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the written file (e.g., "/tmp/file.txt").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_new_file_opts<'a>(
@@ -2502,7 +2115,6 @@ impl Container {
         opts: ContainerWithNewFileOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withNewFile");
-
         query = query.arg("path", path.into());
         if let Some(contents) = opts.contents {
             query = query.arg("contents", contents);
@@ -2513,7 +2125,6 @@ impl Container {
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2522,11 +2133,8 @@ impl Container {
     }
     /// Retrieves this container with a registry authentication for a given address.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `address` - Registry's address to bind the authentication to.
     ///
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g. docker.io/dagger/dagger:main).
@@ -2539,7 +2147,6 @@ impl Container {
         secret: Secret,
     ) -> Container {
         let mut query = self.selection.select("withRegistryAuth");
-
         query = query.arg("address", address.into());
         query = query.arg("username", username.into());
         query = query.arg_lazy(
@@ -2549,7 +2156,6 @@ impl Container {
                 Box::pin(async move { secret.id().await.unwrap().quote() })
             }),
         );
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2558,15 +2164,11 @@ impl Container {
     }
     /// Retrieves the container with the given directory mounted to /.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `directory` - Directory to mount.
     pub fn with_rootfs(&self, directory: Directory) -> Container {
         let mut query = self.selection.select("withRootfs");
-
         query = query.arg_lazy(
             "directory",
             Box::new(move || {
@@ -2574,7 +2176,6 @@ impl Container {
                 Box::pin(async move { directory.id().await.unwrap().quote() })
             }),
         );
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2583,16 +2184,12 @@ impl Container {
     }
     /// Retrieves this container plus an env variable containing the given secret.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - The name of the secret variable (e.g., "API_SECRET").
     /// * `secret` - The identifier of the secret value.
     pub fn with_secret_variable(&self, name: impl Into<String>, secret: Secret) -> Container {
         let mut query = self.selection.select("withSecretVariable");
-
         query = query.arg("name", name.into());
         query = query.arg_lazy(
             "secret",
@@ -2601,7 +2198,6 @@ impl Container {
                 Box::pin(async move { secret.id().await.unwrap().quote() })
             }),
         );
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2613,16 +2209,12 @@ impl Container {
     /// The service will be reachable from the container via the provided hostname alias.
     /// The service dependency will also convey to any files or directories produced by the container.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `alias` - A name that can be used to reach the service from the container
     /// * `service` - Identifier of the service container
     pub fn with_service_binding(&self, alias: impl Into<String>, service: Service) -> Container {
         let mut query = self.selection.select("withServiceBinding");
-
         query = query.arg("alias", alias.into());
         query = query.arg_lazy(
             "service",
@@ -2631,7 +2223,6 @@ impl Container {
                 Box::pin(async move { service.id().await.unwrap().quote() })
             }),
         );
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2640,17 +2231,13 @@ impl Container {
     }
     /// Retrieves this container plus a socket forwarded to the given Unix socket path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the forwarded Unix socket (e.g., "/tmp/socket").
     /// * `source` - Identifier of the socket to forward.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_unix_socket(&self, path: impl Into<String>, source: Socket) -> Container {
         let mut query = self.selection.select("withUnixSocket");
-
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "source",
@@ -2659,21 +2246,16 @@ impl Container {
                 Box::pin(async move { source.id().await.unwrap().quote() })
             }),
         );
-
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Retrieves this container plus a socket forwarded to the given Unix socket path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the forwarded Unix socket (e.g., "/tmp/socket").
     /// * `source` - Identifier of the socket to forward.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -2684,7 +2266,6 @@ impl Container {
         opts: ContainerWithUnixSocketOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withUnixSocket");
-
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "source",
@@ -2696,7 +2277,6 @@ impl Container {
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2705,17 +2285,12 @@ impl Container {
     }
     /// Retrieves this container with a different command user.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - The user to set (e.g., "root").
     pub fn with_user(&self, name: impl Into<String>) -> Container {
         let mut query = self.selection.select("withUser");
-
         query = query.arg("name", name.into());
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2724,17 +2299,12 @@ impl Container {
     }
     /// Retrieves this container with a different working directory.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - The path to set as the working directory (e.g., "/app").
     pub fn with_workdir(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withWorkdir");
-
         query = query.arg("path", path.into());
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2744,7 +2314,6 @@ impl Container {
     /// Retrieves this container with unset default arguments for future commands.
     pub fn without_default_args(&self) -> Container {
         let query = self.selection.select("withoutDefaultArgs");
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2753,37 +2322,27 @@ impl Container {
     }
     /// Retrieves this container with an unset command entrypoint.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn without_entrypoint(&self) -> Container {
         let query = self.selection.select("withoutEntrypoint");
-
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Retrieves this container with an unset command entrypoint.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn without_entrypoint_opts(&self, opts: ContainerWithoutEntrypointOpts) -> Container {
         let mut query = self.selection.select("withoutEntrypoint");
-
         if let Some(keep_default_args) = opts.keep_default_args {
             query = query.arg("keepDefaultArgs", keep_default_args);
         }
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2792,17 +2351,12 @@ impl Container {
     }
     /// Retrieves this container minus the given environment variable.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - The name of the environment variable (e.g., "HOST").
     pub fn without_env_variable(&self, name: impl Into<String>) -> Container {
         let mut query = self.selection.select("withoutEnvVariable");
-
         query = query.arg("name", name.into());
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2811,32 +2365,23 @@ impl Container {
     }
     /// Unexpose a previously exposed port.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `port` - Port number to unexpose
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn without_exposed_port(&self, port: isize) -> Container {
         let mut query = self.selection.select("withoutExposedPort");
-
         query = query.arg("port", port);
-
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Unexpose a previously exposed port.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `port` - Port number to unexpose
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn without_exposed_port_opts(
@@ -2845,12 +2390,10 @@ impl Container {
         opts: ContainerWithoutExposedPortOpts,
     ) -> Container {
         let mut query = self.selection.select("withoutExposedPort");
-
         query = query.arg("port", port);
         if let Some(protocol) = opts.protocol {
             query = query.arg("protocol", protocol);
         }
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2861,7 +2404,6 @@ impl Container {
     /// This is the initial state of all containers.
     pub fn without_focus(&self) -> Container {
         let query = self.selection.select("withoutFocus");
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2870,17 +2412,12 @@ impl Container {
     }
     /// Retrieves this container minus the given environment label.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - The name of the label to remove (e.g., "org.opencontainers.artifact.created").
     pub fn without_label(&self, name: impl Into<String>) -> Container {
         let mut query = self.selection.select("withoutLabel");
-
         query = query.arg("name", name.into());
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2889,17 +2426,12 @@ impl Container {
     }
     /// Retrieves this container after unmounting everything at the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the cache directory (e.g., "/cache/node_modules").
     pub fn without_mount(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withoutMount");
-
         query = query.arg("path", path.into());
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2908,19 +2440,14 @@ impl Container {
     }
     /// Retrieves this container without the registry authentication of a given address.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `address` - Registry's address to remove the authentication from.
     ///
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g. docker.io/dagger/dagger:main).
     pub fn without_registry_auth(&self, address: impl Into<String>) -> Container {
         let mut query = self.selection.select("withoutRegistryAuth");
-
         query = query.arg("address", address.into());
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2929,17 +2456,12 @@ impl Container {
     }
     /// Retrieves this container with a previously added Unix socket removed.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the socket to remove (e.g., "/tmp/socket").
     pub fn without_unix_socket(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withoutUnixSocket");
-
         query = query.arg("path", path.into());
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2950,7 +2472,6 @@ impl Container {
     /// Should default to root.
     pub fn without_user(&self) -> Container {
         let query = self.selection.select("withoutUser");
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2961,7 +2482,6 @@ impl Container {
     /// Should default to "/".
     pub fn without_workdir(&self) -> Container {
         let query = self.selection.select("withoutWorkdir");
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2971,7 +2491,6 @@ impl Container {
     /// Retrieves the working directory for all commands.
     pub async fn workdir(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("workdir");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -2981,7 +2500,6 @@ pub struct CurrentModule {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 #[derive(Builder, Debug, PartialEq)]
 pub struct CurrentModuleWorkdirOpts<'a> {
     /// Exclude artifacts that match the given pattern (e.g., ["node_modules/", ".git*"]).
@@ -2991,24 +2509,20 @@ pub struct CurrentModuleWorkdirOpts<'a> {
     #[builder(setter(into, strip_option), default)]
     pub include: Option<Vec<&'a str>>,
 }
-
 impl CurrentModule {
     /// A unique identifier for this CurrentModule.
     pub async fn id(&self) -> Result<CurrentModuleId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the module being executed in
     pub async fn name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("name");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The directory containing the module's source code loaded into the engine (plus any generated code that may have been created).
     pub fn source(&self) -> Directory {
         let query = self.selection.select("source");
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -3017,32 +2531,23 @@ impl CurrentModule {
     }
     /// Load a directory from the module's scratch working directory, including any changes that may have been made to it during module function execution.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the directory to access (e.g., ".").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn workdir(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("workdir");
-
         query = query.arg("path", path.into());
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Load a directory from the module's scratch working directory, including any changes that may have been made to it during module function execution.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the directory to access (e.g., ".").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn workdir_opts<'a>(
@@ -3051,7 +2556,6 @@ impl CurrentModule {
         opts: CurrentModuleWorkdirOpts<'a>,
     ) -> Directory {
         let mut query = self.selection.select("workdir");
-
         query = query.arg("path", path.into());
         if let Some(exclude) = opts.exclude {
             query = query.arg("exclude", exclude);
@@ -3059,7 +2563,6 @@ impl CurrentModule {
         if let Some(include) = opts.include {
             query = query.arg("include", include);
         }
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -3068,17 +2571,12 @@ impl CurrentModule {
     }
     /// Load a file from the module's scratch working directory, including any changes that may have been made to it during module function execution.Load a file from the module's scratch working directory, including any changes that may have been made to it during module function execution.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the file to retrieve (e.g., "README.md").
     pub fn workdir_file(&self, path: impl Into<String>) -> File {
         let mut query = self.selection.select("workdirFile");
-
         query = query.arg("path", path.into());
-
         File {
             proc: self.proc.clone(),
             selection: query,
@@ -3092,7 +2590,6 @@ pub struct Directory {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryAsModuleOpts<'a> {
     /// An optional subpath of the directory which contains the module's configuration file.
@@ -3174,41 +2671,30 @@ pub struct DirectoryWithNewFileOpts {
     #[builder(setter(into, strip_option), default)]
     pub permissions: Option<isize>,
 }
-
 impl Directory {
     /// Load the directory as a Dagger module
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn as_module(&self) -> Module {
         let query = self.selection.select("asModule");
-
         Module {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Load the directory as a Dagger module
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn as_module_opts<'a>(&self, opts: DirectoryAsModuleOpts<'a>) -> Module {
         let mut query = self.selection.select("asModule");
-
         if let Some(source_root_path) = opts.source_root_path {
             query = query.arg("sourceRootPath", source_root_path);
         }
-
         Module {
             proc: self.proc.clone(),
             selection: query,
@@ -3217,15 +2703,11 @@ impl Directory {
     }
     /// Gets the difference between this directory and an another directory.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `other` - Identifier of the directory to compare.
     pub fn diff(&self, other: Directory) -> Directory {
         let mut query = self.selection.select("diff");
-
         query = query.arg_lazy(
             "other",
             Box::new(move || {
@@ -3233,7 +2715,6 @@ impl Directory {
                 Box::pin(async move { other.id().await.unwrap().quote() })
             }),
         );
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -3242,17 +2723,12 @@ impl Directory {
     }
     /// Retrieves a directory at the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the directory to retrieve (e.g., "/src").
     pub fn directory(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("directory");
-
         query = query.arg("path", path.into());
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -3261,33 +2737,24 @@ impl Directory {
     }
     /// Builds a new Docker container from this directory.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn docker_build(&self) -> Container {
         let query = self.selection.select("dockerBuild");
-
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Builds a new Docker container from this directory.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn docker_build_opts<'a>(&self, opts: DirectoryDockerBuildOpts<'a>) -> Container {
         let mut query = self.selection.select("dockerBuild");
-
         if let Some(platform) = opts.platform {
             query = query.arg("platform", platform);
         }
@@ -3303,7 +2770,6 @@ impl Directory {
         if let Some(secrets) = opts.secrets {
             query = query.arg("secrets", secrets);
         }
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -3312,62 +2778,43 @@ impl Directory {
     }
     /// Returns a list of files and directories at the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn entries(&self) -> Result<Vec<String>, DaggerError> {
         let query = self.selection.select("entries");
-
         query.execute(self.graphql_client.clone()).await
     }
-
     /// Returns a list of files and directories at the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn entries_opts<'a>(
         &self,
         opts: DirectoryEntriesOpts<'a>,
     ) -> Result<Vec<String>, DaggerError> {
         let mut query = self.selection.select("entries");
-
         if let Some(path) = opts.path {
             query = query.arg("path", path);
         }
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Writes the contents of the directory to a path on the host.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the copied directory (e.g., "logs/").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn export(&self, path: impl Into<String>) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
-
         query = query.arg("path", path.into());
-
         query.execute(self.graphql_client.clone()).await
     }
-
     /// Writes the contents of the directory to a path on the host.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the copied directory (e.g., "logs/").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn export_opts(
@@ -3376,27 +2823,20 @@ impl Directory {
         opts: DirectoryExportOpts,
     ) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
-
         query = query.arg("path", path.into());
         if let Some(wipe) = opts.wipe {
             query = query.arg("wipe", wipe);
         }
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves a file at the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the file to retrieve (e.g., "README.md").
     pub fn file(&self, path: impl Into<String>) -> File {
         let mut query = self.selection.select("file");
-
         query = query.arg("path", path.into());
-
         File {
             proc: self.proc.clone(),
             selection: query,
@@ -3405,53 +2845,38 @@ impl Directory {
     }
     /// Returns a list of files and directories that matche the given pattern.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `pattern` - Pattern to match (e.g., "*.md").
     pub async fn glob(&self, pattern: impl Into<String>) -> Result<Vec<String>, DaggerError> {
         let mut query = self.selection.select("glob");
-
         query = query.arg("pattern", pattern.into());
-
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this Directory.
     pub async fn id(&self) -> Result<DirectoryId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Creates a named sub-pipeline.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - Name of the sub-pipeline.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn pipeline(&self, name: impl Into<String>) -> Directory {
         let mut query = self.selection.select("pipeline");
-
         query = query.arg("name", name.into());
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Creates a named sub-pipeline.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - Name of the sub-pipeline.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn pipeline_opts<'a>(
@@ -3460,7 +2885,6 @@ impl Directory {
         opts: DirectoryPipelineOpts<'a>,
     ) -> Directory {
         let mut query = self.selection.select("pipeline");
-
         query = query.arg("name", name.into());
         if let Some(description) = opts.description {
             query = query.arg("description", description);
@@ -3468,7 +2892,6 @@ impl Directory {
         if let Some(labels) = opts.labels {
             query = query.arg("labels", labels);
         }
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -3478,22 +2901,17 @@ impl Directory {
     /// Force evaluation in the engine.
     pub async fn sync(&self) -> Result<DirectoryId, DaggerError> {
         let query = self.selection.select("sync");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves this directory plus a directory written at the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the written directory (e.g., "/src/").
     /// * `directory` - Identifier of the directory to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_directory(&self, path: impl Into<String>, directory: Directory) -> Directory {
         let mut query = self.selection.select("withDirectory");
-
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "directory",
@@ -3502,21 +2920,16 @@ impl Directory {
                 Box::pin(async move { directory.id().await.unwrap().quote() })
             }),
         );
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Retrieves this directory plus a directory written at the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the written directory (e.g., "/src/").
     /// * `directory` - Identifier of the directory to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -3527,7 +2940,6 @@ impl Directory {
         opts: DirectoryWithDirectoryOpts<'a>,
     ) -> Directory {
         let mut query = self.selection.select("withDirectory");
-
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "directory",
@@ -3542,7 +2954,6 @@ impl Directory {
         if let Some(include) = opts.include {
             query = query.arg("include", include);
         }
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -3551,17 +2962,13 @@ impl Directory {
     }
     /// Retrieves this directory plus the contents of the given file copied to the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the copied file (e.g., "/file.txt").
     /// * `source` - Identifier of the file to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_file(&self, path: impl Into<String>, source: File) -> Directory {
         let mut query = self.selection.select("withFile");
-
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "source",
@@ -3570,21 +2977,16 @@ impl Directory {
                 Box::pin(async move { source.id().await.unwrap().quote() })
             }),
         );
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Retrieves this directory plus the contents of the given file copied to the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the copied file (e.g., "/file.txt").
     /// * `source` - Identifier of the file to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -3595,7 +2997,6 @@ impl Directory {
         opts: DirectoryWithFileOpts,
     ) -> Directory {
         let mut query = self.selection.select("withFile");
-
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "source",
@@ -3607,7 +3008,6 @@ impl Directory {
         if let Some(permissions) = opts.permissions {
             query = query.arg("permissions", permissions);
         }
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -3616,34 +3016,25 @@ impl Directory {
     }
     /// Retrieves this directory plus the contents of the given files copied to the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location where copied files should be placed (e.g., "/src").
     /// * `sources` - Identifiers of the files to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_files(&self, path: impl Into<String>, sources: Vec<FileId>) -> Directory {
         let mut query = self.selection.select("withFiles");
-
         query = query.arg("path", path.into());
         query = query.arg("sources", sources);
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Retrieves this directory plus the contents of the given files copied to the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location where copied files should be placed (e.g., "/src").
     /// * `sources` - Identifiers of the files to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -3654,13 +3045,11 @@ impl Directory {
         opts: DirectoryWithFilesOpts,
     ) -> Directory {
         let mut query = self.selection.select("withFiles");
-
         query = query.arg("path", path.into());
         query = query.arg("sources", sources);
         if let Some(permissions) = opts.permissions {
             query = query.arg("permissions", permissions);
         }
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -3669,32 +3058,23 @@ impl Directory {
     }
     /// Retrieves this directory plus a new directory created at the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the directory created (e.g., "/logs").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_new_directory(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("withNewDirectory");
-
         query = query.arg("path", path.into());
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Retrieves this directory plus a new directory created at the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the directory created (e.g., "/logs").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_new_directory_opts(
@@ -3703,12 +3083,10 @@ impl Directory {
         opts: DirectoryWithNewDirectoryOpts,
     ) -> Directory {
         let mut query = self.selection.select("withNewDirectory");
-
         query = query.arg("path", path.into());
         if let Some(permissions) = opts.permissions {
             query = query.arg("permissions", permissions);
         }
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -3717,34 +3095,25 @@ impl Directory {
     }
     /// Retrieves this directory plus a new file written at the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the written file (e.g., "/file.txt").
     /// * `contents` - Content of the written file (e.g., "Hello world!").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_new_file(&self, path: impl Into<String>, contents: impl Into<String>) -> Directory {
         let mut query = self.selection.select("withNewFile");
-
         query = query.arg("path", path.into());
         query = query.arg("contents", contents.into());
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Retrieves this directory plus a new file written at the given path.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the written file (e.g., "/file.txt").
     /// * `contents` - Content of the written file (e.g., "Hello world!").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -3755,13 +3124,11 @@ impl Directory {
         opts: DirectoryWithNewFileOpts,
     ) -> Directory {
         let mut query = self.selection.select("withNewFile");
-
         query = query.arg("path", path.into());
         query = query.arg("contents", contents.into());
         if let Some(permissions) = opts.permissions {
             query = query.arg("permissions", permissions);
         }
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -3770,19 +3137,14 @@ impl Directory {
     }
     /// Retrieves this directory with all file/dir timestamps set to the given time.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `timestamp` - Timestamp to set dir/files in.
     ///
     /// Formatted in seconds following Unix epoch (e.g., 1672531199).
     pub fn with_timestamps(&self, timestamp: isize) -> Directory {
         let mut query = self.selection.select("withTimestamps");
-
         query = query.arg("timestamp", timestamp);
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -3791,17 +3153,12 @@ impl Directory {
     }
     /// Retrieves this directory with the directory at the given path removed.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the directory to remove (e.g., ".github/").
     pub fn without_directory(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("withoutDirectory");
-
         query = query.arg("path", path.into());
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -3810,17 +3167,12 @@ impl Directory {
     }
     /// Retrieves this directory with the file at the given path removed.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the file to remove (e.g., "/file.txt").
     pub fn without_file(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("withoutFile");
-
         query = query.arg("path", path.into());
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -3834,24 +3186,20 @@ pub struct EnvVariable {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl EnvVariable {
     /// A unique identifier for this EnvVariable.
     pub async fn id(&self) -> Result<EnvVariableId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The environment variable name.
     pub async fn name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("name");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The environment variable value.
     pub async fn value(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("value");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -3861,30 +3209,25 @@ pub struct FieldTypeDef {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl FieldTypeDef {
     /// A doc string for the field, if any.
     pub async fn description(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("description");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this FieldTypeDef.
     pub async fn id(&self) -> Result<FieldTypeDefId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the field in lowerCamelCase format.
     pub async fn name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("name");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The type of the field.
     pub fn type_def(&self) -> TypeDef {
         let query = self.selection.select("typeDef");
-
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -3898,45 +3241,33 @@ pub struct File {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 #[derive(Builder, Debug, PartialEq)]
 pub struct FileExportOpts {
     /// If allowParentDirPath is true, the path argument can be a directory path, in which case the file will be created in that directory.
     #[builder(setter(into, strip_option), default)]
     pub allow_parent_dir_path: Option<bool>,
 }
-
 impl File {
     /// Retrieves the contents of the file.
     pub async fn contents(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("contents");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Writes the file to a file path on the host.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the written directory (e.g., "output.txt").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn export(&self, path: impl Into<String>) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
-
         query = query.arg("path", path.into());
-
         query.execute(self.graphql_client.clone()).await
     }
-
     /// Writes the file to a file path on the host.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the written directory (e.g., "output.txt").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn export_opts(
@@ -3945,53 +3276,42 @@ impl File {
         opts: FileExportOpts,
     ) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
-
         query = query.arg("path", path.into());
         if let Some(allow_parent_dir_path) = opts.allow_parent_dir_path {
             query = query.arg("allowParentDirPath", allow_parent_dir_path);
         }
-
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this File.
     pub async fn id(&self) -> Result<FileId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the name of the file.
     pub async fn name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("name");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the size of the file, in bytes.
     pub async fn size(&self) -> Result<isize, DaggerError> {
         let query = self.selection.select("size");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Force evaluation in the engine.
     pub async fn sync(&self) -> Result<FileId, DaggerError> {
         let query = self.selection.select("sync");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves this file with its created/modified timestamps set to the given time.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `timestamp` - Timestamp to set dir/files in.
     ///
     /// Formatted in seconds following Unix epoch (e.g., 1672531199).
     pub fn with_timestamps(&self, timestamp: isize) -> File {
         let mut query = self.selection.select("withTimestamps");
-
         query = query.arg("timestamp", timestamp);
-
         File {
             proc: self.proc.clone(),
             selection: query,
@@ -4005,7 +3325,6 @@ pub struct Function {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 #[derive(Builder, Debug, PartialEq)]
 pub struct FunctionWithArgOpts<'a> {
     /// A default value to use for this argument if not explicitly set by the caller, if any
@@ -4015,12 +3334,10 @@ pub struct FunctionWithArgOpts<'a> {
     #[builder(setter(into, strip_option), default)]
     pub description: Option<&'a str>,
 }
-
 impl Function {
     /// Arguments accepted by the function, if any.
     pub fn args(&self) -> Vec<FunctionArg> {
         let query = self.selection.select("args");
-
         return vec![FunctionArg {
             proc: self.proc.clone(),
             selection: query,
@@ -4030,25 +3347,21 @@ impl Function {
     /// A doc string for the function, if any.
     pub async fn description(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("description");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this Function.
     pub async fn id(&self) -> Result<FunctionId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the function.
     pub async fn name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("name");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The type returned by the function.
     pub fn return_type(&self) -> TypeDef {
         let query = self.selection.select("returnType");
-
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -4057,17 +3370,13 @@ impl Function {
     }
     /// Returns the function with the provided argument
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - The name of the argument
     /// * `type_def` - The type of the argument
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_arg(&self, name: impl Into<String>, type_def: TypeDef) -> Function {
         let mut query = self.selection.select("withArg");
-
         query = query.arg("name", name.into());
         query = query.arg_lazy(
             "typeDef",
@@ -4076,21 +3385,16 @@ impl Function {
                 Box::pin(async move { type_def.id().await.unwrap().quote() })
             }),
         );
-
         Function {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Returns the function with the provided argument
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - The name of the argument
     /// * `type_def` - The type of the argument
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -4101,7 +3405,6 @@ impl Function {
         opts: FunctionWithArgOpts<'a>,
     ) -> Function {
         let mut query = self.selection.select("withArg");
-
         query = query.arg("name", name.into());
         query = query.arg_lazy(
             "typeDef",
@@ -4116,7 +3419,6 @@ impl Function {
         if let Some(default_value) = opts.default_value {
             query = query.arg("defaultValue", default_value);
         }
-
         Function {
             proc: self.proc.clone(),
             selection: query,
@@ -4125,17 +3427,12 @@ impl Function {
     }
     /// Returns the function with the given doc string.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `description` - The doc string to set.
     pub fn with_description(&self, description: impl Into<String>) -> Function {
         let mut query = self.selection.select("withDescription");
-
         query = query.arg("description", description.into());
-
         Function {
             proc: self.proc.clone(),
             selection: query,
@@ -4149,36 +3446,30 @@ pub struct FunctionArg {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl FunctionArg {
     /// A default value to use for this argument when not explicitly set by the caller, if any.
     pub async fn default_value(&self) -> Result<Json, DaggerError> {
         let query = self.selection.select("defaultValue");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// A doc string for the argument, if any.
     pub async fn description(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("description");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this FunctionArg.
     pub async fn id(&self) -> Result<FunctionArgId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the argument in lowerCamelCase format.
     pub async fn name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("name");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The type of the argument.
     pub fn type_def(&self) -> TypeDef {
         let query = self.selection.select("typeDef");
-
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -4192,18 +3483,15 @@ pub struct FunctionCall {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl FunctionCall {
     /// A unique identifier for this FunctionCall.
     pub async fn id(&self) -> Result<FunctionCallId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The argument values the function is being invoked with.
     pub fn input_args(&self) -> Vec<FunctionCallArgValue> {
         let query = self.selection.select("inputArgs");
-
         return vec![FunctionCallArgValue {
             proc: self.proc.clone(),
             selection: query,
@@ -4213,34 +3501,26 @@ impl FunctionCall {
     /// The name of the function being called.
     pub async fn name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("name");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The value of the parent object of the function being called. If the function is top-level to the module, this is always an empty object.
     pub async fn parent(&self) -> Result<Json, DaggerError> {
         let query = self.selection.select("parent");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the parent object of the function being called. If the function is top-level to the module, this is the name of the module.
     pub async fn parent_name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("parentName");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Set the return value of the function call to the provided value.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `value` - JSON serialization of the return value.
     pub async fn return_value(&self, value: Json) -> Result<Void, DaggerError> {
         let mut query = self.selection.select("returnValue");
-
         query = query.arg("value", value);
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -4250,24 +3530,20 @@ pub struct FunctionCallArgValue {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl FunctionCallArgValue {
     /// A unique identifier for this FunctionCallArgValue.
     pub async fn id(&self) -> Result<FunctionCallArgValueId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the argument.
     pub async fn name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("name");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The value of the argument represented as a JSON serialized string.
     pub async fn value(&self) -> Result<Json, DaggerError> {
         let query = self.selection.select("value");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -4277,12 +3553,10 @@ pub struct GeneratedCode {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl GeneratedCode {
     /// The directory containing the generated code.
     pub fn code(&self) -> Directory {
         let query = self.selection.select("code");
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -4292,30 +3566,25 @@ impl GeneratedCode {
     /// A unique identifier for this GeneratedCode.
     pub async fn id(&self) -> Result<GeneratedCodeId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// List of paths to mark generated in version control (i.e. .gitattributes).
     pub async fn vcs_generated_paths(&self) -> Result<Vec<String>, DaggerError> {
         let query = self.selection.select("vcsGeneratedPaths");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// List of paths to ignore in version control (i.e. .gitignore).
     pub async fn vcs_ignored_paths(&self) -> Result<Vec<String>, DaggerError> {
         let query = self.selection.select("vcsIgnoredPaths");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Set the list of paths to mark generated in version control.
     pub fn with_vcs_generated_paths(&self, paths: Vec<impl Into<String>>) -> GeneratedCode {
         let mut query = self.selection.select("withVCSGeneratedPaths");
-
         query = query.arg(
             "paths",
             paths.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
         );
-
         GeneratedCode {
             proc: self.proc.clone(),
             selection: query,
@@ -4325,12 +3594,10 @@ impl GeneratedCode {
     /// Set the list of paths to ignore in version control.
     pub fn with_vcs_ignored_paths(&self, paths: Vec<impl Into<String>>) -> GeneratedCode {
         let mut query = self.selection.select("withVCSIgnoredPaths");
-
         query = query.arg(
             "paths",
             paths.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
         );
-
         GeneratedCode {
             proc: self.proc.clone(),
             selection: query,
@@ -4344,24 +3611,20 @@ pub struct GitModuleSource {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl GitModuleSource {
     /// The URL from which the source's git repo can be cloned.
     pub async fn clone_url(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("cloneURL");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The resolved commit of the git repo this source points to.
     pub async fn commit(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("commit");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The directory containing everything needed to load load and use the module.
     pub fn context_directory(&self) -> Directory {
         let query = self.selection.select("contextDirectory");
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -4371,25 +3634,21 @@ impl GitModuleSource {
     /// The URL to the source's git repo in a web browser
     pub async fn html_url(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("htmlURL");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this GitModuleSource.
     pub async fn id(&self) -> Result<GitModuleSourceId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The path to the root of the module source under the context directory. This directory contains its configuration file. It also contains its source code (possibly as a subdirectory).
     pub async fn root_subpath(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("rootSubpath");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The specified version of the git repo this source points to.
     pub async fn version(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("version");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -4399,7 +3658,6 @@ pub struct GitRef {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 #[derive(Builder, Debug, PartialEq)]
 pub struct GitRefTreeOpts<'a> {
     /// DEPRECATED: This option should be passed to `git` instead.
@@ -4409,56 +3667,43 @@ pub struct GitRefTreeOpts<'a> {
     #[builder(setter(into, strip_option), default)]
     pub ssh_known_hosts: Option<&'a str>,
 }
-
 impl GitRef {
     /// The resolved commit id at this ref.
     pub async fn commit(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("commit");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this GitRef.
     pub async fn id(&self) -> Result<GitRefId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The filesystem tree at this ref.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn tree(&self) -> Directory {
         let query = self.selection.select("tree");
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// The filesystem tree at this ref.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn tree_opts<'a>(&self, opts: GitRefTreeOpts<'a>) -> Directory {
         let mut query = self.selection.select("tree");
-
         if let Some(ssh_known_hosts) = opts.ssh_known_hosts {
             query = query.arg("sshKnownHosts", ssh_known_hosts);
         }
         if let Some(ssh_auth_socket) = opts.ssh_auth_socket {
             query = query.arg("sshAuthSocket", ssh_auth_socket);
         }
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -4472,21 +3717,15 @@ pub struct GitRepository {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl GitRepository {
     /// Returns details of a branch.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - Branch's name (e.g., "main").
     pub fn branch(&self, name: impl Into<String>) -> GitRef {
         let mut query = self.selection.select("branch");
-
         query = query.arg("name", name.into());
-
         GitRef {
             proc: self.proc.clone(),
             selection: query,
@@ -4495,17 +3734,12 @@ impl GitRepository {
     }
     /// Returns details of a commit.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `id` - Identifier of the commit (e.g., "b6315d8f2810962c601af73f86831f6866ea798b").
     pub fn commit(&self, id: impl Into<String>) -> GitRef {
         let mut query = self.selection.select("commit");
-
         query = query.arg("id", id.into());
-
         GitRef {
             proc: self.proc.clone(),
             selection: query,
@@ -4515,7 +3749,6 @@ impl GitRepository {
     /// Returns details for HEAD.
     pub fn head(&self) -> GitRef {
         let query = self.selection.select("head");
-
         GitRef {
             proc: self.proc.clone(),
             selection: query,
@@ -4525,22 +3758,16 @@ impl GitRepository {
     /// A unique identifier for this GitRepository.
     pub async fn id(&self) -> Result<GitRepositoryId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Returns details of a ref.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - Ref's name (can be a commit identifier, a tag name, a branch name, or a fully-qualified ref).
     pub fn r#ref(&self, name: impl Into<String>) -> GitRef {
         let mut query = self.selection.select("ref");
-
         query = query.arg("name", name.into());
-
         GitRef {
             proc: self.proc.clone(),
             selection: query,
@@ -4549,17 +3776,12 @@ impl GitRepository {
     }
     /// Returns details of a tag.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - Tag's name (e.g., "v0.3.9").
     pub fn tag(&self, name: impl Into<String>) -> GitRef {
         let mut query = self.selection.select("tag");
-
         query = query.arg("name", name.into());
-
         GitRef {
             proc: self.proc.clone(),
             selection: query,
@@ -4613,7 +3835,6 @@ pub struct Host {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 #[derive(Builder, Debug, PartialEq)]
 pub struct HostDirectoryOpts<'a> {
     /// Exclude artifacts that match the given pattern (e.g., ["node_modules/", ".git*"]).
@@ -4642,36 +3863,26 @@ pub struct HostTunnelOpts {
     #[builder(setter(into, strip_option), default)]
     pub ports: Option<Vec<PortForward>>,
 }
-
 impl Host {
     /// Accesses a directory on the host.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the directory to access (e.g., ".").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn directory(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("directory");
-
         query = query.arg("path", path.into());
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Accesses a directory on the host.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the directory to access (e.g., ".").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn directory_opts<'a>(
@@ -4680,7 +3891,6 @@ impl Host {
         opts: HostDirectoryOpts<'a>,
     ) -> Directory {
         let mut query = self.selection.select("directory");
-
         query = query.arg("path", path.into());
         if let Some(exclude) = opts.exclude {
             query = query.arg("exclude", exclude);
@@ -4688,7 +3898,6 @@ impl Host {
         if let Some(include) = opts.include {
             query = query.arg("include", include);
         }
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -4697,17 +3906,12 @@ impl Host {
     }
     /// Accesses a file on the host.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the file to retrieve (e.g., "README.md").
     pub fn file(&self, path: impl Into<String>) -> File {
         let mut query = self.selection.select("file");
-
         query = query.arg("path", path.into());
-
         File {
             proc: self.proc.clone(),
             selection: query,
@@ -4717,16 +3921,12 @@ impl Host {
     /// A unique identifier for this Host.
     pub async fn id(&self) -> Result<HostId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Creates a service that forwards traffic to a specified address via the host.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `ports` - Ports to expose via the service, forwarding through the host network.
     ///
     /// If a port's frontend is unspecified or 0, it defaults to the same as the backend port.
@@ -4735,23 +3935,17 @@ impl Host {
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn service(&self, ports: Vec<PortForward>) -> Service {
         let mut query = self.selection.select("service");
-
         query = query.arg("ports", ports);
-
         Service {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Creates a service that forwards traffic to a specified address via the host.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `ports` - Ports to expose via the service, forwarding through the host network.
     ///
     /// If a port's frontend is unspecified or 0, it defaults to the same as the backend port.
@@ -4760,12 +3954,10 @@ impl Host {
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn service_opts<'a>(&self, ports: Vec<PortForward>, opts: HostServiceOpts<'a>) -> Service {
         let mut query = self.selection.select("service");
-
         query = query.arg("ports", ports);
         if let Some(host) = opts.host {
             query = query.arg("host", host);
         }
-
         Service {
             proc: self.proc.clone(),
             selection: query,
@@ -4775,19 +3967,14 @@ impl Host {
     /// Sets a secret given a user-defined name and the file path on the host, and returns the secret.
     /// The file is limited to a size of 512000 bytes.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - The user defined name for this secret.
     /// * `path` - Location of the file to set as a secret.
     pub fn set_secret_file(&self, name: impl Into<String>, path: impl Into<String>) -> Secret {
         let mut query = self.selection.select("setSecretFile");
-
         query = query.arg("name", name.into());
         query = query.arg("path", path.into());
-
         Secret {
             proc: self.proc.clone(),
             selection: query,
@@ -4796,16 +3983,12 @@ impl Host {
     }
     /// Creates a tunnel that forwards traffic from the host to a service.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `service` - Service to send traffic from the tunnel.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn tunnel(&self, service: Service) -> Service {
         let mut query = self.selection.select("tunnel");
-
         query = query.arg_lazy(
             "service",
             Box::new(move || {
@@ -4813,26 +3996,20 @@ impl Host {
                 Box::pin(async move { service.id().await.unwrap().quote() })
             }),
         );
-
         Service {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Creates a tunnel that forwards traffic from the host to a service.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `service` - Service to send traffic from the tunnel.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn tunnel_opts(&self, service: Service, opts: HostTunnelOpts) -> Service {
         let mut query = self.selection.select("tunnel");
-
         query = query.arg_lazy(
             "service",
             Box::new(move || {
@@ -4846,7 +4023,6 @@ impl Host {
         if let Some(native) = opts.native {
             query = query.arg("native", native);
         }
-
         Service {
             proc: self.proc.clone(),
             selection: query,
@@ -4855,17 +4031,12 @@ impl Host {
     }
     /// Accesses a Unix socket on the host.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - Location of the Unix socket (e.g., "/var/run/docker.sock").
     pub fn unix_socket(&self, path: impl Into<String>) -> Socket {
         let mut query = self.selection.select("unixSocket");
-
         query = query.arg("path", path.into());
-
         Socket {
             proc: self.proc.clone(),
             selection: query,
@@ -4879,12 +4050,10 @@ pub struct InputTypeDef {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl InputTypeDef {
     /// Static fields defined on this input object, if any.
     pub fn fields(&self) -> Vec<FieldTypeDef> {
         let query = self.selection.select("fields");
-
         return vec![FieldTypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -4894,13 +4063,11 @@ impl InputTypeDef {
     /// A unique identifier for this InputTypeDef.
     pub async fn id(&self) -> Result<InputTypeDefId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the input object.
     pub async fn name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("name");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -4910,18 +4077,15 @@ pub struct InterfaceTypeDef {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl InterfaceTypeDef {
     /// The doc string for the interface, if any.
     pub async fn description(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("description");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Functions defined on this interface, if any.
     pub fn functions(&self) -> Vec<Function> {
         let query = self.selection.select("functions");
-
         return vec![Function {
             proc: self.proc.clone(),
             selection: query,
@@ -4931,19 +4095,16 @@ impl InterfaceTypeDef {
     /// A unique identifier for this InterfaceTypeDef.
     pub async fn id(&self) -> Result<InterfaceTypeDefId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the interface.
     pub async fn name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("name");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// If this InterfaceTypeDef is associated with a Module, the name of the module. Unset otherwise.
     pub async fn source_module_name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("sourceModuleName");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -4953,24 +4114,20 @@ pub struct Label {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl Label {
     /// A unique identifier for this Label.
     pub async fn id(&self) -> Result<LabelId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The label name.
     pub async fn name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("name");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The label value.
     pub async fn value(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("value");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -4980,12 +4137,10 @@ pub struct ListTypeDef {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl ListTypeDef {
     /// The type of the elements in the list.
     pub fn element_type_def(&self) -> TypeDef {
         let query = self.selection.select("elementTypeDef");
-
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -4995,7 +4150,6 @@ impl ListTypeDef {
     /// A unique identifier for this ListTypeDef.
     pub async fn id(&self) -> Result<ListTypeDefId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -5005,12 +4159,10 @@ pub struct LocalModuleSource {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl LocalModuleSource {
     /// The directory containing everything needed to load load and use the module.
     pub fn context_directory(&self) -> Directory {
         let query = self.selection.select("contextDirectory");
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -5020,13 +4172,11 @@ impl LocalModuleSource {
     /// A unique identifier for this LocalModuleSource.
     pub async fn id(&self) -> Result<LocalModuleSourceId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The path to the root of the module source under the context directory. This directory contains its configuration file. It also contains its source code (possibly as a subdirectory).
     pub async fn root_subpath(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("rootSubpath");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -5036,12 +4186,10 @@ pub struct Module {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl Module {
     /// Modules used by this module.
     pub fn dependencies(&self) -> Vec<Module> {
         let query = self.selection.select("dependencies");
-
         return vec![Module {
             proc: self.proc.clone(),
             selection: query,
@@ -5051,7 +4199,6 @@ impl Module {
     /// The dependencies as configured by the module.
     pub fn dependency_config(&self) -> Vec<ModuleDependency> {
         let query = self.selection.select("dependencyConfig");
-
         return vec![ModuleDependency {
             proc: self.proc.clone(),
             selection: query,
@@ -5061,13 +4208,11 @@ impl Module {
     /// The doc string of the module, if any
     pub async fn description(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("description");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The generated files and directories made on top of the module source's context directory.
     pub fn generated_context_diff(&self) -> Directory {
         let query = self.selection.select("generatedContextDiff");
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -5077,7 +4222,6 @@ impl Module {
     /// The module source's context plus any configuration and source files created by codegen.
     pub fn generated_context_directory(&self) -> Directory {
         let query = self.selection.select("generatedContextDirectory");
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -5087,13 +4231,11 @@ impl Module {
     /// A unique identifier for this Module.
     pub async fn id(&self) -> Result<ModuleId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the module with the objects loaded via its SDK.
     pub fn initialize(&self) -> Module {
         let query = self.selection.select("initialize");
-
         Module {
             proc: self.proc.clone(),
             selection: query,
@@ -5103,7 +4245,6 @@ impl Module {
     /// Interfaces served by this module.
     pub fn interfaces(&self) -> Vec<TypeDef> {
         let query = self.selection.select("interfaces");
-
         return vec![TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -5113,13 +4254,11 @@ impl Module {
     /// The name of the module
     pub async fn name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("name");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Objects served by this module.
     pub fn objects(&self) -> Vec<TypeDef> {
         let query = self.selection.select("objects");
-
         return vec![TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -5129,7 +4268,6 @@ impl Module {
     /// The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile.
     pub fn runtime(&self) -> Container {
         let query = self.selection.select("runtime");
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -5139,20 +4277,17 @@ impl Module {
     /// The SDK used by this module. Either a name of a builtin SDK or a module source ref string pointing to the SDK's implementation.
     pub async fn sdk(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("sdk");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Serve a module's API in the current session.
     /// Note: this can only be called once per session. In the future, it could return a stream or service to remove the side effect.
     pub async fn serve(&self) -> Result<Void, DaggerError> {
         let query = self.selection.select("serve");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The source for the module.
     pub fn source(&self) -> ModuleSource {
         let query = self.selection.select("source");
-
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -5161,17 +4296,12 @@ impl Module {
     }
     /// Retrieves the module with the given description
     ///
-
     /// # Arguments
-
     ///
-
     /// * `description` - The description to set
     pub fn with_description(&self, description: impl Into<String>) -> Module {
         let mut query = self.selection.select("withDescription");
-
         query = query.arg("description", description.into());
-
         Module {
             proc: self.proc.clone(),
             selection: query,
@@ -5181,7 +4311,6 @@ impl Module {
     /// This module plus the given Interface type and associated functions
     pub fn with_interface(&self, iface: TypeDef) -> Module {
         let mut query = self.selection.select("withInterface");
-
         query = query.arg_lazy(
             "iface",
             Box::new(move || {
@@ -5189,7 +4318,6 @@ impl Module {
                 Box::pin(async move { iface.id().await.unwrap().quote() })
             }),
         );
-
         Module {
             proc: self.proc.clone(),
             selection: query,
@@ -5199,7 +4327,6 @@ impl Module {
     /// This module plus the given Object type and associated functions.
     pub fn with_object(&self, object: TypeDef) -> Module {
         let mut query = self.selection.select("withObject");
-
         query = query.arg_lazy(
             "object",
             Box::new(move || {
@@ -5207,7 +4334,6 @@ impl Module {
                 Box::pin(async move { object.id().await.unwrap().quote() })
             }),
         );
-
         Module {
             proc: self.proc.clone(),
             selection: query,
@@ -5216,15 +4342,11 @@ impl Module {
     }
     /// Retrieves the module with basic configuration loaded if present.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `source` - The module source to initialize from.
     pub fn with_source(&self, source: ModuleSource) -> Module {
         let mut query = self.selection.select("withSource");
-
         query = query.arg_lazy(
             "source",
             Box::new(move || {
@@ -5232,7 +4354,6 @@ impl Module {
                 Box::pin(async move { source.id().await.unwrap().quote() })
             }),
         );
-
         Module {
             proc: self.proc.clone(),
             selection: query,
@@ -5246,24 +4367,20 @@ pub struct ModuleDependency {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl ModuleDependency {
     /// A unique identifier for this ModuleDependency.
     pub async fn id(&self) -> Result<ModuleDependencyId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the dependency module.
     pub async fn name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("name");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The source for the dependency module.
     pub fn source(&self) -> ModuleSource {
         let query = self.selection.select("source");
-
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -5277,19 +4394,16 @@ pub struct ModuleSource {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 #[derive(Builder, Debug, PartialEq)]
 pub struct ModuleSourceResolveDirectoryFromCallerOpts<'a> {
     /// If set, the name of the view to apply to the path.
     #[builder(setter(into, strip_option), default)]
     pub view_name: Option<&'a str>,
 }
-
 impl ModuleSource {
     /// If the source is a of kind git, the git source representation of it.
     pub fn as_git_source(&self) -> GitModuleSource {
         let query = self.selection.select("asGitSource");
-
         GitModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -5299,7 +4413,6 @@ impl ModuleSource {
     /// If the source is of kind local, the local source representation of it.
     pub fn as_local_source(&self) -> LocalModuleSource {
         let query = self.selection.select("asLocalSource");
-
         LocalModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -5309,7 +4422,6 @@ impl ModuleSource {
     /// Load the source as a module. If this is a local source, the parent directory must have been provided during module source creation
     pub fn as_module(&self) -> Module {
         let query = self.selection.select("asModule");
-
         Module {
             proc: self.proc.clone(),
             selection: query,
@@ -5319,19 +4431,16 @@ impl ModuleSource {
     /// A human readable ref string representation of this module source.
     pub async fn as_string(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("asString");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Returns whether the module source has a configuration file.
     pub async fn config_exists(&self) -> Result<bool, DaggerError> {
         let query = self.selection.select("configExists");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The directory containing everything needed to load load and use the module.
     pub fn context_directory(&self) -> Directory {
         let query = self.selection.select("contextDirectory");
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -5341,7 +4450,6 @@ impl ModuleSource {
     /// The dependencies of the module source. Includes dependencies from the configuration and any extras from withDependencies calls.
     pub fn dependencies(&self) -> Vec<ModuleDependency> {
         let query = self.selection.select("dependencies");
-
         return vec![ModuleDependency {
             proc: self.proc.clone(),
             selection: query,
@@ -5350,17 +4458,12 @@ impl ModuleSource {
     }
     /// The directory containing the module configuration and source code (source code may be in a subdir).
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - The path from the source directory to select.
     pub fn directory(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("directory");
-
         query = query.arg("path", path.into());
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -5370,44 +4473,35 @@ impl ModuleSource {
     /// A unique identifier for this ModuleSource.
     pub async fn id(&self) -> Result<ModuleSourceId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The kind of source (e.g. local, git, etc.)
     pub async fn kind(&self) -> Result<ModuleSourceKind, DaggerError> {
         let query = self.selection.select("kind");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// If set, the name of the module this source references, including any overrides at runtime by callers.
     pub async fn module_name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("moduleName");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The original name of the module this source references, as defined in the module configuration.
     pub async fn module_original_name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("moduleOriginalName");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The path to the module source's context directory on the caller's filesystem. Only valid for local sources.
     pub async fn resolve_context_path_from_caller(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("resolveContextPathFromCaller");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Resolve the provided module source arg as a dependency relative to this module source.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `dep` - The dependency module source to resolve.
     pub fn resolve_dependency(&self, dep: ModuleSource) -> ModuleSource {
         let mut query = self.selection.select("resolveDependency");
-
         query = query.arg_lazy(
             "dep",
             Box::new(move || {
@@ -5415,7 +4509,6 @@ impl ModuleSource {
                 Box::pin(async move { dep.id().await.unwrap().quote() })
             }),
         );
-
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -5424,32 +4517,23 @@ impl ModuleSource {
     }
     /// Load a directory from the caller optionally with a given view applied.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - The path on the caller's filesystem to load.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn resolve_directory_from_caller(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("resolveDirectoryFromCaller");
-
         query = query.arg("path", path.into());
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Load a directory from the caller optionally with a given view applied.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - The path on the caller's filesystem to load.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn resolve_directory_from_caller_opts<'a>(
@@ -5458,12 +4542,10 @@ impl ModuleSource {
         opts: ModuleSourceResolveDirectoryFromCallerOpts<'a>,
     ) -> Directory {
         let mut query = self.selection.select("resolveDirectoryFromCaller");
-
         query = query.arg("path", path.into());
         if let Some(view_name) = opts.view_name {
             query = query.arg("viewName", view_name);
         }
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -5473,7 +4555,6 @@ impl ModuleSource {
     /// Load the source from its path on the caller's filesystem, including only needed+configured files and directories. Only valid for local sources.
     pub fn resolve_from_caller(&self) -> ModuleSource {
         let query = self.selection.select("resolveFromCaller");
-
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -5483,28 +4564,21 @@ impl ModuleSource {
     /// The path relative to context of the root of the module source, which contains dagger.json. It also contains the module implementation source code, but that may or may not being a subdir of this root.
     pub async fn source_root_subpath(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("sourceRootSubpath");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The path relative to context of the module implementation source code.
     pub async fn source_subpath(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("sourceSubpath");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieve a named view defined for this module source.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - The name of the view to retrieve.
     pub fn view(&self, name: impl Into<String>) -> ModuleSourceView {
         let mut query = self.selection.select("view");
-
         query = query.arg("name", name.into());
-
         ModuleSourceView {
             proc: self.proc.clone(),
             selection: query,
@@ -5514,7 +4588,6 @@ impl ModuleSource {
     /// The named views defined for this module source, which are sets of directory filters that can be applied to directory arguments provided to functions.
     pub fn views(&self) -> Vec<ModuleSourceView> {
         let query = self.selection.select("views");
-
         return vec![ModuleSourceView {
             proc: self.proc.clone(),
             selection: query,
@@ -5523,15 +4596,11 @@ impl ModuleSource {
     }
     /// Update the module source with a new context directory. Only valid for local sources.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `dir` - The directory to set as the context directory.
     pub fn with_context_directory(&self, dir: Directory) -> ModuleSource {
         let mut query = self.selection.select("withContextDirectory");
-
         query = query.arg_lazy(
             "dir",
             Box::new(move || {
@@ -5539,7 +4608,6 @@ impl ModuleSource {
                 Box::pin(async move { dir.id().await.unwrap().quote() })
             }),
         );
-
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -5548,17 +4616,12 @@ impl ModuleSource {
     }
     /// Append the provided dependencies to the module source's dependency list.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `dependencies` - The dependencies to append.
     pub fn with_dependencies(&self, dependencies: Vec<ModuleDependencyId>) -> ModuleSource {
         let mut query = self.selection.select("withDependencies");
-
         query = query.arg("dependencies", dependencies);
-
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -5567,17 +4630,12 @@ impl ModuleSource {
     }
     /// Update the module source with a new name.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - The name to set.
     pub fn with_name(&self, name: impl Into<String>) -> ModuleSource {
         let mut query = self.selection.select("withName");
-
         query = query.arg("name", name.into());
-
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -5586,17 +4644,12 @@ impl ModuleSource {
     }
     /// Update the module source with a new SDK.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `sdk` - The SDK to set.
     pub fn with_sdk(&self, sdk: impl Into<String>) -> ModuleSource {
         let mut query = self.selection.select("withSDK");
-
         query = query.arg("sdk", sdk.into());
-
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -5605,17 +4658,12 @@ impl ModuleSource {
     }
     /// Update the module source with a new source subpath.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `path` - The path to set as the source subpath.
     pub fn with_source_subpath(&self, path: impl Into<String>) -> ModuleSource {
         let mut query = self.selection.select("withSourceSubpath");
-
         query = query.arg("path", path.into());
-
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -5624,11 +4672,8 @@ impl ModuleSource {
     }
     /// Update the module source with a new named view.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - The name of the view to set.
     /// * `patterns` - The patterns to set as the view filters.
     pub fn with_view(
@@ -5637,7 +4682,6 @@ impl ModuleSource {
         patterns: Vec<impl Into<String>>,
     ) -> ModuleSource {
         let mut query = self.selection.select("withView");
-
         query = query.arg("name", name.into());
         query = query.arg(
             "patterns",
@@ -5646,7 +4690,6 @@ impl ModuleSource {
                 .map(|i| i.into())
                 .collect::<Vec<String>>(),
         );
-
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -5660,24 +4703,20 @@ pub struct ModuleSourceView {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl ModuleSourceView {
     /// A unique identifier for this ModuleSourceView.
     pub async fn id(&self) -> Result<ModuleSourceViewId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the view
     pub async fn name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("name");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The patterns of the view used to filter paths
     pub async fn patterns(&self) -> Result<Vec<String>, DaggerError> {
         let query = self.selection.select("patterns");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -5687,12 +4726,10 @@ pub struct ObjectTypeDef {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl ObjectTypeDef {
     /// The function used to construct new instances of this object, if any
     pub fn constructor(&self) -> Function {
         let query = self.selection.select("constructor");
-
         Function {
             proc: self.proc.clone(),
             selection: query,
@@ -5702,13 +4739,11 @@ impl ObjectTypeDef {
     /// The doc string for the object, if any.
     pub async fn description(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("description");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Static fields defined on this object, if any.
     pub fn fields(&self) -> Vec<FieldTypeDef> {
         let query = self.selection.select("fields");
-
         return vec![FieldTypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -5718,7 +4753,6 @@ impl ObjectTypeDef {
     /// Functions defined on this object, if any.
     pub fn functions(&self) -> Vec<Function> {
         let query = self.selection.select("functions");
-
         return vec![Function {
             proc: self.proc.clone(),
             selection: query,
@@ -5728,19 +4762,16 @@ impl ObjectTypeDef {
     /// A unique identifier for this ObjectTypeDef.
     pub async fn id(&self) -> Result<ObjectTypeDefId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the object.
     pub async fn name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("name");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// If this ObjectTypeDef is associated with a Module, the name of the module. Unset otherwise.
     pub async fn source_module_name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("sourceModuleName");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -5750,36 +4781,30 @@ pub struct Port {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl Port {
     /// The port description.
     pub async fn description(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("description");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Skip the health check when run as a service.
     pub async fn experimental_skip_healthcheck(&self) -> Result<bool, DaggerError> {
         let query = self.selection.select("experimentalSkipHealthcheck");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this Port.
     pub async fn id(&self) -> Result<PortId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The port number.
     pub async fn port(&self) -> Result<isize, DaggerError> {
         let query = self.selection.select("port");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The transport layer protocol.
     pub async fn protocol(&self) -> Result<NetworkProtocol, DaggerError> {
         let query = self.selection.select("protocol");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -5789,7 +4814,6 @@ pub struct Query {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 #[derive(Builder, Debug, PartialEq)]
 pub struct QueryContainerOpts {
     /// DEPRECATED: Use `loadContainerFromID` instead.
@@ -5852,15 +4876,11 @@ pub struct QuerySecretOpts<'a> {
     #[builder(setter(into, strip_option), default)]
     pub accessor: Option<&'a str>,
 }
-
 impl Query {
     /// Retrieves a content-addressed blob.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `digest` - Digest of the blob
     /// * `size` - Size of the blob
     /// * `media_type` - Media type of the blob
@@ -5873,12 +4893,10 @@ impl Query {
         uncompressed: impl Into<String>,
     ) -> Directory {
         let mut query = self.selection.select("blob");
-
         query = query.arg("digest", digest.into());
         query = query.arg("size", size);
         query = query.arg("mediaType", media_type.into());
         query = query.arg("uncompressed", uncompressed.into());
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -5887,17 +4905,12 @@ impl Query {
     }
     /// Retrieves a container builtin to the engine.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `digest` - Digest of the image manifest
     pub fn builtin_container(&self, digest: impl Into<String>) -> Container {
         let mut query = self.selection.select("builtinContainer");
-
         query = query.arg("digest", digest.into());
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -5906,17 +4919,12 @@ impl Query {
     }
     /// Constructs a cache volume for a given cache key.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `key` - A string identifier to target this cache volume (e.g., "modules-cache").
     pub fn cache_volume(&self, key: impl Into<String>) -> CacheVolume {
         let mut query = self.selection.select("cacheVolume");
-
         query = query.arg("key", key.into());
-
         CacheVolume {
             proc: self.proc.clone(),
             selection: query,
@@ -5925,60 +4933,45 @@ impl Query {
     }
     /// Checks if the current Dagger Engine is compatible with an SDK's required version.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `version` - Version required by the SDK.
     pub async fn check_version_compatibility(
         &self,
         version: impl Into<String>,
     ) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("checkVersionCompatibility");
-
         query = query.arg("version", version.into());
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Creates a scratch container.
     /// Optional platform argument initializes new containers to execute and publish as that platform. Platform defaults to that of the builder's host.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn container(&self) -> Container {
         let query = self.selection.select("container");
-
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Creates a scratch container.
     /// Optional platform argument initializes new containers to execute and publish as that platform. Platform defaults to that of the builder's host.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn container_opts(&self, opts: QueryContainerOpts) -> Container {
         let mut query = self.selection.select("container");
-
         if let Some(id) = opts.id {
             query = query.arg("id", id);
         }
         if let Some(platform) = opts.platform {
             query = query.arg("platform", platform);
         }
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -5989,7 +4982,6 @@ impl Query {
     /// If the caller is not currently executing in a function, this will return an error.
     pub fn current_function_call(&self) -> FunctionCall {
         let query = self.selection.select("currentFunctionCall");
-
         FunctionCall {
             proc: self.proc.clone(),
             selection: query,
@@ -5999,7 +4991,6 @@ impl Query {
     /// The module currently being served in the session, if any.
     pub fn current_module(&self) -> CurrentModule {
         let query = self.selection.select("currentModule");
-
         CurrentModule {
             proc: self.proc.clone(),
             selection: query,
@@ -6009,7 +5000,6 @@ impl Query {
     /// The TypeDef representations of the objects currently being served in the session.
     pub fn current_type_defs(&self) -> Vec<TypeDef> {
         let query = self.selection.select("currentTypeDefs");
-
         return vec![TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -6019,42 +5009,31 @@ impl Query {
     /// The default platform of the engine.
     pub async fn default_platform(&self) -> Result<Platform, DaggerError> {
         let query = self.selection.select("defaultPlatform");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Creates an empty directory.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn directory(&self) -> Directory {
         let query = self.selection.select("directory");
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Creates an empty directory.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn directory_opts(&self, opts: QueryDirectoryOpts) -> Directory {
         let mut query = self.selection.select("directory");
-
         if let Some(id) = opts.id {
             query = query.arg("id", id);
         }
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -6063,7 +5042,6 @@ impl Query {
     }
     pub fn file(&self, id: File) -> File {
         let mut query = self.selection.select("file");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6071,7 +5049,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         File {
             proc: self.proc.clone(),
             selection: query,
@@ -6080,16 +5057,12 @@ impl Query {
     }
     /// Creates a function.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - Name of the function, in its original format from the implementation language.
     /// * `return_type` - Return type of the function.
     pub fn function(&self, name: impl Into<String>, return_type: TypeDef) -> Function {
         let mut query = self.selection.select("function");
-
         query = query.arg("name", name.into());
         query = query.arg_lazy(
             "returnType",
@@ -6098,7 +5071,6 @@ impl Query {
                 Box::pin(async move { return_type.id().await.unwrap().quote() })
             }),
         );
-
         Function {
             proc: self.proc.clone(),
             selection: query,
@@ -6108,7 +5080,6 @@ impl Query {
     /// Create a code generation result, given a directory containing the generated code.
     pub fn generated_code(&self, code: Directory) -> GeneratedCode {
         let mut query = self.selection.select("generatedCode");
-
         query = query.arg_lazy(
             "code",
             Box::new(move || {
@@ -6116,7 +5087,6 @@ impl Query {
                 Box::pin(async move { code.id().await.unwrap().quote() })
             }),
         );
-
         GeneratedCode {
             proc: self.proc.clone(),
             selection: query,
@@ -6125,11 +5095,8 @@ impl Query {
     }
     /// Queries a Git repository.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `url` - URL of the git repository.
     ///
     /// Can be formatted as `https://{host}/{owner}/{repo}`, `git@{host}:{owner}/{repo}`.
@@ -6138,23 +5105,17 @@ impl Query {
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn git(&self, url: impl Into<String>) -> GitRepository {
         let mut query = self.selection.select("git");
-
         query = query.arg("url", url.into());
-
         GitRepository {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Queries a Git repository.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `url` - URL of the git repository.
     ///
     /// Can be formatted as `https://{host}/{owner}/{repo}`, `git@{host}:{owner}/{repo}`.
@@ -6163,7 +5124,6 @@ impl Query {
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn git_opts<'a>(&self, url: impl Into<String>, opts: QueryGitOpts<'a>) -> GitRepository {
         let mut query = self.selection.select("git");
-
         query = query.arg("url", url.into());
         if let Some(keep_git_dir) = opts.keep_git_dir {
             query = query.arg("keepGitDir", keep_git_dir);
@@ -6177,7 +5137,6 @@ impl Query {
         if let Some(ssh_auth_socket) = opts.ssh_auth_socket {
             query = query.arg("sshAuthSocket", ssh_auth_socket);
         }
-
         GitRepository {
             proc: self.proc.clone(),
             selection: query,
@@ -6187,7 +5146,6 @@ impl Query {
     /// Queries the host environment.
     pub fn host(&self) -> Host {
         let query = self.selection.select("host");
-
         Host {
             proc: self.proc.clone(),
             selection: query,
@@ -6196,42 +5154,31 @@ impl Query {
     }
     /// Returns a file containing an http remote url content.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `url` - HTTP url to get the content from (e.g., "https://docs.dagger.io").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn http(&self, url: impl Into<String>) -> File {
         let mut query = self.selection.select("http");
-
         query = query.arg("url", url.into());
-
         File {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Returns a file containing an http remote url content.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `url` - HTTP url to get the content from (e.g., "https://docs.dagger.io").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn http_opts(&self, url: impl Into<String>, opts: QueryHttpOpts) -> File {
         let mut query = self.selection.select("http");
-
         query = query.arg("url", url.into());
         if let Some(experimental_service_host) = opts.experimental_service_host {
             query = query.arg("experimentalServiceHost", experimental_service_host);
         }
-
         File {
             proc: self.proc.clone(),
             selection: query,
@@ -6241,7 +5188,6 @@ impl Query {
     /// Load a CacheVolume from its ID.
     pub fn load_cache_volume_from_id(&self, id: CacheVolume) -> CacheVolume {
         let mut query = self.selection.select("loadCacheVolumeFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6249,7 +5195,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         CacheVolume {
             proc: self.proc.clone(),
             selection: query,
@@ -6259,7 +5204,6 @@ impl Query {
     /// Load a Container from its ID.
     pub fn load_container_from_id(&self, id: Container) -> Container {
         let mut query = self.selection.select("loadContainerFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6267,7 +5211,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -6277,7 +5220,6 @@ impl Query {
     /// Load a CurrentModule from its ID.
     pub fn load_current_module_from_id(&self, id: CurrentModule) -> CurrentModule {
         let mut query = self.selection.select("loadCurrentModuleFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6285,7 +5227,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         CurrentModule {
             proc: self.proc.clone(),
             selection: query,
@@ -6295,7 +5236,6 @@ impl Query {
     /// Load a Directory from its ID.
     pub fn load_directory_from_id(&self, id: Directory) -> Directory {
         let mut query = self.selection.select("loadDirectoryFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6303,7 +5243,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -6313,7 +5252,6 @@ impl Query {
     /// Load a EnvVariable from its ID.
     pub fn load_env_variable_from_id(&self, id: EnvVariable) -> EnvVariable {
         let mut query = self.selection.select("loadEnvVariableFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6321,7 +5259,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         EnvVariable {
             proc: self.proc.clone(),
             selection: query,
@@ -6331,7 +5268,6 @@ impl Query {
     /// Load a FieldTypeDef from its ID.
     pub fn load_field_type_def_from_id(&self, id: FieldTypeDef) -> FieldTypeDef {
         let mut query = self.selection.select("loadFieldTypeDefFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6339,7 +5275,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         FieldTypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -6349,7 +5284,6 @@ impl Query {
     /// Load a File from its ID.
     pub fn load_file_from_id(&self, id: File) -> File {
         let mut query = self.selection.select("loadFileFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6357,7 +5291,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         File {
             proc: self.proc.clone(),
             selection: query,
@@ -6367,7 +5300,6 @@ impl Query {
     /// Load a FunctionArg from its ID.
     pub fn load_function_arg_from_id(&self, id: FunctionArg) -> FunctionArg {
         let mut query = self.selection.select("loadFunctionArgFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6375,7 +5307,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         FunctionArg {
             proc: self.proc.clone(),
             selection: query,
@@ -6388,7 +5319,6 @@ impl Query {
         id: FunctionCallArgValue,
     ) -> FunctionCallArgValue {
         let mut query = self.selection.select("loadFunctionCallArgValueFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6396,7 +5326,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         FunctionCallArgValue {
             proc: self.proc.clone(),
             selection: query,
@@ -6406,7 +5335,6 @@ impl Query {
     /// Load a FunctionCall from its ID.
     pub fn load_function_call_from_id(&self, id: FunctionCall) -> FunctionCall {
         let mut query = self.selection.select("loadFunctionCallFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6414,7 +5342,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         FunctionCall {
             proc: self.proc.clone(),
             selection: query,
@@ -6424,7 +5351,6 @@ impl Query {
     /// Load a Function from its ID.
     pub fn load_function_from_id(&self, id: Function) -> Function {
         let mut query = self.selection.select("loadFunctionFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6432,7 +5358,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         Function {
             proc: self.proc.clone(),
             selection: query,
@@ -6442,7 +5367,6 @@ impl Query {
     /// Load a GeneratedCode from its ID.
     pub fn load_generated_code_from_id(&self, id: GeneratedCode) -> GeneratedCode {
         let mut query = self.selection.select("loadGeneratedCodeFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6450,7 +5374,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         GeneratedCode {
             proc: self.proc.clone(),
             selection: query,
@@ -6460,7 +5383,6 @@ impl Query {
     /// Load a GitModuleSource from its ID.
     pub fn load_git_module_source_from_id(&self, id: GitModuleSource) -> GitModuleSource {
         let mut query = self.selection.select("loadGitModuleSourceFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6468,7 +5390,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         GitModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -6478,7 +5399,6 @@ impl Query {
     /// Load a GitRef from its ID.
     pub fn load_git_ref_from_id(&self, id: GitRef) -> GitRef {
         let mut query = self.selection.select("loadGitRefFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6486,7 +5406,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         GitRef {
             proc: self.proc.clone(),
             selection: query,
@@ -6496,7 +5415,6 @@ impl Query {
     /// Load a GitRepository from its ID.
     pub fn load_git_repository_from_id(&self, id: GitRepository) -> GitRepository {
         let mut query = self.selection.select("loadGitRepositoryFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6504,7 +5422,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         GitRepository {
             proc: self.proc.clone(),
             selection: query,
@@ -6514,7 +5431,6 @@ impl Query {
     /// Load a Host from its ID.
     pub fn load_host_from_id(&self, id: Host) -> Host {
         let mut query = self.selection.select("loadHostFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6522,7 +5438,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         Host {
             proc: self.proc.clone(),
             selection: query,
@@ -6532,7 +5447,6 @@ impl Query {
     /// Load a InputTypeDef from its ID.
     pub fn load_input_type_def_from_id(&self, id: InputTypeDef) -> InputTypeDef {
         let mut query = self.selection.select("loadInputTypeDefFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6540,7 +5454,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         InputTypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -6550,7 +5463,6 @@ impl Query {
     /// Load a InterfaceTypeDef from its ID.
     pub fn load_interface_type_def_from_id(&self, id: InterfaceTypeDef) -> InterfaceTypeDef {
         let mut query = self.selection.select("loadInterfaceTypeDefFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6558,7 +5470,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         InterfaceTypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -6568,7 +5479,6 @@ impl Query {
     /// Load a Label from its ID.
     pub fn load_label_from_id(&self, id: Label) -> Label {
         let mut query = self.selection.select("loadLabelFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6576,7 +5486,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         Label {
             proc: self.proc.clone(),
             selection: query,
@@ -6586,7 +5495,6 @@ impl Query {
     /// Load a ListTypeDef from its ID.
     pub fn load_list_type_def_from_id(&self, id: ListTypeDef) -> ListTypeDef {
         let mut query = self.selection.select("loadListTypeDefFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6594,7 +5502,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         ListTypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -6604,7 +5511,6 @@ impl Query {
     /// Load a LocalModuleSource from its ID.
     pub fn load_local_module_source_from_id(&self, id: LocalModuleSource) -> LocalModuleSource {
         let mut query = self.selection.select("loadLocalModuleSourceFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6612,7 +5518,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         LocalModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -6622,7 +5527,6 @@ impl Query {
     /// Load a ModuleDependency from its ID.
     pub fn load_module_dependency_from_id(&self, id: ModuleDependency) -> ModuleDependency {
         let mut query = self.selection.select("loadModuleDependencyFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6630,7 +5534,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         ModuleDependency {
             proc: self.proc.clone(),
             selection: query,
@@ -6640,7 +5543,6 @@ impl Query {
     /// Load a Module from its ID.
     pub fn load_module_from_id(&self, id: Module) -> Module {
         let mut query = self.selection.select("loadModuleFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6648,7 +5550,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         Module {
             proc: self.proc.clone(),
             selection: query,
@@ -6658,7 +5559,6 @@ impl Query {
     /// Load a ModuleSource from its ID.
     pub fn load_module_source_from_id(&self, id: ModuleSource) -> ModuleSource {
         let mut query = self.selection.select("loadModuleSourceFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6666,7 +5566,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -6676,7 +5575,6 @@ impl Query {
     /// Load a ModuleSourceView from its ID.
     pub fn load_module_source_view_from_id(&self, id: ModuleSourceView) -> ModuleSourceView {
         let mut query = self.selection.select("loadModuleSourceViewFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6684,7 +5582,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         ModuleSourceView {
             proc: self.proc.clone(),
             selection: query,
@@ -6694,7 +5591,6 @@ impl Query {
     /// Load a ObjectTypeDef from its ID.
     pub fn load_object_type_def_from_id(&self, id: ObjectTypeDef) -> ObjectTypeDef {
         let mut query = self.selection.select("loadObjectTypeDefFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6702,7 +5598,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         ObjectTypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -6712,7 +5607,6 @@ impl Query {
     /// Load a Port from its ID.
     pub fn load_port_from_id(&self, id: Port) -> Port {
         let mut query = self.selection.select("loadPortFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6720,7 +5614,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         Port {
             proc: self.proc.clone(),
             selection: query,
@@ -6730,7 +5623,6 @@ impl Query {
     /// Load a Secret from its ID.
     pub fn load_secret_from_id(&self, id: Secret) -> Secret {
         let mut query = self.selection.select("loadSecretFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6738,7 +5630,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         Secret {
             proc: self.proc.clone(),
             selection: query,
@@ -6748,7 +5639,6 @@ impl Query {
     /// Load a Service from its ID.
     pub fn load_service_from_id(&self, id: Service) -> Service {
         let mut query = self.selection.select("loadServiceFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6756,7 +5646,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         Service {
             proc: self.proc.clone(),
             selection: query,
@@ -6766,7 +5655,6 @@ impl Query {
     /// Load a Socket from its ID.
     pub fn load_socket_from_id(&self, id: Socket) -> Socket {
         let mut query = self.selection.select("loadSocketFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6774,7 +5662,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         Socket {
             proc: self.proc.clone(),
             selection: query,
@@ -6784,7 +5671,6 @@ impl Query {
     /// Load a Terminal from its ID.
     pub fn load_terminal_from_id(&self, id: Terminal) -> Terminal {
         let mut query = self.selection.select("loadTerminalFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6792,7 +5678,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         Terminal {
             proc: self.proc.clone(),
             selection: query,
@@ -6802,7 +5687,6 @@ impl Query {
     /// Load a TypeDef from its ID.
     pub fn load_type_def_from_id(&self, id: TypeDef) -> TypeDef {
         let mut query = self.selection.select("loadTypeDefFromID");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -6810,7 +5694,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -6820,7 +5703,6 @@ impl Query {
     /// Create a new module.
     pub fn module(&self) -> Module {
         let query = self.selection.select("module");
-
         Module {
             proc: self.proc.clone(),
             selection: query,
@@ -6829,16 +5711,12 @@ impl Query {
     }
     /// Create a new module dependency configuration from a module source and name
     ///
-
     /// # Arguments
-
     ///
-
     /// * `source` - The source of the dependency
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn module_dependency(&self, source: ModuleSource) -> ModuleDependency {
         let mut query = self.selection.select("moduleDependency");
-
         query = query.arg_lazy(
             "source",
             Box::new(move || {
@@ -6846,21 +5724,16 @@ impl Query {
                 Box::pin(async move { source.id().await.unwrap().quote() })
             }),
         );
-
         ModuleDependency {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Create a new module dependency configuration from a module source and name
     ///
-
     /// # Arguments
-
     ///
-
     /// * `source` - The source of the dependency
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn module_dependency_opts<'a>(
@@ -6869,7 +5742,6 @@ impl Query {
         opts: QueryModuleDependencyOpts<'a>,
     ) -> ModuleDependency {
         let mut query = self.selection.select("moduleDependency");
-
         query = query.arg_lazy(
             "source",
             Box::new(move || {
@@ -6880,7 +5752,6 @@ impl Query {
         if let Some(name) = opts.name {
             query = query.arg("name", name);
         }
-
         ModuleDependency {
             proc: self.proc.clone(),
             selection: query,
@@ -6889,32 +5760,23 @@ impl Query {
     }
     /// Create a new module source instance from a source ref string.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `ref_string` - The string ref representation of the module source
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn module_source(&self, ref_string: impl Into<String>) -> ModuleSource {
         let mut query = self.selection.select("moduleSource");
-
         query = query.arg("refString", ref_string.into());
-
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Create a new module source instance from a source ref string.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `ref_string` - The string ref representation of the module source
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn module_source_opts(
@@ -6923,12 +5785,10 @@ impl Query {
         opts: QueryModuleSourceOpts,
     ) -> ModuleSource {
         let mut query = self.selection.select("moduleSource");
-
         query = query.arg("refString", ref_string.into());
         if let Some(stable) = opts.stable {
             query = query.arg("stable", stable);
         }
-
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -6937,37 +5797,27 @@ impl Query {
     }
     /// Creates a named sub-pipeline.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - Name of the sub-pipeline.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn pipeline(&self, name: impl Into<String>) -> Query {
         let mut query = self.selection.select("pipeline");
-
         query = query.arg("name", name.into());
-
         Query {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Creates a named sub-pipeline.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - Name of the sub-pipeline.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn pipeline_opts<'a>(&self, name: impl Into<String>, opts: QueryPipelineOpts<'a>) -> Query {
         let mut query = self.selection.select("pipeline");
-
         query = query.arg("name", name.into());
         if let Some(description) = opts.description {
             query = query.arg("description", description);
@@ -6975,7 +5825,6 @@ impl Query {
         if let Some(labels) = opts.labels {
             query = query.arg("labels", labels);
         }
-
         Query {
             proc: self.proc.clone(),
             selection: query,
@@ -6984,40 +5833,29 @@ impl Query {
     }
     /// Reference a secret by name.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn secret(&self, name: impl Into<String>) -> Secret {
         let mut query = self.selection.select("secret");
-
         query = query.arg("name", name.into());
-
         Secret {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Reference a secret by name.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn secret_opts<'a>(&self, name: impl Into<String>, opts: QuerySecretOpts<'a>) -> Secret {
         let mut query = self.selection.select("secret");
-
         query = query.arg("name", name.into());
         if let Some(accessor) = opts.accessor {
             query = query.arg("accessor", accessor);
         }
-
         Secret {
             proc: self.proc.clone(),
             selection: query,
@@ -7027,19 +5865,14 @@ impl Query {
     /// Sets a secret given a user defined name to its plaintext and returns the secret.
     /// The plaintext value is limited to a size of 128000 bytes.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - The user defined name for this secret
     /// * `plaintext` - The plaintext of the secret
     pub fn set_secret(&self, name: impl Into<String>, plaintext: impl Into<String>) -> Secret {
         let mut query = self.selection.select("setSecret");
-
         query = query.arg("name", name.into());
         query = query.arg("plaintext", plaintext.into());
-
         Secret {
             proc: self.proc.clone(),
             selection: query,
@@ -7049,7 +5882,6 @@ impl Query {
     /// Loads a socket by its ID.
     pub fn socket(&self, id: Socket) -> Socket {
         let mut query = self.selection.select("socket");
-
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -7057,7 +5889,6 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
-
         Socket {
             proc: self.proc.clone(),
             selection: query,
@@ -7067,7 +5898,6 @@ impl Query {
     /// Create a new TypeDef.
     pub fn type_def(&self) -> TypeDef {
         let query = self.selection.select("typeDef");
-
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -7081,24 +5911,20 @@ pub struct Secret {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl Secret {
     /// A unique identifier for this Secret.
     pub async fn id(&self) -> Result<SecretId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of this secret.
     pub async fn name(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("name");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The value of this secret.
     pub async fn plaintext(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("plaintext");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -7108,7 +5934,6 @@ pub struct Service {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 #[derive(Builder, Debug, PartialEq)]
 pub struct ServiceEndpointOpts<'a> {
     /// The exposed port number for the endpoint
@@ -7134,65 +5959,51 @@ pub struct ServiceUpOpts {
     #[builder(setter(into, strip_option), default)]
     pub random: Option<bool>,
 }
-
 impl Service {
     /// Retrieves an endpoint that clients can use to reach this container.
     /// If no port is specified, the first exposed port is used. If none exist an error is returned.
     /// If a scheme is specified, a URL is returned. Otherwise, a host:port pair is returned.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn endpoint(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("endpoint");
-
         query.execute(self.graphql_client.clone()).await
     }
-
     /// Retrieves an endpoint that clients can use to reach this container.
     /// If no port is specified, the first exposed port is used. If none exist an error is returned.
     /// If a scheme is specified, a URL is returned. Otherwise, a host:port pair is returned.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn endpoint_opts<'a>(
         &self,
         opts: ServiceEndpointOpts<'a>,
     ) -> Result<String, DaggerError> {
         let mut query = self.selection.select("endpoint");
-
         if let Some(port) = opts.port {
             query = query.arg("port", port);
         }
         if let Some(scheme) = opts.scheme {
             query = query.arg("scheme", scheme);
         }
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves a hostname which can be used by clients to reach this container.
     pub async fn hostname(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("hostname");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this Service.
     pub async fn id(&self) -> Result<ServiceId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the list of ports provided by the service.
     pub fn ports(&self) -> Vec<Port> {
         let query = self.selection.select("ports");
-
         return vec![Port {
             proc: self.proc.clone(),
             selection: query,
@@ -7203,72 +6014,51 @@ impl Service {
     /// Services bound to a Container do not need to be manually started.
     pub async fn start(&self) -> Result<ServiceId, DaggerError> {
         let query = self.selection.select("start");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Stop the service.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn stop(&self) -> Result<ServiceId, DaggerError> {
         let query = self.selection.select("stop");
-
         query.execute(self.graphql_client.clone()).await
     }
-
     /// Stop the service.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn stop_opts(&self, opts: ServiceStopOpts) -> Result<ServiceId, DaggerError> {
         let mut query = self.selection.select("stop");
-
         if let Some(kill) = opts.kill {
             query = query.arg("kill", kill);
         }
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Creates a tunnel that forwards traffic from the caller's network to this service.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn up(&self) -> Result<Void, DaggerError> {
         let query = self.selection.select("up");
-
         query.execute(self.graphql_client.clone()).await
     }
-
     /// Creates a tunnel that forwards traffic from the caller's network to this service.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn up_opts(&self, opts: ServiceUpOpts) -> Result<Void, DaggerError> {
         let mut query = self.selection.select("up");
-
         if let Some(ports) = opts.ports {
             query = query.arg("ports", ports);
         }
         if let Some(random) = opts.random {
             query = query.arg("random", random);
         }
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -7278,12 +6068,10 @@ pub struct Socket {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl Socket {
     /// A unique identifier for this Socket.
     pub async fn id(&self) -> Result<SocketId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -7293,18 +6081,15 @@ pub struct Terminal {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 impl Terminal {
     /// A unique identifier for this Terminal.
     pub async fn id(&self) -> Result<TerminalId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// An http endpoint at which this terminal can be connected to over a websocket.
     pub async fn websocket_endpoint(&self) -> Result<String, DaggerError> {
         let query = self.selection.select("websocketEndpoint");
-
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -7314,7 +6099,6 @@ pub struct TypeDef {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
-
 #[derive(Builder, Debug, PartialEq)]
 pub struct TypeDefWithFieldOpts<'a> {
     /// A doc string for the field, if any
@@ -7331,12 +6115,10 @@ pub struct TypeDefWithObjectOpts<'a> {
     #[builder(setter(into, strip_option), default)]
     pub description: Option<&'a str>,
 }
-
 impl TypeDef {
     /// If kind is INPUT, the input-specific type definition. If kind is not INPUT, this will be null.
     pub fn as_input(&self) -> InputTypeDef {
         let query = self.selection.select("asInput");
-
         InputTypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -7346,7 +6128,6 @@ impl TypeDef {
     /// If kind is INTERFACE, the interface-specific type definition. If kind is not INTERFACE, this will be null.
     pub fn as_interface(&self) -> InterfaceTypeDef {
         let query = self.selection.select("asInterface");
-
         InterfaceTypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -7356,7 +6137,6 @@ impl TypeDef {
     /// If kind is LIST, the list-specific type definition. If kind is not LIST, this will be null.
     pub fn as_list(&self) -> ListTypeDef {
         let query = self.selection.select("asList");
-
         ListTypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -7366,7 +6146,6 @@ impl TypeDef {
     /// If kind is OBJECT, the object-specific type definition. If kind is not OBJECT, this will be null.
     pub fn as_object(&self) -> ObjectTypeDef {
         let query = self.selection.select("asObject");
-
         ObjectTypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -7376,25 +6155,21 @@ impl TypeDef {
     /// A unique identifier for this TypeDef.
     pub async fn id(&self) -> Result<TypeDefId, DaggerError> {
         let query = self.selection.select("id");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// The kind of type this is (e.g. primitive, list, object).
     pub async fn kind(&self) -> Result<TypeDefKind, DaggerError> {
         let query = self.selection.select("kind");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Whether this type can be set to null. Defaults to false.
     pub async fn optional(&self) -> Result<bool, DaggerError> {
         let query = self.selection.select("optional");
-
         query.execute(self.graphql_client.clone()).await
     }
     /// Adds a function for constructing a new instance of an Object TypeDef, failing if the type is not an object.
     pub fn with_constructor(&self, function: Function) -> TypeDef {
         let mut query = self.selection.select("withConstructor");
-
         query = query.arg_lazy(
             "function",
             Box::new(move || {
@@ -7402,7 +6177,6 @@ impl TypeDef {
                 Box::pin(async move { function.id().await.unwrap().quote() })
             }),
         );
-
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -7411,17 +6185,13 @@ impl TypeDef {
     }
     /// Adds a static field for an Object TypeDef, failing if the type is not an object.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - The name of the field in the object
     /// * `type_def` - The type of the field
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_field(&self, name: impl Into<String>, type_def: TypeDef) -> TypeDef {
         let mut query = self.selection.select("withField");
-
         query = query.arg("name", name.into());
         query = query.arg_lazy(
             "typeDef",
@@ -7430,21 +6200,16 @@ impl TypeDef {
                 Box::pin(async move { type_def.id().await.unwrap().quote() })
             }),
         );
-
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Adds a static field for an Object TypeDef, failing if the type is not an object.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `name` - The name of the field in the object
     /// * `type_def` - The type of the field
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -7455,7 +6220,6 @@ impl TypeDef {
         opts: TypeDefWithFieldOpts<'a>,
     ) -> TypeDef {
         let mut query = self.selection.select("withField");
-
         query = query.arg("name", name.into());
         query = query.arg_lazy(
             "typeDef",
@@ -7467,7 +6231,6 @@ impl TypeDef {
         if let Some(description) = opts.description {
             query = query.arg("description", description);
         }
-
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -7477,7 +6240,6 @@ impl TypeDef {
     /// Adds a function for an Object or Interface TypeDef, failing if the type is not one of those kinds.
     pub fn with_function(&self, function: Function) -> TypeDef {
         let mut query = self.selection.select("withFunction");
-
         query = query.arg_lazy(
             "function",
             Box::new(move || {
@@ -7485,7 +6247,6 @@ impl TypeDef {
                 Box::pin(async move { function.id().await.unwrap().quote() })
             }),
         );
-
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -7494,31 +6255,22 @@ impl TypeDef {
     }
     /// Returns a TypeDef of kind Interface with the provided name.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_interface(&self, name: impl Into<String>) -> TypeDef {
         let mut query = self.selection.select("withInterface");
-
         query = query.arg("name", name.into());
-
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Returns a TypeDef of kind Interface with the provided name.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_interface_opts<'a>(
         &self,
@@ -7526,12 +6278,10 @@ impl TypeDef {
         opts: TypeDefWithInterfaceOpts<'a>,
     ) -> TypeDef {
         let mut query = self.selection.select("withInterface");
-
         query = query.arg("name", name.into());
         if let Some(description) = opts.description {
             query = query.arg("description", description);
         }
-
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -7541,9 +6291,7 @@ impl TypeDef {
     /// Sets the kind of the type.
     pub fn with_kind(&self, kind: TypeDefKind) -> TypeDef {
         let mut query = self.selection.select("withKind");
-
         query = query.arg("kind", kind);
-
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -7553,7 +6301,6 @@ impl TypeDef {
     /// Returns a TypeDef of kind List with the provided type for its elements.
     pub fn with_list_of(&self, element_type: TypeDef) -> TypeDef {
         let mut query = self.selection.select("withListOf");
-
         query = query.arg_lazy(
             "elementType",
             Box::new(move || {
@@ -7561,7 +6308,6 @@ impl TypeDef {
                 Box::pin(async move { element_type.id().await.unwrap().quote() })
             }),
         );
-
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -7571,32 +6317,23 @@ impl TypeDef {
     /// Returns a TypeDef of kind Object with the provided name.
     /// Note that an object's fields and functions may be omitted if the intent is only to refer to an object. This is how functions are able to return their own object, or any other circular reference.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_object(&self, name: impl Into<String>) -> TypeDef {
         let mut query = self.selection.select("withObject");
-
         query = query.arg("name", name.into());
-
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-
     /// Returns a TypeDef of kind Object with the provided name.
     /// Note that an object's fields and functions may be omitted if the intent is only to refer to an object. This is how functions are able to return their own object, or any other circular reference.
     ///
-
     /// # Arguments
-
     ///
-
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_object_opts<'a>(
         &self,
@@ -7604,12 +6341,10 @@ impl TypeDef {
         opts: TypeDefWithObjectOpts<'a>,
     ) -> TypeDef {
         let mut query = self.selection.select("withObject");
-
         query = query.arg("name", name.into());
         if let Some(description) = opts.description {
             query = query.arg("description", description);
         }
-
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -7619,9 +6354,7 @@ impl TypeDef {
     /// Sets whether this type can be set to null.
     pub fn with_optional(&self, optional: bool) -> TypeDef {
         let mut query = self.selection.select("withOptional");
-
         query = query.arg("optional", optional);
-
         TypeDef {
             proc: self.proc.clone(),
             selection: query,

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -8,16 +8,19 @@ use tokio::process::Child;
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct CacheVolumeId(pub String);
+
 impl Into<CacheVolumeId> for &str {
     fn into(self) -> CacheVolumeId {
         CacheVolumeId(self.to_string())
     }
 }
+
 impl Into<CacheVolumeId> for String {
     fn into(self) -> CacheVolumeId {
         CacheVolumeId(self.clone())
     }
 }
+
 impl CacheVolumeId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -25,16 +28,19 @@ impl CacheVolumeId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct ContainerId(pub String);
+
 impl Into<ContainerId> for &str {
     fn into(self) -> ContainerId {
         ContainerId(self.to_string())
     }
 }
+
 impl Into<ContainerId> for String {
     fn into(self) -> ContainerId {
         ContainerId(self.clone())
     }
 }
+
 impl ContainerId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -42,16 +48,19 @@ impl ContainerId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct CurrentModuleId(pub String);
+
 impl Into<CurrentModuleId> for &str {
     fn into(self) -> CurrentModuleId {
         CurrentModuleId(self.to_string())
     }
 }
+
 impl Into<CurrentModuleId> for String {
     fn into(self) -> CurrentModuleId {
         CurrentModuleId(self.clone())
     }
 }
+
 impl CurrentModuleId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -59,16 +68,19 @@ impl CurrentModuleId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct DirectoryId(pub String);
+
 impl Into<DirectoryId> for &str {
     fn into(self) -> DirectoryId {
         DirectoryId(self.to_string())
     }
 }
+
 impl Into<DirectoryId> for String {
     fn into(self) -> DirectoryId {
         DirectoryId(self.clone())
     }
 }
+
 impl DirectoryId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -76,16 +88,19 @@ impl DirectoryId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct EnvVariableId(pub String);
+
 impl Into<EnvVariableId> for &str {
     fn into(self) -> EnvVariableId {
         EnvVariableId(self.to_string())
     }
 }
+
 impl Into<EnvVariableId> for String {
     fn into(self) -> EnvVariableId {
         EnvVariableId(self.clone())
     }
 }
+
 impl EnvVariableId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -93,16 +108,19 @@ impl EnvVariableId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct FieldTypeDefId(pub String);
+
 impl Into<FieldTypeDefId> for &str {
     fn into(self) -> FieldTypeDefId {
         FieldTypeDefId(self.to_string())
     }
 }
+
 impl Into<FieldTypeDefId> for String {
     fn into(self) -> FieldTypeDefId {
         FieldTypeDefId(self.clone())
     }
 }
+
 impl FieldTypeDefId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -110,16 +128,19 @@ impl FieldTypeDefId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct FileId(pub String);
+
 impl Into<FileId> for &str {
     fn into(self) -> FileId {
         FileId(self.to_string())
     }
 }
+
 impl Into<FileId> for String {
     fn into(self) -> FileId {
         FileId(self.clone())
     }
 }
+
 impl FileId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -127,16 +148,19 @@ impl FileId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct FunctionArgId(pub String);
+
 impl Into<FunctionArgId> for &str {
     fn into(self) -> FunctionArgId {
         FunctionArgId(self.to_string())
     }
 }
+
 impl Into<FunctionArgId> for String {
     fn into(self) -> FunctionArgId {
         FunctionArgId(self.clone())
     }
 }
+
 impl FunctionArgId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -144,16 +168,19 @@ impl FunctionArgId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct FunctionCallArgValueId(pub String);
+
 impl Into<FunctionCallArgValueId> for &str {
     fn into(self) -> FunctionCallArgValueId {
         FunctionCallArgValueId(self.to_string())
     }
 }
+
 impl Into<FunctionCallArgValueId> for String {
     fn into(self) -> FunctionCallArgValueId {
         FunctionCallArgValueId(self.clone())
     }
 }
+
 impl FunctionCallArgValueId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -161,16 +188,19 @@ impl FunctionCallArgValueId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct FunctionCallId(pub String);
+
 impl Into<FunctionCallId> for &str {
     fn into(self) -> FunctionCallId {
         FunctionCallId(self.to_string())
     }
 }
+
 impl Into<FunctionCallId> for String {
     fn into(self) -> FunctionCallId {
         FunctionCallId(self.clone())
     }
 }
+
 impl FunctionCallId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -178,16 +208,19 @@ impl FunctionCallId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct FunctionId(pub String);
+
 impl Into<FunctionId> for &str {
     fn into(self) -> FunctionId {
         FunctionId(self.to_string())
     }
 }
+
 impl Into<FunctionId> for String {
     fn into(self) -> FunctionId {
         FunctionId(self.clone())
     }
 }
+
 impl FunctionId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -195,16 +228,19 @@ impl FunctionId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct GeneratedCodeId(pub String);
+
 impl Into<GeneratedCodeId> for &str {
     fn into(self) -> GeneratedCodeId {
         GeneratedCodeId(self.to_string())
     }
 }
+
 impl Into<GeneratedCodeId> for String {
     fn into(self) -> GeneratedCodeId {
         GeneratedCodeId(self.clone())
     }
 }
+
 impl GeneratedCodeId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -212,16 +248,19 @@ impl GeneratedCodeId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct GitModuleSourceId(pub String);
+
 impl Into<GitModuleSourceId> for &str {
     fn into(self) -> GitModuleSourceId {
         GitModuleSourceId(self.to_string())
     }
 }
+
 impl Into<GitModuleSourceId> for String {
     fn into(self) -> GitModuleSourceId {
         GitModuleSourceId(self.clone())
     }
 }
+
 impl GitModuleSourceId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -229,16 +268,19 @@ impl GitModuleSourceId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct GitRefId(pub String);
+
 impl Into<GitRefId> for &str {
     fn into(self) -> GitRefId {
         GitRefId(self.to_string())
     }
 }
+
 impl Into<GitRefId> for String {
     fn into(self) -> GitRefId {
         GitRefId(self.clone())
     }
 }
+
 impl GitRefId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -246,16 +288,19 @@ impl GitRefId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct GitRepositoryId(pub String);
+
 impl Into<GitRepositoryId> for &str {
     fn into(self) -> GitRepositoryId {
         GitRepositoryId(self.to_string())
     }
 }
+
 impl Into<GitRepositoryId> for String {
     fn into(self) -> GitRepositoryId {
         GitRepositoryId(self.clone())
     }
 }
+
 impl GitRepositoryId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -263,16 +308,19 @@ impl GitRepositoryId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct HostId(pub String);
+
 impl Into<HostId> for &str {
     fn into(self) -> HostId {
         HostId(self.to_string())
     }
 }
+
 impl Into<HostId> for String {
     fn into(self) -> HostId {
         HostId(self.clone())
     }
 }
+
 impl HostId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -280,16 +328,19 @@ impl HostId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct InputTypeDefId(pub String);
+
 impl Into<InputTypeDefId> for &str {
     fn into(self) -> InputTypeDefId {
         InputTypeDefId(self.to_string())
     }
 }
+
 impl Into<InputTypeDefId> for String {
     fn into(self) -> InputTypeDefId {
         InputTypeDefId(self.clone())
     }
 }
+
 impl InputTypeDefId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -297,16 +348,19 @@ impl InputTypeDefId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct InterfaceTypeDefId(pub String);
+
 impl Into<InterfaceTypeDefId> for &str {
     fn into(self) -> InterfaceTypeDefId {
         InterfaceTypeDefId(self.to_string())
     }
 }
+
 impl Into<InterfaceTypeDefId> for String {
     fn into(self) -> InterfaceTypeDefId {
         InterfaceTypeDefId(self.clone())
     }
 }
+
 impl InterfaceTypeDefId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -314,16 +368,19 @@ impl InterfaceTypeDefId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct Json(pub String);
+
 impl Into<Json> for &str {
     fn into(self) -> Json {
         Json(self.to_string())
     }
 }
+
 impl Into<Json> for String {
     fn into(self) -> Json {
         Json(self.clone())
     }
 }
+
 impl Json {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -331,16 +388,19 @@ impl Json {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct LabelId(pub String);
+
 impl Into<LabelId> for &str {
     fn into(self) -> LabelId {
         LabelId(self.to_string())
     }
 }
+
 impl Into<LabelId> for String {
     fn into(self) -> LabelId {
         LabelId(self.clone())
     }
 }
+
 impl LabelId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -348,16 +408,19 @@ impl LabelId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct ListTypeDefId(pub String);
+
 impl Into<ListTypeDefId> for &str {
     fn into(self) -> ListTypeDefId {
         ListTypeDefId(self.to_string())
     }
 }
+
 impl Into<ListTypeDefId> for String {
     fn into(self) -> ListTypeDefId {
         ListTypeDefId(self.clone())
     }
 }
+
 impl ListTypeDefId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -365,16 +428,19 @@ impl ListTypeDefId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct LocalModuleSourceId(pub String);
+
 impl Into<LocalModuleSourceId> for &str {
     fn into(self) -> LocalModuleSourceId {
         LocalModuleSourceId(self.to_string())
     }
 }
+
 impl Into<LocalModuleSourceId> for String {
     fn into(self) -> LocalModuleSourceId {
         LocalModuleSourceId(self.clone())
     }
 }
+
 impl LocalModuleSourceId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -382,16 +448,19 @@ impl LocalModuleSourceId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct ModuleDependencyId(pub String);
+
 impl Into<ModuleDependencyId> for &str {
     fn into(self) -> ModuleDependencyId {
         ModuleDependencyId(self.to_string())
     }
 }
+
 impl Into<ModuleDependencyId> for String {
     fn into(self) -> ModuleDependencyId {
         ModuleDependencyId(self.clone())
     }
 }
+
 impl ModuleDependencyId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -399,16 +468,19 @@ impl ModuleDependencyId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct ModuleId(pub String);
+
 impl Into<ModuleId> for &str {
     fn into(self) -> ModuleId {
         ModuleId(self.to_string())
     }
 }
+
 impl Into<ModuleId> for String {
     fn into(self) -> ModuleId {
         ModuleId(self.clone())
     }
 }
+
 impl ModuleId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -416,16 +488,19 @@ impl ModuleId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct ModuleSourceId(pub String);
+
 impl Into<ModuleSourceId> for &str {
     fn into(self) -> ModuleSourceId {
         ModuleSourceId(self.to_string())
     }
 }
+
 impl Into<ModuleSourceId> for String {
     fn into(self) -> ModuleSourceId {
         ModuleSourceId(self.clone())
     }
 }
+
 impl ModuleSourceId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -433,16 +508,19 @@ impl ModuleSourceId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct ModuleSourceViewId(pub String);
+
 impl Into<ModuleSourceViewId> for &str {
     fn into(self) -> ModuleSourceViewId {
         ModuleSourceViewId(self.to_string())
     }
 }
+
 impl Into<ModuleSourceViewId> for String {
     fn into(self) -> ModuleSourceViewId {
         ModuleSourceViewId(self.clone())
     }
 }
+
 impl ModuleSourceViewId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -450,16 +528,19 @@ impl ModuleSourceViewId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct ObjectTypeDefId(pub String);
+
 impl Into<ObjectTypeDefId> for &str {
     fn into(self) -> ObjectTypeDefId {
         ObjectTypeDefId(self.to_string())
     }
 }
+
 impl Into<ObjectTypeDefId> for String {
     fn into(self) -> ObjectTypeDefId {
         ObjectTypeDefId(self.clone())
     }
 }
+
 impl ObjectTypeDefId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -467,16 +548,19 @@ impl ObjectTypeDefId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct Platform(pub String);
+
 impl Into<Platform> for &str {
     fn into(self) -> Platform {
         Platform(self.to_string())
     }
 }
+
 impl Into<Platform> for String {
     fn into(self) -> Platform {
         Platform(self.clone())
     }
 }
+
 impl Platform {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -484,16 +568,19 @@ impl Platform {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct PortId(pub String);
+
 impl Into<PortId> for &str {
     fn into(self) -> PortId {
         PortId(self.to_string())
     }
 }
+
 impl Into<PortId> for String {
     fn into(self) -> PortId {
         PortId(self.clone())
     }
 }
+
 impl PortId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -501,16 +588,19 @@ impl PortId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct SecretId(pub String);
+
 impl Into<SecretId> for &str {
     fn into(self) -> SecretId {
         SecretId(self.to_string())
     }
 }
+
 impl Into<SecretId> for String {
     fn into(self) -> SecretId {
         SecretId(self.clone())
     }
 }
+
 impl SecretId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -518,16 +608,19 @@ impl SecretId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct ServiceId(pub String);
+
 impl Into<ServiceId> for &str {
     fn into(self) -> ServiceId {
         ServiceId(self.to_string())
     }
 }
+
 impl Into<ServiceId> for String {
     fn into(self) -> ServiceId {
         ServiceId(self.clone())
     }
 }
+
 impl ServiceId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -535,16 +628,19 @@ impl ServiceId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct SocketId(pub String);
+
 impl Into<SocketId> for &str {
     fn into(self) -> SocketId {
         SocketId(self.to_string())
     }
 }
+
 impl Into<SocketId> for String {
     fn into(self) -> SocketId {
         SocketId(self.clone())
     }
 }
+
 impl SocketId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -552,16 +648,19 @@ impl SocketId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct TerminalId(pub String);
+
 impl Into<TerminalId> for &str {
     fn into(self) -> TerminalId {
         TerminalId(self.to_string())
     }
 }
+
 impl Into<TerminalId> for String {
     fn into(self) -> TerminalId {
         TerminalId(self.clone())
     }
 }
+
 impl TerminalId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -569,16 +668,19 @@ impl TerminalId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct TypeDefId(pub String);
+
 impl Into<TypeDefId> for &str {
     fn into(self) -> TypeDefId {
         TypeDefId(self.to_string())
     }
 }
+
 impl Into<TypeDefId> for String {
     fn into(self) -> TypeDefId {
         TypeDefId(self.clone())
     }
 }
+
 impl TypeDefId {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -586,16 +688,19 @@ impl TypeDefId {
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct Void(pub String);
+
 impl Into<Void> for &str {
     fn into(self) -> Void {
         Void(self.to_string())
     }
 }
+
 impl Into<Void> for String {
     fn into(self) -> Void {
         Void(self.clone())
     }
 }
+
 impl Void {
     fn quote(&self) -> String {
         format!("\"{}\"", self.0.clone())
@@ -621,12 +726,16 @@ pub struct PortForward {
 pub struct CacheVolume {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 impl CacheVolume {
     /// A unique identifier for this CacheVolume.
-    pub async fn id(&self) -> Result<CacheVolumeId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<CacheVolumeId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -634,10 +743,12 @@ impl CacheVolume {
 pub struct Container {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerAsTarballOpts {
+
     /// Force each layer of the image to use the specified compression algorithm.
     /// If this is unset, then if a layer already has a compressed blob in the engine's cache, that will be used (this can result in a mix of compression algorithms for different layers). If this is unset and a layer has no compressed blob in the engine's cache, then it will be compressed using Gzip.
     #[builder(setter(into, strip_option), default)]
@@ -653,6 +764,7 @@ pub struct ContainerAsTarballOpts {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerBuildOpts<'a> {
+
     /// Additional build arguments.
     #[builder(setter(into, strip_option), default)]
     pub build_args: Option<Vec<BuildArg>>,
@@ -670,6 +782,7 @@ pub struct ContainerBuildOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerExportOpts {
+
     /// Force each layer of the exported image to use the specified compression algorithm.
     /// If this is unset, then if a layer already has a compressed blob in the engine's cache, that will be used (this can result in a mix of compression algorithms for different layers). If this is unset and a layer has no compressed blob in the engine's cache, then it will be compressed using Gzip.
     #[builder(setter(into, strip_option), default)]
@@ -685,12 +798,14 @@ pub struct ContainerExportOpts {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerImportOpts<'a> {
+
     /// Identifies the tag to import from the archive, if the archive bundles multiple tags.
     #[builder(setter(into, strip_option), default)]
     pub tag: Option<&'a str>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerPipelineOpts<'a> {
+
     /// Description of the sub-pipeline.
     #[builder(setter(into, strip_option), default)]
     pub description: Option<&'a str>,
@@ -700,6 +815,7 @@ pub struct ContainerPipelineOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerPublishOpts {
+
     /// Force each layer of the published image to use the specified compression algorithm.
     /// If this is unset, then if a layer already has a compressed blob in the engine's cache, that will be used (this can result in a mix of compression algorithms for different layers). If this is unset and a layer has no compressed blob in the engine's cache, then it will be compressed using Gzip.
     #[builder(setter(into, strip_option), default)]
@@ -715,6 +831,7 @@ pub struct ContainerPublishOpts {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerTerminalOpts<'a> {
+
     /// If set, override the container's default terminal command and invoke these command arguments instead.
     #[builder(setter(into, strip_option), default)]
     pub cmd: Option<Vec<&'a str>>,
@@ -728,6 +845,7 @@ pub struct ContainerTerminalOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithDefaultTerminalCmdOpts {
+
     /// Provides Dagger access to the executed command.
     /// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
     #[builder(setter(into, strip_option), default)]
@@ -738,6 +856,7 @@ pub struct ContainerWithDefaultTerminalCmdOpts {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithDirectoryOpts<'a> {
+
     /// Patterns to exclude in the written directory (e.g. ["node_modules/**", ".gitignore", ".git/"]).
     #[builder(setter(into, strip_option), default)]
     pub exclude: Option<Vec<&'a str>>,
@@ -752,18 +871,21 @@ pub struct ContainerWithDirectoryOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithEntrypointOpts {
+
     /// Don't remove the default arguments when setting the entrypoint.
     #[builder(setter(into, strip_option), default)]
     pub keep_default_args: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithEnvVariableOpts {
+
     /// Replace `${VAR}` or `$VAR` in the value according to the current environment variables defined in the container (e.g., "/opt/bin:$PATH").
     #[builder(setter(into, strip_option), default)]
     pub expand: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithExecOpts<'a> {
+
     /// Provides Dagger access to the executed command.
     /// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
     #[builder(setter(into, strip_option), default)]
@@ -786,6 +908,7 @@ pub struct ContainerWithExecOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithExposedPortOpts<'a> {
+
     /// Optional port description
     #[builder(setter(into, strip_option), default)]
     pub description: Option<&'a str>,
@@ -798,6 +921,7 @@ pub struct ContainerWithExposedPortOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithFileOpts<'a> {
+
     /// A user:group to set for the file.
     /// The user and group can either be an ID (1000:1000) or a name (foo:bar).
     /// If the group is omitted, it defaults to the same as the user.
@@ -809,6 +933,7 @@ pub struct ContainerWithFileOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithFilesOpts<'a> {
+
     /// A user:group to set for the files.
     /// The user and group can either be an ID (1000:1000) or a name (foo:bar).
     /// If the group is omitted, it defaults to the same as the user.
@@ -820,6 +945,7 @@ pub struct ContainerWithFilesOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithMountedCacheOpts<'a> {
+
     /// A user:group to set for the mounted cache directory.
     /// Note that this changes the ownership of the specified mount along with the initial filesystem provided by source (if any). It does not have any effect if/when the cache has already been created.
     /// The user and group can either be an ID (1000:1000) or a name (foo:bar).
@@ -835,6 +961,7 @@ pub struct ContainerWithMountedCacheOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithMountedDirectoryOpts<'a> {
+
     /// A user:group to set for the mounted directory and its contents.
     /// The user and group can either be an ID (1000:1000) or a name (foo:bar).
     /// If the group is omitted, it defaults to the same as the user.
@@ -843,6 +970,7 @@ pub struct ContainerWithMountedDirectoryOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithMountedFileOpts<'a> {
+
     /// A user or user:group to set for the mounted file.
     /// The user and group can either be an ID (1000:1000) or a name (foo:bar).
     /// If the group is omitted, it defaults to the same as the user.
@@ -851,6 +979,7 @@ pub struct ContainerWithMountedFileOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithMountedSecretOpts<'a> {
+
     /// Permission given to the mounted secret (e.g., 0600).
     /// This option requires an owner to be set to be active.
     #[builder(setter(into, strip_option), default)]
@@ -863,6 +992,7 @@ pub struct ContainerWithMountedSecretOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithNewFileOpts<'a> {
+
     /// Content of the file to write (e.g., "Hello world!").
     #[builder(setter(into, strip_option), default)]
     pub contents: Option<&'a str>,
@@ -877,6 +1007,7 @@ pub struct ContainerWithNewFileOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithUnixSocketOpts<'a> {
+
     /// A user:group to set for the mounted socket.
     /// The user and group can either be an ID (1000:1000) or a name (foo:bar).
     /// If the group is omitted, it defaults to the same as the user.
@@ -885,21 +1016,27 @@ pub struct ContainerWithUnixSocketOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithoutEntrypointOpts {
+
     /// Don't remove the default arguments when unsetting the entrypoint.
     #[builder(setter(into, strip_option), default)]
     pub keep_default_args: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithoutExposedPortOpts {
+
     /// Port protocol to unexpose
     #[builder(setter(into, strip_option), default)]
     pub protocol: Option<NetworkProtocol>,
 }
+
 impl Container {
     /// Turn the container into a Service.
     /// Be sure to set any exposed ports before this conversion.
-    pub fn as_service(&self) -> Service {
-        let query = self.selection.select("asService");
+    pub fn as_service(
+        &self,
+    ) -> Service {
+        let mut query = self.selection.select("asService");
+
         Service {
             proc: self.proc.clone(),
             selection: query,
@@ -908,33 +1045,48 @@ impl Container {
     }
     /// Returns a File representing the container serialized to a tarball.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn as_tarball(&self) -> File {
-        let query = self.selection.select("asTarball");
+    pub fn as_tarball(
+        &self,
+    ) -> File {
+        let mut query = self.selection.select("asTarball");
+
         File {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Returns a File representing the container serialized to a tarball.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn as_tarball_opts(&self, opts: ContainerAsTarballOpts) -> File {
+    pub fn as_tarball_opts(
+        &self,
+        opts: ContainerAsTarballOpts
+    ) -> File {
         let mut query = self.selection.select("asTarball");
+
         if let Some(platform_variants) = opts.platform_variants {
             query = query.arg("platformVariants", platform_variants);
         }
         if let Some(forced_compression) = opts.forced_compression {
-            query = query.arg_enum("forcedCompression", forced_compression);
+            query = query.arg("forcedCompression", forced_compression);
         }
         if let Some(media_types) = opts.media_types {
-            query = query.arg_enum("mediaTypes", media_types);
+            query = query.arg("mediaTypes", media_types);
         }
+
         File {
             proc: self.proc.clone(),
             selection: query,
@@ -943,12 +1095,19 @@ impl Container {
     }
     /// Initializes this container from a Dockerfile build.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `context` - Directory context used by the Dockerfile.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn build(&self, context: Directory) -> Container {
+    pub fn build(
+        &self,
+        context: Directory,
+    ) -> Container {
         let mut query = self.selection.select("build");
+
         query = query.arg_lazy(
             "context",
             Box::new(move || {
@@ -956,20 +1115,30 @@ impl Container {
                 Box::pin(async move { context.id().await.unwrap().quote() })
             }),
         );
+
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Initializes this container from a Dockerfile build.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `context` - Directory context used by the Dockerfile.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn build_opts<'a>(&self, context: Directory, opts: ContainerBuildOpts<'a>) -> Container {
+    pub fn build_opts<'a>(
+        &self,
+        context: Directory,
+        opts: ContainerBuildOpts<'a>
+    ) -> Container {
         let mut query = self.selection.select("build");
+
         query = query.arg_lazy(
             "context",
             Box::new(move || {
@@ -989,6 +1158,7 @@ impl Container {
         if let Some(secrets) = opts.secrets {
             query = query.arg("secrets", secrets);
         }
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -996,19 +1166,30 @@ impl Container {
         }
     }
     /// Retrieves default arguments for future commands.
-    pub async fn default_args(&self) -> Result<Vec<String>, DaggerError> {
-        let query = self.selection.select("defaultArgs");
+    pub async fn default_args(
+        &self,
+    ) -> Result<Vec<String>, DaggerError> {
+        let mut query = self.selection.select("defaultArgs");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves a directory at the given path.
     /// Mounts are included.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - The path of the directory to retrieve (e.g., "./src").
-    pub fn directory(&self, path: impl Into<String>) -> Directory {
+    pub fn directory(
+        &self,
+        path: impl Into<String>,
+    ) -> Directory {
         let mut query = self.selection.select("directory");
+
         query = query.arg("path", path.into());
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -1016,34 +1197,51 @@ impl Container {
         }
     }
     /// Retrieves entrypoint to be prepended to the arguments of all commands.
-    pub async fn entrypoint(&self) -> Result<Vec<String>, DaggerError> {
-        let query = self.selection.select("entrypoint");
+    pub async fn entrypoint(
+        &self,
+    ) -> Result<Vec<String>, DaggerError> {
+        let mut query = self.selection.select("entrypoint");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the value of the specified environment variable.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - The name of the environment variable to retrieve (e.g., "PATH").
-    pub async fn env_variable(&self, name: impl Into<String>) -> Result<String, DaggerError> {
+    pub async fn env_variable(
+        &self,
+        name: impl Into<String>,
+    ) -> Result<String, DaggerError> {
         let mut query = self.selection.select("envVariable");
+
         query = query.arg("name", name.into());
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the list of environment variables passed to commands.
-    pub fn env_variables(&self) -> Vec<EnvVariable> {
-        let query = self.selection.select("envVariables");
+    pub fn env_variables(
+        &self,
+    ) -> Vec<EnvVariable> {
+        let mut query = self.selection.select("envVariables");
+
         return vec![EnvVariable {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// EXPERIMENTAL API! Subject to change/removal at any time.
     /// Configures all available GPUs on the host to be accessible to this container.
     /// This currently works for Nvidia devices only.
-    pub fn experimental_with_all_gp_us(&self) -> Container {
-        let query = self.selection.select("experimentalWithAllGPUs");
+    pub fn experimental_with_all_gp_us(
+        &self,
+    ) -> Container {
+        let mut query = self.selection.select("experimentalWithAllGPUs");
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1054,18 +1252,20 @@ impl Container {
     /// Configures the provided list of devices to be accessible to this container.
     /// This currently works for Nvidia devices only.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `devices` - List of devices to be accessible to this container.
-    pub fn experimental_with_gpu(&self, devices: Vec<impl Into<String>>) -> Container {
+    pub fn experimental_with_gpu(
+        &self,
+        devices: Vec<impl Into<String>>,
+    ) -> Container {
         let mut query = self.selection.select("experimentalWithGPU");
-        query = query.arg(
-            "devices",
-            devices
-                .into_iter()
-                .map(|i| i.into())
-                .collect::<Vec<String>>(),
-        );
+
+        query = query.arg("devices", devices.into_iter().map(|i| i.into()).collect::<Vec<String>>());
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1076,64 +1276,89 @@ impl Container {
     /// Return true on success.
     /// It can also export platform variants.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Host's destination path (e.g., "./tarball").
-    ///
+    /// 
     /// Path can be relative to the engine's workdir or absolute.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn export(&self, path: impl Into<String>) -> Result<bool, DaggerError> {
+    pub async fn export(
+        &self,
+        path: impl Into<String>,
+    ) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
+
         query = query.arg("path", path.into());
+
         query.execute(self.graphql_client.clone()).await
     }
+
     /// Writes the container as an OCI tarball to the destination file path on the host.
     /// Return true on success.
     /// It can also export platform variants.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Host's destination path (e.g., "./tarball").
-    ///
+    /// 
     /// Path can be relative to the engine's workdir or absolute.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn export_opts(
         &self,
         path: impl Into<String>,
-        opts: ContainerExportOpts,
+        opts: ContainerExportOpts
     ) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
+
         query = query.arg("path", path.into());
         if let Some(platform_variants) = opts.platform_variants {
             query = query.arg("platformVariants", platform_variants);
         }
         if let Some(forced_compression) = opts.forced_compression {
-            query = query.arg_enum("forcedCompression", forced_compression);
+            query = query.arg("forcedCompression", forced_compression);
         }
         if let Some(media_types) = opts.media_types {
-            query = query.arg_enum("mediaTypes", media_types);
+            query = query.arg("mediaTypes", media_types);
         }
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the list of exposed ports.
     /// This includes ports already exposed by the image, even if not explicitly added with dagger.
-    pub fn exposed_ports(&self) -> Vec<Port> {
-        let query = self.selection.select("exposedPorts");
+    pub fn exposed_ports(
+        &self,
+    ) -> Vec<Port> {
+        let mut query = self.selection.select("exposedPorts");
+
         return vec![Port {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// Retrieves a file at the given path.
     /// Mounts are included.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - The path of the file to retrieve (e.g., "./README.md").
-    pub fn file(&self, path: impl Into<String>) -> File {
+    pub fn file(
+        &self,
+        path: impl Into<String>,
+    ) -> File {
         let mut query = self.selection.select("file");
+
         query = query.arg("path", path.into());
+
         File {
             proc: self.proc.clone(),
             selection: query,
@@ -1142,14 +1367,22 @@ impl Container {
     }
     /// Initializes this container from a pulled base image.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `address` - Image's address from its registry.
-    ///
+    /// 
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g., "docker.io/dagger/dagger:main").
-    pub fn from(&self, address: impl Into<String>) -> Container {
+    pub fn from(
+        &self,
+        address: impl Into<String>,
+    ) -> Container {
         let mut query = self.selection.select("from");
+
         query = query.arg("address", address.into());
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1157,23 +1390,36 @@ impl Container {
         }
     }
     /// A unique identifier for this Container.
-    pub async fn id(&self) -> Result<ContainerId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<ContainerId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The unique image reference which can only be retrieved immediately after the 'Container.From' call.
-    pub async fn image_ref(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("imageRef");
+    pub async fn image_ref(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("imageRef");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Reads the container from an OCI tarball.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `source` - File to read the container from.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn import(&self, source: File) -> Container {
+    pub fn import(
+        &self,
+        source: File,
+    ) -> Container {
         let mut query = self.selection.select("import");
+
         query = query.arg_lazy(
             "source",
             Box::new(move || {
@@ -1181,20 +1427,30 @@ impl Container {
                 Box::pin(async move { source.id().await.unwrap().quote() })
             }),
         );
+
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Reads the container from an OCI tarball.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `source` - File to read the container from.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn import_opts<'a>(&self, source: File, opts: ContainerImportOpts<'a>) -> Container {
+    pub fn import_opts<'a>(
+        &self,
+        source: File,
+        opts: ContainerImportOpts<'a>
+    ) -> Container {
         let mut query = self.selection.select("import");
+
         query = query.arg_lazy(
             "source",
             Box::new(move || {
@@ -1205,6 +1461,7 @@ impl Container {
         if let Some(tag) = opts.tag {
             query = query.arg("tag", tag);
         }
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1213,55 +1470,82 @@ impl Container {
     }
     /// Retrieves the value of the specified label.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - The name of the label (e.g., "org.opencontainers.artifact.created").
-    pub async fn label(&self, name: impl Into<String>) -> Result<String, DaggerError> {
+    pub async fn label(
+        &self,
+        name: impl Into<String>,
+    ) -> Result<String, DaggerError> {
         let mut query = self.selection.select("label");
+
         query = query.arg("name", name.into());
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the list of labels passed to container.
-    pub fn labels(&self) -> Vec<Label> {
-        let query = self.selection.select("labels");
+    pub fn labels(
+        &self,
+    ) -> Vec<Label> {
+        let mut query = self.selection.select("labels");
+
         return vec![Label {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// Retrieves the list of paths where a directory is mounted.
-    pub async fn mounts(&self) -> Result<Vec<String>, DaggerError> {
-        let query = self.selection.select("mounts");
+    pub async fn mounts(
+        &self,
+    ) -> Result<Vec<String>, DaggerError> {
+        let mut query = self.selection.select("mounts");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Creates a named sub-pipeline.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - Name of the sub-pipeline.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn pipeline(&self, name: impl Into<String>) -> Container {
+    pub fn pipeline(
+        &self,
+        name: impl Into<String>,
+    ) -> Container {
         let mut query = self.selection.select("pipeline");
+
         query = query.arg("name", name.into());
+
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Creates a named sub-pipeline.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - Name of the sub-pipeline.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn pipeline_opts<'a>(
         &self,
         name: impl Into<String>,
-        opts: ContainerPipelineOpts<'a>,
+        opts: ContainerPipelineOpts<'a>
     ) -> Container {
         let mut query = self.selection.select("pipeline");
+
         query = query.arg("name", name.into());
         if let Some(description) = opts.description {
             query = query.arg("description", description);
@@ -1269,6 +1553,7 @@ impl Container {
         if let Some(labels) = opts.labels {
             query = query.arg("labels", labels);
         }
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1276,56 +1561,76 @@ impl Container {
         }
     }
     /// The platform this container executes and publishes as.
-    pub async fn platform(&self) -> Result<Platform, DaggerError> {
-        let query = self.selection.select("platform");
+    pub async fn platform(
+        &self,
+    ) -> Result<Platform, DaggerError> {
+        let mut query = self.selection.select("platform");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Publishes this container as a new image to the specified address.
     /// Publish returns a fully qualified ref.
     /// It can also publish platform variants.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `address` - Registry's address to publish the image to.
-    ///
+    /// 
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g. "docker.io/dagger/dagger:main").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn publish(&self, address: impl Into<String>) -> Result<String, DaggerError> {
+    pub async fn publish(
+        &self,
+        address: impl Into<String>,
+    ) -> Result<String, DaggerError> {
         let mut query = self.selection.select("publish");
+
         query = query.arg("address", address.into());
+
         query.execute(self.graphql_client.clone()).await
     }
+
     /// Publishes this container as a new image to the specified address.
     /// Publish returns a fully qualified ref.
     /// It can also publish platform variants.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `address` - Registry's address to publish the image to.
-    ///
+    /// 
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g. "docker.io/dagger/dagger:main").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn publish_opts(
         &self,
         address: impl Into<String>,
-        opts: ContainerPublishOpts,
+        opts: ContainerPublishOpts
     ) -> Result<String, DaggerError> {
         let mut query = self.selection.select("publish");
+
         query = query.arg("address", address.into());
         if let Some(platform_variants) = opts.platform_variants {
             query = query.arg("platformVariants", platform_variants);
         }
         if let Some(forced_compression) = opts.forced_compression {
-            query = query.arg_enum("forcedCompression", forced_compression);
+            query = query.arg("forcedCompression", forced_compression);
         }
         if let Some(media_types) = opts.media_types {
-            query = query.arg_enum("mediaTypes", media_types);
+            query = query.arg("mediaTypes", media_types);
         }
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves this container's root filesystem. Mounts are not included.
-    pub fn rootfs(&self) -> Directory {
-        let query = self.selection.select("rootfs");
+    pub fn rootfs(
+        &self,
+    ) -> Directory {
+        let mut query = self.selection.select("rootfs");
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -1334,54 +1639,75 @@ impl Container {
     }
     /// The error stream of the last executed command.
     /// Will execute default command if none is set, or error if there's no default.
-    pub async fn stderr(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("stderr");
+    pub async fn stderr(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("stderr");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The output stream of the last executed command.
     /// Will execute default command if none is set, or error if there's no default.
-    pub async fn stdout(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("stdout");
+    pub async fn stdout(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("stdout");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Forces evaluation of the pipeline in the engine.
     /// It doesn't run the default command if no exec has been set.
-    pub async fn sync(&self) -> Result<ContainerId, DaggerError> {
-        let query = self.selection.select("sync");
+    pub async fn sync(
+        &self,
+    ) -> Result<ContainerId, DaggerError> {
+        let mut query = self.selection.select("sync");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Return an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn terminal(&self) -> Terminal {
-        let query = self.selection.select("terminal");
+    pub fn terminal(
+        &self,
+    ) -> Terminal {
+        let mut query = self.selection.select("terminal");
+
         Terminal {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Return an interactive terminal for this container using its configured default terminal command if not overridden by args (or sh as a fallback default).
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn terminal_opts<'a>(&self, opts: ContainerTerminalOpts<'a>) -> Terminal {
+    pub fn terminal_opts<'a>(
+        &self,
+        opts: ContainerTerminalOpts<'a>
+    ) -> Terminal {
         let mut query = self.selection.select("terminal");
+
         if let Some(cmd) = opts.cmd {
             query = query.arg("cmd", cmd);
         }
         if let Some(experimental_privileged_nesting) = opts.experimental_privileged_nesting {
-            query = query.arg(
-                "experimentalPrivilegedNesting",
-                experimental_privileged_nesting,
-            );
+            query = query.arg("experimentalPrivilegedNesting", experimental_privileged_nesting);
         }
         if let Some(insecure_root_capabilities) = opts.insecure_root_capabilities {
             query = query.arg("insecureRootCapabilities", insecure_root_capabilities);
         }
+
         Terminal {
             proc: self.proc.clone(),
             selection: query,
@@ -1389,21 +1715,29 @@ impl Container {
         }
     }
     /// Retrieves the user to be set for all commands.
-    pub async fn user(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("user");
+    pub async fn user(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("user");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Configures default arguments for future commands.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `args` - Arguments to prepend to future executions (e.g., ["-v", "--no-cache"]).
-    pub fn with_default_args(&self, args: Vec<impl Into<String>>) -> Container {
+    pub fn with_default_args(
+        &self,
+        args: Vec<impl Into<String>>,
+    ) -> Container {
         let mut query = self.selection.select("withDefaultArgs");
-        query = query.arg(
-            "args",
-            args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
-        );
+
+        query = query.arg("args", args.into_iter().map(|i| i.into()).collect::<Vec<String>>());
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1412,47 +1746,52 @@ impl Container {
     }
     /// Set the default command to invoke for the container's terminal API.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `args` - The args of the command.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_default_terminal_cmd(&self, args: Vec<impl Into<String>>) -> Container {
+    pub fn with_default_terminal_cmd(
+        &self,
+        args: Vec<impl Into<String>>,
+    ) -> Container {
         let mut query = self.selection.select("withDefaultTerminalCmd");
-        query = query.arg(
-            "args",
-            args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
-        );
+
+        query = query.arg("args", args.into_iter().map(|i| i.into()).collect::<Vec<String>>());
+
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Set the default command to invoke for the container's terminal API.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `args` - The args of the command.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_default_terminal_cmd_opts(
         &self,
         args: Vec<impl Into<String>>,
-        opts: ContainerWithDefaultTerminalCmdOpts,
+        opts: ContainerWithDefaultTerminalCmdOpts
     ) -> Container {
         let mut query = self.selection.select("withDefaultTerminalCmd");
-        query = query.arg(
-            "args",
-            args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
-        );
+
+        query = query.arg("args", args.into_iter().map(|i| i.into()).collect::<Vec<String>>());
         if let Some(experimental_privileged_nesting) = opts.experimental_privileged_nesting {
-            query = query.arg(
-                "experimentalPrivilegedNesting",
-                experimental_privileged_nesting,
-            );
+            query = query.arg("experimentalPrivilegedNesting", experimental_privileged_nesting);
         }
         if let Some(insecure_root_capabilities) = opts.insecure_root_capabilities {
             query = query.arg("insecureRootCapabilities", insecure_root_capabilities);
         }
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1461,13 +1800,21 @@ impl Container {
     }
     /// Retrieves this container plus a directory written at the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the written directory (e.g., "/tmp/directory").
     /// * `directory` - Identifier of the directory to write
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_directory(&self, path: impl Into<String>, directory: Directory) -> Container {
+    pub fn with_directory(
+        &self,
+        path: impl Into<String>,
+        directory: Directory,
+    ) -> Container {
         let mut query = self.selection.select("withDirectory");
+
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "directory",
@@ -1476,16 +1823,21 @@ impl Container {
                 Box::pin(async move { directory.id().await.unwrap().quote() })
             }),
         );
+
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Retrieves this container plus a directory written at the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the written directory (e.g., "/tmp/directory").
     /// * `directory` - Identifier of the directory to write
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -1493,9 +1845,10 @@ impl Container {
         &self,
         path: impl Into<String>,
         directory: Directory,
-        opts: ContainerWithDirectoryOpts<'a>,
+        opts: ContainerWithDirectoryOpts<'a>
     ) -> Container {
         let mut query = self.selection.select("withDirectory");
+
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "directory",
@@ -1513,6 +1866,7 @@ impl Container {
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1521,41 +1875,49 @@ impl Container {
     }
     /// Retrieves this container but with a different command entrypoint.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `args` - Entrypoint to use for future executions (e.g., ["go", "run"]).
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_entrypoint(&self, args: Vec<impl Into<String>>) -> Container {
+    pub fn with_entrypoint(
+        &self,
+        args: Vec<impl Into<String>>,
+    ) -> Container {
         let mut query = self.selection.select("withEntrypoint");
-        query = query.arg(
-            "args",
-            args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
-        );
+
+        query = query.arg("args", args.into_iter().map(|i| i.into()).collect::<Vec<String>>());
+
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Retrieves this container but with a different command entrypoint.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `args` - Entrypoint to use for future executions (e.g., ["go", "run"]).
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_entrypoint_opts(
         &self,
         args: Vec<impl Into<String>>,
-        opts: ContainerWithEntrypointOpts,
+        opts: ContainerWithEntrypointOpts
     ) -> Container {
         let mut query = self.selection.select("withEntrypoint");
-        query = query.arg(
-            "args",
-            args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
-        );
+
+        query = query.arg("args", args.into_iter().map(|i| i.into()).collect::<Vec<String>>());
         if let Some(keep_default_args) = opts.keep_default_args {
             query = query.arg("keepDefaultArgs", keep_default_args);
         }
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1564,8 +1926,11 @@ impl Container {
     }
     /// Retrieves this container plus the given environment variable.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - The name of the environment variable (e.g., "HOST").
     /// * `value` - The value of the environment variable. (e.g., "localhost").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -1575,18 +1940,24 @@ impl Container {
         value: impl Into<String>,
     ) -> Container {
         let mut query = self.selection.select("withEnvVariable");
+
         query = query.arg("name", name.into());
         query = query.arg("value", value.into());
+
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Retrieves this container plus the given environment variable.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - The name of the environment variable (e.g., "HOST").
     /// * `value` - The value of the environment variable. (e.g., "localhost").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -1594,14 +1965,16 @@ impl Container {
         &self,
         name: impl Into<String>,
         value: impl Into<String>,
-        opts: ContainerWithEnvVariableOpts,
+        opts: ContainerWithEnvVariableOpts
     ) -> Container {
         let mut query = self.selection.select("withEnvVariable");
+
         query = query.arg("name", name.into());
         query = query.arg("value", value.into());
         if let Some(expand) = opts.expand {
             query = query.arg("expand", expand);
         }
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1610,42 +1983,49 @@ impl Container {
     }
     /// Retrieves this container after executing the specified command inside it.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `args` - Command to run instead of the container's default command (e.g., ["run", "main.go"]).
-    ///
+    /// 
     /// If empty, the container's default command is used.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_exec(&self, args: Vec<impl Into<String>>) -> Container {
+    pub fn with_exec(
+        &self,
+        args: Vec<impl Into<String>>,
+    ) -> Container {
         let mut query = self.selection.select("withExec");
-        query = query.arg(
-            "args",
-            args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
-        );
+
+        query = query.arg("args", args.into_iter().map(|i| i.into()).collect::<Vec<String>>());
+
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Retrieves this container after executing the specified command inside it.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `args` - Command to run instead of the container's default command (e.g., ["run", "main.go"]).
-    ///
+    /// 
     /// If empty, the container's default command is used.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_exec_opts<'a>(
         &self,
         args: Vec<impl Into<String>>,
-        opts: ContainerWithExecOpts<'a>,
+        opts: ContainerWithExecOpts<'a>
     ) -> Container {
         let mut query = self.selection.select("withExec");
-        query = query.arg(
-            "args",
-            args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
-        );
+
+        query = query.arg("args", args.into_iter().map(|i| i.into()).collect::<Vec<String>>());
         if let Some(skip_entrypoint) = opts.skip_entrypoint {
             query = query.arg("skipEntrypoint", skip_entrypoint);
         }
@@ -1659,14 +2039,12 @@ impl Container {
             query = query.arg("redirectStderr", redirect_stderr);
         }
         if let Some(experimental_privileged_nesting) = opts.experimental_privileged_nesting {
-            query = query.arg(
-                "experimentalPrivilegedNesting",
-                experimental_privileged_nesting,
-            );
+            query = query.arg("experimentalPrivilegedNesting", experimental_privileged_nesting);
         }
         if let Some(insecure_root_capabilities) = opts.insecure_root_capabilities {
             query = query.arg("insecureRootCapabilities", insecure_root_capabilities);
         }
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1678,37 +2056,50 @@ impl Container {
     /// - For health checks and introspection, when running services
     /// - For setting the EXPOSE OCI field when publishing the container
     ///
+
     /// # Arguments
+
     ///
+
     /// * `port` - Port number to expose
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_exposed_port(&self, port: isize) -> Container {
+    pub fn with_exposed_port(
+        &self,
+        port: isize,
+    ) -> Container {
         let mut query = self.selection.select("withExposedPort");
+
         query = query.arg("port", port);
+
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Expose a network port.
     /// Exposed ports serve two purposes:
     /// - For health checks and introspection, when running services
     /// - For setting the EXPOSE OCI field when publishing the container
     ///
+
     /// # Arguments
+
     ///
+
     /// * `port` - Port number to expose
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_exposed_port_opts<'a>(
         &self,
         port: isize,
-        opts: ContainerWithExposedPortOpts<'a>,
+        opts: ContainerWithExposedPortOpts<'a>
     ) -> Container {
         let mut query = self.selection.select("withExposedPort");
+
         query = query.arg("port", port);
         if let Some(protocol) = opts.protocol {
-            query = query.arg_enum("protocol", protocol);
+            query = query.arg("protocol", protocol);
         }
         if let Some(description) = opts.description {
             query = query.arg("description", description);
@@ -1716,6 +2107,7 @@ impl Container {
         if let Some(experimental_skip_healthcheck) = opts.experimental_skip_healthcheck {
             query = query.arg("experimentalSkipHealthcheck", experimental_skip_healthcheck);
         }
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1724,13 +2116,21 @@ impl Container {
     }
     /// Retrieves this container plus the contents of the given file copied to the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the copied file (e.g., "/tmp/file.txt").
     /// * `source` - Identifier of the file to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_file(&self, path: impl Into<String>, source: File) -> Container {
+    pub fn with_file(
+        &self,
+        path: impl Into<String>,
+        source: File,
+    ) -> Container {
         let mut query = self.selection.select("withFile");
+
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "source",
@@ -1739,16 +2139,21 @@ impl Container {
                 Box::pin(async move { source.id().await.unwrap().quote() })
             }),
         );
+
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Retrieves this container plus the contents of the given file copied to the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the copied file (e.g., "/tmp/file.txt").
     /// * `source` - Identifier of the file to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -1756,9 +2161,10 @@ impl Container {
         &self,
         path: impl Into<String>,
         source: File,
-        opts: ContainerWithFileOpts<'a>,
+        opts: ContainerWithFileOpts<'a>
     ) -> Container {
         let mut query = self.selection.select("withFile");
+
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "source",
@@ -1773,6 +2179,7 @@ impl Container {
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1781,25 +2188,38 @@ impl Container {
     }
     /// Retrieves this container plus the contents of the given files copied to the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location where copied files should be placed (e.g., "/src").
     /// * `sources` - Identifiers of the files to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_files(&self, path: impl Into<String>, sources: Vec<FileId>) -> Container {
+    pub fn with_files(
+        &self,
+        path: impl Into<String>,
+        sources: Vec<FileId>,
+    ) -> Container {
         let mut query = self.selection.select("withFiles");
+
         query = query.arg("path", path.into());
         query = query.arg("sources", sources);
+
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Retrieves this container plus the contents of the given files copied to the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location where copied files should be placed (e.g., "/src").
     /// * `sources` - Identifiers of the files to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -1807,9 +2227,10 @@ impl Container {
         &self,
         path: impl Into<String>,
         sources: Vec<FileId>,
-        opts: ContainerWithFilesOpts<'a>,
+        opts: ContainerWithFilesOpts<'a>
     ) -> Container {
         let mut query = self.selection.select("withFiles");
+
         query = query.arg("path", path.into());
         query = query.arg("sources", sources);
         if let Some(permissions) = opts.permissions {
@@ -1818,6 +2239,7 @@ impl Container {
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1825,8 +2247,11 @@ impl Container {
         }
     }
     /// Indicate that subsequent operations should be featured more prominently in the UI.
-    pub fn with_focus(&self) -> Container {
-        let query = self.selection.select("withFocus");
+    pub fn with_focus(
+        &self,
+    ) -> Container {
+        let mut query = self.selection.select("withFocus");
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1835,14 +2260,23 @@ impl Container {
     }
     /// Retrieves this container plus the given label.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - The name of the label (e.g., "org.opencontainers.artifact.created").
     /// * `value` - The value of the label (e.g., "2023-01-01T00:00:00Z").
-    pub fn with_label(&self, name: impl Into<String>, value: impl Into<String>) -> Container {
+    pub fn with_label(
+        &self,
+        name: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Container {
         let mut query = self.selection.select("withLabel");
+
         query = query.arg("name", name.into());
         query = query.arg("value", value.into());
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1851,13 +2285,21 @@ impl Container {
     }
     /// Retrieves this container plus a cache volume mounted at the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the cache directory (e.g., "/cache/node_modules").
     /// * `cache` - Identifier of the cache volume to mount.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_mounted_cache(&self, path: impl Into<String>, cache: CacheVolume) -> Container {
+    pub fn with_mounted_cache(
+        &self,
+        path: impl Into<String>,
+        cache: CacheVolume,
+    ) -> Container {
         let mut query = self.selection.select("withMountedCache");
+
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "cache",
@@ -1866,16 +2308,21 @@ impl Container {
                 Box::pin(async move { cache.id().await.unwrap().quote() })
             }),
         );
+
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Retrieves this container plus a cache volume mounted at the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the cache directory (e.g., "/cache/node_modules").
     /// * `cache` - Identifier of the cache volume to mount.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -1883,9 +2330,10 @@ impl Container {
         &self,
         path: impl Into<String>,
         cache: CacheVolume,
-        opts: ContainerWithMountedCacheOpts<'a>,
+        opts: ContainerWithMountedCacheOpts<'a>
     ) -> Container {
         let mut query = self.selection.select("withMountedCache");
+
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "cache",
@@ -1898,11 +2346,12 @@ impl Container {
             query = query.arg("source", source);
         }
         if let Some(sharing) = opts.sharing {
-            query = query.arg_enum("sharing", sharing);
+            query = query.arg("sharing", sharing);
         }
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1911,13 +2360,21 @@ impl Container {
     }
     /// Retrieves this container plus a directory mounted at the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the mounted directory (e.g., "/mnt/directory").
     /// * `source` - Identifier of the mounted directory.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_mounted_directory(&self, path: impl Into<String>, source: Directory) -> Container {
+    pub fn with_mounted_directory(
+        &self,
+        path: impl Into<String>,
+        source: Directory,
+    ) -> Container {
         let mut query = self.selection.select("withMountedDirectory");
+
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "source",
@@ -1926,16 +2383,21 @@ impl Container {
                 Box::pin(async move { source.id().await.unwrap().quote() })
             }),
         );
+
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Retrieves this container plus a directory mounted at the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the mounted directory (e.g., "/mnt/directory").
     /// * `source` - Identifier of the mounted directory.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -1943,9 +2405,10 @@ impl Container {
         &self,
         path: impl Into<String>,
         source: Directory,
-        opts: ContainerWithMountedDirectoryOpts<'a>,
+        opts: ContainerWithMountedDirectoryOpts<'a>
     ) -> Container {
         let mut query = self.selection.select("withMountedDirectory");
+
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "source",
@@ -1957,6 +2420,7 @@ impl Container {
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -1965,13 +2429,21 @@ impl Container {
     }
     /// Retrieves this container plus a file mounted at the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the mounted file (e.g., "/tmp/file.txt").
     /// * `source` - Identifier of the mounted file.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_mounted_file(&self, path: impl Into<String>, source: File) -> Container {
+    pub fn with_mounted_file(
+        &self,
+        path: impl Into<String>,
+        source: File,
+    ) -> Container {
         let mut query = self.selection.select("withMountedFile");
+
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "source",
@@ -1980,16 +2452,21 @@ impl Container {
                 Box::pin(async move { source.id().await.unwrap().quote() })
             }),
         );
+
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Retrieves this container plus a file mounted at the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the mounted file (e.g., "/tmp/file.txt").
     /// * `source` - Identifier of the mounted file.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -1997,9 +2474,10 @@ impl Container {
         &self,
         path: impl Into<String>,
         source: File,
-        opts: ContainerWithMountedFileOpts<'a>,
+        opts: ContainerWithMountedFileOpts<'a>
     ) -> Container {
         let mut query = self.selection.select("withMountedFile");
+
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "source",
@@ -2011,6 +2489,7 @@ impl Container {
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2019,13 +2498,21 @@ impl Container {
     }
     /// Retrieves this container plus a secret mounted into a file at the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the secret file (e.g., "/tmp/secret.txt").
     /// * `source` - Identifier of the secret to mount.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_mounted_secret(&self, path: impl Into<String>, source: Secret) -> Container {
+    pub fn with_mounted_secret(
+        &self,
+        path: impl Into<String>,
+        source: Secret,
+    ) -> Container {
         let mut query = self.selection.select("withMountedSecret");
+
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "source",
@@ -2034,16 +2521,21 @@ impl Container {
                 Box::pin(async move { source.id().await.unwrap().quote() })
             }),
         );
+
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Retrieves this container plus a secret mounted into a file at the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the secret file (e.g., "/tmp/secret.txt").
     /// * `source` - Identifier of the secret to mount.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -2051,9 +2543,10 @@ impl Container {
         &self,
         path: impl Into<String>,
         source: Secret,
-        opts: ContainerWithMountedSecretOpts<'a>,
+        opts: ContainerWithMountedSecretOpts<'a>
     ) -> Container {
         let mut query = self.selection.select("withMountedSecret");
+
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "source",
@@ -2068,6 +2561,7 @@ impl Container {
         if let Some(mode) = opts.mode {
             query = query.arg("mode", mode);
         }
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2076,12 +2570,20 @@ impl Container {
     }
     /// Retrieves this container plus a temporary directory mounted at the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the temporary directory (e.g., "/tmp/temp_dir").
-    pub fn with_mounted_temp(&self, path: impl Into<String>) -> Container {
+    pub fn with_mounted_temp(
+        &self,
+        path: impl Into<String>,
+    ) -> Container {
         let mut query = self.selection.select("withMountedTemp");
+
         query = query.arg("path", path.into());
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2090,31 +2592,44 @@ impl Container {
     }
     /// Retrieves this container plus a new file written at the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the written file (e.g., "/tmp/file.txt").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_new_file(&self, path: impl Into<String>) -> Container {
+    pub fn with_new_file(
+        &self,
+        path: impl Into<String>,
+    ) -> Container {
         let mut query = self.selection.select("withNewFile");
+
         query = query.arg("path", path.into());
+
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Retrieves this container plus a new file written at the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the written file (e.g., "/tmp/file.txt").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_new_file_opts<'a>(
         &self,
         path: impl Into<String>,
-        opts: ContainerWithNewFileOpts<'a>,
+        opts: ContainerWithNewFileOpts<'a>
     ) -> Container {
         let mut query = self.selection.select("withNewFile");
+
         query = query.arg("path", path.into());
         if let Some(contents) = opts.contents {
             query = query.arg("contents", contents);
@@ -2125,6 +2640,7 @@ impl Container {
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2133,10 +2649,13 @@ impl Container {
     }
     /// Retrieves this container with a registry authentication for a given address.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `address` - Registry's address to bind the authentication to.
-    ///
+    /// 
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g. docker.io/dagger/dagger:main).
     /// * `username` - The username of the registry's account (e.g., "Dagger").
     /// * `secret` - The API key, password or token to authenticate to this registry.
@@ -2147,6 +2666,7 @@ impl Container {
         secret: Secret,
     ) -> Container {
         let mut query = self.selection.select("withRegistryAuth");
+
         query = query.arg("address", address.into());
         query = query.arg("username", username.into());
         query = query.arg_lazy(
@@ -2156,6 +2676,7 @@ impl Container {
                 Box::pin(async move { secret.id().await.unwrap().quote() })
             }),
         );
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2164,11 +2685,18 @@ impl Container {
     }
     /// Retrieves the container with the given directory mounted to /.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `directory` - Directory to mount.
-    pub fn with_rootfs(&self, directory: Directory) -> Container {
+    pub fn with_rootfs(
+        &self,
+        directory: Directory,
+    ) -> Container {
         let mut query = self.selection.select("withRootfs");
+
         query = query.arg_lazy(
             "directory",
             Box::new(move || {
@@ -2176,6 +2704,7 @@ impl Container {
                 Box::pin(async move { directory.id().await.unwrap().quote() })
             }),
         );
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2184,12 +2713,20 @@ impl Container {
     }
     /// Retrieves this container plus an env variable containing the given secret.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - The name of the secret variable (e.g., "API_SECRET").
     /// * `secret` - The identifier of the secret value.
-    pub fn with_secret_variable(&self, name: impl Into<String>, secret: Secret) -> Container {
+    pub fn with_secret_variable(
+        &self,
+        name: impl Into<String>,
+        secret: Secret,
+    ) -> Container {
         let mut query = self.selection.select("withSecretVariable");
+
         query = query.arg("name", name.into());
         query = query.arg_lazy(
             "secret",
@@ -2198,6 +2735,7 @@ impl Container {
                 Box::pin(async move { secret.id().await.unwrap().quote() })
             }),
         );
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2209,12 +2747,20 @@ impl Container {
     /// The service will be reachable from the container via the provided hostname alias.
     /// The service dependency will also convey to any files or directories produced by the container.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `alias` - A name that can be used to reach the service from the container
     /// * `service` - Identifier of the service container
-    pub fn with_service_binding(&self, alias: impl Into<String>, service: Service) -> Container {
+    pub fn with_service_binding(
+        &self,
+        alias: impl Into<String>,
+        service: Service,
+    ) -> Container {
         let mut query = self.selection.select("withServiceBinding");
+
         query = query.arg("alias", alias.into());
         query = query.arg_lazy(
             "service",
@@ -2223,6 +2769,7 @@ impl Container {
                 Box::pin(async move { service.id().await.unwrap().quote() })
             }),
         );
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2231,13 +2778,21 @@ impl Container {
     }
     /// Retrieves this container plus a socket forwarded to the given Unix socket path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the forwarded Unix socket (e.g., "/tmp/socket").
     /// * `source` - Identifier of the socket to forward.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_unix_socket(&self, path: impl Into<String>, source: Socket) -> Container {
+    pub fn with_unix_socket(
+        &self,
+        path: impl Into<String>,
+        source: Socket,
+    ) -> Container {
         let mut query = self.selection.select("withUnixSocket");
+
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "source",
@@ -2246,16 +2801,21 @@ impl Container {
                 Box::pin(async move { source.id().await.unwrap().quote() })
             }),
         );
+
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Retrieves this container plus a socket forwarded to the given Unix socket path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the forwarded Unix socket (e.g., "/tmp/socket").
     /// * `source` - Identifier of the socket to forward.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -2263,9 +2823,10 @@ impl Container {
         &self,
         path: impl Into<String>,
         source: Socket,
-        opts: ContainerWithUnixSocketOpts<'a>,
+        opts: ContainerWithUnixSocketOpts<'a>
     ) -> Container {
         let mut query = self.selection.select("withUnixSocket");
+
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "source",
@@ -2277,6 +2838,7 @@ impl Container {
         if let Some(owner) = opts.owner {
             query = query.arg("owner", owner);
         }
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2285,12 +2847,20 @@ impl Container {
     }
     /// Retrieves this container with a different command user.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - The user to set (e.g., "root").
-    pub fn with_user(&self, name: impl Into<String>) -> Container {
+    pub fn with_user(
+        &self,
+        name: impl Into<String>,
+    ) -> Container {
         let mut query = self.selection.select("withUser");
+
         query = query.arg("name", name.into());
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2299,12 +2869,20 @@ impl Container {
     }
     /// Retrieves this container with a different working directory.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - The path to set as the working directory (e.g., "/app").
-    pub fn with_workdir(&self, path: impl Into<String>) -> Container {
+    pub fn with_workdir(
+        &self,
+        path: impl Into<String>,
+    ) -> Container {
         let mut query = self.selection.select("withWorkdir");
+
         query = query.arg("path", path.into());
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2312,8 +2890,11 @@ impl Container {
         }
     }
     /// Retrieves this container with unset default arguments for future commands.
-    pub fn without_default_args(&self) -> Container {
-        let query = self.selection.select("withoutDefaultArgs");
+    pub fn without_default_args(
+        &self,
+    ) -> Container {
+        let mut query = self.selection.select("withoutDefaultArgs");
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2322,27 +2903,42 @@ impl Container {
     }
     /// Retrieves this container with an unset command entrypoint.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn without_entrypoint(&self) -> Container {
-        let query = self.selection.select("withoutEntrypoint");
-        Container {
-            proc: self.proc.clone(),
-            selection: query,
-            graphql_client: self.graphql_client.clone(),
-        }
-    }
-    /// Retrieves this container with an unset command entrypoint.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn without_entrypoint_opts(&self, opts: ContainerWithoutEntrypointOpts) -> Container {
+    pub fn without_entrypoint(
+        &self,
+    ) -> Container {
         let mut query = self.selection.select("withoutEntrypoint");
+
+        Container {
+            proc: self.proc.clone(),
+            selection: query,
+            graphql_client: self.graphql_client.clone(),
+        }
+    }
+
+    /// Retrieves this container with an unset command entrypoint.
+    ///
+
+    /// # Arguments
+
+    ///
+
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub fn without_entrypoint_opts(
+        &self,
+        opts: ContainerWithoutEntrypointOpts
+    ) -> Container {
+        let mut query = self.selection.select("withoutEntrypoint");
+
         if let Some(keep_default_args) = opts.keep_default_args {
             query = query.arg("keepDefaultArgs", keep_default_args);
         }
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2351,12 +2947,20 @@ impl Container {
     }
     /// Retrieves this container minus the given environment variable.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - The name of the environment variable (e.g., "HOST").
-    pub fn without_env_variable(&self, name: impl Into<String>) -> Container {
+    pub fn without_env_variable(
+        &self,
+        name: impl Into<String>,
+    ) -> Container {
         let mut query = self.selection.select("withoutEnvVariable");
+
         query = query.arg("name", name.into());
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2365,35 +2969,49 @@ impl Container {
     }
     /// Unexpose a previously exposed port.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `port` - Port number to unexpose
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn without_exposed_port(&self, port: isize) -> Container {
+    pub fn without_exposed_port(
+        &self,
+        port: isize,
+    ) -> Container {
         let mut query = self.selection.select("withoutExposedPort");
+
         query = query.arg("port", port);
+
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Unexpose a previously exposed port.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `port` - Port number to unexpose
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn without_exposed_port_opts(
         &self,
         port: isize,
-        opts: ContainerWithoutExposedPortOpts,
+        opts: ContainerWithoutExposedPortOpts
     ) -> Container {
         let mut query = self.selection.select("withoutExposedPort");
+
         query = query.arg("port", port);
         if let Some(protocol) = opts.protocol {
-            query = query.arg_enum("protocol", protocol);
+            query = query.arg("protocol", protocol);
         }
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2402,8 +3020,11 @@ impl Container {
     }
     /// Indicate that subsequent operations should not be featured more prominently in the UI.
     /// This is the initial state of all containers.
-    pub fn without_focus(&self) -> Container {
-        let query = self.selection.select("withoutFocus");
+    pub fn without_focus(
+        &self,
+    ) -> Container {
+        let mut query = self.selection.select("withoutFocus");
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2412,12 +3033,20 @@ impl Container {
     }
     /// Retrieves this container minus the given environment label.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - The name of the label to remove (e.g., "org.opencontainers.artifact.created").
-    pub fn without_label(&self, name: impl Into<String>) -> Container {
+    pub fn without_label(
+        &self,
+        name: impl Into<String>,
+    ) -> Container {
         let mut query = self.selection.select("withoutLabel");
+
         query = query.arg("name", name.into());
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2426,12 +3055,20 @@ impl Container {
     }
     /// Retrieves this container after unmounting everything at the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the cache directory (e.g., "/cache/node_modules").
-    pub fn without_mount(&self, path: impl Into<String>) -> Container {
+    pub fn without_mount(
+        &self,
+        path: impl Into<String>,
+    ) -> Container {
         let mut query = self.selection.select("withoutMount");
+
         query = query.arg("path", path.into());
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2440,14 +3077,22 @@ impl Container {
     }
     /// Retrieves this container without the registry authentication of a given address.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `address` - Registry's address to remove the authentication from.
-    ///
+    /// 
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g. docker.io/dagger/dagger:main).
-    pub fn without_registry_auth(&self, address: impl Into<String>) -> Container {
+    pub fn without_registry_auth(
+        &self,
+        address: impl Into<String>,
+    ) -> Container {
         let mut query = self.selection.select("withoutRegistryAuth");
+
         query = query.arg("address", address.into());
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2456,12 +3101,20 @@ impl Container {
     }
     /// Retrieves this container with a previously added Unix socket removed.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the socket to remove (e.g., "/tmp/socket").
-    pub fn without_unix_socket(&self, path: impl Into<String>) -> Container {
+    pub fn without_unix_socket(
+        &self,
+        path: impl Into<String>,
+    ) -> Container {
         let mut query = self.selection.select("withoutUnixSocket");
+
         query = query.arg("path", path.into());
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2470,8 +3123,11 @@ impl Container {
     }
     /// Retrieves this container with an unset command user.
     /// Should default to root.
-    pub fn without_user(&self) -> Container {
-        let query = self.selection.select("withoutUser");
+    pub fn without_user(
+        &self,
+    ) -> Container {
+        let mut query = self.selection.select("withoutUser");
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2480,8 +3136,11 @@ impl Container {
     }
     /// Retrieves this container with an unset working directory.
     /// Should default to "/".
-    pub fn without_workdir(&self) -> Container {
-        let query = self.selection.select("withoutWorkdir");
+    pub fn without_workdir(
+        &self,
+    ) -> Container {
+        let mut query = self.selection.select("withoutWorkdir");
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2489,8 +3148,11 @@ impl Container {
         }
     }
     /// Retrieves the working directory for all commands.
-    pub async fn workdir(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("workdir");
+    pub async fn workdir(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("workdir");
+
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -2498,10 +3160,12 @@ impl Container {
 pub struct CurrentModule {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 #[derive(Builder, Debug, PartialEq)]
 pub struct CurrentModuleWorkdirOpts<'a> {
+
     /// Exclude artifacts that match the given pattern (e.g., ["node_modules/", ".git*"]).
     #[builder(setter(into, strip_option), default)]
     pub exclude: Option<Vec<&'a str>>,
@@ -2509,20 +3173,30 @@ pub struct CurrentModuleWorkdirOpts<'a> {
     #[builder(setter(into, strip_option), default)]
     pub include: Option<Vec<&'a str>>,
 }
+
 impl CurrentModule {
     /// A unique identifier for this CurrentModule.
-    pub async fn id(&self) -> Result<CurrentModuleId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<CurrentModuleId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the module being executed in
-    pub async fn name(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("name");
+    pub async fn name(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("name");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The directory containing the module's source code loaded into the engine (plus any generated code that may have been created).
-    pub fn source(&self) -> Directory {
-        let query = self.selection.select("source");
+    pub fn source(
+        &self,
+    ) -> Directory {
+        let mut query = self.selection.select("source");
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -2531,31 +3205,44 @@ impl CurrentModule {
     }
     /// Load a directory from the module's scratch working directory, including any changes that may have been made to it during module function execution.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the directory to access (e.g., ".").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn workdir(&self, path: impl Into<String>) -> Directory {
+    pub fn workdir(
+        &self,
+        path: impl Into<String>,
+    ) -> Directory {
         let mut query = self.selection.select("workdir");
+
         query = query.arg("path", path.into());
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Load a directory from the module's scratch working directory, including any changes that may have been made to it during module function execution.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the directory to access (e.g., ".").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn workdir_opts<'a>(
         &self,
         path: impl Into<String>,
-        opts: CurrentModuleWorkdirOpts<'a>,
+        opts: CurrentModuleWorkdirOpts<'a>
     ) -> Directory {
         let mut query = self.selection.select("workdir");
+
         query = query.arg("path", path.into());
         if let Some(exclude) = opts.exclude {
             query = query.arg("exclude", exclude);
@@ -2563,6 +3250,7 @@ impl CurrentModule {
         if let Some(include) = opts.include {
             query = query.arg("include", include);
         }
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -2571,12 +3259,20 @@ impl CurrentModule {
     }
     /// Load a file from the module's scratch working directory, including any changes that may have been made to it during module function execution.Load a file from the module's scratch working directory, including any changes that may have been made to it during module function execution.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the file to retrieve (e.g., "README.md").
-    pub fn workdir_file(&self, path: impl Into<String>) -> File {
+    pub fn workdir_file(
+        &self,
+        path: impl Into<String>,
+    ) -> File {
         let mut query = self.selection.select("workdirFile");
+
         query = query.arg("path", path.into());
+
         File {
             proc: self.proc.clone(),
             selection: query,
@@ -2588,10 +3284,12 @@ impl CurrentModule {
 pub struct Directory {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryAsModuleOpts<'a> {
+
     /// An optional subpath of the directory which contains the module's configuration file.
     /// This is needed when the module code is in a subdirectory but requires parent directories to be loaded in order to execute. For example, the module source code may need a go.mod, project.toml, package.json, etc. file from a parent directory.
     /// If not set, the module source code is loaded from the root of the directory.
@@ -2600,6 +3298,7 @@ pub struct DirectoryAsModuleOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryDockerBuildOpts<'a> {
+
     /// Build arguments to use in the build.
     #[builder(setter(into, strip_option), default)]
     pub build_args: Option<Vec<BuildArg>>,
@@ -2619,18 +3318,21 @@ pub struct DirectoryDockerBuildOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryEntriesOpts<'a> {
+
     /// Location of the directory to look at (e.g., "/src").
     #[builder(setter(into, strip_option), default)]
     pub path: Option<&'a str>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryExportOpts {
+
     /// If true, then the host directory will be wiped clean before exporting so that it exactly matches the directory being exported; this means it will delete any files on the host that aren't in the exported dir. If false (the default), the contents of the directory will be merged with any existing contents of the host directory, leaving any existing files on the host that aren't in the exported directory alone.
     #[builder(setter(into, strip_option), default)]
     pub wipe: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryPipelineOpts<'a> {
+
     /// Description of the sub-pipeline.
     #[builder(setter(into, strip_option), default)]
     pub description: Option<&'a str>,
@@ -2640,6 +3342,7 @@ pub struct DirectoryPipelineOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryWithDirectoryOpts<'a> {
+
     /// Exclude artifacts that match the given pattern (e.g., ["node_modules/", ".git*"]).
     #[builder(setter(into, strip_option), default)]
     pub exclude: Option<Vec<&'a str>>,
@@ -2649,52 +3352,72 @@ pub struct DirectoryWithDirectoryOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryWithFileOpts {
+
     /// Permission given to the copied file (e.g., 0600).
     #[builder(setter(into, strip_option), default)]
     pub permissions: Option<isize>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryWithFilesOpts {
+
     /// Permission given to the copied files (e.g., 0600).
     #[builder(setter(into, strip_option), default)]
     pub permissions: Option<isize>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryWithNewDirectoryOpts {
+
     /// Permission granted to the created directory (e.g., 0777).
     #[builder(setter(into, strip_option), default)]
     pub permissions: Option<isize>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryWithNewFileOpts {
+
     /// Permission given to the copied file (e.g., 0600).
     #[builder(setter(into, strip_option), default)]
     pub permissions: Option<isize>,
 }
+
 impl Directory {
     /// Load the directory as a Dagger module
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn as_module(&self) -> Module {
-        let query = self.selection.select("asModule");
+    pub fn as_module(
+        &self,
+    ) -> Module {
+        let mut query = self.selection.select("asModule");
+
         Module {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Load the directory as a Dagger module
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn as_module_opts<'a>(&self, opts: DirectoryAsModuleOpts<'a>) -> Module {
+    pub fn as_module_opts<'a>(
+        &self,
+        opts: DirectoryAsModuleOpts<'a>
+    ) -> Module {
         let mut query = self.selection.select("asModule");
+
         if let Some(source_root_path) = opts.source_root_path {
             query = query.arg("sourceRootPath", source_root_path);
         }
+
         Module {
             proc: self.proc.clone(),
             selection: query,
@@ -2703,11 +3426,18 @@ impl Directory {
     }
     /// Gets the difference between this directory and an another directory.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `other` - Identifier of the directory to compare.
-    pub fn diff(&self, other: Directory) -> Directory {
+    pub fn diff(
+        &self,
+        other: Directory,
+    ) -> Directory {
         let mut query = self.selection.select("diff");
+
         query = query.arg_lazy(
             "other",
             Box::new(move || {
@@ -2715,6 +3445,7 @@ impl Directory {
                 Box::pin(async move { other.id().await.unwrap().quote() })
             }),
         );
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -2723,12 +3454,20 @@ impl Directory {
     }
     /// Retrieves a directory at the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the directory to retrieve (e.g., "/src").
-    pub fn directory(&self, path: impl Into<String>) -> Directory {
+    pub fn directory(
+        &self,
+        path: impl Into<String>,
+    ) -> Directory {
         let mut query = self.selection.select("directory");
+
         query = query.arg("path", path.into());
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -2737,24 +3476,38 @@ impl Directory {
     }
     /// Builds a new Docker container from this directory.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn docker_build(&self) -> Container {
-        let query = self.selection.select("dockerBuild");
+    pub fn docker_build(
+        &self,
+    ) -> Container {
+        let mut query = self.selection.select("dockerBuild");
+
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Builds a new Docker container from this directory.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn docker_build_opts<'a>(&self, opts: DirectoryDockerBuildOpts<'a>) -> Container {
+    pub fn docker_build_opts<'a>(
+        &self,
+        opts: DirectoryDockerBuildOpts<'a>
+    ) -> Container {
         let mut query = self.selection.select("dockerBuild");
+
         if let Some(platform) = opts.platform {
             query = query.arg("platform", platform);
         }
@@ -2770,6 +3523,7 @@ impl Directory {
         if let Some(secrets) = opts.secrets {
             query = query.arg("secrets", secrets);
         }
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -2778,65 +3532,99 @@ impl Directory {
     }
     /// Returns a list of files and directories at the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn entries(&self) -> Result<Vec<String>, DaggerError> {
-        let query = self.selection.select("entries");
+    pub async fn entries(
+        &self,
+    ) -> Result<Vec<String>, DaggerError> {
+        let mut query = self.selection.select("entries");
+
         query.execute(self.graphql_client.clone()).await
     }
+
     /// Returns a list of files and directories at the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn entries_opts<'a>(
         &self,
-        opts: DirectoryEntriesOpts<'a>,
+        opts: DirectoryEntriesOpts<'a>
     ) -> Result<Vec<String>, DaggerError> {
         let mut query = self.selection.select("entries");
+
         if let Some(path) = opts.path {
             query = query.arg("path", path);
         }
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Writes the contents of the directory to a path on the host.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the copied directory (e.g., "logs/").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn export(&self, path: impl Into<String>) -> Result<bool, DaggerError> {
+    pub async fn export(
+        &self,
+        path: impl Into<String>,
+    ) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
+
         query = query.arg("path", path.into());
+
         query.execute(self.graphql_client.clone()).await
     }
+
     /// Writes the contents of the directory to a path on the host.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the copied directory (e.g., "logs/").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn export_opts(
         &self,
         path: impl Into<String>,
-        opts: DirectoryExportOpts,
+        opts: DirectoryExportOpts
     ) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
+
         query = query.arg("path", path.into());
         if let Some(wipe) = opts.wipe {
             query = query.arg("wipe", wipe);
         }
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves a file at the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the file to retrieve (e.g., "README.md").
-    pub fn file(&self, path: impl Into<String>) -> File {
+    pub fn file(
+        &self,
+        path: impl Into<String>,
+    ) -> File {
         let mut query = self.selection.select("file");
+
         query = query.arg("path", path.into());
+
         File {
             proc: self.proc.clone(),
             selection: query,
@@ -2845,46 +3633,70 @@ impl Directory {
     }
     /// Returns a list of files and directories that matche the given pattern.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `pattern` - Pattern to match (e.g., "*.md").
-    pub async fn glob(&self, pattern: impl Into<String>) -> Result<Vec<String>, DaggerError> {
+    pub async fn glob(
+        &self,
+        pattern: impl Into<String>,
+    ) -> Result<Vec<String>, DaggerError> {
         let mut query = self.selection.select("glob");
+
         query = query.arg("pattern", pattern.into());
+
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this Directory.
-    pub async fn id(&self) -> Result<DirectoryId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<DirectoryId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Creates a named sub-pipeline.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - Name of the sub-pipeline.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn pipeline(&self, name: impl Into<String>) -> Directory {
+    pub fn pipeline(
+        &self,
+        name: impl Into<String>,
+    ) -> Directory {
         let mut query = self.selection.select("pipeline");
+
         query = query.arg("name", name.into());
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Creates a named sub-pipeline.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - Name of the sub-pipeline.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn pipeline_opts<'a>(
         &self,
         name: impl Into<String>,
-        opts: DirectoryPipelineOpts<'a>,
+        opts: DirectoryPipelineOpts<'a>
     ) -> Directory {
         let mut query = self.selection.select("pipeline");
+
         query = query.arg("name", name.into());
         if let Some(description) = opts.description {
             query = query.arg("description", description);
@@ -2892,6 +3704,7 @@ impl Directory {
         if let Some(labels) = opts.labels {
             query = query.arg("labels", labels);
         }
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -2899,19 +3712,30 @@ impl Directory {
         }
     }
     /// Force evaluation in the engine.
-    pub async fn sync(&self) -> Result<DirectoryId, DaggerError> {
-        let query = self.selection.select("sync");
+    pub async fn sync(
+        &self,
+    ) -> Result<DirectoryId, DaggerError> {
+        let mut query = self.selection.select("sync");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves this directory plus a directory written at the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the written directory (e.g., "/src/").
     /// * `directory` - Identifier of the directory to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_directory(&self, path: impl Into<String>, directory: Directory) -> Directory {
+    pub fn with_directory(
+        &self,
+        path: impl Into<String>,
+        directory: Directory,
+    ) -> Directory {
         let mut query = self.selection.select("withDirectory");
+
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "directory",
@@ -2920,16 +3744,21 @@ impl Directory {
                 Box::pin(async move { directory.id().await.unwrap().quote() })
             }),
         );
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Retrieves this directory plus a directory written at the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the written directory (e.g., "/src/").
     /// * `directory` - Identifier of the directory to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -2937,9 +3766,10 @@ impl Directory {
         &self,
         path: impl Into<String>,
         directory: Directory,
-        opts: DirectoryWithDirectoryOpts<'a>,
+        opts: DirectoryWithDirectoryOpts<'a>
     ) -> Directory {
         let mut query = self.selection.select("withDirectory");
+
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "directory",
@@ -2954,6 +3784,7 @@ impl Directory {
         if let Some(include) = opts.include {
             query = query.arg("include", include);
         }
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -2962,13 +3793,21 @@ impl Directory {
     }
     /// Retrieves this directory plus the contents of the given file copied to the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the copied file (e.g., "/file.txt").
     /// * `source` - Identifier of the file to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_file(&self, path: impl Into<String>, source: File) -> Directory {
+    pub fn with_file(
+        &self,
+        path: impl Into<String>,
+        source: File,
+    ) -> Directory {
         let mut query = self.selection.select("withFile");
+
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "source",
@@ -2977,16 +3816,21 @@ impl Directory {
                 Box::pin(async move { source.id().await.unwrap().quote() })
             }),
         );
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Retrieves this directory plus the contents of the given file copied to the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the copied file (e.g., "/file.txt").
     /// * `source` - Identifier of the file to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -2994,9 +3838,10 @@ impl Directory {
         &self,
         path: impl Into<String>,
         source: File,
-        opts: DirectoryWithFileOpts,
+        opts: DirectoryWithFileOpts
     ) -> Directory {
         let mut query = self.selection.select("withFile");
+
         query = query.arg("path", path.into());
         query = query.arg_lazy(
             "source",
@@ -3008,6 +3853,7 @@ impl Directory {
         if let Some(permissions) = opts.permissions {
             query = query.arg("permissions", permissions);
         }
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -3016,25 +3862,38 @@ impl Directory {
     }
     /// Retrieves this directory plus the contents of the given files copied to the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location where copied files should be placed (e.g., "/src").
     /// * `sources` - Identifiers of the files to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_files(&self, path: impl Into<String>, sources: Vec<FileId>) -> Directory {
+    pub fn with_files(
+        &self,
+        path: impl Into<String>,
+        sources: Vec<FileId>,
+    ) -> Directory {
         let mut query = self.selection.select("withFiles");
+
         query = query.arg("path", path.into());
         query = query.arg("sources", sources);
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Retrieves this directory plus the contents of the given files copied to the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location where copied files should be placed (e.g., "/src").
     /// * `sources` - Identifiers of the files to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -3042,14 +3901,16 @@ impl Directory {
         &self,
         path: impl Into<String>,
         sources: Vec<FileId>,
-        opts: DirectoryWithFilesOpts,
+        opts: DirectoryWithFilesOpts
     ) -> Directory {
         let mut query = self.selection.select("withFiles");
+
         query = query.arg("path", path.into());
         query = query.arg("sources", sources);
         if let Some(permissions) = opts.permissions {
             query = query.arg("permissions", permissions);
         }
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -3058,35 +3919,49 @@ impl Directory {
     }
     /// Retrieves this directory plus a new directory created at the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the directory created (e.g., "/logs").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_new_directory(&self, path: impl Into<String>) -> Directory {
+    pub fn with_new_directory(
+        &self,
+        path: impl Into<String>,
+    ) -> Directory {
         let mut query = self.selection.select("withNewDirectory");
+
         query = query.arg("path", path.into());
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Retrieves this directory plus a new directory created at the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the directory created (e.g., "/logs").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_new_directory_opts(
         &self,
         path: impl Into<String>,
-        opts: DirectoryWithNewDirectoryOpts,
+        opts: DirectoryWithNewDirectoryOpts
     ) -> Directory {
         let mut query = self.selection.select("withNewDirectory");
+
         query = query.arg("path", path.into());
         if let Some(permissions) = opts.permissions {
             query = query.arg("permissions", permissions);
         }
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -3095,25 +3970,38 @@ impl Directory {
     }
     /// Retrieves this directory plus a new file written at the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the written file (e.g., "/file.txt").
     /// * `contents` - Content of the written file (e.g., "Hello world!").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_new_file(&self, path: impl Into<String>, contents: impl Into<String>) -> Directory {
+    pub fn with_new_file(
+        &self,
+        path: impl Into<String>,
+        contents: impl Into<String>,
+    ) -> Directory {
         let mut query = self.selection.select("withNewFile");
+
         query = query.arg("path", path.into());
         query = query.arg("contents", contents.into());
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Retrieves this directory plus a new file written at the given path.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the written file (e.g., "/file.txt").
     /// * `contents` - Content of the written file (e.g., "Hello world!").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -3121,14 +4009,16 @@ impl Directory {
         &self,
         path: impl Into<String>,
         contents: impl Into<String>,
-        opts: DirectoryWithNewFileOpts,
+        opts: DirectoryWithNewFileOpts
     ) -> Directory {
         let mut query = self.selection.select("withNewFile");
+
         query = query.arg("path", path.into());
         query = query.arg("contents", contents.into());
         if let Some(permissions) = opts.permissions {
             query = query.arg("permissions", permissions);
         }
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -3137,14 +4027,22 @@ impl Directory {
     }
     /// Retrieves this directory with all file/dir timestamps set to the given time.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `timestamp` - Timestamp to set dir/files in.
-    ///
+    /// 
     /// Formatted in seconds following Unix epoch (e.g., 1672531199).
-    pub fn with_timestamps(&self, timestamp: isize) -> Directory {
+    pub fn with_timestamps(
+        &self,
+        timestamp: isize,
+    ) -> Directory {
         let mut query = self.selection.select("withTimestamps");
+
         query = query.arg("timestamp", timestamp);
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -3153,12 +4051,20 @@ impl Directory {
     }
     /// Retrieves this directory with the directory at the given path removed.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the directory to remove (e.g., ".github/").
-    pub fn without_directory(&self, path: impl Into<String>) -> Directory {
+    pub fn without_directory(
+        &self,
+        path: impl Into<String>,
+    ) -> Directory {
         let mut query = self.selection.select("withoutDirectory");
+
         query = query.arg("path", path.into());
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -3167,12 +4073,20 @@ impl Directory {
     }
     /// Retrieves this directory with the file at the given path removed.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the file to remove (e.g., "/file.txt").
-    pub fn without_file(&self, path: impl Into<String>) -> Directory {
+    pub fn without_file(
+        &self,
+        path: impl Into<String>,
+    ) -> Directory {
         let mut query = self.selection.select("withoutFile");
+
         query = query.arg("path", path.into());
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -3184,22 +4098,32 @@ impl Directory {
 pub struct EnvVariable {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 impl EnvVariable {
     /// A unique identifier for this EnvVariable.
-    pub async fn id(&self) -> Result<EnvVariableId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<EnvVariableId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The environment variable name.
-    pub async fn name(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("name");
+    pub async fn name(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("name");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The environment variable value.
-    pub async fn value(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("value");
+    pub async fn value(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("value");
+
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -3207,27 +4131,40 @@ impl EnvVariable {
 pub struct FieldTypeDef {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 impl FieldTypeDef {
     /// A doc string for the field, if any.
-    pub async fn description(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("description");
+    pub async fn description(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("description");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this FieldTypeDef.
-    pub async fn id(&self) -> Result<FieldTypeDefId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<FieldTypeDefId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the field in lowerCamelCase format.
-    pub async fn name(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("name");
+    pub async fn name(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("name");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The type of the field.
-    pub fn type_def(&self) -> TypeDef {
-        let query = self.selection.select("typeDef");
+    pub fn type_def(
+        &self,
+    ) -> TypeDef {
+        let mut query = self.selection.select("typeDef");
+
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -3239,79 +4176,119 @@ impl FieldTypeDef {
 pub struct File {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 #[derive(Builder, Debug, PartialEq)]
 pub struct FileExportOpts {
+
     /// If allowParentDirPath is true, the path argument can be a directory path, in which case the file will be created in that directory.
     #[builder(setter(into, strip_option), default)]
     pub allow_parent_dir_path: Option<bool>,
 }
+
 impl File {
     /// Retrieves the contents of the file.
-    pub async fn contents(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("contents");
+    pub async fn contents(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("contents");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Writes the file to a file path on the host.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the written directory (e.g., "output.txt").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn export(&self, path: impl Into<String>) -> Result<bool, DaggerError> {
+    pub async fn export(
+        &self,
+        path: impl Into<String>,
+    ) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
+
         query = query.arg("path", path.into());
+
         query.execute(self.graphql_client.clone()).await
     }
+
     /// Writes the file to a file path on the host.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the written directory (e.g., "output.txt").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn export_opts(
         &self,
         path: impl Into<String>,
-        opts: FileExportOpts,
+        opts: FileExportOpts
     ) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
+
         query = query.arg("path", path.into());
         if let Some(allow_parent_dir_path) = opts.allow_parent_dir_path {
             query = query.arg("allowParentDirPath", allow_parent_dir_path);
         }
+
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this File.
-    pub async fn id(&self) -> Result<FileId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<FileId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the name of the file.
-    pub async fn name(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("name");
+    pub async fn name(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("name");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the size of the file, in bytes.
-    pub async fn size(&self) -> Result<isize, DaggerError> {
-        let query = self.selection.select("size");
+    pub async fn size(
+        &self,
+    ) -> Result<isize, DaggerError> {
+        let mut query = self.selection.select("size");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Force evaluation in the engine.
-    pub async fn sync(&self) -> Result<FileId, DaggerError> {
-        let query = self.selection.select("sync");
+    pub async fn sync(
+        &self,
+    ) -> Result<FileId, DaggerError> {
+        let mut query = self.selection.select("sync");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves this file with its created/modified timestamps set to the given time.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `timestamp` - Timestamp to set dir/files in.
-    ///
+    /// 
     /// Formatted in seconds following Unix epoch (e.g., 1672531199).
-    pub fn with_timestamps(&self, timestamp: isize) -> File {
+    pub fn with_timestamps(
+        &self,
+        timestamp: isize,
+    ) -> File {
         let mut query = self.selection.select("withTimestamps");
+
         query = query.arg("timestamp", timestamp);
+
         File {
             proc: self.proc.clone(),
             selection: query,
@@ -3323,10 +4300,12 @@ impl File {
 pub struct Function {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 #[derive(Builder, Debug, PartialEq)]
 pub struct FunctionWithArgOpts<'a> {
+
     /// A default value to use for this argument if not explicitly set by the caller, if any
     #[builder(setter(into, strip_option), default)]
     pub default_value: Option<Json>,
@@ -3334,34 +4313,50 @@ pub struct FunctionWithArgOpts<'a> {
     #[builder(setter(into, strip_option), default)]
     pub description: Option<&'a str>,
 }
+
 impl Function {
     /// Arguments accepted by the function, if any.
-    pub fn args(&self) -> Vec<FunctionArg> {
-        let query = self.selection.select("args");
+    pub fn args(
+        &self,
+    ) -> Vec<FunctionArg> {
+        let mut query = self.selection.select("args");
+
         return vec![FunctionArg {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// A doc string for the function, if any.
-    pub async fn description(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("description");
+    pub async fn description(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("description");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this Function.
-    pub async fn id(&self) -> Result<FunctionId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<FunctionId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the function.
-    pub async fn name(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("name");
+    pub async fn name(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("name");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The type returned by the function.
-    pub fn return_type(&self) -> TypeDef {
-        let query = self.selection.select("returnType");
+    pub fn return_type(
+        &self,
+    ) -> TypeDef {
+        let mut query = self.selection.select("returnType");
+
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -3370,13 +4365,21 @@ impl Function {
     }
     /// Returns the function with the provided argument
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - The name of the argument
     /// * `type_def` - The type of the argument
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_arg(&self, name: impl Into<String>, type_def: TypeDef) -> Function {
+    pub fn with_arg(
+        &self,
+        name: impl Into<String>,
+        type_def: TypeDef,
+    ) -> Function {
         let mut query = self.selection.select("withArg");
+
         query = query.arg("name", name.into());
         query = query.arg_lazy(
             "typeDef",
@@ -3385,16 +4388,21 @@ impl Function {
                 Box::pin(async move { type_def.id().await.unwrap().quote() })
             }),
         );
+
         Function {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Returns the function with the provided argument
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - The name of the argument
     /// * `type_def` - The type of the argument
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -3402,9 +4410,10 @@ impl Function {
         &self,
         name: impl Into<String>,
         type_def: TypeDef,
-        opts: FunctionWithArgOpts<'a>,
+        opts: FunctionWithArgOpts<'a>
     ) -> Function {
         let mut query = self.selection.select("withArg");
+
         query = query.arg("name", name.into());
         query = query.arg_lazy(
             "typeDef",
@@ -3419,6 +4428,7 @@ impl Function {
         if let Some(default_value) = opts.default_value {
             query = query.arg("defaultValue", default_value);
         }
+
         Function {
             proc: self.proc.clone(),
             selection: query,
@@ -3427,12 +4437,20 @@ impl Function {
     }
     /// Returns the function with the given doc string.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `description` - The doc string to set.
-    pub fn with_description(&self, description: impl Into<String>) -> Function {
+    pub fn with_description(
+        &self,
+        description: impl Into<String>,
+    ) -> Function {
         let mut query = self.selection.select("withDescription");
+
         query = query.arg("description", description.into());
+
         Function {
             proc: self.proc.clone(),
             selection: query,
@@ -3444,32 +4462,48 @@ impl Function {
 pub struct FunctionArg {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 impl FunctionArg {
     /// A default value to use for this argument when not explicitly set by the caller, if any.
-    pub async fn default_value(&self) -> Result<Json, DaggerError> {
-        let query = self.selection.select("defaultValue");
+    pub async fn default_value(
+        &self,
+    ) -> Result<Json, DaggerError> {
+        let mut query = self.selection.select("defaultValue");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// A doc string for the argument, if any.
-    pub async fn description(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("description");
+    pub async fn description(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("description");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this FunctionArg.
-    pub async fn id(&self) -> Result<FunctionArgId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<FunctionArgId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the argument in lowerCamelCase format.
-    pub async fn name(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("name");
+    pub async fn name(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("name");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The type of the argument.
-    pub fn type_def(&self) -> TypeDef {
-        let query = self.selection.select("typeDef");
+    pub fn type_def(
+        &self,
+    ) -> TypeDef {
+        let mut query = self.selection.select("typeDef");
+
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -3481,46 +4515,70 @@ impl FunctionArg {
 pub struct FunctionCall {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 impl FunctionCall {
     /// A unique identifier for this FunctionCall.
-    pub async fn id(&self) -> Result<FunctionCallId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<FunctionCallId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The argument values the function is being invoked with.
-    pub fn input_args(&self) -> Vec<FunctionCallArgValue> {
-        let query = self.selection.select("inputArgs");
+    pub fn input_args(
+        &self,
+    ) -> Vec<FunctionCallArgValue> {
+        let mut query = self.selection.select("inputArgs");
+
         return vec![FunctionCallArgValue {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// The name of the function being called.
-    pub async fn name(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("name");
+    pub async fn name(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("name");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The value of the parent object of the function being called. If the function is top-level to the module, this is always an empty object.
-    pub async fn parent(&self) -> Result<Json, DaggerError> {
-        let query = self.selection.select("parent");
+    pub async fn parent(
+        &self,
+    ) -> Result<Json, DaggerError> {
+        let mut query = self.selection.select("parent");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the parent object of the function being called. If the function is top-level to the module, this is the name of the module.
-    pub async fn parent_name(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("parentName");
+    pub async fn parent_name(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("parentName");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Set the return value of the function call to the provided value.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `value` - JSON serialization of the return value.
-    pub async fn return_value(&self, value: Json) -> Result<Void, DaggerError> {
+    pub async fn return_value(
+        &self,
+        value: Json,
+    ) -> Result<Void, DaggerError> {
         let mut query = self.selection.select("returnValue");
+
         query = query.arg("value", value);
+
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -3528,22 +4586,32 @@ impl FunctionCall {
 pub struct FunctionCallArgValue {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 impl FunctionCallArgValue {
     /// A unique identifier for this FunctionCallArgValue.
-    pub async fn id(&self) -> Result<FunctionCallArgValueId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<FunctionCallArgValueId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the argument.
-    pub async fn name(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("name");
+    pub async fn name(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("name");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The value of the argument represented as a JSON serialized string.
-    pub async fn value(&self) -> Result<Json, DaggerError> {
-        let query = self.selection.select("value");
+    pub async fn value(
+        &self,
+    ) -> Result<Json, DaggerError> {
+        let mut query = self.selection.select("value");
+
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -3551,12 +4619,16 @@ impl FunctionCallArgValue {
 pub struct GeneratedCode {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 impl GeneratedCode {
     /// The directory containing the generated code.
-    pub fn code(&self) -> Directory {
-        let query = self.selection.select("code");
+    pub fn code(
+        &self,
+    ) -> Directory {
+        let mut query = self.selection.select("code");
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -3564,27 +4636,38 @@ impl GeneratedCode {
         }
     }
     /// A unique identifier for this GeneratedCode.
-    pub async fn id(&self) -> Result<GeneratedCodeId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<GeneratedCodeId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// List of paths to mark generated in version control (i.e. .gitattributes).
-    pub async fn vcs_generated_paths(&self) -> Result<Vec<String>, DaggerError> {
-        let query = self.selection.select("vcsGeneratedPaths");
+    pub async fn vcs_generated_paths(
+        &self,
+    ) -> Result<Vec<String>, DaggerError> {
+        let mut query = self.selection.select("vcsGeneratedPaths");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// List of paths to ignore in version control (i.e. .gitignore).
-    pub async fn vcs_ignored_paths(&self) -> Result<Vec<String>, DaggerError> {
-        let query = self.selection.select("vcsIgnoredPaths");
+    pub async fn vcs_ignored_paths(
+        &self,
+    ) -> Result<Vec<String>, DaggerError> {
+        let mut query = self.selection.select("vcsIgnoredPaths");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Set the list of paths to mark generated in version control.
-    pub fn with_vcs_generated_paths(&self, paths: Vec<impl Into<String>>) -> GeneratedCode {
+    pub fn with_vcs_generated_paths(
+        &self,
+        paths: Vec<impl Into<String>>,
+    ) -> GeneratedCode {
         let mut query = self.selection.select("withVCSGeneratedPaths");
-        query = query.arg(
-            "paths",
-            paths.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
-        );
+
+        query = query.arg("paths", paths.into_iter().map(|i| i.into()).collect::<Vec<String>>());
+
         GeneratedCode {
             proc: self.proc.clone(),
             selection: query,
@@ -3592,12 +4675,14 @@ impl GeneratedCode {
         }
     }
     /// Set the list of paths to ignore in version control.
-    pub fn with_vcs_ignored_paths(&self, paths: Vec<impl Into<String>>) -> GeneratedCode {
+    pub fn with_vcs_ignored_paths(
+        &self,
+        paths: Vec<impl Into<String>>,
+    ) -> GeneratedCode {
         let mut query = self.selection.select("withVCSIgnoredPaths");
-        query = query.arg(
-            "paths",
-            paths.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
-        );
+
+        query = query.arg("paths", paths.into_iter().map(|i| i.into()).collect::<Vec<String>>());
+
         GeneratedCode {
             proc: self.proc.clone(),
             selection: query,
@@ -3609,22 +4694,32 @@ impl GeneratedCode {
 pub struct GitModuleSource {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 impl GitModuleSource {
     /// The URL from which the source's git repo can be cloned.
-    pub async fn clone_url(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("cloneURL");
+    pub async fn clone_url(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("cloneURL");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The resolved commit of the git repo this source points to.
-    pub async fn commit(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("commit");
+    pub async fn commit(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("commit");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The directory containing everything needed to load load and use the module.
-    pub fn context_directory(&self) -> Directory {
-        let query = self.selection.select("contextDirectory");
+    pub fn context_directory(
+        &self,
+    ) -> Directory {
+        let mut query = self.selection.select("contextDirectory");
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -3632,23 +4727,35 @@ impl GitModuleSource {
         }
     }
     /// The URL to the source's git repo in a web browser
-    pub async fn html_url(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("htmlURL");
+    pub async fn html_url(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("htmlURL");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this GitModuleSource.
-    pub async fn id(&self) -> Result<GitModuleSourceId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<GitModuleSourceId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The path to the root of the module source under the context directory. This directory contains its configuration file. It also contains its source code (possibly as a subdirectory).
-    pub async fn root_subpath(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("rootSubpath");
+    pub async fn root_subpath(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("rootSubpath");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The specified version of the git repo this source points to.
-    pub async fn version(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("version");
+    pub async fn version(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("version");
+
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -3656,10 +4763,12 @@ impl GitModuleSource {
 pub struct GitRef {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 #[derive(Builder, Debug, PartialEq)]
 pub struct GitRefTreeOpts<'a> {
+
     /// DEPRECATED: This option should be passed to `git` instead.
     #[builder(setter(into, strip_option), default)]
     pub ssh_auth_socket: Option<SocketId>,
@@ -3667,43 +4776,65 @@ pub struct GitRefTreeOpts<'a> {
     #[builder(setter(into, strip_option), default)]
     pub ssh_known_hosts: Option<&'a str>,
 }
+
 impl GitRef {
     /// The resolved commit id at this ref.
-    pub async fn commit(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("commit");
+    pub async fn commit(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("commit");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this GitRef.
-    pub async fn id(&self) -> Result<GitRefId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<GitRefId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The filesystem tree at this ref.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn tree(&self) -> Directory {
-        let query = self.selection.select("tree");
+    pub fn tree(
+        &self,
+    ) -> Directory {
+        let mut query = self.selection.select("tree");
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// The filesystem tree at this ref.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn tree_opts<'a>(&self, opts: GitRefTreeOpts<'a>) -> Directory {
+    pub fn tree_opts<'a>(
+        &self,
+        opts: GitRefTreeOpts<'a>
+    ) -> Directory {
         let mut query = self.selection.select("tree");
+
         if let Some(ssh_known_hosts) = opts.ssh_known_hosts {
             query = query.arg("sshKnownHosts", ssh_known_hosts);
         }
         if let Some(ssh_auth_socket) = opts.ssh_auth_socket {
             query = query.arg("sshAuthSocket", ssh_auth_socket);
         }
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -3715,17 +4846,26 @@ impl GitRef {
 pub struct GitRepository {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 impl GitRepository {
     /// Returns details of a branch.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - Branch's name (e.g., "main").
-    pub fn branch(&self, name: impl Into<String>) -> GitRef {
+    pub fn branch(
+        &self,
+        name: impl Into<String>,
+    ) -> GitRef {
         let mut query = self.selection.select("branch");
+
         query = query.arg("name", name.into());
+
         GitRef {
             proc: self.proc.clone(),
             selection: query,
@@ -3734,12 +4874,20 @@ impl GitRepository {
     }
     /// Returns details of a commit.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `id` - Identifier of the commit (e.g., "b6315d8f2810962c601af73f86831f6866ea798b").
-    pub fn commit(&self, id: impl Into<String>) -> GitRef {
+    pub fn commit(
+        &self,
+        id: impl Into<String>,
+    ) -> GitRef {
         let mut query = self.selection.select("commit");
+
         query = query.arg("id", id.into());
+
         GitRef {
             proc: self.proc.clone(),
             selection: query,
@@ -3747,8 +4895,11 @@ impl GitRepository {
         }
     }
     /// Returns details for HEAD.
-    pub fn head(&self) -> GitRef {
-        let query = self.selection.select("head");
+    pub fn head(
+        &self,
+    ) -> GitRef {
+        let mut query = self.selection.select("head");
+
         GitRef {
             proc: self.proc.clone(),
             selection: query,
@@ -3756,18 +4907,29 @@ impl GitRepository {
         }
     }
     /// A unique identifier for this GitRepository.
-    pub async fn id(&self) -> Result<GitRepositoryId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<GitRepositoryId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Returns details of a ref.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - Ref's name (can be a commit identifier, a tag name, a branch name, or a fully-qualified ref).
-    pub fn r#ref(&self, name: impl Into<String>) -> GitRef {
+    pub fn r#ref(
+        &self,
+        name: impl Into<String>,
+    ) -> GitRef {
         let mut query = self.selection.select("ref");
+
         query = query.arg("name", name.into());
+
         GitRef {
             proc: self.proc.clone(),
             selection: query,
@@ -3776,12 +4938,20 @@ impl GitRepository {
     }
     /// Returns details of a tag.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - Tag's name (e.g., "v0.3.9").
-    pub fn tag(&self, name: impl Into<String>) -> GitRef {
+    pub fn tag(
+        &self,
+        name: impl Into<String>,
+    ) -> GitRef {
         let mut query = self.selection.select("tag");
+
         query = query.arg("name", name.into());
+
         GitRef {
             proc: self.proc.clone(),
             selection: query,
@@ -3833,10 +5003,12 @@ impl GitRepository {
 pub struct Host {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 #[derive(Builder, Debug, PartialEq)]
 pub struct HostDirectoryOpts<'a> {
+
     /// Exclude artifacts that match the given pattern (e.g., ["node_modules/", ".git*"]).
     #[builder(setter(into, strip_option), default)]
     pub exclude: Option<Vec<&'a str>>,
@@ -3846,12 +5018,14 @@ pub struct HostDirectoryOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct HostServiceOpts<'a> {
+
     /// Upstream host to forward traffic to.
     #[builder(setter(into, strip_option), default)]
     pub host: Option<&'a str>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct HostTunnelOpts {
+
     /// Map each service port to the same port on the host, as if the service were running natively.
     /// Note: enabling may result in port conflicts.
     #[builder(setter(into, strip_option), default)]
@@ -3863,34 +5037,48 @@ pub struct HostTunnelOpts {
     #[builder(setter(into, strip_option), default)]
     pub ports: Option<Vec<PortForward>>,
 }
+
 impl Host {
     /// Accesses a directory on the host.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the directory to access (e.g., ".").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn directory(&self, path: impl Into<String>) -> Directory {
+    pub fn directory(
+        &self,
+        path: impl Into<String>,
+    ) -> Directory {
         let mut query = self.selection.select("directory");
+
         query = query.arg("path", path.into());
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Accesses a directory on the host.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the directory to access (e.g., ".").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn directory_opts<'a>(
         &self,
         path: impl Into<String>,
-        opts: HostDirectoryOpts<'a>,
+        opts: HostDirectoryOpts<'a>
     ) -> Directory {
         let mut query = self.selection.select("directory");
+
         query = query.arg("path", path.into());
         if let Some(exclude) = opts.exclude {
             query = query.arg("exclude", exclude);
@@ -3898,6 +5086,7 @@ impl Host {
         if let Some(include) = opts.include {
             query = query.arg("include", include);
         }
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -3906,12 +5095,20 @@ impl Host {
     }
     /// Accesses a file on the host.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the file to retrieve (e.g., "README.md").
-    pub fn file(&self, path: impl Into<String>) -> File {
+    pub fn file(
+        &self,
+        path: impl Into<String>,
+    ) -> File {
         let mut query = self.selection.select("file");
+
         query = query.arg("path", path.into());
+
         File {
             proc: self.proc.clone(),
             selection: query,
@@ -3919,45 +5116,66 @@ impl Host {
         }
     }
     /// A unique identifier for this Host.
-    pub async fn id(&self) -> Result<HostId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<HostId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Creates a service that forwards traffic to a specified address via the host.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `ports` - Ports to expose via the service, forwarding through the host network.
-    ///
+    /// 
     /// If a port's frontend is unspecified or 0, it defaults to the same as the backend port.
-    ///
+    /// 
     /// An empty set of ports is not valid; an error will be returned.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn service(&self, ports: Vec<PortForward>) -> Service {
+    pub fn service(
+        &self,
+        ports: Vec<PortForward>,
+    ) -> Service {
         let mut query = self.selection.select("service");
+
         query = query.arg("ports", ports);
+
         Service {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Creates a service that forwards traffic to a specified address via the host.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `ports` - Ports to expose via the service, forwarding through the host network.
-    ///
+    /// 
     /// If a port's frontend is unspecified or 0, it defaults to the same as the backend port.
-    ///
+    /// 
     /// An empty set of ports is not valid; an error will be returned.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn service_opts<'a>(&self, ports: Vec<PortForward>, opts: HostServiceOpts<'a>) -> Service {
+    pub fn service_opts<'a>(
+        &self,
+        ports: Vec<PortForward>,
+        opts: HostServiceOpts<'a>
+    ) -> Service {
         let mut query = self.selection.select("service");
+
         query = query.arg("ports", ports);
         if let Some(host) = opts.host {
             query = query.arg("host", host);
         }
+
         Service {
             proc: self.proc.clone(),
             selection: query,
@@ -3967,14 +5185,23 @@ impl Host {
     /// Sets a secret given a user-defined name and the file path on the host, and returns the secret.
     /// The file is limited to a size of 512000 bytes.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - The user defined name for this secret.
     /// * `path` - Location of the file to set as a secret.
-    pub fn set_secret_file(&self, name: impl Into<String>, path: impl Into<String>) -> Secret {
+    pub fn set_secret_file(
+        &self,
+        name: impl Into<String>,
+        path: impl Into<String>,
+    ) -> Secret {
         let mut query = self.selection.select("setSecretFile");
+
         query = query.arg("name", name.into());
         query = query.arg("path", path.into());
+
         Secret {
             proc: self.proc.clone(),
             selection: query,
@@ -3983,12 +5210,19 @@ impl Host {
     }
     /// Creates a tunnel that forwards traffic from the host to a service.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `service` - Service to send traffic from the tunnel.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn tunnel(&self, service: Service) -> Service {
+    pub fn tunnel(
+        &self,
+        service: Service,
+    ) -> Service {
         let mut query = self.selection.select("tunnel");
+
         query = query.arg_lazy(
             "service",
             Box::new(move || {
@@ -3996,20 +5230,30 @@ impl Host {
                 Box::pin(async move { service.id().await.unwrap().quote() })
             }),
         );
+
         Service {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Creates a tunnel that forwards traffic from the host to a service.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `service` - Service to send traffic from the tunnel.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn tunnel_opts(&self, service: Service, opts: HostTunnelOpts) -> Service {
+    pub fn tunnel_opts(
+        &self,
+        service: Service,
+        opts: HostTunnelOpts
+    ) -> Service {
         let mut query = self.selection.select("tunnel");
+
         query = query.arg_lazy(
             "service",
             Box::new(move || {
@@ -4023,6 +5267,7 @@ impl Host {
         if let Some(native) = opts.native {
             query = query.arg("native", native);
         }
+
         Service {
             proc: self.proc.clone(),
             selection: query,
@@ -4031,12 +5276,20 @@ impl Host {
     }
     /// Accesses a Unix socket on the host.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - Location of the Unix socket (e.g., "/var/run/docker.sock").
-    pub fn unix_socket(&self, path: impl Into<String>) -> Socket {
+    pub fn unix_socket(
+        &self,
+        path: impl Into<String>,
+    ) -> Socket {
         let mut query = self.selection.select("unixSocket");
+
         query = query.arg("path", path.into());
+
         Socket {
             proc: self.proc.clone(),
             selection: query,
@@ -4048,26 +5301,36 @@ impl Host {
 pub struct InputTypeDef {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 impl InputTypeDef {
     /// Static fields defined on this input object, if any.
-    pub fn fields(&self) -> Vec<FieldTypeDef> {
-        let query = self.selection.select("fields");
+    pub fn fields(
+        &self,
+    ) -> Vec<FieldTypeDef> {
+        let mut query = self.selection.select("fields");
+
         return vec![FieldTypeDef {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// A unique identifier for this InputTypeDef.
-    pub async fn id(&self) -> Result<InputTypeDefId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<InputTypeDefId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the input object.
-    pub async fn name(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("name");
+    pub async fn name(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("name");
+
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -4075,36 +5338,52 @@ impl InputTypeDef {
 pub struct InterfaceTypeDef {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 impl InterfaceTypeDef {
     /// The doc string for the interface, if any.
-    pub async fn description(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("description");
+    pub async fn description(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("description");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Functions defined on this interface, if any.
-    pub fn functions(&self) -> Vec<Function> {
-        let query = self.selection.select("functions");
+    pub fn functions(
+        &self,
+    ) -> Vec<Function> {
+        let mut query = self.selection.select("functions");
+
         return vec![Function {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// A unique identifier for this InterfaceTypeDef.
-    pub async fn id(&self) -> Result<InterfaceTypeDefId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<InterfaceTypeDefId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the interface.
-    pub async fn name(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("name");
+    pub async fn name(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("name");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// If this InterfaceTypeDef is associated with a Module, the name of the module. Unset otherwise.
-    pub async fn source_module_name(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("sourceModuleName");
+    pub async fn source_module_name(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("sourceModuleName");
+
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -4112,22 +5391,32 @@ impl InterfaceTypeDef {
 pub struct Label {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 impl Label {
     /// A unique identifier for this Label.
-    pub async fn id(&self) -> Result<LabelId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<LabelId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The label name.
-    pub async fn name(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("name");
+    pub async fn name(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("name");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The label value.
-    pub async fn value(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("value");
+    pub async fn value(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("value");
+
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -4135,12 +5424,16 @@ impl Label {
 pub struct ListTypeDef {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 impl ListTypeDef {
     /// The type of the elements in the list.
-    pub fn element_type_def(&self) -> TypeDef {
-        let query = self.selection.select("elementTypeDef");
+    pub fn element_type_def(
+        &self,
+    ) -> TypeDef {
+        let mut query = self.selection.select("elementTypeDef");
+
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -4148,8 +5441,11 @@ impl ListTypeDef {
         }
     }
     /// A unique identifier for this ListTypeDef.
-    pub async fn id(&self) -> Result<ListTypeDefId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<ListTypeDefId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -4157,12 +5453,16 @@ impl ListTypeDef {
 pub struct LocalModuleSource {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 impl LocalModuleSource {
     /// The directory containing everything needed to load load and use the module.
-    pub fn context_directory(&self) -> Directory {
-        let query = self.selection.select("contextDirectory");
+    pub fn context_directory(
+        &self,
+    ) -> Directory {
+        let mut query = self.selection.select("contextDirectory");
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -4170,13 +5470,19 @@ impl LocalModuleSource {
         }
     }
     /// A unique identifier for this LocalModuleSource.
-    pub async fn id(&self) -> Result<LocalModuleSourceId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<LocalModuleSourceId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The path to the root of the module source under the context directory. This directory contains its configuration file. It also contains its source code (possibly as a subdirectory).
-    pub async fn root_subpath(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("rootSubpath");
+    pub async fn root_subpath(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("rootSubpath");
+
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -4184,35 +5490,48 @@ impl LocalModuleSource {
 pub struct Module {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 impl Module {
     /// Modules used by this module.
-    pub fn dependencies(&self) -> Vec<Module> {
-        let query = self.selection.select("dependencies");
+    pub fn dependencies(
+        &self,
+    ) -> Vec<Module> {
+        let mut query = self.selection.select("dependencies");
+
         return vec![Module {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// The dependencies as configured by the module.
-    pub fn dependency_config(&self) -> Vec<ModuleDependency> {
-        let query = self.selection.select("dependencyConfig");
+    pub fn dependency_config(
+        &self,
+    ) -> Vec<ModuleDependency> {
+        let mut query = self.selection.select("dependencyConfig");
+
         return vec![ModuleDependency {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// The doc string of the module, if any
-    pub async fn description(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("description");
+    pub async fn description(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("description");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The generated files and directories made on top of the module source's context directory.
-    pub fn generated_context_diff(&self) -> Directory {
-        let query = self.selection.select("generatedContextDiff");
+    pub fn generated_context_diff(
+        &self,
+    ) -> Directory {
+        let mut query = self.selection.select("generatedContextDiff");
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -4220,8 +5539,11 @@ impl Module {
         }
     }
     /// The module source's context plus any configuration and source files created by codegen.
-    pub fn generated_context_directory(&self) -> Directory {
-        let query = self.selection.select("generatedContextDirectory");
+    pub fn generated_context_directory(
+        &self,
+    ) -> Directory {
+        let mut query = self.selection.select("generatedContextDirectory");
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -4229,13 +5551,19 @@ impl Module {
         }
     }
     /// A unique identifier for this Module.
-    pub async fn id(&self) -> Result<ModuleId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<ModuleId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the module with the objects loaded via its SDK.
-    pub fn initialize(&self) -> Module {
-        let query = self.selection.select("initialize");
+    pub fn initialize(
+        &self,
+    ) -> Module {
+        let mut query = self.selection.select("initialize");
+
         Module {
             proc: self.proc.clone(),
             selection: query,
@@ -4243,31 +5571,43 @@ impl Module {
         }
     }
     /// Interfaces served by this module.
-    pub fn interfaces(&self) -> Vec<TypeDef> {
-        let query = self.selection.select("interfaces");
+    pub fn interfaces(
+        &self,
+    ) -> Vec<TypeDef> {
+        let mut query = self.selection.select("interfaces");
+
         return vec![TypeDef {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// The name of the module
-    pub async fn name(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("name");
+    pub async fn name(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("name");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Objects served by this module.
-    pub fn objects(&self) -> Vec<TypeDef> {
-        let query = self.selection.select("objects");
+    pub fn objects(
+        &self,
+    ) -> Vec<TypeDef> {
+        let mut query = self.selection.select("objects");
+
         return vec![TypeDef {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile.
-    pub fn runtime(&self) -> Container {
-        let query = self.selection.select("runtime");
+    pub fn runtime(
+        &self,
+    ) -> Container {
+        let mut query = self.selection.select("runtime");
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -4275,19 +5615,28 @@ impl Module {
         }
     }
     /// The SDK used by this module. Either a name of a builtin SDK or a module source ref string pointing to the SDK's implementation.
-    pub async fn sdk(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("sdk");
+    pub async fn sdk(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("sdk");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Serve a module's API in the current session.
     /// Note: this can only be called once per session. In the future, it could return a stream or service to remove the side effect.
-    pub async fn serve(&self) -> Result<Void, DaggerError> {
-        let query = self.selection.select("serve");
+    pub async fn serve(
+        &self,
+    ) -> Result<Void, DaggerError> {
+        let mut query = self.selection.select("serve");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The source for the module.
-    pub fn source(&self) -> ModuleSource {
-        let query = self.selection.select("source");
+    pub fn source(
+        &self,
+    ) -> ModuleSource {
+        let mut query = self.selection.select("source");
+
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -4296,12 +5645,20 @@ impl Module {
     }
     /// Retrieves the module with the given description
     ///
+
     /// # Arguments
+
     ///
+
     /// * `description` - The description to set
-    pub fn with_description(&self, description: impl Into<String>) -> Module {
+    pub fn with_description(
+        &self,
+        description: impl Into<String>,
+    ) -> Module {
         let mut query = self.selection.select("withDescription");
+
         query = query.arg("description", description.into());
+
         Module {
             proc: self.proc.clone(),
             selection: query,
@@ -4309,8 +5666,12 @@ impl Module {
         }
     }
     /// This module plus the given Interface type and associated functions
-    pub fn with_interface(&self, iface: TypeDef) -> Module {
+    pub fn with_interface(
+        &self,
+        iface: TypeDef,
+    ) -> Module {
         let mut query = self.selection.select("withInterface");
+
         query = query.arg_lazy(
             "iface",
             Box::new(move || {
@@ -4318,6 +5679,7 @@ impl Module {
                 Box::pin(async move { iface.id().await.unwrap().quote() })
             }),
         );
+
         Module {
             proc: self.proc.clone(),
             selection: query,
@@ -4325,8 +5687,12 @@ impl Module {
         }
     }
     /// This module plus the given Object type and associated functions.
-    pub fn with_object(&self, object: TypeDef) -> Module {
+    pub fn with_object(
+        &self,
+        object: TypeDef,
+    ) -> Module {
         let mut query = self.selection.select("withObject");
+
         query = query.arg_lazy(
             "object",
             Box::new(move || {
@@ -4334,6 +5700,7 @@ impl Module {
                 Box::pin(async move { object.id().await.unwrap().quote() })
             }),
         );
+
         Module {
             proc: self.proc.clone(),
             selection: query,
@@ -4342,11 +5709,18 @@ impl Module {
     }
     /// Retrieves the module with basic configuration loaded if present.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `source` - The module source to initialize from.
-    pub fn with_source(&self, source: ModuleSource) -> Module {
+    pub fn with_source(
+        &self,
+        source: ModuleSource,
+    ) -> Module {
         let mut query = self.selection.select("withSource");
+
         query = query.arg_lazy(
             "source",
             Box::new(move || {
@@ -4354,6 +5728,7 @@ impl Module {
                 Box::pin(async move { source.id().await.unwrap().quote() })
             }),
         );
+
         Module {
             proc: self.proc.clone(),
             selection: query,
@@ -4365,22 +5740,32 @@ impl Module {
 pub struct ModuleDependency {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 impl ModuleDependency {
     /// A unique identifier for this ModuleDependency.
-    pub async fn id(&self) -> Result<ModuleDependencyId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<ModuleDependencyId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the dependency module.
-    pub async fn name(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("name");
+    pub async fn name(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("name");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The source for the dependency module.
-    pub fn source(&self) -> ModuleSource {
-        let query = self.selection.select("source");
+    pub fn source(
+        &self,
+    ) -> ModuleSource {
+        let mut query = self.selection.select("source");
+
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -4392,18 +5777,24 @@ impl ModuleDependency {
 pub struct ModuleSource {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 #[derive(Builder, Debug, PartialEq)]
 pub struct ModuleSourceResolveDirectoryFromCallerOpts<'a> {
+
     /// If set, the name of the view to apply to the path.
     #[builder(setter(into, strip_option), default)]
     pub view_name: Option<&'a str>,
 }
+
 impl ModuleSource {
     /// If the source is a of kind git, the git source representation of it.
-    pub fn as_git_source(&self) -> GitModuleSource {
-        let query = self.selection.select("asGitSource");
+    pub fn as_git_source(
+        &self,
+    ) -> GitModuleSource {
+        let mut query = self.selection.select("asGitSource");
+
         GitModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -4411,8 +5802,11 @@ impl ModuleSource {
         }
     }
     /// If the source is of kind local, the local source representation of it.
-    pub fn as_local_source(&self) -> LocalModuleSource {
-        let query = self.selection.select("asLocalSource");
+    pub fn as_local_source(
+        &self,
+    ) -> LocalModuleSource {
+        let mut query = self.selection.select("asLocalSource");
+
         LocalModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -4420,8 +5814,11 @@ impl ModuleSource {
         }
     }
     /// Load the source as a module. If this is a local source, the parent directory must have been provided during module source creation
-    pub fn as_module(&self) -> Module {
-        let query = self.selection.select("asModule");
+    pub fn as_module(
+        &self,
+    ) -> Module {
+        let mut query = self.selection.select("asModule");
+
         Module {
             proc: self.proc.clone(),
             selection: query,
@@ -4429,18 +5826,27 @@ impl ModuleSource {
         }
     }
     /// A human readable ref string representation of this module source.
-    pub async fn as_string(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("asString");
+    pub async fn as_string(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("asString");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Returns whether the module source has a configuration file.
-    pub async fn config_exists(&self) -> Result<bool, DaggerError> {
-        let query = self.selection.select("configExists");
+    pub async fn config_exists(
+        &self,
+    ) -> Result<bool, DaggerError> {
+        let mut query = self.selection.select("configExists");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The directory containing everything needed to load load and use the module.
-    pub fn context_directory(&self) -> Directory {
-        let query = self.selection.select("contextDirectory");
+    pub fn context_directory(
+        &self,
+    ) -> Directory {
+        let mut query = self.selection.select("contextDirectory");
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -4448,22 +5854,33 @@ impl ModuleSource {
         }
     }
     /// The dependencies of the module source. Includes dependencies from the configuration and any extras from withDependencies calls.
-    pub fn dependencies(&self) -> Vec<ModuleDependency> {
-        let query = self.selection.select("dependencies");
+    pub fn dependencies(
+        &self,
+    ) -> Vec<ModuleDependency> {
+        let mut query = self.selection.select("dependencies");
+
         return vec![ModuleDependency {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// The directory containing the module configuration and source code (source code may be in a subdir).
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - The path from the source directory to select.
-    pub fn directory(&self, path: impl Into<String>) -> Directory {
+    pub fn directory(
+        &self,
+        path: impl Into<String>,
+    ) -> Directory {
         let mut query = self.selection.select("directory");
+
         query = query.arg("path", path.into());
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -4471,37 +5888,59 @@ impl ModuleSource {
         }
     }
     /// A unique identifier for this ModuleSource.
-    pub async fn id(&self) -> Result<ModuleSourceId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<ModuleSourceId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The kind of source (e.g. local, git, etc.)
-    pub async fn kind(&self) -> Result<ModuleSourceKind, DaggerError> {
-        let query = self.selection.select("kind");
+    pub async fn kind(
+        &self,
+    ) -> Result<ModuleSourceKind, DaggerError> {
+        let mut query = self.selection.select("kind");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// If set, the name of the module this source references, including any overrides at runtime by callers.
-    pub async fn module_name(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("moduleName");
+    pub async fn module_name(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("moduleName");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The original name of the module this source references, as defined in the module configuration.
-    pub async fn module_original_name(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("moduleOriginalName");
+    pub async fn module_original_name(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("moduleOriginalName");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The path to the module source's context directory on the caller's filesystem. Only valid for local sources.
-    pub async fn resolve_context_path_from_caller(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("resolveContextPathFromCaller");
+    pub async fn resolve_context_path_from_caller(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("resolveContextPathFromCaller");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Resolve the provided module source arg as a dependency relative to this module source.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `dep` - The dependency module source to resolve.
-    pub fn resolve_dependency(&self, dep: ModuleSource) -> ModuleSource {
+    pub fn resolve_dependency(
+        &self,
+        dep: ModuleSource,
+    ) -> ModuleSource {
         let mut query = self.selection.select("resolveDependency");
+
         query = query.arg_lazy(
             "dep",
             Box::new(move || {
@@ -4509,6 +5948,7 @@ impl ModuleSource {
                 Box::pin(async move { dep.id().await.unwrap().quote() })
             }),
         );
+
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -4517,35 +5957,49 @@ impl ModuleSource {
     }
     /// Load a directory from the caller optionally with a given view applied.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - The path on the caller's filesystem to load.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn resolve_directory_from_caller(&self, path: impl Into<String>) -> Directory {
+    pub fn resolve_directory_from_caller(
+        &self,
+        path: impl Into<String>,
+    ) -> Directory {
         let mut query = self.selection.select("resolveDirectoryFromCaller");
+
         query = query.arg("path", path.into());
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Load a directory from the caller optionally with a given view applied.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - The path on the caller's filesystem to load.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn resolve_directory_from_caller_opts<'a>(
         &self,
         path: impl Into<String>,
-        opts: ModuleSourceResolveDirectoryFromCallerOpts<'a>,
+        opts: ModuleSourceResolveDirectoryFromCallerOpts<'a>
     ) -> Directory {
         let mut query = self.selection.select("resolveDirectoryFromCaller");
+
         query = query.arg("path", path.into());
         if let Some(view_name) = opts.view_name {
             query = query.arg("viewName", view_name);
         }
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -4553,8 +6007,11 @@ impl ModuleSource {
         }
     }
     /// Load the source from its path on the caller's filesystem, including only needed+configured files and directories. Only valid for local sources.
-    pub fn resolve_from_caller(&self) -> ModuleSource {
-        let query = self.selection.select("resolveFromCaller");
+    pub fn resolve_from_caller(
+        &self,
+    ) -> ModuleSource {
+        let mut query = self.selection.select("resolveFromCaller");
+
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -4562,23 +6019,37 @@ impl ModuleSource {
         }
     }
     /// The path relative to context of the root of the module source, which contains dagger.json. It also contains the module implementation source code, but that may or may not being a subdir of this root.
-    pub async fn source_root_subpath(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("sourceRootSubpath");
+    pub async fn source_root_subpath(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("sourceRootSubpath");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The path relative to context of the module implementation source code.
-    pub async fn source_subpath(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("sourceSubpath");
+    pub async fn source_subpath(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("sourceSubpath");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieve a named view defined for this module source.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - The name of the view to retrieve.
-    pub fn view(&self, name: impl Into<String>) -> ModuleSourceView {
+    pub fn view(
+        &self,
+        name: impl Into<String>,
+    ) -> ModuleSourceView {
         let mut query = self.selection.select("view");
+
         query = query.arg("name", name.into());
+
         ModuleSourceView {
             proc: self.proc.clone(),
             selection: query,
@@ -4586,21 +6057,31 @@ impl ModuleSource {
         }
     }
     /// The named views defined for this module source, which are sets of directory filters that can be applied to directory arguments provided to functions.
-    pub fn views(&self) -> Vec<ModuleSourceView> {
-        let query = self.selection.select("views");
+    pub fn views(
+        &self,
+    ) -> Vec<ModuleSourceView> {
+        let mut query = self.selection.select("views");
+
         return vec![ModuleSourceView {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// Update the module source with a new context directory. Only valid for local sources.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `dir` - The directory to set as the context directory.
-    pub fn with_context_directory(&self, dir: Directory) -> ModuleSource {
+    pub fn with_context_directory(
+        &self,
+        dir: Directory,
+    ) -> ModuleSource {
         let mut query = self.selection.select("withContextDirectory");
+
         query = query.arg_lazy(
             "dir",
             Box::new(move || {
@@ -4608,6 +6089,7 @@ impl ModuleSource {
                 Box::pin(async move { dir.id().await.unwrap().quote() })
             }),
         );
+
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -4616,12 +6098,20 @@ impl ModuleSource {
     }
     /// Append the provided dependencies to the module source's dependency list.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `dependencies` - The dependencies to append.
-    pub fn with_dependencies(&self, dependencies: Vec<ModuleDependencyId>) -> ModuleSource {
+    pub fn with_dependencies(
+        &self,
+        dependencies: Vec<ModuleDependencyId>,
+    ) -> ModuleSource {
         let mut query = self.selection.select("withDependencies");
+
         query = query.arg("dependencies", dependencies);
+
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -4630,12 +6120,20 @@ impl ModuleSource {
     }
     /// Update the module source with a new name.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - The name to set.
-    pub fn with_name(&self, name: impl Into<String>) -> ModuleSource {
+    pub fn with_name(
+        &self,
+        name: impl Into<String>,
+    ) -> ModuleSource {
         let mut query = self.selection.select("withName");
+
         query = query.arg("name", name.into());
+
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -4644,12 +6142,20 @@ impl ModuleSource {
     }
     /// Update the module source with a new SDK.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `sdk` - The SDK to set.
-    pub fn with_sdk(&self, sdk: impl Into<String>) -> ModuleSource {
+    pub fn with_sdk(
+        &self,
+        sdk: impl Into<String>,
+    ) -> ModuleSource {
         let mut query = self.selection.select("withSDK");
+
         query = query.arg("sdk", sdk.into());
+
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -4658,12 +6164,20 @@ impl ModuleSource {
     }
     /// Update the module source with a new source subpath.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `path` - The path to set as the source subpath.
-    pub fn with_source_subpath(&self, path: impl Into<String>) -> ModuleSource {
+    pub fn with_source_subpath(
+        &self,
+        path: impl Into<String>,
+    ) -> ModuleSource {
         let mut query = self.selection.select("withSourceSubpath");
+
         query = query.arg("path", path.into());
+
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -4672,8 +6186,11 @@ impl ModuleSource {
     }
     /// Update the module source with a new named view.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - The name of the view to set.
     /// * `patterns` - The patterns to set as the view filters.
     pub fn with_view(
@@ -4682,14 +6199,10 @@ impl ModuleSource {
         patterns: Vec<impl Into<String>>,
     ) -> ModuleSource {
         let mut query = self.selection.select("withView");
+
         query = query.arg("name", name.into());
-        query = query.arg(
-            "patterns",
-            patterns
-                .into_iter()
-                .map(|i| i.into())
-                .collect::<Vec<String>>(),
-        );
+        query = query.arg("patterns", patterns.into_iter().map(|i| i.into()).collect::<Vec<String>>());
+
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -4701,22 +6214,32 @@ impl ModuleSource {
 pub struct ModuleSourceView {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 impl ModuleSourceView {
     /// A unique identifier for this ModuleSourceView.
-    pub async fn id(&self) -> Result<ModuleSourceViewId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<ModuleSourceViewId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the view
-    pub async fn name(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("name");
+    pub async fn name(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("name");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The patterns of the view used to filter paths
-    pub async fn patterns(&self) -> Result<Vec<String>, DaggerError> {
-        let query = self.selection.select("patterns");
+    pub async fn patterns(
+        &self,
+    ) -> Result<Vec<String>, DaggerError> {
+        let mut query = self.selection.select("patterns");
+
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -4724,12 +6247,16 @@ impl ModuleSourceView {
 pub struct ObjectTypeDef {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 impl ObjectTypeDef {
     /// The function used to construct new instances of this object, if any
-    pub fn constructor(&self) -> Function {
-        let query = self.selection.select("constructor");
+    pub fn constructor(
+        &self,
+    ) -> Function {
+        let mut query = self.selection.select("constructor");
+
         Function {
             proc: self.proc.clone(),
             selection: query,
@@ -4737,41 +6264,59 @@ impl ObjectTypeDef {
         }
     }
     /// The doc string for the object, if any.
-    pub async fn description(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("description");
+    pub async fn description(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("description");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Static fields defined on this object, if any.
-    pub fn fields(&self) -> Vec<FieldTypeDef> {
-        let query = self.selection.select("fields");
+    pub fn fields(
+        &self,
+    ) -> Vec<FieldTypeDef> {
+        let mut query = self.selection.select("fields");
+
         return vec![FieldTypeDef {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// Functions defined on this object, if any.
-    pub fn functions(&self) -> Vec<Function> {
-        let query = self.selection.select("functions");
+    pub fn functions(
+        &self,
+    ) -> Vec<Function> {
+        let mut query = self.selection.select("functions");
+
         return vec![Function {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// A unique identifier for this ObjectTypeDef.
-    pub async fn id(&self) -> Result<ObjectTypeDefId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<ObjectTypeDefId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the object.
-    pub async fn name(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("name");
+    pub async fn name(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("name");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// If this ObjectTypeDef is associated with a Module, the name of the module. Unset otherwise.
-    pub async fn source_module_name(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("sourceModuleName");
+    pub async fn source_module_name(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("sourceModuleName");
+
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -4779,32 +6324,48 @@ impl ObjectTypeDef {
 pub struct Port {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 impl Port {
     /// The port description.
-    pub async fn description(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("description");
+    pub async fn description(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("description");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Skip the health check when run as a service.
-    pub async fn experimental_skip_healthcheck(&self) -> Result<bool, DaggerError> {
-        let query = self.selection.select("experimentalSkipHealthcheck");
+    pub async fn experimental_skip_healthcheck(
+        &self,
+    ) -> Result<bool, DaggerError> {
+        let mut query = self.selection.select("experimentalSkipHealthcheck");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this Port.
-    pub async fn id(&self) -> Result<PortId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<PortId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The port number.
-    pub async fn port(&self) -> Result<isize, DaggerError> {
-        let query = self.selection.select("port");
+    pub async fn port(
+        &self,
+    ) -> Result<isize, DaggerError> {
+        let mut query = self.selection.select("port");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The transport layer protocol.
-    pub async fn protocol(&self) -> Result<NetworkProtocol, DaggerError> {
-        let query = self.selection.select("protocol");
+    pub async fn protocol(
+        &self,
+    ) -> Result<NetworkProtocol, DaggerError> {
+        let mut query = self.selection.select("protocol");
+
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -4812,10 +6373,12 @@ impl Port {
 pub struct Query {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 #[derive(Builder, Debug, PartialEq)]
 pub struct QueryContainerOpts {
+
     /// DEPRECATED: Use `loadContainerFromID` instead.
     #[builder(setter(into, strip_option), default)]
     pub id: Option<ContainerId>,
@@ -4825,12 +6388,14 @@ pub struct QueryContainerOpts {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct QueryDirectoryOpts {
+
     /// DEPRECATED: Use `loadDirectoryFromID` instead.
     #[builder(setter(into, strip_option), default)]
     pub id: Option<DirectoryId>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct QueryGitOpts<'a> {
+
     /// A service which must be started before the repo is fetched.
     #[builder(setter(into, strip_option), default)]
     pub experimental_service_host: Option<ServiceId>,
@@ -4846,24 +6411,28 @@ pub struct QueryGitOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct QueryHttpOpts {
+
     /// A service which must be started before the URL is fetched.
     #[builder(setter(into, strip_option), default)]
     pub experimental_service_host: Option<ServiceId>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct QueryModuleDependencyOpts<'a> {
+
     /// If set, the name to use for the dependency. Otherwise, once installed to a parent module, the name of the dependency module will be used by default.
     #[builder(setter(into, strip_option), default)]
     pub name: Option<&'a str>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct QueryModuleSourceOpts {
+
     /// If true, enforce that the source is a stable version for source kinds that support versioning.
     #[builder(setter(into, strip_option), default)]
     pub stable: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct QueryPipelineOpts<'a> {
+
     /// Description of the sub-pipeline.
     #[builder(setter(into, strip_option), default)]
     pub description: Option<&'a str>,
@@ -4873,14 +6442,19 @@ pub struct QueryPipelineOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct QuerySecretOpts<'a> {
+
     #[builder(setter(into, strip_option), default)]
     pub accessor: Option<&'a str>,
 }
+
 impl Query {
     /// Retrieves a content-addressed blob.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `digest` - Digest of the blob
     /// * `size` - Size of the blob
     /// * `media_type` - Media type of the blob
@@ -4893,10 +6467,12 @@ impl Query {
         uncompressed: impl Into<String>,
     ) -> Directory {
         let mut query = self.selection.select("blob");
+
         query = query.arg("digest", digest.into());
         query = query.arg("size", size);
         query = query.arg("mediaType", media_type.into());
         query = query.arg("uncompressed", uncompressed.into());
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -4905,12 +6481,20 @@ impl Query {
     }
     /// Retrieves a container builtin to the engine.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `digest` - Digest of the image manifest
-    pub fn builtin_container(&self, digest: impl Into<String>) -> Container {
+    pub fn builtin_container(
+        &self,
+        digest: impl Into<String>,
+    ) -> Container {
         let mut query = self.selection.select("builtinContainer");
+
         query = query.arg("digest", digest.into());
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -4919,12 +6503,20 @@ impl Query {
     }
     /// Constructs a cache volume for a given cache key.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `key` - A string identifier to target this cache volume (e.g., "modules-cache").
-    pub fn cache_volume(&self, key: impl Into<String>) -> CacheVolume {
+    pub fn cache_volume(
+        &self,
+        key: impl Into<String>,
+    ) -> CacheVolume {
         let mut query = self.selection.select("cacheVolume");
+
         query = query.arg("key", key.into());
+
         CacheVolume {
             proc: self.proc.clone(),
             selection: query,
@@ -4933,45 +6525,65 @@ impl Query {
     }
     /// Checks if the current Dagger Engine is compatible with an SDK's required version.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `version` - Version required by the SDK.
     pub async fn check_version_compatibility(
         &self,
         version: impl Into<String>,
     ) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("checkVersionCompatibility");
+
         query = query.arg("version", version.into());
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Creates a scratch container.
     /// Optional platform argument initializes new containers to execute and publish as that platform. Platform defaults to that of the builder's host.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn container(&self) -> Container {
-        let query = self.selection.select("container");
+    pub fn container(
+        &self,
+    ) -> Container {
+        let mut query = self.selection.select("container");
+
         Container {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Creates a scratch container.
     /// Optional platform argument initializes new containers to execute and publish as that platform. Platform defaults to that of the builder's host.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn container_opts(&self, opts: QueryContainerOpts) -> Container {
+    pub fn container_opts(
+        &self,
+        opts: QueryContainerOpts
+    ) -> Container {
         let mut query = self.selection.select("container");
+
         if let Some(id) = opts.id {
             query = query.arg("id", id);
         }
         if let Some(platform) = opts.platform {
             query = query.arg("platform", platform);
         }
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -4980,8 +6592,11 @@ impl Query {
     }
     /// The FunctionCall context that the SDK caller is currently executing in.
     /// If the caller is not currently executing in a function, this will return an error.
-    pub fn current_function_call(&self) -> FunctionCall {
-        let query = self.selection.select("currentFunctionCall");
+    pub fn current_function_call(
+        &self,
+    ) -> FunctionCall {
+        let mut query = self.selection.select("currentFunctionCall");
+
         FunctionCall {
             proc: self.proc.clone(),
             selection: query,
@@ -4989,8 +6604,11 @@ impl Query {
         }
     }
     /// The module currently being served in the session, if any.
-    pub fn current_module(&self) -> CurrentModule {
-        let query = self.selection.select("currentModule");
+    pub fn current_module(
+        &self,
+    ) -> CurrentModule {
+        let mut query = self.selection.select("currentModule");
+
         CurrentModule {
             proc: self.proc.clone(),
             selection: query,
@@ -4998,50 +6616,75 @@ impl Query {
         }
     }
     /// The TypeDef representations of the objects currently being served in the session.
-    pub fn current_type_defs(&self) -> Vec<TypeDef> {
-        let query = self.selection.select("currentTypeDefs");
+    pub fn current_type_defs(
+        &self,
+    ) -> Vec<TypeDef> {
+        let mut query = self.selection.select("currentTypeDefs");
+
         return vec![TypeDef {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// The default platform of the engine.
-    pub async fn default_platform(&self) -> Result<Platform, DaggerError> {
-        let query = self.selection.select("defaultPlatform");
+    pub async fn default_platform(
+        &self,
+    ) -> Result<Platform, DaggerError> {
+        let mut query = self.selection.select("defaultPlatform");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Creates an empty directory.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn directory(&self) -> Directory {
-        let query = self.selection.select("directory");
+    pub fn directory(
+        &self,
+    ) -> Directory {
+        let mut query = self.selection.select("directory");
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Creates an empty directory.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn directory_opts(&self, opts: QueryDirectoryOpts) -> Directory {
+    pub fn directory_opts(
+        &self,
+        opts: QueryDirectoryOpts
+    ) -> Directory {
         let mut query = self.selection.select("directory");
+
         if let Some(id) = opts.id {
             query = query.arg("id", id);
         }
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
-    pub fn file(&self, id: File) -> File {
+    pub fn file(
+        &self,
+        id: File,
+    ) -> File {
         let mut query = self.selection.select("file");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5049,6 +6692,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         File {
             proc: self.proc.clone(),
             selection: query,
@@ -5057,12 +6701,20 @@ impl Query {
     }
     /// Creates a function.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - Name of the function, in its original format from the implementation language.
     /// * `return_type` - Return type of the function.
-    pub fn function(&self, name: impl Into<String>, return_type: TypeDef) -> Function {
+    pub fn function(
+        &self,
+        name: impl Into<String>,
+        return_type: TypeDef,
+    ) -> Function {
         let mut query = self.selection.select("function");
+
         query = query.arg("name", name.into());
         query = query.arg_lazy(
             "returnType",
@@ -5071,6 +6723,7 @@ impl Query {
                 Box::pin(async move { return_type.id().await.unwrap().quote() })
             }),
         );
+
         Function {
             proc: self.proc.clone(),
             selection: query,
@@ -5078,8 +6731,12 @@ impl Query {
         }
     }
     /// Create a code generation result, given a directory containing the generated code.
-    pub fn generated_code(&self, code: Directory) -> GeneratedCode {
+    pub fn generated_code(
+        &self,
+        code: Directory,
+    ) -> GeneratedCode {
         let mut query = self.selection.select("generatedCode");
+
         query = query.arg_lazy(
             "code",
             Box::new(move || {
@@ -5087,6 +6744,7 @@ impl Query {
                 Box::pin(async move { code.id().await.unwrap().quote() })
             }),
         );
+
         GeneratedCode {
             proc: self.proc.clone(),
             selection: query,
@@ -5095,35 +6753,52 @@ impl Query {
     }
     /// Queries a Git repository.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `url` - URL of the git repository.
-    ///
+    /// 
     /// Can be formatted as `https://{host}/{owner}/{repo}`, `git@{host}:{owner}/{repo}`.
-    ///
+    /// 
     /// Suffix ".git" is optional.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn git(&self, url: impl Into<String>) -> GitRepository {
+    pub fn git(
+        &self,
+        url: impl Into<String>,
+    ) -> GitRepository {
         let mut query = self.selection.select("git");
+
         query = query.arg("url", url.into());
+
         GitRepository {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Queries a Git repository.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `url` - URL of the git repository.
-    ///
+    /// 
     /// Can be formatted as `https://{host}/{owner}/{repo}`, `git@{host}:{owner}/{repo}`.
-    ///
+    /// 
     /// Suffix ".git" is optional.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn git_opts<'a>(&self, url: impl Into<String>, opts: QueryGitOpts<'a>) -> GitRepository {
+    pub fn git_opts<'a>(
+        &self,
+        url: impl Into<String>,
+        opts: QueryGitOpts<'a>
+    ) -> GitRepository {
         let mut query = self.selection.select("git");
+
         query = query.arg("url", url.into());
         if let Some(keep_git_dir) = opts.keep_git_dir {
             query = query.arg("keepGitDir", keep_git_dir);
@@ -5137,6 +6812,7 @@ impl Query {
         if let Some(ssh_auth_socket) = opts.ssh_auth_socket {
             query = query.arg("sshAuthSocket", ssh_auth_socket);
         }
+
         GitRepository {
             proc: self.proc.clone(),
             selection: query,
@@ -5144,8 +6820,11 @@ impl Query {
         }
     }
     /// Queries the host environment.
-    pub fn host(&self) -> Host {
-        let query = self.selection.select("host");
+    pub fn host(
+        &self,
+    ) -> Host {
+        let mut query = self.selection.select("host");
+
         Host {
             proc: self.proc.clone(),
             selection: query,
@@ -5154,31 +6833,49 @@ impl Query {
     }
     /// Returns a file containing an http remote url content.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `url` - HTTP url to get the content from (e.g., "https://docs.dagger.io").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn http(&self, url: impl Into<String>) -> File {
+    pub fn http(
+        &self,
+        url: impl Into<String>,
+    ) -> File {
         let mut query = self.selection.select("http");
+
         query = query.arg("url", url.into());
+
         File {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Returns a file containing an http remote url content.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `url` - HTTP url to get the content from (e.g., "https://docs.dagger.io").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn http_opts(&self, url: impl Into<String>, opts: QueryHttpOpts) -> File {
+    pub fn http_opts(
+        &self,
+        url: impl Into<String>,
+        opts: QueryHttpOpts
+    ) -> File {
         let mut query = self.selection.select("http");
+
         query = query.arg("url", url.into());
         if let Some(experimental_service_host) = opts.experimental_service_host {
             query = query.arg("experimentalServiceHost", experimental_service_host);
         }
+
         File {
             proc: self.proc.clone(),
             selection: query,
@@ -5186,8 +6883,12 @@ impl Query {
         }
     }
     /// Load a CacheVolume from its ID.
-    pub fn load_cache_volume_from_id(&self, id: CacheVolume) -> CacheVolume {
+    pub fn load_cache_volume_from_id(
+        &self,
+        id: CacheVolume,
+    ) -> CacheVolume {
         let mut query = self.selection.select("loadCacheVolumeFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5195,6 +6896,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         CacheVolume {
             proc: self.proc.clone(),
             selection: query,
@@ -5202,8 +6904,12 @@ impl Query {
         }
     }
     /// Load a Container from its ID.
-    pub fn load_container_from_id(&self, id: Container) -> Container {
+    pub fn load_container_from_id(
+        &self,
+        id: Container,
+    ) -> Container {
         let mut query = self.selection.select("loadContainerFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5211,6 +6917,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         Container {
             proc: self.proc.clone(),
             selection: query,
@@ -5218,8 +6925,12 @@ impl Query {
         }
     }
     /// Load a CurrentModule from its ID.
-    pub fn load_current_module_from_id(&self, id: CurrentModule) -> CurrentModule {
+    pub fn load_current_module_from_id(
+        &self,
+        id: CurrentModule,
+    ) -> CurrentModule {
         let mut query = self.selection.select("loadCurrentModuleFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5227,6 +6938,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         CurrentModule {
             proc: self.proc.clone(),
             selection: query,
@@ -5234,8 +6946,12 @@ impl Query {
         }
     }
     /// Load a Directory from its ID.
-    pub fn load_directory_from_id(&self, id: Directory) -> Directory {
+    pub fn load_directory_from_id(
+        &self,
+        id: Directory,
+    ) -> Directory {
         let mut query = self.selection.select("loadDirectoryFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5243,6 +6959,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         Directory {
             proc: self.proc.clone(),
             selection: query,
@@ -5250,8 +6967,12 @@ impl Query {
         }
     }
     /// Load a EnvVariable from its ID.
-    pub fn load_env_variable_from_id(&self, id: EnvVariable) -> EnvVariable {
+    pub fn load_env_variable_from_id(
+        &self,
+        id: EnvVariable,
+    ) -> EnvVariable {
         let mut query = self.selection.select("loadEnvVariableFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5259,6 +6980,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         EnvVariable {
             proc: self.proc.clone(),
             selection: query,
@@ -5266,8 +6988,12 @@ impl Query {
         }
     }
     /// Load a FieldTypeDef from its ID.
-    pub fn load_field_type_def_from_id(&self, id: FieldTypeDef) -> FieldTypeDef {
+    pub fn load_field_type_def_from_id(
+        &self,
+        id: FieldTypeDef,
+    ) -> FieldTypeDef {
         let mut query = self.selection.select("loadFieldTypeDefFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5275,6 +7001,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         FieldTypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -5282,8 +7009,12 @@ impl Query {
         }
     }
     /// Load a File from its ID.
-    pub fn load_file_from_id(&self, id: File) -> File {
+    pub fn load_file_from_id(
+        &self,
+        id: File,
+    ) -> File {
         let mut query = self.selection.select("loadFileFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5291,6 +7022,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         File {
             proc: self.proc.clone(),
             selection: query,
@@ -5298,8 +7030,12 @@ impl Query {
         }
     }
     /// Load a FunctionArg from its ID.
-    pub fn load_function_arg_from_id(&self, id: FunctionArg) -> FunctionArg {
+    pub fn load_function_arg_from_id(
+        &self,
+        id: FunctionArg,
+    ) -> FunctionArg {
         let mut query = self.selection.select("loadFunctionArgFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5307,6 +7043,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         FunctionArg {
             proc: self.proc.clone(),
             selection: query,
@@ -5319,6 +7056,7 @@ impl Query {
         id: FunctionCallArgValue,
     ) -> FunctionCallArgValue {
         let mut query = self.selection.select("loadFunctionCallArgValueFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5326,6 +7064,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         FunctionCallArgValue {
             proc: self.proc.clone(),
             selection: query,
@@ -5333,8 +7072,12 @@ impl Query {
         }
     }
     /// Load a FunctionCall from its ID.
-    pub fn load_function_call_from_id(&self, id: FunctionCall) -> FunctionCall {
+    pub fn load_function_call_from_id(
+        &self,
+        id: FunctionCall,
+    ) -> FunctionCall {
         let mut query = self.selection.select("loadFunctionCallFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5342,6 +7085,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         FunctionCall {
             proc: self.proc.clone(),
             selection: query,
@@ -5349,8 +7093,12 @@ impl Query {
         }
     }
     /// Load a Function from its ID.
-    pub fn load_function_from_id(&self, id: Function) -> Function {
+    pub fn load_function_from_id(
+        &self,
+        id: Function,
+    ) -> Function {
         let mut query = self.selection.select("loadFunctionFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5358,6 +7106,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         Function {
             proc: self.proc.clone(),
             selection: query,
@@ -5365,8 +7114,12 @@ impl Query {
         }
     }
     /// Load a GeneratedCode from its ID.
-    pub fn load_generated_code_from_id(&self, id: GeneratedCode) -> GeneratedCode {
+    pub fn load_generated_code_from_id(
+        &self,
+        id: GeneratedCode,
+    ) -> GeneratedCode {
         let mut query = self.selection.select("loadGeneratedCodeFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5374,6 +7127,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         GeneratedCode {
             proc: self.proc.clone(),
             selection: query,
@@ -5381,8 +7135,12 @@ impl Query {
         }
     }
     /// Load a GitModuleSource from its ID.
-    pub fn load_git_module_source_from_id(&self, id: GitModuleSource) -> GitModuleSource {
+    pub fn load_git_module_source_from_id(
+        &self,
+        id: GitModuleSource,
+    ) -> GitModuleSource {
         let mut query = self.selection.select("loadGitModuleSourceFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5390,6 +7148,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         GitModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -5397,8 +7156,12 @@ impl Query {
         }
     }
     /// Load a GitRef from its ID.
-    pub fn load_git_ref_from_id(&self, id: GitRef) -> GitRef {
+    pub fn load_git_ref_from_id(
+        &self,
+        id: GitRef,
+    ) -> GitRef {
         let mut query = self.selection.select("loadGitRefFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5406,6 +7169,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         GitRef {
             proc: self.proc.clone(),
             selection: query,
@@ -5413,8 +7177,12 @@ impl Query {
         }
     }
     /// Load a GitRepository from its ID.
-    pub fn load_git_repository_from_id(&self, id: GitRepository) -> GitRepository {
+    pub fn load_git_repository_from_id(
+        &self,
+        id: GitRepository,
+    ) -> GitRepository {
         let mut query = self.selection.select("loadGitRepositoryFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5422,6 +7190,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         GitRepository {
             proc: self.proc.clone(),
             selection: query,
@@ -5429,8 +7198,12 @@ impl Query {
         }
     }
     /// Load a Host from its ID.
-    pub fn load_host_from_id(&self, id: Host) -> Host {
+    pub fn load_host_from_id(
+        &self,
+        id: Host,
+    ) -> Host {
         let mut query = self.selection.select("loadHostFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5438,6 +7211,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         Host {
             proc: self.proc.clone(),
             selection: query,
@@ -5445,8 +7219,12 @@ impl Query {
         }
     }
     /// Load a InputTypeDef from its ID.
-    pub fn load_input_type_def_from_id(&self, id: InputTypeDef) -> InputTypeDef {
+    pub fn load_input_type_def_from_id(
+        &self,
+        id: InputTypeDef,
+    ) -> InputTypeDef {
         let mut query = self.selection.select("loadInputTypeDefFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5454,6 +7232,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         InputTypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -5461,8 +7240,12 @@ impl Query {
         }
     }
     /// Load a InterfaceTypeDef from its ID.
-    pub fn load_interface_type_def_from_id(&self, id: InterfaceTypeDef) -> InterfaceTypeDef {
+    pub fn load_interface_type_def_from_id(
+        &self,
+        id: InterfaceTypeDef,
+    ) -> InterfaceTypeDef {
         let mut query = self.selection.select("loadInterfaceTypeDefFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5470,6 +7253,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         InterfaceTypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -5477,8 +7261,12 @@ impl Query {
         }
     }
     /// Load a Label from its ID.
-    pub fn load_label_from_id(&self, id: Label) -> Label {
+    pub fn load_label_from_id(
+        &self,
+        id: Label,
+    ) -> Label {
         let mut query = self.selection.select("loadLabelFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5486,6 +7274,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         Label {
             proc: self.proc.clone(),
             selection: query,
@@ -5493,8 +7282,12 @@ impl Query {
         }
     }
     /// Load a ListTypeDef from its ID.
-    pub fn load_list_type_def_from_id(&self, id: ListTypeDef) -> ListTypeDef {
+    pub fn load_list_type_def_from_id(
+        &self,
+        id: ListTypeDef,
+    ) -> ListTypeDef {
         let mut query = self.selection.select("loadListTypeDefFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5502,6 +7295,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         ListTypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -5509,8 +7303,12 @@ impl Query {
         }
     }
     /// Load a LocalModuleSource from its ID.
-    pub fn load_local_module_source_from_id(&self, id: LocalModuleSource) -> LocalModuleSource {
+    pub fn load_local_module_source_from_id(
+        &self,
+        id: LocalModuleSource,
+    ) -> LocalModuleSource {
         let mut query = self.selection.select("loadLocalModuleSourceFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5518,6 +7316,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         LocalModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -5525,8 +7324,12 @@ impl Query {
         }
     }
     /// Load a ModuleDependency from its ID.
-    pub fn load_module_dependency_from_id(&self, id: ModuleDependency) -> ModuleDependency {
+    pub fn load_module_dependency_from_id(
+        &self,
+        id: ModuleDependency,
+    ) -> ModuleDependency {
         let mut query = self.selection.select("loadModuleDependencyFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5534,6 +7337,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         ModuleDependency {
             proc: self.proc.clone(),
             selection: query,
@@ -5541,8 +7345,12 @@ impl Query {
         }
     }
     /// Load a Module from its ID.
-    pub fn load_module_from_id(&self, id: Module) -> Module {
+    pub fn load_module_from_id(
+        &self,
+        id: Module,
+    ) -> Module {
         let mut query = self.selection.select("loadModuleFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5550,6 +7358,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         Module {
             proc: self.proc.clone(),
             selection: query,
@@ -5557,8 +7366,12 @@ impl Query {
         }
     }
     /// Load a ModuleSource from its ID.
-    pub fn load_module_source_from_id(&self, id: ModuleSource) -> ModuleSource {
+    pub fn load_module_source_from_id(
+        &self,
+        id: ModuleSource,
+    ) -> ModuleSource {
         let mut query = self.selection.select("loadModuleSourceFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5566,6 +7379,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -5573,8 +7387,12 @@ impl Query {
         }
     }
     /// Load a ModuleSourceView from its ID.
-    pub fn load_module_source_view_from_id(&self, id: ModuleSourceView) -> ModuleSourceView {
+    pub fn load_module_source_view_from_id(
+        &self,
+        id: ModuleSourceView,
+    ) -> ModuleSourceView {
         let mut query = self.selection.select("loadModuleSourceViewFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5582,6 +7400,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         ModuleSourceView {
             proc: self.proc.clone(),
             selection: query,
@@ -5589,8 +7408,12 @@ impl Query {
         }
     }
     /// Load a ObjectTypeDef from its ID.
-    pub fn load_object_type_def_from_id(&self, id: ObjectTypeDef) -> ObjectTypeDef {
+    pub fn load_object_type_def_from_id(
+        &self,
+        id: ObjectTypeDef,
+    ) -> ObjectTypeDef {
         let mut query = self.selection.select("loadObjectTypeDefFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5598,6 +7421,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         ObjectTypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -5605,8 +7429,12 @@ impl Query {
         }
     }
     /// Load a Port from its ID.
-    pub fn load_port_from_id(&self, id: Port) -> Port {
+    pub fn load_port_from_id(
+        &self,
+        id: Port,
+    ) -> Port {
         let mut query = self.selection.select("loadPortFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5614,6 +7442,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         Port {
             proc: self.proc.clone(),
             selection: query,
@@ -5621,8 +7450,12 @@ impl Query {
         }
     }
     /// Load a Secret from its ID.
-    pub fn load_secret_from_id(&self, id: Secret) -> Secret {
+    pub fn load_secret_from_id(
+        &self,
+        id: Secret,
+    ) -> Secret {
         let mut query = self.selection.select("loadSecretFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5630,6 +7463,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         Secret {
             proc: self.proc.clone(),
             selection: query,
@@ -5637,8 +7471,12 @@ impl Query {
         }
     }
     /// Load a Service from its ID.
-    pub fn load_service_from_id(&self, id: Service) -> Service {
+    pub fn load_service_from_id(
+        &self,
+        id: Service,
+    ) -> Service {
         let mut query = self.selection.select("loadServiceFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5646,6 +7484,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         Service {
             proc: self.proc.clone(),
             selection: query,
@@ -5653,8 +7492,12 @@ impl Query {
         }
     }
     /// Load a Socket from its ID.
-    pub fn load_socket_from_id(&self, id: Socket) -> Socket {
+    pub fn load_socket_from_id(
+        &self,
+        id: Socket,
+    ) -> Socket {
         let mut query = self.selection.select("loadSocketFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5662,6 +7505,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         Socket {
             proc: self.proc.clone(),
             selection: query,
@@ -5669,8 +7513,12 @@ impl Query {
         }
     }
     /// Load a Terminal from its ID.
-    pub fn load_terminal_from_id(&self, id: Terminal) -> Terminal {
+    pub fn load_terminal_from_id(
+        &self,
+        id: Terminal,
+    ) -> Terminal {
         let mut query = self.selection.select("loadTerminalFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5678,6 +7526,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         Terminal {
             proc: self.proc.clone(),
             selection: query,
@@ -5685,8 +7534,12 @@ impl Query {
         }
     }
     /// Load a TypeDef from its ID.
-    pub fn load_type_def_from_id(&self, id: TypeDef) -> TypeDef {
+    pub fn load_type_def_from_id(
+        &self,
+        id: TypeDef,
+    ) -> TypeDef {
         let mut query = self.selection.select("loadTypeDefFromID");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5694,6 +7547,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -5701,8 +7555,11 @@ impl Query {
         }
     }
     /// Create a new module.
-    pub fn module(&self) -> Module {
-        let query = self.selection.select("module");
+    pub fn module(
+        &self,
+    ) -> Module {
+        let mut query = self.selection.select("module");
+
         Module {
             proc: self.proc.clone(),
             selection: query,
@@ -5711,12 +7568,19 @@ impl Query {
     }
     /// Create a new module dependency configuration from a module source and name
     ///
+
     /// # Arguments
+
     ///
+
     /// * `source` - The source of the dependency
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn module_dependency(&self, source: ModuleSource) -> ModuleDependency {
+    pub fn module_dependency(
+        &self,
+        source: ModuleSource,
+    ) -> ModuleDependency {
         let mut query = self.selection.select("moduleDependency");
+
         query = query.arg_lazy(
             "source",
             Box::new(move || {
@@ -5724,24 +7588,30 @@ impl Query {
                 Box::pin(async move { source.id().await.unwrap().quote() })
             }),
         );
+
         ModuleDependency {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Create a new module dependency configuration from a module source and name
     ///
+
     /// # Arguments
+
     ///
+
     /// * `source` - The source of the dependency
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn module_dependency_opts<'a>(
         &self,
         source: ModuleSource,
-        opts: QueryModuleDependencyOpts<'a>,
+        opts: QueryModuleDependencyOpts<'a>
     ) -> ModuleDependency {
         let mut query = self.selection.select("moduleDependency");
+
         query = query.arg_lazy(
             "source",
             Box::new(move || {
@@ -5752,6 +7622,7 @@ impl Query {
         if let Some(name) = opts.name {
             query = query.arg("name", name);
         }
+
         ModuleDependency {
             proc: self.proc.clone(),
             selection: query,
@@ -5760,35 +7631,49 @@ impl Query {
     }
     /// Create a new module source instance from a source ref string.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `ref_string` - The string ref representation of the module source
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn module_source(&self, ref_string: impl Into<String>) -> ModuleSource {
+    pub fn module_source(
+        &self,
+        ref_string: impl Into<String>,
+    ) -> ModuleSource {
         let mut query = self.selection.select("moduleSource");
+
         query = query.arg("refString", ref_string.into());
+
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Create a new module source instance from a source ref string.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `ref_string` - The string ref representation of the module source
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn module_source_opts(
         &self,
         ref_string: impl Into<String>,
-        opts: QueryModuleSourceOpts,
+        opts: QueryModuleSourceOpts
     ) -> ModuleSource {
         let mut query = self.selection.select("moduleSource");
+
         query = query.arg("refString", ref_string.into());
         if let Some(stable) = opts.stable {
             query = query.arg("stable", stable);
         }
+
         ModuleSource {
             proc: self.proc.clone(),
             selection: query,
@@ -5797,27 +7682,44 @@ impl Query {
     }
     /// Creates a named sub-pipeline.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - Name of the sub-pipeline.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn pipeline(&self, name: impl Into<String>) -> Query {
+    pub fn pipeline(
+        &self,
+        name: impl Into<String>,
+    ) -> Query {
         let mut query = self.selection.select("pipeline");
+
         query = query.arg("name", name.into());
+
         Query {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Creates a named sub-pipeline.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - Name of the sub-pipeline.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn pipeline_opts<'a>(&self, name: impl Into<String>, opts: QueryPipelineOpts<'a>) -> Query {
+    pub fn pipeline_opts<'a>(
+        &self,
+        name: impl Into<String>,
+        opts: QueryPipelineOpts<'a>
+    ) -> Query {
         let mut query = self.selection.select("pipeline");
+
         query = query.arg("name", name.into());
         if let Some(description) = opts.description {
             query = query.arg("description", description);
@@ -5825,6 +7727,7 @@ impl Query {
         if let Some(labels) = opts.labels {
             query = query.arg("labels", labels);
         }
+
         Query {
             proc: self.proc.clone(),
             selection: query,
@@ -5833,29 +7736,47 @@ impl Query {
     }
     /// Reference a secret by name.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn secret(&self, name: impl Into<String>) -> Secret {
+    pub fn secret(
+        &self,
+        name: impl Into<String>,
+    ) -> Secret {
         let mut query = self.selection.select("secret");
+
         query = query.arg("name", name.into());
+
         Secret {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Reference a secret by name.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn secret_opts<'a>(&self, name: impl Into<String>, opts: QuerySecretOpts<'a>) -> Secret {
+    pub fn secret_opts<'a>(
+        &self,
+        name: impl Into<String>,
+        opts: QuerySecretOpts<'a>
+    ) -> Secret {
         let mut query = self.selection.select("secret");
+
         query = query.arg("name", name.into());
         if let Some(accessor) = opts.accessor {
             query = query.arg("accessor", accessor);
         }
+
         Secret {
             proc: self.proc.clone(),
             selection: query,
@@ -5865,14 +7786,23 @@ impl Query {
     /// Sets a secret given a user defined name to its plaintext and returns the secret.
     /// The plaintext value is limited to a size of 128000 bytes.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - The user defined name for this secret
     /// * `plaintext` - The plaintext of the secret
-    pub fn set_secret(&self, name: impl Into<String>, plaintext: impl Into<String>) -> Secret {
+    pub fn set_secret(
+        &self,
+        name: impl Into<String>,
+        plaintext: impl Into<String>,
+    ) -> Secret {
         let mut query = self.selection.select("setSecret");
+
         query = query.arg("name", name.into());
         query = query.arg("plaintext", plaintext.into());
+
         Secret {
             proc: self.proc.clone(),
             selection: query,
@@ -5880,8 +7810,12 @@ impl Query {
         }
     }
     /// Loads a socket by its ID.
-    pub fn socket(&self, id: Socket) -> Socket {
+    pub fn socket(
+        &self,
+        id: Socket,
+    ) -> Socket {
         let mut query = self.selection.select("socket");
+
         query = query.arg_lazy(
             "id",
             Box::new(move || {
@@ -5889,6 +7823,7 @@ impl Query {
                 Box::pin(async move { id.id().await.unwrap().quote() })
             }),
         );
+
         Socket {
             proc: self.proc.clone(),
             selection: query,
@@ -5896,8 +7831,11 @@ impl Query {
         }
     }
     /// Create a new TypeDef.
-    pub fn type_def(&self) -> TypeDef {
-        let query = self.selection.select("typeDef");
+    pub fn type_def(
+        &self,
+    ) -> TypeDef {
+        let mut query = self.selection.select("typeDef");
+
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -5909,22 +7847,32 @@ impl Query {
 pub struct Secret {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 impl Secret {
     /// A unique identifier for this Secret.
-    pub async fn id(&self) -> Result<SecretId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<SecretId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of this secret.
-    pub async fn name(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("name");
+    pub async fn name(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("name");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The value of this secret.
-    pub async fn plaintext(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("plaintext");
+    pub async fn plaintext(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("plaintext");
+
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -5932,10 +7880,12 @@ impl Secret {
 pub struct Service {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 #[derive(Builder, Debug, PartialEq)]
 pub struct ServiceEndpointOpts<'a> {
+
     /// The exposed port number for the endpoint
     #[builder(setter(into, strip_option), default)]
     pub port: Option<isize>,
@@ -5945,12 +7895,14 @@ pub struct ServiceEndpointOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ServiceStopOpts {
+
     /// Immediately kill the service without waiting for a graceful exit
     #[builder(setter(into, strip_option), default)]
     pub kill: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ServiceUpOpts {
+
     /// List of frontend/backend port mappings to forward.
     /// Frontend is the port accepting traffic on the host, backend is the service port.
     #[builder(setter(into, strip_option), default)]
@@ -5959,106 +7911,161 @@ pub struct ServiceUpOpts {
     #[builder(setter(into, strip_option), default)]
     pub random: Option<bool>,
 }
+
 impl Service {
     /// Retrieves an endpoint that clients can use to reach this container.
     /// If no port is specified, the first exposed port is used. If none exist an error is returned.
     /// If a scheme is specified, a URL is returned. Otherwise, a host:port pair is returned.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn endpoint(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("endpoint");
+    pub async fn endpoint(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("endpoint");
+
         query.execute(self.graphql_client.clone()).await
     }
+
     /// Retrieves an endpoint that clients can use to reach this container.
     /// If no port is specified, the first exposed port is used. If none exist an error is returned.
     /// If a scheme is specified, a URL is returned. Otherwise, a host:port pair is returned.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn endpoint_opts<'a>(
         &self,
-        opts: ServiceEndpointOpts<'a>,
+        opts: ServiceEndpointOpts<'a>
     ) -> Result<String, DaggerError> {
         let mut query = self.selection.select("endpoint");
+
         if let Some(port) = opts.port {
             query = query.arg("port", port);
         }
         if let Some(scheme) = opts.scheme {
             query = query.arg("scheme", scheme);
         }
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves a hostname which can be used by clients to reach this container.
-    pub async fn hostname(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("hostname");
+    pub async fn hostname(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("hostname");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this Service.
-    pub async fn id(&self) -> Result<ServiceId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<ServiceId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the list of ports provided by the service.
-    pub fn ports(&self) -> Vec<Port> {
-        let query = self.selection.select("ports");
+    pub fn ports(
+        &self,
+    ) -> Vec<Port> {
+        let mut query = self.selection.select("ports");
+
         return vec![Port {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// Start the service and wait for its health checks to succeed.
     /// Services bound to a Container do not need to be manually started.
-    pub async fn start(&self) -> Result<ServiceId, DaggerError> {
-        let query = self.selection.select("start");
+    pub async fn start(
+        &self,
+    ) -> Result<ServiceId, DaggerError> {
+        let mut query = self.selection.select("start");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Stop the service.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn stop(&self) -> Result<ServiceId, DaggerError> {
-        let query = self.selection.select("stop");
-        query.execute(self.graphql_client.clone()).await
-    }
-    /// Stop the service.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn stop_opts(&self, opts: ServiceStopOpts) -> Result<ServiceId, DaggerError> {
+    pub async fn stop(
+        &self,
+    ) -> Result<ServiceId, DaggerError> {
         let mut query = self.selection.select("stop");
+
+        query.execute(self.graphql_client.clone()).await
+    }
+
+    /// Stop the service.
+    ///
+
+    /// # Arguments
+
+    ///
+
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub async fn stop_opts(
+        &self,
+        opts: ServiceStopOpts
+    ) -> Result<ServiceId, DaggerError> {
+        let mut query = self.selection.select("stop");
+
         if let Some(kill) = opts.kill {
             query = query.arg("kill", kill);
         }
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Creates a tunnel that forwards traffic from the caller's network to this service.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn up(&self) -> Result<Void, DaggerError> {
-        let query = self.selection.select("up");
-        query.execute(self.graphql_client.clone()).await
-    }
-    /// Creates a tunnel that forwards traffic from the caller's network to this service.
-    ///
-    /// # Arguments
-    ///
-    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn up_opts(&self, opts: ServiceUpOpts) -> Result<Void, DaggerError> {
+    pub async fn up(
+        &self,
+    ) -> Result<Void, DaggerError> {
         let mut query = self.selection.select("up");
+
+        query.execute(self.graphql_client.clone()).await
+    }
+
+    /// Creates a tunnel that forwards traffic from the caller's network to this service.
+    ///
+
+    /// # Arguments
+
+    ///
+
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub async fn up_opts(
+        &self,
+        opts: ServiceUpOpts
+    ) -> Result<Void, DaggerError> {
+        let mut query = self.selection.select("up");
+
         if let Some(ports) = opts.ports {
             query = query.arg("ports", ports);
         }
         if let Some(random) = opts.random {
             query = query.arg("random", random);
         }
+
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -6066,12 +8073,16 @@ impl Service {
 pub struct Socket {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 impl Socket {
     /// A unique identifier for this Socket.
-    pub async fn id(&self) -> Result<SocketId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<SocketId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -6079,17 +8090,24 @@ impl Socket {
 pub struct Terminal {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 impl Terminal {
     /// A unique identifier for this Terminal.
-    pub async fn id(&self) -> Result<TerminalId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<TerminalId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// An http endpoint at which this terminal can be connected to over a websocket.
-    pub async fn websocket_endpoint(&self) -> Result<String, DaggerError> {
-        let query = self.selection.select("websocketEndpoint");
+    pub async fn websocket_endpoint(
+        &self,
+    ) -> Result<String, DaggerError> {
+        let mut query = self.selection.select("websocketEndpoint");
+
         query.execute(self.graphql_client.clone()).await
     }
 }
@@ -6097,28 +8115,36 @@ impl Terminal {
 pub struct TypeDef {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient,
+    pub graphql_client: DynGraphQLClient
 }
+
 #[derive(Builder, Debug, PartialEq)]
 pub struct TypeDefWithFieldOpts<'a> {
+
     /// A doc string for the field, if any
     #[builder(setter(into, strip_option), default)]
     pub description: Option<&'a str>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct TypeDefWithInterfaceOpts<'a> {
+
     #[builder(setter(into, strip_option), default)]
     pub description: Option<&'a str>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct TypeDefWithObjectOpts<'a> {
+
     #[builder(setter(into, strip_option), default)]
     pub description: Option<&'a str>,
 }
+
 impl TypeDef {
     /// If kind is INPUT, the input-specific type definition. If kind is not INPUT, this will be null.
-    pub fn as_input(&self) -> InputTypeDef {
-        let query = self.selection.select("asInput");
+    pub fn as_input(
+        &self,
+    ) -> InputTypeDef {
+        let mut query = self.selection.select("asInput");
+
         InputTypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -6126,8 +8152,11 @@ impl TypeDef {
         }
     }
     /// If kind is INTERFACE, the interface-specific type definition. If kind is not INTERFACE, this will be null.
-    pub fn as_interface(&self) -> InterfaceTypeDef {
-        let query = self.selection.select("asInterface");
+    pub fn as_interface(
+        &self,
+    ) -> InterfaceTypeDef {
+        let mut query = self.selection.select("asInterface");
+
         InterfaceTypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -6135,8 +8164,11 @@ impl TypeDef {
         }
     }
     /// If kind is LIST, the list-specific type definition. If kind is not LIST, this will be null.
-    pub fn as_list(&self) -> ListTypeDef {
-        let query = self.selection.select("asList");
+    pub fn as_list(
+        &self,
+    ) -> ListTypeDef {
+        let mut query = self.selection.select("asList");
+
         ListTypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -6144,8 +8176,11 @@ impl TypeDef {
         }
     }
     /// If kind is OBJECT, the object-specific type definition. If kind is not OBJECT, this will be null.
-    pub fn as_object(&self) -> ObjectTypeDef {
-        let query = self.selection.select("asObject");
+    pub fn as_object(
+        &self,
+    ) -> ObjectTypeDef {
+        let mut query = self.selection.select("asObject");
+
         ObjectTypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -6153,23 +8188,36 @@ impl TypeDef {
         }
     }
     /// A unique identifier for this TypeDef.
-    pub async fn id(&self) -> Result<TypeDefId, DaggerError> {
-        let query = self.selection.select("id");
+    pub async fn id(
+        &self,
+    ) -> Result<TypeDefId, DaggerError> {
+        let mut query = self.selection.select("id");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// The kind of type this is (e.g. primitive, list, object).
-    pub async fn kind(&self) -> Result<TypeDefKind, DaggerError> {
-        let query = self.selection.select("kind");
+    pub async fn kind(
+        &self,
+    ) -> Result<TypeDefKind, DaggerError> {
+        let mut query = self.selection.select("kind");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Whether this type can be set to null. Defaults to false.
-    pub async fn optional(&self) -> Result<bool, DaggerError> {
-        let query = self.selection.select("optional");
+    pub async fn optional(
+        &self,
+    ) -> Result<bool, DaggerError> {
+        let mut query = self.selection.select("optional");
+
         query.execute(self.graphql_client.clone()).await
     }
     /// Adds a function for constructing a new instance of an Object TypeDef, failing if the type is not an object.
-    pub fn with_constructor(&self, function: Function) -> TypeDef {
+    pub fn with_constructor(
+        &self,
+        function: Function,
+    ) -> TypeDef {
         let mut query = self.selection.select("withConstructor");
+
         query = query.arg_lazy(
             "function",
             Box::new(move || {
@@ -6177,6 +8225,7 @@ impl TypeDef {
                 Box::pin(async move { function.id().await.unwrap().quote() })
             }),
         );
+
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -6185,13 +8234,21 @@ impl TypeDef {
     }
     /// Adds a static field for an Object TypeDef, failing if the type is not an object.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - The name of the field in the object
     /// * `type_def` - The type of the field
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_field(&self, name: impl Into<String>, type_def: TypeDef) -> TypeDef {
+    pub fn with_field(
+        &self,
+        name: impl Into<String>,
+        type_def: TypeDef,
+    ) -> TypeDef {
         let mut query = self.selection.select("withField");
+
         query = query.arg("name", name.into());
         query = query.arg_lazy(
             "typeDef",
@@ -6200,16 +8257,21 @@ impl TypeDef {
                 Box::pin(async move { type_def.id().await.unwrap().quote() })
             }),
         );
+
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Adds a static field for an Object TypeDef, failing if the type is not an object.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `name` - The name of the field in the object
     /// * `type_def` - The type of the field
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
@@ -6217,9 +8279,10 @@ impl TypeDef {
         &self,
         name: impl Into<String>,
         type_def: TypeDef,
-        opts: TypeDefWithFieldOpts<'a>,
+        opts: TypeDefWithFieldOpts<'a>
     ) -> TypeDef {
         let mut query = self.selection.select("withField");
+
         query = query.arg("name", name.into());
         query = query.arg_lazy(
             "typeDef",
@@ -6231,6 +8294,7 @@ impl TypeDef {
         if let Some(description) = opts.description {
             query = query.arg("description", description);
         }
+
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -6238,8 +8302,12 @@ impl TypeDef {
         }
     }
     /// Adds a function for an Object or Interface TypeDef, failing if the type is not one of those kinds.
-    pub fn with_function(&self, function: Function) -> TypeDef {
+    pub fn with_function(
+        &self,
+        function: Function,
+    ) -> TypeDef {
         let mut query = self.selection.select("withFunction");
+
         query = query.arg_lazy(
             "function",
             Box::new(move || {
@@ -6247,6 +8315,7 @@ impl TypeDef {
                 Box::pin(async move { function.id().await.unwrap().quote() })
             }),
         );
+
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -6255,33 +8324,47 @@ impl TypeDef {
     }
     /// Returns a TypeDef of kind Interface with the provided name.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_interface(&self, name: impl Into<String>) -> TypeDef {
+    pub fn with_interface(
+        &self,
+        name: impl Into<String>,
+    ) -> TypeDef {
         let mut query = self.selection.select("withInterface");
+
         query = query.arg("name", name.into());
+
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Returns a TypeDef of kind Interface with the provided name.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_interface_opts<'a>(
         &self,
         name: impl Into<String>,
-        opts: TypeDefWithInterfaceOpts<'a>,
+        opts: TypeDefWithInterfaceOpts<'a>
     ) -> TypeDef {
         let mut query = self.selection.select("withInterface");
+
         query = query.arg("name", name.into());
         if let Some(description) = opts.description {
             query = query.arg("description", description);
         }
+
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -6289,9 +8372,14 @@ impl TypeDef {
         }
     }
     /// Sets the kind of the type.
-    pub fn with_kind(&self, kind: TypeDefKind) -> TypeDef {
+    pub fn with_kind(
+        &self,
+        kind: TypeDefKind,
+    ) -> TypeDef {
         let mut query = self.selection.select("withKind");
-        query = query.arg_enum("kind", kind);
+
+        query = query.arg("kind", kind);
+
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -6299,8 +8387,12 @@ impl TypeDef {
         }
     }
     /// Returns a TypeDef of kind List with the provided type for its elements.
-    pub fn with_list_of(&self, element_type: TypeDef) -> TypeDef {
+    pub fn with_list_of(
+        &self,
+        element_type: TypeDef,
+    ) -> TypeDef {
         let mut query = self.selection.select("withListOf");
+
         query = query.arg_lazy(
             "elementType",
             Box::new(move || {
@@ -6308,6 +8400,7 @@ impl TypeDef {
                 Box::pin(async move { element_type.id().await.unwrap().quote() })
             }),
         );
+
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -6317,34 +8410,48 @@ impl TypeDef {
     /// Returns a TypeDef of kind Object with the provided name.
     /// Note that an object's fields and functions may be omitted if the intent is only to refer to an object. This is how functions are able to return their own object, or any other circular reference.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_object(&self, name: impl Into<String>) -> TypeDef {
+    pub fn with_object(
+        &self,
+        name: impl Into<String>,
+    ) -> TypeDef {
         let mut query = self.selection.select("withObject");
+
         query = query.arg("name", name.into());
+
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
     }
+
     /// Returns a TypeDef of kind Object with the provided name.
     /// Note that an object's fields and functions may be omitted if the intent is only to refer to an object. This is how functions are able to return their own object, or any other circular reference.
     ///
+
     /// # Arguments
+
     ///
+
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_object_opts<'a>(
         &self,
         name: impl Into<String>,
-        opts: TypeDefWithObjectOpts<'a>,
+        opts: TypeDefWithObjectOpts<'a>
     ) -> TypeDef {
         let mut query = self.selection.select("withObject");
+
         query = query.arg("name", name.into());
         if let Some(description) = opts.description {
             query = query.arg("description", description);
         }
+
         TypeDef {
             proc: self.proc.clone(),
             selection: query,
@@ -6352,9 +8459,14 @@ impl TypeDef {
         }
     }
     /// Sets whether this type can be set to null.
-    pub fn with_optional(&self, optional: bool) -> TypeDef {
+    pub fn with_optional(
+        &self,
+        optional: bool,
+    ) -> TypeDef {
         let mut query = self.selection.select("withOptional");
+
         query = query.arg("optional", optional);
+
         TypeDef {
             proc: self.proc.clone(),
             selection: query,

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -726,15 +726,13 @@ pub struct PortForward {
 pub struct CacheVolume {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl CacheVolume {
     /// A unique identifier for this CacheVolume.
-    pub async fn id(
-        &self,
-    ) -> Result<CacheVolumeId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<CacheVolumeId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -743,12 +741,11 @@ impl CacheVolume {
 pub struct Container {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerAsTarballOpts {
-
     /// Force each layer of the image to use the specified compression algorithm.
     /// If this is unset, then if a layer already has a compressed blob in the engine's cache, that will be used (this can result in a mix of compression algorithms for different layers). If this is unset and a layer has no compressed blob in the engine's cache, then it will be compressed using Gzip.
     #[builder(setter(into, strip_option), default)]
@@ -764,7 +761,6 @@ pub struct ContainerAsTarballOpts {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerBuildOpts<'a> {
-
     /// Additional build arguments.
     #[builder(setter(into, strip_option), default)]
     pub build_args: Option<Vec<BuildArg>>,
@@ -782,7 +778,6 @@ pub struct ContainerBuildOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerExportOpts {
-
     /// Force each layer of the exported image to use the specified compression algorithm.
     /// If this is unset, then if a layer already has a compressed blob in the engine's cache, that will be used (this can result in a mix of compression algorithms for different layers). If this is unset and a layer has no compressed blob in the engine's cache, then it will be compressed using Gzip.
     #[builder(setter(into, strip_option), default)]
@@ -798,14 +793,12 @@ pub struct ContainerExportOpts {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerImportOpts<'a> {
-
     /// Identifies the tag to import from the archive, if the archive bundles multiple tags.
     #[builder(setter(into, strip_option), default)]
     pub tag: Option<&'a str>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerPipelineOpts<'a> {
-
     /// Description of the sub-pipeline.
     #[builder(setter(into, strip_option), default)]
     pub description: Option<&'a str>,
@@ -815,7 +808,6 @@ pub struct ContainerPipelineOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerPublishOpts {
-
     /// Force each layer of the published image to use the specified compression algorithm.
     /// If this is unset, then if a layer already has a compressed blob in the engine's cache, that will be used (this can result in a mix of compression algorithms for different layers). If this is unset and a layer has no compressed blob in the engine's cache, then it will be compressed using Gzip.
     #[builder(setter(into, strip_option), default)]
@@ -831,7 +823,6 @@ pub struct ContainerPublishOpts {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerTerminalOpts<'a> {
-
     /// If set, override the container's default terminal command and invoke these command arguments instead.
     #[builder(setter(into, strip_option), default)]
     pub cmd: Option<Vec<&'a str>>,
@@ -845,7 +836,6 @@ pub struct ContainerTerminalOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithDefaultTerminalCmdOpts {
-
     /// Provides Dagger access to the executed command.
     /// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
     #[builder(setter(into, strip_option), default)]
@@ -856,7 +846,6 @@ pub struct ContainerWithDefaultTerminalCmdOpts {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithDirectoryOpts<'a> {
-
     /// Patterns to exclude in the written directory (e.g. ["node_modules/**", ".gitignore", ".git/"]).
     #[builder(setter(into, strip_option), default)]
     pub exclude: Option<Vec<&'a str>>,
@@ -871,21 +860,18 @@ pub struct ContainerWithDirectoryOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithEntrypointOpts {
-
     /// Don't remove the default arguments when setting the entrypoint.
     #[builder(setter(into, strip_option), default)]
     pub keep_default_args: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithEnvVariableOpts {
-
     /// Replace `${VAR}` or `$VAR` in the value according to the current environment variables defined in the container (e.g., "/opt/bin:$PATH").
     #[builder(setter(into, strip_option), default)]
     pub expand: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithExecOpts<'a> {
-
     /// Provides Dagger access to the executed command.
     /// Do not use this option unless you trust the command being executed; the command being executed WILL BE GRANTED FULL ACCESS TO YOUR HOST FILESYSTEM.
     #[builder(setter(into, strip_option), default)]
@@ -908,7 +894,6 @@ pub struct ContainerWithExecOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithExposedPortOpts<'a> {
-
     /// Optional port description
     #[builder(setter(into, strip_option), default)]
     pub description: Option<&'a str>,
@@ -921,7 +906,6 @@ pub struct ContainerWithExposedPortOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithFileOpts<'a> {
-
     /// A user:group to set for the file.
     /// The user and group can either be an ID (1000:1000) or a name (foo:bar).
     /// If the group is omitted, it defaults to the same as the user.
@@ -933,7 +917,6 @@ pub struct ContainerWithFileOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithFilesOpts<'a> {
-
     /// A user:group to set for the files.
     /// The user and group can either be an ID (1000:1000) or a name (foo:bar).
     /// If the group is omitted, it defaults to the same as the user.
@@ -945,7 +928,6 @@ pub struct ContainerWithFilesOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithMountedCacheOpts<'a> {
-
     /// A user:group to set for the mounted cache directory.
     /// Note that this changes the ownership of the specified mount along with the initial filesystem provided by source (if any). It does not have any effect if/when the cache has already been created.
     /// The user and group can either be an ID (1000:1000) or a name (foo:bar).
@@ -961,7 +943,6 @@ pub struct ContainerWithMountedCacheOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithMountedDirectoryOpts<'a> {
-
     /// A user:group to set for the mounted directory and its contents.
     /// The user and group can either be an ID (1000:1000) or a name (foo:bar).
     /// If the group is omitted, it defaults to the same as the user.
@@ -970,7 +951,6 @@ pub struct ContainerWithMountedDirectoryOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithMountedFileOpts<'a> {
-
     /// A user or user:group to set for the mounted file.
     /// The user and group can either be an ID (1000:1000) or a name (foo:bar).
     /// If the group is omitted, it defaults to the same as the user.
@@ -979,7 +959,6 @@ pub struct ContainerWithMountedFileOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithMountedSecretOpts<'a> {
-
     /// Permission given to the mounted secret (e.g., 0600).
     /// This option requires an owner to be set to be active.
     #[builder(setter(into, strip_option), default)]
@@ -992,7 +971,6 @@ pub struct ContainerWithMountedSecretOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithNewFileOpts<'a> {
-
     /// Content of the file to write (e.g., "Hello world!").
     #[builder(setter(into, strip_option), default)]
     pub contents: Option<&'a str>,
@@ -1007,7 +985,6 @@ pub struct ContainerWithNewFileOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithUnixSocketOpts<'a> {
-
     /// A user:group to set for the mounted socket.
     /// The user and group can either be an ID (1000:1000) or a name (foo:bar).
     /// If the group is omitted, it defaults to the same as the user.
@@ -1016,14 +993,12 @@ pub struct ContainerWithUnixSocketOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithoutEntrypointOpts {
-
     /// Don't remove the default arguments when unsetting the entrypoint.
     #[builder(setter(into, strip_option), default)]
     pub keep_default_args: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithoutExposedPortOpts {
-
     /// Port protocol to unexpose
     #[builder(setter(into, strip_option), default)]
     pub protocol: Option<NetworkProtocol>,
@@ -1032,10 +1007,8 @@ pub struct ContainerWithoutExposedPortOpts {
 impl Container {
     /// Turn the container into a Service.
     /// Be sure to set any exposed ports before this conversion.
-    pub fn as_service(
-        &self,
-    ) -> Service {
-        let mut query = self.selection.select("asService");
+    pub fn as_service(&self) -> Service {
+        let query = self.selection.select("asService");
 
         Service {
             proc: self.proc.clone(),
@@ -1051,10 +1024,8 @@ impl Container {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn as_tarball(
-        &self,
-    ) -> File {
-        let mut query = self.selection.select("asTarball");
+    pub fn as_tarball(&self) -> File {
+        let query = self.selection.select("asTarball");
 
         File {
             proc: self.proc.clone(),
@@ -1071,10 +1042,7 @@ impl Container {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn as_tarball_opts(
-        &self,
-        opts: ContainerAsTarballOpts
-    ) -> File {
+    pub fn as_tarball_opts(&self, opts: ContainerAsTarballOpts) -> File {
         let mut query = self.selection.select("asTarball");
 
         if let Some(platform_variants) = opts.platform_variants {
@@ -1102,10 +1070,7 @@ impl Container {
 
     /// * `context` - Directory context used by the Dockerfile.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn build(
-        &self,
-        context: Directory,
-    ) -> Container {
+    pub fn build(&self, context: Directory) -> Container {
         let mut query = self.selection.select("build");
 
         query = query.arg_lazy(
@@ -1132,11 +1097,7 @@ impl Container {
 
     /// * `context` - Directory context used by the Dockerfile.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn build_opts<'a>(
-        &self,
-        context: Directory,
-        opts: ContainerBuildOpts<'a>
-    ) -> Container {
+    pub fn build_opts<'a>(&self, context: Directory, opts: ContainerBuildOpts<'a>) -> Container {
         let mut query = self.selection.select("build");
 
         query = query.arg_lazy(
@@ -1166,10 +1127,8 @@ impl Container {
         }
     }
     /// Retrieves default arguments for future commands.
-    pub async fn default_args(
-        &self,
-    ) -> Result<Vec<String>, DaggerError> {
-        let mut query = self.selection.select("defaultArgs");
+    pub async fn default_args(&self) -> Result<Vec<String>, DaggerError> {
+        let query = self.selection.select("defaultArgs");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -1182,10 +1141,7 @@ impl Container {
     ///
 
     /// * `path` - The path of the directory to retrieve (e.g., "./src").
-    pub fn directory(
-        &self,
-        path: impl Into<String>,
-    ) -> Directory {
+    pub fn directory(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("directory");
 
         query = query.arg("path", path.into());
@@ -1197,10 +1153,8 @@ impl Container {
         }
     }
     /// Retrieves entrypoint to be prepended to the arguments of all commands.
-    pub async fn entrypoint(
-        &self,
-    ) -> Result<Vec<String>, DaggerError> {
-        let mut query = self.selection.select("entrypoint");
+    pub async fn entrypoint(&self) -> Result<Vec<String>, DaggerError> {
+        let query = self.selection.select("entrypoint");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -1212,10 +1166,7 @@ impl Container {
     ///
 
     /// * `name` - The name of the environment variable to retrieve (e.g., "PATH").
-    pub async fn env_variable(
-        &self,
-        name: impl Into<String>,
-    ) -> Result<String, DaggerError> {
+    pub async fn env_variable(&self, name: impl Into<String>) -> Result<String, DaggerError> {
         let mut query = self.selection.select("envVariable");
 
         query = query.arg("name", name.into());
@@ -1223,24 +1174,20 @@ impl Container {
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the list of environment variables passed to commands.
-    pub fn env_variables(
-        &self,
-    ) -> Vec<EnvVariable> {
-        let mut query = self.selection.select("envVariables");
+    pub fn env_variables(&self) -> Vec<EnvVariable> {
+        let query = self.selection.select("envVariables");
 
         return vec![EnvVariable {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }]
+        }];
     }
     /// EXPERIMENTAL API! Subject to change/removal at any time.
     /// Configures all available GPUs on the host to be accessible to this container.
     /// This currently works for Nvidia devices only.
-    pub fn experimental_with_all_gp_us(
-        &self,
-    ) -> Container {
-        let mut query = self.selection.select("experimentalWithAllGPUs");
+    pub fn experimental_with_all_gp_us(&self) -> Container {
+        let query = self.selection.select("experimentalWithAllGPUs");
 
         Container {
             proc: self.proc.clone(),
@@ -1258,13 +1205,16 @@ impl Container {
     ///
 
     /// * `devices` - List of devices to be accessible to this container.
-    pub fn experimental_with_gpu(
-        &self,
-        devices: Vec<impl Into<String>>,
-    ) -> Container {
+    pub fn experimental_with_gpu(&self, devices: Vec<impl Into<String>>) -> Container {
         let mut query = self.selection.select("experimentalWithGPU");
 
-        query = query.arg("devices", devices.into_iter().map(|i| i.into()).collect::<Vec<String>>());
+        query = query.arg(
+            "devices",
+            devices
+                .into_iter()
+                .map(|i| i.into())
+                .collect::<Vec<String>>(),
+        );
 
         Container {
             proc: self.proc.clone(),
@@ -1282,13 +1232,10 @@ impl Container {
     ///
 
     /// * `path` - Host's destination path (e.g., "./tarball").
-    /// 
+    ///
     /// Path can be relative to the engine's workdir or absolute.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn export(
-        &self,
-        path: impl Into<String>,
-    ) -> Result<bool, DaggerError> {
+    pub async fn export(&self, path: impl Into<String>) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
 
         query = query.arg("path", path.into());
@@ -1306,13 +1253,13 @@ impl Container {
     ///
 
     /// * `path` - Host's destination path (e.g., "./tarball").
-    /// 
+    ///
     /// Path can be relative to the engine's workdir or absolute.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn export_opts(
         &self,
         path: impl Into<String>,
-        opts: ContainerExportOpts
+        opts: ContainerExportOpts,
     ) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
 
@@ -1331,16 +1278,14 @@ impl Container {
     }
     /// Retrieves the list of exposed ports.
     /// This includes ports already exposed by the image, even if not explicitly added with dagger.
-    pub fn exposed_ports(
-        &self,
-    ) -> Vec<Port> {
-        let mut query = self.selection.select("exposedPorts");
+    pub fn exposed_ports(&self) -> Vec<Port> {
+        let query = self.selection.select("exposedPorts");
 
         return vec![Port {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }]
+        }];
     }
     /// Retrieves a file at the given path.
     /// Mounts are included.
@@ -1351,10 +1296,7 @@ impl Container {
     ///
 
     /// * `path` - The path of the file to retrieve (e.g., "./README.md").
-    pub fn file(
-        &self,
-        path: impl Into<String>,
-    ) -> File {
+    pub fn file(&self, path: impl Into<String>) -> File {
         let mut query = self.selection.select("file");
 
         query = query.arg("path", path.into());
@@ -1373,12 +1315,9 @@ impl Container {
     ///
 
     /// * `address` - Image's address from its registry.
-    /// 
+    ///
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g., "docker.io/dagger/dagger:main").
-    pub fn from(
-        &self,
-        address: impl Into<String>,
-    ) -> Container {
+    pub fn from(&self, address: impl Into<String>) -> Container {
         let mut query = self.selection.select("from");
 
         query = query.arg("address", address.into());
@@ -1390,18 +1329,14 @@ impl Container {
         }
     }
     /// A unique identifier for this Container.
-    pub async fn id(
-        &self,
-    ) -> Result<ContainerId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<ContainerId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The unique image reference which can only be retrieved immediately after the 'Container.From' call.
-    pub async fn image_ref(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("imageRef");
+    pub async fn image_ref(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("imageRef");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -1414,10 +1349,7 @@ impl Container {
 
     /// * `source` - File to read the container from.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn import(
-        &self,
-        source: File,
-    ) -> Container {
+    pub fn import(&self, source: File) -> Container {
         let mut query = self.selection.select("import");
 
         query = query.arg_lazy(
@@ -1444,11 +1376,7 @@ impl Container {
 
     /// * `source` - File to read the container from.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn import_opts<'a>(
-        &self,
-        source: File,
-        opts: ContainerImportOpts<'a>
-    ) -> Container {
+    pub fn import_opts<'a>(&self, source: File, opts: ContainerImportOpts<'a>) -> Container {
         let mut query = self.selection.select("import");
 
         query = query.arg_lazy(
@@ -1476,10 +1404,7 @@ impl Container {
     ///
 
     /// * `name` - The name of the label (e.g., "org.opencontainers.artifact.created").
-    pub async fn label(
-        &self,
-        name: impl Into<String>,
-    ) -> Result<String, DaggerError> {
+    pub async fn label(&self, name: impl Into<String>) -> Result<String, DaggerError> {
         let mut query = self.selection.select("label");
 
         query = query.arg("name", name.into());
@@ -1487,22 +1412,18 @@ impl Container {
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the list of labels passed to container.
-    pub fn labels(
-        &self,
-    ) -> Vec<Label> {
-        let mut query = self.selection.select("labels");
+    pub fn labels(&self) -> Vec<Label> {
+        let query = self.selection.select("labels");
 
         return vec![Label {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }]
+        }];
     }
     /// Retrieves the list of paths where a directory is mounted.
-    pub async fn mounts(
-        &self,
-    ) -> Result<Vec<String>, DaggerError> {
-        let mut query = self.selection.select("mounts");
+    pub async fn mounts(&self) -> Result<Vec<String>, DaggerError> {
+        let query = self.selection.select("mounts");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -1515,10 +1436,7 @@ impl Container {
 
     /// * `name` - Name of the sub-pipeline.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn pipeline(
-        &self,
-        name: impl Into<String>,
-    ) -> Container {
+    pub fn pipeline(&self, name: impl Into<String>) -> Container {
         let mut query = self.selection.select("pipeline");
 
         query = query.arg("name", name.into());
@@ -1542,7 +1460,7 @@ impl Container {
     pub fn pipeline_opts<'a>(
         &self,
         name: impl Into<String>,
-        opts: ContainerPipelineOpts<'a>
+        opts: ContainerPipelineOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("pipeline");
 
@@ -1561,10 +1479,8 @@ impl Container {
         }
     }
     /// The platform this container executes and publishes as.
-    pub async fn platform(
-        &self,
-    ) -> Result<Platform, DaggerError> {
-        let mut query = self.selection.select("platform");
+    pub async fn platform(&self) -> Result<Platform, DaggerError> {
+        let query = self.selection.select("platform");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -1578,13 +1494,10 @@ impl Container {
     ///
 
     /// * `address` - Registry's address to publish the image to.
-    /// 
+    ///
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g. "docker.io/dagger/dagger:main").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn publish(
-        &self,
-        address: impl Into<String>,
-    ) -> Result<String, DaggerError> {
+    pub async fn publish(&self, address: impl Into<String>) -> Result<String, DaggerError> {
         let mut query = self.selection.select("publish");
 
         query = query.arg("address", address.into());
@@ -1602,13 +1515,13 @@ impl Container {
     ///
 
     /// * `address` - Registry's address to publish the image to.
-    /// 
+    ///
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g. "docker.io/dagger/dagger:main").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn publish_opts(
         &self,
         address: impl Into<String>,
-        opts: ContainerPublishOpts
+        opts: ContainerPublishOpts,
     ) -> Result<String, DaggerError> {
         let mut query = self.selection.select("publish");
 
@@ -1626,10 +1539,8 @@ impl Container {
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves this container's root filesystem. Mounts are not included.
-    pub fn rootfs(
-        &self,
-    ) -> Directory {
-        let mut query = self.selection.select("rootfs");
+    pub fn rootfs(&self) -> Directory {
+        let query = self.selection.select("rootfs");
 
         Directory {
             proc: self.proc.clone(),
@@ -1639,28 +1550,22 @@ impl Container {
     }
     /// The error stream of the last executed command.
     /// Will execute default command if none is set, or error if there's no default.
-    pub async fn stderr(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("stderr");
+    pub async fn stderr(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("stderr");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The output stream of the last executed command.
     /// Will execute default command if none is set, or error if there's no default.
-    pub async fn stdout(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("stdout");
+    pub async fn stdout(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("stdout");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// Forces evaluation of the pipeline in the engine.
     /// It doesn't run the default command if no exec has been set.
-    pub async fn sync(
-        &self,
-    ) -> Result<ContainerId, DaggerError> {
-        let mut query = self.selection.select("sync");
+    pub async fn sync(&self) -> Result<ContainerId, DaggerError> {
+        let query = self.selection.select("sync");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -1672,10 +1577,8 @@ impl Container {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn terminal(
-        &self,
-    ) -> Terminal {
-        let mut query = self.selection.select("terminal");
+    pub fn terminal(&self) -> Terminal {
+        let query = self.selection.select("terminal");
 
         Terminal {
             proc: self.proc.clone(),
@@ -1692,17 +1595,17 @@ impl Container {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn terminal_opts<'a>(
-        &self,
-        opts: ContainerTerminalOpts<'a>
-    ) -> Terminal {
+    pub fn terminal_opts<'a>(&self, opts: ContainerTerminalOpts<'a>) -> Terminal {
         let mut query = self.selection.select("terminal");
 
         if let Some(cmd) = opts.cmd {
             query = query.arg("cmd", cmd);
         }
         if let Some(experimental_privileged_nesting) = opts.experimental_privileged_nesting {
-            query = query.arg("experimentalPrivilegedNesting", experimental_privileged_nesting);
+            query = query.arg(
+                "experimentalPrivilegedNesting",
+                experimental_privileged_nesting,
+            );
         }
         if let Some(insecure_root_capabilities) = opts.insecure_root_capabilities {
             query = query.arg("insecureRootCapabilities", insecure_root_capabilities);
@@ -1715,10 +1618,8 @@ impl Container {
         }
     }
     /// Retrieves the user to be set for all commands.
-    pub async fn user(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("user");
+    pub async fn user(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("user");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -1730,13 +1631,13 @@ impl Container {
     ///
 
     /// * `args` - Arguments to prepend to future executions (e.g., ["-v", "--no-cache"]).
-    pub fn with_default_args(
-        &self,
-        args: Vec<impl Into<String>>,
-    ) -> Container {
+    pub fn with_default_args(&self, args: Vec<impl Into<String>>) -> Container {
         let mut query = self.selection.select("withDefaultArgs");
 
-        query = query.arg("args", args.into_iter().map(|i| i.into()).collect::<Vec<String>>());
+        query = query.arg(
+            "args",
+            args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
+        );
 
         Container {
             proc: self.proc.clone(),
@@ -1753,13 +1654,13 @@ impl Container {
 
     /// * `args` - The args of the command.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_default_terminal_cmd(
-        &self,
-        args: Vec<impl Into<String>>,
-    ) -> Container {
+    pub fn with_default_terminal_cmd(&self, args: Vec<impl Into<String>>) -> Container {
         let mut query = self.selection.select("withDefaultTerminalCmd");
 
-        query = query.arg("args", args.into_iter().map(|i| i.into()).collect::<Vec<String>>());
+        query = query.arg(
+            "args",
+            args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
+        );
 
         Container {
             proc: self.proc.clone(),
@@ -1780,13 +1681,19 @@ impl Container {
     pub fn with_default_terminal_cmd_opts(
         &self,
         args: Vec<impl Into<String>>,
-        opts: ContainerWithDefaultTerminalCmdOpts
+        opts: ContainerWithDefaultTerminalCmdOpts,
     ) -> Container {
         let mut query = self.selection.select("withDefaultTerminalCmd");
 
-        query = query.arg("args", args.into_iter().map(|i| i.into()).collect::<Vec<String>>());
+        query = query.arg(
+            "args",
+            args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
+        );
         if let Some(experimental_privileged_nesting) = opts.experimental_privileged_nesting {
-            query = query.arg("experimentalPrivilegedNesting", experimental_privileged_nesting);
+            query = query.arg(
+                "experimentalPrivilegedNesting",
+                experimental_privileged_nesting,
+            );
         }
         if let Some(insecure_root_capabilities) = opts.insecure_root_capabilities {
             query = query.arg("insecureRootCapabilities", insecure_root_capabilities);
@@ -1808,11 +1715,7 @@ impl Container {
     /// * `path` - Location of the written directory (e.g., "/tmp/directory").
     /// * `directory` - Identifier of the directory to write
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_directory(
-        &self,
-        path: impl Into<String>,
-        directory: Directory,
-    ) -> Container {
+    pub fn with_directory(&self, path: impl Into<String>, directory: Directory) -> Container {
         let mut query = self.selection.select("withDirectory");
 
         query = query.arg("path", path.into());
@@ -1845,7 +1748,7 @@ impl Container {
         &self,
         path: impl Into<String>,
         directory: Directory,
-        opts: ContainerWithDirectoryOpts<'a>
+        opts: ContainerWithDirectoryOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withDirectory");
 
@@ -1882,13 +1785,13 @@ impl Container {
 
     /// * `args` - Entrypoint to use for future executions (e.g., ["go", "run"]).
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_entrypoint(
-        &self,
-        args: Vec<impl Into<String>>,
-    ) -> Container {
+    pub fn with_entrypoint(&self, args: Vec<impl Into<String>>) -> Container {
         let mut query = self.selection.select("withEntrypoint");
 
-        query = query.arg("args", args.into_iter().map(|i| i.into()).collect::<Vec<String>>());
+        query = query.arg(
+            "args",
+            args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
+        );
 
         Container {
             proc: self.proc.clone(),
@@ -1909,11 +1812,14 @@ impl Container {
     pub fn with_entrypoint_opts(
         &self,
         args: Vec<impl Into<String>>,
-        opts: ContainerWithEntrypointOpts
+        opts: ContainerWithEntrypointOpts,
     ) -> Container {
         let mut query = self.selection.select("withEntrypoint");
 
-        query = query.arg("args", args.into_iter().map(|i| i.into()).collect::<Vec<String>>());
+        query = query.arg(
+            "args",
+            args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
+        );
         if let Some(keep_default_args) = opts.keep_default_args {
             query = query.arg("keepDefaultArgs", keep_default_args);
         }
@@ -1965,7 +1871,7 @@ impl Container {
         &self,
         name: impl Into<String>,
         value: impl Into<String>,
-        opts: ContainerWithEnvVariableOpts
+        opts: ContainerWithEnvVariableOpts,
     ) -> Container {
         let mut query = self.selection.select("withEnvVariable");
 
@@ -1989,16 +1895,16 @@ impl Container {
     ///
 
     /// * `args` - Command to run instead of the container's default command (e.g., ["run", "main.go"]).
-    /// 
+    ///
     /// If empty, the container's default command is used.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_exec(
-        &self,
-        args: Vec<impl Into<String>>,
-    ) -> Container {
+    pub fn with_exec(&self, args: Vec<impl Into<String>>) -> Container {
         let mut query = self.selection.select("withExec");
 
-        query = query.arg("args", args.into_iter().map(|i| i.into()).collect::<Vec<String>>());
+        query = query.arg(
+            "args",
+            args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
+        );
 
         Container {
             proc: self.proc.clone(),
@@ -2015,17 +1921,20 @@ impl Container {
     ///
 
     /// * `args` - Command to run instead of the container's default command (e.g., ["run", "main.go"]).
-    /// 
+    ///
     /// If empty, the container's default command is used.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub fn with_exec_opts<'a>(
         &self,
         args: Vec<impl Into<String>>,
-        opts: ContainerWithExecOpts<'a>
+        opts: ContainerWithExecOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withExec");
 
-        query = query.arg("args", args.into_iter().map(|i| i.into()).collect::<Vec<String>>());
+        query = query.arg(
+            "args",
+            args.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
+        );
         if let Some(skip_entrypoint) = opts.skip_entrypoint {
             query = query.arg("skipEntrypoint", skip_entrypoint);
         }
@@ -2039,7 +1948,10 @@ impl Container {
             query = query.arg("redirectStderr", redirect_stderr);
         }
         if let Some(experimental_privileged_nesting) = opts.experimental_privileged_nesting {
-            query = query.arg("experimentalPrivilegedNesting", experimental_privileged_nesting);
+            query = query.arg(
+                "experimentalPrivilegedNesting",
+                experimental_privileged_nesting,
+            );
         }
         if let Some(insecure_root_capabilities) = opts.insecure_root_capabilities {
             query = query.arg("insecureRootCapabilities", insecure_root_capabilities);
@@ -2063,10 +1975,7 @@ impl Container {
 
     /// * `port` - Port number to expose
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_exposed_port(
-        &self,
-        port: isize,
-    ) -> Container {
+    pub fn with_exposed_port(&self, port: isize) -> Container {
         let mut query = self.selection.select("withExposedPort");
 
         query = query.arg("port", port);
@@ -2093,7 +2002,7 @@ impl Container {
     pub fn with_exposed_port_opts<'a>(
         &self,
         port: isize,
-        opts: ContainerWithExposedPortOpts<'a>
+        opts: ContainerWithExposedPortOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withExposedPort");
 
@@ -2124,11 +2033,7 @@ impl Container {
     /// * `path` - Location of the copied file (e.g., "/tmp/file.txt").
     /// * `source` - Identifier of the file to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_file(
-        &self,
-        path: impl Into<String>,
-        source: File,
-    ) -> Container {
+    pub fn with_file(&self, path: impl Into<String>, source: File) -> Container {
         let mut query = self.selection.select("withFile");
 
         query = query.arg("path", path.into());
@@ -2161,7 +2066,7 @@ impl Container {
         &self,
         path: impl Into<String>,
         source: File,
-        opts: ContainerWithFileOpts<'a>
+        opts: ContainerWithFileOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withFile");
 
@@ -2196,11 +2101,7 @@ impl Container {
     /// * `path` - Location where copied files should be placed (e.g., "/src").
     /// * `sources` - Identifiers of the files to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_files(
-        &self,
-        path: impl Into<String>,
-        sources: Vec<FileId>,
-    ) -> Container {
+    pub fn with_files(&self, path: impl Into<String>, sources: Vec<FileId>) -> Container {
         let mut query = self.selection.select("withFiles");
 
         query = query.arg("path", path.into());
@@ -2227,7 +2128,7 @@ impl Container {
         &self,
         path: impl Into<String>,
         sources: Vec<FileId>,
-        opts: ContainerWithFilesOpts<'a>
+        opts: ContainerWithFilesOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withFiles");
 
@@ -2247,10 +2148,8 @@ impl Container {
         }
     }
     /// Indicate that subsequent operations should be featured more prominently in the UI.
-    pub fn with_focus(
-        &self,
-    ) -> Container {
-        let mut query = self.selection.select("withFocus");
+    pub fn with_focus(&self) -> Container {
+        let query = self.selection.select("withFocus");
 
         Container {
             proc: self.proc.clone(),
@@ -2267,11 +2166,7 @@ impl Container {
 
     /// * `name` - The name of the label (e.g., "org.opencontainers.artifact.created").
     /// * `value` - The value of the label (e.g., "2023-01-01T00:00:00Z").
-    pub fn with_label(
-        &self,
-        name: impl Into<String>,
-        value: impl Into<String>,
-    ) -> Container {
+    pub fn with_label(&self, name: impl Into<String>, value: impl Into<String>) -> Container {
         let mut query = self.selection.select("withLabel");
 
         query = query.arg("name", name.into());
@@ -2293,11 +2188,7 @@ impl Container {
     /// * `path` - Location of the cache directory (e.g., "/cache/node_modules").
     /// * `cache` - Identifier of the cache volume to mount.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_mounted_cache(
-        &self,
-        path: impl Into<String>,
-        cache: CacheVolume,
-    ) -> Container {
+    pub fn with_mounted_cache(&self, path: impl Into<String>, cache: CacheVolume) -> Container {
         let mut query = self.selection.select("withMountedCache");
 
         query = query.arg("path", path.into());
@@ -2330,7 +2221,7 @@ impl Container {
         &self,
         path: impl Into<String>,
         cache: CacheVolume,
-        opts: ContainerWithMountedCacheOpts<'a>
+        opts: ContainerWithMountedCacheOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withMountedCache");
 
@@ -2368,11 +2259,7 @@ impl Container {
     /// * `path` - Location of the mounted directory (e.g., "/mnt/directory").
     /// * `source` - Identifier of the mounted directory.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_mounted_directory(
-        &self,
-        path: impl Into<String>,
-        source: Directory,
-    ) -> Container {
+    pub fn with_mounted_directory(&self, path: impl Into<String>, source: Directory) -> Container {
         let mut query = self.selection.select("withMountedDirectory");
 
         query = query.arg("path", path.into());
@@ -2405,7 +2292,7 @@ impl Container {
         &self,
         path: impl Into<String>,
         source: Directory,
-        opts: ContainerWithMountedDirectoryOpts<'a>
+        opts: ContainerWithMountedDirectoryOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withMountedDirectory");
 
@@ -2437,11 +2324,7 @@ impl Container {
     /// * `path` - Location of the mounted file (e.g., "/tmp/file.txt").
     /// * `source` - Identifier of the mounted file.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_mounted_file(
-        &self,
-        path: impl Into<String>,
-        source: File,
-    ) -> Container {
+    pub fn with_mounted_file(&self, path: impl Into<String>, source: File) -> Container {
         let mut query = self.selection.select("withMountedFile");
 
         query = query.arg("path", path.into());
@@ -2474,7 +2357,7 @@ impl Container {
         &self,
         path: impl Into<String>,
         source: File,
-        opts: ContainerWithMountedFileOpts<'a>
+        opts: ContainerWithMountedFileOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withMountedFile");
 
@@ -2506,11 +2389,7 @@ impl Container {
     /// * `path` - Location of the secret file (e.g., "/tmp/secret.txt").
     /// * `source` - Identifier of the secret to mount.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_mounted_secret(
-        &self,
-        path: impl Into<String>,
-        source: Secret,
-    ) -> Container {
+    pub fn with_mounted_secret(&self, path: impl Into<String>, source: Secret) -> Container {
         let mut query = self.selection.select("withMountedSecret");
 
         query = query.arg("path", path.into());
@@ -2543,7 +2422,7 @@ impl Container {
         &self,
         path: impl Into<String>,
         source: Secret,
-        opts: ContainerWithMountedSecretOpts<'a>
+        opts: ContainerWithMountedSecretOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withMountedSecret");
 
@@ -2576,10 +2455,7 @@ impl Container {
     ///
 
     /// * `path` - Location of the temporary directory (e.g., "/tmp/temp_dir").
-    pub fn with_mounted_temp(
-        &self,
-        path: impl Into<String>,
-    ) -> Container {
+    pub fn with_mounted_temp(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withMountedTemp");
 
         query = query.arg("path", path.into());
@@ -2599,10 +2475,7 @@ impl Container {
 
     /// * `path` - Location of the written file (e.g., "/tmp/file.txt").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_new_file(
-        &self,
-        path: impl Into<String>,
-    ) -> Container {
+    pub fn with_new_file(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withNewFile");
 
         query = query.arg("path", path.into());
@@ -2626,7 +2499,7 @@ impl Container {
     pub fn with_new_file_opts<'a>(
         &self,
         path: impl Into<String>,
-        opts: ContainerWithNewFileOpts<'a>
+        opts: ContainerWithNewFileOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withNewFile");
 
@@ -2655,7 +2528,7 @@ impl Container {
     ///
 
     /// * `address` - Registry's address to bind the authentication to.
-    /// 
+    ///
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g. docker.io/dagger/dagger:main).
     /// * `username` - The username of the registry's account (e.g., "Dagger").
     /// * `secret` - The API key, password or token to authenticate to this registry.
@@ -2691,10 +2564,7 @@ impl Container {
     ///
 
     /// * `directory` - Directory to mount.
-    pub fn with_rootfs(
-        &self,
-        directory: Directory,
-    ) -> Container {
+    pub fn with_rootfs(&self, directory: Directory) -> Container {
         let mut query = self.selection.select("withRootfs");
 
         query = query.arg_lazy(
@@ -2720,11 +2590,7 @@ impl Container {
 
     /// * `name` - The name of the secret variable (e.g., "API_SECRET").
     /// * `secret` - The identifier of the secret value.
-    pub fn with_secret_variable(
-        &self,
-        name: impl Into<String>,
-        secret: Secret,
-    ) -> Container {
+    pub fn with_secret_variable(&self, name: impl Into<String>, secret: Secret) -> Container {
         let mut query = self.selection.select("withSecretVariable");
 
         query = query.arg("name", name.into());
@@ -2754,11 +2620,7 @@ impl Container {
 
     /// * `alias` - A name that can be used to reach the service from the container
     /// * `service` - Identifier of the service container
-    pub fn with_service_binding(
-        &self,
-        alias: impl Into<String>,
-        service: Service,
-    ) -> Container {
+    pub fn with_service_binding(&self, alias: impl Into<String>, service: Service) -> Container {
         let mut query = self.selection.select("withServiceBinding");
 
         query = query.arg("alias", alias.into());
@@ -2786,11 +2648,7 @@ impl Container {
     /// * `path` - Location of the forwarded Unix socket (e.g., "/tmp/socket").
     /// * `source` - Identifier of the socket to forward.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_unix_socket(
-        &self,
-        path: impl Into<String>,
-        source: Socket,
-    ) -> Container {
+    pub fn with_unix_socket(&self, path: impl Into<String>, source: Socket) -> Container {
         let mut query = self.selection.select("withUnixSocket");
 
         query = query.arg("path", path.into());
@@ -2823,7 +2681,7 @@ impl Container {
         &self,
         path: impl Into<String>,
         source: Socket,
-        opts: ContainerWithUnixSocketOpts<'a>
+        opts: ContainerWithUnixSocketOpts<'a>,
     ) -> Container {
         let mut query = self.selection.select("withUnixSocket");
 
@@ -2853,10 +2711,7 @@ impl Container {
     ///
 
     /// * `name` - The user to set (e.g., "root").
-    pub fn with_user(
-        &self,
-        name: impl Into<String>,
-    ) -> Container {
+    pub fn with_user(&self, name: impl Into<String>) -> Container {
         let mut query = self.selection.select("withUser");
 
         query = query.arg("name", name.into());
@@ -2875,10 +2730,7 @@ impl Container {
     ///
 
     /// * `path` - The path to set as the working directory (e.g., "/app").
-    pub fn with_workdir(
-        &self,
-        path: impl Into<String>,
-    ) -> Container {
+    pub fn with_workdir(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withWorkdir");
 
         query = query.arg("path", path.into());
@@ -2890,10 +2742,8 @@ impl Container {
         }
     }
     /// Retrieves this container with unset default arguments for future commands.
-    pub fn without_default_args(
-        &self,
-    ) -> Container {
-        let mut query = self.selection.select("withoutDefaultArgs");
+    pub fn without_default_args(&self) -> Container {
+        let query = self.selection.select("withoutDefaultArgs");
 
         Container {
             proc: self.proc.clone(),
@@ -2909,10 +2759,8 @@ impl Container {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn without_entrypoint(
-        &self,
-    ) -> Container {
-        let mut query = self.selection.select("withoutEntrypoint");
+    pub fn without_entrypoint(&self) -> Container {
+        let query = self.selection.select("withoutEntrypoint");
 
         Container {
             proc: self.proc.clone(),
@@ -2929,10 +2777,7 @@ impl Container {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn without_entrypoint_opts(
-        &self,
-        opts: ContainerWithoutEntrypointOpts
-    ) -> Container {
+    pub fn without_entrypoint_opts(&self, opts: ContainerWithoutEntrypointOpts) -> Container {
         let mut query = self.selection.select("withoutEntrypoint");
 
         if let Some(keep_default_args) = opts.keep_default_args {
@@ -2953,10 +2798,7 @@ impl Container {
     ///
 
     /// * `name` - The name of the environment variable (e.g., "HOST").
-    pub fn without_env_variable(
-        &self,
-        name: impl Into<String>,
-    ) -> Container {
+    pub fn without_env_variable(&self, name: impl Into<String>) -> Container {
         let mut query = self.selection.select("withoutEnvVariable");
 
         query = query.arg("name", name.into());
@@ -2976,10 +2818,7 @@ impl Container {
 
     /// * `port` - Port number to unexpose
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn without_exposed_port(
-        &self,
-        port: isize,
-    ) -> Container {
+    pub fn without_exposed_port(&self, port: isize) -> Container {
         let mut query = self.selection.select("withoutExposedPort");
 
         query = query.arg("port", port);
@@ -3003,7 +2842,7 @@ impl Container {
     pub fn without_exposed_port_opts(
         &self,
         port: isize,
-        opts: ContainerWithoutExposedPortOpts
+        opts: ContainerWithoutExposedPortOpts,
     ) -> Container {
         let mut query = self.selection.select("withoutExposedPort");
 
@@ -3020,10 +2859,8 @@ impl Container {
     }
     /// Indicate that subsequent operations should not be featured more prominently in the UI.
     /// This is the initial state of all containers.
-    pub fn without_focus(
-        &self,
-    ) -> Container {
-        let mut query = self.selection.select("withoutFocus");
+    pub fn without_focus(&self) -> Container {
+        let query = self.selection.select("withoutFocus");
 
         Container {
             proc: self.proc.clone(),
@@ -3039,10 +2876,7 @@ impl Container {
     ///
 
     /// * `name` - The name of the label to remove (e.g., "org.opencontainers.artifact.created").
-    pub fn without_label(
-        &self,
-        name: impl Into<String>,
-    ) -> Container {
+    pub fn without_label(&self, name: impl Into<String>) -> Container {
         let mut query = self.selection.select("withoutLabel");
 
         query = query.arg("name", name.into());
@@ -3061,10 +2895,7 @@ impl Container {
     ///
 
     /// * `path` - Location of the cache directory (e.g., "/cache/node_modules").
-    pub fn without_mount(
-        &self,
-        path: impl Into<String>,
-    ) -> Container {
+    pub fn without_mount(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withoutMount");
 
         query = query.arg("path", path.into());
@@ -3083,12 +2914,9 @@ impl Container {
     ///
 
     /// * `address` - Registry's address to remove the authentication from.
-    /// 
+    ///
     /// Formatted as [host]/[user]/[repo]:[tag] (e.g. docker.io/dagger/dagger:main).
-    pub fn without_registry_auth(
-        &self,
-        address: impl Into<String>,
-    ) -> Container {
+    pub fn without_registry_auth(&self, address: impl Into<String>) -> Container {
         let mut query = self.selection.select("withoutRegistryAuth");
 
         query = query.arg("address", address.into());
@@ -3107,10 +2935,7 @@ impl Container {
     ///
 
     /// * `path` - Location of the socket to remove (e.g., "/tmp/socket").
-    pub fn without_unix_socket(
-        &self,
-        path: impl Into<String>,
-    ) -> Container {
+    pub fn without_unix_socket(&self, path: impl Into<String>) -> Container {
         let mut query = self.selection.select("withoutUnixSocket");
 
         query = query.arg("path", path.into());
@@ -3123,10 +2948,8 @@ impl Container {
     }
     /// Retrieves this container with an unset command user.
     /// Should default to root.
-    pub fn without_user(
-        &self,
-    ) -> Container {
-        let mut query = self.selection.select("withoutUser");
+    pub fn without_user(&self) -> Container {
+        let query = self.selection.select("withoutUser");
 
         Container {
             proc: self.proc.clone(),
@@ -3136,10 +2959,8 @@ impl Container {
     }
     /// Retrieves this container with an unset working directory.
     /// Should default to "/".
-    pub fn without_workdir(
-        &self,
-    ) -> Container {
-        let mut query = self.selection.select("withoutWorkdir");
+    pub fn without_workdir(&self) -> Container {
+        let query = self.selection.select("withoutWorkdir");
 
         Container {
             proc: self.proc.clone(),
@@ -3148,10 +2969,8 @@ impl Container {
         }
     }
     /// Retrieves the working directory for all commands.
-    pub async fn workdir(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("workdir");
+    pub async fn workdir(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("workdir");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -3160,12 +2979,11 @@ impl Container {
 pub struct CurrentModule {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 #[derive(Builder, Debug, PartialEq)]
 pub struct CurrentModuleWorkdirOpts<'a> {
-
     /// Exclude artifacts that match the given pattern (e.g., ["node_modules/", ".git*"]).
     #[builder(setter(into, strip_option), default)]
     pub exclude: Option<Vec<&'a str>>,
@@ -3176,26 +2994,20 @@ pub struct CurrentModuleWorkdirOpts<'a> {
 
 impl CurrentModule {
     /// A unique identifier for this CurrentModule.
-    pub async fn id(
-        &self,
-    ) -> Result<CurrentModuleId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<CurrentModuleId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the module being executed in
-    pub async fn name(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("name");
+    pub async fn name(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("name");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The directory containing the module's source code loaded into the engine (plus any generated code that may have been created).
-    pub fn source(
-        &self,
-    ) -> Directory {
-        let mut query = self.selection.select("source");
+    pub fn source(&self) -> Directory {
+        let query = self.selection.select("source");
 
         Directory {
             proc: self.proc.clone(),
@@ -3212,10 +3024,7 @@ impl CurrentModule {
 
     /// * `path` - Location of the directory to access (e.g., ".").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn workdir(
-        &self,
-        path: impl Into<String>,
-    ) -> Directory {
+    pub fn workdir(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("workdir");
 
         query = query.arg("path", path.into());
@@ -3239,7 +3048,7 @@ impl CurrentModule {
     pub fn workdir_opts<'a>(
         &self,
         path: impl Into<String>,
-        opts: CurrentModuleWorkdirOpts<'a>
+        opts: CurrentModuleWorkdirOpts<'a>,
     ) -> Directory {
         let mut query = self.selection.select("workdir");
 
@@ -3265,10 +3074,7 @@ impl CurrentModule {
     ///
 
     /// * `path` - Location of the file to retrieve (e.g., "README.md").
-    pub fn workdir_file(
-        &self,
-        path: impl Into<String>,
-    ) -> File {
+    pub fn workdir_file(&self, path: impl Into<String>) -> File {
         let mut query = self.selection.select("workdirFile");
 
         query = query.arg("path", path.into());
@@ -3284,12 +3090,11 @@ impl CurrentModule {
 pub struct Directory {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryAsModuleOpts<'a> {
-
     /// An optional subpath of the directory which contains the module's configuration file.
     /// This is needed when the module code is in a subdirectory but requires parent directories to be loaded in order to execute. For example, the module source code may need a go.mod, project.toml, package.json, etc. file from a parent directory.
     /// If not set, the module source code is loaded from the root of the directory.
@@ -3298,7 +3103,6 @@ pub struct DirectoryAsModuleOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryDockerBuildOpts<'a> {
-
     /// Build arguments to use in the build.
     #[builder(setter(into, strip_option), default)]
     pub build_args: Option<Vec<BuildArg>>,
@@ -3318,21 +3122,18 @@ pub struct DirectoryDockerBuildOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryEntriesOpts<'a> {
-
     /// Location of the directory to look at (e.g., "/src").
     #[builder(setter(into, strip_option), default)]
     pub path: Option<&'a str>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryExportOpts {
-
     /// If true, then the host directory will be wiped clean before exporting so that it exactly matches the directory being exported; this means it will delete any files on the host that aren't in the exported dir. If false (the default), the contents of the directory will be merged with any existing contents of the host directory, leaving any existing files on the host that aren't in the exported directory alone.
     #[builder(setter(into, strip_option), default)]
     pub wipe: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryPipelineOpts<'a> {
-
     /// Description of the sub-pipeline.
     #[builder(setter(into, strip_option), default)]
     pub description: Option<&'a str>,
@@ -3342,7 +3143,6 @@ pub struct DirectoryPipelineOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryWithDirectoryOpts<'a> {
-
     /// Exclude artifacts that match the given pattern (e.g., ["node_modules/", ".git*"]).
     #[builder(setter(into, strip_option), default)]
     pub exclude: Option<Vec<&'a str>>,
@@ -3352,28 +3152,24 @@ pub struct DirectoryWithDirectoryOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryWithFileOpts {
-
     /// Permission given to the copied file (e.g., 0600).
     #[builder(setter(into, strip_option), default)]
     pub permissions: Option<isize>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryWithFilesOpts {
-
     /// Permission given to the copied files (e.g., 0600).
     #[builder(setter(into, strip_option), default)]
     pub permissions: Option<isize>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryWithNewDirectoryOpts {
-
     /// Permission granted to the created directory (e.g., 0777).
     #[builder(setter(into, strip_option), default)]
     pub permissions: Option<isize>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct DirectoryWithNewFileOpts {
-
     /// Permission given to the copied file (e.g., 0600).
     #[builder(setter(into, strip_option), default)]
     pub permissions: Option<isize>,
@@ -3388,10 +3184,8 @@ impl Directory {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn as_module(
-        &self,
-    ) -> Module {
-        let mut query = self.selection.select("asModule");
+    pub fn as_module(&self) -> Module {
+        let query = self.selection.select("asModule");
 
         Module {
             proc: self.proc.clone(),
@@ -3408,10 +3202,7 @@ impl Directory {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn as_module_opts<'a>(
-        &self,
-        opts: DirectoryAsModuleOpts<'a>
-    ) -> Module {
+    pub fn as_module_opts<'a>(&self, opts: DirectoryAsModuleOpts<'a>) -> Module {
         let mut query = self.selection.select("asModule");
 
         if let Some(source_root_path) = opts.source_root_path {
@@ -3432,10 +3223,7 @@ impl Directory {
     ///
 
     /// * `other` - Identifier of the directory to compare.
-    pub fn diff(
-        &self,
-        other: Directory,
-    ) -> Directory {
+    pub fn diff(&self, other: Directory) -> Directory {
         let mut query = self.selection.select("diff");
 
         query = query.arg_lazy(
@@ -3460,10 +3248,7 @@ impl Directory {
     ///
 
     /// * `path` - Location of the directory to retrieve (e.g., "/src").
-    pub fn directory(
-        &self,
-        path: impl Into<String>,
-    ) -> Directory {
+    pub fn directory(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("directory");
 
         query = query.arg("path", path.into());
@@ -3482,10 +3267,8 @@ impl Directory {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn docker_build(
-        &self,
-    ) -> Container {
-        let mut query = self.selection.select("dockerBuild");
+    pub fn docker_build(&self) -> Container {
+        let query = self.selection.select("dockerBuild");
 
         Container {
             proc: self.proc.clone(),
@@ -3502,10 +3285,7 @@ impl Directory {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn docker_build_opts<'a>(
-        &self,
-        opts: DirectoryDockerBuildOpts<'a>
-    ) -> Container {
+    pub fn docker_build_opts<'a>(&self, opts: DirectoryDockerBuildOpts<'a>) -> Container {
         let mut query = self.selection.select("dockerBuild");
 
         if let Some(platform) = opts.platform {
@@ -3538,10 +3318,8 @@ impl Directory {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn entries(
-        &self,
-    ) -> Result<Vec<String>, DaggerError> {
-        let mut query = self.selection.select("entries");
+    pub async fn entries(&self) -> Result<Vec<String>, DaggerError> {
+        let query = self.selection.select("entries");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -3556,7 +3334,7 @@ impl Directory {
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn entries_opts<'a>(
         &self,
-        opts: DirectoryEntriesOpts<'a>
+        opts: DirectoryEntriesOpts<'a>,
     ) -> Result<Vec<String>, DaggerError> {
         let mut query = self.selection.select("entries");
 
@@ -3575,10 +3353,7 @@ impl Directory {
 
     /// * `path` - Location of the copied directory (e.g., "logs/").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn export(
-        &self,
-        path: impl Into<String>,
-    ) -> Result<bool, DaggerError> {
+    pub async fn export(&self, path: impl Into<String>) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
 
         query = query.arg("path", path.into());
@@ -3598,7 +3373,7 @@ impl Directory {
     pub async fn export_opts(
         &self,
         path: impl Into<String>,
-        opts: DirectoryExportOpts
+        opts: DirectoryExportOpts,
     ) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
 
@@ -3617,10 +3392,7 @@ impl Directory {
     ///
 
     /// * `path` - Location of the file to retrieve (e.g., "README.md").
-    pub fn file(
-        &self,
-        path: impl Into<String>,
-    ) -> File {
+    pub fn file(&self, path: impl Into<String>) -> File {
         let mut query = self.selection.select("file");
 
         query = query.arg("path", path.into());
@@ -3639,10 +3411,7 @@ impl Directory {
     ///
 
     /// * `pattern` - Pattern to match (e.g., "*.md").
-    pub async fn glob(
-        &self,
-        pattern: impl Into<String>,
-    ) -> Result<Vec<String>, DaggerError> {
+    pub async fn glob(&self, pattern: impl Into<String>) -> Result<Vec<String>, DaggerError> {
         let mut query = self.selection.select("glob");
 
         query = query.arg("pattern", pattern.into());
@@ -3650,10 +3419,8 @@ impl Directory {
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this Directory.
-    pub async fn id(
-        &self,
-    ) -> Result<DirectoryId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<DirectoryId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -3666,10 +3433,7 @@ impl Directory {
 
     /// * `name` - Name of the sub-pipeline.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn pipeline(
-        &self,
-        name: impl Into<String>,
-    ) -> Directory {
+    pub fn pipeline(&self, name: impl Into<String>) -> Directory {
         let mut query = self.selection.select("pipeline");
 
         query = query.arg("name", name.into());
@@ -3693,7 +3457,7 @@ impl Directory {
     pub fn pipeline_opts<'a>(
         &self,
         name: impl Into<String>,
-        opts: DirectoryPipelineOpts<'a>
+        opts: DirectoryPipelineOpts<'a>,
     ) -> Directory {
         let mut query = self.selection.select("pipeline");
 
@@ -3712,10 +3476,8 @@ impl Directory {
         }
     }
     /// Force evaluation in the engine.
-    pub async fn sync(
-        &self,
-    ) -> Result<DirectoryId, DaggerError> {
-        let mut query = self.selection.select("sync");
+    pub async fn sync(&self) -> Result<DirectoryId, DaggerError> {
+        let query = self.selection.select("sync");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -3729,11 +3491,7 @@ impl Directory {
     /// * `path` - Location of the written directory (e.g., "/src/").
     /// * `directory` - Identifier of the directory to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_directory(
-        &self,
-        path: impl Into<String>,
-        directory: Directory,
-    ) -> Directory {
+    pub fn with_directory(&self, path: impl Into<String>, directory: Directory) -> Directory {
         let mut query = self.selection.select("withDirectory");
 
         query = query.arg("path", path.into());
@@ -3766,7 +3524,7 @@ impl Directory {
         &self,
         path: impl Into<String>,
         directory: Directory,
-        opts: DirectoryWithDirectoryOpts<'a>
+        opts: DirectoryWithDirectoryOpts<'a>,
     ) -> Directory {
         let mut query = self.selection.select("withDirectory");
 
@@ -3801,11 +3559,7 @@ impl Directory {
     /// * `path` - Location of the copied file (e.g., "/file.txt").
     /// * `source` - Identifier of the file to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_file(
-        &self,
-        path: impl Into<String>,
-        source: File,
-    ) -> Directory {
+    pub fn with_file(&self, path: impl Into<String>, source: File) -> Directory {
         let mut query = self.selection.select("withFile");
 
         query = query.arg("path", path.into());
@@ -3838,7 +3592,7 @@ impl Directory {
         &self,
         path: impl Into<String>,
         source: File,
-        opts: DirectoryWithFileOpts
+        opts: DirectoryWithFileOpts,
     ) -> Directory {
         let mut query = self.selection.select("withFile");
 
@@ -3870,11 +3624,7 @@ impl Directory {
     /// * `path` - Location where copied files should be placed (e.g., "/src").
     /// * `sources` - Identifiers of the files to copy.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_files(
-        &self,
-        path: impl Into<String>,
-        sources: Vec<FileId>,
-    ) -> Directory {
+    pub fn with_files(&self, path: impl Into<String>, sources: Vec<FileId>) -> Directory {
         let mut query = self.selection.select("withFiles");
 
         query = query.arg("path", path.into());
@@ -3901,7 +3651,7 @@ impl Directory {
         &self,
         path: impl Into<String>,
         sources: Vec<FileId>,
-        opts: DirectoryWithFilesOpts
+        opts: DirectoryWithFilesOpts,
     ) -> Directory {
         let mut query = self.selection.select("withFiles");
 
@@ -3926,10 +3676,7 @@ impl Directory {
 
     /// * `path` - Location of the directory created (e.g., "/logs").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_new_directory(
-        &self,
-        path: impl Into<String>,
-    ) -> Directory {
+    pub fn with_new_directory(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("withNewDirectory");
 
         query = query.arg("path", path.into());
@@ -3953,7 +3700,7 @@ impl Directory {
     pub fn with_new_directory_opts(
         &self,
         path: impl Into<String>,
-        opts: DirectoryWithNewDirectoryOpts
+        opts: DirectoryWithNewDirectoryOpts,
     ) -> Directory {
         let mut query = self.selection.select("withNewDirectory");
 
@@ -3978,11 +3725,7 @@ impl Directory {
     /// * `path` - Location of the written file (e.g., "/file.txt").
     /// * `contents` - Content of the written file (e.g., "Hello world!").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_new_file(
-        &self,
-        path: impl Into<String>,
-        contents: impl Into<String>,
-    ) -> Directory {
+    pub fn with_new_file(&self, path: impl Into<String>, contents: impl Into<String>) -> Directory {
         let mut query = self.selection.select("withNewFile");
 
         query = query.arg("path", path.into());
@@ -4009,7 +3752,7 @@ impl Directory {
         &self,
         path: impl Into<String>,
         contents: impl Into<String>,
-        opts: DirectoryWithNewFileOpts
+        opts: DirectoryWithNewFileOpts,
     ) -> Directory {
         let mut query = self.selection.select("withNewFile");
 
@@ -4033,12 +3776,9 @@ impl Directory {
     ///
 
     /// * `timestamp` - Timestamp to set dir/files in.
-    /// 
+    ///
     /// Formatted in seconds following Unix epoch (e.g., 1672531199).
-    pub fn with_timestamps(
-        &self,
-        timestamp: isize,
-    ) -> Directory {
+    pub fn with_timestamps(&self, timestamp: isize) -> Directory {
         let mut query = self.selection.select("withTimestamps");
 
         query = query.arg("timestamp", timestamp);
@@ -4057,10 +3797,7 @@ impl Directory {
     ///
 
     /// * `path` - Location of the directory to remove (e.g., ".github/").
-    pub fn without_directory(
-        &self,
-        path: impl Into<String>,
-    ) -> Directory {
+    pub fn without_directory(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("withoutDirectory");
 
         query = query.arg("path", path.into());
@@ -4079,10 +3816,7 @@ impl Directory {
     ///
 
     /// * `path` - Location of the file to remove (e.g., "/file.txt").
-    pub fn without_file(
-        &self,
-        path: impl Into<String>,
-    ) -> Directory {
+    pub fn without_file(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("withoutFile");
 
         query = query.arg("path", path.into());
@@ -4098,31 +3832,25 @@ impl Directory {
 pub struct EnvVariable {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl EnvVariable {
     /// A unique identifier for this EnvVariable.
-    pub async fn id(
-        &self,
-    ) -> Result<EnvVariableId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<EnvVariableId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The environment variable name.
-    pub async fn name(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("name");
+    pub async fn name(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("name");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The environment variable value.
-    pub async fn value(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("value");
+    pub async fn value(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("value");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -4131,39 +3859,31 @@ impl EnvVariable {
 pub struct FieldTypeDef {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl FieldTypeDef {
     /// A doc string for the field, if any.
-    pub async fn description(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("description");
+    pub async fn description(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("description");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this FieldTypeDef.
-    pub async fn id(
-        &self,
-    ) -> Result<FieldTypeDefId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<FieldTypeDefId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the field in lowerCamelCase format.
-    pub async fn name(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("name");
+    pub async fn name(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("name");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The type of the field.
-    pub fn type_def(
-        &self,
-    ) -> TypeDef {
-        let mut query = self.selection.select("typeDef");
+    pub fn type_def(&self) -> TypeDef {
+        let query = self.selection.select("typeDef");
 
         TypeDef {
             proc: self.proc.clone(),
@@ -4176,12 +3896,11 @@ impl FieldTypeDef {
 pub struct File {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 #[derive(Builder, Debug, PartialEq)]
 pub struct FileExportOpts {
-
     /// If allowParentDirPath is true, the path argument can be a directory path, in which case the file will be created in that directory.
     #[builder(setter(into, strip_option), default)]
     pub allow_parent_dir_path: Option<bool>,
@@ -4189,10 +3908,8 @@ pub struct FileExportOpts {
 
 impl File {
     /// Retrieves the contents of the file.
-    pub async fn contents(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("contents");
+    pub async fn contents(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("contents");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -4205,10 +3922,7 @@ impl File {
 
     /// * `path` - Location of the written directory (e.g., "output.txt").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn export(
-        &self,
-        path: impl Into<String>,
-    ) -> Result<bool, DaggerError> {
+    pub async fn export(&self, path: impl Into<String>) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
 
         query = query.arg("path", path.into());
@@ -4228,7 +3942,7 @@ impl File {
     pub async fn export_opts(
         &self,
         path: impl Into<String>,
-        opts: FileExportOpts
+        opts: FileExportOpts,
     ) -> Result<bool, DaggerError> {
         let mut query = self.selection.select("export");
 
@@ -4240,34 +3954,26 @@ impl File {
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this File.
-    pub async fn id(
-        &self,
-    ) -> Result<FileId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<FileId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the name of the file.
-    pub async fn name(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("name");
+    pub async fn name(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("name");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the size of the file, in bytes.
-    pub async fn size(
-        &self,
-    ) -> Result<isize, DaggerError> {
-        let mut query = self.selection.select("size");
+    pub async fn size(&self) -> Result<isize, DaggerError> {
+        let query = self.selection.select("size");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// Force evaluation in the engine.
-    pub async fn sync(
-        &self,
-    ) -> Result<FileId, DaggerError> {
-        let mut query = self.selection.select("sync");
+    pub async fn sync(&self) -> Result<FileId, DaggerError> {
+        let query = self.selection.select("sync");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -4279,12 +3985,9 @@ impl File {
     ///
 
     /// * `timestamp` - Timestamp to set dir/files in.
-    /// 
+    ///
     /// Formatted in seconds following Unix epoch (e.g., 1672531199).
-    pub fn with_timestamps(
-        &self,
-        timestamp: isize,
-    ) -> File {
+    pub fn with_timestamps(&self, timestamp: isize) -> File {
         let mut query = self.selection.select("withTimestamps");
 
         query = query.arg("timestamp", timestamp);
@@ -4300,12 +4003,11 @@ impl File {
 pub struct Function {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 #[derive(Builder, Debug, PartialEq)]
 pub struct FunctionWithArgOpts<'a> {
-
     /// A default value to use for this argument if not explicitly set by the caller, if any
     #[builder(setter(into, strip_option), default)]
     pub default_value: Option<Json>,
@@ -4316,46 +4018,36 @@ pub struct FunctionWithArgOpts<'a> {
 
 impl Function {
     /// Arguments accepted by the function, if any.
-    pub fn args(
-        &self,
-    ) -> Vec<FunctionArg> {
-        let mut query = self.selection.select("args");
+    pub fn args(&self) -> Vec<FunctionArg> {
+        let query = self.selection.select("args");
 
         return vec![FunctionArg {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }]
+        }];
     }
     /// A doc string for the function, if any.
-    pub async fn description(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("description");
+    pub async fn description(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("description");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this Function.
-    pub async fn id(
-        &self,
-    ) -> Result<FunctionId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<FunctionId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the function.
-    pub async fn name(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("name");
+    pub async fn name(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("name");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The type returned by the function.
-    pub fn return_type(
-        &self,
-    ) -> TypeDef {
-        let mut query = self.selection.select("returnType");
+    pub fn return_type(&self) -> TypeDef {
+        let query = self.selection.select("returnType");
 
         TypeDef {
             proc: self.proc.clone(),
@@ -4373,11 +4065,7 @@ impl Function {
     /// * `name` - The name of the argument
     /// * `type_def` - The type of the argument
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_arg(
-        &self,
-        name: impl Into<String>,
-        type_def: TypeDef,
-    ) -> Function {
+    pub fn with_arg(&self, name: impl Into<String>, type_def: TypeDef) -> Function {
         let mut query = self.selection.select("withArg");
 
         query = query.arg("name", name.into());
@@ -4410,7 +4098,7 @@ impl Function {
         &self,
         name: impl Into<String>,
         type_def: TypeDef,
-        opts: FunctionWithArgOpts<'a>
+        opts: FunctionWithArgOpts<'a>,
     ) -> Function {
         let mut query = self.selection.select("withArg");
 
@@ -4443,10 +4131,7 @@ impl Function {
     ///
 
     /// * `description` - The doc string to set.
-    pub fn with_description(
-        &self,
-        description: impl Into<String>,
-    ) -> Function {
+    pub fn with_description(&self, description: impl Into<String>) -> Function {
         let mut query = self.selection.select("withDescription");
 
         query = query.arg("description", description.into());
@@ -4462,47 +4147,37 @@ impl Function {
 pub struct FunctionArg {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl FunctionArg {
     /// A default value to use for this argument when not explicitly set by the caller, if any.
-    pub async fn default_value(
-        &self,
-    ) -> Result<Json, DaggerError> {
-        let mut query = self.selection.select("defaultValue");
+    pub async fn default_value(&self) -> Result<Json, DaggerError> {
+        let query = self.selection.select("defaultValue");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// A doc string for the argument, if any.
-    pub async fn description(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("description");
+    pub async fn description(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("description");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this FunctionArg.
-    pub async fn id(
-        &self,
-    ) -> Result<FunctionArgId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<FunctionArgId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the argument in lowerCamelCase format.
-    pub async fn name(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("name");
+    pub async fn name(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("name");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The type of the argument.
-    pub fn type_def(
-        &self,
-    ) -> TypeDef {
-        let mut query = self.selection.select("typeDef");
+    pub fn type_def(&self) -> TypeDef {
+        let query = self.selection.select("typeDef");
 
         TypeDef {
             proc: self.proc.clone(),
@@ -4515,51 +4190,41 @@ impl FunctionArg {
 pub struct FunctionCall {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl FunctionCall {
     /// A unique identifier for this FunctionCall.
-    pub async fn id(
-        &self,
-    ) -> Result<FunctionCallId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<FunctionCallId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The argument values the function is being invoked with.
-    pub fn input_args(
-        &self,
-    ) -> Vec<FunctionCallArgValue> {
-        let mut query = self.selection.select("inputArgs");
+    pub fn input_args(&self) -> Vec<FunctionCallArgValue> {
+        let query = self.selection.select("inputArgs");
 
         return vec![FunctionCallArgValue {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }]
+        }];
     }
     /// The name of the function being called.
-    pub async fn name(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("name");
+    pub async fn name(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("name");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The value of the parent object of the function being called. If the function is top-level to the module, this is always an empty object.
-    pub async fn parent(
-        &self,
-    ) -> Result<Json, DaggerError> {
-        let mut query = self.selection.select("parent");
+    pub async fn parent(&self) -> Result<Json, DaggerError> {
+        let query = self.selection.select("parent");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the parent object of the function being called. If the function is top-level to the module, this is the name of the module.
-    pub async fn parent_name(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("parentName");
+    pub async fn parent_name(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("parentName");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -4571,10 +4236,7 @@ impl FunctionCall {
     ///
 
     /// * `value` - JSON serialization of the return value.
-    pub async fn return_value(
-        &self,
-        value: Json,
-    ) -> Result<Void, DaggerError> {
+    pub async fn return_value(&self, value: Json) -> Result<Void, DaggerError> {
         let mut query = self.selection.select("returnValue");
 
         query = query.arg("value", value);
@@ -4586,31 +4248,25 @@ impl FunctionCall {
 pub struct FunctionCallArgValue {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl FunctionCallArgValue {
     /// A unique identifier for this FunctionCallArgValue.
-    pub async fn id(
-        &self,
-    ) -> Result<FunctionCallArgValueId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<FunctionCallArgValueId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the argument.
-    pub async fn name(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("name");
+    pub async fn name(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("name");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The value of the argument represented as a JSON serialized string.
-    pub async fn value(
-        &self,
-    ) -> Result<Json, DaggerError> {
-        let mut query = self.selection.select("value");
+    pub async fn value(&self) -> Result<Json, DaggerError> {
+        let query = self.selection.select("value");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -4619,15 +4275,13 @@ impl FunctionCallArgValue {
 pub struct GeneratedCode {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl GeneratedCode {
     /// The directory containing the generated code.
-    pub fn code(
-        &self,
-    ) -> Directory {
-        let mut query = self.selection.select("code");
+    pub fn code(&self) -> Directory {
+        let query = self.selection.select("code");
 
         Directory {
             proc: self.proc.clone(),
@@ -4636,37 +4290,31 @@ impl GeneratedCode {
         }
     }
     /// A unique identifier for this GeneratedCode.
-    pub async fn id(
-        &self,
-    ) -> Result<GeneratedCodeId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<GeneratedCodeId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// List of paths to mark generated in version control (i.e. .gitattributes).
-    pub async fn vcs_generated_paths(
-        &self,
-    ) -> Result<Vec<String>, DaggerError> {
-        let mut query = self.selection.select("vcsGeneratedPaths");
+    pub async fn vcs_generated_paths(&self) -> Result<Vec<String>, DaggerError> {
+        let query = self.selection.select("vcsGeneratedPaths");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// List of paths to ignore in version control (i.e. .gitignore).
-    pub async fn vcs_ignored_paths(
-        &self,
-    ) -> Result<Vec<String>, DaggerError> {
-        let mut query = self.selection.select("vcsIgnoredPaths");
+    pub async fn vcs_ignored_paths(&self) -> Result<Vec<String>, DaggerError> {
+        let query = self.selection.select("vcsIgnoredPaths");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// Set the list of paths to mark generated in version control.
-    pub fn with_vcs_generated_paths(
-        &self,
-        paths: Vec<impl Into<String>>,
-    ) -> GeneratedCode {
+    pub fn with_vcs_generated_paths(&self, paths: Vec<impl Into<String>>) -> GeneratedCode {
         let mut query = self.selection.select("withVCSGeneratedPaths");
 
-        query = query.arg("paths", paths.into_iter().map(|i| i.into()).collect::<Vec<String>>());
+        query = query.arg(
+            "paths",
+            paths.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
+        );
 
         GeneratedCode {
             proc: self.proc.clone(),
@@ -4675,13 +4323,13 @@ impl GeneratedCode {
         }
     }
     /// Set the list of paths to ignore in version control.
-    pub fn with_vcs_ignored_paths(
-        &self,
-        paths: Vec<impl Into<String>>,
-    ) -> GeneratedCode {
+    pub fn with_vcs_ignored_paths(&self, paths: Vec<impl Into<String>>) -> GeneratedCode {
         let mut query = self.selection.select("withVCSIgnoredPaths");
 
-        query = query.arg("paths", paths.into_iter().map(|i| i.into()).collect::<Vec<String>>());
+        query = query.arg(
+            "paths",
+            paths.into_iter().map(|i| i.into()).collect::<Vec<String>>(),
+        );
 
         GeneratedCode {
             proc: self.proc.clone(),
@@ -4694,31 +4342,25 @@ impl GeneratedCode {
 pub struct GitModuleSource {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl GitModuleSource {
     /// The URL from which the source's git repo can be cloned.
-    pub async fn clone_url(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("cloneURL");
+    pub async fn clone_url(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("cloneURL");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The resolved commit of the git repo this source points to.
-    pub async fn commit(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("commit");
+    pub async fn commit(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("commit");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The directory containing everything needed to load load and use the module.
-    pub fn context_directory(
-        &self,
-    ) -> Directory {
-        let mut query = self.selection.select("contextDirectory");
+    pub fn context_directory(&self) -> Directory {
+        let query = self.selection.select("contextDirectory");
 
         Directory {
             proc: self.proc.clone(),
@@ -4727,34 +4369,26 @@ impl GitModuleSource {
         }
     }
     /// The URL to the source's git repo in a web browser
-    pub async fn html_url(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("htmlURL");
+    pub async fn html_url(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("htmlURL");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this GitModuleSource.
-    pub async fn id(
-        &self,
-    ) -> Result<GitModuleSourceId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<GitModuleSourceId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The path to the root of the module source under the context directory. This directory contains its configuration file. It also contains its source code (possibly as a subdirectory).
-    pub async fn root_subpath(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("rootSubpath");
+    pub async fn root_subpath(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("rootSubpath");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The specified version of the git repo this source points to.
-    pub async fn version(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("version");
+    pub async fn version(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("version");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -4763,12 +4397,11 @@ impl GitModuleSource {
 pub struct GitRef {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 #[derive(Builder, Debug, PartialEq)]
 pub struct GitRefTreeOpts<'a> {
-
     /// DEPRECATED: This option should be passed to `git` instead.
     #[builder(setter(into, strip_option), default)]
     pub ssh_auth_socket: Option<SocketId>,
@@ -4779,18 +4412,14 @@ pub struct GitRefTreeOpts<'a> {
 
 impl GitRef {
     /// The resolved commit id at this ref.
-    pub async fn commit(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("commit");
+    pub async fn commit(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("commit");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this GitRef.
-    pub async fn id(
-        &self,
-    ) -> Result<GitRefId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<GitRefId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -4802,10 +4431,8 @@ impl GitRef {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn tree(
-        &self,
-    ) -> Directory {
-        let mut query = self.selection.select("tree");
+    pub fn tree(&self) -> Directory {
+        let query = self.selection.select("tree");
 
         Directory {
             proc: self.proc.clone(),
@@ -4822,10 +4449,7 @@ impl GitRef {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn tree_opts<'a>(
-        &self,
-        opts: GitRefTreeOpts<'a>
-    ) -> Directory {
+    pub fn tree_opts<'a>(&self, opts: GitRefTreeOpts<'a>) -> Directory {
         let mut query = self.selection.select("tree");
 
         if let Some(ssh_known_hosts) = opts.ssh_known_hosts {
@@ -4846,7 +4470,7 @@ impl GitRef {
 pub struct GitRepository {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl GitRepository {
@@ -4858,10 +4482,7 @@ impl GitRepository {
     ///
 
     /// * `name` - Branch's name (e.g., "main").
-    pub fn branch(
-        &self,
-        name: impl Into<String>,
-    ) -> GitRef {
+    pub fn branch(&self, name: impl Into<String>) -> GitRef {
         let mut query = self.selection.select("branch");
 
         query = query.arg("name", name.into());
@@ -4880,10 +4501,7 @@ impl GitRepository {
     ///
 
     /// * `id` - Identifier of the commit (e.g., "b6315d8f2810962c601af73f86831f6866ea798b").
-    pub fn commit(
-        &self,
-        id: impl Into<String>,
-    ) -> GitRef {
+    pub fn commit(&self, id: impl Into<String>) -> GitRef {
         let mut query = self.selection.select("commit");
 
         query = query.arg("id", id.into());
@@ -4895,10 +4513,8 @@ impl GitRepository {
         }
     }
     /// Returns details for HEAD.
-    pub fn head(
-        &self,
-    ) -> GitRef {
-        let mut query = self.selection.select("head");
+    pub fn head(&self) -> GitRef {
+        let query = self.selection.select("head");
 
         GitRef {
             proc: self.proc.clone(),
@@ -4907,10 +4523,8 @@ impl GitRepository {
         }
     }
     /// A unique identifier for this GitRepository.
-    pub async fn id(
-        &self,
-    ) -> Result<GitRepositoryId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<GitRepositoryId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -4922,10 +4536,7 @@ impl GitRepository {
     ///
 
     /// * `name` - Ref's name (can be a commit identifier, a tag name, a branch name, or a fully-qualified ref).
-    pub fn r#ref(
-        &self,
-        name: impl Into<String>,
-    ) -> GitRef {
+    pub fn r#ref(&self, name: impl Into<String>) -> GitRef {
         let mut query = self.selection.select("ref");
 
         query = query.arg("name", name.into());
@@ -4944,10 +4555,7 @@ impl GitRepository {
     ///
 
     /// * `name` - Tag's name (e.g., "v0.3.9").
-    pub fn tag(
-        &self,
-        name: impl Into<String>,
-    ) -> GitRef {
+    pub fn tag(&self, name: impl Into<String>) -> GitRef {
         let mut query = self.selection.select("tag");
 
         query = query.arg("name", name.into());
@@ -5003,12 +4611,11 @@ impl GitRepository {
 pub struct Host {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 #[derive(Builder, Debug, PartialEq)]
 pub struct HostDirectoryOpts<'a> {
-
     /// Exclude artifacts that match the given pattern (e.g., ["node_modules/", ".git*"]).
     #[builder(setter(into, strip_option), default)]
     pub exclude: Option<Vec<&'a str>>,
@@ -5018,14 +4625,12 @@ pub struct HostDirectoryOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct HostServiceOpts<'a> {
-
     /// Upstream host to forward traffic to.
     #[builder(setter(into, strip_option), default)]
     pub host: Option<&'a str>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct HostTunnelOpts {
-
     /// Map each service port to the same port on the host, as if the service were running natively.
     /// Note: enabling may result in port conflicts.
     #[builder(setter(into, strip_option), default)]
@@ -5048,10 +4653,7 @@ impl Host {
 
     /// * `path` - Location of the directory to access (e.g., ".").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn directory(
-        &self,
-        path: impl Into<String>,
-    ) -> Directory {
+    pub fn directory(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("directory");
 
         query = query.arg("path", path.into());
@@ -5075,7 +4677,7 @@ impl Host {
     pub fn directory_opts<'a>(
         &self,
         path: impl Into<String>,
-        opts: HostDirectoryOpts<'a>
+        opts: HostDirectoryOpts<'a>,
     ) -> Directory {
         let mut query = self.selection.select("directory");
 
@@ -5101,10 +4703,7 @@ impl Host {
     ///
 
     /// * `path` - Location of the file to retrieve (e.g., "README.md").
-    pub fn file(
-        &self,
-        path: impl Into<String>,
-    ) -> File {
+    pub fn file(&self, path: impl Into<String>) -> File {
         let mut query = self.selection.select("file");
 
         query = query.arg("path", path.into());
@@ -5116,10 +4715,8 @@ impl Host {
         }
     }
     /// A unique identifier for this Host.
-    pub async fn id(
-        &self,
-    ) -> Result<HostId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<HostId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -5131,15 +4728,12 @@ impl Host {
     ///
 
     /// * `ports` - Ports to expose via the service, forwarding through the host network.
-    /// 
+    ///
     /// If a port's frontend is unspecified or 0, it defaults to the same as the backend port.
-    /// 
+    ///
     /// An empty set of ports is not valid; an error will be returned.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn service(
-        &self,
-        ports: Vec<PortForward>,
-    ) -> Service {
+    pub fn service(&self, ports: Vec<PortForward>) -> Service {
         let mut query = self.selection.select("service");
 
         query = query.arg("ports", ports);
@@ -5159,16 +4753,12 @@ impl Host {
     ///
 
     /// * `ports` - Ports to expose via the service, forwarding through the host network.
-    /// 
+    ///
     /// If a port's frontend is unspecified or 0, it defaults to the same as the backend port.
-    /// 
+    ///
     /// An empty set of ports is not valid; an error will be returned.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn service_opts<'a>(
-        &self,
-        ports: Vec<PortForward>,
-        opts: HostServiceOpts<'a>
-    ) -> Service {
+    pub fn service_opts<'a>(&self, ports: Vec<PortForward>, opts: HostServiceOpts<'a>) -> Service {
         let mut query = self.selection.select("service");
 
         query = query.arg("ports", ports);
@@ -5192,11 +4782,7 @@ impl Host {
 
     /// * `name` - The user defined name for this secret.
     /// * `path` - Location of the file to set as a secret.
-    pub fn set_secret_file(
-        &self,
-        name: impl Into<String>,
-        path: impl Into<String>,
-    ) -> Secret {
+    pub fn set_secret_file(&self, name: impl Into<String>, path: impl Into<String>) -> Secret {
         let mut query = self.selection.select("setSecretFile");
 
         query = query.arg("name", name.into());
@@ -5217,10 +4803,7 @@ impl Host {
 
     /// * `service` - Service to send traffic from the tunnel.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn tunnel(
-        &self,
-        service: Service,
-    ) -> Service {
+    pub fn tunnel(&self, service: Service) -> Service {
         let mut query = self.selection.select("tunnel");
 
         query = query.arg_lazy(
@@ -5247,11 +4830,7 @@ impl Host {
 
     /// * `service` - Service to send traffic from the tunnel.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn tunnel_opts(
-        &self,
-        service: Service,
-        opts: HostTunnelOpts
-    ) -> Service {
+    pub fn tunnel_opts(&self, service: Service, opts: HostTunnelOpts) -> Service {
         let mut query = self.selection.select("tunnel");
 
         query = query.arg_lazy(
@@ -5282,10 +4861,7 @@ impl Host {
     ///
 
     /// * `path` - Location of the Unix socket (e.g., "/var/run/docker.sock").
-    pub fn unix_socket(
-        &self,
-        path: impl Into<String>,
-    ) -> Socket {
+    pub fn unix_socket(&self, path: impl Into<String>) -> Socket {
         let mut query = self.selection.select("unixSocket");
 
         query = query.arg("path", path.into());
@@ -5301,35 +4877,29 @@ impl Host {
 pub struct InputTypeDef {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl InputTypeDef {
     /// Static fields defined on this input object, if any.
-    pub fn fields(
-        &self,
-    ) -> Vec<FieldTypeDef> {
-        let mut query = self.selection.select("fields");
+    pub fn fields(&self) -> Vec<FieldTypeDef> {
+        let query = self.selection.select("fields");
 
         return vec![FieldTypeDef {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }]
+        }];
     }
     /// A unique identifier for this InputTypeDef.
-    pub async fn id(
-        &self,
-    ) -> Result<InputTypeDefId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<InputTypeDefId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the input object.
-    pub async fn name(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("name");
+    pub async fn name(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("name");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -5338,51 +4908,41 @@ impl InputTypeDef {
 pub struct InterfaceTypeDef {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl InterfaceTypeDef {
     /// The doc string for the interface, if any.
-    pub async fn description(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("description");
+    pub async fn description(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("description");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// Functions defined on this interface, if any.
-    pub fn functions(
-        &self,
-    ) -> Vec<Function> {
-        let mut query = self.selection.select("functions");
+    pub fn functions(&self) -> Vec<Function> {
+        let query = self.selection.select("functions");
 
         return vec![Function {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }]
+        }];
     }
     /// A unique identifier for this InterfaceTypeDef.
-    pub async fn id(
-        &self,
-    ) -> Result<InterfaceTypeDefId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<InterfaceTypeDefId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the interface.
-    pub async fn name(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("name");
+    pub async fn name(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("name");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// If this InterfaceTypeDef is associated with a Module, the name of the module. Unset otherwise.
-    pub async fn source_module_name(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("sourceModuleName");
+    pub async fn source_module_name(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("sourceModuleName");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -5391,31 +4951,25 @@ impl InterfaceTypeDef {
 pub struct Label {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl Label {
     /// A unique identifier for this Label.
-    pub async fn id(
-        &self,
-    ) -> Result<LabelId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<LabelId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The label name.
-    pub async fn name(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("name");
+    pub async fn name(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("name");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The label value.
-    pub async fn value(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("value");
+    pub async fn value(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("value");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -5424,15 +4978,13 @@ impl Label {
 pub struct ListTypeDef {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl ListTypeDef {
     /// The type of the elements in the list.
-    pub fn element_type_def(
-        &self,
-    ) -> TypeDef {
-        let mut query = self.selection.select("elementTypeDef");
+    pub fn element_type_def(&self) -> TypeDef {
+        let query = self.selection.select("elementTypeDef");
 
         TypeDef {
             proc: self.proc.clone(),
@@ -5441,10 +4993,8 @@ impl ListTypeDef {
         }
     }
     /// A unique identifier for this ListTypeDef.
-    pub async fn id(
-        &self,
-    ) -> Result<ListTypeDefId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<ListTypeDefId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -5453,15 +5003,13 @@ impl ListTypeDef {
 pub struct LocalModuleSource {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl LocalModuleSource {
     /// The directory containing everything needed to load load and use the module.
-    pub fn context_directory(
-        &self,
-    ) -> Directory {
-        let mut query = self.selection.select("contextDirectory");
+    pub fn context_directory(&self) -> Directory {
+        let query = self.selection.select("contextDirectory");
 
         Directory {
             proc: self.proc.clone(),
@@ -5470,18 +5018,14 @@ impl LocalModuleSource {
         }
     }
     /// A unique identifier for this LocalModuleSource.
-    pub async fn id(
-        &self,
-    ) -> Result<LocalModuleSourceId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<LocalModuleSourceId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The path to the root of the module source under the context directory. This directory contains its configuration file. It also contains its source code (possibly as a subdirectory).
-    pub async fn root_subpath(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("rootSubpath");
+    pub async fn root_subpath(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("rootSubpath");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -5490,47 +5034,39 @@ impl LocalModuleSource {
 pub struct Module {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl Module {
     /// Modules used by this module.
-    pub fn dependencies(
-        &self,
-    ) -> Vec<Module> {
-        let mut query = self.selection.select("dependencies");
+    pub fn dependencies(&self) -> Vec<Module> {
+        let query = self.selection.select("dependencies");
 
         return vec![Module {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }]
+        }];
     }
     /// The dependencies as configured by the module.
-    pub fn dependency_config(
-        &self,
-    ) -> Vec<ModuleDependency> {
-        let mut query = self.selection.select("dependencyConfig");
+    pub fn dependency_config(&self) -> Vec<ModuleDependency> {
+        let query = self.selection.select("dependencyConfig");
 
         return vec![ModuleDependency {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }]
+        }];
     }
     /// The doc string of the module, if any
-    pub async fn description(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("description");
+    pub async fn description(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("description");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The generated files and directories made on top of the module source's context directory.
-    pub fn generated_context_diff(
-        &self,
-    ) -> Directory {
-        let mut query = self.selection.select("generatedContextDiff");
+    pub fn generated_context_diff(&self) -> Directory {
+        let query = self.selection.select("generatedContextDiff");
 
         Directory {
             proc: self.proc.clone(),
@@ -5539,10 +5075,8 @@ impl Module {
         }
     }
     /// The module source's context plus any configuration and source files created by codegen.
-    pub fn generated_context_directory(
-        &self,
-    ) -> Directory {
-        let mut query = self.selection.select("generatedContextDirectory");
+    pub fn generated_context_directory(&self) -> Directory {
+        let query = self.selection.select("generatedContextDirectory");
 
         Directory {
             proc: self.proc.clone(),
@@ -5551,18 +5085,14 @@ impl Module {
         }
     }
     /// A unique identifier for this Module.
-    pub async fn id(
-        &self,
-    ) -> Result<ModuleId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<ModuleId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the module with the objects loaded via its SDK.
-    pub fn initialize(
-        &self,
-    ) -> Module {
-        let mut query = self.selection.select("initialize");
+    pub fn initialize(&self) -> Module {
+        let query = self.selection.select("initialize");
 
         Module {
             proc: self.proc.clone(),
@@ -5571,42 +5101,34 @@ impl Module {
         }
     }
     /// Interfaces served by this module.
-    pub fn interfaces(
-        &self,
-    ) -> Vec<TypeDef> {
-        let mut query = self.selection.select("interfaces");
+    pub fn interfaces(&self) -> Vec<TypeDef> {
+        let query = self.selection.select("interfaces");
 
         return vec![TypeDef {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }]
+        }];
     }
     /// The name of the module
-    pub async fn name(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("name");
+    pub async fn name(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("name");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// Objects served by this module.
-    pub fn objects(
-        &self,
-    ) -> Vec<TypeDef> {
-        let mut query = self.selection.select("objects");
+    pub fn objects(&self) -> Vec<TypeDef> {
+        let query = self.selection.select("objects");
 
         return vec![TypeDef {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }]
+        }];
     }
     /// The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile.
-    pub fn runtime(
-        &self,
-    ) -> Container {
-        let mut query = self.selection.select("runtime");
+    pub fn runtime(&self) -> Container {
+        let query = self.selection.select("runtime");
 
         Container {
             proc: self.proc.clone(),
@@ -5615,27 +5137,21 @@ impl Module {
         }
     }
     /// The SDK used by this module. Either a name of a builtin SDK or a module source ref string pointing to the SDK's implementation.
-    pub async fn sdk(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("sdk");
+    pub async fn sdk(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("sdk");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// Serve a module's API in the current session.
     /// Note: this can only be called once per session. In the future, it could return a stream or service to remove the side effect.
-    pub async fn serve(
-        &self,
-    ) -> Result<Void, DaggerError> {
-        let mut query = self.selection.select("serve");
+    pub async fn serve(&self) -> Result<Void, DaggerError> {
+        let query = self.selection.select("serve");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The source for the module.
-    pub fn source(
-        &self,
-    ) -> ModuleSource {
-        let mut query = self.selection.select("source");
+    pub fn source(&self) -> ModuleSource {
+        let query = self.selection.select("source");
 
         ModuleSource {
             proc: self.proc.clone(),
@@ -5651,10 +5167,7 @@ impl Module {
     ///
 
     /// * `description` - The description to set
-    pub fn with_description(
-        &self,
-        description: impl Into<String>,
-    ) -> Module {
+    pub fn with_description(&self, description: impl Into<String>) -> Module {
         let mut query = self.selection.select("withDescription");
 
         query = query.arg("description", description.into());
@@ -5666,10 +5179,7 @@ impl Module {
         }
     }
     /// This module plus the given Interface type and associated functions
-    pub fn with_interface(
-        &self,
-        iface: TypeDef,
-    ) -> Module {
+    pub fn with_interface(&self, iface: TypeDef) -> Module {
         let mut query = self.selection.select("withInterface");
 
         query = query.arg_lazy(
@@ -5687,10 +5197,7 @@ impl Module {
         }
     }
     /// This module plus the given Object type and associated functions.
-    pub fn with_object(
-        &self,
-        object: TypeDef,
-    ) -> Module {
+    pub fn with_object(&self, object: TypeDef) -> Module {
         let mut query = self.selection.select("withObject");
 
         query = query.arg_lazy(
@@ -5715,10 +5222,7 @@ impl Module {
     ///
 
     /// * `source` - The module source to initialize from.
-    pub fn with_source(
-        &self,
-        source: ModuleSource,
-    ) -> Module {
+    pub fn with_source(&self, source: ModuleSource) -> Module {
         let mut query = self.selection.select("withSource");
 
         query = query.arg_lazy(
@@ -5740,31 +5244,25 @@ impl Module {
 pub struct ModuleDependency {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl ModuleDependency {
     /// A unique identifier for this ModuleDependency.
-    pub async fn id(
-        &self,
-    ) -> Result<ModuleDependencyId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<ModuleDependencyId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the dependency module.
-    pub async fn name(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("name");
+    pub async fn name(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("name");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The source for the dependency module.
-    pub fn source(
-        &self,
-    ) -> ModuleSource {
-        let mut query = self.selection.select("source");
+    pub fn source(&self) -> ModuleSource {
+        let query = self.selection.select("source");
 
         ModuleSource {
             proc: self.proc.clone(),
@@ -5777,12 +5275,11 @@ impl ModuleDependency {
 pub struct ModuleSource {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 #[derive(Builder, Debug, PartialEq)]
 pub struct ModuleSourceResolveDirectoryFromCallerOpts<'a> {
-
     /// If set, the name of the view to apply to the path.
     #[builder(setter(into, strip_option), default)]
     pub view_name: Option<&'a str>,
@@ -5790,10 +5287,8 @@ pub struct ModuleSourceResolveDirectoryFromCallerOpts<'a> {
 
 impl ModuleSource {
     /// If the source is a of kind git, the git source representation of it.
-    pub fn as_git_source(
-        &self,
-    ) -> GitModuleSource {
-        let mut query = self.selection.select("asGitSource");
+    pub fn as_git_source(&self) -> GitModuleSource {
+        let query = self.selection.select("asGitSource");
 
         GitModuleSource {
             proc: self.proc.clone(),
@@ -5802,10 +5297,8 @@ impl ModuleSource {
         }
     }
     /// If the source is of kind local, the local source representation of it.
-    pub fn as_local_source(
-        &self,
-    ) -> LocalModuleSource {
-        let mut query = self.selection.select("asLocalSource");
+    pub fn as_local_source(&self) -> LocalModuleSource {
+        let query = self.selection.select("asLocalSource");
 
         LocalModuleSource {
             proc: self.proc.clone(),
@@ -5814,10 +5307,8 @@ impl ModuleSource {
         }
     }
     /// Load the source as a module. If this is a local source, the parent directory must have been provided during module source creation
-    pub fn as_module(
-        &self,
-    ) -> Module {
-        let mut query = self.selection.select("asModule");
+    pub fn as_module(&self) -> Module {
+        let query = self.selection.select("asModule");
 
         Module {
             proc: self.proc.clone(),
@@ -5826,26 +5317,20 @@ impl ModuleSource {
         }
     }
     /// A human readable ref string representation of this module source.
-    pub async fn as_string(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("asString");
+    pub async fn as_string(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("asString");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// Returns whether the module source has a configuration file.
-    pub async fn config_exists(
-        &self,
-    ) -> Result<bool, DaggerError> {
-        let mut query = self.selection.select("configExists");
+    pub async fn config_exists(&self) -> Result<bool, DaggerError> {
+        let query = self.selection.select("configExists");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The directory containing everything needed to load load and use the module.
-    pub fn context_directory(
-        &self,
-    ) -> Directory {
-        let mut query = self.selection.select("contextDirectory");
+    pub fn context_directory(&self) -> Directory {
+        let query = self.selection.select("contextDirectory");
 
         Directory {
             proc: self.proc.clone(),
@@ -5854,16 +5339,14 @@ impl ModuleSource {
         }
     }
     /// The dependencies of the module source. Includes dependencies from the configuration and any extras from withDependencies calls.
-    pub fn dependencies(
-        &self,
-    ) -> Vec<ModuleDependency> {
-        let mut query = self.selection.select("dependencies");
+    pub fn dependencies(&self) -> Vec<ModuleDependency> {
+        let query = self.selection.select("dependencies");
 
         return vec![ModuleDependency {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }]
+        }];
     }
     /// The directory containing the module configuration and source code (source code may be in a subdir).
     ///
@@ -5873,10 +5356,7 @@ impl ModuleSource {
     ///
 
     /// * `path` - The path from the source directory to select.
-    pub fn directory(
-        &self,
-        path: impl Into<String>,
-    ) -> Directory {
+    pub fn directory(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("directory");
 
         query = query.arg("path", path.into());
@@ -5888,42 +5368,32 @@ impl ModuleSource {
         }
     }
     /// A unique identifier for this ModuleSource.
-    pub async fn id(
-        &self,
-    ) -> Result<ModuleSourceId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<ModuleSourceId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The kind of source (e.g. local, git, etc.)
-    pub async fn kind(
-        &self,
-    ) -> Result<ModuleSourceKind, DaggerError> {
-        let mut query = self.selection.select("kind");
+    pub async fn kind(&self) -> Result<ModuleSourceKind, DaggerError> {
+        let query = self.selection.select("kind");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// If set, the name of the module this source references, including any overrides at runtime by callers.
-    pub async fn module_name(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("moduleName");
+    pub async fn module_name(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("moduleName");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The original name of the module this source references, as defined in the module configuration.
-    pub async fn module_original_name(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("moduleOriginalName");
+    pub async fn module_original_name(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("moduleOriginalName");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The path to the module source's context directory on the caller's filesystem. Only valid for local sources.
-    pub async fn resolve_context_path_from_caller(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("resolveContextPathFromCaller");
+    pub async fn resolve_context_path_from_caller(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("resolveContextPathFromCaller");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -5935,10 +5405,7 @@ impl ModuleSource {
     ///
 
     /// * `dep` - The dependency module source to resolve.
-    pub fn resolve_dependency(
-        &self,
-        dep: ModuleSource,
-    ) -> ModuleSource {
+    pub fn resolve_dependency(&self, dep: ModuleSource) -> ModuleSource {
         let mut query = self.selection.select("resolveDependency");
 
         query = query.arg_lazy(
@@ -5964,10 +5431,7 @@ impl ModuleSource {
 
     /// * `path` - The path on the caller's filesystem to load.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn resolve_directory_from_caller(
-        &self,
-        path: impl Into<String>,
-    ) -> Directory {
+    pub fn resolve_directory_from_caller(&self, path: impl Into<String>) -> Directory {
         let mut query = self.selection.select("resolveDirectoryFromCaller");
 
         query = query.arg("path", path.into());
@@ -5991,7 +5455,7 @@ impl ModuleSource {
     pub fn resolve_directory_from_caller_opts<'a>(
         &self,
         path: impl Into<String>,
-        opts: ModuleSourceResolveDirectoryFromCallerOpts<'a>
+        opts: ModuleSourceResolveDirectoryFromCallerOpts<'a>,
     ) -> Directory {
         let mut query = self.selection.select("resolveDirectoryFromCaller");
 
@@ -6007,10 +5471,8 @@ impl ModuleSource {
         }
     }
     /// Load the source from its path on the caller's filesystem, including only needed+configured files and directories. Only valid for local sources.
-    pub fn resolve_from_caller(
-        &self,
-    ) -> ModuleSource {
-        let mut query = self.selection.select("resolveFromCaller");
+    pub fn resolve_from_caller(&self) -> ModuleSource {
+        let query = self.selection.select("resolveFromCaller");
 
         ModuleSource {
             proc: self.proc.clone(),
@@ -6019,18 +5481,14 @@ impl ModuleSource {
         }
     }
     /// The path relative to context of the root of the module source, which contains dagger.json. It also contains the module implementation source code, but that may or may not being a subdir of this root.
-    pub async fn source_root_subpath(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("sourceRootSubpath");
+    pub async fn source_root_subpath(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("sourceRootSubpath");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The path relative to context of the module implementation source code.
-    pub async fn source_subpath(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("sourceSubpath");
+    pub async fn source_subpath(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("sourceSubpath");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -6042,10 +5500,7 @@ impl ModuleSource {
     ///
 
     /// * `name` - The name of the view to retrieve.
-    pub fn view(
-        &self,
-        name: impl Into<String>,
-    ) -> ModuleSourceView {
+    pub fn view(&self, name: impl Into<String>) -> ModuleSourceView {
         let mut query = self.selection.select("view");
 
         query = query.arg("name", name.into());
@@ -6057,16 +5512,14 @@ impl ModuleSource {
         }
     }
     /// The named views defined for this module source, which are sets of directory filters that can be applied to directory arguments provided to functions.
-    pub fn views(
-        &self,
-    ) -> Vec<ModuleSourceView> {
-        let mut query = self.selection.select("views");
+    pub fn views(&self) -> Vec<ModuleSourceView> {
+        let query = self.selection.select("views");
 
         return vec![ModuleSourceView {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }]
+        }];
     }
     /// Update the module source with a new context directory. Only valid for local sources.
     ///
@@ -6076,10 +5529,7 @@ impl ModuleSource {
     ///
 
     /// * `dir` - The directory to set as the context directory.
-    pub fn with_context_directory(
-        &self,
-        dir: Directory,
-    ) -> ModuleSource {
+    pub fn with_context_directory(&self, dir: Directory) -> ModuleSource {
         let mut query = self.selection.select("withContextDirectory");
 
         query = query.arg_lazy(
@@ -6104,10 +5554,7 @@ impl ModuleSource {
     ///
 
     /// * `dependencies` - The dependencies to append.
-    pub fn with_dependencies(
-        &self,
-        dependencies: Vec<ModuleDependencyId>,
-    ) -> ModuleSource {
+    pub fn with_dependencies(&self, dependencies: Vec<ModuleDependencyId>) -> ModuleSource {
         let mut query = self.selection.select("withDependencies");
 
         query = query.arg("dependencies", dependencies);
@@ -6126,10 +5573,7 @@ impl ModuleSource {
     ///
 
     /// * `name` - The name to set.
-    pub fn with_name(
-        &self,
-        name: impl Into<String>,
-    ) -> ModuleSource {
+    pub fn with_name(&self, name: impl Into<String>) -> ModuleSource {
         let mut query = self.selection.select("withName");
 
         query = query.arg("name", name.into());
@@ -6148,10 +5592,7 @@ impl ModuleSource {
     ///
 
     /// * `sdk` - The SDK to set.
-    pub fn with_sdk(
-        &self,
-        sdk: impl Into<String>,
-    ) -> ModuleSource {
+    pub fn with_sdk(&self, sdk: impl Into<String>) -> ModuleSource {
         let mut query = self.selection.select("withSDK");
 
         query = query.arg("sdk", sdk.into());
@@ -6170,10 +5611,7 @@ impl ModuleSource {
     ///
 
     /// * `path` - The path to set as the source subpath.
-    pub fn with_source_subpath(
-        &self,
-        path: impl Into<String>,
-    ) -> ModuleSource {
+    pub fn with_source_subpath(&self, path: impl Into<String>) -> ModuleSource {
         let mut query = self.selection.select("withSourceSubpath");
 
         query = query.arg("path", path.into());
@@ -6201,7 +5639,13 @@ impl ModuleSource {
         let mut query = self.selection.select("withView");
 
         query = query.arg("name", name.into());
-        query = query.arg("patterns", patterns.into_iter().map(|i| i.into()).collect::<Vec<String>>());
+        query = query.arg(
+            "patterns",
+            patterns
+                .into_iter()
+                .map(|i| i.into())
+                .collect::<Vec<String>>(),
+        );
 
         ModuleSource {
             proc: self.proc.clone(),
@@ -6214,31 +5658,25 @@ impl ModuleSource {
 pub struct ModuleSourceView {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl ModuleSourceView {
     /// A unique identifier for this ModuleSourceView.
-    pub async fn id(
-        &self,
-    ) -> Result<ModuleSourceViewId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<ModuleSourceViewId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the view
-    pub async fn name(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("name");
+    pub async fn name(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("name");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The patterns of the view used to filter paths
-    pub async fn patterns(
-        &self,
-    ) -> Result<Vec<String>, DaggerError> {
-        let mut query = self.selection.select("patterns");
+    pub async fn patterns(&self) -> Result<Vec<String>, DaggerError> {
+        let query = self.selection.select("patterns");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -6247,15 +5685,13 @@ impl ModuleSourceView {
 pub struct ObjectTypeDef {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl ObjectTypeDef {
     /// The function used to construct new instances of this object, if any
-    pub fn constructor(
-        &self,
-    ) -> Function {
-        let mut query = self.selection.select("constructor");
+    pub fn constructor(&self) -> Function {
+        let query = self.selection.select("constructor");
 
         Function {
             proc: self.proc.clone(),
@@ -6264,58 +5700,46 @@ impl ObjectTypeDef {
         }
     }
     /// The doc string for the object, if any.
-    pub async fn description(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("description");
+    pub async fn description(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("description");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// Static fields defined on this object, if any.
-    pub fn fields(
-        &self,
-    ) -> Vec<FieldTypeDef> {
-        let mut query = self.selection.select("fields");
+    pub fn fields(&self) -> Vec<FieldTypeDef> {
+        let query = self.selection.select("fields");
 
         return vec![FieldTypeDef {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }]
+        }];
     }
     /// Functions defined on this object, if any.
-    pub fn functions(
-        &self,
-    ) -> Vec<Function> {
-        let mut query = self.selection.select("functions");
+    pub fn functions(&self) -> Vec<Function> {
+        let query = self.selection.select("functions");
 
         return vec![Function {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }]
+        }];
     }
     /// A unique identifier for this ObjectTypeDef.
-    pub async fn id(
-        &self,
-    ) -> Result<ObjectTypeDefId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<ObjectTypeDefId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of the object.
-    pub async fn name(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("name");
+    pub async fn name(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("name");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// If this ObjectTypeDef is associated with a Module, the name of the module. Unset otherwise.
-    pub async fn source_module_name(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("sourceModuleName");
+    pub async fn source_module_name(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("sourceModuleName");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -6324,47 +5748,37 @@ impl ObjectTypeDef {
 pub struct Port {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl Port {
     /// The port description.
-    pub async fn description(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("description");
+    pub async fn description(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("description");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// Skip the health check when run as a service.
-    pub async fn experimental_skip_healthcheck(
-        &self,
-    ) -> Result<bool, DaggerError> {
-        let mut query = self.selection.select("experimentalSkipHealthcheck");
+    pub async fn experimental_skip_healthcheck(&self) -> Result<bool, DaggerError> {
+        let query = self.selection.select("experimentalSkipHealthcheck");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this Port.
-    pub async fn id(
-        &self,
-    ) -> Result<PortId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<PortId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The port number.
-    pub async fn port(
-        &self,
-    ) -> Result<isize, DaggerError> {
-        let mut query = self.selection.select("port");
+    pub async fn port(&self) -> Result<isize, DaggerError> {
+        let query = self.selection.select("port");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The transport layer protocol.
-    pub async fn protocol(
-        &self,
-    ) -> Result<NetworkProtocol, DaggerError> {
-        let mut query = self.selection.select("protocol");
+    pub async fn protocol(&self) -> Result<NetworkProtocol, DaggerError> {
+        let query = self.selection.select("protocol");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -6373,12 +5787,11 @@ impl Port {
 pub struct Query {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 #[derive(Builder, Debug, PartialEq)]
 pub struct QueryContainerOpts {
-
     /// DEPRECATED: Use `loadContainerFromID` instead.
     #[builder(setter(into, strip_option), default)]
     pub id: Option<ContainerId>,
@@ -6388,14 +5801,12 @@ pub struct QueryContainerOpts {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct QueryDirectoryOpts {
-
     /// DEPRECATED: Use `loadDirectoryFromID` instead.
     #[builder(setter(into, strip_option), default)]
     pub id: Option<DirectoryId>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct QueryGitOpts<'a> {
-
     /// A service which must be started before the repo is fetched.
     #[builder(setter(into, strip_option), default)]
     pub experimental_service_host: Option<ServiceId>,
@@ -6411,28 +5822,24 @@ pub struct QueryGitOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct QueryHttpOpts {
-
     /// A service which must be started before the URL is fetched.
     #[builder(setter(into, strip_option), default)]
     pub experimental_service_host: Option<ServiceId>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct QueryModuleDependencyOpts<'a> {
-
     /// If set, the name to use for the dependency. Otherwise, once installed to a parent module, the name of the dependency module will be used by default.
     #[builder(setter(into, strip_option), default)]
     pub name: Option<&'a str>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct QueryModuleSourceOpts {
-
     /// If true, enforce that the source is a stable version for source kinds that support versioning.
     #[builder(setter(into, strip_option), default)]
     pub stable: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct QueryPipelineOpts<'a> {
-
     /// Description of the sub-pipeline.
     #[builder(setter(into, strip_option), default)]
     pub description: Option<&'a str>,
@@ -6442,7 +5849,6 @@ pub struct QueryPipelineOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct QuerySecretOpts<'a> {
-
     #[builder(setter(into, strip_option), default)]
     pub accessor: Option<&'a str>,
 }
@@ -6487,10 +5893,7 @@ impl Query {
     ///
 
     /// * `digest` - Digest of the image manifest
-    pub fn builtin_container(
-        &self,
-        digest: impl Into<String>,
-    ) -> Container {
+    pub fn builtin_container(&self, digest: impl Into<String>) -> Container {
         let mut query = self.selection.select("builtinContainer");
 
         query = query.arg("digest", digest.into());
@@ -6509,10 +5912,7 @@ impl Query {
     ///
 
     /// * `key` - A string identifier to target this cache volume (e.g., "modules-cache").
-    pub fn cache_volume(
-        &self,
-        key: impl Into<String>,
-    ) -> CacheVolume {
+    pub fn cache_volume(&self, key: impl Into<String>) -> CacheVolume {
         let mut query = self.selection.select("cacheVolume");
 
         query = query.arg("key", key.into());
@@ -6550,10 +5950,8 @@ impl Query {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn container(
-        &self,
-    ) -> Container {
-        let mut query = self.selection.select("container");
+    pub fn container(&self) -> Container {
+        let query = self.selection.select("container");
 
         Container {
             proc: self.proc.clone(),
@@ -6571,10 +5969,7 @@ impl Query {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn container_opts(
-        &self,
-        opts: QueryContainerOpts
-    ) -> Container {
+    pub fn container_opts(&self, opts: QueryContainerOpts) -> Container {
         let mut query = self.selection.select("container");
 
         if let Some(id) = opts.id {
@@ -6592,10 +5987,8 @@ impl Query {
     }
     /// The FunctionCall context that the SDK caller is currently executing in.
     /// If the caller is not currently executing in a function, this will return an error.
-    pub fn current_function_call(
-        &self,
-    ) -> FunctionCall {
-        let mut query = self.selection.select("currentFunctionCall");
+    pub fn current_function_call(&self) -> FunctionCall {
+        let query = self.selection.select("currentFunctionCall");
 
         FunctionCall {
             proc: self.proc.clone(),
@@ -6604,10 +5997,8 @@ impl Query {
         }
     }
     /// The module currently being served in the session, if any.
-    pub fn current_module(
-        &self,
-    ) -> CurrentModule {
-        let mut query = self.selection.select("currentModule");
+    pub fn current_module(&self) -> CurrentModule {
+        let query = self.selection.select("currentModule");
 
         CurrentModule {
             proc: self.proc.clone(),
@@ -6616,22 +6007,18 @@ impl Query {
         }
     }
     /// The TypeDef representations of the objects currently being served in the session.
-    pub fn current_type_defs(
-        &self,
-    ) -> Vec<TypeDef> {
-        let mut query = self.selection.select("currentTypeDefs");
+    pub fn current_type_defs(&self) -> Vec<TypeDef> {
+        let query = self.selection.select("currentTypeDefs");
 
         return vec![TypeDef {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }]
+        }];
     }
     /// The default platform of the engine.
-    pub async fn default_platform(
-        &self,
-    ) -> Result<Platform, DaggerError> {
-        let mut query = self.selection.select("defaultPlatform");
+    pub async fn default_platform(&self) -> Result<Platform, DaggerError> {
+        let query = self.selection.select("defaultPlatform");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -6643,10 +6030,8 @@ impl Query {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn directory(
-        &self,
-    ) -> Directory {
-        let mut query = self.selection.select("directory");
+    pub fn directory(&self) -> Directory {
+        let query = self.selection.select("directory");
 
         Directory {
             proc: self.proc.clone(),
@@ -6663,10 +6048,7 @@ impl Query {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn directory_opts(
-        &self,
-        opts: QueryDirectoryOpts
-    ) -> Directory {
+    pub fn directory_opts(&self, opts: QueryDirectoryOpts) -> Directory {
         let mut query = self.selection.select("directory");
 
         if let Some(id) = opts.id {
@@ -6679,10 +6061,7 @@ impl Query {
             graphql_client: self.graphql_client.clone(),
         }
     }
-    pub fn file(
-        &self,
-        id: File,
-    ) -> File {
+    pub fn file(&self, id: File) -> File {
         let mut query = self.selection.select("file");
 
         query = query.arg_lazy(
@@ -6708,11 +6087,7 @@ impl Query {
 
     /// * `name` - Name of the function, in its original format from the implementation language.
     /// * `return_type` - Return type of the function.
-    pub fn function(
-        &self,
-        name: impl Into<String>,
-        return_type: TypeDef,
-    ) -> Function {
+    pub fn function(&self, name: impl Into<String>, return_type: TypeDef) -> Function {
         let mut query = self.selection.select("function");
 
         query = query.arg("name", name.into());
@@ -6731,10 +6106,7 @@ impl Query {
         }
     }
     /// Create a code generation result, given a directory containing the generated code.
-    pub fn generated_code(
-        &self,
-        code: Directory,
-    ) -> GeneratedCode {
+    pub fn generated_code(&self, code: Directory) -> GeneratedCode {
         let mut query = self.selection.select("generatedCode");
 
         query = query.arg_lazy(
@@ -6759,15 +6131,12 @@ impl Query {
     ///
 
     /// * `url` - URL of the git repository.
-    /// 
+    ///
     /// Can be formatted as `https://{host}/{owner}/{repo}`, `git@{host}:{owner}/{repo}`.
-    /// 
+    ///
     /// Suffix ".git" is optional.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn git(
-        &self,
-        url: impl Into<String>,
-    ) -> GitRepository {
+    pub fn git(&self, url: impl Into<String>) -> GitRepository {
         let mut query = self.selection.select("git");
 
         query = query.arg("url", url.into());
@@ -6787,16 +6156,12 @@ impl Query {
     ///
 
     /// * `url` - URL of the git repository.
-    /// 
+    ///
     /// Can be formatted as `https://{host}/{owner}/{repo}`, `git@{host}:{owner}/{repo}`.
-    /// 
+    ///
     /// Suffix ".git" is optional.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn git_opts<'a>(
-        &self,
-        url: impl Into<String>,
-        opts: QueryGitOpts<'a>
-    ) -> GitRepository {
+    pub fn git_opts<'a>(&self, url: impl Into<String>, opts: QueryGitOpts<'a>) -> GitRepository {
         let mut query = self.selection.select("git");
 
         query = query.arg("url", url.into());
@@ -6820,10 +6185,8 @@ impl Query {
         }
     }
     /// Queries the host environment.
-    pub fn host(
-        &self,
-    ) -> Host {
-        let mut query = self.selection.select("host");
+    pub fn host(&self) -> Host {
+        let query = self.selection.select("host");
 
         Host {
             proc: self.proc.clone(),
@@ -6840,10 +6203,7 @@ impl Query {
 
     /// * `url` - HTTP url to get the content from (e.g., "https://docs.dagger.io").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn http(
-        &self,
-        url: impl Into<String>,
-    ) -> File {
+    pub fn http(&self, url: impl Into<String>) -> File {
         let mut query = self.selection.select("http");
 
         query = query.arg("url", url.into());
@@ -6864,11 +6224,7 @@ impl Query {
 
     /// * `url` - HTTP url to get the content from (e.g., "https://docs.dagger.io").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn http_opts(
-        &self,
-        url: impl Into<String>,
-        opts: QueryHttpOpts
-    ) -> File {
+    pub fn http_opts(&self, url: impl Into<String>, opts: QueryHttpOpts) -> File {
         let mut query = self.selection.select("http");
 
         query = query.arg("url", url.into());
@@ -6883,10 +6239,7 @@ impl Query {
         }
     }
     /// Load a CacheVolume from its ID.
-    pub fn load_cache_volume_from_id(
-        &self,
-        id: CacheVolume,
-    ) -> CacheVolume {
+    pub fn load_cache_volume_from_id(&self, id: CacheVolume) -> CacheVolume {
         let mut query = self.selection.select("loadCacheVolumeFromID");
 
         query = query.arg_lazy(
@@ -6904,10 +6257,7 @@ impl Query {
         }
     }
     /// Load a Container from its ID.
-    pub fn load_container_from_id(
-        &self,
-        id: Container,
-    ) -> Container {
+    pub fn load_container_from_id(&self, id: Container) -> Container {
         let mut query = self.selection.select("loadContainerFromID");
 
         query = query.arg_lazy(
@@ -6925,10 +6275,7 @@ impl Query {
         }
     }
     /// Load a CurrentModule from its ID.
-    pub fn load_current_module_from_id(
-        &self,
-        id: CurrentModule,
-    ) -> CurrentModule {
+    pub fn load_current_module_from_id(&self, id: CurrentModule) -> CurrentModule {
         let mut query = self.selection.select("loadCurrentModuleFromID");
 
         query = query.arg_lazy(
@@ -6946,10 +6293,7 @@ impl Query {
         }
     }
     /// Load a Directory from its ID.
-    pub fn load_directory_from_id(
-        &self,
-        id: Directory,
-    ) -> Directory {
+    pub fn load_directory_from_id(&self, id: Directory) -> Directory {
         let mut query = self.selection.select("loadDirectoryFromID");
 
         query = query.arg_lazy(
@@ -6967,10 +6311,7 @@ impl Query {
         }
     }
     /// Load a EnvVariable from its ID.
-    pub fn load_env_variable_from_id(
-        &self,
-        id: EnvVariable,
-    ) -> EnvVariable {
+    pub fn load_env_variable_from_id(&self, id: EnvVariable) -> EnvVariable {
         let mut query = self.selection.select("loadEnvVariableFromID");
 
         query = query.arg_lazy(
@@ -6988,10 +6329,7 @@ impl Query {
         }
     }
     /// Load a FieldTypeDef from its ID.
-    pub fn load_field_type_def_from_id(
-        &self,
-        id: FieldTypeDef,
-    ) -> FieldTypeDef {
+    pub fn load_field_type_def_from_id(&self, id: FieldTypeDef) -> FieldTypeDef {
         let mut query = self.selection.select("loadFieldTypeDefFromID");
 
         query = query.arg_lazy(
@@ -7009,10 +6347,7 @@ impl Query {
         }
     }
     /// Load a File from its ID.
-    pub fn load_file_from_id(
-        &self,
-        id: File,
-    ) -> File {
+    pub fn load_file_from_id(&self, id: File) -> File {
         let mut query = self.selection.select("loadFileFromID");
 
         query = query.arg_lazy(
@@ -7030,10 +6365,7 @@ impl Query {
         }
     }
     /// Load a FunctionArg from its ID.
-    pub fn load_function_arg_from_id(
-        &self,
-        id: FunctionArg,
-    ) -> FunctionArg {
+    pub fn load_function_arg_from_id(&self, id: FunctionArg) -> FunctionArg {
         let mut query = self.selection.select("loadFunctionArgFromID");
 
         query = query.arg_lazy(
@@ -7072,10 +6404,7 @@ impl Query {
         }
     }
     /// Load a FunctionCall from its ID.
-    pub fn load_function_call_from_id(
-        &self,
-        id: FunctionCall,
-    ) -> FunctionCall {
+    pub fn load_function_call_from_id(&self, id: FunctionCall) -> FunctionCall {
         let mut query = self.selection.select("loadFunctionCallFromID");
 
         query = query.arg_lazy(
@@ -7093,10 +6422,7 @@ impl Query {
         }
     }
     /// Load a Function from its ID.
-    pub fn load_function_from_id(
-        &self,
-        id: Function,
-    ) -> Function {
+    pub fn load_function_from_id(&self, id: Function) -> Function {
         let mut query = self.selection.select("loadFunctionFromID");
 
         query = query.arg_lazy(
@@ -7114,10 +6440,7 @@ impl Query {
         }
     }
     /// Load a GeneratedCode from its ID.
-    pub fn load_generated_code_from_id(
-        &self,
-        id: GeneratedCode,
-    ) -> GeneratedCode {
+    pub fn load_generated_code_from_id(&self, id: GeneratedCode) -> GeneratedCode {
         let mut query = self.selection.select("loadGeneratedCodeFromID");
 
         query = query.arg_lazy(
@@ -7135,10 +6458,7 @@ impl Query {
         }
     }
     /// Load a GitModuleSource from its ID.
-    pub fn load_git_module_source_from_id(
-        &self,
-        id: GitModuleSource,
-    ) -> GitModuleSource {
+    pub fn load_git_module_source_from_id(&self, id: GitModuleSource) -> GitModuleSource {
         let mut query = self.selection.select("loadGitModuleSourceFromID");
 
         query = query.arg_lazy(
@@ -7156,10 +6476,7 @@ impl Query {
         }
     }
     /// Load a GitRef from its ID.
-    pub fn load_git_ref_from_id(
-        &self,
-        id: GitRef,
-    ) -> GitRef {
+    pub fn load_git_ref_from_id(&self, id: GitRef) -> GitRef {
         let mut query = self.selection.select("loadGitRefFromID");
 
         query = query.arg_lazy(
@@ -7177,10 +6494,7 @@ impl Query {
         }
     }
     /// Load a GitRepository from its ID.
-    pub fn load_git_repository_from_id(
-        &self,
-        id: GitRepository,
-    ) -> GitRepository {
+    pub fn load_git_repository_from_id(&self, id: GitRepository) -> GitRepository {
         let mut query = self.selection.select("loadGitRepositoryFromID");
 
         query = query.arg_lazy(
@@ -7198,10 +6512,7 @@ impl Query {
         }
     }
     /// Load a Host from its ID.
-    pub fn load_host_from_id(
-        &self,
-        id: Host,
-    ) -> Host {
+    pub fn load_host_from_id(&self, id: Host) -> Host {
         let mut query = self.selection.select("loadHostFromID");
 
         query = query.arg_lazy(
@@ -7219,10 +6530,7 @@ impl Query {
         }
     }
     /// Load a InputTypeDef from its ID.
-    pub fn load_input_type_def_from_id(
-        &self,
-        id: InputTypeDef,
-    ) -> InputTypeDef {
+    pub fn load_input_type_def_from_id(&self, id: InputTypeDef) -> InputTypeDef {
         let mut query = self.selection.select("loadInputTypeDefFromID");
 
         query = query.arg_lazy(
@@ -7240,10 +6548,7 @@ impl Query {
         }
     }
     /// Load a InterfaceTypeDef from its ID.
-    pub fn load_interface_type_def_from_id(
-        &self,
-        id: InterfaceTypeDef,
-    ) -> InterfaceTypeDef {
+    pub fn load_interface_type_def_from_id(&self, id: InterfaceTypeDef) -> InterfaceTypeDef {
         let mut query = self.selection.select("loadInterfaceTypeDefFromID");
 
         query = query.arg_lazy(
@@ -7261,10 +6566,7 @@ impl Query {
         }
     }
     /// Load a Label from its ID.
-    pub fn load_label_from_id(
-        &self,
-        id: Label,
-    ) -> Label {
+    pub fn load_label_from_id(&self, id: Label) -> Label {
         let mut query = self.selection.select("loadLabelFromID");
 
         query = query.arg_lazy(
@@ -7282,10 +6584,7 @@ impl Query {
         }
     }
     /// Load a ListTypeDef from its ID.
-    pub fn load_list_type_def_from_id(
-        &self,
-        id: ListTypeDef,
-    ) -> ListTypeDef {
+    pub fn load_list_type_def_from_id(&self, id: ListTypeDef) -> ListTypeDef {
         let mut query = self.selection.select("loadListTypeDefFromID");
 
         query = query.arg_lazy(
@@ -7303,10 +6602,7 @@ impl Query {
         }
     }
     /// Load a LocalModuleSource from its ID.
-    pub fn load_local_module_source_from_id(
-        &self,
-        id: LocalModuleSource,
-    ) -> LocalModuleSource {
+    pub fn load_local_module_source_from_id(&self, id: LocalModuleSource) -> LocalModuleSource {
         let mut query = self.selection.select("loadLocalModuleSourceFromID");
 
         query = query.arg_lazy(
@@ -7324,10 +6620,7 @@ impl Query {
         }
     }
     /// Load a ModuleDependency from its ID.
-    pub fn load_module_dependency_from_id(
-        &self,
-        id: ModuleDependency,
-    ) -> ModuleDependency {
+    pub fn load_module_dependency_from_id(&self, id: ModuleDependency) -> ModuleDependency {
         let mut query = self.selection.select("loadModuleDependencyFromID");
 
         query = query.arg_lazy(
@@ -7345,10 +6638,7 @@ impl Query {
         }
     }
     /// Load a Module from its ID.
-    pub fn load_module_from_id(
-        &self,
-        id: Module,
-    ) -> Module {
+    pub fn load_module_from_id(&self, id: Module) -> Module {
         let mut query = self.selection.select("loadModuleFromID");
 
         query = query.arg_lazy(
@@ -7366,10 +6656,7 @@ impl Query {
         }
     }
     /// Load a ModuleSource from its ID.
-    pub fn load_module_source_from_id(
-        &self,
-        id: ModuleSource,
-    ) -> ModuleSource {
+    pub fn load_module_source_from_id(&self, id: ModuleSource) -> ModuleSource {
         let mut query = self.selection.select("loadModuleSourceFromID");
 
         query = query.arg_lazy(
@@ -7387,10 +6674,7 @@ impl Query {
         }
     }
     /// Load a ModuleSourceView from its ID.
-    pub fn load_module_source_view_from_id(
-        &self,
-        id: ModuleSourceView,
-    ) -> ModuleSourceView {
+    pub fn load_module_source_view_from_id(&self, id: ModuleSourceView) -> ModuleSourceView {
         let mut query = self.selection.select("loadModuleSourceViewFromID");
 
         query = query.arg_lazy(
@@ -7408,10 +6692,7 @@ impl Query {
         }
     }
     /// Load a ObjectTypeDef from its ID.
-    pub fn load_object_type_def_from_id(
-        &self,
-        id: ObjectTypeDef,
-    ) -> ObjectTypeDef {
+    pub fn load_object_type_def_from_id(&self, id: ObjectTypeDef) -> ObjectTypeDef {
         let mut query = self.selection.select("loadObjectTypeDefFromID");
 
         query = query.arg_lazy(
@@ -7429,10 +6710,7 @@ impl Query {
         }
     }
     /// Load a Port from its ID.
-    pub fn load_port_from_id(
-        &self,
-        id: Port,
-    ) -> Port {
+    pub fn load_port_from_id(&self, id: Port) -> Port {
         let mut query = self.selection.select("loadPortFromID");
 
         query = query.arg_lazy(
@@ -7450,10 +6728,7 @@ impl Query {
         }
     }
     /// Load a Secret from its ID.
-    pub fn load_secret_from_id(
-        &self,
-        id: Secret,
-    ) -> Secret {
+    pub fn load_secret_from_id(&self, id: Secret) -> Secret {
         let mut query = self.selection.select("loadSecretFromID");
 
         query = query.arg_lazy(
@@ -7471,10 +6746,7 @@ impl Query {
         }
     }
     /// Load a Service from its ID.
-    pub fn load_service_from_id(
-        &self,
-        id: Service,
-    ) -> Service {
+    pub fn load_service_from_id(&self, id: Service) -> Service {
         let mut query = self.selection.select("loadServiceFromID");
 
         query = query.arg_lazy(
@@ -7492,10 +6764,7 @@ impl Query {
         }
     }
     /// Load a Socket from its ID.
-    pub fn load_socket_from_id(
-        &self,
-        id: Socket,
-    ) -> Socket {
+    pub fn load_socket_from_id(&self, id: Socket) -> Socket {
         let mut query = self.selection.select("loadSocketFromID");
 
         query = query.arg_lazy(
@@ -7513,10 +6782,7 @@ impl Query {
         }
     }
     /// Load a Terminal from its ID.
-    pub fn load_terminal_from_id(
-        &self,
-        id: Terminal,
-    ) -> Terminal {
+    pub fn load_terminal_from_id(&self, id: Terminal) -> Terminal {
         let mut query = self.selection.select("loadTerminalFromID");
 
         query = query.arg_lazy(
@@ -7534,10 +6800,7 @@ impl Query {
         }
     }
     /// Load a TypeDef from its ID.
-    pub fn load_type_def_from_id(
-        &self,
-        id: TypeDef,
-    ) -> TypeDef {
+    pub fn load_type_def_from_id(&self, id: TypeDef) -> TypeDef {
         let mut query = self.selection.select("loadTypeDefFromID");
 
         query = query.arg_lazy(
@@ -7555,10 +6818,8 @@ impl Query {
         }
     }
     /// Create a new module.
-    pub fn module(
-        &self,
-    ) -> Module {
-        let mut query = self.selection.select("module");
+    pub fn module(&self) -> Module {
+        let query = self.selection.select("module");
 
         Module {
             proc: self.proc.clone(),
@@ -7575,10 +6836,7 @@ impl Query {
 
     /// * `source` - The source of the dependency
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn module_dependency(
-        &self,
-        source: ModuleSource,
-    ) -> ModuleDependency {
+    pub fn module_dependency(&self, source: ModuleSource) -> ModuleDependency {
         let mut query = self.selection.select("moduleDependency");
 
         query = query.arg_lazy(
@@ -7608,7 +6866,7 @@ impl Query {
     pub fn module_dependency_opts<'a>(
         &self,
         source: ModuleSource,
-        opts: QueryModuleDependencyOpts<'a>
+        opts: QueryModuleDependencyOpts<'a>,
     ) -> ModuleDependency {
         let mut query = self.selection.select("moduleDependency");
 
@@ -7638,10 +6896,7 @@ impl Query {
 
     /// * `ref_string` - The string ref representation of the module source
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn module_source(
-        &self,
-        ref_string: impl Into<String>,
-    ) -> ModuleSource {
+    pub fn module_source(&self, ref_string: impl Into<String>) -> ModuleSource {
         let mut query = self.selection.select("moduleSource");
 
         query = query.arg("refString", ref_string.into());
@@ -7665,7 +6920,7 @@ impl Query {
     pub fn module_source_opts(
         &self,
         ref_string: impl Into<String>,
-        opts: QueryModuleSourceOpts
+        opts: QueryModuleSourceOpts,
     ) -> ModuleSource {
         let mut query = self.selection.select("moduleSource");
 
@@ -7689,10 +6944,7 @@ impl Query {
 
     /// * `name` - Name of the sub-pipeline.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn pipeline(
-        &self,
-        name: impl Into<String>,
-    ) -> Query {
+    pub fn pipeline(&self, name: impl Into<String>) -> Query {
         let mut query = self.selection.select("pipeline");
 
         query = query.arg("name", name.into());
@@ -7713,11 +6965,7 @@ impl Query {
 
     /// * `name` - Name of the sub-pipeline.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn pipeline_opts<'a>(
-        &self,
-        name: impl Into<String>,
-        opts: QueryPipelineOpts<'a>
-    ) -> Query {
+    pub fn pipeline_opts<'a>(&self, name: impl Into<String>, opts: QueryPipelineOpts<'a>) -> Query {
         let mut query = self.selection.select("pipeline");
 
         query = query.arg("name", name.into());
@@ -7742,10 +6990,7 @@ impl Query {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn secret(
-        &self,
-        name: impl Into<String>,
-    ) -> Secret {
+    pub fn secret(&self, name: impl Into<String>) -> Secret {
         let mut query = self.selection.select("secret");
 
         query = query.arg("name", name.into());
@@ -7765,11 +7010,7 @@ impl Query {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn secret_opts<'a>(
-        &self,
-        name: impl Into<String>,
-        opts: QuerySecretOpts<'a>
-    ) -> Secret {
+    pub fn secret_opts<'a>(&self, name: impl Into<String>, opts: QuerySecretOpts<'a>) -> Secret {
         let mut query = self.selection.select("secret");
 
         query = query.arg("name", name.into());
@@ -7793,11 +7034,7 @@ impl Query {
 
     /// * `name` - The user defined name for this secret
     /// * `plaintext` - The plaintext of the secret
-    pub fn set_secret(
-        &self,
-        name: impl Into<String>,
-        plaintext: impl Into<String>,
-    ) -> Secret {
+    pub fn set_secret(&self, name: impl Into<String>, plaintext: impl Into<String>) -> Secret {
         let mut query = self.selection.select("setSecret");
 
         query = query.arg("name", name.into());
@@ -7810,10 +7047,7 @@ impl Query {
         }
     }
     /// Loads a socket by its ID.
-    pub fn socket(
-        &self,
-        id: Socket,
-    ) -> Socket {
+    pub fn socket(&self, id: Socket) -> Socket {
         let mut query = self.selection.select("socket");
 
         query = query.arg_lazy(
@@ -7831,10 +7065,8 @@ impl Query {
         }
     }
     /// Create a new TypeDef.
-    pub fn type_def(
-        &self,
-    ) -> TypeDef {
-        let mut query = self.selection.select("typeDef");
+    pub fn type_def(&self) -> TypeDef {
+        let query = self.selection.select("typeDef");
 
         TypeDef {
             proc: self.proc.clone(),
@@ -7847,31 +7079,25 @@ impl Query {
 pub struct Secret {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl Secret {
     /// A unique identifier for this Secret.
-    pub async fn id(
-        &self,
-    ) -> Result<SecretId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<SecretId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The name of this secret.
-    pub async fn name(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("name");
+    pub async fn name(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("name");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The value of this secret.
-    pub async fn plaintext(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("plaintext");
+    pub async fn plaintext(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("plaintext");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -7880,12 +7106,11 @@ impl Secret {
 pub struct Service {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 #[derive(Builder, Debug, PartialEq)]
 pub struct ServiceEndpointOpts<'a> {
-
     /// The exposed port number for the endpoint
     #[builder(setter(into, strip_option), default)]
     pub port: Option<isize>,
@@ -7895,14 +7120,12 @@ pub struct ServiceEndpointOpts<'a> {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ServiceStopOpts {
-
     /// Immediately kill the service without waiting for a graceful exit
     #[builder(setter(into, strip_option), default)]
     pub kill: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ServiceUpOpts {
-
     /// List of frontend/backend port mappings to forward.
     /// Frontend is the port accepting traffic on the host, backend is the service port.
     #[builder(setter(into, strip_option), default)]
@@ -7923,10 +7146,8 @@ impl Service {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn endpoint(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("endpoint");
+    pub async fn endpoint(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("endpoint");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -7943,7 +7164,7 @@ impl Service {
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
     pub async fn endpoint_opts<'a>(
         &self,
-        opts: ServiceEndpointOpts<'a>
+        opts: ServiceEndpointOpts<'a>,
     ) -> Result<String, DaggerError> {
         let mut query = self.selection.select("endpoint");
 
@@ -7957,39 +7178,31 @@ impl Service {
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves a hostname which can be used by clients to reach this container.
-    pub async fn hostname(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("hostname");
+    pub async fn hostname(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("hostname");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// A unique identifier for this Service.
-    pub async fn id(
-        &self,
-    ) -> Result<ServiceId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<ServiceId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// Retrieves the list of ports provided by the service.
-    pub fn ports(
-        &self,
-    ) -> Vec<Port> {
-        let mut query = self.selection.select("ports");
+    pub fn ports(&self) -> Vec<Port> {
+        let query = self.selection.select("ports");
 
         return vec![Port {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }]
+        }];
     }
     /// Start the service and wait for its health checks to succeed.
     /// Services bound to a Container do not need to be manually started.
-    pub async fn start(
-        &self,
-    ) -> Result<ServiceId, DaggerError> {
-        let mut query = self.selection.select("start");
+    pub async fn start(&self) -> Result<ServiceId, DaggerError> {
+        let query = self.selection.select("start");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -8001,10 +7214,8 @@ impl Service {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn stop(
-        &self,
-    ) -> Result<ServiceId, DaggerError> {
-        let mut query = self.selection.select("stop");
+    pub async fn stop(&self) -> Result<ServiceId, DaggerError> {
+        let query = self.selection.select("stop");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -8017,10 +7228,7 @@ impl Service {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn stop_opts(
-        &self,
-        opts: ServiceStopOpts
-    ) -> Result<ServiceId, DaggerError> {
+    pub async fn stop_opts(&self, opts: ServiceStopOpts) -> Result<ServiceId, DaggerError> {
         let mut query = self.selection.select("stop");
 
         if let Some(kill) = opts.kill {
@@ -8037,10 +7245,8 @@ impl Service {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn up(
-        &self,
-    ) -> Result<Void, DaggerError> {
-        let mut query = self.selection.select("up");
+    pub async fn up(&self) -> Result<Void, DaggerError> {
+        let query = self.selection.select("up");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -8053,10 +7259,7 @@ impl Service {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn up_opts(
-        &self,
-        opts: ServiceUpOpts
-    ) -> Result<Void, DaggerError> {
+    pub async fn up_opts(&self, opts: ServiceUpOpts) -> Result<Void, DaggerError> {
         let mut query = self.selection.select("up");
 
         if let Some(ports) = opts.ports {
@@ -8073,15 +7276,13 @@ impl Service {
 pub struct Socket {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl Socket {
     /// A unique identifier for this Socket.
-    pub async fn id(
-        &self,
-    ) -> Result<SocketId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<SocketId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -8090,23 +7291,19 @@ impl Socket {
 pub struct Terminal {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 impl Terminal {
     /// A unique identifier for this Terminal.
-    pub async fn id(
-        &self,
-    ) -> Result<TerminalId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<TerminalId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// An http endpoint at which this terminal can be connected to over a websocket.
-    pub async fn websocket_endpoint(
-        &self,
-    ) -> Result<String, DaggerError> {
-        let mut query = self.selection.select("websocketEndpoint");
+    pub async fn websocket_endpoint(&self) -> Result<String, DaggerError> {
+        let query = self.selection.select("websocketEndpoint");
 
         query.execute(self.graphql_client.clone()).await
     }
@@ -8115,35 +7312,30 @@ impl Terminal {
 pub struct TypeDef {
     pub proc: Option<Arc<Child>>,
     pub selection: Selection,
-    pub graphql_client: DynGraphQLClient
+    pub graphql_client: DynGraphQLClient,
 }
 
 #[derive(Builder, Debug, PartialEq)]
 pub struct TypeDefWithFieldOpts<'a> {
-
     /// A doc string for the field, if any
     #[builder(setter(into, strip_option), default)]
     pub description: Option<&'a str>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct TypeDefWithInterfaceOpts<'a> {
-
     #[builder(setter(into, strip_option), default)]
     pub description: Option<&'a str>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct TypeDefWithObjectOpts<'a> {
-
     #[builder(setter(into, strip_option), default)]
     pub description: Option<&'a str>,
 }
 
 impl TypeDef {
     /// If kind is INPUT, the input-specific type definition. If kind is not INPUT, this will be null.
-    pub fn as_input(
-        &self,
-    ) -> InputTypeDef {
-        let mut query = self.selection.select("asInput");
+    pub fn as_input(&self) -> InputTypeDef {
+        let query = self.selection.select("asInput");
 
         InputTypeDef {
             proc: self.proc.clone(),
@@ -8152,10 +7344,8 @@ impl TypeDef {
         }
     }
     /// If kind is INTERFACE, the interface-specific type definition. If kind is not INTERFACE, this will be null.
-    pub fn as_interface(
-        &self,
-    ) -> InterfaceTypeDef {
-        let mut query = self.selection.select("asInterface");
+    pub fn as_interface(&self) -> InterfaceTypeDef {
+        let query = self.selection.select("asInterface");
 
         InterfaceTypeDef {
             proc: self.proc.clone(),
@@ -8164,10 +7354,8 @@ impl TypeDef {
         }
     }
     /// If kind is LIST, the list-specific type definition. If kind is not LIST, this will be null.
-    pub fn as_list(
-        &self,
-    ) -> ListTypeDef {
-        let mut query = self.selection.select("asList");
+    pub fn as_list(&self) -> ListTypeDef {
+        let query = self.selection.select("asList");
 
         ListTypeDef {
             proc: self.proc.clone(),
@@ -8176,10 +7364,8 @@ impl TypeDef {
         }
     }
     /// If kind is OBJECT, the object-specific type definition. If kind is not OBJECT, this will be null.
-    pub fn as_object(
-        &self,
-    ) -> ObjectTypeDef {
-        let mut query = self.selection.select("asObject");
+    pub fn as_object(&self) -> ObjectTypeDef {
+        let query = self.selection.select("asObject");
 
         ObjectTypeDef {
             proc: self.proc.clone(),
@@ -8188,34 +7374,25 @@ impl TypeDef {
         }
     }
     /// A unique identifier for this TypeDef.
-    pub async fn id(
-        &self,
-    ) -> Result<TypeDefId, DaggerError> {
-        let mut query = self.selection.select("id");
+    pub async fn id(&self) -> Result<TypeDefId, DaggerError> {
+        let query = self.selection.select("id");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// The kind of type this is (e.g. primitive, list, object).
-    pub async fn kind(
-        &self,
-    ) -> Result<TypeDefKind, DaggerError> {
-        let mut query = self.selection.select("kind");
+    pub async fn kind(&self) -> Result<TypeDefKind, DaggerError> {
+        let query = self.selection.select("kind");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// Whether this type can be set to null. Defaults to false.
-    pub async fn optional(
-        &self,
-    ) -> Result<bool, DaggerError> {
-        let mut query = self.selection.select("optional");
+    pub async fn optional(&self) -> Result<bool, DaggerError> {
+        let query = self.selection.select("optional");
 
         query.execute(self.graphql_client.clone()).await
     }
     /// Adds a function for constructing a new instance of an Object TypeDef, failing if the type is not an object.
-    pub fn with_constructor(
-        &self,
-        function: Function,
-    ) -> TypeDef {
+    pub fn with_constructor(&self, function: Function) -> TypeDef {
         let mut query = self.selection.select("withConstructor");
 
         query = query.arg_lazy(
@@ -8242,11 +7419,7 @@ impl TypeDef {
     /// * `name` - The name of the field in the object
     /// * `type_def` - The type of the field
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_field(
-        &self,
-        name: impl Into<String>,
-        type_def: TypeDef,
-    ) -> TypeDef {
+    pub fn with_field(&self, name: impl Into<String>, type_def: TypeDef) -> TypeDef {
         let mut query = self.selection.select("withField");
 
         query = query.arg("name", name.into());
@@ -8279,7 +7452,7 @@ impl TypeDef {
         &self,
         name: impl Into<String>,
         type_def: TypeDef,
-        opts: TypeDefWithFieldOpts<'a>
+        opts: TypeDefWithFieldOpts<'a>,
     ) -> TypeDef {
         let mut query = self.selection.select("withField");
 
@@ -8302,10 +7475,7 @@ impl TypeDef {
         }
     }
     /// Adds a function for an Object or Interface TypeDef, failing if the type is not one of those kinds.
-    pub fn with_function(
-        &self,
-        function: Function,
-    ) -> TypeDef {
+    pub fn with_function(&self, function: Function) -> TypeDef {
         let mut query = self.selection.select("withFunction");
 
         query = query.arg_lazy(
@@ -8330,10 +7500,7 @@ impl TypeDef {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_interface(
-        &self,
-        name: impl Into<String>,
-    ) -> TypeDef {
+    pub fn with_interface(&self, name: impl Into<String>) -> TypeDef {
         let mut query = self.selection.select("withInterface");
 
         query = query.arg("name", name.into());
@@ -8356,7 +7523,7 @@ impl TypeDef {
     pub fn with_interface_opts<'a>(
         &self,
         name: impl Into<String>,
-        opts: TypeDefWithInterfaceOpts<'a>
+        opts: TypeDefWithInterfaceOpts<'a>,
     ) -> TypeDef {
         let mut query = self.selection.select("withInterface");
 
@@ -8372,10 +7539,7 @@ impl TypeDef {
         }
     }
     /// Sets the kind of the type.
-    pub fn with_kind(
-        &self,
-        kind: TypeDefKind,
-    ) -> TypeDef {
+    pub fn with_kind(&self, kind: TypeDefKind) -> TypeDef {
         let mut query = self.selection.select("withKind");
 
         query = query.arg("kind", kind);
@@ -8387,10 +7551,7 @@ impl TypeDef {
         }
     }
     /// Returns a TypeDef of kind List with the provided type for its elements.
-    pub fn with_list_of(
-        &self,
-        element_type: TypeDef,
-    ) -> TypeDef {
+    pub fn with_list_of(&self, element_type: TypeDef) -> TypeDef {
         let mut query = self.selection.select("withListOf");
 
         query = query.arg_lazy(
@@ -8416,10 +7577,7 @@ impl TypeDef {
     ///
 
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub fn with_object(
-        &self,
-        name: impl Into<String>,
-    ) -> TypeDef {
+    pub fn with_object(&self, name: impl Into<String>) -> TypeDef {
         let mut query = self.selection.select("withObject");
 
         query = query.arg("name", name.into());
@@ -8443,7 +7601,7 @@ impl TypeDef {
     pub fn with_object_opts<'a>(
         &self,
         name: impl Into<String>,
-        opts: TypeDefWithObjectOpts<'a>
+        opts: TypeDefWithObjectOpts<'a>,
     ) -> TypeDef {
         let mut query = self.selection.select("withObject");
 
@@ -8459,10 +7617,7 @@ impl TypeDef {
         }
     }
     /// Sets whether this type can be set to null.
-    pub fn with_optional(
-        &self,
-        optional: bool,
-    ) -> TypeDef {
+    pub fn with_optional(&self, optional: bool) -> TypeDef {
         let mut query = self.selection.select("withOptional");
 
         query = query.arg("optional", optional);

--- a/sdk/rust/crates/dagger-sdk/src/querybuilder.rs
+++ b/sdk/rust/crates/dagger-sdk/src/querybuilder.rs
@@ -79,7 +79,7 @@ impl Selection {
     {
         let mut s = self.clone();
 
-        let val = serde_json::to_string(&value).unwrap();
+        let val = serde_graphql_input::to_string_pretty(&value).unwrap();
 
         match s.args.as_mut() {
             Some(args) => {
@@ -116,34 +116,11 @@ impl Selection {
         s
     }
 
-    pub fn arg_enum<S>(&self, name: &str, value: S) -> Selection
-    where
-        S: Serialize,
-    {
-        let mut s = self.clone();
-
-        let val = serde_json::to_string(&value).unwrap();
-        let val = val[1..val.len() - 1].to_string();
-
-        match s.args.as_mut() {
-            Some(args) => {
-                let _ = args.insert(name.to_string(), val.into());
-            }
-            None => {
-                let mut hm = HashMap::new();
-                let _ = hm.insert(name.to_string(), val.into());
-                s.args = Some(hm);
-            }
-        }
-
-        s
-    }
-
     pub async fn build(&self) -> Result<String, DaggerError> {
         let mut fields = vec!["query".to_string()];
 
         for sel in self.path() {
-            if let Some(mut query) = sel.name.map(|q| q.clone()) {
+            if let Some(mut query) = sel.name {
                 if let Some(args) = sel.args {
                     let mut actualargs = Vec::new();
                     for (name, arg) in args.iter() {
@@ -348,8 +325,7 @@ mod tests {
 
         assert_eq!(
             query,
-            r#"query{a(arg:{"name":"some-name","s":{"name":"some-other-name","s":null}})}"#
-                .to_string()
+            r#"query{a(arg:{name:"some-name",s:{name:"some-other-name",s:null}})}"#.to_string()
         )
     }
 }


### PR DESCRIPTION
This PR adds a new serializer for graphql input. The previous serializer (serde_json) was just a regular json parser, however, as graphql input functions aren't strictly json (missing quotes on keyes, and enums) it turned out to not be a great fit, and couldn't implement a lot of the functionality we wanted.

As such this pr introduces a purpose built serializer which can handle this.

This should also fix: #5928

Edit: also contains an update to rust versions. Note that this is only for the building, we support down to Windows MSVC
