### PR TITLE
cli: de-clutter CLI

### DIFF
--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -16,7 +16,7 @@ var outputPath string
 var jsonOutput bool
 
 var callCmd = &FuncCommand{
-	Name:  "call [ARGUMENTS] [FUNCTION]...",
+	Name:  "call [OPTIONS] [FUNCTION]...",
 	Short: "Call a module function",
 	Long: strings.ReplaceAll(`Call a module function and print the result.
 

--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -16,7 +16,7 @@ var outputPath string
 var jsonOutput bool
 
 var callCmd = &FuncCommand{
-	Name:  "call [flags] [FUNCTION]...",
+	Name:  "call [ARGUMENTS] [FUNCTION]...",
 	Short: "Call a module function",
 	Long: strings.ReplaceAll(`Call a module function and print the result.
 

--- a/cmd/dagger/config.go
+++ b/cmd/dagger/config.go
@@ -82,7 +82,7 @@ dagger config -m github.com/dagger/hello-dagger
 }
 
 var configViewsCmd = configSubcmd{
-	Use:   "views [name]",
+	Use:   "views [NAME]",
 	Short: "Get or set the views of a Dagger module",
 	Long:  "Get or set the views of a Dagger module. By default, print the views of the specified module.",
 	PersistentFlags: func(fs *pflag.FlagSet) {

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -43,7 +43,7 @@ var funcCmds = FuncCommands{
 }
 
 var funcListCmd = &FuncCommand{
-	Name:  "functions [ARGUMENTS] [FUNCTION]...",
+	Name:  "functions [OPTIONS] [FUNCTION]...",
 	Short: `List available functions`,
 	Long: strings.ReplaceAll(`List available functions in a module.
 

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -34,7 +34,7 @@ const (
 
 var funcGroup = &cobra.Group{
 	ID:    "functions",
-	Title: "Function Commands",
+	Title: "Functions",
 }
 
 var funcCmds = FuncCommands{
@@ -43,7 +43,7 @@ var funcCmds = FuncCommands{
 }
 
 var funcListCmd = &FuncCommand{
-	Name:  "functions [flags] [FUNCTION]...",
+	Name:  "functions [ARGUMENTS] [FUNCTION]...",
 	Short: `List available functions`,
 	Long: strings.ReplaceAll(`List available functions in a module.
 

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -287,6 +287,9 @@ func (fc *FuncCommand) execute(c *cobra.Command, a []string) (rerr error) {
 			cmd.PrintErrln("Error:", rerr.Error())
 
 			if fc.showHelp {
+				// Intentionally add newline to separate error from usage
+				cmd.PrintErrln()
+
 				// Explicitly show the help here while still returning the error.
 				// This handles the case of `dagger call --help` run on a broken module; in that case
 				// we want to error out since we can't actually load the module and show all subcommands

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -334,7 +334,7 @@ func toUpperBold(s string) string {
 	return termenv.String(upperCase).Bold().String()
 }
 
-const usageTemplate = `{{ "Usage" | toUpperBold }}:
+const usageTemplate = `{{ "Usage" | toUpperBold }}
 
 {{- if .Runnable}}
   {{.UseLine}}
@@ -345,28 +345,28 @@ const usageTemplate = `{{ "Usage" | toUpperBold }}:
 
 {{- if gt (len .Aliases) 0}}
 
-{{ "Aliases" | toUpperBold }}:
+{{ "Aliases" | toUpperBold }}
   {{.NameAndAliases}}
 
 {{- end}}
 
 {{- if isExperimental .}}
 
-{{ "EXPERIMENTAL" | toUpperBold }}:
+{{ "EXPERIMENTAL" | toUpperBold }}
   {{.CommandPath}} is currently under development and may change in the future.
 
 {{- end}}
 
 {{- if .HasExample}}
 
-{{ "Examples" | toUpperBold }}:
+{{ "Examples" | toUpperBold }}
 {{ .Example }}
 
 {{- end}}
 
 {{- if .HasAvailableLocalFlags}}
 
-{{ "Flags" | toUpperBold }}:
+{{ "Flags" | toUpperBold }}
 {{ flagUsagesWrapped .LocalFlags | trimTrailingWhitespaces}}
 
 {{- end}}
@@ -374,7 +374,7 @@ const usageTemplate = `{{ "Usage" | toUpperBold }}:
 {{- if .HasAvailableSubCommands}}{{$cmds := .Commands}}
 {{- if eq (len .Groups) 0}}
 
-{{ "Available Commands" | toUpperBold }}:
+{{ "Available Commands" | toUpperBold }}
 {{- range $cmds }}
 {{- if (or .IsAvailableCommand (eq .Name "help"))}}
 {{cmdShortWrapped .}}
@@ -384,7 +384,7 @@ const usageTemplate = `{{ "Usage" | toUpperBold }}:
 {{- else}}
 {{- range $group := .Groups}}
 
-{{.Title | toUpperBold}}:
+{{.Title | toUpperBold}}
 {{- range $cmds }}
 {{- if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
 {{cmdShortWrapped .}}
@@ -394,7 +394,7 @@ const usageTemplate = `{{ "Usage" | toUpperBold }}:
 
 {{- if not .AllChildCommandsHaveGroup}}
 
-{{ "Additional Commands" | toUpperBold }}:
+{{ "Additional Commands" | toUpperBold }}
 {{- range $cmds }}
 {{- if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
 {{cmdShortWrapped .}}
@@ -406,14 +406,14 @@ const usageTemplate = `{{ "Usage" | toUpperBold }}:
 
 {{- if .HasAvailableInheritedFlags}}
 
-{{ "Global Flags" | toUpperBold }}:
+{{ "Global Flags" | toUpperBold }}
 {{ flagUsagesWrapped .InheritedFlags | trimTrailingWhitespaces}}
 
 {{- end}}
 
 {{- if .HasHelpSubCommands}}
 
-{{ "Additional help topics" | toUpperBold }}:
+{{ "Additional help topics" | toUpperBold }}
 {{- range .Commands}}
 {{- if .IsAdditionalHelpTopicCommand}}
   {{rpad .CommandPath .CommandPathPadding}} {{.Short}}

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -340,7 +340,7 @@ const usageTemplate = `{{ "Usage" | toUpperBold }}
   {{.UseLine}}
 {{- end}}
 {{- if .HasAvailableSubCommands}}
-  {{ .CommandPath}}{{ if .HasAvailableFlags}} [flags]{{end}} [command]
+  {{ .CommandPath}}{{ if .HasAvailableFlags}} [ARGUMENTS]{{end}} [COMMAND]
 {{- end}}
 
 {{- if gt (len .Aliases) 0}}
@@ -366,7 +366,7 @@ const usageTemplate = `{{ "Usage" | toUpperBold }}
 
 {{- if .HasAvailableLocalFlags}}
 
-{{ "Flags" | toUpperBold }}
+{{ "Arguments" | toUpperBold }}
 {{ flagUsagesWrapped .LocalFlags | trimTrailingWhitespaces}}
 
 {{- end}}
@@ -424,6 +424,6 @@ const usageTemplate = `{{ "Usage" | toUpperBold }}
 
 {{- if .HasAvailableSubCommands }}
 
-Use "{{.CommandPath}} [command] --help" for more information about a command.
+Use "{{.CommandPath}} [COMMAND] --help" for more information about a command.
 {{- end}}
 `

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mattn/go-isatty"
 	"github.com/muesli/reflow/indent"
 	"github.com/muesli/reflow/wordwrap"
+	"github.com/muesli/termenv"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -86,6 +87,7 @@ func init() {
 	cobra.AddTemplateFunc("isExperimental", isExperimental)
 	cobra.AddTemplateFunc("flagUsagesWrapped", flagUsagesWrapped)
 	cobra.AddTemplateFunc("cmdShortWrapped", cmdShortWrapped)
+	cobra.AddTemplateFunc("toUpperBold", toUpperBold)
 	rootCmd.SetUsageTemplate(usageTemplate)
 
 	// hide the help flag as it's ubiquitous and thus noisy
@@ -326,7 +328,13 @@ func cmdShortWrapped(c *cobra.Command) string {
 	return name + description
 }
 
-const usageTemplate = `Usage:
+func toUpperBold(s string) string {
+	upperCase := strings.ToUpper(s)
+
+	return termenv.String(upperCase).Bold().String()
+}
+
+const usageTemplate = `{{ "Usage" | toUpperBold }}:
 
 {{- if .Runnable}}
   {{.UseLine}}
@@ -337,28 +345,28 @@ const usageTemplate = `Usage:
 
 {{- if gt (len .Aliases) 0}}
 
-Aliases:
+{{ "Aliases" | toUpperBold }}:
   {{.NameAndAliases}}
 
 {{- end}}
 
 {{- if isExperimental .}}
 
-EXPERIMENTAL:
+{{ "EXPERIMENTAL" | toUpperBold }}:
   {{.CommandPath}} is currently under development and may change in the future.
 
 {{- end}}
 
 {{- if .HasExample}}
 
-Examples:
+{{ "Examples" | toUpperBold }}:
 {{ .Example }}
 
 {{- end}}
 
 {{- if .HasAvailableLocalFlags}}
 
-Flags:
+{{ "Flags" | toUpperBold }}:
 {{ flagUsagesWrapped .LocalFlags | trimTrailingWhitespaces}}
 
 {{- end}}
@@ -366,7 +374,7 @@ Flags:
 {{- if .HasAvailableSubCommands}}{{$cmds := .Commands}}
 {{- if eq (len .Groups) 0}}
 
-Available Commands:
+{{ "Available Commands" | toUpperBold }}:
 {{- range $cmds }}
 {{- if (or .IsAvailableCommand (eq .Name "help"))}}
 {{cmdShortWrapped .}}
@@ -376,7 +384,7 @@ Available Commands:
 {{- else}}
 {{- range $group := .Groups}}
 
-{{.Title}}:
+{{.Title | toUpperBold}}:
 {{- range $cmds }}
 {{- if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
 {{cmdShortWrapped .}}
@@ -386,7 +394,7 @@ Available Commands:
 
 {{- if not .AllChildCommandsHaveGroup}}
 
-Additional Commands:
+{{ "Additional Commands" | toUpperBold }}:
 {{- range $cmds }}
 {{- if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
 {{cmdShortWrapped .}}
@@ -398,14 +406,14 @@ Additional Commands:
 
 {{- if .HasAvailableInheritedFlags}}
 
-Global Flags:
+{{ "Global Flags" | toUpperBold }}:
 {{ flagUsagesWrapped .InheritedFlags | trimTrailingWhitespaces}}
 
 {{- end}}
 
 {{- if .HasHelpSubCommands}}
 
-Additional help topics:
+{{ "Additional help topics" | toUpperBold }}:
 {{- range .Commands}}
 {{- if .IsAdditionalHelpTopicCommand}}
   {{rpad .CommandPath .CommandPathPadding}} {{.Short}}

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -78,7 +78,7 @@ func init() {
 }
 
 var moduleInitCmd = &cobra.Command{
-	Use:   "init [flags] [PATH]",
+	Use:   "init [OPTIONS] [PATH]",
 	Short: "Initialize a new Dagger module",
 	Long: `Initialize a new Dagger module in a local directory.
 By default, create a new dagger.json configuration in the current working directory. If the positional argument PATH is provided, create the module in that directory instead.
@@ -173,7 +173,7 @@ The "--source" flag allows controlling the directory in which the actual module 
 }
 
 var moduleInstallCmd = &cobra.Command{
-	Use:     "install [flags] MODULE",
+	Use:     "install [OPTIONS] MODULE",
 	Aliases: []string{"use"},
 	Short:   "Add a new dependency to a Dagger module",
 	Long:    "Add a Dagger module as a dependency of a local module.",

--- a/cmd/dagger/query.go
+++ b/cmd/dagger/query.go
@@ -22,7 +22,7 @@ var (
 )
 
 var queryCmd = &cobra.Command{
-	Use:     "query [flags] [OPERATION]",
+	Use:     "query [OPTIONS] [OPERATION]",
 	Aliases: []string{"q"},
 	Short:   "Send API queries to a dagger engine",
 	Long: `Send API queries to a dagger engine.

--- a/cmd/dagger/query.go
+++ b/cmd/dagger/query.go
@@ -115,37 +115,6 @@ func getKVInput(kvs []string) map[string]interface{} {
 }
 
 func init() {
-	// changing usage template so examples are displayed below flags
-	queryCmd.SetUsageTemplate(`Usage:{{if .Runnable}}
-  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
-
-Aliases:
-  {{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{if eq (len .Groups) 0}}
-
-Available Commands:{{range $cmds}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{else}}{{range $group := .Groups}}
-
-{{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
-
-Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
-
-Flags:
-{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}{{if .HasExample}}
-
-Examples:
-{{.Example}}{{end}}
-Global Flags:
-{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
-
-Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
-  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
-
-Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
-`)
-
 	queryCmd.Flags().StringVar(&queryFile, "doc", "", "Read query from file (defaults to reading from stdin)")
 	queryCmd.Flags().StringSliceVar(&queryVarsInput, "var", nil, "List of query variables, in key=value format")
 	queryCmd.Flags().StringVar(&queryVarsJSONInput, "var-json", "", "Query variables in JSON format (overrides --var)")

--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -20,7 +20,7 @@ import (
 )
 
 var runCmd = &cobra.Command{
-	Use:     "run [flags] COMMAND",
+	Use:     "run [OPTIONS] COMMAND",
 	Aliases: []string{"r"},
 	Short:   "Run a command in a Dagger session",
 	Long: strings.ReplaceAll(

--- a/cmd/dagger/watch.go
+++ b/cmd/dagger/watch.go
@@ -10,7 +10,7 @@ import (
 )
 
 var watchCmd = &cobra.Command{
-	Use:    "watch [flags] COMMAND",
+	Use:    "watch [OPTIONS] COMMAND",
 	Hidden: true,
 	Annotations: map[string]string{
 		"experimental": "true",


### PR DESCRIPTION

### Details of current draft implementation

@helderco we had a sync, but I might have forgotten some parts ahah (sorry 👼). Feel free to tell if I'm completely off on some interpretation / implementation:

- [x] **Add line break between error and usage**
This has been added in `cmd/dagger/functions.go`

- [x] **Style headings in BOLD UPPERCASE to help break sections visually**
A new helper function has been added and the corresponding template has been updated

- [x] **Remove discrepancy between `dagger query` and the rest of the commands**
This sub-command hasn't been updated in months and having a separate template is more coordination work. It might be time to make them 1:1 ?

- [x] **Conventionalize on either `<command>` or `COMMAND` syntax in cmd.Use**
I updated all COMMAND as uppercase. I did not remember if you were also referencing on the usage examples inside square brackets like `[arguments]` -> `[ARGUMENTS]`  ? I followed the CLI examples we discussed and some did it that way, in doubt I applied it everywhere but totally open for change

- [x] **Figure out if arguments are better above or below functions/commands ??**
I experimented on this one, and I haven't found an easy way: on a given function call, I do agree that having the commands at the bottom does make sense. However, changing the order on the template directly also changes the order for commands such as: `dagger --help`. _What do you think is the best implementation on this one ? Shall we tweak the template to make it specific for just the `dagger call` section ?_ I feared adding complexity to the template logic

- [x] **Visual cue for required flags**
As you proposed last time, the idea would be to have a required flags section for the `dagger call function` subcommands only ? Will take a look tomorrow. Same fear on the added complexity on the main template, but this one seems more manageable: it is just a section wrapped in an if to show it on `dagger call` subcommand context 

- [x] **"Options" instead of "Flags"?[1](https://github.com/dagger/dagger/issues/6943#user-content-fn-1-6303e1ecaa2e73e24edcc8788f13dcde)**
This is done, with our own implementation of `useLine` to print options instead of args by default.
Solomon requested `arguments` on above issue though. I followed your terminology, but shall we make a specific case for arguments in `dagger call` / `dagger functions` scope ?

- [ ] **Help topics for dagger call to keep --help lean while still providing more documentation**
What topics do you think we should cover first ? More than the implementation, the most important might be the documentation added to those topics. Which could be the first 2 topics to create, so that i draft the implementation tomorrow ?
 
- [ ] **Global flags only on root command and top level commands**
    * Remove persistent flags from child commands after being parsed? Or just hide?
        * TUI (--silent, --focus)
        * Modules (-m)

This is the one I am currently trying to implement in a clean way (using the hiding method at first), and might need some guidance again. I have been trying to extend the `callCmd` implementation by implementing a new `persistentPreRunE`:
```go
PersistentPreRunE: func(_ *FuncCommand, cmd *cobra.Command, _ []string) error {
    rootCmd := cmd
    for rootCmd.Parent() != nil {
        rootCmd = rootCmd.Parent()
    }
    hideGlobalFlags(rootCmd)
    return nil
},
```
to control the behavior and potentially use the funcCommand infos or the cmd infos to mark as hidden, as you suggested, when the call command has subcommands 
However, I'm still having a hard time on this part. Will keep iterating tomorrow again

- [x] **Talk about Functions and arguments instead of Function commands**
This is partially done as I used your `options` terminology globally instead of `arguments`. It is true that `arguments` is pretty accurate in a `dagger call functions` context, but then, do we talk about `arguments` inside `dagger functions` usage examples too ?
 
cc @helderco 