### PR TITLE
ci: add max timeout of 1 hour for hack/make workflows

### DIFF
--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -12,6 +12,13 @@ on:
         type: boolean
         default: false
         required: false
+      timeout:
+        description: "How many minutes to timeout after"
+        type: number
+        required: false
+        # none of our jobs should take longer than a hour to run (and if they do,
+        # should require *explicit* config)
+        default: 60  
       size:
         type: string
         default: "dagger-runner-2c-8g"
@@ -49,9 +56,11 @@ jobs:
             chmod +x $_EXPERIMENTAL_DAGGER_CLI_BIN
           fi
           ./hack/make engine:connect
+        timeout-minutes: ${{ inputs.timeout }}
       - name: ${{ inputs.mage-targets }}
         run: |
           ./hack/make ${{ inputs.mage-targets }}
+        timeout-minutes: ${{ inputs.timeout }}
 
   # Use our own Dagger runner when running in the dagger/dagger repo (including PRs)
   dagger-runner:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,3 +23,4 @@ jobs:
     secrets: inherit
     with:
       mage-targets: docs:lint
+      timeout: 10

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -24,3 +24,4 @@ jobs:
     secrets: inherit
     with:
       mage-targets: helm:test
+      timeout: 10

--- a/.github/workflows/sdk-elixir.yml
+++ b/.github/workflows/sdk-elixir.yml
@@ -22,9 +22,11 @@ jobs:
     secrets: inherit
     with:
       mage-targets: sdk:elixir:lint
+      timeout: 10
 
   test:
     uses: ./.github/workflows/_hack_make.yml
     secrets: inherit
     with:
       mage-targets: sdk:elixir:test
+      timeout: 10

--- a/.github/workflows/sdk-go.yml
+++ b/.github/workflows/sdk-go.yml
@@ -22,9 +22,11 @@ jobs:
     secrets: inherit
     with:
       mage-targets: sdk:go:lint
+      timeout: 10
 
   test:
     uses: ./.github/workflows/_hack_make.yml
     secrets: inherit
     with:
       mage-targets: sdk:go:test
+      timeout: 10

--- a/.github/workflows/sdk-java.yml
+++ b/.github/workflows/sdk-java.yml
@@ -22,9 +22,11 @@ jobs:
     secrets: inherit
     with:
       mage-targets: sdk:java:lint
+      timeout: 10
 
   test:
     uses: ./.github/workflows/_hack_make.yml
     secrets: inherit
     with:
       mage-targets: sdk:java:test
+      timeout: 10

--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -22,9 +22,11 @@ jobs:
     secrets: inherit
     with:
       mage-targets: sdk:python:lint
+      timeout: 10
 
   test:
     uses: ./.github/workflows/_hack_make.yml
     secrets: inherit
     with:
       mage-targets: sdk:python:test
+      timeout: 10

--- a/.github/workflows/sdk-rust.yml
+++ b/.github/workflows/sdk-rust.yml
@@ -23,6 +23,7 @@ jobs:
     with:
       mage-targets: sdk:rust:lint
       size: dagger-runner-16c-64g
+      timeout: 10
 
   test:
     uses: ./.github/workflows/_hack_make.yml
@@ -30,3 +31,4 @@ jobs:
     with:
       mage-targets: sdk:rust:test
       size: dagger-runner-16c-64g
+      timeout: 10

--- a/.github/workflows/sdk-typescript.yml
+++ b/.github/workflows/sdk-typescript.yml
@@ -22,9 +22,11 @@ jobs:
     secrets: inherit
     with:
       mage-targets: sdk:typescript:lint
+      timeout: 10
 
   test:
     uses: ./.github/workflows/_hack_make.yml
     secrets: inherit
     with:
       mage-targets: sdk:typescript:test
+      timeout: 10


### PR DESCRIPTION
The default is 360 minutes (6 hours) - at this point, something has *definitely* gone wrong for us, so we should explicitly fail.

Also, for jobs that are known to be short, we can cap at 10 minutes: specifically SDK linting + testing jobs.

This would have prevented long run-away jobs like we discovered with the failed typescript linting intersecting with a crash (causing a client hang):
- https://github.com/dagger/dagger/pull/7153
- https://github.com/dagger/dagger/pull/7154