### PR TITLE
Improve standard go linter

### DIFF
--- a/ci/default-golangci.yml
+++ b/ci/default-golangci.yml
@@ -27,6 +27,7 @@ linters:
     - unused
     - unparam
     - whitespace
+    - gomodguard
 
 issues:
   exclude-rules:

--- a/ci/engine.go
+++ b/ci/engine.go
@@ -159,31 +159,13 @@ func (e *Engine) Service(
 }
 
 // Lint the engine
-func (e *Engine) Lint(
-	ctx context.Context,
-	// +optional
-	all bool,
-) error {
-	// Packages to lint
-	packages := []string{
-		"",
-		// FIXME: should the CI lint itself?
-		"ci",
-		"ci/dirdiff",
-		"ci/std/go",
-		"ci/std/graphql",
+func (e *Engine) Lint(ctx context.Context) error {
+	src, err := e.Dagger.Generate(ctx)
+	if err != nil {
+		return err
 	}
-	// Packages that need codegen
-	codegen := []string{
-		"",
-		"ci/dirdiff",
-		"ci/std/go",
-		"ci/std/graphql",
-	}
-
-	return e.Dagger.Go().
-		WithCodegen(codegen).
-		Lint(ctx, packages, all)
+	_, err = dag.Go(src).AssertLintPass(ctx)
+	return err
 }
 
 // Publish all engine images to a registry

--- a/ci/lint.go
+++ b/ci/lint.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+)
+
+const (
+	golangCiLintImage = "docker.io/golangci/golangci-lint@sha256:b5f8712114561f1e2fbe74d04ed07ddfd992768705033a6251f3c7b848eac38e"
+)
+
+// A linting report
+type LintReport struct {
+	mu     sync.Mutex
+	Issues []LintIssue
+	// +private
+	LLReport *File `json:"-"`
+}
+
+// An individual linting issue
+type LintIssue struct {
+	// The name of the tool that produced the issue
+	Tool string
+	// True if the issue is an error, false if it's a warning'
+	IsError bool
+	// The text explaining the issue
+	Text string
+	// FIXME add more fields
+}
+
+// Return the linting report as a JSON file
+func (lr *LintReport) JSON(
+	ctx context.Context,
+	// Return the low-level linting tool's report instead of the high-level one
+	// +optional
+	ll bool,
+) (*File, error) {
+	if ll {
+		if lr.LLReport == nil {
+			return nil, fmt.Errorf("no low-level report available")
+		}
+		return lr.LLReport, nil
+	}
+	data, err := json.MarshalIndent(lr, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	f := dag.
+		Directory().
+		WithNewFile("lint.json", string(data)).
+		File("lint.json")
+	return f, nil
+}
+
+// Return the total number of linting errors
+func (lr *LintReport) ErrorCount() int {
+	var count int
+	for _, issue := range lr.Issues {
+		if issue.IsError {
+			count += 1
+		}
+	}
+	return count
+}
+
+// Return the total number of linting warnings
+func (lr *LintReport) WarningCount() int {
+	var count int
+	for _, issue := range lr.Issues {
+		if !issue.IsError {
+			count += 1
+		}
+	}
+	return count
+}
+
+// Return the total number of linting issues (errors and warnings)
+func (lr *LintReport) IssueCount() int {
+	return len(lr.Issues)
+}
+
+// Return an error if there are errors
+func (lr *LintReport) AssertPass(ctx context.Context) error {
+	if count := lr.ErrorCount(); count > 0 {
+		return fmt.Errorf("linting failed with %d errors", count)
+	}
+	return nil
+}
+
+func (lr *LintReport) merge(other *LintReport) error {
+	lr.mu.Lock()
+	defer lr.mu.Unlock()
+	lr.Issues = append(lr.Issues, other.Issues...)
+	return nil
+}
+
+func (lr *LintReport) WithIssue(text string, isError bool) *LintReport {
+	return &LintReport{
+		Issues: append(lr.Issues, LintIssue{
+			IsError: isError,
+			Text:    text,
+		}),
+	}
+}

--- a/ci/lint_go.go
+++ b/ci/lint_go.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// A go linter
+type GoLint struct{}
+
+// Lint a go codebae
+func (gl GoLint) Lint(
+	ctx context.Context,
+	// The Go source directory to lint
+	source *Directory,
+) (*LintReport, error) {
+	config := dag.CurrentModule().Source().File("default-golangci.yml")
+	cmd := []string{
+		"golangci-lint", "run",
+		"-v",
+		"--timeout", "5m",
+		// Disable limits, we can filter the report instead
+		"--max-issues-per-linter", "0",
+		"--max-same-issues", "0",
+		"--out-format", "json",
+		"--issues-exit-code", "0",
+		"./...",
+	}
+	llreportFile := dag.
+		Container().
+		From(golangCiLintImage).
+		WithFile("/etc/golangci.yml", config).
+		WithEnvVariable("GOLANGCI_LINT_CONFIG", "/etc/golangci.yml").
+		WithMountedDirectory("/src", source).
+		WithWorkdir("/src").
+		WithExec(cmd, ContainerWithExecOpts{RedirectStdout: "golangci-lint-report.json"}).
+		File("golangci-lint-report.json")
+	llreportJSON, err := llreportFile.Contents(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// Unmarshal the low-level report from linting tool
+	var llreport struct {
+		Issues []struct {
+			Text        string   `json:"Text"`
+			FromLinter  string   `json:"FromLinter"`
+			SourceLines []string `json:"SourceLines"`
+			Replacement *struct {
+				Text string `json:"Text"`
+			} `json:"Replacement,omitempty"`
+			Pos struct {
+				Filename string `json:"Filename"`
+				Offset   int    `json:"Offset"`
+				Line     int    `json:"Line"`
+				Column   int    `json:"Column"`
+			} `json:"Pos"`
+			ExpectedNoLint bool   `json:"ExpectedNoLint"`
+			Severity       string `json:"Severity"`
+		} `json:"Issues"`
+	}
+	if err := json.Unmarshal([]byte(llreportJSON), &llreport); err != nil {
+		return nil, err
+	}
+	report := &LintReport{
+		Issues:   make([]LintIssue, len(llreport.Issues)),
+		LLReport: llreportFile, // Keep the low-level report just in case
+	}
+	for i := range llreport.Issues {
+		report.Issues[i].Text = llreport.Issues[i].Text
+		if llreport.Issues[i].Severity == "error" {
+			report.Issues[i].IsError = true
+		}
+		report.Issues[i].Tool = "golangci-lint"
+	}
+	return report, nil
+}

--- a/ci/lint_python.go
+++ b/ci/lint_python.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// A Python linter
+type PythonLint struct{}
+
+func (pl PythonLint) Lint(
+	ctx context.Context,
+	// The Python source directory to lint
+	source *Directory,
+) (*LintReport, error) {
+	var (
+		version    = "3.11"
+		baseDigest = "sha256:fc39d2e68b554c3f0a5cb8a776280c0b3d73b4c04b83dbade835e2a171ca27ef"
+		cmd        = []string{
+			"ruff", "check",
+			"--exit-zero",
+			"--output-format", "json",
+			".",
+		}
+	)
+	llreportFile := dag.
+		Container().
+		From(fmt.Sprintf("docker.io/library/python:%s-slim@%s", version, baseDigest)).
+		WithExec([]string{"pip", "install", "ruff==0.4.9"}).
+		WithMountedDirectory("/src", source).
+		WithWorkdir("/src").
+		//		WithEnvVariable("PIPX_BIN_DIR", "/usr/local/bin").
+		//		WithMountedCache("/root/.cache/pip", dag.CacheVolume("pip_cache_"+version)).
+		//		WithMountedCache("/root/.local/pipx/cache", dag.CacheVolume("pipx_cache_"+version)).
+		//		WithMountedCache("/root/.cache/hatch", dag.CacheVolume("hatch_cache_"+version)).
+		//		WithMountedFile("/pipx.pyz", dag.HTTP("https://github.com/pypa/pipx/releases/download/1.2.0/pipx.pyz")).
+		//		WithExec([]string{"python", "/pipx.pyz", "install", "hatch==1.7.0"}).
+		//		WithExec([]string{"python", "-m", "venv", "/opt/venv"}).
+		//		WithEnvVariable("VIRTUAL_ENV", "/opt/venv").
+		//		WithEnvVariable(
+		//			"PATH",
+		//			"$VIRTUAL_ENV/bin:$PATH",
+		//			dagger.ContainerWithEnvVariableOpts{Expand: true},
+		//		).
+		//		WithEnvVariable("HATCH_ENV_TYPE_VIRTUAL_PATH", "/opt/venv").
+		//		WithMountedFile("requirements.txt", source.File("requirements.txt")).
+		//		WithExec([]string{"pip", "install", "-r", "requirements.txt"}).
+		WithExec(cmd, ContainerWithExecOpts{RedirectStdout: "ruff-report.json"}).
+		File("ruff-report.json")
+	llreportJSON, err := llreportFile.Contents(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var llreport []struct {
+		Cell        *string `json:"cell"`
+		Code        string  `json:"code"`
+		EndLocation struct {
+			Column int `json:"column"`
+			Row    int `json:"row"`
+		} `json:"end_location"`
+		Filename string `json:"filename"`
+		Fix      struct {
+			Applicability string `json:"applicability"`
+			Edits         []struct {
+				Content     string `json:"content"`
+				EndLocation struct {
+					Column int `json:"column"`
+					Row    int `json:"row"`
+				} `json:"end_location"`
+				Location struct {
+					Column int `json:"column"`
+					Row    int `json:"row"`
+				} `json:"location"`
+			} `json:"edits"`
+			Message string `json:"message"`
+		} `json:"fix"`
+		Location struct {
+			Column int `json:"column"`
+			Row    int `json:"row"`
+		} `json:"location"`
+		Message string `json:"message"`
+		NoqaRow int    `json:"noqa_row"`
+		URL     string `json:"url"`
+	}
+	if err := json.Unmarshal([]byte(llreportJSON), &llreport); err != nil {
+		return nil, err
+	}
+	report := &LintReport{
+		Issues:   []LintIssue{},
+		LLReport: llreportFile, // Keep the low-level report just in case
+	}
+	for _, llissue := range llreport {
+		report.Issues = append(report.Issues, LintIssue{
+			Text:    llissue.Message,
+			IsError: true, // No concept of error/warning
+			Tool:    "ruff",
+		})
+	}
+	return report, nil
+}

--- a/ci/sdk_go.go
+++ b/ci/sdk_go.go
@@ -7,26 +7,19 @@ import (
 	"strings"
 
 	"github.com/moby/buildkit/identity"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/dagger/dagger/ci/consts"
-	"github.com/dagger/dagger/ci/util"
 )
 
 type GoSDK struct {
 	Dagger *Dagger // +private
 }
 
-// Lint the Go SDK
+// Lint the Go SDK source code
 func (t GoSDK) Lint(ctx context.Context) error {
-	eg, ctx := errgroup.WithContext(ctx)
-	eg.Go(func() error {
-		return t.Dagger.Go().Lint(ctx, []string{"sdk/go"}, false)
-	})
-	eg.Go(func() error {
-		return util.DiffDirectoryF(ctx, t.Dagger.Source, t.Generate, "sdk/go")
-	})
-	return eg.Wait()
+	src := t.Dagger.Source.Directory("sdk/go")
+	_, err := dag.Go(src).AssertLintPass(ctx)
+	return err
 }
 
 // Test the Go SDK

--- a/docs/current_docs/.ruff.toml
+++ b/docs/current_docs/.ruff.toml
@@ -2,7 +2,7 @@
 # and very doc specific rules in the SDK's pyproject.toml.
 extend = "../../sdk/python/pyproject.toml"
 
-ignore = [
+lint.ignore = [
     "D1",    # docstrings
     "E501",  # line too long
     "S108",  # probable insecure usage of temporary file or directory


### PR DESCRIPTION
First pass at improving our standard Go linter.

- Skeleton implementation works, but needs refinement
- Breaks the rest of our CI, which depends on the old `Lint()`. Need to wire in the new `LintAssertPass` for retro-compat
- Ideally start using the new `Lint` directly at least in one place.