### PR TITLE
ci: avoid panic in sdk building

### DIFF
--- a/ci/build/builder.go
+++ b/ci/build/builder.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containerd/containerd/platforms"
 	"github.com/dagger/dagger/engine/distconsts"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/dagger/dagger/ci/consts"
 	"github.com/dagger/dagger/ci/internal/dagger"
@@ -110,6 +111,22 @@ func (build *Builder) CLI(ctx context.Context) (*dagger.File, error) {
 }
 
 func (build *Builder) Engine(ctx context.Context) (*dagger.Container, error) {
+	eg, ctx := errgroup.WithContext(ctx)
+
+	sdks := []sdkContentF{build.goSDKContent, build.pythonSDKContent, build.typescriptSDKContent}
+	sdkContents := make([]*sdkContent, len(sdks))
+	for i, sdk := range sdks {
+		i, sdk := i, sdk
+		eg.Go(func() error {
+			content, err := sdk(ctx)
+			if err != nil {
+				return err
+			}
+			sdkContents[i] = content
+			return nil
+		})
+	}
+
 	var base *dagger.Container
 	switch build.base {
 	case "alpine", "":
@@ -156,9 +173,6 @@ func (build *Builder) Engine(ctx context.Context) (*dagger.Container, error) {
 		WithFile("/opt/cni/bin/dnsname", build.dnsnameBinary()).
 		WithFile("/usr/local/bin/runc", build.runcBin(), dagger.ContainerWithFileOpts{Permissions: 0o700}).
 		WithDirectory("/usr/local/bin", build.qemuBins()).
-		With(build.goSDKContent(ctx)).
-		With(build.pythonSDKContent(ctx)).
-		With(build.typescriptSDKContent(ctx)).
 		WithDirectory("/", build.cniPlugins()).
 		WithDirectory(distconsts.EngineDefaultStateDir, dag.Directory())
 
@@ -172,6 +186,13 @@ func (build *Builder) Engine(ctx context.Context) (*dagger.Container, error) {
 		ctr = ctr.With(util.ShellCmd(`curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg`))
 		ctr = ctr.With(util.ShellCmd(`curl -s -L https://nvidia.github.io/libnvidia-container/experimental/"$(. /etc/os-release;echo $ID$VERSION_ID)"/libnvidia-container.list | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | tee /etc/apt/sources.list.d/nvidia-container-toolkit.list`))
 		ctr = ctr.With(util.ShellCmd(`apt-get update && apt-get install -y nvidia-container-toolkit`))
+	}
+
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+	for _, content := range sdkContents {
+		ctr = ctr.With(content.apply)
 	}
 
 	return ctr, nil

--- a/ci/build/sdk.go
+++ b/ci/build/sdk.go
@@ -12,114 +12,53 @@ import (
 	"github.com/dagger/dagger/ci/internal/dagger"
 )
 
-func (build *Builder) pythonSDKContent(ctx context.Context) dagger.WithContainerFunc {
-	return func(ctr *dagger.Container) *dagger.Container {
-		rootfs := dag.Directory().WithDirectory("/", build.source.Directory("sdk/python"), dagger.DirectoryWithDirectoryOpts{
-			Include: []string{
-				"pyproject.toml",
-				"src/**/*.py",
-				"src/**/*.typed",
-				"codegen/src/**/*.py",
-				"codegen/pyproject.toml",
-				"codegen/requirements.lock",
-				"runtime/",
-				"LICENSE",
-				"README.md",
-			},
+type sdkContent struct {
+	index   ocispecs.Index
+	sdkDir  *dagger.Directory
+	envName string
+}
+
+func (content *sdkContent) apply(ctr *dagger.Container) *dagger.Container {
+	manifest := content.index.Manifests[0]
+	manifestDgst := manifest.Digest.String()
+
+	return ctr.
+		WithEnvVariable(content.envName, manifestDgst).
+		WithDirectory(distconsts.EngineContainerBuiltinContentDir, content.sdkDir, dagger.ContainerWithDirectoryOpts{
+			Include: []string{"blobs/"},
+		})
+}
+
+type sdkContentF func(ctx context.Context) (*sdkContent, error)
+
+func (build *Builder) pythonSDKContent(ctx context.Context) (*sdkContent, error) {
+	rootfs := dag.Directory().WithDirectory("/", build.source.Directory("sdk/python"), dagger.DirectoryWithDirectoryOpts{
+		Include: []string{
+			"pyproject.toml",
+			"src/**/*.py",
+			"src/**/*.typed",
+			"codegen/src/**/*.py",
+			"codegen/pyproject.toml",
+			"codegen/requirements.lock",
+			"runtime/",
+			"LICENSE",
+			"README.md",
+		},
+	})
+
+	sdkCtrTarball := dag.Container().
+		WithRootfs(rootfs).
+		AsTarball(dagger.ContainerAsTarballOpts{
+			ForcedCompression: dagger.Uncompressed,
 		})
 
-		sdkCtrTarball := dag.Container().
-			WithRootfs(rootfs).
-			AsTarball(dagger.ContainerAsTarballOpts{
-				ForcedCompression: dagger.Uncompressed,
-			})
+	sdkDir := dag.Container().
+		From(consts.AlpineImage).
+		WithMountedDirectory("/out", dag.Directory()).
+		WithMountedFile("/sdk.tar", sdkCtrTarball).
+		WithExec([]string{"tar", "xf", "/sdk.tar", "-C", "/out"}).
+		Directory("/out")
 
-		sdkDir := dag.Container().
-			From(consts.AlpineImage).
-			WithMountedDirectory("/out", dag.Directory()).
-			WithMountedFile("/sdk.tar", sdkCtrTarball).
-			WithExec([]string{"tar", "xf", "/sdk.tar", "-C", "/out"}).
-			Directory("/out")
-
-		content, err := sdkContent(ctx, ctr, sdkDir, distconsts.PythonSDKManifestDigestEnvName)
-		if err != nil {
-			// FIXME: would be nice to not panic
-			panic(err)
-		}
-		return content
-	}
-}
-
-func (build *Builder) typescriptSDKContent(ctx context.Context) dagger.WithContainerFunc {
-	return func(ctr *dagger.Container) *dagger.Container {
-		rootfs := dag.Directory().WithDirectory("/", build.source.Directory("sdk/typescript"), dagger.DirectoryWithDirectoryOpts{
-			Include: []string{
-				"**/*.ts",
-				"LICENSE",
-				"README.md",
-				"runtime",
-				"package.json",
-				"dagger.json",
-			},
-			Exclude: []string{
-				"node_modules",
-				"dist",
-				"**/test",
-				"**/*.spec.ts",
-				"dev",
-			},
-		})
-		sdkCtrTarball := dag.Container().
-			WithRootfs(rootfs).
-			WithFile("/codegen", build.CodegenBinary()).
-			AsTarball(dagger.ContainerAsTarballOpts{
-				ForcedCompression: dagger.Uncompressed,
-			})
-
-		sdkDir := dag.Container().From("alpine:"+consts.AlpineVersion).
-			WithMountedDirectory("/out", dag.Directory()).
-			WithMountedFile("/sdk.tar", sdkCtrTarball).
-			WithExec([]string{"tar", "xf", "/sdk.tar", "-C", "/out"}).
-			Directory("/out")
-
-		content, err := sdkContent(ctx, ctr, sdkDir, distconsts.TypescriptSDKManifestDigestEnvName)
-		if err != nil {
-			// FIXME: would be nice to not panic
-			panic(err)
-		}
-		return content
-	}
-}
-
-func (build *Builder) goSDKContent(ctx context.Context) dagger.WithContainerFunc {
-	return func(ctr *dagger.Container) *dagger.Container {
-		base := dag.Container(dagger.ContainerOpts{Platform: build.platform}).
-			From(fmt.Sprintf("golang:%s-alpine%s", consts.GolangVersion, consts.AlpineVersion))
-
-		sdkCtrTarball := base.
-			WithEnvVariable("GOTOOLCHAIN", "auto").
-			WithFile("/usr/local/bin/codegen", build.CodegenBinary()).
-			WithEntrypoint([]string{"/usr/local/bin/codegen"}).
-			AsTarball(dagger.ContainerAsTarballOpts{
-				ForcedCompression: dagger.Uncompressed,
-			})
-
-		sdkDir := base.
-			WithMountedDirectory("/out", dag.Directory()).
-			WithMountedFile("/sdk.tar", sdkCtrTarball).
-			WithExec([]string{"tar", "xf", "/sdk.tar", "-C", "/out"}).
-			Directory("/out")
-
-		content, err := sdkContent(ctx, ctr, sdkDir, distconsts.GoSDKManifestDigestEnvName)
-		if err != nil {
-			// FIXME: would be nice to not panic
-			panic(err)
-		}
-		return content
-	}
-}
-
-func sdkContent(ctx context.Context, ctr *dagger.Container, sdkDir *dagger.Directory, envName string) (*dagger.Container, error) {
 	var index ocispecs.Index
 	indexContents, err := sdkDir.File("index.json").Contents(ctx)
 	if err != nil {
@@ -128,12 +67,91 @@ func sdkContent(ctx context.Context, ctr *dagger.Container, sdkDir *dagger.Direc
 	if err := json.Unmarshal([]byte(indexContents), &index); err != nil {
 		return nil, err
 	}
-	manifest := index.Manifests[0]
-	manifestDgst := manifest.Digest.String()
 
-	return ctr.
-		WithEnvVariable(envName, manifestDgst).
-		WithDirectory(distconsts.EngineContainerBuiltinContentDir, sdkDir, dagger.ContainerWithDirectoryOpts{
-			Include: []string{"blobs/"},
-		}), nil
+	return &sdkContent{
+		index:   index,
+		sdkDir:  sdkDir,
+		envName: distconsts.PythonSDKManifestDigestEnvName,
+	}, nil
+}
+
+func (build *Builder) typescriptSDKContent(ctx context.Context) (*sdkContent, error) {
+	rootfs := dag.Directory().WithDirectory("/", build.source.Directory("sdk/typescript"), dagger.DirectoryWithDirectoryOpts{
+		Include: []string{
+			"**/*.ts",
+			"LICENSE",
+			"README.md",
+			"runtime",
+			"package.json",
+			"dagger.json",
+		},
+		Exclude: []string{
+			"node_modules",
+			"dist",
+			"**/test",
+			"**/*.spec.ts",
+			"dev",
+		},
+	})
+	sdkCtrTarball := dag.Container().
+		WithRootfs(rootfs).
+		WithFile("/codegen", build.CodegenBinary()).
+		AsTarball(dagger.ContainerAsTarballOpts{
+			ForcedCompression: dagger.Uncompressed,
+		})
+
+	sdkDir := dag.Container().From("alpine:"+consts.AlpineVersion).
+		WithMountedDirectory("/out", dag.Directory()).
+		WithMountedFile("/sdk.tar", sdkCtrTarball).
+		WithExec([]string{"tar", "xf", "/sdk.tar", "-C", "/out"}).
+		Directory("/out")
+
+	var index ocispecs.Index
+	indexContents, err := sdkDir.File("index.json").Contents(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal([]byte(indexContents), &index); err != nil {
+		return nil, err
+	}
+
+	return &sdkContent{
+		index:   index,
+		sdkDir:  sdkDir,
+		envName: distconsts.TypescriptSDKManifestDigestEnvName,
+	}, nil
+}
+
+func (build *Builder) goSDKContent(ctx context.Context) (*sdkContent, error) {
+	base := dag.Container(dagger.ContainerOpts{Platform: build.platform}).
+		From(fmt.Sprintf("golang:%s-alpine%s", consts.GolangVersion, consts.AlpineVersion))
+
+	sdkCtrTarball := base.
+		WithEnvVariable("GOTOOLCHAIN", "auto").
+		WithFile("/usr/local/bin/codegen", build.CodegenBinary()).
+		WithEntrypoint([]string{"/usr/local/bin/codegen"}).
+		AsTarball(dagger.ContainerAsTarballOpts{
+			ForcedCompression: dagger.Uncompressed,
+		})
+
+	sdkDir := base.
+		WithMountedDirectory("/out", dag.Directory()).
+		WithMountedFile("/sdk.tar", sdkCtrTarball).
+		WithExec([]string{"tar", "xf", "/sdk.tar", "-C", "/out"}).
+		Directory("/out")
+
+	var index ocispecs.Index
+	indexContents, err := sdkDir.File("index.json").Contents(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal([]byte(indexContents), &index); err != nil {
+		return nil, err
+	}
+
+	return &sdkContent{
+		index:   index,
+		sdkDir:  sdkDir,
+		envName: distconsts.GoSDKManifestDigestEnvName,
+	}, nil
 }


### PR DESCRIPTION
Using functions that can error in `Container.With` is a bad idea. So, what we can do is to put the actual computation into an error group (which has the convenient little side-effect that they all get computed in parallel, hopefully improving build times).

This lets us remove the panic, which was crashing the binary. Because of (I think) telemetry draining, this meant that the client job hung forever on this kind of failure.

cc @helderco I know we discussed previously :tada: