### PR TITLE
fix: ensure nested frontend builds get secret translation

### DIFF
--- a/.changes/unreleased/Fixed-20240610-162518.yaml
+++ b/.changes/unreleased/Fixed-20240610-162518.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: 'core: handle secrets in dockerfile builds with syntax directives'
+time: 2024-06-10T16:25:18.328274656+01:00
+custom:
+  Author: jedevc
+  PR: "7595"


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/7522.

When doing a nested frontend build - i.e. when dockerfile.v0 calls gateway.v0 (triggered by a syntax directive), we need to ensure that the second frontend gets the same secret translation as each prior layer.
    
To do this, we heavily refactor the filtering gateway and essentially have it pass itself into the frontend Solve - this propagates the filtering all the way down, so secrets can be correctly accessed.

Once we have the session cleanup and refactoring in https://github.com/dagger/dagger/pull/7315, hopefully this logic can go - but this is a quick fix we can get in for the next release.