### PR TITLE
ci: use nested dagger for testdev

### DIFF
--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -42,25 +42,14 @@ jobs:
       - name: Install dagger
         run: |
           curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ inputs.dagger-version }} BIN_DIR=/usr/local/bin/ sudo -E sh
-      - name: Waiting for Dagger Engine to be ready...
-        run: |
-          if [ "${{ inputs.dev-engine }}" == "true" ]
-          then
-            ./hack/dev
-
-            export _EXPERIMENTAL_DAGGER_CLI_BIN="$PWD/bin/dagger"
-            echo "_EXPERIMENTAL_DAGGER_CLI_BIN=${_EXPERIMENTAL_DAGGER_CLI_BIN}" >> "$GITHUB_ENV"
-            export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev
-            echo "_EXPERIMENTAL_DAGGER_RUNNER_HOST=${_EXPERIMENTAL_DAGGER_RUNNER_HOST}" >> "$GITHUB_ENV"
-
-            chmod +x $_EXPERIMENTAL_DAGGER_CLI_BIN
-          fi
-          ./hack/make engine:connect
-        timeout-minutes: ${{ inputs.timeout }}
       - name: ${{ inputs.mage-targets }}
-        run: |
-          ./hack/make ${{ inputs.mage-targets }}
         timeout-minutes: ${{ inputs.timeout }}
+        run: |
+          if [ "${{ inputs.dev-engine }}" == "true" ]; then
+            dagger call --source=. dev --target=. with-exec --args "sh,-c,./hack/make ${{ inputs.mage-targets }}"
+          else
+            ./hack/make ${{ inputs.mage-targets }}
+          fi
 
   # Use our own Dagger runner when running in the dagger/dagger repo (including PRs)
   dagger-runner:
@@ -78,29 +67,14 @@ jobs:
       - name: Install dagger
         run: |
           curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${{ inputs.dagger-version }} BIN_DIR=/usr/local/bin/ sudo -E sh
-      - name: Starting Dagger Engine
-        run: |
-          if [ "${{ inputs.dev-engine }}" == "true" ]
-          then
-            ./hack/dev
-
-            export _EXPERIMENTAL_DAGGER_CLI_BIN="$PWD/bin/dagger"
-            chmod +x $_EXPERIMENTAL_DAGGER_CLI_BIN
-            echo "_EXPERIMENTAL_DAGGER_CLI_BIN=${_EXPERIMENTAL_DAGGER_CLI_BIN}" >> "$GITHUB_ENV"
-
-            export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev
-          fi
-
-          echo "_EXPERIMENTAL_DAGGER_RUNNER_HOST=${_EXPERIMENTAL_DAGGER_RUNNER_HOST}" >> "$GITHUB_ENV"
+      - name: ${{ inputs.mage-targets }}
+        timeout-minutes: ${{ inputs.timeout }}
         env:
           _EXPERIMENTAL_DAGGER_RUNNER_HOST: "unix:///var/run/buildkit/buildkitd.sock"
-      - name: Waiting for Dagger Engine to be ready...
-        run: |
-          ./hack/make engine:connect
-        env:
           DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
-      - name: ${{ inputs.mage-targets }}
         run: |
-          ./hack/make ${{ inputs.mage-targets }}
-        env:
-          DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
+          if [ "${{ inputs.dev-engine }}" == "true" ]; then
+            dagger call --source=. dev --target=. with-exec --args "sh,-c,./hack/make ${{ inputs.mage-targets }}"
+          else
+            ./hack/make ${{ inputs.mage-targets }}
+          fi

--- a/.github/workflows/_hack_make.yml
+++ b/.github/workflows/_hack_make.yml
@@ -25,7 +25,7 @@ on:
         required: false
       dagger-version:
         type: string
-        default: "0.11.0"
+        default: "0.11.1"
         required: false
 
 jobs:

--- a/ci/engine.go
+++ b/ci/engine.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/containerd/containerd/platforms"
 	"github.com/dagger/dagger/engine/distconsts"
-	"github.com/moby/buildkit/identity"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/dagger/dagger/ci/build"
@@ -98,7 +97,6 @@ func (e *Engine) Service(
 	} else {
 		cacheVolumeName = "dagger-dev-engine-state"
 	}
-	cacheVolumeName += identity.NewID()
 
 	e = e.
 		WithConfig("grpc", `address=["unix:///var/run/buildkit/buildkitd.sock", "tcp://0.0.0.0:1234"]`).

--- a/ci/engine.go
+++ b/ci/engine.go
@@ -101,7 +101,7 @@ func (e *Engine) Service(
 	e = e.
 		WithConfig("grpc", `address=["unix:///var/run/buildkit/buildkitd.sock", "tcp://0.0.0.0:1234"]`).
 		WithArg(`network-name`, `dagger-dev`).
-		WithArg(`network-cidr`, `10.88.0.0/16`)
+		WithArg(`network-cidr`, `10.89.0.0/16`)
 	devEngine, err := e.Container(ctx, "")
 	if err != nil {
 		return nil, err

--- a/ci/main.go
+++ b/ci/main.go
@@ -120,6 +120,7 @@ func (ci *Dagger) Dev(
 	}
 
 	return util.GoBase(ci.Source).
+		WithExec([]string{"apk", "add", "bash"}).
 		WithMountedDirectory("/mnt", target).
 		WithMountedFile("/usr/bin/dagger", client).
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_CLI_BIN", "/usr/bin/dagger").

--- a/ci/sdk.go
+++ b/ci/sdk.go
@@ -5,29 +5,30 @@ import (
 
 	"github.com/dagger/dagger/ci/build"
 	"github.com/dagger/dagger/ci/consts"
+	"github.com/moby/buildkit/identity"
 )
 
 // A dev environment for the official Dagger SDKs
 type SDK struct {
 	// Develop the Dagger Go SDK
-	Go         *GoSDK
+	Go *GoSDK
 	// Develop the Dagger Python SDK
-	Python     *PythonSDK
+	Python *PythonSDK
 	// Develop the Dagger Typescript SDK
 	Typescript *TypescriptSDK
 
 	// Develop the Dagger Elixir SDK (experimental)
 	Elixir *ElixirSDK
 	// Develop the Dagger Rust SDK (experimental)
-	Rust   *RustSDK
+	Rust *RustSDK
 	// Develop the Dagger Java SDK (experimental)
-	Java   *JavaSDK
+	Java *JavaSDK
 	// Develop the Dagger PHP SDK (experimental)
-	PHP    *PHPSDK
+	PHP *PHPSDK
 }
 
 func (ci *Dagger) installer(ctx context.Context, name string) (func(*Container) *Container, error) {
-	engineSvc, err := ci.Engine().Service(ctx, name)
+	engineSvc, err := ci.Engine().Service(ctx, name+"-"+identity.NewID())
 	if err != nil {
 		return nil, err
 	}

--- a/ci/test.go
+++ b/ci/test.go
@@ -133,7 +133,7 @@ func (t *Test) testCmd(ctx context.Context) (*Container, error) {
 		WithServiceBinding("registry", registrySvc).
 		WithServiceBinding("privateregistry", privateRegistry()).
 		WithExposedPort(1234, ContainerWithExposedPortOpts{Protocol: Tcp}).
-		WithMountedCache(distconsts.EngineDefaultStateDir, dag.CacheVolume("dagger-dev-engine-test-state"+identity.NewID())).
+		WithMountedCache(distconsts.EngineDefaultStateDir, dag.CacheVolume("dagger-dev-engine-test-state-"+identity.NewID())).
 		WithExec(nil, ContainerWithExecOpts{
 			InsecureRootCapabilities: true,
 		}).


### PR DESCRIPTION
Specifically! This doesn't spin up a docker container with a dev version of dagger, it spins up a dagger service with a dev version of dagger - dagger in dagger!

This simplifies deployment to the new CI runners (since docker is no longer needed).

---

At some point, it would be nice to have the `./hack/dev` script use this as well - however, I'm not 100% sure how this would work with other core devs' workflows. Personally, I periodically run `./hack/dev` to build and restart the docker engine, and use `./hack/with-dev` to run commands in that context. This doesn't work *as* well with this setup, where it's more difficult to observe the logs in a running service, etc.

So maybe we need to keep `./hack/dev` at least for now - we can discuss and maybe do this in the future though.