### PR TITLE
re-align submodule name and path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "telemetry/opentelemetry-proto"]
+[submodule "engine/telemetry/opentelemetry-proto"]
 	path = engine/telemetry/opentelemetry-proto
 	url = https://github.com/open-telemetry/opentelemetry-proto


### PR DESCRIPTION
This mismatch (caused by `git mv`) seems to confuse the Buildkit Git source.