### PR TITLE
fix(ts-sdk) set corepack inside of SDK install instead of global

### DIFF
--- a/sdk/typescript/.changes/unreleased/Fixed-20240531-102026.yaml
+++ b/sdk/typescript/.changes/unreleased/Fixed-20240531-102026.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Correctly support all node package managers dependencies downloading
+time: 2024-05-31T10:20:26.694994+02:00
+custom:
+  Author: TomChv
+  PR: "7518"

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -90,7 +90,7 @@ func (t *TypescriptSdk) ModuleRuntime(ctx context.Context, modSource *ModuleSour
 	case Node:
 		return ctr.
 			// Install dependencies
-			WithExec([]string{"npm", "install", "--omit=dev"}).
+			WithExec([]string{"yarn", "install", "--production"}).
 			// need to specify --tsconfig because final runtime container will change working directory to a separate scratch
 			// dir, without this the paths mapped in the tsconfig.json will not be used and js module loading will fail
 			// need to specify --no-deprecation because the default package.json has no main field which triggers a warning
@@ -177,8 +177,6 @@ func (t *TypescriptSdk) Base(runtime SupportedTSRuntime) (*Container, error) {
 		return dag.Container().
 			From(nodeImageRef).
 			WithoutEntrypoint().
-			// Enable corepack so we can use yarn v4 which is supposed to be faster than npm or yarn v1.
-			WithExec([]string{"corepack", "enable"}).
 			// Install default CA certificates and configure node to use them instead of its compiled in CA bundle.
 			// This enables use of custom CA certificates if configured in the dagger engine.
 			WithExec([]string{"apk", "add", "ca-certificates"}).
@@ -263,6 +261,8 @@ func (t *TypescriptSdk) installedSDK(ctr *Container, runtime SupportedTSRuntime)
 		return ctr.WithExec([]string{"bun", "install", "--no-verify", "--no-progress", "--summary"}).Directory(ModSourceDirPath)
 	case Node:
 		return ctr.
+			// Enable corepack so we can use yarn v4 which is supposed to be faster than npm or yarn v1.
+			WithExec([]string{"corepack", "enable"}).
 			WithExec([]string{"yarn", "set", "version", "stable"}).
 			WithExec([]string{"yarn", "workspaces", "focus", "--production"}).Directory(ModSourceDirPath)
 	default:

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -90,7 +90,7 @@ func (t *TypescriptSdk) ModuleRuntime(ctx context.Context, modSource *ModuleSour
 	case Node:
 		return ctr.
 			// Install dependencies
-			WithExec([]string{"yarn", "install", "--production"}).
+			WithExec([]string{"yarn", "install"}).
 			// need to specify --tsconfig because final runtime container will change working directory to a separate scratch
 			// dir, without this the paths mapped in the tsconfig.json will not be used and js module loading will fail
 			// need to specify --no-deprecation because the default package.json has no main field which triggers a warning

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -90,7 +90,8 @@ func (t *TypescriptSdk) ModuleRuntime(ctx context.Context, modSource *ModuleSour
 	case Node:
 		return ctr.
 			// Install dependencies
-			WithExec([]string{"yarn", "install", "--production"}).
+			//WithExec([]string{"yarn", "set", "version", "stable"}).
+			WithExec([]string{"npm", "install", "--omit=dev"}).
 			// need to specify --tsconfig because final runtime container will change working directory to a separate scratch
 			// dir, without this the paths mapped in the tsconfig.json will not be used and js module loading will fail
 			// need to specify --no-deprecation because the default package.json has no main field which triggers a warning

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -90,7 +90,6 @@ func (t *TypescriptSdk) ModuleRuntime(ctx context.Context, modSource *ModuleSour
 	case Node:
 		return ctr.
 			// Install dependencies
-			//WithExec([]string{"yarn", "set", "version", "stable"}).
 			WithExec([]string{"npm", "install", "--omit=dev"}).
 			// need to specify --tsconfig because final runtime container will change working directory to a separate scratch
 			// dir, without this the paths mapped in the tsconfig.json will not be used and js module loading will fail


### PR DESCRIPTION
#7096 introduced a regression by using `yarn install --production`. If the field `packagaManager` is set, it might lead to failure because yarn post v1.22.11 doesn't support the `--production` flag anymore, it has been removed in favor of `yarn workspaces focus --production`.

However, depending on the yarn major version (v2, v3, v4), the options are different but also the results and the way they handle subdependencies.

### Current state (that work)

~~It seems `npm` is the only package manager that actually force install all the sub dependencies, which ensure the TS SDK runtime properly works.~~

By initialiazing corepack inside the SDK installation, we ignore the field `packageManager` when installing dependencies with yarn, which will be compatible with any package manager version.
It's a nice way to keep yarn because it's faster than npm but be generic!

**Also based ont the discussion below, I removed the `--production` flag since TS module are not transpiled to javascript, and dependencies are isolated into their own sub `package.json`, it is less likely that unusefull dependencies will be installed from `devDependencies`, and if that's the case, it should impact performances that much**

### Things I tried that didn't worked

**Adapt yarn install command based on the yarn version**
- For some reasons, every major version has a special way to handle production dependencies.
  * v1: `yarn install --production`
  * v2: `yarn install`, there's no concept of `--production` (https://stackoverflow.com/questions/70992443/yarn-2-0-zero-installs-production-vs-development-deployment)
  * v3: `yarn workspaces focus --production` but it requires to enable the worspace plugin (https://stackoverflow.com/questions/74104685/how-to-install-only-production-dependencies-in-modern-yarn-when-using-node-modul)
  * v4: `yarn workspace focus --production` (no pre setting required)

However, it seems that the v3 and v2 doesn't correctly save `node_modules` subDependencies which leads to fails in the runtime (because of missing sub dep, example: `@opentelemetry/core`)

**Use pnpm**
- Create issue if you have the field `packageManager` set to `yarn`, you need to force use `pnpm` using `corepack use pnpm@<tag>`. This is not optimal at all.
- Same issues as yarn, pnpm has no such concept as not module, you can use `--shameless-hoist` to fill `node_modules` but it creates the same issue.

**Use `yarn install`**
- Same issue, I got some missing dependencies, it seems each package manager and each version of this package has a specific way of doing things.

**Force set yarn pkgManager field inside runtime**
- I'm testing right now, this is the last solution I have in mind, it's still failing :/

**Use `npm install --production`**
This is the worst solution possible because it might impact performances, but this ensure generic support no matter the package manager used
Npm works, but will reduce TS performances sadly.

### Another possible solution

Another workaround would be for you to set `packageManager`to v4.x.x which supports `yarn workspace focus --production` natively.
So we check the yarn version and then:
- if yarn version < 2 -> `yarn install --production`
- if > 4 `yarn workspace focus --production`
