### PR TITLE
chore: restore install.ps1

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,6 +12,7 @@ This describes how to release Dagger:
 - [🛝 Playground ⏱ `2mins`](#-playground--2mins)
 - [🌌 Daggerverse ⏱ `2mins`](#-daggerverse--2mins)
 - [☁️ Dagger Cloud ⏱ `2mins`](#-dagger-cloud--2mins)
+- [🪣 Install scripts ⏱ `2mins`](#-install-scripts--2mins#)
 - [🐙 dagger-for-github ⏱ `2mins`](#-dagger-for-github--2mins#)
 - [🍺 dagger Homebrew ⏱ `2mins`](#-dagger-homebrew--2mins#)
 - [❄️ nix ⏱ `2mins`](#-nix--2mins#)
@@ -488,6 +489,12 @@ update once there's a new release of the Dagger Engine.
 
 - [ ] Mention in the release thread on Discord that Dagger Cloud can be updated
   to the just-released version. cc @marcosnils @matipan @sipsma
+
+## 🪣 Install scripts ⏱ `2mins`
+
+- [ ] If the install scripts `install.sh` or `install.ps1` have changed since
+  the last release, they must be manually updated on Amazon S3 (CloudFront
+  should also be manually invalidated). cc @gerhard
 
 ## 🐙 dagger-for-github ⏱ `2mins`
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,95 @@
+#Requires -Version 7.0
+
+param (
+    [Parameter(Mandatory = $false)] [System.Management.Automation.SemanticVersion]$DaggerVersion,
+    [Parameter(Mandatory = $false)] [string]$InstallPath = $env:HOMEPATH + '\dagger',
+
+    [Parameter(Mandatory = $false)] [System.Boolean]$InteractiveInstall = $false
+)
+
+@"
+---------------------------------------------------------------------------------
+Author: Alessandro Festa
+Co Author: Brittan DeYoung
+Dagger Installation Utility for Windows users
+---------------------------------------------------------------------------------
+"@
+
+$name="dagger"
+$base="https://dl.dagger.io"
+
+function execute {
+    $url = base_url
+    $filename = tarball
+    $url = $url + "/" + $filename
+    write-host $url
+    if ($InteractiveInstall) {
+        Pause
+    }
+
+    Invoke-WebRequest -Uri $url -OutFile $env:temp/$filename -ErrorAction Stop
+    Expand-Archive -Path $env:temp/$filename -DestinationPath $InstallPath -Force -ErrorVariable ProcessError;
+    If ($ProcessError) {
+@"
+---------------------------------------------------------------------------
+Whoops apparently we had an issue in unzipping the file, please check
+you have the right permission to do so and try to unzip manually the file.
+Currently we saved Dagger at your temp folder.
+---------------------------------------------------------------------------
+"@
+        exit
+    } else {
+@"
+
+Thank You for downloading Dagger!
+
+-----------------------------------------------------
+Dagger has been saved at <YOUR HOME FOLDER>/dagger/
+Please add dagger.exe to your PATH in order to use it
+----------------------------------------------------
+
+"@
+    }
+
+}
+
+function latest_version {
+    $response = Invoke-RestMethod 'http://dl.dagger.io/dagger/latest_version' -Method 'GET' -Body $body -ErrorAction SilentlyContinue -ErrorVariable DownloadError
+    If ($DownloadError) {
+@"
+---------------------------------------------------------------------------
+Houston we have a problem!
+
+Apparently we had an issue in downloading the file, please try again
+run the script and if it still fail please open an issue on the Dagger repo.
+----------------------------------------------------------------------------
+"@
+        exit
+    }
+    $response=$response -replace '[""]'
+    $response=$response -replace '\n'
+    return $response
+}
+
+function base_url {
+    if ($DaggerVersion) {
+        $version = $DaggerVersion
+    } else {
+        $version = latest_version
+    }
+    $url = $base + "/" + $name + "/releases/" + $version
+    return $url
+}
+
+function tarball {
+    if ($DaggerVersion) {
+        $version = $DaggerVersion
+    } else {
+        $version = latest_version
+    }
+    $fileName="dagger_v" + $version + "_windows_amd64"
+    $filename = $filename + ".zip"
+    return $filename
+}
+
+execute

--- a/install.ps1
+++ b/install.ps1
@@ -7,13 +7,11 @@ param (
     [Parameter(Mandatory = $false)] [System.Boolean]$InteractiveInstall = $false
 )
 
-@"
----------------------------------------------------------------------------------
-Author: Alessandro Festa
-Co Author: Brittan DeYoung
-Dagger Installation Utility for Windows users
----------------------------------------------------------------------------------
-"@
+# ---------------------------------------------------------------------------------
+# Author: Alessandro Festa
+# Co Author: Brittan DeYoung
+# Dagger Installation Utility for Windows users
+# ---------------------------------------------------------------------------------
 
 $name="dagger"
 $base="https://dl.dagger.io"


### PR DESCRIPTION
Fix https://github.com/dagger/dagger/issues/6901.

This script was removed in https://github.com/dagger/dagger/commit/5a9c772020363668c18e73472534f01a5b03b8d5, and we still have windows install instructions, so we should probably restore this!

I've also updated the script with a few additions, like making the function names map to the same as the unix script.