### PR TITLE
chore: fix yaml error in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
           - "*"
 
   - package-ecosystem: "gomod"
-    directory: "/ci
+    directory: "/ci"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
With this typo, the yaml file was invalid and so the config failed to be applied.

I *finally* found where you can check the validity of a dependabot config - see https://github.com/dagger/dagger/network/updates.