### PR TITLE
engine: add logging to help debug "transport not supported"

### DIFF
--- a/engine/server/server.go
+++ b/engine/server/server.go
@@ -245,6 +245,15 @@ func (s *DaggerServer) ServeClientConn(
 func (s *DaggerServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	// Debug https://github.com/dagger/dagger/issues/7592 by logging method and some headers, which
+	// are checked by gqlgen's handler
+	bklog.G(ctx).WithFields(logrus.Fields{
+		"path":          r.URL.Path,
+		"method":        r.Method,
+		"upgradeHeader": r.Header.Get("Upgrade"),
+		"contentType":   r.Header.Get("Content-Type"),
+	}).Debug("handling http request")
+
 	// propagate span context from the client (i.e. for Dagger-in-Dagger)
 	ctx = otel.GetTextMapPropagator().Extract(ctx, propagation.HeaderCarrier(r.Header))
 


### PR DESCRIPTION
[This has been reported](https://github.com/dagger/dagger/issues/7592) to happen intermittently by a few users. [The error originates from gqlgen](https://github.com/99designs/gqlgen/blob/d9ba340552d1adb25e32584b2a4d3dfc9e254d24/graphql/handler/server.go#L119) and suggests that something in the http request is unhandled; it basically tries to find a matching pattern for gql requests based on http method and some headers.

It's unclear how this could happen only occasionally and I've never seen this myself yet, so I think our best bet is to log the parts of the request checked by gqlgen and wait for it to get hit again.