### PR TITLE
Fix powershell install script to work when on a different drive

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -3,7 +3,7 @@
 param (
     [Parameter(Mandatory = $false)] [System.Management.Automation.SemanticVersion]$DaggerVersion,
     [Parameter(Mandatory = $false)] [string]$DaggerCommit,
-    [Parameter(Mandatory = $false)] [string]$InstallPath = $env:HOMEPATH + '\dagger',
+    [Parameter(Mandatory = $false)] [string]$InstallPath = $env:USERPROFILE + '\dagger',
 
     [Parameter(Mandatory = $false)] [System.Boolean]$InteractiveInstall = $false
 )


### PR DESCRIPTION
Changed the default install path from $env:HOMEPATH to $env:USERPROFILE as this includes the drive. Currently when calling the install script on the D: drive the transfer from the temp directory to the install path fails. This is not reported as an error and the install script appears to have worked correctly. This is because $env:HOMEPATH does not include the drive in the path. Changing this to $env:USERPROFILE has the same path but the path includes the drive, this fixes the issue. 