### PR TITLE
core: support automatic installation of custom CA certs.

### DIFF
--- a/cmd/engine/cacerts/cacerts.go
+++ b/cmd/engine/cacerts/cacerts.go
@@ -1,0 +1,93 @@
+package cacerts
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	EngineCustomCACertsDir = "/usr/local/share/ca-certificates"
+)
+
+type Installer interface {
+	Install(ctx context.Context) error
+	Uninstall(context.Context) error
+	detect(context.Context) (bool, error)
+}
+
+type executeContainerFunc func(ctx context.Context, args ...string) error
+
+func NewInstaller(
+	ctx context.Context,
+	spec *specs.Spec,
+	executeContainer executeContainerFunc,
+) (Installer, error) {
+	dirEnts, err := os.ReadDir(EngineCustomCACertsDir)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	if len(dirEnts) == 0 {
+		return noopInstaller{}, nil
+	}
+
+	ctrFS, err := newContainerFS(spec, executeContainer)
+	if err != nil {
+		return nil, err
+	}
+
+	var eg errgroup.Group
+	matchChan := make(chan Installer, 1)
+	for _, installer := range []Installer{
+		&debianLike{ctrFS: ctrFS},
+		&rhelLike{ctrFS: ctrFS},
+	} {
+		installer := installer
+		eg.Go(func() error {
+			match, err := installer.detect(ctx)
+			if err != nil {
+				return err
+			}
+			if match {
+				select {
+				case matchChan <- installer:
+				default:
+				}
+			}
+			return nil
+		})
+	}
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- eg.Wait()
+	}()
+
+	select {
+	case match := <-matchChan:
+		return match, nil
+	case err := <-errChan:
+		// double check there wasn't an obscure race condition where a match
+		// was found but we weren't signaled until after the errgroup finished
+		select {
+		case match := <-matchChan:
+			return match, nil
+		default:
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// no match found
+	return noopInstaller{}, nil
+}
+
+type noopInstaller struct{}
+
+func (noopInstaller) Install(context.Context) error        { return nil }
+func (noopInstaller) Uninstall(context.Context) error      { return nil }
+func (noopInstaller) detect(context.Context) (bool, error) { return false, nil }

--- a/cmd/engine/cacerts/cacerts.go
+++ b/cmd/engine/cacerts/cacerts.go
@@ -42,8 +42,8 @@ func NewInstaller(
 	var eg errgroup.Group
 	matchChan := make(chan Installer, 1)
 	for _, installer := range []Installer{
-		&debianLike{ctrFS: ctrFS},
-		&rhelLike{ctrFS: ctrFS},
+		newDebianLike(ctrFS),
+		newRhelLike(ctrFS),
 	} {
 		installer := installer
 		eg.Go(func() error {

--- a/cmd/engine/cacerts/distros.go
+++ b/cmd/engine/cacerts/distros.go
@@ -186,6 +186,7 @@ type commonInstaller struct {
 	installedSymlinks map[string]string
 }
 
+//nolint:gocyclo
 func (d *commonInstaller) Install(ctx context.Context) (rerr error) {
 	cleanups := &cleanups{}
 	defer func() {
@@ -342,6 +343,7 @@ func (d *commonInstaller) Install(ctx context.Context) (rerr error) {
 	return nil
 }
 
+//nolint:gocyclo
 func (d *commonInstaller) Uninstall(ctx context.Context) error {
 	bundleExists, err := d.ctrFS.PathExists(d.bundlePath)
 	if err != nil {

--- a/cmd/engine/cacerts/distros.go
+++ b/cmd/engine/cacerts/distros.go
@@ -1,0 +1,497 @@
+package cacerts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+/* TODO: open questions
+* Alpine has both /etc/ssl/ and /etc/ssl1.1 dirs...
+* LibreSSL does it's own thing? https://wiki.archlinux.org/title/Transport_Layer_Security
+* GNUTLS too; uses pkcs11 stuff (can other things be custom compiled to use that?)
+* More variations here: https://go.dev/src/crypto/x509/root_linux.go
+
+More distros to handle:
+* Arch Linux
+* OpenSUSE/sles
+* NiXOS
+* BusyBox
+* Wolfi
+*/
+
+/*
+This is anything that uses:
+* bundle path: /etc/ssl/certs/ca-certificates.crt
+* custom CA dir: /usr/local/share/ca-certificates
+* update command: update-ca-certificates
+
+This is known to include:
+* Debian/Ubuntu/other derivatives
+* Alpine
+* Gentoo
+
+Which are obviously not all Debian derivatives...
+It's named debianLike for lack of a better name :-)
+*/
+type debianLike struct {
+	ctrFS *containerFS
+
+	bundleExisted          bool
+	customCACertDirExisted bool
+	updateCommandExisted   bool
+
+	existingCerts  map[string]string
+	installedCerts map[string]string
+
+	existingBundledCerts map[string]struct{}
+
+	existingSymlinks  map[string]string
+	installedSymlinks map[string]string
+}
+
+func (debianLike) bundlePath() string {
+	return "/etc/ssl/certs/ca-certificates.crt"
+}
+
+func (debianLike) customCACertDir() string {
+	return "/usr/local/share/ca-certificates"
+}
+
+func (d *debianLike) detect(ctx context.Context) (bool, error) {
+	if exists, err := d.ctrFS.AnyPathExists([]string{
+		"/etc/debian_version",
+		"/etc/alpine-release",
+		"/etc/gentoo-release",
+	}); err != nil {
+		return false, err
+	} else if exists {
+		return true, nil
+	}
+
+	return d.ctrFS.OSReleaseFileContains(
+		[][]byte{
+			[]byte("debian"),
+			[]byte("ubuntu"),
+			[]byte("alpine"),
+			[]byte("gentoo"),
+		},
+		[][]byte{
+			[]byte("debian"),
+			[]byte("ubuntu"),
+			[]byte("alpine"),
+			[]byte("gentoo"),
+		},
+	)
+}
+
+func (d *debianLike) Install(ctx context.Context) error {
+	var err error
+	d.bundleExisted, err = d.ctrFS.PathExists(d.bundlePath())
+	if err != nil {
+		return err
+	}
+
+	d.customCACertDirExisted, err = d.ctrFS.PathExists(d.customCACertDir())
+	if err != nil {
+		return err
+	}
+
+	updateCmdPath, lookupErr := d.ctrFS.LookPath("update-ca-certificates")
+	d.updateCommandExisted = lookupErr == nil
+	if !d.updateCommandExisted && !errors.Is(lookupErr, exec.ErrNotFound) {
+		return fmt.Errorf("failed to lookup update-ca-certificates: %w", lookupErr)
+	}
+
+	d.installedCerts, d.installedSymlinks, err = ReadHostCustomCADir(EngineCustomCACertsDir)
+	if err != nil {
+		return fmt.Errorf("failed to read custom CA dir: %w", err)
+	}
+
+	if d.bundleExisted {
+		d.existingBundledCerts, err = d.ctrFS.ReadCABundleFile(d.bundlePath())
+		if err != nil {
+			return fmt.Errorf("failed to read existing bundle: %w", err)
+		}
+	}
+
+	if d.customCACertDirExisted {
+		d.existingCerts, d.existingSymlinks, err = d.ctrFS.ReadCustomCADir(d.customCACertDir())
+		if err != nil {
+			return fmt.Errorf("failed to read existing custom CA dir: %w", err)
+		}
+	} else {
+		// TODO: track what parent dirs we create so we can clean up fully
+		// TODO: double check perms here
+		if err := d.ctrFS.MkdirAll(d.customCACertDir(), 0755); err != nil {
+			return err
+		}
+	}
+
+	// install to custom CA dir even when command doesn't exist to handle case where the exec installs ca-certificates
+	// TODO: parallelize symlink+file install
+	for installSymlink, target := range d.installedSymlinks {
+		destPath := filepath.Join(d.customCACertDir(), installSymlink)
+		if _, err := d.ctrFS.Lstat(destPath); err == nil {
+			// already exists, skip
+			delete(d.installedSymlinks, installSymlink)
+			continue
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+		if err := d.ctrFS.Symlink(target, destPath); err != nil {
+			return err
+		}
+	}
+	for certContents, certFileName := range d.installedCerts {
+		destPath := filepath.Join(d.customCACertDir(), certFileName)
+		if _, err := d.ctrFS.Lstat(destPath); err == nil {
+			// already exists, skip
+			delete(d.installedCerts, certContents)
+			continue
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+		if err := d.ctrFS.WriteFile(destPath, []byte(certContents+"\n"), 0644); err != nil {
+			return err
+		}
+	}
+
+	if d.updateCommandExisted {
+		if err := d.ctrFS.Exec(ctx, updateCmdPath); err != nil {
+			return fmt.Errorf("failed to run update-ca-certificates for install: %w", err)
+		}
+		return nil
+	}
+
+	if !d.bundleExisted {
+		// TODO: track what parent dirs we create so we can clean up fully
+		// TODO: double check perms here
+		if err := d.ctrFS.MkdirAll(filepath.Dir(d.bundlePath()), 0755); err != nil {
+			return err
+		}
+	}
+
+	f, err := d.ctrFS.OpenFile(d.bundlePath(), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	for installCert := range d.installedCerts {
+		// skip installing certs that are already in the bundle
+		if _, exists := d.existingBundledCerts[installCert]; exists {
+			delete(d.installedCerts, installCert)
+			continue
+		}
+		if _, err := f.WriteString(installCert + "\n\n"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *debianLike) Uninstall(ctx context.Context) error {
+	// TODO: parallelize symlink+file uninstall
+	for installSymlink := range d.installedSymlinks {
+		destPath := filepath.Join(d.customCACertDir(), installSymlink)
+		// best effort, if it didn't exist because the exec deleted it, that's fine
+		d.ctrFS.Remove(destPath)
+	}
+	// TODO: it's *technically* possible that the exec overwrote a file here, in which case
+	// we don't want to delete it. Can use create time
+	for _, certFileName := range d.installedCerts {
+		destPath := filepath.Join(d.customCACertDir(), certFileName)
+		// best effort, if it didn't exist because the exec deleted it, that's fine
+		d.ctrFS.Remove(destPath)
+	}
+
+	// The update command could have existed before but got uninstalled, or it could have not existed
+	// before and got installed by the exec. Either way, need to check for it again now.
+	updateCmdPath, lookupErr := d.ctrFS.LookPath("update-ca-certificates")
+	updateCommandExists := lookupErr == nil
+	if !updateCommandExists && !errors.Is(lookupErr, exec.ErrNotFound) {
+		return fmt.Errorf("failed to lookup update-ca-certificates: %w", lookupErr)
+	}
+
+	// update the bundle using the command if available, otherwise manually remove the certs
+	if updateCommandExists {
+		if err := d.ctrFS.Exec(ctx, updateCmdPath); err != nil {
+			return fmt.Errorf("failed to run update-ca-certificates for uninstall: %w", err)
+		}
+	} else if err := d.ctrFS.RemoveCertsFromCABundle(d.bundlePath(), d.installedCerts); err != nil {
+		return err
+	}
+
+	if !d.bundleExisted {
+		// if the bundle didn't exist before, remove it provided it's now empty after removing our installed certs
+		stat, err := d.ctrFS.Stat(d.bundlePath())
+		if err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		if stat != nil && stat.Size() == 0 {
+			if err := d.ctrFS.Remove(d.bundlePath()); err != nil {
+				return err
+			}
+		}
+	}
+
+	// only remove the custom CA dir if it didn't exist before and it expected to have been created or removed
+	// by the exec. We heuristically determine this by checking the before/after state of the update command, which
+	// tells us whether the dir is expected to exist or not.
+	cmdNeverExisted := !d.updateCommandExisted && !updateCommandExists
+	cmdWasRemoved := d.updateCommandExisted && !updateCommandExists
+	if (!d.customCACertDirExisted && cmdNeverExisted) || (d.customCACertDirExisted && cmdWasRemoved) {
+		// if the custom CA dir didn't exist before, remove it provided it's now empty after removing our installed certs
+		isEmpty, err := d.ctrFS.DirIsEmpty(d.customCACertDir())
+		if err != nil {
+			return err
+		}
+		if isEmpty {
+			if err := d.ctrFS.Remove(d.customCACertDir()); err != nil && !os.IsNotExist(err) {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+/*
+RHEL and derivatives use:
+* bundle path: /etc/pki/tls/certs/ca-bundle.crt
+* custom CA dir: /etc/pki/ca-trust/source/anchors
+* update command: trust extract
+
+This is known to include:
+* RHEL
+* Fedora
+* CentOS
+* Amazon Linux
+*/
+type rhelLike struct {
+	ctrFS *containerFS
+
+	bundleExisted          bool
+	customCACertDirExisted bool
+	updateCommandExisted   bool
+
+	existingCerts  map[string]string
+	installedCerts map[string]string
+
+	existingBundledCerts map[string]struct{}
+
+	existingSymlinks  map[string]string
+	installedSymlinks map[string]string
+}
+
+func (rhelLike) bundlePath() string {
+	return "/etc/pki/tls/certs/ca-bundle.crt"
+}
+
+func (rhelLike) customCACertDir() string {
+	return "/etc/pki/ca-trust/source/anchors"
+}
+
+func (rhelLike) updateCmd() []string {
+	return []string{"update-ca-trust"}
+}
+
+func (d *rhelLike) detect(ctx context.Context) (bool, error) {
+	if exists, err := d.ctrFS.AnyPathExists([]string{
+		"/etc/redhat-release",
+		"/etc/redhat-version",
+		"/etc/centos-release",
+	}); err != nil {
+		return false, err
+	} else if exists {
+		return true, nil
+	}
+
+	return d.ctrFS.OSReleaseFileContains(
+		[][]byte{
+			[]byte("rhel"),
+			[]byte("fedora"),
+			[]byte("centos"),
+			[]byte("amzn"),
+		},
+		[][]byte{
+			[]byte("rhel"),
+			[]byte("centos"),
+			[]byte("fedora"),
+		},
+	)
+}
+
+func (d *rhelLike) Install(ctx context.Context) error {
+	var err error
+	d.bundleExisted, err = d.ctrFS.PathExists(d.bundlePath())
+	if err != nil {
+		return err
+	}
+
+	d.customCACertDirExisted, err = d.ctrFS.PathExists(d.customCACertDir())
+	if err != nil {
+		return err
+	}
+
+	_, lookupErr := d.ctrFS.LookPath(d.updateCmd()[0])
+	d.updateCommandExisted = lookupErr == nil
+	if !d.updateCommandExisted && !errors.Is(lookupErr, exec.ErrNotFound) {
+		return fmt.Errorf("failed to lookup %s: %w", d.updateCmd()[0], lookupErr)
+	}
+
+	d.installedCerts, d.installedSymlinks, err = ReadHostCustomCADir(EngineCustomCACertsDir)
+	if err != nil {
+		return fmt.Errorf("failed to read custom CA dir: %w", err)
+	}
+
+	if d.bundleExisted {
+		d.existingBundledCerts, err = d.ctrFS.ReadCABundleFile(d.bundlePath())
+		if err != nil {
+			return fmt.Errorf("failed to read existing bundle: %w", err)
+		}
+	}
+
+	if d.customCACertDirExisted {
+		d.existingCerts, d.existingSymlinks, err = d.ctrFS.ReadCustomCADir(d.customCACertDir())
+		if err != nil {
+			return fmt.Errorf("failed to read existing custom CA dir: %w", err)
+		}
+	} else {
+		// TODO: track what parent dirs we create so we can clean up fully
+		// TODO: double check perms here
+		if err := d.ctrFS.MkdirAll(d.customCACertDir(), 0755); err != nil {
+			return err
+		}
+	}
+
+	// install to custom CA dir even when command doesn't exist to handle case where the exec installs ca-certificates
+	// TODO: parallelize symlink+file install
+	for installSymlink, target := range d.installedSymlinks {
+		destPath := filepath.Join(d.customCACertDir(), installSymlink)
+		if _, err := d.ctrFS.Lstat(destPath); err == nil {
+			// already exists, skip
+			delete(d.installedSymlinks, installSymlink)
+			continue
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+		if err := d.ctrFS.Symlink(target, destPath); err != nil {
+			return err
+		}
+	}
+	for certContents, certFileName := range d.installedCerts {
+		destPath := filepath.Join(d.customCACertDir(), certFileName)
+		if _, err := d.ctrFS.Lstat(destPath); err == nil {
+			// already exists, skip
+			delete(d.installedCerts, certContents)
+			continue
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+		if err := d.ctrFS.WriteFile(destPath, []byte(certContents+"\n"), 0644); err != nil {
+			return err
+		}
+	}
+
+	if d.updateCommandExisted {
+		if err := d.ctrFS.Exec(ctx, d.updateCmd()...); err != nil {
+			return fmt.Errorf("failed to run %v for install: %w", d.updateCmd(), err)
+		}
+		return nil
+	}
+
+	if !d.bundleExisted {
+		// TODO: track what parent dirs we create so we can clean up fully
+		// TODO: double check perms here
+		if err := d.ctrFS.MkdirAll(filepath.Dir(d.bundlePath()), 0755); err != nil {
+			return err
+		}
+	}
+
+	f, err := d.ctrFS.OpenFile(d.bundlePath(), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	for installCert := range d.installedCerts {
+		// skip installing certs that are already in the bundle
+		if _, exists := d.existingBundledCerts[installCert]; exists {
+			delete(d.installedCerts, installCert)
+			continue
+		}
+		if _, err := f.WriteString(installCert + "\n\n"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *rhelLike) Uninstall(ctx context.Context) error {
+	// TODO: parallelize symlink+file uninstall
+	for installSymlink := range d.installedSymlinks {
+		destPath := filepath.Join(d.customCACertDir(), installSymlink)
+		// best effort, if it didn't exist because the exec deleted it, that's fine
+		d.ctrFS.Remove(destPath)
+	}
+	// TODO: it's *technically* possible that the exec overwrote a file here, in which case
+	// we don't want to delete it. Can use create time
+	for _, certFileName := range d.installedCerts {
+		destPath := filepath.Join(d.customCACertDir(), certFileName)
+		// best effort, if it didn't exist because the exec deleted it, that's fine
+		d.ctrFS.Remove(destPath)
+	}
+
+	// The update command could have existed before but got uninstalled, or it could have not existed
+	// before and got installed by the exec. Either way, need to check for it again now.
+	_, lookupErr := d.ctrFS.LookPath(d.updateCmd()[0])
+	updateCommandExists := lookupErr == nil
+	if !updateCommandExists && !errors.Is(lookupErr, exec.ErrNotFound) {
+		return fmt.Errorf("failed to lookup %s: %w", d.updateCmd()[0], lookupErr)
+	}
+
+	// update the bundle using the command if available, otherwise manually remove the certs
+	if updateCommandExists {
+		if err := d.ctrFS.Exec(ctx, d.updateCmd()...); err != nil {
+			return fmt.Errorf("failed to run %v for install: %w", d.updateCmd(), err)
+		}
+	} else if err := d.ctrFS.RemoveCertsFromCABundle(d.bundlePath(), d.installedCerts); err != nil {
+		return err
+	}
+
+	if !d.bundleExisted {
+		// if the bundle didn't exist before, remove it provided it's now empty after removing our installed certs
+		stat, err := d.ctrFS.Stat(d.bundlePath())
+		if err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		if stat != nil && stat.Size() == 0 {
+			if err := d.ctrFS.Remove(d.bundlePath()); err != nil {
+				return err
+			}
+		}
+	}
+
+	// only remove the custom CA dir if it didn't exist before and it expected to have been created or removed
+	// by the exec. We heuristically determine this by checking the before/after state of the update command, which
+	// tells us whether the dir is expected to exist or not.
+	cmdNeverExisted := !d.updateCommandExisted && !updateCommandExists
+	cmdWasRemoved := d.updateCommandExisted && !updateCommandExists
+	if (!d.customCACertDirExisted && cmdNeverExisted) || (d.customCACertDirExisted && cmdWasRemoved) {
+		// if the custom CA dir didn't exist before, remove it provided it's now empty after removing our installed certs
+		isEmpty, err := d.ctrFS.DirIsEmpty(d.customCACertDir())
+		if err != nil {
+			return err
+		}
+		if isEmpty {
+			if err := d.ctrFS.Remove(d.customCACertDir()); err != nil && !os.IsNotExist(err) {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/engine/cacerts/fs.go
+++ b/cmd/engine/cacerts/fs.go
@@ -1,0 +1,487 @@
+package cacerts
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func newContainerFS(spec *specs.Spec, executeContainer executeContainerFunc) (*containerFS, error) {
+	// hopefully the source is never a symlink, but resolve them just in case
+	// in order to simplify later code
+	for i, m := range spec.Mounts {
+		switch m.Type {
+		case "proc", "sysfs", "tmpfs", "devpts", "shm", "mqueue", "cgroup", "cgroup2":
+			continue
+		default:
+		}
+		var err error
+		if m.Source, err = filepath.EvalSymlinks(m.Source); err != nil {
+			return nil, err
+		}
+		spec.Mounts[i] = m
+	}
+
+	ctrFS := &containerFS{spec: spec, executeContainer: executeContainer}
+	ctrFS.mounts = []mount{{
+		Mount: specs.Mount{
+			Destination: "/",
+			Source:      spec.Root.Path,
+		},
+		ResolvedDest: "/",
+	}}
+
+	for _, m := range spec.Mounts {
+		resolvedDest, err := ctrFS.mountPointPath(m.Destination)
+		if err != nil {
+			return nil, err
+		}
+		ctrFS.mounts = append(ctrFS.mounts, mount{
+			Mount:        m,
+			ResolvedDest: resolvedDest,
+		})
+	}
+	return ctrFS, nil
+}
+
+type containerFS struct {
+	spec             *specs.Spec
+	executeContainer executeContainerFunc
+	mounts           []mount
+}
+
+type mount struct {
+	specs.Mount
+	ResolvedDest string
+}
+
+func (ctrFS *containerFS) Open(name string) (fs.File, error) {
+	hostPath, err := ctrFS.hostPath(name)
+	if err != nil {
+		return nil, err
+	}
+	return os.Open(hostPath)
+}
+
+func (ctrFS *containerFS) OpenFile(name string, flag int, perm fs.FileMode) (*os.File, error) {
+	hostPath, err := ctrFS.hostPath(name)
+	if err != nil {
+		return nil, err
+	}
+	return os.OpenFile(hostPath, flag, perm)
+}
+
+func (ctrFS *containerFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	hostPath, err := ctrFS.hostPath(name)
+	if err != nil {
+		return nil, err
+	}
+	return os.ReadDir(hostPath)
+}
+
+func (ctrFS *containerFS) Stat(name string) (fs.FileInfo, error) {
+	hostPath, err := ctrFS.hostPath(name)
+	if err != nil {
+		return nil, err
+	}
+	return os.Stat(hostPath)
+}
+
+func (ctrFS *containerFS) Lstat(name string) (fs.FileInfo, error) {
+	hostPath, err := ctrFS.hostPath(name)
+	if err != nil {
+		return nil, err
+	}
+	return os.Lstat(hostPath)
+}
+
+func (ctrFS *containerFS) Symlink(oldname, newname string) error {
+	newHostPath, err := ctrFS.hostPath(newname)
+	if err != nil {
+		return err
+	}
+	return os.Symlink(oldname, newHostPath)
+}
+
+func (ctrFS *containerFS) Readlink(name string) (string, error) {
+	hostPath, err := ctrFS.hostPath(name)
+	if err != nil {
+		return "", err
+	}
+	return os.Readlink(hostPath)
+}
+
+func (ctrFS *containerFS) ReadFile(path string) ([]byte, error) {
+	hostPath, err := ctrFS.hostPath(path)
+	if err != nil {
+		return nil, err
+	}
+	return os.ReadFile(hostPath)
+}
+
+func (ctrFS *containerFS) WriteFile(path string, data []byte, perm fs.FileMode) error {
+	hostPath, err := ctrFS.hostPath(path)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(hostPath, data, perm)
+}
+
+func (ctrFS *containerFS) Remove(path string) error {
+	hostPath, err := ctrFS.hostPath(path)
+	if err != nil {
+		return err
+	}
+	return os.Remove(hostPath)
+}
+
+func (ctrFS *containerFS) MkdirAll(path string, perm fs.FileMode) error {
+	hostPath, err := ctrFS.hostPath(path)
+	if err != nil {
+		return err
+	}
+	return os.MkdirAll(hostPath, perm)
+}
+
+func (ctrFS *containerFS) LookPath(cmd string) (string, error) {
+	if filepath.IsAbs(cmd) {
+		return cmd, nil
+	}
+
+	// TODO: may caller need to augment PATH with sbins when user not root
+	var pathEnvVal string
+	for _, env := range ctrFS.spec.Process.Env {
+		if strings.HasPrefix(env, "PATH=") {
+			pathEnvVal = strings.TrimPrefix(env, "PATH=")
+			break
+		}
+	}
+	if pathEnvVal == "" {
+		pathEnvVal = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	}
+	for _, dir := range filepath.SplitList(pathEnvVal) {
+		execPath := filepath.Join(dir, cmd)
+		stat, err := ctrFS.Stat(execPath)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return "", err
+		}
+		if stat.Mode().IsRegular() && stat.Mode().Perm()&0111 != 0 {
+			return execPath, nil
+		}
+	}
+	return "", exec.ErrNotFound
+}
+
+func (ctrFS *containerFS) Exec(ctx context.Context, args ...string) error {
+	return ctrFS.executeContainer(ctx, args...)
+}
+
+func (ctrFS *containerFS) AnyPathExists(paths []string) (bool, error) {
+	// TODO: parallelize?
+	for _, path := range paths {
+		exists, err := ctrFS.PathExists(path)
+		if err != nil {
+			return false, err
+		}
+		if exists {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (ctrFS *containerFS) PathExists(path string) (bool, error) {
+	_, err := ctrFS.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
+}
+
+func (ctrFS *containerFS) OSReleaseFileContains(ids [][]byte, idLikes [][]byte) (bool, error) {
+	// read /etc/os-release line by line
+	f, err := ctrFS.Open("/etc/os-release")
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+
+	idDone := ids == nil
+	idLikeDone := idLikes == nil
+	for scanner.Scan() {
+		if idDone && idLikeDone {
+			break
+		}
+		line := scanner.Bytes()
+		switch {
+		case len(line) > 0 && line[0] == '#':
+			// skip comment
+		case !idDone && bytes.HasPrefix(line, []byte("ID=")):
+			idDone = true
+			val := bytes.TrimPrefix(line, []byte("ID="))
+			val = bytes.Trim(bytes.TrimSpace(val), `"`)
+			for _, id := range ids {
+				if bytes.Equal(val, id) {
+					return true, nil
+				}
+			}
+		case !idLikeDone && bytes.HasPrefix(line, []byte("ID_LIKE=")):
+			idLikeDone = true
+			val := bytes.TrimPrefix(line, []byte("ID_LIKE="))
+			val = bytes.Trim(bytes.TrimSpace(val), `"`)
+			for _, v := range bytes.Fields(val) {
+				for _, idLike := range idLikes {
+					if bytes.Equal(v, idLike) {
+						return true, nil
+					}
+				}
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+func (ctrFS *containerFS) ReadCABundleFile(path string) (map[string]struct{}, error) {
+	certs := make(map[string]struct{})
+	f, err := ctrFS.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	var curCert []byte
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			if len(curCert) > 0 {
+				certs[string(curCert[:len(curCert)-1])] = struct{}{}
+				curCert = nil
+			}
+			continue
+		}
+		curCert = append(curCert, line...)
+		curCert = append(curCert, byte('\n'))
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if len(curCert) > 0 {
+		certs[string(curCert[:len(curCert)-1])] = struct{}{}
+	}
+	return certs, nil
+}
+
+func (ctrFS *containerFS) RemoveCertsFromCABundle(path string, certs map[string]string) error {
+	f, err := ctrFS.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	var updatedFileContents []byte
+	var curCert []byte
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			if len(curCert) > 0 {
+				if _, exists := certs[string(curCert[:len(curCert)-1])]; !exists {
+					updatedFileContents = append(updatedFileContents, curCert...)
+					updatedFileContents = append(updatedFileContents, byte('\n'))
+				}
+				curCert = nil
+			}
+			continue
+		}
+		curCert = append(curCert, line...)
+		curCert = append(curCert, byte('\n'))
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	if len(curCert) > 0 {
+		if _, exists := certs[string(curCert[:len(curCert)-1])]; !exists {
+			updatedFileContents = append(updatedFileContents, curCert...)
+			updatedFileContents = append(updatedFileContents, byte('\n'))
+		}
+	}
+
+	f.Close()
+	// TODO: preserve permissions/ownership/mtime
+	if err := ctrFS.WriteFile(path, updatedFileContents, 0644); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (ctrFS *containerFS) ReadCustomCADir(path string) (
+	certsToFileName map[string]string,
+	symlinks map[string]string,
+	rerr error,
+) {
+	hostPath, err := ctrFS.hostPath(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ReadHostCustomCADir(hostPath)
+}
+
+func (ctrFS *containerFS) DirIsEmpty(path string) (bool, error) {
+	dirEnts, err := ctrFS.ReadDir(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return true, nil
+		}
+		return false, err
+	}
+	return len(dirEnts) == 0, nil
+}
+
+func (ctrFS *containerFS) mountPointPath(containerPath string) (string, error) {
+	containerPath, _, err := ctrFS.resolvePath(containerPath, true, 0)
+	return containerPath, err
+}
+
+func (ctrFS *containerFS) hostPath(containerPath string) (string, error) {
+	_, hostPath, err := ctrFS.resolvePath(containerPath, false, 0)
+	if hostPath == "" {
+		return "", fmt.Errorf("cannot resolve path %q", containerPath)
+	}
+	return hostPath, err
+}
+
+func (ctrFS *containerFS) resolvePath(path string, resolveBase bool, linkCount int) (
+	containerPath string,
+	hostPath string,
+	rerr error,
+) {
+	if linkCount > 255 {
+		return "", "", errors.New("too many links")
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join("/", path)
+	}
+
+	split := strings.Split(path, "/")
+	curPath := "/" // invariant: curPath never contains symlinks at beginning of each loop
+	var srcPath string
+	for i, part := range split {
+		if part == "" {
+			continue
+		}
+		curPath = filepath.Join(curPath, part)
+		rest := strings.Join(split[i+1:], "/")
+
+		// figure out the mount point that must contain curPath
+		var resolvedMount *mount
+		var relPath string
+		for j := len(ctrFS.mounts) - 1; j >= 0; j-- {
+			resolvedMount = &ctrFS.mounts[j]
+			var err error
+			relPath, err = filepath.Rel(resolvedMount.ResolvedDest, curPath)
+			if err != nil {
+				return "", "", err
+			}
+			if filepath.IsLocal(relPath) {
+				break
+			}
+		}
+
+		switch resolvedMount.Type {
+		case "proc", "sysfs", "tmpfs", "devpts", "shm", "mqueue", "cgroup", "cgroup2":
+			// can't resolve any paths under special mounts
+			return filepath.Join(curPath, rest), "", nil
+		default:
+		}
+
+		srcPath = filepath.Join(resolvedMount.Source, relPath)
+		if !resolveBase && rest == "" {
+			// we are on the last part of the path, don't follow any symlinks
+			break
+		}
+
+		stat, err := os.Lstat(srcPath)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				// cannot be any symlinks to resolve anymore
+				return filepath.Join(curPath, rest), filepath.Join(srcPath, rest), nil
+			}
+			return "", "", err
+		}
+		if stat.Mode().Type() == fs.ModeSymlink {
+			target, err := os.Readlink(srcPath)
+			if err != nil {
+				return "", "", err
+			}
+			if filepath.IsAbs(target) {
+				return ctrFS.resolvePath(filepath.Join(target, rest), resolveBase, linkCount+1)
+			}
+			return ctrFS.resolvePath(filepath.Join(filepath.Dir(curPath), target, rest), resolveBase, linkCount+1)
+		}
+	}
+	return filepath.Clean(curPath), filepath.Clean(srcPath), nil
+}
+
+func ReadHostCustomCADir(path string) (
+	certsToFileName map[string]string,
+	symlinks map[string]string,
+	rerr error,
+) {
+	certsToFileName = make(map[string]string)
+	symlinks = make(map[string]string)
+
+	dirEnts, err := os.ReadDir(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return certsToFileName, symlinks, nil
+		}
+		return nil, nil, err
+	}
+	for _, dirEnt := range dirEnts {
+		dirEntPath := filepath.Join(path, dirEnt.Name())
+		switch dirEnt.Type() {
+		case os.ModeSymlink:
+			linkPath, err := os.Readlink(dirEntPath)
+			if err != nil {
+				return nil, nil, err
+			}
+			symlinks[dirEnt.Name()] = linkPath
+		case os.ModeDir:
+			// TODO: handle?
+		default:
+			// TODO: only read .pem/.crt files?
+			bs, err := os.ReadFile(dirEntPath)
+			if err != nil {
+				return nil, nil, err
+			}
+			certsToFileName[strings.TrimSpace(string(bs))] = dirEnt.Name()
+		}
+	}
+	return certsToFileName, symlinks, nil
+}

--- a/cmd/engine/cacerts/fs.go
+++ b/cmd/engine/cacerts/fs.go
@@ -378,11 +378,14 @@ func (ctrFS *containerFS) hostPath(containerPath string) (string, error) {
 	// resolveBase is false since we want to support e.g. Lstat on a symlink path
 	// (while still resolving symlinks in the parent dirs)
 	_, hostPath, err := ctrFS.resolvePath(containerPath, false, 0)
+	if err != nil {
+		return "", err
+	}
 	if hostPath == "" {
 		// happens when the mount containerPath is under is a special mount (tmpfs, proc, etc.)
 		return "", fmt.Errorf("cannot resolve path %q", containerPath)
 	}
-	return hostPath, err
+	return hostPath, nil
 }
 
 /*

--- a/cmd/engine/executor.go
+++ b/cmd/engine/executor.go
@@ -1,0 +1,1045 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/containerd/console"
+	"github.com/containerd/containerd/content/local"
+	"github.com/containerd/containerd/diff/apply"
+	"github.com/containerd/containerd/diff/walking"
+	ctdmetadata "github.com/containerd/containerd/metadata"
+	"github.com/containerd/containerd/mount"
+	containerdoci "github.com/containerd/containerd/oci"
+	"github.com/containerd/containerd/platforms"
+	ctdsnapshot "github.com/containerd/containerd/snapshots"
+	"github.com/containerd/continuity/fs"
+	runc "github.com/containerd/go-runc"
+	"github.com/dagger/dagger/cmd/engine/cacerts"
+	"github.com/docker/docker/pkg/idtools"
+	"github.com/moby/buildkit/cache/metadata"
+	"github.com/moby/buildkit/executor"
+	"github.com/moby/buildkit/executor/oci"
+	resourcestypes "github.com/moby/buildkit/executor/resources/types"
+	gatewayapi "github.com/moby/buildkit/frontend/gateway/pb"
+	randid "github.com/moby/buildkit/identity"
+	containerdsnapshot "github.com/moby/buildkit/snapshot/containerd"
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/bklog"
+	"github.com/moby/buildkit/util/leaseutil"
+	"github.com/moby/buildkit/util/network"
+	"github.com/moby/buildkit/util/network/netproviders"
+	"github.com/moby/buildkit/util/stack"
+	"github.com/moby/buildkit/util/winlayers"
+	"github.com/moby/buildkit/worker/base"
+	wlabel "github.com/moby/buildkit/worker/label"
+	workerrunc "github.com/moby/buildkit/worker/runc"
+	"github.com/moby/sys/signal"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+	bolt "go.etcd.io/bbolt"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/semaphore"
+)
+
+func NewWorkerOpt(
+	root string,
+	snFactory workerrunc.SnapshotterFactory,
+	processMode oci.ProcessMode,
+	labels map[string]string,
+	idmap *idtools.IdentityMapping,
+	nopt netproviders.Opt,
+	dns *oci.DNSConfig,
+	apparmorProfile string,
+	selinux bool,
+	parallelismSem *semaphore.Weighted,
+	traceSocket,
+	defaultCgroupParent string,
+) (base.WorkerOpt, error) {
+	var opt base.WorkerOpt
+	name := "runc-" + snFactory.Name
+	root = filepath.Join(root, name)
+	if err := os.MkdirAll(root, 0700); err != nil {
+		return opt, err
+	}
+
+	np, npResolvedMode, err := netproviders.Providers(nopt)
+	if err != nil {
+		return opt, err
+	}
+
+	exe, err := New(Opt{
+		Root:                filepath.Join(root, "executor"),
+		Cmd:                 "/usr/local/bin/dagger-shim",
+		ProcessMode:         processMode,
+		IdentityMapping:     idmap,
+		DNS:                 dns,
+		ApparmorProfile:     apparmorProfile,
+		SELinux:             selinux,
+		TracingSocket:       traceSocket,
+		DefaultCgroupParent: defaultCgroupParent,
+	}, np)
+	if err != nil {
+		return opt, err
+	}
+	s, err := snFactory.New(filepath.Join(root, "snapshots"))
+	if err != nil {
+		return opt, err
+	}
+
+	localstore, err := local.NewStore(filepath.Join(root, "content"))
+	if err != nil {
+		return opt, err
+	}
+
+	db, err := bolt.Open(filepath.Join(root, "containerdmeta.db"), 0644, nil)
+	if err != nil {
+		return opt, err
+	}
+
+	mdb := ctdmetadata.NewDB(db, localstore, map[string]ctdsnapshot.Snapshotter{
+		snFactory.Name: s,
+	})
+	if err := mdb.Init(context.TODO()); err != nil {
+		return opt, err
+	}
+
+	c := containerdsnapshot.NewContentStore(mdb.ContentStore(), "buildkit")
+
+	id, err := base.ID(root)
+	if err != nil {
+		return opt, err
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "unknown"
+	}
+	xlabels := map[string]string{
+		wlabel.Executor:       "oci",
+		wlabel.Snapshotter:    snFactory.Name,
+		wlabel.Hostname:       hostname,
+		wlabel.Network:        npResolvedMode,
+		wlabel.OCIProcessMode: processMode.String(),
+		wlabel.SELinuxEnabled: strconv.FormatBool(selinux),
+	}
+	if apparmorProfile != "" {
+		xlabels[wlabel.ApparmorProfile] = apparmorProfile
+	}
+
+	for k, v := range labels {
+		xlabels[k] = v
+	}
+	lm := leaseutil.WithNamespace(ctdmetadata.NewLeaseManager(mdb), "buildkit")
+	snap := containerdsnapshot.NewSnapshotter(snFactory.Name, mdb.Snapshotter(snFactory.Name), "buildkit", idmap)
+	md, err := metadata.NewStore(filepath.Join(root, "metadata_v2.db"))
+	if err != nil {
+		return opt, err
+	}
+
+	opt = base.WorkerOpt{
+		ID:               id,
+		Labels:           xlabels,
+		MetadataStore:    md,
+		NetworkProviders: np,
+		Executor:         exe,
+		Snapshotter:      snap,
+		ContentStore:     c,
+		Applier:          winlayers.NewFileSystemApplierWithWindows(c, apply.NewFileSystemApplier(c)),
+		Differ:           winlayers.NewWalkingDiffWithWindows(c, walking.NewWalkingDiff(c)),
+		ImageStore:       nil, // explicitly
+		Platforms:        []ocispecs.Platform{platforms.Normalize(platforms.DefaultSpec())},
+		IdentityMapping:  idmap,
+		LeaseManager:     lm,
+		GarbageCollect:   mdb.GarbageCollect,
+		ParallelismSem:   parallelismSem,
+		MountPoolRoot:    filepath.Join(root, "cachemounts"),
+	}
+	return opt, nil
+}
+
+type Opt struct {
+	// root directory
+	Root string
+	Cmd  string
+	// DefaultCgroupParent is the cgroup-parent name for executor
+	DefaultCgroupParent string
+	// ProcessMode
+	ProcessMode     oci.ProcessMode
+	IdentityMapping *idtools.IdentityMapping
+	// runc run --no-pivot (unrecommended)
+	NoPivot         bool
+	DNS             *oci.DNSConfig
+	OOMScoreAdj     *int
+	ApparmorProfile string
+	SELinux         bool
+	TracingSocket   string
+}
+
+type runcExecutor struct {
+	runc             *runc.Runc
+	root             string
+	cgroupParent     string
+	networkProviders map[pb.NetMode]network.Provider
+	processMode      oci.ProcessMode
+	idmap            *idtools.IdentityMapping
+	noPivot          bool
+	dns              *oci.DNSConfig
+	oomScoreAdj      *int
+	running          map[string]chan error
+	mu               sync.Mutex
+	apparmorProfile  string
+	selinux          bool
+	tracingSocket    string
+}
+
+func New(opt Opt, networkProviders map[pb.NetMode]network.Provider) (executor.Executor, error) {
+	root := opt.Root
+
+	if err := os.MkdirAll(root, 0o711); err != nil {
+		return nil, errors.Wrapf(err, "failed to create %s", root)
+	}
+
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return nil, err
+	}
+	root, err = filepath.EvalSymlinks(root)
+	if err != nil {
+		return nil, err
+	}
+
+	// clean up old hosts/resolv.conf file. ignore errors
+	os.RemoveAll(filepath.Join(root, "hosts"))
+	os.RemoveAll(filepath.Join(root, "resolv.conf"))
+
+	runtime := &runc.Runc{
+		Command:   opt.Cmd,
+		Log:       filepath.Join(root, "runc-log.json"),
+		LogFormat: runc.JSON,
+		Setpgid:   true,
+	}
+
+	updateRuncFieldsForHostOS(runtime)
+
+	w := &runcExecutor{
+		runc:             runtime,
+		root:             root,
+		cgroupParent:     opt.DefaultCgroupParent,
+		networkProviders: networkProviders,
+		processMode:      opt.ProcessMode,
+		idmap:            opt.IdentityMapping,
+		noPivot:          opt.NoPivot,
+		dns:              opt.DNS,
+		oomScoreAdj:      opt.OOMScoreAdj,
+		running:          make(map[string]chan error),
+		apparmorProfile:  opt.ApparmorProfile,
+		selinux:          opt.SELinux,
+		tracingSocket:    opt.TracingSocket,
+	}
+	return w, nil
+}
+
+func (w *runcExecutor) Run(ctx context.Context, id string, root executor.Mount, mounts []executor.Mount, process executor.ProcessInfo, started chan<- struct{}) (_ resourcestypes.Recorder, rerr error) {
+	meta := process.Meta
+	if meta.NetMode == pb.NetMode_HOST {
+		bklog.G(ctx).Info("enabling HostNetworking")
+	}
+
+	provider, ok := w.networkProviders[meta.NetMode]
+	if !ok {
+		return nil, errors.Errorf("unknown network mode %s", meta.NetMode)
+	}
+	namespace, err := provider.New(ctx, meta.Hostname)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := namespace.Close(); err != nil {
+			bklog.G(ctx).Errorf("failed to close network namespace: %v", err)
+		}
+	}()
+
+	mountable, err := root.Src.Mount(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+
+	rootMount, release, err := mountable.Mount()
+	if err != nil {
+		return nil, err
+	}
+	if release != nil {
+		defer release()
+	}
+
+	if id == "" {
+		id = randid.NewID()
+	}
+
+	identity := idtools.Identity{}
+	if w.idmap != nil {
+		identity = w.idmap.RootPair()
+	}
+
+	rootFSPath, err := os.MkdirTemp("", "rootfs")
+	if err != nil {
+		return nil, err
+	}
+	if err := idtools.MkdirAllAndChown(rootFSPath, 0o700, identity); err != nil {
+		return nil, err
+	}
+	if err := mount.All(rootMount, rootFSPath); err != nil {
+		return nil, err
+	}
+	defer mount.Unmount(rootFSPath, 0)
+
+	defer executor.MountStubsCleaner(ctx, rootFSPath, mounts, meta.RemoveMountStubsRecursive)()
+
+	setupCACerts := true
+	return nil, w.run(
+		ctx,
+		id,
+		root,
+		mounts,
+		rootFSPath,
+		process,
+		namespace,
+		started,
+		setupCACerts,
+	)
+}
+
+func (w *runcExecutor) run(
+	ctx context.Context,
+	id string,
+	root executor.Mount,
+	mounts []executor.Mount,
+	rootFSPath string,
+	process executor.ProcessInfo,
+	namespace network.Namespace,
+	started chan<- struct{},
+	installCACerts bool,
+) (err error) {
+	startedOnce := sync.Once{}
+	done := make(chan error, 1)
+	w.mu.Lock()
+	w.running[id] = done
+	w.mu.Unlock()
+	defer func() {
+		w.mu.Lock()
+		delete(w.running, id)
+		w.mu.Unlock()
+		done <- err
+		close(done)
+		if started != nil {
+			startedOnce.Do(func() {
+				close(started)
+			})
+		}
+	}()
+
+	bundle := filepath.Join(w.root, id)
+	if err := os.Mkdir(bundle, 0o711); err != nil {
+		return err
+	}
+	defer os.RemoveAll(bundle)
+
+	uid, gid, sgids, err := oci.GetUser(rootFSPath, process.Meta.User)
+	if err != nil {
+		return err
+	}
+
+	resolvConf, err := oci.GetResolvConf(ctx, w.root, w.idmap, w.dns, process.Meta.NetMode)
+	if err != nil {
+		return err
+	}
+
+	hostsFile, clean, err := oci.GetHostsFile(ctx, w.root, process.Meta.ExtraHosts, w.idmap, process.Meta.Hostname)
+	if err != nil {
+		return err
+	}
+	if clean != nil {
+		defer clean()
+	}
+
+	configPath := filepath.Join(bundle, "config.json")
+	f, err := os.Create(configPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	opts := []containerdoci.SpecOpts{oci.WithUIDGID(uid, gid, sgids)}
+
+	if process.Meta.ReadonlyRootFS {
+		opts = append(opts, containerdoci.WithRootFSReadonly())
+	}
+
+	identity := idtools.Identity{
+		UID: int(uid),
+		GID: int(gid),
+	}
+	if w.idmap != nil {
+		identity, err = w.idmap.ToHost(identity)
+		if err != nil {
+			return err
+		}
+	}
+
+	spec, cleanup, err := oci.GenerateSpec(
+		ctx,
+		process.Meta,
+		mounts,
+		id,
+		resolvConf,
+		hostsFile,
+		namespace,
+		w.cgroupParent,
+		w.processMode,
+		w.idmap,
+		w.apparmorProfile,
+		w.selinux,
+		w.tracingSocket,
+		opts...,
+	)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	spec.Root.Path = rootFSPath
+	if root.Readonly {
+		spec.Root.Readonly = true
+	}
+
+	newp, err := fs.RootPath(rootFSPath, process.Meta.Cwd)
+	if err != nil {
+		return errors.Wrapf(err, "working dir %s points to invalid target", newp)
+	}
+	if _, err := os.Stat(newp); err != nil {
+		if err := idtools.MkdirAllAndChown(newp, 0o755, identity); err != nil {
+			return errors.Wrapf(err, "failed to create working directory %s", newp)
+		}
+	}
+
+	spec.Process.Terminal = process.Meta.Tty
+	spec.Process.OOMScoreAdj = w.oomScoreAdj
+
+	if err := json.NewEncoder(f).Encode(spec); err != nil {
+		return err
+	}
+	f.Close()
+
+	if installCACerts {
+		caInstaller, err := cacerts.NewInstaller(ctx, spec, func(ctx context.Context, args ...string) error {
+			id := randid.NewID()
+			meta := process.Meta
+			meta.Args = args
+			meta.User = "0:0"
+			meta.Cwd = "/"
+			meta.Tty = false
+			output := new(bytes.Buffer)
+			process := executor.ProcessInfo{
+				Stdout: nopCloser{output},
+				Stderr: nopCloser{output},
+				Meta:   meta,
+			}
+			started := make(chan struct{}, 1)
+			installCACerts := false
+			err := w.run(
+				ctx,
+				id,
+				root,
+				mounts,
+				rootFSPath,
+				process,
+				namespace,
+				started,
+				installCACerts,
+			)
+			return err
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create cacerts installer: %w", err)
+		}
+		// TODO: make non-fatal, but be sure to cleanup any half-installed state
+		if err := caInstaller.Install(ctx); err != nil {
+			return fmt.Errorf("failed to install cacerts: %w", err)
+		}
+		defer func() {
+			if err := caInstaller.Uninstall(ctx); err != nil {
+				bklog.G(ctx).Errorf("failed to uninstall cacerts: %v", err)
+			}
+		}()
+	}
+
+	bklog.G(ctx).Debugf("> creating %s %v", id, process.Meta.Args)
+	defer bklog.G(ctx).Debugf("> container done %s %v", id, process.Meta.Args)
+
+	trace.SpanFromContext(ctx).AddEvent("Container created")
+	killer := newRunProcKiller(w.runc, id)
+	startedCallback := func() {
+		startedOnce.Do(func() {
+			trace.SpanFromContext(ctx).AddEvent("Container started")
+			if started != nil {
+				close(started)
+			}
+		})
+	}
+	runcCall := func(ctx context.Context, started chan<- int, io runc.IO, pidfile string) error {
+		_, err := w.runc.Run(ctx, id, bundle, &runc.CreateOpts{
+			NoPivot:   w.noPivot,
+			Started:   started,
+			IO:        io,
+			ExtraArgs: []string{"--keep"},
+		})
+		return err
+	}
+	err = exitError(ctx, w.callWithIO(ctx, id, bundle, process, startedCallback, killer, runcCall))
+	if err != nil {
+		w.runc.Delete(context.TODO(), id, &runc.DeleteOpts{})
+		return err
+	}
+
+	return w.runc.Delete(context.TODO(), id, &runc.DeleteOpts{})
+}
+
+func (w *runcExecutor) Exec(ctx context.Context, id string, process executor.ProcessInfo) (err error) {
+	// first verify the container is running, if we get an error assume the container
+	// is in the process of being created and check again every 100ms or until
+	// context is canceled.
+	var state *runc.Container
+	for {
+		w.mu.Lock()
+		done, ok := w.running[id]
+		w.mu.Unlock()
+		if !ok {
+			return errors.Errorf("container %s not found", id)
+		}
+
+		state, _ = w.runc.State(ctx, id)
+		if state != nil && state.Status == "running" {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		case err, ok := <-done:
+			if !ok || err == nil {
+				return errors.Errorf("container %s has stopped", id)
+			}
+			return errors.Wrapf(err, "container %s has exited with error", id)
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+
+	// load default process spec (for Env, Cwd etc) from bundle
+	f, err := os.Open(filepath.Join(state.Bundle, "config.json"))
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer f.Close()
+
+	spec := &specs.Spec{}
+	if err := json.NewDecoder(f).Decode(spec); err != nil {
+		return err
+	}
+
+	if process.Meta.User != "" {
+		uid, gid, sgids, err := oci.GetUser(state.Rootfs, process.Meta.User)
+		if err != nil {
+			return err
+		}
+		spec.Process.User = specs.User{
+			UID:            uid,
+			GID:            gid,
+			AdditionalGids: sgids,
+		}
+	}
+
+	spec.Process.Terminal = process.Meta.Tty
+	spec.Process.Args = process.Meta.Args
+	if process.Meta.Cwd != "" {
+		spec.Process.Cwd = process.Meta.Cwd
+	}
+
+	if len(process.Meta.Env) > 0 {
+		spec.Process.Env = process.Meta.Env
+	}
+
+	err = w.exec(ctx, id, state.Bundle, spec.Process, process, nil)
+	return exitError(ctx, err)
+}
+
+func (w *runcExecutor) exec(ctx context.Context, id, bundle string, specsProcess *specs.Process, process executor.ProcessInfo, started func()) error {
+	killer, err := newExecProcKiller(w.runc, id)
+	if err != nil {
+		return errors.Wrap(err, "failed to initialize process killer")
+	}
+	defer killer.Cleanup()
+
+	return w.callWithIO(ctx, id, bundle, process, started, killer, func(ctx context.Context, started chan<- int, io runc.IO, pidfile string) error {
+		return w.runc.Exec(ctx, id, *specsProcess, &runc.ExecOpts{
+			Started: started,
+			IO:      io,
+			PidFile: pidfile,
+		})
+	})
+}
+
+func exitError(ctx context.Context, err error) error {
+	if err != nil {
+		exitErr := &gatewayapi.ExitError{
+			ExitCode: gatewayapi.UnknownExitStatus,
+			Err:      err,
+		}
+		var runcExitError *runc.ExitError
+		if errors.As(err, &runcExitError) && runcExitError.Status >= 0 {
+			exitErr = &gatewayapi.ExitError{
+				ExitCode: uint32(runcExitError.Status),
+			}
+		}
+		trace.SpanFromContext(ctx).AddEvent(
+			"Container exited",
+			trace.WithAttributes(
+				attribute.Int("exit.code", int(exitErr.ExitCode)),
+			),
+		)
+		select {
+		case <-ctx.Done():
+			exitErr.Err = errors.Wrapf(context.Cause(ctx), exitErr.Error())
+			return exitErr
+		default:
+			return stack.Enable(exitErr)
+		}
+	}
+
+	trace.SpanFromContext(ctx).AddEvent(
+		"Container exited",
+		trace.WithAttributes(attribute.Int("exit.code", 0)),
+	)
+	return nil
+}
+
+type forwardIO struct {
+	stdin          io.ReadCloser
+	stdout, stderr io.WriteCloser
+}
+
+func (s *forwardIO) Close() error {
+	return nil
+}
+
+func (s *forwardIO) Set(cmd *exec.Cmd) {
+	cmd.Stdin = s.stdin
+	cmd.Stdout = s.stdout
+	cmd.Stderr = s.stderr
+}
+
+func (s *forwardIO) Stdin() io.WriteCloser {
+	return nil
+}
+
+func (s *forwardIO) Stdout() io.ReadCloser {
+	return nil
+}
+
+func (s *forwardIO) Stderr() io.ReadCloser {
+	return nil
+}
+
+// newRuncProcKiller returns an abstraction for sending SIGKILL to the
+// process inside the container initiated from `runc run`.
+func newRunProcKiller(runC *runc.Runc, id string) procKiller {
+	return procKiller{runC: runC, id: id}
+}
+
+// newExecProcKiller returns an abstraction for sending SIGKILL to the
+// process inside the container initiated from `runc exec`.
+func newExecProcKiller(runC *runc.Runc, id string) (procKiller, error) {
+	// for `runc exec` we need to create a pidfile and read it later to kill
+	// the process
+	tdir, err := os.MkdirTemp("", "runc")
+	if err != nil {
+		return procKiller{}, errors.Wrap(err, "failed to create directory for runc pidfile")
+	}
+
+	return procKiller{
+		runC:    runC,
+		id:      id,
+		pidfile: filepath.Join(tdir, "pidfile"),
+		cleanup: func() {
+			os.RemoveAll(tdir)
+		},
+	}, nil
+}
+
+type procKiller struct {
+	runC    *runc.Runc
+	id      string
+	pidfile string
+	cleanup func()
+}
+
+// Cleanup will delete any tmp files created for the pidfile allocation
+// if this killer was for a `runc exec` process.
+func (k procKiller) Cleanup() {
+	if k.cleanup != nil {
+		k.cleanup()
+	}
+}
+
+// Kill will send SIGKILL to the process running inside the container.
+// If the process was created by `runc run` then we will use `runc kill`,
+// otherwise for `runc exec` we will read the pid from a pidfile and then
+// send the signal directly that process.
+func (k procKiller) Kill(ctx context.Context) (err error) {
+	bklog.G(ctx).Debugf("sending sigkill to process in container %s", k.id)
+	defer func() {
+		if err != nil {
+			bklog.G(ctx).Errorf("failed to kill process in container id %s: %+v", k.id, err)
+		}
+	}()
+
+	// this timeout is generally a no-op, the Kill ctx should already have a
+	// shorter timeout but here as a fail-safe for future refactoring.
+	ctx, cancel := context.WithCancelCause(ctx)
+	ctx, _ = context.WithTimeoutCause(ctx, 10*time.Second, errors.WithStack(context.DeadlineExceeded))
+	defer cancel(errors.WithStack(context.Canceled))
+
+	if k.pidfile == "" {
+		// for `runc run` process we use `runc kill` to terminate the process
+		return k.runC.Kill(ctx, k.id, int(syscall.SIGKILL), nil)
+	}
+
+	// `runc exec` will write the pidfile a few milliseconds after we
+	// get the runc pid via the startedCh, so we might need to retry until
+	// it appears in the edge case where we want to kill a process
+	// immediately after it was created.
+	var pidData []byte
+	for {
+		pidData, err = os.ReadFile(k.pidfile)
+		if err != nil {
+			if os.IsNotExist(err) {
+				select {
+				case <-ctx.Done():
+					return errors.New("context cancelled before runc wrote pidfile")
+				case <-time.After(10 * time.Millisecond):
+					continue
+				}
+			}
+			return errors.Wrap(err, "failed to read pidfile from runc")
+		}
+		break
+	}
+	pid, err := strconv.Atoi(string(pidData))
+	if err != nil {
+		return errors.Wrap(err, "read invalid pid from pidfile")
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		// error only possible on non-unix hosts
+		return errors.Wrapf(err, "failed to find process for pid %d from pidfile", pid)
+	}
+	defer process.Release()
+	return process.Signal(syscall.SIGKILL)
+}
+
+// procHandle is to track the process so we can send signals to it
+// and handle graceful shutdown.
+type procHandle struct {
+	// this is for the runc process (not the process in-container)
+	monitorProcess *os.Process
+	ready          chan struct{}
+	ended          chan struct{}
+	shutdown       func(error)
+	// this this only used when the request context is canceled and we need
+	// to kill the in-container process.
+	killer procKiller
+}
+
+// runcProcessHandle will create a procHandle that will be monitored, where
+// on ctx.Done the in-container process will receive a SIGKILL.  The returned
+// context should be used for the go-runc.(Run|Exec) invocations.  The returned
+// context will only be canceled in the case where the request context is
+// canceled and we are unable to send the SIGKILL to the in-container process.
+// The goal is to allow for runc to gracefully shutdown when the request context
+// is cancelled.
+func runcProcessHandle(ctx context.Context, killer procKiller) (*procHandle, context.Context) {
+	runcCtx, cancel := context.WithCancelCause(context.Background())
+	p := &procHandle{
+		ready:    make(chan struct{}),
+		ended:    make(chan struct{}),
+		shutdown: cancel,
+		killer:   killer,
+	}
+	// preserve the logger on the context used for the runc process handling
+	runcCtx = bklog.WithLogger(runcCtx, bklog.G(ctx))
+
+	go func() {
+		// Wait for pid
+		select {
+		case <-ctx.Done():
+			return // nothing to kill
+		case <-p.ready:
+		}
+
+		for {
+			select {
+			case <-ctx.Done():
+				killCtx, timeout := context.WithCancelCause(context.Background())
+				killCtx, _ = context.WithTimeoutCause(killCtx, 7*time.Second, errors.WithStack(context.DeadlineExceeded))
+				if err := p.killer.Kill(killCtx); err != nil {
+					select {
+					case <-killCtx.Done():
+						cancel(errors.WithStack(context.Cause(ctx)))
+						return
+					default:
+					}
+				}
+				timeout(errors.WithStack(context.Canceled))
+				select {
+				case <-time.After(50 * time.Millisecond):
+				case <-p.ended:
+					return
+				}
+			case <-p.ended:
+				return
+			}
+		}
+	}()
+
+	return p, runcCtx
+}
+
+// Release will free resources with a procHandle.
+func (p *procHandle) Release() {
+	close(p.ended)
+	if p.monitorProcess != nil {
+		p.monitorProcess.Release()
+	}
+}
+
+// Shutdown should be called after the runc process has exited. This will allow
+// the signal handling and tty resize loops to exit, terminating the
+// goroutines.
+func (p *procHandle) Shutdown() {
+	if p.shutdown != nil {
+		p.shutdown(errors.WithStack(context.Canceled))
+	}
+}
+
+// WaitForReady will wait until we have received the runc pid via the go-runc
+// Started channel, or until the request context is canceled.  This should
+// return without errors before attempting to send signals to the runc process.
+func (p *procHandle) WaitForReady(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	case <-p.ready:
+		return nil
+	}
+}
+
+// WaitForStart will record the runc pid reported by go-runc via the channel.
+// We wait for up to 10s for the runc pid to be reported.  If the started
+// callback is non-nil it will be called after receiving the pid.
+func (p *procHandle) WaitForStart(ctx context.Context, startedCh <-chan int, started func()) error {
+	ctx, cancel := context.WithCancelCause(ctx)
+	ctx, _ = context.WithTimeoutCause(ctx, 10*time.Second, errors.WithStack(context.DeadlineExceeded))
+	defer cancel(errors.WithStack(context.Canceled))
+	select {
+	case <-ctx.Done():
+		return errors.New("go-runc started message never received")
+	case runcPid, ok := <-startedCh:
+		if !ok {
+			return errors.New("go-runc failed to send pid")
+		}
+		if started != nil {
+			started()
+		}
+		var err error
+		p.monitorProcess, err = os.FindProcess(runcPid)
+		if err != nil {
+			// error only possible on non-unix hosts
+			return errors.Wrapf(err, "failed to find runc process %d", runcPid)
+		}
+		close(p.ready)
+	}
+	return nil
+}
+
+func updateRuncFieldsForHostOS(runtime *runc.Runc) {
+	// PdeathSignal only supported on unix platforms
+	runtime.PdeathSignal = syscall.SIGKILL // this can still leak the process
+}
+
+// handleSignals will wait until the procHandle is ready then will
+// send each signal received on the channel to the runc process (not directly
+// to the in-container process)
+func handleSignals(ctx context.Context, runcProcess *procHandle, signals <-chan syscall.Signal) error {
+	if signals == nil {
+		return nil
+	}
+	err := runcProcess.WaitForReady(ctx)
+	if err != nil {
+		return err
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case sig := <-signals:
+			if sig == syscall.SIGKILL {
+				// never send SIGKILL directly to runc, it needs to go to the
+				// process in-container
+				if err := runcProcess.killer.Kill(ctx); err != nil {
+					return err
+				}
+				continue
+			}
+			if err := runcProcess.monitorProcess.Signal(sig); err != nil {
+				bklog.G(ctx).Errorf("failed to signal %s to process: %s", sig, err)
+				return err
+			}
+		}
+	}
+}
+
+type runcCall func(ctx context.Context, started chan<- int, io runc.IO, pidfile string) error
+
+func (w *runcExecutor) callWithIO(ctx context.Context, id, bundle string, process executor.ProcessInfo, started func(), killer procKiller, call runcCall) error {
+	runcProcess, ctx := runcProcessHandle(ctx, killer)
+	defer runcProcess.Release()
+
+	eg, ctx := errgroup.WithContext(ctx)
+	defer func() {
+		if err := eg.Wait(); err != nil && !errors.Is(err, context.Canceled) {
+			bklog.G(ctx).Errorf("runc process monitoring error: %s", err)
+		}
+	}()
+	defer runcProcess.Shutdown()
+
+	startedCh := make(chan int, 1)
+	eg.Go(func() error {
+		return runcProcess.WaitForStart(ctx, startedCh, started)
+	})
+
+	eg.Go(func() error {
+		return handleSignals(ctx, runcProcess, process.Signal)
+	})
+
+	if !process.Meta.Tty {
+		return call(ctx, startedCh, &forwardIO{stdin: process.Stdin, stdout: process.Stdout, stderr: process.Stderr}, killer.pidfile)
+	}
+
+	ptm, ptsName, err := console.NewPty()
+	if err != nil {
+		return err
+	}
+
+	pts, err := os.OpenFile(ptsName, os.O_RDWR|syscall.O_NOCTTY, 0)
+	if err != nil {
+		ptm.Close()
+		return err
+	}
+
+	defer func() {
+		if process.Stdin != nil {
+			process.Stdin.Close()
+		}
+		pts.Close()
+		ptm.Close()
+		runcProcess.Shutdown()
+		err := eg.Wait()
+		if err != nil {
+			bklog.G(ctx).Warningf("error while shutting down tty io: %s", err)
+		}
+	}()
+
+	if process.Stdin != nil {
+		eg.Go(func() error {
+			_, err := io.Copy(ptm, process.Stdin)
+			// stdin might be a pipe, so this is like EOF
+			if errors.Is(err, io.ErrClosedPipe) {
+				return nil
+			}
+			return err
+		})
+	}
+
+	if process.Stdout != nil {
+		eg.Go(func() error {
+			_, err := io.Copy(process.Stdout, ptm)
+			// ignore `read /dev/ptmx: input/output error` when ptm is closed
+			var ptmClosedError *os.PathError
+			if errors.As(err, &ptmClosedError) {
+				if ptmClosedError.Op == "read" &&
+					ptmClosedError.Path == "/dev/ptmx" &&
+					ptmClosedError.Err == syscall.EIO {
+					return nil
+				}
+			}
+			return err
+		})
+	}
+
+	eg.Go(func() error {
+		err := runcProcess.WaitForReady(ctx)
+		if err != nil {
+			return err
+		}
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			case resize := <-process.Resize:
+				err = ptm.Resize(console.WinSize{
+					Height: uint16(resize.Rows),
+					Width:  uint16(resize.Cols),
+				})
+				if err != nil {
+					bklog.G(ctx).Errorf("failed to resize ptm: %s", err)
+				}
+				// SIGWINCH must be sent to the runc monitor process, as
+				// terminal resizing is done in runc.
+				err = runcProcess.monitorProcess.Signal(signal.SIGWINCH)
+				if err != nil {
+					bklog.G(ctx).Errorf("failed to send SIGWINCH to process: %s", err)
+				}
+			}
+		}
+	})
+
+	runcIO := &forwardIO{}
+	if process.Stdin != nil {
+		runcIO.stdin = pts
+	}
+	if process.Stdout != nil {
+		runcIO.stdout = pts
+	}
+	if process.Stderr != nil {
+		runcIO.stderr = pts
+	}
+
+	return call(ctx, startedCh, runcIO, killer.pidfile)
+}
+
+type nopCloser struct {
+	io.Writer
+}
+
+func (nopCloser) Close() error { return nil }

--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -230,13 +230,15 @@ func main() { //nolint:gocyclo
 		ctx, cancel := context.WithCancel(appcontext.Context())
 		defer cancel()
 
-		// install CA certs in case the user has a custom engine w/ extra certs
-		// installed to /usr/local/share/ca-certificates
-		// TODO: test this works on the ubuntu GPU image
+		// install CA certs in case the user has a custom engine w/ extra certs installed to
+		// /usr/local/share/ca-certificates
 		if out, err := exec.CommandContext(ctx, "update-ca-certificates").CombinedOutput(); err != nil {
 			bklog.G(ctx).WithError(err).Warnf("failed to update ca-certificates: %s", out)
-		} else if out, err = exec.CommandContext(ctx, "c_rehash", cacerts.EngineCustomCACertsDir).CombinedOutput(); err != nil {
-			bklog.G(ctx).WithError(err).Warnf("failed to rehash ca-certificates: %s", out)
+		} else {
+			//nolint:gosec // it thinks we're using untrusted input even though we're only using consts here...?
+			if out, err := exec.CommandContext(ctx, "c_rehash", cacerts.EngineCustomCACertsDir).CombinedOutput(); err != nil {
+				bklog.G(ctx).WithError(err).Warnf("failed to rehash ca-certificates: %s", out)
+			}
 		}
 
 		ctx, pubsub := InitTelemetry(ctx)

--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/exec"
 	"os/user"
 	"path/filepath"
 	"sort"
@@ -64,6 +65,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 
+	"github.com/dagger/dagger/cmd/engine/cacerts"
 	"github.com/dagger/dagger/engine/cache"
 	"github.com/dagger/dagger/engine/server"
 	"github.com/dagger/dagger/engine/slog"
@@ -227,6 +229,15 @@ func main() { //nolint:gocyclo
 		}
 		ctx, cancel := context.WithCancel(appcontext.Context())
 		defer cancel()
+
+		// install CA certs in case the user has a custom engine w/ extra certs
+		// installed to /usr/local/share/ca-certificates
+		// TODO: test this works on the ubuntu GPU image
+		if out, err := exec.CommandContext(ctx, "update-ca-certificates").CombinedOutput(); err != nil {
+			bklog.G(ctx).WithError(err).Warnf("failed to update ca-certificates: %s", out)
+		} else if out, err = exec.CommandContext(ctx, "c_rehash", cacerts.EngineCustomCACertsDir).CombinedOutput(); err != nil {
+			bklog.G(ctx).WithError(err).Warnf("failed to rehash ca-certificates: %s", out)
+		}
 
 		ctx, pubsub := InitTelemetry(ctx)
 

--- a/cmd/engine/main_oci_worker.go
+++ b/cmd/engine/main_oci_worker.go
@@ -334,7 +334,20 @@ func ociWorkerInitializer(c *cli.Context, common workerInitializerOpt) ([]worker
 		cfg.Labels["maxParallelism"] = strconv.Itoa(cfg.MaxParallelism)
 	}
 
-	opt, err := runc.NewWorkerOpt(common.config.Root, snFactory, cfg.Rootless, processMode, cfg.Labels, idmapping, nc, dns, cfg.Binary, cfg.ApparmorProfile, cfg.SELinux, parallelismSem, common.traceSocket, cfg.DefaultCgroupParent)
+	opt, err := NewWorkerOpt(
+		common.config.Root,
+		snFactory,
+		processMode,
+		cfg.Labels,
+		idmapping,
+		nc,
+		dns,
+		cfg.ApparmorProfile,
+		cfg.SELinux,
+		parallelismSem,
+		common.traceSocket,
+		cfg.DefaultCgroupParent,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -46,7 +46,7 @@ const (
 	stdinPath     = metaMountPath + "/stdin"
 	exitCodePath  = metaMountPath + "/exitCode"
 	runcPath      = "/usr/local/bin/runc"
-	shimPath      = "/_shim"
+	shimPath      = metaMountPath + "/shim"
 
 	errorExitCode = 125
 )

--- a/cmd/shim/main.go
+++ b/cmd/shim/main.go
@@ -355,10 +355,14 @@ func shim() (returnExitCode int) {
 
 func setupBundle() (returnExitCode int) {
 	var errWriter io.Writer = os.Stderr
+	var stderrFile *os.File
 	defer func() {
 		if err := recover(); err != nil {
 			fmt.Fprintf(errWriter, "shim error: %v\n%s", err, string(debug.Stack()))
 			returnExitCode = errorExitCode
+		}
+		if stderrFile != nil {
+			stderrFile.Close()
 		}
 	}()
 
@@ -427,7 +431,8 @@ func setupBundle() (returnExitCode int) {
 				// for stderr specifically, also update errWriter to that file so that any
 				// errors here actually show up in the final error message passed to clients
 				if metaPath == stderrPath {
-					stderrFile, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o666)
+					var err error
+					stderrFile, err = os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o666)
 					if err != nil {
 						panic(err)
 					}

--- a/core/integration/cacert_test.go
+++ b/core/integration/cacert_test.go
@@ -1,0 +1,491 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"dagger.io/dagger"
+	"github.com/moby/buildkit/identity"
+	"github.com/stretchr/testify/require"
+)
+
+type caCertsTest struct {
+	name string
+	run  func(*testing.T, *dagger.Client, caCertsTestFixtures)
+}
+
+type caCertsTestFixtures struct {
+	serverCtr      *dagger.Container
+	caCertContents string
+}
+
+func customCACertTests(
+	ctx context.Context,
+	t *testing.T,
+	c *dagger.Client,
+	netID int,
+	tests ...caCertsTest,
+) {
+	t.Helper()
+
+	executeTestEnvName := fmt.Sprintf("DAGGER_TEST_%s", strings.ToUpper(t.Name()))
+
+	if os.Getenv(executeTestEnvName) == "" {
+		// TODO: this would be a good module
+		const password = "hunter4"
+		genCtr := c.Container().From(alpineImage).
+			WithExec([]string{"apk", "add", "openssl"}).
+			WithExec([]string{"openssl", "dhparam",
+				"-out", "/dhparam.pem",
+				"2048",
+			}).
+			WithExec([]string{"openssl", "genrsa",
+				"-des3",
+				"-out", "/ca.key",
+				"-passout", "pass:" + password,
+				"2048",
+			}).
+			WithExec([]string{"openssl", "req",
+				"-x509",
+				"-new",
+				"-nodes",
+				"-key", "/ca.key",
+				"-sha256",
+				"-days", "99999",
+				"-out", "/ca.pem",
+				"-passin", "pass:" + password,
+				"-subj", "/C=US/ST=CA/L=San Francisco/O=Example/CN=example.com",
+			}).
+			WithExec([]string{"openssl", "genrsa",
+				"-out", "/server.key",
+				"2048",
+			}).
+			WithExec([]string{"openssl", "req",
+				"-new",
+				"-key", "/server.key",
+				"-out", "/server.csr",
+				"-passin", "pass:" + password,
+				"-subj", "/C=US/ST=CA/L=San Francisco/O=Example/CN=example.com",
+			}).
+			WithNewFile("/server.ext", dagger.ContainerWithNewFileOpts{
+				Contents: `authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = server
+`,
+			}).
+			WithExec([]string{"openssl", "x509",
+				"-req",
+				"-in", "/server.csr",
+				"-CA", "/ca.pem",
+				"-CAkey", "/ca.key",
+				"-CAcreateserial",
+				"-out", "/server.crt",
+				"-days", "99999",
+				"-sha256",
+				"-extfile", "/server.ext",
+				"-passin", "pass:" + password,
+			})
+
+		caRootCert := genCtr.File("/ca.pem")
+		serverCert := genCtr.File("/server.crt")
+		serverKey := genCtr.File("/server.key")
+		dhParam := genCtr.File("/dhparam.pem")
+
+		devEngine := devEngineContainer(c).
+			WithMountedFile("/usr/local/share/ca-certificates/dagger-test-custom-ca.crt", caRootCert).
+			WithMountedCache("/var/lib/dagger", c.CacheVolume("dagger-dev-engine-state-"+identity.NewID())).
+			WithExec([]string{
+				"--addr", "tcp://0.0.0.0:1234",
+				"--network-cidr", fmt.Sprintf("10.%d.0.0/16", netID), // avoid conflicts with other tests
+				"--network-name", "testcacerts",
+			}, dagger.ContainerWithExecOpts{
+				InsecureRootCapabilities: true,
+			})
+
+		thisRepoPath, err := filepath.Abs("../..")
+		require.NoError(t, err)
+		thisRepo := c.Host().Directory(thisRepoPath)
+
+		_, err = c.Container().From(golangImage).
+			With(goCache(c)).
+			WithMountedDirectory("/src", thisRepo).
+			WithWorkdir("/src").
+			WithMountedFile("/ca.crt", caRootCert).
+			WithMountedFile("/server.crt", serverCert).
+			WithMountedFile("/server.key", serverKey).
+			WithMountedFile("/dhparam.pem", dhParam).
+			WithServiceBinding("engine", devEngine.AsService()).
+			WithMountedFile("/bin/dagger", daggerCliFile(t, c)).
+			WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", "/bin/dagger").
+			WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", "tcp://engine:1234").
+			WithEnvVariable(executeTestEnvName, "ya").
+			WithExec([]string{"go", "test",
+				"-v",
+				"-timeout", "20m",
+				"-count", "1",
+				"-run", fmt.Sprintf("^%s$", t.Name()),
+				"./core/integration",
+			}).Sync(ctx)
+		require.NoError(t, err)
+		return
+	}
+
+	// we're in the container depending on the custom engine, run the actual tests
+	caCert := c.Host().File("/ca.crt")
+	serverCert := c.Host().File("/server.crt")
+	serverKey := c.Host().File("/server.key")
+	dhParam := c.Host().File("/dhparam.pem")
+
+	// TODO: pin image
+	serverCtr := c.Container().From("nginx:latest").
+		WithMountedFile("/etc/ssl/certs/server.crt", serverCert).
+		WithMountedFile("/etc/ssl/certs/dhparam.pem", dhParam).
+		WithMountedFile("/etc/ssl/private/server.key", serverKey).
+		WithNewFile("/etc/nginx/snippets/self-signed.conf", dagger.ContainerWithNewFileOpts{
+			Contents: `ssl_certificate /etc/ssl/certs/server.crt;
+ssl_certificate_key /etc/ssl/private/server.key;
+`}).WithNewFile("/etc/nginx/snippets/ssl-params.conf", dagger.ContainerWithNewFileOpts{
+		Contents: `ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+ssl_prefer_server_ciphers on;
+ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
+ssl_ecdh_curve secp384r1;
+ssl_session_cache shared:SSL:10m;
+ssl_session_tickets off;
+ssl_stapling_verify on;
+resolver 10.90.0.1 valid=300s;
+resolver_timeout 5s;
+add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
+add_header X-Frame-Options DENY;
+add_header X-Content-Type-Options nosniff;
+ssl_dhparam /etc/ssl/certs/dhparam.pem;
+`}).WithNewFile("/etc/nginx/conf.d/default.conf", dagger.ContainerWithNewFileOpts{
+		Contents: `server {
+	listen 80 default_server;
+	listen [::]:80 default_server;
+	server_name server;
+	return 302 https://$server_name$request_uri;
+}
+
+server {
+	listen 443 ssl http2 default_server;
+	listen [::]:443 ssl http2 default_server;
+	include snippets/self-signed.conf;
+	include snippets/ssl-params.conf;
+	server_name server;
+	location / {
+		return 200 "hello";
+	}
+}
+`}).WithExec([]string{"nginx", "-t"}).
+		WithExposedPort(443).
+		WithExec([]string{"nginx"})
+
+	caCertContents, err := caCert.Contents(ctx)
+	require.NoError(t, err)
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			test.run(t, c, caCertsTestFixtures{
+				serverCtr:      serverCtr,
+				caCertContents: caCertContents,
+			})
+		})
+	}
+}
+func TestContainerSystemCACerts(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := connect(t)
+
+	customCACertTests(ctx, t, c, 100,
+		caCertsTest{"alpine basic", func(t *testing.T, c *dagger.Client, f caCertsTestFixtures) {
+			ctr := c.Container().From(alpineImage).
+				WithExec([]string{"apk", "add", "curl"})
+			initialBundleContents, err := ctr.File("/etc/ssl/certs/ca-certificates.crt").Contents(ctx)
+			require.NoError(t, err)
+
+			ctr, err = ctr.
+				WithServiceBinding("server", f.serverCtr.AsService()).
+				WithExec([]string{"curl", "https://server"}).
+				Sync(ctx)
+			require.NoError(t, err)
+
+			// verify no system CAs are leftover
+			ents, err := ctr.Directory("/usr/local/share/ca-certificates").Entries(ctx)
+			require.NoError(t, err)
+			require.Empty(t, ents)
+
+			bundleContents, err := ctr.File("/etc/ssl/certs/ca-certificates.crt").Contents(ctx)
+			require.NoError(t, err)
+			require.NotContains(t, bundleContents, f.caCertContents)
+			require.Equal(t, initialBundleContents, bundleContents)
+		}},
+
+		caCertsTest{"alpine non-root user", func(t *testing.T, c *dagger.Client, f caCertsTestFixtures) {
+			ctr := c.Container().From(alpineImage).
+				WithExec([]string{"apk", "add", "curl"})
+			initialBundleContents, err := ctr.File("/etc/ssl/certs/ca-certificates.crt").Contents(ctx)
+			require.NoError(t, err)
+
+			ctr, err = ctr.
+				WithServiceBinding("server", f.serverCtr.AsService()).
+				WithUser("nobody").
+				WithExec([]string{"/usr/bin/curl", "https://server"}).
+				Sync(ctx)
+			require.NoError(t, err)
+
+			// verify no system CAs are leftover
+			ents, err := ctr.Directory("/usr/local/share/ca-certificates").Entries(ctx)
+			require.NoError(t, err)
+			require.Empty(t, ents)
+
+			bundleContents, err := ctr.File("/etc/ssl/certs/ca-certificates.crt").Contents(ctx)
+			require.NoError(t, err)
+			require.NotContains(t, bundleContents, f.caCertContents)
+			require.Equal(t, initialBundleContents, bundleContents)
+		}},
+
+		caCertsTest{"alpine install ca-certificates and curl at once", func(t *testing.T, c *dagger.Client, f caCertsTestFixtures) {
+			ctr, err := c.Container().From(alpineImage).
+				WithServiceBinding("server", f.serverCtr.AsService()).
+				WithExec([]string{"sh", "-c", "apk add curl && curl https://server"}).
+				Sync(ctx)
+			require.NoError(t, err)
+
+			// verify no system CAs are leftover
+			ents, err := ctr.Directory("/usr/local/share/ca-certificates").Entries(ctx)
+			require.NoError(t, err)
+			require.Empty(t, ents)
+
+			bundleContents, err := ctr.File("/etc/ssl/certs/ca-certificates.crt").Contents(ctx)
+			require.NoError(t, err)
+			require.NotEmpty(t, bundleContents)
+			require.NotContains(t, bundleContents, f.caCertContents)
+		}},
+
+		caCertsTest{"alpine ca-certificates not installed", func(t *testing.T, c *dagger.Client, f caCertsTestFixtures) {
+			ctr := c.Container().From(golangImage).
+				WithExec([]string{"apk", "del", "ca-certificates"})
+
+			// verify no system CAs are leftover
+			_, err := ctr.Directory("/usr/local/share/ca-certificates").Entries(ctx)
+			require.ErrorContains(t, err, "no such file or directory")
+
+			bundleContents, err := ctr.File("/etc/ssl/certs/ca-certificates.crt").Contents(ctx)
+			require.NoError(t, err)
+			require.NotEmpty(t, bundleContents)
+			require.NotContains(t, bundleContents, f.caCertContents)
+
+			ctr, err = ctr.
+				WithNewFile("/src/main.go", dagger.ContainerWithNewFileOpts{
+					Contents: `package main
+
+				import (
+					"fmt"
+					"net/http"
+					"io"
+				)
+
+				func main() {
+					resp, err := http.Get("https://server")
+					if err != nil {
+						panic(err)
+					}
+					if resp.StatusCode != 200 {
+						panic(fmt.Sprintf("unexpected status code: %d", resp.StatusCode))
+					}
+					bs, err := io.ReadAll(resp.Body)
+					if err != nil {
+						panic(err)
+					}
+					if string(bs) != "hello" {
+						panic("unexpected response: " + string(bs))
+					}
+				}
+				`}).
+				WithWorkdir("/src").
+				WithExec([]string{"go", "mod", "init", "test"}).
+				WithServiceBinding("server", f.serverCtr.AsService()).
+				WithExec([]string{"go", "run", "main.go"}).
+				Sync(ctx)
+			require.NoError(t, err)
+
+			// verify no system CAs are leftover
+			_, err = ctr.Directory("/usr/local/share/ca-certificates").Entries(ctx)
+			require.ErrorContains(t, err, "no such file or directory")
+
+			bundleContents, err = ctr.File("/etc/ssl/certs/ca-certificates.crt").Contents(ctx)
+			require.NoError(t, err)
+			require.NotEmpty(t, bundleContents)
+			require.NotContains(t, bundleContents, f.caCertContents)
+		}},
+
+		caCertsTest{"debian basic", func(t *testing.T, c *dagger.Client, f caCertsTestFixtures) {
+			ctr := c.Container().From(debianImage).
+				WithExec([]string{"apt", "update"}).
+				WithExec([]string{"apt", "install", "-y", "curl"})
+			initialBundleContents, err := ctr.File("/etc/ssl/certs/ca-certificates.crt").Contents(ctx)
+			require.NoError(t, err)
+
+			ctr, err = ctr.
+				WithServiceBinding("server", f.serverCtr.AsService()).
+				WithExec([]string{"curl", "https://server"}).
+				Sync(ctx)
+			require.NoError(t, err)
+
+			// verify no system CAs are leftover
+			ents, err := ctr.Directory("/usr/local/share/ca-certificates").Entries(ctx)
+			require.NoError(t, err)
+			require.Empty(t, ents)
+
+			bundleContents, err := ctr.File("/etc/ssl/certs/ca-certificates.crt").Contents(ctx)
+			require.NoError(t, err)
+			require.NotContains(t, bundleContents, f.caCertContents)
+			require.Equal(t, initialBundleContents, bundleContents)
+		}},
+
+		caCertsTest{"debian non-root user", func(t *testing.T, c *dagger.Client, f caCertsTestFixtures) {
+			ctr := c.Container().From(debianImage).
+				WithExec([]string{"apt", "update"}).
+				WithExec([]string{"apt", "install", "-y", "curl"})
+			initialBundleContents, err := ctr.File("/etc/ssl/certs/ca-certificates.crt").Contents(ctx)
+			require.NoError(t, err)
+
+			ctr, err = ctr.
+				WithServiceBinding("server", f.serverCtr.AsService()).
+				WithUser("nobody").
+				WithExec([]string{"/usr/bin/curl", "https://server"}).
+				Sync(ctx)
+			require.NoError(t, err)
+
+			// verify no system CAs are leftover
+			ents, err := ctr.Directory("/usr/local/share/ca-certificates").Entries(ctx)
+			require.NoError(t, err)
+			require.Empty(t, ents)
+
+			bundleContents, err := ctr.File("/etc/ssl/certs/ca-certificates.crt").Contents(ctx)
+			require.NoError(t, err)
+			require.NotContains(t, bundleContents, f.caCertContents)
+			require.Equal(t, initialBundleContents, bundleContents)
+		}},
+
+		caCertsTest{"debian install ca-certificates and curl at once", func(t *testing.T, c *dagger.Client, f caCertsTestFixtures) {
+			ctr, err := c.Container().From(debianImage).
+				WithExec([]string{"apt", "update"}).
+				WithServiceBinding("server", f.serverCtr.AsService()).
+				WithExec([]string{"sh", "-c", "apt install -y curl && curl https://server"}).
+				Sync(ctx)
+			require.NoError(t, err)
+
+			// verify no system CAs are leftover
+			ents, err := ctr.Directory("/usr/local/share/ca-certificates").Entries(ctx)
+			require.NoError(t, err)
+			require.Empty(t, ents)
+
+			bundleContents, err := ctr.File("/etc/ssl/certs/ca-certificates.crt").Contents(ctx)
+			require.NoError(t, err)
+			require.NotEmpty(t, bundleContents)
+			require.NotContains(t, bundleContents, f.caCertContents)
+		}},
+
+		caCertsTest{"debian ca-certificates not installed", func(t *testing.T, c *dagger.Client, f caCertsTestFixtures) {
+			ctr, err := c.Container().From(debianImage).
+				WithExec([]string{"apt", "update"}).
+				WithExec([]string{"apt", "install", "-y", "golang"}).
+				WithNewFile("/src/main.go", dagger.ContainerWithNewFileOpts{
+					Contents: `package main
+
+					import (
+						"fmt"
+						"net/http"
+						"io"
+					)
+
+					func main() {
+						resp, err := http.Get("https://server")
+						if err != nil {
+							panic(err)
+						}
+						if resp.StatusCode != 200 {
+							panic(fmt.Sprintf("unexpected status code: %d", resp.StatusCode))
+						}
+						bs, err := io.ReadAll(resp.Body)
+						if err != nil {
+							panic(err)
+						}
+						if string(bs) != "hello" {
+							panic("unexpected response: " + string(bs))
+						}
+					}
+					`}).
+				WithWorkdir("/src").
+				WithExec([]string{"go", "mod", "init", "test"}).
+				WithServiceBinding("server", f.serverCtr.AsService()).
+				WithExec([]string{"go", "run", "main.go"}).
+				Sync(ctx)
+			require.NoError(t, err)
+
+			// verify no system CAs are leftover
+			_, err = ctr.Directory("/usr/local/share/ca-certificates").Entries(ctx)
+			require.ErrorContains(t, err, "no such file or directory")
+
+			_, err = ctr.File("/etc/ssl/certs/ca-certificates.crt").Contents(ctx)
+			require.ErrorContains(t, err, "no such file or directory")
+		}},
+
+		caCertsTest{"rhel basic", func(t *testing.T, c *dagger.Client, f caCertsTestFixtures) {
+			ctr := c.Container().From(rhelImage)
+			initialBundleContents, err := ctr.File("/etc/pki/tls/certs/ca-bundle.crt").Contents(ctx)
+			require.NoError(t, err)
+
+			ctr, err = ctr.
+				WithServiceBinding("server", f.serverCtr.AsService()).
+				WithExec([]string{"curl", "https://server"}).
+				Sync(ctx)
+			require.NoError(t, err)
+
+			// verify no system CAs are leftover
+			ents, err := ctr.Directory("/etc/pki/ca-trust/source/anchors").Entries(ctx)
+			require.NoError(t, err)
+			require.Empty(t, ents)
+
+			bundleContents, err := ctr.File("/etc/pki/tls/certs/ca-bundle.crt").Contents(ctx)
+			require.NoError(t, err)
+			require.NotContains(t, bundleContents, f.caCertContents)
+			require.Equal(t, initialBundleContents, bundleContents)
+		}},
+
+		caCertsTest{"rhel non-root user", func(t *testing.T, c *dagger.Client, f caCertsTestFixtures) {
+			ctr := c.Container().From(rhelImage)
+			initialBundleContents, err := ctr.File("/etc/pki/tls/certs/ca-bundle.crt").Contents(ctx)
+			require.NoError(t, err)
+
+			ctr, err = ctr.
+				WithUser("nobody").
+				WithServiceBinding("server", f.serverCtr.AsService()).
+				WithExec([]string{"curl", "https://server"}).
+				Sync(ctx)
+			require.NoError(t, err)
+
+			// verify no system CAs are leftover
+			ents, err := ctr.Directory("/etc/pki/ca-trust/source/anchors").Entries(ctx)
+			require.NoError(t, err)
+			require.Empty(t, ents)
+
+			bundleContents, err := ctr.File("/etc/pki/tls/certs/ca-bundle.crt").Contents(ctx)
+			require.NoError(t, err)
+			require.NotContains(t, bundleContents, f.caCertContents)
+			require.Equal(t, initialBundleContents, bundleContents)
+		}},
+	)
+}

--- a/core/integration/images.go
+++ b/core/integration/images.go
@@ -3,6 +3,8 @@ package core
 const (
 	alpineImage = "alpine:3.18.2"
 	golangImage = "golang:1.22.2-alpine"
+	debianImage = "debian:bookworm"
+	rhelImage   = "registry.access.redhat.com/ubi9/ubi"
 
 	// TODO: use these
 	// registryImage   = "registry:2"


### PR DESCRIPTION
Still some cleanup left, but good enough for feedback. TODOs:
- [x] finish description
- [x] dedupe some of the distro ca installation code
- [x] make ca installation/uninstallation non-fatal and cleaned up in case of failure partial way through
- [x] make final call on whether to only selectively enable or just apply to all containers when custom CAs are installed in the engine (at `/usr/local/share/ca-certificates`)
   * I'm personally good with this now. These codepaths only get hit when users have a custom engine w/ CA certs installed and I made the install best-effort with cleanup in case of errors. Still open to feedback from others on this though.
- [ ] expand test coverage a bit more (more debian/rhel derivatives, cover cleanup in case of install failure)
- [ ] test ubuntu gpu image (manually for now since we don't have any automated tests for that yet)
- [x] double check umask clearing mentioned here: https://github.com/dagger/dagger/pull/7067#discussion_r1558135886
- [x] add more comments to extra gnarly/subtle parts of code

---

This adds support for automatic installation of custom CA certs to containers. Originally this was gonna just be the first step outlined [here](https://github.com/dagger/dagger/issues/6599) but as I started implementing the CA certs part it required enough complication that it seemed best to just implement the full support for automatic CA installation for all containers.

## Helpful docs/prior art
* https://wiki.archlinux.org/title/Transport_Layer_Security
* https://go.dev/src/crypto/x509/root_linux.go
* @vito's bass CA autoinstall https://github.com/vito/bass/blob/bf53c90d467e0eaf7125cfbfd005c65349125481/pkg/runtimes/shim/tls.go
* https://github.com/containers/podman/issues/2317
* https://github.com/flatpak/flatpak/pull/1757
* https://github.com/flatpak/flatpak/issues/2721
* https://p11-glue.github.io/p11-glue/p11-kit/manual/remoting.html
   * we don't do this in our implementation, but an interesting possibility for systems/libs using p11 kit
* https://minikube.sigs.k8s.io/docs/handbook/untrusted_certs/
   * https://github.com/kubernetes/minikube/blob/master/pkg/minikube/kubeconfig/settings.go#L85

## CA Certs
I learned a lot about the various nuances surrounding CAs as part of this (and I'm sure I've only scratched the surface), braindump below.

CAs are not standardized in any way; the way they are configured depends on a few (sometimes orthogonal) factors:
1. Consuming software/TLS library
   * "Generic" - includes openssl and many/most language stdlibs
     * The closest thing to a generic default is the use of a "bundle" file, which is a single file containing each CA cert that should be trusted along with a dir containing individual files for each of those CAs and symlinks of the hash of those files to the file (created with the `c_rehash` command)
     * Typically there will also be a command that can be used to automatically update the bundle file and CA dir when custom CAs are installed in another directory.
     * The location of the bundle file and other dirs and the name of the command to update CAs depends on the distro. Typically the distro will compile packages like `curl` with options that point to the right bundle file and/or CA dir to use.
   * `PKCS #11` and `p11-kit`
     * Have not gone too deep into this yet, but my limited understanding is PKCS 11 is an attempt at a standard around trust/key-management and includes CA certs. Not all distros/libraries use the standard, but those that do can load CA certs that are configured via the `trust` or `update-ca-trust` command.
     * RHEL-based distros typically use this for example
     * The `trust` command has an `extract` subcommand that creates a layout compatible with the above "generic" setup, for better compatibility with libs that don't use `libp11-kit`
   * Other TLS implementations like GnuTLS and LibreSSL do their own thing
   * The JVM has it's own CA cert store
   * Browsers typically also have their own CA store
   * Different versions of a given TLS lib may also have their own CA trust store (i.e. the alpine base image has both `/etc/ssl/certs` and `/etc/ssl1.1/certs`
2. Distro
   * As mentioned above, all the paths used for each TLS implementation (bundle file, CA dir, etc.) depend on compile-time options set by each distro when building packages
   * CA functionality is typically implemented as optional packages (rather than as pseudo-required packages like `libc`) and whether said package is installed in base images varies from distro to distro:
      * the rhel based base images seem to usually come with `ca-certificates` fully installed
      * `debian` comes without it installed
      * `alpine` does not have it installed, but nonetheless does have a base bundle file installed (though no separate cert files)

## Implementation Notes
* Automatic install
   * If the user puts certs at `/usr/local/share/ca-certificates` in their custom engine image, the engine will attempt to install that in all containers (but only if it can identify the distro of the container, fallback is a nop right now)
   * would like to leave this in, but requires that any failure during install/uninstall can be made non-fatal and cleanup-able. Otherwise will change this to be configurable somehow
* Uninstall + cleanup
   * It's important that we follow the "leave no trace" rule here; any CAs that we autoinstall in a container should be auto-*un*installed so they don't pollute the final container result unexpectedly
   * This becomes extra complicated in cases where the user's exec actually modifies the state of bundle files/CA dirs, in which case we also want to be very careful to not uninstall anything that the exec actually purposefully modified.
     * This isn't an obscure case; e.g. if you `apk install curl` off the base alpine image the `ca-certificates` package will be installed as a dep and modify the bundle file and CA dir.
* Execution location
   * At first, I implemented all this in the shim process that we currently run as the init of each container. However, this didn't end up working/was not ideal:
      1. If the container user was not root, we would not have permissions to modify certain files/dirs and couldn't run update command like `update-ca-certificates`
      2. We have a long-term goal of removing the need to inject our own init to each container (https://github.com/dagger/dagger/issues/4989), but this approach buries us even deeper into that dependency
   * Instead, we had the option to either A) run it exclusively in the part of the shim that executes outside the container or B) implement our own custom buildkit `Executor` (which runs in the `dagger-engine` process). I ended up going with the `Executor` approach for a few reasons:
     1. In the long-term, we can migrate *all* of the current shim functionality to this Executor. This should result in a much simpler overall architecture since we will be able to avoid all the messy hacks around passing special env vars to the shim process and trying to sneak uncached data into the container via `ftp_proxy`
     2. As mentioned below, ca cert install/uninstall may need to run actual commands as root inside the container, which is much simpler to implement from the Executor relative to the shim (which would need to have new logic for creating a separate bundle for each command, whereas the Executor already has all that logic)
   * The biggest annoyance here is that we need to read/write certain files/dirs from the container before/after the container has actually run, which meant either A) creating all the container mounts temporarily (and unmounting them before the container starts to avoid various corner cases around multiple mounts of overlay) or B) a "vfs" approach that maps read/write operations on files/dirs to the correct underlying source mount even though those haven't been mounted yet.
     * I went with B) because A) is a bit too frought with weird cases and felt like more performance overhead (mount/unmount can be expensive in some cases). This is implement in `cmd/engine/cacerts/fs.go` as `containerFS`. The main complication comes from needing to *very* carefully handle symlinks so that any symlinks in parent dirs of a given path are always resolved correctly to the final mount where they actually point to.
* Commands 
   * Have to support running command like `update-ca-certificates` and similar by actually starting separate container that reuses the same rootfs+mounts as the "actual" user exec container.
   * This is done from the Executor level so there's no extra layers and overhead is relatively minimal, but still does impose some latency unfortunately. This currently only happens when the engine actually has any custom certs installed, so it's relatively safe and won't slow down all users immediately.
   * I think we can optimize this in time to skip running these commands in cases where we are sure we can manually implement the same functionality via file/dir operations directly. Went with this approach for now to be extra safe to start.
* Distro detection
   * We need to positively identify which distro is in use because some don't come with a base image containing any bundle file/ca dir/ etc. (e.g. `debian`), but other packages may still try to check those (we need to manually set those up in these cases).
   * This requires checking various `/etc/` files. Used https://github.com/dekobon/distro-detect/blob/master/linux/distrochecks.go as a reference
   * Currently only implemented support for alpine/debian-derivatives/rhel-derivatives