### PR TITLE
Various TS + general test fixes + improvements

### DIFF
--- a/ci/sdk_typescript.go
+++ b/ci/sdk_typescript.go
@@ -22,7 +22,7 @@ const (
 	nodeVersionMaintenance = "18"
 	nodeVersionLTS         = "20"
 
-	bunVersion = "1.0.27"
+	bunVersion = "1.1.12"
 )
 
 type TypescriptSDK struct {
@@ -211,7 +211,7 @@ func (t TypescriptSDK) bunJsBase() *Container {
 	mountPath := fmt.Sprintf("/%s", appDir)
 
 	return dag.Container().
-		From("oven/bun:"+bunVersion).
+		From("oven/bun:"+bunVersion+"-alpine").
 		WithWorkdir(mountPath).
 		WithMountedCache("/root/.bun/install/cache", dag.CacheVolume("bun_cache")).
 		WithFile(fmt.Sprintf("%s/package.json", mountPath), src.File("package.json")).

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -39,6 +39,7 @@ func (m *Test) Container() *Container {
 	)
 
 	t.Run("no required arg validation", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerCall("container", "--help")).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "USAGE")
@@ -46,6 +47,7 @@ func (m *Test) Container() *Container {
 	})
 
 	t.Run("globally parsed", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerCall("container", "--help", "directory")).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "USAGE")
@@ -207,6 +209,7 @@ func (m *Minimal) Reads(ctx context.Context, files []File) (string, error) {
 			t.Parallel()
 
 			t.Run("abs path", func(t *testing.T) {
+				t.Parallel()
 				c, ctx := connect(t)
 
 				modGen := c.Container().From(golangImage).
@@ -329,6 +332,7 @@ func (m *Test) Fn(
 			} {
 				tc := tc
 				t.Run(fmt.Sprintf("%s:%s", tc.baseURL, tc.subpath), func(t *testing.T) {
+					t.Parallel()
 					url := tc.baseURL + "#v0.9.1"
 					if tc.subpath != "" {
 						url += ":" + tc.subpath
@@ -353,6 +357,7 @@ func (m *Test) Fn(
 		t.Parallel()
 
 		t.Run("abs path", func(t *testing.T) {
+			t.Parallel()
 			c, ctx := connect(t)
 
 			modGen := c.Container().From(golangImage).
@@ -448,12 +453,15 @@ func (m *Test) Insecure(ctx context.Context, token *Secret) (string, error) {
 			WithNewFile("/mysupersecret", dagger.ContainerWithNewFileOpts{Contents: "file shhh"})
 
 		t.Run("explicit env", func(t *testing.T) {
+			t.Parallel()
 			t.Run("happy", func(t *testing.T) {
+				t.Parallel()
 				out, err := modGen.With(daggerCall("insecure", "--token", "env:TOPSECRET")).Stdout(ctx)
 				require.NoError(t, err)
 				require.Equal(t, "shhh", out)
 			})
 			t.Run("sad", func(t *testing.T) {
+				t.Parallel()
 				_, err := modGen.With(daggerCall("insecure", "--token", "env:NOWHERETOBEFOUND")).Stdout(ctx)
 				require.ErrorContains(t, err, `secret env var not found: "NOW..."`)
 			})
@@ -462,41 +470,50 @@ func (m *Test) Insecure(ctx context.Context, token *Secret) (string, error) {
 		t.Run("implicit env", func(t *testing.T) {
 			t.Parallel()
 			t.Run("happy", func(t *testing.T) {
+				t.Parallel()
 				out, err := modGen.With(daggerCall("insecure", "--token", "TOPSECRET")).Stdout(ctx)
 				require.NoError(t, err)
 				require.Equal(t, "shhh", out)
 			})
 			t.Run("sad", func(t *testing.T) {
+				t.Parallel()
 				_, err := modGen.With(daggerCall("insecure", "--token", "NOWHERETOBEFOUND")).Stdout(ctx)
 				require.ErrorContains(t, err, `secret env var not found: "NOW..."`)
 			})
 		})
 
 		t.Run("file", func(t *testing.T) {
+			t.Parallel()
 			t.Run("happy", func(t *testing.T) {
+				t.Parallel()
 				out, err := modGen.With(daggerCall("insecure", "--token", "file:/mysupersecret")).Stdout(ctx)
 				require.NoError(t, err)
 				require.Equal(t, "file shhh", out)
 			})
 			t.Run("sad", func(t *testing.T) {
+				t.Parallel()
 				_, err := modGen.With(daggerCall("insecure", "--token", "file:/nowheretobefound")).Stdout(ctx)
 				require.ErrorContains(t, err, `failed to read secret file "/nowheretobefound": open /nowheretobefound: no such file or directory`)
 			})
 		})
 
 		t.Run("cmd", func(t *testing.T) {
+			t.Parallel()
 			t.Run("happy", func(t *testing.T) {
+				t.Parallel()
 				out, err := modGen.With(daggerCall("insecure", "--token", "cmd:echo -n cmd shhh")).Stdout(ctx)
 				require.NoError(t, err)
 				require.Equal(t, "cmd shhh", out)
 			})
 			t.Run("sad", func(t *testing.T) {
+				t.Parallel()
 				_, err := modGen.With(daggerCall("insecure", "--token", "cmd:exit 1")).Stdout(ctx)
 				require.ErrorContains(t, err, `failed to run secret command "exit 1": exit status 1`)
 			})
 		})
 
 		t.Run("invalid source", func(t *testing.T) {
+			t.Parallel()
 			_, err := modGen.With(daggerCall("insecure", "--token", "wtf:HUH")).Stdout(ctx)
 			require.ErrorContains(t, err, `unsupported secret arg source: "wtf"`)
 		})
@@ -701,12 +718,14 @@ func (m *Minimal) Fn() []*Foo {
 		expected := "0\n1\n2\n"
 
 		t.Run("print", func(t *testing.T) {
+			t.Parallel()
 			out, err := modGen.With(daggerCall("fn", "bar")).Stdout(ctx)
 			require.NoError(t, err)
 			require.Equal(t, expected, out)
 		})
 
 		t.Run("output", func(t *testing.T) {
+			t.Parallel()
 			out, err := modGen.
 				With(daggerCall("fn", "bar", "-o", "./outfile")).
 				File("./outfile").
@@ -716,6 +735,7 @@ func (m *Minimal) Fn() []*Foo {
 		})
 
 		t.Run("json", func(t *testing.T) {
+			t.Parallel()
 			out, err := modGen.
 				With(daggerCall("fn", "bar", "--json")).
 				Stdout(ctx)
@@ -748,6 +768,7 @@ type Test struct {
 		logGen(ctx, t, modGen.Directory("."))
 
 		t.Run("default", func(t *testing.T) {
+			t.Parallel()
 			ctr := modGen.With(daggerCall("ctr"))
 			out, err := ctr.Stdout(ctx)
 			require.NoError(t, err)
@@ -758,6 +779,7 @@ type Test struct {
 		})
 
 		t.Run("output", func(t *testing.T) {
+			t.Parallel()
 			modGen, err := modGen.With(daggerCall("ctr", "-o", "./container.tar")).Sync(ctx)
 			require.NoError(t, err)
 			size, err := modGen.File("./container.tar").Size(ctx)
@@ -794,6 +816,7 @@ type Test struct {
 		logGen(ctx, t, modGen.Directory("."))
 
 		t.Run("default", func(t *testing.T) {
+			t.Parallel()
 			ctr := modGen.With(daggerCall("dir"))
 			out, err := ctr.Stdout(ctx)
 			require.NoError(t, err)
@@ -804,6 +827,7 @@ type Test struct {
 		})
 
 		t.Run("output", func(t *testing.T) {
+			t.Parallel()
 			modGen, err := modGen.With(daggerCall("dir", "-o", "./outdir")).Sync(ctx)
 			require.NoError(t, err)
 
@@ -847,6 +871,7 @@ type Test struct {
 		logGen(ctx, t, modGen.Directory("."))
 
 		t.Run("default", func(t *testing.T) {
+			t.Parallel()
 			ctr := modGen.With(daggerCall("file"))
 			out, err := ctr.Stdout(ctx)
 			require.NoError(t, err)
@@ -857,6 +882,7 @@ type Test struct {
 		})
 
 		t.Run("output", func(t *testing.T) {
+			t.Parallel()
 			out, err := modGen.
 				With(daggerCall("file", "-o", "./outfile")).
 				File("./outfile").
@@ -919,12 +945,14 @@ type Test struct {
 			})
 
 		t.Run("file", func(t *testing.T) {
+			t.Parallel()
 			out, err := modGen.With(daggerCall("ctr", "file", "--path=/etc/alpine-release", "contents")).Stdout(ctx)
 			require.NoError(t, err)
 			require.Equal(t, "3.18.5\n", out)
 		})
 
 		t.Run("export", func(t *testing.T) {
+			t.Parallel()
 			modGen, err := modGen.With(daggerCall("ctr", "export", "--path=./container.tar.gz")).Sync(ctx)
 			require.NoError(t, err)
 			size, err := modGen.File("./container.tar.gz").Size(ctx)
@@ -957,12 +985,14 @@ type Test struct {
 			})
 
 		t.Run("file", func(t *testing.T) {
+			t.Parallel()
 			out, err := modGen.With(daggerCall("dir", "file", "--path=foo.txt", "contents")).Stdout(ctx)
 			require.NoError(t, err)
 			require.Equal(t, "foo", out)
 		})
 
 		t.Run("export", func(t *testing.T) {
+			t.Parallel()
 			modGen, err := modGen.With(daggerCall("dir", "export", "--path=./outdir")).Sync(ctx)
 			require.NoError(t, err)
 			ents, err := modGen.Directory("./outdir").Entries(ctx)
@@ -995,12 +1025,14 @@ type Test struct {
 			})
 
 		t.Run("size", func(t *testing.T) {
+			t.Parallel()
 			out, err := modGen.With(daggerCall("file", "size")).Stdout(ctx)
 			require.NoError(t, err)
 			require.Equal(t, "3", out)
 		})
 
 		t.Run("export", func(t *testing.T) {
+			t.Parallel()
 			modGen, err := modGen.With(daggerCall("file", "export", "--path=./outfile")).Sync(ctx)
 			require.NoError(t, err)
 			contents, err := modGen.File("./outfile").Contents(ctx)
@@ -1040,6 +1072,7 @@ func (t *Test) File() *File {
 	logGen(ctx, t, modGen.Directory("."))
 
 	t.Run("truncate file", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.
 			WithNewFile("foo.txt", dagger.ContainerWithNewFileOpts{
 				Contents: "foobar",
@@ -1052,11 +1085,13 @@ func (t *Test) File() *File {
 	})
 
 	t.Run("not a file", func(t *testing.T) {
+		t.Parallel()
 		_, err := modGen.With(daggerCall("hello", "-o", ".")).Sync(ctx)
 		require.ErrorContains(t, err, "is a directory")
 	})
 
 	t.Run("allow dir for file", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.
 			With(daggerCall("file", "-o", ".")).
 			File("foo.txt").
@@ -1066,10 +1101,12 @@ func (t *Test) File() *File {
 	})
 
 	t.Run("create parent dirs", func(t *testing.T) {
+		t.Parallel()
 		ctr, err := modGen.With(daggerCall("hello", "-o", "foo/bar.txt")).Sync(ctx)
 		require.NoError(t, err)
 
 		t.Run("print success", func(t *testing.T) {
+			t.Parallel()
 			// should print success to stderr so it doesn't interfere with piping output
 			out, err := ctr.Stderr(ctx)
 			require.NoError(t, err)
@@ -1077,12 +1114,14 @@ func (t *Test) File() *File {
 		})
 
 		t.Run("check directory permissions", func(t *testing.T) {
+			t.Parallel()
 			out, err := ctr.WithExec([]string{"stat", "-c", "%a", "foo"}).Stdout(ctx)
 			require.NoError(t, err)
 			require.Equal(t, "755\n", out)
 		})
 
 		t.Run("check file permissions", func(t *testing.T) {
+			t.Parallel()
 			out, err := ctr.WithExec([]string{"stat", "-c", "%a", "foo/bar.txt"}).Stdout(ctx)
 			require.NoError(t, err)
 			require.Equal(t, "644\n", out)
@@ -1090,6 +1129,7 @@ func (t *Test) File() *File {
 	})
 
 	t.Run("check umask", func(t *testing.T) {
+		t.Parallel()
 		ctr, err := modGen.
 			WithNewFile("/entrypoint.sh", dagger.ContainerWithNewFileOpts{
 				Contents: `#!/bin/sh
@@ -1104,12 +1144,14 @@ exec "$@"
 		require.NoError(t, err)
 
 		t.Run("directory", func(t *testing.T) {
+			t.Parallel()
 			out, err := ctr.WithExec([]string{"stat", "-c", "%a", "/tmp/foo"}).Stdout(ctx)
 			require.NoError(t, err)
 			require.Equal(t, "750\n", out)
 		})
 
 		t.Run("file", func(t *testing.T) {
+			t.Parallel()
 			out, err := ctr.WithExec([]string{"stat", "-c", "%a", "/tmp/foo/bar.txt"}).Stdout(ctx)
 			require.NoError(t, err)
 			require.Equal(t, "640\n", out)
@@ -1276,6 +1318,7 @@ func (m *Chain) Echo(msg string) string {
 	)
 
 	t.Run("functions list", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerCall("--help")).Stdout(ctx)
 		require.NoError(t, err)
 
@@ -1290,6 +1333,7 @@ func (m *Chain) Echo(msg string) string {
 	})
 
 	t.Run("arguments list", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerCall("fn-b", "--help")).Stdout(ctx)
 		require.NoError(t, err)
 
@@ -1298,17 +1342,20 @@ func (m *Chain) Echo(msg string) string {
 	})
 
 	t.Run("in chain", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerCall("fn-b", "--msg", "", "echo", "--msg", "hello")).Stdout(ctx)
 		require.NoError(t, err)
 		require.Contains(t, out, "hello")
 	})
 
 	t.Run("no sub-command", func(t *testing.T) {
+		t.Parallel()
 		_, err := modGen.With(daggerCall("fn-a")).Sync(ctx)
 		require.ErrorContains(t, err, `unknown command "fn-a"`)
 	})
 
 	t.Run("no flag", func(t *testing.T) {
+		t.Parallel()
 		_, err := modGen.With(daggerCall("fn-b", "--msg", "hello", "--matrix", "")).Sync(ctx)
 		require.ErrorContains(t, err, `unknown flag: --matrix`)
 	})

--- a/core/integration/module_functions_test.go
+++ b/core/integration/module_functions_test.go
@@ -89,6 +89,7 @@ func (m *OtherObj) FnE() *Container {
 		})
 
 	t.Run("top-level", func(t *testing.T) {
+		t.Parallel()
 		out, err := ctr.With(daggerFunctions()).Stdout(ctx)
 		require.NoError(t, err)
 		lines := strings.Split(out, "\n")
@@ -99,6 +100,7 @@ func (m *OtherObj) FnE() *Container {
 	})
 
 	t.Run("top-level from subdir", func(t *testing.T) {
+		t.Parallel()
 		// find-up should kick in
 		out, err := ctr.
 			WithWorkdir("/work/some/subdir").
@@ -113,6 +115,7 @@ func (m *OtherObj) FnE() *Container {
 	})
 
 	t.Run("return core object", func(t *testing.T) {
+		t.Parallel()
 		out, err := ctr.With(daggerFunctions("fn-a")).Stdout(ctx)
 		require.NoError(t, err)
 		lines := strings.Split(out, "\n")
@@ -122,11 +125,13 @@ func (m *OtherObj) FnE() *Container {
 	})
 
 	t.Run("return primitive", func(t *testing.T) {
+		t.Parallel()
 		_, err := ctr.With(daggerFunctions("prim")).Stdout(ctx)
 		require.ErrorContains(t, err, `function "prim" returns type "STRING_KIND" with no further functions available`)
 	})
 
 	t.Run("alt casing", func(t *testing.T) {
+		t.Parallel()
 		out, err := ctr.With(daggerFunctions("fnA")).Stdout(ctx)
 		require.NoError(t, err)
 		lines := strings.Split(out, "\n")
@@ -136,6 +141,7 @@ func (m *OtherObj) FnE() *Container {
 	})
 
 	t.Run("return user interface", func(t *testing.T) {
+		t.Parallel()
 		out, err := ctr.With(daggerFunctions("fn-b")).Stdout(ctx)
 		require.NoError(t, err)
 		lines := strings.Split(out, "\n")
@@ -143,6 +149,7 @@ func (m *OtherObj) FnE() *Container {
 	})
 
 	t.Run("return user object", func(t *testing.T) {
+		t.Parallel()
 		out, err := ctr.With(daggerFunctions("fn-c")).Stdout(ctx)
 		require.NoError(t, err)
 		lines := strings.Split(out, "\n")
@@ -155,6 +162,7 @@ func (m *OtherObj) FnE() *Container {
 	})
 
 	t.Run("return user object nested", func(t *testing.T) {
+		t.Parallel()
 		out, err := ctr.With(daggerFunctions("fn-c", "field-d")).Stdout(ctx)
 		require.NoError(t, err)
 		lines := strings.Split(out, "\n")

--- a/core/integration/module_python_test.go
+++ b/core/integration/module_python_test.go
@@ -468,6 +468,7 @@ func TestModulePythonAltRuntime(t *testing.T) {
 		WithExec([]string{"sed", "-i", "s#../../../../../sdk/python/##", "/work/extended/dagger.json"})
 
 	t.Run("git dependency", func(t *testing.T) {
+		t.Parallel()
 		out, err := base.
 			WithMountedDirectory("/work/git-dep", c.Host().Directory(moduleSrcPath)).
 			WithWorkdir("/work/git-dep").
@@ -479,6 +480,7 @@ func TestModulePythonAltRuntime(t *testing.T) {
 	})
 
 	t.Run("disabled custom config", func(t *testing.T) {
+		t.Parallel()
 		out, err := base.
 			WithWorkdir("/work/test").
 			With(fileContents(".python-version", "3.12")).
@@ -685,6 +687,7 @@ func TestModulePythonLockHashes(t *testing.T) {
 	t.Logf("requirements.lock:\n%s", requirements)
 
 	t.Run("uv", func(t *testing.T) {
+		t.Parallel()
 		_, err := base.
 			With(fileContents("requirements.lock", requirements)).
 			With(daggerExec("develop")).
@@ -696,6 +699,7 @@ func TestModulePythonLockHashes(t *testing.T) {
 	})
 
 	t.Run("pip", func(t *testing.T) {
+		t.Parallel()
 		_, err := base.
 			With(fileContents("requirements.lock", requirements)).
 			With(pyprojectExtra(`
@@ -970,6 +974,7 @@ func TestModulePythonSignaturesBuiltinTypes(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			out, err := modGen.With(daggerQuery(tc.query)).Stdout(ctx)
 			require.NoError(t, err)
 			require.JSONEq(t, tc.expected, out)
@@ -1288,7 +1293,9 @@ func TestModulePythonWithOtherModuleTypes(t *testing.T) {
 		With(daggerExec("install", "../dep"))
 
 	t.Run("return as other module object", func(t *testing.T) {
+		t.Parallel()
 		t.Run("direct", func(t *testing.T) {
+			t.Parallel()
 			_, err := ctr.
 				With(pythonSource(`
                     import dagger
@@ -1309,6 +1316,7 @@ func TestModulePythonWithOtherModuleTypes(t *testing.T) {
 		})
 
 		t.Run("list", func(t *testing.T) {
+			t.Parallel()
 			_, err := ctr.
 				With(pythonSource(`
                     import dagger
@@ -1330,7 +1338,9 @@ func TestModulePythonWithOtherModuleTypes(t *testing.T) {
 	})
 
 	t.Run("arg as other module object", func(t *testing.T) {
+		t.Parallel()
 		t.Run("direct", func(t *testing.T) {
+			t.Parallel()
 			_, err := ctr.With(pythonSource(`
                 import dagger
 
@@ -1350,6 +1360,7 @@ func TestModulePythonWithOtherModuleTypes(t *testing.T) {
 		})
 
 		t.Run("list", func(t *testing.T) {
+			t.Parallel()
 			_, err := ctr.With(pythonSource(`
                 import dagger
 
@@ -1370,7 +1381,9 @@ func TestModulePythonWithOtherModuleTypes(t *testing.T) {
 	})
 
 	t.Run("field as other module object", func(t *testing.T) {
+		t.Parallel()
 		t.Run("direct", func(t *testing.T) {
+			t.Parallel()
 			_, err := ctr.
 				With(pythonSource(`
                     import dagger
@@ -1395,6 +1408,7 @@ func TestModulePythonWithOtherModuleTypes(t *testing.T) {
 		})
 
 		t.Run("list", func(t *testing.T) {
+			t.Parallel()
 			_, err := ctr.
 				With(pythonSource(`
                     import dagger

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -110,6 +110,7 @@ func TestModuleGoInit(t *testing.T) {
 		require.JSONEq(t, `{"beneathGoMod":{"containerEcho":{"stdout":"hello\n"}}}`, out)
 
 		t.Run("names Go module after Dagger module", func(t *testing.T) {
+			t.Parallel()
 			generated, err := modGen.Directory("dagger").File("go.mod").Contents(ctx)
 			require.NoError(t, err)
 			require.Contains(t, generated, "module dagger/beneath-go-mod")
@@ -134,12 +135,14 @@ func TestModuleGoInit(t *testing.T) {
 		require.JSONEq(t, `{"hasGoMod":{"containerEcho":{"stdout":"hello\n"}}}`, out)
 
 		t.Run("preserves module name", func(t *testing.T) {
+			t.Parallel()
 			generated, err := modGen.File("go.mod").Contents(ctx)
 			require.NoError(t, err)
 			require.Contains(t, generated, "module example.com/test")
 		})
 
 		t.Run("no new go.mod", func(t *testing.T) {
+			t.Parallel()
 			_, err := modGen.File("dagger/go.mod").Contents(ctx)
 			require.ErrorContains(t, err, "no such file or directory")
 		})
@@ -163,6 +166,7 @@ func TestModuleGoInit(t *testing.T) {
 		require.JSONEq(t, `{"hasGoMod":{"containerEcho":{"stdout":"hello\n"}}}`, out)
 
 		t.Run("go.work is edited", func(t *testing.T) {
+			t.Parallel()
 			generated, err := modGen.File("go.work").Contents(ctx)
 			require.NoError(t, err)
 			require.Contains(t, generated, "use ./dagger\n")
@@ -189,6 +193,7 @@ func TestModuleGoInit(t *testing.T) {
 		require.JSONEq(t, `{"hasGoMod":{"containerEcho":{"stdout":"hello\n"}}}`, out)
 
 		t.Run("go.work is edited", func(t *testing.T) {
+			t.Parallel()
 			generated, err := modGen.File("go.work").Contents(ctx)
 			require.NoError(t, err)
 			require.Contains(t, generated, "use .\n")
@@ -214,6 +219,7 @@ func TestModuleGoInit(t *testing.T) {
 		require.JSONEq(t, `{"hasGoMod":{"containerEcho":{"stdout":"hello\n"}}}`, out)
 
 		t.Run("go.work is edited", func(t *testing.T) {
+			t.Parallel()
 			generated, err := modGen.File("go.work").Contents(ctx)
 			require.NoError(t, err)
 			require.Contains(t, generated, "use ./subdir/dagger\n")
@@ -243,6 +249,7 @@ func TestModuleGoInit(t *testing.T) {
 		require.JSONEq(t, `{"hasGoMod":{"containerEcho":{"stdout":"hello\n"}}}`, out)
 
 		t.Run("go.work is unedited", func(t *testing.T) {
+			t.Parallel()
 			generated, err := modGen.File("go.work").Contents(ctx)
 			require.NoError(t, err)
 			require.NotContains(t, generated, "use")
@@ -276,6 +283,7 @@ func TestModuleGoInit(t *testing.T) {
 		require.NotContains(t, childEntries, "go.mod")
 
 		t.Run("preserves parent module name", func(t *testing.T) {
+			t.Parallel()
 			goMod, err := generated.File("go.mod").Contents(ctx)
 			require.NoError(t, err)
 			require.Contains(t, goMod, "module example.com/test")
@@ -601,6 +609,7 @@ func TestModuleGit(t *testing.T) {
 			require.JSONEq(t, `{"bare":{"containerEcho":{"stdout":"hello\n"}}}`, out)
 
 			t.Run("configures .gitattributes", func(t *testing.T) {
+				t.Parallel()
 				ignore, err := modGen.File("dagger/.gitattributes").Contents(ctx)
 				require.NoError(t, err)
 				for _, fileName := range tc.gitGeneratedFiles {
@@ -609,6 +618,7 @@ func TestModuleGit(t *testing.T) {
 			})
 
 			t.Run("configures .gitignore", func(t *testing.T) {
+				t.Parallel()
 				ignore, err := modGen.File("dagger/.gitignore").Contents(ctx)
 				require.NoError(t, err)
 				for _, fileName := range tc.gitIgnoredFiles {
@@ -617,6 +627,7 @@ func TestModuleGit(t *testing.T) {
 			})
 
 			t.Run("does not configure .gitignore if disabled", func(t *testing.T) {
+				t.Parallel()
 				modGen := goGitBase(t, c).
 					With(daggerExec("init", "--name=bare"))
 
@@ -660,30 +671,35 @@ func TestModuleGoSignatures(t *testing.T) {
 		})
 
 	t.Run("func Hello() string", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{hello}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"hello":"hello"}}`, out)
 	})
 
 	t.Run("func Echo(string) string", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echo(msg: "hello")}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echo":"hello...hello...hello..."}}`, out)
 	})
 
 	t.Run("func EchoPointer(*string) string", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echoPointer(msg: "hello")}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoPointer":"hello...hello...hello..."}}`, out)
 	})
 
 	t.Run("func EchoPointerPointer(**string) string", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echoPointerPointer(msg: "hello")}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoPointerPointer":"hello...hello...hello..."}}`, out)
 	})
 
 	t.Run("func EchoOptional(string) string", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echoOptional(msg: "hello")}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoOptional":"hello...hello...hello..."}}`, out)
@@ -693,6 +709,7 @@ func TestModuleGoSignatures(t *testing.T) {
 	})
 
 	t.Run("func EchoOptionalPointer(string) string", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echoOptionalPointer(msg: "hello")}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoOptionalPointer":"hello...hello...hello..."}}`, out)
@@ -702,6 +719,7 @@ func TestModuleGoSignatures(t *testing.T) {
 	})
 
 	t.Run("func EchoOptionalSlice([]string) string", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echoOptionalSlice(msg: ["hello", "there"])}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoOptionalSlice":"hello+there...hello+there...hello+there..."}}`, out)
@@ -711,48 +729,56 @@ func TestModuleGoSignatures(t *testing.T) {
 	})
 
 	t.Run("func Echoes([]string) []string", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echoes(msgs: ["hello"])}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoes":["hello...hello...hello..."]}}`, out)
 	})
 
 	t.Run("func EchoesVariadic(...string) string", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echoesVariadic(msgs: ["hello"])}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoesVariadic":"hello...hello...hello..."}}`, out)
 	})
 
 	t.Run("func HelloContext(context.Context) string", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{helloContext}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"helloContext":"hello context"}}`, out)
 	})
 
 	t.Run("func EchoContext(context.Context, string) string", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echoContext(msg: "hello")}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoContext":"ctx.hello...ctx.hello...ctx.hello..."}}`, out)
 	})
 
 	t.Run("func HelloStringError() (string, error)", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{helloStringError}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"helloStringError":"hello i worked"}}`, out)
 	})
 
 	t.Run("func HelloVoid()", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{helloVoid}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"helloVoid":null}}`, out)
 	})
 
 	t.Run("func HelloVoidError() error", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{helloVoidError}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"helloVoidError":null}}`, out)
 	})
 
 	t.Run("func EchoOpts(string, string, int) error", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echoOpts(msg: "hi")}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoOpts":"hi"}}`, out)
@@ -763,6 +789,7 @@ func TestModuleGoSignatures(t *testing.T) {
 	})
 
 	t.Run("func EchoOptsInline(struct{string, string, int}) error", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echoOptsInline(msg: "hi")}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoOptsInline":"hi"}}`, out)
@@ -773,6 +800,7 @@ func TestModuleGoSignatures(t *testing.T) {
 	})
 
 	t.Run("func EchoOptsInlinePointer(*struct{string, string, int}) error", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echoOptsInlinePointer(msg: "hi")}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoOptsInlinePointer":"hi"}}`, out)
@@ -783,6 +811,7 @@ func TestModuleGoSignatures(t *testing.T) {
 	})
 
 	t.Run("func EchoOptsInlineCtx(ctx, struct{string, string, int}) error", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echoOptsInlineCtx(msg: "hi")}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoOptsInlineCtx":"hi"}}`, out)
@@ -793,6 +822,7 @@ func TestModuleGoSignatures(t *testing.T) {
 	})
 
 	t.Run("func EchoOptsInlineTags(struct{string, string, int}) error", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echoOptsInlineTags(msg: "hi")}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoOptsInlineTags":"hi"}}`, out)
@@ -803,6 +833,7 @@ func TestModuleGoSignatures(t *testing.T) {
 	})
 
 	t.Run("func EchoOptsPragmas(string, string, int) error", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echoOptsPragmas(msg: "hi")}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoOptsPragmas":"hi...hi...hi..."}}`, out)
@@ -858,30 +889,35 @@ func (m *Minimal) ReadOptional(
 	dirID := gjson.Get(out, "directory.withNewFile.id").String()
 
 	t.Run("func Read(ctx, Directory) (string, error)", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(fmt.Sprintf(`{minimal{read(dir: "%s")}}`, dirID))).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"read":"bar"}}`, out)
 	})
 
 	t.Run("func ReadPointer(ctx, *Directory) (string, error)", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(fmt.Sprintf(`{minimal{readPointer(dir: "%s")}}`, dirID))).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"readPointer":"bar"}}`, out)
 	})
 
 	t.Run("func ReadSlice(ctx, []Directory) (string, error)", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(fmt.Sprintf(`{minimal{readSlice(dir: ["%s"])}}`, dirID))).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"readSlice":"bar"}}`, out)
 	})
 
 	t.Run("func ReadVariadic(ctx, ...Directory) (string, error)", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(fmt.Sprintf(`{minimal{readVariadic(dir: ["%s"])}}`, dirID))).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"readVariadic":"bar"}}`, out)
 	})
 
 	t.Run("func ReadOptional(ctx, Optional[Directory]) (string, error)", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(fmt.Sprintf(`{minimal{readOptional(dir: "%s")}}`, dirID))).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"readOptional":"bar"}}`, out)
@@ -1838,6 +1874,7 @@ class Test {
 			args := gjson.Get(out, "__type.fields.#(name=foo).args")
 
 			t.Run("a: String!", func(t *testing.T) {
+				t.Parallel()
 				// required, i.e., non-null and no default
 				arg := args.Get("#(name=a)")
 				require.Equal(t, "NON_NULL", arg.Get("type.kind").String())
@@ -1846,6 +1883,7 @@ class Test {
 			})
 
 			t.Run("b: String", func(t *testing.T) {
+				t.Parallel()
 				// GraphQL implicitly sets default to null for nullable types
 				arg := args.Get("#(name=b)")
 				require.Equal(t, "SCALAR", arg.Get("type.kind").String())
@@ -1853,6 +1891,7 @@ class Test {
 			})
 
 			t.Run(`c: String! = "foo"`, func(t *testing.T) {
+				t.Parallel()
 				// non-null, with default
 				arg := args.Get("#(name=c)")
 				require.Equal(t, "NON_NULL", arg.Get("type.kind").String())
@@ -1861,6 +1900,7 @@ class Test {
 			})
 
 			t.Run("d: String = null", func(t *testing.T) {
+				t.Parallel()
 				// nullable, with explicit null default; same as b in practice
 				arg := args.Get("#(name=d)")
 				require.Equal(t, "SCALAR", arg.Get("type.kind").String())
@@ -1868,6 +1908,7 @@ class Test {
 			})
 
 			t.Run(`e: String = "bar"`, func(t *testing.T) {
+				t.Parallel()
 				// nullable, with non-null default
 				arg := args.Get("#(name=e)")
 				require.Equal(t, "SCALAR", arg.Get("type.kind").String())
@@ -1875,6 +1916,7 @@ class Test {
 			})
 
 			t.Run("default values", func(t *testing.T) {
+				t.Parallel()
 				out, err = modGen.With(daggerCall("foo", "--a=test")).Stdout(ctx)
 				require.NoError(t, err)
 				require.Equal(t, tc.expected, out)
@@ -3341,7 +3383,9 @@ func (m *Dep) Fn() Obj {
 		WithWorkdir("/work/test")
 
 	t.Run("return as other module object", func(t *testing.T) {
+		t.Parallel()
 		t.Run("direct", func(t *testing.T) {
+			t.Parallel()
 			_, err := ctr.
 				WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 					Contents: `package main
@@ -3363,6 +3407,7 @@ func (m *Test) Fn() (*DepObj, error) {
 		})
 
 		t.Run("list", func(t *testing.T) {
+			t.Parallel()
 			_, err := ctr.
 				WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 					Contents: `package main
@@ -3385,7 +3430,9 @@ func (m *Test) Fn() ([]*DepObj, error) {
 	})
 
 	t.Run("arg as other module object", func(t *testing.T) {
+		t.Parallel()
 		t.Run("direct", func(t *testing.T) {
+			t.Parallel()
 			_, err := ctr.WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 
@@ -3406,6 +3453,7 @@ func (m *Test) Fn(obj *DepObj) error {
 		})
 
 		t.Run("list", func(t *testing.T) {
+			t.Parallel()
 			_, err := ctr.WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 				Contents: `package main
 
@@ -3427,7 +3475,9 @@ func (m *Test) Fn(obj []*DepObj) error {
 	})
 
 	t.Run("field as other module object", func(t *testing.T) {
+		t.Parallel()
 		t.Run("direct", func(t *testing.T) {
+			t.Parallel()
 			_, err := ctr.
 				WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 					Contents: `package main
@@ -3453,6 +3503,7 @@ func (m *Test) Fn() (*Obj, error) {
 		})
 
 		t.Run("list", func(t *testing.T) {
+			t.Parallel()
 			_, err := ctr.
 				WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
 					Contents: `package main
@@ -5398,6 +5449,7 @@ func TestModuleSecretNested(t *testing.T) {
 	t.Parallel()
 
 	t.Run("pass secrets between modules", func(t *testing.T) {
+		t.Parallel()
 		// check that we can pass valid secret objects between functions in
 		// different modules
 
@@ -5464,11 +5516,13 @@ func (t *Toplevel) TryArg(ctx context.Context) error {
 			})
 
 		t.Run("can pass secrets", func(t *testing.T) {
+			t.Parallel()
 			_, err := ctr.With(daggerQuery(`{toplevel{tryArg}}`)).Stdout(ctx)
 			require.NoError(t, err)
 		})
 
 		t.Run("can return secrets", func(t *testing.T) {
+			t.Parallel()
 			_, err := ctr.With(daggerQuery(`{toplevel{tryReturn}}`)).Stdout(ctx)
 			require.NoError(t, err)
 		})
@@ -5808,11 +5862,13 @@ func diffSecret(ctx context.Context, first, second *Secret) error {
 			})
 
 		t.Run("internal secrets cache", func(t *testing.T) {
+			t.Parallel()
 			_, err := ctr.With(daggerQuery(`{toplevel{attemptInternal}}`)).Stdout(ctx)
 			require.NoError(t, err)
 		})
 
 		t.Run("external secrets cache", func(t *testing.T) {
+			t.Parallel()
 			_, err := ctr.With(daggerQuery(`{toplevel{attemptExternal}}`)).Stdout(ctx)
 			require.NoError(t, err)
 		})

--- a/core/integration/module_typescript_test.go
+++ b/core/integration/module_typescript_test.go
@@ -207,6 +207,7 @@ func TestModuleTypescriptSyntaxSupport(t *testing.T) {
 		With(sdkSource("typescript", tsSyntax))
 
 	t.Run("singleQuoteDefaultArgHello(msg: string = 'world'): string", func(t *testing.T) {
+		t.Parallel()
 		defaultOut, err := modGen.With(daggerQuery(`{syntax{singleQuoteDefaultArgHello}}`)).Stdout(ctx)
 
 		require.NoError(t, err)
@@ -219,6 +220,7 @@ func TestModuleTypescriptSyntaxSupport(t *testing.T) {
 	})
 
 	t.Run("doubleQuotesDefaultArgHello(msg: string = \"world\"): string", func(t *testing.T) {
+		t.Parallel()
 		defaultOut, err := modGen.With(daggerQuery(`{syntax{doubleQuotesDefaultArgHello}}`)).Stdout(ctx)
 
 		require.NoError(t, err)
@@ -246,6 +248,7 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 		With(sdkSource("typescript", tsSignatures))
 
 	t.Run("hello(): string", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{hello}}`)).Stdout(ctx)
 
 		require.NoError(t, err)
@@ -253,6 +256,7 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 	})
 
 	t.Run("echoes(msgs: string[]): string[]", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echoes(msgs: ["hello"])}}`)).Stdout(ctx)
 
 		require.NoError(t, err)
@@ -260,6 +264,7 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 	})
 
 	t.Run("echoOptional(msg = 'default'): string", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echoOptional(msg: "hello")}}`)).Stdout(ctx)
 
 		require.NoError(t, err)
@@ -272,6 +277,7 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 	})
 
 	t.Run("echoesVariadic(...msgs: string[]): string", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echoesVariadic(msgs: ["hello"])}}`)).Stdout(ctx)
 
 		require.NoError(t, err)
@@ -279,6 +285,7 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 	})
 
 	t.Run("echo(msg: string): string", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echo(msg: "hello")}}`)).Stdout(ctx)
 
 		require.NoError(t, err)
@@ -286,6 +293,7 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 	})
 
 	t.Run("echoOptionalSlice(msg = ['foobar']): string", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echoOptionalSlice(msg: ["hello", "there"])}}`)).Stdout(ctx)
 
 		require.NoError(t, err)
@@ -298,6 +306,7 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 	})
 
 	t.Run("helloVoid(): void", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{helloVoid}}`)).Stdout(ctx)
 
 		require.NoError(t, err)
@@ -305,6 +314,7 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 	})
 
 	t.Run("echoOpts(msg: string, suffix: string = '', times: number = 1): string", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echoOpts(msg: "hi")}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoOpts":"hi"}}`, out)
@@ -321,6 +331,7 @@ func TestModuleTypescriptSignatures(t *testing.T) {
 	})
 
 	t.Run("echoMaybe(msg: string, isQuestion = false): string", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{minimal{echoMaybe(msg: "hi")}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"echoMaybe":"hi...hi...hi..."}}`, out)
@@ -356,24 +367,28 @@ func TestModuleTypescriptSignaturesBuildinTypes(t *testing.T) {
 	dirID := gjson.Get(out, "directory.withNewFile.id").String()
 
 	t.Run("async read(dir: Directory): Promise<string>", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(fmt.Sprintf(`{minimal{read(dir: "%s")}}`, dirID))).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"read":"bar"}}`, out)
 	})
 
 	t.Run("async readSlice(dir: Directory[]): Promise<string>", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(fmt.Sprintf(`{minimal{readSlice(dir: ["%s"])}}`, dirID))).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"readSlice":"bar"}}`, out)
 	})
 
 	t.Run("async readVariadic(...dir: Directory[]): Promise<string>", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(fmt.Sprintf(`{minimal{readVariadic(dir: ["%s"])}}`, dirID))).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"readVariadic":"bar"}}`, out)
 	})
 
 	t.Run("async readOptional(dir?: Directory): Promise<string>", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(fmt.Sprintf(`{minimal{readOptional(dir: "%s")}}`, dirID))).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"minimal":{"readOptional":"bar"}}`, out)
@@ -495,12 +510,14 @@ func TestModuleTypescriptRuntimeDetection(t *testing.T) {
 		`))
 
 	t.Run("should default to node", func(t *testing.T) {
+		t.Parallel()
 		out, err := modGen.With(daggerQuery(`{runtimeDetection{echoRuntime}}`)).Stdout(ctx)
 		require.NoError(t, err)
 		require.JSONEq(t, `{"runtimeDetection":{"echoRuntime":"node"}}`, out)
 	})
 
 	t.Run("should use package.json configuration node", func(t *testing.T) {
+		t.Parallel()
 		modGen := modGen.WithNewFile("/work/dagger/package.json", dagger.ContainerWithNewFileOpts{
 			Contents: `{
 				"dagger": {
@@ -515,6 +532,7 @@ func TestModuleTypescriptRuntimeDetection(t *testing.T) {
 	})
 
 	t.Run("should use package.json configuration bun", func(t *testing.T) {
+		t.Parallel()
 		modGen := modGen.WithNewFile("/work/dagger/package.json", dagger.ContainerWithNewFileOpts{
 			Contents: `{
 				"dagger": {
@@ -529,6 +547,7 @@ func TestModuleTypescriptRuntimeDetection(t *testing.T) {
 	})
 
 	t.Run("should detect package-lock.json", func(t *testing.T) {
+		t.Parallel()
 		modGen := c.Container().From("node:20-alpine").
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
@@ -553,6 +572,7 @@ func TestModuleTypescriptRuntimeDetection(t *testing.T) {
 	})
 
 	t.Run("should detect bun.lockb", func(t *testing.T) {
+		t.Parallel()
 		modGen := c.Container().From("oven/bun:1.0.27-alpine").
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
@@ -577,6 +597,7 @@ func TestModuleTypescriptRuntimeDetection(t *testing.T) {
 	})
 
 	t.Run("should prioritize package.json config over file detection", func(t *testing.T) {
+		t.Parallel()
 		modGen := c.Container().From("node:20-alpine").
 			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 			WithWorkdir("/work").
@@ -608,6 +629,7 @@ func TestModuleTypescriptRuntimeDetection(t *testing.T) {
 	})
 
 	t.Run("should error if configured runtime is unknown", func(t *testing.T) {
+		t.Parallel()
 		modGen := modGen.WithNewFile("/work/dagger/package.json", dagger.ContainerWithNewFileOpts{
 			Contents: `{
 				"dagger": {
@@ -659,7 +681,9 @@ class Foo {}
 		WithWorkdir("/work/test")
 
 	t.Run("return as other module object", func(t *testing.T) {
+		t.Parallel()
 		t.Run("direct", func(t *testing.T) {
+			t.Parallel()
 			_, err := ctr.With(sdkSource("typescript", `
 			import { object, func, DepObj } from "@dagger.io/dagger"
 
@@ -681,6 +705,7 @@ class Foo {}
 		})
 
 		t.Run("list", func(t *testing.T) {
+			t.Parallel()
 			_, err := ctr.With(sdkSource("typescript", `
 			import { object, func, DepObj } from "@dagger.io/dagger"
 
@@ -703,7 +728,9 @@ class Foo {}
 	})
 
 	t.Run("arg as other module object", func(t *testing.T) {
+		t.Parallel()
 		t.Run("direct", func(t *testing.T) {
+			t.Parallel()
 			_, err := ctr.With(sdkSource("typescript", `
 import { object, func, DepObj } from "@dagger.io/dagger"
 
@@ -723,6 +750,7 @@ class Test {
 		})
 
 		t.Run("list", func(t *testing.T) {
+			t.Parallel()
 			_, err := ctr.
 				With(sdkSource("typescript", `
 import { object, func, DepObj } from "@dagger.io/dagger"
@@ -744,7 +772,9 @@ class Test {
 	})
 
 	t.Run("field as other module object", func(t *testing.T) {
+		t.Parallel()
 		t.Run("direct", func(t *testing.T) {
+			t.Parallel()
 			_, err := ctr.
 				With(sdkSource("typescript", `
 import { object, func, DepObj } from "@dagger.io/dagger"
@@ -773,6 +803,7 @@ class Obj {
 		})
 
 		t.Run("list", func(t *testing.T) {
+			t.Parallel()
 			_, err := ctr.
 				With(sdkSource("typescript", `
 import { object, func, DepObj } from "@dagger.io/dagger"

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -659,6 +659,7 @@ func (c *Client) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+
 	proxyReq := &http.Request{
 		Method: r.Method,
 		URL: &url.URL{

--- a/sdk/typescript/api/test/api.spec.ts
+++ b/sdk/typescript/api/test/api.spec.ts
@@ -86,7 +86,7 @@ describe("TypeScript SDK api", function () {
 
   it("Pass a client with an explicit ID as a parameter", async function () {
     this.timeout(60000)
-    connect(async (client: Client) => {
+    await connect(async (client: Client) => {
       const image = await client
         .loadContainerFromID(
           await client
@@ -105,7 +105,7 @@ describe("TypeScript SDK api", function () {
 
   it("Pass a cache volume with an implicit ID as a parameter", async function () {
     this.timeout(60000)
-    connect(async (client: Client) => {
+    await connect(async (client: Client) => {
       const cacheVolume = client.cacheVolume("cache_key")
       const image = await client
         .container()

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -12,11 +12,11 @@ import (
 )
 
 const (
-	bunVersion  = "1.0.27"
+	bunVersion  = "1.1.12"
 	nodeVersion = "21.3"
 
 	nodeImageDigest = "sha256:3dab5cc219983a5f1904d285081cceffc9d181e64bed2a4a18855d2d62c64ccb"
-	bunImageDigest  = "sha256:a87fa7c4c7fbd2e98cf9c5616e1d47aed65f96805c7a7830f734b27ef8bd75de"
+	bunImageDigest  = "sha256:6568a679b87107d3d7d46b829f614c443e73bbe3bf7d6ea5c9ceb8f845869c96"
 
 	nodeImageRef = "node:" + nodeVersion + "-alpine@" + nodeImageDigest
 	bunImageRef  = "oven/bun:" + bunVersion + "-alpine@" + bunImageDigest

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -16,7 +16,7 @@ const (
 	nodeVersion = "21.3"
 
 	nodeImageDigest = "sha256:3dab5cc219983a5f1904d285081cceffc9d181e64bed2a4a18855d2d62c64ccb"
-	bunImageDigest  = "sha256:82d3d3b8ad96c4eea45c88167ce46e7e24afc726897d48e48cc6d6bf230c061c"
+	bunImageDigest  = "sha256:a87fa7c4c7fbd2e98cf9c5616e1d47aed65f96805c7a7830f734b27ef8bd75de"
 
 	nodeImageRef = "node:" + nodeVersion + "-alpine@" + nodeImageDigest
 	bunImageRef  = "oven/bun:" + bunVersion + "-alpine@" + bunImageDigest

--- a/sdk/typescript/test/connect.spec.ts
+++ b/sdk/typescript/test/connect.spec.ts
@@ -110,31 +110,39 @@ describe("TypeScript default client", function () {
 })
 
 describe("TypeScript sdk Connect", function () {
-  it("Should parse DAGGER_SESSION_PORT and DAGGER_SESSION_TOKEN correctly", async function () {
-    this.timeout(60000)
+  describe("DAGGER_SESSION envs", function () {
+    let oldEnv: string
 
-    process.env["DAGGER_SESSION_TOKEN"] = "foo"
-    process.env["DAGGER_SESSION_PORT"] = "1234"
+    before(() => {
+      oldEnv = JSON.stringify(process.env)
+      process.env["DAGGER_SESSION_TOKEN"] = "foo"
+      process.env["DAGGER_SESSION_PORT"] = "1234"
+    })
 
-    await connect(
-      async (client) => {
-        const authorization = JSON.stringify(
-          client["_ctx"]["_client"]?.requestConfig.headers,
-        )
+    it("Should parse DAGGER_SESSION_PORT and DAGGER_SESSION_TOKEN correctly", async function () {
+      this.timeout(60000)
 
-        assert.equal(
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          client["_ctx"]["_client"]["url"],
-          "http://127.0.0.1:1234/query",
-        )
-        assert.equal(authorization, `{"Authorization":"Basic Zm9vOg=="}`)
-      },
-      { LogOutput: process.stderr },
-    )
+      await connect(
+        async (client) => {
+          const authorization = JSON.stringify(
+            client["_ctx"]["_client"]?.requestConfig.headers,
+          )
 
-    delete process.env["DAGGER_SESSION_PORT"]
-    delete process.env["DAGGER_SESSION_TOKEN"]
+          assert.equal(
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            client["_ctx"]["_client"]["url"],
+            "http://127.0.0.1:1234/query",
+          )
+          assert.equal(authorization, `{"Authorization":"Basic Zm9vOg=="}`)
+        },
+        { LogOutput: process.stderr },
+      )
+    })
+
+    after(() => {
+      process.env = JSON.parse(oldEnv)
+    })
   })
 
   it.skip("Connect to local engine and execute a simple query to make sure it does not fail", async function () {


### PR DESCRIPTION
While debugging something nodejs-related in https://github.com/dagger/dagger/pull/7315 I noticed a bunch of problems with the TS tests and some related areas:
1. Fix missing awaits in TS tests that caused accidental parallelism + tidy up env restoration: https://github.com/dagger/dagger/commit/15c43aef428a74dbe9c18d3c08ae2feba1e4a2d6 https://github.com/dagger/dagger/commit/32638a4809cfca968ebacddfb4e2428d9d769fed
2. Fix bun image to be multiplatform and upgrade bun version to avoid SIGSEGV/SIGABRT crashes: https://github.com/dagger/dagger/commit/22653f1c951abec324440582b6c8eba31e12e3a7 https://github.com/dagger/dagger/commit/f884fe9dcd6010a1fbedb3c684760d4ce51d2db5
3. Fill in a bunch of module integ tests that were missing `t.Parallel()` calls https://github.com/dagger/dagger/pull/7571/commits/b4e860f2738e361bd446b347822128cfa1fcf3f4

Sort of a grab-bag but all small + related enough to just group together in this PR.

I can't be 100% sure, but I was seeing a lot of flakes locally that looked similar to the ones in our CI that went away after https://github.com/dagger/dagger/commit/15c43aef428a74dbe9c18d3c08ae2feba1e4a2d6 specifically, so 🤞those are gone. cc @kpenfound 