### PR TITLE
feat(sdk/elixir): introduce Dagger.with_connection/2

### DIFF
--- a/sdk/elixir/.changes/unreleased/Added-20240510-171513.yaml
+++ b/sdk/elixir/.changes/unreleased/Added-20240510-171513.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Add `Dagger.with_connection/2`
+time: 2024-05-10T17:15:13.736305227+07:00
+custom:
+  Author: wingyplus
+  PR: "7348"

--- a/sdk/elixir/lib/dagger.ex
+++ b/sdk/elixir/lib/dagger.ex
@@ -87,6 +87,21 @@ defmodule Dagger do
   end
 
   @doc """
+  Connect to Dagger Engine and close connection automatically after `fun` executed.
+
+  See `connect/1` for available options.
+  """
+  def with_connection(fun, opts \\ []) when is_function(fun, 1) and is_list(opts) do
+    with {:ok, client} <- Dagger.connect(opts) do
+      try do
+        fun.(client)
+      after
+        close(client)
+      end
+    end
+  end
+
+  @doc """
   Disconnecting the client from Dagger Engine session.
   """
   def close(%Dagger.Client{client: client}) do


### PR DESCRIPTION
Introduce a new function to automatic open and close connection after execute a function. Here is an example

```elixir
Dagger.with_connection(fn client ->
  client
  |> Dagger.Client.container()
  |> Dagger.Container.from("alpine")
  |> Dagger.Container.with_exec(~w"echo hello")
  |> Dagger.Container.stdout()
end)
|> IO.inspect() # Result: {:ok, "hello\n"}
```