### PR TITLE
ci: update goreleaser to v1.26.0

### DIFF
--- a/ci/cli.go
+++ b/ci/cli.go
@@ -34,7 +34,7 @@ func (cli *CLI) File(
 
 const (
 	// https://github.com/goreleaser/goreleaser/releases
-	goReleaserVersion = "v1.22.1-pro"
+	goReleaserVersion = "v1.26.0"
 )
 
 // Publish the CLI using GoReleaser
@@ -151,7 +151,7 @@ func (cli *CLI) TestPublish(ctx context.Context) error {
 
 func publishEnv(ctx context.Context) (*dagger.Container, error) {
 	ctr := dag.Container().
-		From(fmt.Sprintf("ghcr.io/goreleaser/goreleaser-pro:%s", goReleaserVersion)).
+		From(fmt.Sprintf("ghcr.io/goreleaser/goreleaser-pro:%s-pro", goReleaserVersion)).
 		WithEntrypoint([]string{}).
 		WithExec([]string{"apk", "add", "aws-cli"})
 


### PR DESCRIPTION
https://github.com/dagger/dagger/pull/7264 updated to explicitly use go 1.21.7 everywhere.

However - the go releaser version we were using apparently only supports up to 1.21.4 - so we should update it, so that the failing publish job on `main` can pass: https://github.com/dagger/dagger/actions/runs/9064274083/job/24903799826