### PR TITLE
fix: throw error on invalid module registration

### DIFF
--- a/sdk/typescript/.changes/unreleased/Fixed-20240522-001342.yaml
+++ b/sdk/typescript/.changes/unreleased/Fixed-20240522-001342.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Throw an error on invalid module registration
+time: 2024-05-22T00:13:42.153205+02:00
+custom:
+  Author: TomChv
+  PR: "7434"

--- a/sdk/typescript/entrypoint/entrypoint.ts
+++ b/sdk/typescript/entrypoint/entrypoint.ts
@@ -29,7 +29,7 @@ export async function entrypoint() {
       const moduleName = await dag.currentModule().name()
       const parentName = await fnCall.parentName()
 
-      const scanResult = await scan(files, moduleName)
+      const scanResult = scan(files, moduleName)
 
       // Pre allocate the result, we got one in both case.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/sdk/typescript/introspector/scanner/scan.ts
+++ b/sdk/typescript/introspector/scanner/scan.ts
@@ -1,6 +1,5 @@
 import ts from "typescript"
 
-import { UnknownDaggerError } from "../../common/errors/UnknownDaggerError.js"
 import { DaggerModule } from "./abtractions/module.js"
 import { ClassTypeDef, FunctionTypedef } from "./typeDefs.js"
 
@@ -25,12 +24,17 @@ export type ScanResult = {
  */
 export function scan(files: string[], moduleName = ""): DaggerModule {
   if (files.length === 0) {
-    throw new UnknownDaggerError("no files to introspect found", {})
+    throw new Error("no files to introspect found")
   }
 
   // Interpret the given typescript source files.
   const program = ts.createProgram(files, { experimentalDecorators: true })
   const checker = program.getTypeChecker()
 
-  return new DaggerModule(checker, moduleName, program.getSourceFiles())
+  const module = new DaggerModule(checker, moduleName, program.getSourceFiles())
+  if (Object.keys(module.objects).length === 0) {
+    throw new Error("no objects found in the module")
+  }
+
+  return module
 }

--- a/sdk/typescript/introspector/test/scan.spec.ts
+++ b/sdk/typescript/introspector/test/scan.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import assert from "assert"
 import * as fs from "fs"
 import { describe, it } from "mocha"
@@ -25,10 +26,6 @@ describe("scan static TypeScript", function () {
     {
       name: "Should correctly scan multiple arguments",
       directory: "multiArgs",
-    },
-    {
-      name: "Should ignore class that does not have the object decorator",
-      directory: "noDecorators",
     },
     {
       name: "Should supports multiple files and classes that returns classes",
@@ -93,4 +90,37 @@ describe("scan static TypeScript", function () {
       assert.deepEqual(JSON.parse(jsonResult), JSON.parse(expected))
     })
   }
+
+  describe("Should throw error on invalid module", function () {
+    it("Should throw an error when no files are provided", async function () {
+      try {
+        await scan([], "")
+        assert.fail("Should throw an error")
+      } catch (e: any) {
+        assert.equal(e.message, "no files to introspect found")
+      }
+    })
+
+    it("Should throw an error if the module is invalid", async function () {
+      try {
+        const files = await listFiles(`${rootDirectory}/invalid`)
+
+        scan(files, "invalid")
+        assert.fail("Should throw an error")
+      } catch (e: any) {
+        assert.equal(e.message, "no objects found in the module")
+      }
+    })
+
+    it("Should throw an error if the module class has no decorators", async function () {
+      try {
+        const files = await listFiles(`${rootDirectory}/noDecorators`)
+
+        scan(files, "noDecorators")
+        assert.fail("Should throw an error")
+      } catch (e: any) {
+        assert.equal(e.message, "no objects found in the module")
+      }
+    })
+  })
 })

--- a/sdk/typescript/introspector/test/testdata/invalid/index.ts
+++ b/sdk/typescript/introspector/test/testdata/invalid/index.ts
@@ -1,0 +1,1 @@
+console.log("Hello world")


### PR DESCRIPTION
Fixes #6624 

Improve error message clarity.
Remove non-required `await`