### PR TITLE
ci: fix typo in publish go sdk

### DIFF
--- a/.github/workflows/publish-sdk-go.yml
+++ b/.github/workflows/publish-sdk-go.yml
@@ -9,7 +9,7 @@ jobs:
     uses: ./.github/workflows/_dagger_call.yml
     secrets: inherit
     with:
-      function: sdk elixir publish --tag="${{ github.ref_name }}" --github-token=env:RELEASE_DAGGER_CI_TOKEN
+      function: sdk go publish --tag="${{ github.ref_name }}" --github-token=env:RELEASE_DAGGER_CI_TOKEN
 
   notify:
     if: github.ref_type == 'tag'


### PR DESCRIPTION
Follow-up to #7349

This should be "go", not "elixir". Looks like a bad case of copy-pasta.