### PR TITLE
fix: preserve windows output

### DIFF
--- a/.changes/unreleased/Fixed-20240415-151604.yaml
+++ b/.changes/unreleased/Fixed-20240415-151604.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fixed regression that caused crash on windows when TUI output was enabled
+time: 2024-04-15T15:16:04.645921317+01:00
+custom:
+  Author: jedevc
+  PR: "7095"

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -107,8 +107,8 @@ func (fe *Frontend) Run(ctx context.Context, run func(context.Context) error) er
 
 	// find a TTY anywhere in stdio. stdout might be redirected, in which case we
 	// can show the TUI on stderr.
-	tty, isTTY := findTTY()
-	if !isTTY {
+	ttyIn, ttyOut := findTTYs()
+	if ttyOut == nil {
 		// Simplify logic elsewhere by just setting Plain to true.
 		fe.Plain = true
 	}
@@ -124,7 +124,7 @@ func (fe *Frontend) Run(ctx context.Context, run func(context.Context) error) er
 		runErr = run(ctx)
 	} else {
 		// run the TUI until it exits and cleans up the TTY
-		runErr = fe.runWithTUI(ctx, tty, run)
+		runErr = fe.runWithTUI(ctx, ttyIn, ttyOut, run)
 	}
 
 	// print the final output display to stderr
@@ -160,13 +160,13 @@ func (fe *Frontend) SetPrimary(spanID trace.SpanID) {
 	fe.mu.Unlock()
 }
 
-func (fe *Frontend) runWithTUI(ctx context.Context, tty *os.File, run func(context.Context) error) error {
+func (fe *Frontend) runWithTUI(ctx context.Context, ttyIn *os.File, ttyOut *os.File, run func(context.Context) error) error {
 	// NOTE: establish color cache before we start consuming stdin
-	fe.out = NewOutput(tty, termenv.WithProfile(fe.profile), termenv.WithColorCache(true))
+	fe.out = NewOutput(ttyOut, termenv.WithProfile(fe.profile), termenv.WithColorCache(true))
 
 	// Bubbletea will just receive an `io.Reader` for its input rather than the
 	// raw TTY *os.File, so we need to set up the TTY ourselves.
-	ttyFd := int(tty.Fd())
+	ttyFd := int(ttyIn.Fd())
 	oldState, err := term.MakeRaw(ttyFd)
 	if err != nil {
 		return err
@@ -181,7 +181,7 @@ func (fe *Frontend) runWithTUI(ctx context.Context, tty *os.File, run func(conte
 
 	// keep program state so we can send messages to it
 	fe.program = tea.NewProgram(fe,
-		tea.WithInput(tty),
+		tea.WithInput(ttyIn),
 		tea.WithOutput(fe.out),
 		// We set up the TTY ourselves, so Bubbletea's panic handler becomes
 		// counter-productive.
@@ -279,14 +279,17 @@ func (fe *Frontend) renderPrimaryOutput() error {
 	return nil
 }
 
-func findTTY() (*os.File, bool) {
-	// some of these may be redirected
-	for _, f := range []*os.File{os.Stderr, os.Stdout, os.Stdin} {
+func findTTYs() (in *os.File, out *os.File) {
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		in = os.Stdin
+	}
+	for _, f := range []*os.File{os.Stderr, os.Stdout} {
 		if term.IsTerminal(int(f.Fd())) {
-			return f, true
+			out = f
+			break
 		}
 	}
-	return nil, false
+	return
 }
 
 var _ sdktrace.SpanExporter = (*Frontend)(nil)


### PR DESCRIPTION
Fixes #7045 (nightmare issue yay)

Essentially, with the new TUI, we were failing to set the TUI to raw mode. The reason for this was that we were passing a non-input buffer to containerd/console (through os.Stdin). Unlike on *nix, on windows, the raw mode we were trying to set is *not* interchangeable between stdin/stdout.

Something is insanely weird about what bubbletea is doing here - it's making *loads* of funky assumptions about how terminals can be constructed, and honestly I'm not sure how it works. However, it seems like we can get the right behavior as long as we preserve the differences between input and output buffers - instead of creating one single tty to pass around, we keep two file objects around.