### PR TITLE
fix(tssdk): correcly handle list of nested object

### DIFF
--- a/sdk/typescript/.changes/unreleased/Fixed-20240514-210710.yaml
+++ b/sdk/typescript/.changes/unreleased/Fixed-20240514-210710.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: returned nested list of object
+time: 2024-05-14T21:07:10.439029+02:00
+custom:
+  Author: TomChv
+  PR: "7381"

--- a/sdk/typescript/entrypoint/load.ts
+++ b/sdk/typescript/entrypoint/load.ts
@@ -250,9 +250,7 @@ export async function loadResult(
         // If the original type is an object, we use it as the referenced object.
         if (_property.kind === TypeDefKind.ObjectKind) {
           referencedObject =
-            module.objects[
-              (_property as TypeDef<TypeDefKind.ObjectKind>).name
-            ]
+            module.objects[(_property as TypeDef<TypeDefKind.ObjectKind>).name]
         }
       }
 

--- a/sdk/typescript/entrypoint/load.ts
+++ b/sdk/typescript/entrypoint/load.ts
@@ -229,11 +229,31 @@ export async function loadResult(
       }
 
       let referencedObject: DaggerObject | undefined = undefined
+
+      // Handle nested objects
       if (property.type.kind === TypeDefKind.ObjectKind) {
         referencedObject =
           module.objects[
             (property.type as TypeDef<TypeDefKind.ObjectKind>).name
           ]
+      }
+
+      // Handle list of nested objects
+      if (property.type.kind === TypeDefKind.ListKind) {
+        let _property = property.type
+
+        // Loop until we find the original type.
+        while (_property.kind === TypeDefKind.ListKind) {
+          _property = (_property as TypeDef<TypeDefKind.ListKind>).typeDef
+        }
+
+        // If the original type is an object, we use it as the referenced object.
+        if (_property.kind === TypeDefKind.ObjectKind) {
+          referencedObject =
+            module.objects[
+              (_property as TypeDef<TypeDefKind.ObjectKind>).name
+            ]
+        }
       }
 
       // If there's no referenced object, we use the current object.

--- a/sdk/typescript/introspector/test/invoke.spec.ts
+++ b/sdk/typescript/introspector/test/invoke.spec.ts
@@ -490,6 +490,7 @@ describe("Invoke typescript function", function () {
 
     const resultList = await invoke(scanResult, input)
 
-    console.log(resultList)
+    assert.equal(resultList.length, 3)
+    assert.deepEqual(resultList, [{ value: -1 }, { value: 2 }, { value: 3 }])
   })
 })

--- a/sdk/typescript/introspector/test/invoke.spec.ts
+++ b/sdk/typescript/introspector/test/invoke.spec.ts
@@ -470,4 +470,26 @@ describe("Invoke typescript function", function () {
       { content: "HELLO UNIVERSE" },
     ])
   })
+
+  it("Should correctly handle list of returned object", async function () {
+    const files = await listFiles(`${rootDirectory}/list`)
+
+    // Load function
+    await load(files)
+
+    const scanResult = scan(files)
+
+    const input = {
+      parentName: "List",
+      fnName: "create",
+      parentArgs: {},
+      fnArgs: {
+        n: [-1, 2, 3],
+      },
+    }
+
+    const resultList = await invoke(scanResult, input)
+
+    console.log(resultList)
+  })
 })

--- a/sdk/typescript/introspector/test/scan.spec.ts
+++ b/sdk/typescript/introspector/test/scan.spec.ts
@@ -74,6 +74,10 @@ describe("scan static TypeScript", function () {
       name: "Should correctly scan scalar arguments",
       directory: "scalar",
     },
+    {
+      name: "Should correctly scan list of objects",
+      directory: "list",
+    }
   ]
 
   for (const test of testCases) {

--- a/sdk/typescript/introspector/test/scan.spec.ts
+++ b/sdk/typescript/introspector/test/scan.spec.ts
@@ -77,7 +77,7 @@ describe("scan static TypeScript", function () {
     {
       name: "Should correctly scan list of objects",
       directory: "list",
-    }
+    },
   ]
 
   for (const test of testCases) {

--- a/sdk/typescript/introspector/test/testdata/generate_expected_scan.ts
+++ b/sdk/typescript/introspector/test/testdata/generate_expected_scan.ts
@@ -26,7 +26,7 @@ async function generateExpectedScan() {
     const diffExpectedPath = path.join(__dirname, entry, diffExpectedFileName)
     const currentExpected = fs.readFileSync(expectedPath, "utf8")
 
-    if (currentExpected !== JSON.stringify(result, null, 2)) {
+    if (currentExpected.trimEnd() !== JSON.stringify(result, null, 2)) {
       console.log(
         `/!\\ Expected scan file for : ${path.join(entry, expectedFilename)} is different from the current result.`,
       )

--- a/sdk/typescript/introspector/test/testdata/list/expected.json
+++ b/sdk/typescript/introspector/test/testdata/list/expected.json
@@ -1,0 +1,76 @@
+{
+  "name": "List",
+  "objects": {
+    "Number": {
+      "name": "Number",
+      "description": "",
+      "constructor": {
+        "args": {
+          "value": {
+            "name": "value",
+            "description": "",
+            "type": {
+              "kind": "INTEGER_KIND"
+            },
+            "isVariadic": false,
+            "isNullable": false,
+            "isOptional": false
+          }
+        }
+      },
+      "methods": {
+        "positive": {
+          "name": "positive",
+          "description": "",
+          "arguments": {},
+          "returnType": {
+            "kind": "BOOLEAN_KIND"
+          }
+        }
+      },
+      "properties": {
+        "value": {
+          "name": "value",
+          "description": "",
+          "type": {
+            "kind": "INTEGER_KIND"
+          },
+          "isExposed": true
+        }
+      }
+    },
+    "List": {
+      "name": "List",
+      "description": "",
+      "methods": {
+        "create": {
+          "name": "create",
+          "description": "",
+          "arguments": {
+            "n": {
+              "name": "n",
+              "description": "",
+              "type": {
+                "kind": "LIST_KIND",
+                "typeDef": {
+                  "kind": "INTEGER_KIND"
+                }
+              },
+              "isVariadic": true,
+              "isNullable": false,
+              "isOptional": true
+            }
+          },
+          "returnType": {
+            "kind": "LIST_KIND",
+            "typeDef": {
+              "kind": "OBJECT_KIND",
+              "name": "Number"
+            }
+          }
+        }
+      },
+      "properties": {}
+    }
+  }
+}

--- a/sdk/typescript/introspector/test/testdata/list/index.ts
+++ b/sdk/typescript/introspector/test/testdata/list/index.ts
@@ -1,0 +1,26 @@
+import { func, object, field } from "../../../decorators/decorators.js"
+
+@object()
+class Number {
+  @field()
+  value: number
+
+
+  constructor(value: number) {
+    this.value = value
+  }
+
+  @func()
+  positive(): boolean {
+    return this.value > 0
+  }
+}
+
+@object()
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+class List {
+  @func()
+  create(...n: number[]): Number[] {
+    return n.map((v) => new Number(v))
+  }
+}


### PR DESCRIPTION
A regression was introduced by #6833 and listof nested object were not supported anymore.
This changes fixes the behaviour by using the correct referenced object when the type of an object property is a list
of object.