### PR TITLE
ci: avoid installing git on wolfi

### DIFF
--- a/.github/workflows/sdk-go.yml
+++ b/.github/workflows/sdk-go.yml
@@ -30,3 +30,10 @@ jobs:
     with:
       function: sdk go test
       timeout: 10
+
+  test-publish:
+    uses: ./.github/workflows/_dagger_call.yml
+    secrets: inherit
+    with:
+      function: sdk go publish --dry-run=true --tag=$GITHUB_REF
+      timeout: 10

--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -30,3 +30,10 @@ jobs:
     with:
       function: sdk python test
       timeout: 10
+
+  test-publish:
+    uses: ./.github/workflows/_dagger_call.yml
+    secrets: inherit
+    with:
+      function: sdk python publish --dry-run=true --tag=$GITHUB_REF
+      timeout: 10

--- a/.github/workflows/sdk-typescript.yml
+++ b/.github/workflows/sdk-typescript.yml
@@ -30,3 +30,10 @@ jobs:
     with:
       function: sdk typescript test
       timeout: 10
+
+  test-publish:
+    uses: ./.github/workflows/_dagger_call.yml
+    secrets: inherit
+    with:
+      function: sdk typescript publish --dry-run=true --tag=$GITHUB_REF
+      timeout: 10

--- a/ci/sdk_go.go
+++ b/ci/sdk_go.go
@@ -134,12 +134,13 @@ type gitPublishOpts struct {
 func gitPublish(ctx context.Context, opts gitPublishOpts) error {
 	base := opts.sourceEnv
 	if base == nil {
-		base = dag.Container().From(consts.AlpineImage)
+		base = dag.Container().
+			From(consts.AlpineImage).
+			WithExec([]string{"apk", "add", "-U", "--no-cache", "git"})
 	}
 
 	// FIXME: move this into std modules
 	git := base.
-		WithExec([]string{"apk", "add", "-U", "--no-cache", "git"}).
 		WithExec([]string{"git", "config", "--global", "user.name", opts.username}).
 		WithExec([]string{"git", "config", "--global", "user.email", opts.email})
 	if !opts.dryRun {

--- a/ci/sdk_go.go
+++ b/ci/sdk_go.go
@@ -155,16 +155,18 @@ func gitPublish(ctx context.Context, opts gitPublishOpts) error {
 			WithSecretVariable("GIT_CONFIG_VALUE_0", dag.SetSecret("GITHUB_HEADER", fmt.Sprintf("AUTHORIZATION: Basic %s", encodedPAT)))
 	}
 
+	tmpBranch := "internal/publish"
 	result := git.
 		WithEnvVariable("CACHEBUSTER", identity.NewID()).
-		WithExec([]string{"git", "clone", opts.source, "/src/dagger"}).
 		WithWorkdir("/src/dagger").
+		WithExec([]string{"git", "clone", opts.source, "."}).
+		WithExec([]string{"git", "fetch", "origin", opts.sourceTag + ":" + tmpBranch}).
 		WithEnvVariable("FILTER_BRANCH_SQUELCH_WARNING", "1").
 		WithExec([]string{
 			"git", "filter-branch", "-f", "--prune-empty",
 			"--subdirectory-filter", opts.sourcePath,
 			"--tree-filter", opts.sourceFilter,
-			"--", opts.sourceTag,
+			"--", tmpBranch,
 		})
 	if !opts.dryRun {
 		result = result.WithExec([]string{

--- a/ci/sdk_python.go
+++ b/ci/sdk_python.go
@@ -147,6 +147,9 @@ func (t PythonSDK) Publish(
 	pypiToken *Secret,
 ) error {
 	version := strings.TrimPrefix(tag, "sdk/python/v")
+	if dryRun {
+		version = "0.0.0"
+	}
 	if pypiRepo == "" || pypiRepo == "pypi" {
 		pypiRepo = "main"
 	}

--- a/ci/sdk_typescript.go
+++ b/ci/sdk_typescript.go
@@ -139,6 +139,9 @@ func (t TypescriptSDK) Publish(
 	npmToken *Secret,
 ) error {
 	version := strings.TrimPrefix(tag, "sdk/typescript/v")
+	if dryRun {
+		version = "prepatch"
+	}
 
 	build := t.nodeJsBase().
 		WithExec([]string{"npm", "run", "build"}).

--- a/ci/std/go/main.go
+++ b/ci/std/go/main.go
@@ -33,7 +33,7 @@ func (p *Go) Base() *Container {
 	return dag.
 		Wolfi().
 		Container(WolfiContainerOpts{Packages: []string{
-			"go=" + p.Version,
+			"go~" + p.Version,
 			// gcc is needed to run go test -race https://github.com/golang/go/issues/9918 (???)
 			"build-base",
 			// adding the git CLI to inject vcs info


### PR DESCRIPTION
It's already installed.

And also, we should move all our dependency installation *out* of here, and into previous steps, this is generally a bad practice in the first place.