### PR TITLE
fix(sdk/elixir): add :inets to :extra_applications

### DIFF
--- a/sdk/elixir/.changes/unreleased/Fixed-20240510-225656.yaml
+++ b/sdk/elixir/.changes/unreleased/Fixed-20240510-225656.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fix `:inets` application doesn't start before using the SDK
+time: 2024-05-10T22:56:56.496219888+07:00
+custom:
+  Author: wingyplus
+  PR: "7352"

--- a/sdk/elixir/mix.exs
+++ b/sdk/elixir/mix.exs
@@ -19,7 +19,7 @@ defmodule Dagger.MixProject do
 
   def application do
     [
-      extra_applications: [:logger, :public_key, :ssl]
+      extra_applications: [:logger, :public_key, :ssl, :inets]
     ]
   end
 


### PR DESCRIPTION
`:inets` requires to start before using the SDK because of `:httpc` module.