### PR TITLE
ci: fix mage registry username

### DIFF
--- a/ci/mage/engine.go
+++ b/ci/mage/engine.go
@@ -50,8 +50,8 @@ func (t Engine) Publish(ctx context.Context, version string) error {
 	if v, ok := os.LookupEnv("DAGGER_ENGINE_IMAGE_REGISTRY"); ok {
 		commonArgs = append(commonArgs, "--registry="+v)
 	}
-	if _, ok := os.LookupEnv("DAGGER_ENGINE_IMAGE_USERNAME"); ok {
-		commonArgs = append(commonArgs, "--registry-username=env:DAGGER_ENGINE_IMAGE_USERNAME")
+	if v, ok := os.LookupEnv("DAGGER_ENGINE_IMAGE_USERNAME"); ok {
+		commonArgs = append(commonArgs, "--registry-username="+v)
 	}
 	if _, ok := os.LookupEnv("DAGGER_ENGINE_IMAGE_PASSWORD"); ok {
 		commonArgs = append(commonArgs, "--registry-password=env:DAGGER_ENGINE_IMAGE_PASSWORD")


### PR DESCRIPTION
`env:` prefix is only supported for secrets.

Agh, more: https://github.com/dagger/dagger/actions/runs/8613689129/job/23605520739