### PR TITLE
fix: parse go pragmas with CRLF line endings

### DIFF
--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -1007,7 +1007,7 @@ func (ps *parseState) functionCallArgCode(t types.Type, access *Statement) (type
 	}
 }
 
-var pragmaCommentRegexp = regexp.MustCompile(`\+\s*(\S+?)(?:=(.+))?(?:\n|$)`)
+var pragmaCommentRegexp = regexp.MustCompile(`\+\s*(\S+?)(?:=(.+?))?(?:\r?\n|$)`)
 
 // parsePragmaComment parses a dagger "pragma", that is used to define additional metadata about a parameter.
 func parsePragmaComment(comment string) (data map[string]string, rest string) {

--- a/cmd/codegen/generator/go/templates/modules_test.go
+++ b/cmd/codegen/generator/go/templates/modules_test.go
@@ -22,6 +22,22 @@ func TestParsePragmaComment(t *testing.T) {
 			rest: "",
 		},
 		{
+			name:    "single key with trailing lf",
+			comment: "+foo\n",
+			expected: map[string]string{
+				"foo": "",
+			},
+			rest: "",
+		},
+		{
+			name:    "single key with trailing crlf",
+			comment: "+foo\r\n",
+			expected: map[string]string{
+				"foo": "",
+			},
+			rest: "",
+		},
+		{
 			name:    "single key-value",
 			comment: "+foo=bar",
 			expected: map[string]string{
@@ -63,6 +79,15 @@ func TestParsePragmaComment(t *testing.T) {
 				"baz": "qux",
 			},
 			rest: "line 1\nline 2\nline 3\n",
+		},
+		{
+			name:    "interpolated key-value with crlf",
+			comment: "line 1\r\n+foo=bar\r\nline 2\r\n+baz=qux\r\nline 3",
+			expected: map[string]string{
+				"foo": "bar",
+				"baz": "qux",
+			},
+			rest: "line 1\r\nline 2\r\nline 3",
 		},
 	}
 


### PR DESCRIPTION
Pragmas were not being correctly parsed when we had windows line endings - this fix ensures that we correctly handle these.

This was resulting in some *very* weird to debug issues where optional arguments could be detected as required instead.