### PR TITLE
chore: add DAGGER_COMMIT option to install.sh

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -2,7 +2,7 @@
 
 param (
     [Parameter(Mandatory = $false)] [System.Management.Automation.SemanticVersion]$DaggerVersion,
-    [Parameter(Mandatory = $false)] [System.Management.Automation.SemanticVersion]$DaggerCommit,
+    [Parameter(Mandatory = $false)] [string]$DaggerCommit,
     [Parameter(Mandatory = $false)] [string]$InstallPath = $env:HOMEPATH + '\dagger',
 
     [Parameter(Mandatory = $false)] [System.Boolean]$InteractiveInstall = $false
@@ -73,10 +73,10 @@ run the script and if it still fail please open an issue on the Dagger repo.
 function base_url {
     if ($DaggerVersion) {
         $path = "releases/" + $DaggerVersion
-    } else if ($DaggerCommit) {
+    } elseif ($DaggerCommit) {
         $path = "main/" + $DaggerCommit
     } else {
-        $path = "releases/" + latest_version
+        $path = "releases/" + (latest_version)
     }
     $url = $base + "/" + $name + "/" + $path
     return $url
@@ -85,10 +85,10 @@ function base_url {
 function tarball {
     if ($DaggerVersion) {
         $version = "v" + $DaggerVersion
-    } else if ($DaggerCommit) {
-        $url = $DaggerCommit
+    } elseif ($DaggerCommit) {
+        $version = $DaggerCommit
     } else {
-        $version = "v" + latest_version
+        $version = "v" + (latest_version)
     }
     $fileName="dagger_" + $version + "_windows_amd64"
     $filename = $filename + ".zip"

--- a/install.ps1
+++ b/install.ps1
@@ -2,6 +2,7 @@
 
 param (
     [Parameter(Mandatory = $false)] [System.Management.Automation.SemanticVersion]$DaggerVersion,
+    [Parameter(Mandatory = $false)] [System.Management.Automation.SemanticVersion]$DaggerCommit,
     [Parameter(Mandatory = $false)] [string]$InstallPath = $env:HOMEPATH + '\dagger',
 
     [Parameter(Mandatory = $false)] [System.Boolean]$InteractiveInstall = $false
@@ -71,21 +72,25 @@ run the script and if it still fail please open an issue on the Dagger repo.
 
 function base_url {
     if ($DaggerVersion) {
-        $version = $DaggerVersion
+        $path = "releases/" + $DaggerVersion
+    } else if ($DaggerCommit) {
+        $path = "main/" + $DaggerCommit
     } else {
-        $version = latest_version
+        $path = "releases/" + latest_version
     }
-    $url = $base + "/" + $name + "/releases/" + $version
+    $url = $base + "/" + $name + "/" + $path
     return $url
 }
 
 function tarball {
     if ($DaggerVersion) {
-        $version = $DaggerVersion
+        $version = "v" + $DaggerVersion
+    } else if ($DaggerCommit) {
+        $url = $DaggerCommit
     } else {
-        $version = latest_version
+        $version = "v" + latest_version
     }
-    $fileName="dagger_v" + $version + "_windows_amd64"
+    $fileName="dagger_" + $version + "_windows_amd64"
     $filename = $filename + ".zip"
     return $filename
 }


### PR DESCRIPTION
This allows installing an arbitrary commit from main, to make it easier to install versions from main for testing.

TODO:
- [x] Test `install.ps1` changes on windows