### PR TITLE
ts: pin tsx version installed for modules

### DIFF
--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -187,7 +187,7 @@ func (t *TypescriptSdk) Base(runtime SupportedTSRuntime) (*Container, error) {
 			// Comment cache here, it seems it creates cache conflicts with yarn (v1 and v4).
 			// We should investigate this further and see if we hit the same issue with pnpm.
 			// WithMountedCache("/usr/local/share/.cache/yarn", dag.CacheVolume(fmt.Sprintf("mod-yarn-cache-%s", nodeVersion))).
-			WithExec([]string{"npm", "install", "-g", "tsx"}), nil
+			WithExec([]string{"npm", "install", "-g", "tsx@4.13.0"}), nil
 	default:
 		return nil, fmt.Errorf("unknown runtime: %s", runtime)
 	}


### PR DESCRIPTION
tsx pushed a release an hour ago that caused all Typescript modules to break out of band with errors like:
```
Transforming JavaScript decorators to the configured target environment
("node21.3.0") is not supported yet
```

It broke out-of-band because our install of tsx was not pinned to any version. I pinned it now to the previous patch release and things work again.

Hopefully there's some better way of pinning this version since it's currently just a direct `npm install` call and not in a lock file, but this at least fixes the problem in the immediate term.