### PR TITLE
Improved connection progress

### DIFF
--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -25,10 +25,6 @@ func withEngine(
 
 	params.DisableHostRW = disableHostRW
 
-	params.EngineNameCallback = Frontend.ConnectedToEngine
-
-	params.CloudURLCallback = Frontend.ConnectedToCloud
-
 	params.EngineTrace = telemetry.SpanForwarder{
 		Processors: telemetry.SpanProcessors,
 	}

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dagger/dagger/analytics"
 	"github.com/dagger/dagger/dagql/idtui"
 	"github.com/dagger/dagger/engine"
+	"github.com/dagger/dagger/engine/slog"
 	"github.com/dagger/dagger/telemetry"
 	"github.com/dagger/dagger/telemetry/sdklog"
 )
@@ -271,6 +272,10 @@ func main() {
 		ctx, stdout, stderr := telemetry.WithStdioToOtel(ctx, "dagger")
 		rootCmd.SetOut(stdout)
 		rootCmd.SetErr(stderr)
+
+		if url, ok := telemetry.URLForTrace(ctx); ok {
+			slog.Info("Connected to cloud", "url", url)
+		}
 
 		return rootCmd.ExecuteContext(ctx)
 	}); err != nil {

--- a/core/integration/engine_test.go
+++ b/core/integration/engine_test.go
@@ -139,7 +139,8 @@ func TestEngineSetsNameFromEnv(t *testing.T) {
 		WithExec([]string{"dagger", "query", "--debug", "--doc", "/query.graphql"}).
 		Stderr(ctx)
 	require.NoError(t, err)
-	require.Contains(t, out, "Connected to engine "+engineName)
+	require.Contains(t, out, "Connected to engine")
+	require.Contains(t, out, engineName)
 }
 
 func TestDaggerRun(t *testing.T) {

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -96,12 +96,14 @@ func New() *Frontend {
 // Run starts the TUI, calls the run function, stops the TUI, and finally
 // prints the primary output to the appropriate stdout/stderr streams.
 func (fe *Frontend) Run(ctx context.Context, run func(context.Context) error) error {
+	ctx = telemetry.WithLogProfile(ctx, fe.profile)
+
 	// redirect slog to the logs pane
 	level := slog.LevelInfo
 	if fe.Debug {
 		level = slog.LevelDebug
 	}
-	slog.SetDefault(telemetry.PrettyLogger(fe.messagesW, level))
+	slog.SetDefault(telemetry.PrettyLogger(fe.messagesW, fe.profile, level))
 
 	// find a TTY anywhere in stdio. stdout might be redirected, in which case we
 	// can show the TUI on stderr.

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -27,8 +27,6 @@ import (
 	"github.com/dagger/dagger/telemetry/sdklog"
 )
 
-var consoleSink = os.Stderr
-
 type Frontend struct {
 	// Debug tells the frontend to show everything and do one big final render.
 	Debug bool
@@ -99,7 +97,7 @@ func New() *Frontend {
 // prints the primary output to the appropriate stdout/stderr streams.
 func (fe *Frontend) Run(ctx context.Context, run func(context.Context) error) error {
 	// redirect slog to the logs pane
-	level := slog.LevelWarn
+	level := slog.LevelInfo
 	if fe.Debug {
 		level = slog.LevelDebug
 	}
@@ -134,21 +132,6 @@ func (fe *Frontend) Run(ctx context.Context, run func(context.Context) error) er
 
 	// return original err
 	return runErr
-}
-
-// ConnectedToEngine is called when the CLI connects to an engine.
-func (fe *Frontend) ConnectedToEngine(name string) {
-	if !fe.Silent && fe.Plain {
-		fmt.Fprintln(consoleSink, "Connected to engine", name)
-	}
-}
-
-// ConnectedToCloud is called when the CLI has started emitting events to
-// The Cloud.
-func (fe *Frontend) ConnectedToCloud(cloudURL string) {
-	if !fe.Silent && fe.Plain {
-		fmt.Fprintln(consoleSink, "Dagger Cloud URL:", cloudURL)
-	}
 }
 
 // SetPrimary tells the frontend which span should be treated like the focal

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -234,12 +234,8 @@ func (fe *Frontend) renderPrimaryOutput() error {
 	if len(logs) == 0 {
 		return nil
 	}
-	var trailingLn bool
 	for _, l := range logs {
 		data := l.Body().AsString()
-		if strings.HasSuffix(data, "\n") {
-			trailingLn = true
-		}
 		var stream int
 		l.WalkAttributes(func(attr log.KeyValue) bool {
 			if attr.Key == telemetry.LogStreamAttr {
@@ -258,6 +254,11 @@ func (fe *Frontend) renderPrimaryOutput() error {
 				return err
 			}
 		}
+	}
+
+	trailingLn := false
+	if len(logs) > 0 {
+		trailingLn = strings.HasSuffix(logs[len(logs)-1].Body().AsString(), "\n")
 	}
 	if !trailingLn && term.IsTerminal(int(os.Stdout.Fd())) {
 		// NB: ensure there's a trailing newline if stdout is a TTY, so we don't

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -228,6 +228,7 @@ func (fe *Frontend) renderMessages(out *termenv.Output, full bool) (bool, error)
 		fe.messagesView.SetHeight(10)
 	}
 	_, err := fmt.Fprint(out, fe.messagesView.View())
+	fmt.Fprintln(out)
 	return true, err
 }
 
@@ -368,10 +369,10 @@ func (fe *Frontend) Background(cmd tea.ExecCommand) error {
 
 func (fe *Frontend) Render(out *termenv.Output) error {
 	fe.recalculateView()
-	if _, err := fe.renderProgress(out); err != nil {
+	if _, err := fe.renderMessages(out, false); err != nil {
 		return err
 	}
-	if _, err := fe.renderMessages(out, false); err != nil {
+	if _, err := fe.renderProgress(out); err != nil {
 		return err
 	}
 	return nil

--- a/engine/client/buildkit.go
+++ b/engine/client/buildkit.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/client/drivers"
-	"github.com/dagger/dagger/telemetry"
 )
 
 const (
@@ -28,9 +27,6 @@ func newBuildkitClient(ctx context.Context, remote *url.URL, connector drivers.C
 	opts = append(opts, bkclient.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 		return connector.Connect(ctx)
 	}))
-
-	ctx, span := Tracer().Start(ctx, "starting engine")
-	defer telemetry.End(span, func() error { return rerr })
 
 	c, err := bkclient.New(ctx, remote.String(), opts...)
 	if err != nil {

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -224,11 +224,13 @@ func (c *Client) startEngine(ctx context.Context) (rerr error) {
 	}
 
 	provisionCtx, provisionSpan := Tracer().Start(ctx, "starting engine")
+	provisionCtx, provisionCancel := context.WithTimeout(provisionCtx, 10*time.Minute)
 	connector, err := driver.Provision(provisionCtx, remote, &drivers.DriverOpts{
 		UserAgent:        c.UserAgent,
 		DaggerCloudToken: cloudToken,
 		GPUSupport:       os.Getenv(drivers.EnvGPUSupport),
 	})
+	provisionCancel()
 	telemetry.End(provisionSpan, func() error { return err })
 	if err != nil {
 		return err

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -295,7 +295,7 @@ func (c *Client) startSession(ctx context.Context) (rerr error) {
 	ctx, sessionSpan := Tracer().Start(ctx, "starting session")
 	defer telemetry.End(sessionSpan, func() error { return rerr })
 
-	ctx, stdout, stderr := telemetry.WithStdioToOtel(ctx, InstrumentationLibrary)
+	ctx, _, stderr := telemetry.WithStdioToOtel(ctx, InstrumentationLibrary)
 
 	hostname, err := os.Hostname()
 	if err != nil {
@@ -382,8 +382,6 @@ func (c *Client) startSession(ctx context.Context) (rerr error) {
 			if elapsed > time.Second {
 				fmt.Fprintln(stderr, "Failed to connect; retrying...", err)
 			}
-		} else {
-			fmt.Fprintln(stdout, "OK!")
 		}
 		return err
 	}); err != nil {

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -63,10 +63,8 @@ type Params struct {
 
 	DisableHostRW bool
 
-	EngineNameCallback func(string)
-	CloudURLCallback   func(string)
-	EngineTrace        sdktrace.SpanExporter
-	EngineLogs         sdklog.LogExporter
+	EngineTrace sdktrace.SpanExporter
+	EngineLogs  sdklog.LogExporter
 }
 
 type Client struct {
@@ -283,10 +281,7 @@ func (c *Client) startEngine(ctx context.Context) (rerr error) {
 
 	c.bkClient = bkClient
 
-	if c.EngineNameCallback != nil {
-		engineName := fmt.Sprintf("%s (version %s)", bkInfo.BuildkitVersion.Revision, bkInfo.BuildkitVersion.Version)
-		c.EngineNameCallback(engineName)
-	}
+	slog.Info("Connected to engine", "name", bkInfo.BuildkitVersion.Revision, "version", bkInfo.BuildkitVersion.Version)
 
 	return nil
 }

--- a/telemetry/init.go
+++ b/telemetry/init.go
@@ -32,6 +32,7 @@ import (
 
 var configuredCloudSpanExporter sdktrace.SpanExporter
 var configuredCloudLogsExporter sdklog.LogExporter
+var configuredCloudTelemetry bool
 var ocnfiguredCloudExportersOnce sync.Once
 
 func ConfiguredCloudExporters(ctx context.Context) (sdktrace.SpanExporter, sdklog.LogExporter, bool) {
@@ -99,10 +100,11 @@ func ConfiguredCloudExporters(ctx context.Context) (sdktrace.SpanExporter, sdklo
 			Headers:  headers,
 		}
 		configuredCloudLogsExporter = otlploghttp.NewClient(cfg)
+
+		configuredCloudTelemetry = true
 	})
 
-	return configuredCloudSpanExporter, configuredCloudLogsExporter,
-		configuredCloudSpanExporter != nil
+	return configuredCloudSpanExporter, configuredCloudLogsExporter, configuredCloudTelemetry
 }
 
 func OtelConfigured() bool {

--- a/telemetry/url.go
+++ b/telemetry/url.go
@@ -1,0 +1,39 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/dagger/dagger/internal/cloud/auth"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func URLForTrace(ctx context.Context) (string, bool) {
+	if !configuredCloudTelemetry {
+		return "", false
+	}
+
+	var orgName string
+	if cloudToken := os.Getenv("DAGGER_CLOUD_TOKEN"); cloudToken != "" {
+		// Try token auth first
+		token, ok := parseDaggerToken(cloudToken)
+		if ok {
+			orgName = token.orgName
+		}
+	} else {
+		// Try OAuth next
+		org, err := auth.CurrentOrg()
+		if err != nil {
+			return "", false
+		}
+		orgName = org.Name
+	}
+
+	url := fmt.Sprintf(
+		"https://dagger.cloud/%s/traces/%s",
+		orgName,
+		trace.SpanContextFromContext(ctx).TraceID().String(),
+	)
+	return url, true
+}

--- a/telemetry/util.go
+++ b/telemetry/util.go
@@ -45,6 +45,28 @@ func parseSCPLike(endpoint string) (string, bool) {
 	return fmt.Sprintf("%s/%s", host, strings.TrimSuffix(path, ".git")), true
 }
 
+type daggerToken struct {
+	orgName string
+	token   string
+}
+
+func parseDaggerToken(s string) (daggerToken, bool) {
+	s, ok := strings.CutPrefix(s, "dag_")
+	if !ok {
+		return daggerToken{}, false
+	}
+
+	orgName, token, ok := strings.Cut(s, "_")
+	if !ok {
+		return daggerToken{}, false
+	}
+
+	return daggerToken{
+		orgName: orgName,
+		token:   token,
+	}, true
+}
+
 // matchesURLScheme returns true if the given string matches a URL-like
 // format scheme.
 func matchesURLScheme(url string) bool {


### PR DESCRIPTION
Continued progress exploration! I just kinda kept pulling on #7375, and kept finding more things to tidy up :tada:

Fixes:
- #7375
- #6643

This changes a few things about the initial connection:
- Changes timeouts, to provide a sane upper limit on the amount of time allowed to provision an engine, e.g. pulling+starting a docker container (10 minutes) 
- Splits up the `connect` step into separate parts - this allows for improved debugability if this step is hanging - we can see exactly which part is being slow.
	- Removes noisy "OK!" message from session connection - this isn't really needed anymore, success is indicated by the completion of the span.
- Makes sure that `Connected to engine` messages correctly appear with our pretty progress (they weren't being displayed)
- Restores support for `Connected to cloud` messages.
- Ensures that all logging messages respect the detected terminal color profile.

Before:

```
$ dagger call --source=.:default helm test -v
✔ connect 0.8s
✔ initialize 1.1s
✔ ModuleSource.resolveFromCaller: ModuleSource! 0.1s
  ✔ upload /home/jedevc/Documents/Projects/dagger from dragon (client id: kh8jcn3x5ql8ba7z8dhurxnzi) (exclude: **/.git) (include: **/go.mod, **/go.sum, **/go.work, **/go.work.sum, **/vendor/, **/*.go, dagger.json, ci/**/*) 0.1s
✔ ModuleSource.resolveDirectoryFromCaller(path: ".", viewName: "default"): Directory! 0.3s
  ✔ upload /home/jedevc/Documents/Projects/dagger from dragon (client id: kh8jcn3x5ql8ba7z8dhurxnzi) (exclude: bin, .git, **/node_modules, **/.venv, **/__pycache__) 0.3s
✔ dagger(
    source: ✔ blob(digest: "sha256:cbe8a7976450916e3ed0ebadd6eb143df283cc4f4610601bbbb0a32a48662059", mediaType: "application/vnd.oci.image.layer.v1.tar+zstd", size: 5153392, uncompressed: "sha256:a6464e8f195d11a5f4f4588cd8ab8362b85ed8870953b8d66863c637ab9a3c80"): Directory! 0.0s
  ): Dagger! 0.8s
✔ Dagger.helm: DaggerHelm! 0.6s
✔ DaggerHelm.test: Void 1.5s
  ✔ Container.from(address: "alpine/helm:3.12.3"): Container! 0.8s
    ✔ HTTP GET 0.3s
    ✔ remotes.docker.resolver.HTTPRequest 0.4s
      ✔ HTTP HEAD 0.4s

<nil>
```

After:

```
$ dagger call --source=.:default helm test -v
12:11:45 INF Connected to cloud url=https://dagger.cloud/traces/8d82a45c63f06f1cdd68607d76263869
12:11:46 INF Connected to engine name=cda0040f8104 version=v0.11.4

✔ connect 0.8s
  ✔ starting engine 0.6s
  ✔ connecting to engine 0.1s
  ✔ starting session 0.2s
✔ initialize 0.9s
✔ dagger(
    source: ✔ blob(digest: "sha256:cbe8a7976450916e3ed0ebadd6eb143df283cc4f4610601bbbb0a32a48662059", mediaType: "application/vnd.oci.image.layer.v1.tar+zstd", size: 5153392, uncompressed: "sha256:a6464e8f195d11a5f4f4588cd8ab8362b85ed8870953b8d66863c637ab9a3c80"): Directory! 0.0s
  ): Dagger! 0.6s
✔ Dagger.helm: DaggerHelm! 0.6s
✔ DaggerHelm.test: Void 1.1s
  ✔ Container.from(address: "alpine/helm:3.12.3"): Container! 0.4s
    ✔ remotes.docker.resolver.HTTPRequest 0.4s
      ✔ HTTP HEAD 0.4s

<nil>
```                                                                                          