### PR TITLE
engine: fix engine panic during dagger call ... terminal with nesting

### DIFF
--- a/core/integration/module_terminal_test.go
+++ b/core/integration/module_terminal_test.go
@@ -232,6 +232,86 @@ type Test struct {
 		err = cmd.Wait()
 		require.NoError(t, err)
 	})
+
+	t.Run("nested client", func(t *testing.T) {
+		modDir := t.TempDir()
+		err := os.WriteFile(filepath.Join(modDir, "main.go"), []byte(`package main
+import "context"
+
+func New(ctx context.Context, daggerCLI *File) *Test {
+	return &Test{
+		Ctr: dag.Container().
+			From("mirror.gcr.io/alpine:3.18").
+			WithWorkdir("/w").
+			WithMountedFile("/d", daggerCLI).
+			WithDefaultTerminalCmd([]string{"/bin/sh"}),
+	}
+}
+
+type Test struct {
+	Ctr *Container
+}
+`), 0644)
+		require.NoError(t, err)
+
+		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")
+		require.NoError(t, err)
+
+		// cache the module load itself so there's less to wait for in the shell invocation below
+		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "functions")
+		require.NoError(t, err)
+
+		// timeout for waiting for each expected line is very generous in case CI is under heavy load or something
+		console, err := newTUIConsole(t, 60*time.Second)
+		require.NoError(t, err)
+		defer console.Close()
+
+		tty := console.Tty()
+
+		// We want the size to be big enough to fit the output we're expecting, but increasing
+		// the size also eventually slows down the tests due to more output being generated and
+		// needing parsing.
+		err = pty.Setsize(tty, &pty.Winsize{Rows: 6, Cols: 41})
+		require.NoError(t, err)
+
+		// TODO:
+		// TODO:
+		// TODO: This won't work if doing a go test direct on macos/windows (though calling in a module should be fine)
+		cmd := hostDaggerCommand(ctx, t, modDir, "call", "--dagger-cli", daggerCliPath(t), "ctr", "terminal", "--experimental-privileged-nesting")
+		cmd.Stdin = tty
+		cmd.Stdout = tty
+		cmd.Stderr = tty
+
+		err = cmd.Start()
+		require.NoError(t, err)
+
+		_, err = console.ExpectString("/w #")
+		require.NoError(t, err)
+
+		_, err = console.SendLine(`echo '{defaultPlatform} | dagger -s query`)
+		require.NoError(t, err)
+
+		err = console.ExpectLineRegex(ctx, "{")
+		require.NoError(t, err)
+
+		err = console.ExpectLineRegex(ctx, `    "defaultPlatform": "linux/.*"`)
+		require.NoError(t, err)
+
+		err = console.ExpectLineRegex(ctx, "}")
+		require.NoError(t, err)
+
+		_, err = console.ExpectString("/w #")
+		require.NoError(t, err)
+
+		_, err = console.SendLine("exit")
+		require.NoError(t, err)
+
+		go console.ExpectEOF()
+
+		err = cmd.Wait()
+		require.NoError(t, err)
+	})
+
 }
 
 // tuiConsole wraps expect.Console with methods that allow us to enforce


### PR DESCRIPTION
TODO:
- [ ] Actually fix, just reproing in integ test so far and sending out so I don't forget about this
   * Problem is the engine hits a nil panic due to `dagql.CurrentID()` being nil during `Query.RegisterClient`, which is due to the fact that the terminal is being connected to direct over a websocket at that point, not via a gql query
   * This will also be fixed by https://github.com/dagger/dagger/pull/7315, so if that's merged first then I'll just throw this test in there so we have coverage of this flag on terminal now.
- [ ] Perhaps separate issue, but the fact that the CLI hangs when this panic happens rather than exiting is also a bug