### PR TITLE
engine: log buildkit progress to stderr with debug enabled

### DIFF
--- a/ci/config.go
+++ b/ci/config.go
@@ -40,7 +40,8 @@ exec {{.EngineBin}} --config {{.EngineConfig}} {{ range $key := .EntrypointArgKe
 `
 
 const engineConfigTmpl = `
-debug = true
+debug = {{.Debug}}
+trace = {{.Trace}}
 insecure-entitlements = ["security.insecure"]
 {{ range $key := .ConfigKeys }}
 [{{ $key }}]
@@ -87,7 +88,7 @@ func generateEntrypoint(kvs []string) (*File, error) {
 	return entrypoint, nil
 }
 
-func generateConfig(kvs []string) (*File, error) {
+func generateConfig(debug, trace bool, kvs []string) (*File, error) {
 	opts := map[string]string{}
 	for _, kv := range kvs {
 		k, v, ok := strings.Cut(kv, "=")
@@ -100,12 +101,16 @@ func generateConfig(kvs []string) (*File, error) {
 	sort.Strings(keys)
 
 	type configTmplParams struct {
+		Debug         bool
+		Trace         bool
 		ConfigEntries map[string]string
 		ConfigKeys    []string
 	}
 	tmpl := template.Must(template.New("config").Parse(engineConfigTmpl))
 	buf := new(bytes.Buffer)
 	err := tmpl.Execute(buf, configTmplParams{
+		Debug:         debug,
+		Trace:         trace,
 		ConfigEntries: opts,
 		ConfigKeys:    keys,
 	})

--- a/ci/config.go
+++ b/ci/config.go
@@ -40,7 +40,7 @@ exec {{.EngineBin}} --config {{.EngineConfig}} {{ range $key := .EntrypointArgKe
 `
 
 const engineConfigTmpl = `
-debug = {{.Debug}}
+debug = true
 trace = {{.Trace}}
 insecure-entitlements = ["security.insecure"]
 {{ range $key := .ConfigKeys }}
@@ -88,7 +88,7 @@ func generateEntrypoint(kvs []string) (*File, error) {
 	return entrypoint, nil
 }
 
-func generateConfig(debug, trace bool, kvs []string) (*File, error) {
+func generateConfig(trace bool, kvs []string) (*File, error) {
 	opts := map[string]string{}
 	for _, kv := range kvs {
 		k, v, ok := strings.Cut(kv, "=")
@@ -101,7 +101,6 @@ func generateConfig(debug, trace bool, kvs []string) (*File, error) {
 	sort.Strings(keys)
 
 	type configTmplParams struct {
-		Debug         bool
 		Trace         bool
 		ConfigEntries map[string]string
 		ConfigKeys    []string
@@ -109,7 +108,6 @@ func generateConfig(debug, trace bool, kvs []string) (*File, error) {
 	tmpl := template.Must(template.New("config").Parse(engineConfigTmpl))
 	buf := new(bytes.Buffer)
 	err := tmpl.Execute(buf, configTmplParams{
-		Debug:         debug,
 		Trace:         trace,
 		ConfigEntries: opts,
 		ConfigKeys:    keys,

--- a/ci/engine.go
+++ b/ci/engine.go
@@ -23,7 +23,6 @@ type Engine struct {
 	Args   []string // +private
 	Config []string // +private
 
-	Debug bool // +private
 	Trace bool // +private
 
 	GPUSupport bool // +private
@@ -44,11 +43,6 @@ func (e *Engine) WithGPUSupport() *Engine {
 	return e
 }
 
-func (e *Engine) WithDebug() *Engine {
-	e.Debug = true
-	return e
-}
-
 func (e *Engine) WithTrace() *Engine {
 	e.Trace = true
 	return e
@@ -61,7 +55,7 @@ func (e *Engine) Container(
 	// +optional
 	platform dagger.Platform,
 ) (*Container, error) {
-	cfg, err := generateConfig(e.Debug, e.Trace, e.Config)
+	cfg, err := generateConfig(e.Trace, e.Config)
 	if err != nil {
 		return nil, err
 	}

--- a/ci/engine.go
+++ b/ci/engine.go
@@ -23,6 +23,9 @@ type Engine struct {
 	Args   []string // +private
 	Config []string // +private
 
+	Debug bool // +private
+	Trace bool // +private
+
 	GPUSupport bool // +private
 }
 
@@ -41,6 +44,16 @@ func (e *Engine) WithGPUSupport() *Engine {
 	return e
 }
 
+func (e *Engine) WithDebug() *Engine {
+	e.Debug = true
+	return e
+}
+
+func (e *Engine) WithTrace() *Engine {
+	e.Trace = true
+	return e
+}
+
 // Build the engine container
 func (e *Engine) Container(
 	ctx context.Context,
@@ -48,7 +61,7 @@ func (e *Engine) Container(
 	// +optional
 	platform dagger.Platform,
 ) (*Container, error) {
-	cfg, err := generateConfig(e.Config)
+	cfg, err := generateConfig(e.Debug, e.Trace, e.Config)
 	if err != nil {
 		return nil, err
 	}

--- a/ci/mage/engine.go
+++ b/ci/mage/engine.go
@@ -122,14 +122,15 @@ func (t Engine) test(ctx context.Context, additional ...string) error {
 
 // Dev builds and starts an Engine & CLI from local source code
 func (t Engine) Dev(ctx context.Context) error {
-	gpuSupport := false
-	if v := os.Getenv(util.GPUSupportEnvName); v != "" {
-		gpuSupport = true
-	}
+	gpuSupport := os.Getenv(util.GPUSupportEnvName) != ""
+	trace := os.Getenv(util.TraceEnvName) != ""
 
-	args := []string{"engine"}
+	args := []string{"engine", "with-debug"}
 	if gpuSupport {
 		args = append(args, "with-gpusupport")
+	}
+	if trace {
+		args = append(args, "with-trace")
 	}
 	tarPath := "./bin/engine.tar"
 	args = append(args, "container", "export", "--path="+tarPath)

--- a/ci/mage/engine.go
+++ b/ci/mage/engine.go
@@ -125,7 +125,7 @@ func (t Engine) Dev(ctx context.Context) error {
 	gpuSupport := os.Getenv(util.GPUSupportEnvName) != ""
 	trace := os.Getenv(util.TraceEnvName) != ""
 
-	args := []string{"engine", "with-debug"}
+	args := []string{"engine"}
 	if gpuSupport {
 		args = append(args, "with-gpusupport")
 	}

--- a/ci/mage/util/const.go
+++ b/ci/mage/util/const.go
@@ -5,4 +5,6 @@ const (
 
 	CacheConfigEnvName = "_EXPERIMENTAL_DAGGER_CACHE_CONFIG"
 	GPUSupportEnvName  = "_EXPERIMENTAL_DAGGER_GPU_SUPPORT"
+
+	TraceEnvName = "TRACE"
 )

--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -770,7 +770,7 @@ func newController(ctx context.Context, c *cli.Context, cfg *config.Config, pubs
 	}
 
 	bkLogsW := io.Discard
-	if cfg.Trace {
+	if cfg.Debug {
 		bkLogsW = os.Stderr
 	}
 

--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -769,6 +769,11 @@ func newController(ctx context.Context, c *cli.Context, cfg *config.Config, pubs
 		},
 	}
 
+	bkLogsW := io.Discard
+	if cfg.Trace {
+		bkLogsW = os.Stderr
+	}
+
 	bklog.G(context.Background()).Debugf("engine name: %s", engineName)
 	ctrler, err := server.NewBuildkitController(server.BuildkitControllerOpts{
 		WorkerController:       wc,
@@ -783,6 +788,7 @@ func newController(ctx context.Context, c *cli.Context, cfg *config.Config, pubs
 		UpstreamCacheExporters: remoteCacheExporterFuncs,
 		UpstreamCacheImporters: remoteCacheImporterFuncs,
 		DNSConfig:              getDNSConfig(cfg.DNS),
+		BuildkitLogSink:        bkLogsW,
 	})
 	if err != nil {
 		return nil, nil, err

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -67,6 +67,7 @@ type Opts struct {
 	MainClientCallerID string
 	DNSConfig          *oci.DNSConfig
 	Frontends          map[string]bkfrontend.Frontend
+	BuildkitLogSink    io.Writer
 	sharedClientState
 }
 
@@ -179,9 +180,11 @@ func NewClient(ctx context.Context, opts *Opts) (*Client, error) {
 		}
 	}
 
-	// NB(vito): break glass (replace with os.Stderr) to troubleshoot otel
-	// logging issues, since it's otherwise hard to see a command's output
-	go client.WriteStatusesTo(ctx, io.Discard)
+	bkLogsW := opts.BuildkitLogSink
+	if bkLogsW == nil {
+		bkLogsW = io.Discard
+	}
+	go client.WriteStatusesTo(ctx, bkLogsW)
 
 	return client, nil
 }

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -190,7 +190,8 @@ func NewClient(ctx context.Context, opts *Opts) (*Client, error) {
 }
 
 func (c *Client) WriteStatusesTo(ctx context.Context, dest io.Writer) {
-	dest = prefixw.New(dest, fmt.Sprintf("[buildkit] [%s] ", c.ID()))
+	prefix := fmt.Sprintf("[buildkit] [trace=%s] [client=%s] ", c.spanCtx.TraceID(), c.ID())
+	dest = prefixw.New(dest, prefix)
 	statusCh := make(chan *bkclient.SolveStatus, 8)
 	pw, err := progressui.NewDisplay(dest, progressui.PlainMode)
 	if err != nil {

--- a/engine/server/buildkitcontroller.go
+++ b/engine/server/buildkitcontroller.go
@@ -71,6 +71,7 @@ type BuildkitControllerOpts struct {
 	UpstreamCacheExporters map[string]remotecache.ResolveCacheExporterFunc
 	UpstreamCacheImporters map[string]remotecache.ResolveCacheImporterFunc
 	DNSConfig              *oci.DNSConfig
+	BuildkitLogSink        io.Writer
 }
 
 func NewBuildkitController(opts BuildkitControllerOpts) (*BuildkitController, error) {

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -152,6 +152,7 @@ func (e *BuildkitController) newDaggerServer(ctx context.Context, clientMetadata
 			MainClientCallerID:    s.mainClientCallerID,
 			DNSConfig:             e.DNSConfig,
 			Frontends:             e.Frontends,
+			BuildkitLogSink:       e.BuildkitLogSink,
 		},
 		Services:          s.services,
 		Platform:          core.Platform(e.worker.Platforms(true)[0]),


### PR DESCRIPTION
Right now if something goes wrong internal to the shim before all the OpenTelemetry plumbing can be wired up, you just get an `exit status 125` with no other output. (The shim currently has to manually send the command's stdout/stderr to OpenTelemetry logging, so there are extra moving parts.)

I added a "break glass to debug telemetry" bit that prints Buildkit logs to stderr, but didn't make it configurable, figuring it would only be useful to me while I bootstrap the OpenTelemetry stack.

But now, as is tradition, a user has a hit this case in production.

So with this PR, now when the engine is configured with `debug = true` it'll also print Buildkit's logs in console format to stderr like this:

```
time="2024-04-17T03:31:29Z" level=debug msg=Unauthorized header="Bearer realm=\"https://cgr.dev/token\",service=\"cgr.dev\",scope=\"repository:chainguard/apko:pull\"" host=cgr.dev
[buildkit] [11bgeg5ytjd3h8dy06z9j18re] #47 ...
[buildkit] [11bgeg5ytjd3h8dy06z9j18re] 
[buildkit] [11bgeg5ytjd3h8dy06z9j18re] #48 resolve image config for docker-image://cgr.dev/chainguard/apko:latest
[buildkit] [11bgeg5ytjd3h8dy06z9j18re] #48 DONE 0.6s
time="2024-04-17T03:31:29Z" level=debug msg="load cache for mkfile /config.yml with 8e1cq0osjisihh8if42eb91d6::nl306rmhh3uqw60xhfd4x4dly"
time="2024-04-17T03:31:29Z" level=debug msg="checked for cached auth handler namespace" cached=true key="cgr.dev/chainguard/apko::pull" name=cgr.dev/chainguard/apko scope=pull
time="2024-04-17T03:31:29Z" level=debug msg="checked for cached auth handler namespace" cached=true key="cgr.dev/chainguard/apko::pull" name=cgr.dev/chainguard/apko scope=pull
time="2024-04-17T03:31:29Z" level=debug msg="load cache for exec apko build --cache-dir /apkache/ ./twLXXUiV_kQ=/config.yml latest ./layout.tar with 8e1cq0osjisihh8if42eb91d6::oavny64osuh8e5c7fqwjoj58t"
[buildkit] [11bgeg5ytjd3h8dy06z9j18re] 
[buildkit] [11bgeg5ytjd3h8dy06z9j18re] #49 mkdir /
[buildkit] [11bgeg5ytjd3h8dy06z9j18re] #49 DONE 0.0s
[buildkit] [11bgeg5ytjd3h8dy06z9j18re] 
[buildkit] [11bgeg5ytjd3h8dy06z9j18re] #50 mkfile /config.yml
[buildkit] [11bgeg5ytjd3h8dy06z9j18re] #50 CACHED
```

I thought about putting this at trace level, but I actually think this is pretty useful in all contexts where `debug = true`, so there's an extra commit for making trace level configurable like `env TRACE=1 ./hack/dev`, which I kept even though it's not needed for this change.