### PR TITLE
ci: build dumb-init for target platform and add verification

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,6 @@ linters:
     - misspell
     - nakedret
     - nolintlint
-    - prealloc
     - revive
     - rowserrcheck
     - staticcheck


### PR DESCRIPTION
dumb-init was accidentally always being built for the host platform, which meant if it was built on an x86 host the published arm64 image would incorrectly be x86.

This fixes that and also adds general purpose verification of all the binaries we build checking that they are of the expected target platform, to reduce the chances of this happening again.

---

Tested the verification logic by locally going back to building the dumb-init binary for the host platform and getting an error when I built for x86 on my arm host.