### PR TITLE
engine: use image target image platform

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -325,6 +325,7 @@ func (container *Container) From(ctx context.Context, addr string) (*Container, 
 
 	container.Config = mergeImageConfig(container.Config, imgSpec.Config)
 	container.ImageRef = digested.String()
+	container.Platform = Platform(platforms.Normalize(imgSpec.Platform))
 
 	return container, nil
 }

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -115,7 +115,7 @@ CMD goenv
 	t.Run("with syntax pragma", func(t *testing.T) {
 		src := contextDir.
 			WithNewFile("Dockerfile",
-				`# syntax = docker/dockerfile:1 
+				`# syntax = docker/dockerfile:1
 FROM golang:1.18.2-alpine
 WORKDIR /src
 COPY main.go .
@@ -2968,13 +2968,25 @@ func TestContainerImport(t *testing.T) {
 	})
 }
 
-func TestContainerFromIDPlatform(t *testing.T) {
+func TestContainerFromImagePlatform(t *testing.T) {
 	c, ctx := connect(t)
 
 	var desiredPlatform dagger.Platform = "linux/arm64"
 
+	ctr := c.Container().From(alpineArm)
+	ctrPlatform, err := ctr.Platform(ctx)
+	require.NoError(t, err)
+	require.Equal(t, desiredPlatform, ctrPlatform)
+}
+
+func TestContainerFromIDPlatform(t *testing.T) {
+	c, ctx := connect(t)
+
+	var targetPlatform dagger.Platform = "linux/arm64/v8"
+	var desiredPlatform dagger.Platform = "linux/arm64"
+
 	id, err := c.Container(dagger.ContainerOpts{
-		Platform: desiredPlatform,
+		Platform: targetPlatform,
 	}).From(alpineImage).ID(ctx)
 	require.NoError(t, err)
 

--- a/core/integration/images.go
+++ b/core/integration/images.go
@@ -5,6 +5,7 @@ const (
 	golangImage = "golang:1.22.2-alpine"
 	debianImage = "debian:bookworm"
 	rhelImage   = "registry.access.redhat.com/ubi9/ubi"
+	alpineArm   = "arm64v8/alpine"
 
 	// TODO: use these
 	// registryImage   = "registry:2"


### PR DESCRIPTION
always resolves to the target image platform to set the Container
platform. 

we're currently defaulting to the `defaultPlatform` if  `ContainerOpts.Platform` is not set when creating the container. 

ref: https://play.dagger.cloud/playground/uIkzqEKNG9J

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
