### PR TITLE
cli: list available functions when chain ends in an object

### DIFF
--- a/.changes/unreleased/Changed-20240520-155221.yaml
+++ b/.changes/unreleased/Changed-20240520-155221.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: 'cli: list available functions when chain ends in an object'
+time: 2024-05-20T15:52:21.507104Z
+custom:
+  Author: helderco
+  PR: "7421"

--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -20,12 +20,9 @@ var callCmd = &FuncCommand{
 	Short: "Call a module function",
 	Long: strings.ReplaceAll(`Call a module function and print the result.
 
-If the last argument is either a Container, Directory, or File, the pipeline
-will be evaluated (the result of calling ´sync´) without presenting any output.
-Providing the ´--output´ option (shorthand: ´-o´) is equivalent to calling
-´export´ instead. To print a property of these core objects, continue chaining
-by appending it to the end of the command (for example, ´stdout´, ´entries´, or
-´contents´).
+If the last argument is either a Container, Directory, or File, and the
+´--output´ option is provided (shorthand: ´-o´), it's equivalent
+to appending the ´export´ function.
 `,
 		"´",
 		"`",

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -710,10 +710,8 @@ type Test struct {
 			ctr := modGen.With(daggerCall("ctr"))
 			out, err := ctr.Stdout(ctx)
 			require.NoError(t, err)
-			require.Empty(t, out)
-			out, err = ctr.Stderr(ctx)
-			require.NoError(t, err)
-			require.Contains(t, out, "Container evaluated")
+			require.Contains(t, out, "AVAILABLE FUNCTIONS")
+			require.Contains(t, out, "stdout")
 		})
 
 		t.Run("output", func(t *testing.T) {
@@ -756,10 +754,8 @@ type Test struct {
 			ctr := modGen.With(daggerCall("dir"))
 			out, err := ctr.Stdout(ctx)
 			require.NoError(t, err)
-			require.Empty(t, out)
-			out, err = ctr.Stderr(ctx)
-			require.NoError(t, err)
-			require.Contains(t, out, "Directory evaluated")
+			require.Contains(t, out, "AVAILABLE FUNCTIONS")
+			require.Contains(t, out, "entries")
 		})
 
 		t.Run("output", func(t *testing.T) {
@@ -809,10 +805,8 @@ type Test struct {
 			ctr := modGen.With(daggerCall("file"))
 			out, err := ctr.Stdout(ctx)
 			require.NoError(t, err)
-			require.Empty(t, out)
-			out, err = ctr.Stderr(ctx)
-			require.NoError(t, err)
-			require.Contains(t, out, "File evaluated")
+			require.Contains(t, out, "AVAILABLE FUNCTIONS")
+			require.Contains(t, out, "contents")
 		})
 
 		t.Run("output", func(t *testing.T) {
@@ -846,8 +840,7 @@ type Test struct {
 `,
 			})
 
-		// adding sync disables the default behavior of **not** printing the ID
-		// just verify it works without error for now
+		// sync should still work if used explicitly
 		_, err := modGen.With(daggerCall("ctr", "sync")).Stdout(ctx)
 		require.NoError(t, err)
 	})

--- a/docs/current_docs/reference/979596-cli.mdx
+++ b/docs/current_docs/reference/979596-cli.mdx
@@ -40,12 +40,9 @@ Call a module function
 
 Call a module function and print the result.
 
-If the last argument is either a Container, Directory, or File, the pipeline
-will be evaluated (the result of calling `sync`) without presenting any output.
-Providing the `--output` option (shorthand: `-o`) is equivalent to calling
-`export` instead. To print a property of these core objects, continue chaining
-by appending it to the end of the command (for example, `stdout`, `entries`, or
-`contents`).
+If the last argument is either a Container, Directory, or File, and the
+`--output` option is provided (shorthand: `-o`), it's equivalent
+to appending the `export` function.
 
 
 ```


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/6515

This allows for a much **nicer feedback loop** while you navigate the command tree. It also makes `dagger function` redundant.[^1]

[^1]: If we deprecate `dagger function` it also solves an issue with chains that end in a leaf, which return an error that there are no more functions available. With `dagger call` it just executes it.

### Before

```console
❯ dagger call cli file
File evaluated. Use "dagger call cli file --help" to see available sub-commands.
```

**Waited a long time** while the `File` was evaluated, to end in a usage message.

### After

**Fast response** because no query is executed (and more informative):

```console
❯ dagger call cli file
AVAILABLE FUNCTIONS
  contents          Retrieves the contents of the file.
  export            Writes the file to a file path on the host.
  name              Retrieves the name of the file.
  size              Retrieves the size of the file, in bytes.
  sync              Force evaluation in the engine.
  with-timestamps   Retrieves this file with its created/modified timestamps set to the given time.

Use 'dagger call cli file <function> --help' for more information about a function.
```

> [!NOTE]
> This removes `sync` as a default selection for commands ending in a `Container`, `Directory` or `File`.   \cc @vikram-dagger for impact on docs.