### PR TITLE
core: multi SCM support

### DIFF
--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -511,7 +511,7 @@ forced), to avoid mistakenly depending on uncommitted files.
 func originToPath(origin string) (string, error) {
 	parsedURL, err := gitutil.ParseURL(origin)
 	if err != nil {
-		// If no procotol was specified, try with "https://"
+		// If no protocol was specified, try with "https://"
 		if err == gitutil.ErrUnknownProtocol {
 			parsedURL, err = gitutil.ParseURL("https://" + origin)
 		}

--- a/cmd/dagger/module_test.go
+++ b/cmd/dagger/module_test.go
@@ -50,6 +50,236 @@ func TestOriginToPath(t *testing.T) {
 	}
 }
 
+// TestConvertRef tests the conversion of a ref to a BuildKit-compatible ref.
+// This is used to convert a multi VCS ref to a BuildKit-compatible ref.
+func TestConvertRef(t *testing.T) {
+	testCases := []struct {
+		name           string
+		urlStr         string
+		expectedUrlStr string
+	}{
+		// SSH ref without version or subdir
+		{
+			name:           "SSH ref without .git",
+			urlStr:         "ssh://git@github.com/shykes/daggerverse",
+			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse",
+		},
+		{
+			name:           "SSH ref with .git",
+			urlStr:         "ssh://git@github.com/shykes/daggerverse.git",
+			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse.git",
+		},
+
+		// SSH ref with version
+		{
+			name:           "SSH ref with version",
+			urlStr:         "ssh://git@github.com/shykes/daggerverse@v0.9.1",
+			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse#v0.9.1",
+		},
+		{
+			name:           "SSH ref with .git and version",
+			urlStr:         "ssh://git@github.com/shykes/daggerverse.git@v0.9.1",
+			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse.git#v0.9.1",
+		},
+
+		// SSH ref with version and subdir
+		{
+			name:           "SSH ref with subdir and version",
+			urlStr:         "ssh://git@github.com/shykes/daggerverse/subdir1/subdir2@v0.9.1",
+			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse#v0.9.1:subdir1/subdir2",
+		},
+		{
+			name:           "SSH ref with .git, subdir and version",
+			urlStr:         "ssh://git@github.com/shykes/daggerverse.git/subdir1/subdir2@v0.9.1",
+			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse.git#v0.9.1:subdir1/subdir2",
+		},
+
+		// Implicit SSH ref without version or subdir
+		{
+			name:           "Git ref without .git",
+			urlStr:         "git@github.com:sipsma/daggerverse",
+			expectedUrlStr: "ssh://git@github.com:sipsma/daggerverse",
+		},
+		{
+			name:           "Git ref with .git",
+			urlStr:         "git@github.com:sipsma/daggerverse.git",
+			expectedUrlStr: "ssh://git@github.com:sipsma/daggerverse.git",
+		},
+
+		// Implicit SSH ref with version
+		{
+			name:           "Git ref with version",
+			urlStr:         "git@github.com:sipsma/daggerverse@v0.9.1",
+			expectedUrlStr: "ssh://git@github.com:sipsma/daggerverse#v0.9.1",
+		},
+		{
+			name:           "Git ref with .git and version",
+			urlStr:         "git@github.com:sipsma/daggerverse.git@v0.9.1",
+			expectedUrlStr: "ssh://git@github.com:sipsma/daggerverse.git#v0.9.1",
+		},
+
+		// Implicit SSH ref with version and subdir
+		{
+			name:           "Git ref with subdir and version",
+			urlStr:         "git@github.com:sipsma/daggerverse/subdir1/subdir2@v0.9.1",
+			expectedUrlStr: "ssh://git@github.com:sipsma/daggerverse#v0.9.1:subdir1/subdir2",
+		},
+		{
+			name:           "Git ref with .git, subdir and version",
+			urlStr:         "git@github.com:sipsma/daggerverse.git/subdir1/subdir2@v0.9.1",
+			expectedUrlStr: "ssh://git@github.com:sipsma/daggerverse.git#v0.9.1:subdir1/subdir2",
+		},
+
+		// Explicit HTTPS ref with version and subdir
+		{
+			name:           "HTTPS ref with subdir and version",
+			urlStr:         "https://github.com/sipsma/daggerverse/subdir1/subdir2@v0.9.1",
+			expectedUrlStr: "https://github.com/sipsma/daggerverse#v0.9.1:subdir1/subdir2",
+		},
+		{
+			name:           "HTTPS ref with .git, subdir and version",
+			urlStr:         "https://github.com/sipsma/daggerverse.git/subdir1/subdir2@v0.9.1",
+			expectedUrlStr: "https://github.com/sipsma/daggerverse.git#v0.9.1:subdir1/subdir2",
+		},
+
+		// Implicit HTTPS without subdir or version
+		{
+			name:           "ref without scheme with subdir",
+			urlStr:         "github.com/sipsma/daggerverse",
+			expectedUrlStr: "https://github.com/sipsma/daggerverse",
+		},
+		{
+			name:           "ref without scheme with subdir and .git",
+			urlStr:         "github.com/sipsma/daggerverse.git",
+			expectedUrlStr: "https://github.com/sipsma/daggerverse.git",
+		},
+
+		// Implicit HTTPS with subdir
+		{
+			name:           "ref without scheme and subdir",
+			urlStr:         "github.com/sipsma/daggerverse/subdir1/subdir2",
+			expectedUrlStr: "https://github.com/sipsma/daggerverse:subdir1/subdir2",
+		},
+		{
+			name:           "ref without scheme, subdir and version, with .git",
+			urlStr:         "github.com/sipsma/daggerverse.git/subdir1/subdir2",
+			expectedUrlStr: "https://github.com/sipsma/daggerverse.git:subdir1/subdir2",
+		},
+
+		// Implicit HTTPS with version
+		{
+			name:           "ref without scheme with version",
+			urlStr:         "github.com/sipsma/daggerverse@v0.9.1",
+			expectedUrlStr: "https://github.com/sipsma/daggerverse#v0.9.1",
+		},
+		{
+			name:           "ref without scheme with version and .git",
+			urlStr:         "github.com/sipsma/daggerverse.git@v0.9.1",
+			expectedUrlStr: "https://github.com/sipsma/daggerverse.git#v0.9.1",
+		},
+
+		// Implicit HTTPS with version and subdir
+		{
+			name:           "ref without scheme with subdir and version",
+			urlStr:         "github.com/sipsma/daggerverse/subdir1/subdir2@v0.9.1",
+			expectedUrlStr: "https://github.com/sipsma/daggerverse#v0.9.1:subdir1/subdir2",
+		},
+		{
+			name:           "ref without scheme with subdir and version and .git",
+			urlStr:         "github.com/sipsma/daggerverse.git/subdir1/subdir2",
+			expectedUrlStr: "https://github.com/sipsma/daggerverse.git:subdir1/subdir2",
+		},
+
+		// Vanity ref
+		{
+			name:           "Vanity ref with version",
+			urlStr:         "dagger.io/dagger@v0.9.1",
+			expectedUrlStr: "https://github.com/dagger/dagger-go-sdk#v0.9.1",
+		},
+		// { // with subdir, requires to modify dagger.io/dagger netlify's redirect
+		// 	name:           "Vanity refL with version",
+		// 	urlStr:         "dagger.io/dagger@v0.9.1",
+		// 	expectedUrlStr: "https://github.com/dagger/dagger-go-sdk#v0.9.1",
+		// },
+
+		// Edge cases
+		{
+			name:           "Empty ref",
+			urlStr:         "",
+			expectedUrlStr: "",
+		},
+		{
+			name:           "Invalid ref",
+			urlStr:         "invalid-url",
+			expectedUrlStr: "invalid-url",
+		},
+		{
+			name:           "Invalid FTP scheme",
+			urlStr:         "ftp://github.com/sipsma/daggerverse",
+			expectedUrlStr: "ftp://github.com/sipsma/daggerverse",
+		},
+
+		// Retro-compatibility test cases
+		{
+			name:           "Retro SSH ref with version",
+			urlStr:         "ssh://git@github.com/shykes/daggerverse#v0.9.1",
+			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse#v0.9.1",
+		},
+		{
+			name:           "Retro SSH ref with .git and version",
+			urlStr:         "ssh://git@github.com/shykes/daggerverse.git#v0.9.1",
+			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse.git#v0.9.1",
+		},
+		{
+			name:           "Retro SSH ref with subdir and version",
+			urlStr:         "ssh://git@github.com/shykes/daggerverse#v0.9.1:subdir1/subdir2",
+			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse#v0.9.1:subdir1/subdir2",
+		},
+		{
+			name:           "Retro SSH ref with .git, subdir and version",
+			urlStr:         "ssh://git@github.com/shykes/daggerverse.git#v0.9.1:subdir1/subdir2",
+			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse.git#v0.9.1:subdir1/subdir2",
+		},
+		{
+			name:           "Retro Git ref with version",
+			urlStr:         "git@github.com:sipsma/daggerverse#v0.9.1",
+			expectedUrlStr: "git@github.com:sipsma/daggerverse#v0.9.1",
+		},
+		{
+			name:           "Retro Git ref with .git and version",
+			urlStr:         "git@github.com:sipsma/daggerverse.git#v0.9.1",
+			expectedUrlStr: "git@github.com:sipsma/daggerverse.git#v0.9.1",
+		},
+		{
+			name:           "Retro Git ref with subdir and version",
+			urlStr:         "git@github.com:sipsma/daggerverse#v0.9.1:subdir1/subdir2",
+			expectedUrlStr: "git@github.com:sipsma/daggerverse#v0.9.1:subdir1/subdir2",
+		},
+		{
+			name:           "Retro Git ref with .git, subdir and version",
+			urlStr:         "git@github.com:sipsma/daggerverse.git#v0.9.1:subdir1/subdir2",
+			expectedUrlStr: "git@github.com:sipsma/daggerverse.git#v0.9.1:subdir1/subdir2",
+		},
+		{
+			name:           "Retro no sheme ref with subdir and version",
+			urlStr:         "github.com:sipsma/daggerverse#v0.9.1:subdir1/subdir2",
+			expectedUrlStr: "github.com:sipsma/daggerverse#v0.9.1:subdir1/subdir2",
+		},
+		{
+			name:           "Retro no scheme ref with .git, subdir and version",
+			urlStr:         "github.com:sipsma/daggerverse.git#v0.9.1:subdir1/subdir2",
+			expectedUrlStr: "github.com:sipsma/daggerverse.git#v0.9.1:subdir1/subdir2",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			convertedUrlStr := vcsToBuildKitRef(tc.urlStr)
+			require.Equal(t, tc.expectedUrlStr, convertedUrlStr)
+		})
+	}
+}
+
 // This covers cases that the full integ test in core/integration/module_test.go can't
 // cover right now due to limitation in needing real SSH keys to test e2e.
 func TestParseGit(t *testing.T) {

--- a/cmd/dagger/module_test.go
+++ b/cmd/dagger/module_test.go
@@ -50,235 +50,235 @@ func TestOriginToPath(t *testing.T) {
 	}
 }
 
-// TestConvertRef tests the conversion of a ref to a BuildKit-compatible ref.
-// This is used to convert a multi VCS ref to a BuildKit-compatible ref.
-func TestConvertRef(t *testing.T) {
-	testCases := []struct {
-		name           string
-		urlStr         string
-		expectedUrlStr string
-	}{
-		// SSH ref without version or subdir
-		{
-			name:           "SSH ref without .git",
-			urlStr:         "ssh://git@github.com/shykes/daggerverse",
-			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse",
-		},
-		{
-			name:           "SSH ref with .git",
-			urlStr:         "ssh://git@github.com/shykes/daggerverse.git",
-			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse.git",
-		},
+// // TestConvertRef tests the conversion of a ref to a BuildKit-compatible ref.
+// // This is used to convert a multi VCS ref to a BuildKit-compatible ref.
+// func TestConvertRef(t *testing.T) {
+// 	testCases := []struct {
+// 		name           string
+// 		urlStr         string
+// 		expectedUrlStr string
+// 	}{
+// 		// SSH ref without version or subdir
+// 		{
+// 			name:           "SSH ref without .git",
+// 			urlStr:         "ssh://git@github.com/shykes/daggerverse",
+// 			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse",
+// 		},
+// 		{
+// 			name:           "SSH ref with .git",
+// 			urlStr:         "ssh://git@github.com/shykes/daggerverse.git",
+// 			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse.git",
+// 		},
 
-		// SSH ref with version
-		{
-			name:           "SSH ref with version",
-			urlStr:         "ssh://git@github.com/shykes/daggerverse@v0.9.1",
-			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse#v0.9.1",
-		},
-		{
-			name:           "SSH ref with .git and version",
-			urlStr:         "ssh://git@github.com/shykes/daggerverse.git@v0.9.1",
-			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse.git#v0.9.1",
-		},
+// 		// SSH ref with version
+// 		{
+// 			name:           "SSH ref with version",
+// 			urlStr:         "ssh://git@github.com/shykes/daggerverse@v0.9.1",
+// 			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse#v0.9.1",
+// 		},
+// 		{
+// 			name:           "SSH ref with .git and version",
+// 			urlStr:         "ssh://git@github.com/shykes/daggerverse.git@v0.9.1",
+// 			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse.git#v0.9.1",
+// 		},
 
-		// SSH ref with version and subdir
-		{
-			name:           "SSH ref with subdir and version",
-			urlStr:         "ssh://git@github.com/shykes/daggerverse/subdir1/subdir2@v0.9.1",
-			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse#v0.9.1:subdir1/subdir2",
-		},
-		{
-			name:           "SSH ref with .git, subdir and version",
-			urlStr:         "ssh://git@github.com/shykes/daggerverse.git/subdir1/subdir2@v0.9.1",
-			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse.git#v0.9.1:subdir1/subdir2",
-		},
+// 		// SSH ref with version and subdir
+// 		{
+// 			name:           "SSH ref with subdir and version",
+// 			urlStr:         "ssh://git@github.com/shykes/daggerverse/subdir1/subdir2@v0.9.1",
+// 			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse#v0.9.1:subdir1/subdir2",
+// 		},
+// 		{
+// 			name:           "SSH ref with .git, subdir and version",
+// 			urlStr:         "ssh://git@github.com/shykes/daggerverse.git/subdir1/subdir2@v0.9.1",
+// 			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse.git#v0.9.1:subdir1/subdir2",
+// 		},
 
-		// Implicit SSH ref without version or subdir
-		{
-			name:           "Git ref without .git",
-			urlStr:         "git@github.com:sipsma/daggerverse",
-			expectedUrlStr: "ssh://git@github.com:sipsma/daggerverse",
-		},
-		{
-			name:           "Git ref with .git",
-			urlStr:         "git@github.com:sipsma/daggerverse.git",
-			expectedUrlStr: "ssh://git@github.com:sipsma/daggerverse.git",
-		},
+// 		// Implicit SSH ref without version or subdir
+// 		{
+// 			name:           "Git ref without .git",
+// 			urlStr:         "git@github.com:sipsma/daggerverse",
+// 			expectedUrlStr: "ssh://git@github.com:sipsma/daggerverse",
+// 		},
+// 		{
+// 			name:           "Git ref with .git",
+// 			urlStr:         "git@github.com:sipsma/daggerverse.git",
+// 			expectedUrlStr: "ssh://git@github.com:sipsma/daggerverse.git",
+// 		},
 
-		// Implicit SSH ref with version
-		{
-			name:           "Git ref with version",
-			urlStr:         "git@github.com:sipsma/daggerverse@v0.9.1",
-			expectedUrlStr: "ssh://git@github.com:sipsma/daggerverse#v0.9.1",
-		},
-		{
-			name:           "Git ref with .git and version",
-			urlStr:         "git@github.com:sipsma/daggerverse.git@v0.9.1",
-			expectedUrlStr: "ssh://git@github.com:sipsma/daggerverse.git#v0.9.1",
-		},
+// 		// Implicit SSH ref with version
+// 		{
+// 			name:           "Git ref with version",
+// 			urlStr:         "git@github.com:sipsma/daggerverse@v0.9.1",
+// 			expectedUrlStr: "ssh://git@github.com:sipsma/daggerverse#v0.9.1",
+// 		},
+// 		{
+// 			name:           "Git ref with .git and version",
+// 			urlStr:         "git@github.com:sipsma/daggerverse.git@v0.9.1",
+// 			expectedUrlStr: "ssh://git@github.com:sipsma/daggerverse.git#v0.9.1",
+// 		},
 
-		// Implicit SSH ref with version and subdir
-		{
-			name:           "Git ref with subdir and version",
-			urlStr:         "git@github.com:sipsma/daggerverse/subdir1/subdir2@v0.9.1",
-			expectedUrlStr: "ssh://git@github.com:sipsma/daggerverse#v0.9.1:subdir1/subdir2",
-		},
-		{
-			name:           "Git ref with .git, subdir and version",
-			urlStr:         "git@github.com:sipsma/daggerverse.git/subdir1/subdir2@v0.9.1",
-			expectedUrlStr: "ssh://git@github.com:sipsma/daggerverse.git#v0.9.1:subdir1/subdir2",
-		},
+// 		// Implicit SSH ref with version and subdir
+// 		{
+// 			name:           "Git ref with subdir and version",
+// 			urlStr:         "git@github.com:sipsma/daggerverse/subdir1/subdir2@v0.9.1",
+// 			expectedUrlStr: "ssh://git@github.com:sipsma/daggerverse#v0.9.1:subdir1/subdir2",
+// 		},
+// 		{
+// 			name:           "Git ref with .git, subdir and version",
+// 			urlStr:         "git@github.com:sipsma/daggerverse.git/subdir1/subdir2@v0.9.1",
+// 			expectedUrlStr: "ssh://git@github.com:sipsma/daggerverse.git#v0.9.1:subdir1/subdir2",
+// 		},
 
-		// Explicit HTTPS ref with version and subdir
-		{
-			name:           "HTTPS ref with subdir and version",
-			urlStr:         "https://github.com/sipsma/daggerverse/subdir1/subdir2@v0.9.1",
-			expectedUrlStr: "https://github.com/sipsma/daggerverse#v0.9.1:subdir1/subdir2",
-		},
-		{
-			name:           "HTTPS ref with .git, subdir and version",
-			urlStr:         "https://github.com/sipsma/daggerverse.git/subdir1/subdir2@v0.9.1",
-			expectedUrlStr: "https://github.com/sipsma/daggerverse.git#v0.9.1:subdir1/subdir2",
-		},
+// 		// Explicit HTTPS ref with version and subdir
+// 		{
+// 			name:           "HTTPS ref with subdir and version",
+// 			urlStr:         "https://github.com/sipsma/daggerverse/subdir1/subdir2@v0.9.1",
+// 			expectedUrlStr: "https://github.com/sipsma/daggerverse#v0.9.1:subdir1/subdir2",
+// 		},
+// 		{
+// 			name:           "HTTPS ref with .git, subdir and version",
+// 			urlStr:         "https://github.com/sipsma/daggerverse.git/subdir1/subdir2@v0.9.1",
+// 			expectedUrlStr: "https://github.com/sipsma/daggerverse.git#v0.9.1:subdir1/subdir2",
+// 		},
 
-		// Implicit HTTPS without subdir or version
-		{
-			name:           "ref without scheme with subdir",
-			urlStr:         "github.com/sipsma/daggerverse",
-			expectedUrlStr: "https://github.com/sipsma/daggerverse",
-		},
-		{
-			name:           "ref without scheme with subdir and .git",
-			urlStr:         "github.com/sipsma/daggerverse.git",
-			expectedUrlStr: "https://github.com/sipsma/daggerverse.git",
-		},
+// 		// Implicit HTTPS without subdir or version
+// 		{
+// 			name:           "ref without scheme with subdir",
+// 			urlStr:         "github.com/sipsma/daggerverse",
+// 			expectedUrlStr: "https://github.com/sipsma/daggerverse",
+// 		},
+// 		{
+// 			name:           "ref without scheme with subdir and .git",
+// 			urlStr:         "github.com/sipsma/daggerverse.git",
+// 			expectedUrlStr: "https://github.com/sipsma/daggerverse.git",
+// 		},
 
-		// Implicit HTTPS with subdir
-		{
-			name:           "ref without scheme and subdir",
-			urlStr:         "github.com/sipsma/daggerverse/subdir1/subdir2",
-			expectedUrlStr: "https://github.com/sipsma/daggerverse:subdir1/subdir2",
-		},
-		{
-			name:           "ref without scheme, subdir and version, with .git",
-			urlStr:         "github.com/sipsma/daggerverse.git/subdir1/subdir2",
-			expectedUrlStr: "https://github.com/sipsma/daggerverse.git:subdir1/subdir2",
-		},
+// 		// Implicit HTTPS with subdir
+// 		{
+// 			name:           "ref without scheme and subdir",
+// 			urlStr:         "github.com/sipsma/daggerverse/subdir1/subdir2",
+// 			expectedUrlStr: "https://github.com/sipsma/daggerverse:subdir1/subdir2",
+// 		},
+// 		{
+// 			name:           "ref without scheme, subdir and version, with .git",
+// 			urlStr:         "github.com/sipsma/daggerverse.git/subdir1/subdir2",
+// 			expectedUrlStr: "https://github.com/sipsma/daggerverse.git:subdir1/subdir2",
+// 		},
 
-		// Implicit HTTPS with version
-		{
-			name:           "ref without scheme with version",
-			urlStr:         "github.com/sipsma/daggerverse@v0.9.1",
-			expectedUrlStr: "https://github.com/sipsma/daggerverse#v0.9.1",
-		},
-		{
-			name:           "ref without scheme with version and .git",
-			urlStr:         "github.com/sipsma/daggerverse.git@v0.9.1",
-			expectedUrlStr: "https://github.com/sipsma/daggerverse.git#v0.9.1",
-		},
+// 		// Implicit HTTPS with version
+// 		{
+// 			name:           "ref without scheme with version",
+// 			urlStr:         "github.com/sipsma/daggerverse@v0.9.1",
+// 			expectedUrlStr: "https://github.com/sipsma/daggerverse#v0.9.1",
+// 		},
+// 		{
+// 			name:           "ref without scheme with version and .git",
+// 			urlStr:         "github.com/sipsma/daggerverse.git@v0.9.1",
+// 			expectedUrlStr: "https://github.com/sipsma/daggerverse.git#v0.9.1",
+// 		},
 
-		// Implicit HTTPS with version and subdir
-		{
-			name:           "ref without scheme with subdir and version",
-			urlStr:         "github.com/sipsma/daggerverse/subdir1/subdir2@v0.9.1",
-			expectedUrlStr: "https://github.com/sipsma/daggerverse#v0.9.1:subdir1/subdir2",
-		},
-		{
-			name:           "ref without scheme with subdir and version and .git",
-			urlStr:         "github.com/sipsma/daggerverse.git/subdir1/subdir2",
-			expectedUrlStr: "https://github.com/sipsma/daggerverse.git:subdir1/subdir2",
-		},
+// 		// Implicit HTTPS with version and subdir
+// 		{
+// 			name:           "ref without scheme with subdir and version",
+// 			urlStr:         "github.com/sipsma/daggerverse/subdir1/subdir2@v0.9.1",
+// 			expectedUrlStr: "https://github.com/sipsma/daggerverse#v0.9.1:subdir1/subdir2",
+// 		},
+// 		{
+// 			name:           "ref without scheme with subdir and version and .git",
+// 			urlStr:         "github.com/sipsma/daggerverse.git/subdir1/subdir2",
+// 			expectedUrlStr: "https://github.com/sipsma/daggerverse.git:subdir1/subdir2",
+// 		},
 
-		// Vanity ref
-		{
-			name:           "Vanity ref with version",
-			urlStr:         "dagger.io/dagger@v0.9.1",
-			expectedUrlStr: "https://github.com/dagger/dagger-go-sdk#v0.9.1",
-		},
-		// { // with subdir, requires to modify dagger.io/dagger netlify's redirect
-		// 	name:           "Vanity refL with version",
-		// 	urlStr:         "dagger.io/dagger@v0.9.1",
-		// 	expectedUrlStr: "https://github.com/dagger/dagger-go-sdk#v0.9.1",
-		// },
+// 		// Vanity ref
+// 		{
+// 			name:           "Vanity ref with version",
+// 			urlStr:         "dagger.io/dagger@v0.9.1",
+// 			expectedUrlStr: "https://github.com/dagger/dagger-go-sdk#v0.9.1",
+// 		},
+// 		// { // with subdir, requires to modify dagger.io/dagger netlify's redirect
+// 		// 	name:           "Vanity refL with version",
+// 		// 	urlStr:         "dagger.io/dagger@v0.9.1",
+// 		// 	expectedUrlStr: "https://github.com/dagger/dagger-go-sdk#v0.9.1",
+// 		// },
 
-		// Edge cases
-		{
-			name:           "Empty ref",
-			urlStr:         "",
-			expectedUrlStr: "",
-		},
-		{
-			name:           "Invalid ref",
-			urlStr:         "invalid-url",
-			expectedUrlStr: "invalid-url",
-		},
-		{
-			name:           "Invalid FTP scheme",
-			urlStr:         "ftp://github.com/sipsma/daggerverse",
-			expectedUrlStr: "ftp://github.com/sipsma/daggerverse",
-		},
+// 		// Edge cases
+// 		{
+// 			name:           "Empty ref",
+// 			urlStr:         "",
+// 			expectedUrlStr: "",
+// 		},
+// 		{
+// 			name:           "Invalid ref",
+// 			urlStr:         "invalid-url",
+// 			expectedUrlStr: "invalid-url",
+// 		},
+// 		{
+// 			name:           "Invalid FTP scheme",
+// 			urlStr:         "ftp://github.com/sipsma/daggerverse",
+// 			expectedUrlStr: "ftp://github.com/sipsma/daggerverse",
+// 		},
 
-		// Retro-compatibility test cases
-		{
-			name:           "Retro SSH ref with version",
-			urlStr:         "ssh://git@github.com/shykes/daggerverse#v0.9.1",
-			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse#v0.9.1",
-		},
-		{
-			name:           "Retro SSH ref with .git and version",
-			urlStr:         "ssh://git@github.com/shykes/daggerverse.git#v0.9.1",
-			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse.git#v0.9.1",
-		},
-		{
-			name:           "Retro SSH ref with subdir and version",
-			urlStr:         "ssh://git@github.com/shykes/daggerverse#v0.9.1:subdir1/subdir2",
-			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse#v0.9.1:subdir1/subdir2",
-		},
-		{
-			name:           "Retro SSH ref with .git, subdir and version",
-			urlStr:         "ssh://git@github.com/shykes/daggerverse.git#v0.9.1:subdir1/subdir2",
-			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse.git#v0.9.1:subdir1/subdir2",
-		},
-		{
-			name:           "Retro Git ref with version",
-			urlStr:         "git@github.com:sipsma/daggerverse#v0.9.1",
-			expectedUrlStr: "git@github.com:sipsma/daggerverse#v0.9.1",
-		},
-		{
-			name:           "Retro Git ref with .git and version",
-			urlStr:         "git@github.com:sipsma/daggerverse.git#v0.9.1",
-			expectedUrlStr: "git@github.com:sipsma/daggerverse.git#v0.9.1",
-		},
-		{
-			name:           "Retro Git ref with subdir and version",
-			urlStr:         "git@github.com:sipsma/daggerverse#v0.9.1:subdir1/subdir2",
-			expectedUrlStr: "git@github.com:sipsma/daggerverse#v0.9.1:subdir1/subdir2",
-		},
-		{
-			name:           "Retro Git ref with .git, subdir and version",
-			urlStr:         "git@github.com:sipsma/daggerverse.git#v0.9.1:subdir1/subdir2",
-			expectedUrlStr: "git@github.com:sipsma/daggerverse.git#v0.9.1:subdir1/subdir2",
-		},
-		{
-			name:           "Retro no sheme ref with subdir and version",
-			urlStr:         "github.com:sipsma/daggerverse#v0.9.1:subdir1/subdir2",
-			expectedUrlStr: "github.com:sipsma/daggerverse#v0.9.1:subdir1/subdir2",
-		},
-		{
-			name:           "Retro no scheme ref with .git, subdir and version",
-			urlStr:         "github.com:sipsma/daggerverse.git#v0.9.1:subdir1/subdir2",
-			expectedUrlStr: "github.com:sipsma/daggerverse.git#v0.9.1:subdir1/subdir2",
-		},
-	}
+// 		// Retro-compatibility test cases
+// 		{
+// 			name:           "Retro SSH ref with version",
+// 			urlStr:         "ssh://git@github.com/shykes/daggerverse#v0.9.1",
+// 			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse#v0.9.1",
+// 		},
+// 		{
+// 			name:           "Retro SSH ref with .git and version",
+// 			urlStr:         "ssh://git@github.com/shykes/daggerverse.git#v0.9.1",
+// 			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse.git#v0.9.1",
+// 		},
+// 		{
+// 			name:           "Retro SSH ref with subdir and version",
+// 			urlStr:         "ssh://git@github.com/shykes/daggerverse#v0.9.1:subdir1/subdir2",
+// 			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse#v0.9.1:subdir1/subdir2",
+// 		},
+// 		{
+// 			name:           "Retro SSH ref with .git, subdir and version",
+// 			urlStr:         "ssh://git@github.com/shykes/daggerverse.git#v0.9.1:subdir1/subdir2",
+// 			expectedUrlStr: "ssh://git@github.com/shykes/daggerverse.git#v0.9.1:subdir1/subdir2",
+// 		},
+// 		{
+// 			name:           "Retro Git ref with version",
+// 			urlStr:         "git@github.com:sipsma/daggerverse#v0.9.1",
+// 			expectedUrlStr: "git@github.com:sipsma/daggerverse#v0.9.1",
+// 		},
+// 		{
+// 			name:           "Retro Git ref with .git and version",
+// 			urlStr:         "git@github.com:sipsma/daggerverse.git#v0.9.1",
+// 			expectedUrlStr: "git@github.com:sipsma/daggerverse.git#v0.9.1",
+// 		},
+// 		{
+// 			name:           "Retro Git ref with subdir and version",
+// 			urlStr:         "git@github.com:sipsma/daggerverse#v0.9.1:subdir1/subdir2",
+// 			expectedUrlStr: "git@github.com:sipsma/daggerverse#v0.9.1:subdir1/subdir2",
+// 		},
+// 		{
+// 			name:           "Retro Git ref with .git, subdir and version",
+// 			urlStr:         "git@github.com:sipsma/daggerverse.git#v0.9.1:subdir1/subdir2",
+// 			expectedUrlStr: "git@github.com:sipsma/daggerverse.git#v0.9.1:subdir1/subdir2",
+// 		},
+// 		{
+// 			name:           "Retro no sheme ref with subdir and version",
+// 			urlStr:         "github.com:sipsma/daggerverse#v0.9.1:subdir1/subdir2",
+// 			expectedUrlStr: "github.com:sipsma/daggerverse#v0.9.1:subdir1/subdir2",
+// 		},
+// 		{
+// 			name:           "Retro no scheme ref with .git, subdir and version",
+// 			urlStr:         "github.com:sipsma/daggerverse.git#v0.9.1:subdir1/subdir2",
+// 			expectedUrlStr: "github.com:sipsma/daggerverse.git#v0.9.1:subdir1/subdir2",
+// 		},
+// 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			convertedUrlStr := vcsToBuildKitRef(tc.urlStr)
-			require.Equal(t, tc.expectedUrlStr, convertedUrlStr)
-		})
-	}
-}
+// 	for _, tc := range testCases {
+// 		t.Run(tc.name, func(t *testing.T) {
+// 			convertedUrlStr := vcsToBuildKitRef(tc.urlStr)
+// 			require.Equal(t, tc.expectedUrlStr, convertedUrlStr)
+// 		})
+// 	}
+// }
 
 // This covers cases that the full integ test in core/integration/module_test.go can't
 // cover right now due to limitation in needing real SSH keys to test e2e.

--- a/cmd/dagger/module_test.go
+++ b/cmd/dagger/module_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestOriginToPath(t *testing.T) {
 	// Define test cases for each parameter
-	schemes := []string{"ssh://git", "git@", "https://", ""}
+	schemes := []string{"ssh://git@", "git@", "https://", ""}
 	rootURLs := []string{"github.com/shykes/daggerverse", "github.com/shykes/daggerverse.git"}
 	paths := []string{"/foo/bar", ""}
 	versions := []string{"@v0.9.1", ""}

--- a/cmd/dagger/module_test.go
+++ b/cmd/dagger/module_test.go
@@ -9,38 +9,44 @@ import (
 )
 
 func TestOriginToPath(t *testing.T) {
-	for _, tc := range []struct {
+	// Define test cases for each parameter
+	schemes := []string{"ssh://git", "git@", "https://", ""}
+	rootURLs := []string{"github.com/shykes/daggerverse", "github.com/shykes/daggerverse.git"}
+	paths := []string{"/foo/bar", ""}
+	versions := []string{"@v0.9.1", ""}
+
+	// Combine test cases
+	var testCases []struct {
 		origin string
 		want   string
-	}{
-		{
-			origin: "ssh://git@github.com/shykes/daggerverse",
-			want:   "github.com/shykes/daggerverse",
-		},
-		{
-			origin: "ssh://git@github.com/shykes/daggerverse.git",
-			want:   "github.com/shykes/daggerverse",
-		},
-		{
-			origin: "git@github.com:sipsma/daggerverse",
-			want:   "github.com/sipsma/daggerverse",
-		},
-		{
-			origin: "git@github.com:sipsma/daggerverse.git",
-			want:   "github.com/sipsma/daggerverse",
-		},
-		{
-			origin: "https://github.com/sipsma/daggerverse",
-			want:   "github.com/sipsma/daggerverse",
-		},
-		{
-			origin: "https://github.com/sipsma/daggerverse.git",
-			want:   "github.com/sipsma/daggerverse",
-		},
-	} {
-		p, err := originToPath(tc.origin)
-		require.NoError(t, err)
-		require.Equal(t, tc.want, p)
+	}
+	for _, scheme := range schemes {
+		for _, rootURL := range rootURLs {
+			for _, path := range paths {
+				for _, version := range versions {
+					origin := scheme + rootURL + path + version
+					want := "github.com/shykes/daggerverse" + path + version
+					testCases = append(testCases, struct {
+						origin string
+						want   string
+					}{
+						origin: origin,
+						want:   want,
+					})
+				}
+			}
+		}
+	}
+
+	for _, tc := range testCases {
+		got, err := originToPath(tc.origin)
+		if err != nil {
+			t.Errorf("originToPath(%q) returned an error: %v", tc.origin, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("originToPath(%q) = %q; want %q", tc.origin, got, tc.want)
+		}
 	}
 }
 

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -187,8 +187,8 @@ func splitRootAndSubdir(ref, rootURLPath, modPath string) (string, string) {
 	trimmedModPath := strings.TrimPrefix(modPath, "/")
 
 	// Remove .git from the paths
-	noGitTrimmedRootURLPath := strings.Replace(trimmedRootURLPath, ".git", "", -1)
-	noGitTrimmedModPath := strings.Replace(trimmedModPath, ".git", "", -1)
+	noGitTrimmedRootURLPath := strings.ReplaceAll(trimmedRootURLPath, ".git", "")
+	noGitTrimmedModPath := strings.ReplaceAll(trimmedModPath, ".git", "")
 
 	// Check if the root URL path is a prefix of the module path
 	if !strings.HasPrefix(noGitTrimmedModPath, noGitTrimmedRootURLPath) {

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -221,7 +221,7 @@ func parseRefString(ctx context.Context, bk *buildkit.Client, refString string) 
 	var parsed parsedRefString
 	parsed.modPath, parsed.modVersion, parsed.hasVersion = strings.Cut(refString, "@")
 
-	// Is present locally
+	// We do a stat in case the mod path github.com/username is a local directory
 	stat, err := bk.StatCallerHostPath(ctx, parsed.modPath, false)
 	if err == nil {
 		if !parsed.hasVersion && stat.IsDir() {

--- a/engine/vcs/LICENSE
+++ b/engine/vcs/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/engine/vcs/discovery.go
+++ b/engine/vcs/discovery.go
@@ -1,0 +1,83 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vcs
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// charsetReader returns a reader for the given charset. Currently
+// it only supports UTF-8 and ASCII. Otherwise, it returns a meaningful
+// error which is printed by go get, so the user can find why the package
+// wasn't downloaded if the encoding is not supported. Note that, in
+// order to reduce potential errors, ASCII is treated as UTF-8 (i.e. characters
+// greater than 0x7f are not rejected).
+func charsetReader(charset string, input io.Reader) (io.Reader, error) {
+	switch strings.ToLower(charset) {
+	case "ascii":
+		return input, nil
+	default:
+		return nil, fmt.Errorf("can't decode XML document using charset %q", charset)
+	}
+}
+
+// parseMetaGoImports returns meta imports from the HTML in r.
+// Parsing ends at the end of the <head> section or the beginning of the <body>.
+//
+// This copy of cmd/go/internal/vcs.parseMetaGoImports always operates
+// in IgnoreMod ModuleMode.
+func parseMetaGoImports(r io.Reader) (imports []metaImport, err error) {
+	d := xml.NewDecoder(r)
+	d.CharsetReader = charsetReader
+	d.Strict = false
+	var t xml.Token
+	for {
+		t, err = d.RawToken()
+		if err != nil {
+			if err == io.EOF || len(imports) > 0 {
+				err = nil
+			}
+			return
+		}
+		if e, ok := t.(xml.StartElement); ok && strings.EqualFold(e.Name.Local, "body") {
+			return
+		}
+		if e, ok := t.(xml.EndElement); ok && strings.EqualFold(e.Name.Local, "head") {
+			return
+		}
+		e, ok := t.(xml.StartElement)
+		if !ok || !strings.EqualFold(e.Name.Local, "meta") {
+			continue
+		}
+		if attrValue(e.Attr, "name") != "go-import" {
+			continue
+		}
+		if f := strings.Fields(attrValue(e.Attr, "content")); len(f) == 3 {
+			// Ignore VCS type "mod", which is applicable only in module mode.
+			if f[1] == "mod" {
+				continue
+			}
+			imports = append(imports, metaImport{
+				Prefix:   f[0],
+				VCS:      f[1],
+				RepoRoot: f[2],
+			})
+		}
+	}
+}
+
+// attrValue returns the attribute value for the case-insensitive key
+// `name', or the empty string if nothing is found.
+func attrValue(attrs []xml.Attr, name string) string {
+	for _, a := range attrs {
+		if strings.EqualFold(a.Name.Local, name) {
+			return a.Value
+		}
+	}
+	return ""
+}

--- a/engine/vcs/discovery.go
+++ b/engine/vcs/discovery.go
@@ -42,12 +42,15 @@ func parseMetaGoImports(r io.Reader) (imports []metaImport, err error) {
 			if err == io.EOF || len(imports) > 0 {
 				err = nil
 			}
+			//nolint:nakedret
 			return
 		}
 		if e, ok := t.(xml.StartElement); ok && strings.EqualFold(e.Name.Local, "body") {
+			//nolint:nakedret
 			return
 		}
 		if e, ok := t.(xml.EndElement); ok && strings.EqualFold(e.Name.Local, "head") {
+			//nolint:nakedret
 			return
 		}
 		e, ok := t.(xml.StartElement)

--- a/engine/vcs/env.go
+++ b/engine/vcs/env.go
@@ -1,0 +1,39 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vcs
+
+import (
+	"os"
+	"strings"
+)
+
+// envForDir returns a copy of the environment
+// suitable for running in the given directory.
+// The environment is the current process's environment
+// but with an updated $PWD, so that an os.Getwd in the
+// child will be faster.
+func envForDir(dir string) []string {
+	env := os.Environ()
+	// Internally we only use rooted paths, so dir is rooted.
+	// Even if dir is not rooted, no harm done.
+	return mergeEnvLists([]string{"PWD=" + dir}, env)
+}
+
+// mergeEnvLists merges the two environment lists such that
+// variables with the same name in "in" replace those in "out".
+func mergeEnvLists(in, out []string) []string {
+NextVar:
+	for _, inkv := range in {
+		k := strings.SplitAfterN(inkv, "=", 2)[0]
+		for i, outkv := range out {
+			if strings.HasPrefix(outkv, k) {
+				out[i] = inkv
+				continue NextVar
+			}
+		}
+		out = append(out, inkv)
+	}
+	return out
+}

--- a/engine/vcs/http.go
+++ b/engine/vcs/http.go
@@ -28,7 +28,7 @@ func httpGET(url string) ([]byte, error) {
 	}
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %v", url, err)
+		return nil, fmt.Errorf("%s: %w", url, err)
 	}
 	return b, nil
 }
@@ -64,6 +64,7 @@ func httpsOrHTTP(importPath string) (urlStr string, body io.ReadCloser, err erro
 			}
 		}
 		closeBody(res)
+		//nolint:bodyclose
 		urlStr, res, err = fetch("http")
 	}
 	if err != nil {

--- a/engine/vcs/http.go
+++ b/engine/vcs/http.go
@@ -1,0 +1,79 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vcs
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+)
+
+// httpClient is the default HTTP client, but a variable so it can be
+// changed by tests, without modifying http.DefaultClient.
+var httpClient = http.DefaultClient
+
+// httpGET returns the data from an HTTP GET request for the given URL.
+func httpGET(url string) ([]byte, error) {
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("%s: %s", url, resp.Status)
+	}
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %v", url, err)
+	}
+	return b, nil
+}
+
+// httpsOrHTTP returns the body of either the importPath's
+// https resource or, if unavailable, the http resource.
+func httpsOrHTTP(importPath string) (urlStr string, body io.ReadCloser, err error) {
+	fetch := func(scheme string) (urlStr string, res *http.Response, err error) {
+		u, err := url.Parse(scheme + "://" + importPath)
+		if err != nil {
+			return "", nil, err
+		}
+		u.RawQuery = "go-get=1"
+		urlStr = u.String()
+		if Verbose {
+			log.Printf("Fetching %s", urlStr)
+		}
+		res, err = httpClient.Get(urlStr)
+		return
+	}
+	closeBody := func(res *http.Response) {
+		if res != nil {
+			res.Body.Close()
+		}
+	}
+	urlStr, res, err := fetch("https")
+	if err != nil || res.StatusCode != 200 {
+		if Verbose {
+			if err != nil {
+				log.Printf("https fetch failed.")
+			} else {
+				log.Printf("ignoring https fetch with status code %d", res.StatusCode)
+			}
+		}
+		closeBody(res)
+		urlStr, res, err = fetch("http")
+	}
+	if err != nil {
+		closeBody(res)
+		return "", nil, err
+	}
+	// Note: accepting a non-200 OK here, so people can serve a
+	// meta import in their http 404 page.
+	if Verbose {
+		log.Printf("Parsing meta tags from %s (status code %d)", urlStr, res.StatusCode)
+	}
+	return urlStr, res.Body, nil
+}

--- a/engine/vcs/vcs.go
+++ b/engine/vcs/vcs.go
@@ -580,7 +580,7 @@ var vcsPaths = []*vcsPath{
 	// Github
 	{
 		prefix: "github.com/",
-		re:     `^(?P<root>github\.com/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+)(/[\p{L}0-9_.\-]+)*$`,
+		re:     `^(?P<root>github\.com/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+)(/[\p{L}0-9_.\-]+)*(/.*)?$`,
 		vcs:    "git",
 		repo:   "https://{root}",
 		check:  noVCSSuffix,
@@ -589,7 +589,7 @@ var vcsPaths = []*vcsPath{
 	// Bitbucket
 	{
 		prefix: "bitbucket.org/",
-		re:     `^(?P<root>bitbucket\.org/(?P<bitname>[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+))(/[A-Za-z0-9_.\-]+)*$`,
+		re:     `^(?P<root>bitbucket\.org/(?P<bitname>[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+))(/[A-Za-z0-9_.\-]+)*(/.*)?$`,
 		repo:   "https://{root}",
 		vcs:    "git",
 		check:  noVCSSuffix,
@@ -598,7 +598,7 @@ var vcsPaths = []*vcsPath{
 	// IBM DevOps Services (JazzHub)
 	{
 		prefix: "hub.jazz.net/git",
-		re:     `^(?P<root>hub\.jazz\.net/git/[a-z0-9]+/[A-Za-z0-9_.\-]+)(/[A-Za-z0-9_.\-]+)*$`,
+		re:     `^(?P<root>hub\.jazz\.net/git/[a-z0-9]+/[A-Za-z0-9_.\-]+)(/[A-Za-z0-9_.\-]+)*(/.*)?$`,
 		vcs:    "git",
 		repo:   "https://{root}",
 		check:  noVCSSuffix,
@@ -607,7 +607,7 @@ var vcsPaths = []*vcsPath{
 	// Git at Apache
 	{
 		prefix: "git.apache.org",
-		re:     `^(?P<root>git\.apache\.org/[a-z0-9_.\-]+\.git)(/[A-Za-z0-9_.\-]+)*$`,
+		re:     `^(?P<root>git\.apache\.org/[a-z0-9_.\-]+\.git)(/[A-Za-z0-9_.\-]+)*(/.*)?$`,
 		vcs:    "git",
 		repo:   "https://{root}",
 	},
@@ -615,7 +615,7 @@ var vcsPaths = []*vcsPath{
 	// Git at OpenStack
 	{
 		prefix: "git.openstack.org",
-		re:     `^(?P<root>git\.openstack\.org/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+)(\.git)?(/[A-Za-z0-9_.\-]+)*$`,
+		re:     `^(?P<root>git\.openstack\.org/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+)(\.git)?(/[A-Za-z0-9_.\-]+)*(/.*)?$`,
 		vcs:    "git",
 		repo:   "https://{root}",
 	},
@@ -623,7 +623,7 @@ var vcsPaths = []*vcsPath{
 	// Launchpad
 	{
 		prefix: "launchpad.net/",
-		re:     `^(?P<root>launchpad\.net/((?P<project>[A-Za-z0-9_.\-]+)(?P<series>/[A-Za-z0-9_.\-]+)?|~[A-Za-z0-9_.\-]+/(\+junk|[A-Za-z0-9_.\-]+)/[A-Za-z0-9_.\-]+))(/[A-Za-z0-9_.\-]+)*$`,
+		re:     `^(?P<root>launchpad\.net/((?P<project>[A-Za-z0-9_.\-]+)(?P<series>/[A-Za-z0-9_.\-]+)?|~[A-Za-z0-9_.\-]+/(\+junk|[A-Za-z0-9_.\-]+)/[A-Za-z0-9_.\-]+))(/[A-Za-z0-9_.\-]+)*(/.*)?$`,
 		vcs:    "bzr",
 		repo:   "https://{root}",
 		check:  launchpadVCS,

--- a/engine/vcs/vcs.go
+++ b/engine/vcs/vcs.go
@@ -1,0 +1,684 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package vcs exposes functions for resolving import paths
+// and using version control systems, which can be used to
+// implement behavior similar to the standard "go get" command.
+
+package vcs
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	exec "golang.org/x/sys/execabs"
+)
+
+// Verbose enables verbose operation logging.
+var Verbose bool
+
+// ShowCmd controls whether VCS commands are printed.
+var ShowCmd bool
+
+// A Cmd describes how to use a version control system
+// like Mercurial, Git, or Subversion.
+type Cmd struct {
+	Name string
+	Cmd  string // name of binary to invoke command
+
+	CreateCmd   string // command to download a fresh copy of a repository
+	DownloadCmd string // command to download updates into an existing repository
+
+	TagCmd         []TagCmd // commands to list tags
+	TagLookupCmd   []TagCmd // commands to lookup tags before running tagSyncCmd
+	TagSyncCmd     string   // command to sync to specific tag
+	TagSyncDefault string   // command to sync to default tag
+
+	LogCmd string // command to list repository changelogs in an XML format
+
+	Scheme  []string
+	PingCmd string
+}
+
+// A TagCmd describes a command to list available tags
+// that can be passed to Cmd.TagSyncCmd.
+type TagCmd struct {
+	Cmd     string // command to list tags
+	Pattern string // regexp to extract tags from list
+}
+
+// vcsList lists the known version control systems
+var vcsList = []*Cmd{
+	vcsGit,
+}
+
+// ByCmd returns the version control system for the given
+// command name (hg, git, svn, bzr).
+func ByCmd(cmd string) *Cmd {
+	for _, vcs := range vcsList {
+		if vcs.Cmd == cmd {
+			return vcs
+		}
+	}
+	return nil
+}
+
+// vcsGit describes how to use Git.
+var vcsGit = &Cmd{
+	Name: "Git",
+	Cmd:  "git",
+
+	CreateCmd:   "clone {repo} {dir}",
+	DownloadCmd: "pull --ff-only",
+
+	TagCmd: []TagCmd{
+		// tags/xxx matches a git tag named xxx
+		// origin/xxx matches a git branch named xxx on the default remote repository
+		{"show-ref", `(?:tags|origin)/(\S+)$`},
+	},
+	TagLookupCmd: []TagCmd{
+		{"show-ref tags/{tag} origin/{tag}", `((?:tags|origin)/\S+)$`},
+	},
+	TagSyncCmd:     "checkout {tag}",
+	TagSyncDefault: "checkout master",
+
+	Scheme:  []string{"git", "https", "http", "git+ssh"},
+	PingCmd: "ls-remote {scheme}://{repo}",
+}
+
+func (v *Cmd) String() string {
+	return v.Name
+}
+
+// run runs the command line cmd in the given directory.
+// keyval is a list of key, value pairs.  run expands
+// instances of {key} in cmd into value, but only after
+// splitting cmd into individual arguments.
+// If an error occurs, run prints the command line and the
+// command's combined stdout+stderr to standard error.
+// Otherwise run discards the command's output.
+func (v *Cmd) run(dir string, cmd string, keyval ...string) error {
+	_, err := v.run1(dir, cmd, keyval, true)
+	return err
+}
+
+// runVerboseOnly is like run but only generates error output to standard error in verbose mode.
+func (v *Cmd) runVerboseOnly(dir string, cmd string, keyval ...string) error {
+	_, err := v.run1(dir, cmd, keyval, false)
+	return err
+}
+
+// runOutput is like run but returns the output of the command.
+func (v *Cmd) runOutput(dir string, cmd string, keyval ...string) ([]byte, error) {
+	return v.run1(dir, cmd, keyval, true)
+}
+
+// run1 is the generalized implementation of run and runOutput.
+func (v *Cmd) run1(dir string, cmdline string, keyval []string, verbose bool) ([]byte, error) {
+	m := make(map[string]string)
+	for i := 0; i < len(keyval); i += 2 {
+		m[keyval[i]] = keyval[i+1]
+	}
+	args := strings.Fields(cmdline)
+	for i, arg := range args {
+		args[i] = expand(m, arg)
+	}
+
+	_, err := exec.LookPath(v.Cmd)
+	if err != nil {
+		fmt.Fprintf(os.Stderr,
+			"go: missing %s command. See http://golang.org/s/gogetcmd\n",
+			v.Name)
+		return nil, err
+	}
+
+	cmd := exec.Command(v.Cmd, args...)
+	cmd.Dir = dir
+	cmd.Env = envForDir(cmd.Dir)
+	if ShowCmd {
+		fmt.Printf("cd %s\n", dir)
+		fmt.Printf("%s %s\n", v.Cmd, strings.Join(args, " "))
+	}
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err = cmd.Run()
+	out := buf.Bytes()
+	if err != nil {
+		if verbose || Verbose {
+			fmt.Fprintf(os.Stderr, "# cd %s; %s %s\n", dir, v.Cmd, strings.Join(args, " "))
+			os.Stderr.Write(out)
+		}
+		return nil, err
+	}
+	return out, nil
+}
+
+// Ping pings the repo to determine if scheme used is valid.
+// This repo must be pingable with this scheme and VCS.
+func (v *Cmd) Ping(scheme, repo string) error {
+	return v.runVerboseOnly(".", v.PingCmd, "scheme", scheme, "repo", repo)
+}
+
+// Create creates a new copy of repo in dir.
+// The parent of dir must exist; dir must not.
+func (v *Cmd) Create(dir, repo string) error {
+	return v.run(".", v.CreateCmd, "dir", dir, "repo", repo)
+}
+
+// CreateAtRev creates a new copy of repo in dir at revision rev.
+// The parent of dir must exist; dir must not.
+// rev must be a valid revision in repo.
+func (v *Cmd) CreateAtRev(dir, repo, rev string) error {
+	if err := v.Create(dir, repo); err != nil {
+		return err
+	}
+	return v.run(dir, v.TagSyncCmd, "tag", rev)
+}
+
+// Download downloads any new changes for the repo in dir.
+// dir must be a valid VCS repo compatible with v.
+func (v *Cmd) Download(dir string) error {
+	return v.run(dir, v.DownloadCmd)
+}
+
+// Tags returns the list of available tags for the repo in dir.
+// dir must be a valid VCS repo compatible with v.
+func (v *Cmd) Tags(dir string) ([]string, error) {
+	var tags []string
+	for _, tc := range v.TagCmd {
+		out, err := v.runOutput(dir, tc.Cmd)
+		if err != nil {
+			return nil, err
+		}
+		re := regexp.MustCompile(`(?m-s)` + tc.Pattern)
+		for _, m := range re.FindAllStringSubmatch(string(out), -1) {
+			tags = append(tags, m[1])
+		}
+	}
+	return tags, nil
+}
+
+// TagSync syncs the repo in dir to the named tag, which is either a
+// tag returned by Tags or the empty string (the default tag).
+// dir must be a valid VCS repo compatible with v and the tag must exist.
+func (v *Cmd) TagSync(dir, tag string) error {
+	if v.TagSyncCmd == "" {
+		return nil
+	}
+	if tag != "" {
+		for _, tc := range v.TagLookupCmd {
+			out, err := v.runOutput(dir, tc.Cmd, "tag", tag)
+			if err != nil {
+				return err
+			}
+			re := regexp.MustCompile(`(?m-s)` + tc.Pattern)
+			m := re.FindStringSubmatch(string(out))
+			if len(m) > 1 {
+				tag = m[1]
+				break
+			}
+		}
+	}
+	if tag == "" && v.TagSyncDefault != "" {
+		return v.run(dir, v.TagSyncDefault)
+	}
+	return v.run(dir, v.TagSyncCmd, "tag", tag)
+}
+
+// Log logs the changes for the repo in dir.
+// dir must be a valid VCS repo compatible with v.
+func (v *Cmd) Log(dir, logTemplate string) ([]byte, error) {
+	if err := v.Download(dir); err != nil {
+		return []byte{}, err
+	}
+
+	const N = 50 // how many revisions to grab
+	return v.runOutput(dir, v.LogCmd, "limit", strconv.Itoa(N), "template", logTemplate)
+}
+
+// LogAtRev logs the change for repo in dir at the rev revision.
+// dir must be a valid VCS repo compatible with v.
+// rev must be a valid revision for the repo in dir.
+func (v *Cmd) LogAtRev(dir, rev, logTemplate string) ([]byte, error) {
+	if err := v.Download(dir); err != nil {
+		return []byte{}, err
+	}
+
+	// Append revision flag to LogCmd.
+	logAtRevCmd := v.LogCmd + " --rev=" + rev
+	return v.runOutput(dir, logAtRevCmd, "limit", strconv.Itoa(1), "template", logTemplate)
+}
+
+// A vcsPath describes how to convert an import path into a
+// version control system and repository name.
+type vcsPath struct {
+	prefix string                              // prefix this description applies to
+	re     string                              // pattern for import path
+	repo   string                              // repository to use (expand with match of re)
+	vcs    string                              // version control system to use (expand with match of re)
+	check  func(match map[string]string) error // additional checks
+	ping   bool                                // ping for scheme to use to download repo
+
+	regexp *regexp.Regexp // cached compiled form of re
+}
+
+// FromDir inspects dir and its parents to determine the
+// version control system and code repository to use.
+// On return, root is the import path
+// corresponding to the root of the repository.
+func FromDir(dir, srcRoot string) (vcs *Cmd, root string, err error) {
+	// Clean and double-check that dir is in (a subdirectory of) srcRoot.
+	dir = filepath.Clean(dir)
+	srcRoot = filepath.Clean(srcRoot)
+	if len(dir) <= len(srcRoot) || dir[len(srcRoot)] != filepath.Separator {
+		return nil, "", fmt.Errorf("directory %q is outside source root %q", dir, srcRoot)
+	}
+
+	var vcsRet *Cmd
+	var rootRet string
+
+	origDir := dir
+	for len(dir) > len(srcRoot) {
+		for _, vcs := range vcsList {
+			if _, err := os.Stat(filepath.Join(dir, "."+vcs.Cmd)); err == nil {
+				root := filepath.ToSlash(dir[len(srcRoot)+1:])
+				// Record first VCS we find, but keep looking,
+				// to detect mistakes like one kind of VCS inside another.
+				if vcsRet == nil {
+					vcsRet = vcs
+					rootRet = root
+					continue
+				}
+				// Allow .git inside .git, which can arise due to submodules.
+				if vcsRet == vcs && vcs.Cmd == "git" {
+					continue
+				}
+				// Otherwise, we have one VCS inside a different VCS.
+				return nil, "", fmt.Errorf("directory %q uses %s, but parent %q uses %s",
+					filepath.Join(srcRoot, rootRet), vcsRet.Cmd, filepath.Join(srcRoot, root), vcs.Cmd)
+			}
+		}
+
+		// Move to parent.
+		ndir := filepath.Dir(dir)
+		if len(ndir) >= len(dir) {
+			// Shouldn't happen, but just in case, stop.
+			break
+		}
+		dir = ndir
+	}
+
+	if vcsRet != nil {
+		return vcsRet, rootRet, nil
+	}
+
+	return nil, "", fmt.Errorf("directory %q is not using a known version control system", origDir)
+}
+
+// RepoRoot represents a version control system, a repo, and a root of
+// where to put it on disk.
+type RepoRoot struct {
+	VCS *Cmd
+
+	// Repo is the repository URL, including scheme.
+	Repo string
+
+	// Root is the import path corresponding to the root of the
+	// repository.
+	Root string
+}
+
+// RepoRootForImportPath analyzes importPath to determine the
+// version control system, and code repository to use.
+func RepoRootForImportPath(importPath string, verbose bool) (*RepoRoot, error) {
+	rr, err := RepoRootForImportPathStatic(importPath, "")
+	if err == errUnknownSite {
+		rr, err = RepoRootForImportDynamic(importPath, verbose)
+
+		// RepoRootForImportDynamic returns error detail
+		// that is irrelevant if the user didn't intend to use a
+		// dynamic import in the first place.
+		// Squelch it.
+		if err != nil {
+			if Verbose {
+				log.Printf("import %q: %v", importPath, err)
+			}
+			err = fmt.Errorf("unrecognized import path %q", importPath)
+		}
+	}
+
+	if err == nil && strings.Contains(importPath, "...") && strings.Contains(rr.Root, "...") {
+		// Do not allow wildcards in the repo root.
+		rr = nil
+		err = fmt.Errorf("cannot expand ... in %q", importPath)
+	}
+	return rr, err
+}
+
+var errUnknownSite = errors.New("dynamic lookup required to find mapping")
+
+// RepoRootForImportPathStatic attempts to map importPath to a
+// RepoRoot using the commonly-used VCS hosting sites in vcsPaths
+// (github.com/user/dir), or from a fully-qualified importPath already
+// containing its VCS type (foo.com/repo.git/dir)
+//
+// If scheme is non-empty, that scheme is forced.
+func RepoRootForImportPathStatic(importPath, scheme string) (*RepoRoot, error) {
+	if strings.Contains(importPath, "://") {
+		return nil, fmt.Errorf("invalid import path %q", importPath)
+	}
+	for _, srv := range vcsPaths {
+		if !strings.HasPrefix(importPath, srv.prefix) {
+			continue
+		}
+		m := srv.regexp.FindStringSubmatch(importPath)
+		if m == nil {
+			if srv.prefix != "" {
+				return nil, fmt.Errorf("invalid %s import path %q", srv.prefix, importPath)
+			}
+			continue
+		}
+
+		// Build map of named subexpression matches for expand.
+		match := map[string]string{
+			"prefix": srv.prefix,
+			"import": importPath,
+		}
+		for i, name := range srv.regexp.SubexpNames() {
+			if name != "" && match[name] == "" {
+				match[name] = m[i]
+			}
+		}
+		if srv.vcs != "" {
+			match["vcs"] = expand(match, srv.vcs)
+		}
+		if srv.repo != "" {
+			match["repo"] = expand(match, srv.repo)
+		}
+		if srv.check != nil {
+			if err := srv.check(match); err != nil {
+				return nil, err
+			}
+		}
+		vcs := ByCmd(match["vcs"])
+		if vcs == nil {
+			return nil, fmt.Errorf("unknown version control system %q", match["vcs"])
+		}
+		if srv.ping {
+			if scheme != "" {
+				match["repo"] = scheme + "://" + match["repo"]
+			} else {
+				for _, scheme := range vcs.Scheme {
+					if vcs.Ping(scheme, match["repo"]) == nil {
+						match["repo"] = scheme + "://" + match["repo"]
+						break
+					}
+				}
+			}
+		}
+		rr := &RepoRoot{
+			VCS:  vcs,
+			Repo: match["repo"],
+			Root: match["root"],
+		}
+		return rr, nil
+	}
+	return nil, errUnknownSite
+}
+
+// RepoRootForImportDynamic finds a *RepoRoot for a custom domain that's not
+// statically known by RepoRootForImportPathStatic.
+//
+// This handles custom import paths like "name.tld/pkg/foo" or just "name.tld".
+func RepoRootForImportDynamic(importPath string, verbose bool) (*RepoRoot, error) {
+	slash := strings.Index(importPath, "/")
+	if slash < 0 {
+		slash = len(importPath)
+	}
+	host := importPath[:slash]
+	if !strings.Contains(host, ".") {
+		return nil, errors.New("import path doesn't contain a hostname")
+	}
+	urlStr, body, err := httpsOrHTTP(importPath)
+	if err != nil {
+		return nil, fmt.Errorf("http/https fetch: %v", err)
+	}
+	defer body.Close()
+	imports, err := parseMetaGoImports(body)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %v", importPath, err)
+	}
+	metaImport, err := matchGoImport(imports, importPath)
+	if err != nil {
+		if err != errNoMatch {
+			return nil, fmt.Errorf("parse %s: %v", urlStr, err)
+		}
+		return nil, fmt.Errorf("parse %s: no go-import meta tags", urlStr)
+	}
+	if verbose {
+		log.Printf("get %q: found meta tag %#v at %s", importPath, metaImport, urlStr)
+	}
+	// If the import was "uni.edu/bob/project", which said the
+	// prefix was "uni.edu" and the RepoRoot was "evilroot.com",
+	// make sure we don't trust Bob and check out evilroot.com to
+	// "uni.edu" yet (possibly overwriting/preempting another
+	// non-evil student).  Instead, first verify the root and see
+	// if it matches Bob's claim.
+	if metaImport.Prefix != importPath {
+		if verbose {
+			log.Printf("get %q: verifying non-authoritative meta tag", importPath)
+		}
+		urlStr0 := urlStr
+		urlStr, body, err = httpsOrHTTP(metaImport.Prefix)
+		if err != nil {
+			return nil, fmt.Errorf("fetch %s: %v", urlStr, err)
+		}
+		imports, err := parseMetaGoImports(body)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s: %v", importPath, err)
+		}
+		if len(imports) == 0 {
+			return nil, fmt.Errorf("fetch %s: no go-import meta tag", urlStr)
+		}
+		metaImport2, err := matchGoImport(imports, importPath)
+		if err != nil || metaImport != metaImport2 {
+			return nil, fmt.Errorf("%s and %s disagree about go-import for %s", urlStr0, urlStr, metaImport.Prefix)
+		}
+	}
+
+	if err := validateRepoRoot(metaImport.RepoRoot); err != nil {
+		return nil, fmt.Errorf("%s: invalid repo root %q: %v", urlStr, metaImport.RepoRoot, err)
+	}
+	rr := &RepoRoot{
+		VCS:  ByCmd(metaImport.VCS),
+		Repo: metaImport.RepoRoot,
+		Root: metaImport.Prefix,
+	}
+	if rr.VCS == nil {
+		return nil, fmt.Errorf("%s: unknown vcs %q", urlStr, metaImport.VCS)
+	}
+	return rr, nil
+}
+
+// validateRepoRoot returns an error if repoRoot does not seem to be
+// a valid URL with scheme.
+func validateRepoRoot(repoRoot string) error {
+	url, err := url.Parse(repoRoot)
+	if err != nil {
+		return err
+	}
+	if url.Scheme == "" {
+		return errors.New("no scheme")
+	}
+	return nil
+}
+
+// metaImport represents the parsed <meta name="go-import"
+// content="prefix vcs reporoot" /> tags from HTML files.
+type metaImport struct {
+	Prefix, VCS, RepoRoot string
+}
+
+// errNoMatch is returned from matchGoImport when there's no applicable match.
+var errNoMatch = errors.New("no import match")
+
+// pathPrefix reports whether sub is a prefix of s,
+// only considering entire path components.
+func pathPrefix(s, sub string) bool {
+	// strings.HasPrefix is necessary but not sufficient.
+	if !strings.HasPrefix(s, sub) {
+		return false
+	}
+	// The remainder after the prefix must either be empty or start with a slash.
+	rem := s[len(sub):]
+	return rem == "" || rem[0] == '/'
+}
+
+// matchGoImport returns the metaImport from imports matching importPath.
+// An error is returned if there are multiple matches.
+// errNoMatch is returned if none match.
+func matchGoImport(imports []metaImport, importPath string) (_ metaImport, err error) {
+	match := -1
+	for i, im := range imports {
+		if !pathPrefix(importPath, im.Prefix) {
+			continue
+		}
+
+		if match != -1 {
+			err = fmt.Errorf("multiple meta tags match import path %q", importPath)
+			return
+		}
+		match = i
+	}
+	if match == -1 {
+		err = errNoMatch
+		return
+	}
+	return imports[match], nil
+}
+
+// expand rewrites s to replace {k} with match[k] for each key k in match.
+func expand(match map[string]string, s string) string {
+	for k, v := range match {
+		s = strings.Replace(s, "{"+k+"}", v, -1)
+	}
+	return s
+}
+
+// vcsPaths lists the known vcs paths.
+var vcsPaths = []*vcsPath{
+	// Github
+	{
+		prefix: "github.com/",
+		re:     `^(?P<root>github\.com/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+)(/[\p{L}0-9_.\-]+)*$`,
+		vcs:    "git",
+		repo:   "https://{root}",
+		check:  noVCSSuffix,
+	},
+
+	// Bitbucket
+	{
+		prefix: "bitbucket.org/",
+		re:     `^(?P<root>bitbucket\.org/(?P<bitname>[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+))(/[A-Za-z0-9_.\-]+)*$`,
+		repo:   "https://{root}",
+		vcs:    "git",
+		check:  noVCSSuffix,
+	},
+
+	// IBM DevOps Services (JazzHub)
+	{
+		prefix: "hub.jazz.net/git",
+		re:     `^(?P<root>hub\.jazz\.net/git/[a-z0-9]+/[A-Za-z0-9_.\-]+)(/[A-Za-z0-9_.\-]+)*$`,
+		vcs:    "git",
+		repo:   "https://{root}",
+		check:  noVCSSuffix,
+	},
+
+	// Git at Apache
+	{
+		prefix: "git.apache.org",
+		re:     `^(?P<root>git\.apache\.org/[a-z0-9_.\-]+\.git)(/[A-Za-z0-9_.\-]+)*$`,
+		vcs:    "git",
+		repo:   "https://{root}",
+	},
+
+	// Git at OpenStack
+	{
+		prefix: "git.openstack.org",
+		re:     `^(?P<root>git\.openstack\.org/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+)(\.git)?(/[A-Za-z0-9_.\-]+)*$`,
+		vcs:    "git",
+		repo:   "https://{root}",
+	},
+
+	// Launchpad
+	{
+		prefix: "launchpad.net/",
+		re:     `^(?P<root>launchpad\.net/((?P<project>[A-Za-z0-9_.\-]+)(?P<series>/[A-Za-z0-9_.\-]+)?|~[A-Za-z0-9_.\-]+/(\+junk|[A-Za-z0-9_.\-]+)/[A-Za-z0-9_.\-]+))(/[A-Za-z0-9_.\-]+)*$`,
+		vcs:    "bzr",
+		repo:   "https://{root}",
+		check:  launchpadVCS,
+	},
+
+	// Git at OpenStack
+	{
+		prefix: "git.openstack.org",
+		re:     `^(?P<root>git\.openstack\.org/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+)(\.git)?(/[A-Za-z0-9_.\-]+)*$`,
+		vcs:    "git",
+		repo:   "https://{root}",
+		check:  noVCSSuffix,
+	},
+
+	// General syntax for any server.
+	{
+		re:   `^(?P<root>(?P<repo>([a-z0-9.\-]+\.)+[a-z0-9.\-]+(:[0-9]+)?/[A-Za-z0-9_.\-/]*?)\.(?P<vcs>bzr|git|hg|svn))(/[A-Za-z0-9_.\-]+)*$`,
+		ping: true,
+	},
+}
+
+func init() {
+	// fill in cached regexps.
+	// Doing this eagerly discovers invalid regexp syntax
+	// without having to run a command that needs that regexp.
+	for _, srv := range vcsPaths {
+		srv.regexp = regexp.MustCompile(srv.re)
+	}
+}
+
+// noVCSSuffix checks that the repository name does not
+// end in .foo for any version control system foo.
+// The usual culprit is ".git".
+func noVCSSuffix(match map[string]string) error {
+	repo := match["repo"]
+	for _, vcs := range vcsList {
+		if strings.HasSuffix(repo, "."+vcs.Cmd) {
+			return fmt.Errorf("invalid version control suffix in %s path", match["prefix"])
+		}
+	}
+	return nil
+}
+
+// launchpadVCS solves the ambiguity for "lp.net/project/foo". In this case,
+// "foo" could be a series name registered in Launchpad with its own branch,
+// and it could also be the name of a directory within the main project
+// branch one level up.
+func launchpadVCS(match map[string]string) error {
+	if match["project"] == "" || match["series"] == "" {
+		return nil
+	}
+	_, err := httpGET(expand(match, "https://code.launchpad.net/{project}{series}/.bzr/branch-format"))
+	if err != nil {
+		match["root"] = expand(match, "launchpad.net/{project}")
+		match["repo"] = expand(match, "https://{root}")
+	}
+	return nil
+}

--- a/engine/vcs/vcs.go
+++ b/engine/vcs/vcs.go
@@ -141,7 +141,7 @@ func (v *Cmd) run1(dir string, cmdline string, keyval []string, verbose bool) ([
 		return nil, err
 	}
 
-	cmd := exec.Command(v.Cmd, args...)
+	cmd := exec.Command(v.Cmd, args...) //nolint:gosec
 	cmd.Dir = dir
 	cmd.Env = envForDir(cmd.Dir)
 	if ShowCmd {
@@ -451,17 +451,17 @@ func RepoRootForImportDynamic(importPath string, verbose bool) (*RepoRoot, error
 	}
 	urlStr, body, err := httpsOrHTTP(importPath)
 	if err != nil {
-		return nil, fmt.Errorf("http/https fetch: %v", err)
+		return nil, fmt.Errorf("http/https fetch: %w", err)
 	}
 	defer body.Close()
 	imports, err := parseMetaGoImports(body)
 	if err != nil {
-		return nil, fmt.Errorf("parsing %s: %v", importPath, err)
+		return nil, fmt.Errorf("parsing %s: %w", importPath, err)
 	}
 	metaImport, err := matchGoImport(imports, importPath)
 	if err != nil {
 		if err != errNoMatch {
-			return nil, fmt.Errorf("parse %s: %v", urlStr, err)
+			return nil, fmt.Errorf("parse %s: %w", urlStr, err)
 		}
 		return nil, fmt.Errorf("parse %s: no go-import meta tags", urlStr)
 	}
@@ -481,11 +481,11 @@ func RepoRootForImportDynamic(importPath string, verbose bool) (*RepoRoot, error
 		urlStr0 := urlStr
 		urlStr, body, err = httpsOrHTTP(metaImport.Prefix)
 		if err != nil {
-			return nil, fmt.Errorf("fetch %s: %v", urlStr, err)
+			return nil, fmt.Errorf("fetch %s: %w", urlStr, err)
 		}
 		imports, err := parseMetaGoImports(body)
 		if err != nil {
-			return nil, fmt.Errorf("parsing %s: %v", importPath, err)
+			return nil, fmt.Errorf("parsing %s: %w", importPath, err)
 		}
 		if len(imports) == 0 {
 			return nil, fmt.Errorf("fetch %s: no go-import meta tag", urlStr)
@@ -497,7 +497,7 @@ func RepoRootForImportDynamic(importPath string, verbose bool) (*RepoRoot, error
 	}
 
 	if err := validateRepoRoot(metaImport.RepoRoot); err != nil {
-		return nil, fmt.Errorf("%s: invalid repo root %q: %v", urlStr, metaImport.RepoRoot, err)
+		return nil, fmt.Errorf("%s: invalid repo root %q: %w", urlStr, metaImport.RepoRoot, err)
 	}
 	rr := &RepoRoot{
 		VCS:  ByCmd(metaImport.VCS),
@@ -570,7 +570,7 @@ func matchGoImport(imports []metaImport, importPath string) (_ metaImport, err e
 // expand rewrites s to replace {k} with match[k] for each key k in match.
 func expand(match map[string]string, s string) string {
 	for k, v := range match {
-		s = strings.Replace(s, "{"+k+"}", v, -1)
+		s = strings.ReplaceAll(s, "{"+k+"}", v)
 	}
 	return s
 }

--- a/engine/vcs/vcs_test.go
+++ b/engine/vcs/vcs_test.go
@@ -1,0 +1,386 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vcs
+
+import (
+	"errors"
+	"os"
+	"path"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Test that RepoRootForImportPath creates the correct RepoRoot for a given importPath.
+// TODO(cmang): Add tests for SVN and BZR.
+func TestRepoRootForImportPath(t *testing.T) {
+	if runtime.GOOS == "android" {
+		t.Skipf("incomplete source tree on %s", runtime.GOOS)
+	}
+
+	tests := []struct {
+		path string
+		want *RepoRoot
+	}{
+		{
+			"github.com/golang/groupcache",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://github.com/golang/groupcache",
+			},
+		},
+		// Unicode letters are allowed in import paths.
+		// issue https://github.com/golang/go/issues/18660
+		{
+			"github.com/user/unicode/испытание",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://github.com/user/unicode",
+			},
+		},
+		// IBM DevOps Services tests
+		{
+			"hub.jazz.net/git/user1/pkgname",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://hub.jazz.net/git/user1/pkgname",
+			},
+		},
+		{
+			"hub.jazz.net/git/user1/pkgname/submodule/submodule/submodule",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://hub.jazz.net/git/user1/pkgname",
+			},
+		},
+		// Trailing .git is less preferred but included for
+		// compatibility purposes while the same source needs to
+		// be compilable on both old and new go
+		{
+			"git.openstack.org/openstack/swift.git",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://git.openstack.org/openstack/swift.git",
+			},
+		},
+		{
+			"git.openstack.org/openstack/swift/go/hummingbird",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://git.openstack.org/openstack/swift",
+			},
+		},
+		{
+			"git.apache.org/package-name.git",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://git.apache.org/package-name.git",
+			},
+		},
+		{
+			"git.apache.org/package-name_2.x.git/path/to/lib",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://git.apache.org/package-name_2.x.git",
+			},
+		},
+		{
+			"git.sr.ht/~jacqueline/tangara-fw/subdir",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://git.sr.ht/~jacqueline/tangara-fw",
+			},
+		},
+		{
+			"bitbucket.org/workspace/pkgname",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://bitbucket.org/workspace/pkgname",
+			},
+		},
+		{
+			"bitbucket.org/workspace/pkgname/subdir",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://bitbucket.org/workspace/pkgname",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		got, err := RepoRootForImportPath(test.path, false)
+		if err != nil {
+			t.Errorf("RepoRootForImportPath(%q): %v", test.path, err)
+			continue
+		}
+		want := test.want
+		if want == nil {
+			if got != nil {
+				t.Errorf("RepoRootForImportPath(%q) = %v, want nil", test.path, got)
+			}
+			continue
+		}
+		if got.VCS == nil || want.VCS == nil {
+			t.Errorf("RepoRootForImportPath(%q): got.VCS or want.VCS is nil", test.path)
+			continue
+		}
+		if got.VCS.Name != want.VCS.Name || got.Repo != want.Repo {
+			t.Errorf("RepoRootForImportPath(%q) = VCS(%s) Repo(%s), want VCS(%s) Repo(%s)", test.path, got.VCS, got.Repo, want.VCS, want.Repo)
+		}
+	}
+}
+
+// Test that FromDir correctly inspects a given directory and returns the right VCS and root.
+func TestFromDir(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "vcstest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	for j, vcs := range vcsList {
+		dir := filepath.Join(tempDir, "example.com", vcs.Name, "."+vcs.Cmd)
+		if j&1 == 0 {
+			err := os.MkdirAll(dir, 0755)
+			if err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			err := os.MkdirAll(filepath.Dir(dir), 0755)
+			if err != nil {
+				t.Fatal(err)
+			}
+			f, err := os.Create(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			f.Close()
+		}
+
+		want := RepoRoot{
+			VCS:  vcs,
+			Root: path.Join("example.com", vcs.Name),
+		}
+		var got RepoRoot
+		got.VCS, got.Root, err = FromDir(dir, tempDir)
+		if err != nil {
+			t.Errorf("FromDir(%q, %q): %v", dir, tempDir, err)
+			continue
+		}
+		if got.VCS.Name != want.VCS.Name || got.Root != want.Root {
+			t.Errorf("FromDir(%q, %q) = VCS(%s) Root(%s), want VCS(%s) Root(%s)", dir, tempDir, got.VCS, got.Root, want.VCS, want.Root)
+		}
+	}
+}
+
+var parseMetaGoImportsTests = []struct {
+	in  string
+	out []metaImport
+}{
+	{
+		`<meta name="go-import" content="foo/bar git https://github.com/rsc/foo/bar">`,
+		[]metaImport{{"foo/bar", "git", "https://github.com/rsc/foo/bar"}},
+	},
+	{
+		`<meta name="go-import" content="foo/bar git https://github.com/rsc/foo/bar">
+		<meta name="go-import" content="baz/quux git http://github.com/rsc/baz/quux">`,
+		[]metaImport{
+			{"foo/bar", "git", "https://github.com/rsc/foo/bar"},
+			{"baz/quux", "git", "http://github.com/rsc/baz/quux"},
+		},
+	},
+	{
+		`<meta name="go-import" content="foo/bar git https://github.com/rsc/foo/bar">
+		<meta name="go-import" content="foo/bar mod http://github.com/rsc/baz/quux">`,
+		[]metaImport{
+			{"foo/bar", "git", "https://github.com/rsc/foo/bar"},
+		},
+	},
+	{
+		`<meta name="go-import" content="foo/bar mod http://github.com/rsc/baz/quux">
+		<meta name="go-import" content="foo/bar git https://github.com/rsc/foo/bar">`,
+		[]metaImport{
+			{"foo/bar", "git", "https://github.com/rsc/foo/bar"},
+		},
+	},
+	{
+		`<head>
+		<meta name="go-import" content="foo/bar git https://github.com/rsc/foo/bar">
+		</head>`,
+		[]metaImport{{"foo/bar", "git", "https://github.com/rsc/foo/bar"}},
+	},
+	{
+		`<meta name="go-import" content="foo/bar git https://github.com/rsc/foo/bar">
+		<body>`,
+		[]metaImport{{"foo/bar", "git", "https://github.com/rsc/foo/bar"}},
+	},
+	{
+		`<!doctype html><meta name="go-import" content="foo/bar git https://github.com/rsc/foo/bar">`,
+		[]metaImport{{"foo/bar", "git", "https://github.com/rsc/foo/bar"}},
+	},
+	{
+		// XML doesn't like <div style=position:relative>.
+		`<!doctype html><title>Page Not Found</title><meta name=go-import content="chitin.io/chitin git https://github.com/chitin-io/chitin"><div style=position:relative>DRAFT</div>`,
+		[]metaImport{{"chitin.io/chitin", "git", "https://github.com/chitin-io/chitin"}},
+	},
+	{
+		`<meta name="go-import" content="myitcv.io git https://github.com/myitcv/x">
+	        <meta name="go-import" content="myitcv.io/blah2 mod https://raw.githubusercontent.com/myitcv/pubx/master">
+	        `,
+		[]metaImport{{"myitcv.io", "git", "https://github.com/myitcv/x"}},
+	},
+}
+
+func TestParseMetaGoImports(t *testing.T) {
+	for i, tt := range parseMetaGoImportsTests {
+		out, err := parseMetaGoImports(strings.NewReader(tt.in))
+		if err != nil {
+			t.Errorf("test#%d: %v", i, err)
+			continue
+		}
+		if !reflect.DeepEqual(out, tt.out) {
+			t.Errorf("test#%d:\n\thave %q\n\twant %q", i, out, tt.out)
+		}
+	}
+}
+
+func TestValidateRepoRoot(t *testing.T) {
+	tests := []struct {
+		root string
+		ok   bool
+	}{
+		{
+			root: "",
+			ok:   false,
+		},
+		{
+			root: "http://",
+			ok:   true,
+		},
+		{
+			root: "git+ssh://",
+			ok:   true,
+		},
+		{
+			root: "http#://",
+			ok:   false,
+		},
+		{
+			root: "-config",
+			ok:   false,
+		},
+		{
+			root: "-config://",
+			ok:   false,
+		},
+	}
+
+	for _, test := range tests {
+		err := validateRepoRoot(test.root)
+		ok := err == nil
+		if ok != test.ok {
+			want := "error"
+			if test.ok {
+				want = "nil"
+			}
+			t.Errorf("validateRepoRoot(%q) = %q, want %s", test.root, err, want)
+		}
+	}
+}
+
+func TestMatchGoImport(t *testing.T) {
+	tests := []struct {
+		imports []metaImport
+		path    string
+		mi      metaImport
+		err     error
+	}{
+		{
+			imports: []metaImport{
+				{Prefix: "example.com/user/foo", VCS: "git", RepoRoot: "https://example.com/repo/target"},
+			},
+			path: "example.com/user/foo",
+			mi:   metaImport{Prefix: "example.com/user/foo", VCS: "git", RepoRoot: "https://example.com/repo/target"},
+		},
+		{
+			imports: []metaImport{
+				{Prefix: "example.com/user/foo", VCS: "git", RepoRoot: "https://example.com/repo/target"},
+			},
+			path: "example.com/user/foo/",
+			mi:   metaImport{Prefix: "example.com/user/foo", VCS: "git", RepoRoot: "https://example.com/repo/target"},
+		},
+		{
+			imports: []metaImport{
+				{Prefix: "example.com/user/foo", VCS: "git", RepoRoot: "https://example.com/repo/target"},
+				{Prefix: "example.com/user/fooa", VCS: "git", RepoRoot: "https://example.com/repo/target"},
+			},
+			path: "example.com/user/foo",
+			mi:   metaImport{Prefix: "example.com/user/foo", VCS: "git", RepoRoot: "https://example.com/repo/target"},
+		},
+		{
+			imports: []metaImport{
+				{Prefix: "example.com/user/foo", VCS: "git", RepoRoot: "https://example.com/repo/target"},
+				{Prefix: "example.com/user/fooa", VCS: "git", RepoRoot: "https://example.com/repo/target"},
+			},
+			path: "example.com/user/fooa",
+			mi:   metaImport{Prefix: "example.com/user/fooa", VCS: "git", RepoRoot: "https://example.com/repo/target"},
+		},
+		{
+			imports: []metaImport{
+				{Prefix: "example.com/user/foo", VCS: "git", RepoRoot: "https://example.com/repo/target"},
+				{Prefix: "example.com/user/foo/bar", VCS: "git", RepoRoot: "https://example.com/repo/target"},
+			},
+			path: "example.com/user/foo/bar",
+			err:  errors.New("should not be allowed to create nested repo"),
+		},
+		{
+			imports: []metaImport{
+				{Prefix: "example.com/user/foo", VCS: "git", RepoRoot: "https://example.com/repo/target"},
+				{Prefix: "example.com/user/foo/bar", VCS: "git", RepoRoot: "https://example.com/repo/target"},
+			},
+			path: "example.com/user/foo/bar/baz",
+			err:  errors.New("should not be allowed to create nested repo"),
+		},
+		{
+			imports: []metaImport{
+				{Prefix: "example.com/user/foo", VCS: "git", RepoRoot: "https://example.com/repo/target"},
+				{Prefix: "example.com/user/foo/bar", VCS: "git", RepoRoot: "https://example.com/repo/target"},
+			},
+			path: "example.com/user/foo/bar/baz/qux",
+			err:  errors.New("should not be allowed to create nested repo"),
+		},
+		{
+			imports: []metaImport{
+				{Prefix: "example.com/user/foo", VCS: "git", RepoRoot: "https://example.com/repo/target"},
+				{Prefix: "example.com/user/foo/bar", VCS: "git", RepoRoot: "https://example.com/repo/target"},
+			},
+			path: "example.com/user/foo/bar/baz/",
+			err:  errors.New("should not be allowed to create nested repo"),
+		},
+		{
+			imports: []metaImport{
+				{Prefix: "example.com/user/foo", VCS: "git", RepoRoot: "https://example.com/repo/target"},
+				{Prefix: "example.com/user/foo/bar", VCS: "git", RepoRoot: "https://example.com/repo/target"},
+			},
+			path: "example.com",
+			err:  errors.New("pathologically short path"),
+		},
+	}
+
+	for _, test := range tests {
+		mi, err := matchGoImport(test.imports, test.path)
+		if mi != test.mi {
+			t.Errorf("unexpected metaImport; got %v, want %v", mi, test.mi)
+		}
+
+		got := err
+		want := test.err
+		if (got == nil) != (want == nil) {
+			t.Errorf("unexpected error; got %v, want %v", got, want)
+		}
+	}
+}

--- a/engine/vcs/vcs_test.go
+++ b/engine/vcs/vcs_test.go
@@ -33,6 +33,20 @@ func TestRepoRootForImportPath(t *testing.T) {
 				Repo: "https://github.com/golang/groupcache",
 			},
 		},
+		{
+			"github.com/dagger/dagger-test-modules/../..",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://github.com/dagger/dagger-test-modules",
+			},
+		},
+		{
+			"github.com/dagger/dagger-test-modules/../../",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://github.com/dagger/dagger-test-modules",
+			},
+		},
 		// Unicode letters are allowed in import paths.
 		// issue https://github.com/golang/go/issues/18660
 		{
@@ -93,6 +107,20 @@ func TestRepoRootForImportPath(t *testing.T) {
 			&RepoRoot{
 				VCS:  vcsGit,
 				Repo: "https://git.sr.ht/~jacqueline/tangara-fw",
+			},
+		},
+		{
+			"bitbucket.org/workspace/pkgname/../..",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://bitbucket.org/workspace/pkgname",
+			},
+		},
+		{
+			"bitbucket.org/workspace/pkgname/../../",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://bitbucket.org/workspace/pkgname",
 			},
 		},
 		{


### PR DESCRIPTION
First working draft of multi SCM support.

Currently only works on public VCS repo, as well as public vanity URL relying on the `go-get` vanity URL logic from Go.

**TODO**
- [x] More detailed history of https://github.com/grouville/go-vcs when merging
- [x] Improve error messages: on init, install, call, functions -> add ++++ integration tests
- [x] Add vanity URL test by changing `dagger.io/dagger` redirect (side PR) -> https://github.com/dagger/dagger.io/pull/3730
- [ ] Add `vcsToBuildKitRef` logic in core/schema/git` to handle same ref format for dirs (follow-up PR), and remove test from this one
- [ ] Extend `moduleSource` type to handle `SSH_AUTH_SOCK` (ongoing) for private module handling (potentially follow-up PR)