### PR TITLE
cli: line break between error and usage

### DIFF
--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -287,6 +287,9 @@ func (fc *FuncCommand) execute(c *cobra.Command, a []string) (rerr error) {
 			cmd.PrintErrln("Error:", rerr.Error())
 
 			if fc.showHelp {
+				// Intentionally add newline to separate error from usage
+				cmd.PrintErrln()
+
 				// Explicitly show the help here while still returning the error.
 				// This handles the case of `dagger call --help` run on a broken module; in that case
 				// we want to error out since we can't actually load the module and show all subcommands


### PR DESCRIPTION
Part of the de-clutter CLI implementation: https://github.com/dagger/dagger/issues/6943#issuecomment-2021310987.

When querying `dagger call --help` and `dagger functions --help` without being in a module or for an inexistant function, an error is being raised.

This commit adds a newline between the usage and the error, as it was hard to distinct between them

Example:
```shell
./dagger -m . functions toto --help
✔ initialize 41.2s

Error: no function 'toto' in object type 'Dagger'
```