### PR TITLE
ci: don't set --progress=plain

### DIFF
--- a/ci/mage/util/dagger.go
+++ b/ci/mage/util/dagger.go
@@ -11,7 +11,7 @@ func DaggerCall(ctx context.Context, args ...string) error {
 	if path, ok := os.LookupEnv("_EXPERIMENTAL_DAGGER_CLI_BIN"); ok {
 		binary = path
 	}
-	args = append([]string{"--progress=plain", "call", "--source=."}, args...)
+	args = append([]string{"call", "--source=."}, args...)
 	cmd := exec.CommandContext(ctx, binary, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
It'll pick the right thing all on its own; no need to manually set it. This way we can still have the nice TUI in `./hack/dev`