### PR TITLE
Build Dagger docs with Dagger

### DIFF
--- a/ci/docs-nginx.conf
+++ b/ci/docs-nginx.conf
@@ -1,0 +1,15 @@
+server {
+    listen       8000 default_server;
+    server_name  _;
+    gzip on;
+    gzip_types text/plain application/xml text/css text/javascript application/javascript application/json;
+
+    location / {
+        root   /var/www;
+        try_files $uri $uri/ /index.html;
+    }
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /var/www;
+    }
+}

--- a/ci/go.mod
+++ b/ci/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/sosodev/duration v1.3.0 // indirect
+	github.com/stretchr/testify v1.9.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.2.0 // indirect

--- a/ci/go.sum
+++ b/ci/go.sum
@@ -46,8 +46,8 @@ github.com/sosodev/duration v1.3.0 h1:g3E6mto+hFdA2uZXeNDYff8LYeg7v5D4YKP/Ng/NUk
 github.com/sosodev/duration v1.3.0/go.mod h1:RQIBBX0+fMLc/D9+Jb/fwvVmo0eZvDDEERAikUR6SDg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/vektah/gqlparser/v2 v2.5.11 h1:JJxLtXIoN7+3x6MBdtIP59TP1RANnY7pXOaDnADQSf8=
 github.com/vektah/gqlparser/v2 v2.5.11/go.mod h1:1rCcfwB2ekJofmluGWXMSEnPMZgbxzwj6FaZ/4OT8Cc=
 go.opentelemetry.io/otel v1.24.0 h1:0LAOdjNmQeSTzGBzduGe/rU4tZhMwL5rWgtp9Ku5Jfo=

--- a/dagger.json
+++ b/dagger.json
@@ -1,8 +1,14 @@
 {
   "name": "dagger",
   "sdk": "go",
+  "dependencies": [
+    {
+      "name": "docusaurus",
+      "source": "github.com/levlaz/daggerverse/docusaurus@72ec19206da7dbe2815da94c62e491b54935b633"
+    }
+  ],
   "source": "ci",
-  "engineVersion": "v0.11.3",
+  "engineVersion": "v0.11.4",
   "views": [
     {
       "name": "default",


### PR DESCRIPTION
Examples:

- Build the docs site: `dagger call --source=. site export --path=./docs-site`
- Build the docs server: `dagger call --source=. server`
- Run docs locally: `dagger call --source=. server as-service up`
- Run docs for a PR: `dagger call --source=https://github.com/dagger/dagger#pull/7382/head server as-service up`
