### PR TITLE
cli: indent examples in `--help`

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -91,6 +91,7 @@ func init() {
 	cobra.AddTemplateFunc("toUpperBold", toUpperBold)
 	cobra.AddTemplateFunc("sortRequiredFlags", sortRequiredFlags)
 	cobra.AddTemplateFunc("groupFlags", groupFlags)
+	cobra.AddTemplateFunc("indent", indent.String)
 	rootCmd.SetUsageTemplate(usageTemplate)
 
 	// hide the help flag as it's ubiquitous and thus noisy
@@ -434,7 +435,7 @@ const usageTemplate = `{{ if .Runnable}}{{ "Usage" | toUpperBold }}
 {{- if .HasExample}}
 
 {{ "Examples" | toUpperBold }}
-{{ .Example }}
+{{ indent .Example 2 }}
 
 {{- end}}
 


### PR DESCRIPTION
Every section was indented except for the examples.

Follow up to:
- https://github.com/dagger/dagger/pull/7286

Part of:
- https://github.com/dagger/dagger/issues/6943


## Before

<img width="462" alt="Screenshot 2024-05-05 at 23 56 41" src="https://github.com/dagger/dagger/assets/174525/fb553758-bbd7-4dee-a8c6-d1c4ceea5298">

## After

<img width="435" alt="Screenshot 2024-05-05 at 23 57 54" src="https://github.com/dagger/dagger/assets/174525/a8217428-0bf3-41df-af25-722633a00615">
