### PR TITLE
chore: Add ci module `dagger develop` info to README

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -20,6 +20,17 @@ Available functionality:
 > engine) as defined in [`.github/workflows/_hack_make.yml`](../.github/workflows/_hack_make.yml).
 > Without this, you may hit unexpected errors or other weird behavior.
 
+## Developing after a fresh clone
+
+If you want to develop this module following a repository clone, remember to
+run the following one-off command:
+
+    cd ..
+    dagger develop --sdk go --source ci
+
+This will re-create all the files required by your code editor - see
+`.gitignore` for a list of what they are.
+
 ## Tests
 
 Run all tests:

--- a/ci/README.md
+++ b/ci/README.md
@@ -35,17 +35,17 @@ This will re-create all the files required by your code editor - see
 
 Run all tests:
 
-    $ dagger call --source=. test all
+    dagger call --source=. test all
 
 Run a specific test (e.g. `TestModuleNamespacing`):
 
-    $ dagger call --source=. test custom --run="^TestModuleNamespacing" --pkg="./core/integration"
+    dagger call --source=. test custom --run="^TestModuleNamespacing" --pkg="./core/integration"
 
 ## Dev environment
 
 Start a little dev shell with dagger-in-dagger:
 
-    $ dagger call --source=. dev
+    dagger call --source=. dev
 
 ## Engine & CLI
 
@@ -53,49 +53,49 @@ Start a little dev shell with dagger-in-dagger:
 
 Run the engine linter:
 
-    $ dagger call --source=. engine lint
+    dagger call --source=. engine lint
 
 ### Build the CLI
 
 Build the CLI:
 
-    $ dagger call --source=. cli file export --path=./dagger
+    dagger call --source=. cli file export --path=./dagger
 
 ### Run the engine service
 
 Run the engine as a service:
 
-    $ dagger call --source=. engine service --name=dagger-engine up --ports=1234:1234
+    dagger call --source=. engine service --name=dagger-engine up --ports=1234:1234
 
 Connect to it from a dagger cli:
 
-    $ export _EXPERIMENTAL_DAGGER_RUNNER_HOST=tcp://0.0.0.0:1234
-    $ dagger call -m github.com/shykes/daggerverse/hello@main hello
-    hello, world!
+    export _EXPERIMENTAL_DAGGER_RUNNER_HOST=tcp://0.0.0.0:1234
+    dagger call -m github.com/shykes/daggerverse/hello@main hello
+    # hello, world!
 
 ## Docs
 
 Lint the docs:
 
-    $ dagger call --source=. docs lint
+    dagger call --source=. docs lint
 
 Auto-generate docs components:
 
-    $ dagger call --source=. docs generate export --path=.
+    dagger call --source=. docs generate export --path=.
 
 ## SDKs
 
 Available SDKs:
 
-    $ dagger functions sdk
-    Name         Description
-    elixir       -
-    go           -
-    java         -
-    php          -
-    python       -
-    rust         -
-    typescript   -
+    dagger functions sdk
+    # Name         Description
+    # elixir       -
+    # go           -
+    # java         -
+    # php          -
+    # python       -
+    # rust         -
+    # typescript   -
 
 All SDKs have the same functions defined:
 
@@ -110,28 +110,28 @@ All SDKs have the same functions defined:
 
 Run an SDK linter (replace `<sdk>` with one of the supported SDKs):
 
-    $ dagger call --source=. sdk <sdk> lint
+    dagger call --source=. sdk <sdk> lint
 
 ### Tests
 
 Run SDK tests (replace `<sdk>` with one of the supported SDKs):
 
-    $ dagger call --source=. sdk <sdk> test
+    dagger call --source=. sdk <sdk> test
 
 ### Generate
 
 Generate SDK static files (replace `<sdk>` with one of the supported SDKs):
 
-    $ dagger call --source=. sdk <sdk> generate export --path=.
+    dagger call --source=. sdk <sdk> generate export --path=.
 
 ### Publish
 
 Dry-run an SDK publishing step (replace `<sdk>` with one of the supported SDKs):
 
-    $ dagger call --source=. sdk <sdk> publish --dry-run
+    dagger call --source=. sdk <sdk> publish --dry-run
 
 ### Bump
 
 Bump an SDK version for releasing (replace `<sdk>` with one of the supported SDKs):
 
-    $ dagger call --source=. sdk <sdk> bump --version=$VERSION export --path=.
+    dagger call --source=. sdk <sdk> bump --version=$VERSION export --path=.


### PR DESCRIPTION
Required after a fresh clone.

Also:
- Bump ci module Engine version to v0.11.1
- Remove `$` from ci README code snippets