### PR TITLE
fix(core): check error on `normalizeCallerLoadedSource`

### DIFF
--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -805,6 +805,9 @@ func (s *moduleSchema) normalizeCallerLoadedSource(
 			},
 		},
 	)
+	if err != nil {
+		return inst, fmt.Errorf("failed to load the context directory: %w", err)
+	}
 
 	if src.WithName != "" {
 		err = s.dag.Select(ctx, inst, &inst,


### PR DESCRIPTION
`normalizeCallerLoadedSource` function can segfault if `withContextDirectory` returns an error, as we do not check for the returned error on the `withContextDirectory` call.

The following dagql calls can be executed: on the `dagger init`, for example, the `withName` gets called on my tests, and trigger the segfault.

It is currently (almost) never triggered, as there are two potential edge cases in which we return an error on `withContextDirectory`:
1. when the modulesourcekind is not local
2. when we fail to load the dir