### PR TITLE
cli: don't show inherited flags in function commands

### DIFF
--- a/.changes/unreleased/Changed-20240520-152502.yaml
+++ b/.changes/unreleased/Changed-20240520-152502.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: "cli: don't show inherited flags in function commands"
+time: 2024-05-20T15:25:02.833118Z
+custom:
+  Author: helderco
+  PR: "7419"

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -478,6 +478,11 @@ func (fc *FuncCommand) makeSubCmd(ctx context.Context, dag *dagger.Client, fn *m
 			// Need to make the query selection before chaining off.
 			return fc.selectFunc(ctx, fn.Name, fn, cmd, dag)
 		},
+		// FIXME: Persistent flags should be marked as hidden for sub-commands
+		// but it's not working, so setting an annotation to circumvent it.
+		Annotations: map[string]string{
+			"help:hideInherited": "true",
+		},
 
 		// This is going to be executed in the "execution" vertex, when
 		// we have the final/leaf command.

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -87,6 +87,7 @@ func init() {
 
 	cobra.AddTemplateFunc("isExperimental", isExperimental)
 	cobra.AddTemplateFunc("flagUsagesWrapped", flagUsagesWrapped)
+	cobra.AddTemplateFunc("hasInheritedFlags", hasInheritedFlags)
 	cobra.AddTemplateFunc("cmdShortWrapped", cmdShortWrapped)
 	cobra.AddTemplateFunc("toUpperBold", toUpperBold)
 	cobra.AddTemplateFunc("sortRequiredFlags", sortRequiredFlags)
@@ -325,6 +326,13 @@ func isExperimental(cmd *cobra.Command) bool {
 	return experimental
 }
 
+func hasInheritedFlags(cmd *cobra.Command) bool {
+	if val, ok := cmd.Annotations["help:hideInherited"]; ok && val == "true" {
+		return false
+	}
+	return cmd.HasAvailableInheritedFlags()
+}
+
 // getViewWidth returns the width of the terminal, or 80 if it cannot be determined.
 func getViewWidth() int {
 	width, _, err := term.GetSize(int(os.Stdout.Fd()))
@@ -502,7 +510,7 @@ const usageTemplate = `{{ if .Runnable}}{{ "Usage" | toUpperBold }}
 
 {{- end}}
 
-{{- if .HasAvailableInheritedFlags}}
+{{- if hasInheritedFlags . }}
 
 {{ "Inherited Options" | toUpperBold }}
 {{ flagUsagesWrapped .InheritedFlags | trimTrailingWhitespaces }}


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/7400

Note that `dagger call` still shows them, they're hidden only on function commands.

## Example

```
❯ dagger call sdk python --help
```

### Before

```
Develop the Dagger Python SDK

USAGE
  dagger call sdk python <function>

FUNCTIONS
  bump          Bump the Python SDK's Engine dependency
  generate      Regenerate the Python SDK API
  lint          Lint the Python SDK
  publish       Publish the Python SDK
  test          Test the Python SDK

INHERITED OPTIONS
  -d, --debug             show debug logs and full verbosity
      --json              Present result as JSON
  -m, --mod string        Path to dagger.json config file for the module or a directory containing that file.
                          Either local path (e.g. "/path/to/some/dir") or a github repo (e.g.
                          "github.com/dagger/dagger/path/to/some/subdir")
  -o, --output string     Path in the host to save the result to
      --progress string   progress output format (auto, plain, tty) (default "auto")
  -s, --silent            disable terminal UI and progress output
  -v, --verbose count     increase verbosity (use -vv or -vvv for more)

Use "dagger call sdk python [command] --help" for more information about a command.
```

### After

```
Develop the Dagger Python SDK

USAGE
  dagger call sdk python <function>

FUNCTIONS
  bump          Bump the Python SDK's Engine dependency
  generate      Regenerate the Python SDK API
  lint          Lint the Python SDK
  publish       Publish the Python SDK
  test          Test the Python SDK

Use "dagger call sdk python [command] --help" for more information about a command.
```
