### PR TITLE
Migrate Publish Engine & CLI to the new CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,16 +20,13 @@ jobs:
   publish:
     if: ${{ github.repository == 'dagger/dagger' && github.event_name == 'push' }}
     # Use our own Dagger runner when running in the dagger/dagger repo (including PRs)
-    runs-on: dagger-runner-16c-64g
+    runs-on: dagger-v0-11-2-16c-nvme
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version: "1.22"
           cache-dependency-path: "ci/go.sum"
-      - name: Install dagger
-        run: |
-          curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.11.2 BIN_DIR=/usr/local/bin/ sudo -E sh
       - name: "Publish Engine & CLI"
         run: |
           if [ $GITHUB_REF_NAME == 'main' ]; then


### PR DESCRIPTION
We probably want Publish Engine & CLI to re-use _hack_make. The main benefit of doing that is that we control the dagger version being used in a single place and trigger all jobs with the same logic. However, we can to unblock jobs from main quickly since we deleted the legacy CI and now no jobs can be execute.