### PR TITLE
ci: pin macos version to 12

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,7 +99,7 @@ jobs:
       always() &&
       github.repository == 'dagger/dagger' &&
       (needs.publish.result == 'success' || needs.publish.result == 'skipped')
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - name: "Set CLI Test URL"
         run: |


### PR DESCRIPTION
An automatic upgrade here seems to have caused an issue where colima was not available.