### PR TITLE
chore: update alpine base to 3.20

### DIFF
--- a/ci/build/builder.go
+++ b/ci/build/builder.go
@@ -320,7 +320,7 @@ func (build *Builder) runcBin() *dagger.File {
 	// We build runc from source to enable upgrades to go and other dependencies that
 	// can contain CVEs in the builds on github releases
 	buildCtr := dag.Container().
-		From(consts.GolangVersionRuncHackImage).
+		From(consts.GolangImage).
 		With(build.goPlatformEnv).
 		WithEnvVariable("BUILDPLATFORM", "linux/"+runtime.GOARCH).
 		WithEnvVariable("TARGETPLATFORM", string(build.platform)).

--- a/ci/build/builder.go
+++ b/ci/build/builder.go
@@ -320,7 +320,7 @@ func (build *Builder) runcBin() *dagger.File {
 	// We build runc from source to enable upgrades to go and other dependencies that
 	// can contain CVEs in the builds on github releases
 	buildCtr := dag.Container().
-		From(fmt.Sprintf("golang:%s-alpine%s", consts.GolangVersionRuncHack, consts.AlpineVersion)).
+		From(consts.GolangVersionRuncHackImage).
 		With(build.goPlatformEnv).
 		WithEnvVariable("BUILDPLATFORM", "linux/"+runtime.GOARCH).
 		WithEnvVariable("TARGETPLATFORM", string(build.platform)).
@@ -373,8 +373,8 @@ func (build *Builder) cniPlugins() []*dagger.File {
 	ctr := dag.Container()
 	switch build.base {
 	case "alpine", "":
-		ctr = ctr.From(fmt.Sprintf("golang:%s-alpine%s", consts.GolangVersion, consts.AlpineVersion)).
-			WithExec([]string{"apk", "add", "build-base", "go", "git"})
+		ctr = ctr.From(consts.GolangImage).
+			WithExec([]string{"apk", "add", "build-base", "git"})
 	case "ubuntu":
 		// TODO: there's no guarantee the bullseye libc is compatible with the ubuntu image w/ rebase this onto
 		ctr = ctr.From(fmt.Sprintf("golang:%s-bullseye", consts.GolangVersion)).

--- a/ci/build/sdk.go
+++ b/ci/build/sdk.go
@@ -3,7 +3,6 @@ package build
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/dagger/dagger/engine/distconsts"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -124,7 +123,7 @@ func (build *Builder) typescriptSDKContent(ctx context.Context) (*sdkContent, er
 
 func (build *Builder) goSDKContent(ctx context.Context) (*sdkContent, error) {
 	base := dag.Container(dagger.ContainerOpts{Platform: build.platform}).
-		From(fmt.Sprintf("golang:%s-alpine%s", consts.GolangVersion, consts.AlpineVersion)).
+		From(consts.GolangImage).
 		WithExec([]string{"apk", "add", "git"})
 
 	sdkCtrTarball := base.

--- a/ci/consts/versions.go
+++ b/ci/consts/versions.go
@@ -9,19 +9,21 @@ const (
 )
 
 const (
-	GolangVersion = "1.22.3"
+	GolangVersion = distconsts.GolangVersion
+	GolangImage   = distconsts.GolangImage
 	// GolangVersionRuncHack needs to be 1.21, since 1.22 is not yet
 	// supported, and can cause crashes: opencontainers/runc#4233
-	GolangVersionRuncHack = "1.21.7"
+	GolangVersionRuncHackVersion = "1.21.7"
+	GolangVersionRuncHackImage   = "golang:" + GolangVersionRuncHackVersion + "-alpine"
+
+	AlpineVersion = distconsts.AlpineVersion
+	AlpineImage   = distconsts.AlpineImage
+
+	WolfiImage   = "cgr.dev/chainguard/wolfi-base"
+	WolfiVersion = "latest" // Wolfi is a rolling distro; no release to pin to
 
 	GolangLintVersion = "v1.57"
-
-	AlpineVersion = "3.18"
-	AlpineImage   = "alpine:" + AlpineVersion
-	WolfiImage    = "cgr.dev/chainguard/wolfi-base"
-	WolfiVersion  = "latest" // Wolfi is a rolling distro; no release to pin to
-
-	GolangLintImage = "golangci/golangci-lint:" + GolangLintVersion + "-alpine"
+	GolangLintImage   = "golangci/golangci-lint:" + GolangLintVersion + "-alpine"
 
 	UbuntuVersion   = "22.04"
 	RuncVersion     = "v1.1.12"

--- a/ci/consts/versions.go
+++ b/ci/consts/versions.go
@@ -11,10 +11,6 @@ const (
 const (
 	GolangVersion = distconsts.GolangVersion
 	GolangImage   = distconsts.GolangImage
-	// GolangVersionRuncHack needs to be 1.21, since 1.22 is not yet
-	// supported, and can cause crashes: opencontainers/runc#4233
-	GolangVersionRuncHackVersion = "1.21.7"
-	GolangVersionRuncHackImage   = "golang:" + GolangVersionRuncHackVersion + "-alpine"
 
 	AlpineVersion = distconsts.AlpineVersion
 	AlpineImage   = distconsts.AlpineImage

--- a/ci/std/go/main.go
+++ b/ci/std/go/main.go
@@ -12,7 +12,7 @@ func New(
 	source *Directory,
 	// Go version
 	// +optional
-	// +default="1.22.3"
+	// +default="1.22.4"
 	version string,
 ) *Go {
 	if source == nil {

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/core/schema"
 	"github.com/dagger/dagger/engine/buildkit"
+	"github.com/dagger/dagger/engine/distconsts"
 	"github.com/dagger/dagger/internal/testutil"
 )
 
@@ -78,7 +79,9 @@ func TestContainerFrom(t *testing.T) {
 			}
 		}`, &res, nil)
 	require.NoError(t, err)
-	require.Equal(t, res.Container.From.File.Contents, "3.18.2\n")
+
+	releaseStr := res.Container.From.File.Contents
+	require.Equal(t, distconsts.AlpineVersion, strings.TrimSpace(releaseStr))
 }
 
 func TestContainerBuild(t *testing.T) {
@@ -334,7 +337,7 @@ func TestContainerWithRootFS(t *testing.T) {
 	releaseStr, err := alpine315ReplacedFS.File("/etc/alpine-release").Contents(ctx)
 	require.NoError(t, err)
 
-	require.Equal(t, "3.18.2\n", releaseStr)
+	require.Equal(t, distconsts.AlpineVersion, strings.TrimSpace(releaseStr))
 }
 
 //go:embed testdata/hello.go
@@ -2601,7 +2604,8 @@ func TestContainerFSDirectory(t *testing.T) {
 		}})
 	require.NoError(t, err)
 
-	require.Equal(t, "3.18.2\n", execRes.Container.From.WithMountedDirectory.WithExec.Stdout)
+	releaseStr := execRes.Container.From.WithMountedDirectory.WithExec.Stdout
+	require.Equal(t, distconsts.AlpineVersion, strings.TrimSpace(releaseStr))
 }
 
 func TestContainerRelativePaths(t *testing.T) {
@@ -2808,7 +2812,7 @@ func TestContainerPublish(t *testing.T) {
 	pulledCtr := c.Container().From(pushedRef)
 	contents, err := pulledCtr.File("/etc/alpine-release").Contents(ctx)
 	require.NoError(t, err)
-	require.Equal(t, contents, "3.18.2\n")
+	require.Equal(t, distconsts.AlpineVersion, strings.TrimSpace(contents))
 
 	output, err := pulledCtr.WithExec(nil).Stdout(ctx)
 	require.NoError(t, err)
@@ -3342,7 +3346,7 @@ func TestContainerImageRef(t *testing.T) {
 				}
 			}`, &res, nil)
 		require.NoError(t, err)
-		require.Contains(t, res.Container.From.ImageRef, "docker.io/library/alpine:3.18.2@sha256:")
+		require.Regexp(t, res.Container.From.ImageRef, "docker.io/library/"+alpineImage+"@sha256:")
 	})
 
 	t.Run("should throw error after the container image modification with exec", func(t *testing.T) {

--- a/core/integration/container_test.go
+++ b/core/integration/container_test.go
@@ -3346,7 +3346,7 @@ func TestContainerImageRef(t *testing.T) {
 				}
 			}`, &res, nil)
 		require.NoError(t, err)
-		require.Regexp(t, res.Container.From.ImageRef, "docker.io/library/"+alpineImage+"@sha256:")
+		require.Contains(t, res.Container.From.ImageRef, "docker.io/library/"+alpineImage+"@sha256:")
 	})
 
 	t.Run("should throw error after the container image modification with exec", func(t *testing.T) {

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -226,7 +226,7 @@ func TestDirectoryWithDirectory(t *testing.T) {
 			WithNewFile("some-file", "some content", dagger.DirectoryWithNewFileOpts{Permissions: 0o444}).
 			WithNewDirectory("some-dir", dagger.DirectoryWithNewDirectoryOpts{Permissions: 0o444}).
 			WithNewFile("some-dir/sub-file", "sub-content", dagger.DirectoryWithNewFileOpts{Permissions: 0o444})
-		ctr := c.Container().From("alpine").WithDirectory("/permissions-test", dir)
+		ctr := c.Container().From(alpineImage).WithDirectory("/permissions-test", dir)
 
 		stdout, err := ctr.WithExec([]string{"ls", "-ld", "/permissions-test"}).Stdout(ctx)
 
@@ -380,7 +380,7 @@ func TestDirectoryWithFile(t *testing.T) {
 				"this should have rwxrwxrwx permissions",
 				dagger.DirectoryWithNewFileOpts{Permissions: 0o777})
 
-		ctr := c.Container().From("alpine").WithDirectory("/permissions-test", dir)
+		ctr := c.Container().From(alpineImage).WithDirectory("/permissions-test", dir)
 
 		stdout, err := ctr.WithExec([]string{"ls", "-l", "/permissions-test/file-with-permissions"}).Stdout(ctx)
 		require.NoError(t, err)
@@ -390,7 +390,7 @@ func TestDirectoryWithFile(t *testing.T) {
 			WithNewFile(
 				"file-with-permissions",
 				"this should have rw-r--r-- permissions")
-		ctr2 := c.Container().From("alpine").WithDirectory("/permissions-test", dir2)
+		ctr2 := c.Container().From(alpineImage).WithDirectory("/permissions-test", dir2)
 		stdout2, err := ctr2.WithExec([]string{"ls", "-l", "/permissions-test/file-with-permissions"}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, stdout2, "rw-r--r--")
@@ -442,13 +442,13 @@ func TestDirectoryWithFiles(t *testing.T) {
 		dir := c.Directory().
 			WithFiles("/", files)
 
-		ctr := c.Container().From("alpine").WithDirectory("/permissions-test", dir)
+		ctr := c.Container().From(alpineImage).WithDirectory("/permissions-test", dir)
 
 		stdout, err := ctr.WithExec([]string{"ls", "-l", "/permissions-test/file-set-permissions"}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, stdout, "rwxrwxrwx")
 
-		ctr2 := c.Container().From("alpine").WithDirectory("/permissions-test", dir)
+		ctr2 := c.Container().From(alpineImage).WithDirectory("/permissions-test", dir)
 		stdout2, err := ctr2.WithExec([]string{"ls", "-l", "/permissions-test/file-default-permissions"}).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, stdout2, "rw-r--r--")

--- a/core/integration/file_test.go
+++ b/core/integration/file_test.go
@@ -16,6 +16,7 @@ import (
 	"dagger.io/dagger"
 	"github.com/dagger/dagger/core"
 	"github.com/dagger/dagger/engine/buildkit"
+	"github.com/dagger/dagger/engine/distconsts"
 	"github.com/dagger/dagger/internal/testutil"
 )
 
@@ -230,7 +231,7 @@ func TestFileExport(t *testing.T) {
 
 		contents, err := os.ReadFile(dest)
 		require.NoError(t, err)
-		require.Equal(t, "3.18.2\n", string(contents))
+		require.True(t, strings.HasPrefix(string(contents), distconsts.AlpineVersion), string(contents))
 
 		entries, err := ls(targetDir)
 		require.NoError(t, err)
@@ -244,7 +245,7 @@ func TestFileExport(t *testing.T) {
 
 		contents, err := os.ReadFile(filepath.Join(wd, "some-file"))
 		require.NoError(t, err)
-		require.Equal(t, "3.18.2\n", string(contents))
+		require.True(t, strings.HasPrefix(string(contents), distconsts.AlpineVersion), string(contents))
 
 		entries, err := ls(wd)
 		require.NoError(t, err)

--- a/core/integration/images.go
+++ b/core/integration/images.go
@@ -1,8 +1,10 @@
 package core
 
+import "github.com/dagger/dagger/engine/distconsts"
+
 const (
-	alpineImage = "alpine:3.18.2"
-	golangImage = "golang:1.22.3-alpine"
+	alpineImage = distconsts.AlpineImage
+	golangImage = distconsts.GolangImage
 	debianImage = "debian:bookworm"
 	rhelImage   = "registry.access.redhat.com/ubi9/ubi"
 	alpineArm   = "arm64v8/alpine"

--- a/core/integration/module_terminal_test.go
+++ b/core/integration/module_terminal_test.go
@@ -26,13 +26,13 @@ func TestModuleDaggerTerminal(t *testing.T) {
 
 	t.Run("default arg /bin/sh", func(t *testing.T) {
 		modDir := t.TempDir()
-		err := os.WriteFile(filepath.Join(modDir, "main.go"), []byte(`package main
+		err := os.WriteFile(filepath.Join(modDir, "main.go"), []byte(fmt.Sprintf(`package main
 import "context"
 
 func New(ctx context.Context) *Test {
 	return &Test{
 		Ctr: dag.Container().
-			From("mirror.gcr.io/alpine:3.18").
+			From("%s").
 			WithEnvVariable("COOLENV", "woo").
 			WithWorkdir("/coolworkdir"),
 	}
@@ -41,7 +41,7 @@ func New(ctx context.Context) *Test {
 type Test struct {
 	Ctr *Container
 }
-`), 0644)
+`, alpineImage)), 0644)
 		require.NoError(t, err)
 
 		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")
@@ -95,13 +95,13 @@ type Test struct {
 
 	t.Run("basic", func(t *testing.T) {
 		modDir := t.TempDir()
-		err := os.WriteFile(filepath.Join(modDir, "main.go"), []byte(`package main
+		err := os.WriteFile(filepath.Join(modDir, "main.go"), []byte(fmt.Sprintf(`package main
 import "context"
 
 func New(ctx context.Context) *Test {
 	return &Test{
 		Ctr: dag.Container().
-			From("mirror.gcr.io/alpine:3.18").
+			From("%s").
 			WithEnvVariable("COOLENV", "woo").
 			WithWorkdir("/coolworkdir").
 			WithDefaultTerminalCmd([]string{"/bin/sh"}),
@@ -111,7 +111,7 @@ func New(ctx context.Context) *Test {
 type Test struct {
 	Ctr *Container
 }
-`), 0644)
+`, alpineImage)), 0644)
 		require.NoError(t, err)
 
 		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")
@@ -165,13 +165,13 @@ type Test struct {
 
 	t.Run("override args", func(t *testing.T) {
 		modDir := t.TempDir()
-		err := os.WriteFile(filepath.Join(modDir, "main.go"), []byte(`package main
+		err := os.WriteFile(filepath.Join(modDir, "main.go"), []byte(fmt.Sprintf(`package main
 import "context"
 
 func New(ctx context.Context) *Test {
 	return &Test{
 		Ctr: dag.Container().
-			From("mirror.gcr.io/alpine:3.18").
+			From("%s").
 			WithEnvVariable("COOLENV", "woo").
 			WithWorkdir("/coolworkdir").
 			WithExec([]string{"apk", "add", "python3"}).
@@ -182,7 +182,7 @@ func New(ctx context.Context) *Test {
 type Test struct {
 	Ctr *Container
 }
-`), 0644)
+`, alpineImage)), 0644)
 		require.NoError(t, err)
 
 		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")

--- a/core/integration/proxy_test.go
+++ b/core/integration/proxy_test.go
@@ -269,7 +269,7 @@ func TestContainerSystemProxies(t *testing.T) {
 					Stderr(ctx)
 				require.NoError(t, err)
 				require.Regexp(t, `.*< HTTP/1\.1 200 OK.*`, out)
-				require.Regexp(t, `.*< Via: .* \(squid/5.9\).*`, out)
+				require.Regexp(t, `.*< Via: .* \(squid/.*\).*`, out)
 			}},
 
 			proxyTest{name: "https", run: func(t *testing.T, c *dagger.Client, f proxyTestFixtures) {
@@ -308,7 +308,7 @@ func TestContainerSystemProxies(t *testing.T) {
 					Stderr(ctx)
 				require.NoError(t, err)
 				require.Regexp(t, `.*< HTTP/1\.1 200 OK.*`, out)
-				require.Regexp(t, `.*< Via: .* \(squid/5.9\).*`, out)
+				require.Regexp(t, `.*< Via: .* \(squid/.*\).*`, out)
 
 				// verify we fail if we override the proxy with a bad password
 				u := f.httpProxyURL

--- a/core/integration/services_test.go
+++ b/core/integration/services_test.go
@@ -1692,7 +1692,7 @@ func TestServiceSearchDomainAlwaysSet(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { c.Close() })
 
-	resolvContents, err := c.Container().From("alpine").
+	resolvContents, err := c.Container().From(alpineImage).
 		WithExec([]string{"cat", "/etc/resolv.conf"}).
 		Stdout(ctx)
 	require.NoError(t, err)
@@ -1732,7 +1732,7 @@ func TestServiceSearchDomainAlwaysSet(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { c2.Close() })
 
-	resolvContents2, err := c2.Container().From("alpine").
+	resolvContents2, err := c2.Container().From(alpineImage).
 		WithExec([]string{"cat", "/etc/resolv.conf"}).
 		Stdout(ctx)
 	require.NoError(t, err)

--- a/engine/distconsts/consts.go
+++ b/engine/distconsts/consts.go
@@ -16,3 +16,11 @@ const (
 	PythonSDKManifestDigestEnvName     = "DAGGER_PYTHON_SDK_MANIFEST_DIGEST"
 	TypescriptSDKManifestDigestEnvName = "DAGGER_TYPESCRIPT_SDK_MANIFEST_DIGEST"
 )
+
+const (
+	AlpineVersion = "3.20.0"
+	AlpineImage   = "alpine:" + AlpineVersion
+
+	GolangVersion = "1.22.3"
+	GolangImage   = "golang:" + GolangVersion + "-alpine"
+)

--- a/engine/distconsts/consts.go
+++ b/engine/distconsts/consts.go
@@ -21,6 +21,6 @@ const (
 	AlpineVersion = "3.20.0"
 	AlpineImage   = "alpine:" + AlpineVersion
 
-	GolangVersion = "1.22.3"
+	GolangVersion = "1.22.4"
 	GolangImage   = "golang:" + GolangVersion + "-alpine"
 )


### PR DESCRIPTION
Revival of https://github.com/dagger/dagger/pull/7323.

This is motivated slightly by some of the issues in https://github.com/dagger/dagger/pull/7554 - running up-to-date software is pretty important.