### PR TITLE
feat: propagate DAGGER_ENGINE_* environ variables on engine to pipelines

### DIFF
--- a/.changes/unreleased/Added-20240426-170021.yaml
+++ b/.changes/unreleased/Added-20240426-170021.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: 'engine: propagate DAGGER_ENGINE_* env variables to pipelines'
+time: 2024-04-26T17:00:21.476822377+08:00
+custom:
+  Author: haoqixu
+  PR: "7186"


### PR DESCRIPTION
This PR updates the shim to propagate `DAGGER_ENGINE_*` environ on the engine to pipeline containers. Part of #6599