### PR TITLE
ci: Add Wolfi base

### DIFF
--- a/ci/build/builder.go
+++ b/ci/build/builder.go
@@ -203,21 +203,23 @@ func (build *Builder) Engine(ctx context.Context) (*dagger.Container, error) {
 		WithDirectory(distconsts.EngineDefaultStateDir, dag.Directory())
 
 	if build.gpuSupport {
-		if build.base != "ubuntu" && build.base != "wolfi" {
-			return nil, fmt.Errorf("gpu support requires %q base, not %q", "ubuntu or wolfi", build.base)
-		}
-		if build.platformSpec.Architecture != "amd64" {
+		switch build.platformSpec.Architecture {
+		case "amd64":
+		default:
 			return nil, fmt.Errorf("gpu support requires %q arch, not %q", "amd64", build.platformSpec.Architecture)
 		}
 
-		if build.base == "ubuntu" {
+		switch build.base {
+		case "ubuntu":
 			ctr = ctr.With(util.ShellCmd(`curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg`))
 			ctr = ctr.With(util.ShellCmd(`curl -s -L https://nvidia.github.io/libnvidia-container/experimental/"$(. /etc/os-release;echo $ID$VERSION_ID)"/libnvidia-container.list | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | tee /etc/apt/sources.list.d/nvidia-container-toolkit.list`))
 			ctr = ctr.With(util.ShellCmd(`apt-get update && apt-get install -y nvidia-container-toolkit`))
-		} else if build.base == "wolfi" {
+		case "wolfi":
 			ctr = ctr.With(util.ShellCmd(`apk add chainguard-keys`))
 			ctr = ctr.With(util.ShellCmd(`echo "https://packages.cgr.dev/extras" >> /etc/apk/repositories`))
 			ctr = ctr.With(util.ShellCmd(`apk update && apk add nvidia-driver nvidia-tools`))
+		default:
+			return nil, fmt.Errorf("gpu support requires %q base, not %q", "ubuntu or wolfi", build.base)
 		}
 	}
 

--- a/ci/build/builder.go
+++ b/ci/build/builder.go
@@ -207,7 +207,7 @@ func (build *Builder) Engine(ctx context.Context) (*dagger.Container, error) {
 			return nil, fmt.Errorf("gpu support requires %q base, not %q", "ubuntu or wolfi", build.base)
 		}
 		if build.platformSpec.Architecture != "amd64" {
-			return nil, fmt.Errorf("gpu support requires %q arch, not %q", "ubuntu", build.platformSpec.Architecture)
+			return nil, fmt.Errorf("gpu support requires %q arch, not %q", "amd64", build.platformSpec.Architecture)
 		}
 
 		if build.base == "ubuntu" {

--- a/ci/build/builder.go
+++ b/ci/build/builder.go
@@ -329,7 +329,7 @@ func (build *Builder) cniPlugins() *dagger.Directory {
 			WithExec([]string{"apt-get", "update"}).
 			WithExec([]string{"apt-get", "install", "-y", "git", "build-essential"})
 	case "wolfi":
-		ctr = ctr.From("cgr.dev/chainguard/wolfi-base:latest").
+		ctr = ctr.From(fmt.Sprintf("%s:%s", consts.WolfiImage, consts.WolfiVersion)).
 			WithExec([]string{"apk", "add", "build-base", "go", "git"})
 	}
 

--- a/ci/build/builder.go
+++ b/ci/build/builder.go
@@ -215,7 +215,7 @@ func (build *Builder) Engine(ctx context.Context) (*dagger.Container, error) {
 			ctr = ctr.With(util.ShellCmd(`curl -s -L https://nvidia.github.io/libnvidia-container/experimental/"$(. /etc/os-release;echo $ID$VERSION_ID)"/libnvidia-container.list | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | tee /etc/apt/sources.list.d/nvidia-container-toolkit.list`))
 			ctr = ctr.With(util.ShellCmd(`apt-get update && apt-get install -y nvidia-container-toolkit`))
 		} else if build.base == "wolfi" {
-			ctr = ctr.With(util.ShellCmd(`apk add wget && wget -q -O /etc/apk/keys/chainguard-extras.rsa.pub > https://packages.cgr.dev/extras/chainguard-extras.rsa.pub`))
+			ctr = ctr.With(util.ShellCmd(`apk add chainguard-keys`))
 			ctr = ctr.With(util.ShellCmd(`echo "https://packages.cgr.dev/extras" >> /etc/apk/repositories`))
 			ctr = ctr.With(util.ShellCmd(`apk update && apk add nvidia-driver nvidia-tools`))
 		}

--- a/ci/build/builder.go
+++ b/ci/build/builder.go
@@ -100,6 +100,12 @@ func (build *Builder) WithAlpineBase() *Builder {
 	return &b
 }
 
+func (build *Builder) WithWolfiBase() *Builder {
+	b := *build
+	b.base = "wolfi"
+	return &b
+}
+
 func (build *Builder) WithGPUSupport() *Builder {
 	b := *build
 	b.gpuSupport = true
@@ -161,6 +167,26 @@ func (build *Builder) Engine(ctx context.Context) (*dagger.Container, error) {
 				"gpg", "curl",
 			}).
 			WithoutEnvVariable("DAGGER_APT_CACHE_BUSTER")
+	case "wolfi":
+		base = dag.
+			Container(dagger.ContainerOpts{Platform: build.platform}).
+			From(consts.WolfiImage).
+			// NOTE: wrapping the apk installs with this time based env ensures that the cache is invalidated
+			// once-per day. This is a very unfortunate workaround for the poor caching "apk add" as an exec
+			// gives us.
+			// Fortunately, better approaches are on the horizon w/ Zenith, for which there are already apk
+			// modules that fix this problem and always result in the latest apk packages for the given alpine
+			// version being used (with optimal caching).
+			WithEnvVariable("DAGGER_APK_CACHE_BUSTER", fmt.Sprintf("%d", time.Now().Truncate(24*time.Hour).Unix())).
+			WithExec([]string{"apk", "upgrade"}).
+			WithExec([]string{
+				"apk", "add", "--no-cache",
+				// for Buildkit
+				"git", "openssh", "pigz", "xz",
+				// for CNI
+				"iptables", "ip6tables", "dnsmasq",
+			}).
+			WithoutEnvVariable("DAGGER_APK_CACHE_BUSTER")
 	default:
 		return nil, fmt.Errorf("unsupported engine base %q", build.base)
 	}
@@ -177,15 +203,22 @@ func (build *Builder) Engine(ctx context.Context) (*dagger.Container, error) {
 		WithDirectory(distconsts.EngineDefaultStateDir, dag.Directory())
 
 	if build.gpuSupport {
-		if build.base != "ubuntu" {
-			return nil, fmt.Errorf("gpu support requires %q base, not %q", "ubuntu", build.base)
+		if build.base != "ubuntu" && build.base != "wolfi" {
+			return nil, fmt.Errorf("gpu support requires %q base, not %q", "ubuntu or wolfi", build.base)
 		}
 		if build.platformSpec.Architecture != "amd64" {
 			return nil, fmt.Errorf("gpu support requires %q arch, not %q", "ubuntu", build.platformSpec.Architecture)
 		}
-		ctr = ctr.With(util.ShellCmd(`curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg`))
-		ctr = ctr.With(util.ShellCmd(`curl -s -L https://nvidia.github.io/libnvidia-container/experimental/"$(. /etc/os-release;echo $ID$VERSION_ID)"/libnvidia-container.list | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | tee /etc/apt/sources.list.d/nvidia-container-toolkit.list`))
-		ctr = ctr.With(util.ShellCmd(`apt-get update && apt-get install -y nvidia-container-toolkit`))
+
+		if build.base == "ubuntu" {
+			ctr = ctr.With(util.ShellCmd(`curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg`))
+			ctr = ctr.With(util.ShellCmd(`curl -s -L https://nvidia.github.io/libnvidia-container/experimental/"$(. /etc/os-release;echo $ID$VERSION_ID)"/libnvidia-container.list | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | tee /etc/apt/sources.list.d/nvidia-container-toolkit.list`))
+			ctr = ctr.With(util.ShellCmd(`apt-get update && apt-get install -y nvidia-container-toolkit`))
+		} else if build.base == "wolfi" {
+			ctr = ctr.With(util.ShellCmd(`apk add wget && wget -q -O /etc/apk/keys/chainguard-extras.rsa.pub > https://packages.cgr.dev/extras/chainguard-extras.rsa.pub`))
+			ctr = ctr.With(util.ShellCmd(`echo "https://packages.cgr.dev/extras" >> /etc/apk/repositories`))
+			ctr = ctr.With(util.ShellCmd(`apk update && apk add nvidia-driver nvidia-tools`))
+		}
 	}
 
 	if err := eg.Wait(); err != nil {
@@ -295,6 +328,9 @@ func (build *Builder) cniPlugins() *dagger.Directory {
 		ctr = ctr.From(fmt.Sprintf("golang:%s-bullseye", consts.GolangVersion)).
 			WithExec([]string{"apt-get", "update"}).
 			WithExec([]string{"apt-get", "install", "-y", "git", "build-essential"})
+	case "wolfi":
+		ctr = ctr.From("cgr.dev/chainguard/wolfi-base:latest").
+			WithExec([]string{"apk", "add", "build-base", "go", "git"})
 	}
 
 	ctr = ctr.WithMountedCache("/root/go/pkg/mod", dag.CacheVolume("go-mod")).

--- a/ci/consts/versions.go
+++ b/ci/consts/versions.go
@@ -20,6 +20,7 @@ const (
 	AlpineVersion = "3.18"
 	AlpineImage   = "alpine:" + AlpineVersion
 	WolfiImage    = "cgr.dev/chainguard/wolfi-base"
+	WolfiVersion  = "latest" // Wolfi is a rolling distro; no release to pin to
 
 	GolangLintImage = "golangci/golangci-lint:" + GolangLintVersion + "-alpine"
 

--- a/ci/consts/versions.go
+++ b/ci/consts/versions.go
@@ -19,6 +19,7 @@ const (
 
 	AlpineVersion = "3.18"
 	AlpineImage   = "alpine:" + AlpineVersion
+	WolfiImage    = "cgr.dev/chainguard/wolfi-base"
 
 	GolangLintImage = "golangci/golangci-lint:" + GolangLintVersion + "-alpine"
 

--- a/ci/engine.go
+++ b/ci/engine.go
@@ -25,7 +25,8 @@ type Engine struct {
 
 	Trace bool // +private
 
-	GPUSupport bool // +private
+	GPUSupport bool   // +private
+	ImageBase  string // +private
 }
 
 func (e *Engine) WithConfig(key, value string) *Engine {
@@ -45,6 +46,11 @@ func (e *Engine) WithGPUSupport() *Engine {
 
 func (e *Engine) WithTrace() *Engine {
 	e.Trace = true
+	return e
+}
+
+func (e *Engine) WithBase(image string) *Engine {
+	e.ImageBase = image
 	return e
 }
 
@@ -72,8 +78,22 @@ func (e *Engine) Container(
 	if platform != "" {
 		builder = builder.WithPlatform(platform)
 	}
+
+	if e.ImageBase != "" {
+		switch e.ImageBase {
+		case "wolfi":
+			builder = builder.WithWolfiBase()
+		case "alpine":
+			builder = builder.WithAlpineBase()
+		case "ubuntu":
+			builder = builder.WithUbuntuBase()
+		default:
+			return nil, fmt.Errorf("unknown image type %s", e.ImageBase)
+		}
+	}
+
 	if e.GPUSupport {
-		builder = builder.WithUbuntuBase().WithGPUSupport()
+		builder = builder.WithGPUSupport()
 	}
 
 	ctr, err := builder.Engine(ctx)

--- a/ci/engine.go
+++ b/ci/engine.go
@@ -39,18 +39,23 @@ func (e *Engine) WithArg(key, value string) *Engine {
 	return e
 }
 
-func (e *Engine) WithGPUSupport() *Engine {
-	e.GPUSupport = true
-	return e
-}
-
 func (e *Engine) WithTrace() *Engine {
 	e.Trace = true
 	return e
 }
 
-func (e *Engine) WithBase(image string) *Engine {
-	e.ImageBase = image
+func (e *Engine) WithBase(
+	// +optional
+	image *string,
+	// +optional
+	gpuSupport *bool,
+) *Engine {
+	if image != nil {
+		e.ImageBase = *image
+	}
+	if gpuSupport != nil {
+		e.GPUSupport = *gpuSupport
+	}
 	return e
 }
 
@@ -88,7 +93,7 @@ func (e *Engine) Container(
 		case "ubuntu":
 			builder = builder.WithUbuntuBase()
 		default:
-			return nil, fmt.Errorf("unknown image type %s", e.ImageBase)
+			return nil, fmt.Errorf("unknown base image type %s", e.ImageBase)
 		}
 	}
 

--- a/ci/mage/engine.go
+++ b/ci/mage/engine.go
@@ -70,7 +70,7 @@ func (t Engine) Publish(ctx context.Context, version string) error {
 		return err
 	}
 
-	args = []string{"--version=" + version, "engine", "with-gpusupport", "publish"}
+	args = []string{"--version=" + version, "engine", "with-base", "--image=ubuntu", "--gpu-support=true", "publish"}
 	args = append(args, commonArgs...)
 	for _, p := range publishedGPUEnginePlatforms {
 		args = append(args, "--platform="+p)
@@ -99,7 +99,7 @@ func (t Engine) TestPublish(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	err = util.DaggerCall(ctx, "engine", "with-gpusupport", "test-publish")
+	err = util.DaggerCall(ctx, "engine", "with-base", "--image=ubuntu", "--gpu-support=true", "test-publish")
 	if err != nil {
 		return err
 	}
@@ -138,7 +138,7 @@ func (t Engine) Dev(ctx context.Context) error {
 
 	args := []string{"engine"}
 	if gpuSupport {
-		args = append(args, "with-gpusupport")
+		args = append(args, "with-base", "--image=ubuntu", "--gpu-support=true")
 	}
 	if trace {
 		args = append(args, "with-trace")

--- a/ci/main.go
+++ b/ci/main.go
@@ -99,7 +99,8 @@ func (ci *Dagger) Dev(
 
 	engine := ci.Engine()
 	if experimentalGPUSupport {
-		engine = engine.WithGPUSupport()
+		img := "ubuntu"
+		engine = engine.WithBase(&img, &experimentalGPUSupport)
 	}
 	svc, err := engine.Service(ctx, "dev")
 	if err != nil {


### PR DESCRIPTION
This PR adds the option of running the engine on top of the Wolfi base image.

There are some advantages to using Wolfi here:
 - similarly small size to the Alpine image
 - support for glibc
 - support for GPU tools

This PR is really a work-in-progress, but I wanted to get some feedback. To test, I manually [set the base image in the struct](https://github.com/dagger/dagger/blob/main/ci/build/builder.go#L71), ran `hack/dev` then verified the engine container was running on-top of Wolfi.

Missing pieces:
 - plumbing through setting the base image to allow user to choose wolfi/debian/alpine
 - running tests (the suite is a bit overwhelming and I get failures with main)

Let me know if what I've done so far makes sense. 

It would be great to get some help with the remaining tasks, while they're not hard, I would like some guidance/help on how they should be done.

