### PR TITLE
fix: make TestDaggerRun pass

### DIFF
--- a/core/integration/engine_test.go
+++ b/core/integration/engine_test.go
@@ -148,6 +148,7 @@ func TestDaggerRun(t *testing.T) {
 	require.NoError(t, err)
 
 	runCommand := `
+	export NO_COLOR=1
 	jq -n '{query:"{container{from(address: \"alpine:3.18.2\"){file(path: \"/etc/alpine-release\"){contents}}}}"}' | \
 	dagger run sh -c 'curl -s \
 		-u $DAGGER_SESSION_TOKEN: \

--- a/core/integration/engine_test.go
+++ b/core/integration/engine_test.go
@@ -168,6 +168,7 @@ func TestDaggerRun(t *testing.T) {
 	stdout, err := clientCtr.Stdout(ctx)
 	require.NoError(t, err)
 	require.Contains(t, stdout, "3.18.2")
+	require.JSONEq(t, `{"data": {"container": {"from": {"file": {"contents": "3.18.2\n"}}}}}`, stdout)
 
 	stderr, err := clientCtr.Stderr(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
:tada: This fixes DaggerRun, so hopefully we can have our CI go green again! (cc @matipan @gerhard who helped investigate)

This was "introduced" in #7069, when we changed our plain progress to include colors - in conjunction with the new TUI output, this means that we don't have a plain "Container.From", instead, we have magical control codes strewn throughout it. The trick to fix this, is to just set `NO_COLOR`, and the test passes again!

However! There's another issue here - this test was always "failing". The `from` in it was *never* working, due to network issues. We weren't setting the right network/cidr range, which we *were* doing in other tests, this was likely causing some network conflict (since these are required to be unique). We need to properly set this for *every* dev engine, so I've refactored the helper for that - note, we also do something similar to this in our internal magicache tests.

Finally, I've reworked the test a little bit, so that we check the output in more detail - to make sure that it never starts erroneously passing again, we expect a *very* specific form of output, which should make it more resilient to such breakages in the future.