### PR TITLE
docs: Uses version/arch placeholder in Argo Workflow snippet

### DIFF
--- a/docs/current_docs/integrations/snippets/argo-workflow.yaml
+++ b/docs/current_docs/integrations/snippets/argo-workflow.yaml
@@ -26,7 +26,7 @@ spec:
             mode: 0755
             http:
               # replace with the latest available version of Dagger for your platform
-              url: https://github.com/dagger/dagger/releases/download/vX.Y.Z/dagger_vX.Y.Z_PLATFORM_ARCH.tar.gz
+              url: https://github.com/dagger/dagger/releases/download/vX.Y.Z/dagger_vX.Y.Z_OS_ARCH.tar.gz
       container:
         image: alpine:latest
         command: ["sh", "-c"]

--- a/docs/current_docs/integrations/snippets/argo-workflow.yaml
+++ b/docs/current_docs/integrations/snippets/argo-workflow.yaml
@@ -18,13 +18,15 @@ spec:
           - name: project-source
             path: /work
             git:
+              # replace with your repository URL
               repo: YOUR_REPOSITORY_URL_HERE
               revision: "main"
           - name: dagger-cli
             path: /usr/local/bin
             mode: 0755
             http:
-              url: https://github.com/dagger/dagger/releases/download/v0.10.2/dagger_v0.10.2_linux_arm64.tar.gz
+              # replace with the latest available version of Dagger for your platform
+              url: https://github.com/dagger/dagger/releases/download/vX.Y.Z/dagger_vX.Y.Z_PLATFORM_ARCH.tar.gz
       container:
         image: alpine:latest
         command: ["sh", "-c"]


### PR DESCRIPTION
This commit removes the hardcoded version in the snippet in favour of a placeholder. There were already other placeholders in the snippet, so this should not cause a major disruption. More information in https://discord.com/channels/707636530424053791/1231554152815919114/1231554152815919114