### PR TITLE
engine: bump default oci worker keep to 75%

### DIFF
--- a/cmd/engine/main_oci_worker.go
+++ b/cmd/engine/main_oci_worker.go
@@ -157,7 +157,7 @@ func init() {
 		Value: func() int64 {
 			keep := defaultConf.Workers.OCI.GCKeepStorage.AsBytes(defaultConf.Root)
 			if keep == 0 {
-				keep = config.DetectDefaultGCCap().AsBytes(defaultConf.Root)
+				keep = config.DiskSpace{Percentage: 75}.AsBytes(defaultConf.Root)
 			}
 			return keep / 1e6
 		}(),


### PR DESCRIPTION
stopgap fix for #7392. Increasing the GC keep size to more reasonable defaults
so users don't get cache evicted so aggresively.

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
