### PR TITLE
telemetry: record an API call's LLB op digests

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -1185,6 +1185,21 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 		runOpts = append(runOpts, llb.Security(llb.SecurityModeInsecure))
 	}
 
+	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	execMeta := buildkit.ContainerExecUncachedMetadata{
+		ParentClientIDs: clientMetadata.ClientIDs(),
+		ServerID:        clientMetadata.ServerID,
+	}
+	proxyVal, err := execMeta.ToPBFtpProxyVal()
+	if err != nil {
+		return nil, fmt.Errorf("ftp proxy val: %w", err)
+	}
+	runOpts = append(runOpts, llb.WithProxy(llb.ProxyEnv{
+		FTPProxy: proxyVal,
+	}))
 	fsSt, err := container.FSState()
 	if err != nil {
 		return nil, fmt.Errorf("fs state: %w", err)

--- a/telemetry/attrs.go
+++ b/telemetry/attrs.go
@@ -53,6 +53,10 @@ const (
 	// span represents.
 	LLBOpAttr = "dagger.io/llb.op"
 
+	// The digests of the LLB operations that this span depends on, allowing the
+	// UI to attribute their future "cost."
+	LLBDigestsAttr = "dagger.io/llb.digests"
+
 	// The amount of progress that needs to be reached.
 	ProgressTotalAttr = "dagger.io/progress.total"
 


### PR DESCRIPTION
This data allows the UI to track where lazy operations came from so we can tie them back to the call site that installed them (i.e. `withExec`). This visualization angle is super useful when you're trying to gauge the "cost" of API calls.

Something like this (note the "shadow bars" - UI subject to change):

![image](https://github.com/dagger/dagger/assets/1880/bf0550a6-1bac-4387-8bed-3fe0c7ba7af8)

**NOTE:** As a prerequisite, I moved the `ftp_proxy` hackery back to `Container.WithExec` instead of doing it "just-in-time" in the Buildkit client. Otherwise the span ends up with a different digest than what we return, so they can't be correlated at all. The switch from Progrock => OpenTelemetry allows us to do this, I believe; we couldn't before because we had to pass the Progrock parent vertex ID, but the OpenTelemetry equivalent is handled for us by Buildkit itself.

(edit - side note: it seems like we could potentially remove the `ftp_proxy` hack _entirely_ if we replace ServerID with the OpenTelemetry trace + span ID.)