### PR TITLE
core: clarify withMountedTemp docs that they are ephemeral

### DIFF
--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -191,7 +191,7 @@ func (s *containerSchema) Install() {
 				`If the group is omitted, it defaults to the same as the user.`),
 
 		dagql.Func("withMountedTemp", s.withMountedTemp).
-			Doc(`Retrieves this container plus a temporary directory mounted at the given path.`).
+			Doc(`Retrieves this container plus a temporary directory mounted at the given path. Any writes will be ephemeral to a single withExec call; they will not be persisted to subsequent withExecs.`).
 			ArgDoc("path", `Location of the temporary directory (e.g., "/tmp/temp_dir").`),
 
 		dagql.Func("withMountedCache", s.withMountedCache).

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -681,6 +681,8 @@ type Container {
 
   """
   Retrieves this container plus a temporary directory mounted at the given path.
+  Any writes will be ephemeral to a single withExec call; they will not be
+  persisted to subsequent withExecs.
   """
   withMountedTemp(
     """Location of the temporary directory (e.g., "/tmp/temp_dir")."""

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -768,7 +768,7 @@ defmodule Dagger.Container do
     }
   end
 
-  @doc "Retrieves this container plus a temporary directory mounted at the given path."
+  @doc "Retrieves this container plus a temporary directory mounted at the given path. Any writes will be ephemeral to a single withExec call; they will not be persisted to subsequent withExecs."
   @spec with_mounted_temp(t(), String.t()) :: Dagger.Container.t()
   def with_mounted_temp(%__MODULE__{} = container, path) do
     selection =

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -1400,7 +1400,7 @@ func (r *Container) WithMountedSecret(path string, source *Secret, opts ...Conta
 	}
 }
 
-// Retrieves this container plus a temporary directory mounted at the given path.
+// Retrieves this container plus a temporary directory mounted at the given path. Any writes will be ephemeral to a single withExec call; they will not be persisted to subsequent withExecs.
 func (r *Container) WithMountedTemp(path string) *Container {
 	q := r.query.Select("withMountedTemp")
 	q = q.Arg("path", path)

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -681,7 +681,7 @@ class Container extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
-     * Retrieves this container plus a temporary directory mounted at the given path.
+     * Retrieves this container plus a temporary directory mounted at the given path. Any writes will be ephemeral to a single withExec call; they will not be persisted to subsequent withExecs.
      */
     public function withMountedTemp(string $path): Container
     {

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -1549,7 +1549,8 @@ class Container(Type):
 
     def with_mounted_temp(self, path: str) -> Self:
         """Retrieves this container plus a temporary directory mounted at the
-        given path.
+        given path. Any writes will be ephemeral to a single withExec call;
+        they will not be persisted to subsequent withExecs.
 
         Parameters
         ----------

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -2690,7 +2690,7 @@ impl Container {
             graphql_client: self.graphql_client.clone(),
         }
     }
-    /// Retrieves this container plus a temporary directory mounted at the given path.
+    /// Retrieves this container plus a temporary directory mounted at the given path. Any writes will be ephemeral to a single withExec call; they will not be persisted to subsequent withExecs.
     ///
     /// # Arguments
     ///

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -2266,7 +2266,7 @@ export class Container extends BaseClient {
   }
 
   /**
-   * Retrieves this container plus a temporary directory mounted at the given path.
+   * Retrieves this container plus a temporary directory mounted at the given path. Any writes will be ephemeral to a single withExec call; they will not be persisted to subsequent withExecs.
    * @param path Location of the temporary directory (e.g., "/tmp/temp_dir").
    */
   withMountedTemp = (path: string): Container => {


### PR DESCRIPTION
Just a doc string update, but something odd is happening when I run `./hack/make sdk:elixir:generate` locally:
```
✘ DaggerElixirSdk.generate: Directory! 11.8s
! call function "Generate": process "/runtime" did not complete successfully: exit code: 2
┃ marshal: json: error calling MarshalJSON for type *dagger.Directory: input: container.from.withWorkdir.withDirectory.withExec.withExec.withExec.withServiceBinding.withEnvVariable.withMountedFile.withEnvVariable.withExec.withMountedSecret.withWorkd
┃                                                                                                                                                                                                                                                        
┃ Stdout:                                                                                                                                                                                                                                                
┃ Resolving Hex dependencies...                                                                                                                                                                                                                          
┃ Stderr:                                                                                                                                                                                                                                                
┃ eheap_alloc: Cannot allocate 976733209832459912 bytes of memory (of type "heap_frag").                                                                                                                                                                 
┃                                                                                                                                                                                                                                                        
┃ Crash dump is being written to: erl_crash.dump...beam/erl_term.h:1492:tag_val_def() Assertion failed: tag_val_def error                                                                                                                                
  ✘ Container.directory(path: "gen"): Directory! 1.4s
  ! process "mix deps.get" did not complete successfully: exit code: 255
    ✘ exec mix deps.get 1.4s
    ! process "mix deps.get" did not complete successfully: exit code: 255
    ┃ Resolving Hex dependencies...                                                                                                                                                                                                                      
    ┃ eheap_alloc: Cannot allocate 976733209832459912 bytes of memory (of type "heap_frag").                                                                                                                                                             
    ┃                                                                                                                                                                                                                                                    
    ┃ Crash dump is being written to: erl_crash.dump...beam/erl_term.h:1492:tag_val_def() Assertion failed: tag_val_def error                                                                                                                            

Error: response from query: input: dagger.sdk.elixir.generate resolve: call function "Generate": process "/runtime" did not complete successfully: exit code: 2

Stdout:
marshal: json: error calling MarshalJSON for type *dagger.Directory: input: container.from.withWorkdir.withDirectory.withExec.withExec.withExec.withServiceBinding.withEnvVariable.withMountedFile.withEnvVariable.withExec.withMountedSecret.withWorkdir

Stdout:
Resolving Hex dependencies...
Stderr:
eheap_alloc: Cannot allocate 976733209832459912 bytes of memory (of type "heap_frag").

Crash dump is being written to: erl_crash.dump...beam/erl_term.h:1492:tag_val_def() Assertion failed: tag_val_def error
Error: exit status 1
exit status 1
```

@wingyplus any ideas why it would be trying to allocate 976733209832459912 bytes of memory? 😂 I'm gonna have to download more RAM if it's actually needed.

Not a blocker if no easy fix, I can resort to just hand editing the file for now since it's just a doc string update.