### PR TITLE
feat: mark `[internal]` buildkit prefixes as internal

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -1022,16 +1022,9 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 		return nil, err
 	}
 
-	var namef string
-	if container.Focused {
-		namef = buildkit.FocusPrefix + "exec %s"
-	} else {
-		namef = "exec %s"
-	}
-
 	runOpts := []llb.RunOption{
 		llb.Args(args),
-		llb.WithCustomNamef(namef, strings.Join(args, " ")),
+		llb.WithCustomNamef("exec %s", strings.Join(args, " ")),
 	}
 
 	// this allows executed containers to communicate back to this API

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -41,7 +41,6 @@ import (
 )
 
 const (
-	FocusPrefix    = "[focus] "
 	InternalPrefix = "[internal] "
 
 	DaggerWorkerJobKey = "dagger.worker"

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -733,6 +733,7 @@ func withOutgoingContext(ctx context.Context) context.Context {
 	if ok {
 		ctx = metadata.NewOutgoingContext(ctx, md)
 	}
+	ctx = buildkitTelemetryContext(ctx)
 	return ctx
 }
 

--- a/engine/buildkit/telemetry.go
+++ b/engine/buildkit/telemetry.go
@@ -1,0 +1,71 @@
+package buildkit
+
+import (
+	"context"
+	"strings"
+
+	"github.com/dagger/dagger/telemetry"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/embedded"
+)
+
+// buildkitTelemetryContext returns a context with a wrapped span that has a
+// TracerProvider that can process spans produced by buildkit. This works,
+// because of how buildkit heavily relies on trace.SpanFromContext.
+func buildkitTelemetryContext(ctx context.Context) context.Context {
+	if ctx == nil {
+		return nil
+	}
+	sp := trace.SpanFromContext(ctx)
+	sp = buildkitSpan{Span: sp, provider: &buildkitTraceProvider{tp: sp.TracerProvider()}}
+	return trace.ContextWithSpan(ctx, sp)
+}
+
+type buildkitTraceProvider struct {
+	embedded.TracerProvider
+	tp trace.TracerProvider
+}
+
+func (tp *buildkitTraceProvider) Tracer(name string, options ...trace.TracerOption) trace.Tracer {
+	return &buildkitTracer{
+		tracer:   tp.tp.Tracer(name, options...),
+		provider: tp,
+	}
+}
+
+type buildkitTracer struct {
+	embedded.Tracer
+	tracer   trace.Tracer
+	provider *buildkitTraceProvider
+}
+
+func (t *buildkitTracer) Start(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	internal := false
+
+	if rest, ok := strings.CutPrefix(spanName, InternalPrefix); ok {
+		spanName = rest
+		internal = true
+	} else if rest, ok := strings.CutPrefix(spanName, "load cache: "+InternalPrefix); ok {
+		spanName = "load cache: " + rest
+		internal = true
+	}
+
+	if internal {
+		opts = append([]trace.SpanStartOption{}, opts...)
+		opts = append(opts, trace.WithAttributes(attribute.Bool(telemetry.UIInternalAttr, true)))
+	}
+
+	ctx, span := t.tracer.Start(ctx, spanName, opts...)
+	newSpan := buildkitSpan{Span: span, provider: t.provider}
+	return trace.ContextWithSpan(ctx, newSpan), newSpan
+}
+
+type buildkitSpan struct {
+	trace.Span
+	provider *buildkitTraceProvider
+}
+
+func (s buildkitSpan) TracerProvider() trace.TracerProvider {
+	return s.provider
+}

--- a/telemetry/inflight/proxy.go
+++ b/telemetry/inflight/proxy.go
@@ -47,7 +47,8 @@ type ProxyTracer struct {
 
 func (t ProxyTracer) Start(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
 	ctx, span := t.tracer.Start(ctx, spanName, opts...)
-	return ctx, proxySpan{sp: span, onUpdate: t.onUpdate}
+	span = proxySpan{sp: span, onUpdate: t.onUpdate}
+	return trace.ContextWithSpan(ctx, span), span
 }
 
 type proxySpan struct {


### PR DESCRIPTION
Follow-up to #6835 (found during hackery on #7272)

We used to use the magic `[internal]` prefix in buildkit vertex names to mark these as internal to the UI. However, we've since updated our TUI and cloud logic to instead pull this information from an OTEL span attribute (which makes much more sense). However, we didn't have a way of connecting buildkit vertices to this attribute.

This wasn't immediately obvious - because of how [our TUI logic doesn't show spans that last longer than 100 milliseconds](https://github.com/dagger/dagger/blob/e25ff72f7111d09800ffa208492f00e0d1b6c309/dagql/idtui/frontend.go#L433-L436), and because lots of these were very quick `[internal] merge`s, then we didn't see these most of the time. However, some of the longer ones, like our internal blob copying, could show up if the context directory was too large. Additionally, if we remove this logic for `--progress=plain`, it shows up every time.

This patch provides this hiding functionality again, by making a custom `TraceProvider` implementation that wraps another one - with this provider, we can intercept calls to `Tracer.Start`, using this to strip the `[internal]` prefix from the name, and set the correct attribute on the span.