### PR TITLE
helm: Allow disabling `--oci-max-parallelism num-cpu`

### DIFF
--- a/docs/current_docs/integrations/snippets/tekton-dagger-task.yaml
+++ b/docs/current_docs/integrations/snippets/tekton-dagger-task.yaml
@@ -19,9 +19,6 @@ spec:
     - name: dagger-engine
       # modify to use the desired Dagger version
       image: registry.dagger.io/engine:vX.Y.Z 
-      args:
-        - "--oci-max-parallelism"
-        - "num-cpu"
       securityContext:
         privileged: true
         capabilities:

--- a/helm/dagger/templates/engine-daemonset.yaml
+++ b/helm/dagger/templates/engine-daemonset.yaml
@@ -45,9 +45,10 @@ spec:
         - name: dagger-engine
           image: {{ .Values.engine.image.repository }}:{{ if .Values.engine.image.tag }}{{ .Values.engine.image.tag }}{{ else }}{{ .Chart.AppVersion }}{{ end }}
           imagePullPolicy: {{ .Values.engine.image.pullPolicy }}
+          {{- if .Values.engine.args }}
           args:
-            - "--oci-max-parallelism"
-            - "num-cpu"
+            {{- toYaml .Values.engine.args | nindent 12 }}
+          {{- end }}
           {{- if .Values.magicache.enabled }}
           env:
           - name: _EXPERIMENTAL_DAGGER_CACHESERVICE_URL

--- a/helm/dagger/values.yaml
+++ b/helm/dagger/values.yaml
@@ -14,6 +14,12 @@ engine:
   #   [log]
   #     format = "json"
   labels: {}
+  ### Customize Dagger Engine start args
+  # "--oci-max-parallelism num-cpu" is kept as the default behaviour so that we don't surprise users.
+  # You may want to remove it in your deployments. FTR: https://github.com/dagger/dagger/pull/7395
+  args:
+    - "--oci-max-parallelism"
+    - "num-cpu"
   resources:
     limits: {}
     # limits:


### PR DESCRIPTION
While we are keeping this default so that we don't break existing users, setting this value is something that we want to move away from.

The problem is that this setting limits how many operations can run in parallel. It is still possible for a single operation to max out all available cores. It is also known for a value of `2` to cause deadlocks, i.e. https://github.com/dagger/dagger/issues/6894

For now, we just allow this to be disabled with either `--set engine.args=''` or by explicitly setting this value to an empty list.

This started as https://github.com/dagger/dagger/pull/7395 which turned out to be too big of a change. We since scaled back the initial ambition & are taking a smaller step towards eventually phasing this out.

FWIW, all the Dagger Engines that we run inside the Dagger infra do not use the `--oci-max-parallelism` option.

This also removes the option from tekton-dagger-task docs example.