### PR TITLE
ci: mark CVE-2024-3154 as a false scan positive

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,5 @@
+vulnerabilities:
+  # https://github.com/advisories/GHSA-c5pj-mqfh-rvc3
+  # This issue is not fixed in a version of runc we can feasibly upgrade to. We
+  # simply do not use CRI-O for starting runc, so this is a false positive.
+  - id: CVE-2024-3154


### PR DESCRIPTION
This feels insane, I'm not quite sure what is going on here. There appear to be 2 separate vulnerability advisories, one in runc and one in cri-o (which doesn't seem to be available yet).

However, this issue definitely doesn't affect us - we don't use cri-o anywhere in our stack, we're not spawning pods in the dagger engine, etc.

There's also not a version of runc we can feasibly upgrade to - 1.2.0-rc1 (as suggested in https://github.com/advisories/GHSA-c5pj-mqfh-rvc3), is a minor release, and is also an RC, so we shouldn't depend on it.

We should keep an eye on what the status of these vulnerabilities are, since disclosure still seems ongoing, but we can at least stop CI going red on these.