### PR TITLE
engine: pass system proxy envs to git subcommands

### DIFF
--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -807,13 +807,7 @@ func (w *Worker) setupSecretScrubbing(ctx context.Context, state *execState) err
 }
 
 func (w *Worker) setProxyEnvs(_ context.Context, state *execState) error {
-	for _, upperProxyEnvName := range []string{
-		"HTTP_PROXY",
-		"HTTPS_PROXY",
-		"FTP_PROXY",
-		"NO_PROXY",
-		"ALL_PROXY",
-	} {
+	for _, upperProxyEnvName := range engine.ProxyEnvNames {
 		upperProxyVal, upperSet := state.origEnvMap[upperProxyEnvName]
 
 		lowerProxyEnvName := strings.ToLower(upperProxyEnvName)

--- a/engine/consts.go
+++ b/engine/consts.go
@@ -6,4 +6,18 @@ const (
 	StderrPrefix = "\x02,"
 	ResizePrefix = "resize,"
 	ExitPrefix   = "exit,"
+
+	HTTPProxyEnvName  = "HTTP_PROXY"
+	HTTPSProxyEnvName = "HTTPS_PROXY"
+	FTPProxyEnvName   = "FTP_PROXY"
+	NoProxyEnvName    = "NO_PROXY"
+	AllProxyEnvName   = "ALL_PROXY"
 )
+
+var ProxyEnvNames = []string{
+	HTTPProxyEnvName,
+	HTTPSProxyEnvName,
+	FTPProxyEnvName,
+	NoProxyEnvName,
+	AllProxyEnvName,
+}


### PR DESCRIPTION
Otherwise, operations done by shelling out to git won't honor the proxy values.

The integ test added here runs a pipeline that triggers a git pull and then asserts that the squid proxy logs show a connection to github.com.

Fixes https://github.com/dagger/dagger/issues/7503