### PR TITLE
improve releasing during v0.11.6

### DIFF
--- a/.github/workflows/_dagger_call.yml
+++ b/.github/workflows/_dagger_call.yml
@@ -24,7 +24,7 @@ on:
 
       size:
         type: string
-        default: "dagger-v0-11-5-4c-nvme"
+        default: "dagger-v0-11-6-4c-nvme"
         required: false
 
       dagger-version:
@@ -110,7 +110,7 @@ jobs:
 
   dagger-runner-v2-dind:
     if: ${{ inputs.dev-engine && github.repository == 'dagger/dagger' }}
-    runs-on: dagger-v0-11-5-dind
+    runs-on: dagger-v0-11-6-dind
     concurrency:
       group: ${{github.workflow}}-${{ inputs.function }}-${{ github.head_ref || github.run_id }}-v2
       cancel-in-progress: true

--- a/.github/workflows/_dagger_call.yml
+++ b/.github/workflows/_dagger_call.yml
@@ -29,7 +29,7 @@ on:
 
       dagger-version:
         type: string
-        default: "0.11.5"
+        default: "0.11.6"
         required: false
 
 jobs:

--- a/.github/workflows/_new_release_notification.yml
+++ b/.github/workflows/_new_release_notification.yml
@@ -16,6 +16,6 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.NEW_RELEASE_DISCORD_WEBHOOK }}
         uses: dagger/dagger-for-github@v5
         with:
-          version: "0.11.5"
+          version: "0.11.6"
           module: "github.com/gerhard/daggerverse/notify@2024-02-13"
           args: discord --webhook-url env:DISCORD_WEBHOOK --message '${{ inputs.message }}'

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -26,7 +26,7 @@ jobs:
     secrets: inherit
     with:
       function: test all --race=true --parallel=16
-      size: "dagger-v0-11-5-16c-nvme"
+      size: "dagger-v0-11-6-16c-nvme"
 
   # Run Engine tests in dev Engine so that we can spot integration failures early
   # Only run a subset of important test cases since we just need to verify basic

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
   publish:
     if: ${{ github.repository == 'dagger/dagger' && github.event_name == 'push' }}
     # Use our own Dagger runner when running in the dagger/dagger repo (including PRs)
-    runs-on: dagger-v0-11-5-16c-nvme
+    runs-on: dagger-v0-11-6-16c-nvme
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -155,7 +155,7 @@ and improve it. We want small, constant improvements which compound. Therefore:
 > SDK. This will ensure that all the APIs in the SDK are also available in the
 > Engine it depends on.
 
-- [ ] Create e.g. `.changes/v0.11.5.md` by either running `changie batch patch`
+- [ ] Create e.g. `.changes/v0.11.6.md` by either running `changie batch patch`
       (or `changie batch minor` if this is a new minor).
 
 > [!NOTE]
@@ -163,9 +163,9 @@ and improve it. We want small, constant improvements which compound. Therefore:
 > If you do not have `changie` installed, see https://changie.dev
 
 - [ ] Make any necessary edits to the newly generated file, e.g.
-      `.changes/v0.11.5.md`
+      `.changes/v0.11.6.md`
 - [ ] Update `CHANGELOG.md` by running `changie merge`.
-- [ ] `30 mins` Submit a PR - e.g. `add-v0.11.5-release-notes` with the new release notes
+- [ ] `30 mins` Submit a PR - e.g. `add-v0.11.6-release-notes` with the new release notes
       so that they can be used in the new release. Get the PR reviewed & merged.
       The merge commit is what gets tagged in the next step.
 - [ ] Ensure that all checks are green ✅ for the `<ENGINE_GIT_SHA>` on the
@@ -282,30 +282,41 @@ cd ci
 go mod edit -require github.com/dagger/dagger@${ENGINE_VERSION:?must be set}
 go mod tidy
 cd ..
+```
 
-# Check that the most important workflow works locally (requires local Docker):
-./hack/make engine:test
+- [ ] Update all dagger versions in `.github/` to `$ENGINE_VERSION`
+      - The version numbers (of the form `<major>.<minor>.<patch>`) should be updated to the new version
+      - The worker runner versions (of the form `dagger-v<major>-<minor>-<patch>-<worker>`)
 
+- [ ] Update all dagger versions in `docs/current_docs/partials/_install-cli.mdx` to `$ENGINE_VERSION`
+
+- [ ] Open a PR with the title `Improve Releasing during $ENGINE_VERSION`
+
+```console
 git checkout -b improve-releasing-during-${ENGINE_VERSION:?must be set}
+git add .  # or any other files changed during the last few steps
+git commit -s -m "Improve releasing during $ENGINE_VERSION"
+git push 
+```
 
-# Update .github/workflows dagger versions $ENGINE_VERSION
-# Update docs/current_docs files to point to new dagger version
+Ensure that all the workflows succeed before continuing (specifically `test` and `testdev`)!
 
-# Commit & push
+- [ ] Download and install the latest release, and continue the rest of the
+      release process using the just-released CLI.
 
-# Test using the just-released CLI
-# curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin DAGGER_VERSION=0.11.5 sh
-# mv ~/.local/bin/dagger{,-0.11.5}
-dagger version | grep ${ENGINE_VERSION:?must be set}
-dagger run ./hack/make engine:test
+```console
+curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin DAGGER_VERSION=0.11.6 sh
+# install the cli to dagger-0.11.6, and symlink dagger to it
+mv ~/.local/bin/dagger{,-0.11.6}
+ln -s ~/.local/bin/dagger{-0.11.6,}
+
+dagger version
 ```
 
 - [ ] After you confirm that our internal tooling works with the new Go SDK
-      release, [🐙
-      github.com/dagger/dagger-go-sdk](https://github.com/dagger/dagger-go-sdk/tags),
-      double-check that is was picked up by
-      [pkg.go.dev](https://pkg.go.dev/dagger.io/dagger). You can manually request
-      this new version via `open https://pkg.go.dev/dagger.io/dagger@${GO_SDK_VERSION:?must be set}`.
+      release, [🐙 github.com/dagger/dagger-go-sdk](https://github.com/dagger/dagger-go-sdk/tags),
+      double-check that is was picked up by [pkg.go.dev](https://pkg.go.dev/dagger.io/dagger).
+      You can manually request this new version via `open https://pkg.go.dev/dagger.io/dagger@${GO_SDK_VERSION:?must be set}`.
       The new version can take up to `60mins` to appear, it's OK to move on.
 
 > [!NOTE]
@@ -559,7 +570,8 @@ git push origin <NEXT_PATCH_VERSION> --force
 ## 🍺 dagger Homebrew ⏱ `2mins`
 
 - [ ] Check that Dagger Homebrew formula has been updated to latest, e.g.
-  [dagger 0.10.2](https://github.com/Homebrew/homebrew-core/pull/165904)
+  [dagger 0.10.2](https://github.com/Homebrew/homebrew-core/pull/165904).
+  This is automated, but note that it may take several hours to trigger.
 
 ## ❄️ nix ⏱ `2mins`
 

--- a/ci/go.mod
+++ b/ci/go.mod
@@ -2,7 +2,7 @@ module github.com/dagger/dagger/ci
 
 go 1.21.7
 
-require github.com/dagger/dagger/engine/distconsts v0.11.5
+require github.com/dagger/dagger/engine/distconsts v0.11.6
 
 replace github.com/dagger/dagger/engine/distconsts => ../engine/distconsts
 

--- a/dagger.json
+++ b/dagger.json
@@ -8,7 +8,7 @@
     }
   ],
   "source": "ci",
-  "engineVersion": "v0.11.5",
+  "engineVersion": "v0.11.6",
   "views": [
     {
       "name": "default",

--- a/docs/current_docs/partials/_install-cli.mdx
+++ b/docs/current_docs/partials/_install-cli.mdx
@@ -30,17 +30,17 @@ If you do not have Homebrew installed, or you want to install a specific version
 
 ```shell
 cd /usr/local
-curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.11.5 sh
+curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.11.6 sh
 
 ./bin/dagger version
-dagger 0.11.5 (registry.dagger.io/engine) darwin/arm64
+dagger 0.11.6 (registry.dagger.io/engine) darwin/arm64
 ```
 
 If your user account doesn't have sufficient privileges to install in `/usr/local` and `sudo` is available, use the following command instead:
 
 ```shell
 cd /usr/local
-curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.11.5 sudo sh
+curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.11.6 sudo sh
 ```
 
 </TabItem>
@@ -63,10 +63,10 @@ dagger is $HOME/.local/bin/dagger
 If you want to install a specific version of `dagger`, you can run:
 
 ```shell
-curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.11.5 sh
+curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.11.6 sh
 
 ./bin/dagger version
-dagger 0.11.5 (registry.dagger.io/engine) linux/amd64
+dagger 0.11.6 (registry.dagger.io/engine) linux/amd64
 ```
 
 </TabItem>
@@ -93,7 +93,7 @@ If you want to install a specific version of `dagger`, pass in a version number 
 
 ```Powershell
 $script = Invoke-WebRequest -UseBasicParsing -Uri https://dl.dagger.io/dagger/install.ps1
-$params = "-DaggerVersion 0.11.5"
+$params = "-DaggerVersion 0.11.6"
 "$script $params" | Invoke-Expression
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dagger/dagger
 go 1.21.7
 
 require (
-	dagger.io/dagger v0.11.5
+	dagger.io/dagger v0.11.6
 	github.com/dagger/dagger/engine/distconsts v0.11.5
 )
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.7
 
 require (
 	dagger.io/dagger v0.11.6
-	github.com/dagger/dagger/engine/distconsts v0.11.5
+	github.com/dagger/dagger/engine/distconsts v0.11.6
 )
 
 replace (


### PR DESCRIPTION
TODO:
- [ ] get rid of references to `./hack/make` 
- [ ] clarify `# Update .github/workflows dagger versions $ENGINE_VERSION` and `# Update docs/current_docs files to point to new dagger version` steps
   - I had to do some careful grepping around (can't prefix with `v` to find the docs file, yamls use v0-11-5, etc.)
- [ ] add note that homebrew-core repo may not get an automated update PR for a few hours (based on timestamps from previous release)