### PR TITLE
tssdk: disable corepack requirement in TS SDK

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -157,11 +157,15 @@ jobs:
       - name: "Test TypeScript SDK (Node)"
         run: |
           cd sdk/typescript
+          corepack enable
+          yarn set version stable
           yarn install
           yarn test:node -g 'Automatic Provisioned CLI Binary'
       - name: "Test TypeScript SDK (Bun)"
         run: |
           cd sdk/typescript
+          corepack enable
+          yarn set version stable
           yarn install
           yarn test:bun -g 'Automatic Provisioned CLI Binary'
 
@@ -293,11 +297,15 @@ jobs:
       - name: "Test TypeScript SDK (Node)"
         run: |
           cd sdk/typescript
+          corepack enable
+          yarn set version stable
           yarn install
           yarn test:node -g 'Automatic Provisioned CLI Binary'
       - name: "Test TypeScript SDK (Bun)"
         run: |
           cd sdk/typescript
+          corepack enable
+          yarn set version stable
           yarn install
           yarn test:bun -g 'Automatic Provisioned CLI Binary'
       - name: "ALWAYS print engine logs - especially useful on failure"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -157,15 +157,11 @@ jobs:
       - name: "Test TypeScript SDK (Node)"
         run: |
           cd sdk/typescript
-          corepack enable
-          yarn set version stable
           yarn install
           yarn test:node -g 'Automatic Provisioned CLI Binary'
       - name: "Test TypeScript SDK (Bun)"
         run: |
           cd sdk/typescript
-          corepack enable
-          yarn set version stable
           yarn install
           yarn test:bun -g 'Automatic Provisioned CLI Binary'
 
@@ -297,15 +293,11 @@ jobs:
       - name: "Test TypeScript SDK (Node)"
         run: |
           cd sdk/typescript
-          corepack enable
-          yarn set version stable
           yarn install
           yarn test:node -g 'Automatic Provisioned CLI Binary'
       - name: "Test TypeScript SDK (Bun)"
         run: |
           cd sdk/typescript
-          corepack enable
-          yarn set version stable
           yarn install
           yarn test:bun -g 'Automatic Provisioned CLI Binary'
       - name: "ALWAYS print engine logs - especially useful on failure"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -64,6 +64,5 @@
     "prettier": "^3.2.5",
     "ts-node": "^10.9.1",
     "typescript-eslint": "^7.8.0"
-  },
-  "packageManager": "yarn@4.2.2"
+  }
 }

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -262,7 +262,9 @@ func (t *TypescriptSdk) installedSDK(ctr *Container, runtime SupportedTSRuntime)
 	case Bun:
 		return ctr.WithExec([]string{"bun", "install", "--no-verify", "--no-progress", "--summary"}).Directory(ModSourceDirPath)
 	case Node:
-		return ctr.WithExec([]string{"yarn", "workspaces", "focus", "--production"}).Directory(ModSourceDirPath)
+		return ctr.
+			WithExec([]string{"yarn", "set", "version", "stable"}).
+			WithExec([]string{"yarn", "workspaces", "focus", "--production"}).Directory(ModSourceDirPath)
 	default:
 		// Should never happen since we verify the runtime before calling this function.
 		return nil


### PR DESCRIPTION
~~Fixes https://github.com/dagger/dagger/pull/7096#issuecomment-2125073758 issue by enabling corepack and setting yarn version to v4 in our provision tests~~

Fixes https://github.com/dagger/dagger/pull/7096#issuecomment-2125073758 by removing the `packageManager` field so corepack and yarn v4 isn't required to use the TS SDK, this let the changes introduced in #7096 to be backward compatible.

We're still gonna use corepack and yarn v4 in the TS module runtime though.