### PR TITLE
cli: use "functions" and "arguments" instead of "commands" and "options" in `dagger call --help`

### DIFF
--- a/.changes/unreleased/Changed-20240505-232946.yaml
+++ b/.changes/unreleased/Changed-20240505-232946.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: 'cli: conventionalized usage syntax in `--help`'
+time: 2024-05-05T23:29:46.072408Z
+custom:
+  Author: grouville
+  PR: "7143"

--- a/.changes/unreleased/Changed-20240505-234902.yaml
+++ b/.changes/unreleased/Changed-20240505-234902.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: 'cli: use "functions" and "arguments" in `dagger call --help`'
+time: 2024-05-05T23:49:02.189991Z
+custom:
+  Author: helderco
+  PR: "7286"

--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -16,7 +16,7 @@ var outputPath string
 var jsonOutput bool
 
 var callCmd = &FuncCommand{
-	Name:  "call [options] <command>",
+	Name:  "call [options]",
 	Short: "Call a module function",
 	Long: strings.ReplaceAll(`Call a module function and print the result.
 

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -34,7 +34,7 @@ const (
 
 var funcGroup = &cobra.Group{
 	ID:    "functions",
-	Title: "Function Commands",
+	Title: "Functions",
 }
 
 var funcCmds = FuncCommands{
@@ -443,12 +443,16 @@ func (fc *FuncCommand) addSubCommands(cmd *cobra.Command, dag *dagger.Client, fn
 			subCmd := fc.makeSubCmd(dag, fn)
 			cmd.AddCommand(subCmd)
 		}
+
+		if cmd.HasAvailableSubCommands() {
+			cmd.Use += " <function>"
+		}
 	}
 }
 
 func (fc *FuncCommand) makeSubCmd(dag *dagger.Client, fn *modFunction) *cobra.Command {
 	newCmd := &cobra.Command{
-		Use:                   cliName(fn.Name) + " [options]",
+		Use:                   cliName(fn.Name),
 		Short:                 strings.SplitN(fn.Description, "\n", 2)[0],
 		Long:                  fn.Description,
 		GroupID:               funcGroup.ID,
@@ -557,6 +561,15 @@ func (fc *FuncCommand) addArgsForFunction(cmd *cobra.Command, cmdArgs []string, 
 		if arg.IsRequired() {
 			cmd.MarkFlagRequired(arg.FlagName())
 		}
+		cmd.Flags().SetAnnotation(
+			arg.FlagName(),
+			"help:group",
+			[]string{"Arguments"},
+		)
+	}
+
+	if len(fn.Args) > 0 {
+		cmd.Use += " [arguments]"
 	}
 
 	if fc.BeforeParse != nil {

--- a/docs/current_docs/reference/979596-cli.mdx
+++ b/docs/current_docs/reference/979596-cli.mdx
@@ -49,7 +49,7 @@ by appending it to the end of the command (for example, `stdout`, `entries`, or
 
 
 ```
-dagger call [options] <command>
+dagger call [options]
 ```
 
 ### Examples


### PR DESCRIPTION
Follow up to:
- https://github.com/dagger/dagger/pull/7262#pullrequestreview-2038470837
- https://github.com/dagger/dagger/pull/7143

Part of:
- https://github.com/dagger/dagger/issues/6943

## What changed?

- Removed `COMMANDS` from the list of subcommands heading, in favor of just `FUNCTIONS`.
- Added `[arguments]` and `<function>` to the usage line when appropriate.
- Flags created for function arguments are split into its own `ARGUMENTS` section. So constructor arguments will now appear separately from call’s own flags.

## Before

<img width="765" alt="Screenshot 2024-05-05 at 23 45 27" src="https://github.com/dagger/dagger/assets/174525/75d44c43-87c9-4363-84c1-d1073be01540">


## After

<img width="771" alt="Screenshot 2024-05-05 at 23 44 08" src="https://github.com/dagger/dagger/assets/174525/7eaaec5f-b649-45e3-9c79-6b3800a71f19">

