### PR TITLE
ci: remove kernel logs from github logs

### DIFF
--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -52,9 +52,6 @@ jobs:
       - name: ${{ inputs.mage-targets }}
         run: |
           ./hack/make ${{ inputs.mage-targets }}
-      - name: "ALWAYS print kernel logs - especialy useful on failure"
-        if: always()
-        run: sudo dmesg
 
   # Use our own Dagger runner when running in the dagger/dagger repo (including PRs)
   dagger-runner:
@@ -93,6 +90,3 @@ jobs:
           ./hack/make ${{ inputs.mage-targets }}
         env:
           _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
-      - name: "ALWAYS print kernel logs - especialy useful on failure"
-        if: always()
-        run: sudo dmesg

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -175,10 +175,6 @@ jobs:
         if: always()
         run: docker logs $(docker ps -q --filter name=dagger-engine)
 
-      - name: "ALWAYS print kernel logs - especially useful on failure"
-        if: always()
-        run: sudo dmesg
-
   test-provision-go-linux:
     name: "Test SDK Provision / go / linux"
     needs: publish
@@ -219,9 +215,6 @@ jobs:
       - name: "ALWAYS print engine logs - especially useful on failure"
         if: always()
         run: docker logs $(docker ps -q --filter name=dagger-engine)
-      - name: "ALWAYS print kernel logs - especially useful on failure"
-        if: always()
-        run: sudo dmesg
 
   test-provision-python-linux:
     name: "Test SDK Provision / python / linux"
@@ -266,9 +259,6 @@ jobs:
       - name: "ALWAYS print engine logs - especially useful on failure"
         if: always()
         run: docker logs $(docker ps -q --filter name=dagger-engine)
-      - name: "ALWAYS print kernel logs - especially useful on failure"
-        if: always()
-        run: sudo dmesg
 
   test-provision-typescript-linux:
     name: "Test SDK Provision / TypeScript / linux"
@@ -319,6 +309,3 @@ jobs:
       - name: "ALWAYS print engine logs - especially useful on failure"
         if: always()
         run: docker logs $(docker ps -q --filter name=dagger-engine)
-      - name: "ALWAYS print kernel logs - especially useful on failure"
-        if: always()
-        run: sudo dmesg


### PR DESCRIPTION
Came across this while working on continued modularization - ideally, we want to end up in a place where *all* of our CI is just a `dagger call` away! Then we can use https://github.com/dagger/dagger-for-github, and dogfood that more.

This step is more fiddly to modularize (which we want to do so it would show up in dagger cloud) - I think it can be done, but I think we might also just be able to remove it. It was added quite a while ago in https://github.com/dagger/dagger/pull/3785, to help debug https://github.com/dagger/dagger/issues/3784 - which now doesn't occur anymore.

I think it makes sense to just remove these now, I personally have never used them, and they just provide a little bit of friction when trying to scan for failures! If anyone *has* used them recently, I can port them to a dagger function, but just proposing the simpler removal for now.