### PR TITLE
feat: Adding winget to goreleaser

### DIFF
--- a/.goreleaser.common.yml
+++ b/.goreleaser.common.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/goreleaser/goreleaser/v2.2.0/www/docs/static/schema-pro.json
+
 version: 2
 
 project_name: dagger

--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/goreleaser/goreleaser/v2.2.0/www/docs/static/schema-pro.json
+
 version: 2
 
 includes:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/goreleaser/goreleaser/v2.2.0/www/docs/static/schema-pro.json
+
 version: 2
 
 includes:
@@ -52,15 +54,21 @@ nix:
 # https://goreleaser.com/customization/winget/
 winget:
   - name: dagger
+    repository:
+      owner: "{{ .Env.GH_ORG_NAME }}"
+      name: winget
+    commit_author:
+      name: dagger-bot
+      email: noreply@dagger.io
+    url_template: "https://{{ .Env.ARTEFACTS_FQDN }}/dagger/releases/{{ .Version }}/{{ .ArtifactName }}"
+    homepage: "https://dagger.io"
     publisher: Dagger
     short_description: "Dagger is an integrated platform to orchestrate the delivery of applications"
     license: "asl20"
-    homepage: "https://dagger.io"
     publisher_url: "https://dagger.io"
     publisher_support_url: https://github.com/dagger/dagger/issues/new/choose
     package_identifier: Dagger.Cli
-    use: archive
-    url_template: "https://{{ .Env.ARTEFACTS_FQDN }}/dagger/releases/{{ .Version }}/{{ .ArtifactName }}"
+    use: archive    
     skip_upload: false
     tags:
       - dagger

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,6 +49,24 @@ nix:
         --fish <($out/bin/dagger completion fish) \
         --zsh <($out/bin/dagger completion zsh)
 
+# https://goreleaser.com/customization/winget/
+winget:
+  - name: dagger
+    publisher: Dagger
+    short_description: "Dagger is an integrated platform to orchestrate the delivery of applications"
+    license: "asl20"
+    homepage: "https://dagger.io"
+    publisher_url: "https://dagger.io"
+    publisher_support_url: https://github.com/dagger/dagger/issues/new/choose
+    package_identifier: Dagger.Cli
+    use: archive
+    url_template: "https://{{ .Env.ARTEFACTS_FQDN }}/dagger/releases/{{ .Version }}/{{ .ArtifactName }}"
+    skip_upload: false
+    tags:
+      - dagger
+      - cli
+      - cicd
+
 blobs:
   - provider: s3
     region: "{{ .Env.AWS_REGION }}"

--- a/docs/current_docs/partials/_install-cli.mdx
+++ b/docs/current_docs/partials/_install-cli.mdx
@@ -75,9 +75,25 @@ dagger v0.12.6 (registry.dagger.io/engine:v0.12.6) linux/amd64
 
 <TabItem value="Windows">
 
-`dagger` can be installed on Windows via a PowerShell 7.0 script.
+You can install `dagger` on Windows using winget or PowerShell 7.0.
 
-The quickest way of installing `dagger` on Windows is to run the following command:
+<Tabs>
+
+<TabItem value="winget">
+
+Winget is the Windows package manager and is available on Windows 10 version 1809 and later.
+
+To install `dagger` using `winget`, run the following command from the Terminal:
+
+```powershell
+winget install Dagger.Cli
+```
+
+</TabItem>
+
+<TabItem value="powershell 7">
+
+To install `dagger` using PowerShell, run the following command from the PowerShell terminal:
 
 ```powershell
 Invoke-WebRequest -UseBasicParsing -Uri https://dl.dagger.io/dagger/install.ps1 | Invoke-Expression; Install-Dagger
@@ -120,6 +136,8 @@ To verify that Dagger has been installed correctly, use where.exe
 where.exe dagger
 # Expected output: C:\<your home folder>\dagger\dagger.exe
 ```
+</TabItem>
+</Tabs>
 
 </TabItem>
 


### PR DESCRIPTION
I strongly believe this would be a perfect replacement for official releases of Dagger on Windows, making the `install.ps1` a secondary option (which has the ability for Git Commit installs, or for anyone who is not having WinGet, - but WinGet is the official package manager for windows, and is basically apt-get for Windows

Attempting to solve #6441 

This seems like a more Dagger supported method for installation because:

- Its supported by existing goreleaser
- It handles the checksum
- winget allows the portable zip binary 
- It can also handle adding the install to the users PATH via an alias 
- Supports simple uninstall and upgrades of the Cli


I have used the existing package Id that was already found by someone who published the 0.9.6 to Winget, since that time, I have published later versions but it also is a common pattern with winget, Cli tools are having this `suffix`. I have also added tags which is a supported winget feature

**Note**: These versions in the screenshot did not come from goreleaser, they're previous releases from me and 1 other contributor

![image](https://github.com/dagger/dagger/assets/292720/954c3f19-01a5-477b-a334-ad5d10de4353)

Not sure how we can test the goreleaser, I'm not too familiar with that tool 

Previous releases look like this, when using the winget tool locally to publish:


`wingetcreate update --submit --urls https://dl.dagger.io/dagger/releases/0.11.7/dagger_v0.11.7_windows_amd64.zip https://dl.dagger.io/dagger/releases/0.11.7/dagger_v0.11.7_windows_arm64.zip https://dl.dagger.io/dagger/releases/0.11.7/dagger_v0.11.7_windows_armv7.zip --version 0.11.7 Dagger.Cli`

https://github.com/microsoft/winget-pkgs/pulls?q=Dagger.Cli

