### PR TITLE
docs: don't use command line plaintext injection

### DIFF
--- a/docs/current_docs/manuals/developer/go/snippets/secrets/main.go
+++ b/docs/current_docs/manuals/developer/go/snippets/secrets/main.go
@@ -8,13 +8,10 @@ import (
 type MyModule struct{}
 
 func (m *MyModule) GithubApi(ctx context.Context, endpoint string, token *Secret) (string, error) {
-	plaintext, err := token.Plaintext(ctx)
-	if err != nil {
-		return "", err
-	}
 	return dag.Container().
 		From("alpine:3.17").
 		WithExec([]string{"apk", "add", "curl"}).
-		WithExec([]string{"sh", "-c", fmt.Sprintf("curl \"%s\" --header \"Accept: application/vnd.github+json\" --header \"Authorization: Bearer %s\"", endpoint, plaintext)}).
+		WithSecretVariable("GITHUB_TOKEN", token).
+		WithExec([]string{"sh", "-c", fmt.Sprintf("curl \"%s\" --header \"Accept: application/vnd.github+json\" --header \"Authorization: Bearer $GITHUB_TOKEN\"", endpoint)}).
 		Stdout(ctx)
 }

--- a/docs/current_docs/manuals/developer/python/snippets/secrets/main.py
+++ b/docs/current_docs/manuals/developer/python/snippets/secrets/main.py
@@ -6,16 +6,16 @@ from dagger import dag, function, object_type
 class MyModule:
     @function
     async def github_api(self, endpoint: str, token: dagger.Secret) -> str:
-        plaintext = await token.plaintext()
         return await (
             dag.container()
             .from_("alpine:3.17")
             .with_exec(["apk", "add", "curl"])
+            .with_secret_variable("GITHUB_TOKEN", token)
             .with_exec(
                 [
                     "sh",
                     "-c",
-                    f"""curl "{endpoint}" --header "Accept: application/vnd.github+json" --header "Authorization: Bearer {plaintext}" """,
+                    f"""curl "{endpoint}" --header "Accept: application/vnd.github+json" --header "Authorization: Bearer $GITHUB_TOKEN" """,
                 ]
             )
             .stdout()

--- a/docs/current_docs/manuals/developer/typescript/snippets/secrets/index.ts
+++ b/docs/current_docs/manuals/developer/typescript/snippets/secrets/index.ts
@@ -9,10 +9,11 @@ class MyModule {
       .container()
       .from("alpine:3.17")
       .withExec(["apk", "add", "curl"])
+      .withSecretVariable("GITHUB_TOKEN", token)
       .withExec([
         "sh",
         "-c",
-        `curl "${endpoint}" --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${plaintext}"`,
+        `curl "${endpoint}" --header "Accept: application/vnd.github+json" --header "Authorization: Bearer $GITHUB_TOKEN"`,
       ])
       .stdout()
   }


### PR DESCRIPTION
This is a very bad default to recommend - essentially this "de-secrets" a value, and this could then be leaked accidentally:
- Potentially into OTEL spans
- Potentially into cache keys
- Potentially into engine logs

We should recommend using `WithSecretVariable` instead, which is much better - then rely on the shell to do the interpolation, which avoids all of these problems. The secret scrubber will then guarantee that we don't secrets leaked into logs.