### PR TITLE
core: fix custom CA certs in modules + add integ test coverage

### DIFF
--- a/core/integration/cacert_test.go
+++ b/core/integration/cacert_test.go
@@ -526,7 +526,7 @@ func newGeneratedCerts(c *dagger.Client, caHostname string) *generatedCerts {
 		WithExec([]string{"sh", "-c", strings.Join([]string{"openssl", "dhparam",
 			"-out", "/dhparam.pem",
 			"2048",
-			// supress extremely noisy+useless output
+			// suppress extremely noisy+useless output
 			"&> /dev/null",
 		}, " ")}).
 		WithExec([]string{"openssl", "genrsa",

--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -382,6 +382,17 @@ func (w *Worker) run(
 		caInstaller, err := cacerts.NewInstaller(ctx, spec, func(ctx context.Context, args ...string) error {
 			id := randid.NewID()
 			meta := process.Meta
+
+			// don't run this as a nested client, not necessary
+			var filteredEnvs []string
+			for _, env := range meta.Env {
+				if strings.HasPrefix(env, "_DAGGER_NESTED_CLIENT_ID=") {
+					continue
+				}
+				filteredEnvs = append(filteredEnvs, env)
+			}
+			meta.Env = filteredEnvs
+
 			meta.Args = args
 			meta.User = "0:0"
 			meta.Cwd = "/"

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -218,6 +218,10 @@ func (t *TypeScriptSdk) Base(runtime SupportedTSRuntime) (*Container, error) {
 		return dag.Container().
 			From(nodeImageRef).
 			WithoutEntrypoint().
+			// Install default CA certificates and configure node to use them instead of its compiled in CA bundle.
+			// This enables use of custom CA certificates if configured in the dagger engine.
+			WithExec([]string{"apk", "add", "ca-certificates"}).
+			WithEnvVariable("NODE_OPTIONS", "--use-openssl-ca").
 			WithMountedCache("/root/.npm", dag.CacheVolume(fmt.Sprintf("mod-npm-cache-%s", nodeVersion))).
 			WithExec([]string{"npm", "install", "-g", "tsx"}), nil
 	default:


### PR DESCRIPTION
A [recent commit that changed client IDs](https://github.com/dagger/dagger/pull/7335) to be random again accidentally made it so that commands run to update CA certificates (when a custom engine has those installed) hit errors about client tokens not matching when the exec being run was nested, which includes module function calls.

This was due to the fact that those commands run in the same container with the same client ID but the secret token was generated by the client each time it ran, which resulted in mismatches.

The fix here just updates those extra CA commands to never be nested execs since there's no purpose in that anyways and it's nothing but overhead.
* We just unset the relevant env var for those commands, which is a bit ugly but not any more than the existing ugliness. Fortunately the [other ongoing effort to clean all this up](https://github.com/dagger/dagger/pull/7315) should help a lot here.

This was missed because I forgot to include integ tests that invoke module functions amongst all the other many tests that were added for custom CA support. Those have been added now for go, python and typescript.

When adding the test for typescript functions, I also learned that nodejs will by default only use a CA bundle compiled into the node binary. So this also updates the typescript SDK to tell nodejs to use the system CAs instead (while also making sure they include the default Mozilla CA set, which is what nodejs is compiled with anyways).