### PR TITLE
ci: enable best-effort cache reuse for nested engines

### DIFF
--- a/ci/engine.go
+++ b/ci/engine.go
@@ -121,8 +121,9 @@ func (e *Engine) Container(
 // Create a test engine service
 func (e *Engine) Service(
 	ctx context.Context,
-	version *VersionInfo,
 	name string,
+	// +optional
+	version *VersionInfo,
 ) (*Service, error) {
 	var cacheVolumeName string
 	if version != nil {

--- a/ci/engine.go
+++ b/ci/engine.go
@@ -121,15 +121,18 @@ func (e *Engine) Container(
 // Create a test engine service
 func (e *Engine) Service(
 	ctx context.Context,
+	version *VersionInfo,
 	name string,
 ) (*Service, error) {
 	var cacheVolumeName string
-	if name != "" {
-		cacheVolumeName = "dagger-dev-engine-state-" + name
+	if version != nil {
+		cacheVolumeName = "dagger-dev-engine-state-" + version.String()
 	} else {
-		cacheVolumeName = "dagger-dev-engine-state"
+		cacheVolumeName = "dagger-dev-engine-state-" + identity.NewID()
 	}
-	cacheVolumeName += identity.NewID()
+	if name != "" {
+		cacheVolumeName += "-" + name
+	}
 
 	e = e.
 		WithConfig("grpc", `address=["unix:///var/run/buildkit/buildkitd.sock", "tcp://0.0.0.0:1234"]`).
@@ -141,7 +144,12 @@ func (e *Engine) Service(
 	}
 	devEngine = devEngine.
 		WithExposedPort(1234, ContainerWithExposedPortOpts{Protocol: Tcp}).
-		WithMountedCache(distconsts.EngineDefaultStateDir, dag.CacheVolume(cacheVolumeName)).
+		WithMountedCache(distconsts.EngineDefaultStateDir, dag.CacheVolume(cacheVolumeName), ContainerWithMountedCacheOpts{
+			// only one engine can run off it's local state dir at a time; Private means that we will attempt to re-use
+			// these cache volumes if they are not already locked to another running engine but otherwise will create a new
+			// one, which gets us best-effort cache re-use for these nested engine services
+			Sharing: Private,
+		}).
 		WithExec(nil, ContainerWithExecOpts{
 			InsecureRootCapabilities: true,
 		})

--- a/ci/main.go
+++ b/ci/main.go
@@ -165,7 +165,7 @@ func (ci *Dagger) Dev(
 		img := "ubuntu"
 		engine = engine.WithBase(&img, &experimentalGPUSupport)
 	}
-	svc, err := engine.Service(ctx, "dev")
+	svc, err := engine.Service(ctx, ci.Version, "")
 	if err != nil {
 		return nil, err
 	}

--- a/ci/main.go
+++ b/ci/main.go
@@ -165,7 +165,7 @@ func (ci *Dagger) Dev(
 		img := "ubuntu"
 		engine = engine.WithBase(&img, &experimentalGPUSupport)
 	}
-	svc, err := engine.Service(ctx, ci.Version, "")
+	svc, err := engine.Service(ctx, "", ci.Version)
 	if err != nil {
 		return nil, err
 	}

--- a/ci/sdk.go
+++ b/ci/sdk.go
@@ -53,7 +53,7 @@ func (sdk *SDK) allSDKs() []sdkBase {
 }
 
 func (ci *Dagger) installer(ctx context.Context, name string) (func(*Container) *Container, error) {
-	engineSvc, err := ci.Engine().Service(ctx, name)
+	engineSvc, err := ci.Engine().Service(ctx, ci.Version, name)
 	if err != nil {
 		return nil, err
 	}

--- a/ci/sdk.go
+++ b/ci/sdk.go
@@ -53,7 +53,7 @@ func (sdk *SDK) allSDKs() []sdkBase {
 }
 
 func (ci *Dagger) installer(ctx context.Context, name string) (func(*Container) *Container, error) {
-	engineSvc, err := ci.Engine().Service(ctx, ci.Version, name)
+	engineSvc, err := ci.Engine().Service(ctx, name, ci.Version)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We were previously always putting a random id in the cache volume used for engines created in various CI functions, which meant none of them ever had any local cache. The main reason was that two engines can't use the same local cache at the same time.

We can't lift that limitation, but by using the engine version and private cache mounts we can get *best effort* re-use of these cache volumes, which is a simple enough performance improvement for some cases that we may as well take it.