### PR TITLE
cli: print module object fields with `dagger call`

### DIFF
--- a/.changes/unreleased/Changed-20240628-141105.yaml
+++ b/.changes/unreleased/Changed-20240628-141105.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: 'cli: print module object fields with `dagger call`'
+time: 2024-06-28T14:11:05.367066Z
+custom:
+    Author: helderco
+    PR: "7479"

--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -23,7 +23,7 @@ var callCmd = &FuncCommand{
 	Init: func(cmd *cobra.Command) {
 		cmd.PersistentFlags().StringVarP(&outputPath, "output", "o", "", "Save the result to a local file or directory")
 
-		cmd.PersistentFlags().BoolVar(&jsonOutput, "json", false, "Present result as JSON")
+		cmd.PersistentFlags().BoolVarP(&jsonOutput, "json", "j", false, "Present result as JSON")
 	},
 	OnSelectObjectLeaf: func(fc *FuncCommand, obj functionProvider) error {
 		typeName := obj.ProviderName()
@@ -81,8 +81,10 @@ var callCmd = &FuncCommand{
 
 			// Use yaml when printing scalars because it's more human-readable
 			// and handles lists and multiline strings well.
-			if outputFormat == "" {
+			if stdoutIsTTY {
 				outputFormat = "yaml"
+			} else {
+				outputFormat = "json"
 			}
 		}
 

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -177,7 +177,7 @@ type FuncCommand struct {
 	// If set, it should make another selection on the object that results
 	// return no error. Otherwise if it doesn't handle the object, it should
 	// return an error.
-	OnSelectObjectLeaf func(*FuncCommand, string) error
+	OnSelectObjectLeaf func(*FuncCommand, functionProvider) error
 
 	// BeforeRequest is called before making the request with the query that
 	// contains the whole chain of functions.
@@ -304,6 +304,30 @@ func (fc *FuncCommand) Command() *cobra.Command {
 	return fc.cmd
 }
 
+// printCommands prints the available functions for the current command.
+func (fc *FuncCommand) Suggestions(cmd *cobra.Command) string {
+	var buf strings.Builder
+	if cmd.HasAvailableSubCommands() {
+		fmt.Fprintln(&buf, toUpperBold("Available functions"))
+		for _, c := range cmd.Commands() {
+			if c.IsAvailableCommand() {
+				fmt.Fprintln(&buf, cmdShortWrapped(c))
+			}
+		}
+		if skipped, ok := cmd.Annotations[skippedCmdsAnnotation]; ok {
+			fmt.Fprintln(&buf)
+			msg := fmt.Sprintf("Skipped %d function(s) with unsupported types: %s",
+				len(strings.Split(skipped, ", ")),
+				skipped,
+			)
+			fmt.Fprintln(&buf, termenv.String(msg).Faint().String())
+		}
+		fmt.Fprintln(&buf)
+		fmt.Fprintf(&buf, "Use '%v [function] --help' for more information.\n", cmd.CommandPath())
+	}
+	return buf.String()
+}
+
 func (fc *FuncCommand) Help(cmd *cobra.Command) error {
 	var args []any
 	// We need to store these in annotations because during traversal all
@@ -378,9 +402,9 @@ func (fc *FuncCommand) execute(c *cobra.Command, a []string) (rerr error) {
 		return fc.Execute(fc, cmd)
 	}
 
-	// No args to the parent command, default to showing help.
+	// No args to the parent command
 	if cmd == c {
-		return fc.Help(cmd)
+		return fc.RunE(ctx, fc.mod.MainObject)(cmd, flags)
 	}
 
 	return cmd.RunE(cmd, flags)
@@ -480,8 +504,6 @@ func (fc *FuncCommand) traverse(c *cobra.Command, a []string, build func(*cobra.
 // cobraBuilder returns a PreRunE compatible function to add the next set of
 // flags and sub-commands to the command tree, based on a function definition.
 func (fc *FuncCommand) cobraBuilder(ctx context.Context, fn *modFunction) func(*cobra.Command, []string) error {
-	dag := fc.c.Dagger()
-
 	return func(c *cobra.Command, a []string) error {
 		if err := fc.addFlagsForFunction(c, fn); err != nil {
 			return err
@@ -493,7 +515,7 @@ func (fc *FuncCommand) cobraBuilder(ctx context.Context, fn *modFunction) func(*
 			return c.FlagErrorFunc()(c, err)
 		}
 
-		fc.addSubCommands(ctx, c, dag, fn.ReturnType)
+		fc.addSubCommands(ctx, c, fn.ReturnType)
 
 		if fc.needsHelp {
 			// May be too noisy to always show a warning for skipped functions
@@ -513,7 +535,7 @@ func (fc *FuncCommand) cobraBuilder(ctx context.Context, fn *modFunction) func(*
 		}
 
 		// Easier to add query builder selections as we traverse the command tree.
-		return fc.selectFunc(fn, c, dag)
+		return fc.selectFunc(fn, c)
 	}
 }
 
@@ -554,7 +576,7 @@ func (fc *FuncCommand) addFlagsForFunction(cmd *cobra.Command, fn *modFunction) 
 
 // addSubCommands creates sub-commands for the functions in an object or
 // interface type definition.
-func (fc *FuncCommand) addSubCommands(ctx context.Context, cmd *cobra.Command, dag *dagger.Client, typeDef *modTypeDef) {
+func (fc *FuncCommand) addSubCommands(ctx context.Context, cmd *cobra.Command, typeDef *modTypeDef) {
 	fc.mod.LoadTypeDef(typeDef)
 
 	fnProvider := typeDef.AsFunctionProvider()
@@ -575,7 +597,7 @@ func (fc *FuncCommand) addSubCommands(ctx context.Context, cmd *cobra.Command, d
 			skipped = append(skipped, cliName(fn.Name))
 			continue
 		}
-		subCmd := fc.makeSubCmd(ctx, dag, fn)
+		subCmd := fc.makeSubCmd(ctx, fn)
 		cmd.AddCommand(subCmd)
 	}
 
@@ -589,7 +611,7 @@ func (fc *FuncCommand) addSubCommands(ctx context.Context, cmd *cobra.Command, d
 }
 
 // makeSubCmd creates a sub-command for a function definition.
-func (fc *FuncCommand) makeSubCmd(ctx context.Context, dag *dagger.Client, fn *modFunction) *cobra.Command {
+func (fc *FuncCommand) makeSubCmd(ctx context.Context, fn *modFunction) *cobra.Command {
 	newCmd := &cobra.Command{
 		Use:                   cliName(fn.Name),
 		Short:                 strings.SplitN(fn.Description, "\n", 2)[0],
@@ -607,62 +629,7 @@ func (fc *FuncCommand) makeSubCmd(ctx context.Context, dag *dagger.Client, fn *m
 		PreRunE: fc.cobraBuilder(ctx, fn),
 		// This is going to be executed in the "execution" vertex, when
 		// we have the final/leaf command.
-		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			switch fn.ReturnType.Kind {
-			case dagger.ObjectKind, dagger.InterfaceKind:
-				if fc.OnSelectObjectLeaf == nil {
-					// there is no handling of this object and no further selections, error out
-					return fmt.Errorf("%q requires a sub-command", cmd.Name())
-				}
-
-				// the top-level command may handle this via OnSelectObjectLeaf
-				err := fc.OnSelectObjectLeaf(fc, fn.ReturnType.Name())
-				if err != nil {
-					return fmt.Errorf("invalid selection for command %q: %w", cmd.Name(), err)
-				}
-
-			case dagger.ListKind:
-				fnProvider := fn.ReturnType.AsList.ElementTypeDef.AsFunctionProvider()
-				if fnProvider != nil && len(fnProvider.GetFunctions()) > 0 {
-					// we don't handle lists of objects/interfaces w/ extra functions on any commands right now
-					return fmt.Errorf("%q requires a sub-command", cmd.Name())
-				}
-			}
-
-			// Silence usage from this point on as errors don't likely come
-			// from wrong CLI usage.
-			fc.showUsage = false
-
-			if fc.BeforeRequest != nil {
-				if err = fc.BeforeRequest(fc, cmd, fn.ReturnType); err != nil {
-					return err
-				}
-			}
-
-			query, _ := fc.q.Build(ctx)
-
-			slog.Debug("executing query", "query", query)
-
-			var response any
-
-			q := fc.q.Bind(&response).Client(dag.GraphQLClient())
-
-			if err := q.Execute(cmd.Context()); err != nil {
-				return fmt.Errorf("response from query: %w", err)
-			}
-
-			if fn.ReturnType.Kind == dagger.VoidKind {
-				return nil
-			}
-
-			if fc.AfterResponse != nil {
-				return fc.AfterResponse(fc, cmd, fn.ReturnType, response)
-			}
-
-			cmd.Println(response)
-
-			return nil
-		},
+		RunE: fc.RunE(ctx, fn.ReturnType),
 	}
 
 	newCmd.Flags().SetInterspersed(false)
@@ -672,7 +639,9 @@ func (fc *FuncCommand) makeSubCmd(ctx context.Context, dag *dagger.Client, fn *m
 }
 
 // selectFunc adds the function selection to the query.
-func (fc *FuncCommand) selectFunc(fn *modFunction, cmd *cobra.Command, dag *dagger.Client) error {
+func (fc *FuncCommand) selectFunc(fn *modFunction, cmd *cobra.Command) error {
+	dag := fc.c.Dagger()
+
 	fc.Select(fn.Name)
 
 	for _, arg := range fn.SupportedArgs() {
@@ -710,13 +679,79 @@ func (fc *FuncCommand) selectFunc(fn *modFunction, cmd *cobra.Command, dag *dagg
 	return nil
 }
 
-func (fc *FuncCommand) Select(name string) {
+func (fc *FuncCommand) Select(name ...string) {
 	if fc.q == nil {
 		fc.q = querybuilder.Query()
 	}
-	fc.q = fc.q.Select(name)
+	fc.q = fc.q.Select(name...)
 }
 
 func (fc *FuncCommand) Arg(name string, value any) {
 	fc.q = fc.q.Arg(name, value)
+}
+
+func (fc *FuncCommand) RunE(ctx context.Context, typeDef *modTypeDef) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		t := typeDef
+		if t.AsList != nil {
+			t = t.AsList.ElementTypeDef
+		}
+
+		switch t.Kind {
+		case dagger.ObjectKind, dagger.InterfaceKind:
+			origSel := fc.q
+			obj := t.AsFunctionProvider()
+
+			if fc.OnSelectObjectLeaf != nil {
+				if err := fc.OnSelectObjectLeaf(fc, obj); err != nil {
+					return fmt.Errorf("invalid selection for command %q: %w", cmd.Name(), err)
+				}
+			}
+
+			if origSel == fc.q {
+				if cmd.HasAvailableSubCommands() {
+					cmd.Print(fc.Suggestions(cmd))
+					return nil
+				}
+				// TODO: give more details to help out
+				// bar has no available functions
+				// x are unsupported
+				return fmt.Errorf("there's no available functions to print or chain")
+			}
+		}
+
+		// Silence usage from this point on as errors don't likely come
+		// from wrong CLI usage.
+		fc.showUsage = false
+
+		if fc.BeforeRequest != nil {
+			if err := fc.BeforeRequest(fc, cmd, typeDef); err != nil {
+				return err
+			}
+		}
+
+		query, _ := fc.q.Build(ctx)
+
+		slog.Debug("executing query", "query", query)
+
+		var response any
+
+		q := fc.q.Bind(&response).Client(fc.c.Dagger().GraphQLClient())
+
+		if err := q.Execute(ctx); err != nil {
+			return fmt.Errorf("response from query: %w", err)
+		}
+
+		if typeDef.Kind == dagger.VoidKind {
+			return nil
+		}
+
+		if fc.AfterResponse != nil {
+			return fc.AfterResponse(fc, cmd, typeDef, response)
+		}
+
+		cmd.Println(response)
+
+		return nil
+	}
 }

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -1096,6 +1096,11 @@ var skipLeaves = map[string][]string{
 		// hard to check for here.
 		"imageRef",
 	},
+	"File": {
+		// This could be a binary file, so until we can tell which type of
+		// file it is, best to skip it for now.
+		"contents",
+	},
 }
 
 // GetLeafFunctions returns the leaf functions of a function provider, which are

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -721,12 +721,12 @@ func (m *Minimal) Fn() []*Foo {
 
 		logGen(ctx, t, modGen.Directory("."))
 		expected := "0\n1\n2\n"
-		expectedJson := `[{"bar": 0}, {"bar": 1}, {"bar": 2}]`
+		expectedJSON := `[{"bar": 0}, {"bar": 1}, {"bar": 2}]`
 
 		t.Run("default", func(ctx context.Context, t *testctx.T) {
 			out, err := modGen.With(daggerCall("fn")).Stdout(ctx)
 			require.NoError(t, err)
-			require.JSONEq(t, expectedJson, gjson.Get(out, "#.{bar}").Raw)
+			require.JSONEq(t, expectedJSON, gjson.Get(out, "#.{bar}").Raw)
 		})
 
 		t.Run("print", func(ctx context.Context, t *testctx.T) {
@@ -749,7 +749,7 @@ func (m *Minimal) Fn() []*Foo {
 				With(daggerCall("fn", "bar", "--json")).
 				Stdout(ctx)
 			require.NoError(t, err)
-			require.JSONEq(t, expectedJson, out)
+			require.JSONEq(t, expectedJSON, out)
 		})
 	})
 

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dagger/dagger/testctx"
 	"github.com/moby/buildkit/identity"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 
 	"dagger.io/dagger"
 )
@@ -720,6 +721,13 @@ func (m *Minimal) Fn() []*Foo {
 
 		logGen(ctx, t, modGen.Directory("."))
 		expected := "0\n1\n2\n"
+		expectedJson := `[{"bar": 0}, {"bar": 1}, {"bar": 2}]`
+
+		t.Run("default", func(ctx context.Context, t *testctx.T) {
+			out, err := modGen.With(daggerCall("fn")).Stdout(ctx)
+			require.NoError(t, err)
+			require.JSONEq(t, expectedJson, gjson.Get(out, "#.{bar}").Raw)
+		})
 
 		t.Run("print", func(ctx context.Context, t *testctx.T) {
 			out, err := modGen.With(daggerCall("fn", "bar")).Stdout(ctx)
@@ -741,7 +749,7 @@ func (m *Minimal) Fn() []*Foo {
 				With(daggerCall("fn", "bar", "--json")).
 				Stdout(ctx)
 			require.NoError(t, err)
-			require.JSONEq(t, `[{"bar": 0}, {"bar": 1}, {"bar": 2}]`, out)
+			require.JSONEq(t, expectedJson, out)
 		})
 	})
 
@@ -768,13 +776,10 @@ type Test struct {
 		logGen(ctx, t, modGen.Directory("."))
 
 		t.Run("default", func(ctx context.Context, t *testctx.T) {
-			ctr := modGen.With(daggerCall("ctr"))
-			out, err := ctr.Stdout(ctx)
+			out, err := modGen.With(daggerCall("ctr")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Empty(t, out)
-			out, err = ctr.Stderr(ctx)
-			require.NoError(t, err)
-			require.Contains(t, out, "Container evaluated")
+			actual := gjson.Get(out, "[@this].#(_type==Container).stdout").String()
+			require.Equal(t, "hello world\n", actual)
 		})
 
 		t.Run("output", func(ctx context.Context, t *testctx.T) {
@@ -813,13 +818,12 @@ type Test struct {
 		logGen(ctx, t, modGen.Directory("."))
 
 		t.Run("default", func(ctx context.Context, t *testctx.T) {
-			ctr := modGen.With(daggerCall("dir"))
-			out, err := ctr.Stdout(ctx)
+			out, err := modGen.With(daggerCall("dir")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Empty(t, out)
-			out, err = ctr.Stderr(ctx)
-			require.NoError(t, err)
-			require.Contains(t, out, "Directory evaluated")
+			actual := gjson.Get(out, "[@this].#(_type==Directory).entries").Array()
+			require.Len(t, actual, 2)
+			require.Equal(t, "bar.txt", actual[0].String())
+			require.Equal(t, "foo.txt", actual[1].String())
 		})
 
 		t.Run("output", func(ctx context.Context, t *testctx.T) {
@@ -865,13 +869,10 @@ type Test struct {
 		logGen(ctx, t, modGen.Directory("."))
 
 		t.Run("default", func(ctx context.Context, t *testctx.T) {
-			ctr := modGen.With(daggerCall("file"))
-			out, err := ctr.Stdout(ctx)
+			out, err := modGen.With(daggerCall("file")).Stdout(ctx)
 			require.NoError(t, err)
-			require.Empty(t, out)
-			out, err = ctr.Stderr(ctx)
-			require.NoError(t, err)
-			require.Contains(t, out, "File evaluated")
+			actual := gjson.Get(out, "[@this].#(_type==File).name").String()
+			require.Equal(t, "foo.txt", actual)
 		})
 
 		t.Run("output", func(ctx context.Context, t *testctx.T) {
@@ -1019,6 +1020,67 @@ type Test struct {
 			require.NoError(t, err)
 			require.Equal(t, "foo", contents)
 		})
+	})
+}
+
+func (ModuleSuite) TestDaggerCallReturnObject(ctx context.Context, t *testctx.T) {
+	// NB: Container, Directory and File are tested in TestDaggerCallReturnTypes.
+
+	c := connect(ctx, t)
+
+	modGen := modInit(t, c, "go", `package main
+
+func New() *Test {
+    return &Test{
+        BaseImage: "`+alpineImage+`",
+    }
+}
+
+type Test struct {
+    BaseImage string
+}
+
+func (t *Test) Foo() *Foo {
+    return &Foo{Ctr: dag.Container().From(t.BaseImage)}
+}
+
+func (t *Test) Files() []*File {
+    return []*File{
+        dag.Directory().WithNewFile("foo.txt", "foo").File("foo.txt"),
+        dag.Directory().WithNewFile("bar.txt", "bar").File("bar.txt"),
+    }
+}
+
+type Foo struct {
+    Ctr *Container
+}
+`,
+	)
+
+	t.Run("main object", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.With(daggerCall()).Stdout(ctx)
+		require.NoError(t, err)
+		require.Equal(t, "Test", gjson.Get(out, "_type").String())
+		require.Equal(t, alpineImage, gjson.Get(out, "baseImage").String())
+	})
+
+	t.Run("no scalars", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.With(daggerCall("foo")).Stdout(ctx)
+		require.NoError(t, err)
+		// At minimum should print the type of the object
+		require.JSONEq(t, `{"_type": "TestFoo"}`, out)
+	})
+
+	t.Run("list of objects", func(ctx context.Context, t *testctx.T) {
+		expected := []string{"foo.txt", "bar.txt"}
+		out, err := modGen.With(daggerCall("files")).Stdout(ctx)
+		require.NoError(t, err)
+		actual := gjson.Get(out, "@this").Array()
+		require.Len(t, actual, len(expected))
+		for i, res := range actual {
+			require.Equal(t, "File", res.Get("_type").String())
+			require.Equal(t, expected[i], res.Get("name").String())
+		}
 	})
 }
 

--- a/docs/current_docs/reference/cli.mdx
+++ b/docs/current_docs/reference/cli.mdx
@@ -43,7 +43,7 @@ dagger call [options]
 ### Options
 
 ```
-  -f, --format string   Format output using 'json', 'yaml' or 'none' (default "auto")
+  -f, --format string   Format output using 'json' or 'yaml' (default "")
   -m, --mod string      Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
   -o, --output string   Save the result to a local file or directory
 ```

--- a/docs/current_docs/reference/cli.mdx
+++ b/docs/current_docs/reference/cli.mdx
@@ -43,7 +43,7 @@ dagger call [options]
 ### Options
 
 ```
-  -f, --format string   Format output using 'json' or 'yaml' (default "")
+  -j, --json            Present result as JSON
   -m, --mod string      Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
   -o, --output string   Save the result to a local file or directory
 ```

--- a/docs/current_docs/reference/cli.mdx
+++ b/docs/current_docs/reference/cli.mdx
@@ -36,36 +36,16 @@ The Dagger CLI provides a command-line interface to Dagger.
 
 Call a module function
 
-### Synopsis
-
-Call a module function and print the result.
-
-If the last argument is either a Container, Directory, or File, the pipeline
-will be evaluated (the result of calling `sync`) without presenting any output.
-Providing the `--output` option (shorthand: `-o`) is equivalent to calling
-`export` instead. To print a property of these core objects, continue chaining
-by appending it to the end of the command (for example, `stdout`, `entries`, or
-`contents`).
-
-
 ```
 dagger call [options]
-```
-
-### Examples
-
-```
-dagger call test
-dagger call build -o ./bin/myapp
-dagger call lint stdout
 ```
 
 ### Options
 
 ```
-      --json            Present result as JSON
+  -f, --format string   Format output using 'json', 'yaml' or 'none' (default "auto")
   -m, --mod string      Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
-  -o, --output string   Path in the host to save the result to
+  -o, --output string   Save the result to a local file or directory
 ```
 
 ### Options inherited from parent commands

--- a/hack/with-dev
+++ b/hack/with-dev
@@ -5,8 +5,8 @@ set -e -u
 export DAGGER_SRC_ROOT="$(cd $(dirname $(realpath "${BASH_SOURCE[0]}"))/.. && pwd)"
 export MAGEDIR="$DAGGER_SRC_ROOT/ci/mage"
 
-pushd $MAGEDIR
+pushd $MAGEDIR > /dev/null
 eval $(go run main.go -w $DAGGER_SRC_ROOT engine:devenv)
-popd
+popd > /dev/null
 
 exec "$@"


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/6514
Fixes https://github.com/dagger/dagger/issues/6515

Previously, when a `dagger call` chain ended in an object, the result was inconsistent and not very useful:
- Without any functions, it would show `--help`
- `Container`, `Directory` and `File` core types evaluated the pipeline and returned a "XXX evaluated." message
- For custom user types, an error was returned: "return type XXX requires a sub-command"

With this change, in all of those cases, **the CLI finds all functions without required arguments that return a scalar/primitive value, and prints them**. This includes a module's main object, when calling `dagger call` without any more arguments.

> [!NOTE]
> At minimum, a `_type` field is added to the response so there's always something to show. 
> When not a TTY, `--json` format is used instead of the more human-readable default format.

See following examples.

## Module’s main object

### Before

```console
❯ dagger call
[output of --help]
```

### After

```console
❯ dagger call
_type: Playground
baseImage: python:3.12-alpine
cacheKey: playground-cache
```

## Object with no available functions

### Before

```console
❯ dagger call bar
Error: invalid selection for command "bar": return type "PlaygroundBar" requires a sub-command
Run 'dagger call bar --help' for usage.
exit status 1
```

### After

```console
❯ dagger call bar
_type: PlaygroundBar
```

## Container

### Before

```console
❯ dagger call container
Container evaluated. Use "dagger call container --help" to see available sub-commands.
```

### After

```console
❯ dagger call container
_type: Container
defaultArgs:
    - /bin/sh
entrypoint: []
mounts: []
platform: linux/arm64
stderr: ""
stdout: |
    NAME="Alpine Linux"
    ID=alpine
    VERSION_ID=3.20.0
    PRETTY_NAME="Alpine Linux v3.20"
    HOME_URL="https://alpinelinux.org/"
    BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"
user: ""
workdir: ""
```

## Directory

### Before

```console
❯ dagger call container directory --path=/etc/ssl
Directory evaluated. Use "dagger call echo directory --help" to see available sub-commands.
```

### After

```console
❯ dagger call container directory --path=/etc/ssl
_type: Directory
entries:
    - cert.pem
    - certs
    - ct_log_list.cnf
    - ct_log_list.cnf.dist
    - openssl.cnf
    - openssl.cnf.dist
    - private
```

## File

### Before

```console
❯ dagger call container file --path=/etc/os-release
File evaluated. Use "dagger call echo file --help" to see available sub-commands.
```

### After

```console
❯ dagger call container file --path=/etc/os-release
_type: File
name: os-release
size: 188
```

## List of containers

### Before

```console
❯ dagger call containers
Error: "containers" requires a sub-command
Run 'dagger call foo containers --help' for usage.
exit status 1
```

### After

```console
❯ dagger call containers
- _type: Container
  defaultArgs:
    - /bin/sh
  entrypoint: []
  mounts: []
  platform: linux/arm64
  stderr: ""
  stdout: |
    NAME="Alpine Linux"
    ID=alpine
    VERSION_ID=3.20.0
    PRETTY_NAME="Alpine Linux v3.20"
    HOME_URL="https://alpinelinux.org/"
    BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"
  user: ""
  workdir: ""
- _type: Container
  defaultArgs:
    - /bin/sh
  entrypoint: []
  mounts: []
  platform: linux/amd64
  stderr: ""
  stdout: |
    NAME="Alpine Linux"
    ID=alpine
    VERSION_ID=3.20.0
    PRETTY_NAME="Alpine Linux v3.20"
    HOME_URL="https://alpinelinux.org/"
    BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"
  user: ""
  workdir: ""
- _type: Container
  defaultArgs:
    - /bin/sh
  entrypoint: []
  mounts: []
  platform: linux/386
  stderr: ""
  stdout: |
    NAME="Alpine Linux"
    ID=alpine
    VERSION_ID=3.20.0
    PRETTY_NAME="Alpine Linux v3.20"
    HOME_URL="https://alpinelinux.org/"
    BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"
  user: ""
  workdir: ""
```
