### PR TITLE
feat: expand env variable by default

### DIFF
--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -441,14 +441,17 @@ type Container {
 
   """Retrieves this container plus the given environment variable."""
   withEnvVariable(
-    """
-    Replace `${VAR}` or `$VAR` in the value according to the current environment
-    variables defined in the container (e.g., "/opt/bin:$PATH").
-    """
+    """DEPRECATED: The environment variable will be expand by default."""
     expand: Boolean = false
 
     """The name of the environment variable (e.g., "HOST")."""
     name: String!
+
+    """
+    Do not replace `${VAR}` or `$VAR` in the value according to the current
+    environment variables defined in the container (e.g., "/opt/bin:$PATH").
+    """
+    noExpand: Boolean = false
 
     """The value of the environment variable. (e.g., "localhost")."""
     value: String!

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -547,8 +547,10 @@ defmodule Dagger.Container do
   end
 
   @doc "Retrieves this container plus the given environment variable."
-  @spec with_env_variable(t(), String.t(), String.t(), [{:expand, boolean() | nil}]) ::
-          Dagger.Container.t()
+  @spec with_env_variable(t(), String.t(), String.t(), [
+          {:expand, boolean() | nil},
+          {:no_expand, boolean() | nil}
+        ]) :: Dagger.Container.t()
   def with_env_variable(%__MODULE__{} = container, name, value, optional_args \\ []) do
     selection =
       container.selection
@@ -556,6 +558,7 @@ defmodule Dagger.Container do
       |> put_arg("name", name)
       |> put_arg("value", value)
       |> maybe_put_arg("expand", optional_args[:expand])
+      |> maybe_put_arg("noExpand", optional_args[:no_expand])
 
     %Dagger.Container{
       selection: selection,

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -1064,8 +1064,10 @@ func (r *Container) WithEntrypoint(args []string, opts ...ContainerWithEntrypoin
 
 // ContainerWithEnvVariableOpts contains options for Container.WithEnvVariable
 type ContainerWithEnvVariableOpts struct {
-	// Replace `${VAR}` or `$VAR` in the value according to the current environment variables defined in the container (e.g., "/opt/bin:$PATH").
+	// DEPRECATED: The environment variable will be expand by default.
 	Expand bool
+	// Do not replace `${VAR}` or `$VAR` in the value according to the current environment variables defined in the container (e.g., "/opt/bin:$PATH").
+	NoExpand bool
 }
 
 // Retrieves this container plus the given environment variable.
@@ -1075,6 +1077,10 @@ func (r *Container) WithEnvVariable(name string, value string, opts ...Container
 		// `expand` optional argument
 		if !querybuilder.IsZeroValue(opts[i].Expand) {
 			q = q.Arg("expand", opts[i].Expand)
+		}
+		// `noExpand` optional argument
+		if !querybuilder.IsZeroValue(opts[i].NoExpand) {
+			q = q.Arg("noExpand", opts[i].NoExpand)
 		}
 	}
 	q = q.Arg("name", name)

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -468,13 +468,21 @@ class Container extends Client\AbstractObject implements Client\IdAble
     /**
      * Retrieves this container plus the given environment variable.
      */
-    public function withEnvVariable(string $name, string $value, ?bool $expand = false): Container
+    public function withEnvVariable(
+        string $name,
+        string $value,
+        ?bool $expand = false,
+        ?bool $noExpand = false,
+    ): Container
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withEnvVariable');
         $innerQueryBuilder->setArgument('name', $name);
         $innerQueryBuilder->setArgument('value', $value);
         if (null !== $expand) {
         $innerQueryBuilder->setArgument('expand', $expand);
+        }
+        if (null !== $noExpand) {
+        $innerQueryBuilder->setArgument('noExpand', $noExpand);
         }
         return new \Dagger\Container($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -1203,6 +1203,7 @@ class Container(Type):
         value: str,
         *,
         expand: bool | None = False,
+        no_expand: bool | None = False,
     ) -> Self:
         """Retrieves this container plus the given environment variable.
 
@@ -1213,14 +1214,17 @@ class Container(Type):
         value:
             The value of the environment variable. (e.g., "localhost").
         expand:
-            Replace `${VAR}` or `$VAR` in the value according to the current
-            environment variables defined in the container (e.g.,
+            DEPRECATED: The environment variable will be expand by default.
+        no_expand:
+            Do not replace `${VAR}` or `$VAR` in the value according to the
+            current environment variables defined in the container (e.g.,
             "/opt/bin:$PATH").
         """
         _args = [
             Arg("name", name),
             Arg("value", value),
             Arg("expand", expand, False),
+            Arg("noExpand", no_expand, False),
         ]
         _ctx = self._select("withEnvVariable", _args)
         return Container(_ctx)

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -1346,9 +1346,12 @@ pub struct ContainerWithEntrypointOpts {
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithEnvVariableOpts {
-    /// Replace `${VAR}` or `$VAR` in the value according to the current environment variables defined in the container (e.g., "/opt/bin:$PATH").
+    /// DEPRECATED: The environment variable will be expand by default.
     #[builder(setter(into, strip_option), default)]
     pub expand: Option<bool>,
+    /// Do not replace `${VAR}` or `$VAR` in the value according to the current environment variables defined in the container (e.g., "/opt/bin:$PATH").
+    #[builder(setter(into, strip_option), default)]
+    pub no_expand: Option<bool>,
 }
 #[derive(Builder, Debug, PartialEq)]
 pub struct ContainerWithExecOpts<'a> {
@@ -2201,6 +2204,9 @@ impl Container {
         query = query.arg("value", value.into());
         if let Some(expand) = opts.expand {
             query = query.arg("expand", expand);
+        }
+        if let Some(no_expand) = opts.no_expand {
+            query = query.arg("noExpand", no_expand);
         }
         Container {
             proc: self.proc.clone(),

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -260,9 +260,14 @@ export type ContainerWithEntrypointOpts = {
 
 export type ContainerWithEnvVariableOpts = {
   /**
-   * Replace `${VAR}` or `$VAR` in the value according to the current environment variables defined in the container (e.g., "/opt/bin:$PATH").
+   * DEPRECATED: The environment variable will be expand by default.
    */
   expand?: boolean
+
+  /**
+   * Do not replace `${VAR}` or `$VAR` in the value according to the current environment variables defined in the container (e.g., "/opt/bin:$PATH").
+   */
+  noExpand?: boolean
 }
 
 export type ContainerWithExecOpts = {
@@ -1978,7 +1983,8 @@ export class Container extends BaseClient {
    * Retrieves this container plus the given environment variable.
    * @param name The name of the environment variable (e.g., "HOST").
    * @param value The value of the environment variable. (e.g., "localhost").
-   * @param opts.expand Replace `${VAR}` or `$VAR` in the value according to the current environment variables defined in the container (e.g., "/opt/bin:$PATH").
+   * @param opts.expand DEPRECATED: The environment variable will be expand by default.
+   * @param opts.noExpand Do not replace `${VAR}` or `$VAR` in the value according to the current environment variables defined in the container (e.g., "/opt/bin:$PATH").
    */
   withEnvVariable = (
     name: string,


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/7171

The `withEnvVariable` API will expand shell env variable by default. And
add `noExpand` option to do not expand when it's set to `true`. The
`expand` option is now deprecated but still compatible with the previous
version.