### PR TITLE
ci: remove yaml aliases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
-    schedule: &schedule-weekly
+    schedule:
       interval: "weekly"
       day: "monday"
       time: "07:00"
@@ -19,7 +19,11 @@ updates:
 
   - package-ecosystem: "gomod"
     directory: "/ci
-    schedule: *schedule-weekly
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "UTC"
     labels:
       - "kind/dependencies"
       - "area/ci"
@@ -31,7 +35,11 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/sdk/typescript"
-    schedule: *schedule-weekly
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "UTC"
     labels:
       - "kind/dependencies"
       - "sdk/typescript"
@@ -46,7 +54,11 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/website"
-    schedule: *schedule-weekly
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "UTC"
     labels:
       - "kind/dependencies"
       - "area/docs"
@@ -61,7 +73,11 @@ updates:
 
   - package-ecosystem: "gomod"
     directory: "/sdk/go"
-    schedule: *schedule-weekly
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "UTC"
     labels:
       - "kind/dependencies"
       - "sdk/go"
@@ -76,7 +92,11 @@ updates:
 
   - package-ecosystem: "pip"
     directory: "/sdk/python"
-    schedule: *schedule-weekly
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "UTC"
     labels:
       - "kind/dependencies"
       - "sdk/python"
@@ -91,7 +111,11 @@ updates:
 
   - package-ecosystem: "maven"
     directory: "/sdk/java"
-    schedule: *schedule-weekly
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "UTC"
     labels:
       - "kind/dependencies"
       - "sdk/java"


### PR DESCRIPTION
Spotted this failure just now: https://github.com/dagger/dagger/pull/6959/checks?check_run_id=23515980223
![image](https://github.com/dagger/dagger/assets/7352848/6218f39e-f33d-4bb8-a556-d47b738873ac)

No aliases :cry: https://github.com/dependabot/dependabot-core/issues/1582

This regression was introduced in #6811.