### PR TITLE
ci: fix elixir publish version

### DIFF
--- a/ci/sdk_elixir.go
+++ b/ci/sdk_elixir.go
@@ -97,7 +97,7 @@ func (t ElixirSDK) Publish(
 ) error {
 	var (
 		version = strings.TrimPrefix(tag, "sdk/elixir/v")
-		mixFile = "sdk/elixir/mix.exs"
+		mixFile = "/sdk/elixir/mix.exs"
 	)
 
 	ctr := t.elixirBase(elixirVersions[1])


### PR DESCRIPTION
Ugh, *again*. The elixir path wasn't right here, this would mean we were instead publishing v0.0.0.

![image](https://github.com/dagger/dagger/assets/7352848/8369a65f-8cf6-4739-9a40-2f7cf4db981c)