### PR TITLE
docs: fix wrong argument in directories quickstart readme

### DIFF
--- a/docs/current_docs/quickstart/853930-directories.mdx
+++ b/docs/current_docs/quickstart/853930-directories.mdx
@@ -20,7 +20,7 @@ Try calling this Go builder Dagger Function, which builds the Dagger CLI:
 dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.10 call build --source=https://github.com/dagger/dagger --args=./cmd/dagger --os=$(uname -s | awk '{print tolower($0)}')
 ```
 
-This function takes a `project` argument of type `Directory`. Here, you're passing the address of Dagger's open-source repository. It also takes an `args` argument, which is a list of strings representing the arguments to be passed to the `go build` command.
+This function takes a `source` argument of type `Directory`. Here, you're passing the address of Dagger's open-source repository. It also takes an `args` argument, which is a list of strings representing the arguments to be passed to the `go build` command.
 
 :::note
 By default, the Go builder Dagger Function builds a binary based on information derived from the runtime container. Since the runtime container uses Linux, this usually means that the compiled binary will be a `linux/amd64` binary. This can be overridden by passing additional `--os` and `--arch` arguments to the Go builder Dagger Function. The previous example uses `uname` to dynamically derive the host operating system type, and passes that to the Dagger Function via the `--os` argument.


### PR DESCRIPTION
fix: `project` argument is named `source`.