### PR TITLE
executor: always include search setting in resolv.conf

### DIFF
--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -192,6 +192,7 @@ func (w *Worker) setupNetwork(ctx context.Context, state *execState) error {
 	}
 
 	scanner := bufio.NewScanner(baseResolvFile)
+	var replaced bool
 	for scanner.Scan() {
 		line := scanner.Text()
 		if !strings.HasPrefix(line, "search") {
@@ -205,9 +206,15 @@ func (w *Worker) setupNetwork(ctx context.Context, state *execState) error {
 		if _, err := fmt.Fprintln(ctrResolvFile, "search", strings.Join(domains, " ")); err != nil {
 			return fmt.Errorf("write resolv.conf: %w", err)
 		}
+		replaced = true
 	}
 	if err := scanner.Err(); err != nil {
 		return fmt.Errorf("read resolv.conf: %w", err)
+	}
+	if !replaced {
+		if _, err := fmt.Fprintln(ctrResolvFile, "search", extraSearchDomain); err != nil {
+			return fmt.Errorf("write resolv.conf: %w", err)
+		}
 	}
 
 	if len(w.execMD.HostAliases) == 0 {


### PR DESCRIPTION
Draft pending:
- [x] test, need to fully grok the situations in which this bug was occurring since it seems to be host dependent
   - Added now, FTR the host dependency was whether or not the host's /etc/resolv.conf had a `search` setting or not. That ends up propagated to the engine container and to execs, but this bug was triggered when there was no `search` setting in the base resolv.conf, so it ended up being dependent on the resolv.conf of the host.