### PR TITLE
chore: bump go images to 1.22.3

### DIFF
--- a/ci/consts/versions.go
+++ b/ci/consts/versions.go
@@ -10,7 +10,7 @@ const (
 )
 
 const (
-	GolangVersion = "1.22.2"
+	GolangVersion = "1.22.3"
 	// GolangVersionRuncHack needs to be 1.21, since 1.22 is not yet
 	// supported, and can cause crashes: opencontainers/runc#4233
 	GolangVersionRuncHack = "1.21.7"

--- a/core/integration/images.go
+++ b/core/integration/images.go
@@ -2,7 +2,7 @@ package core
 
 const (
 	alpineImage = "alpine:3.18.2"
-	golangImage = "golang:1.22.2-alpine"
+	golangImage = "golang:1.22.3-alpine"
 	debianImage = "debian:bookworm"
 	rhelImage   = "registry.access.redhat.com/ubi9/ubi"
 	alpineArm   = "arm64v8/alpine"


### PR DESCRIPTION
From https://go.dev/doc/devel/release:

> go1.22.3 (released 2024-05-07) includes security fixes to the go command and the net package, as well as bug fixes to the compiler, the runtime, and the net/http package. See the [Go 1.22.3 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.22.3+label%3ACherryPickApproved) on our issue tracker for details.

Specifically, this allows dagger modules written with an explicit `go 1.22.3` directive to compile.