### PR TITLE
cli: fix `--help` for `dagger functions`

### DIFF
--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -16,7 +16,7 @@ var outputPath string
 var jsonOutput bool
 
 var callCmd = &FuncCommand{
-	Name:  "call [flags] [FUNCTION]...",
+	Name:  "call [options] [FUNCTION]...",
 	Short: "Call a module function",
 	Long: strings.ReplaceAll(`Call a module function and print the result.
 

--- a/cmd/dagger/config.go
+++ b/cmd/dagger/config.go
@@ -359,7 +359,7 @@ func (c configSubcmd) Command() *cobra.Command {
 	if c.SetCmd != nil {
 		setCmd := &cobra.Command{
 			// TODO: make these specific based on the parent
-			Use:     "set [options] <pattern>",
+			Use:     "set [options] <pattern>...",
 			Short:   "Set the configuration value",
 			Long:    "Set the configuration value",
 			Example: c.SetExample,
@@ -378,7 +378,7 @@ func (c configSubcmd) Command() *cobra.Command {
 	if c.AddCmd != nil {
 		addCmd := &cobra.Command{
 			// TODO: make these specific based on the parent
-			Use:     "add [options]",
+			Use:     "add [options] <pattern>...",
 			Short:   "Add a value to the configuration",
 			Long:    "Add a value to the configuration",
 			Example: c.AddExample,
@@ -397,7 +397,7 @@ func (c configSubcmd) Command() *cobra.Command {
 	if c.RemoveCmd != nil {
 		removeCmd := &cobra.Command{
 			// TODO: make these specific based on the parent
-			Use:     "remove [options]",
+			Use:     "remove [options] <pattern>...",
 			Short:   "Remove a value from the configuration",
 			Long:    "Remove a value from the configuration",
 			Example: c.RemoveExample,

--- a/cmd/dagger/config.go
+++ b/cmd/dagger/config.go
@@ -28,7 +28,7 @@ func init() {
 }
 
 var configCmd = &cobra.Command{
-	Use:   "config",
+	Use:   "config [options]",
 	Short: "Get or set the configuration of a Dagger module",
 	Long:  "Get or set the configuration of a Dagger module. By default, print the configuration of the specified module.",
 	Example: strings.TrimSpace(`
@@ -82,7 +82,7 @@ dagger config -m github.com/dagger/hello-dagger
 }
 
 var configViewsCmd = configSubcmd{
-	Use:   "views [name]",
+	Use:   "views [options] [name]",
 	Short: "Get or set the views of a Dagger module",
 	Long:  "Get or set the views of a Dagger module. By default, print the views of the specified module.",
 	PersistentFlags: func(fs *pflag.FlagSet) {
@@ -359,7 +359,7 @@ func (c configSubcmd) Command() *cobra.Command {
 	if c.SetCmd != nil {
 		setCmd := &cobra.Command{
 			// TODO: make these specific based on the parent
-			Use:     "set",
+			Use:     "set [options] <pattern>",
 			Short:   "Set the configuration value",
 			Long:    "Set the configuration value",
 			Example: c.SetExample,
@@ -378,7 +378,7 @@ func (c configSubcmd) Command() *cobra.Command {
 	if c.AddCmd != nil {
 		addCmd := &cobra.Command{
 			// TODO: make these specific based on the parent
-			Use:     "add",
+			Use:     "add [options]",
 			Short:   "Add a value to the configuration",
 			Long:    "Add a value to the configuration",
 			Example: c.AddExample,
@@ -397,7 +397,7 @@ func (c configSubcmd) Command() *cobra.Command {
 	if c.RemoveCmd != nil {
 		removeCmd := &cobra.Command{
 			// TODO: make these specific based on the parent
-			Use:     "remove",
+			Use:     "remove [options]",
 			Short:   "Remove a value from the configuration",
 			Long:    "Remove a value from the configuration",
 			Example: c.RemoveExample,

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -54,6 +54,13 @@ available functions.
 		"`",
 	),
 	Execute: func(fc *FuncCommand, cmd *cobra.Command) error {
+		// Manually check for --help in the arguments
+		for _, arg := range cmd.Flags().Args() {
+			if arg == "--help" || arg == "-h" {
+				return cmd.Help()
+			}
+		}
+
 		tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 3, ' ', tabwriter.DiscardEmptyColumns)
 		var o functionProvider = fc.mod.GetMainObject()
 		fmt.Fprintf(tw, "%s\t%s\n",

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -43,7 +43,7 @@ var funcCmds = FuncCommands{
 }
 
 var funcListCmd = &FuncCommand{
-	Name:  "functions [flags] [FUNCTION]...",
+	Name:  "functions [options] [FUNCTION]...",
 	Short: `List available functions`,
 	Long: strings.ReplaceAll(`List available functions in a module.
 
@@ -441,10 +441,11 @@ func (fc *FuncCommand) addSubCommands(cmd *cobra.Command, dag *dagger.Client, fn
 
 func (fc *FuncCommand) makeSubCmd(dag *dagger.Client, fn *modFunction) *cobra.Command {
 	newCmd := &cobra.Command{
-		Use:     cliName(fn.Name),
-		Short:   strings.SplitN(fn.Description, "\n", 2)[0],
-		Long:    fn.Description,
-		GroupID: funcGroup.ID,
+		Use:                   cliName(fn.Name) + " [options]",
+		Short:                 strings.SplitN(fn.Description, "\n", 2)[0],
+		Long:                  fn.Description,
+		GroupID:               funcGroup.ID,
+		DisableFlagsInUseLine: true,
 		PreRunE: func(cmd *cobra.Command, args []string) (err error) {
 			if err := fc.addArgsForFunction(cmd, args, fn, dag); err != nil {
 				return err

--- a/cmd/dagger/gen.go
+++ b/cmd/dagger/gen.go
@@ -19,7 +19,7 @@ func newGenCmd() *cobra.Command {
 	)
 
 	var cmd = &cobra.Command{
-		Use:    "gen FILE",
+		Use:    "gen [options] FILE",
 		Short:  "Generate CLI reference documentation",
 		Long:   "Generate CLI reference documentation in the given file path.",
 		Args:   cobra.NoArgs,

--- a/cmd/dagger/listen.go
+++ b/cmd/dagger/listen.go
@@ -23,7 +23,7 @@ var (
 )
 
 var listenCmd = &cobra.Command{
-	Use:     "listen",
+	Use:     "listen [options]",
 	Aliases: []string{"l"},
 	RunE:    optionalModCmdWrapper(Listen, os.Getenv("DAGGER_SESSION_TOKEN")),
 	Hidden:  true,

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -94,6 +94,8 @@ func init() {
 	// we'll add it in the last line of the usage template
 	rootCmd.PersistentFlags().BoolP("help", "h", false, "Print usage")
 	rootCmd.PersistentFlags().Lookup("help").Hidden = true
+
+	disableFlagsInUseLine(rootCmd)
 }
 
 var rootCmd = &cobra.Command{
@@ -169,6 +171,15 @@ func installGlobalFlags(flags *pflag.FlagSet) {
 			fmt.Println("Error hiding flag: "+fl, err)
 			os.Exit(1)
 		}
+	}
+}
+
+// disableFlagsInUseLine disables the automatic addition of [flags]
+// when calling UseLine.
+func disableFlagsInUseLine(cmd *cobra.Command) {
+	for _, c := range cmd.Commands() {
+		c.DisableFlagsInUseLine = true
+		disableFlagsInUseLine(c)
 	}
 }
 
@@ -340,7 +351,7 @@ const usageTemplate = `{{ "Usage" | toUpperBold }}
   {{.UseLine}}
 {{- end}}
 {{- if .HasAvailableSubCommands}}
-  {{ .CommandPath}}{{ if .HasAvailableFlags}} [flags]{{end}} [command]
+  {{ .CommandPath}}{{ if .HasAvailableFlags}} [options]{{end}} [command]
 {{- end}}
 
 {{- if gt (len .Aliases) 0}}
@@ -399,14 +410,14 @@ const usageTemplate = `{{ "Usage" | toUpperBold }}
 
 {{- if .HasAvailableLocalFlags}}
 
-{{ "Flags" | toUpperBold }}
+{{ "Options" | toUpperBold }}
 {{ flagUsagesWrapped .LocalFlags | trimTrailingWhitespaces}}
 
 {{- end}}
 
 {{- if .HasAvailableInheritedFlags}}
 
-{{ "Global Flags" | toUpperBold }}
+{{ "Inherited Options" | toUpperBold }}
 {{ flagUsagesWrapped .InheritedFlags | trimTrailingWhitespaces}}
 
 {{- end}}

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -78,7 +78,7 @@ func init() {
 }
 
 var moduleInitCmd = &cobra.Command{
-	Use:   "init [flags] [PATH]",
+	Use:   "init [options] [PATH]",
 	Short: "Initialize a new Dagger module",
 	Long: `Initialize a new Dagger module in a local directory.
 By default, create a new dagger.json configuration in the current working directory. If the positional argument PATH is provided, create the module in that directory instead.
@@ -173,7 +173,7 @@ The "--source" flag allows controlling the directory in which the actual module 
 }
 
 var moduleInstallCmd = &cobra.Command{
-	Use:     "install [flags] MODULE",
+	Use:     "install [options] MODULE",
 	Aliases: []string{"use"},
 	Short:   "Add a new dependency to a Dagger module",
 	Long:    "Add a Dagger module as a dependency of a local module.",
@@ -289,7 +289,7 @@ var moduleInstallCmd = &cobra.Command{
 }
 
 var moduleDevelopCmd = &cobra.Command{
-	Use:   "develop",
+	Use:   "develop [options]",
 	Short: "Setup or update all the resources needed to develop on a module locally",
 	Long: `Setup or update all the resources needed to develop on a module locally.
 
@@ -383,7 +383,7 @@ If not updating source or SDK, this is only required for IDE auto-completion/LSP
 const daDaggerverse = "https://daggerverse.dev"
 
 var modulePublishCmd = &cobra.Command{
-	Use:    "publish",
+	Use:    "publish [options]",
 	Hidden: true, // Hide while we finalize publishing workflow
 	Short:  "Publish a Dagger module to the Daggerverse",
 	Long: fmt.Sprintf(`Publish a local module to the Daggerverse (%s).

--- a/cmd/dagger/query.go
+++ b/cmd/dagger/query.go
@@ -22,7 +22,7 @@ var (
 )
 
 var queryCmd = &cobra.Command{
-	Use:     "query [flags] [OPERATION]",
+	Use:     "query [options] [OPERATION]",
 	Aliases: []string{"q"},
 	Short:   "Send API queries to a dagger engine",
 	Long: `Send API queries to a dagger engine.

--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -20,7 +20,7 @@ import (
 )
 
 var runCmd = &cobra.Command{
-	Use:     "run [flags] COMMAND",
+	Use:     "run [options] COMMAND",
 	Aliases: []string{"r"},
 	Short:   "Run a command in a Dagger session",
 	Long: strings.ReplaceAll(

--- a/cmd/dagger/session.go
+++ b/cmd/dagger/session.go
@@ -23,7 +23,7 @@ var sessionLabels = telemetry.NewLabelFlag()
 
 func sessionCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "session",
+		Use:          "session [options]",
 		Long:         "WARNING: this is an internal-only command used by Dagger SDKs to communicate with the Dagger Engine. It is not intended to be used by humans directly.",
 		Hidden:       true,
 		RunE:         EngineSession,

--- a/cmd/dagger/version.go
+++ b/cmd/dagger/version.go
@@ -10,7 +10,7 @@ import (
 )
 
 var versionCmd = &cobra.Command{
-	Use:   "version",
+	Use:   "version [options]",
 	Short: "Print dagger version",
 	// Disable version hook here to avoid double version check
 	PersistentPreRun:  func(*cobra.Command, []string) {},

--- a/cmd/dagger/version.go
+++ b/cmd/dagger/version.go
@@ -10,7 +10,7 @@ import (
 )
 
 var versionCmd = &cobra.Command{
-	Use:   "version [options]",
+	Use:   "version",
 	Short: "Print dagger version",
 	// Disable version hook here to avoid double version check
 	PersistentPreRun:  func(*cobra.Command, []string) {},

--- a/cmd/dagger/watch.go
+++ b/cmd/dagger/watch.go
@@ -10,7 +10,7 @@ import (
 )
 
 var watchCmd = &cobra.Command{
-	Use:    "watch [options] COMMAND",
+	Use:    "watch",
 	Hidden: true,
 	Annotations: map[string]string{
 		"experimental": "true",

--- a/cmd/dagger/watch.go
+++ b/cmd/dagger/watch.go
@@ -10,7 +10,7 @@ import (
 )
 
 var watchCmd = &cobra.Command{
-	Use:    "watch [flags] COMMAND",
+	Use:    "watch [options] COMMAND",
 	Hidden: true,
 	Annotations: map[string]string{
 		"experimental": "true",

--- a/docs/current_docs/reference/979596-cli.mdx
+++ b/docs/current_docs/reference/979596-cli.mdx
@@ -446,7 +446,7 @@ dagger run python main.py
 Print dagger version
 
 ```
-dagger version [options]
+dagger version
 ```
 
 ### Options inherited from parent commands

--- a/docs/current_docs/reference/979596-cli.mdx
+++ b/docs/current_docs/reference/979596-cli.mdx
@@ -49,7 +49,7 @@ by appending it to the end of the command (for example, `stdout`, `entries`, or
 
 
 ```
-dagger call [flags] [FUNCTION]...
+dagger call [options] [FUNCTION]...
 ```
 
 ### Examples
@@ -90,7 +90,7 @@ Get or set the configuration of a Dagger module
 Get or set the configuration of a Dagger module. By default, print the configuration of the specified module.
 
 ```
-dagger config [flags]
+dagger config [options]
 ```
 
 ### Examples
@@ -141,7 +141,7 @@ If not updating source or SDK, this is only required for IDE auto-completion/LSP
 
 
 ```
-dagger develop [flags]
+dagger develop [options]
 ```
 
 ### Options
@@ -178,7 +178,7 @@ available functions.
 
 
 ```
-dagger functions [flags] [FUNCTION]...
+dagger functions [options] [FUNCTION]...
 ```
 
 ### Options
@@ -219,7 +219,7 @@ The "--source" flag allows controlling the directory in which the actual module 
 
 
 ```
-dagger init [flags] [PATH]
+dagger init [options] [PATH]
 ```
 
 ### Examples
@@ -259,7 +259,7 @@ Add a new dependency to a Dagger module
 Add a Dagger module as a dependency of a local module.
 
 ```
-dagger install [flags] MODULE
+dagger install [options] MODULE
 ```
 
 ### Examples
@@ -293,7 +293,7 @@ dagger install github.com/shykes/daggerverse/ttlsh@16e40ec244966e55e36a13cb6e1ff
 Log in to Dagger Cloud
 
 ```
-dagger login [flags]
+dagger login
 ```
 
 ### Options inherited from parent commands
@@ -314,7 +314,7 @@ dagger login [flags]
 Log out from Dagger Cloud
 
 ```
-dagger logout [flags]
+dagger logout
 ```
 
 ### Options inherited from parent commands
@@ -345,7 +345,7 @@ queries in the document.
 
 
 ```
-dagger query [flags] [OPERATION]
+dagger query [options] [OPERATION]
 ```
 
 ### Examples
@@ -410,7 +410,7 @@ jq -n '{query:"{container{id}}"}' | \
 ```
 
 ```
-dagger run [flags] COMMAND
+dagger run [options] COMMAND
 ```
 
 ### Examples
@@ -446,7 +446,7 @@ dagger run python main.py
 Print dagger version
 
 ```
-dagger version [flags]
+dagger version [options]
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
 `dagger functions func1 --help` is currently breaking, as `--help` is interpreted / manually parsed as a function and not as a flag
 
 This was discussed here: https://github.com/dagger/dagger/issues/6943#issuecomment-2067514623. 
Branched from https://github.com/dagger/dagger/pull/7170. To be rebased once merged

#### Before
```shell
dagger -m github.com/levlaz/daggerverse/mariadb@v0.2.1 functions base --help
✔ initialize 2.1s

Error: no function '--help' in object type 'Container'
```

#### After
```shell
./dagger -m github.com/levlaz/daggerverse/mariadb@v0.2.1 functions base --help
List available functions in a module.

This is similar to `dagger call --help`, but only focused on showing the
available functions.

USAGE
  dagger functions [options] [FUNCTION]...

OPTIONS
  -m, --mod string   Path to dagger.json config file for the module or a directory
                     containing that file. Either local path (e.g.
                     "/path/to/some/dir") or a github repo (e.g.
                     "github.com/dagger/dagger/path/to/some/subdir")

INHERITED OPTIONS
  -d, --debug             show debug logs and full verbosity
      --progress string   progress output format (auto, plain, tty) (default "auto")
  -s, --silent            disable terminal UI and progress output
  -v, --verbose count     increase verbosity (use -vv or -vvv for more)
```