### PR TITLE
core: make Directory.diff logic less fragile

### DIFF
--- a/core/directory.go
+++ b/core/directory.go
@@ -6,7 +6,6 @@ import (
 	"io/fs"
 	"path"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"time"
 
@@ -647,14 +646,17 @@ func (dir *Directory) WithNewDirectory(ctx context.Context, dest string, permiss
 func (dir *Directory) Diff(ctx context.Context, other *Directory) (*Directory, error) {
 	dir = dir.Clone()
 
-	if dir.Dir != other.Dir {
-		// TODO(vito): work around with llb.Copy shenanigans?
-		return nil, fmt.Errorf("TODO: cannot diff with different relative paths: %q != %q", dir.Dir, other.Dir)
+	thisDirPath := dir.Dir
+	if thisDirPath == "" {
+		thisDirPath = "/"
 	}
-
-	if !reflect.DeepEqual(dir.Platform, other.Platform) {
+	otherDirPath := other.Dir
+	if otherDirPath == "" {
+		otherDirPath = "/"
+	}
+	if thisDirPath != otherDirPath {
 		// TODO(vito): work around with llb.Copy shenanigans?
-		return nil, fmt.Errorf("TODO: cannot diff across platforms: %+v != %+v", dir.Platform, other.Platform)
+		return nil, fmt.Errorf("cannot diff with different relative paths: %q != %q", dir.Dir, other.Dir)
 	}
 
 	lowerSt, err := dir.State()

--- a/sdk/typescript/runtime/dagger.json
+++ b/sdk/typescript/runtime/dagger.json
@@ -2,5 +2,5 @@
   "name": "TypeScriptSDK",
   "sdk": "go",
   "source": ".",
-  "engineVersion": "v0.11.2"
+  "engineVersion": "v0.11.3"
 }

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -107,9 +107,7 @@ func (t *TypeScriptSdk) Codegen(ctx context.Context, modSource *ModuleSource, in
 	if err != nil {
 		return nil, err
 	}
-	dir := dag.Directory().WithDirectory("", ctr.Directory(ModSourceDirPath))
-
-	return dag.GeneratedCode(dir).
+	return dag.GeneratedCode(ctr.Directory(ModSourceDirPath)).
 		WithVCSGeneratedPaths([]string{
 			GenDir + "/**",
 		}).


### PR DESCRIPTION
The TS SDK was very subtly broken when used from a git ref due to the fact that the `Directory.diff` logic was way too fragile (has existed since the beginning of time). This fixes that logic and updates the TS SDK to be slightly simpler now that it doesn't need to try to avoid that fragility. 

Individual commits have more detailed messages.

---

We also need to add integ tests that use SDKs other than go sourced from git refs. Starting the effort now, will send out a separate PR if this one is merged by the time I'm done.