### PR TITLE
Fix miss makezero bug

### DIFF
--- a/telemetry/servers.go
+++ b/telemetry/servers.go
@@ -213,13 +213,13 @@ func logValue(v *otlpcommonv1.AnyValue) log.Value {
 	case *otlpcommonv1.AnyValue_BoolValue:
 		return log.BoolValue(v.GetBoolValue())
 	case *otlpcommonv1.AnyValue_KvlistValue:
-		kvs := make([]log.KeyValue, len(x.KvlistValue.GetValues()))
+		kvs := make([]log.KeyValue, 0, len(x.KvlistValue.GetValues()))
 		for _, kv := range x.KvlistValue.GetValues() {
 			kvs = append(kvs, logKeyValue(kv))
 		}
 		return log.MapValue(kvs...)
 	case *otlpcommonv1.AnyValue_ArrayValue:
-		vals := make([]log.Value, len(x.ArrayValue.GetValues()))
+		vals := make([]log.Value, 0, len(x.ArrayValue.GetValues()))
 		for _, v := range x.ArrayValue.GetValues() {
 			vals = append(vals, logValue(v))
 		}


### PR DESCRIPTION
when I want to add feature for linter  [`makezero`](https://github.com/ashanbrown/makezero) in PR https://github.com/ashanbrown/makezero/pull/15 , I run a github action for real world repos,  and github action report this bug.

I not going to add this `makezero` to your `golangci.yaml` , but I suggest to set to `enable-all: true` and add some `disable` linters.
