### PR TITLE
fix: hide remotes.docker.resolver spans

### DIFF
--- a/dagql/idtui/db.go
+++ b/dagql/idtui/db.go
@@ -232,6 +232,9 @@ func (db *DB) maybeRecordSpan(traceData *Trace, span sdktrace.ReadOnlySpan) {
 		case telemetry.UIEncapsulateAttr:
 			spanData.Encapsulate = attr.Value.AsBool()
 
+		case telemetry.UIEncapsulatedAttr:
+			spanData.Encapsulated = attr.Value.AsBool()
+
 		case telemetry.UIInternalAttr:
 			spanData.Internal = attr.Value.AsBool()
 

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -592,8 +592,10 @@ func (fe *Frontend) renderRow(out *termenv.Output, row *TraceRow, depth int) err
 	}
 	if !row.Span.Encapsulate || row.Span.Status().Code == codes.Error || fe.Verbosity >= 2 {
 		for _, child := range row.Children {
-			if err := fe.renderRow(out, child, depth); err != nil {
-				return err
+			if !child.Span.Encapsulated || row.Span.Status().Code == codes.Error || fe.Verbosity >= 2 {
+				if err := fe.renderRow(out, child, depth); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/dagql/idtui/spans.go
+++ b/dagql/idtui/spans.go
@@ -26,11 +26,12 @@ type Span struct {
 	Canceled bool
 	Inputs   []string
 
-	Primary     bool
-	Encapsulate bool
-	Mask        bool
-	Passthrough bool
-	Ignore      bool
+	Primary      bool
+	Encapsulate  bool
+	Encapsulated bool
+	Mask         bool
+	Passthrough  bool
+	Ignore       bool
 
 	db    *DB
 	trace *Trace

--- a/telemetry/attrs.go
+++ b/telemetry/attrs.go
@@ -33,7 +33,15 @@ const (
 	UIInternalAttr = "dagger.io/ui.internal"
 
 	// Hide child spans by default.
+	//
+	// Encapsulated child spans may typically be revealed if the parent span errors.
 	UIEncapsulateAttr = "dagger.io/ui.encapsulate"
+
+	// Hide span by default.
+	//
+	// This is functionally the same as UIEncapsulateAttr, but is instead set
+	// on a child instead of a parent.
+	UIEncapsulatedAttr = "dagger.io/ui.encapsulated"
 
 	// Substitute the span for its children and move its logs to its parent.
 	UIPassthroughAttr = "dagger.io/ui.passthrough" //nolint: gosec // lol

--- a/telemetry/span.go
+++ b/telemetry/span.go
@@ -20,6 +20,12 @@ func Encapsulate() trace.SpanStartOption {
 	return trace.WithAttributes(attribute.Bool(UIEncapsulateAttr, true))
 }
 
+// Encapsulated can be applied to a child span to indicate that it should be
+// collapsed by default.
+func Encapsulated() trace.SpanStartOption {
+	return trace.WithAttributes(attribute.Bool(UIEncapsulatedAttr, true))
+}
+
 // Internal can be applied to a span to indicate that this span should not be
 // shown to the user by default.
 func Internal() trace.SpanStartOption {


### PR DESCRIPTION
Before this, we would display all the containerd/buildkit spans that relate to pulling an image. These are *super* unhelpful by default, so we want to hide them in the TUI (unless the parent command errors).

We already have this concept today with `telemetry.Encapsulate`. However, this is set on the parent (in our case, `Container.from`), which isn't quite what we want. Firstly, this would silence all output from this function (even if later we would want to add some more useful output of our own). Secondly, in some builds, these requests might not necessarily even occur as part of `Container.From` - we might end up lazily pulling the image later.

So, we add a new `telemetry.Encapsulated` property - this is exactly the same as the above, but is instead set on a child span. We can set this using our new buildkit tracing interceptor, and only set it on the buildkit spans that we care about.

Before:
```
$ dagger call --source=.:default engine lint -v
✔ connect 1.0s
✔ initialize 7.3s
...
● DaggerEngine.lint: Void 8.1s
  ✔ Container.from(address: "golangci/golangci-lint:v1.57-alpine"): Container! 0.7s
    ✘ remotes.docker.resolver.HTTPRequest 0.3s
      ✘ HTTP HEAD 0.3s
    ✔ HTTP GET 0.2s
    ✔ remotes.docker.resolver.HTTPRequest 0.2s
      ✔ HTTP HEAD 0.2s
  ✔ Container.from(address: "golang:1.22.3-alpine3.18"): Container! 0.9s
    ✔ HTTP GET 0.4s
    ✔ remotes.docker.resolver.HTTPRequest 0.1s
      ✔ HTTP HEAD 0.1s
    ✔ remotes.docker.resolver.HTTPRequest 0.3s
      ✔ HTTP GET 0.3s
```

After:
```
$ dagger call --source=.:default engine lint -v
...
● DaggerEngine.lint: Void 8.9s
  ✔ Container.from(address: "golangci/golangci-lint:v1.57-alpine"): Container! 0.9s
```