### PR TITLE
CI: Try running Engine & CLI workflow in larger GitHub runners

### DIFF
--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -21,7 +21,7 @@ on:
         default: 60  
       size:
         type: string
-        default: "dagger-runner-2c-8g"
+        default: "ubuntu-latest"
         required: false
       dagger-version:
         type: string
@@ -62,8 +62,8 @@ jobs:
           ./hack/make ${{ inputs.mage-targets }}
         timeout-minutes: ${{ inputs.timeout }}
 
-  # Use our own Dagger runner when running in the dagger/dagger repo (including PRs)
-  dagger-runner:
+  # Allow larger GitHub Runners when running in the dagger/dagger repo (including PRs)
+  github-larger-runner:
     if: ${{ github.repository == 'dagger/dagger' }}
     runs-on: ${{ inputs.size }}
     concurrency:
@@ -89,11 +89,9 @@ jobs:
             echo "_EXPERIMENTAL_DAGGER_CLI_BIN=${_EXPERIMENTAL_DAGGER_CLI_BIN}" >> "$GITHUB_ENV"
 
             export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev
+            echo "_EXPERIMENTAL_DAGGER_RUNNER_HOST=${_EXPERIMENTAL_DAGGER_RUNNER_HOST}" >> "$GITHUB_ENV"
           fi
 
-          echo "_EXPERIMENTAL_DAGGER_RUNNER_HOST=${_EXPERIMENTAL_DAGGER_RUNNER_HOST}" >> "$GITHUB_ENV"
-        env:
-          _EXPERIMENTAL_DAGGER_RUNNER_HOST: "unix:///var/run/buildkit/buildkitd.sock"
       - name: Waiting for Dagger Engine to be ready...
         run: |
           ./hack/make engine:connect

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -26,7 +26,7 @@ jobs:
     secrets: inherit
     with:
       mage-targets: engine:testrace
-      size: dagger-runner-16c-64g
+      size: ubuntu-22.04-16c-64g-600gb
 
   # Run Engine tests in dev Engine so that we can spot integration failures early
   # Only run a subset of important test cases since we just need to verify basic
@@ -36,7 +36,7 @@ jobs:
     secrets: inherit
     with:
       mage-targets: engine:testimportant
-      size: dagger-runner-docker-fix
+      size: ubuntu-22.04-16c-64g-600gb
       dev-engine: true
 
   test-publish-cli:
@@ -57,4 +57,3 @@ jobs:
     secrets: inherit
     with:
       mage-targets: engine:scan
-

--- a/.github/workflows/sdk-rust.yml
+++ b/.github/workflows/sdk-rust.yml
@@ -22,7 +22,6 @@ jobs:
     secrets: inherit
     with:
       mage-targets: sdk:rust:lint
-      size: dagger-runner-16c-64g
       timeout: 10
 
   test:
@@ -30,5 +29,4 @@ jobs:
     secrets: inherit
     with:
       mage-targets: sdk:rust:test
-      size: dagger-runner-16c-64g
       timeout: 10


### PR DESCRIPTION
Is this an intermediary step that we can take towards migrating to new CI runners? Related to:
- https://github.com/dagger/dagger/pull/7082

If the Engine & CLI workflows passes, I would be tempted to merge this before the other PR. The focus is to migrate off the legacy CI as soon as possible.

Trade-offs:
- If we keep the current `DAGGER_CLOUD_TOKEN`, we will not be able to use the Cloud Cache in PRs coming from forks
- If we add the `DAGGER_CLOUD_TOKEN` secret, this will not be available to PRs coming from forks, meaning that we will not have Dagger Cloud Traces in those PRs
