### PR TITLE
install.sh - fix bash completion instructions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -295,8 +295,8 @@ ${binexe} has built-in shell completion. This is how you can install it for:
 
     2. Add dagger completion to your personal bash completions dir
 
-      mkdir -p $XDG_DATA_HOME/bash-completion/completions
-      ${binexe} completion bash > $XDG_DATA_HOME/bash-completion/completions/dagger
+      mkdir -p ${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions
+      ${binexe} completion bash > ${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions/dagger
 
   ZSH:
 


### PR DESCRIPTION
The XDG_DATA_HOME env var can be empty (expectedly), and it breaks the printed bash completion setup instructions. This little PR makes the install script use the default $HOME/.local/share location when the XDG_DATA_HOME is empty. See  https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html