### PR TITLE
fix: all paths should be encoded over-the-wire

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ linters:
     - dogsled
     - dupl
     - exportloopref
+    - errorlint
     - gocritic
     - gocyclo
     - gofmt
@@ -46,4 +47,9 @@ linters-settings:
 
   govet:
     enable:
-      - nilness
+
+  errorlint:
+    errorf: true
+    errorf-multi: false
+    asserts: false
+    comparison: false

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -602,7 +602,7 @@ func getModuleConfigurationForSourceRef(
 			}
 			var modCfg modules.ModuleConfig
 			if err := json.Unmarshal(contents, &modCfg); err != nil {
-				return nil, fmt.Errorf("failed to unmarshal %s: %s", configPath, err)
+				return nil, fmt.Errorf("failed to unmarshal %s: %w", configPath, err)
 			}
 
 			namedDep, ok := modCfg.DependencyByName(srcRefStr)
@@ -677,13 +677,13 @@ func findUp(curDirPath string) (string, bool, error) {
 		return curDirPath, true, nil
 
 	default:
-		return "", false, fmt.Errorf("failed to lstat %s: %s", configPath, err)
+		return "", false, fmt.Errorf("failed to lstat %s: %w", configPath, err)
 	}
 
 	// didn't exist, try parent unless we've hit the root or a git repo checkout root
 	curDirAbsPath, err := filepath.Abs(curDirPath)
 	if err != nil {
-		return "", false, fmt.Errorf("failed to get absolute path for %s: %s", curDirPath, err)
+		return "", false, fmt.Errorf("failed to get absolute path for %s: %w", curDirPath, err)
 	}
 	if curDirAbsPath[len(curDirAbsPath)-1] == os.PathSeparator {
 		// path ends in separator, we're at root

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -296,7 +296,7 @@ func (fn *ModuleFunction) Call(ctx context.Context, caller *call.ID, opts *CallO
 	dec := json.NewDecoder(strings.NewReader(string(outputBytes)))
 	dec.UseNumber()
 	if err := dec.Decode(&returnValue); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal result: %s", err)
+		return nil, fmt.Errorf("failed to unmarshal result: %w", err)
 	}
 
 	returnValueTyped, err := fn.returnType.ConvertFromSDKResult(ctx, returnValue)

--- a/core/schema/host.go
+++ b/core/schema/host.go
@@ -41,11 +41,11 @@ func (s *hostSchema) Install() {
 		}) (*core.Directory, error) {
 			dig, err := digest.Parse(args.Digest)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse digest: %s", err)
+				return nil, fmt.Errorf("failed to parse digest: %w", err)
 			}
 			uncompressedDig, err := digest.Parse(args.Uncompressed)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse digest: %s", err)
+				return nil, fmt.Errorf("failed to parse digest: %w", err)
 			}
 			blobDef, err := blob.LLB(specs.Descriptor{
 				MediaType: args.MediaType,
@@ -58,7 +58,7 @@ func (s *hostSchema) Install() {
 				},
 			}).Marshal(ctx)
 			if err != nil {
-				return nil, fmt.Errorf("failed to marshal blob source: %s", err)
+				return nil, fmt.Errorf("failed to marshal blob source: %w", err)
 			}
 			return core.NewDirectory(parent, blobDef.ToPB(), "/", parent.Platform, nil), nil
 		}).Doc("Retrieves a content-addressed blob."),

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -638,7 +638,7 @@ func (s *moduleSchema) moduleSourceResolveFromCaller(
 
 	sourceRootRelPath, err := filepath.Rel(contextAbsPath, sourceRootAbsPath)
 	if err != nil {
-		return inst, fmt.Errorf("failed to get source root relative path: %s", err)
+		return inst, fmt.Errorf("failed to get source root relative path: %w", err)
 	}
 
 	collectedDeps := dagql.NewCacheMap[string, *callerLocalDep]()
@@ -656,7 +656,7 @@ func (s *moduleSchema) moduleSourceResolveFromCaller(
 	for _, rootPath := range sourceRootPaths {
 		rootRelPath, err := filepath.Rel(contextAbsPath, rootPath)
 		if err != nil {
-			return inst, fmt.Errorf("failed to get source root relative path: %s", err)
+			return inst, fmt.Errorf("failed to get source root relative path: %w", err)
 		}
 		if !filepath.IsLocal(rootRelPath) {
 			return inst, fmt.Errorf("local module dep source path %q escapes context %q", rootRelPath, contextAbsPath)
@@ -695,7 +695,7 @@ func (s *moduleSchema) moduleSourceResolveFromCaller(
 			absPath := filepath.Join(sourceRootAbsPath, path)
 			relPath, err := filepath.Rel(contextAbsPath, absPath)
 			if err != nil {
-				return fmt.Errorf("failed to get relative path of config include/exclude: %s", err)
+				return fmt.Errorf("failed to get relative path of config include/exclude: %w", err)
 			}
 			if !filepath.IsLocal(relPath) {
 				return fmt.Errorf("local module dep source include/exclude path %q escapes context %q", relPath, contextAbsPath)
@@ -720,7 +720,7 @@ func (s *moduleSchema) moduleSourceResolveFromCaller(
 		// always include the config file
 		configRelPath, err := filepath.Rel(contextAbsPath, filepath.Join(rootPath, modules.Filename))
 		if err != nil {
-			return inst, fmt.Errorf("failed to get relative path: %s", err)
+			return inst, fmt.Errorf("failed to get relative path: %w", err)
 		}
 		includeSet[configRelPath] = struct{}{}
 
@@ -732,7 +732,7 @@ func (s *moduleSchema) moduleSourceResolveFromCaller(
 		sourceAbsSubpath := filepath.Join(rootPath, source)
 		sourceRelSubpath, err := filepath.Rel(contextAbsPath, sourceAbsSubpath)
 		if err != nil {
-			return inst, fmt.Errorf("failed to get relative path: %s", err)
+			return inst, fmt.Errorf("failed to get relative path: %w", err)
 		}
 		if !filepath.IsLocal(sourceRelSubpath) {
 			return inst, fmt.Errorf("local module source path %q escapes context %q", sourceRelSubpath, contextAbsPath)
@@ -909,7 +909,7 @@ func (s *moduleSchema) collectCallerLocalDeps(
 	_, _, err := collectedDeps.GetOrInitialize(ctx, sourceRootAbsPath, func(ctx context.Context) (*callerLocalDep, error) {
 		sourceRootRelPath, err := filepath.Rel(contextAbsPath, sourceRootAbsPath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get source root relative path: %s", err)
+			return nil, fmt.Errorf("failed to get source root relative path: %w", err)
 		}
 		if !filepath.IsLocal(sourceRootRelPath) {
 			return nil, fmt.Errorf("local module dep source path %q escapes context %q", sourceRootRelPath, contextAbsPath)
@@ -935,7 +935,7 @@ func (s *moduleSchema) collectCallerLocalDeps(
 			}
 
 		default:
-			return nil, fmt.Errorf("error reading config %s: %s", configPath, err)
+			return nil, fmt.Errorf("error reading config %s: %w", configPath, err)
 		}
 
 		if topLevel {
@@ -1004,7 +1004,7 @@ func (s *moduleSchema) collectCallerLocalDeps(
 				callerCwd := callerCwdStat.Path
 				sdkCallerRelPath, err := filepath.Rel(callerCwd, sdkPath)
 				if err != nil {
-					return nil, fmt.Errorf("failed to get relative path of local sdk: %s", err)
+					return nil, fmt.Errorf("failed to get relative path of local sdk: %w", err)
 				}
 				var sdkMod dagql.Instance[*core.Module]
 				err = s.dag.Select(ctx, s.dag.Root(), &sdkMod,
@@ -1062,7 +1062,7 @@ func callerHostFindUpContext(
 		return curDirPath, true, nil
 	}
 	if !strings.Contains(err.Error(), "no such file or directory") && !strings.Contains(err.Error(), "not found") {
-		return "", false, fmt.Errorf("failed to lstat .git: %s", err)
+		return "", false, fmt.Errorf("failed to lstat .git: %w", err)
 	}
 
 	nextDirPath := filepath.Dir(curDirPath)

--- a/core/schema/query.go
+++ b/core/schema/query.go
@@ -89,13 +89,13 @@ func (s *querySchema) checkVersionCompatibility(ctx context.Context, _ *core.Que
 	engineVersionStr := strings.TrimPrefix(engine.Version, "v")
 	engineVersion, err := semver.Parse(engineVersionStr)
 	if err != nil {
-		return false, fmt.Errorf("failed to parse engine version as semver: %s", err)
+		return false, fmt.Errorf("failed to parse engine version as semver: %w", err)
 	}
 
 	sdkVersionStr := strings.TrimPrefix(args.Version, "v")
 	sdkVersion, err := semver.Parse(sdkVersionStr)
 	if err != nil {
-		return false, fmt.Errorf("failed to parse SDK version as semver: %s", err)
+		return false, fmt.Errorf("failed to parse SDK version as semver: %w", err)
 	}
 
 	// If the Engine is a major version above the SDK version, fails

--- a/engine/buildkit/blob.go
+++ b/engine/buildkit/blob.go
@@ -32,7 +32,7 @@ func (c *Client) DefToBlob(
 	}
 	resultProxy, err := res.SingleRef()
 	if err != nil {
-		return nil, desc, fmt.Errorf("failed to get single ref: %s", err)
+		return nil, desc, fmt.Errorf("failed to get single ref: %w", err)
 	}
 	cachedRes, err := resultProxy.Result(ctx)
 	if err != nil {
@@ -51,7 +51,7 @@ func (c *Client) DefToBlob(
 	// is tricky and ultimately only result in a marginal performance optimization.
 	err = ref.Extract(ctx, nil)
 	if err != nil {
-		return nil, desc, fmt.Errorf("failed to extract ref: %s", err)
+		return nil, desc, fmt.Errorf("failed to extract ref: %w", err)
 	}
 
 	remotes, err := ref.GetRemotes(ctx, true, cacheconfig.RefConfig{
@@ -64,7 +64,7 @@ func (c *Client) DefToBlob(
 		},
 	}, false, nil)
 	if err != nil {
-		return nil, desc, fmt.Errorf("failed to get remotes: %s", err)
+		return nil, desc, fmt.Errorf("failed to get remotes: %w", err)
 	}
 	if len(remotes) != 1 {
 		return nil, desc, fmt.Errorf("expected 1 remote, got %d", len(remotes))
@@ -78,7 +78,7 @@ func (c *Client) DefToBlob(
 
 	blobDef, err := blob.LLB(desc).Marshal(ctx)
 	if err != nil {
-		return nil, desc, fmt.Errorf("failed to marshal blob source: %s", err)
+		return nil, desc, fmt.Errorf("failed to marshal blob source: %w", err)
 	}
 	blobPB := blobDef.ToPB()
 

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -497,14 +497,14 @@ func (c *Client) UpstreamCacheExport(ctx context.Context, cacheExportFuncs []Res
 	}
 	cacheRes, err := ConvertToWorkerCacheResult(ctx, combinedResult)
 	if err != nil {
-		return fmt.Errorf("failed to convert result: %s", err)
+		return fmt.Errorf("failed to convert result: %w", err)
 	}
 	bklog.G(ctx).Debugf("converting to solverRes")
 	solverRes, err := solverresult.ConvertResult(combinedResult, func(rf *ref) (bksolver.CachedResult, error) {
 		return rf.resultProxy.Result(ctx)
 	})
 	if err != nil {
-		return fmt.Errorf("failed to convert result: %s", err)
+		return fmt.Errorf("failed to convert result: %w", err)
 	}
 
 	sessionGroup := bksession.NewGroup(c.ID())
@@ -580,13 +580,13 @@ func (c *Client) ListenHostToContainer(
 	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
 	if err != nil {
 		cancel()
-		return nil, nil, fmt.Errorf("failed to get requester session ID: %s", err)
+		return nil, nil, fmt.Errorf("failed to get requester session ID: %w", err)
 	}
 
 	clientCaller, err := c.SessionManager.Get(ctx, clientMetadata.ClientID, false)
 	if err != nil {
 		cancel()
-		return nil, nil, fmt.Errorf("failed to get requester session: %s", err)
+		return nil, nil, fmt.Errorf("failed to get requester session: %w", err)
 	}
 
 	conn := clientCaller.Conn()
@@ -596,7 +596,7 @@ func (c *Client) ListenHostToContainer(
 	listener, err := tunnelClient.Listen(ctx)
 	if err != nil {
 		cancel()
-		return nil, nil, fmt.Errorf("failed to listen: %s", err)
+		return nil, nil, fmt.Errorf("failed to listen: %w", err)
 	}
 
 	err = listener.Send(&session.ListenRequest{
@@ -605,13 +605,13 @@ func (c *Client) ListenHostToContainer(
 	})
 	if err != nil {
 		cancel()
-		return nil, nil, fmt.Errorf("failed to send listen request: %s", err)
+		return nil, nil, fmt.Errorf("failed to send listen request: %w", err)
 	}
 
 	listenRes, err := listener.Recv()
 	if err != nil {
 		cancel()
-		return nil, nil, fmt.Errorf("failed to receive listen response: %s", err)
+		return nil, nil, fmt.Errorf("failed to receive listen response: %w", err)
 	}
 
 	conns := map[string]net.Conn{}

--- a/engine/buildkit/containerimage.go
+++ b/engine/buildkit/containerimage.go
@@ -48,12 +48,12 @@ func (c *Client) PublishContainerImage(
 
 	expInstance, err := exporter.Resolve(ctx, 0, opts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve exporter: %s", err)
+		return nil, fmt.Errorf("failed to resolve exporter: %w", err)
 	}
 
 	resp, descRef, err := expInstance.Export(ctx, combinedResult, nil, c.ID())
 	if err != nil {
-		return nil, fmt.Errorf("failed to export: %s", err)
+		return nil, fmt.Errorf("failed to export: %w", err)
 	}
 	if descRef != nil {
 		descRef.Release()
@@ -95,12 +95,12 @@ func (c *Client) ExportContainerImage(
 
 	expInstance, err := exporter.Resolve(ctx, 0, opts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve exporter: %s", err)
+		return nil, fmt.Errorf("failed to resolve exporter: %w", err)
 	}
 
 	clientMetadata, err := engine.ClientMetadataFromContext(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get requester session ID from client metadata: %s", err)
+		return nil, fmt.Errorf("failed to get requester session ID from client metadata: %w", err)
 	}
 
 	ctx = engine.LocalExportOpts{
@@ -110,7 +110,7 @@ func (c *Client) ExportContainerImage(
 
 	resp, descRef, err := expInstance.Export(ctx, combinedResult, nil, clientMetadata.ClientID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to export: %s", err)
+		return nil, fmt.Errorf("failed to export: %w", err)
 	}
 	if descRef != nil {
 		descRef.Release()
@@ -148,12 +148,12 @@ func (c *Client) ContainerImageToTarball(
 
 	expInstance, err := exporter.Resolve(ctx, 0, opts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve exporter: %s", err)
+		return nil, fmt.Errorf("failed to resolve exporter: %w", err)
 	}
 
 	tmpDir, err := os.MkdirTemp("", "dagger-tarball")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create temp dir for tarball export: %s", err)
+		return nil, fmt.Errorf("failed to create temp dir for tarball export: %w", err)
 	}
 	defer os.RemoveAll(tmpDir)
 	destPath := path.Join(tmpDir, fileName)
@@ -165,7 +165,7 @@ func (c *Client) ContainerImageToTarball(
 
 	_, descRef, err := expInstance.Export(ctx, combinedResult, nil, c.ID())
 	if err != nil {
-		return nil, fmt.Errorf("failed to export: %s", err)
+		return nil, fmt.Errorf("failed to export: %w", err)
 	}
 	if descRef != nil {
 		defer descRef.Release()
@@ -173,7 +173,7 @@ func (c *Client) ContainerImageToTarball(
 
 	pbDef, _, err := c.EngineContainerLocalImport(ctx, engineHostPlatform, tmpDir, nil, []string{fileName})
 	if err != nil {
-		return nil, fmt.Errorf("failed to import container tarball from engine container filesystem: %s", err)
+		return nil, fmt.Errorf("failed to import container tarball from engine container filesystem: %w", err)
 	}
 	return pbDef, nil
 }
@@ -193,11 +193,11 @@ func (c *Client) getContainerResult(
 			Evaluate:   true,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("failed to solve for container publish: %s", err)
+			return nil, fmt.Errorf("failed to solve for container publish: %w", err)
 		}
 		cacheRes, err := ConvertToWorkerCacheResult(ctx, res)
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert result: %s", err)
+			return nil, fmt.Errorf("failed to convert result: %w", err)
 		}
 		ref, err := cacheRes.SingleRef()
 		if err != nil {

--- a/engine/buildkit/filesync.go
+++ b/engine/buildkit/filesync.go
@@ -134,7 +134,7 @@ func (c *Client) diffcopy(ctx context.Context, opts engine.LocalImportOpts, msg 
 func (c *Client) ReadCallerHostFile(ctx context.Context, path string) ([]byte, error) {
 	msg := filesync.BytesMessage{}
 	err := c.diffcopy(ctx, engine.LocalImportOpts{
-		Path:               filepath.ToSlash(path),
+		Path:               path,
 		ReadSingleFileOnly: true,
 		MaxFileSize:        MaxFileContentsChunkSize,
 	}, &msg)
@@ -147,7 +147,7 @@ func (c *Client) ReadCallerHostFile(ctx context.Context, path string) ([]byte, e
 func (c *Client) StatCallerHostPath(ctx context.Context, path string, returnAbsPath bool) (*fsutiltypes.Stat, error) {
 	msg := fsutiltypes.Stat{}
 	err := c.diffcopy(ctx, engine.LocalImportOpts{
-		Path:              filepath.ToSlash(path),
+		Path:              path,
 		StatPathOnly:      true,
 		StatReturnAbsPath: returnAbsPath,
 	}, &msg)

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -273,10 +273,10 @@ func decodeMeta(md metadata.MD, key string, dest interface{}) error {
 	}
 	jsonPayload, err := base64.StdEncoding.DecodeString(vals[0])
 	if err != nil {
-		return fmt.Errorf("failed to base64-decode %s: %v", key, err)
+		return fmt.Errorf("failed to base64-decode %s: %w", key, err)
 	}
 	if err := json.Unmarshal(jsonPayload, dest); err != nil {
-		return fmt.Errorf("failed to JSON-unmarshal %s: %v", key, err)
+		return fmt.Errorf("failed to JSON-unmarshal %s: %w", key, err)
 	}
 	return nil
 }

--- a/sdk/go/internal/engineconn/session.go
+++ b/sdk/go/internal/engineconn/session.go
@@ -192,7 +192,7 @@ func startCLISession(ctx context.Context, binPath string, cfg *Config) (_ Engine
 		if rerr != nil {
 			stderrContents := stderrBuf.String()
 			if stderrContents != "" {
-				rerr = fmt.Errorf("%s: %s", rerr, stderrContents)
+				rerr = fmt.Errorf("%w: %s", rerr, stderrContents)
 			}
 		}
 	}()


### PR DESCRIPTION
Fixes #6923 #7114 (second time's the charm hopefully), follow-up to #7003.

*Right*. Descriptions are split up into commits to make it a bit easier to understand, but TL;DR, there were two main issues:
- Paths weren't being correctly decoded after being encoded on the wire - I should have caught this and didn't (my bad). The correct way to do this is to handle the encoding/decoding as close as possible in the code to sending/receiving, then it doesn't sneak everywhere through the code.
- Windows has different file-not-found message strings for `os.Stat` and `os.ReadFile` (for reasons, I have no idea). We were missing a check for the message you get from `os.ReadFile` ("The system cannot find the file specified"). Instead of adding *yet another check*, I move the check to the client with `errors.Is(err, os.ErrNotExist)`, and then transforming this into a nice gRPC status code (but need to preserve the other one for backwards-compat, yay).
	- Also, as part of this, I discovered that we weren't doing error-wrapping properly in loads of places (so the status codes didn't get propagated nicely). To solve this, I added a linter check to *always* use the `%w` formatting directive where possible, and then fixed *all* the instances in the codebase.

Windows is hard :cry: 