### PR TITLE
OTel log draining follow-ups

### DIFF
--- a/cmd/dagger/licenses.go
+++ b/cmd/dagger/licenses.go
@@ -61,7 +61,7 @@ var licenseFiles = []string{
 }
 
 func findOrCreateLicense(ctx context.Context, dir string) error {
-	_, slog := slog.SpanLogger(ctx, InstrumentationLibrary, slog.LevelWarn)
+	slog := slog.SpanLogger(ctx, InstrumentationLibrary, slog.LevelWarn)
 
 	id := licenseID
 	if id == "" {

--- a/cmd/dagger/licenses.go
+++ b/cmd/dagger/licenses.go
@@ -61,7 +61,7 @@ var licenseFiles = []string{
 }
 
 func findOrCreateLicense(ctx context.Context, dir string) error {
-	slog := slog.SpanLogger(ctx, InstrumentationLibrary, slog.LevelWarn)
+	slog := slog.SpanLogger(ctx, InstrumentationLibrary)
 
 	id := licenseID
 	if id == "" {

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/dagger/dagger/analytics"
 	"github.com/dagger/dagger/dagql/idtui"
 	"github.com/dagger/dagger/engine"
+	"github.com/dagger/dagger/engine/slog"
 	enginetel "github.com/dagger/dagger/engine/telemetry"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 )
@@ -269,6 +270,8 @@ func main() {
 	installGlobalFlags(rootCmd.PersistentFlags())
 
 	ctx := context.Background()
+	ctx = slog.ContextWithColorMode(ctx, termenv.EnvNoColor())
+	ctx = slog.ContextWithDebugMode(ctx, debug)
 
 	if err := Frontend.Run(ctx, opts, func(ctx context.Context) (rerr error) {
 		telemetryCfg := telemetry.Config{

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -298,11 +298,11 @@ func main() {
 		// Set the span as the primary span for the frontend.
 		Frontend.SetPrimary(span.SpanContext().SpanID())
 
-		// Direct command stdout/stderr to span logs via OpenTelemetry.
-		logs := telemetry.Logs(ctx, InstrumentationLibrary)
-		defer logs.Close()
-		rootCmd.SetOut(logs.Stdout)
-		rootCmd.SetErr(logs.Stderr)
+		// Direct command stdout/stderr to span stdio via OpenTelemetry.
+		stdio := telemetry.SpanStdio(ctx, InstrumentationLibrary)
+		defer stdio.Close()
+		rootCmd.SetOut(stdio.Stdout)
+		rootCmd.SetErr(stdio.Stderr)
 
 		return rootCmd.ExecuteContext(ctx)
 	}); err != nil {

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -399,7 +399,7 @@ forced), to avoid mistakenly depending on uncommitted files.
 	RunE: func(cmd *cobra.Command, extraArgs []string) (rerr error) {
 		ctx := cmd.Context()
 		return withEngine(ctx, client.Params{}, func(ctx context.Context, engineClient *client.Client) (err error) {
-			slog := slog.SpanLogger(ctx, InstrumentationLibrary, slog.LevelWarn)
+			slog := slog.SpanLogger(ctx, InstrumentationLibrary)
 
 			dag := engineClient.Dagger()
 			modConf, err := getDefaultModuleConfiguration(ctx, dag, true, true)

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -399,7 +399,7 @@ forced), to avoid mistakenly depending on uncommitted files.
 	RunE: func(cmd *cobra.Command, extraArgs []string) (rerr error) {
 		ctx := cmd.Context()
 		return withEngine(ctx, client.Params{}, func(ctx context.Context, engineClient *client.Client) (err error) {
-			_, slog := slog.SpanLogger(ctx, InstrumentationLibrary, slog.LevelWarn)
+			slog := slog.SpanLogger(ctx, InstrumentationLibrary, slog.LevelWarn)
 
 			dag := engineClient.Dagger()
 			modConf, err := getDefaultModuleConfiguration(ctx, dag, true, true)

--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -71,9 +71,7 @@ func init() {
 }
 
 func Run(cmd *cobra.Command, args []string) error {
-	ctx := cmd.Context()
-
-	err := run(ctx, args)
+	err := run(cmd, args)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			fmt.Fprintln(os.Stderr, "run canceled")
@@ -89,7 +87,9 @@ func Run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func run(ctx context.Context, args []string) error {
+func run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
 	u, err := uuid.NewRandom()
 	if err != nil {
 		return fmt.Errorf("generate uuid: %w", err)
@@ -133,19 +133,16 @@ func run(ctx context.Context, args []string) error {
 
 		go srv.Serve(sessionL)
 
-		logs := telemetry.Logs(ctx, InstrumentationLibrary)
-		defer logs.Close()
-
 		var cmdErr error
 		if !silent {
 			if stdoutIsTTY {
-				subCmd.Stdout = logs.Stdout
+				subCmd.Stdout = cmd.OutOrStdout()
 			} else {
 				subCmd.Stdout = os.Stdout
 			}
 
 			if stderrIsTTY {
-				subCmd.Stderr = logs.Stderr
+				subCmd.Stderr = cmd.ErrOrStderr()
 			} else {
 				subCmd.Stderr = os.Stderr
 			}

--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -134,6 +134,7 @@ func run(ctx context.Context, args []string) error {
 		go srv.Serve(sessionL)
 
 		logs := telemetry.Logs(ctx, InstrumentationLibrary)
+		defer logs.Close()
 
 		var cmdErr error
 		if !silent {

--- a/core/c2h.go
+++ b/core/c2h.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 
 	"github.com/dagger/dagger/engine/buildkit"
+	"github.com/dagger/dagger/engine/slog"
 	"github.com/moby/buildkit/session/sshforward"
 	"github.com/sourcegraph/conc/pool"
 	"google.golang.org/grpc/metadata"
@@ -20,7 +20,6 @@ type c2hTunnel struct {
 	tunnelServiceHost  string
 	tunnelServicePorts []PortForward
 	sessionID          string
-	logWriter          io.Writer
 }
 
 func (d *c2hTunnel) Tunnel(ctx context.Context) (rerr error) {
@@ -28,6 +27,8 @@ func (d *c2hTunnel) Tunnel(ctx context.Context) (rerr error) {
 	if err != nil {
 		return fmt.Errorf("failed to get buildkit session caller %s: %w", d.sessionID, err)
 	}
+
+	slog := slog.SpanLogger(ctx, InstrumentationLibrary, slog.LevelDebug)
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -44,14 +45,22 @@ func (d *c2hTunnel) Tunnel(ctx context.Context) (rerr error) {
 			)
 
 			frontend := port.FrontendOrBackendPort()
+
+			srvSlog := slog.With(
+				"protocol", port.Protocol.Network(),
+				"frontend", frontend,
+				"backend", port.Backend,
+			)
+
 			listener, err := buildkit.RunInNetNS(ctx, d.bk, d.ns, func() (net.Listener, error) {
 				return net.Listen(port.Protocol.Network(), fmt.Sprintf(":%d", frontend))
 			})
 			if err != nil {
-				fmt.Fprintf(d.logWriter, "failed to listen on %s:%d : %v\n", port.Protocol.Network(), frontend, err)
+				srvSlog.Error("failed to listen", "error", err)
 				return fmt.Errorf("failed to listen on network namespace: %w", err)
 			}
-			fmt.Fprintf(d.logWriter, "listening on %s:%d\n", port.Protocol.Network(), frontend)
+
+			srvSlog.Info("listening", "addr", listener.Addr())
 
 			go func() {
 				<-ctx.Done()
@@ -62,13 +71,15 @@ func (d *c2hTunnel) Tunnel(ctx context.Context) (rerr error) {
 				downstreamConn, err := listener.Accept()
 				if err != nil {
 					if errors.Is(err, net.ErrClosed) {
-						fmt.Fprintf(d.logWriter, "listener closed\n")
+						srvSlog.Debug("listener closed")
 						return nil
 					}
 					return fmt.Errorf("fatal accept error: %w", err)
 				}
 
-				fmt.Fprintf(d.logWriter, "handling %s\n", downstreamConn.RemoteAddr())
+				connSlog := slog.With("addr", downstreamConn.RemoteAddr())
+
+				connSlog.Debug("handling connection")
 
 				upstreamClient, err := sshforward.NewSSHClient(hostCaller.Conn()).ForwardAgent(
 					metadata.NewOutgoingContext(ctx, map[string][]string{
@@ -76,14 +87,14 @@ func (d *c2hTunnel) Tunnel(ctx context.Context) (rerr error) {
 					}),
 				)
 				if err != nil {
-					fmt.Fprintf(d.logWriter, "failed to create upstream client %s: %v\n", upstreamSock.SSHID(), err)
+					connSlog.Error("failed to create upstream client", "id", upstreamSock.SSHID(), "error", err)
 					return fmt.Errorf("failed to create upstream client %s: %w", upstreamSock.SSHID(), err)
 				}
 
 				proxyConnPool.Go(func(ctx context.Context) error {
 					err := sshforward.Copy(ctx, downstreamConn, upstreamClient, upstreamClient.CloseSend)
 					if err != nil {
-						fmt.Fprintf(d.logWriter, "failed to copy: %v\n", err)
+						connSlog.Error("failed to copy data", "error", err)
 					}
 					return err
 				})
@@ -98,7 +109,7 @@ func (d *c2hTunnel) Tunnel(ctx context.Context) (rerr error) {
 		rerr = errors.Join(rerr, fmt.Errorf("proxy conn pool failed: %w", err))
 	}
 	if rerr != nil {
-		fmt.Fprintf(d.logWriter, "tunnel failed: %v\n", rerr)
+		slog.Error("tunnel finished with errors", "error", rerr)
 	}
 	return rerr
 }

--- a/core/c2h.go
+++ b/core/c2h.go
@@ -28,7 +28,7 @@ func (d *c2hTunnel) Tunnel(ctx context.Context) (rerr error) {
 		return fmt.Errorf("failed to get buildkit session caller %s: %w", d.sessionID, err)
 	}
 
-	slog := slog.SpanLogger(ctx, InstrumentationLibrary, slog.LevelDebug)
+	slog := slog.SpanLogger(ctx, InstrumentationLibrary)
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/core/healthcheck.go
+++ b/core/healthcheck.go
@@ -47,7 +47,7 @@ func (d *portHealthChecker) Check(ctx context.Context) (rerr error) {
 	ctx, span := Tracer().Start(ctx, strings.Join(portStrs, " "))
 	defer telemetry.End(span, func() error { return rerr })
 
-	slog := slog.SpanLogger(ctx, InstrumentationLibrary, slog.LevelDebug)
+	slog := slog.SpanLogger(ctx, InstrumentationLibrary)
 
 	dialer := net.Dialer{
 		Timeout: time.Second,
@@ -78,7 +78,7 @@ func (d *portHealthChecker) Check(ctx context.Context) (rerr error) {
 			return fmt.Errorf("checking for port %d/%s: %w", port.Port, port.Protocol.Network(), err)
 		}
 
-		slog.Info("port is healthy", "port", endpoint)
+		slog.Info("port is healthy", "endpoint", endpoint)
 	}
 
 	return nil

--- a/core/integration/module_up_test.go
+++ b/core/integration/module_up_test.go
@@ -89,10 +89,11 @@ type Test struct {
 
 		tty := console.Tty()
 
-		err = pty.Setsize(tty, &pty.Winsize{Rows: 10, Cols: 28})
+		err = pty.Setsize(tty, &pty.Winsize{Rows: 10, Cols: 80})
 		require.NoError(t, err)
 
 		cmd := hostDaggerCommand(ctx, t, modDir, "call", "ctr", "as-service", "up", "--random")
+		cmd.Env = append(os.Environ(), "NO_COLOR=true")
 		cmd.Stdin = nil
 		cmd.Stdout = tty
 		cmd.Stderr = tty
@@ -101,7 +102,7 @@ type Test struct {
 		require.NoError(t, err)
 		defer cmd.Process.Kill()
 
-		_, matches, err := console.MatchLine(ctx, `(\d+)/TCP:`)
+		_, matches, err := console.MatchLine(ctx, `tunnel started port=(\d+)`)
 		require.NoError(t, err)
 
 		port := matches[1]

--- a/core/schema/query.go
+++ b/core/schema/query.go
@@ -80,7 +80,7 @@ type checkVersionCompatibilityArgs struct {
 }
 
 func (s *querySchema) checkVersionCompatibility(ctx context.Context, _ *core.Query, args checkVersionCompatibilityArgs) (dagql.Boolean, error) {
-	slog := slog.SpanLogger(ctx, InstrumentationLibrary, slog.LevelWarn,
+	slog := slog.SpanLogger(ctx, InstrumentationLibrary,
 		log.Bool(telemetry.LogsGlobalAttr, true))
 
 	// Skip development version

--- a/core/schema/query.go
+++ b/core/schema/query.go
@@ -80,7 +80,7 @@ type checkVersionCompatibilityArgs struct {
 }
 
 func (s *querySchema) checkVersionCompatibility(ctx context.Context, _ *core.Query, args checkVersionCompatibilityArgs) (dagql.Boolean, error) {
-	_, slog := slog.SpanLogger(ctx, InstrumentationLibrary, slog.LevelWarn,
+	slog := slog.SpanLogger(ctx, InstrumentationLibrary, slog.LevelWarn,
 		log.Bool(telemetry.LogsGlobalAttr, true))
 
 	// Skip development version

--- a/core/schema/service.go
+++ b/core/schema/service.go
@@ -148,6 +148,7 @@ func (s *serviceSchema) up(ctx context.Context, svc dagql.Instance[*core.Service
 	}
 
 	logs := telemetry.Logs(ctx, InstrumentationLibrary)
+	defer logs.Close()
 
 	for _, port := range runningSvc.Ports {
 		portStr := fmt.Sprintf("%d/%s", port.Port, port.Protocol)

--- a/core/schema/service.go
+++ b/core/schema/service.go
@@ -148,7 +148,7 @@ func (s *serviceSchema) up(ctx context.Context, svc dagql.Instance[*core.Service
 		return void, fmt.Errorf("failed to start host service: %w", err)
 	}
 
-	slog := slog.SpanLogger(ctx, InstrumentationLibrary, slog.LevelDebug)
+	slog := slog.SpanLogger(ctx, InstrumentationLibrary)
 
 	for _, port := range runningSvc.Ports {
 		slog.Info(

--- a/core/service.go
+++ b/core/service.go
@@ -386,6 +386,11 @@ func (svc *Service) startContainer(
 	var exitErr error
 	exited := make(chan struct{})
 	go func() {
+		// terminate the span; we're not interested in setting an error, since
+		// services return a benign error like `exit status 1` on exit
+		defer span.End()
+		defer logs.Close()
+
 		defer func() {
 			if stdinClient != nil {
 				stdinClient.Close()
@@ -410,10 +415,6 @@ func (svc *Service) startContainer(
 				exitErr = fmt.Errorf("release: %w", err)
 			}
 		}
-
-		// terminate the span; we're not interested in setting an error, since
-		// services return a benign error like `exit status 1` on exit
-		span.End()
 	}()
 
 	stopSvc := func(ctx context.Context, force bool) error {

--- a/core/telemetry.go
+++ b/core/telemetry.go
@@ -51,11 +51,9 @@ func AroundFunc(ctx context.Context, self dagql.Object, id *call.ID) (context.Co
 	}
 
 	ctx, span := dagql.Tracer().Start(ctx, spanName, trace.WithAttributes(attrs...))
-	logs := telemetry.Logs(ctx, dagql.InstrumentationLibrary)
 
 	return ctx, func(res dagql.Typed, cached bool, err error) {
 		defer telemetry.End(span, func() error { return err })
-		defer logs.Close()
 
 		if cached {
 			// TODO maybe this should be an event?

--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -118,9 +118,6 @@ func (fe *frontendPlain) ConnectedToCloud(url string) {
 func (fe *frontendPlain) Run(ctx context.Context, opts FrontendOpts, run func(context.Context) error) error {
 	fe.FrontendOpts = opts
 
-	// set default context logs
-	ctx = slog.WithLogProfile(ctx, fe.profile)
-
 	// redirect slog to the logs pane
 	level := slog.LevelInfo
 	if fe.Debug {

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -94,9 +94,6 @@ func (fe *frontendPretty) ConnectedToCloud(url string) {
 func (fe *frontendPretty) Run(ctx context.Context, opts FrontendOpts, run func(context.Context) error) error {
 	fe.FrontendOpts = opts
 
-	// set default context logs
-	ctx = slog.WithLogProfile(ctx, fe.profile)
-
 	// redirect slog to the logs pane
 	level := slog.LevelInfo
 	if fe.Debug {

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -255,7 +255,7 @@ func (c *Client) startEngine(ctx context.Context) (rerr error) {
 	ctx, span := Tracer().Start(ctx, "connecting to engine")
 	defer telemetry.End(span, func() error { return rerr })
 
-	slog := slog.SpanLogger(ctx, InstrumentationLibrary, c.LogLevel)
+	slog := slog.SpanLogger(ctx, InstrumentationLibrary)
 
 	slog.Info("connecting", "runner", c.RunnerHost, "client", c.ID)
 
@@ -331,7 +331,7 @@ func (c *Client) startSession(ctx context.Context) (rerr error) {
 	ctx, sessionSpan := Tracer().Start(ctx, "starting session")
 	defer telemetry.End(sessionSpan, func() error { return rerr })
 
-	slog := slog.SpanLogger(ctx, InstrumentationLibrary, c.LogLevel)
+	slog := slog.SpanLogger(ctx, InstrumentationLibrary)
 
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -255,8 +255,7 @@ func (c *Client) startEngine(ctx context.Context) (rerr error) {
 	ctx, span := Tracer().Start(ctx, "connecting to engine")
 	defer telemetry.End(span, func() error { return rerr })
 
-	logs, slog := slog.SpanLogger(ctx, InstrumentationLibrary, c.LogLevel)
-	defer logs.Close()
+	slog := slog.SpanLogger(ctx, InstrumentationLibrary, c.LogLevel)
 
 	slog.Info("connecting", "runner", c.RunnerHost, "client", c.ID)
 
@@ -332,8 +331,7 @@ func (c *Client) startSession(ctx context.Context) (rerr error) {
 	ctx, sessionSpan := Tracer().Start(ctx, "starting session")
 	defer telemetry.End(sessionSpan, func() error { return rerr })
 
-	logs, slog := slog.SpanLogger(ctx, InstrumentationLibrary, c.LogLevel)
-	defer logs.Close()
+	slog := slog.SpanLogger(ctx, InstrumentationLibrary, c.LogLevel)
 
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/engine/client/drivers/docker.go
+++ b/engine/client/drivers/docker.go
@@ -64,7 +64,7 @@ const InstrumentationLibrary = "dagger.io/client.drivers"
 func (d *dockerDriver) create(ctx context.Context, imageRef string, opts *DriverOpts) (helper *connh.ConnectionHelper, rerr error) {
 	ctx, span := otel.Tracer("").Start(ctx, "create")
 	defer telemetry.End(span, func() error { return rerr })
-	slog := slog.SpanLogger(ctx, InstrumentationLibrary, slog.LevelWarn)
+	slog := slog.SpanLogger(ctx, InstrumentationLibrary)
 
 	// Get the SHA digest of the image to use as an ID for the container we'll create
 	var id string

--- a/engine/client/drivers/docker.go
+++ b/engine/client/drivers/docker.go
@@ -64,8 +64,7 @@ const InstrumentationLibrary = "dagger.io/client.drivers"
 func (d *dockerDriver) create(ctx context.Context, imageRef string, opts *DriverOpts) (helper *connh.ConnectionHelper, rerr error) {
 	ctx, span := otel.Tracer("").Start(ctx, "create")
 	defer telemetry.End(span, func() error { return rerr })
-	logs, slog := slog.SpanLogger(ctx, InstrumentationLibrary, slog.LevelWarn)
-	defer logs.Close()
+	slog := slog.SpanLogger(ctx, InstrumentationLibrary, slog.LevelWarn)
 
 	// Get the SHA digest of the image to use as an ID for the container we'll create
 	var id string
@@ -208,11 +207,11 @@ func garbageCollectEngines(ctx context.Context, log *slog.Logger, engines []stri
 func traceExec(ctx context.Context, cmd *exec.Cmd) (out string, rerr error) {
 	ctx, span := otel.Tracer("").Start(ctx, fmt.Sprintf("exec %s", strings.Join(cmd.Args, " ")))
 	defer telemetry.End(span, func() error { return rerr })
-	logs := telemetry.Logs(ctx, "")
-	defer logs.Close()
+	stdio := telemetry.SpanStdio(ctx, "")
+	defer stdio.Close()
 	outBuf := new(bytes.Buffer)
-	cmd.Stdout = io.MultiWriter(logs.Stdout, outBuf)
-	cmd.Stderr = io.MultiWriter(logs.Stderr, outBuf)
+	cmd.Stdout = io.MultiWriter(stdio.Stdout, outBuf)
+	cmd.Stderr = io.MultiWriter(stdio.Stderr, outBuf)
 	if err := cmd.Run(); err != nil {
 		return outBuf.String(), errors.Wrap(err, "failed to run command")
 	}

--- a/engine/session/h2c.go
+++ b/engine/session/h2c.go
@@ -41,7 +41,7 @@ func (s TunnelListenerAttachable) Register(srv *grpc.Server) {
 const InstrumentationLibrary = "dagger.io/engine.session"
 
 func (s TunnelListenerAttachable) Listen(srv TunnelListener_ListenServer) error {
-	_, slog := slog.SpanLogger(s.rootCtx, InstrumentationLibrary, slog.LevelWarn)
+	slog := slog.SpanLogger(s.rootCtx, InstrumentationLibrary, slog.LevelWarn)
 
 	req, err := srv.Recv()
 	if err != nil {

--- a/engine/session/h2c.go
+++ b/engine/session/h2c.go
@@ -41,7 +41,7 @@ func (s TunnelListenerAttachable) Register(srv *grpc.Server) {
 const InstrumentationLibrary = "dagger.io/engine.session"
 
 func (s TunnelListenerAttachable) Listen(srv TunnelListener_ListenServer) error {
-	slog := slog.SpanLogger(s.rootCtx, InstrumentationLibrary, slog.LevelWarn)
+	slog := slog.SpanLogger(s.rootCtx, InstrumentationLibrary)
 
 	req, err := srv.Recv()
 	if err != nil {

--- a/engine/slog/slog.go
+++ b/engine/slog/slog.go
@@ -4,15 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
-
-	"github.com/muesli/termenv"
 )
-
-type logProfileKey struct{}
-
-func WithLogProfile(ctx context.Context, profile termenv.Profile) context.Context {
-	return context.WithValue(ctx, logProfileKey{}, profile)
-}
 
 const (
 	// standard levels

--- a/engine/slog/telemetry.go
+++ b/engine/slog/telemetry.go
@@ -9,20 +9,46 @@ import (
 	"dagger.io/dagger/telemetry"
 	"github.com/lmittmann/tint"
 	"github.com/muesli/termenv"
+	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/log"
 )
 
-type logProfileKey struct{}
+const (
+	debugBaggageKey   = "debug"
+	noColorBaggageKey = "no-color"
+)
 
-func WithLogProfile(ctx context.Context, profile termenv.Profile) context.Context {
-	return context.WithValue(ctx, logProfileKey{}, profile)
+// ContextWithDebugMode enables or disables debug mode in the given context's
+// OpenTelemetry baggage.
+func ContextWithDebugMode(ctx context.Context, debug bool) context.Context {
+	return toggleBaggage(ctx, debugBaggageKey, debug)
+}
+
+// ContextWithDebugMode enables or disables color mode in the given context's
+// OpenTelemetry baggage.
+func ContextWithColorMode(ctx context.Context, noColor bool) context.Context {
+	return toggleBaggage(ctx, noColorBaggageKey, noColor)
 }
 
 // SpanLogger returns a Logger that writes to the give context's span logs.
-func SpanLogger(ctx context.Context, name string, level slog.Level, attrs ...log.KeyValue) *Logger {
+//
+// The logger will use the context's baggage to determine the log level and
+// color profile:
+//
+// - If no-color=true is set in baggage, the profile will be Ascii. Otherwise,
+// it will be ANSI.
+//
+// - If debug=true is set in baggage, the log level will be Debug. Otherwise,
+// it will be Info.
+func SpanLogger(ctx context.Context, name string, attrs ...log.KeyValue) *Logger {
+	bag := baggage.FromContext(ctx)
 	profile := termenv.ANSI
-	if v := ctx.Value(logProfileKey{}); v != nil {
-		profile = v.(termenv.Profile)
+	if bag.Member(noColorBaggageKey).Value() == "true" {
+		profile = termenv.Ascii
+	}
+	level := LevelInfo
+	if bag.Member(debugBaggageKey).Value() == "true" {
+		level = LevelDebug
 	}
 	return PrettyLogger(
 		telemetry.NewWriter(ctx, name, attrs...),
@@ -38,4 +64,23 @@ func PrettyLogger(dest io.Writer, profile termenv.Profile, level slog.Level) *Lo
 		Level:      level,
 	}
 	return New(tint.NewHandler(dest, slogOpts))
+}
+
+func toggleBaggage(ctx context.Context, key string, value bool) context.Context {
+	bag := baggage.FromContext(ctx)
+	if value {
+		m, err := baggage.NewMember(key, "true")
+		if err != nil {
+			// value would have to be invalid; 'true' is fine
+			panic(err)
+		}
+		bag, err = bag.SetMember(m)
+		if err != nil {
+			// member would have to be invalid, but it ain't
+			panic(err)
+		}
+	} else {
+		bag = bag.DeleteMember(key)
+	}
+	return baggage.ContextWithBaggage(ctx, bag)
 }

--- a/sdk/go/telemetry/logging.go
+++ b/sdk/go/telemetry/logging.go
@@ -14,65 +14,89 @@ func Logger(name string) log.Logger {
 	return loggerProvider.Logger(name) // TODO more instrumentation attrs
 }
 
-type SpanLogs struct {
+// SpanStdio returns a pair of io.WriteClosers which will send log records with
+// stdio.stream=1 for stdout and stdio.stream=2 for stderr. Closing either of
+// them will send a log record for that stream with an empty body and
+// stdio.eof=true.
+//
+// SpanStdio should be used when a span represents a process that writes to
+// stdout/stderr and terminates them with an EOF, to confirm that all data has
+// been received. It should not be used for general-purpose logging.
+//
+// Both streamsm must be closed to ensure that draining completes.
+func SpanStdio(ctx context.Context, name string, attrs ...log.KeyValue) SpanStreams {
+	logger := Logger(name)
+	return SpanStreams{
+		Stdout: &spanStream{
+			Writer: &Writer{
+				ctx:    ctx,
+				logger: logger,
+				attrs:  append([]log.KeyValue{log.Int(StdioStreamAttr, 1)}, attrs...),
+			},
+		},
+		Stderr: &spanStream{
+			Writer: &Writer{
+				ctx:    ctx,
+				logger: logger,
+				attrs:  append([]log.KeyValue{log.Int(StdioStreamAttr, 2)}, attrs...),
+			},
+		},
+	}
+}
+
+// Writer is an io.Writer that emits log records.
+type Writer struct {
+	ctx    context.Context
+	logger log.Logger
+	attrs  []log.KeyValue
+}
+
+// NewWriter returns a new Writer that emits log records with the given logger
+// name and attributes.
+func NewWriter(ctx context.Context, name string, attrs ...log.KeyValue) io.Writer {
+	return &Writer{
+		ctx:    ctx,
+		logger: Logger(name),
+		attrs:  attrs,
+	}
+}
+
+// Write emits a log record with the given payload as a string body.
+func (w *Writer) Write(p []byte) (int, error) {
+	w.Emit(log.StringValue(string(p)))
+	return len(p), nil
+}
+
+// Emit sends a log record with the given body and additional attributes.
+func (w *Writer) Emit(body log.Value, attrs ...log.KeyValue) {
+	rec := log.Record{}
+	rec.SetTimestamp(time.Now())
+	rec.SetBody(body)
+	rec.AddAttributes(w.attrs...)
+	rec.AddAttributes(attrs...)
+	w.logger.Emit(w.ctx, rec)
+}
+
+// SpanStreams contains the stdout and stderr for a span.
+type SpanStreams struct {
 	Stdout io.WriteCloser
 	Stderr io.WriteCloser
 }
 
-func (sl SpanLogs) Close() error {
+// Calling Close closes both streams.
+func (sl SpanStreams) Close() error {
 	return errors.Join(
 		sl.Stdout.Close(),
 		sl.Stderr.Close(),
 	)
 }
 
-// Logs returns a pair of io.WriteClosers which will send log records with
-// stdio.stream=1 for stdout and stdio.stream=2 for stderr. Closing either of
-// them will send a log record with an empty body and stdio.eof=true.
-//
-// A typical pattern is to start a new span, call Logs, and defer logs.Close().
-// If a function does not create its own span, it should not call Close().
-func Logs(ctx context.Context, name string, attrs ...log.KeyValue) SpanLogs {
-	logger := Logger(name)
-	return SpanLogs{
-		Stdout: &logStream{
-			ctx:    ctx,
-			logger: logger,
-			stream: 1,
-			attrs:  attrs,
-		},
-		Stderr: &logStream{
-			ctx:    ctx,
-			logger: logger,
-			stream: 2,
-			attrs:  attrs,
-		},
-	}
+type spanStream struct {
+	*Writer
 }
 
-type logStream struct {
-	ctx    context.Context
-	logger log.Logger
-	stream int
-	attrs  []log.KeyValue
-}
-
-func (w *logStream) Write(p []byte) (int, error) {
-	rec := log.Record{}
-	rec.SetTimestamp(time.Now())
-	rec.SetBody(log.StringValue(string(p)))
-	rec.AddAttributes(log.Int(StdioStreamAttr, w.stream))
-	rec.AddAttributes(w.attrs...)
-	w.logger.Emit(w.ctx, rec)
-	return len(p), nil
-}
-
-func (w *logStream) Close() error {
-	rec := log.Record{}
-	rec.SetTimestamp(time.Now())
-	rec.SetBody(log.StringValue(""))
-	rec.AddAttributes(log.Int(StdioStreamAttr, w.stream), log.Bool(StdioEOFAttr, true))
-	rec.AddAttributes(w.attrs...)
-	w.logger.Emit(w.ctx, rec)
+// Close emits an EOF log record.
+func (w *spanStream) Close() error {
+	w.Writer.Emit(log.StringValue(""), log.Bool(StdioEOFAttr, true))
 	return nil
 }


### PR DESCRIPTION
* Standardize on `slog` everywhere that we print output from the engine, instead of "faking" stdout/stderr in places.
  * Goal: `SpanLogger` no longer leaves ambiguity as to whether caller needs to `Close()`. It _never_ does.
  * We will no longer drain to ensure we get every last log, but this was never really an issue, doesn't seem worthwhile atm.
* Rename `telemetry.Logs` to `telemetry.SpanStdio` so its intentions are clearer.
  * Goal: again, remove ambiguity as to whether caller needs to `Close()`. It _always_ does.
* Propagate client-side `NO_COLOR=true` and `--debug` through to the engine so `SpanLogger` can respect it.
  * Goal: now that everything is `slog` we should respect the user's preferences.
  * I needed this to get the `dagger up --random` test to pass without choking on ANSI colors.