### PR TITLE
core: reduce module ID size by not including full schemas

### DIFF
--- a/.changes/unreleased/Breaking-20240605-112436.yaml
+++ b/.changes/unreleased/Breaking-20240605-112436.yaml
@@ -1,0 +1,6 @@
+kind: Breaking
+body: SDK module interface accepts schema as File instead of string for improved performance
+time: 2024-06-05T11:24:36.09669896-07:00
+custom:
+  Author: sipsma
+  PR: "7549"

--- a/cmd/introspect/main.go
+++ b/cmd/introspect/main.go
@@ -15,14 +15,13 @@ func main() {
 	root := &core.Query{}
 	dag := dagql.NewServer(root)
 	coreMod := &schema.CoreMod{Dag: dag}
-	coreModDeps := core.NewModDeps(root, []core.Mod{coreMod})
 	if err := coreMod.Install(ctx, dag); err != nil {
 		panic(err)
 	}
 
-	res, err := coreModDeps.SchemaIntrospectionJSON(ctx, false)
+	res, err := schema.SchemaIntrospectionJSON(ctx, dag)
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println(res)
+	fmt.Println(string(res))
 }

--- a/core/directory.go
+++ b/core/directory.go
@@ -12,6 +12,7 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	bkgw "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/solver/pb"
+	"github.com/moby/buildkit/util/compression"
 	"github.com/moby/patternmatcher"
 	"github.com/pkg/errors"
 	fstypes "github.com/tonistiigi/fsutil/types"
@@ -757,7 +758,7 @@ func (dir *Directory) AsBlob(
 	}
 	pbDef := def.ToPB()
 
-	_, desc, err := dir.Query.Buildkit.DefToBlob(ctx, pbDef)
+	_, desc, err := dir.Query.Buildkit.DefToBlob(ctx, pbDef, compression.Zstd)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get blob descriptor: %w", err)
 	}

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -998,11 +998,11 @@ func (m *Test) Fn() *Directory {
 
 type Coolsdk struct {}
 
-func (m *Coolsdk) ModuleRuntime(modSource *ModuleSource, introspectionJson string) *Container {
+func (m *Coolsdk) ModuleRuntime(modSource *ModuleSource, introspectionJson *File) *Container {
 	return modSource.WithSDK("go").AsModule().Runtime().WithEnvVariable("COOL", "true")
 }
 
-func (m *Coolsdk) Codegen(modSource *ModuleSource, introspectionJson string) *GeneratedCode {
+func (m *Coolsdk) Codegen(modSource *ModuleSource, introspectionJson *File) *GeneratedCode {
 	return dag.GeneratedCode(modSource.WithSDK("go").AsModule().GeneratedContextDirectory())
 }
 
@@ -1113,12 +1113,12 @@ func TestModuleContextDefaultsToSourceRoot(t *testing.T) {
 
 type CoolSdk struct {}
 
-func (m *CoolSdk) ModuleRuntime(modSource *ModuleSource, introspectionJson string) *Container {
+func (m *CoolSdk) ModuleRuntime(modSource *ModuleSource, introspectionJson *File) *Container {
 	return modSource.WithSDK("go").AsModule().Runtime().
 		WithMountedDirectory("/da-context", modSource.ContextDirectory())
 }
 
-func (m *CoolSdk) Codegen(modSource *ModuleSource, introspectionJson string) *GeneratedCode {
+func (m *CoolSdk) Codegen(modSource *ModuleSource, introspectionJson *File) *GeneratedCode {
 	return dag.GeneratedCode(modSource.WithSDK("go").AsModule().GeneratedContextDirectory())
 }
 

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5170,11 +5170,11 @@ func TestModuleCustomSDK(t *testing.T) {
 
 type CoolSdk struct {}
 
-func (m *CoolSdk) ModuleRuntime(modSource *ModuleSource, introspectionJson string) *Container {
+func (m *CoolSdk) ModuleRuntime(modSource *ModuleSource, introspectionJson *File) *Container {
 	return modSource.WithSDK("go").AsModule().Runtime().WithEnvVariable("COOL", "true")
 }
 
-func (m *CoolSdk) Codegen(modSource *ModuleSource, introspectionJson string) *GeneratedCode {
+func (m *CoolSdk) Codegen(modSource *ModuleSource, introspectionJson *File) *GeneratedCode {
 	return dag.GeneratedCode(modSource.WithSDK("go").AsModule().GeneratedContextDirectory())
 }
 

--- a/core/integration/testdata/modules/python/extended/src/main/__init__.py
+++ b/core/integration/testdata/modules/python/extended/src/main/__init__.py
@@ -7,7 +7,7 @@ class ExtPythonSdk:
     required_paths: list[str] = field(default=list)
 
     @function
-    def codegen(self, mod_source: dagger.ModuleSource, introspection_json: str) -> dagger.GeneratedCode:
+    def codegen(self, mod_source: dagger.ModuleSource, introspection_json: dagger.File) -> dagger.GeneratedCode:
         return (
             dag
             .generated_code(
@@ -20,14 +20,14 @@ class ExtPythonSdk:
         )
 
     @function
-    def module_runtime(self, mod_source: dagger.ModuleSource, introspection_json: str) -> dagger.Container:
+    def module_runtime(self, mod_source: dagger.ModuleSource, introspection_json: dagger.File) -> dagger.Container:
         return (
             self.common(mod_source, introspection_json)
             .container()
             .with_entrypoint(["/runtime"])
         )
 
-    def common(self, mod_source: dagger.ModuleSource, introspection_json: str) -> dagger.PythonSdk:
+    def common(self, mod_source: dagger.ModuleSource, introspection_json: dagger.File) -> dagger.PythonSdk:
         base = (
             dag
             .python_sdk(sdk_source_dir=dag.current_module().source().directory("sdk"))

--- a/core/module.go
+++ b/core/module.go
@@ -236,10 +236,6 @@ func (mod *Module) TypeDefs(ctx context.Context) ([]*TypeDef, error) {
 	return typeDefs, nil
 }
 
-func (mod *Module) DependencySchemaIntrospectionJSON(ctx context.Context, forModule bool) (string, error) {
-	return mod.Deps.SchemaIntrospectionJSON(ctx, forModule)
-}
-
 func (mod *Module) ModTypeFor(ctx context.Context, typeDef *TypeDef, checkDirectDeps bool) (ModType, bool, error) {
 	var modType ModType
 	switch typeDef.Kind {

--- a/core/schema/coremod.go
+++ b/core/schema/coremod.go
@@ -104,7 +104,7 @@ func (m *CoreMod) ModTypeFor(ctx context.Context, typeDef *core.TypeDef, checkDi
 }
 
 func (m *CoreMod) TypeDefs(ctx context.Context) ([]*core.TypeDef, error) {
-	introspectionJSON, err := schemaIntrospectionJSON(ctx, m.Dag)
+	introspectionJSON, err := SchemaIntrospectionJSON(ctx, m.Dag)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get schema introspection JSON: %w", err)
 	}

--- a/core/schema/sdk.go
+++ b/core/schema/sdk.go
@@ -144,7 +144,7 @@ func (s *moduleSchema) newModuleSDK(
 
 // Codegen calls the Codegen function on the SDK Module
 func (sdk *moduleSDK) Codegen(ctx context.Context, deps *core.ModDeps, source dagql.Instance[*core.ModuleSource]) (*core.GeneratedCode, error) {
-	schemaJSONFile, err := deps.SchemaIntrospectionJSONFile(ctx, true)
+	schemaJSONFile, err := deps.SchemaIntrospectionJSONFile(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get schema introspection json during %s module sdk codegen: %w", sdk.mod.Self.Name(), err)
 	}
@@ -171,7 +171,7 @@ func (sdk *moduleSDK) Codegen(ctx context.Context, deps *core.ModDeps, source da
 
 // Runtime calls the Runtime function on the SDK Module
 func (sdk *moduleSDK) Runtime(ctx context.Context, deps *core.ModDeps, source dagql.Instance[*core.ModuleSource]) (*core.Container, error) {
-	schemaJSONFile, err := deps.SchemaIntrospectionJSONFile(ctx, true)
+	schemaJSONFile, err := deps.SchemaIntrospectionJSONFile(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get schema introspection json during %s module sdk runtime: %w", sdk.mod.Self.Name(), err)
 	}
@@ -413,7 +413,7 @@ func (sdk *goSDK) baseWithCodegen(
 ) (dagql.Instance[*core.Container], error) {
 	var ctr dagql.Instance[*core.Container]
 
-	schemaJSONFile, err := deps.SchemaIntrospectionJSONFile(ctx, true)
+	schemaJSONFile, err := deps.SchemaIntrospectionJSONFile(ctx)
 	if err != nil {
 		return ctr, fmt.Errorf("failed to get schema introspection json during module sdk codegen: %w", err)
 	}

--- a/core/schema/util.go
+++ b/core/schema/util.go
@@ -60,7 +60,7 @@ func asArrayInput[T any, I dagql.Input](ts []T, conv func(T) I) dagql.ArrayInput
 	return ins
 }
 
-func schemaIntrospectionJSON(ctx context.Context, dag *dagql.Server) (json.RawMessage, error) {
+func SchemaIntrospectionJSON(ctx context.Context, dag *dagql.Server) (json.RawMessage, error) {
 	data, err := dag.Query(ctx, introspection.Query, nil)
 	if err != nil {
 		return nil, fmt.Errorf("introspection query failed: %w", err)

--- a/engine/buildkit/filesync.go
+++ b/engine/buildkit/filesync.go
@@ -19,6 +19,7 @@ import (
 	"github.com/moby/buildkit/snapshot"
 	bksolverpb "github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/bklog"
+	"github.com/moby/buildkit/util/compression"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	fsutiltypes "github.com/tonistiigi/fsutil/types"
 
@@ -79,7 +80,7 @@ func (c *Client) LocalImport(
 	}
 	copyPB := copyDef.ToPB()
 
-	return c.DefToBlob(ctx, copyPB)
+	return c.DefToBlob(ctx, copyPB, compression.Zstd)
 }
 
 // Import a directory from the engine container, as opposed to from a client

--- a/sdk/elixir/runtime/main.go
+++ b/sdk/elixir/runtime/main.go
@@ -44,7 +44,7 @@ type ElixirSdk struct {
 func (m *ElixirSdk) ModuleRuntime(
 	ctx context.Context,
 	modSource *ModuleSource,
-	introspectionJson string,
+	introspectionJson *File,
 ) (*Container, error) {
 	modName, err := modSource.ModuleName(ctx)
 	if err != nil {
@@ -71,7 +71,7 @@ func (m *ElixirSdk) ModuleRuntime(
 func (m *ElixirSdk) Codegen(
 	ctx context.Context,
 	modSource *ModuleSource,
-	introspectionJson string,
+	introspectionJson *File,
 ) (*GeneratedCode, error) {
 	ctr, err := m.Common(ctx, modSource, introspectionJson)
 	if err != nil {
@@ -85,7 +85,7 @@ func (m *ElixirSdk) Codegen(
 
 func (m *ElixirSdk) Common(ctx context.Context,
 	modSource *ModuleSource,
-	introspectionJson string,
+	introspectionJson *File,
 ) (*Container, error) {
 	modName, err := modSource.ModuleName(ctx)
 	if err != nil {
@@ -142,7 +142,7 @@ func (m *ElixirSdk) WithNewElixirPackage(ctx context.Context, modName string) *E
 }
 
 // Generate the SDK into the container.
-func (m *ElixirSdk) WithSDK(introspectionJson string) *ElixirSdk {
+func (m *ElixirSdk) WithSDK(introspectionJson *File) *ElixirSdk {
 	if m.err != nil {
 		return m
 	}
@@ -172,11 +172,9 @@ func (m *ElixirSdk) WithDaggerCodegen() *Container {
 		WithExec([]string{"mix", "escript.install", "--force"})
 }
 
-func (m *ElixirSdk) GenerateCode(introspectionJson string) *Directory {
+func (m *ElixirSdk) GenerateCode(introspectionJson *File) *Directory {
 	return m.WithDaggerCodegen().
-		WithNewFile(schemaPath, ContainerWithNewFileOpts{
-			Contents: introspectionJson,
-		}).
+		WithMountedFile(schemaPath, introspectionJson).
 		WithExec([]string{
 			"dagger_codegen", "generate",
 			"--outdir", "/gen",

--- a/sdk/python/runtime/main.go
+++ b/sdk/python/runtime/main.go
@@ -92,7 +92,7 @@ type PythonSdk struct {
 }
 
 // Generated code for the Python module
-func (m *PythonSdk) Codegen(ctx context.Context, modSource *ModuleSource, introspectionJSON string) (*GeneratedCode, error) {
+func (m *PythonSdk) Codegen(ctx context.Context, modSource *ModuleSource, introspectionJSON *File) (*GeneratedCode, error) {
 	ctr, err := m.Common(ctx, modSource, introspectionJSON)
 	if err != nil {
 		return nil, err
@@ -110,7 +110,7 @@ func (m *PythonSdk) Codegen(ctx context.Context, modSource *ModuleSource, intros
 func (m *PythonSdk) ModuleRuntime(
 	ctx context.Context,
 	modSource *ModuleSource,
-	introspectionJSON string,
+	introspectionJSON *File,
 ) (*Container, error) {
 	ctr, err := m.Common(ctx, modSource, introspectionJSON)
 	if err != nil {
@@ -120,7 +120,7 @@ func (m *PythonSdk) ModuleRuntime(
 }
 
 // Common steps for the ModuleRuntime and Codegen functions.
-func (m *PythonSdk) Common(ctx context.Context, modSource *ModuleSource, introspectionJSON string) (*Container, error) {
+func (m *PythonSdk) Common(ctx context.Context, modSource *ModuleSource, introspectionJSON *File) (*Container, error) {
 	// The following functions were built to be composable in a granular way,
 	// to allow a custom SDK to depend on this one and hook into before or
 	// after major steps in the process. For example, you can get the base
@@ -258,21 +258,19 @@ func (m *PythonSdk) WithTemplate() *PythonSdk {
 // Add the SDK package to the source directory
 //
 // This includes regenerating the client for the current API schema.
-func (m *PythonSdk) WithSDK(introspectionJSON string) *PythonSdk {
+func (m *PythonSdk) WithSDK(introspectionJSON *File) *PythonSdk {
 	// "codegen" dir included in the exported sdk directory to support
 	// extending the runtime module in a custom SDK.
 	m.Discovery.AddDirectory(GenDir, m.SDKSourceDir)
 
 	// Allow empty introspection to facilitate debugging the container with a
 	// `dagger call module-runtime terminal` command.
-	if introspectionJSON != "" {
+	if introspectionJSON != nil {
 		genFile := m.Container.
 			WithMountedDirectory("/codegen", m.SDKSourceDir.Directory("codegen")).
 			WithWorkdir("/codegen").
 			With(m.install("-r", LockFilePath)).
-			WithNewFile(SchemaPath, ContainerWithNewFileOpts{
-				Contents: introspectionJSON,
-			}).
+			WithMountedFile(SchemaPath, introspectionJSON).
 			WithExec([]string{
 				"python", "-m", "codegen", "generate", "-i", SchemaPath, "-o", "/gen.py",
 			}).


### PR DESCRIPTION
Before this, we were passing full introspection schema JSONs as strings as args to non-Go SDKs, which resulted in them being included in the full IDs for non-Go modules.

Those strings got huge and could appear multiple times in a single ID, which inflated their size, and also ended up in progress output (I think the source of `ETOOBIG`?) + telemetry.

This has been a known issue for a while but not harmful enough to be prioritized for a fix. However, my [other PR](https://github.com/dagger/dagger/pull/7315) that refactors a bunch of stuff around sessions ended up hitting this problem hard since it required including Module+FunctionCall IDs as HTTP headers, but then hitting limits on the max size of HTTP headers (go defaults to 1MB, which is pretty reasonable+generous).
* Some headers in that PR that previously ended up summing to 1.7MB now max out at 70kb (still too high but I think there's other issues to fix separately).

The fix here changes the introspection json to be passed as type File rather than string. The File is created using the existing blob-functionality so it's all nice and content hashed.

As I updated the SDK implementations to account for this (technically a small breaking change), I also noticed that all of them turned the string into a File anyways internally, so this seems like an all around better approach for everyone involved.

---

cc @helderco @TomChv @wingyplus this is a very small but technically breaking change to the SDKs-as-modules interface, as noted above, so just FYI. Let me know if there's anyone else I should `@`