### PR TITLE
add `testctx` for instrumenting integration tests with OTel

### DIFF
--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -100,12 +100,12 @@ runs:
         if [[ "${{ inputs.module }}" == "." ]]; then
           # set some sane defaults for the current module
           if [[ -f $HOME/.docker/config.json ]]; then
-            dagger -m . call --source=".:default" --host-docker-config=file:"$HOME/.docker/config.json" ${{ inputs.function }}
+            dagger -s -m . call --source=".:default" --host-docker-config=file:"$HOME/.docker/config.json" ${{ inputs.function }}
           else
-            dagger -m . call --source=".:default" ${{ inputs.function }}
+            dagger -s -m . call --source=".:default" ${{ inputs.function }}
           fi
         else
-          dagger -m "${{ inputs.module }}" call ${{ inputs.function }}
+          dagger -s -m "${{ inputs.module }}" call ${{ inputs.function }}
         fi
       env:
         DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"

--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -100,12 +100,12 @@ runs:
         if [[ "${{ inputs.module }}" == "." ]]; then
           # set some sane defaults for the current module
           if [[ -f $HOME/.docker/config.json ]]; then
-            dagger -s -m . call --source=".:default" --host-docker-config=file:"$HOME/.docker/config.json" ${{ inputs.function }}
+            dagger -m . call --source=".:default" --host-docker-config=file:"$HOME/.docker/config.json" ${{ inputs.function }}
           else
-            dagger -s -m . call --source=".:default" ${{ inputs.function }}
+            dagger -m . call --source=".:default" ${{ inputs.function }}
           fi
         else
-          dagger -s -m "${{ inputs.module }}" call ${{ inputs.function }}
+          dagger -m "${{ inputs.module }}" call ${{ inputs.function }}
         fi
       env:
         DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"

--- a/core/integration/cache_test.go
+++ b/core/integration/cache_test.go
@@ -13,11 +13,16 @@ import (
 	"dagger.io/dagger"
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/internal/testutil"
+	"github.com/dagger/dagger/testctx"
 )
 
-func TestCacheVolume(t *testing.T) {
-	t.Parallel()
+type CacheSuite struct{}
 
+func TestCache(t *testing.T) {
+	testctx.Run(testCtx, t, CacheSuite{}, Middleware()...)
+}
+
+func (CacheSuite) TestVolume(ctx context.Context, t *testctx.T) {
 	type creatVolumeRes struct {
 		CacheVolume struct {
 			ID core.CacheVolumeID
@@ -26,9 +31,9 @@ func TestCacheVolume(t *testing.T) {
 
 	var idOrig, idSame, idDiff core.CacheVolumeID
 
-	t.Run("creating from a key", func(t *testing.T) {
+	t.Run("creating from a key", func(ctx context.Context, t *testctx.T) {
 		var res creatVolumeRes
-		err := testutil.Query(
+		err := testutil.Query(t,
 			`{
 				cacheVolume(key: "ab") {
 					id
@@ -40,9 +45,9 @@ func TestCacheVolume(t *testing.T) {
 		require.NotEmpty(t, res.CacheVolume.ID)
 	})
 
-	t.Run("creating from same key again", func(t *testing.T) {
+	t.Run("creating from same key again", func(ctx context.Context, t *testctx.T) {
 		var res creatVolumeRes
-		err := testutil.Query(
+		err := testutil.Query(t,
 			`{
 				cacheVolume(key: "ab") {
 					id
@@ -56,9 +61,9 @@ func TestCacheVolume(t *testing.T) {
 		require.Equal(t, idOrig, idSame)
 	})
 
-	t.Run("creating from a different key", func(t *testing.T) {
+	t.Run("creating from a different key", func(ctx context.Context, t *testctx.T) {
 		var res creatVolumeRes
-		err := testutil.Query(
+		err := testutil.Query(t,
 			`{
 				cacheVolume(key: "ac") {
 					id
@@ -73,12 +78,10 @@ func TestCacheVolume(t *testing.T) {
 	})
 }
 
-func TestCacheVolumeWithSubmount(t *testing.T) {
-	t.Parallel()
-	c, ctx := connect(t)
+func (CacheSuite) TestVolumeWithSubmount(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
-	t.Run("file mount", func(t *testing.T) {
-		t.Parallel()
+	t.Run("file mount", func(ctx context.Context, t *testctx.T) {
 		subfile := c.Directory().WithNewFile("foo", "bar").File("foo")
 		ctr := c.Container().From(alpineImage).
 			WithMountedCache("/cache", c.CacheVolume(identity.NewID())).
@@ -93,8 +96,7 @@ func TestCacheVolumeWithSubmount(t *testing.T) {
 		require.Equal(t, "bar", strings.TrimSpace(contents))
 	})
 
-	t.Run("dir mount", func(t *testing.T) {
-		t.Parallel()
+	t.Run("dir mount", func(ctx context.Context, t *testctx.T) {
 		subdir := c.Directory().WithNewFile("foo", "bar").WithNewFile("baz", "qux")
 		ctr := c.Container().From(alpineImage).
 			WithMountedCache("/cache", c.CacheVolume(identity.NewID())).
@@ -121,14 +123,12 @@ func TestCacheVolumeWithSubmount(t *testing.T) {
 	})
 }
 
-func TestLocalImportCacheReuse(t *testing.T) {
-	t.Parallel()
-
+func (CacheSuite) TestLocalImportCacheReuse(ctx context.Context, t *testctx.T) {
 	hostDirPath := t.TempDir()
 	err := os.WriteFile(filepath.Join(hostDirPath, "foo"), []byte("bar"), 0o644)
 	require.NoError(t, err)
 
-	runExec := func(ctx context.Context, t *testing.T, c *dagger.Client) string {
+	runExec := func(c *dagger.Client) string {
 		out, err := c.Container().From(alpineImage).
 			WithDirectory("/fromhost", c.Host().Directory(hostDirPath)).
 			WithExec([]string{"stat", "/fromhost/foo"}).
@@ -138,11 +138,11 @@ func TestLocalImportCacheReuse(t *testing.T) {
 		return out
 	}
 
-	c1, ctx1 := connect(t)
-	out1 := runExec(ctx1, t, c1)
+	c1 := connect(ctx, t)
+	out1 := runExec(c1)
 
-	c2, ctx2 := connect(t)
-	out2 := runExec(ctx2, t, c2)
+	c2 := connect(ctx, t)
+	out2 := runExec(c2)
 
 	require.Equal(t, out1, out2)
 }

--- a/core/integration/client_test.go
+++ b/core/integration/client_test.go
@@ -35,7 +35,7 @@ func (ClientSuite) TestMultiSameTrace(ctx context.Context, t *testctx.T) {
 	newClient := func(ctx context.Context, name string) (*dagger.Client, *safeBuffer) {
 		out := new(safeBuffer)
 		c, err := dagger.Connect(ctx,
-			dagger.WithLogOutput(io.MultiWriter(prefixw.New(testutil.NewTWriter(t), name+": "), out)))
+			dagger.WithLogOutput(io.MultiWriter(prefixw.New(testutil.NewTWriter(t.T), name+": "), out)))
 		require.NoError(t, err)
 		t.Cleanup(func() { c.Close() })
 		return c, out

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"bytes"
+	"context"
 	_ "embed"
 	"encoding/base64"
 	"encoding/json"
@@ -28,11 +29,16 @@ import (
 	"github.com/dagger/dagger/engine/buildkit"
 	"github.com/dagger/dagger/engine/distconsts"
 	"github.com/dagger/dagger/internal/testutil"
+	"github.com/dagger/dagger/testctx"
 )
 
-func TestContainerScratch(t *testing.T) {
-	t.Parallel()
+type ContainerSuite struct{}
 
+func TestContainer(t *testing.T) {
+	testctx.Run(testCtx, t, ContainerSuite{}, Middleware()...)
+}
+
+func (ContainerSuite) TestScratch(ctx context.Context, t *testctx.T) {
 	res := struct {
 		Container struct {
 			ID     string
@@ -42,7 +48,7 @@ func TestContainerScratch(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			container {
 				id
@@ -55,9 +61,7 @@ func TestContainerScratch(t *testing.T) {
 	require.Empty(t, res.Container.Rootfs.Entries)
 }
 
-func TestContainerFrom(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestFrom(ctx context.Context, t *testctx.T) {
 	res := struct {
 		Container struct {
 			From struct {
@@ -68,7 +72,7 @@ func TestContainerFrom(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			container {
 				from(address: "`+alpineImage+`") {
@@ -84,8 +88,8 @@ func TestContainerFrom(t *testing.T) {
 	require.Equal(t, distconsts.AlpineVersion, strings.TrimSpace(releaseStr))
 }
 
-func TestContainerBuild(t *testing.T) {
-	c, ctx := connect(t)
+func (ContainerSuite) TestBuild(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	contextDir := c.Directory().
 		WithNewFile("main.go",
@@ -98,7 +102,7 @@ func main() {
 	}
 }`)
 
-	t.Run("default Dockerfile location", func(t *testing.T) {
+	t.Run("default Dockerfile location", func(ctx context.Context, t *testctx.T) {
 		src := contextDir.
 			WithNewFile("Dockerfile",
 				`FROM golang:1.18.2-alpine
@@ -115,7 +119,7 @@ CMD goenv
 		require.Contains(t, env, "FOO=bar\n")
 	})
 
-	t.Run("with syntax pragma", func(t *testing.T) {
+	t.Run("with syntax pragma", func(ctx context.Context, t *testctx.T) {
 		src := contextDir.
 			WithNewFile("Dockerfile",
 				`# syntax = docker/dockerfile:1
@@ -133,7 +137,7 @@ CMD goenv
 		require.Contains(t, env, "FOO=bar\n")
 	})
 
-	t.Run("custom Dockerfile location", func(t *testing.T) {
+	t.Run("custom Dockerfile location", func(ctx context.Context, t *testctx.T) {
 		src := contextDir.
 			WithNewFile("subdir/Dockerfile.whee",
 				`FROM golang:1.18.2-alpine
@@ -152,7 +156,7 @@ CMD goenv
 		require.Contains(t, env, "FOO=bar\n")
 	})
 
-	t.Run("subdirectory with default Dockerfile location", func(t *testing.T) {
+	t.Run("subdirectory with default Dockerfile location", func(ctx context.Context, t *testctx.T) {
 		src := contextDir.
 			WithNewFile("Dockerfile",
 				`FROM golang:1.18.2-alpine
@@ -171,7 +175,7 @@ CMD goenv
 		require.Contains(t, env, "FOO=bar\n")
 	})
 
-	t.Run("subdirectory with custom Dockerfile location", func(t *testing.T) {
+	t.Run("subdirectory with custom Dockerfile location", func(ctx context.Context, t *testctx.T) {
 		src := contextDir.
 			WithNewFile("subdir/Dockerfile.whee",
 				`FROM golang:1.18.2-alpine
@@ -192,7 +196,7 @@ CMD goenv
 		require.Contains(t, env, "FOO=bar\n")
 	})
 
-	t.Run("with build args", func(t *testing.T) {
+	t.Run("with build args", func(ctx context.Context, t *testctx.T) {
 		src := contextDir.
 			WithNewFile("Dockerfile",
 				`FROM golang:1.18.2-alpine
@@ -214,7 +218,7 @@ CMD goenv
 		require.Contains(t, env, "FOO=barbar\n")
 	})
 
-	t.Run("with target", func(t *testing.T) {
+	t.Run("with target", func(ctx context.Context, t *testctx.T) {
 		src := contextDir.
 			WithNewFile("Dockerfile",
 				`FROM golang:1.18.2-alpine AS base
@@ -237,7 +241,7 @@ CMD echo "stage2"
 		require.NotContains(t, output, "stage2\n")
 	})
 
-	t.Run("with build secrets", func(t *testing.T) {
+	t.Run("with build secrets", func(ctx context.Context, t *testctx.T) {
 		sec := c.SetSecret("my-secret", "barbar")
 
 		dockerfile := `FROM golang:1.18.2-alpine
@@ -247,7 +251,7 @@ RUN --mount=type=secret,id=my-secret,required=true cp /run/secrets/my-secret /se
 CMD cat /secret && (cat /secret | tr "[a-z]" "[A-Z]")
 `
 
-		t.Run("builtin frontend", func(t *testing.T) {
+		t.Run("builtin frontend", func(ctx context.Context, t *testctx.T) {
 			src := contextDir.WithNewFile("Dockerfile", dockerfile)
 
 			stdout, err := c.Container().Build(src, dagger.ContainerBuildOpts{
@@ -258,7 +262,7 @@ CMD cat /secret && (cat /secret | tr "[a-z]" "[A-Z]")
 			require.Contains(t, stdout, "BARBAR")
 		})
 
-		t.Run("remote frontend", func(t *testing.T) {
+		t.Run("remote frontend", func(ctx context.Context, t *testctx.T) {
 			src := contextDir.WithNewFile("Dockerfile", "#syntax=docker/dockerfile:1\n"+dockerfile)
 
 			stdout, err := c.Container().Build(src, dagger.ContainerBuildOpts{
@@ -270,7 +274,7 @@ CMD cat /secret && (cat /secret | tr "[a-z]" "[A-Z]")
 		})
 	})
 
-	t.Run("prevent duplicate secret transform", func(t *testing.T) {
+	t.Run("prevent duplicate secret transform", func(ctx context.Context, t *testctx.T) {
 		sec := c.SetSecret("my-secret", "barbar")
 
 		// src is a directory that has a secret dependency in it's build graph
@@ -291,7 +295,7 @@ CMD cat /secret && (cat /secret | tr "[a-z]" "[A-Z]")
 		require.NoError(t, err)
 	})
 
-	t.Run("just build, don't execute", func(t *testing.T) {
+	t.Run("just build, don't execute", func(ctx context.Context, t *testctx.T) {
 		src := contextDir.
 			WithNewFile("Dockerfile", "FROM "+alpineImage+"\nCMD false")
 
@@ -303,7 +307,7 @@ CMD cat /secret && (cat /secret | tr "[a-z]" "[A-Z]")
 		require.NotEmpty(t, err)
 	})
 
-	t.Run("just build, short-circuit", func(t *testing.T) {
+	t.Run("just build, short-circuit", func(ctx context.Context, t *testctx.T) {
 		src := contextDir.
 			WithNewFile("Dockerfile", "FROM "+alpineImage+"\nRUN false")
 
@@ -312,10 +316,8 @@ CMD cat /secret && (cat /secret | tr "[a-z]" "[A-Z]")
 	})
 }
 
-func TestContainerWithRootFS(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ContainerSuite) TestWithRootFS(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	alpine316 := c.Container().From(alpineImage)
 
@@ -357,10 +359,8 @@ func TestContainerWithRootFS(t *testing.T) {
 //go:embed testdata/hello.go
 var helloSrc string
 
-func TestContainerWithRootFSSubdir(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ContainerSuite) TestWithRootFSSubdir(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	hello := c.Directory().WithNewFile("main.go", helloSrc).File("main.go")
 
@@ -378,13 +378,11 @@ func TestContainerWithRootFSSubdir(t *testing.T) {
 	require.Equal(t, "Hello, world!\n", out)
 }
 
-func TestContainerExecSync(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestExecSync(ctx context.Context, t *testctx.T) {
 	// A successful sync doesn't prove anything. As soon as you call other
 	// leaves to check things, they could be the ones triggering execution.
 	// Still, sync can be useful for short-circuiting.
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			container {
 				from(address: "`+alpineImage+`") {
@@ -397,9 +395,7 @@ func TestContainerExecSync(t *testing.T) {
 	require.Contains(t, err.Error(), `process "false" did not complete successfully`)
 }
 
-func TestContainerExecStdoutStderr(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestExecStdoutStderr(ctx context.Context, t *testctx.T) {
 	res := struct {
 		Container struct {
 			From struct {
@@ -411,7 +407,7 @@ func TestContainerExecStdoutStderr(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			container {
 				from(address: "`+alpineImage+`") {
@@ -427,9 +423,7 @@ func TestContainerExecStdoutStderr(t *testing.T) {
 	require.Equal(t, res.Container.From.WithExec.Stderr, "goodbye\n")
 }
 
-func TestContainerExecStdin(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestExecStdin(ctx context.Context, t *testctx.T) {
 	res := struct {
 		Container struct {
 			From struct {
@@ -440,7 +434,7 @@ func TestContainerExecStdin(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			container {
 				from(address: "`+alpineImage+`") {
@@ -454,9 +448,7 @@ func TestContainerExecStdin(t *testing.T) {
 	require.Equal(t, res.Container.From.WithExec.Stdout, "hello")
 }
 
-func TestContainerExecRedirectStdoutStderr(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestExecRedirectStdoutStderr(ctx context.Context, t *testctx.T) {
 	res := struct {
 		Container struct {
 			From struct {
@@ -469,7 +461,7 @@ func TestContainerExecRedirectStdoutStderr(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			container {
 				from(address: "`+alpineImage+`") {
@@ -493,7 +485,7 @@ func TestContainerExecRedirectStdoutStderr(t *testing.T) {
 	require.Equal(t, res.Container.From.WithExec.Out.Contents, "hello\n")
 	require.Equal(t, res.Container.From.WithExec.Err.Contents, "goodbye\n")
 
-	c, ctx := connect(t)
+	c := connect(ctx, t)
 
 	execWithMount := c.Container().From(alpineImage).
 		WithMountedDirectory("/mnt", c.Directory()).
@@ -518,9 +510,7 @@ func TestContainerExecRedirectStdoutStderr(t *testing.T) {
 	require.Equal(t, "goodbye\n", stderr)
 }
 
-func TestContainerExecWithWorkdir(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestExecWithWorkdir(ctx context.Context, t *testctx.T) {
 	res := struct {
 		Container struct {
 			From struct {
@@ -533,7 +523,7 @@ func TestContainerExecWithWorkdir(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			container {
 				from(address: "`+alpineImage+`") {
@@ -549,9 +539,8 @@ func TestContainerExecWithWorkdir(t *testing.T) {
 	require.Equal(t, res.Container.From.WithWorkdir.WithExec.Stdout, "/usr\n")
 }
 
-func TestContainerExecWithoutWorkdir(t *testing.T) {
-	t.Parallel()
-	c, ctx := connect(t)
+func (ContainerSuite) TestExecWithoutWorkdir(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	res, err := c.Container().
 		From(alpineImage).
@@ -564,10 +553,8 @@ func TestContainerExecWithoutWorkdir(t *testing.T) {
 	require.Equal(t, "/\n", res)
 }
 
-func TestContainerExecWithUser(t *testing.T) {
-	t.Parallel()
-
-	res := struct {
+func (ContainerSuite) TestExecWithUser(ctx context.Context, t *testctx.T) {
+	type resType struct {
 		Container struct {
 			From struct {
 				User string
@@ -580,10 +567,11 @@ func TestContainerExecWithUser(t *testing.T) {
 				}
 			}
 		}
-	}{}
+	}
 
-	t.Run("user name", func(t *testing.T) {
-		err := testutil.Query(
+	t.Run("user name", func(ctx context.Context, t *testctx.T) {
+		var res resType
+		err := testutil.Query(t,
 			`{
 			container {
 				from(address: "`+alpineImage+`") {
@@ -603,8 +591,9 @@ func TestContainerExecWithUser(t *testing.T) {
 		require.Equal(t, "daemon\n", res.Container.From.WithUser.WithExec.Stdout)
 	})
 
-	t.Run("user and group name", func(t *testing.T) {
-		err := testutil.Query(
+	t.Run("user and group name", func(ctx context.Context, t *testctx.T) {
+		var res resType
+		err := testutil.Query(t,
 			`{
 			container {
 				from(address: "`+alpineImage+`") {
@@ -624,8 +613,9 @@ func TestContainerExecWithUser(t *testing.T) {
 		require.Equal(t, "daemon\nfloppy\n", res.Container.From.WithUser.WithExec.Stdout)
 	})
 
-	t.Run("user ID", func(t *testing.T) {
-		err := testutil.Query(
+	t.Run("user ID", func(ctx context.Context, t *testctx.T) {
+		var res resType
+		err := testutil.Query(t,
 			`{
 			container {
 				from(address: "`+alpineImage+`") {
@@ -645,8 +635,9 @@ func TestContainerExecWithUser(t *testing.T) {
 		require.Equal(t, "daemon\n", res.Container.From.WithUser.WithExec.Stdout)
 	})
 
-	t.Run("user and group ID", func(t *testing.T) {
-		err := testutil.Query(
+	t.Run("user and group ID", func(ctx context.Context, t *testctx.T) {
+		var res resType
+		err := testutil.Query(t,
 			`{
 			container {
 				from(address: "`+alpineImage+`") {
@@ -666,8 +657,9 @@ func TestContainerExecWithUser(t *testing.T) {
 		require.Equal(t, "daemon\nfloppy\n", res.Container.From.WithUser.WithExec.Stdout)
 	})
 
-	t.Run("stdin", func(t *testing.T) {
-		err := testutil.Query(
+	t.Run("stdin", func(ctx context.Context, t *testctx.T) {
+		var res resType
+		err := testutil.Query(t,
 			`{
 			container {
 				from(address: "`+alpineImage+`") {
@@ -684,9 +676,8 @@ func TestContainerExecWithUser(t *testing.T) {
 	})
 }
 
-func TestContainerExecWithoutUser(t *testing.T) {
-	t.Parallel()
-	c, ctx := connect(t)
+func (ContainerSuite) TestExecWithoutUser(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	res, err := c.Container().
 		From(alpineImage).
@@ -699,39 +690,37 @@ func TestContainerExecWithoutUser(t *testing.T) {
 	require.Equal(t, "root\n", res)
 }
 
-func TestContainerExecWithEntrypoint(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ContainerSuite) TestExecWithEntrypoint(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	base := c.Container().From(alpineImage)
 	withEntry := base.WithEntrypoint([]string{"sh"})
 
-	t.Run("before", func(t *testing.T) {
+	t.Run("before", func(ctx context.Context, t *testctx.T) {
 		before, err := base.Entrypoint(ctx)
 		require.NoError(t, err)
 		require.Empty(t, before)
 	})
 
-	t.Run("after", func(t *testing.T) {
+	t.Run("after", func(ctx context.Context, t *testctx.T) {
 		after, err := withEntry.Entrypoint(ctx)
 		require.NoError(t, err)
 		require.Equal(t, []string{"sh"}, after)
 	})
 
-	t.Run("used", func(t *testing.T) {
+	t.Run("used", func(ctx context.Context, t *testctx.T) {
 		used, err := withEntry.WithExec([]string{"-c", "echo $HOME"}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Equal(t, "/root\n", used)
 	})
 
-	t.Run("prepended to exec", func(t *testing.T) {
+	t.Run("prepended to exec", func(ctx context.Context, t *testctx.T) {
 		_, err := withEntry.WithExec([]string{"sh", "-c", "echo $HOME"}).Sync(ctx)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "can't open 'sh'")
 	})
 
-	t.Run("skipped", func(t *testing.T) {
+	t.Run("skipped", func(ctx context.Context, t *testctx.T) {
 		skipped, err := withEntry.WithExec([]string{"sh", "-c", "echo $HOME"}, dagger.ContainerWithExecOpts{
 			SkipEntrypoint: true,
 		}).Stdout(ctx)
@@ -739,7 +728,7 @@ func TestContainerExecWithEntrypoint(t *testing.T) {
 		require.Equal(t, "/root\n", skipped)
 	})
 
-	t.Run("unset default args", func(t *testing.T) {
+	t.Run("unset default args", func(ctx context.Context, t *testctx.T) {
 		removed, err := base.
 			WithDefaultArgs([]string{"foobar"}).
 			WithEntrypoint([]string{"echo"}).
@@ -748,7 +737,7 @@ func TestContainerExecWithEntrypoint(t *testing.T) {
 		require.Equal(t, "\n", removed)
 	})
 
-	t.Run("kept default args", func(t *testing.T) {
+	t.Run("kept default args", func(ctx context.Context, t *testctx.T) {
 		kept, err := base.
 			WithDefaultArgs([]string{"foobar"}).
 			WithEntrypoint([]string{"echo"}, dagger.ContainerWithEntrypointOpts{
@@ -759,7 +748,7 @@ func TestContainerExecWithEntrypoint(t *testing.T) {
 		require.Equal(t, "foobar\n", kept)
 	})
 
-	t.Run("cleared", func(t *testing.T) {
+	t.Run("cleared", func(ctx context.Context, t *testctx.T) {
 		withoutEntry := withEntry.WithEntrypoint(nil)
 		removed, err := withoutEntry.Entrypoint(ctx)
 		require.NoError(t, err)
@@ -767,11 +756,10 @@ func TestContainerExecWithEntrypoint(t *testing.T) {
 	})
 }
 
-func TestContainerExecWithoutEntrypoint(t *testing.T) {
-	t.Parallel()
-	c, ctx := connect(t)
+func (ContainerSuite) TestExecWithoutEntrypoint(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
-	t.Run("cleared entrypoint", func(t *testing.T) {
+	t.Run("cleared entrypoint", func(ctx context.Context, t *testctx.T) {
 		res, err := c.Container().
 			From(alpineImage).
 			// if not unset this would return an error
@@ -783,7 +771,7 @@ func TestContainerExecWithoutEntrypoint(t *testing.T) {
 		require.Equal(t, "foobar", res)
 	})
 
-	t.Run("cleared entrypoint with default args", func(t *testing.T) {
+	t.Run("cleared entrypoint with default args", func(ctx context.Context, t *testctx.T) {
 		res, err := c.Container().
 			From(alpineImage).
 			WithEntrypoint([]string{"foo"}).
@@ -794,7 +782,7 @@ func TestContainerExecWithoutEntrypoint(t *testing.T) {
 		require.Empty(t, res)
 	})
 
-	t.Run("cleared entrypoint without default args", func(t *testing.T) {
+	t.Run("cleared entrypoint without default args", func(ctx context.Context, t *testctx.T) {
 		res, err := c.Container().
 			From(alpineImage).
 			WithEntrypoint([]string{"foo"}).
@@ -808,9 +796,7 @@ func TestContainerExecWithoutEntrypoint(t *testing.T) {
 	})
 }
 
-func TestContainerWithDefaultArgs(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestWithDefaultArgs(ctx context.Context, t *testctx.T) {
 	res := struct {
 		Container struct {
 			From struct {
@@ -841,7 +827,7 @@ func TestContainerWithDefaultArgs(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			container {
 				from(address: "`+alpineImage+`") {
@@ -872,27 +858,27 @@ func TestContainerWithDefaultArgs(t *testing.T) {
 				}
 			}
 		}`, &res, nil)
-	t.Run("default alpine (no entrypoint)", func(t *testing.T) {
+	t.Run("default alpine (no entrypoint)", func(ctx context.Context, t *testctx.T) {
 		require.NoError(t, err)
 		require.Empty(t, res.Container.From.Entrypoint)
 		require.Equal(t, []string{"/bin/sh"}, res.Container.From.DefaultArgs)
 	})
 
-	t.Run("with nil default args", func(t *testing.T) {
+	t.Run("with nil default args", func(ctx context.Context, t *testctx.T) {
 		require.Empty(t, res.Container.From.WithDefaultArgs.Entrypoint)
 		require.Empty(t, res.Container.From.WithDefaultArgs.DefaultArgs)
 	})
 
-	t.Run("with entrypoint set", func(t *testing.T) {
+	t.Run("with entrypoint set", func(ctx context.Context, t *testctx.T) {
 		require.Equal(t, []string{"sh", "-c"}, res.Container.From.WithEntrypoint.Entrypoint)
 		require.Empty(t, res.Container.From.WithEntrypoint.DefaultArgs)
 	})
 
-	t.Run("with exec args", func(t *testing.T) {
+	t.Run("with exec args", func(ctx context.Context, t *testctx.T) {
 		require.Equal(t, "/root\n", res.Container.From.WithEntrypoint.WithExec.Stdout)
 	})
 
-	t.Run("with default args set", func(t *testing.T) {
+	t.Run("with default args set", func(ctx context.Context, t *testctx.T) {
 		require.Equal(t, []string{"sh", "-c"}, res.Container.From.WithEntrypoint.WithDefaultArgs.Entrypoint)
 		require.Equal(t, []string{"id"}, res.Container.From.WithEntrypoint.WithDefaultArgs.DefaultArgs)
 
@@ -900,9 +886,8 @@ func TestContainerWithDefaultArgs(t *testing.T) {
 	})
 }
 
-func TestContainerExecWithoutDefaultArgs(t *testing.T) {
-	t.Parallel()
-	c, ctx := connect(t)
+func (ContainerSuite) TestExecWithoutDefaultArgs(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	res, err := c.Container().
 		From(alpineImage).
@@ -916,9 +901,7 @@ func TestContainerExecWithoutDefaultArgs(t *testing.T) {
 	require.Equal(t, "", res)
 }
 
-func TestContainerExecWithEnvVariable(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestExecWithEnvVariable(ctx context.Context, t *testctx.T) {
 	res := struct {
 		Container struct {
 			From struct {
@@ -931,7 +914,7 @@ func TestContainerExecWithEnvVariable(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			container {
 				from(address: "`+alpineImage+`") {
@@ -947,9 +930,7 @@ func TestContainerExecWithEnvVariable(t *testing.T) {
 	require.Contains(t, res.Container.From.WithEnvVariable.WithExec.Stdout, "FOO=bar\n")
 }
 
-func TestContainerVariables(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestVariables(ctx context.Context, t *testctx.T) {
 	res := struct {
 		Container struct {
 			From struct {
@@ -961,7 +942,7 @@ func TestContainerVariables(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			container {
 				from(address: "golang:1.18.2-alpine") {
@@ -984,9 +965,7 @@ func TestContainerVariables(t *testing.T) {
 	require.Contains(t, res.Container.From.WithExec.Stdout, "GOPATH=/go\n")
 }
 
-func TestContainerVariable(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestVariable(ctx context.Context, t *testctx.T) {
 	res := struct {
 		Container struct {
 			From struct {
@@ -995,7 +974,7 @@ func TestContainerVariable(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			container {
 				from(address: "golang:1.18.2-alpine") {
@@ -1007,7 +986,7 @@ func TestContainerVariable(t *testing.T) {
 	require.NotNil(t, res.Container.From.EnvVariable)
 	require.Equal(t, "1.18.2", *res.Container.From.EnvVariable)
 
-	err = testutil.Query(
+	err = testutil.Query(t,
 		`{
 			container {
 				from(address: "golang:1.18.2-alpine") {
@@ -1019,9 +998,7 @@ func TestContainerVariable(t *testing.T) {
 	require.Nil(t, res.Container.From.EnvVariable)
 }
 
-func TestContainerWithoutVariable(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestWithoutVariable(ctx context.Context, t *testctx.T) {
 	res := struct {
 		Container struct {
 			From struct {
@@ -1035,7 +1012,7 @@ func TestContainerWithoutVariable(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			container {
 				from(address: "golang:1.18.2-alpine") {
@@ -1059,9 +1036,7 @@ func TestContainerWithoutVariable(t *testing.T) {
 	require.NotContains(t, res.Container.From.WithoutEnvVariable.WithExec.Stdout, "GOLANG_VERSION")
 }
 
-func TestContainerEnvVariablesReplace(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestEnvVariablesReplace(ctx context.Context, t *testctx.T) {
 	res := struct {
 		Container struct {
 			From struct {
@@ -1075,7 +1050,7 @@ func TestContainerEnvVariablesReplace(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			container {
 				from(address: "golang:1.18.2-alpine") {
@@ -1100,11 +1075,10 @@ func TestContainerEnvVariablesReplace(t *testing.T) {
 	require.Contains(t, res.Container.From.WithEnvVariable.WithExec.Stdout, "GOPATH=/gone\n")
 }
 
-func TestContainerWithEnvVariableExpand(t *testing.T) {
-	t.Parallel()
-	c, ctx := connect(t)
+func (ContainerSuite) TestWithEnvVariableExpand(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
-	t.Run("add env var without expansion", func(t *testing.T) {
+	t.Run("add env var without expansion", func(ctx context.Context, t *testctx.T) {
 		out, err := c.Container().
 			From(alpineImage).
 			WithEnvVariable("FOO", "foo:$PATH").
@@ -1115,7 +1089,7 @@ func TestContainerWithEnvVariableExpand(t *testing.T) {
 		require.Equal(t, "foo:$PATH\n", out)
 	})
 
-	t.Run("add env var with expansion", func(t *testing.T) {
+	t.Run("add env var with expansion", func(ctx context.Context, t *testctx.T) {
 		out, err := c.Container().
 			From(alpineImage).
 			WithEnvVariable("USER_PATH", "/opt").
@@ -1137,10 +1111,10 @@ func TestContainerWithEnvVariableExpand(t *testing.T) {
 	})
 }
 
-func TestContainerLabel(t *testing.T) {
-	c, ctx := connect(t)
+func (ContainerSuite) TestLabel(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
-	t.Run("container with new label", func(t *testing.T) {
+	t.Run("container with new label", func(ctx context.Context, t *testctx.T) {
 		label, err := c.Container().From(alpineImage).WithLabel("FOO", "BAR").Label(ctx, "FOO")
 
 		require.NoError(t, err)
@@ -1149,7 +1123,7 @@ func TestContainerLabel(t *testing.T) {
 
 	// implementing this test as GraphQL query until
 	// https://github.com/dagger/dagger/issues/4398 gets resolved
-	t.Run("container labels", func(t *testing.T) {
+	t.Run("container labels", func(ctx context.Context, t *testctx.T) {
 		res := struct {
 			Container struct {
 				From struct {
@@ -1158,7 +1132,7 @@ func TestContainerLabel(t *testing.T) {
 			}
 		}{}
 
-		err := testutil.Query(
+		err := testutil.Query(t,
 			`{
 				container {
 				  from(address: "nginx") {
@@ -1175,35 +1149,35 @@ func TestContainerLabel(t *testing.T) {
 		}, res.Container.From.Labels)
 	})
 
-	t.Run("container without label", func(t *testing.T) {
+	t.Run("container without label", func(ctx context.Context, t *testctx.T) {
 		label, err := c.Container().From("nginx").WithoutLabel("maintainer").Label(ctx, "maintainer")
 
 		require.NoError(t, err)
 		require.Empty(t, label)
 	})
 
-	t.Run("container replace label", func(t *testing.T) {
+	t.Run("container replace label", func(ctx context.Context, t *testctx.T) {
 		label, err := c.Container().From("nginx").WithLabel("maintainer", "bar").Label(ctx, "maintainer")
 
 		require.NoError(t, err)
 		require.Contains(t, label, "bar")
 	})
 
-	t.Run("container with new label - nil panics", func(t *testing.T) {
+	t.Run("container with new label - nil panics", func(ctx context.Context, t *testctx.T) {
 		label, err := c.Container().WithLabel("FOO", "BAR").Label(ctx, "FOO")
 
 		require.NoError(t, err)
 		require.Contains(t, label, "BAR")
 	})
 
-	t.Run("container label - nil panics", func(t *testing.T) {
+	t.Run("container label - nil panics", func(ctx context.Context, t *testctx.T) {
 		label, err := c.Container().Label(ctx, "FOO")
 
 		require.NoError(t, err)
 		require.Empty(t, label)
 	})
 
-	t.Run("container without label - nil panics", func(t *testing.T) {
+	t.Run("container without label - nil panics", func(ctx context.Context, t *testctx.T) {
 		label, err := c.Container().WithoutLabel("maintainer").Label(ctx, "maintainer")
 
 		require.NoError(t, err)
@@ -1212,7 +1186,7 @@ func TestContainerLabel(t *testing.T) {
 
 	// implementing this test as GraphQL query until
 	// https://github.com/dagger/dagger/issues/4398 gets resolved
-	t.Run("container labels - nil panics", func(t *testing.T) {
+	t.Run("container labels - nil panics", func(ctx context.Context, t *testctx.T) {
 		res := struct {
 			Container struct {
 				From struct {
@@ -1221,7 +1195,7 @@ func TestContainerLabel(t *testing.T) {
 			}
 		}{}
 
-		err := testutil.Query(
+		err := testutil.Query(t,
 			`{
 				container {
 				  labels {
@@ -1235,9 +1209,7 @@ func TestContainerLabel(t *testing.T) {
 	})
 }
 
-func TestContainerWorkdir(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestWorkdir(ctx context.Context, t *testctx.T) {
 	res := struct {
 		Container struct {
 			From struct {
@@ -1249,7 +1221,7 @@ func TestContainerWorkdir(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			container {
 			  from(address: "golang:1.18.2-alpine") {
@@ -1265,9 +1237,7 @@ func TestContainerWorkdir(t *testing.T) {
 	require.Equal(t, res.Container.From.WithExec.Stdout, "/go\n")
 }
 
-func TestContainerWithWorkdir(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestWithWorkdir(ctx context.Context, t *testctx.T) {
 	res := struct {
 		Container struct {
 			From struct {
@@ -1281,7 +1251,7 @@ func TestContainerWithWorkdir(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			container {
 				from(address: "golang:1.18.2-alpine") {
@@ -1299,9 +1269,7 @@ func TestContainerWithWorkdir(t *testing.T) {
 	require.Equal(t, res.Container.From.WithWorkdir.WithExec.Stdout, "/usr\n")
 }
 
-func TestContainerWithMountedDirectory(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestWithMountedDirectory(ctx context.Context, t *testctx.T) {
 	dirRes := struct {
 		Directory struct {
 			WithNewFile struct {
@@ -1312,7 +1280,7 @@ func TestContainerWithMountedDirectory(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			directory {
 				withNewFile(path: "some-file", contents: "some-content") {
@@ -1341,7 +1309,7 @@ func TestContainerWithMountedDirectory(t *testing.T) {
 			}
 		}
 	}{}
-	err = testutil.Query(
+	err = testutil.Query(t,
 		`query Test($id: DirectoryID!) {
 			container {
 				from(address: "`+alpineImage+`") {
@@ -1364,9 +1332,7 @@ func TestContainerWithMountedDirectory(t *testing.T) {
 	require.Equal(t, "sub-content", execRes.Container.From.WithMountedDirectory.WithExec.WithExec.Stdout)
 }
 
-func TestContainerWithMountedDirectorySourcePath(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestWithMountedDirectorySourcePath(ctx context.Context, t *testctx.T) {
 	dirRes := struct {
 		Directory struct {
 			WithNewFile struct {
@@ -1379,7 +1345,7 @@ func TestContainerWithMountedDirectorySourcePath(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			directory {
 				withNewFile(path: "some-file", contents: "some-content") {
@@ -1408,7 +1374,7 @@ func TestContainerWithMountedDirectorySourcePath(t *testing.T) {
 			}
 		}
 	}{}
-	err = testutil.Query(
+	err = testutil.Query(t,
 		`query Test($id: DirectoryID!) {
 			container {
 				from(address: "`+alpineImage+`") {
@@ -1428,9 +1394,7 @@ func TestContainerWithMountedDirectorySourcePath(t *testing.T) {
 	require.Equal(t, "sub-content\nmore-content", execRes.Container.From.WithMountedDirectory.WithExec.WithExec.Stdout)
 }
 
-func TestContainerWithMountedDirectoryPropagation(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestWithMountedDirectoryPropagation(ctx context.Context, t *testctx.T) {
 	dirRes := struct {
 		Directory struct {
 			WithNewFile struct {
@@ -1439,7 +1403,7 @@ func TestContainerWithMountedDirectoryPropagation(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			directory {
 				withNewFile(path: "some-file", contents: "some-content") {
@@ -1475,7 +1439,7 @@ func TestContainerWithMountedDirectoryPropagation(t *testing.T) {
 			}
 		}
 	}{}
-	err = testutil.Query(
+	err = testutil.Query(t,
 		`query Test($id: DirectoryID!) {
 			container {
 				from(address: "`+alpineImage+`") {
@@ -1526,9 +1490,7 @@ func TestContainerWithMountedDirectoryPropagation(t *testing.T) {
 		execRes.Container.From.WithMountedDirectory.WithExec.WithExec.WithExec.WithMountedDirectory.WithExec.WithExec.Stdout)
 }
 
-func TestContainerWithMountedFile(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestWithMountedFile(ctx context.Context, t *testctx.T) {
 	dirRes := struct {
 		Directory struct {
 			WithNewFile struct {
@@ -1539,7 +1501,7 @@ func TestContainerWithMountedFile(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			directory {
 				withNewFile(path: "some-dir/sub-file", contents: "sub-content") {
@@ -1564,7 +1526,7 @@ func TestContainerWithMountedFile(t *testing.T) {
 			}
 		}
 	}{}
-	err = testutil.Query(
+	err = testutil.Query(t,
 		`query Test($id: FileID!) {
 			container {
 				from(address: "`+alpineImage+`") {
@@ -1582,9 +1544,7 @@ func TestContainerWithMountedFile(t *testing.T) {
 	require.Equal(t, "sub-content", execRes.Container.From.WithMountedFile.WithExec.Stdout)
 }
 
-func TestContainerWithMountedCache(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestWithMountedCache(ctx context.Context, t *testctx.T) {
 	cacheID := newCache(t)
 
 	execRes := struct {
@@ -1616,7 +1576,7 @@ func TestContainerWithMountedCache(t *testing.T) {
 		}`
 
 	rand1 := identity.NewID()
-	err := testutil.Query(query, &execRes, &testutil.QueryOptions{Variables: map[string]any{
+	err := testutil.Query(t, query, &execRes, &testutil.QueryOptions{Variables: map[string]any{
 		"cache": cacheID,
 		"rand":  rand1,
 	}})
@@ -1624,7 +1584,7 @@ func TestContainerWithMountedCache(t *testing.T) {
 	require.Equal(t, rand1+"\n", execRes.Container.From.WithEnvVariable.WithMountedCache.WithExec.Stdout)
 
 	rand2 := identity.NewID()
-	err = testutil.Query(query, &execRes, &testutil.QueryOptions{Variables: map[string]any{
+	err = testutil.Query(t, query, &execRes, &testutil.QueryOptions{Variables: map[string]any{
 		"cache": cacheID,
 		"rand":  rand2,
 	}})
@@ -1632,9 +1592,7 @@ func TestContainerWithMountedCache(t *testing.T) {
 	require.Equal(t, rand1+"\n"+rand2+"\n", execRes.Container.From.WithEnvVariable.WithMountedCache.WithExec.Stdout)
 }
 
-func TestContainerWithMountedCacheFromDirectory(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestWithMountedCacheFromDirectory(ctx context.Context, t *testctx.T) {
 	dirRes := struct {
 		Directory struct {
 			WithNewFile struct {
@@ -1645,7 +1603,7 @@ func TestContainerWithMountedCacheFromDirectory(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			directory {
 				withNewFile(path: "some-dir/sub-file", contents: "initial-content\n") {
@@ -1690,7 +1648,7 @@ func TestContainerWithMountedCacheFromDirectory(t *testing.T) {
 		}`
 
 	rand1 := identity.NewID()
-	err = testutil.Query(query, &execRes, &testutil.QueryOptions{Variables: map[string]any{
+	err = testutil.Query(t, query, &execRes, &testutil.QueryOptions{Variables: map[string]any{
 		"init":  initialID,
 		"rand":  rand1,
 		"cache": cacheID,
@@ -1699,7 +1657,7 @@ func TestContainerWithMountedCacheFromDirectory(t *testing.T) {
 	require.Equal(t, "initial-content\n"+rand1+"\n", execRes.Container.From.WithEnvVariable.WithMountedCache.WithExec.Stdout)
 
 	rand2 := identity.NewID()
-	err = testutil.Query(query, &execRes, &testutil.QueryOptions{Variables: map[string]any{
+	err = testutil.Query(t, query, &execRes, &testutil.QueryOptions{Variables: map[string]any{
 		"init":  initialID,
 		"rand":  rand2,
 		"cache": cacheID,
@@ -1708,9 +1666,7 @@ func TestContainerWithMountedCacheFromDirectory(t *testing.T) {
 	require.Equal(t, "initial-content\n"+rand1+"\n"+rand2+"\n", execRes.Container.From.WithEnvVariable.WithMountedCache.WithExec.Stdout)
 }
 
-func TestContainerWithMountedTemp(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestWithMountedTemp(ctx context.Context, t *testctx.T) {
 	execRes := struct {
 		Container struct {
 			From struct {
@@ -1723,7 +1679,7 @@ func TestContainerWithMountedTemp(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(`{
+	err := testutil.Query(t, `{
 			container {
 				from(address: "`+alpineImage+`") {
 					withMountedTemp(path: "/mnt/tmp") {
@@ -1738,10 +1694,8 @@ func TestContainerWithMountedTemp(t *testing.T) {
 	require.Contains(t, execRes.Container.From.WithMountedTemp.WithExec.Stdout, "tmpfs /mnt/tmp tmpfs")
 }
 
-func TestContainerWithDirectory(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ContainerSuite) TestWithDirectory(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	dir := c.Directory().
 		WithNewFile("some-file", "some-content").
@@ -1797,10 +1751,8 @@ func TestContainerWithDirectory(t *testing.T) {
 	require.Equal(t, "some-content", contents)
 }
 
-func TestContainerWithFile(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ContainerSuite) TestWithFile(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	file := c.Directory().
 		WithNewFile("some-file", "some-content").
@@ -1822,10 +1774,8 @@ func TestContainerWithFile(t *testing.T) {
 	require.Equal(t, "some-content", contents)
 }
 
-func TestContainerWithoutPath(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ContainerSuite) TestWithoutPath(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	ctr := c.Container().
 		From(alpineImage).
@@ -1836,7 +1786,7 @@ func TestContainerWithoutPath(t *testing.T) {
 		WithNewFile("bat/man").
 		WithNewFile("/ual")
 
-	t.Run("no error if not exists", func(t *testing.T) {
+	t.Run("no error if not exists", func(ctx context.Context, t *testctx.T) {
 		out, err := ctr.
 			WithoutFile("not-exists").
 			WithExec([]string{"ls", "-1"}).
@@ -1845,7 +1795,7 @@ func TestContainerWithoutPath(t *testing.T) {
 		require.Equal(t, "bar\nbat\nfoo\nmoo\n", out)
 	})
 
-	t.Run("files, with pattern", func(t *testing.T) {
+	t.Run("files, with pattern", func(ctx context.Context, t *testctx.T) {
 		out, err := ctr.
 			WithoutFile("*oo").
 			WithExec([]string{"ls", "-1"}).
@@ -1854,7 +1804,7 @@ func TestContainerWithoutPath(t *testing.T) {
 		require.Equal(t, "bar\nbat\n", out)
 	})
 
-	t.Run("directory", func(t *testing.T) {
+	t.Run("directory", func(ctx context.Context, t *testctx.T) {
 		out, err := ctr.
 			WithoutDirectory("bar").
 			WithExec([]string{"ls", "-1"}).
@@ -1863,7 +1813,7 @@ func TestContainerWithoutPath(t *testing.T) {
 		require.Equal(t, "bat\nfoo\nmoo\n", out)
 	})
 
-	t.Run("current dir", func(t *testing.T) {
+	t.Run("current dir", func(ctx context.Context, t *testctx.T) {
 		out, err := ctr.
 			WithoutDirectory("").
 			WithExec([]string{"find", "/workdir"}).
@@ -1872,7 +1822,7 @@ func TestContainerWithoutPath(t *testing.T) {
 		require.Equal(t, "/workdir\n", out)
 	})
 
-	t.Run("absolute", func(t *testing.T) {
+	t.Run("absolute", func(ctx context.Context, t *testctx.T) {
 		out, err := ctr.
 			WithoutFile("/ual").
 			WithExec([]string{"ls", "-1", "/"}).
@@ -1883,10 +1833,8 @@ func TestContainerWithoutPath(t *testing.T) {
 	})
 }
 
-func TestContainerWithFiles(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ContainerSuite) TestWithFiles(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	file1 := c.Directory().
 		WithNewFile("first-file", "file1 content").
@@ -1911,10 +1859,8 @@ func TestContainerWithFiles(t *testing.T) {
 	require.Equal(t, "file2 content", contents)
 }
 
-func TestContainerWithFilesAbsolute(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ContainerSuite) TestWithFilesAbsolute(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	file1 := c.Directory().
 		WithNewFile("first-file", "file1 content").
@@ -1942,10 +1888,8 @@ func TestContainerWithFilesAbsolute(t *testing.T) {
 	require.Equal(t, "file2 content", contents)
 }
 
-func TestContainerWithNewFile(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ContainerSuite) TestWithNewFile(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	ctr := c.Container().
 		From(alpineImage).
@@ -1965,10 +1909,8 @@ func TestContainerWithNewFile(t *testing.T) {
 	require.Equal(t, "some-content", contents)
 }
 
-func TestContainerMountsWithoutMount(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ContainerSuite) TestMountsWithoutMount(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	scratchID, err := c.Directory().ID(ctx)
 	require.NoError(t, err)
@@ -1983,7 +1925,7 @@ func TestContainerMountsWithoutMount(t *testing.T) {
 		}
 	}{}
 
-	err = testutil.Query(
+	err = testutil.Query(t,
 		`{
 			directory {
 				withNewFile(path: "some-file", contents: "some-content") {
@@ -2020,7 +1962,7 @@ func TestContainerMountsWithoutMount(t *testing.T) {
 			}
 		}
 	}{}
-	err = testutil.Query(
+	err = testutil.Query(t,
 		`query Test($id: DirectoryID!, $scratch: DirectoryID!) {
 			container {
 				from(address: "`+alpineImage+`") {
@@ -2055,10 +1997,8 @@ func TestContainerMountsWithoutMount(t *testing.T) {
 	require.Equal(t, []string{"/mnt/tmp"}, execRes.Container.From.WithDirectory.WithMountedTemp.WithMountedDirectory.WithExec.WithoutMount.Mounts)
 }
 
-func TestContainerReplacedMounts(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ContainerSuite) TestReplacedMounts(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	lower := c.Directory().WithNewFile("some-file", "lower-content")
 
@@ -2068,7 +2008,7 @@ func TestContainerReplacedMounts(t *testing.T) {
 		From(alpineImage).
 		WithMountedDirectory("/mnt/dir", lower)
 
-	t.Run("initial content is lower", func(t *testing.T) {
+	t.Run("initial content is lower", func(ctx context.Context, t *testctx.T) {
 		mnts, err := ctr.Mounts(ctx)
 		require.NoError(t, err)
 		require.Equal(t, []string{"/mnt/dir"}, mnts)
@@ -2080,7 +2020,7 @@ func TestContainerReplacedMounts(t *testing.T) {
 
 	replaced := ctr.WithMountedDirectory("/mnt/dir", upper)
 
-	t.Run("mounts of same path are replaced", func(t *testing.T) {
+	t.Run("mounts of same path are replaced", func(ctx context.Context, t *testctx.T) {
 		mnts, err := replaced.Mounts(ctx)
 		require.NoError(t, err)
 		require.Equal(t, []string{"/mnt/dir"}, mnts)
@@ -2090,7 +2030,7 @@ func TestContainerReplacedMounts(t *testing.T) {
 		require.Equal(t, "upper-content", out)
 	})
 
-	t.Run("removing a replaced mount does not reveal previous mount", func(t *testing.T) {
+	t.Run("removing a replaced mount does not reveal previous mount", func(ctx context.Context, t *testctx.T) {
 		removed := replaced.WithoutMount("/mnt/dir")
 		mnts, err := removed.Mounts(ctx)
 		require.NoError(t, err)
@@ -2100,7 +2040,7 @@ func TestContainerReplacedMounts(t *testing.T) {
 	clobberedDir := c.Directory().WithNewFile("some-file", "clobbered-content")
 	clobbered := replaced.WithMountedDirectory("/mnt", clobberedDir)
 
-	t.Run("replacing parent of a mount clobbers child", func(t *testing.T) {
+	t.Run("replacing parent of a mount clobbers child", func(ctx context.Context, t *testctx.T) {
 		mnts, err := clobbered.Mounts(ctx)
 		require.NoError(t, err)
 		require.Equal(t, []string{"/mnt"}, mnts)
@@ -2113,7 +2053,7 @@ func TestContainerReplacedMounts(t *testing.T) {
 	clobberedSubDir := c.Directory().WithNewFile("some-file", "clobbered-sub-content")
 	clobberedSub := clobbered.WithMountedDirectory("/mnt/dir", clobberedSubDir)
 
-	t.Run("restoring mount under clobbered mount", func(t *testing.T) {
+	t.Run("restoring mount under clobbered mount", func(ctx context.Context, t *testctx.T) {
 		mnts, err := clobberedSub.Mounts(ctx)
 		require.NoError(t, err)
 		require.Equal(t, []string{"/mnt", "/mnt/dir"}, mnts)
@@ -2124,9 +2064,7 @@ func TestContainerReplacedMounts(t *testing.T) {
 	})
 }
 
-func TestContainerDirectory(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestDirectory(ctx context.Context, t *testctx.T) {
 	dirRes := struct {
 		Directory struct {
 			WithNewFile struct {
@@ -2137,7 +2075,7 @@ func TestContainerDirectory(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			directory {
 				withNewFile(path: "some-file", contents: "some-content") {
@@ -2166,7 +2104,7 @@ func TestContainerDirectory(t *testing.T) {
 			}
 		}
 	}{}
-	err = testutil.Query(
+	err = testutil.Query(t,
 		`query Test($id: DirectoryID!) {
 			container {
 				from(address: "`+alpineImage+`") {
@@ -2199,7 +2137,7 @@ func TestContainerDirectory(t *testing.T) {
 			}
 		}
 	}{}
-	err = testutil.Query(
+	err = testutil.Query(t,
 		`query Test($id: DirectoryID!) {
 			container {
 				from(address: "`+alpineImage+`") {
@@ -2218,9 +2156,7 @@ func TestContainerDirectory(t *testing.T) {
 	require.Equal(t, "hello\n", execRes.Container.From.WithMountedDirectory.WithExec.Stdout)
 }
 
-func TestContainerDirectoryErrors(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestDirectoryErrors(ctx context.Context, t *testctx.T) {
 	dirRes := struct {
 		Directory struct {
 			WithNewFile struct {
@@ -2231,7 +2167,7 @@ func TestContainerDirectoryErrors(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			directory {
 				withNewFile(path: "some-file", contents: "some-content") {
@@ -2245,7 +2181,7 @@ func TestContainerDirectoryErrors(t *testing.T) {
 
 	id := dirRes.Directory.WithNewFile.WithNewFile.ID
 
-	err = testutil.Query(
+	err = testutil.Query(t,
 		`query Test($id: DirectoryID!) {
 			container {
 				from(address: "`+alpineImage+`") {
@@ -2262,7 +2198,7 @@ func TestContainerDirectoryErrors(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "path /mnt/dir/some-file is a file, not a directory")
 
-	err = testutil.Query(
+	err = testutil.Query(t,
 		`query Test($id: DirectoryID!) {
 			container {
 				from(address: "`+alpineImage+`") {
@@ -2279,7 +2215,7 @@ func TestContainerDirectoryErrors(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "bogus: no such file or directory")
 
-	err = testutil.Query(
+	err = testutil.Query(t,
 		`{
 			container {
 				from(address: "`+alpineImage+`") {
@@ -2295,7 +2231,7 @@ func TestContainerDirectoryErrors(t *testing.T) {
 	require.Contains(t, err.Error(), "bogus: cannot retrieve path from tmpfs")
 
 	cacheID := newCache(t)
-	err = testutil.Query(
+	err = testutil.Query(t,
 		`query Test($cache: CacheVolumeID!) {
 			container {
 				from(address: "`+alpineImage+`") {
@@ -2313,9 +2249,7 @@ func TestContainerDirectoryErrors(t *testing.T) {
 	require.Contains(t, err.Error(), "bogus: cannot retrieve path from cache")
 }
 
-func TestContainerDirectorySourcePath(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestDirectorySourcePath(ctx context.Context, t *testctx.T) {
 	dirRes := struct {
 		Directory struct {
 			WithNewFile struct {
@@ -2326,7 +2260,7 @@ func TestContainerDirectorySourcePath(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			directory {
 				withNewFile(path: "some-dir/sub-dir/sub-file", contents: "sub-content\n") {
@@ -2353,7 +2287,7 @@ func TestContainerDirectorySourcePath(t *testing.T) {
 			}
 		}
 	}{}
-	err = testutil.Query(
+	err = testutil.Query(t,
 		`query Test($id: DirectoryID!) {
 			container {
 				from(address: "`+alpineImage+`") {
@@ -2384,7 +2318,7 @@ func TestContainerDirectorySourcePath(t *testing.T) {
 			}
 		}
 	}{}
-	err = testutil.Query(
+	err = testutil.Query(t,
 		`query Test($id: DirectoryID!) {
 			container {
 				from(address: "`+alpineImage+`") {
@@ -2403,9 +2337,7 @@ func TestContainerDirectorySourcePath(t *testing.T) {
 	require.Equal(t, "sub-content\nmore-content\n", execRes.Container.From.WithMountedDirectory.WithExec.Stdout)
 }
 
-func TestContainerFile(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestFile(ctx context.Context, t *testctx.T) {
 	id := newDirWithFile(t, "some-file", "some-content-")
 
 	writeRes := struct {
@@ -2423,7 +2355,7 @@ func TestContainerFile(t *testing.T) {
 			}
 		}
 	}{}
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`query Test($id: DirectoryID!) {
 			container {
 				from(address: "`+alpineImage+`") {
@@ -2456,7 +2388,7 @@ func TestContainerFile(t *testing.T) {
 			}
 		}
 	}{}
-	err = testutil.Query(
+	err = testutil.Query(t,
 		`query Test($id: FileID!) {
 			container {
 				from(address: "`+alpineImage+`") {
@@ -2475,13 +2407,12 @@ func TestContainerFile(t *testing.T) {
 	require.Equal(t, "some-content-appended", execRes.Container.From.WithMountedFile.WithExec.Stdout)
 }
 
-func TestContainerFileErrors(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestFileErrors(ctx context.Context, t *testctx.T) {
 	id := newDirWithFile(t, "some-file", "some-content")
 
-	err := testutil.Query(
-		`query Test($id: DirectoryID!) {
+	t.Run("path not found", func(ctx context.Context, t *testctx.T) {
+		err := testutil.Query(t,
+			`query Test($id: DirectoryID!) {
 			container {
 				from(address: "`+alpineImage+`") {
 					withMountedDirectory(path: "/mnt/dir", source: $id) {
@@ -2492,13 +2423,15 @@ func TestContainerFileErrors(t *testing.T) {
 				}
 			}
 		}`, nil, &testutil.QueryOptions{Variables: map[string]any{
-			"id": id,
-		}})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "bogus: no such file or directory")
+				"id": id,
+			}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "bogus: no such file or directory")
+	})
 
-	err = testutil.Query(
-		`query Test($id: DirectoryID!) {
+	t.Run("get directory as file", func(ctx context.Context, t *testctx.T) {
+		err := testutil.Query(t,
+			`query Test($id: DirectoryID!) {
 			container {
 				from(address: "`+alpineImage+`") {
 					withMountedDirectory(path: "/mnt/dir", source: $id) {
@@ -2509,13 +2442,15 @@ func TestContainerFileErrors(t *testing.T) {
 				}
 			}
 		}`, nil, &testutil.QueryOptions{Variables: map[string]any{
-			"id": id,
-		}})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "path /mnt/dir is a directory, not a file")
+				"id": id,
+			}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "path /mnt/dir is a directory, not a file")
+	})
 
-	err = testutil.Query(
-		`{
+	t.Run("get path under tmpfs", func(ctx context.Context, t *testctx.T) {
+		err := testutil.Query(t,
+			`{
 			container {
 				from(address: "`+alpineImage+`") {
 					withMountedTemp(path: "/mnt/tmp") {
@@ -2526,12 +2461,14 @@ func TestContainerFileErrors(t *testing.T) {
 				}
 			}
 		}`, nil, nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "bogus: cannot retrieve path from tmpfs")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "bogus: cannot retrieve path from tmpfs")
+	})
 
-	cacheID := newCache(t)
-	err = testutil.Query(
-		`query Test($cache: CacheVolumeID!) {
+	t.Run("get path under cache", func(ctx context.Context, t *testctx.T) {
+		cacheID := newCache(t)
+		err := testutil.Query(t,
+			`query Test($cache: CacheVolumeID!) {
 			container {
 				from(address: "`+alpineImage+`") {
 					withMountedCache(path: "/mnt/cache", cache: $cache) {
@@ -2542,13 +2479,15 @@ func TestContainerFileErrors(t *testing.T) {
 				}
 			}
 		}`, nil, &testutil.QueryOptions{Variables: map[string]any{
-			"cache": cacheID,
-		}})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "bogus: cannot retrieve path from cache")
+				"cache": cacheID,
+			}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "bogus: cannot retrieve path from cache")
+	})
 
-	err = testutil.Query(
-		`query Test($secret: SecretID!) {
+	t.Run("get secret mount contents", func(ctx context.Context, t *testctx.T) {
+		err := testutil.Query(t,
+			`query Test($secret: SecretID!) {
 			container {
 				from(address: "`+alpineImage+`") {
 					withMountedSecret(path: "/sekret", source: $secret) {
@@ -2559,15 +2498,14 @@ func TestContainerFileErrors(t *testing.T) {
 				}
 			}
 		}`, nil, &testutil.QueryOptions{Secrets: map[string]string{
-			"secret": "some-secret",
-		}})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "sekret: no such file or directory")
+				"secret": "some-secret",
+			}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "sekret: no such file or directory")
+	})
 }
 
-func TestContainerFSDirectory(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestFSDirectory(ctx context.Context, t *testctx.T) {
 	dirRes := struct {
 		Container struct {
 			From struct {
@@ -2577,7 +2515,7 @@ func TestContainerFSDirectory(t *testing.T) {
 			}
 		}
 	}{}
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			container {
 				from(address: "`+alpineImage+`") {
@@ -2602,7 +2540,7 @@ func TestContainerFSDirectory(t *testing.T) {
 			}
 		}
 	}{}
-	err = testutil.Query(
+	err = testutil.Query(t,
 		`query Test($id: DirectoryID!) {
 			container {
 				from(address: "`+alpineImage+`") {
@@ -2622,9 +2560,7 @@ func TestContainerFSDirectory(t *testing.T) {
 	require.Equal(t, distconsts.AlpineVersion, strings.TrimSpace(releaseStr))
 }
 
-func TestContainerRelativePaths(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestRelativePaths(ctx context.Context, t *testctx.T) {
 	dirRes := struct {
 		Directory struct {
 			WithNewFile struct {
@@ -2633,7 +2569,7 @@ func TestContainerRelativePaths(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			directory {
 				withNewFile(path: "some-file", contents: "some-content") {
@@ -2675,7 +2611,7 @@ func TestContainerRelativePaths(t *testing.T) {
 	}{}
 
 	cacheID := newCache(t)
-	err = testutil.Query(
+	err = testutil.Query(t,
 		`query Test($id: DirectoryID!, $cache: CacheVolumeID!) {
 			container {
 				from(address: "`+alpineImage+`") {
@@ -2730,7 +2666,7 @@ func TestContainerRelativePaths(t *testing.T) {
 			}
 		}
 	}{}
-	err = testutil.Query(
+	err = testutil.Query(t,
 		`query Test($id: DirectoryID!) {
 			container {
 				from(address: "`+alpineImage+`") {
@@ -2749,16 +2685,14 @@ func TestContainerRelativePaths(t *testing.T) {
 	require.Equal(t, "another-file\nsome-file\n", execRes.Container.From.WithMountedDirectory.WithExec.Stdout)
 }
 
-func TestContainerMultiFrom(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestMultiFrom(ctx context.Context, t *testctx.T) {
 	dirRes := struct {
 		Directory struct {
 			ID core.DirectoryID
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			directory {
 				id
@@ -2785,7 +2719,7 @@ func TestContainerMultiFrom(t *testing.T) {
 			}
 		}
 	}{}
-	err = testutil.Query(
+	err = testutil.Query(t,
 		`query Test($id: DirectoryID!) {
 			container {
 				from(address: "node:18.10.0-alpine") {
@@ -2810,8 +2744,8 @@ func TestContainerMultiFrom(t *testing.T) {
 	require.Contains(t, execRes.Container.From.WithMountedDirectory.WithExec.From.WithExec.WithExec.Stdout, "go version go1.18.2")
 }
 
-func TestContainerPublish(t *testing.T) {
-	c, ctx := connect(t)
+func (ContainerSuite) TestPublish(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	testRef := registryRef("container-publish")
 
@@ -2833,8 +2767,8 @@ func TestContainerPublish(t *testing.T) {
 	require.Equal(t, "im-a-entrypoint\n", output)
 }
 
-func TestExecFromScratch(t *testing.T) {
-	c, ctx := connect(t)
+func (ContainerSuite) TestExecFromScratch(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	// execute it from scratch, where there is no default platform, make sure it works and can be pushed
 	execBusybox := c.Container().
@@ -2848,8 +2782,8 @@ func TestExecFromScratch(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestContainerMultipleMounts(t *testing.T) {
-	c, ctx := connect(t)
+func (ContainerSuite) TestMultipleMounts(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "one"), []byte("1"), 0o600))
@@ -2874,21 +2808,19 @@ func TestContainerMultipleMounts(t *testing.T) {
 	require.Equal(t, "123", out)
 }
 
-func TestContainerExport(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestExport(ctx context.Context, t *testctx.T) {
 	wd := t.TempDir()
 	dest := t.TempDir()
 
-	c, ctx := connect(t, dagger.WithWorkdir(wd))
+	c := connect(ctx, t, dagger.WithWorkdir(wd))
 
 	entrypoint := []string{"sh", "-c", "im-a-entrypoint"}
 	ctr := c.Container().From(alpineImage).
 		WithEntrypoint(entrypoint)
 
-	t.Run("to absolute dir", func(t *testing.T) {
+	t.Run("to absolute dir", func(ctx context.Context, t *testctx.T) {
 		for _, useAsTarball := range []bool{true, false} {
-			t.Run(fmt.Sprintf("useAsTarball=%t", useAsTarball), func(t *testing.T) {
+			t.Run(fmt.Sprintf("useAsTarball=%t", useAsTarball), func(ctx context.Context, t *testctx.T) {
 				imagePath := filepath.Join(dest, "image.tar")
 
 				if useAsTarball {
@@ -2931,7 +2863,7 @@ func TestContainerExport(t *testing.T) {
 		}
 	})
 
-	t.Run("to workdir", func(t *testing.T) {
+	t.Run("to workdir", func(ctx context.Context, t *testctx.T) {
 		ok, err := ctr.Export(ctx, "./image.tar")
 		require.NoError(t, err)
 		require.True(t, ok)
@@ -2947,7 +2879,7 @@ func TestContainerExport(t *testing.T) {
 		require.Contains(t, entries, "manifest.json")
 	})
 
-	t.Run("to subdir", func(t *testing.T) {
+	t.Run("to subdir", func(ctx context.Context, t *testctx.T) {
 		ok, err := ctr.Export(ctx, "./foo/image.tar")
 		require.NoError(t, err)
 		require.True(t, ok)
@@ -2958,7 +2890,7 @@ func TestContainerExport(t *testing.T) {
 		require.Contains(t, entries, "manifest.json")
 	})
 
-	t.Run("to outer dir", func(t *testing.T) {
+	t.Run("to outer dir", func(ctx context.Context, t *testctx.T) {
 		ok, err := ctr.Export(ctx, "../")
 		require.Error(t, err)
 		require.False(t, ok)
@@ -2966,10 +2898,8 @@ func TestContainerExport(t *testing.T) {
 }
 
 // NOTE: more test coverage of Container.AsTarball are in TestContainerExport and TestContainerMultiPlatformExport
-func TestContainerAsTarball(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ContainerSuite) TestAsTarball(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 	ctr := c.Container().From(alpineImage)
 	output, err := ctr.
 		WithMountedFile("/foo.tar", ctr.AsTarball()).
@@ -2980,12 +2910,10 @@ func TestContainerAsTarball(t *testing.T) {
 	require.Equal(t, "/foo.tar: POSIX tar archive\n", output)
 }
 
-func TestContainerImport(t *testing.T) {
-	t.Parallel()
+func (ContainerSuite) TestImport(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
-	c, ctx := connect(t)
-
-	t.Run("OCI", func(t *testing.T) {
+	t.Run("OCI", func(ctx context.Context, t *testctx.T) {
 		pf, err := c.DefaultPlatform(ctx)
 		require.NoError(t, err)
 
@@ -3036,7 +2964,7 @@ func TestContainerImport(t *testing.T) {
 		require.Equal(t, "bar\n", out)
 	})
 
-	t.Run("Docker", func(t *testing.T) {
+	t.Run("Docker", func(ctx context.Context, t *testctx.T) {
 		out, err := c.Container().
 			Import(c.Container().From(alpineImage).WithEnvVariable("FOO", "bar").AsTarball(dagger.ContainerAsTarballOpts{
 				MediaTypes: dagger.Dockermediatypes,
@@ -3047,8 +2975,8 @@ func TestContainerImport(t *testing.T) {
 	})
 }
 
-func TestContainerFromImagePlatform(t *testing.T) {
-	c, ctx := connect(t)
+func (ContainerSuite) TestFromImagePlatform(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	var desiredPlatform dagger.Platform = "linux/arm64"
 
@@ -3058,8 +2986,8 @@ func TestContainerFromImagePlatform(t *testing.T) {
 	require.Equal(t, desiredPlatform, ctrPlatform)
 }
 
-func TestContainerFromIDPlatform(t *testing.T) {
-	c, ctx := connect(t)
+func (ContainerSuite) TestFromIDPlatform(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	var targetPlatform dagger.Platform = "linux/arm64/v8"
 	var desiredPlatform dagger.Platform = "linux/arm64"
@@ -3074,10 +3002,10 @@ func TestContainerFromIDPlatform(t *testing.T) {
 	require.Equal(t, desiredPlatform, platform)
 }
 
-func TestContainerMultiPlatformExport(t *testing.T) {
+func (ContainerSuite) TestMultiPlatformExport(ctx context.Context, t *testctx.T) {
 	for _, useAsTarball := range []bool{true, false} {
-		t.Run(fmt.Sprintf("useAsTarball=%t", useAsTarball), func(t *testing.T) {
-			c, ctx := connect(t)
+		t.Run(fmt.Sprintf("useAsTarball=%t", useAsTarball), func(ctx context.Context, t *testctx.T) {
+			c := connect(ctx, t)
 
 			variants := make([]*dagger.Container, 0, len(platformToUname))
 			for platform, uname := range platformToUname {
@@ -3146,8 +3074,8 @@ func TestContainerMultiPlatformExport(t *testing.T) {
 }
 
 // Multiplatform publish is also tested in more complicated scenarios in platform_test.go
-func TestContainerMultiPlatformPublish(t *testing.T) {
-	c, ctx := connect(t)
+func (ContainerSuite) TestMultiPlatformPublish(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	variants := make([]*dagger.Container, 0, len(platformToUname))
 	for platform, uname := range platformToUname {
@@ -3174,8 +3102,8 @@ func TestContainerMultiPlatformPublish(t *testing.T) {
 	}
 }
 
-func TestContainerMultiPlatformImport(t *testing.T) {
-	c, ctx := connect(t)
+func (ContainerSuite) TestMultiPlatformImport(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	variants := make([]*dagger.Container, 0, len(platformToUname))
 	for platform := range platformToUname {
@@ -3204,10 +3132,8 @@ func TestContainerMultiPlatformImport(t *testing.T) {
 	}
 }
 
-func TestContainerWithDirectoryToMount(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ContainerSuite) TestWithDirectoryToMount(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	mnt := c.Directory().
 		WithNewDirectory("/top/sub-dir/sub-file").
@@ -3232,17 +3158,15 @@ func TestContainerWithDirectoryToMount(t *testing.T) {
 	}, strings.Split(strings.Trim(contents, "\n"), "\n"))
 }
 
-func TestContainerExecError(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ContainerSuite) TestExecError(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	outMsg := "THIS SHOULD GO TO STDOUT"
 	encodedOutMsg := base64.StdEncoding.EncodeToString([]byte(outMsg))
 	errMsg := "THIS SHOULD GO TO STDERR"
 	encodedErrMsg := base64.StdEncoding.EncodeToString([]byte(errMsg))
 
-	t.Run("includes output of failed exec in error", func(t *testing.T) {
+	t.Run("includes output of failed exec in error", func(ctx context.Context, t *testctx.T) {
 		_, err := c.Container().
 			From(alpineImage).
 			WithExec([]string{"sh", "-c", fmt.Sprintf(
@@ -3257,7 +3181,7 @@ func TestContainerExecError(t *testing.T) {
 		require.Equal(t, errMsg, exErr.Stderr)
 	})
 
-	t.Run("includes output of failed exec in error when redirects are enabled", func(t *testing.T) {
+	t.Run("includes output of failed exec in error when redirects are enabled", func(ctx context.Context, t *testctx.T) {
 		_, err := c.Container().
 			From(alpineImage).
 			WithExec(
@@ -3278,7 +3202,7 @@ func TestContainerExecError(t *testing.T) {
 		require.Equal(t, errMsg, exErr.Stderr)
 	})
 
-	t.Run("truncates output past a maximum size", func(t *testing.T) {
+	t.Run("truncates output past a maximum size", func(ctx context.Context, t *testctx.T) {
 		// fill a byte buffer with a string that is slightly over the size of the max output
 		// size, then base64 encode it
 		var stdoutBuf bytes.Buffer
@@ -3314,10 +3238,8 @@ func TestContainerExecError(t *testing.T) {
 	})
 }
 
-func TestContainerWithRegistryAuth(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ContainerSuite) TestWithRegistryAuth(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	testRef := privateRegistryRef("container-with-registry-auth")
 	container := c.Container().From(alpineImage)
@@ -3339,10 +3261,8 @@ func TestContainerWithRegistryAuth(t *testing.T) {
 	require.Contains(t, pushedRef, "@sha256:")
 }
 
-func TestContainerImageRef(t *testing.T) {
-	t.Parallel()
-
-	t.Run("should test query returning imageRef", func(t *testing.T) {
+func (ContainerSuite) TestImageRef(ctx context.Context, t *testctx.T) {
+	t.Run("should test query returning imageRef", func(ctx context.Context, t *testctx.T) {
 		res := struct {
 			Container struct {
 				From struct {
@@ -3351,7 +3271,7 @@ func TestContainerImageRef(t *testing.T) {
 			}
 		}{}
 
-		err := testutil.Query(
+		err := testutil.Query(t,
 			`{
 				container {
 					from(address: "`+alpineImage+`") {
@@ -3363,7 +3283,7 @@ func TestContainerImageRef(t *testing.T) {
 		require.Contains(t, res.Container.From.ImageRef, "docker.io/library/"+alpineImage+"@sha256:")
 	})
 
-	t.Run("should throw error after the container image modification with exec", func(t *testing.T) {
+	t.Run("should throw error after the container image modification with exec", func(ctx context.Context, t *testctx.T) {
 		res := struct {
 			Container struct {
 				From struct {
@@ -3372,7 +3292,7 @@ func TestContainerImageRef(t *testing.T) {
 			}
 		}{}
 
-		err := testutil.Query(
+		err := testutil.Query(t,
 			`{
 				container {
 					from(address:"hello-world") {
@@ -3386,7 +3306,7 @@ func TestContainerImageRef(t *testing.T) {
 		require.Contains(t, err.Error(), "Image reference can only be retrieved immediately after the 'Container.From' call. Error in fetching imageRef as the container image is changed")
 	})
 
-	t.Run("should throw error after the container image modification with exec", func(t *testing.T) {
+	t.Run("should throw error after the container image modification with exec", func(ctx context.Context, t *testctx.T) {
 		res := struct {
 			Container struct {
 				From struct {
@@ -3395,7 +3315,7 @@ func TestContainerImageRef(t *testing.T) {
 			}
 		}{}
 
-		err := testutil.Query(
+		err := testutil.Query(t,
 			`{
 				container {
 					from(address:"hello-world") {
@@ -3409,8 +3329,8 @@ func TestContainerImageRef(t *testing.T) {
 		require.Contains(t, err.Error(), "Image reference can only be retrieved immediately after the 'Container.From' call. Error in fetching imageRef as the container image is changed")
 	})
 
-	t.Run("should throw error after the container image modification with directory", func(t *testing.T) {
-		c, ctx := connect(t)
+	t.Run("should throw error after the container image modification with directory", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		dir := c.Directory().
 			WithNewFile("some-file", "some-content").
@@ -3429,11 +3349,9 @@ func TestContainerImageRef(t *testing.T) {
 	})
 }
 
-func TestContainerBuildNilContextError(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestBuildNilContextError(ctx context.Context, t *testctx.T) {
 	// regression test, this previously caused the engine to panic
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			container {
 				build(context: "") {
@@ -3444,8 +3362,8 @@ func TestContainerBuildNilContextError(t *testing.T) {
 	require.ErrorContains(t, err, "cannot decode empty string as ID")
 }
 
-func TestContainerInsecureRootCapabilites(t *testing.T) {
-	c, ctx := connect(t)
+func (ContainerSuite) TestInsecureRootCapabilites(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	// This isn't exhaustive, but it's the major important ones. Being exhaustive
 	// is trickier since the full list of caps is host dependent based on the kernel version.
@@ -3484,8 +3402,8 @@ func TestContainerInsecureRootCapabilites(t *testing.T) {
 	}
 }
 
-func TestContainerInsecureRootCapabilitesWithService(t *testing.T) {
-	c, ctx := connect(t)
+func (ContainerSuite) TestInsecureRootCapabilitesWithService(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	// verify the root capabilities setting works by executing dockerd with it and
 	// testing it can startup, create containers and bind mount from its filesystem to
@@ -3525,8 +3443,8 @@ func TestContainerInsecureRootCapabilitesWithService(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("%s-from-outside\n%s-from-inside\n", randID, randID), out)
 }
 
-func TestContainerNoExec(t *testing.T) {
-	c, ctx := connect(t)
+func (ContainerSuite) TestNoExec(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	stdout, err := c.Container().From(alpineImage).Stdout(ctx)
 	require.NoError(t, err)
@@ -3545,10 +3463,10 @@ func TestContainerNoExec(t *testing.T) {
 	require.Contains(t, err.Error(), "no command has been set")
 }
 
-func TestContainerWithMountedFileOwner(t *testing.T) {
-	c, ctx := connect(t)
+func (ContainerSuite) TestWithMountedFileOwner(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
-	t.Run("simple file", func(t *testing.T) {
+	t.Run("simple file", func(ctx context.Context, t *testctx.T) {
 		tmp := t.TempDir()
 
 		err := os.WriteFile(filepath.Join(tmp, "message.txt"), []byte("hello world"), 0o600)
@@ -3556,14 +3474,14 @@ func TestContainerWithMountedFileOwner(t *testing.T) {
 
 		file := c.Host().Directory(tmp).File("message.txt")
 
-		testOwnership(ctx, t, c, func(ctr *dagger.Container, name string, owner string) *dagger.Container {
+		testOwnership(t, c, func(ctr *dagger.Container, name string, owner string) *dagger.Container {
 			return ctr.WithMountedFile(name, file, dagger.ContainerWithMountedFileOpts{
 				Owner: owner,
 			})
 		})
 	})
 
-	t.Run("file from subdirectory", func(t *testing.T) {
+	t.Run("file from subdirectory", func(ctx context.Context, t *testctx.T) {
 		tmp := t.TempDir()
 
 		err := os.Mkdir(filepath.Join(tmp, "subdir"), 0o755)
@@ -3574,7 +3492,7 @@ func TestContainerWithMountedFileOwner(t *testing.T) {
 
 		file := c.Host().Directory(tmp).Directory("subdir").File("message.txt")
 
-		testOwnership(ctx, t, c, func(ctr *dagger.Container, name string, owner string) *dagger.Container {
+		testOwnership(t, c, func(ctr *dagger.Container, name string, owner string) *dagger.Container {
 			return ctr.WithMountedFile(name, file, dagger.ContainerWithMountedFileOpts{
 				Owner: owner,
 			})
@@ -3582,10 +3500,10 @@ func TestContainerWithMountedFileOwner(t *testing.T) {
 	})
 }
 
-func TestContainerWithMountedDirectoryOwner(t *testing.T) {
-	c, ctx := connect(t)
+func (ContainerSuite) TestWithMountedDirectoryOwner(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
-	t.Run("simple directory", func(t *testing.T) {
+	t.Run("simple directory", func(ctx context.Context, t *testctx.T) {
 		tmp := t.TempDir()
 
 		err := os.WriteFile(filepath.Join(tmp, "message.txt"), []byte("hello world"), 0o600)
@@ -3593,14 +3511,14 @@ func TestContainerWithMountedDirectoryOwner(t *testing.T) {
 
 		dir := c.Host().Directory(tmp)
 
-		testOwnership(ctx, t, c, func(ctr *dagger.Container, name string, owner string) *dagger.Container {
+		testOwnership(t, c, func(ctr *dagger.Container, name string, owner string) *dagger.Container {
 			return ctr.WithMountedDirectory(name, dir, dagger.ContainerWithMountedDirectoryOpts{
 				Owner: owner,
 			})
 		})
 	})
 
-	t.Run("subdirectory", func(t *testing.T) {
+	t.Run("subdirectory", func(ctx context.Context, t *testctx.T) {
 		tmp := t.TempDir()
 
 		err := os.Mkdir(filepath.Join(tmp, "subdir"), 0o755)
@@ -3611,14 +3529,14 @@ func TestContainerWithMountedDirectoryOwner(t *testing.T) {
 
 		dir := c.Host().Directory(tmp).Directory("subdir")
 
-		testOwnership(ctx, t, c, func(ctr *dagger.Container, name string, owner string) *dagger.Container {
+		testOwnership(t, c, func(ctr *dagger.Container, name string, owner string) *dagger.Container {
 			return ctr.WithMountedDirectory(name, dir, dagger.ContainerWithMountedDirectoryOpts{
 				Owner: owner,
 			})
 		})
 	})
 
-	t.Run("permissions", func(t *testing.T) {
+	t.Run("permissions", func(ctx context.Context, t *testctx.T) {
 		dir := c.Directory().
 			WithNewDirectory("perms", dagger.DirectoryWithNewDirectoryOpts{
 				Permissions: 0o745,
@@ -3647,10 +3565,10 @@ func TestContainerWithMountedDirectoryOwner(t *testing.T) {
 	})
 }
 
-func TestContainerWithFileOwner(t *testing.T) {
-	c, ctx := connect(t)
+func (ContainerSuite) TestWithFileOwner(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
-	t.Run("simple file", func(t *testing.T) {
+	t.Run("simple file", func(ctx context.Context, t *testctx.T) {
 		tmp := t.TempDir()
 
 		err := os.WriteFile(filepath.Join(tmp, "message.txt"), []byte("hello world"), 0o600)
@@ -3658,14 +3576,14 @@ func TestContainerWithFileOwner(t *testing.T) {
 
 		file := c.Host().Directory(tmp).File("message.txt")
 
-		testOwnership(ctx, t, c, func(ctr *dagger.Container, name string, owner string) *dagger.Container {
+		testOwnership(t, c, func(ctr *dagger.Container, name string, owner string) *dagger.Container {
 			return ctr.WithFile(name, file, dagger.ContainerWithFileOpts{
 				Owner: owner,
 			})
 		})
 	})
 
-	t.Run("file from subdirectory", func(t *testing.T) {
+	t.Run("file from subdirectory", func(ctx context.Context, t *testctx.T) {
 		tmp := t.TempDir()
 
 		err := os.Mkdir(filepath.Join(tmp, "subdir"), 0o755)
@@ -3676,7 +3594,7 @@ func TestContainerWithFileOwner(t *testing.T) {
 
 		file := c.Host().Directory(tmp).Directory("subdir").File("message.txt")
 
-		testOwnership(ctx, t, c, func(ctr *dagger.Container, name string, owner string) *dagger.Container {
+		testOwnership(t, c, func(ctr *dagger.Container, name string, owner string) *dagger.Container {
 			return ctr.WithFile(name, file, dagger.ContainerWithFileOpts{
 				Owner: owner,
 			})
@@ -3684,10 +3602,10 @@ func TestContainerWithFileOwner(t *testing.T) {
 	})
 }
 
-func TestContainerWithDirectoryOwner(t *testing.T) {
-	c, ctx := connect(t)
+func (ContainerSuite) TestWithDirectoryOwner(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
-	t.Run("simple directory", func(t *testing.T) {
+	t.Run("simple directory", func(ctx context.Context, t *testctx.T) {
 		tmp := t.TempDir()
 
 		err := os.WriteFile(filepath.Join(tmp, "message.txt"), []byte("hello world"), 0o600)
@@ -3695,14 +3613,14 @@ func TestContainerWithDirectoryOwner(t *testing.T) {
 
 		dir := c.Host().Directory(tmp)
 
-		testOwnership(ctx, t, c, func(ctr *dagger.Container, name string, owner string) *dagger.Container {
+		testOwnership(t, c, func(ctr *dagger.Container, name string, owner string) *dagger.Container {
 			return ctr.WithDirectory(name, dir, dagger.ContainerWithDirectoryOpts{
 				Owner: owner,
 			})
 		})
 	})
 
-	t.Run("subdirectory", func(t *testing.T) {
+	t.Run("subdirectory", func(ctx context.Context, t *testctx.T) {
 		tmp := t.TempDir()
 
 		err := os.Mkdir(filepath.Join(tmp, "subdir"), 0o755)
@@ -3713,7 +3631,7 @@ func TestContainerWithDirectoryOwner(t *testing.T) {
 
 		dir := c.Host().Directory(tmp).Directory("subdir")
 
-		testOwnership(ctx, t, c, func(ctr *dagger.Container, name string, owner string) *dagger.Container {
+		testOwnership(t, c, func(ctr *dagger.Container, name string, owner string) *dagger.Container {
 			return ctr.WithDirectory(name, dir, dagger.ContainerWithDirectoryOpts{
 				Owner: owner,
 			})
@@ -3721,28 +3639,28 @@ func TestContainerWithDirectoryOwner(t *testing.T) {
 	})
 }
 
-func TestContainerWithNewFileOwner(t *testing.T) {
-	c, ctx := connect(t)
+func (ContainerSuite) TestWithNewFileOwner(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
-	testOwnership(ctx, t, c, func(ctr *dagger.Container, name string, owner string) *dagger.Container {
+	testOwnership(t, c, func(ctr *dagger.Container, name string, owner string) *dagger.Container {
 		return ctr.WithNewFile(name, dagger.ContainerWithNewFileOpts{
 			Owner: owner,
 		})
 	})
 }
 
-func TestContainerWithMountedCacheOwner(t *testing.T) {
-	c, ctx := connect(t)
+func (ContainerSuite) TestWithMountedCacheOwner(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	cache := c.CacheVolume("test")
 
-	testOwnership(ctx, t, c, func(ctr *dagger.Container, name string, owner string) *dagger.Container {
+	testOwnership(t, c, func(ctr *dagger.Container, name string, owner string) *dagger.Container {
 		return ctr.WithMountedCache(name, cache, dagger.ContainerWithMountedCacheOpts{
 			Owner: owner,
 		})
 	})
 
-	t.Run("permissions (empty)", func(t *testing.T) {
+	t.Run("permissions (empty)", func(ctx context.Context, t *testctx.T) {
 		ctr := c.Container().From(alpineImage).
 			WithExec([]string{"adduser", "-D", "inherituser"}).
 			WithExec([]string{"adduser", "-u", "1234", "-D", "auser"}).
@@ -3757,7 +3675,7 @@ func TestContainerWithMountedCacheOwner(t *testing.T) {
 		require.Equal(t, "755:auser:agroup\n", out)
 	})
 
-	t.Run("permissions (source)", func(t *testing.T) {
+	t.Run("permissions (source)", func(ctx context.Context, t *testctx.T) {
 		dir := c.Directory().
 			WithNewDirectory("perms", dagger.DirectoryWithNewDirectoryOpts{
 				Permissions: 0o745,
@@ -3787,21 +3705,19 @@ func TestContainerWithMountedCacheOwner(t *testing.T) {
 	})
 }
 
-func TestContainerWithMountedSecretOwner(t *testing.T) {
-	c, ctx := connect(t)
+func (ContainerSuite) TestWithMountedSecretOwner(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	secret := c.SetSecret("test", "hunter2")
 
-	testOwnership(ctx, t, c, func(ctr *dagger.Container, name string, owner string) *dagger.Container {
+	testOwnership(t, c, func(ctr *dagger.Container, name string, owner string) *dagger.Container {
 		return ctr.WithMountedSecret(name, secret, dagger.ContainerWithMountedSecretOpts{
 			Owner: owner,
 		})
 	})
 }
 
-func TestContainerParallelMutation(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestParallelMutation(ctx context.Context, t *testctx.T) {
 	res := struct {
 		Container struct {
 			A struct {
@@ -3811,7 +3727,7 @@ func TestContainerParallelMutation(t *testing.T) {
 		}
 	}{}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			container {
 				a: withEnvVariable(name: "FOO", value: "BAR") {
@@ -3825,9 +3741,7 @@ func TestContainerParallelMutation(t *testing.T) {
 	require.Empty(t, res.Container.B, "BAR")
 }
 
-func TestContainerForceCompression(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestForceCompression(ctx context.Context, t *testctx.T) {
 	for _, tc := range []struct {
 		compression          dagger.ImageLayerCompression
 		expectedOCIMediaType string
@@ -3850,10 +3764,8 @@ func TestContainerForceCompression(t *testing.T) {
 		},
 	} {
 		tc := tc
-		t.Run(string(tc.compression), func(t *testing.T) {
-			t.Parallel()
-
-			c, ctx := connect(t)
+		t.Run(string(tc.compression), func(ctx context.Context, t *testctx.T) {
+			c := connect(ctx, t)
 
 			ref := registryRef("testcontainerpublishforcecompression" + strings.ToLower(string(tc.compression)))
 			_, err := c.Container().
@@ -3905,9 +3817,7 @@ func TestContainerForceCompression(t *testing.T) {
 	}
 }
 
-func TestContainerMediaTypes(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestMediaTypes(ctx context.Context, t *testctx.T) {
 	for _, tc := range []struct {
 		mediaTypes           dagger.ImageMediaTypes
 		expectedOCIMediaType string
@@ -3926,10 +3836,8 @@ func TestContainerMediaTypes(t *testing.T) {
 		},
 	} {
 		tc := tc
-		t.Run(string(tc.mediaTypes), func(t *testing.T) {
-			t.Parallel()
-
-			c, ctx := connect(t)
+		t.Run(string(tc.mediaTypes), func(ctx context.Context, t *testctx.T) {
+			c := connect(ctx, t)
 
 			ref := registryRef("testcontainerpublishmediatypes" + strings.ToLower(string(tc.mediaTypes)))
 			_, err := c.Container().
@@ -3956,7 +3864,7 @@ func TestContainerMediaTypes(t *testing.T) {
 
 			for _, useAsTarball := range []bool{true, false} {
 				useAsTarball := useAsTarball
-				t.Run(fmt.Sprintf("useAsTarball=%t", useAsTarball), func(t *testing.T) {
+				t.Run(fmt.Sprintf("useAsTarball=%t", useAsTarball), func(ctx context.Context, t *testctx.T) {
 					tarPath := filepath.Join(t.TempDir(), "export.tar")
 					if useAsTarball {
 						_, err := c.Container().
@@ -3996,10 +3904,8 @@ func TestContainerMediaTypes(t *testing.T) {
 	}
 }
 
-func TestContainerBuildMergesWithParent(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ContainerSuite) TestBuildMergesWithParent(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	// Create a builder container
 	builderCtr := c.Directory().WithNewFile("Dockerfile",
@@ -4048,7 +3954,7 @@ EXPOSE 8080
 		} `json:"loadContainerFromID"`
 	}{}
 
-	err = testutil.Query(`
+	err = testutil.Query(t, `
         query Test($id: ContainerID!) {
             loadContainerFromID(id: $id) {
                 exposedPorts {
@@ -4083,10 +3989,8 @@ EXPOSE 8080
 	}
 }
 
-func TestContainerFromMergesWithParent(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ContainerSuite) TestFromMergesWithParent(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	// Create a container with envs and pull alpine image on it
 	testCtr := c.Container().
@@ -4125,9 +4029,8 @@ func TestContainerFromMergesWithParent(t *testing.T) {
 	require.Equal(t, 5000, port)
 }
 
-func TestContainerImageLoadCompatibility(t *testing.T) {
-	t.Parallel()
-	c, ctx := connect(t)
+func (ContainerSuite) TestImageLoadCompatibility(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	for i, dockerVersion := range []string{"20.10", "23.0", "24.0"} {
 		dockerVersion := dockerVersion
@@ -4155,8 +4058,7 @@ func TestContainerImageLoadCompatibility(t *testing.T) {
 			mediaType := mediaType
 			for _, compression := range []dagger.ImageLayerCompression{dagger.Gzip, dagger.Zstd, dagger.Uncompressed} {
 				compression := compression
-				t.Run(fmt.Sprintf("%s-%s-%s-%s", t.Name(), dockerVersion, mediaType, compression), func(t *testing.T) {
-					t.Parallel()
+				t.Run(fmt.Sprintf("%s-%s-%s-%s", t.Name(), dockerVersion, mediaType, compression), func(ctx context.Context, t *testctx.T) {
 					tmpdir := t.TempDir()
 					tmpfile := filepath.Join(tmpdir, fmt.Sprintf("test-%s-%s-%s.tar", dockerVersion, mediaType, compression))
 					_, err := c.Container().From(alpineImage).
@@ -4202,10 +4104,8 @@ func TestContainerImageLoadCompatibility(t *testing.T) {
 	}
 }
 
-func TestContainerWithMountedSecretMode(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ContainerSuite) TestWithMountedSecretMode(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 	t.Cleanup(func() { c.Close() })
 
 	secret := c.SetSecret("test", "secret")
@@ -4220,9 +4120,8 @@ func TestContainerWithMountedSecretMode(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestContainerNestedExec(t *testing.T) {
-	t.Parallel()
-	c, ctx := connect(t)
+func (ContainerSuite) TestNestedExec(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	_, err := c.Container().From(alpineImage).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -4236,11 +4135,11 @@ func TestContainerNestedExec(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestContainerEmptyExecDiff(t *testing.T) {
+func (ContainerSuite) TestEmptyExecDiff(ctx context.Context, t *testctx.T) {
 	// if an exec makes no changes, the diff should be empty, including of files
 	// mounted in by the engine like the init/resolv.conf/etc.
-	t.Parallel()
-	c, ctx := connect(t)
+
+	c := connect(ctx, t)
 
 	base := c.Container().From(alpineImage)
 	ents, err := base.Rootfs().Diff(base.WithExec([]string{"true"}).Rootfs()).Entries(ctx)

--- a/core/integration/dind_test.go
+++ b/core/integration/dind_test.go
@@ -1,16 +1,15 @@
 package core
 
 import (
-	"testing"
+	"context"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/dagger/dagger/internal/testutil"
+	"github.com/dagger/dagger/testctx"
 )
 
-func TestDIND(t *testing.T) {
-	t.Parallel()
-
+func (ContainerSuite) TestDIND(ctx context.Context, t *testctx.T) {
 	var res struct {
 		Container struct {
 			From struct {
@@ -23,7 +22,7 @@ func TestDIND(t *testing.T) {
 		}
 	}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`
 {
   container {

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"os"
 	"regexp"
 	"strings"
@@ -13,11 +14,16 @@ import (
 	"dagger.io/dagger"
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/internal/testutil"
+	"github.com/dagger/dagger/testctx"
 )
 
-func TestEmptyDirectory(t *testing.T) {
-	t.Parallel()
+type DirectorySuite struct{}
 
+func TestDirectory(t *testing.T) {
+	testctx.Run(testCtx, t, DirectorySuite{}, Middleware()...)
+}
+
+func (DirectorySuite) TestEmpty(ctx context.Context, t *testctx.T) {
 	var res struct {
 		Directory struct {
 			ID      core.DirectoryID
@@ -25,7 +31,7 @@ func TestEmptyDirectory(t *testing.T) {
 		}
 	}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			directory {
 				entries
@@ -35,19 +41,15 @@ func TestEmptyDirectory(t *testing.T) {
 	require.Empty(t, res.Directory.Entries)
 }
 
-func TestScratchDirectory(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (DirectorySuite) TestScratch(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	_, err := c.Container().Directory("/").Entries(ctx)
 	require.NoError(t, err)
 	// require.ErrorContains(t, err, "no such file or directory")
 }
 
-func TestDirectoryWithNewFile(t *testing.T) {
-	t.Parallel()
-
+func (DirectorySuite) TestWithNewFile(ctx context.Context, t *testctx.T) {
 	var res struct {
 		Directory struct {
 			WithNewFile struct {
@@ -57,7 +59,7 @@ func TestDirectoryWithNewFile(t *testing.T) {
 		}
 	}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			directory {
 				withNewFile(path: "some-file", contents: "some-content") {
@@ -71,9 +73,7 @@ func TestDirectoryWithNewFile(t *testing.T) {
 	require.Equal(t, []string{"some-file"}, res.Directory.WithNewFile.Entries)
 }
 
-func TestDirectoryEntries(t *testing.T) {
-	t.Parallel()
-
+func (DirectorySuite) TestEntries(ctx context.Context, t *testctx.T) {
 	var res struct {
 		Directory struct {
 			WithNewFile struct {
@@ -84,7 +84,7 @@ func TestDirectoryEntries(t *testing.T) {
 		}
 	}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			directory {
 				withNewFile(path: "some-file", contents: "some-content") {
@@ -98,9 +98,7 @@ func TestDirectoryEntries(t *testing.T) {
 	require.ElementsMatch(t, []string{"some-file", "some-dir"}, res.Directory.WithNewFile.WithNewFile.Entries)
 }
 
-func TestDirectoryEntriesOfPath(t *testing.T) {
-	t.Parallel()
-
+func (DirectorySuite) TestEntriesOfPath(ctx context.Context, t *testctx.T) {
 	var res struct {
 		Directory struct {
 			WithNewFile struct {
@@ -111,7 +109,7 @@ func TestDirectoryEntriesOfPath(t *testing.T) {
 		}
 	}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			directory {
 				withNewFile(path: "some-file", contents: "some-content") {
@@ -125,9 +123,7 @@ func TestDirectoryEntriesOfPath(t *testing.T) {
 	require.Equal(t, []string{"sub-file"}, res.Directory.WithNewFile.WithNewFile.Entries)
 }
 
-func TestDirectoryDirectory(t *testing.T) {
-	t.Parallel()
-
+func (DirectorySuite) TestDirectory(ctx context.Context, t *testctx.T) {
 	var res struct {
 		Directory struct {
 			WithNewFile struct {
@@ -140,7 +136,7 @@ func TestDirectoryDirectory(t *testing.T) {
 		}
 	}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			directory {
 				withNewFile(path: "some-file", contents: "some-content") {
@@ -156,9 +152,7 @@ func TestDirectoryDirectory(t *testing.T) {
 	require.Equal(t, []string{"sub-file"}, res.Directory.WithNewFile.WithNewFile.Directory.Entries)
 }
 
-func TestDirectoryDirectoryWithNewFile(t *testing.T) {
-	t.Parallel()
-
+func (DirectorySuite) TestDirectoryWithNewFile(ctx context.Context, t *testctx.T) {
 	var res struct {
 		Directory struct {
 			WithNewFile struct {
@@ -173,7 +167,7 @@ func TestDirectoryDirectoryWithNewFile(t *testing.T) {
 		}
 	}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			directory {
 				withNewFile(path: "some-file", contents: "some-content") {
@@ -193,10 +187,8 @@ func TestDirectoryDirectoryWithNewFile(t *testing.T) {
 		res.Directory.WithNewFile.WithNewFile.Directory.WithNewFile.Entries)
 }
 
-func TestDirectoryWithDirectory(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (DirectorySuite) TestWithDirectory(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	dir := c.Directory().
 		WithNewFile("some-file", "some-content").
@@ -215,13 +207,13 @@ func TestDirectoryWithDirectory(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"sub-file"}, entries)
 
-	t.Run("copies directory contents to .", func(t *testing.T) {
+	t.Run("copies directory contents to .", func(ctx context.Context, t *testctx.T) {
 		entries, err := c.Directory().WithDirectory(".", dir).Entries(ctx)
 		require.NoError(t, err)
 		require.Equal(t, []string{"sub-file"}, entries)
 	})
 
-	t.Run("respects permissions", func(t *testing.T) {
+	t.Run("respects permissions", func(ctx context.Context, t *testctx.T) {
 		dir := c.Directory().
 			WithNewFile("some-file", "some content", dagger.DirectoryWithNewFileOpts{Permissions: 0o444}).
 			WithNewDirectory("some-dir", dagger.DirectoryWithNewDirectoryOpts{Permissions: 0o444}).
@@ -250,10 +242,8 @@ func TestDirectoryWithDirectory(t *testing.T) {
 	})
 }
 
-func TestDirectoryWithDirectoryIncludeExclude(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (DirectorySuite) TestWithDirectoryIncludeExclude(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	dir := c.Directory().
 		WithNewFile("a.txt", "").
@@ -263,7 +253,7 @@ func TestDirectoryWithDirectoryIncludeExclude(t *testing.T) {
 		WithNewFile("subdir/e.txt", "").
 		WithNewFile("subdir/f.txt.rar", "")
 
-	t.Run("exclude", func(t *testing.T) {
+	t.Run("exclude", func(ctx context.Context, t *testctx.T) {
 		entries, err := c.Directory().WithDirectory(".", dir, dagger.DirectoryWithDirectoryOpts{
 			Exclude: []string{"*.rar"},
 		}).Entries(ctx)
@@ -271,7 +261,7 @@ func TestDirectoryWithDirectoryIncludeExclude(t *testing.T) {
 		require.Equal(t, []string{"a.txt", "b.txt", "subdir"}, entries)
 	})
 
-	t.Run("include", func(t *testing.T) {
+	t.Run("include", func(ctx context.Context, t *testctx.T) {
 		entries, err := c.Directory().WithDirectory(".", dir, dagger.DirectoryWithDirectoryOpts{
 			Include: []string{"*.rar"},
 		}).Entries(ctx)
@@ -279,7 +269,7 @@ func TestDirectoryWithDirectoryIncludeExclude(t *testing.T) {
 		require.Equal(t, []string{"c.txt.rar"}, entries)
 	})
 
-	t.Run("exclude overrides include", func(t *testing.T) {
+	t.Run("exclude overrides include", func(ctx context.Context, t *testctx.T) {
 		entries, err := c.Directory().WithDirectory(".", dir, dagger.DirectoryWithDirectoryOpts{
 			Include: []string{"*.txt"},
 			Exclude: []string{"b.txt"},
@@ -288,7 +278,7 @@ func TestDirectoryWithDirectoryIncludeExclude(t *testing.T) {
 		require.Equal(t, []string{"a.txt"}, entries)
 	})
 
-	t.Run("include does not override exclude", func(t *testing.T) {
+	t.Run("include does not override exclude", func(ctx context.Context, t *testctx.T) {
 		entries, err := c.Directory().WithDirectory(".", dir, dagger.DirectoryWithDirectoryOpts{
 			Include: []string{"a.txt"},
 			Exclude: []string{"*.txt"},
@@ -297,7 +287,7 @@ func TestDirectoryWithDirectoryIncludeExclude(t *testing.T) {
 		require.Equal(t, []string{}, entries)
 	})
 
-	t.Run("exclude works on directory", func(t *testing.T) {
+	t.Run("exclude works on directory", func(ctx context.Context, t *testctx.T) {
 		entries, err := c.Directory().WithDirectory(".", dir, dagger.DirectoryWithDirectoryOpts{
 			Exclude: []string{"subdir"},
 		}).Entries(ctx)
@@ -307,7 +297,7 @@ func TestDirectoryWithDirectoryIncludeExclude(t *testing.T) {
 
 	subdir := dir.Directory("subdir")
 
-	t.Run("exclude respects subdir", func(t *testing.T) {
+	t.Run("exclude respects subdir", func(ctx context.Context, t *testctx.T) {
 		entries, err := c.Directory().WithDirectory(".", subdir, dagger.DirectoryWithDirectoryOpts{
 			Exclude: []string{"*.rar"},
 		}).Entries(ctx)
@@ -316,9 +306,8 @@ func TestDirectoryWithDirectoryIncludeExclude(t *testing.T) {
 	})
 }
 
-func TestDirectoryWithNewDirectory(t *testing.T) {
-	t.Parallel()
-	c, ctx := connect(t)
+func (DirectorySuite) TestWithNewDirectory(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	dir := c.Directory().
 		WithNewDirectory("a").
@@ -334,15 +323,14 @@ func TestDirectoryWithNewDirectory(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"c"}, entries)
 
-	t.Run("does not permit creating directory outside of root", func(t *testing.T) {
+	t.Run("does not permit creating directory outside of root", func(ctx context.Context, t *testctx.T) {
 		_, err := dir.Directory("b").WithNewDirectory("../c").ID(ctx)
 		require.Error(t, err)
 	})
 }
 
-func TestDirectoryWithFile(t *testing.T) {
-	t.Parallel()
-	c, ctx := connect(t)
+func (DirectorySuite) TestWithFile(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	file := c.Directory().
 		WithNewFile("some-file", "some-content").
@@ -373,7 +361,7 @@ func TestDirectoryWithFile(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "some-content", content)
 
-	t.Run("respects permissions", func(t *testing.T) {
+	t.Run("respects permissions", func(ctx context.Context, t *testctx.T) {
 		dir := c.Directory().
 			WithNewFile(
 				"file-with-permissions",
@@ -397,9 +385,8 @@ func TestDirectoryWithFile(t *testing.T) {
 	})
 }
 
-func TestDirectoryWithFiles(t *testing.T) {
-	t.Parallel()
-	c, ctx := connect(t)
+func (DirectorySuite) TestWithFiles(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	file1 := c.Directory().
 		WithNewFile("first-file", "file1 content").
@@ -431,7 +418,7 @@ func TestDirectoryWithFiles(t *testing.T) {
 	require.Equal(t, "file1 content", content)
 	require.NoError(t, err)
 
-	t.Run("respects permissions", func(t *testing.T) {
+	t.Run("respects permissions", func(ctx context.Context, t *testctx.T) {
 		file1 := c.Directory().
 			WithNewFile("file-set-permissions", "this should have rwxrwxrwx permissions", dagger.DirectoryWithNewFileOpts{Permissions: 0o777}).
 			File("file-set-permissions")
@@ -455,9 +442,8 @@ func TestDirectoryWithFiles(t *testing.T) {
 	})
 }
 
-func TestDirectoryWithTimestamps(t *testing.T) {
-	t.Parallel()
-	c, ctx := connect(t)
+func (DirectorySuite) TestWithTimestamps(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	reallyImportantTime := time.Date(1985, 10, 26, 8, 15, 0, 0, time.UTC)
 
@@ -472,7 +458,7 @@ func TestDirectoryWithTimestamps(t *testing.T) {
 		Directory("output").
 		WithTimestamps(int(reallyImportantTime.Unix()))
 
-	t.Run("changes file and directory timestamps recursively", func(t *testing.T) {
+	t.Run("changes file and directory timestamps recursively", func(ctx context.Context, t *testctx.T) {
 		ls, err := c.Container().
 			From(alpineImage).
 			WithMountedDirectory("/dir", dir).
@@ -485,7 +471,7 @@ func TestDirectoryWithTimestamps(t *testing.T) {
 		require.Regexp(t, regexp.MustCompile(`-rw-r--r--\s+1 root\s+root\s+\d+ Oct 26  1985 sub-file`), ls)
 	})
 
-	t.Run("results in stable tar archiving", func(t *testing.T) {
+	t.Run("results in stable tar archiving", func(ctx context.Context, t *testctx.T) {
 		content, err := c.Container().
 			From(alpineImage).
 			WithMountedDirectory("/dir", dir).
@@ -499,9 +485,8 @@ func TestDirectoryWithTimestamps(t *testing.T) {
 	})
 }
 
-func TestDirectoryWithoutDirectoryWithoutFile(t *testing.T) {
-	t.Parallel()
-	c, ctx := connect(t)
+func (DirectorySuite) TestWithoutDirectoryWithoutFile(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	dir1 := c.Directory().
 		WithNewFile("some-file", "some-content").
@@ -590,11 +575,8 @@ func TestDirectoryWithoutDirectoryWithoutFile(t *testing.T) {
 	require.Equal(t, []string{"some-other-file"}, entries)
 }
 
-func TestDirectoryDiff(t *testing.T) {
-	t.Parallel()
-
-	t.Run("basic", func(t *testing.T) {
-		t.Parallel()
+func (DirectorySuite) TestDiff(ctx context.Context, t *testctx.T) {
+	t.Run("basic", func(ctx context.Context, t *testctx.T) {
 		aID := newDirWithFile(t, "a-file", "a-content")
 		bID := newDirWithFile(t, "b-file", "b-content")
 
@@ -613,7 +595,7 @@ func TestDirectoryDiff(t *testing.T) {
 				}
 			}
 		}`
-		err := testutil.Query(diff, &res, &testutil.QueryOptions{
+		err := testutil.Query(t, diff, &res, &testutil.QueryOptions{
 			Variables: map[string]any{
 				"id":    aID,
 				"other": bID,
@@ -623,7 +605,7 @@ func TestDirectoryDiff(t *testing.T) {
 
 		require.Equal(t, []string{"b-file"}, res.Directory.Diff.Entries)
 
-		err = testutil.Query(diff, &res, &testutil.QueryOptions{
+		err = testutil.Query(t, diff, &res, &testutil.QueryOptions{
 			Variables: map[string]any{
 				"id":    bID,
 				"other": aID,
@@ -635,8 +617,8 @@ func TestDirectoryDiff(t *testing.T) {
 	})
 
 	// this is a regression test for: https://github.com/dagger/dagger/pull/7328
-	t.Run("equivalent subdirs", func(t *testing.T) {
-		c, ctx := connect(t)
+	t.Run("equivalent subdirs", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 		a := c.Git("github.com/dagger/dagger").Ref("main").Tree()
 		b := c.Directory().WithDirectory("", a)
 		ents, err := a.Diff(b).Entries(ctx)
@@ -663,17 +645,15 @@ func TestDirectoryDiff(t *testing.T) {
 	*/
 }
 
-func TestDirectoryExport(t *testing.T) {
-	t.Parallel()
-
+func (DirectorySuite) TestExport(ctx context.Context, t *testctx.T) {
 	wd := t.TempDir()
 	dest := t.TempDir()
 
-	c, ctx := connect(t, dagger.WithWorkdir(wd))
+	c := connect(ctx, t, dagger.WithWorkdir(wd))
 
 	dir := c.Container().From(alpineImage).Directory("/etc/profile.d")
 
-	t.Run("to absolute dir", func(t *testing.T) {
+	t.Run("to absolute dir", func(ctx context.Context, t *testctx.T) {
 		ok, err := dir.Export(ctx, dest)
 		require.NoError(t, err)
 		require.True(t, ok)
@@ -683,7 +663,7 @@ func TestDirectoryExport(t *testing.T) {
 		require.Equal(t, []string{"20locale.sh", "README", "color_prompt.sh.disabled"}, entries)
 	})
 
-	t.Run("to workdir", func(t *testing.T) {
+	t.Run("to workdir", func(ctx context.Context, t *testctx.T) {
 		ok, err := dir.Export(ctx, ".")
 		require.NoError(t, err)
 		require.True(t, ok)
@@ -692,7 +672,7 @@ func TestDirectoryExport(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, []string{"20locale.sh", "README", "color_prompt.sh.disabled"}, entries)
 
-		t.Run("wipe flag", func(t *testing.T) {
+		t.Run("wipe flag", func(ctx context.Context, t *testctx.T) {
 			dir := dir.WithoutFile("README")
 
 			// by default a delete in the source dir won't overwrite the destination on the host
@@ -713,16 +693,15 @@ func TestDirectoryExport(t *testing.T) {
 		})
 	})
 
-	t.Run("to outer dir", func(t *testing.T) {
+	t.Run("to outer dir", func(ctx context.Context, t *testctx.T) {
 		ok, err := dir.Export(ctx, "../")
 		require.Error(t, err)
 		require.False(t, ok)
 	})
 }
 
-func TestDirectoryDockerBuild(t *testing.T) {
-	t.Parallel()
-	c, ctx := connect(t)
+func (DirectorySuite) TestDockerBuild(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	contextDir := c.Directory().
 		WithNewFile("main.go",
@@ -735,7 +714,7 @@ func main() {
 	}
 }`)
 
-	t.Run("default Dockerfile location", func(t *testing.T) {
+	t.Run("default Dockerfile location", func(ctx context.Context, t *testctx.T) {
 		src := contextDir.
 			WithNewFile("Dockerfile",
 				`FROM golang:1.18.2-alpine
@@ -752,7 +731,7 @@ CMD goenv
 		require.Contains(t, env, "FOO=bar\n")
 	})
 
-	t.Run("custom Dockerfile location", func(t *testing.T) {
+	t.Run("custom Dockerfile location", func(ctx context.Context, t *testctx.T) {
 		src := contextDir.
 			WithNewFile("subdir/Dockerfile.whee",
 				`FROM golang:1.18.2-alpine
@@ -771,7 +750,7 @@ CMD goenv
 		require.Contains(t, env, "FOO=bar\n")
 	})
 
-	t.Run("subdirectory with default Dockerfile location", func(t *testing.T) {
+	t.Run("subdirectory with default Dockerfile location", func(ctx context.Context, t *testctx.T) {
 		src := contextDir.
 			WithNewFile("Dockerfile",
 				`FROM golang:1.18.2-alpine
@@ -790,7 +769,7 @@ CMD goenv
 		require.Contains(t, env, "FOO=bar\n")
 	})
 
-	t.Run("subdirectory with custom Dockerfile location", func(t *testing.T) {
+	t.Run("subdirectory with custom Dockerfile location", func(ctx context.Context, t *testctx.T) {
 		src := contextDir.
 			WithNewFile("subdir/Dockerfile.whee",
 				`FROM golang:1.18.2-alpine
@@ -811,7 +790,7 @@ CMD goenv
 		require.Contains(t, env, "FOO=bar\n")
 	})
 
-	t.Run("with build args", func(t *testing.T) {
+	t.Run("with build args", func(ctx context.Context, t *testctx.T) {
 		src := contextDir.
 			WithNewFile("Dockerfile",
 				`FROM golang:1.18.2-alpine
@@ -833,7 +812,7 @@ CMD goenv
 		require.Contains(t, env, "FOO=barbar\n")
 	})
 
-	t.Run("with target", func(t *testing.T) {
+	t.Run("with target", func(ctx context.Context, t *testctx.T) {
 		src := contextDir.
 			WithNewFile("Dockerfile",
 				`FROM golang:1.18.2-alpine AS base
@@ -858,7 +837,7 @@ CMD echo "stage2"
 		require.NotContains(t, output, "stage2\n")
 	})
 
-	t.Run("with build secrets", func(t *testing.T) {
+	t.Run("with build secrets", func(ctx context.Context, t *testctx.T) {
 		sec := c.SetSecret("my-secret", "barbar")
 
 		src := contextDir.
@@ -876,9 +855,7 @@ CMD cat /secret
 	})
 }
 
-func TestDirectoryWithNewFileExceedingLength(t *testing.T) {
-	t.Parallel()
-
+func (DirectorySuite) TestWithNewFileExceedingLength(ctx context.Context, t *testctx.T) {
 	var res struct {
 		Directory struct {
 			WithNewFile struct {
@@ -887,7 +864,7 @@ func TestDirectoryWithNewFileExceedingLength(t *testing.T) {
 		}
 	}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			directory {
 				withNewFile(path: "bhhivbryticrxrjssjtflvkxjsqyltawpjexixdfnzoxpoxtdheuhvqalteblsqspfeblfaayvrxejknhpezrxtwxmqzaxgtjdupwnwyosqbvypdwroozcyplzhdxrrvhpskmocmgtdnoeaecbyvpovpwdwpytdxwwedueyaxytxsnnnsfpfjtnlkrxwxtcikcocnkobvdxdqpbafqhmidqbrnhxlxqynesyijgkfepokrnsfqneixfvgsdy.txt", contents: "some-content") {
@@ -899,9 +876,7 @@ func TestDirectoryWithNewFileExceedingLength(t *testing.T) {
 	require.Contains(t, err.Error(), "File name length exceeds the maximum supported 255 characters")
 }
 
-func TestDirectoryWithFileExceedingLength(t *testing.T) {
-	t.Parallel()
-
+func (DirectorySuite) TestWithFileExceedingLength(ctx context.Context, t *testctx.T) {
 	var res struct {
 		Directory struct {
 			WithNewFile struct {
@@ -912,7 +887,7 @@ func TestDirectoryWithFileExceedingLength(t *testing.T) {
 		}
 	}
 
-	err := testutil.Query(
+	err := testutil.Query(t,
 		`{
 			directory {
 				withNewFile(path: "dir/bhhivbryticrxrjssjtflvkxjsqyltawpjexixdfnzoxpoxtdheuhvqalteblsqspfeblfaayvrxejknhpezrxtwxmqzaxgtjdupwnwyosqbvypdwroozcyplzhdxrrvhpskmocmgtdnoeaecbyvpovpwdwpytdxwwedueyaxytxsnnnsfpfjtnlkrxwxtcikcocnkobvdxdqpbafqhmidqbrnhxlxqynesyijgkfepokrnsfqneixfvgsdy.txt", contents: "some-content") {
@@ -926,11 +901,10 @@ func TestDirectoryWithFileExceedingLength(t *testing.T) {
 	require.Contains(t, err.Error(), "File name length exceeds the maximum supported 255 characters")
 }
 
-func TestDirectoryDirectMerge(t *testing.T) {
-	t.Parallel()
-	c, ctx := connect(t)
+func (DirectorySuite) TestDirectMerge(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
-	getDirAndInodes := func(t *testing.T, fileNames ...string) (*dagger.Directory, []string) {
+	getDirAndInodes := func(t *testctx.T, fileNames ...string) (*dagger.Directory, []string) {
 		t.Helper()
 		ctr := c.Container().From(alpineImage).
 			WithMountedDirectory("/src", c.Directory()).
@@ -978,11 +952,10 @@ func TestDirectoryDirectMerge(t *testing.T) {
 	}
 }
 
-func TestDirectoryFallbackMerge(t *testing.T) {
-	t.Parallel()
-	c, ctx := connect(t)
+func (DirectorySuite) TestFallbackMerge(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
-	t.Run("dest path same as src selector", func(t *testing.T) {
+	t.Run("dest path same as src selector", func(ctx context.Context, t *testctx.T) {
 		// corner case where we need to use the fallback rather than direct merge
 		srcDir := c.Directory().
 			WithNewFile("/toplevel", "").
@@ -997,12 +970,10 @@ func TestDirectoryFallbackMerge(t *testing.T) {
 	})
 }
 
-func TestDirectorySync(t *testing.T) {
-	t.Parallel()
+func (DirectorySuite) TestSync(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
-	c, ctx := connect(t)
-
-	t.Run("empty", func(t *testing.T) {
+	t.Run("empty", func(ctx context.Context, t *testctx.T) {
 		dir, err := c.Directory().Sync(ctx)
 		require.NoError(t, err)
 
@@ -1011,7 +982,7 @@ func TestDirectorySync(t *testing.T) {
 		require.Empty(t, entries)
 	})
 
-	t.Run("triggers error", func(t *testing.T) {
+	t.Run("triggers error", func(ctx context.Context, t *testctx.T) {
 		_, err := c.Directory().Directory("/foo").Sync(ctx)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no such file or directory")
@@ -1021,7 +992,7 @@ func TestDirectorySync(t *testing.T) {
 		require.Contains(t, err.Error(), "no such file or directory")
 	})
 
-	t.Run("allows chaining", func(t *testing.T) {
+	t.Run("allows chaining", func(ctx context.Context, t *testctx.T) {
 		dir, err := c.Directory().WithNewFile("foo", "bar").Sync(ctx)
 		require.NoError(t, err)
 
@@ -1031,10 +1002,8 @@ func TestDirectorySync(t *testing.T) {
 	})
 }
 
-func TestDirectoryGlob(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (DirectorySuite) TestGlob(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	srcDir := c.Directory().
 		WithNewFile("main.go", "").
@@ -1061,7 +1030,7 @@ func TestDirectoryGlob(t *testing.T) {
 		WithDirectory("/foo/bar", srcDir).
 		Directory("/foo/bar")
 
-	var testCases = []struct {
+	testCases := []struct {
 		name string
 		src  *dagger.Directory
 	}{
@@ -1082,15 +1051,15 @@ func TestDirectoryGlob(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 
-		t.Run(tc.name, func(t *testing.T) {
-			t.Run("include only markdown", func(t *testing.T) {
+		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
+			t.Run("include only markdown", func(ctx context.Context, t *testctx.T) {
 				entries, err := tc.src.Glob(ctx, "*.md")
 
 				require.NoError(t, err)
 				require.ElementsMatch(t, entries, []string{"test.md"})
 			})
 
-			t.Run("recursive listing", func(t *testing.T) {
+			t.Run("recursive listing", func(ctx context.Context, t *testctx.T) {
 				entries, err := tc.src.Glob(ctx, "**/*")
 
 				require.NoError(t, err)
@@ -1103,7 +1072,7 @@ func TestDirectoryGlob(t *testing.T) {
 				})
 			})
 
-			t.Run("recursive that include only markdown", func(t *testing.T) {
+			t.Run("recursive that include only markdown", func(ctx context.Context, t *testctx.T) {
 				entries, err := tc.src.Glob(ctx, "**/*.md")
 
 				require.NoError(t, err)
@@ -1115,7 +1084,7 @@ func TestDirectoryGlob(t *testing.T) {
 		})
 	}
 
-	t.Run("recursive with directories in the pattern", func(t *testing.T) {
+	t.Run("recursive with directories in the pattern", func(ctx context.Context, t *testctx.T) {
 		srcDir := c.Directory().
 			WithNewFile("foo/bar.md/x.md", "").
 			WithNewFile("foo/bar.md/y.go", "")
@@ -1126,7 +1095,7 @@ func TestDirectoryGlob(t *testing.T) {
 		require.ElementsMatch(t, entries, []string{"foo/bar.md", "foo/bar.md/x.md"})
 	})
 
-	t.Run("sub directory in path", func(t *testing.T) {
+	t.Run("sub directory in path", func(ctx context.Context, t *testctx.T) {
 		srcDir := c.Directory().
 			WithNewFile("foo/bar/x.md", "").
 			WithNewFile("foo/bar/y.go", "")
@@ -1137,19 +1106,19 @@ func TestDirectoryGlob(t *testing.T) {
 		require.ElementsMatch(t, entries, []string{"bar/x.md"})
 	})
 
-	t.Run("empty sub directory", func(t *testing.T) {
+	t.Run("empty sub directory", func(ctx context.Context, t *testctx.T) {
 		entries, err := c.Directory().WithNewDirectory("foo").Glob(ctx, "**/*.md")
 		require.NoError(t, err)
 		require.Empty(t, entries)
 	})
 
-	t.Run("empty directory", func(t *testing.T) {
+	t.Run("empty directory", func(ctx context.Context, t *testctx.T) {
 		entries, err := c.Directory().Glob(ctx, "**/*")
 		require.NoError(t, err)
 		require.Empty(t, entries)
 	})
 
-	t.Run("directory doesn't exist", func(t *testing.T) {
+	t.Run("directory doesn't exist", func(ctx context.Context, t *testctx.T) {
 		_, err := c.Directory().Directory("foo").Glob(ctx, "**/*")
 		require.ErrorContains(t, err, "no such file or directory")
 	})

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -466,9 +466,9 @@ func (DirectorySuite) TestWithTimestamps(ctx context.Context, t *testctx.T) {
 			WithExec([]string{"sh", "-c", "ls -al /dir && ls -al /dir/sub-dir"}).
 			Stdout(ctx)
 		require.NoError(t, err)
-		require.Regexp(t, regexp.MustCompile(`-rw-r--r--\s+1 root\s+root\s+\d+ Oct 26  1985 some-file`), ls)
-		require.Regexp(t, regexp.MustCompile(`drwxr-xr-x\s+2 root\s+root\s+\d+ Oct 26  1985 sub-dir`), ls)
-		require.Regexp(t, regexp.MustCompile(`-rw-r--r--\s+1 root\s+root\s+\d+ Oct 26  1985 sub-file`), ls)
+		require.Regexp(t, regexp.MustCompile(`-rw-r--r--\s+\d+ root\s+root\s+\d+ Oct 26  1985 some-file`), ls)
+		require.Regexp(t, regexp.MustCompile(`drwxr-xr-x\s+\d+ root\s+root\s+\d+ Oct 26  1985 sub-dir`), ls)
+		require.Regexp(t, regexp.MustCompile(`-rw-r--r--\s+\d+ root\s+root\s+\d+ Oct 26  1985 sub-file`), ls)
 	})
 
 	t.Run("results in stable tar archiving", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/engine_test.go
+++ b/core/integration/engine_test.go
@@ -76,7 +76,7 @@ func (EngineSuite) TestExitsZeroOnSignal(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
 	// engine should shutdown with exit code 0 when receiving SIGTERM
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	t = t.WithContext(ctx)
 	_, err := devEngineContainer(c, 101, func(c *dagger.Container) *dagger.Container {

--- a/core/integration/engine_test.go
+++ b/core/integration/engine_test.go
@@ -10,11 +10,18 @@ import (
 	"time"
 
 	"github.com/dagger/dagger/engine/distconsts"
+	"github.com/dagger/dagger/testctx"
 	"github.com/moby/buildkit/identity"
 	"github.com/stretchr/testify/require"
 
 	"dagger.io/dagger"
 )
+
+type EngineSuite struct{}
+
+func TestEngine(t *testing.T) {
+	testctx.Run(testCtx, t, EngineSuite{}, Middleware()...)
+}
 
 // devEngineContainer returns a nested dev engine.
 //
@@ -50,7 +57,7 @@ func devEngineContainer(c *dagger.Client, engineInstance uint8, withs ...func(*d
 		})
 }
 
-func engineClientContainer(ctx context.Context, t *testing.T, c *dagger.Client, devEngine *dagger.Service) (*dagger.Container, error) {
+func engineClientContainer(ctx context.Context, t *testctx.T, c *dagger.Client, devEngine *dagger.Service) (*dagger.Container, error) {
 	daggerCli := daggerCliFile(t, c)
 
 	cliBinPath := "/bin/dagger"
@@ -65,13 +72,13 @@ func engineClientContainer(ctx context.Context, t *testing.T, c *dagger.Client, 
 		WithEnvVariable("_EXPERIMENTAL_DAGGER_RUNNER_HOST", endpoint), nil
 }
 
-func TestEngineExitsZeroOnSignal(t *testing.T) {
-	t.Parallel()
-	c, ctx := connect(t)
+func (EngineSuite) TestExitsZeroOnSignal(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	// engine should shutdown with exit code 0 when receiving SIGTERM
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
+	t = t.WithContext(ctx)
 	_, err := devEngineContainer(c, 101, func(c *dagger.Container) *dagger.Container {
 		return c.WithNewFile("/usr/local/bin/dagger-entrypoint.sh", dagger.ContainerWithNewFileOpts{
 			Contents: `#!/bin/sh
@@ -90,10 +97,8 @@ exit $?
 	require.NoError(t, err)
 }
 
-func TestClientWaitsForEngine(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ClientSuite) TestWaitsForEngine(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	devEngine := devEngineContainer(c, 102, func(c *dagger.Container) *dagger.Container {
 		return c.
@@ -121,9 +126,8 @@ func TestClientWaitsForEngine(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestEngineSetsNameFromEnv(t *testing.T) {
-	t.Parallel()
-	c, ctx := connect(t)
+func (EngineSuite) TestSetsNameFromEnv(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	engineName := "my-special-engine"
 	engineVersion := "v1000.0.0-special"
@@ -152,10 +156,8 @@ func TestEngineSetsNameFromEnv(t *testing.T) {
 	require.Contains(t, stdout, engineVersion)
 }
 
-func TestDaggerRun(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (EngineSuite) TestDaggerRun(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	devEngine := devEngineContainer(c, 104).AsService()
 
@@ -188,9 +190,8 @@ func TestDaggerRun(t *testing.T) {
 	require.Contains(t, stderr, "Container.from")
 }
 
-func TestClientSendsLabelsInTelemetry(t *testing.T) {
-	t.Parallel()
-	c, ctx := connect(t)
+func (ClientSuite) TestSendsLabelsInTelemetry(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	devEngine := devEngineContainer(c, 105).AsService()
 	thisRepoPath, err := filepath.Abs("../..")
@@ -257,9 +258,8 @@ func TestClientSendsLabelsInTelemetry(t *testing.T) {
 	require.Contains(t, receivedEvents, "init test repo")
 }
 
-func TestEngineVersionCompat(t *testing.T) {
-	t.Parallel()
-	c, ctx := connect(t)
+func (EngineSuite) TestVersionCompat(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	devEngineVersion := "v2.0.0"
 	devEngineSvc := devEngineContainer(c, 106, func(c *dagger.Container) *dagger.Container {

--- a/core/integration/host_test.go
+++ b/core/integration/host_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"crypto/md5"
 	"crypto/rand"
 	"encoding/hex"
@@ -9,22 +10,27 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dagger/dagger/testctx"
 	"github.com/moby/buildkit/identity"
 	"github.com/stretchr/testify/require"
 
 	"dagger.io/dagger"
 )
 
-func TestHostWorkdir(t *testing.T) {
-	t.Parallel()
+type HostSuite struct{}
 
+func TestHost(t *testing.T) {
+	testctx.Run(testCtx, t, HostSuite{}, Middleware()...)
+}
+
+func (HostSuite) TestWorkdir(ctx context.Context, t *testctx.T) {
 	dir := t.TempDir()
-	err := os.WriteFile(filepath.Join(dir, "foo"), []byte("bar"), 0600)
+	err := os.WriteFile(filepath.Join(dir, "foo"), []byte("bar"), 0o600)
 	require.NoError(t, err)
 
-	c, ctx := connect(t, dagger.WithWorkdir(dir))
+	c := connect(ctx, t, dagger.WithWorkdir(dir))
 
-	t.Run("contains the workdir's content", func(t *testing.T) {
+	t.Run("contains the workdir's content", func(ctx context.Context, t *testctx.T) {
 		contents, err := c.Container().
 			From(alpineImage).
 			WithMountedDirectory("/host", c.Host().Directory(".")).
@@ -34,8 +40,8 @@ func TestHostWorkdir(t *testing.T) {
 		require.Equal(t, "foo\n", contents)
 	})
 
-	t.Run("does NOT re-sync on each call", func(t *testing.T) {
-		err := os.WriteFile(filepath.Join(dir, "fizz"), []byte("buzz"), 0600)
+	t.Run("does NOT re-sync on each call", func(ctx context.Context, t *testctx.T) {
+		err := os.WriteFile(filepath.Join(dir, "fizz"), []byte("buzz"), 0o600)
 		require.NoError(t, err)
 
 		contents, err := c.Container().
@@ -48,19 +54,17 @@ func TestHostWorkdir(t *testing.T) {
 	})
 }
 
-func TestHostWorkdirExcludeInclude(t *testing.T) {
-	t.Parallel()
-
+func (HostSuite) TestWorkdirExcludeInclude(ctx context.Context, t *testctx.T) {
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("1"), 0600))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.txt"), []byte("2"), 0600))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "c.txt.rar"), []byte("3"), 0600))
-	require.NoError(t, os.MkdirAll(filepath.Join(dir, "subdir"), 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "subdir", "sub-file"), []byte("goodbye"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("1"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.txt"), []byte("2"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "c.txt.rar"), []byte("3"), 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "subdir"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "subdir", "sub-file"), []byte("goodbye"), 0o600))
 
-	c, ctx := connect(t, dagger.WithWorkdir(dir))
+	c := connect(ctx, t, dagger.WithWorkdir(dir))
 
-	t.Run("exclude", func(t *testing.T) {
+	t.Run("exclude", func(ctx context.Context, t *testctx.T) {
 		wd := c.Host().Directory(".", dagger.HostDirectoryOpts{
 			Exclude: []string{"*.rar"},
 		})
@@ -74,7 +78,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 		require.Equal(t, "a.txt\nb.txt\nsubdir\n", contents)
 	})
 
-	t.Run("exclude directory", func(t *testing.T) {
+	t.Run("exclude directory", func(ctx context.Context, t *testctx.T) {
 		wd := c.Host().Directory(".", dagger.HostDirectoryOpts{
 			Exclude: []string{"subdir"},
 		})
@@ -88,7 +92,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 		require.Equal(t, "a.txt\nb.txt\nc.txt.rar\n", contents)
 	})
 
-	t.Run("include", func(t *testing.T) {
+	t.Run("include", func(ctx context.Context, t *testctx.T) {
 		wd := c.Host().Directory(".", dagger.HostDirectoryOpts{
 			Include: []string{"*.rar"},
 		})
@@ -102,7 +106,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 		require.Equal(t, "c.txt.rar\n", contents)
 	})
 
-	t.Run("exclude overrides include", func(t *testing.T) {
+	t.Run("exclude overrides include", func(ctx context.Context, t *testctx.T) {
 		wd := c.Host().Directory(".", dagger.HostDirectoryOpts{
 			Include: []string{"*.txt"},
 			Exclude: []string{"b.txt"},
@@ -117,7 +121,7 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 		require.Equal(t, "a.txt\n", contents)
 	})
 
-	t.Run("include does not override exclude", func(t *testing.T) {
+	t.Run("include does not override exclude", func(ctx context.Context, t *testctx.T) {
 		wd := c.Host().Directory(".", dagger.HostDirectoryOpts{
 			Include: []string{"a.txt"},
 			Exclude: []string{"*.txt"},
@@ -133,16 +137,15 @@ func TestHostWorkdirExcludeInclude(t *testing.T) {
 	})
 }
 
-func TestHostDirectoryRelative(t *testing.T) {
-	t.Parallel()
+func (HostSuite) TestDirectoryRelative(ctx context.Context, t *testctx.T) {
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "some-file"), []byte("hello"), 0600))
-	require.NoError(t, os.MkdirAll(filepath.Join(dir, "some-dir"), 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "some-dir", "sub-file"), []byte("goodbye"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "some-file"), []byte("hello"), 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "some-dir"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "some-dir", "sub-file"), []byte("goodbye"), 0o600))
 
-	c, ctx := connect(t, dagger.WithWorkdir(dir))
+	c := connect(ctx, t, dagger.WithWorkdir(dir))
 
-	t.Run(". is same as workdir", func(t *testing.T) {
+	t.Run(". is same as workdir", func(ctx context.Context, t *testctx.T) {
 		wdID1, err := c.Host().Directory(".").ID(ctx)
 		require.NoError(t, err)
 
@@ -152,13 +155,13 @@ func TestHostDirectoryRelative(t *testing.T) {
 		require.Equal(t, wdID1, wdID2)
 	})
 
-	t.Run("./foo is relative to workdir", func(t *testing.T) {
+	t.Run("./foo is relative to workdir", func(ctx context.Context, t *testctx.T) {
 		contents, err := c.Host().Directory("some-dir").Entries(ctx)
 		require.NoError(t, err)
 		require.Equal(t, []string{"sub-file"}, contents)
 	})
 
-	t.Run("../ does not allow escaping", func(t *testing.T) {
+	t.Run("../ does not allow escaping", func(ctx context.Context, t *testctx.T) {
 		_, err := c.Host().Directory("../").ID(ctx)
 		require.Error(t, err)
 
@@ -167,9 +170,7 @@ func TestHostDirectoryRelative(t *testing.T) {
 	})
 }
 
-func TestHostSetSecretFile(t *testing.T) {
-	t.Parallel()
-
+func (HostSuite) TestSetSecretFile(ctx context.Context, t *testctx.T) {
 	// Generate 512000 random bytes (non UTF-8)
 	// This is our current limit: secrets break at 512001 bytes
 	data := make([]byte, 512000)
@@ -183,11 +184,11 @@ func TestHostSetSecretFile(t *testing.T) {
 	hashStr := hex.EncodeToString(hash[:])
 
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "some-file"), data, 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "some-file"), data, 0o600))
 
-	c, ctx := connect(t, dagger.WithWorkdir(dir))
+	c := connect(ctx, t, dagger.WithWorkdir(dir))
 
-	t.Run("non utf8 binary data is properly set as secret", func(t *testing.T) {
+	t.Run("non utf8 binary data is properly set as secret", func(ctx context.Context, t *testctx.T) {
 		secret := c.Host().SetSecretFile("mysecret", filepath.Join(dir, "some-file"))
 
 		output, err := c.Container().From(alpineImage).
@@ -205,35 +206,32 @@ func TestHostSetSecretFile(t *testing.T) {
 	})
 }
 
-func TestHostDirectoryAbsolute(t *testing.T) {
-	t.Parallel()
+func (HostSuite) TestDirectoryAbsolute(ctx context.Context, t *testctx.T) {
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "some-file"), []byte("hello"), 0600))
-	require.NoError(t, os.MkdirAll(filepath.Join(dir, "some-dir"), 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "some-dir", "sub-file"), []byte("goodbye"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "some-file"), []byte("hello"), 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "some-dir"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "some-dir", "sub-file"), []byte("goodbye"), 0o600))
 
-	c, ctx := connect(t, dagger.WithWorkdir(dir))
+	c := connect(ctx, t, dagger.WithWorkdir(dir))
 
 	entries, err := c.Host().Directory(filepath.Join(dir, "some-dir")).Entries(ctx)
 	require.NoError(t, err)
 	require.Equal(t, []string{"sub-file"}, entries)
 }
 
-func TestHostDirectoryExcludeInclude(t *testing.T) {
-	t.Parallel()
-
+func (HostSuite) TestDirectoryExcludeInclude(ctx context.Context, t *testctx.T) {
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("1"), 0600))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.txt"), []byte("2"), 0600))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "c.txt.rar"), []byte("3"), 0600))
-	require.NoError(t, os.MkdirAll(filepath.Join(dir, "subdir"), 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "subdir", "d.txt"), []byte("1"), 0600))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "subdir", "e.txt"), []byte("2"), 0600))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "subdir", "f.txt.rar"), []byte("3"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("1"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.txt"), []byte("2"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "c.txt.rar"), []byte("3"), 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "subdir"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "subdir", "d.txt"), []byte("1"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "subdir", "e.txt"), []byte("2"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "subdir", "f.txt.rar"), []byte("3"), 0o600))
 
-	c, ctx := connect(t)
+	c := connect(ctx, t)
 
-	t.Run("exclude", func(t *testing.T) {
+	t.Run("exclude", func(ctx context.Context, t *testctx.T) {
 		entries, err := c.Host().Directory(dir, dagger.HostDirectoryOpts{
 			Exclude: []string{"*.rar"},
 		}).Entries(ctx)
@@ -241,7 +239,7 @@ func TestHostDirectoryExcludeInclude(t *testing.T) {
 		require.Equal(t, []string{"a.txt", "b.txt", "subdir"}, entries)
 	})
 
-	t.Run("include", func(t *testing.T) {
+	t.Run("include", func(ctx context.Context, t *testctx.T) {
 		entries, err := c.Host().Directory(dir, dagger.HostDirectoryOpts{
 			Include: []string{"*.rar"},
 		}).Entries(ctx)
@@ -249,7 +247,7 @@ func TestHostDirectoryExcludeInclude(t *testing.T) {
 		require.Equal(t, []string{"c.txt.rar"}, entries)
 	})
 
-	t.Run("exclude overrides include", func(t *testing.T) {
+	t.Run("exclude overrides include", func(ctx context.Context, t *testctx.T) {
 		entries, err := c.Host().Directory(dir, dagger.HostDirectoryOpts{
 			Include: []string{"*.txt"},
 			Exclude: []string{"b.txt"},
@@ -258,7 +256,7 @@ func TestHostDirectoryExcludeInclude(t *testing.T) {
 		require.Equal(t, []string{"a.txt"}, entries)
 	})
 
-	t.Run("include does not override exclude", func(t *testing.T) {
+	t.Run("include does not override exclude", func(ctx context.Context, t *testctx.T) {
 		entries, err := c.Host().Directory(dir, dagger.HostDirectoryOpts{
 			Include: []string{"a.txt"},
 			Exclude: []string{"*.txt"},
@@ -268,24 +266,22 @@ func TestHostDirectoryExcludeInclude(t *testing.T) {
 	})
 }
 
-func TestHostFile(t *testing.T) {
-	t.Parallel()
-
+func (HostSuite) TestFile(ctx context.Context, t *testctx.T) {
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("1"), 0600))
-	require.NoError(t, os.MkdirAll(filepath.Join(dir, "subdir"), 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "subdir", "d.txt"), []byte("hello world"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("1"), 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "subdir"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "subdir", "d.txt"), []byte("hello world"), 0o600))
 
-	c, ctx := connect(t)
+	c := connect(ctx, t)
 
-	t.Run("get simple file", func(t *testing.T) {
+	t.Run("get simple file", func(ctx context.Context, t *testctx.T) {
 		content, err := c.Host().File(filepath.Join(dir, "a.txt")).Contents(ctx)
 
 		require.NoError(t, err)
 		require.Equal(t, "1", content)
 	})
 
-	t.Run("get nested file", func(t *testing.T) {
+	t.Run("get nested file", func(ctx context.Context, t *testctx.T) {
 		content, err := c.Host().File(filepath.Join(dir, "subdir", "d.txt")).Contents(ctx)
 
 		require.NoError(t, err)

--- a/core/integration/local_test.go
+++ b/core/integration/local_test.go
@@ -1,22 +1,22 @@
 package core
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
-	"testing"
 
+	"github.com/dagger/dagger/testctx"
 	"github.com/stretchr/testify/require"
 )
 
-func TestLocalImportsAcrossSessions(t *testing.T) {
-	t.Parallel()
+func (DirectorySuite) TestLocalImportsAcrossSessions(ctx context.Context, t *testctx.T) {
 	tmpdir := t.TempDir()
 
-	c1, ctx1 := connect(t)
+	c1 := connect(ctx, t)
 
 	fileName := "afile"
-	err := os.WriteFile(filepath.Join(tmpdir, fileName), []byte("1"), 0644)
+	err := os.WriteFile(filepath.Join(tmpdir, fileName), []byte("1"), 0o644)
 	require.NoError(t, err)
 
 	hostDir1 := c1.Host().Directory(tmpdir)
@@ -24,28 +24,28 @@ func TestLocalImportsAcrossSessions(t *testing.T) {
 	out1, err := c1.Container().From(alpineImage).
 		WithMountedDirectory("/mnt", hostDir1).
 		WithExec([]string{"cat", "/mnt/" + fileName}).
-		Stdout(ctx1)
+		Stdout(ctx)
 	require.NoError(t, err)
 	out1 = strings.TrimSpace(out1)
 	require.Equal(t, "1", out1)
 
 	// repeat with new session but overwrite the host file before it's loaded
 
-	err = os.WriteFile(filepath.Join(tmpdir, fileName), []byte("2"), 0644)
+	err = os.WriteFile(filepath.Join(tmpdir, fileName), []byte("2"), 0o644)
 	require.NoError(t, err)
 	// just do a sanity check the file contents are what we just wrote
 	contents, err := os.ReadFile(filepath.Join(tmpdir, fileName))
 	require.NoError(t, err)
 	require.Equal(t, "2", string(contents))
 
-	c2, ctx2 := connect(t)
+	c2 := connect(ctx, t)
 
 	hostDir2 := c2.Host().Directory(tmpdir)
 
 	out2, err := c2.Container().From(alpineImage).
 		WithMountedDirectory("/mnt", hostDir2).
 		WithExec([]string{"cat", "/mnt/" + fileName}).
-		Stdout(ctx2)
+		Stdout(ctx)
 	require.NoError(t, err)
 	out2 = strings.TrimSpace(out2)
 	require.Equal(t, "2", out2)

--- a/core/integration/module_functions_test.go
+++ b/core/integration/module_functions_test.go
@@ -1,18 +1,17 @@
 package core
 
 import (
+	"context"
 	"strings"
-	"testing"
 
+	"github.com/dagger/dagger/testctx"
 	"github.com/stretchr/testify/require"
 
 	"dagger.io/dagger"
 )
 
-func TestModuleDaggerCLIFunctions(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ModuleSuite) TestDaggerCLIFunctions(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	ctr := c.Container().From(golangImage).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -88,8 +87,7 @@ func (m *OtherObj) FnE() *Container {
 `,
 		})
 
-	t.Run("top-level", func(t *testing.T) {
-		t.Parallel()
+	t.Run("top-level", func(ctx context.Context, t *testctx.T) {
 		out, err := ctr.With(daggerFunctions()).Stdout(ctx)
 		require.NoError(t, err)
 		lines := strings.Split(out, "\n")
@@ -99,8 +97,7 @@ func (m *OtherObj) FnE() *Container {
 		require.Contains(t, lines, "prim   doc for Prim")
 	})
 
-	t.Run("top-level from subdir", func(t *testing.T) {
-		t.Parallel()
+	t.Run("top-level from subdir", func(ctx context.Context, t *testctx.T) {
 		// find-up should kick in
 		out, err := ctr.
 			WithWorkdir("/work/some/subdir").
@@ -114,8 +111,7 @@ func (m *OtherObj) FnE() *Container {
 		require.Contains(t, lines, "prim   doc for Prim")
 	})
 
-	t.Run("return core object", func(t *testing.T) {
-		t.Parallel()
+	t.Run("return core object", func(ctx context.Context, t *testctx.T) {
 		out, err := ctr.With(daggerFunctions("fn-a")).Stdout(ctx)
 		require.NoError(t, err)
 		lines := strings.Split(out, "\n")
@@ -124,14 +120,12 @@ func (m *OtherObj) FnE() *Container {
 		require.Contains(t, lines, "as-tarball                    Returns a File representing the container serialized to a tarball.")
 	})
 
-	t.Run("return primitive", func(t *testing.T) {
-		t.Parallel()
+	t.Run("return primitive", func(ctx context.Context, t *testctx.T) {
 		_, err := ctr.With(daggerFunctions("prim")).Stdout(ctx)
 		require.ErrorContains(t, err, `function "prim" returns type "STRING_KIND" with no further functions available`)
 	})
 
-	t.Run("alt casing", func(t *testing.T) {
-		t.Parallel()
+	t.Run("alt casing", func(ctx context.Context, t *testctx.T) {
 		out, err := ctr.With(daggerFunctions("fnA")).Stdout(ctx)
 		require.NoError(t, err)
 		lines := strings.Split(out, "\n")
@@ -140,16 +134,14 @@ func (m *OtherObj) FnE() *Container {
 		require.Contains(t, lines, "as-tarball                    Returns a File representing the container serialized to a tarball.")
 	})
 
-	t.Run("return user interface", func(t *testing.T) {
-		t.Parallel()
+	t.Run("return user interface", func(ctx context.Context, t *testctx.T) {
 		out, err := ctr.With(daggerFunctions("fn-b")).Stdout(ctx)
 		require.NoError(t, err)
 		lines := strings.Split(out, "\n")
 		require.Contains(t, lines, "quack   quack that thang")
 	})
 
-	t.Run("return user object", func(t *testing.T) {
-		t.Parallel()
+	t.Run("return user object", func(ctx context.Context, t *testctx.T) {
 		out, err := ctr.With(daggerFunctions("fn-c")).Stdout(ctx)
 		require.NoError(t, err)
 		lines := strings.Split(out, "\n")
@@ -161,8 +153,7 @@ func (m *OtherObj) FnE() *Container {
 		require.Contains(t, lines, "fn-d      doc for FnD")
 	})
 
-	t.Run("return user object nested", func(t *testing.T) {
-		t.Parallel()
+	t.Run("return user object nested", func(ctx context.Context, t *testctx.T) {
 		out, err := ctr.With(daggerFunctions("fn-c", "field-d")).Stdout(ctx)
 		require.NoError(t, err)
 		lines := strings.Split(out, "\n")

--- a/core/integration/module_iface_test.go
+++ b/core/integration/module_iface_test.go
@@ -1,18 +1,17 @@
 package core
 
 import (
+	"context"
 	"strings"
-	"testing"
 
+	"github.com/dagger/dagger/testctx"
 	"github.com/stretchr/testify/require"
 
 	"dagger.io/dagger"
 )
 
-func TestModuleIfaceBasic(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ModuleSuite) TestIfaceBasic(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	_, err := c.Container().From(golangImage).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -23,13 +22,10 @@ func TestModuleIfaceBasic(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestModuleIfaceGoSadPaths(t *testing.T) {
-	t.Parallel()
-
-	t.Run("no dagger object embed", func(t *testing.T) {
-		t.Parallel()
+func (ModuleSuite) TestIfaceGoSadPaths(ctx context.Context, t *testctx.T) {
+	t.Run("no dagger object embed", func(ctx context.Context, t *testctx.T) {
 		var logs safeBuffer
-		c, ctx := connect(t, dagger.WithLogOutput(&logs))
+		c := connect(ctx, t, dagger.WithLogOutput(&logs))
 
 		_, err := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -56,10 +52,8 @@ func (m *Test) Fn() BadIface {
 	})
 }
 
-func TestModuleIfaceGoDanglingInterface(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ModuleSuite) TestIfaceGoDanglingInterface(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	modGen, err := c.Container().From(golangImage).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -94,10 +88,8 @@ type DanglingIface interface {
 	require.JSONEq(t, `{"test":{"hello":"hello"}}`, out)
 }
 
-func TestModuleIfaceDaggerCall(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ModuleSuite) TestIfaceDaggerCall(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	out, err := c.Container().From(golangImage).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).

--- a/core/integration/module_python_test.go
+++ b/core/integration/module_python_test.go
@@ -1,12 +1,14 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/dagger/dagger/testctx"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 
@@ -15,13 +17,9 @@ import (
 
 const pythonSourcePath = "src/main/__init__.py"
 
-func TestModulePythonInit(t *testing.T) {
-	t.Parallel()
-
-	t.Run("from scratch", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+func (ModuleSuite) TestPythonInit(ctx context.Context, t *testctx.T) {
+	t.Run("from scratch", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		out, err := daggerCliBase(t, c).
 			With(daggerInitPython()).
@@ -32,10 +30,8 @@ func TestModulePythonInit(t *testing.T) {
 		require.Equal(t, "hello\n", out)
 	})
 
-	t.Run("with different root", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("with different root", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		out, err := daggerCliBase(t, c).
 			With(daggerInitPythonAt("child")).
@@ -46,10 +42,8 @@ func TestModulePythonInit(t *testing.T) {
 		require.Equal(t, "hello\n", out)
 	})
 
-	t.Run("on develop", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("on develop", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		out, err := daggerCliBase(t, c).
 			With(daggerExec("init")).
@@ -61,10 +55,8 @@ func TestModulePythonInit(t *testing.T) {
 		require.Equal(t, "hello\n", out)
 	})
 
-	t.Run("doesn't create files in develop with existing pyproject.toml", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("doesn't create files in develop with existing pyproject.toml", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		_, err := daggerCliBase(t, c).
 			With(daggerExec("init")).
@@ -80,10 +72,8 @@ version = "0.0.0"
 		require.ErrorContains(t, err, "no python files found")
 	})
 
-	t.Run("uses expected field casing", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("uses expected field casing", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		out, err := daggerCliBase(t, c).
 			With(daggerInitPython("--name=hello-world")).
@@ -106,10 +96,8 @@ version = "0.0.0"
 	})
 }
 
-func TestModulePythonProjectLayout(t *testing.T) {
-	t.Parallel()
-
-	var testCases = []struct {
+func (ModuleSuite) TestPythonProjectLayout(ctx context.Context, t *testctx.T) {
+	testCases := []struct {
 		name string
 		path string
 		conf string
@@ -284,10 +272,8 @@ build-backend = "poetry.core.masonry.api"
 	for _, tc := range testCases {
 		tc := tc
 
-		t.Run(fmt.Sprintf("%s/%s", tc.name, tc.path), func(t *testing.T) {
-			t.Parallel()
-
-			c, ctx := connect(t)
+		t.Run(fmt.Sprintf("%s/%s", tc.name, tc.path), func(ctx context.Context, t *testctx.T) {
+			c := connect(ctx, t)
 
 			out, err := daggerCliBase(t, c).
 				With(fileContents("pyproject.toml", tc.conf)).
@@ -309,9 +295,7 @@ def hello() -> str:
 	}
 }
 
-func TestModulePythonVersion(t *testing.T) {
-	t.Parallel()
-
+func (ModuleSuite) TestPythonVersion(ctx context.Context, t *testctx.T) {
 	source := pythonSource(`
 import sys
 from dagger import function
@@ -328,10 +312,8 @@ def relaxed() -> str:
 `,
 	)
 
-	t.Run("relaxed requires-python", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("relaxed requires-python", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		out, err := daggerCliBase(t, c).
 			With(pyprojectExtra(`requires-python = ">=3.10"`)).
@@ -344,10 +326,8 @@ def relaxed() -> str:
 		require.Equal(t, "3.10", out)
 	})
 
-	t.Run("pinned requires-python", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("pinned requires-python", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		out, err := daggerCliBase(t, c).
 			// NB: This is **not** the latest version.
@@ -362,10 +342,8 @@ def relaxed() -> str:
 		require.Equal(t, "3.10.10", out)
 	})
 
-	t.Run("relaxed .python-version", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("relaxed .python-version", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		out, err := daggerCliBase(t, c).
 			With(fileContents(".python-version", "3.12")).
@@ -378,10 +356,8 @@ def relaxed() -> str:
 		require.Equal(t, "3.12", out)
 	})
 
-	t.Run("pinned .python-version", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("pinned .python-version", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		out, err := daggerCliBase(t, c).
 			With(fileContents(".python-version", "3.12.1")).
@@ -394,10 +370,8 @@ def relaxed() -> str:
 		require.Equal(t, "3.12.1", out)
 	})
 
-	t.Run(".python-version takes precedence", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run(".python-version takes precedence", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		out, err := daggerCliBase(t, c).
 			With(pyprojectExtra(`requires-python = ">=3.10"`)).
@@ -411,10 +385,8 @@ def relaxed() -> str:
 		require.Equal(t, "3.12", out)
 	})
 
-	t.Run("pinned base image", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("pinned base image", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		out, err := daggerCliBase(t, c).
 			// base image takes precedence over .python-version
@@ -432,10 +404,8 @@ def relaxed() -> str:
 		require.Equal(t, "3.10.13", out)
 	})
 
-	t.Run("default", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("default", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		out, err := daggerCliBase(t, c).
 			With(source).
@@ -448,10 +418,8 @@ def relaxed() -> str:
 	})
 }
 
-func TestModulePythonAltRuntime(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ModuleSuite) TestPythonAltRuntime(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	runtimeSrcPath, err := filepath.Abs("../../sdk/python/runtime")
 	require.NoError(t, err)
@@ -467,8 +435,7 @@ func TestModulePythonAltRuntime(t *testing.T) {
 		WithMountedDirectory("/work/extended", c.Host().Directory(extSrcPath)).
 		WithExec([]string{"sed", "-i", "s#../../../../../sdk/python/##", "/work/extended/dagger.json"})
 
-	t.Run("git dependency", func(t *testing.T) {
-		t.Parallel()
+	t.Run("git dependency", func(ctx context.Context, t *testctx.T) {
 		out, err := base.
 			WithMountedDirectory("/work/git-dep", c.Host().Directory(moduleSrcPath)).
 			WithWorkdir("/work/git-dep").
@@ -479,8 +446,7 @@ func TestModulePythonAltRuntime(t *testing.T) {
 		require.Contains(t, out, "git version")
 	})
 
-	t.Run("disabled custom config", func(t *testing.T) {
-		t.Parallel()
+	t.Run("disabled custom config", func(ctx context.Context, t *testctx.T) {
 		out, err := base.
 			WithWorkdir("/work/test").
 			With(fileContents(".python-version", "3.12")).
@@ -503,9 +469,7 @@ def version() -> str:
 	})
 }
 
-func TestModulePythonUv(t *testing.T) {
-	t.Parallel()
-
+func (ModuleSuite) TestPythonUv(ctx context.Context, t *testctx.T) {
 	source := pythonSource(`
 import anyio
 from dagger import function
@@ -523,10 +487,8 @@ async def version() -> str:
 `,
 	)
 
-	t.Run("disable", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("disable", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		out, err := daggerCliBase(t, c).
 			With(pyprojectExtra(`
@@ -542,10 +504,8 @@ async def version() -> str:
 		require.Equal(t, "n/d", out)
 	})
 
-	t.Run("pinned version", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("pinned version", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		out, err := daggerCliBase(t, c).
 			With(pyprojectExtra(`
@@ -561,10 +521,8 @@ async def version() -> str:
 		require.Equal(t, "0.1.25", out)
 	})
 
-	t.Run("upper bound", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("upper bound", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		out, err := daggerCliBase(t, c).
 			With(pyprojectExtra(`
@@ -581,10 +539,8 @@ async def version() -> str:
 	})
 }
 
-func TestModulePythonLock(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ModuleSuite) TestPythonLock(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	base := daggerCliBase(t, c).With(pythonSource(`
 from importlib import metadata
@@ -637,10 +593,8 @@ def version(name: str) -> str:
 	require.Equal(t, "4.1.0", out)
 }
 
-func TestModulePythonLockHashes(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ModuleSuite) TestPythonLockHashes(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	base := daggerCliBase(t, c).With(daggerInitPython())
 
@@ -686,8 +640,7 @@ func TestModulePythonLockHashes(t *testing.T) {
 	requirements := lock.String()
 	t.Logf("requirements.lock:\n%s", requirements)
 
-	t.Run("uv", func(t *testing.T) {
-		t.Parallel()
+	t.Run("uv", func(ctx context.Context, t *testctx.T) {
 		_, err := base.
 			With(fileContents("requirements.lock", requirements)).
 			With(daggerExec("develop")).
@@ -698,8 +651,7 @@ func TestModulePythonLockHashes(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("pip", func(t *testing.T) {
-		t.Parallel()
+	t.Run("pip", func(ctx context.Context, t *testctx.T) {
 		_, err := base.
 			With(fileContents("requirements.lock", requirements)).
 			With(pyprojectExtra(`
@@ -714,9 +666,7 @@ func TestModulePythonLockHashes(t *testing.T) {
 	})
 }
 
-func TestModulePythonLockAddedDep(t *testing.T) {
-	t.Parallel()
-
+func (ModuleSuite) TestPythonLockAddedDep(ctx context.Context, t *testctx.T) {
 	source := pythonSource(`
 from importlib import metadata
 from dagger import function
@@ -727,10 +677,8 @@ def version() -> str:
 `,
 	)
 
-	t.Run("new module", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("new module", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		out, err := daggerCliBase(t, c).
 			With(pyprojectExtra(`dependencies = ["packaging<24.0"]`)).
@@ -744,10 +692,8 @@ def version() -> str:
 		require.Equal(t, "23.2", out)
 	})
 
-	t.Run("existing module", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("existing module", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		out, err := daggerCliBase(t, c).
 			With(daggerInitPython()).
@@ -763,10 +709,8 @@ def version() -> str:
 		require.Equal(t, "23.2", out)
 	})
 
-	t.Run("sdk overrides local changes", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("sdk overrides local changes", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		_, err := daggerCliBase(t, c).
 			With(daggerInitPython()).
@@ -780,10 +724,8 @@ def version() -> str:
 	})
 }
 
-func TestModulePythonSignatures(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ModuleSuite) TestPythonSignatures(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	modGen := pythonModInit(t, c, `
         from collections.abc import Sequence
@@ -910,7 +852,7 @@ func TestModulePythonSignatures(t *testing.T) {
 		},
 	} {
 		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
 			out, err := modGen.With(daggerQuery(tc.query)).Stdout(ctx)
 			require.NoError(t, err)
 			require.JSONEq(t, tc.expected, out)
@@ -918,10 +860,8 @@ func TestModulePythonSignatures(t *testing.T) {
 	}
 }
 
-func TestModulePythonSignaturesBuiltinTypes(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ModuleSuite) TestPythonSignaturesBuiltinTypes(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	modGen := pythonModInit(t, c, `
         import dagger
@@ -973,8 +913,7 @@ func TestModulePythonSignaturesBuiltinTypes(t *testing.T) {
 		},
 	} {
 		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
 			out, err := modGen.With(daggerQuery(tc.query)).Stdout(ctx)
 			require.NoError(t, err)
 			require.JSONEq(t, tc.expected, out)
@@ -982,13 +921,9 @@ func TestModulePythonSignaturesBuiltinTypes(t *testing.T) {
 	}
 }
 
-func TestModulePythonDocs(t *testing.T) {
-	t.Parallel()
-
-	t.Run("basic", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+func (ModuleSuite) TestPythonDocs(ctx context.Context, t *testctx.T) {
+	t.Run("basic", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		modGen := pythonModInit(t, c, `
             from typing import Annotated
@@ -1043,10 +978,8 @@ func TestModulePythonDocs(t *testing.T) {
 		require.Equal(t, "overridden description", over.Get("description").String())
 	})
 
-	t.Run("autogenerated constructor", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("autogenerated constructor", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		modGen := pythonModInit(t, c, `
             from dataclasses import field as datafield
@@ -1088,10 +1021,8 @@ func TestModulePythonDocs(t *testing.T) {
 		require.True(t, obj.Get("constructor.args.#(name=onlyInit).defaultValue").Bool())
 	})
 
-	t.Run("alternative constructor", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("alternative constructor", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		modGen := pythonModInit(t, c, `
             from typing import Annotated, Self
@@ -1116,10 +1047,8 @@ func TestModulePythonDocs(t *testing.T) {
 		require.Equal(t, "factory constructor", cns.Get("description").String())
 	})
 
-	t.Run("external constructor", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("external constructor", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		modGen := pythonModInit(t, c, `
             from typing import Annotated, Self
@@ -1156,10 +1085,8 @@ func TestModulePythonDocs(t *testing.T) {
 		})
 	})
 
-	t.Run("external alternative constructor", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("external alternative constructor", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		modGen := pythonModInit(t, c, `
             from typing import Annotated, Self
@@ -1185,10 +1112,8 @@ func TestModulePythonDocs(t *testing.T) {
 		require.Equal(t, "factory constructor", obj.Get("functions.#(name=external).description").String())
 	})
 
-	t.Run("inheritance", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("inheritance", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		modGen := pythonModInit(t, c, `
             from typing import Annotated, Self
@@ -1214,10 +1139,8 @@ func TestModulePythonDocs(t *testing.T) {
 	})
 }
 
-func TestModulePythonNameOverrides(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ModuleSuite) TestPythonNameOverrides(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	modGen := pythonModInit(t, c, `
         from typing import Annotated
@@ -1241,10 +1164,8 @@ func TestModulePythonNameOverrides(t *testing.T) {
 	require.Equal(t, "field", obj.Get("constructor.args.0.name").String())
 }
 
-func TestModulePythonReturnSelf(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ModuleSuite) TestPythonReturnSelf(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	out, err := pythonModInit(t, c, `
         from typing import Self
@@ -1267,10 +1188,8 @@ func TestModulePythonReturnSelf(t *testing.T) {
 	require.JSONEq(t, `{"test":{"foo":{"message":"bar"}}}`, out)
 }
 
-func TestModulePythonWithOtherModuleTypes(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ModuleSuite) TestPythonWithOtherModuleTypes(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	ctr := goGitBase(t, c).
 		WithWorkdir("/work/dep").
@@ -1292,10 +1211,8 @@ func TestModulePythonWithOtherModuleTypes(t *testing.T) {
 		With(daggerInitPython()).
 		With(daggerExec("install", "../dep"))
 
-	t.Run("return as other module object", func(t *testing.T) {
-		t.Parallel()
-		t.Run("direct", func(t *testing.T) {
-			t.Parallel()
+	t.Run("return as other module object", func(ctx context.Context, t *testctx.T) {
+		t.Run("direct", func(ctx context.Context, t *testctx.T) {
 			_, err := ctr.
 				With(pythonSource(`
                     import dagger
@@ -1315,8 +1232,7 @@ func TestModulePythonWithOtherModuleTypes(t *testing.T) {
 			))
 		})
 
-		t.Run("list", func(t *testing.T) {
-			t.Parallel()
+		t.Run("list", func(ctx context.Context, t *testctx.T) {
 			_, err := ctr.
 				With(pythonSource(`
                     import dagger
@@ -1337,10 +1253,8 @@ func TestModulePythonWithOtherModuleTypes(t *testing.T) {
 		})
 	})
 
-	t.Run("arg as other module object", func(t *testing.T) {
-		t.Parallel()
-		t.Run("direct", func(t *testing.T) {
-			t.Parallel()
+	t.Run("arg as other module object", func(ctx context.Context, t *testctx.T) {
+		t.Run("direct", func(ctx context.Context, t *testctx.T) {
 			_, err := ctr.With(pythonSource(`
                 import dagger
 
@@ -1359,8 +1273,7 @@ func TestModulePythonWithOtherModuleTypes(t *testing.T) {
 			))
 		})
 
-		t.Run("list", func(t *testing.T) {
-			t.Parallel()
+		t.Run("list", func(ctx context.Context, t *testctx.T) {
 			_, err := ctr.With(pythonSource(`
                 import dagger
 
@@ -1380,10 +1293,8 @@ func TestModulePythonWithOtherModuleTypes(t *testing.T) {
 		})
 	})
 
-	t.Run("field as other module object", func(t *testing.T) {
-		t.Parallel()
-		t.Run("direct", func(t *testing.T) {
-			t.Parallel()
+	t.Run("field as other module object", func(ctx context.Context, t *testctx.T) {
+		t.Run("direct", func(ctx context.Context, t *testctx.T) {
 			_, err := ctr.
 				With(pythonSource(`
                     import dagger
@@ -1407,8 +1318,7 @@ func TestModulePythonWithOtherModuleTypes(t *testing.T) {
 			))
 		})
 
-		t.Run("list", func(t *testing.T) {
-			t.Parallel()
+		t.Run("list", func(ctx context.Context, t *testctx.T) {
 			_, err := ctr.
 				With(pythonSource(`
                     import dagger

--- a/core/integration/module_terminal_test.go
+++ b/core/integration/module_terminal_test.go
@@ -8,12 +8,13 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"testing"
 	"time"
 
 	"github.com/Netflix/go-expect"
 	"github.com/containerd/continuity/fs"
 	"github.com/creack/pty"
+	"github.com/dagger/dagger/internal/testutil"
+	"github.com/dagger/dagger/testctx"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,11 +22,8 @@ import (
 // directly interact with the dagger shell tui without resorting to embedding more go code
 // into a container for driving it.
 
-func TestModuleDaggerTerminal(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	t.Run("default arg /bin/sh", func(t *testing.T) {
+func (ModuleSuite) TestDaggerTerminal(ctx context.Context, t *testctx.T) {
+	t.Run("default arg /bin/sh", func(ctx context.Context, t *testctx.T) {
 		modDir := t.TempDir()
 		err := os.WriteFile(filepath.Join(modDir, "main.go"), []byte(fmt.Sprintf(`package main
 import "context"
@@ -94,7 +92,7 @@ type Test struct {
 		require.NoError(t, err)
 	})
 
-	t.Run("basic", func(t *testing.T) {
+	t.Run("basic", func(ctx context.Context, t *testctx.T) {
 		modDir := t.TempDir()
 		err := os.WriteFile(filepath.Join(modDir, "main.go"), []byte(fmt.Sprintf(`package main
 	import "context"
@@ -167,7 +165,7 @@ type Test struct {
 		require.NoError(t, err)
 	})
 
-	t.Run("override args", func(t *testing.T) {
+	t.Run("override args", func(ctx context.Context, t *testctx.T) {
 		modDir := t.TempDir()
 		err := os.WriteFile(filepath.Join(modDir, "main.go"), []byte(fmt.Sprintf(`package main
 	import "context"
@@ -238,7 +236,7 @@ type Test struct {
 		require.NoError(t, err)
 	})
 
-	t.Run("nested client", func(t *testing.T) {
+	t.Run("nested client", func(ctx context.Context, t *testctx.T) {
 		modDir := t.TempDir()
 		err := os.WriteFile(filepath.Join(modDir, "main.go"), []byte(`package main
 	import "context"
@@ -325,7 +323,7 @@ type Test struct {
 		require.NoError(t, err)
 	})
 
-	t.Run("directory", func(t *testing.T) {
+	t.Run("directory", func(ctx context.Context, t *testctx.T) {
 		modDir := t.TempDir()
 		err := os.WriteFile(filepath.Join(modDir, "main.go"), []byte(`package main
 import "context"
@@ -397,10 +395,10 @@ type tuiConsole struct {
 	output            *bytes.Buffer
 }
 
-func newTUIConsole(t *testing.T, expectLineTimeout time.Duration) (*tuiConsole, error) {
+func newTUIConsole(t *testctx.T, expectLineTimeout time.Duration) (*tuiConsole, error) {
 	output := bytes.NewBuffer(nil)
 	console, err := expect.NewConsole(
-		expect.WithStdout(io.MultiWriter(newTWriter(t), output)),
+		expect.WithStdout(io.MultiWriter(testutil.NewTWriter(t), output)),
 		expect.WithDefaultTimeout(expectLineTimeout),
 	)
 	if err != nil {

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -469,7 +469,7 @@ func (ModuleSuite) TestInitLICENSE(ctx context.Context, t *testctx.T) {
 		require.NotContains(t, files, "LICENSE")
 
 		t.Run("do not bootstrap LICENSE file if no sdk is specified", func(ctx context.Context, t *testctx.T) {
-			modGen = modGen.With(daggerExec("develop", "--source=dagger"))
+			modGen := modGen.With(daggerExec("develop", "--source=dagger"))
 
 			files, err := modGen.Directory(".").Entries(ctx)
 			require.NoError(t, err)
@@ -477,7 +477,7 @@ func (ModuleSuite) TestInitLICENSE(ctx context.Context, t *testctx.T) {
 		})
 
 		t.Run("do not bootstrap LICENSE file if license is empty", func(ctx context.Context, t *testctx.T) {
-			modGen = modGen.With(daggerExec("develop", "--source=dagger", `--license=""`))
+			modGen := modGen.With(daggerExec("develop", "--source=dagger", `--license=""`))
 
 			files, err := modGen.Directory(".").Entries(ctx)
 			require.NoError(t, err)
@@ -485,7 +485,7 @@ func (ModuleSuite) TestInitLICENSE(ctx context.Context, t *testctx.T) {
 		})
 
 		t.Run("bootstrap a license after sdk is set on dagger develop", func(ctx context.Context, t *testctx.T) {
-			modGen = modGen.With(daggerExec("develop", "--sdk=go"))
+			modGen := modGen.With(daggerExec("develop", "--sdk=go"))
 
 			content, err := modGen.File("LICENSE").Contents(ctx)
 			require.NoError(t, err)
@@ -493,7 +493,7 @@ func (ModuleSuite) TestInitLICENSE(ctx context.Context, t *testctx.T) {
 		})
 
 		t.Run("boostrap custom LICENSE file if sdk and license are specified", func(ctx context.Context, t *testctx.T) {
-			modGen = modGen.With(daggerExec("develop", "--sdk=go", `--license=MIT`))
+			modGen := modGen.With(daggerExec("develop", "--sdk=go", `--license=MIT`))
 
 			content, err := modGen.File("LICENSE").Contents(ctx)
 			require.NoError(t, err)

--- a/core/integration/module_typescript_test.go
+++ b/core/integration/module_typescript_test.go
@@ -1,23 +1,20 @@
 package core
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
-	"testing"
 
+	"github.com/dagger/dagger/testctx"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 
 	"dagger.io/dagger"
 )
 
-func TestModuleTypescriptInit(t *testing.T) {
-	t.Parallel()
-
-	t.Run("from scratch", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+func (ModuleSuite) TestTypescriptInit(ctx context.Context, t *testctx.T) {
+	t.Run("from scratch", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -31,10 +28,8 @@ func TestModuleTypescriptInit(t *testing.T) {
 		require.JSONEq(t, `{"bare":{"containerEcho":{"stdout":"hello\n"}}}`, out)
 	})
 
-	t.Run("with different root", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("with different root", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		modGen := goGitBase(t, c).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -48,10 +43,8 @@ func TestModuleTypescriptInit(t *testing.T) {
 		require.JSONEq(t, `{"bare":{"containerEcho":{"stdout":"hello\n"}}}`, out)
 	})
 
-	t.Run("camel-cases Dagger module name", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("camel-cases Dagger module name", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -65,10 +58,8 @@ func TestModuleTypescriptInit(t *testing.T) {
 		require.JSONEq(t, `{"myModule":{"containerEcho":{"stdout":"hello\n"}}}`, out)
 	})
 
-	t.Run("respect existing package.json", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("respect existing package.json", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -94,7 +85,7 @@ func TestModuleTypescriptInit(t *testing.T) {
 		require.NoError(t, err)
 		require.JSONEq(t, `{"hasPkgJson":{"containerEcho":{"stdout":"hello\n"}}}`, out)
 
-		t.Run("Add dagger dependencies to the existing package.json", func(t *testing.T) {
+		t.Run("Add dagger dependencies to the existing package.json", func(ctx context.Context, t *testctx.T) {
 			pkgJSON, err := modGen.File("/work/package.json").Contents(ctx)
 			require.NoError(t, err)
 			require.Contains(t, pkgJSON, `"@dagger.io/dagger":`)
@@ -102,10 +93,8 @@ func TestModuleTypescriptInit(t *testing.T) {
 		})
 	})
 
-	t.Run("respect existing tsconfig.json", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("respect existing tsconfig.json", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -127,17 +116,15 @@ func TestModuleTypescriptInit(t *testing.T) {
 		require.NoError(t, err)
 		require.JSONEq(t, `{"hasTsConfig":{"containerEcho":{"stdout":"hello\n"}}}`, out)
 
-		t.Run("Add dagger paths to the existing tsconfig.json", func(t *testing.T) {
+		t.Run("Add dagger paths to the existing tsconfig.json", func(ctx context.Context, t *testctx.T) {
 			tsConfig, err := modGen.File("/work/dagger/tsconfig.json").Contents(ctx)
 			require.NoError(t, err)
 			require.Contains(t, tsConfig, `"@dagger.io/dagger":`)
 		})
 	})
 
-	t.Run("respect existing src/index.ts", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("respect existing src/index.ts", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -166,10 +153,8 @@ func TestModuleTypescriptInit(t *testing.T) {
 		require.JSONEq(t, `{"existingSource":{"helloWorld":{"stdout":"hello\n"}}}`, out)
 	})
 
-	t.Run("with source", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("with source", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -195,10 +180,8 @@ func TestModuleTypescriptInit(t *testing.T) {
 //go:embed testdata/modules/typescript/syntax/index.ts
 var tsSyntax string
 
-func TestModuleTypescriptSyntaxSupport(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ModuleSuite) TestTypescriptSyntaxSupport(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	modGen := c.Container().From(golangImage).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -206,8 +189,7 @@ func TestModuleTypescriptSyntaxSupport(t *testing.T) {
 		With(daggerExec("init", "--name=syntax", "--sdk=typescript")).
 		With(sdkSource("typescript", tsSyntax))
 
-	t.Run("singleQuoteDefaultArgHello(msg: string = 'world'): string", func(t *testing.T) {
-		t.Parallel()
+	t.Run("singleQuoteDefaultArgHello(msg: string = 'world'): string", func(ctx context.Context, t *testctx.T) {
 		defaultOut, err := modGen.With(daggerQuery(`{syntax{singleQuoteDefaultArgHello}}`)).Stdout(ctx)
 
 		require.NoError(t, err)
@@ -219,8 +201,7 @@ func TestModuleTypescriptSyntaxSupport(t *testing.T) {
 		require.JSONEq(t, `{"syntax":{"singleQuoteDefaultArgHello":"hello dagger"}}`, out)
 	})
 
-	t.Run("doubleQuotesDefaultArgHello(msg: string = \"world\"): string", func(t *testing.T) {
-		t.Parallel()
+	t.Run("doubleQuotesDefaultArgHello(msg: string = \"world\"): string", func(ctx context.Context, t *testctx.T) {
 		defaultOut, err := modGen.With(daggerQuery(`{syntax{doubleQuotesDefaultArgHello}}`)).Stdout(ctx)
 
 		require.NoError(t, err)
@@ -236,10 +217,8 @@ func TestModuleTypescriptSyntaxSupport(t *testing.T) {
 //go:embed testdata/modules/typescript/minimal/index.ts
 var tsSignatures string
 
-func TestModuleTypescriptSignatures(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ModuleSuite) TestTypescriptSignatures(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	modGen := c.Container().From(golangImage).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -247,24 +226,21 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 		With(daggerExec("init", "--name=minimal", "--sdk=typescript")).
 		With(sdkSource("typescript", tsSignatures))
 
-	t.Run("hello(): string", func(t *testing.T) {
-		t.Parallel()
+	t.Run("hello(): string", func(ctx context.Context, t *testctx.T) {
 		out, err := modGen.With(daggerQuery(`{minimal{hello}}`)).Stdout(ctx)
 
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"hello":"hello"}}`, out)
 	})
 
-	t.Run("echoes(msgs: string[]): string[]", func(t *testing.T) {
-		t.Parallel()
+	t.Run("echoes(msgs: string[]): string[]", func(ctx context.Context, t *testctx.T) {
 		out, err := modGen.With(daggerQuery(`{minimal{echoes(msgs: ["hello"])}}`)).Stdout(ctx)
 
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoes":["hello...hello...hello..."]}}`, out)
 	})
 
-	t.Run("echoOptional(msg = 'default'): string", func(t *testing.T) {
-		t.Parallel()
+	t.Run("echoOptional(msg = 'default'): string", func(ctx context.Context, t *testctx.T) {
 		out, err := modGen.With(daggerQuery(`{minimal{echoOptional(msg: "hello")}}`)).Stdout(ctx)
 
 		require.NoError(t, err)
@@ -276,24 +252,21 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 		require.JSONEq(t, `{"minimal":{"echoOptional":"default...default...default..."}}`, out)
 	})
 
-	t.Run("echoesVariadic(...msgs: string[]): string", func(t *testing.T) {
-		t.Parallel()
+	t.Run("echoesVariadic(...msgs: string[]): string", func(ctx context.Context, t *testctx.T) {
 		out, err := modGen.With(daggerQuery(`{minimal{echoesVariadic(msgs: ["hello"])}}`)).Stdout(ctx)
 
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoesVariadic":"hello...hello...hello..."}}`, out)
 	})
 
-	t.Run("echo(msg: string): string", func(t *testing.T) {
-		t.Parallel()
+	t.Run("echo(msg: string): string", func(ctx context.Context, t *testctx.T) {
 		out, err := modGen.With(daggerQuery(`{minimal{echo(msg: "hello")}}`)).Stdout(ctx)
 
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echo":"hello...hello...hello..."}}`, out)
 	})
 
-	t.Run("echoOptionalSlice(msg = ['foobar']): string", func(t *testing.T) {
-		t.Parallel()
+	t.Run("echoOptionalSlice(msg = ['foobar']): string", func(ctx context.Context, t *testctx.T) {
 		out, err := modGen.With(daggerQuery(`{minimal{echoOptionalSlice(msg: ["hello", "there"])}}`)).Stdout(ctx)
 
 		require.NoError(t, err)
@@ -305,16 +278,14 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 		require.JSONEq(t, `{"minimal":{"echoOptionalSlice":"foobar...foobar...foobar..."}}`, out)
 	})
 
-	t.Run("helloVoid(): void", func(t *testing.T) {
-		t.Parallel()
+	t.Run("helloVoid(): void", func(ctx context.Context, t *testctx.T) {
 		out, err := modGen.With(daggerQuery(`{minimal{helloVoid}}`)).Stdout(ctx)
 
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"helloVoid":null}}`, out)
 	})
 
-	t.Run("echoOpts(msg: string, suffix: string = '', times: number = 1): string", func(t *testing.T) {
-		t.Parallel()
+	t.Run("echoOpts(msg: string, suffix: string = '', times: number = 1): string", func(ctx context.Context, t *testctx.T) {
 		out, err := modGen.With(daggerQuery(`{minimal{echoOpts(msg: "hi")}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoOpts":"hi"}}`, out)
@@ -323,15 +294,14 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoOpts":"hi!hi!"}}`, out)
 
-		t.Run("execute with unordered args", func(t *testing.T) {
+		t.Run("execute with unordered args", func(ctx context.Context, t *testctx.T) {
 			out, err = modGen.With(daggerQuery(`{minimal{echoOpts(times: 2, msg: "order", suffix: "?")}}`)).Stdout(ctx)
 			require.NoError(t, err)
 			require.JSONEq(t, `{"minimal":{"echoOpts":"order?order?"}}`, out)
 		})
 	})
 
-	t.Run("echoMaybe(msg: string, isQuestion = false): string", func(t *testing.T) {
-		t.Parallel()
+	t.Run("echoMaybe(msg: string, isQuestion = false): string", func(ctx context.Context, t *testctx.T) {
 		out, err := modGen.With(daggerQuery(`{minimal{echoMaybe(msg: "hi")}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoMaybe":"hi...hi...hi..."}}`, out)
@@ -340,7 +310,7 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoMaybe":"hi?...hi?...hi?..."}}`, out)
 
-		t.Run("execute with unordered args", func(t *testing.T) {
+		t.Run("execute with unordered args", func(ctx context.Context, t *testctx.T) {
 			out, err = modGen.With(daggerQuery(`{minimal{echoMaybe(isQuestion: false, msg: "hi")}}`)).Stdout(ctx)
 			require.NoError(t, err)
 			require.JSONEq(t, `{"minimal":{"echoMaybe":"hi...hi...hi..."}}`, out)
@@ -351,10 +321,8 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 //go:embed testdata/modules/typescript/minimal/builtin.ts
 var tsSignaturesBuiltin string
 
-func TestModuleTypescriptSignaturesBuildinTypes(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ModuleSuite) TestTypescriptSignaturesBuildinTypes(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	modGen := c.Container().From(golangImage).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -366,29 +334,25 @@ func TestModuleTypescriptSignaturesBuildinTypes(t *testing.T) {
 	require.NoError(t, err)
 	dirID := gjson.Get(out, "directory.withNewFile.id").String()
 
-	t.Run("async read(dir: Directory): Promise<string>", func(t *testing.T) {
-		t.Parallel()
+	t.Run("async read(dir: Directory): Promise<string>", func(ctx context.Context, t *testctx.T) {
 		out, err := modGen.With(daggerQuery(fmt.Sprintf(`{minimal{read(dir: "%s")}}`, dirID))).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"read":"bar"}}`, out)
 	})
 
-	t.Run("async readSlice(dir: Directory[]): Promise<string>", func(t *testing.T) {
-		t.Parallel()
+	t.Run("async readSlice(dir: Directory[]): Promise<string>", func(ctx context.Context, t *testctx.T) {
 		out, err := modGen.With(daggerQuery(fmt.Sprintf(`{minimal{readSlice(dir: ["%s"])}}`, dirID))).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"readSlice":"bar"}}`, out)
 	})
 
-	t.Run("async readVariadic(...dir: Directory[]): Promise<string>", func(t *testing.T) {
-		t.Parallel()
+	t.Run("async readVariadic(...dir: Directory[]): Promise<string>", func(ctx context.Context, t *testctx.T) {
 		out, err := modGen.With(daggerQuery(fmt.Sprintf(`{minimal{readVariadic(dir: ["%s"])}}`, dirID))).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"readVariadic":"bar"}}`, out)
 	})
 
-	t.Run("async readOptional(dir?: Directory): Promise<string>", func(t *testing.T) {
-		t.Parallel()
+	t.Run("async readOptional(dir?: Directory): Promise<string>", func(ctx context.Context, t *testctx.T) {
 		out, err := modGen.With(daggerQuery(fmt.Sprintf(`{minimal{readOptional(dir: "%s")}}`, dirID))).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"readOptional":"bar"}}`, out)
@@ -402,10 +366,8 @@ func TestModuleTypescriptSignaturesBuildinTypes(t *testing.T) {
 var tsSignaturesUnexported string
 
 // TODO: Fixes DEV-3343 and update this test
-func TestModuleTypescriptSignatureUnexported(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ModuleSuite) TestTypescriptSignatureUnexported(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	modGen := c.Container().From(golangImage).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -420,10 +382,8 @@ func TestModuleTypescriptSignatureUnexported(t *testing.T) {
 	require.Equal(t, "MinimalFoo", objs.Get("0.name").String())
 }
 
-func TestModuleTypescriptDocs(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ModuleSuite) TestTypescriptDocs(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	modGen := c.Container().From(golangImage).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -468,10 +428,8 @@ func TestModuleTypescriptDocs(t *testing.T) {
 //go:embed testdata/modules/typescript/optional/index.ts
 var tsOptional string
 
-func TestModuleTypescriptOptional(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ModuleSuite) TestTypescriptOptional(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	modGen := c.Container().From(golangImage).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -488,10 +446,8 @@ func TestModuleTypescriptOptional(t *testing.T) {
 	require.JSONEq(t, `{"minimal": {"isEmpty": true}}`, out)
 }
 
-func TestModuleTypescriptRuntimeDetection(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ModuleSuite) TestTypescriptRuntimeDetection(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	modGen := c.Container().From(golangImage).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -509,15 +465,13 @@ func TestModuleTypescriptRuntimeDetection(t *testing.T) {
 			}
 		`))
 
-	t.Run("should default to node", func(t *testing.T) {
-		t.Parallel()
+	t.Run("should default to node", func(ctx context.Context, t *testctx.T) {
 		out, err := modGen.With(daggerQuery(`{runtimeDetection{echoRuntime}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"runtimeDetection":{"echoRuntime":"node"}}`, out)
 	})
 
-	t.Run("should use package.json configuration node", func(t *testing.T) {
-		t.Parallel()
+	t.Run("should use package.json configuration node", func(ctx context.Context, t *testctx.T) {
 		modGen := modGen.WithNewFile("/work/dagger/package.json", dagger.ContainerWithNewFileOpts{
 			Contents: `{
 				"dagger": {
@@ -531,8 +485,7 @@ func TestModuleTypescriptRuntimeDetection(t *testing.T) {
 		require.JSONEq(t, `{"runtimeDetection":{"echoRuntime":"node"}}`, out)
 	})
 
-	t.Run("should use package.json configuration bun", func(t *testing.T) {
-		t.Parallel()
+	t.Run("should use package.json configuration bun", func(ctx context.Context, t *testctx.T) {
 		modGen := modGen.WithNewFile("/work/dagger/package.json", dagger.ContainerWithNewFileOpts{
 			Contents: `{
 				"dagger": {
@@ -546,8 +499,7 @@ func TestModuleTypescriptRuntimeDetection(t *testing.T) {
 		require.JSONEq(t, `{"runtimeDetection":{"echoRuntime":"bun"}}`, out)
 	})
 
-	t.Run("should detect package-lock.json", func(t *testing.T) {
-		t.Parallel()
+	t.Run("should detect package-lock.json", func(ctx context.Context, t *testctx.T) {
 		modGen := c.Container().From("node:20-alpine").
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
@@ -571,8 +523,7 @@ func TestModuleTypescriptRuntimeDetection(t *testing.T) {
 		require.JSONEq(t, `{"runtimeDetection":{"echoRuntime":"node"}}`, out)
 	})
 
-	t.Run("should detect bun.lockb", func(t *testing.T) {
-		t.Parallel()
+	t.Run("should detect bun.lockb", func(ctx context.Context, t *testctx.T) {
 		modGen := c.Container().From("oven/bun:1.0.27-alpine").
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
@@ -596,8 +547,7 @@ func TestModuleTypescriptRuntimeDetection(t *testing.T) {
 		require.JSONEq(t, `{"runtimeDetection":{"echoRuntime":"bun"}}`, out)
 	})
 
-	t.Run("should prioritize package.json config over file detection", func(t *testing.T) {
-		t.Parallel()
+	t.Run("should prioritize package.json config over file detection", func(ctx context.Context, t *testctx.T) {
 		modGen := c.Container().From("node:20-alpine").
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
@@ -628,8 +578,7 @@ func TestModuleTypescriptRuntimeDetection(t *testing.T) {
 		require.JSONEq(t, `{"runtimeDetection":{"echoRuntime":"bun"}}`, out)
 	})
 
-	t.Run("should error if configured runtime is unknown", func(t *testing.T) {
-		t.Parallel()
+	t.Run("should error if configured runtime is unknown", func(ctx context.Context, t *testctx.T) {
 		modGen := modGen.WithNewFile("/work/dagger/package.json", dagger.ContainerWithNewFileOpts{
 			Contents: `{
 				"dagger": {
@@ -642,10 +591,8 @@ func TestModuleTypescriptRuntimeDetection(t *testing.T) {
 	})
 }
 
-func TestModuleTypescriptWithOtherModuleTypes(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (ModuleSuite) TestTypescriptWithOtherModuleTypes(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	ctr := goGitBase(t, c).
 		WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -680,10 +627,8 @@ class Foo {}
 		With(daggerExec("install", "-m=test", "./dep")).
 		WithWorkdir("/work/test")
 
-	t.Run("return as other module object", func(t *testing.T) {
-		t.Parallel()
-		t.Run("direct", func(t *testing.T) {
-			t.Parallel()
+	t.Run("return as other module object", func(ctx context.Context, t *testctx.T) {
+		t.Run("direct", func(ctx context.Context, t *testctx.T) {
 			_, err := ctr.With(sdkSource("typescript", `
 			import { object, func, DepObj } from "@dagger.io/dagger"
 
@@ -704,8 +649,7 @@ class Foo {}
 			), err.Error())
 		})
 
-		t.Run("list", func(t *testing.T) {
-			t.Parallel()
+		t.Run("list", func(ctx context.Context, t *testctx.T) {
 			_, err := ctr.With(sdkSource("typescript", `
 			import { object, func, DepObj } from "@dagger.io/dagger"
 
@@ -727,10 +671,8 @@ class Foo {}
 		})
 	})
 
-	t.Run("arg as other module object", func(t *testing.T) {
-		t.Parallel()
-		t.Run("direct", func(t *testing.T) {
-			t.Parallel()
+	t.Run("arg as other module object", func(ctx context.Context, t *testctx.T) {
+		t.Run("direct", func(ctx context.Context, t *testctx.T) {
 			_, err := ctr.With(sdkSource("typescript", `
 import { object, func, DepObj } from "@dagger.io/dagger"
 
@@ -749,8 +691,7 @@ class Test {
 			), err.Error())
 		})
 
-		t.Run("list", func(t *testing.T) {
-			t.Parallel()
+		t.Run("list", func(ctx context.Context, t *testctx.T) {
 			_, err := ctr.
 				With(sdkSource("typescript", `
 import { object, func, DepObj } from "@dagger.io/dagger"
@@ -771,10 +712,8 @@ class Test {
 		})
 	})
 
-	t.Run("field as other module object", func(t *testing.T) {
-		t.Parallel()
-		t.Run("direct", func(t *testing.T) {
-			t.Parallel()
+	t.Run("field as other module object", func(ctx context.Context, t *testctx.T) {
+		t.Run("direct", func(ctx context.Context, t *testctx.T) {
 			_, err := ctr.
 				With(sdkSource("typescript", `
 import { object, func, DepObj } from "@dagger.io/dagger"
@@ -802,8 +741,7 @@ class Obj {
 			), err.Error())
 		})
 
-		t.Run("list", func(t *testing.T) {
-			t.Parallel()
+		t.Run("list", func(ctx context.Context, t *testctx.T) {
 			_, err := ctr.
 				With(sdkSource("typescript", `
 import { object, func, DepObj } from "@dagger.io/dagger"
@@ -833,13 +771,9 @@ class Obj {
 	})
 }
 
-func TestModuleTypescriptAliases(t *testing.T) {
-	t.Parallel()
-
-	t.Run("alias in function", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+func (ModuleSuite) TestTypescriptAliases(ctx context.Context, t *testctx.T) {
+	t.Run("alias in function", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -862,10 +796,8 @@ class Alias {
 		require.JSONEq(t, `{"alias": {"bar": "hello world"}}`, out)
 	})
 
-	t.Run("nested alias in function", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("nested alias in function", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -904,10 +836,8 @@ class Alias {
 		require.JSONEq(t, `{"alias": {"bar": {"hello": {"zoo": "hello world"}}}}`, out)
 	})
 
-	t.Run("nested alias in field", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("nested alias in field", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -958,13 +888,9 @@ class Alias {
 	})
 }
 
-func TestModuleTypeScriptPrototype(t *testing.T) {
-	t.Parallel()
-
-	t.Run("keep class prototype inside module", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+func (ModuleSuite) TestTypeScriptPrototype(ctx context.Context, t *testctx.T) {
+	t.Run("keep class prototype inside module", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -975,7 +901,7 @@ import { func, object } from "@dagger.io/dagger"
 
 @object()
 class Test {
-  @func() 
+  @func()
   test() {
     return new PModule(new PCheck(4))
   }
@@ -983,7 +909,7 @@ class Test {
 
 @object()
 class PCheck {
-  @func() 
+  @func()
   value: number
 
   constructor(value: number) {
@@ -997,13 +923,13 @@ class PCheck {
 
 @object()
 class PModule {
-  @func() 
+  @func()
   value: PCheck
-  
+
   constructor(value: PCheck) {
     this.value = value
   }
-  @func() 
+  @func()
   print() {
     return this.value.doubled ?? 0
   }
@@ -1016,13 +942,9 @@ class PModule {
 	})
 }
 
-func TestModuleTypeScriptSubPathLoading(t *testing.T) {
-	t.Parallel()
-
-	t.Run("load from subpath", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+func (ModuleSuite) TestModuleTypeScriptSubPathLoading(ctx context.Context, t *testctx.T) {
+	t.Run("load from subpath", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -1035,13 +957,9 @@ func TestModuleTypeScriptSubPathLoading(t *testing.T) {
 	})
 }
 
-func TestModuleTypeScriptPrimitiveType(t *testing.T) {
-	t.Parallel()
-
-	t.Run("should throw error on String", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+func (ModuleSuite) TestTypeScriptPrimitiveType(ctx context.Context, t *testctx.T) {
+	t.Run("should throw error on String", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -1052,7 +970,7 @@ import { func, object } from "@dagger.io/dagger"
 
 @object()
 class Test {
-  @func() 
+  @func()
   str(s: String): String {
     return s
   }
@@ -1063,10 +981,8 @@ class Test {
 		require.ErrorContains(t, err, "Use of primitive String type detected, did you mean string?")
 	})
 
-	t.Run("should throw error on Number", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("should throw error on Number", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -1077,7 +993,7 @@ import { func, object } from "@dagger.io/dagger"
 
 @object()
 class Test {
-  @func() 
+  @func()
   integer(n: Number): Number {
     return n
   }
@@ -1088,10 +1004,8 @@ class Test {
 		require.ErrorContains(t, err, "Use of primitive Number type detected, did you mean number?")
 	})
 
-	t.Run("should throw error on Boolean", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+	t.Run("should throw error on Boolean", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -1102,7 +1016,7 @@ import { func, object } from "@dagger.io/dagger"
 
 @object()
 class Test {
-  @func() 
+  @func()
   bool(b: Boolean): Boolean {
     return b
   }
@@ -1114,13 +1028,9 @@ class Test {
 	})
 }
 
-func TestModuleTypeScriptDeprecatedFieldDecorator(t *testing.T) {
-	t.Parallel()
-
-	t.Run("@field still working", func(t *testing.T) {
-		t.Parallel()
-
-		c, ctx := connect(t)
+func (ModuleSuite) TestTypeScriptDeprecatedFieldDecorator(ctx context.Context, t *testctx.T) {
+	t.Run("@field still working", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
 
 		modGen := c.Container().From(golangImage).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
@@ -1131,7 +1041,7 @@ import { field, object } from "@dagger.io/dagger"
 
 @object()
 class Test {
-  @field() 
+  @field()
   foo: string = "bar"
 
 	constructor() {}

--- a/core/integration/module_up_test.go
+++ b/core/integration/module_up_test.go
@@ -6,21 +6,23 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"testing"
 	"time"
 
 	"github.com/creack/pty"
+	"github.com/dagger/dagger/testctx"
 	"github.com/stretchr/testify/require"
 )
 
-func TestModuleDaggerUp(t *testing.T) {
-	ctx := context.Background()
-
+func (ModuleSuite) TestDaggerUp(ctx context.Context, t *testctx.T) {
 	modDir := t.TempDir()
 	err := os.WriteFile(filepath.Join(modDir, "main.go"), []byte(`package main
-import "context"
+import  "strconv"
 
-func New(ctx context.Context) *Test {
+func New(
+	// +optional
+	// +default=23457
+	port int,
+) *Test {
 	return &Test{
 		Ctr: dag.Container().
 			From("python").
@@ -29,15 +31,15 @@ func New(ctx context.Context) *Test {
 				dag.Directory().WithNewFile("index.html", "hey there"),
 			).
 			WithWorkdir("/srv/www").
-			WithExposedPort(23457).
-			WithExec([]string{"python", "-m", "http.server", "23457"}),
+			WithExposedPort(port).
+			WithExec([]string{"python", "-m", "http.server", strconv.Itoa(port)}),
 	}
 }
 
 type Test struct {
 	Ctr *Container
 }
-`), 0644)
+`), 0o644)
 	require.NoError(t, err)
 
 	_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")
@@ -47,10 +49,9 @@ type Test struct {
 	_, err = hostDaggerExec(ctx, t, modDir, "--debug", "functions")
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Minute)
-	defer cancel()
+	t = t.WithTimeout(3 * time.Minute)
 
-	t.Run("native", func(t *testing.T) {
+	t.Run("native", func(ctx context.Context, t *testctx.T) {
 		cmd := hostDaggerCommand(ctx, t, modDir, "call", "ctr", "as-service", "up")
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
@@ -58,7 +59,7 @@ type Test struct {
 
 		err = cmd.Start()
 		require.NoError(t, err)
-		defer cmd.Process.Kill()
+		cleanupExec(t, cmd)
 
 		for {
 			select {
@@ -83,7 +84,7 @@ type Test struct {
 		}
 	})
 
-	t.Run("random", func(t *testing.T) {
+	t.Run("random", func(ctx context.Context, t *testctx.T) {
 		console, err := newTUIConsole(t, time.Minute)
 		require.NoError(t, err)
 
@@ -100,7 +101,7 @@ type Test struct {
 
 		err = cmd.Start()
 		require.NoError(t, err)
-		defer cmd.Process.Kill()
+		cleanupExec(t, cmd)
 
 		_, matches, err := console.MatchLine(ctx, `tunnel started port=(\d+)`)
 		require.NoError(t, err)
@@ -131,7 +132,7 @@ type Test struct {
 		}
 	})
 
-	t.Run("port map", func(t *testing.T) {
+	t.Run("port map", func(ctx context.Context, t *testctx.T) {
 		cmd := hostDaggerCommand(ctx, t, modDir, "call", "ctr", "as-service", "up", "--ports", "23458:23457")
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
@@ -139,7 +140,7 @@ type Test struct {
 
 		err = cmd.Start()
 		require.NoError(t, err)
-		defer cmd.Process.Kill()
+		cleanupExec(t, cmd)
 
 		for {
 			select {
@@ -164,15 +165,15 @@ type Test struct {
 		}
 	})
 
-	t.Run("port map with same front+back", func(t *testing.T) {
-		cmd := hostDaggerCommand(ctx, t, modDir, "call", "ctr", "as-service", "up", "--ports", "23457:23457")
+	t.Run("port map with same front+back", func(ctx context.Context, t *testctx.T) {
+		cmd := hostDaggerCommand(ctx, t, modDir, "call", "--port", "23459", "ctr", "as-service", "up", "--ports", "23459:23459")
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 
 		err = cmd.Start()
 		require.NoError(t, err)
-		defer cmd.Process.Kill()
+		cleanupExec(t, cmd)
 
 		for {
 			select {
@@ -181,7 +182,7 @@ type Test struct {
 			default:
 			}
 
-			resp, err := http.Get("http://127.0.0.1:23457")
+			resp, err := http.Get("http://127.0.0.1:23459")
 			if err != nil {
 				t.Logf("waiting for container to start: %s", err)
 				time.Sleep(time.Second)

--- a/core/integration/module_up_test.go
+++ b/core/integration/module_up_test.go
@@ -94,7 +94,7 @@ type Test struct {
 		require.NoError(t, err)
 
 		cmd := hostDaggerCommand(ctx, t, modDir, "call", "ctr", "as-service", "up", "--random")
-		cmd.Env = append(os.Environ(), "NO_COLOR=true")
+		cmd.Env = append(cmd.Env, "NO_COLOR=true")
 		cmd.Stdin = nil
 		cmd.Stdout = tty
 		cmd.Stderr = tty

--- a/core/integration/ownership_test.go
+++ b/core/integration/ownership_test.go
@@ -3,21 +3,18 @@ package core
 import (
 	"context"
 	"strings"
-	"testing"
-
-	"github.com/stretchr/testify/require"
 
 	"dagger.io/dagger"
+
+	"github.com/dagger/dagger/testctx"
+	"github.com/stretchr/testify/require"
 )
 
 func testOwnership(
-	ctx context.Context,
-	t *testing.T,
+	t *testctx.T,
 	c *dagger.Client,
 	addContent func(ctr *dagger.Container, name, owner string) *dagger.Container,
 ) {
-	t.Parallel()
-
 	ctr := c.Container().From(alpineImage).
 		WithExec([]string{"adduser", "-D", "inherituser"}).
 		WithExec([]string{"adduser", "-u", "1234", "-D", "auser"}).
@@ -59,7 +56,7 @@ func testOwnership(
 		{name: "no-inherit", owner: "", output: "root root"},
 	} {
 		example := example
-		t.Run(example.name, func(t *testing.T) {
+		t.Run(example.name, func(ctx context.Context, t *testctx.T) {
 			withOwner := addContent(ctr, example.name, example.owner)
 			output, err := withOwner.
 				WithUser("root"). // go back to root so we can see 0400 files

--- a/core/integration/platform_test.go
+++ b/core/integration/platform_test.go
@@ -1,10 +1,12 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/dagger/dagger/testctx"
 	"github.com/moby/buildkit/identity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,6 +14,12 @@ import (
 
 	"dagger.io/dagger"
 )
+
+type PlatformSuite struct{}
+
+func TestPlatform(t *testing.T) {
+	testctx.Run(testCtx, t, PlatformSuite{}, Middleware()...)
+}
 
 var platformToUname = map[dagger.Platform]string{
 	"linux/amd64": "x86_64",
@@ -25,9 +33,8 @@ var platformToFileArch = map[dagger.Platform]string{
 	"linux/s390x": "IBM S/390",
 }
 
-func TestPlatformEmulatedExecAndPush(t *testing.T) {
-	t.Parallel()
-	c, ctx := connect(t)
+func (PlatformSuite) TestEmulatedExecAndPush(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	variants := make([]*dagger.Container, 0, len(platformToUname))
 	for platform, uname := range platformToUname {
@@ -63,10 +70,8 @@ func TestPlatformEmulatedExecAndPush(t *testing.T) {
 	}
 }
 
-func TestPlatformCrossCompile(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t, dagger.WithWorkdir("../.."))
+func (PlatformSuite) TestCrossCompile(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t, dagger.WithWorkdir("../.."))
 
 	// cross compile the dagger binary for each platform
 	defaultPlatform, err := c.DefaultPlatform(ctx)
@@ -151,10 +156,8 @@ func TestPlatformCrossCompile(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestPlatformCacheMounts(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (PlatformSuite) TestCacheMounts(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	randomID := identity.NewID()
 
@@ -183,19 +186,15 @@ func TestPlatformCacheMounts(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestPlatformInvalid(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (PlatformSuite) TestInvalid(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	_, err := c.Container(dagger.ContainerOpts{Platform: "windows98"}).ID(ctx)
 	require.ErrorContains(t, err, "unknown operating system or architecture")
 }
 
-func TestPlatformWindows(t *testing.T) {
-	t.Parallel()
-
-	c, ctx := connect(t)
+func (PlatformSuite) TestWindows(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	// It's not possible to exec, but we can pull and read files
 	ents, err := c.Container(dagger.ContainerOpts{Platform: "windows/amd64"}).

--- a/core/integration/ref_test.go
+++ b/core/integration/ref_test.go
@@ -1,23 +1,22 @@
 package core
 
 import (
+	"context"
 	"strings"
-	"testing"
 
 	"dagger.io/dagger"
+	"github.com/dagger/dagger/testctx"
 	"github.com/stretchr/testify/require"
 )
 
-func TestRefIntegration(t *testing.T) {
-	t.Parallel()
-	c, ctx := connect(t)
+func (ModuleSuite) TestRefIntegration(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
 	// This test handles a very edgy case:
 	// goGitBase inits a /work directory with a git context
 	// we then create a local dir with the same structure as a git remote: `/work/github.com/dagger/dagger`
 	// It should be resolved as a local ref, not a remote one
-	t.Run("local module with same format as remote: github.com/dagger/dagger", func(t *testing.T) {
-		t.Parallel()
+	t.Run("local module with same format as remote: github.com/dagger/dagger", func(ctx context.Context, t *testctx.T) {
 		out, err := goGitBase(t, c).
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work/github.com/dagger/dagger").

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -1587,7 +1587,7 @@ func (ServiceSuite) TestSearchDomainAlwaysSet(ctx context.Context, t *testctx.T)
 	// verify that even if the engine doesn't have any search domains to propagate to execs, we still
 	// set search domains in those execs
 
-	c, err := dagger.Connect(ctx, dagger.WithLogOutput(testutil.NewTWriter(t)))
+	c, err := dagger.Connect(ctx, dagger.WithLogOutput(testutil.NewTWriter(t.T)))
 	require.NoError(t, err)
 	t.Cleanup(func() { c.Close() })
 
@@ -1628,7 +1628,7 @@ func (ServiceSuite) TestSearchDomainAlwaysSet(ctx context.Context, t *testctx.T)
 
 	c2, err := dagger.Connect(ctx,
 		dagger.WithRunnerHost("tcp://127.0.0.1:32132"),
-		dagger.WithLogOutput(testutil.NewTWriter(t)))
+		dagger.WithLogOutput(testutil.NewTWriter(t.T)))
 	require.NoError(t, err)
 	t.Cleanup(func() { c2.Close() })
 

--- a/core/integration/suite_test.go
+++ b/core/integration/suite_test.go
@@ -56,7 +56,7 @@ func Middleware() []testctx.Middleware {
 
 func connect(ctx context.Context, t *testctx.T, opts ...dagger.ClientOpt) *dagger.Client {
 	opts = append([]dagger.ClientOpt{
-		dagger.WithLogOutput(testutil.NewTWriter(t)),
+		dagger.WithLogOutput(testutil.NewTWriter(t.T)),
 	}, opts...)
 	client, err := dagger.Connect(ctx, opts...)
 	require.NoError(t, err)

--- a/core/integration/telemetry_test.go
+++ b/core/integration/telemetry_test.go
@@ -1,25 +1,29 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
 
+	"github.com/dagger/dagger/testctx"
 	"github.com/stretchr/testify/require"
 
 	"dagger.io/dagger"
 )
 
-func TestInternalVertexes(t *testing.T) {
-	t.Parallel()
+type TelemetrySuite struct{}
 
+func TestTelemetry(t *testing.T) {
+	testctx.Run(testCtx, t, TelemetrySuite{}, Middleware()...)
+}
+
+func (TelemetrySuite) TestInternalVertexes(ctx context.Context, t *testctx.T) {
 	cacheBuster := fmt.Sprintf("%d", time.Now().UTC().UnixNano())
 
-	t.Run("merge pipeline", func(t *testing.T) {
-		t.Parallel()
-
+	t.Run("merge pipeline", func(ctx context.Context, t *testctx.T) {
 		var logs safeBuffer
-		c, ctx := connect(t, dagger.WithLogOutput(&logs))
+		c := connect(ctx, t, dagger.WithLogOutput(&logs))
 
 		dirA := c.Directory().WithNewFile("/foo", "foo")
 		dirB := c.Directory().WithNewFile("/bar", "bar")

--- a/internal/testutil/query.go
+++ b/internal/testutil/query.go
@@ -5,6 +5,7 @@ import (
 
 	"dagger.io/dagger"
 	"github.com/dagger/dagger/core"
+	"github.com/dagger/dagger/testctx"
 )
 
 type QueryOptions struct {
@@ -13,8 +14,8 @@ type QueryOptions struct {
 	Secrets   map[string]string
 }
 
-func Query(query string, res any, opts *QueryOptions, clientOpts ...dagger.ClientOpt) error {
-	ctx := context.Background()
+func Query(t *testctx.T, query string, res any, opts *QueryOptions, clientOpts ...dagger.ClientOpt) error {
+	ctx := t.Context()
 
 	if opts == nil {
 		opts = &QueryOptions{}
@@ -25,6 +26,10 @@ func Query(query string, res any, opts *QueryOptions, clientOpts ...dagger.Clien
 	if opts.Secrets == nil {
 		opts.Secrets = make(map[string]string)
 	}
+
+	clientOpts = append([]dagger.ClientOpt{
+		dagger.WithLogOutput(NewTWriter(t)),
+	}, clientOpts...)
 
 	c, err := dagger.Connect(ctx, clientOpts...)
 	if err != nil {

--- a/internal/testutil/query.go
+++ b/internal/testutil/query.go
@@ -28,7 +28,7 @@ func Query(t *testctx.T, query string, res any, opts *QueryOptions, clientOpts .
 	}
 
 	clientOpts = append([]dagger.ClientOpt{
-		dagger.WithLogOutput(NewTWriter(t)),
+		dagger.WithLogOutput(NewTWriter(t.T)),
 	}, clientOpts...)
 
 	c, err := dagger.Connect(ctx, clientOpts...)

--- a/internal/testutil/twriter.go
+++ b/internal/testutil/twriter.go
@@ -1,0 +1,56 @@
+package testutil
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// tWriter is a writer that writes to testing.T
+type tWriter struct {
+	t   testing.TB
+	buf bytes.Buffer
+	mu  sync.Mutex
+}
+
+// NewTWriter creates a new TWriter
+func NewTWriter(t testing.TB) io.Writer {
+	tw := &tWriter{t: t}
+	t.Cleanup(tw.flush)
+	return tw
+}
+
+// Write writes data to the testing.T
+func (tw *tWriter) Write(p []byte) (n int, err error) {
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
+
+	tw.t.Helper()
+
+	if n, err = tw.buf.Write(p); err != nil {
+		return n, err
+	}
+
+	for {
+		line, err := tw.buf.ReadBytes('\n')
+		if err == io.EOF {
+			// If we've reached the end of the buffer, write it back, because it doesn't have a newline
+			tw.buf.Write(line)
+			break
+		}
+		if err != nil {
+			return n, err
+		}
+
+		tw.t.Log(strings.TrimSuffix(string(line), "\n"))
+	}
+	return n, nil
+}
+
+func (tw *tWriter) flush() {
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
+	tw.t.Log(tw.buf.String())
+}

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -51,6 +51,15 @@ func WithConn(conn engineconn.EngineConn) ClientOpt {
 	})
 }
 
+// WithRunnerHost sets the runner host URL for provisioning and connecting to
+// an engine. This only has effect when connecting via the CLI, and is only
+// exposed for testing purposes.
+func WithRunnerHost(runnerHost string) ClientOpt {
+	return clientOptFunc(func(cfg *engineconn.Config) {
+		cfg.RunnerHost = runnerHost
+	})
+}
+
 // Connect to a Dagger Engine
 func Connect(ctx context.Context, opts ...ClientOpt) (*Client, error) {
 	cfg := &engineconn.Config{}

--- a/sdk/go/internal/engineconn/engineconn.go
+++ b/sdk/go/internal/engineconn/engineconn.go
@@ -22,9 +22,10 @@ type EngineConn interface {
 }
 
 type Config struct {
-	Workdir   string
-	LogOutput io.Writer
-	Conn      EngineConn
+	Workdir    string
+	LogOutput  io.Writer
+	RunnerHost string
+	Conn       EngineConn
 }
 
 type ConnectParams struct {

--- a/sdk/go/internal/engineconn/session.go
+++ b/sdk/go/internal/engineconn/session.go
@@ -87,6 +87,10 @@ func startCLISession(ctx context.Context, binPath string, cfg *Config) (_ Engine
 
 	env := os.Environ()
 
+	if cfg.RunnerHost != "" {
+		env = append(env, "_EXPERIMENTAL_DAGGER_RUNNER_HOST="+cfg.RunnerHost)
+	}
+
 	// detect $TRACEPARENT set by 'dagger run'
 	ctx = fallbackSpanContext(ctx)
 

--- a/testctx/testctx.go
+++ b/testctx/testctx.go
@@ -130,10 +130,12 @@ func (tc T) WithLogger(logger func(*T, string)) *T {
 	return &tc
 }
 
-func (tc *T) WithTimeout(timeout time.Duration) *T {
-	ctx, cancel := context.WithTimeout(tc.Context(), timeout)
-	tc.Cleanup(cancel)
-	return tc.WithContext(ctx)
+func (t *T) WithTimeout(timeout time.Duration) *T {
+	return t.BeforeEach(func(t *T) *T {
+		ctx, cancel := context.WithTimeout(t.Context(), timeout)
+		t.Cleanup(cancel)
+		return t.WithContext(ctx)
+	})
 }
 
 // BeforeAll calls f immediately with itself and returns the result.

--- a/testctx/testctx.go
+++ b/testctx/testctx.go
@@ -1,0 +1,241 @@
+package testctx
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type Middleware = func(*T) *T
+
+func WithParallel(t *T) *T {
+	t.Parallel()
+	return t.
+		BeforeEach(func(t *T) *T {
+			t.Parallel()
+			return t
+		})
+}
+
+func Run(ctx context.Context, t *testing.T, suite any, middleware ...Middleware) {
+	tc := New(ctx, t)
+	for _, m := range middleware {
+		tc = m(tc)
+	}
+
+	suiteT := reflect.TypeOf(suite)
+	suiteV := reflect.ValueOf(suite)
+
+	for i := 0; i < suiteV.NumMethod(); i++ {
+		methT := suiteT.Method(i)
+		if !strings.HasPrefix(methT.Name, "Test") {
+			continue
+		}
+
+		methV := suiteV.Method(i)
+		tf, ok := methV.Interface().(func(context.Context, *T))
+		if !ok {
+			t.Fatalf("suite method %s does not have the right signature; must be func(testctx.T); have %T",
+				methT.Name,
+				methV.Interface())
+		}
+
+		tc.Run(methT.Name, tf)
+	}
+}
+
+func WithOTelTracing(tracer trace.Tracer) Middleware {
+	wrapSpan := func(t *T) *T {
+		ctx, span := tracer.Start(t.Context(), t.BaseName())
+		t.Cleanup(func() {
+			if t.Failed() {
+				span.SetStatus(codes.Error, "test failed")
+			}
+			span.End()
+		})
+		return t.WithContext(ctx)
+	}
+	return func(t *T) *T {
+		return t.
+			BeforeAll(wrapSpan).
+			BeforeEach(wrapSpan)
+	}
+}
+
+func WithOTelLogging(logger log.Logger) Middleware {
+	return func(t *T) *T {
+		return t.WithLogger(func(t2 *T, msg string) {
+			var rec log.Record
+			rec.SetBody(log.StringValue(msg))
+			rec.SetTimestamp(time.Now())
+			logger.Emit(t2.Context(), rec)
+		})
+	}
+}
+
+func Combine(middleware ...Middleware) Middleware {
+	return func(t *T) *T {
+		for _, m := range middleware {
+			t = m(t)
+		}
+		return t
+	}
+}
+
+func New(ctx context.Context, t *testing.T) *T {
+	// Interrupt the context when the test is done.
+	ctx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+	return &T{
+		T:   t,
+		ctx: ctx,
+	}
+}
+
+type T struct {
+	*testing.T
+
+	ctx        context.Context
+	baseName   string
+	logger     func(*T, string)
+	beforeEach []func(*T) *T
+	errors     []string
+}
+
+func (t *T) BaseName() string {
+	if t.baseName != "" {
+		return t.baseName
+	}
+	return t.Name()
+}
+
+func (t *T) Context() context.Context {
+	return t.ctx
+}
+
+func (t T) WithContext(ctx context.Context) *T {
+	t.ctx = ctx
+	return &t
+}
+
+func (tc T) WithLogger(logger func(*T, string)) *T {
+	tc.logger = logger
+	return &tc
+}
+
+func (tc *T) WithTimeout(timeout time.Duration) *T {
+	ctx, cancel := context.WithTimeout(tc.Context(), timeout)
+	tc.Cleanup(cancel)
+	return tc.WithContext(ctx)
+}
+
+// BeforeAll calls f immediately with itself and returns the result.
+//
+// It is not inherited by subtests.
+func (tc *T) BeforeAll(f func(*T) *T) *T {
+	return f(tc)
+}
+
+// BeforeEach configures f to run prior to each subtest.
+func (tc T) BeforeEach(f Middleware) *T {
+	cpM := make([]Middleware, len(tc.beforeEach))
+	copy(cpM, tc.beforeEach)
+	cpM = append(cpM, f)
+	tc.beforeEach = cpM
+	return &tc
+}
+
+func (tc *T) Run(name string, f func(context.Context, *T)) bool {
+	return tc.T.Run(name, func(t *testing.T) {
+		sub := tc.sub(name, t)
+		for _, setup := range tc.beforeEach {
+			sub = setup(sub)
+		}
+		f(sub.Context(), sub)
+	})
+}
+
+func (tc *T) sub(name string, t *testing.T) *T {
+	sub := New(tc.ctx, t)
+	sub.baseName = name
+	sub.logger = tc.logger
+	sub.beforeEach = tc.beforeEach
+	return sub
+}
+
+func (tc *T) Log(vals ...any) {
+	tc.log(fmt.Sprintln(vals...))
+	tc.T.Log(vals...)
+}
+
+func (tc *T) Logf(format string, vals ...any) {
+	tc.logf(format, vals...)
+	tc.T.Logf(format, vals...)
+}
+
+func (tc *T) Error(vals ...any) {
+	msg := fmt.Sprint(vals...)
+	tc.errors = append(tc.errors, msg)
+	tc.log(msg)
+	tc.T.Error(vals...)
+}
+
+func (tc *T) Errorf(format string, vals ...any) {
+	tc.logf(format, vals...)
+	tc.errors = append(tc.errors, fmt.Sprintf(format, vals...))
+	tc.T.Errorf(format, vals...)
+}
+
+func (tc *T) Fatal(vals ...any) {
+	tc.log(fmt.Sprintln(vals...))
+	tc.errors = append(tc.errors, fmt.Sprint(vals...))
+	tc.T.Fatal(vals...)
+}
+
+func (tc *T) Fatalf(format string, vals ...any) {
+	tc.logf(format, vals...)
+	tc.errors = append(tc.errors, fmt.Sprintf(format, vals...))
+	tc.T.Fatalf(format, vals...)
+}
+
+func (tc *T) Skip(vals ...any) {
+	tc.log(fmt.Sprintln(vals...))
+	tc.T.Skip(vals...)
+}
+
+func (tc *T) Skipf(format string, vals ...any) {
+	tc.logf(format, vals...)
+	tc.T.Skipf(format, vals...)
+}
+
+func (tc *T) Errors() string {
+	return strings.Join(tc.errors, "\n")
+}
+
+func (tc *T) log(out string) {
+	if tc.logger != nil {
+		if !strings.HasSuffix(out, "\n") {
+			out += "\n"
+		}
+		tc.logger(tc, out)
+		return
+	}
+}
+
+func (tc *T) logf(format string, vals ...any) {
+	if tc.logger != nil {
+		out := fmt.Sprintf(format, vals...)
+		if !strings.HasSuffix(out, "\n") {
+			out += "\n"
+		}
+		tc.logger(tc, out)
+		return
+	}
+}


### PR DESCRIPTION

Adds `testsctx`, a little `*testing.T` compatible testing library that adds `ctx` propagation and middleware. Ideally we'd extract it for general use once it's fully baked so Go folks can use it and get pretty OTel integration in Cloud.

Adds the following `testctx` middleware to our integration test suite:

* `t.Parallel` everywhere. Non-parallel tests have been adapted to work in parallel. (I think.)
  * If we need to adjust this, the middleware can be made conditional on `t.Name()` or something (i.e. put "sync" in the test name), or we can just add a non-parallel suite that doesn't use the middleware and treat it like tracking tech debt.
* OTel tracing integration: each test and sub-test becomes a span.
* OTel logging integration: `t.Log` and friends log to the OTel span.

The net result is a fully instrumented integration test suite, where you don't have to read `go test` or `gotestsum` output; you can just see everything visualized in the TUI or Cloud.

TODO (in future PRs):

* [ ] Finish `testctx` design
  * The `FooSuite` type is mostly a convenient way to corral around a set of methods, but currently the value itself serves no purpose. Worse, it's tempting to put state there, but `t.Run` sub-tests will all capture the same var, causing race conditions.
* [ ] Better parallelism internals than `t.Parallel`?
   * Probably still need use `t.Parallel` as a primitive for compatibility with `go test` - there's no way to access the `-parallel` flag value, so we have to just respect it. Don't want a custom CLI.
   * This mostly comes down to "how to initialize state without races," so maybe related to previous point

Leaving these alone for now because they're hard and I'm tired of rebasing this PR. :sweat_smile: 