### PR TITLE
client: set a minimum connect timeout for buildkit

### DIFF
--- a/.changes/unreleased/Changed-20240611-113054.yaml
+++ b/.changes/unreleased/Changed-20240611-113054.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: decrease connect timeout in grpc dial
+time: 2024-06-11T11:30:54.423975174-03:00
+custom:
+    Author: marcosnils
+    PR: "7599"


### PR DESCRIPTION
we're changing the default minConnectTimeout and backoff settings since
in some cases, the `connect` happens before the engine is ready to
accept connections, causing the client to wait for the default
minConnectTimeout (20s) before retrying. This causes very long
connection times when the engine is not ready to accept connections.

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
