### PR TITLE
cli: visual cue for required flags

### DIFF
--- a/.changes/unreleased/Changed-20240503-160132.yaml
+++ b/.changes/unreleased/Changed-20240503-160132.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: 'cli: Added a visual cue for required flags in `--help`'
+time: 2024-05-03T16:01:32.316206Z
+custom:
+  Author: grouville
+  PR: "7262"

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -356,7 +356,8 @@ func sortRequiredFlags(originalFlags *pflag.FlagSet) *pflag.FlagSet {
 	// separate optional flags from required flags
 	originalFlags.VisitAll(func(flag *pflag.Flag) {
 		// Append [required] and show required flags first
-		if flag.Annotations["cobra_annotation_bash_completion_one_required_flag"] != nil {
+		requiredAnnotation, found := flag.Annotations[cobra.BashCompOneRequiredFlag]
+		if found && requiredAnnotation[0] == "true" {
 			flag.Usage += " [required]"
 			mergedFlags.AddFlag(flag)
 		} else {

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -367,9 +367,7 @@ func sortRequiredFlags(originalFlags *pflag.FlagSet) *pflag.FlagSet {
 	})
 
 	// Add optional flags back, after all required flags
-	optionalFlags.VisitAll(func(flag *pflag.Flag) {
-		mergedFlags.AddFlag(flag)
-	})
+	mergedFlags.AddFlagSet(optionalFlags)
 
 	return mergedFlags
 }

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -88,7 +88,7 @@ func init() {
 	cobra.AddTemplateFunc("flagUsagesWrapped", flagUsagesWrapped)
 	cobra.AddTemplateFunc("cmdShortWrapped", cmdShortWrapped)
 	cobra.AddTemplateFunc("toUpperBold", toUpperBold)
-	cobra.AddTemplateFunc("separateAndModifyFlags", separateAndModifyFlags)
+	cobra.AddTemplateFunc("sortRequiredFlags", sortRequiredFlags)
 	rootCmd.SetUsageTemplate(usageTemplate)
 
 	// hide the help flag as it's ubiquitous and thus noisy
@@ -346,8 +346,8 @@ func toUpperBold(s string) string {
 	return termenv.String(upperCase).Bold().String()
 }
 
-// separateAndModifyFlags separates optional flags from required flags
-func separateAndModifyFlags(originalFlags *pflag.FlagSet) *pflag.FlagSet {
+// sortRequiredFlags separates optional flags from required flags.
+func sortRequiredFlags(originalFlags *pflag.FlagSet) *pflag.FlagSet {
 	mergedFlags := pflag.NewFlagSet("merged", pflag.ContinueOnError)
 	mergedFlags.SortFlags = false
 
@@ -440,7 +440,7 @@ const usageTemplate = `{{ "Usage" | toUpperBold }}
 {{- if .HasAvailableLocalFlags}}
 
 {{ "Options" | toUpperBold }}
-{{ flagUsagesWrapped (separateAndModifyFlags .LocalFlags) | trimTrailingWhitespaces}}
+{{ flagUsagesWrapped (sortRequiredFlags .LocalFlags) | trimTrailingWhitespaces}}
 
 {{- end}}
 

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -355,14 +355,12 @@ func sortRequiredFlags(originalFlags *pflag.FlagSet) *pflag.FlagSet {
 
 	// separate optional flags from required flags
 	originalFlags.VisitAll(func(flag *pflag.Flag) {
-		clone := *flag
-
 		// Append [required] and show required flags first
 		if flag.Annotations["cobra_annotation_bash_completion_one_required_flag"] != nil {
-			clone.Usage += " [required]"
-			mergedFlags.AddFlag(&clone)
+			flag.Usage += " [required]"
+			mergedFlags.AddFlag(flag)
 		} else {
-			optionalFlags.AddFlag(&clone)
+			optionalFlags.AddFlag(flag)
 		}
 	})
 


### PR DESCRIPTION
One of the action items discussed in https://github.com/dagger/dagger/pull/7107#issuecomment-2061525961

Append [required] to flags that are marked as required. As proposed by Helder, this follows the behavior of Typer: https://typer.tiangolo.com/tutorial/options/required/

Required flags are shown first, then option arguments are shown. Apart from this, they are sorted in the order of the first flagset: https://discord.com/channels/707636530424053791/1232477387724292209/1232711077415092295

**Example**
```shell
./dagger -m github.com/jpadams/chainloop@8374b22aee238452467bd712e874937b8e4254c9 call  init --help

OPTIONS
      --token Secret               Chainloop API token [required]
      --contract-revision string   Workflow Contract revision, default is the latest
      --repository Directory       Path to the source repository to be attested

```