### PR TITLE
chore: use temporary buildkit fork with bug fixes pending upstream merge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,13 @@ go 1.21
 
 replace dagger.io/dagger => ./sdk/go
 
+// Needed pending merge of these upstream PRs:
+// - https://github.com/moby/buildkit/pull/4887
+//   - purposely only picking the first commit for now since it's what we know we need to fix the problem we've been hitting
+// - https://github.com/moby/buildkit/pull/4902
+// Link to commit: https://github.com/dagger/buildkit/commit/3c1a806b01b1b4fefc637289146533f636029138
+replace github.com/moby/buildkit => github.com/dagger/buildkit v0.0.0-20240506175627-3c1a806b01b1
+
 require (
 	dagger.io/dagger v0.11.2
 	github.com/99designs/gqlgen v0.17.44

--- a/go.sum
+++ b/go.sum
@@ -204,6 +204,8 @@ github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
+github.com/dagger/buildkit v0.0.0-20240506175627-3c1a806b01b1 h1:IusWZSyPQjK0dFxoU1FNOMCDVQIMmDfxTUEKDGHSLl4=
+github.com/dagger/buildkit v0.0.0-20240506175627-3c1a806b01b1/go.mod h1:wH5RTVyFjMQ67euC1e3UUSw7yQe7JkAHmf8OZkQY7Y4=
 github.com/dave/jennifer v1.7.0 h1:uRbSBH9UTS64yXbh4FrMHfgfY762RD+C7bUPKODpSJE=
 github.com/dave/jennifer v1.7.0/go.mod h1:nXbxhEmQfOZhWml3D1cDK5M1FLnMSozpbFN/m3RmGZc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -475,8 +477,6 @@ github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4
 github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c h1:cqn374mizHuIWj+OSJCajGr/phAmuMug9qIX3l9CflE=
 github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/moby/buildkit v0.13.0-rc3.0.20240501212635-51d85d712fad h1:acX5lJRvUENtB/ac78Iyg59ffbfZlsVxj6LvyOwLdLI=
-github.com/moby/buildkit v0.13.0-rc3.0.20240501212635-51d85d712fad/go.mod h1:wH5RTVyFjMQ67euC1e3UUSw7yQe7JkAHmf8OZkQY7Y4=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=


### PR DESCRIPTION
We really want these bug fixes for the next release but they are still in PR upstream, so we made [a fork of buildkit in the dagger org](https://github.com/dagger/buildkit) and I cherry-picked those fixes.
* This fork is only intended to be used on temporary bases for situations like this where we want bug fixes but upstream hasn't updated yet. Not intended to be used for any long term divergence.

The upstream PRs with cherry-picked commits are:
- https://github.com/moby/buildkit/pull/4887
- https://github.com/moby/buildkit/pull/4902