### PR TITLE
💥 api: return absolute path on export instead of boolean

### DIFF
--- a/.changes/unreleased/Breaking-20240529-181906.yaml
+++ b/.changes/unreleased/Breaking-20240529-181906.yaml
@@ -1,0 +1,6 @@
+kind: Breaking
+body: 'api: return absolute path on export instead of boolean'
+time: 2024-05-29T18:19:06.709015Z
+custom:
+  Author: helderco
+  PR: "7500"

--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -67,7 +68,11 @@ var callCmd = &FuncCommand{
 		switch modType.Name() {
 		case Container, Directory, File:
 			if outputPath != "" {
-				logOutputSuccess(cmd, outputPath)
+				respPath, ok := response.(string)
+				if !ok {
+					return fmt.Errorf("unexpected response %T: %+v", response, response)
+				}
+				cmd.PrintErrf("Saved to %q.\n", respPath)
 				return nil
 			}
 		}
@@ -123,7 +128,13 @@ var callCmd = &FuncCommand{
 			if err := writeOutputFile(outputPath, buf); err != nil {
 				return fmt.Errorf("couldn't write output to file: %w", err)
 			}
-			logOutputSuccess(cmd, outputPath)
+			path, err := filepath.Abs(outputPath)
+			if err != nil {
+				// don't fail because at this point the output has been saved successfully
+				slog.Warn("Failed to get absolute path", "error", err)
+				path = outputPath
+			}
+			cmd.PrintErrf("Saved output to %q.\n", path)
 		}
 
 		writer := cmd.OutOrStdout()
@@ -178,17 +189,6 @@ func writeOutputFile(path string, buf *bytes.Buffer) error {
 		return err
 	}
 	return os.WriteFile(path, buf.Bytes(), 0o644) //nolint: gosec
-}
-
-// logOutputSuccess prints to stderr the output path to the user.
-func logOutputSuccess(cmd *cobra.Command, path string) {
-	path, err := filepath.Abs(path)
-	if err != nil {
-		// don't fail because at this point the output has been saved successfully
-		cmd.PrintErrf("WARNING: failed to get absolute path: %s\n", err)
-		path = outputPath
-	}
-	cmd.PrintErrf("Saved output to %q.\n", path)
 }
 
 func printFunctionResult(w io.Writer, r any) error {

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -2825,13 +2825,13 @@ func (ContainerSuite) TestExport(ctx context.Context, t *testctx.T) {
 
 				if useAsTarball {
 					tarFile := ctr.AsTarball()
-					ok, err := tarFile.Export(ctx, imagePath)
+					actual, err := tarFile.Export(ctx, imagePath)
 					require.NoError(t, err)
-					require.True(t, ok)
+					require.Equal(t, imagePath, actual)
 				} else {
-					ok, err := ctr.Export(ctx, imagePath)
+					actual, err := ctr.Export(ctx, imagePath)
 					require.NoError(t, err)
-					require.True(t, ok)
+					require.Equal(t, imagePath, actual)
 				}
 
 				stat, err := os.Stat(imagePath)
@@ -2865,9 +2865,9 @@ func (ContainerSuite) TestExport(ctx context.Context, t *testctx.T) {
 
 	t.Run("to workdir", func(ctx context.Context, t *testctx.T) {
 		relPath := "./" + identity.NewID() + ".tar"
-		ok, err := ctr.Export(ctx, relPath)
+		actual, err := ctr.Export(ctx, relPath)
 		require.NoError(t, err)
-		require.True(t, ok)
+		require.Equal(t, filepath.Join(wd, relPath), actual)
 
 		stat, err := os.Stat(filepath.Join(wd, relPath))
 		require.NoError(t, err)
@@ -2882,9 +2882,9 @@ func (ContainerSuite) TestExport(ctx context.Context, t *testctx.T) {
 
 	t.Run("to subdir", func(ctx context.Context, t *testctx.T) {
 		relPath := "./foo/" + identity.NewID() + ".tar"
-		ok, err := ctr.Export(ctx, relPath)
+		actual, err := ctr.Export(ctx, relPath)
 		require.NoError(t, err)
-		require.True(t, ok)
+		require.Equal(t, filepath.Join(wd, relPath), actual)
 
 		entries := tarEntries(t, filepath.Join(wd, relPath))
 		require.Contains(t, entries, "oci-layout")
@@ -2893,9 +2893,9 @@ func (ContainerSuite) TestExport(ctx context.Context, t *testctx.T) {
 	})
 
 	t.Run("to outer dir", func(ctx context.Context, t *testctx.T) {
-		ok, err := ctr.Export(ctx, "../")
+		actual, err := ctr.Export(ctx, "../")
 		require.Error(t, err)
-		require.False(t, ok)
+		require.Empty(t, actual)
 	})
 }
 
@@ -3024,15 +3024,15 @@ func (ContainerSuite) TestMultiPlatformExport(ctx context.Context, t *testctx.T)
 				tarFile := c.Container().AsTarball(dagger.ContainerAsTarballOpts{
 					PlatformVariants: variants,
 				})
-				ok, err := tarFile.Export(ctx, dest)
+				actual, err := tarFile.Export(ctx, dest)
 				require.NoError(t, err)
-				require.True(t, ok)
+				require.Equal(t, dest, actual)
 			} else {
-				ok, err := c.Container().Export(ctx, dest, dagger.ContainerExportOpts{
+				actual, err := c.Container().Export(ctx, dest, dagger.ContainerExportOpts{
 					PlatformVariants: variants,
 				})
 				require.NoError(t, err)
-				require.True(t, ok)
+				require.Equal(t, dest, actual)
 			}
 
 			entries := tarEntries(t, dest)
@@ -3118,11 +3118,11 @@ func (ContainerSuite) TestMultiPlatformImport(ctx context.Context, t *testctx.T)
 	tmp := t.TempDir()
 	imagePath := filepath.Join(tmp, "image.tar")
 
-	ok, err := c.Container().Export(ctx, imagePath, dagger.ContainerExportOpts{
+	actual, err := c.Container().Export(ctx, imagePath, dagger.ContainerExportOpts{
 		PlatformVariants: variants,
 	})
 	require.NoError(t, err)
-	require.True(t, ok)
+	require.Equal(t, imagePath, actual)
 
 	for platform, uname := range platformToUname {
 		imported := c.Container(dagger.ContainerOpts{Platform: platform}).

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -654,9 +654,9 @@ func (DirectorySuite) TestExport(ctx context.Context, t *testctx.T) {
 	dir := c.Container().From(alpineImage).Directory("/etc/profile.d")
 
 	t.Run("to absolute dir", func(ctx context.Context, t *testctx.T) {
-		ok, err := dir.Export(ctx, dest)
+		actual, err := dir.Export(ctx, dest)
 		require.NoError(t, err)
-		require.True(t, ok)
+		require.Equal(t, dest, actual)
 
 		entries, err := ls(dest)
 		require.NoError(t, err)
@@ -664,9 +664,9 @@ func (DirectorySuite) TestExport(ctx context.Context, t *testctx.T) {
 	})
 
 	t.Run("to workdir", func(ctx context.Context, t *testctx.T) {
-		ok, err := dir.Export(ctx, ".")
+		actual, err := dir.Export(ctx, ".")
 		require.NoError(t, err)
-		require.True(t, ok)
+		require.Equal(t, wd, actual)
 
 		entries, err := ls(wd)
 		require.NoError(t, err)
@@ -676,17 +676,17 @@ func (DirectorySuite) TestExport(ctx context.Context, t *testctx.T) {
 			dir := dir.WithoutFile("README")
 
 			// by default a delete in the source dir won't overwrite the destination on the host
-			ok, err := dir.Export(ctx, ".")
+			actual, err := dir.Export(ctx, ".")
 			require.NoError(t, err)
-			require.True(t, ok)
+			require.Contains(t, wd, actual)
 			entries, err = ls(wd)
 			require.NoError(t, err)
 			require.Equal(t, []string{"20locale.sh", "README", "color_prompt.sh.disabled"}, entries)
 
 			// wipe results in the destination being replaced with the source entirely, including deletes
-			ok, err = dir.Export(ctx, ".", dagger.DirectoryExportOpts{Wipe: true})
+			actual, err = dir.Export(ctx, ".", dagger.DirectoryExportOpts{Wipe: true})
 			require.NoError(t, err)
-			require.True(t, ok)
+			require.Equal(t, wd, actual)
 			entries, err = ls(wd)
 			require.NoError(t, err)
 			require.Equal(t, []string{"20locale.sh", "color_prompt.sh.disabled"}, entries)
@@ -694,9 +694,9 @@ func (DirectorySuite) TestExport(ctx context.Context, t *testctx.T) {
 	})
 
 	t.Run("to outer dir", func(ctx context.Context, t *testctx.T) {
-		ok, err := dir.Export(ctx, "../")
+		actual, err := dir.Export(ctx, "../")
 		require.Error(t, err)
-		require.False(t, ok)
+		require.Empty(t, actual)
 	})
 }
 

--- a/core/integration/file_test.go
+++ b/core/integration/file_test.go
@@ -207,9 +207,9 @@ func (FileSuite) TestExport(ctx context.Context, t *testctx.T) {
 		targetDir := t.TempDir()
 		dest := filepath.Join(targetDir, "some-file")
 
-		ok, err := file(c).Export(ctx, dest)
+		actual, err := file(c).Export(ctx, dest)
 		require.NoError(t, err)
-		require.True(t, ok)
+		require.Equal(t, dest, actual)
 
 		contents, err := os.ReadFile(dest)
 		require.NoError(t, err)
@@ -223,9 +223,9 @@ func (FileSuite) TestExport(ctx context.Context, t *testctx.T) {
 	t.Run("to relative path", func(ctx context.Context, t *testctx.T) {
 		wd := t.TempDir()
 		c := connect(ctx, t, dagger.WithWorkdir(wd))
-		ok, err := file(c).Export(ctx, "some-file")
+		actual, err := file(c).Export(ctx, "some-file")
 		require.NoError(t, err)
-		require.True(t, ok)
+		require.Equal(t, filepath.Join(wd, "some-file"), actual)
 
 		contents, err := os.ReadFile(filepath.Join(wd, "some-file"))
 		require.NoError(t, err)
@@ -239,25 +239,25 @@ func (FileSuite) TestExport(ctx context.Context, t *testctx.T) {
 	t.Run("to path in outer dir", func(ctx context.Context, t *testctx.T) {
 		wd := t.TempDir()
 		c := connect(ctx, t, dagger.WithWorkdir(wd))
-		ok, err := file(c).Export(ctx, "../some-file")
+		actual, err := file(c).Export(ctx, "../some-file")
 		require.Error(t, err)
-		require.False(t, ok)
+		require.Empty(t, actual)
 	})
 
 	t.Run("to absolute dir", func(ctx context.Context, t *testctx.T) {
 		targetDir := t.TempDir()
 		c := connect(ctx, t)
-		ok, err := file(c).Export(ctx, targetDir)
+		actual, err := file(c).Export(ctx, targetDir)
 		require.Error(t, err)
-		require.False(t, ok)
+		require.Empty(t, actual)
 	})
 
 	t.Run("to workdir", func(ctx context.Context, t *testctx.T) {
 		wd := t.TempDir()
 		c := connect(ctx, t, dagger.WithWorkdir(wd))
-		ok, err := file(c).Export(ctx, ".")
+		actual, err := file(c).Export(ctx, ".")
 		require.Error(t, err)
-		require.False(t, ok)
+		require.Empty(t, actual)
 	})
 
 	t.Run("file under subdir", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -738,9 +738,9 @@ func (ContainerSuite) TestExportServices(ctx context.Context, t *testctx.T) {
 		WithExec([]string{"wget", httpURL})
 
 	filePath := filepath.Join(t.TempDir(), "image.tar")
-	ok, err := client.Export(ctx, filePath)
+	actual, err := client.Export(ctx, filePath)
 	require.NoError(t, err)
-	require.True(t, ok)
+	require.Equal(t, filePath, actual)
 }
 
 func (ContainerSuite) TestMultiPlatformExportServices(ctx context.Context, t *testctx.T) {
@@ -760,11 +760,11 @@ func (ContainerSuite) TestMultiPlatformExportServices(ctx context.Context, t *te
 	}
 
 	dest := filepath.Join(t.TempDir(), "image.tar")
-	ok, err := c.Container().Export(ctx, dest, dagger.ContainerExportOpts{
+	actual, err := c.Container().Export(ctx, dest, dagger.ContainerExportOpts{
 		PlatformVariants: variants,
 	})
 	require.NoError(t, err)
-	require.True(t, ok)
+	require.Equal(t, dest, actual)
 }
 
 func (ServiceSuite) TestContainerPublish(ctx context.Context, t *testctx.T) {
@@ -872,9 +872,9 @@ func (ContainerSuite) TestDirectoryServices(ctx context.Context, t *testctx.T) {
 	t.Run("runs services for Container.Directory.Export", func(ctx context.Context, t *testctx.T) {
 		dest := t.TempDir()
 
-		ok, err := wget.Directory(".").Export(ctx, dest)
+		actual, err := wget.Directory(".").Export(ctx, dest)
 		require.NoError(t, err)
-		require.True(t, ok)
+		require.Equal(t, dest, actual)
 
 		fileContent, err := os.ReadFile(filepath.Join(dest, "index.html"))
 		require.NoError(t, err)
@@ -1040,12 +1040,12 @@ func (ServiceSuite) TestDirectoryExport(ctx context.Context, t *testctx.T) {
 
 	dest := t.TempDir()
 
-	ok, err := c.Git(repoURL, dagger.GitOpts{ExperimentalServiceHost: gitDaemon}).
+	actual, err := c.Git(repoURL, dagger.GitOpts{ExperimentalServiceHost: gitDaemon}).
 		Branch("main").
 		Tree().
 		Export(ctx, dest)
 	require.NoError(t, err)
-	require.True(t, ok)
+	require.Equal(t, dest, actual)
 
 	exportedContent, err := os.ReadFile(filepath.Join(dest, "README.md"))
 	require.NoError(t, err)
@@ -1110,13 +1110,13 @@ func (FileSuite) TestServiceExport(ctx context.Context, t *testctx.T) {
 	dest := t.TempDir()
 	filePath := filepath.Join(dest, "README.md")
 
-	ok, err := c.Git(repoURL, dagger.GitOpts{ExperimentalServiceHost: gitDaemon}).
+	actual, err := c.Git(repoURL, dagger.GitOpts{ExperimentalServiceHost: gitDaemon}).
 		Branch("main").
 		Tree().
 		File("README.md").
 		Export(ctx, filePath)
 	require.NoError(t, err)
-	require.True(t, ok)
+	require.Equal(t, filePath, actual)
 
 	exportedContent, err := os.ReadFile(filePath)
 	require.NoError(t, err)

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -280,13 +280,17 @@ type dirExportArgs struct {
 	Wipe bool `default:"false"`
 }
 
-func (s *directorySchema) export(ctx context.Context, parent *core.Directory, args dirExportArgs) (dagql.Boolean, error) {
+func (s *directorySchema) export(ctx context.Context, parent *core.Directory, args dirExportArgs) (dagql.String, error) {
 	err := parent.Export(ctx, args.Path, !args.Wipe)
 	if err != nil {
-		return false, err
+		return "", err
 	}
-
-	return true, nil
+	bk := parent.Query.Buildkit
+	stat, err := bk.StatCallerHostPath(ctx, args.Path, true)
+	if err != nil {
+		return "", err
+	}
+	return dagql.String(stat.Path), err
 }
 
 type dirDockerBuildArgs struct {

--- a/core/schema/file.go
+++ b/core/schema/file.go
@@ -93,13 +93,17 @@ type fileExportArgs struct {
 	AllowParentDirPath bool `default:"false"`
 }
 
-func (s *fileSchema) export(ctx context.Context, parent *core.File, args fileExportArgs) (dagql.Boolean, error) {
+func (s *fileSchema) export(ctx context.Context, parent *core.File, args fileExportArgs) (dagql.String, error) {
 	err := parent.Export(ctx, args.Path, args.AllowParentDirPath)
 	if err != nil {
-		return false, err
+		return "", err
 	}
-
-	return true, nil
+	bk := parent.Query.Buildkit
+	stat, err := bk.StatCallerHostPath(ctx, args.Path, true)
+	if err != nil {
+		return "", err
+	}
+	return dagql.String(stat.Path), err
 }
 
 type fileWithTimestampsArgs struct {

--- a/core/schema/schema_test.go
+++ b/core/schema/schema_test.go
@@ -109,7 +109,7 @@ func TestCoreModTypeDefs(t *testing.T) {
 
 	exportFn, ok := fileObj.FunctionByName("export")
 	require.True(t, ok)
-	require.Equal(t, core.TypeDefKindBoolean, exportFn.ReturnType.Kind)
+	require.Equal(t, core.TypeDefKindString, exportFn.ReturnType.Kind)
 	require.Len(t, exportFn.Args, 2)
 
 	exportFnPathArg := exportFn.Args[0]

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -164,8 +164,6 @@ type Container {
   """
   Writes the container as an OCI tarball to the destination file path on the host.
   
-  Return true on success.
-  
   It can also export platform variants.
   """
   export(
@@ -200,7 +198,7 @@ type Container {
     Used for multi-platform image.
     """
     platformVariants: [ContainerID!] = []
-  ): Boolean!
+  ): String!
 
   """
   Retrieves the list of exposed ports.
@@ -1025,7 +1023,7 @@ type Directory {
     aren't in the exported directory alone.
     """
     wipe: Boolean = false
-  ): Boolean!
+  ): String!
 
   """Retrieves a file at the given path."""
   file(
@@ -1286,7 +1284,7 @@ type File {
 
     """Location of the written directory (e.g., "output.txt")."""
     path: String!
-  ): Boolean!
+  ): String!
 
   """A unique identifier for this File."""
   id: FileID!

--- a/sdk/elixir/lib/dagger/gen/container.ex
+++ b/sdk/elixir/lib/dagger/gen/container.ex
@@ -183,15 +183,13 @@ defmodule Dagger.Container do
   @doc """
   Writes the container as an OCI tarball to the destination file path on the host.
 
-  Return true on success.
-
   It can also export platform variants.
   """
   @spec export(t(), String.t(), [
           {:platform_variants, [Dagger.ContainerID.t()]},
           {:forced_compression, Dagger.ImageLayerCompression.t() | nil},
           {:media_types, Dagger.ImageMediaTypes.t() | nil}
-        ]) :: {:ok, boolean()} | {:error, term()}
+        ]) :: {:ok, String.t()} | {:error, term()}
   def export(%__MODULE__{} = container, path, optional_args \\ []) do
     selection =
       container.selection

--- a/sdk/elixir/lib/dagger/gen/directory.ex
+++ b/sdk/elixir/lib/dagger/gen/directory.ex
@@ -88,7 +88,8 @@ defmodule Dagger.Directory do
   end
 
   @doc "Writes the contents of the directory to a path on the host."
-  @spec export(t(), String.t(), [{:wipe, boolean() | nil}]) :: {:ok, boolean()} | {:error, term()}
+  @spec export(t(), String.t(), [{:wipe, boolean() | nil}]) ::
+          {:ok, String.t()} | {:error, term()}
   def export(%__MODULE__{} = directory, path, optional_args \\ []) do
     selection =
       directory.selection

--- a/sdk/elixir/lib/dagger/gen/file.ex
+++ b/sdk/elixir/lib/dagger/gen/file.ex
@@ -21,7 +21,7 @@ defmodule Dagger.File do
 
   @doc "Writes the file to a file path on the host."
   @spec export(t(), String.t(), [{:allow_parent_dir_path, boolean() | nil}]) ::
-          {:ok, boolean()} | {:error, term()}
+          {:ok, String.t()} | {:error, term()}
   def export(%__MODULE__{} = file, path, optional_args \\ []) do
     selection =
       file.selection

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -312,7 +312,7 @@ type Container struct {
 	query *querybuilder.Selection
 
 	envVariable *string
-	export      *bool
+	export      *string
 	id          *ContainerID
 	imageRef    *string
 	label       *string
@@ -558,10 +558,8 @@ type ContainerExportOpts struct {
 
 // Writes the container as an OCI tarball to the destination file path on the host.
 //
-// Return true on success.
-//
 // It can also export platform variants.
-func (r *Container) Export(ctx context.Context, path string, opts ...ContainerExportOpts) (bool, error) {
+func (r *Container) Export(ctx context.Context, path string, opts ...ContainerExportOpts) (string, error) {
 	if r.export != nil {
 		return *r.export, nil
 	}
@@ -582,7 +580,7 @@ func (r *Container) Export(ctx context.Context, path string, opts ...ContainerEx
 	}
 	q = q.Arg("path", path)
 
-	var response bool
+	var response string
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
@@ -1849,7 +1847,7 @@ func (r *CurrentModule) WorkdirFile(path string) *File {
 type Directory struct {
 	query *querybuilder.Selection
 
-	export *bool
+	export *string
 	id     *DirectoryID
 	sync   *DirectoryID
 }
@@ -1990,7 +1988,7 @@ type DirectoryExportOpts struct {
 }
 
 // Writes the contents of the directory to a path on the host.
-func (r *Directory) Export(ctx context.Context, path string, opts ...DirectoryExportOpts) (bool, error) {
+func (r *Directory) Export(ctx context.Context, path string, opts ...DirectoryExportOpts) (string, error) {
 	if r.export != nil {
 		return *r.export, nil
 	}
@@ -2003,7 +2001,7 @@ func (r *Directory) Export(ctx context.Context, path string, opts ...DirectoryEx
 	}
 	q = q.Arg("path", path)
 
-	var response bool
+	var response string
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)
@@ -2685,7 +2683,7 @@ type File struct {
 	query *querybuilder.Selection
 
 	contents *string
-	export   *bool
+	export   *string
 	id       *FileID
 	name     *string
 	size     *int
@@ -2726,7 +2724,7 @@ type FileExportOpts struct {
 }
 
 // Writes the file to a file path on the host.
-func (r *File) Export(ctx context.Context, path string, opts ...FileExportOpts) (bool, error) {
+func (r *File) Export(ctx context.Context, path string, opts ...FileExportOpts) (string, error) {
 	if r.export != nil {
 		return *r.export, nil
 	}
@@ -2739,7 +2737,7 @@ func (r *File) Export(ctx context.Context, path string, opts ...FileExportOpts) 
 	}
 	q = q.Arg("path", path)
 
-	var response bool
+	var response string
 
 	q = q.Bind(&response)
 	return response, q.Execute(ctx)

--- a/sdk/php/generated/Container.php
+++ b/sdk/php/generated/Container.php
@@ -153,8 +153,6 @@ class Container extends Client\AbstractObject implements Client\IdAble
     /**
      * Writes the container as an OCI tarball to the destination file path on the host.
      *
-     * Return true on success.
-     *
      * It can also export platform variants.
      */
     public function export(
@@ -162,7 +160,7 @@ class Container extends Client\AbstractObject implements Client\IdAble
         ?array $platformVariants = null,
         ?ImageLayerCompression $forcedCompression = null,
         ?ImageMediaTypes $mediaTypes = null,
-    ): bool
+    ): string
     {
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('export');
         $leafQueryBuilder->setArgument('path', $path);
@@ -175,7 +173,7 @@ class Container extends Client\AbstractObject implements Client\IdAble
         if (null !== $mediaTypes) {
         $leafQueryBuilder->setArgument('mediaTypes', $mediaTypes);
         }
-        return (bool)$this->queryLeaf($leafQueryBuilder, 'export');
+        return (string)$this->queryLeaf($leafQueryBuilder, 'export');
     }
 
     /**

--- a/sdk/php/generated/Directory.php
+++ b/sdk/php/generated/Directory.php
@@ -90,14 +90,14 @@ class Directory extends Client\AbstractObject implements Client\IdAble
     /**
      * Writes the contents of the directory to a path on the host.
      */
-    public function export(string $path, ?bool $wipe = false): bool
+    public function export(string $path, ?bool $wipe = false): string
     {
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('export');
         $leafQueryBuilder->setArgument('path', $path);
         if (null !== $wipe) {
         $leafQueryBuilder->setArgument('wipe', $wipe);
         }
-        return (bool)$this->queryLeaf($leafQueryBuilder, 'export');
+        return (string)$this->queryLeaf($leafQueryBuilder, 'export');
     }
 
     /**

--- a/sdk/php/generated/File.php
+++ b/sdk/php/generated/File.php
@@ -25,14 +25,14 @@ class File extends Client\AbstractObject implements Client\IdAble
     /**
      * Writes the file to a file path on the host.
      */
-    public function export(string $path, ?bool $allowParentDirPath = false): bool
+    public function export(string $path, ?bool $allowParentDirPath = false): string
     {
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('export');
         $leafQueryBuilder->setArgument('path', $path);
         if (null !== $allowParentDirPath) {
         $leafQueryBuilder->setArgument('allowParentDirPath', $allowParentDirPath);
         }
-        return (bool)$this->queryLeaf($leafQueryBuilder, 'export');
+        return (string)$this->queryLeaf($leafQueryBuilder, 'export');
     }
 
     /**

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -600,11 +600,9 @@ class Container(Type):
         platform_variants: "list[Container] | None" = None,
         forced_compression: ImageLayerCompression | None = None,
         media_types: ImageMediaTypes | None = ImageMediaTypes.OCIMediaTypes,
-    ) -> bool:
+    ) -> str:
         """Writes the container as an OCI tarball to the destination file path on
         the host.
-
-        Return true on success.
 
         It can also export platform variants.
 
@@ -632,8 +630,10 @@ class Container(Type):
 
         Returns
         -------
-        bool
-            The `Boolean` scalar type represents `true` or `false`.
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
 
         Raises
         ------
@@ -652,7 +652,7 @@ class Container(Type):
             Arg("mediaTypes", media_types, ImageMediaTypes.OCIMediaTypes),
         ]
         _ctx = self._select("export", _args)
-        return await _ctx.execute(bool)
+        return await _ctx.execute(str)
 
     async def exposed_ports(self) -> list["Port"]:
         """Retrieves the list of exposed ports.
@@ -2206,7 +2206,7 @@ class Directory(Type):
         path: str,
         *,
         wipe: bool | None = False,
-    ) -> bool:
+    ) -> str:
         """Writes the contents of the directory to a path on the host.
 
         Parameters
@@ -2224,8 +2224,10 @@ class Directory(Type):
 
         Returns
         -------
-        bool
-            The `Boolean` scalar type represents `true` or `false`.
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
 
         Raises
         ------
@@ -2239,7 +2241,7 @@ class Directory(Type):
             Arg("wipe", wipe, False),
         ]
         _ctx = self._select("export", _args)
-        return await _ctx.execute(bool)
+        return await _ctx.execute(str)
 
     def file(self, path: str) -> "File":
         """Retrieves a file at the given path.
@@ -2948,7 +2950,7 @@ class File(Type):
         path: str,
         *,
         allow_parent_dir_path: bool | None = False,
-    ) -> bool:
+    ) -> str:
         """Writes the file to a file path on the host.
 
         Parameters
@@ -2962,8 +2964,10 @@ class File(Type):
 
         Returns
         -------
-        bool
-            The `Boolean` scalar type represents `true` or `false`.
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
 
         Raises
         ------
@@ -2977,7 +2981,7 @@ class File(Type):
             Arg("allowParentDirPath", allow_parent_dir_path, False),
         ]
         _ctx = self._select("export", _args)
-        return await _ctx.execute(bool)
+        return await _ctx.execute(str)
 
     async def id(self) -> FileID:
         """A unique identifier for this File.

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -1702,7 +1702,6 @@ impl Container {
         }
     }
     /// Writes the container as an OCI tarball to the destination file path on the host.
-    /// Return true on success.
     /// It can also export platform variants.
     ///
     /// # Arguments
@@ -1711,13 +1710,12 @@ impl Container {
     ///
     /// Path can be relative to the engine's workdir or absolute.
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn export(&self, path: impl Into<String>) -> Result<bool, DaggerError> {
+    pub async fn export(&self, path: impl Into<String>) -> Result<String, DaggerError> {
         let mut query = self.selection.select("export");
         query = query.arg("path", path.into());
         query.execute(self.graphql_client.clone()).await
     }
     /// Writes the container as an OCI tarball to the destination file path on the host.
-    /// Return true on success.
     /// It can also export platform variants.
     ///
     /// # Arguments
@@ -1730,7 +1728,7 @@ impl Container {
         &self,
         path: impl Into<String>,
         opts: ContainerExportOpts,
-    ) -> Result<bool, DaggerError> {
+    ) -> Result<String, DaggerError> {
         let mut query = self.selection.select("export");
         query = query.arg("path", path.into());
         if let Some(platform_variants) = opts.platform_variants {
@@ -3529,7 +3527,7 @@ impl Directory {
     ///
     /// * `path` - Location of the copied directory (e.g., "logs/").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn export(&self, path: impl Into<String>) -> Result<bool, DaggerError> {
+    pub async fn export(&self, path: impl Into<String>) -> Result<String, DaggerError> {
         let mut query = self.selection.select("export");
         query = query.arg("path", path.into());
         query.execute(self.graphql_client.clone()).await
@@ -3544,7 +3542,7 @@ impl Directory {
         &self,
         path: impl Into<String>,
         opts: DirectoryExportOpts,
-    ) -> Result<bool, DaggerError> {
+    ) -> Result<String, DaggerError> {
         let mut query = self.selection.select("export");
         query = query.arg("path", path.into());
         if let Some(wipe) = opts.wipe {
@@ -4087,7 +4085,7 @@ impl File {
     ///
     /// * `path` - Location of the written directory (e.g., "output.txt").
     /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
-    pub async fn export(&self, path: impl Into<String>) -> Result<bool, DaggerError> {
+    pub async fn export(&self, path: impl Into<String>) -> Result<String, DaggerError> {
         let mut query = self.selection.select("export");
         query = query.arg("path", path.into());
         query.execute(self.graphql_client.clone()).await
@@ -4102,7 +4100,7 @@ impl File {
         &self,
         path: impl Into<String>,
         opts: FileExportOpts,
-    ) -> Result<bool, DaggerError> {
+    ) -> Result<String, DaggerError> {
         let mut query = self.selection.select("export");
         query = query.arg("path", path.into());
         if let Some(allow_parent_dir_path) = opts.allow_parent_dir_path {

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -1192,7 +1192,7 @@ export class CacheVolume extends BaseClient {
 export class Container extends BaseClient {
   private readonly _id?: ContainerID = undefined
   private readonly _envVariable?: string = undefined
-  private readonly _export?: boolean = undefined
+  private readonly _export?: string = undefined
   private readonly _imageRef?: string = undefined
   private readonly _label?: string = undefined
   private readonly _platform?: Platform = undefined
@@ -1210,7 +1210,7 @@ export class Container extends BaseClient {
     parent?: { queryTree?: QueryTree[]; ctx: Context },
     _id?: ContainerID,
     _envVariable?: string,
-    _export?: boolean,
+    _export?: string,
     _imageRef?: string,
     _label?: string,
     _platform?: Platform,
@@ -1487,8 +1487,6 @@ export class Container extends BaseClient {
   /**
    * Writes the container as an OCI tarball to the destination file path on the host.
    *
-   * Return true on success.
-   *
    * It can also export platform variants.
    * @param path Host's destination path (e.g., "./tarball").
    *
@@ -1506,7 +1504,7 @@ export class Container extends BaseClient {
   export = async (
     path: string,
     opts?: ContainerExportOpts,
-  ): Promise<boolean> => {
+  ): Promise<string> => {
     if (this._export) {
       return this._export
     }
@@ -1516,7 +1514,7 @@ export class Container extends BaseClient {
       mediaTypes: { is_enum: true },
     }
 
-    const response: Awaited<boolean> = await computeQuery(
+    const response: Awaited<string> = await computeQuery(
       [
         ...this._queryTree,
         {
@@ -2898,7 +2896,7 @@ export class CurrentModule extends BaseClient {
  */
 export class Directory extends BaseClient {
   private readonly _id?: DirectoryID = undefined
-  private readonly _export?: boolean = undefined
+  private readonly _export?: string = undefined
   private readonly _sync?: DirectoryID = undefined
 
   /**
@@ -2907,7 +2905,7 @@ export class Directory extends BaseClient {
   constructor(
     parent?: { queryTree?: QueryTree[]; ctx: Context },
     _id?: DirectoryID,
-    _export?: boolean,
+    _export?: string,
     _sync?: DirectoryID,
   ) {
     super(parent)
@@ -3043,12 +3041,12 @@ export class Directory extends BaseClient {
   export = async (
     path: string,
     opts?: DirectoryExportOpts,
-  ): Promise<boolean> => {
+  ): Promise<string> => {
     if (this._export) {
       return this._export
     }
 
-    const response: Awaited<boolean> = await computeQuery(
+    const response: Awaited<string> = await computeQuery(
       [
         ...this._queryTree,
         {
@@ -3770,7 +3768,7 @@ export class FieldTypeDef extends BaseClient {
 export class File extends BaseClient {
   private readonly _id?: FileID = undefined
   private readonly _contents?: string = undefined
-  private readonly _export?: boolean = undefined
+  private readonly _export?: string = undefined
   private readonly _name?: string = undefined
   private readonly _size?: number = undefined
   private readonly _sync?: FileID = undefined
@@ -3782,7 +3780,7 @@ export class File extends BaseClient {
     parent?: { queryTree?: QueryTree[]; ctx: Context },
     _id?: FileID,
     _contents?: string,
-    _export?: boolean,
+    _export?: string,
     _name?: string,
     _size?: number,
     _sync?: FileID,
@@ -3844,12 +3842,12 @@ export class File extends BaseClient {
    * @param path Location of the written directory (e.g., "output.txt").
    * @param opts.allowParentDirPath If allowParentDirPath is true, the path argument can be a directory path, in which case the file will be created in that directory.
    */
-  export = async (path: string, opts?: FileExportOpts): Promise<boolean> => {
+  export = async (path: string, opts?: FileExportOpts): Promise<string> => {
     if (this._export) {
       return this._export
     }
 
-    const response: Awaited<boolean> = await computeQuery(
+    const response: Awaited<string> = await computeQuery(
       [
         ...this._queryTree,
         {

--- a/sdk/typescript/api/test/api.spec.ts
+++ b/sdk/typescript/api/test/api.spec.ts
@@ -353,14 +353,14 @@ describe("TypeScript SDK api", function () {
           seededPlatformVariants.push(ctr)
         }
 
-        const exportID = `./export-${randomUUID()}`
+        const exportID = `export-${randomUUID()}`
 
-        const isSuccess = await client.container().export(exportID, {
+        const success = await client.container().export(`./${exportID}`, {
           platformVariants: seededPlatformVariants,
         })
 
         await fs.unlinkSync(exportID)
-        assert.strictEqual(isSuccess, true)
+        assert.ok(success.endsWith(exportID))
       },
       { LogOutput: process.stderr },
     )


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/7131

It's much more useful for `export` to return the absolute path on the host where the asset (Container, Directory, File) was exported to, rather than a boolean. The boolean wasn't useful at all because it's never false. It's either true or an error.

It's possibly a breaking change in Go if any user is assigning the return value (boolean), which is now a different type. However, since that boolean value is useless this is considered very low impact. Affected users (if any), aren't probably aware that it's never `false`.