### PR TITLE
Modularize CI followups

### DIFF
--- a/ci/engine.go
+++ b/ci/engine.go
@@ -61,6 +61,7 @@ func (e *Engine) Container(
 	if err != nil {
 		return nil, err
 	}
+	builder = builder.WithVersion(e.Dagger.Version.String())
 	if platform != "" {
 		builder = builder.WithPlatform(platform)
 	}
@@ -145,12 +146,8 @@ func (e *Engine) Publish(
 	if len(platform) == 0 {
 		platform = []Platform{Platform(platforms.DefaultString())}
 	}
-	builder, err := build.NewBuilder(ctx, e.Dagger.Source)
-	if err != nil {
-		return "", err
-	}
 
-	ref := fmt.Sprintf("%s:%s", image, builder.EngineVersion())
+	ref := fmt.Sprintf("%s:%s", image, e.Dagger.Version)
 	if e.GPUSupport {
 		ref += "-gpu"
 	}

--- a/ci/mage/cli.go
+++ b/ci/mage/cli.go
@@ -13,7 +13,7 @@ type Cli mg.Namespace
 
 // Publish publishes dagger CLI using GoReleaser
 func (cl Cli) Publish(ctx context.Context, version string) error {
-	args := []string{"cli", "publish", "--version=" + version}
+	args := []string{"--version=" + version, "cli", "publish"}
 
 	if v, ok := os.LookupEnv("GH_ORG_NAME"); ok {
 		args = append(args, "--github-org-name="+v)

--- a/ci/mage/engine.go
+++ b/ci/mage/engine.go
@@ -57,7 +57,7 @@ func (t Engine) Publish(ctx context.Context, version string) error {
 		commonArgs = append(commonArgs, "--registry-password=env:DAGGER_ENGINE_IMAGE_PASSWORD")
 	}
 
-	args := []string{"engine", "publish", "--version=" + version}
+	args := []string{"--version=" + version, "engine", "publish"}
 	args = append(args, commonArgs...)
 	for _, p := range publishedEnginePlatforms {
 		args = append(args, "--platform="+p)
@@ -67,7 +67,7 @@ func (t Engine) Publish(ctx context.Context, version string) error {
 		return err
 	}
 
-	args = []string{"engine", "with-gpusupport", "publish", "--version=" + version}
+	args = []string{"--version=" + version, "engine", "with-gpusupport", "publish"}
 	args = append(args, commonArgs...)
 	for _, p := range publishedGPUEnginePlatforms {
 		args = append(args, "--platform="+p)

--- a/ci/version.go
+++ b/ci/version.go
@@ -1,4 +1,4 @@
-package build
+package main
 
 import (
 	"context"
@@ -15,7 +15,7 @@ type VersionInfo struct {
 	TreeHash string
 }
 
-func getVersionFromGit(ctx context.Context, dir *dagger.Directory) (*VersionInfo, error) {
+func newVersionFromGit(ctx context.Context, dir *dagger.Directory) (*VersionInfo, error) {
 	base := dag.Container().
 		From(consts.AlpineImage).
 		WithExec([]string{"apk", "add", "git"}).
@@ -38,7 +38,7 @@ func getVersionFromGit(ctx context.Context, dir *dagger.Directory) (*VersionInfo
 	return info, nil
 }
 
-func (info VersionInfo) EngineVersion() string {
+func (info *VersionInfo) String() string {
 	if info.Tag != "" {
 		return info.Tag
 	}


### PR DESCRIPTION
Follow-up to #6843.

Fixes:
- Broken Go SDK publish on `main`: https://github.com/dagger/dagger/actions/runs/8602295935/job/23571547672
	- Due to an incorrect refactoring, we need to restore some of the original functionality
- Broken image publish on `main`: https://github.com/dagger/dagger/actions/runs/8602589466/job/23572487550
	- Due to completely inconsistent handling of version data
	- Instead of just applying a simple fix in the shim, we need to rework how versioning works entirely. Now it's a top-level arg in the constructor, and when that's not provided, we try and cleverly load it from git.
	- By having this at the top-level now, we ensure that all of the binaries produced have the right tags specified (which they weren't really before :scream:)