### PR TITLE
fix: fix terminal broken on Windows

### DIFF
--- a/.changes/unreleased/Fixed-20240507-224849.yaml
+++ b/.changes/unreleased/Fixed-20240507-224849.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fix terminal broken on Windows
+time: 2024-05-07T22:48:49.058847426+07:00
+custom:
+  Author: wingyplus
+  PR: "7305"

--- a/cmd/dagger/shell.go
+++ b/cmd/dagger/shell.go
@@ -149,7 +149,7 @@ func (ts *terminalSession) Run() error {
 }
 
 func (ts *terminalSession) sendSize(wsconn *websocket.Conn) error {
-	f, ok := ts.stdin.(*os.File)
+	f, ok := ts.stdout.(*os.File)
 	if !ok || !isatty.IsTerminal(f.Fd()) {
 		slog.Debug("stdin is not a terminal; cannot get terminal size")
 		return nil


### PR DESCRIPTION
Uses `ts.stdout` instead of `ts.stdin` to get terminal size.

Fixes #7282