### PR TITLE
fix(sdk/elixir): fix sdk:elixir:generate task crash

### DIFF
--- a/ci/sdk_elixir.go
+++ b/ci/sdk_elixir.go
@@ -21,8 +21,8 @@ const (
 var elixirVersions = []string{"1.16.2", "1.15.7", "1.14.5"}
 
 const (
-	otpVersion    = "26.2.3"
-	debianVersion = "20240130"
+	otpVersion    = "26.2.4"
+	debianVersion = "20240423"
 )
 
 type ElixirSDK struct {


### PR DESCRIPTION
Upgrading the Erlang/OTP to fix Erlang
https://github.com/erlang/otp/issues/8238 bug.