### PR TITLE
fix: ensure git labels can use worktrees

### DIFF
--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -412,7 +412,8 @@ forced), to avoid mistakenly depending on uncommitted files.
 				return fmt.Errorf("module must be fully initialized")
 			}
 			repo, err := git.PlainOpenWithOptions(modConf.LocalRootSourcePath, &git.PlainOpenOptions{
-				DetectDotGit: true,
+				DetectDotGit:          true,
+				EnableDotGitCommonDir: true,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to open git repo: %w", err)

--- a/telemetry/labels.go
+++ b/telemetry/labels.go
@@ -81,7 +81,8 @@ func (labels Labels) WithVCSLabels(workdir string) Labels {
 
 func (labels Labels) WithGitLabels(workdir string) Labels {
 	repo, err := git.PlainOpenWithOptions(workdir, &git.PlainOpenOptions{
-		DetectDotGit: true,
+		DetectDotGit:          true,
+		EnableDotGitCommonDir: true,
 	})
 	if err != nil {
 		if !errors.Is(err, git.ErrRepositoryNotExists) {


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/7030.

Git worktrees use a `.git/commondir` to ensure that refs and similar are shared. We need to explicitly enable this with go-git.

Technically, this change is only required in the `telemetry` package to fix the above issue, but we can also just add it everywhere that we call this function.