### PR TITLE
cli: repositioning flags below all commands

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -364,13 +364,6 @@ const usageTemplate = `{{ "Usage" | toUpperBold }}
 
 {{- end}}
 
-{{- if .HasAvailableLocalFlags}}
-
-{{ "Flags" | toUpperBold }}
-{{ flagUsagesWrapped .LocalFlags | trimTrailingWhitespaces}}
-
-{{- end}}
-
 {{- if .HasAvailableSubCommands}}{{$cmds := .Commands}}
 {{- if eq (len .Groups) 0}}
 
@@ -403,6 +396,13 @@ const usageTemplate = `{{ "Usage" | toUpperBold }}
 {{- end}}{{/* if not .AllChildCommandsHaveGroup */}}
 {{- end}}{{/* if eq (len .Groups) 0 */}}
 {{- end}}{{/* if .HasAvailableSubCommands */}}
+
+{{- if .HasAvailableLocalFlags}}
+
+{{ "Flags" | toUpperBold }}
+{{ flagUsagesWrapped .LocalFlags | trimTrailingWhitespaces}}
+
+{{- end}}
 
 {{- if .HasAvailableInheritedFlags}}
 


### PR DESCRIPTION
One of the action items discussed in https://github.com/dagger/dagger/pull/7107#issuecomment-2061525961. With added context from @helderco [here](https://github.com/dagger/dagger/pull/7107#issuecomment-2065511351)

Reposition flags below commands to find them more easily on big subcommand outputs.

#### New output
```shell
 ./dagger -m github.com/levlaz/daggerverse/mariadb@v0.2.1 call base --help
Return MariaDB Container

USAGE
  dagger call base [flags]
  dagger call base [flags] [command]

FUNCTION COMMANDS
  as-service                    Turn the container into a Service.
  as-tarball                    Returns a File representing the container serialized to a tarball.
  build                         Initializes this container from a Dockerfile build.
  default-args                  Retrieves default arguments for future commands.
  directory                     Retrieves a directory at the given path.
  entrypoint                    Retrieves entrypoint to be prepended to the arguments of all commands.
  env-variable                  Retrieves the value of the specified environment variable.
  env-variables                 Retrieves the list of environment variables passed to commands.
  experimental-with-all-gp-us   EXPERIMENTAL API! Subject to change/removal at any time.
  experimental-with-gpu         EXPERIMENTAL API! Subject to change/removal at any time.
  export                        Writes the container as an OCI tarball to the destination file path on the host.
  exposed-ports                 Retrieves the list of exposed ports.
  file                          Retrieves a file at the given path.
  from                          Initializes this container from a pulled base image.
  image-ref                     The unique image reference which can only be retrieved immediately after the 'Container.From' call.
  import                        Reads the container from an OCI tarball.
  label                         Retrieves the value of the specified label.
  labels                        Retrieves the list of labels passed to container.
  mounts                        Retrieves the list of paths where a directory is mounted.
  pipeline                      Creates a named sub-pipeline.
  platform                      The platform this container executes and publishes as.
  publish                       Publishes this container as a new image to the specified address.
  rootfs                        Retrieves this container's root filesystem. Mounts are not included.
  stderr                        The error stream of the last executed command.
  stdout                        The output stream of the last executed command.
  sync                          Forces evaluation of the pipeline in the engine.
  terminal                      Return an interactive terminal for this container using its configured default terminal command if not
                                overridden by args (or sh as a fallback default).
  user                          Retrieves the user to be set for all commands.
  with-default-args             Configures default arguments for future commands.
  with-default-terminal-cmd     Set the default command to invoke for the container's terminal API.
  with-directory                Retrieves this container plus a directory written at the given path.
  with-entrypoint               Retrieves this container but with a different command entrypoint.
  with-env-variable             Retrieves this container plus the given environment variable.
  with-exec                     Retrieves this container after executing the specified command inside it.
  with-exposed-port             Expose a network port.
  with-file                     Retrieves this container plus the contents of the given file copied to the given path.
  with-files                    Retrieves this container plus the contents of the given files copied to the given path.
  with-focus                    Indicate that subsequent operations should be featured more prominently in the UI.
  with-label                    Retrieves this container plus the given label.
  with-mounted-cache            Retrieves this container plus a cache volume mounted at the given path.
  with-mounted-directory        Retrieves this container plus a directory mounted at the given path.
  with-mounted-file             Retrieves this container plus a file mounted at the given path.
  with-mounted-secret           Retrieves this container plus a secret mounted into a file at the given path.
  with-mounted-temp             Retrieves this container plus a temporary directory mounted at the given path.
  with-new-file                 Retrieves this container plus a new file written at the given path.
  with-registry-auth            Retrieves this container with a registry authentication for a given address.
  with-rootfs                   Retrieves the container with the given directory mounted to /.
  with-secret-variable          Retrieves this container plus an env variable containing the given secret.
  with-service-binding          Establish a runtime dependency on a service.
  with-unix-socket              Retrieves this container plus a socket forwarded to the given Unix socket path.
  with-user                     Retrieves this container with a different command user.
  with-workdir                  Retrieves this container with a different working directory.
  without-default-args          Retrieves this container with unset default arguments for future commands.
  without-entrypoint            Retrieves this container with an unset command entrypoint.
  without-env-variable          Retrieves this container minus the given environment variable.
  without-exposed-port          Unexpose a previously exposed port.
  without-focus                 Indicate that subsequent operations should not be featured more prominently in the UI.
  without-label                 Retrieves this container minus the given environment label.
  without-mount                 Retrieves this container after unmounting everything at the given path.
  without-registry-auth         Retrieves this container without the registry authentication of a given address.
  without-unix-socket           Retrieves this container with a previously added Unix socket removed.
  without-user                  Retrieves this container with an unset command user.
  without-workdir               Retrieves this container with an unset working directory.
  workdir                       Retrieves the working directory for all commands.

FLAGS
      --db-name string   Database name
      --version string   Version of MariaDB to use (default "latest")

GLOBAL FLAGS
  -d, --debug             show debug logs and full verbosity
      --json              Present result as JSON
  -m, --mod string        Path to dagger.json config file for the module or a directory containing that file. Either local path
                          (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
  -o, --output string     Path in the host to save the result to
      --progress string   progress output format (auto, plain, tty) (default "auto")
  -s, --silent            disable terminal UI and progress output
  -v, --verbose count     increase verbosity (use -vv or -vvv for more)

Use "dagger call base [command] --help" for more information about a command.
```

This also impacts the ordering on the main help menu, however this does not impact lisibility nor UX: 
```shell
./dagger --help                                                           
The Dagger CLI provides a command-line interface to Dagger.

USAGE
  dagger [flags] [command]

DAGGER CLOUD COMMANDS
  login         Log in to Dagger Cloud
  logout        Log out from Dagger Cloud

DAGGER MODULE COMMANDS
  call          Call a module function
  config        Get or set the configuration of a Dagger module
  develop       Setup or update all the resources needed to develop on a module locally
  functions     List available functions
  init          Initialize a new Dagger module
  install       Add a new dependency to a Dagger module

EXECUTION COMMANDS
  query         Send API queries to a dagger engine
  run           Run a command in a Dagger session

ADDITIONAL COMMANDS
  completion    Generate the autocompletion script for the specified shell
  help          Help about any command
  version       Print dagger version

FLAGS
  -d, --debug             show debug logs and full verbosity
      --progress string   progress output format (auto, plain, tty) (default "auto")
  -s, --silent            disable terminal UI and progress output
  -v, --verbose count     increase verbosity (use -vv or -vvv for more)

Use "dagger [command] --help" for more information about a command.
```