### PR TITLE
cli: remove special template on query subcommand

### DIFF
--- a/cmd/dagger/query.go
+++ b/cmd/dagger/query.go
@@ -115,37 +115,6 @@ func getKVInput(kvs []string) map[string]interface{} {
 }
 
 func init() {
-	// changing usage template so examples are displayed below flags
-	queryCmd.SetUsageTemplate(`Usage:{{if .Runnable}}
-  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
-
-Aliases:
-  {{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{if eq (len .Groups) 0}}
-
-Available Commands:{{range $cmds}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{else}}{{range $group := .Groups}}
-
-{{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
-
-Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
-
-Flags:
-{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}{{if .HasExample}}
-
-Examples:
-{{.Example}}{{end}}
-Global Flags:
-{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
-
-Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
-  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
-
-Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
-`)
-
 	queryCmd.Flags().StringVar(&queryFile, "doc", "", "Read query from file (defaults to reading from stdin)")
 	queryCmd.Flags().StringSliceVar(&queryVarsInput, "var", nil, "List of query variables, in key=value format")
 	queryCmd.Flags().StringVar(&queryVarsJSONInput, "var-json", "", "Query variables in JSON format (overrides --var)")


### PR DESCRIPTION
One of the action items discussed in https://github.com/dagger/dagger/pull/7107#issuecomment-2061525961

`dagger query` is not the main entrypoint of the dagger CLI anymore. Even though the special template made some sense, it is a code duplication to maintain. With the upcoming changes (titles in bold, etc ...) and the remaining presence of the example on the command's help, it does make sense to remove it and keep a single source of truth

#### New output
```shell
./dagger query --help
Send API queries to a dagger engine.

When no document file is provided, reads query from standard input.

Can optionally provide the GraphQL operation name if there are multiple
queries in the document.

Usage:
  dagger query [flags] [OPERATION]

Aliases:
  query, q

Examples:
dagger query <<EOF
{
  container {
    from(address:"hello-world") {
      withExec(args:["/hello"]) {
        stdout
      }
    }
  }
}
EOF


Flags:
      --doc string        Read query from file (defaults to reading from stdin)
  -m, --mod string        Path to dagger.json config file for the module or a directory containing that file. Either local
                          path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
      --var strings       List of query variables, in key=value format
      --var-json string   Query variables in JSON format (overrides --var)

Global Flags:
  -d, --debug             show debug logs and full verbosity
      --progress string   progress output format (auto, plain, tty) (default "auto")
  -s, --silent            disable terminal UI and progress output
  -v, --verbose count     increase verbosity (use -vv or -vvv for more)
  ```


cc @marcosnils, as he was the original author of this