### PR TITLE
Run a single instance of each job per pull request

### DIFF
--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -57,6 +57,9 @@ jobs:
   dagger-runner:
     if: ${{ github.repository == 'dagger/dagger' }}
     runs-on: ${{ inputs.size }}
+    concurrency:
+      group: ${{github.workflow}}-${{ inputs.mage-targets }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
At the moment our CI costs have gotten quite high. As a way of optimizing (although we are unsure of how much this will help us) we want to reduce the amount of parallel jobs running. The current setup is allowing all jobs of all commits in a PR to complete, even when new commits have been pushed. While this can certainly be useful, it is way too costly. Each time we run jobs for a pull request in our legacy CI we are requesting approximately 64 cores and 384 Gi of memory. This is definitely excessive and until we can optimize it we believe it makes sense to allow a single parallel run per job per pull request.

This PR leverages the `mage-targets` to separate the job itself and uses the `head_ref` when in a PR to have a single instance per PR. When running in main we allow for every commit to have its own run by using the `job_id`.