### PR TITLE
chore: keep pointer receiver consistent in generated go code

### DIFF
--- a/cmd/codegen/generator/go/templates/module_objects.go
+++ b/cmd/codegen/generator/go/templates/module_objects.go
@@ -374,7 +374,7 @@ func (spec *parsedObjectType) marshalJSONMethodCode() (*Statement, error) {
 		getFieldCodes = append(getFieldCodes, getFieldCode)
 	}
 
-	return Func().Params(Id("r").Id(spec.name)).
+	return Func().Params(Id("r").Op("*").Id(spec.name)).
 		Id("MarshalJSON").
 		Params().
 		Params(Id("[]byte"), Id("error")).


### PR DESCRIPTION
Some linters don't like this, which is a small issue, but it's super easy to fix :D