### PR TITLE
Setup dagger engines with buildkit gc disabled

### DIFF
--- a/.github/workflows/_dagger_call.yml
+++ b/.github/workflows/_dagger_call.yml
@@ -27,9 +27,22 @@ on:
         default: "dagger-v0-11-4-4c-nvme"
         required: false
 
+      size-dind:
+        type: string
+        default: "dagger-v0-11-4-dind"
+        required: false
+
       dagger-version:
         type: string
         default: "0.11.4"
+        required: false
+
+      # use to control concurrency groups from the caller. It will be appended
+      # to the existing concurrency group of the job
+      # to the concurrency groups 
+      concurrency:
+        type: string
+        default: ""
         required: false
 
 jobs:
@@ -80,7 +93,7 @@ jobs:
     if: ${{ !inputs.dev-engine && github.repository == 'dagger/dagger' }}
     runs-on: ${{ inputs.size }}
     concurrency:
-      group: ${{github.workflow}}-${{ inputs.function }}-${{ github.head_ref || github.run_id }}
+      group: ${{github.workflow}}-${{ inputs.function }}-${{ github.head_ref || github.run_id }}${{ inputs.concurrency }}
       cancel-in-progress: true
     timeout-minutes: ${{ inputs.timeout }}
     steps:
@@ -110,9 +123,9 @@ jobs:
 
   dagger-runner-v2-dind:
     if: ${{ inputs.dev-engine && github.repository == 'dagger/dagger' }}
-    runs-on: dagger-v0-11-4-dind
+    runs-on: ${{ inputs.size-dind }}
     concurrency:
-      group: ${{github.workflow}}-${{ inputs.function }}-${{ github.head_ref || github.run_id }}-v2
+      group: ${{github.workflow}}-${{ inputs.function }}-${{ github.head_ref || github.run_id }}${{ inputs.concurrency }}
       cancel-in-progress: true
     timeout-minutes: ${{ inputs.timeout }}
     steps:

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -28,6 +28,14 @@ jobs:
       function: test all --race=true
       size: "dagger-v0-11-4-16c-nvme"
 
+  test-nogc:
+    uses: ./.github/workflows/_dagger_call.yml
+    secrets: inherit
+    with:
+      function: test all --race=true
+      size: "dagger-v0-11-4-16c-nogc"
+      concurrency: "-nogc"
+
   # Run Engine tests in dev Engine so that we can spot integration failures early
   # Only run a subset of important test cases since we just need to verify basic
   # functionality rather than repeat every test already run in the other targets.
@@ -37,6 +45,15 @@ jobs:
     with:
       function: test important --race=true
       dev-engine: true
+
+  testdev-nogc:
+    uses: ./.github/workflows/_dagger_call.yml
+    secrets: inherit
+    with:
+      function: test important --race=true
+      dev-engine: true
+      size-dind: "dagger-v0-11-4-dind-nogc"
+      concurrency: "-nogc"
 
   test-publish-cli:
     uses: ./.github/workflows/_dagger_call.yml


### PR DESCRIPTION
This is a follow up from an internal discussion where @samalba has been investigating the performance of our CI and found that disabling bulidkit's GC has the potential of improving stability of the most heavy jobs. We want to test this in production for a few days and have side by side data to compare the performance and stability of the jobs. I've been running a few isolated tests here: https://github.com/dagger/dagger/actions/runs/9084221778, but we need more data in order to drive a conclusion regarding the GC.

In this PR we are adding two jobs for the engine-and-cli workflow:
- test-nogc
- testdev-nogc

This jobs will run in parallel and in a synchronous manner to baseline jobs. To implement it there were two minor changes introduced to `_dagger_call`:
- size-dind variable: this variable allows us to customize the `runs-on` for testdev which we couldn't so far.
- concurrency: allows the workflow dispatching dagger_call to control the concurrency group. We need this, otherwise nogc and baseline will step over each other's toes and cancel each other out.