### PR TITLE
chore: use `load*FromID` in tests

### DIFF
--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -2960,9 +2960,7 @@ func TestContainerFromIDPlatform(t *testing.T) {
 	}).From(alpineImage).ID(ctx)
 	require.NoError(t, err)
 
-	platform, err := c.Container(dagger.ContainerOpts{
-		ID: id,
-	}).Platform(ctx)
+	platform, err := c.LoadContainerFromID(id).Platform(ctx)
 	require.NoError(t, err)
 	require.Equal(t, desiredPlatform, platform)
 }
@@ -3938,12 +3936,12 @@ EXPOSE 8080
 	res := struct {
 		Container struct {
 			ExposedPorts []core.Port
-		}
+		} `json:"loadContainerFromID"`
 	}{}
 
 	err = testutil.Query(`
         query Test($id: ContainerID!) {
-            container(id: $id) {
+            loadContainerFromID(id: $id) {
                 exposedPorts {
                     port
                     protocol

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -273,11 +273,11 @@ func TestContainerPortLifecycle(t *testing.T) {
 				Protocol    dagger.NetworkProtocol
 				Description *string
 			}
-		}
+		} `json:"loadContainerFromID"`
 	}{}
 
 	getPorts := `query Test($id: ContainerID!) {
-		container(id: $id) {
+		loadContainerFromID(id: $id) {
 			exposedPorts {
 				port
 				protocol

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -55,7 +55,7 @@ func TestGit(t *testing.T) {
 	readmeID, err := readmeFile.ID(ctx)
 	require.NoError(t, err)
 
-	otherReadme, err := c.File(readmeID).Contents(ctx)
+	otherReadme, err := c.LoadFileFromID(readmeID).Contents(ctx)
 	require.NoError(t, err)
 	require.Equal(t, readme, otherReadme)
 }
@@ -88,9 +88,7 @@ func TestContainer(t *testing.T) {
 	id, err := alpine.ID(ctx)
 	require.NoError(t, err)
 	contents, err = c.
-		Container(ContainerOpts{
-			ID: id,
-		}).
+		LoadContainerFromID(id).
 		File("/etc/alpine-release").
 		Contents(ctx)
 	require.NoError(t, err)

--- a/sdk/rust/crates/dagger-sdk/tests/mod.rs
+++ b/sdk/rust/crates/dagger-sdk/tests/mod.rs
@@ -50,7 +50,7 @@ async fn test_git() {
     let readme = readme_file.contents().await.unwrap();
     assert_eq!(true, readme.find("Dagger").is_some());
 
-    let other_readme = c.file(readme_file).contents().await.unwrap();
+    let other_readme = c.load_file_from_id(readme_file).contents().await.unwrap();
 
     assert_eq!(readme, other_readme);
 }
@@ -73,10 +73,7 @@ async fn test_container() {
 
     let id = alpine.id().await.unwrap();
     let contents = client
-        .container_opts(dagger_sdk::QueryContainerOpts {
-            id: Some(id),
-            platform: None,
-        })
+        .load_container_from_id(id)
         .file("/etc/alpine-release")
         .contents()
         .await

--- a/sdk/typescript/api/test/api.spec.ts
+++ b/sdk/typescript/api/test/api.spec.ts
@@ -88,13 +88,13 @@ describe("TypeScript SDK api", function () {
     this.timeout(60000)
     connect(async (client: Client) => {
       const image = await client
-        .container({
-          id: await client
+        .loadContainerFromID(
+          await client
             .container()
             .from("alpine:3.16.2")
             .withExec(["apk", "add", "yarn"])
             .id(),
-        })
+        )
         .withMountedCache("/root/.cache", client.cacheVolume("cache_key"))
         .withExec(["echo", "foo bar"])
         .stdout()


### PR DESCRIPTION
Use these newer methods instead of using `container` and `file` to load IDs, which is deprecated and *going to be removed soon*.

This is now possible because of #7038, and is a step towards #6934.