### PR TITLE
ci: fix elixir publish

### DIFF
--- a/ci/mage/sdk/elixir.go
+++ b/ci/mage/sdk/elixir.go
@@ -38,7 +38,7 @@ func (Elixir) Publish(ctx context.Context, tag string) error {
 	}
 
 	if _, ok := os.LookupEnv("HEX_API_KEY"); ok {
-		args = append(args, "--hex-api-key=env:HEX_API_KEY")
+		args = append(args, "--hex-apikey=env:HEX_API_KEY")
 	}
 
 	return util.DaggerCall(ctx, args...)


### PR DESCRIPTION
Elixir publish `--hex-apikey` had a typo:

	$ dagger call --source=. sdk elixir publish --help
	Publish the Elixir SDK

	Usage:
	  dagger call sdk elixir publish [flags]

	Flags:
	      --dry-run
	      --hex-apikey Secret
	      --tag string

	Global Flags:
	  -d, --debug             show debug logs and full verbosity
	      --json              Present result as JSON
	  -m, --mod string        Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g.
				  "github.com/dagger/dagger/path/to/some/subdir")
	  -o, --output string     Path in the host to save the result to
	      --progress string   progress output format (auto, plain, tty) (default "auto")
	  -s, --silent            disable terminal UI and progress output
	  -v, --verbose count     increase verbosity (use -vv or -vvv for more)

It should be `--hex-apikey`, not `--hex-api-key`.