### PR TITLE
avoid panic when masked parent is missing

### DIFF
--- a/dagql/idtui/types.go
+++ b/dagql/idtui/types.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/dagger/dagger/engine/slog"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -49,7 +50,17 @@ func CollectSpans(db *DB, traceID trace.TraceID) []*Span {
 			continue
 		}
 		if span.Mask && span.Parent().IsValid() {
-			db.Spans[span.Parent().SpanID()].Passthrough = true
+			masked := db.Spans[span.Parent().SpanID()]
+			if masked != nil {
+				masked.Passthrough = true
+			} else {
+				// FIXME(vito): still investigating why this happens, but in
+				// the mean time, better not to panic
+				slog.Warn("masked parent span not found; possible data loss?",
+					"traceID", traceID,
+					"spanID", span.SpanContext().SpanID(),
+					"parentID", span.Parent().SpanID())
+			}
 		}
 		spans = append(spans, span)
 	}


### PR DESCRIPTION
Still not sure why this happens, but I'll be on PTO soon, so best to apply a band-aid for now.

So far I've only seen this happen when there's total loss of data from the `dagger-engine` otel service, indicating something went very wrong with the engine pub/sub, since that's >~90% of the data.

A log will help for now.