### PR TITLE
ci: stick to fluent builder pattern.

### DIFF
--- a/ci/build/builder.go
+++ b/ci/build/builder.go
@@ -96,13 +96,13 @@ func (build *Builder) WithUbuntuBase() *Builder {
 
 func (build *Builder) WithAlpineBase() *Builder {
 	b := *build
-	build.base = "alpine"
+	b.base = "alpine"
 	return &b
 }
 
 func (build *Builder) WithGPUSupport() *Builder {
 	b := *build
-	build.gpuSupport = true
+	b.gpuSupport = true
 	return &b
 }
 


### PR DESCRIPTION
Fixes a couple of instances where the base object is changed instead of the copy.