### PR TITLE
fix: ensure we filter buildkit http spans from publishing

### DIFF
--- a/engine/buildkit/containerimage.go
+++ b/engine/buildkit/containerimage.go
@@ -30,6 +30,7 @@ func (c *Client) PublishContainerImage(
 	inputByPlatform map[string]ContainerExport,
 	opts map[string]string, // TODO: make this an actual type, this leaks too much untyped buildkit api
 ) (map[string]string, error) {
+	ctx = buildkitTelemetryContext(ctx)
 	ctx, cancel, err := c.withClientCloseCancel(ctx)
 	if err != nil {
 		return nil, err
@@ -67,6 +68,7 @@ func (c *Client) ExportContainerImage(
 	destPath string,
 	opts map[string]string, // TODO: make this an actual type, this leaks too much untyped buildkit api
 ) (map[string]string, error) {
+	ctx = buildkitTelemetryContext(ctx)
 	ctx, cancel, err := c.withClientCloseCancel(ctx)
 	if err != nil {
 		return nil, err
@@ -125,6 +127,7 @@ func (c *Client) ContainerImageToTarball(
 	inputByPlatform map[string]ContainerExport,
 	opts map[string]string,
 ) (*bksolverpb.Definition, error) {
+	ctx = buildkitTelemetryContext(ctx)
 	ctx, cancel, err := c.withClientCloseCancel(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Reported by @nipuna-perera on [discord](https://discord.com/channels/707636530424053791/1120503349599543376/1245006420706070631):

> Ok now I'm definitely on 0.11.5, but I am still seeing the HTTP spans when doing a Publish. Did that get missed? 
>
> ![image](https://github.com/dagger/dagger/assets/7352848/f9e2f57b-bd77-4c92-b649-89c9aac94f89)

This was introduced in #7386, and made much more apparent in the plain progress from #7272.

We just need to make sure that we apply our magical telemetry context to the export steps as well, which I just missed.

Before:
```
❯ dagger call -v container-echo --string-arg=xyz publish --address=ttl.sh/jedevc-container-echo-1
✔ connect 1.0s
  ✔ starting engine 0.6s
  ✔ starting session 0.3s
✔ initialize 0.8s
✔ Foo.containerEcho(stringArg: "xyz"): Container! 1.8s
  ✔ Container.from(address: "alpine:latest"): Container! 1.3s
✔ Container.publish(address: "ttl.sh/jedevc-container-echo-1"): String! 7.2s
  ✔ exec echo xyz 0.3s
  ┃ xyz                                                                                                                                         
  ✔ export layers 0.2s
  ✘ remotes.docker.resolver.HTTPRequest 0.4s
    ✘ HTTP HEAD 0.4s
  ✘ remotes.docker.resolver.HTTPRequest 0.4s
    ✘ HTTP HEAD 0.4s
  ✘ remotes.docker.resolver.HTTPRequest 0.4s
    ✘ HTTP HEAD 0.4s
  ✔ remotes.docker.resolver.HTTPRequest 0.5s
    ✔ HTTP POST 0.5s
  ✔ remotes.docker.resolver.HTTPRequest 0.5s
    ✔ HTTP POST 0.5s
  ✔ remotes.docker.resolver.HTTPRequest 0.5s
    ✔ HTTP POST 0.5s
  ✔ remotes.docker.resolver.HTTPRequest 1.7s
    ✔ HTTP PUT 1.7s
  ✔ remotes.docker.resolver.HTTPRequest 3.7s
    ✔ HTTP PUT 3.7s
  ✔ remotes.docker.resolver.HTTPRequest 1.5s
    ✔ HTTP PUT 1.5s
  ✘ remotes.docker.resolver.HTTPRequest 0.1s
    ✘ HTTP HEAD 0.1s
  ✔ remotes.docker.resolver.HTTPRequest 0.9s
    ✔ HTTP PUT 0.9s
```

After:
```
ttl.sh/jedevc-container-echo-1@sha256:869f6600b3be2824d03cace274186f81cce2a83eb7e435362b9476adfefafa0a
❯ with-dev dagger call -v container-echo --string-arg=xyz publish --address=ttl.sh/jedevc-container-echo-2
✔ connect 0.3s
  ✔ connecting to engine 0.1s
  ✔ starting session 0.2s
✔ initialize 7.3s
✔ Foo.containerEcho(stringArg: "xyz"): Container! 2.0s
  ✔ Container.from(address: "alpine:latest"): Container! 1.5s
✔ Container.publish(address: "ttl.sh/jedevc-container-echo-2"): String! 7.0s
  ✔ exec echo xyz 0.6s
  ┃ xyz                                                                                                                                         
  ✔ export layers 0.2s

ttl.sh/jedevc-container-echo-2@sha256:448fbcea9c8f19f5823337b7aa27f7d31787dbc94c6013f48b7e69f2690426e2
```