### PR TITLE
cli: don’t show functions that can’t be called

### DIFF
--- a/.changes/unreleased/Changed-20240520-151710.yaml
+++ b/.changes/unreleased/Changed-20240520-151710.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: "cli: don't show functions that can't be called"
+time: 2024-05-20T15:17:10.696904Z
+custom:
+  Author: helderco
+  PR: "7418"

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -562,6 +562,10 @@ func (fc *FuncCommand) addArgsForFunction(cmd *cobra.Command, cmdArgs []string, 
 
 	for _, arg := range fn.Args {
 		if err := arg.AddFlag(cmd.Flags()); err != nil {
+			var e *UnsupportedFlagError
+			if errors.As(err, &e) {
+				continue
+			}
 			return err
 		}
 		if arg.IsRequired() {

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -561,8 +561,7 @@ func (fc *FuncCommand) addArgsForFunction(cmd *cobra.Command, cmdArgs []string, 
 	}
 
 	for _, arg := range fn.Args {
-		_, err := arg.AddFlag(cmd.Flags())
-		if err != nil {
+		if err := arg.AddFlag(cmd.Flags()); err != nil {
 			return err
 		}
 		if arg.IsRequired() {

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -612,7 +612,7 @@ func (fc *FuncCommand) addArgsForFunction(cmd *cobra.Command, cmdArgs []string, 
 func (fc *FuncCommand) selectFunc(ctx context.Context, selectName string, fn *modFunction, cmd *cobra.Command, dag *dagger.Client) error {
 	fc.Select(selectName)
 
-	for _, arg := range fn.Args {
+	for _, arg := range fn.SupportedArgs() {
 		var val any
 
 		flag := cmd.Flags().Lookup(arg.FlagName())

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -1139,7 +1139,7 @@ type modFunction struct {
 
 func (f *modFunction) IsUnsupported() bool {
 	for _, arg := range f.Args {
-		if arg.IsUnsupportedFlag() {
+		if arg.IsRequired() && arg.IsUnsupportedFlag() {
 			return true
 		}
 	}

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -1137,6 +1137,16 @@ type modFunction struct {
 	Args        []*modFunctionArg
 }
 
+func (f *modFunction) SupportedArgs() []*modFunctionArg {
+	args := make([]*modFunctionArg, 0, len(f.Args))
+	for _, arg := range f.Args {
+		if !arg.IsUnsupportedFlag() {
+			args = append(args, arg)
+		}
+	}
+	return args
+}
+
 func (f *modFunction) IsUnsupported() bool {
 	for _, arg := range f.Args {
 		if arg.IsRequired() && arg.IsUnsupportedFlag() {

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -1221,7 +1221,14 @@ func (m *Test) FnB(
     msg string,
     // +optional
     matrix [][]string,
-) string {
+) *Chain {
+    return new(Chain)
+}
+
+type Chain struct {}
+
+// Repeat message back
+func (m *Chain) Echo(msg string) string {
     return msg
 }
 `,
@@ -1247,6 +1254,12 @@ func (m *Test) FnB(
 
 		require.Contains(t, out, "--msg")
 		require.NotContains(t, out, "--matrix")
+	})
+
+	t.Run("in chain", func(t *testing.T) {
+		out, err := modGen.With(daggerCall("fn-b", "--msg", "", "echo", "--msg", "hello")).Stdout(ctx)
+		require.NoError(t, err)
+		require.Contains(t, out, "hello")
 	})
 
 	t.Run("no sub-command", func(t *testing.T) {

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -1094,7 +1094,7 @@ func TestModuleCallByName(t *testing.T) {
 
 			type ModA struct {}
 
-			func (m *ModA) Fn(ctx context.Context) string { 
+			func (m *ModA) Fn(ctx context.Context) string {
 				return "hi from mod-a"
 			}
 			`,
@@ -1108,7 +1108,7 @@ func TestModuleCallByName(t *testing.T) {
 
 			type ModB struct {}
 
-			func (m *ModB) Fn(ctx context.Context) string { 
+			func (m *ModB) Fn(ctx context.Context) string {
 				return "hi from mod-b"
 			}
 			`,
@@ -1196,4 +1196,66 @@ func TestModuleCallFindup(t *testing.T) {
 		Stdout(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "yo", strings.TrimSpace(out))
+}
+
+func TestModuleCallUnsupportedFunctions(t *testing.T) {
+	t.Parallel()
+	c, ctx := connect(t)
+
+	modGen := modInit(t, c, "go", `package main
+
+type Test struct {}
+
+// Sanity check
+func (m *Test) Echo(msg string) string {
+    return msg
+}
+
+// Skips adding the function
+func (m *Test) FnA(msg string, matrix [][]string) string {
+    return msg
+}
+
+// Skips adding the optional flag
+func (m *Test) FnB(
+    msg string,
+    // +optional
+    matrix [][]string,
+) string {
+    return msg
+}
+`,
+	)
+
+	t.Run("functions list", func(t *testing.T) {
+		out, err := modGen.With(daggerCall("--help")).Stdout(ctx)
+		require.NoError(t, err)
+
+		require.Contains(t, out, "echo")
+		require.Contains(t, out, "Sanity check")
+
+		require.NotContains(t, out, "fn-a")
+		require.NotContains(t, out, "Skips adding the function")
+
+		require.Contains(t, out, "fn-b")
+		require.Contains(t, out, "Skips adding the optional flag")
+	})
+
+	t.Run("arguments list", func(t *testing.T) {
+		out, err := modGen.With(daggerCall("fn-b", "--help")).Stdout(ctx)
+		require.NoError(t, err)
+
+		require.Contains(t, out, "--msg")
+		require.NotContains(t, out, "--matrix")
+	})
+
+	t.Run("no sub-command", func(t *testing.T) {
+		_, err := modGen.With(daggerCall("fn-a")).Sync(ctx)
+		require.ErrorContains(t, err, `unknown command "fn-a"`)
+	})
+
+	t.Run("no flag", func(t *testing.T) {
+		_, err := modGen.With(daggerCall("fn-b", "--msg", "hello", "--matrix", "")).Sync(ctx)
+		require.ErrorContains(t, err, `unknown flag: --matrix`)
+	})
 }


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/6608

Most common reason for not being able to call a function is unsupported flags. A function will be skipped if there's any required arguments with unsupported flags, but if the unsupported flags are only for optional arguments, they just won't be available to the CLI.