### PR TITLE
chore: remove .trivyignore.yaml

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,5 +1,0 @@
-vulnerabilities:
-  # https://github.com/advisories/GHSA-c5pj-mqfh-rvc3
-  # This issue is not fixed in a version of runc we can feasibly upgrade to. We
-  # simply do not use CRI-O for starting runc, so this is a false positive.
-  - id: CVE-2024-3154


### PR DESCRIPTION
Follow-up to https://github.com/dagger/dagger/pull/7215.

It looks like https://github.com/advisories/GHSA-c5pj-mqfh-rvc3 has now been withdrawn - trivy seems to have picked up on this now, so we can remove this file now :tada: