### PR TITLE
ci: forward host docker dir into tests

### DIFF
--- a/ci/mage/engine.go
+++ b/ci/mage/engine.go
@@ -116,6 +116,9 @@ func (t Engine) test(ctx context.Context, additional ...string) error {
 	if cfg, ok := os.LookupEnv("_EXPERIMENTAL_DAGGER_CACHE_CONFIG"); ok {
 		args = append(args, "with-cache", "--config="+cfg)
 	}
+	if dockerPath, err := util.HostDockerDir(); err == nil {
+		args = append(args, "with-host-docker", "--directory="+dockerPath)
+	}
 	args = append(args, additional...)
 	return util.DaggerCall(ctx, args...)
 }

--- a/ci/mage/util/dagger.go
+++ b/ci/mage/util/dagger.go
@@ -2,8 +2,10 @@ package util
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 func DaggerCall(ctx context.Context, args ...string) error {
@@ -16,5 +18,6 @@ func DaggerCall(ctx context.Context, args ...string) error {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	fmt.Println(">", strings.Join(cmd.Args, " "))
 	return cmd.Run()
 }

--- a/ci/mage/util/docker.go
+++ b/ci/mage/util/docker.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+func HostDockerDir() (string, error) {
+	if runtime.GOOS != "linux" {
+		// doesn't work on darwin, untested on windows
+		return "", fmt.Errorf("cannot get docker dir on %s", runtime.GOOS)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(home, ".docker")
+	if _, err := os.Stat(path); err != nil {
+		return "", err
+	}
+	return path, nil
+}


### PR DESCRIPTION
See https://github.com/dagger/dagger/pull/6843#discussion_r1552464269 (this behavior was originally removed, this PR just restores it to the prior state)

This ensures that we use the host creds in the test container, so we don't end up maxing out our anonymous usage of docker hub.

We may be able to get rid of this once #6916 lands? But in the meantime, we're seeing a ton of ephemeral failures which are quite annoying :tada: