### PR TITLE
cli: convert Windows paths to / slash format

### DIFF
--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -244,6 +244,7 @@ func (v *directoryValue) Get(ctx context.Context, dag *dagger.Client, modSrc *da
 	// POSIX "portable filename character set":
 	// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282
 	path, viewName, _ := strings.Cut(path, ":")
+	path = filepath.ToSlash(path) // make windows paths usable in the Linux engine container
 	return modSrc.ResolveDirectoryFromCaller(path, dagger.ModuleSourceResolveDirectoryFromCallerOpts{
 		ViewName: viewName,
 	}).Sync(ctx)
@@ -319,6 +320,7 @@ func (v *fileValue) Get(_ context.Context, dag *dagger.Client, _ *dagger.ModuleS
 			return nil, fmt.Errorf("failed to resolve absolute path: %w", err)
 		}
 	}
+	vStr = filepath.ToSlash(vStr) // make windows paths usable in the Linux engine container
 	return dag.Host().File(vStr), nil
 }
 

--- a/engine/client/filesync.go
+++ b/engine/client/filesync.go
@@ -281,6 +281,7 @@ func (t FilesyncTarget) DiffCopy(stream filesync.FileSend_DiffCopyServer) (rerr 
 }
 
 func (f Filesyncer) fullRootPathAndBaseName(reqPath string) (rootPath string, baseName string, err error) {
+	// NOTE: filepath.Clean also handles calling FromSlash (relevant when this is a Windows client)
 	reqPath = filepath.Clean(reqPath)
 
 	if f.rootDir == "" {


### PR DESCRIPTION
Before this, file+dir arg values to dagger call on a Windows client were not converted from `\` format to `/` format, which resulted in calls like `filepath.Split` in the Linux engine container to not work as expected.

Now the CLI calls `filepath.ToSlash` before sending paths, which *helps* handle the paths better in the engine container; specifically enough to avoid at least one bug that resulted in the engine trying to find a path at e.g. `/C:\Foo\Bar`.

To be clear, this is probably not the end of our need for improved Windows path handling, but may be enough to at least squash this one bug.

---

Fixes https://github.com/dagger/dagger/issues/7505

TODO:
- [x] Test on Windows manually to verify (mostly theoretical at this point still)
   * Done, could successfully call both of these now
      * `dagger.exe -m github.com/shykes/daggerverse/wolfi@v0.1.2 call container with-file --path=/README.md --source=C:\\Users\me\repo\README.md with-exec --args="cat","/README.md" stdout`
      * `dagger.exe -m github.com/shykes/daggerverse/wolfi@v0.1.2 call container with-file --path=/README.md --source=.\README.md with-exec --args="cat","/README.md" stdout`