### PR TITLE
chore: update images to go 1.22

### DIFF
--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           cache-dependency-path: "ci/go.sum"
       - name: Install dagger
         run: |
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           cache-dependency-path: "ci/go.sum"
       - name: Install dagger
         run: |

--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
       - name: "Publish Helm Chart"
         run: ./hack/make helm:publish ${{ github.ref_name }}

--- a/.github/workflows/publish-sdk-elixir.yml
+++ b/.github/workflows/publish-sdk-elixir.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: Install dagger
         run: |
           curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ inputs.dagger-version }} BIN_DIR=/usr/local/bin/ sudo -E sh

--- a/.github/workflows/publish-sdk-go.yml
+++ b/.github/workflows/publish-sdk-go.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: Install dagger
         run: |
           curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ inputs.dagger-version }} BIN_DIR=/usr/local/bin/ sudo -E sh

--- a/.github/workflows/publish-sdk-php.yml
+++ b/.github/workflows/publish-sdk-php.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: Install dagger
         run: |
           curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ inputs.dagger-version }} BIN_DIR=/usr/local/bin/ sudo -E sh

--- a/.github/workflows/publish-sdk-python.yml
+++ b/.github/workflows/publish-sdk-python.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: Install dagger
         run: |
           curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ inputs.dagger-version }} BIN_DIR=/usr/local/bin/ sudo -E sh

--- a/.github/workflows/publish-sdk-rust.yml
+++ b/.github/workflows/publish-sdk-rust.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: Install dagger
         run: |
           curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ inputs.dagger-version }} BIN_DIR=/usr/local/bin/ sudo -E sh

--- a/.github/workflows/publish-sdk-typescript.yml
+++ b/.github/workflows/publish-sdk-typescript.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: Install dagger
         run: |
           curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ inputs.dagger-version }} BIN_DIR=/usr/local/bin/ sudo -E sh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           cache-dependency-path: "ci/go.sum"
       - name: Install dagger
         run: |
@@ -133,7 +133,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: "Test Go SDK"
         run: |
           cd sdk/go
@@ -203,7 +203,7 @@ jobs:
         shell: bash
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: "Test Go SDK"
         run: |
           cd sdk/go

--- a/ci/build/builder.go
+++ b/ci/build/builder.go
@@ -225,7 +225,7 @@ func (build *Builder) runcBin() *dagger.File {
 	// We build runc from source to enable upgrades to go and other dependencies that
 	// can contain CVEs in the builds on github releases
 	buildCtr := dag.Container().
-		From(fmt.Sprintf("golang:%s-alpine%s", consts.GolangVersion, consts.AlpineVersion)).
+		From(fmt.Sprintf("golang:%s-alpine%s", consts.GolangVersionRuncHack, consts.AlpineVersion)).
 		With(build.goPlatformEnv).
 		WithEnvVariable("BUILDPLATFORM", "linux/"+runtime.GOARCH).
 		WithEnvVariable("TARGETPLATFORM", string(build.platform)).

--- a/ci/consts/versions.go
+++ b/ci/consts/versions.go
@@ -10,7 +10,11 @@ const (
 )
 
 const (
-	GolangVersion     = "1.21.7"
+	GolangVersion = "1.22.2"
+	// GolangVersionRuncHack needs to be 1.21, since 1.22 is not yet
+	// supported, and can cause crashes: opencontainers/runc#4233
+	GolangVersionRuncHack = "1.21.7"
+
 	GolangLintVersion = "v1.57"
 
 	AlpineVersion = "3.18"

--- a/core/integration/images.go
+++ b/core/integration/images.go
@@ -2,7 +2,7 @@ package core
 
 const (
 	alpineImage = "alpine:3.18.2"
-	golangImage = "golang:1.21.7-alpine"
+	golangImage = "golang:1.22.2-alpine"
 
 	// TODO: use these
 	// registryImage   = "registry:2"


### PR DESCRIPTION
This patch updates all the go base images to versions that have go 1.22.

Note! We can't update the version used to build runc, due to an upstream incompatability - however, because the build is separate, we can keep building it using an older version of go.

Also note, we can't *yet* bump to actually use 1.22 in our code by updating the go.mod. This is because the `ci` package must continue using 1.21 until the next release (insert elaborate codegen reasons here) - and then the `ci` package depends on the top-level package, so that must also stay at 1.21. There *is* a potential workaround that would allow us to split out `distconsts` into it's own go.mod, and then we could do this, but this can be a follow-up if we really want this.