### PR TITLE
fix: remove automatic go optional primitives

### DIFF
--- a/cmd/codegen/generator/go/templates/module_types.go
+++ b/cmd/codegen/generator/go/templates/module_types.go
@@ -141,9 +141,6 @@ func (spec *parsedPrimitiveType) TypeDefCode() (*Statement, error) {
 	def := Qual("dag", "TypeDef").Call().Dot("WithKind").Call(
 		kind,
 	)
-	if spec.isPtr {
-		def = def.Dot("WithOptional").Call(Lit(true))
-	}
 	return def, nil
 }
 


### PR DESCRIPTION
Previously, we would mark a parameter as optional in two cases:
- With a `// +optional` pragma comment,
- Any pointer to a primitive (string, integer, boolean)

This second one is a leftover from when optionals in the Go SDK was purely indicated using pointer-iness. When working on this before, I think I must have missed this one, or I would have tried to remove it then :D