### PR TITLE
Migrate to new ci runners

### DIFF
--- a/.github/workflows/_async_hack_make.yml
+++ b/.github/workflows/_async_hack_make.yml
@@ -1,6 +1,6 @@
 # This is run asynchronously, triggered from "hack/make".
 # The purpose is to compare the behaviour of different runner configurations.
-name: cfg-runner
+name: "async/hack/make"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -21,7 +21,7 @@ on:
         default: 60  
       size:
         type: string
-        default: "dagger-v0-11-1"
+        default: "dagger-v0-11-1-4c-nvme"
         required: false
       dagger-version:
         type: string

--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -88,33 +88,17 @@ jobs:
 
   dagger-runner-gerhard-production:
     if: ${{ !inputs.dev-engine && github.repository == 'dagger/dagger' && inputs.mage-targets == 'engine:testrace' }}
-    runs-on: dagger-v011-on-k8s-gerhard-production
+    runs-on: ubuntu-latest
     concurrency:
-      group: ${{github.workflow}}-${{ inputs.mage-targets }}-${{ github.head_ref || github.run_id }}-vertical-scaling
+      group: ${{github.workflow}}-${{ inputs.mage-targets }}-${{ github.head_ref || github.run_id }}-gp
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      # https://github.com/benc-uk/workflow-dispatch/tree/v1
+      - name: Trigger ${{ inputs.mage-targets }} on 
+        uses: benc-uk/workflow-dispatch@v1
         with:
-          go-version: "1.21"
-          cache-dependency-path: "ci/go.sum"
-      - name: Install tools
-        run: |
-          sudo apt update
-          sudo apt install -y curl
-      - name: Install dagger
-        run: |
-          curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ inputs.dagger-version }} BIN_DIR=/usr/local/bin/ sudo -E sh
-      - name: Waiting for Dagger Engine to be ready...
-        run: |
-          ./hack/make engine:connect
-        env:
-          DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
-      - name: ${{ inputs.mage-targets }}
-        run: |
-          ./hack/make ${{ inputs.mage-targets }}
-        env:
-          DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
+          workflow: ./.github/workflows/cfg-runner.yml
+          inputs: '{ "mage-targets": "${{ inputs.mage-targets }}", "concurrency-group": "${{ inputs.mage-targets }}-${{ github.head_ref || github.run_id }}-gp", "runner": "dagger-v011-on-k8s-gerhard-production" }'
 
   # Use legacy Dagger runners when running in the dagger/dagger repo (including PRs) & needing Docker
   dagger-runner-legacy:

--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -117,24 +117,23 @@ jobs:
         with:
           go-version: "1.21"
           cache-dependency-path: "internal/mage/go.sum"
-      - name: Install dagger
+      - name: Install Dagger CLI
         run: |
           curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ inputs.dagger-version }} BIN_DIR=/usr/local/bin/ sudo -E sh
-      - name: Waiting for Dagger Engine to be ready...
+      - name: Build Dagger Dev Engine...
         run: |
           ./hack/dev
-
-          export _EXPERIMENTAL_DAGGER_CLI_BIN="$PWD/bin/dagger"
-          chmod +x $_EXPERIMENTAL_DAGGER_CLI_BIN
-          echo "_EXPERIMENTAL_DAGGER_CLI_BIN=${_EXPERIMENTAL_DAGGER_CLI_BIN}" >> "$GITHUB_ENV"
-
-          echo _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev >> "$GITHUB_ENV"
-
-          ./hack/make engine:connect
+          docker ps -a
+          docker image ls
+        env:
+          DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
+      - name: Waiting for Dagger Dev Engine to be ready...
+        run: |
+          ./hack/with-dev ./hack/make engine:connect
         env:
           DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
       - name: ${{ inputs.mage-targets }}
         run: |
-          ./hack/make ${{ inputs.mage-targets }}
+          ./hack/with-dev ./hack/make ${{ inputs.mage-targets }}
         env:
           DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"

--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -21,7 +21,7 @@ on:
         default: 60  
       size:
         type: string
-        default: "dagger-v0-11-1-4c-nvme"
+        default: "dagger-v0-11-2-4c-nvme"
         required: false
       dagger-version:
         type: string
@@ -86,6 +86,9 @@ jobs:
         env:
           DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
 
+  # The job will succesfully trigger, but the async job is expected to fail.
+  # We confirmed that this requires at least 16CPUs & 32GB of RAM: https://github.com/dagger/dagger/pull/7223#issuecomment-2091059448
+  # The current machine only has 12CPUs, so it is likely to fail. The value is in capturing measurements & seeing them improve over time.
   dagger-runner-gerhard-production:
     if: ${{ !inputs.dev-engine && github.repository == 'dagger/dagger' && inputs.mage-targets == 'engine:testrace' }}
     runs-on: ubuntu-latest
@@ -100,10 +103,11 @@ jobs:
           workflow: ./.github/workflows/_async_hack_make.yml
           inputs: '{ "mage-targets": "${{ inputs.mage-targets }}", "concurrency-group": "${{ inputs.mage-targets }}-${{ github.head_ref || github.run_id }}-gp", "runner": "dagger-v011-on-k8s-gerhard-production" }'
 
-  # Use legacy Dagger runners when running in the dagger/dagger repo (including PRs) & needing Docker
-  dagger-runner-legacy:
+  # Use GitHub Large Runners when running in the dagger/dagger repo (including PRs) & needing Docker
+  # TODO: https://github.com/dagger/dagger/pull/7223
+  github-large-runner:
     if: ${{ inputs.dev-engine && github.repository == 'dagger/dagger' }}
-    runs-on: ${{ inputs.size }}
+    runs-on: ubuntu-22.04-16c-64g-600gb
     concurrency:
       group: ${{github.workflow}}-${{ inputs.mage-targets }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true

--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -63,7 +63,7 @@ jobs:
         timeout-minutes: ${{ inputs.timeout }}
 
   # Use new Dagger runners when running in the dagger/dagger repo (including PRs)
-  dagger-runner:
+  dagger-runner-v2:
     if: ${{ !inputs.dev-engine && github.repository == 'dagger/dagger' }}
     runs-on: ${{ inputs.size }}
     concurrency:
@@ -103,11 +103,12 @@ jobs:
           workflow: ./.github/workflows/_async_hack_make.yml
           inputs: '{ "mage-targets": "${{ inputs.mage-targets }}", "concurrency-group": "${{ inputs.mage-targets }}-${{ github.head_ref || github.run_id }}-gp", "runner": "dagger-v011-on-k8s-gerhard-production" }'
 
-  # Use GitHub Large Runners when running in the dagger/dagger repo (including PRs) & needing Docker
-  # TODO: https://github.com/dagger/dagger/pull/7223
-  github-large-runner:
+  # Use Legacy Dagger Runners until either:
+  # 1. Dagger in Dagger: https://github.com/dagger/dagger/pull/7223
+  # 2. Docker on v2 runners gets set up
+  dagger-runner-v1:
     if: ${{ inputs.dev-engine && github.repository == 'dagger/dagger' }}
-    runs-on: ubuntu-22.04-16c-64g-600gb
+    runs-on: dagger-runner-docker-fix
     concurrency:
       group: ${{github.workflow}}-${{ inputs.mage-targets }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true

--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -94,10 +94,10 @@ jobs:
       cancel-in-progress: true
     steps:
       # https://github.com/benc-uk/workflow-dispatch/tree/v1
-      - name: Trigger ${{ inputs.mage-targets }} on 
+      - name: Trigger ${{ inputs.mage-targets }} on dagger-v011-on-k8s-gerhard-production
         uses: benc-uk/workflow-dispatch@v1
         with:
-          workflow: ./.github/workflows/cfg-runner.yml
+          workflow: ./.github/workflows/_async_hack_make.yml
           inputs: '{ "mage-targets": "${{ inputs.mage-targets }}", "concurrency-group": "${{ inputs.mage-targets }}-${{ github.head_ref || github.run_id }}-gp", "runner": "dagger-v011-on-k8s-gerhard-production" }'
 
   # Use legacy Dagger runners when running in the dagger/dagger repo (including PRs) & needing Docker

--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -21,7 +21,7 @@ on:
         default: 60  
       size:
         type: string
-        default: "dagger-runner-2c-8g"
+        default: "dagger-v0-11-0"
         required: false
       dagger-version:
         type: string
@@ -62,9 +62,9 @@ jobs:
           ./hack/make ${{ inputs.mage-targets }}
         timeout-minutes: ${{ inputs.timeout }}
 
-  # Use our own Dagger runner when running in the dagger/dagger repo (including PRs)
+  # Use new Dagger runners when running in the dagger/dagger repo (including PRs)
   dagger-runner:
-    if: ${{ github.repository == 'dagger/dagger' }}
+    if: ${{ inputs.dev-engine != 'true' && github.repository == 'dagger/dagger' }}
     runs-on: ${{ inputs.size }}
     concurrency:
       group: ${{github.workflow}}-${{ inputs.mage-targets }}-${{ github.head_ref || github.run_id }}
@@ -80,25 +80,41 @@ jobs:
           curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ inputs.dagger-version }} BIN_DIR=/usr/local/bin/ sudo -E sh
       - name: Starting Dagger Engine
         run: |
-          if [ "${{ inputs.dev-engine }}" == "true" ]
-          then
-            ./hack/dev
-
-            export _EXPERIMENTAL_DAGGER_CLI_BIN="$PWD/bin/dagger"
-            chmod +x $_EXPERIMENTAL_DAGGER_CLI_BIN
-            echo "_EXPERIMENTAL_DAGGER_CLI_BIN=${_EXPERIMENTAL_DAGGER_CLI_BIN}" >> "$GITHUB_ENV"
-
-            export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev
-          fi
-
-          echo "_EXPERIMENTAL_DAGGER_RUNNER_HOST=${_EXPERIMENTAL_DAGGER_RUNNER_HOST}" >> "$GITHUB_ENV"
-        env:
-          _EXPERIMENTAL_DAGGER_RUNNER_HOST: "unix:///var/run/buildkit/buildkitd.sock"
-      - name: Waiting for Dagger Engine to be ready...
-        run: |
           ./hack/make engine:connect
         env:
-          DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
+          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
+      - name: ${{ inputs.mage-targets }}
+        run: |
+          ./hack/make ${{ inputs.mage-targets }}
+        env:
+          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
+      - name: "ALWAYS print kernel logs - especialy useful on failure"
+        if: always()
+        run: sudo dmesg
+
+  # Use legacy Dagger runners when running in the dagger/dagger repo (including PRs) & needing Docker
+  dagger-runner-legacy:
+    if: ${{ inputs.dev-engine == 'true' && github.repository == 'dagger/dagger' }}
+    runs-on: ${{ inputs.size }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+          cache-dependency-path: "internal/mage/go.sum"
+      - name: Waiting for Dagger Engine to be ready...
+        run: |
+          ./hack/dev
+
+          export _EXPERIMENTAL_DAGGER_CLI_BIN="$PWD/bin/dagger"
+          chmod +x $_EXPERIMENTAL_DAGGER_CLI_BIN
+          echo "_EXPERIMENTAL_DAGGER_CLI_BIN=${_EXPERIMENTAL_DAGGER_CLI_BIN}" >> "$GITHUB_ENV"
+
+          echo _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev >> "$GITHUB_ENV"
+
+          ./hack/make engine:connect
+        env:
+          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
       - name: ${{ inputs.mage-targets }}
         run: |
           ./hack/make ${{ inputs.mage-targets }}

--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -98,6 +98,10 @@ jobs:
         with:
           go-version: "1.21"
           cache-dependency-path: "ci/go.sum"
+      - name: Install tools
+        run: |
+          sudo apt update
+          sudo apt install -y curl
       - name: Install dagger
         run: |
           curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ inputs.dagger-version }} BIN_DIR=/usr/local/bin/ sudo -E sh

--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -21,7 +21,7 @@ on:
         default: 60  
       size:
         type: string
-        default: "dagger-v0-11-0"
+        default: "dagger-v0-11-1"
         required: false
       dagger-version:
         type: string
@@ -64,7 +64,7 @@ jobs:
 
   # Use new Dagger runners when running in the dagger/dagger repo (including PRs)
   dagger-runner:
-    if: ${{ inputs.dev-engine != 'true' && github.repository == 'dagger/dagger' }}
+    if: ${{ !inputs.dev-engine && github.repository == 'dagger/dagger' }}
     runs-on: ${{ inputs.size }}
     concurrency:
       group: ${{github.workflow}}-${{ inputs.mage-targets }}-${{ github.head_ref || github.run_id }}
@@ -75,33 +75,32 @@ jobs:
         with:
           go-version: "1.22"
           cache-dependency-path: "ci/go.sum"
-      - name: Install dagger
-        run: |
-          curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ inputs.dagger-version }} BIN_DIR=/usr/local/bin/ sudo -E sh
-      - name: Starting Dagger Engine
+      - name: Waiting for Dagger Engine to be ready...
         run: |
           ./hack/make engine:connect
         env:
-          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
+          DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
       - name: ${{ inputs.mage-targets }}
         run: |
           ./hack/make ${{ inputs.mage-targets }}
         env:
-          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
-      - name: "ALWAYS print kernel logs - especialy useful on failure"
-        if: always()
-        run: sudo dmesg
+          DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
 
-  # Use legacy Dagger runners when running in the dagger/dagger repo (including PRs) & needing Docker
-  dagger-runner-legacy:
-    if: ${{ inputs.dev-engine == 'true' && github.repository == 'dagger/dagger' }}
-    runs-on: ${{ inputs.size }}
+  dagger-runner-gerhard-production:
+    if: ${{ !inputs.dev-engine && github.repository == 'dagger/dagger' && inputs.mage-targets == 'engine:testrace' }}
+    runs-on: dagger-v011-on-k8s-gerhard-production
+    concurrency:
+      group: ${{github.workflow}}-${{ inputs.mage-targets }}-${{ github.head_ref || github.run_id }}-gerhard-production
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version: "1.21"
-          cache-dependency-path: "internal/mage/go.sum"
+          cache-dependency-path: "ci/go.sum"
+      - name: Install dagger
+        run: |
+          curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ inputs.dagger-version }} BIN_DIR=/usr/local/bin/ sudo -E sh
       - name: Waiting for Dagger Engine to be ready...
         run: |
           ./hack/dev
@@ -114,7 +113,42 @@ jobs:
 
           ./hack/make engine:connect
         env:
-          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
+          DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
+      - name: ${{ inputs.mage-targets }}
+        run: |
+          ./hack/make ${{ inputs.mage-targets }}
+        env:
+          DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
+
+  # Use legacy Dagger runners when running in the dagger/dagger repo (including PRs) & needing Docker
+  dagger-runner-legacy:
+    if: ${{ inputs.dev-engine && github.repository == 'dagger/dagger' }}
+    runs-on: ${{ inputs.size }}
+    concurrency:
+      group: ${{github.workflow}}-${{ inputs.mage-targets }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+          cache-dependency-path: "internal/mage/go.sum"
+      - name: Install dagger
+        run: |
+          curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ inputs.dagger-version }} BIN_DIR=/usr/local/bin/ sudo -E sh
+      - name: Waiting for Dagger Engine to be ready...
+        run: |
+          ./hack/dev
+
+          export _EXPERIMENTAL_DAGGER_CLI_BIN="$PWD/bin/dagger"
+          chmod +x $_EXPERIMENTAL_DAGGER_CLI_BIN
+          echo "_EXPERIMENTAL_DAGGER_CLI_BIN=${_EXPERIMENTAL_DAGGER_CLI_BIN}" >> "$GITHUB_ENV"
+
+          echo _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev >> "$GITHUB_ENV"
+
+          ./hack/make engine:connect
+        env:
+          DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
       - name: ${{ inputs.mage-targets }}
         run: |
           ./hack/make ${{ inputs.mage-targets }}

--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -90,7 +90,7 @@ jobs:
     if: ${{ !inputs.dev-engine && github.repository == 'dagger/dagger' && inputs.mage-targets == 'engine:testrace' }}
     runs-on: dagger-v011-on-k8s-gerhard-production
     concurrency:
-      group: ${{github.workflow}}-${{ inputs.mage-targets }}-${{ github.head_ref || github.run_id }}-gerhard-production
+      group: ${{github.workflow}}-${{ inputs.mage-targets }}-${{ github.head_ref || github.run_id }}-vertical-scaling
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -103,14 +103,6 @@ jobs:
           curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ inputs.dagger-version }} BIN_DIR=/usr/local/bin/ sudo -E sh
       - name: Waiting for Dagger Engine to be ready...
         run: |
-          ./hack/dev
-
-          export _EXPERIMENTAL_DAGGER_CLI_BIN="$PWD/bin/dagger"
-          chmod +x $_EXPERIMENTAL_DAGGER_CLI_BIN
-          echo "_EXPERIMENTAL_DAGGER_CLI_BIN=${_EXPERIMENTAL_DAGGER_CLI_BIN}" >> "$GITHUB_ENV"
-
-          echo _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev >> "$GITHUB_ENV"
-
           ./hack/make engine:connect
         env:
           DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"

--- a/.github/workflows/cfg-runner.yml
+++ b/.github/workflows/cfg-runner.yml
@@ -1,0 +1,67 @@
+# This is run asynchronously, triggered from "hack/make".
+# The purpose is to compare the behaviour of different runner configurations.
+name: cfg-runner
+
+on:
+  workflow_dispatch:
+    inputs:
+      mage-targets:
+        description: "The mage target(s) to execute"
+        type: string
+        required: true
+      dev-engine:
+        description: "Run against a dev Engine"
+        type: boolean
+        default: false
+        required: false
+      dagger-cloud-cache:
+        description: "Use Dagger Cloud Cache"
+        type: boolean
+        default: false
+        required: false
+      runner:
+        description: "Runner"
+        type: string
+        default: "dagger-v011-on-k8s-gerhard-production"
+        required: false
+      concurrency-group:
+        description: "Concurrency group"
+        type: string
+        default: "global"
+        required: false
+
+jobs:
+  depot-runner:
+    if: ${{ github.repository == 'dagger/dagger' }}
+    runs-on: ${{ inputs.runner }}
+    name: ${{ inputs.mage-targets }} on ${{ inputs.runner }} dev-engine:${{ inputs.dev-engine }} dagger-cloud-cache:${{ inputs.dagger-cloud-cache }}
+    concurrency:
+      group: ${{ inputs.concurrency-group }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.21"
+          cache-dependency-path: "internal/mage/go.sum"
+      - name: Waiting for Dagger Engine to be ready...
+        run: |
+          if [ "${{ inputs.dev-engine }}" == "true" ]
+          then
+            ./hack/dev
+            export _EXPERIMENTAL_DAGGER_CLI_BIN="$PWD/bin/dagger"
+            chmod +x $_EXPERIMENTAL_DAGGER_CLI_BIN
+            echo "_EXPERIMENTAL_DAGGER_CLI_BIN=${_EXPERIMENTAL_DAGGER_CLI_BIN}" >> "$GITHUB_ENV"
+            export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev
+            echo "_EXPERIMENTAL_DAGGER_RUNNER_HOST=${_EXPERIMENTAL_DAGGER_RUNNER_HOST}" >> "$GITHUB_ENV"
+          fi
+          ./hack/make engine:connect
+      - name: ${{ inputs.mage-targets }}
+        run: |
+          if [ "${{ inputs.dagger-cloud-cache }}" == "true" ]
+          then
+            export DAGGER_CLOUD_TOKEN="${{ secrets.DAGGER_CLOUD_TOKEN }}"
+          fi
+          ./hack/make ${{ inputs.mage-targets }}
+        env:
+          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -26,7 +26,7 @@ jobs:
     secrets: inherit
     with:
       mage-targets: engine:testrace
-      size: "dagger-v0-11-1-16c"
+      size: "dagger-v0-11-1-16c-nvme"
 
   # Run Engine tests in dev Engine so that we can spot integration failures early
   # Only run a subset of important test cases since we just need to verify basic

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -26,7 +26,6 @@ jobs:
     secrets: inherit
     with:
       mage-targets: engine:testrace
-      size: dagger-runner-16c-64g
 
   # Run Engine tests in dev Engine so that we can spot integration failures early
   # Only run a subset of important test cases since we just need to verify basic
@@ -57,4 +56,4 @@ jobs:
     secrets: inherit
     with:
       mage-targets: engine:scan
-
+      size: dagger-runner-docker-fix

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -26,6 +26,7 @@ jobs:
     secrets: inherit
     with:
       mage-targets: engine:testrace
+      size: "dagger-v0-11-0-16c"
 
   # Run Engine tests in dev Engine so that we can spot integration failures early
   # Only run a subset of important test cases since we just need to verify basic
@@ -56,4 +57,3 @@ jobs:
     secrets: inherit
     with:
       mage-targets: engine:scan
-      size: dagger-runner-docker-fix

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -26,7 +26,7 @@ jobs:
     secrets: inherit
     with:
       mage-targets: engine:testrace
-      size: "dagger-v0-11-1-16c-nvme"
+      size: "dagger-v0-11-2-16c-nvme"
 
   # Run Engine tests in dev Engine so that we can spot integration failures early
   # Only run a subset of important test cases since we just need to verify basic

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -26,7 +26,7 @@ jobs:
     secrets: inherit
     with:
       mage-targets: engine:testrace
-      size: "dagger-v0-11-0-16c"
+      size: "dagger-v0-11-1-16c"
 
   # Run Engine tests in dev Engine so that we can spot integration failures early
   # Only run a subset of important test cases since we just need to verify basic

--- a/.github/workflows/sdk-rust.yml
+++ b/.github/workflows/sdk-rust.yml
@@ -22,7 +22,6 @@ jobs:
     secrets: inherit
     with:
       mage-targets: sdk:rust:lint
-      size: dagger-runner-16c-64g
       timeout: 10
 
   test:
@@ -30,5 +29,4 @@ jobs:
     secrets: inherit
     with:
       mage-targets: sdk:rust:test
-      size: dagger-runner-16c-64g
       timeout: 10


### PR DESCRIPTION
This switches all our GitHub workflows to use the second generation of Dagger Runners. They are based on [Run Dagger on Amazon EKS with GitHub Actions Runner and Karpenter](https://archive.docs.dagger.io/0.9/934191/eks-github-karpenter), currently running:
- AWS EKS `v1.28.7`
- Karpenter `v0.32.0`

As of today, we expose the following runner options:
- `dagger-v0-10-1`
- `dagger-v0-10-2`
- `dagger-v0-10-3`
- `dagger-v0-10-3-4c`
- `dagger-v0-10-3-8c`
- `dagger-v0-10-3-16c`
- `dagger-v0-11-0`
- `dagger-v0-11-0-4c`
- `dagger-v0-11-0-8c`
- `dagger-v0-11-0-16c`
- `dagger-v0-11-1`
- `dagger-v0-11-1-4c`
- `dagger-v0-11-1-4c-nvme`
- `dagger-v0-11-1-8c`
- `dagger-v0-11-1-8c-nvme`
- `dagger-v0-11-1-16c`
- `dagger-v0-11-1-16c-nvme`
- `dagger-v0-11-2`
- `dagger-v0-11-2-4c`
- `dagger-v0-11-2-4c-nvme`
- `dagger-v0-11-2-8c`
- `dagger-v0-11-2-8c-nvme`
- `dagger-v0-11-2-16c`
- `dagger-v0-11-2-16c-nvme`

As soon as a new version of Dagger gets released - e.g. `v0.11.3` - a bunch of variants with that version will appear automatically.

This change is great because:
1. Dagger Engine version can be bumped by changing the GitHub Workflow definition - no more coordination required!
2. We can test different configurations (and versions!) in PRs and see which one performs best
3. We are not forced to bump the Engine version for all workflows at the same time - it was an all-or-nothing proposition before

To learn more, see the following (private) [infra repo](https://github.com/dagger/dagger.io/tree/47aba9e81162bf4790baa648c9ef258e0668272d/infra/ci/eks-2023-12-15). @matipan @gerhard that have all the context.

---

Something worth mentioning separately is that this also introduces asynchronous triggers.

We are running a specific job - `engine:testrace` - in a production bare-metal K8s cluster. This is done **for comparison reasons only** since we know that it's going to fail (we only have 12CPU threads available). See https://github.com/dagger/dagger/pull/7223#issuecomment-2091059448 for more details.

The goal of this is to capture measurements - https://github.com/dagger/dagger/pull/6492 - and see how they change over time.

FTR, this job will fail until we merge into `main` since the new workflow will not be recognised:
<img width="900" alt="image" src="https://github.com/dagger/dagger/assets/3342/2b86fff4-6996-402a-b642-005e97f377ef">

---
Split out to avoid blocking the release:
- https://github.com/dagger/dagger/pull/7018 