### PR TITLE
fix gitlab before_script

### DIFF
--- a/docs/current_docs/integrations/snippets/gitlab.yml
+++ b/docs/current_docs/integrations/snippets/gitlab.yml
@@ -17,7 +17,7 @@
   extends: [.docker]
   before_script:
     - apk add curl
-    - curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin sh
+    - curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=/usr/local sh
 build:
   extends: [.dagger]
   script:

--- a/docs/current_docs/integrations/snippets/gitlab.yml
+++ b/docs/current_docs/integrations/snippets/gitlab.yml
@@ -17,7 +17,7 @@
   extends: [.docker]
   before_script:
     - apk add curl
-    - curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=/usr/local sh
+    - curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=/usr/local/bin sh
 build:
   extends: [.dagger]
   script:


### PR DESCRIPTION
Fixes gitlab beore script by installing the Dagger CLI in a location that's availabe in the $PATH