### PR TITLE
feat(ts): keep function prototype during loading

### DIFF
--- a/core/integration/module_typescript_test.go
+++ b/core/integration/module_typescript_test.go
@@ -945,7 +945,7 @@ import { field, func, object } from "@dagger.io/dagger"
 @object()
 class Test {
   @func() 
-	test() {
+  test() {
     return new PModule(new PCheck(4))
   }
 }
@@ -953,7 +953,7 @@ class Test {
 @object()
 class PCheck {
   @field() 
-	value: number
+  value: number
 
   constructor(value: number) {
     this.value = value
@@ -967,13 +967,13 @@ class PCheck {
 @object()
 class PModule {
   @field() 
-	value: PCheck
+  value: PCheck
   
-	constructor(value: PCheck) {
+  constructor(value: PCheck) {
     this.value = value
   }
   @func() 
-	print() {
+  print() {
     return this.value.doubled ?? 0
   }
 }

--- a/core/integration/module_typescript_test.go
+++ b/core/integration/module_typescript_test.go
@@ -926,3 +926,61 @@ class Alias {
 		require.JSONEq(t, `{"alias": {"bar": {"hello": "a", "foo": {"zoo": 4, "hey": [true, false, true], "far": {"farFarNested": true} }}}}`, out)
 	})
 }
+
+func TestModuleTypeScriptPrototype(t *testing.T) {
+	t.Parallel()
+
+	t.Run("keep class prototype inside module", func(t *testing.T) {
+		t.Parallel()
+
+		c, ctx := connect(t)
+
+		modGen := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work").
+			With(daggerExec("init", "--name=test", "--sdk=typescript")).
+			With(sdkSource("typescript", `
+import { field, func, object } from "@dagger.io/dagger"
+
+@object()
+class Test {
+  @func() 
+	test() {
+    return new PModule(new PCheck(4))
+  }
+}
+
+@object()
+class PCheck {
+  @field() 
+	value: number
+
+  constructor(value: number) {
+    this.value = value
+  }
+
+  get doubled() {
+    return this.value * 2
+  }
+}
+
+@object()
+class PModule {
+  @field() 
+	value: PCheck
+  
+	constructor(value: PCheck) {
+    this.value = value
+  }
+  @func() 
+	print() {
+    return this.value.doubled ?? 0
+  }
+}
+`))
+
+		out, err := modGen.With(daggerQuery(`{test{test{print}}}`)).Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"test": {"test": {"print": 8 }}}`, out)
+	})
+}

--- a/core/integration/testdata/modules/go/ifaces/test/.gitattributes
+++ b/core/integration/testdata/modules/go/ifaces/test/.gitattributes
@@ -1,0 +1,4 @@
+/dagger.gen.go linguist-generated
+/internal/dagger/** linguist-generated
+/internal/querybuilder/** linguist-generated
+/internal/telemetry/** linguist-generated

--- a/sdk/typescript/.changes/unreleased/Added-20240527-231234.yaml
+++ b/sdk/typescript/.changes/unreleased/Added-20240527-231234.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Load parameter and field class prototype inside module
+time: 2024-05-27T23:12:34.469417+02:00
+custom:
+  Author: TomChv
+  PR: "7477"

--- a/sdk/typescript/entrypoint/invoke.ts
+++ b/sdk/typescript/entrypoint/invoke.ts
@@ -36,8 +36,8 @@ export async function invoke(module: DaggerModule, ctx: InvokeCtx) {
     throw new Error(`could not find method ${ctx.fnName}`)
   }
 
-  const args = await loadArgs(method, ctx)
-  const parentState = await loadParentState(object, ctx)
+  const args = await loadArgs(registry, method, ctx)
+  const parentState = await loadParentState(registry, object, ctx)
 
   let result = await registry.getResult(
     object.name,

--- a/sdk/typescript/entrypoint/load.ts
+++ b/sdk/typescript/entrypoint/load.ts
@@ -62,7 +62,11 @@ export async function loadArgs(
       throw new Error(`could not find argument ${argName}`)
     }
 
-    const loadedArg = await loadValue(registry, ctx.fnArgs[argName], argument.type)
+    const loadedArg = await loadValue(
+      registry,
+      ctx.fnArgs[argName],
+      argument.type,
+    )
 
     // If the argument is variadic, we need to load each args independently
     // so it's correctly propagated when it's sent to the function.
@@ -136,7 +140,11 @@ export async function loadValue(
       return Promise.all(
         value.map(
           async (v: any) =>
-            await loadValue(registry, v, (type as TypeDef<TypeDefKind.ListKind>).typeDef),
+            await loadValue(
+              registry,
+              v,
+              (type as TypeDef<TypeDefKind.ListKind>).typeDef,
+            ),
         ),
       )
     case TypeDefKind.ObjectKind: {

--- a/sdk/typescript/introspector/registry/registry.ts
+++ b/sdk/typescript/introspector/registry/registry.ts
@@ -84,13 +84,10 @@ export class Registry {
   /**
    * Build a class that is part of the module itself so you can
    * access its sub functions.
-   * 
+   *
    * If there's no class associated, return the object itself.
    */
-  buildClass(
-    object: string,
-    state: State,
-  ): any{
+  buildClass(object: string, state: State): any {
     const resolver = Reflect.getMetadata(object, this) as RegistryClass
     if (!resolver) {
       return object

--- a/sdk/typescript/introspector/registry/registry.ts
+++ b/sdk/typescript/introspector/registry/registry.ts
@@ -82,6 +82,27 @@ export class Registry {
   }
 
   /**
+   * Build a class that is part of the module itself so you can
+   * access its sub functions.
+   * 
+   * If there's no class associated, return the object itself.
+   */
+  buildClass(
+    object: string,
+    state: State,
+  ): any{
+    const resolver = Reflect.getMetadata(object, this) as RegistryClass
+    if (!resolver) {
+      return object
+    }
+
+    let r = Object.create(resolver.class_.prototype)
+    r = Object.assign(r, state)
+
+    return r
+  }
+
+  /**
    * getResult check for the object and method in the registry and call it
    * with the given input and state.
    *


### PR DESCRIPTION
Fixes #7446 by loading the object as class if it exist inside the module.

If an object exists inside the module, it loads the class by calling his constructor so now public methods can be called inside the module.