### PR TITLE
core: don't bust cache with random OTEL values in function calls

### DIFF
--- a/.changes/unreleased/Fixed-20240509-114745.yaml
+++ b/.changes/unreleased/Fixed-20240509-114745.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Avoid unneccessary module cache invalidation from internal plumbing values
+time: 2024-05-09T11:47:45.1739708+01:00
+custom:
+  Author: sipsma
+  PR: "7336"

--- a/core/container.go
+++ b/core/container.go
@@ -1036,6 +1036,7 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 
 	// this allows executed containers to communicate back to this API
 	var clientID string
+	var otelEnvs []string
 	if opts.ExperimentalPrivilegedNesting {
 		callerOpts := opts.NestedExecFunctionCall
 		if callerOpts == nil {
@@ -1048,6 +1049,7 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 		if err != nil {
 			return nil, fmt.Errorf("register caller: %w", err)
 		}
+		otelEnvs = callerOpts.OTELEnvs
 
 		// include the engine version so that these execs get invalidated if the engine/API change
 		runOpts = append(runOpts, llb.AddEnv("_DAGGER_ENGINE_VERSION", engine.Version))
@@ -1233,6 +1235,7 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 	execMD := buildkit.ExecutionMetadata{
 		SystemEnvNames: container.SystemEnvNames,
 		ClientID:       clientID,
+		OTELEnvs:       otelEnvs,
 	}
 	execMDOpt, err := execMD.AsConstraintsOpt()
 	if err != nil {

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -911,6 +911,9 @@ type FunctionCall struct {
 
 	// Whether to serve the schema for the function's own module to it or not
 	SkipSelfSchema bool
+
+	// Various OTEL values that need to be set in the function container
+	OTELEnvs []string
 }
 
 func (*FunctionCall) Type() *ast.Type {

--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -157,10 +157,10 @@ func (w *Worker) updateEnvs(proc *executor.ProcessInfo) error {
 	}
 
 	proc.Meta.Env = append(proc.Meta.Env, "_DAGGER_SERVER_ID="+w.serverID)
-
 	if execMD.ClientID != "" {
 		proc.Meta.Env = append(proc.Meta.Env, "_DAGGER_NESTED_CLIENT_ID="+execMD.ClientID)
 	}
+	proc.Meta.Env = append(proc.Meta.Env, execMD.OTELEnvs...)
 
 	origEnvMap := make(map[string]string)
 	for _, env := range proc.Meta.Env {
@@ -223,6 +223,7 @@ func (w *Worker) updateEnvs(proc *executor.ProcessInfo) error {
 type ExecutionMetadata struct {
 	SystemEnvNames []string
 	ClientID       string
+	OTELEnvs       []string
 }
 
 const executionMetadataKey = "dagger.executionMetadata"


### PR DESCRIPTION
When OTEL support was added, module functions were updated to set env vars with the OTEL traceparent values. These values appear to be random every time a function is invoked, even if coming from the same caller and making the call with the same inputs, etc.

That resulted in them busting the Buildkit cache every time.

Fortunately, most of the time the dagql cache within the context of a session prevented this from being noticeable, but in the case where dagql IDs were impure (which prevented dagql caching from being hit), then we'd run the Function every call without any cache hits at all.

The fix here just uses our new and improved mechanism for passing random IDs to containers without invalidating the cache, which was added for proxy env support but has been repeatedly paying dividends since.

I would not be suprised if this is a noticeable performance improvement, hopefully restoring what it was pre-v0.11 since this cache invalidation also prevented SDK codegen calls (which were supposed to be cached across all sessions) from being cached.