### PR TITLE
fix: fix File cannot export on Windows

### DIFF
--- a/engine/client/filesync.go
+++ b/engine/client/filesync.go
@@ -262,8 +262,10 @@ func (t FilesyncTarget) DiffCopy(stream filesync.FileSend_DiffCopyServer) (rerr 
 		return fmt.Errorf("failed to create synctarget dest file %s: %w", finalDestPath, err)
 	}
 	defer destF.Close()
-	if err := destF.Chown(int(t.uid), int(t.gid)); err != nil {
-		return fmt.Errorf("failed to chown synctarget dest file %s: %w", finalDestPath, err)
+	if runtime.GOOS != "windows" {
+		if err := destF.Chown(int(t.uid), int(t.gid)); err != nil {
+			return fmt.Errorf("failed to chown synctarget dest file %s: %w", finalDestPath, err)
+		}
 	}
 
 	for {


### PR DESCRIPTION
The `export` function does `chown` cause Windows crash due to it's unsupported. This commit fixed by skip `chown` operation when running in Windows.

Fixes #7558