### PR TITLE
cli: allow calling core functions directly

### DIFF
--- a/.changes/unreleased/Added-20240629-000342.yaml
+++ b/.changes/unreleased/Added-20240629-000342.yaml
@@ -5,9 +5,13 @@ body: |
   Usage: `dagger core <function>`
   Example: `dagger core container from --address=alpine terminal`
 
-  Works the same as `dagger call`, but instead of loading a user module, it only uses functions in the core API.
+  Works the same as `dagger call`, but instead of loading a user module, 
+  it only uses functions from the core API.
   
   Run `dagger core --help` for available functions.
+
+  _Note that this command is experimental and the DX for calling core functions 
+  in the CLI may change in the future._
 
 time: 2024-06-29T00:03:42.175445Z
 custom:

--- a/.changes/unreleased/Added-20240629-000342.yaml
+++ b/.changes/unreleased/Added-20240629-000342.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: 'cli: allow calling core functions directly'
+time: 2024-06-29T00:03:42.175445Z
+custom:
+    Author: helderco
+    PR: "7310"

--- a/.changes/unreleased/Added-20240629-000342.yaml
+++ b/.changes/unreleased/Added-20240629-000342.yaml
@@ -1,5 +1,14 @@
 kind: Added
-body: 'cli: allow calling core functions directly'
+body: |
+  cli: allow calling core functions directly
+
+  Usage: `dagger core <function>`
+  Example: `dagger core container from --address=alpine terminal`
+
+  Works the same as `dagger call`, but instead of loading a user module, it only uses functions in the core API.
+  
+  Run `dagger core --help` for available functions.
+
 time: 2024-06-29T00:03:42.175445Z
 custom:
     Author: helderco

--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -1,232 +1,112 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
-	"log/slog"
-	"os"
-	"path/filepath"
+	"sort"
+	"strings"
 
+	"github.com/dagger/dagger/engine/client"
+	"github.com/juju/ansiterm/tabwriter"
+	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
-var outputFormat string
-var outputPath string
-var jsonOutput bool
-var responsePayload map[string]any
+var funcCmds = []*FuncCommand{
+	callModCmd,
+	callCoreCmd,
+}
 
-var callCmd = &FuncCommand{
+var callCoreCmd = &FuncCommand{
+	Name:              "core [options]",
+	Short:             "Call a core function",
+	DisableModuleLoad: true,
+}
+
+var callModCmd = &FuncCommand{
 	Name:  "call [options]",
 	Short: "Call one or more functions, interconnected into a pipeline",
-	Init: func(cmd *cobra.Command) {
-		cmd.PersistentFlags().StringVarP(&outputPath, "output", "o", "", "Save the result to a local file or directory")
+}
 
-		cmd.PersistentFlags().BoolVarP(&jsonOutput, "json", "j", false, "Present result as JSON")
-	},
-	OnSelectObjectLeaf: func(ctx context.Context, fc *FuncCommand, obj functionProvider) error {
-		typeName := obj.ProviderName()
-		switch typeName {
-		case Container, Directory, File:
-			if outputPath != "" {
-				fc.Select("export")
-				fc.Arg("path", outputPath)
-				if typeName == File {
-					fc.Arg("allowParentDirPath", true)
+var funcListCmd = &cobra.Command{
+	Use:   "functions [options] [function]...",
+	Short: `List available functions`,
+	Long: strings.ReplaceAll(`List available functions in a module.
+
+This is similar to ´dagger call --help´, but only focused on showing the
+available functions.
+`,
+		"´",
+		"`",
+	),
+	GroupID: moduleGroup.ID,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return withEngine(cmd.Context(), client.Params{}, func(ctx context.Context, engineClient *client.Client) (rerr error) {
+			mod, err := initializeModule(ctx, engineClient.Dagger(), true)
+			if err != nil {
+				return err
+			}
+			tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 3, ' ', tabwriter.DiscardEmptyColumns)
+			var o functionProvider = mod.MainObject.AsFunctionProvider()
+			fmt.Fprintf(tw, "%s\t%s\n",
+				termenv.String("Name").Bold(),
+				termenv.String("Description").Bold(),
+			)
+			// Walk the hypothetical function pipeline specified by the args
+			for _, field := range cmd.Flags().Args() {
+				// Lookup the next function in the specified pipeline
+				nextFunc, err := GetFunction(o, field)
+				if err != nil {
+					return err
 				}
-				return nil
-			}
-		}
-
-		// There's no fields in `Container` that trigger container execution so
-		// we use `sync` first to evaluate, and then load the new `Container`
-		// from that response before continuing.
-		if typeName == Container || typeName == Terminal {
-			var id string
-			fc.Select("sync")
-			if err := fc.Request(ctx, &id); err != nil {
-				return err
-			}
-			fc.q = fc.q.Root().Select(fmt.Sprintf("load%sFromID", typeName)).Arg("id", id)
-		}
-
-		// Add the object's name so we always have something to show.
-		responsePayload = make(map[string]any)
-		responsePayload["_type"] = typeName
-
-		names := make([]string, 0)
-		for _, f := range GetLeafFunctions(obj) {
-			names = append(names, f.Name)
-		}
-
-		if len(names) > 0 {
-			// FIXME: Consider adding a method to the query builder speficically
-			// for multiple selections to avoid this workaround. Even if there's
-			// just one field it helps to show the field's name, not just the
-			// value, and multiple selection allows it because it binds to the
-			// parent selection.
-			if len(names) == 1 {
-				names = append(names, "")
-			}
-
-			fc.Select(names...)
-		}
-
-		return nil
-	},
-	AfterResponse: func(c *FuncCommand, cmd *cobra.Command, modType *modTypeDef, response any) error {
-		switch modType.Name() {
-		case Container, Directory, File:
-			if outputPath != "" {
-				respPath, ok := response.(string)
-				if !ok {
-					return fmt.Errorf("unexpected response %T: %+v", response, response)
+				nextType := nextFunc.ReturnType
+				if nextType.AsList != nil {
+					nextType = nextType.AsList.ElementTypeDef
 				}
-				cmd.PrintErrf("Saved to %q.\n", respPath)
-				return nil
+				if nextType.AsFunctionProvider() != nil {
+					// sipsma explains why 'nextType.AsObject' is not enough:
+					// > when we're returning the hierarchies of TypeDefs from the API,
+					// > and an object shows up as an output/input type to a function,
+					// > we just return a TypeDef with a name of the object rather than the full object definition.
+					// > You can get the full object definition only from the "top-level" returned object on the api call.
+					//
+					// > The reason is that if we repeated the full object definition every time,
+					// > you'd at best be using O(n^2) space in the result,
+					// > and at worst cause json serialization errors due to cyclic references
+					// > (i.e. with* functions on an object that return the object itself).
+					o = mod.GetFunctionProvider(nextType.Name())
+					continue
+				}
+				return fmt.Errorf("function %q returns type %q with no further functions available", field, nextType.Kind)
 			}
-		}
 
-		if responsePayload != nil {
-			r, err := addPayload(response, responsePayload)
-			if err != nil {
-				return err
+			// List functions on the final object
+			fns := o.GetFunctions()
+			sort.Slice(fns, func(i, j int) bool {
+				return fns[i].Name < fns[j].Name
+			})
+			skipped := make([]string, 0)
+			for _, fn := range fns {
+				if fn.IsUnsupported() {
+					skipped = append(skipped, cliName(fn.Name))
+					continue
+				}
+				desc := strings.SplitN(fn.Description, "\n", 2)[0]
+				if desc == "" {
+					desc = "-"
+				}
+				fmt.Fprintf(tw, "%s\t%s\n",
+					cliName(fn.Name),
+					desc,
+				)
 			}
-			response = r
-
-			// Use yaml when printing scalars because it's more human-readable
-			// and handles lists and multiline strings well.
-			if stdoutIsTTY {
-				outputFormat = "yaml"
-			} else {
-				outputFormat = "json"
+			if len(skipped) > 0 {
+				msg := fmt.Sprintf("Skipped %d function(s) with unsupported types: %s", len(skipped), strings.Join(skipped, ", "))
+				fmt.Fprintf(tw, "\n%s\n",
+					termenv.String(msg).Faint().String(),
+				)
 			}
-		}
-
-		if jsonOutput {
-			outputFormat = "json"
-		}
-
-		buf := new(bytes.Buffer)
-
-		switch outputFormat {
-		case "json":
-			// disable HTML escaping to improve readability
-			encoder := json.NewEncoder(buf)
-			encoder.SetEscapeHTML(false)
-			encoder.SetIndent("", "    ")
-			if err := encoder.Encode(response); err != nil {
-				return err
-			}
-		case "yaml":
-			out, err := yaml.Marshal(response)
-			if err != nil {
-				return err
-			}
-			if _, err := buf.Write(out); err != nil {
-				return err
-			}
-		case "":
-			if err := printFunctionResult(buf, response); err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf("wrong output format %q", outputFormat)
-		}
-
-		if outputPath != "" {
-			if err := writeOutputFile(outputPath, buf); err != nil {
-				return fmt.Errorf("couldn't write output to file: %w", err)
-			}
-			path, err := filepath.Abs(outputPath)
-			if err != nil {
-				// don't fail because at this point the output has been saved successfully
-				slog.Warn("Failed to get absolute path", "error", err)
-				path = outputPath
-			}
-			cmd.PrintErrf("Saved output to %q.\n", path)
-		}
-
-		writer := cmd.OutOrStdout()
-		buf.WriteTo(writer)
-
-		// TODO(vito) right now when stdoutIsTTY we'll be printing to a Progrock
-		// vertex, which currently adds its own linebreak (as well as all the
-		// other UI clutter), so there's no point doing this. consider adding
-		// back when we switch to printing "clean" output on exit.
-		// if stdoutIsTTY && !strings.HasSuffix(buf.String(), "\n") {
-		// 	fmt.Fprintln(writer, "⏎")
-		// }
-
-		return nil
+			return tw.Flush()
+		})
 	},
-}
-
-// addPayload merges a map into a response from getting an object's values.
-func addPayload(response any, payload map[string]any) (any, error) {
-	switch t := response.(type) {
-	case []any:
-		r := make([]any, 0, len(t))
-		for _, v := range t {
-			p, err := addPayload(v, payload)
-			if err != nil {
-				return nil, err
-			}
-			r = append(r, p)
-		}
-		return r, nil
-	case map[string]any:
-		if len(t) == 0 {
-			return payload, nil
-		}
-		r := make(map[string]any, len(t)+len(payload))
-		for k, v := range t {
-			r[k] = v
-		}
-		for k, v := range responsePayload {
-			r[k] = v
-		}
-		return r, nil
-	default:
-		return nil, fmt.Errorf("unexpected response %T for object values: %+v", response, response)
-	}
-}
-
-// writeOutputFile writes the buffer to a file, creating the parent directories
-// if needed.
-func writeOutputFile(path string, buf *bytes.Buffer) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
-	return os.WriteFile(path, buf.Bytes(), 0o644) //nolint: gosec
-}
-
-func printFunctionResult(w io.Writer, r any) error {
-	switch t := r.(type) {
-	case []any:
-		for _, v := range t {
-			if err := printFunctionResult(w, v); err != nil {
-				return err
-			}
-			fmt.Fprintln(w)
-		}
-		return nil
-	case map[string]any:
-		// NB: we're only interested in values because this is where we unwrap
-		// things like {"container":{"from":{"withExec":{"stdout":"foo"}}}}.
-		for _, v := range t {
-			if err := printFunctionResult(w, v); err != nil {
-				return err
-			}
-		}
-		return nil
-	case string:
-		fmt.Fprint(w, t)
-	default:
-		fmt.Fprintf(w, "%+v", t)
-	}
-	return nil
 }

--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -21,6 +21,9 @@ var callCoreCmd = &FuncCommand{
 	Name:              "core [options]",
 	Short:             "Call a core function",
 	DisableModuleLoad: true,
+	Annotations: map[string]string{
+		"experimental": "true",
+	},
 }
 
 var callModCmd = &FuncCommand{

--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -791,6 +791,16 @@ func (r *modFunctionArg) AddFlag(flags *pflag.FlagSet) error {
 	case dagger.ObjectKind:
 		objName := r.TypeDef.AsObject.Name
 
+		if name == "id" && r.TypeDef.AsObject.IsCore() {
+			// FIXME: The core TypeDefs have ids converted to objects, but we'd
+			// need the CLI to recognize that and either use the object's ID
+			// or allow inputing it directly. Just don't support it for now.
+			return &UnsupportedFlagError{
+				Name: name,
+				Type: fmt.Sprintf("%sID", objName),
+			}
+		}
+
 		if val := GetCustomFlagValue(objName); val != nil {
 			flags.Var(val, name, usage)
 			return nil

--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -284,6 +284,11 @@ func (v *directoryValue) Get(ctx context.Context, dag *dagger.Client, modSrc *da
 	path := v.String()
 	path = strings.TrimPrefix(path, "file://")
 
+	// The core module doesn't have a ModuleSource.
+	if modSrc == nil {
+		return dag.Host().Directory(path), nil
+	}
+
 	// Check if there's a :view.
 	// This technically prevents use of paths containing a ":", but that's
 	// generally considered a no-no anyways since it isn't in the

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -32,9 +32,6 @@ const (
 	Platform     string = "Platform"
 	Socket       string = "Socket"
 	Terminal     string = "Terminal"
-
-	// coreModRef is the exact value for `-m` to call fields from Query.
-	coreModRef string = "-"
 )
 
 var (
@@ -128,16 +125,6 @@ available functions.
 }
 
 type FuncCommands []*FuncCommand
-
-func (fcs FuncCommands) AddFlagSet(flags *pflag.FlagSet) {
-	for _, cmd := range fcs.All() {
-		cmd.PersistentFlags().AddFlagSet(flags)
-	}
-}
-
-func (fcs FuncCommands) AddParent(rootCmd *cobra.Command) {
-	rootCmd.AddCommand(fcs.All()...)
-}
 
 func (fcs FuncCommands) All() []*cobra.Command {
 	cmds := make([]*cobra.Command, len(fcs))
@@ -404,8 +391,7 @@ func (fc *FuncCommand) initializeModule(ctx context.Context) (rerr error) {
 	ctx, span := Tracer().Start(ctx, "initialize")
 	defer telemetry.End(span, func() error { return rerr })
 
-	srcRefStr, ok := getExplicitModuleSourceRef()
-	if ok && srcRefStr == coreModRef {
+	if loadCoreFuncs {
 		fc.mod = &moduleDef{}
 	} else {
 		resolveCtx, resolveSpan := Tracer().Start(ctx, "resolving module ref", telemetry.Encapsulate())

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -1,22 +1,33 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 
-	"github.com/juju/ansiterm/tabwriter"
-	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"gopkg.in/yaml.v3"
 
 	"dagger.io/dagger"
 	"dagger.io/dagger/querybuilder"
 	"dagger.io/dagger/telemetry"
 	"github.com/dagger/dagger/engine/client"
 	"github.com/dagger/dagger/engine/slog"
+)
+
+var (
+	// jsonOutput is true if the `-j,--json` flag is used.
+	jsonOutput bool
+
+	// outputPath is the parsed value of the `--output` flag.
+	outputPath string
 )
 
 const (
@@ -44,96 +55,6 @@ var funcGroup = &cobra.Group{
 	Title: "Functions",
 }
 
-var funcCmds = FuncCommands{
-	funcListCmd,
-	callCmd,
-}
-
-var funcListCmd = &FuncCommand{
-	Name:  "functions [options] [function]...",
-	Short: `List available functions`,
-	Long: strings.ReplaceAll(`List available functions in a module.
-
-This is similar to ´dagger call --help´, but only focused on showing the
-available functions.
-`,
-		"´",
-		"`",
-	),
-	Execute: func(fc *FuncCommand, cmd *cobra.Command) error {
-		tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 3, ' ', tabwriter.DiscardEmptyColumns)
-		var o functionProvider = fc.mod.MainObject.AsFunctionProvider()
-		fmt.Fprintf(tw, "%s\t%s\n",
-			termenv.String("Name").Bold(),
-			termenv.String("Description").Bold(),
-		)
-		// Walk the hypothetical function pipeline specified by the args
-		for _, field := range cmd.Flags().Args() {
-			// Lookup the next function in the specified pipeline
-			nextFunc, err := GetFunction(o, field)
-			if err != nil {
-				return err
-			}
-			nextType := nextFunc.ReturnType
-			if nextType.AsList != nil {
-				nextType = nextType.AsList.ElementTypeDef
-			}
-			if nextType.AsFunctionProvider() != nil {
-				// sipsma explains why 'nextType.AsObject' is not enough:
-				// > when we're returning the hierarchies of TypeDefs from the API,
-				// > and an object shows up as an output/input type to a function,
-				// > we just return a TypeDef with a name of the object rather than the full object definition.
-				// > You can get the full object definition only from the "top-level" returned object on the api call.
-				//
-				// > The reason is that if we repeated the full object definition every time,
-				// > you'd at best be using O(n^2) space in the result,
-				// > and at worst cause json serialization errors due to cyclic references
-				// > (i.e. with* functions on an object that return the object itself).
-				o = fc.mod.GetFunctionProvider(nextType.Name())
-				continue
-			}
-			return fmt.Errorf("function %q returns type %q with no further functions available", field, nextType.Kind)
-		}
-		// List functions on the final object
-		fns := o.GetFunctions()
-		sort.Slice(fns, func(i, j int) bool {
-			return fns[i].Name < fns[j].Name
-		})
-		skipped := make([]string, 0)
-		for _, fn := range fns {
-			if fn.IsUnsupported() {
-				skipped = append(skipped, cliName(fn.Name))
-				continue
-			}
-			desc := strings.SplitN(fn.Description, "\n", 2)[0]
-			if desc == "" {
-				desc = "-"
-			}
-			fmt.Fprintf(tw, "%s\t%s\n",
-				cliName(fn.Name),
-				desc,
-			)
-		}
-		if len(skipped) > 0 {
-			msg := fmt.Sprintf("Skipped %d function(s) with unsupported types: %s", len(skipped), strings.Join(skipped, ", "))
-			fmt.Fprintf(tw, "\n%s\n",
-				termenv.String(msg).Faint().String(),
-			)
-		}
-		return tw.Flush()
-	},
-}
-
-type FuncCommands []*FuncCommand
-
-func (fcs FuncCommands) All() []*cobra.Command {
-	cmds := make([]*cobra.Command, len(fcs))
-	for i, fc := range fcs {
-		cmds[i] = fc.Command()
-	}
-	return cmds
-}
-
 // FuncCommand is a config object used to create a dynamic set of commands
 // for querying a module's functions.
 type FuncCommand struct {
@@ -152,34 +73,8 @@ type FuncCommand struct {
 	// Example is examples of how to use the command.
 	Example string
 
-	// Init is called when the command is created and initialized,
-	// before execution.
-	//
-	// It can be useful to add persistent flags for all subcommands here.
-	Init func(*cobra.Command)
-
-	// Execute circumvents the default behavior of traversing  subcommands
-	// from the arguments, but still has access to the loaded objects from
-	// the module.
-	Execute func(*FuncCommand, *cobra.Command) error
-
-	// OnSelectObjectLeaf is called when a user provided command ends in a
-	// object and no more sub-commands are provided.
-	//
-	// If set, it should make another selection on the object that results
-	// return no error. Otherwise if it doesn't handle the object, it should
-	// return an error.
-	OnSelectObjectLeaf func(context.Context, *FuncCommand, functionProvider) error
-
-	// BeforeRequest is called before making the request with the query that
-	// contains the whole chain of functions.
-	//
-	// It can be useful to validate the return type of the function or as a
-	// last effort to select a GraphQL sub-field.
-	BeforeRequest func(*FuncCommand, *cobra.Command, *modTypeDef) error
-
-	// AfterResponse is called when the query has completed and returned a result.
-	AfterResponse func(*FuncCommand, *cobra.Command, *modTypeDef, any) error
+	// DisableModuleLoad skips adding a flag for loading a user Dagger Module.
+	DisableModuleLoad bool
 
 	// cmd is the parent cobra command.
 	cmd *cobra.Command
@@ -197,6 +92,9 @@ type FuncCommand struct {
 	// warnSkipped flags whether to show a warning for skipped functions and
 	// arguments rather than a debug level log.
 	warnSkipped bool
+
+	// selectedObject is not empty if the command chain end in an object.
+	selectedObject functionProvider
 
 	q   *querybuilder.Selection
 	c   *client.Client
@@ -262,6 +160,7 @@ func (fc *FuncCommand) Command() *cobra.Command {
 			RunE: func(c *cobra.Command, a []string) error {
 				return withEngine(c.Context(), client.Params{}, func(ctx context.Context, engineClient *client.Client) (rerr error) {
 					fc.c = engineClient
+					fc.q = querybuilder.Query().Client(engineClient.Dagger().GraphQLClient())
 
 					// withEngine changes the context.
 					c.SetContext(ctx)
@@ -295,9 +194,9 @@ func (fc *FuncCommand) Command() *cobra.Command {
 			return pflag.NormalizedName(cliName(name))
 		})
 
-		if fc.Init != nil {
-			fc.Init(fc.cmd)
-		}
+		fc.cmd.PersistentFlags().StringVarP(&outputPath, "output", "o", "", "Save the result to a local file or directory")
+
+		fc.cmd.PersistentFlags().BoolVarP(&jsonOutput, "json", "j", false, "Present result as JSON")
 	}
 	return fc.cmd
 }
@@ -355,9 +254,11 @@ func (fc *FuncCommand) execute(c *cobra.Command, a []string) (rerr error) {
 		}
 	}()
 
-	if err := fc.initializeModule(ctx); err != nil {
+	mod, err := initializeModule(ctx, fc.c.Dagger(), !fc.DisableModuleLoad)
+	if err != nil {
 		return err
 	}
+	fc.mod = mod
 
 	// Now that the module is loaded, show usage by default since errors
 	// are more likely to be from wrong CLI usage.
@@ -372,45 +273,41 @@ func (fc *FuncCommand) execute(c *cobra.Command, a []string) (rerr error) {
 		return fc.Help(cmd)
 	}
 
-	if fc.Execute != nil {
-		return fc.Execute(fc, cmd)
-	}
-
 	// No args to the parent command
 	if cmd == c {
-		return fc.RunE(ctx, fc.mod.MainObject)(cmd, flags)
+		return fc.RunE(ctx, fc.mod.MainObject.AsObject.Constructor)(cmd, flags)
 	}
 
 	return cmd.RunE(cmd, flags)
 }
 
 // initializeModule loads the module's type definitions.
-func (fc *FuncCommand) initializeModule(ctx context.Context) (rerr error) {
-	dag := fc.c.Dagger()
+func initializeModule(ctx context.Context, dag *dagger.Client, loadModule bool) (rdef *moduleDef, rerr error) {
+	def := &moduleDef{}
 
 	ctx, span := Tracer().Start(ctx, "initialize")
 	defer telemetry.End(span, func() error { return rerr })
 
-	if loadCoreFuncs {
-		fc.mod = &moduleDef{}
-	} else {
+	if loadModule {
 		resolveCtx, resolveSpan := Tracer().Start(ctx, "resolving module ref", telemetry.Encapsulate())
 		defer telemetry.End(resolveSpan, func() error { return rerr })
 		modConf, err := getDefaultModuleConfiguration(resolveCtx, dag, true, true)
 		if err != nil {
-			return fmt.Errorf("failed to get configured module: %w", err)
+			return nil, fmt.Errorf("failed to get configured module: %w", err)
 		}
 		if !modConf.FullyInitialized() {
-			return fmt.Errorf("module at source dir %q doesn't exist or is invalid", modConf.LocalRootSourcePath)
+			return nil, fmt.Errorf("module at source dir %q doesn't exist or is invalid", modConf.LocalRootSourcePath)
 		}
 		resolveSpan.End()
+
+		def.Source = modConf.Source
 		mod := modConf.Source.AsModule().Initialize()
 
 		serveCtx, serveSpan := Tracer().Start(ctx, "installing module", telemetry.Encapsulate())
 		err = mod.Serve(serveCtx)
 		telemetry.End(serveSpan, func() error { return err })
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		ctx, loadSpan := Tracer().Start(ctx, "analyzing module", telemetry.Encapsulate())
@@ -418,34 +315,24 @@ func (fc *FuncCommand) initializeModule(ctx context.Context) (rerr error) {
 
 		name, err := mod.Name(ctx)
 		if err != nil {
-			return fmt.Errorf("get module name: %w", err)
+			return nil, fmt.Errorf("get module name: %w", err)
 		}
-
-		fc.mod = &moduleDef{
-			Name:   name,
-			Source: modConf.Source,
-		}
+		def.Name = name
 	}
 
-	if err := fc.mod.loadTypeDefs(ctx, dag); err != nil {
-		return err
+	if err := def.loadTypeDefs(ctx, dag); err != nil {
+		return nil, err
 	}
 
-	if fc.mod.MainObject == nil {
-		return fmt.Errorf("main object not found")
+	if def.MainObject == nil {
+		return nil, fmt.Errorf("main object not found")
 	}
 
-	return nil
+	return def, nil
 }
 
 // loadCommand finds the leaf command to run.
 func (fc *FuncCommand) loadCommand(c *cobra.Command, a []string) (rcmd *cobra.Command, rargs []string, rerr error) {
-	// If a command implements Execute, it doesn't need to build and
-	// traverse the command tree.
-	if fc.Execute != nil {
-		return c, nil, nil
-	}
-
 	ctx := c.Context()
 
 	spanCtx, span := Tracer().Start(ctx, "prepare", telemetry.Encapsulate())
@@ -538,6 +425,8 @@ func (fc *FuncCommand) cobraBuilder(ctx context.Context, fn *modFunction) func(*
 func (fc *FuncCommand) addFlagsForFunction(cmd *cobra.Command, fn *modFunction) error {
 	var skipped []string
 
+	var hasArgs bool
+
 	for _, arg := range fn.Args {
 		fc.mod.LoadTypeDef(arg.TypeDef)
 
@@ -556,9 +445,10 @@ func (fc *FuncCommand) addFlagsForFunction(cmd *cobra.Command, fn *modFunction) 
 			"help:group",
 			[]string{"Arguments"},
 		)
+		hasArgs = true
 	}
 
-	if cmd.HasAvailableLocalFlags() {
+	if hasArgs {
 		cmd.Use += " [arguments]"
 	}
 
@@ -624,7 +514,7 @@ func (fc *FuncCommand) makeSubCmd(ctx context.Context, fn *modFunction) *cobra.C
 		PreRunE: fc.cobraBuilder(ctx, fn),
 		// This is going to be executed in the "execution" vertex, when
 		// we have the final/leaf command.
-		RunE: fc.RunE(ctx, fn.ReturnType),
+		RunE: fc.RunE(ctx, fn),
 	}
 
 	newCmd.Flags().SetInterspersed(false)
@@ -637,7 +527,7 @@ func (fc *FuncCommand) makeSubCmd(ctx context.Context, fn *modFunction) *cobra.C
 func (fc *FuncCommand) selectFunc(fn *modFunction, cmd *cobra.Command) error {
 	dag := fc.c.Dagger()
 
-	fc.Select(fn.Name)
+	fc.q = fc.q.Select(fn.Name)
 
 	for _, arg := range fn.SupportedArgs() {
 		var val any
@@ -668,24 +558,15 @@ func (fc *FuncCommand) selectFunc(fn *modFunction, cmd *cobra.Command) error {
 			val = v.GetSlice()
 		}
 
-		fc.Arg(arg.Name, val)
+		fc.q = fc.q.Arg(arg.Name, val)
 	}
 
 	return nil
 }
 
-func (fc *FuncCommand) Select(name ...string) {
-	if fc.q == nil {
-		fc.q = querybuilder.Query().Client(fc.c.Dagger().GraphQLClient())
-	}
-	fc.q = fc.q.Select(name...)
-}
-
-func (fc *FuncCommand) Arg(name string, value any) {
-	fc.q = fc.q.Arg(name, value)
-}
-
-func (fc *FuncCommand) RunE(ctx context.Context, typeDef *modTypeDef) func(*cobra.Command, []string) error {
+// RunE is the final command in the function chain, where the API request is made.
+func (fc *FuncCommand) RunE(ctx context.Context, fn *modFunction) func(*cobra.Command, []string) error {
+	typeDef := fn.ReturnType
 	return func(cmd *cobra.Command, args []string) error {
 		t := typeDef
 		if t.AsList != nil {
@@ -697,21 +578,18 @@ func (fc *FuncCommand) RunE(ctx context.Context, typeDef *modTypeDef) func(*cobr
 			origSel := fc.q
 			obj := t.AsFunctionProvider()
 
-			if fc.OnSelectObjectLeaf != nil {
-				if err := fc.OnSelectObjectLeaf(ctx, fc, obj); err != nil {
-					return fmt.Errorf("invalid selection for command %q: %w", cmd.Name(), err)
-				}
+			if err := fc.SelectObjectLeaf(ctx, obj); err != nil {
+				return err
 			}
 
-			// If the selection didn't change, it means OnSelectObjectLeaf
-			// didn't handle it. Rather than error, just simulate an empty
-			// response for AfterResponse.
+			// If the selection didn't change, it means SelectObjectLeaf
+			// didn't handle it, probably because there's no scalars to select
+			// for printing. Rather than error, just return an empty
+			// response without making an API request. At minimum, the
+			// object's name will be returned.
 			if origSel == fc.q {
-				if fc.AfterResponse == nil {
-					return fmt.Errorf("%q requires a sub-command", cmd.Name())
-				}
 				response := map[string]any{}
-				return fc.AfterResponse(fc, cmd, typeDef, response)
+				return fc.HandleResponse(cmd, typeDef, response)
 			}
 		}
 
@@ -719,30 +597,58 @@ func (fc *FuncCommand) RunE(ctx context.Context, typeDef *modTypeDef) func(*cobr
 		// from wrong CLI usage.
 		fc.showUsage = false
 
-		if fc.BeforeRequest != nil {
-			if err := fc.BeforeRequest(fc, cmd, typeDef); err != nil {
-				return err
-			}
-		}
-
 		var response any
 
 		if err := fc.Request(ctx, &response); err != nil {
 			return err
 		}
 
-		if typeDef.Kind == dagger.VoidKind {
+		return fc.HandleResponse(cmd, typeDef, response)
+	}
+}
+
+func (fc *FuncCommand) SelectObjectLeaf(ctx context.Context, obj functionProvider) error {
+	fc.selectedObject = obj
+	typeName := obj.ProviderName()
+
+	// Convenience for sub-selecting `export` when `--output` is used
+	// on a core type that supports it.
+	// TODO: Replace with interface when possible.
+	switch typeName {
+	case Container, Directory, File:
+		if outputPath != "" {
+			fc.q = fc.q.Select("export").Arg("path", outputPath)
+			if typeName == File {
+				fc.q = fc.q.Arg("allowParentDirPath", true)
+			}
 			return nil
 		}
-
-		if fc.AfterResponse != nil {
-			return fc.AfterResponse(fc, cmd, typeDef, response)
-		}
-
-		cmd.Println(response)
-
-		return nil
 	}
+
+	switch typeName {
+	case Container, Terminal:
+		// There's no fields in `Container` that trigger container execution so
+		// we use `sync` first to evaluate, and then load the new `Container`
+		// from that response before continuing.
+		// TODO: Use an interface when possible.
+		var id string
+		fc.q = fc.q.Select("sync")
+		if err := fc.Request(ctx, &id); err != nil {
+			return err
+		}
+		fc.q = fc.q.Root().Select(fmt.Sprintf("load%sFromID", typeName)).Arg("id", id)
+	}
+
+	fns := GetLeafFunctions(obj)
+	names := make([]string, 0, len(fns))
+	for _, f := range fns {
+		names = append(names, f.Name)
+	}
+	if len(names) > 0 {
+		fc.q = fc.q.SelectMultiple(names...)
+	}
+
+	return nil
 }
 
 func (fc *FuncCommand) Request(ctx context.Context, response any) error {
@@ -756,5 +662,180 @@ func (fc *FuncCommand) Request(ctx context.Context, response any) error {
 		return fmt.Errorf("response from query: %w", err)
 	}
 
+	return nil
+}
+
+func (fc *FuncCommand) HandleResponse(cmd *cobra.Command, modType *modTypeDef, response any) error {
+	if modType.Kind == dagger.VoidKind {
+		return nil
+	}
+
+	// Handle the `export` convenience.
+	switch modType.Name() {
+	case Container, Directory, File:
+		if outputPath != "" {
+			respPath, ok := response.(string)
+			if !ok {
+				return fmt.Errorf("unexpected response %T: %+v", response, response)
+			}
+			cmd.PrintErrf("Saved to %q.\n", respPath)
+			return nil
+		}
+	}
+
+	var outputFormat string
+
+	// Command chain ended in an object.
+	if fc.selectedObject != nil {
+		typeName := fc.selectedObject.ProviderName()
+
+		if typeName == "Query" {
+			typeName = "Client"
+		}
+
+		// Add the object's name so we always have something to show.
+		payload := make(map[string]any)
+		payload["_type"] = typeName
+
+		if response == nil {
+			response = payload
+		} else {
+			r, err := addPayload(response, payload)
+			if err != nil {
+				return err
+			}
+			response = r
+		}
+
+		// Use yaml when printing scalars because it's more human-readable
+		// and handles lists and multiline strings well.
+		if stdoutIsTTY {
+			outputFormat = "yaml"
+		} else {
+			outputFormat = "json"
+		}
+	}
+
+	// The --json flag has precedence over the autodetected format above.
+	if jsonOutput {
+		outputFormat = "json"
+	}
+
+	buf := new(bytes.Buffer)
+	switch outputFormat {
+	case "json":
+		// disable HTML escaping to improve readability
+		encoder := json.NewEncoder(buf)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "    ")
+		if err := encoder.Encode(response); err != nil {
+			return err
+		}
+	case "yaml":
+		out, err := yaml.Marshal(response)
+		if err != nil {
+			return err
+		}
+		if _, err := buf.Write(out); err != nil {
+			return err
+		}
+	case "":
+		if err := printFunctionResult(buf, response); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("wrong output format %q", outputFormat)
+	}
+
+	if outputPath != "" {
+		if err := writeOutputFile(outputPath, buf); err != nil {
+			return fmt.Errorf("couldn't write output to file: %w", err)
+		}
+		path, err := filepath.Abs(outputPath)
+		if err != nil {
+			// don't fail because at this point the output has been saved successfully
+			slog.Warn("Failed to get absolute path", "error", err)
+			path = outputPath
+		}
+		cmd.PrintErrf("Saved output to %q.\n", path)
+	}
+
+	writer := cmd.OutOrStdout()
+	buf.WriteTo(writer)
+
+	// TODO(vito) right now when stdoutIsTTY we'll be printing to a Progrock
+	// vertex, which currently adds its own linebreak (as well as all the
+	// other UI clutter), so there's no point doing this. consider adding
+	// back when we switch to printing "clean" output on exit.
+	// if stdoutIsTTY && !strings.HasSuffix(buf.String(), "\n") {
+	// 	fmt.Fprintln(writer, "⏎")
+	// }
+
+	return nil
+}
+
+// addPayload merges a map into a response from getting an object's values.
+func addPayload(response any, payload map[string]any) (any, error) {
+	switch t := response.(type) {
+	case []any:
+		r := make([]any, 0, len(t))
+		for _, v := range t {
+			p, err := addPayload(v, payload)
+			if err != nil {
+				return nil, err
+			}
+			r = append(r, p)
+		}
+		return r, nil
+	case map[string]any:
+		if len(t) == 0 {
+			return payload, nil
+		}
+		r := make(map[string]any, len(t)+len(payload))
+		for k, v := range t {
+			r[k] = v
+		}
+		for k, v := range payload {
+			r[k] = v
+		}
+		return r, nil
+	default:
+		return nil, fmt.Errorf("unexpected response %T for object values: %+v", response, response)
+	}
+}
+
+// writeOutputFile writes the buffer to a file, creating the parent directories
+// if needed.
+func writeOutputFile(path string, buf *bytes.Buffer) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, buf.Bytes(), 0o644) //nolint: gosec
+}
+
+func printFunctionResult(w io.Writer, r any) error {
+	switch t := r.(type) {
+	case []any:
+		for _, v := range t {
+			if err := printFunctionResult(w, v); err != nil {
+				return err
+			}
+			fmt.Fprintln(w)
+		}
+		return nil
+	case map[string]any:
+		// NB: we're only interested in values because this is where we unwrap
+		// things like {"container":{"from":{"withExec":{"stdout":"foo"}}}}.
+		for _, v := range t {
+			if err := printFunctionResult(w, v); err != nil {
+				return err
+			}
+		}
+		return nil
+	case string:
+		fmt.Fprint(w, t)
+	default:
+		fmt.Fprintf(w, "%+v", t)
+	}
 	return nil
 }

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -73,6 +73,10 @@ type FuncCommand struct {
 	// Example is examples of how to use the command.
 	Example string
 
+	// Annotations are key/value pairs that can be used to identify or
+	// group commands or set special options.
+	Annotations map[string]string
+
 	// DisableModuleLoad skips adding a flag for loading a user Dagger Module.
 	DisableModuleLoad bool
 
@@ -109,8 +113,8 @@ func (fc *FuncCommand) Command() *cobra.Command {
 			Short:       fc.Short,
 			Long:        fc.Long,
 			Example:     fc.Example,
+			Annotations: fc.Annotations,
 			GroupID:     moduleGroup.ID,
-			Annotations: map[string]string{},
 
 			// We need to disable flag parsing because it'll act on --help
 			// and validate the args before we have a chance to add the
@@ -182,6 +186,10 @@ func (fc *FuncCommand) Command() *cobra.Command {
 					return nil
 				})
 			},
+		}
+
+		if fc.cmd.Annotations == nil {
+			fc.cmd.Annotations = map[string]string{}
 		}
 
 		// Allow using flags with the name that was reported by the SDK.

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -84,7 +84,7 @@ func init() {
 		newGenCmd(),
 	)
 
-	funcCmds.AddParent(rootCmd)
+	rootCmd.AddCommand(funcCmds.All()...)
 
 	rootCmd.AddGroup(moduleGroup)
 	rootCmd.AddGroup(execGroup)

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -80,11 +80,12 @@ func init() {
 		moduleInstallCmd,
 		moduleDevelopCmd,
 		modulePublishCmd,
+		funcListCmd,
+		callCoreCmd.Command(),
+		callModCmd.Command(),
 		sessionCmd(),
 		newGenCmd(),
 	)
-
-	rootCmd.AddCommand(funcCmds.All()...)
 
 	rootCmd.AddGroup(moduleGroup)
 	rootCmd.AddGroup(execGroup)

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -36,6 +36,9 @@ var (
 	moduleURL   string
 	moduleFlags = pflag.NewFlagSet("module", pflag.ContinueOnError)
 
+	loadCoreFuncs bool
+	functionFlags = pflag.NewFlagSet("functions", pflag.ContinueOnError)
+
 	sdk           string
 	licenseID     string
 	compatVersion string
@@ -60,9 +63,16 @@ const (
 func init() {
 	moduleFlags.StringVarP(&moduleURL, "mod", "m", "", "Path to the module directory. Either local path or a remote git repo")
 
+	functionFlags.BoolVarP(&loadCoreFuncs, "core", "c", false, "Load core functions instead of a module (mutually exclusive with -m)")
+
+	for _, c := range funcCmds.All() {
+		c.PersistentFlags().AddFlagSet(moduleFlags)
+		c.PersistentFlags().AddFlagSet(functionFlags)
+		c.MarkFlagsMutuallyExclusive("core", "mod")
+	}
+
 	listenCmd.PersistentFlags().AddFlagSet(moduleFlags)
 	queryCmd.PersistentFlags().AddFlagSet(moduleFlags)
-	funcCmds.AddFlagSet(moduleFlags)
 	configCmd.PersistentFlags().AddFlagSet(moduleFlags)
 
 	moduleInitCmd.Flags().StringVar(&sdk, "sdk", "", "Optionally install a Dagger SDK")

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -2186,3 +2186,19 @@ func (m *Test) Quit() {
 	require.ErrorAs(t, err, &exErr)
 	require.Equal(t, 6, exErr.ExitCode)
 }
+
+func (ModuleSuite) TestCallCore(ctx context.Context, t *testctx.T) {
+	t.Run("call container", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		out, err := daggerCliBase(t, c).
+			With(daggerExec(
+				"core", "container",
+				"from", "--address", alpineImage,
+				"file", "--path", "/etc/os-release",
+				"contents",
+			)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "Alpine Linux")
+	})
+}

--- a/core/schema/coremod.go
+++ b/core/schema/coremod.go
@@ -99,7 +99,7 @@ func (m *CoreMod) ModTypeFor(ctx context.Context, typeDef *core.TypeDef, checkDi
 		modType = &CoreModEnum{coreMod: m, typeDef: typeDef.AsEnum.Value}
 
 	case core.TypeDefKindInterface:
-		// core does not yet defined any interfaces
+		// core does not yet define any interfaces
 		return nil, false, nil
 
 	default:
@@ -182,7 +182,7 @@ func (m *CoreMod) TypeDefs(ctx context.Context) ([]*core.TypeDef, error) {
 				typeDef.Functions = append(typeDef.Functions, fn)
 			}
 
-			if !isIdable {
+			if !isIdable && typeDef.Name != "Query" {
 				continue
 			}
 

--- a/docs/current_docs/reference/cli.mdx
+++ b/docs/current_docs/reference/cli.mdx
@@ -25,6 +25,7 @@ A tool to run CI/CD pipelines in containers, anywhere
 
 * [dagger call](#dagger-call)	 - Call one or more functions, interconnected into a pipeline
 * [dagger config](#dagger-config)	 - Get or set module configuration
+* [dagger core](#dagger-core)	 - Call a core function
 * [dagger develop](#dagger-develop)	 - Prepare a local module for development
 * [dagger functions](#dagger-functions)	 - List available functions
 * [dagger init](#dagger-init)	 - Initialize a new module
@@ -46,7 +47,6 @@ dagger call [options]
 ### Options
 
 ```
-  -c, --core            Load core functions instead of a module (mutually exclusive with -m)
   -j, --json            Present result as JSON
   -m, --mod string      Path to the module directory. Either local path or a remote git repo
   -o, --output string   Save the result to a local file or directory
@@ -92,6 +92,37 @@ dagger config -m github.com/dagger/hello-dagger
 ```
       --json         output in JSON format
   -m, --mod string   Path to the module directory. Either local path or a remote git repo
+```
+
+### Options inherited from parent commands
+
+```
+  -d, --debug             Show debug logs and full verbosity
+  -i, --interactive       Spawn a terminal on container exec failure
+      --progress string   Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent            Do not show progress at all
+  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
+  -w, --web               Open trace URL in a web browser
+```
+
+### SEE ALSO
+
+* [dagger](#dagger)	 - A tool to run CI/CD pipelines in containers, anywhere
+
+## dagger core
+
+Call a core function
+
+```
+dagger core [options]
+```
+
+### Options
+
+```
+  -j, --json            Present result as JSON
+  -o, --output string   Save the result to a local file or directory
 ```
 
 ### Options inherited from parent commands
@@ -183,7 +214,6 @@ dagger functions [options] [function]...
 ### Options
 
 ```
-  -c, --core         Load core functions instead of a module (mutually exclusive with -m)
   -m, --mod string   Path to the module directory. Either local path or a remote git repo
 ```
 

--- a/docs/current_docs/reference/cli.mdx
+++ b/docs/current_docs/reference/cli.mdx
@@ -46,6 +46,7 @@ dagger call [options]
 ### Options
 
 ```
+  -c, --core            Load core functions instead of a module (mutually exclusive with -m)
   -j, --json            Present result as JSON
   -m, --mod string      Path to the module directory. Either local path or a remote git repo
   -o, --output string   Save the result to a local file or directory
@@ -182,6 +183,7 @@ dagger functions [options] [function]...
 ### Options
 
 ```
+  -c, --core         Load core functions instead of a module (mutually exclusive with -m)
   -m, --mod string   Path to the module directory. Either local path or a remote git repo
 ```
 

--- a/sdk/go/querybuilder/querybuilder_test.go
+++ b/sdk/go/querybuilder/querybuilder_test.go
@@ -154,7 +154,7 @@ func TestSiblings(t *testing.T) {
 	q, err := Query().
 		Select("foo").
 		Select("bar").
-		Select("one", "two", "three").
+		SelectMultiple("one", "two", "three").
 		Build(context.Background())
 
 	require.NoError(t, err)
@@ -164,7 +164,7 @@ func TestSiblings(t *testing.T) {
 func TestSiblingsLeaf(t *testing.T) {
 	_, err := Query().
 		Select("foo").
-		Select("one", "two", "three").
+		SelectMultiple("one", "two", "three").
 		Select("bar").
 		Build(context.Background())
 
@@ -181,8 +181,8 @@ func TestUnpackSiblings(t *testing.T) {
 	root := Query().
 		Select("foo").
 		Select("bar").
-		Bind(&contents).
-		Select("one", "two", "three")
+		SelectMultiple("one", "two", "three").
+		Bind(&contents)
 
 	var response any
 	err := json.Unmarshal([]byte(`


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/6947

Current implementation uses a top-level command for core functions:
- `dagger core <function>`  → execute a function from the core API
- `dagger call -m <module> <function>` → execute a function from a module

## How

Can be run from anywhere as it doesn't require a module to load:

```console
❯ dagger core version
[dev-fdc07a5bfb46ca6a37ae379d767210d54f141c4f](version: v0.12.5-010101000000-dev-8e3b1f29b72b)
```

Allows experimentation in the CLI without the need for a module

```console
❯ dagger core container from --address=alpine file --path=/etc/os-release contents
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.20.2
PRETTY_NAME="Alpine Linux v3.20"
HOME_URL="https://alpinelinux.org/"
BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"
```

Can be a nice alternative to `docker run`:

```console
❯ dagger core container from --address=cgr.dev/chainguard/wolfi-base terminal
dagger / $ 
```

Without arguments:

```console
❯  dagger core
_type: Client
defaultPlatform: linux/arm64
version: v0.12.5-010101000000-dev-8e3b1f29b72b
```

Listing:

```console
❯  dagger core --help
Call a core function

USAGE
  dagger core [options] <function>

FUNCTIONS
  blob                Retrieves a content-addressed blob.
  container           Creates a scratch container.
  current-type-defs   The TypeDef representations of the objects currently being served in the session.
  dagger-engine       The Dagger engine container configuration and state
  default-platform    The default platform of the engine.
  directory           Creates an empty directory.
  git                 Queries a Git repository.
  host                Queries the host environment.
  http                Returns a file containing an http remote url content.
  module              Create a new module.
  module-dependency   Create a new module dependency configuration from a module source and name
  module-source       Create a new module source instance from a source ref string.
  version             Get the current Dagger Engine version.

OPTIONS
  -j, --json            Present result as JSON
  -o, --output string   Save the result to a local file or directory

INHERITED OPTIONS
  -d, --debug             Show debug logs and full verbosity
  -i, --interactive       Spawn a terminal on container exec failure
      --progress string   Progress output format (auto, plain, tty) (default "auto")
  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
  -s, --silent            Do not show progress at all
  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
  -w, --web               Open trace URL in a web browser

Use "dagger core [command] --help" for more information about a command.
```

## Next

The `core` top-level command is possibly a stepping stone to select a few core functions as their own top-level commands. That'll open up creating more commands by implementing them via the API rather than client side. \cc @sipsma 