### PR TITLE
engine: make client IDs fully random again

### DIFF
--- a/.changes/unreleased/Fixed-20240509-114653.yaml
+++ b/.changes/unreleased/Fixed-20240509-114653.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Avoid hang caused by client id conflicts
+time: 2024-05-09T11:46:53.847848236+01:00
+custom:
+  Author: sipsma
+  PR: "7335"

--- a/core/container.go
+++ b/core/container.go
@@ -1052,6 +1052,9 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 		// include the engine version so that these execs get invalidated if the engine/API change
 		runOpts = append(runOpts, llb.AddEnv("_DAGGER_ENGINE_VERSION", engine.Version))
 
+		// include a digest of the current call so that we scope of the cache of the ExecOp to this call
+		runOpts = append(runOpts, llb.AddEnv("_DAGGER_CALL_DIGEST", string(dagql.CurrentID(ctx).Digest())))
+
 		if !callerOpts.Cache {
 			// include the ServerID here so that we bust cache once-per-session
 			clientMetadata, err := engine.ClientMetadataFromContext(ctx)

--- a/core/container.go
+++ b/core/container.go
@@ -1035,6 +1035,7 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 	}
 
 	// this allows executed containers to communicate back to this API
+	var clientID string
 	if opts.ExperimentalPrivilegedNesting {
 		callerOpts := opts.NestedExecFunctionCall
 		if callerOpts == nil {
@@ -1043,15 +1044,22 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 				Cache: true,
 			}
 		}
-		clientID, err := container.Query.RegisterCaller(ctx, callerOpts)
+		clientID, err = container.Query.RegisterCaller(ctx, callerOpts)
 		if err != nil {
 			return nil, fmt.Errorf("register caller: %w", err)
 		}
-		runOpts = append(runOpts,
-			llb.AddEnv("_DAGGER_NESTED_CLIENT_ID", clientID),
-			// include the engine version so that these execs get invalidated if the engine/API change
-			llb.AddEnv("_DAGGER_ENGINE_VERSION", engine.Version),
-		)
+
+		// include the engine version so that these execs get invalidated if the engine/API change
+		runOpts = append(runOpts, llb.AddEnv("_DAGGER_ENGINE_VERSION", engine.Version))
+
+		if !callerOpts.Cache {
+			// include the ServerID here so that we bust cache once-per-session
+			clientMetadata, err := engine.ClientMetadataFromContext(ctx)
+			if err != nil {
+				return nil, err
+			}
+			runOpts = append(runOpts, llb.AddEnv("_DAGGER_SERVER_ID", clientMetadata.ServerID))
+		}
 	}
 
 	metaSt, metaSourcePath := metaMount(opts.Stdin)
@@ -1221,6 +1229,7 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 
 	execMD := buildkit.ExecutionMetadata{
 		SystemEnvNames: container.SystemEnvNames,
+		ClientID:       clientID,
 	}
 	execMDOpt, err := execMD.AsConstraintsOpt()
 	if err != nil {

--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -134,11 +134,15 @@ func (w *Worker) Run(
 }
 
 func (w *Worker) addExtraEnvs(proc *executor.ProcessInfo) error {
-	proc.Meta.Env = append(proc.Meta.Env, fmt.Sprintf("_DAGGER_SERVER_ID=%s", w.serverID))
-
 	execMD, err := executionMetadataFromVtx(w.vtx)
 	if err != nil {
 		return err
+	}
+
+	proc.Meta.Env = append(proc.Meta.Env, "_DAGGER_SERVER_ID="+w.serverID)
+
+	if execMD.ClientID != "" {
+		proc.Meta.Env = append(proc.Meta.Env, "_DAGGER_NESTED_CLIENT_ID="+execMD.ClientID)
 	}
 
 	origEnvMap := make(map[string]string)
@@ -201,6 +205,7 @@ func (w *Worker) addExtraEnvs(proc *executor.ProcessInfo) error {
 
 type ExecutionMetadata struct {
 	SystemEnvNames []string
+	ClientID       string
 }
 
 const executionMetadataKey = "dagger.executionMetadata"

--- a/engine/server/buildkitcontroller.go
+++ b/engine/server/buildkitcontroller.go
@@ -262,12 +262,6 @@ func (e *BuildkitController) Session(stream controlapi.Control_SessionServer) (r
 	if err != nil {
 		return fmt.Errorf("failed to register client: %w", err)
 	}
-	defer func() {
-		err := srv.UnregisterClient(opts.ClientID)
-		if err != nil {
-			slog.Error("failed to unregister client", "err", err)
-		}
-	}()
 
 	eg.Go(func() error {
 		bklog.G(ctx).Trace("waiting for server")

--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -407,13 +407,6 @@ func (s *DaggerServer) VerifyClient(clientID, secretToken string) error {
 	return nil
 }
 
-func (s *DaggerServer) UnregisterClient(clientID string) error {
-	s.clientIDMu.Lock()
-	defer s.clientIDMu.Unlock()
-	delete(s.clientIDToSecretToken, clientID)
-	return nil
-}
-
 func (s *DaggerServer) ClientCallContext(clientID string) (*core.ClientCallContext, bool) {
 	s.clientCallMu.RLock()
 	defer s.clientCallMu.RUnlock()


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/7334

A few releases ago, client IDs were changed to be digests of the dagql.CurrentID in order to remove the number fields in our ftp_proxy hack and to consolidate client ID w/ module caller digest.

This is not entirely working as expected though (detailed below). Fortunately the new custom worker gives us a non-hacky path to set whatever IDs we want in containers without worrying about cache busting or the various problems caused by the ftp_proxy hack, which has been gone entirely as of last release.

This updates the engine to make client IDs random strings again.

The problem we're hitting is that when there are inputs to a Function of type Secret, the Functions seem to always run without any caching no matter what, even in the same dagger server. And even though before this client IDs would be the same, each client still generated it's own random secret token and thus conflicted with each other. Making client IDs random again fixes it because the secret tokens no longer mismatch.

However, the fact that we are not getting cache hits when invoking the same function repeatedly when there is an input of type Secret is still a mystery at this time. I confirmed that we do get the expected caching for other input types (string, Container, etc.), it's somehow only happening for Secret inputs.

I'm going to open a separate issue with more details for figuring out what's happening there.