### PR TITLE
fix: avoid lost log colors when CI=true

### DIFF
--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -87,7 +87,7 @@ func New() *Frontend {
 		view:         new(strings.Builder),
 		messagesView: logsView,
 		messagesBuf:  logsOut,
-		messagesW:    ui.NewOutput(io.MultiWriter(logsView, logsOut), termenv.WithProfile(profile)),
+		messagesW:    ui.NewOutput(io.MultiWriter(logsView, logsOut), termenv.WithProfile(profile), termenv.WithUnsafe()),
 	}
 }
 


### PR DESCRIPTION
fix #7047