### PR TITLE
tests: add coverage for non-go SDKs used from git

### DIFF
--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -1152,12 +1152,35 @@ func TestModuleCallGitMod(t *testing.T) {
 	t.Parallel()
 	c, ctx := connect(t)
 
-	out, err := c.Container().From(golangImage).
-		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
-		With(daggerCallAt(testGitModuleRef("top-level"), "fn")).
-		Stdout(ctx)
-	require.NoError(t, err)
-	require.Equal(t, "hi from top level hi from dep hi from dep2", strings.TrimSpace(out))
+	t.Run("go", func(t *testing.T) {
+		t.Parallel()
+		out, err := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			With(daggerCallAt(testGitModuleRef("top-level"), "fn")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "hi from top level hi from dep hi from dep2", strings.TrimSpace(out))
+	})
+
+	t.Run("typescript", func(t *testing.T) {
+		t.Parallel()
+		out, err := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			With(daggerCallAt(testGitModuleRef("ts"), "container-echo", "--string-arg", "yoyo", "stdout")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "yoyo", strings.TrimSpace(out))
+	})
+
+	t.Run("python", func(t *testing.T) {
+		t.Parallel()
+		out, err := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			With(daggerCallAt(testGitModuleRef("py"), "container-echo", "--string-arg", "yoyo", "stdout")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "yoyo", strings.TrimSpace(out))
+	})
 }
 
 func TestModuleCallFindup(t *testing.T) {

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -1168,7 +1168,7 @@ func (m *Test) Fn() ([]string, error) {
 
 const (
 	gitTestRepoURL    = "github.com/dagger/dagger-test-modules"
-	gitTestRepoCommit = "d7299e935a195f3e1a29bc39537ed270f4f378d5"
+	gitTestRepoCommit = "2cb6cb4b0dba52c1e65b3ff46dd1a4a8f9a02f94"
 )
 
 func testGitModuleRef(subpath string) string {


### PR DESCRIPTION
While in theory SDKs should be agnostic of whether module source is
coming from git, local dirs, etc. a very subtle issue arose recently
that broke TS modules only when sourced from Git (related to
Directory.diff path handling).

That would have been caught by coverage of those SDKs used from git,
so adding tests here. Verified that tests pass with `./hack/dev` but the
TS one fails if run direct against v0.11.3, so it's working as intended.

---

Related: https://github.com/dagger/dagger/pull/7328
Test repo change: https://github.com/dagger/dagger-test-modules/commit/2cb6cb4b0dba52c1e65b3ff46dd1a4a8f9a02f94