### PR TITLE
ci: ensure cli release has git dir

### DIFF
--- a/ci/cli.go
+++ b/ci/cli.go
@@ -41,6 +41,8 @@ const (
 func (cli *CLI) Publish(
 	ctx context.Context,
 
+	gitDir *Directory,
+
 	githubOrgName string,
 	githubToken *Secret,
 
@@ -71,6 +73,7 @@ func (cli *CLI) Publish(
 	_, err = ctr.
 		WithWorkdir("/app").
 		WithMountedDirectory("/app", cli.Dagger.Source).
+		WithDirectory("/app/.git", gitDir).
 		WithEnvVariable("GH_ORG_NAME", githubOrgName).
 		WithSecretVariable("GITHUB_TOKEN", githubToken).
 		WithSecretVariable("GORELEASER_KEY", goreleaserKey).

--- a/ci/mage/cli.go
+++ b/ci/mage/cli.go
@@ -15,6 +15,9 @@ type Cli mg.Namespace
 func (cl Cli) Publish(ctx context.Context, version string) error {
 	args := []string{"--version=" + version, "cli", "publish"}
 
+	// explicitly pass the git directory - goreleaser needs it
+	args = append(args, "--git-dir=./.git")
+
 	if v, ok := os.LookupEnv("GH_ORG_NAME"); ok {
 		args = append(args, "--github-org-name="+v)
 	}


### PR DESCRIPTION
Bleh, I broke this in https://github.com/dagger/dagger/pull/7234.

Goreleaser needs this :(