### PR TITLE
chore: update alpine base to 3.19

### DIFF
--- a/ci/consts/versions.go
+++ b/ci/consts/versions.go
@@ -17,7 +17,7 @@ const (
 
 	GolangLintVersion = "v1.57"
 
-	AlpineVersion = "3.18"
+	AlpineVersion = "3.19"
 	AlpineImage   = "alpine:" + AlpineVersion
 	WolfiImage    = "cgr.dev/chainguard/wolfi-base"
 	WolfiVersion  = "latest" // Wolfi is a rolling distro; no release to pin to

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -78,7 +78,7 @@ func TestContainerFrom(t *testing.T) {
 			}
 		}`, &res, nil)
 	require.NoError(t, err)
-	require.Equal(t, res.Container.From.File.Contents, "3.18.2\n")
+	require.Equal(t, res.Container.From.File.Contents, "3.19.1\n")
 }
 
 func TestContainerBuild(t *testing.T) {
@@ -334,7 +334,7 @@ func TestContainerWithRootFS(t *testing.T) {
 	releaseStr, err := alpine315ReplacedFS.File("/etc/alpine-release").Contents(ctx)
 	require.NoError(t, err)
 
-	require.Equal(t, "3.18.2\n", releaseStr)
+	require.Equal(t, "3.19.1\n", releaseStr)
 }
 
 //go:embed testdata/hello.go
@@ -2601,7 +2601,7 @@ func TestContainerFSDirectory(t *testing.T) {
 		}})
 	require.NoError(t, err)
 
-	require.Equal(t, "3.18.2\n", execRes.Container.From.WithMountedDirectory.WithExec.Stdout)
+	require.Equal(t, "3.19.1\n", execRes.Container.From.WithMountedDirectory.WithExec.Stdout)
 }
 
 func TestContainerRelativePaths(t *testing.T) {
@@ -2808,7 +2808,7 @@ func TestContainerPublish(t *testing.T) {
 	pulledCtr := c.Container().From(pushedRef)
 	contents, err := pulledCtr.File("/etc/alpine-release").Contents(ctx)
 	require.NoError(t, err)
-	require.Equal(t, contents, "3.18.2\n")
+	require.Equal(t, contents, "3.19.1\n")
 
 	output, err := pulledCtr.WithExec(nil).Stdout(ctx)
 	require.NoError(t, err)
@@ -3342,7 +3342,7 @@ func TestContainerImageRef(t *testing.T) {
 				}
 			}`, &res, nil)
 		require.NoError(t, err)
-		require.Contains(t, res.Container.From.ImageRef, "docker.io/library/alpine:3.18.2@sha256:")
+		require.Contains(t, res.Container.From.ImageRef, "docker.io/library/alpine:3.19.1@sha256:")
 	})
 
 	t.Run("should throw error after the container image modification with exec", func(t *testing.T) {

--- a/core/integration/engine_test.go
+++ b/core/integration/engine_test.go
@@ -154,7 +154,7 @@ func TestDaggerRun(t *testing.T) {
 
 	runCommand := `
 	export NO_COLOR=1
-	jq -n '{query:"{container{from(address: \"alpine:3.18.2\"){file(path: \"/etc/alpine-release\"){contents}}}}"}' | \
+	jq -n '{query:"{container{from(address: \"alpine:3.19.1\"){file(path: \"/etc/alpine-release\"){contents}}}}"}' | \
 	dagger run sh -c 'curl -s \
 		-u $DAGGER_SESSION_TOKEN: \
 		-H "content-type:application/json" \
@@ -167,8 +167,8 @@ func TestDaggerRun(t *testing.T) {
 
 	stdout, err := clientCtr.Stdout(ctx)
 	require.NoError(t, err)
-	require.Contains(t, stdout, "3.18.2")
-	require.JSONEq(t, `{"data": {"container": {"from": {"file": {"contents": "3.18.2\n"}}}}}`, stdout)
+	require.Contains(t, stdout, "3.19.1")
+	require.JSONEq(t, `{"data": {"container": {"from": {"file": {"contents": "3.19.1\n"}}}}}`, stdout)
 
 	stderr, err := clientCtr.Stderr(ctx)
 	require.NoError(t, err)

--- a/core/integration/file_test.go
+++ b/core/integration/file_test.go
@@ -194,7 +194,7 @@ func TestFileExport(t *testing.T) {
 
 		contents, err := os.ReadFile(dest)
 		require.NoError(t, err)
-		require.Equal(t, "3.18.2\n", string(contents))
+		require.Equal(t, "3.19.1\n", string(contents))
 
 		entries, err := ls(targetDir)
 		require.NoError(t, err)
@@ -208,7 +208,7 @@ func TestFileExport(t *testing.T) {
 
 		contents, err := os.ReadFile(filepath.Join(wd, "some-file"))
 		require.NoError(t, err)
-		require.Equal(t, "3.18.2\n", string(contents))
+		require.Equal(t, "3.19.1\n", string(contents))
 
 		entries, err := ls(wd)
 		require.NoError(t, err)

--- a/core/integration/images.go
+++ b/core/integration/images.go
@@ -1,7 +1,7 @@
 package core
 
 const (
-	alpineImage = "alpine:3.18.2"
+	alpineImage = "alpine:3.19.1"
 	golangImage = "golang:1.22.2-alpine"
 	debianImage = "debian:bookworm"
 	rhelImage   = "registry.access.redhat.com/ubi9/ubi"

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -868,7 +868,7 @@ func TestModuleDaggerCallCoreChaining(t *testing.T) {
 				Contents: `package main
 
 func New() *Test {
-	return &Test{Ctr: dag.Container().From("alpine:3.18.5")}
+	return &Test{Ctr: dag.Container().From("alpine:3.19.1")}
 }
 
 type Test struct {
@@ -880,7 +880,7 @@ type Test struct {
 		t.Run("file", func(t *testing.T) {
 			out, err := modGen.With(daggerCall("ctr", "file", "--path=/etc/alpine-release", "contents")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Equal(t, "3.18.5\n", out)
+			require.Equal(t, "3.19.1\n", out)
 		})
 
 		t.Run("export", func(t *testing.T) {

--- a/core/integration/module_terminal_test.go
+++ b/core/integration/module_terminal_test.go
@@ -32,7 +32,7 @@ import "context"
 func New(ctx context.Context) *Test {
 	return &Test{
 		Ctr: dag.Container().
-			From("mirror.gcr.io/alpine:3.18").
+			From("mirror.gcr.io/alpine:3.19").
 			WithEnvVariable("COOLENV", "woo").
 			WithWorkdir("/coolworkdir"),
 	}
@@ -101,7 +101,7 @@ import "context"
 func New(ctx context.Context) *Test {
 	return &Test{
 		Ctr: dag.Container().
-			From("mirror.gcr.io/alpine:3.18").
+			From("mirror.gcr.io/alpine:3.19").
 			WithEnvVariable("COOLENV", "woo").
 			WithWorkdir("/coolworkdir").
 			WithDefaultTerminalCmd([]string{"/bin/sh"}),
@@ -171,7 +171,7 @@ import "context"
 func New(ctx context.Context) *Test {
 	return &Test{
 		Ctr: dag.Container().
-			From("mirror.gcr.io/alpine:3.18").
+			From("mirror.gcr.io/alpine:3.19").
 			WithEnvVariable("COOLENV", "woo").
 			WithWorkdir("/coolworkdir").
 			WithExec([]string{"apk", "add", "python3"}).

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -4087,7 +4087,7 @@ import (
 )
 
 func New(ctx context.Context) (Test, error) {
-	v, err := dag.Container().From("alpine:3.18.4").File("/etc/alpine-release").Contents(ctx)
+	v, err := dag.Container().From("alpine:3.19.1").File("/etc/alpine-release").Contents(ctx)
 	if err != nil {
 		return Test{}, err
 	}
@@ -4113,7 +4113,7 @@ class Test:
     async def create(cls) -> "Test":
         return cls(alpine_version=await (
             dag.container()
-            .from_("alpine:3.18.4")
+            .from_("alpine:3.19.1")
             .file("/etc/alpine-release")
             .contents()
         ))
@@ -4133,7 +4133,7 @@ class Test {
   // This is only for testing purpose but it shouldn't be done in real usage.
   constructor() {
     return (async () => {
-      this.alpineVersion = await dag.container().from("alpine:3.18.4").file("/etc/alpine-release").contents()
+      this.alpineVersion = await dag.container().from("alpine:3.19.1").file("/etc/alpine-release").contents()
 
       return this; // Return the newly-created instance
     })();
@@ -4156,7 +4156,7 @@ class Test {
 
 				out, err := ctr.With(daggerCall("alpine-version")).Stdout(ctx)
 				require.NoError(t, err)
-				require.Equal(t, strings.TrimSpace(out), "3.18.4")
+				require.Equal(t, strings.TrimSpace(out), "3.19.1")
 			})
 		}
 	})
@@ -5295,12 +5295,12 @@ func TestModuleDaggerListen(t *testing.T) {
 			var out []byte
 			for range limitTicker(time.Second, 60) {
 				callCmd := hostDaggerCommand(ctx, t, modDir, "--debug", "query")
-				callCmd.Stdin = strings.NewReader(`query{container{from(address:"alpine:3.18.6"){file(path:"/etc/alpine-release"){contents}}}}`)
+				callCmd.Stdin = strings.NewReader(`query{container{from(address:"alpine:3.19.1"){file(path:"/etc/alpine-release"){contents}}}}`)
 				callCmd.Env = append(callCmd.Env, os.Environ()...)
 				callCmd.Env = append(callCmd.Env, "DAGGER_SESSION_PORT=12457", "DAGGER_SESSION_TOKEN=lol")
 				out, err = callCmd.CombinedOutput()
 				if err == nil {
-					require.Contains(t, string(out), "3.18.6")
+					require.Contains(t, string(out), "3.19.1")
 					return
 				}
 				time.Sleep(1 * time.Second)
@@ -5333,12 +5333,12 @@ func TestModuleDaggerListen(t *testing.T) {
 			var err error
 			for range limitTicker(time.Second, 60) {
 				callCmd := hostDaggerCommand(ctx, t, tmpdir, "--debug", "query")
-				callCmd.Stdin = strings.NewReader(`query{container{from(address:"alpine:3.18.6"){file(path:"/etc/alpine-release"){contents}}}}`)
+				callCmd.Stdin = strings.NewReader(`query{container{from(address:"alpine:3.19.1"){file(path:"/etc/alpine-release"){contents}}}}`)
 				callCmd.Env = append(callCmd.Env, os.Environ()...)
 				callCmd.Env = append(callCmd.Env, "DAGGER_SESSION_PORT=12458", "DAGGER_SESSION_TOKEN=lol")
 				out, err = callCmd.CombinedOutput()
 				if err == nil {
-					require.Contains(t, string(out), "3.18.6")
+					require.Contains(t, string(out), "3.19.1")
 					return
 				}
 				time.Sleep(1 * time.Second)
@@ -5833,7 +5833,7 @@ func TestModuleStartServices(t *testing.T) {
 			AsService()
 
 		ctr := dag.Container().
-			From("alpine:3.18.6").
+			From("alpine:3.19.1").
 			WithServiceBinding("svc", svc).
 			WithExec([]string{"wget", "-O", "-", "http://svc:23457"})
 


### PR DESCRIPTION
Yay - somehow, https://github.com/dagger/dagger/pull/7111 wasn't entirely right - the git version in alpine 3.18 is too old, and `git fetch --porcelain` isn't supported. However, in alpine 3.19, the version is new enough, and this new flag works.

See https://github.com/dagger/dagger/actions/runs/9003172745/job/24733214096?pr=7319#step:4:71.
```
14:06:47 WRN failed to fetch branch err="error fetching branch from origin: exit status 129\nerror: unknown option `porcelain'\nusage: git fetch [<options>] [<repository> [<refspec>...]]\n   or: git fetch [<options>] <group>\n   or: git fetch --multiple [<options>] [(<repository> | <group>)...]\n   or: git fetch --all [<options>]\n\n    -v, --verbose         be more verbose\n    -q, --quiet           be more quiet\n    --all                 fetch from all remotes\n    --set-upstream        set upstream for git pull/fetch\n    -a, --append          append to .git/FETCH_HEAD instead of overwriting\n    --atomic              use atomic transaction to update references\n    --upload-pack <path>  path to upload pack on remote end\n    -f, --force           force overwrite of local reference\n    -m, --multiple        fetch from multiple remotes\n    -t, --tags            fetch all tags and associated objects\n    -n                    do not fetch all tags (--no-tags)\n    -j, --jobs <n>        number of submodules fetched in parallel\n    --prefetch            modify the refspec to place all refs within refs/prefetch/\n    -p, --prune           prune remote-tracking branches no longer on remote\n    -P, --prune-tags      prune local tags no longer on remote and clobber changed tags\n    --recurse-submodules[=<on-demand>]\n                          control recursive fetching of submodules\n    --dry-run             dry run\n    --write-fetch-head    write fetched references to the FETCH_HEAD file\n    -k, --keep            keep downloaded pack\n    -u, --update-head-ok  allow updating of HEAD ref\n    --progress            force progress reporting\n    --depth <depth>       deepen history of shallow clone\n    --shallow-since <time>\n                          deepen history of shallow repository based on time\n    --shallow-exclude <revision>\n                          deepen history of shallow clone, excluding rev\n    --deepen <n>          deepen history of shallow clone\n    --unshallow           convert to a complete repository\n    --update-shallow      accept refs that update .git/shallow\n    --refmap <refmap>     specify fetch refmap\n    -o, --server-option <server-specific>\n                          option to transmit\n    -4, --ipv4            use IPv4 addresses only\n    -6, --ipv6            use IPv6 addresses only\n    --negotiation-tip <revision>\n                          report that we have only objects reachable from this object\n    --negotiate-only      do not fetch a packfile; instead, print ancestors of negotiation tips\n    --filter <args>       object filtering\n    --auto-maintenance    run 'maintenance --auto' after fetching\n    --auto-gc             run 'maintenance --auto' after fetching\n    --show-forced-updates\n                          check for forced-updates on all updated branches\n    --write-commit-graph  write the commit-graph after fetching\n    --stdin               accept refspecs from stdin\n\n"
```

Compare with 3.18:

```
❯ docker run -it alpine:3.18 sh -c "apk add git && git version && git fetch -h | grep porcelain"
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/x86_64/APKINDEX.tar.gz
(1/9) Installing ca-certificates (20240226-r0)
(2/9) Installing brotli-libs (1.0.9-r14)
(3/9) Installing libunistring (1.1-r1)
(4/9) Installing libidn2 (2.3.4-r1)
(5/9) Installing nghttp2-libs (1.57.0-r0)
(6/9) Installing libcurl (8.5.0-r0)
(7/9) Installing libexpat (2.6.2-r0)
(8/9) Installing pcre2 (10.42-r1)
(9/9) Installing git (2.40.1-r0)
Executing busybox-1.36.1-r5.trigger
Executing ca-certificates-20240226-r0.trigger
OK: 18 MiB in 24 packages
git version 2.40.1
```

And 3.19:

```
❯ docker run -it alpine:3.19 sh -c "apk add git && git version && git fetch -h | grep porcelain"
fetch https://dl-cdn.alpinelinux.org/alpine/v3.19/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.19/community/x86_64/APKINDEX.tar.gz
(1/10) Installing ca-certificates (20240226-r0)
(2/10) Installing brotli-libs (1.1.0-r1)
(3/10) Installing c-ares (1.27.0-r0)
(4/10) Installing libunistring (1.1-r2)
(5/10) Installing libidn2 (2.3.4-r4)
(6/10) Installing nghttp2-libs (1.58.0-r0)
(7/10) Installing libcurl (8.5.0-r0)
(8/10) Installing libexpat (2.6.2-r0)
(9/10) Installing pcre2 (10.42-r2)
(10/10) Installing git (2.43.0-r0)
Executing busybox-1.36.1-r15.trigger
Executing ca-certificates-20240226-r0.trigger
OK: 18 MiB in 25 packages
git version 2.43.0
    --[no-]porcelain      machine-readable output
```

Because https://github.com/dagger/dagger/pull/7111 requires the git `--porcelain` flag, we can upgrade to alpine 3.19 to get this.

Alternatively, if this breaks *something* for some reason, we could potentially find another way, and avoid using the newer option (though I'd rather not do this if possible).