### PR TITLE
chore: allow symlinking to hack scripts

### DIFF
--- a/hack/dev
+++ b/hack/dev
@@ -2,7 +2,7 @@
 
 set -e -u -x
 
-DAGGER_SRC_ROOT="$(cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)"
+DAGGER_SRC_ROOT="$(cd $(dirname $(realpath "${BASH_SOURCE[0]}"))/.. && pwd)"
 MAGEDIR="$DAGGER_SRC_ROOT/ci/mage"
 
 pushd $MAGEDIR

--- a/hack/make
+++ b/hack/make
@@ -2,7 +2,7 @@
 
 set -e -u -x
 
-DAGGER_SRC_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+DAGGER_SRC_ROOT="$(cd $(dirname $(realpath "${BASH_SOURCE[0]}"))/.. && pwd)"
 MAGEDIR="$DAGGER_SRC_ROOT/ci/mage"
 
 cd "$MAGEDIR"

--- a/hack/with-dev
+++ b/hack/with-dev
@@ -2,7 +2,7 @@
 
 set -e -u
 
-DAGGER_SRC_ROOT="$(cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)"
+DAGGER_SRC_ROOT="$(cd $(dirname $(realpath "${BASH_SOURCE[0]}"))/.. && pwd)"
 
 export _EXPERIMENTAL_DAGGER_CLI_BIN=$DAGGER_SRC_ROOT/bin/dagger
 export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev


### PR DESCRIPTION
Essentially, by calling `readlink` on the source, we can get the location without any symlinks. This allows a dev (like me) to create a symlink to these scripts, dump those in a `bin` folder somewhere on my system and then access them from anywhere.