### PR TITLE
engine: fix context error wrapping in executor

### DIFF
--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -414,7 +414,7 @@ func exitError(ctx context.Context, exitCodePath string, err error) error {
 
 		select {
 		case <-ctx.Done():
-			exitErr.Err = fmt.Errorf(exitErr.Error())
+			exitErr.Err = fmt.Errorf("%s: %w", exitErr.Error(), context.Cause(ctx))
 			return exitErr
 		default:
 			return stack.Enable(exitErr)


### PR DESCRIPTION
When an exec fails due to context canceled, we were dropping the cancelation error and just returning the exec error. I believe this got fat-fingered while updating the code from upstream to use fmt.Errorf instead of github.com/pkg/errors.

It's not clear if this is really meaningful, but noticed it changed while attempting to debug occurances of "exit code 137" in our CI, which plausibly could be related to all of this. It's possible there's calling code that tries to handle cancelation with errors.Is, which this would have broken. This is purely hypothetical at this point though.

---

This is the related upstream version of this code, if helpful https://github.com/moby/buildkit/blob/715276d7423f006dab1c96bd6910d4ca55faa230/executor/runcexecutor/executor.go#L374