### PR TITLE
ca certs: include output of failed update command

### DIFF
--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -280,7 +280,10 @@ func (w *Worker) run(
 				started,
 				installCACerts,
 			)
-			return err
+			if err != nil {
+				return fmt.Errorf("installer command failed: %w, output: %s", err, output.String())
+			}
+			return nil
 		})
 		if err == nil {
 			err = caInstaller.Install(ctx)


### PR DESCRIPTION
We collected this output but didn't actually put it in the error message, which left us with only an exit code to debug with.

Now the actual output is there, which is much more useful.