### PR TITLE
Add Values.engine.labels value to Helm Chart.

### DIFF
--- a/helm/dagger/templates/_helpers.tpl
+++ b/helm/dagger/templates/_helpers.tpl
@@ -41,6 +41,9 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: {{ template "dagger.name" . }}
+{{- if .Values.engine.labels }}
+{{ toYaml .Values.engine.labels }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/helm/dagger/values.yaml
+++ b/helm/dagger/values.yaml
@@ -13,6 +13,7 @@ engine:
   #     mirrors = ["mirror.gcr.io"]
   #   [log]
   #     format = "json"
+  labels: {}
   resources:
     limits: {}
     # limits:


### PR DESCRIPTION
This is required in cases where labels are required to provide access, ETC. I.E.:

I need this change because I'd like to execute Terraform code in Dagger Runners under an Azure MSI context using aadPodIdentity in an AKS cluster. To provide the necessary access, the dagger-engine DaemonSet requires an `aadpodidentity` label for aadPodIdentity to attach an Azure MSI context to it.