### PR TITLE
fix(sdk/elixir): format function only deprecation message

### DIFF
--- a/sdk/elixir/dagger_codegen/lib/dagger/codegen/elixir_generator/renderer.ex
+++ b/sdk/elixir/dagger_codegen/lib/dagger/codegen/elixir_generator/renderer.ex
@@ -59,7 +59,7 @@ defmodule Dagger.Codegen.ElixirGenerator.Renderer do
   def render_doc(%{description: ""}), do: ""
 
   def render_doc(%{description: description}) do
-    ["@doc", ~c" ", render_string(Formatter.format_doc(description))]
+    ["@doc", ~c" ", render_string(description)]
     |> IO.iodata_to_binary()
   end
 

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -1047,7 +1047,7 @@ defmodule Dagger.Container do
   @doc """
   Retrieves this container with an unset working directory.
 
-  Should default to \"/\".
+  Should default to "/".
   """
   @spec without_workdir(t()) :: Dagger.Container.t()
   def without_workdir(%__MODULE__{} = container) do


### PR DESCRIPTION
Follow-up conversation in
https://github.com/dagger/dagger/pull/6559#discussion_r1539733323. The function in backquote should convert to snake case only deprecation message.

Fixes #6939