### PR TITLE
ci: run sdk lint+test using dev cli+engine

### DIFF
--- a/.github/workflows/sdk-elixir.yml
+++ b/.github/workflows/sdk-elixir.yml
@@ -22,6 +22,7 @@ jobs:
     secrets: inherit
     with:
       function: sdk elixir lint
+      dev-engine: true
       timeout: 10
 
   test:
@@ -29,4 +30,5 @@ jobs:
     secrets: inherit
     with:
       function: sdk elixir test
+      dev-engine: true
       timeout: 10

--- a/.github/workflows/sdk-go.yml
+++ b/.github/workflows/sdk-go.yml
@@ -22,6 +22,7 @@ jobs:
     secrets: inherit
     with:
       function: sdk go lint
+      dev-engine: true
       timeout: 10
 
   test:
@@ -29,6 +30,7 @@ jobs:
     secrets: inherit
     with:
       function: sdk go test
+      dev-engine: true
       timeout: 10
 
   test-publish:

--- a/.github/workflows/sdk-java.yml
+++ b/.github/workflows/sdk-java.yml
@@ -22,6 +22,7 @@ jobs:
     secrets: inherit
     with:
       function: sdk java lint
+      dev-engine: true
       timeout: 10
 
   test:
@@ -29,4 +30,5 @@ jobs:
     secrets: inherit
     with:
       function: sdk java test
+      dev-engine: true
       timeout: 10

--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -22,6 +22,7 @@ jobs:
     secrets: inherit
     with:
       function: sdk python lint
+      dev-engine: true
       timeout: 10
 
   test:
@@ -29,6 +30,7 @@ jobs:
     secrets: inherit
     with:
       function: sdk python test
+      dev-engine: true
       timeout: 10
 
   test-publish:

--- a/.github/workflows/sdk-rust.yml
+++ b/.github/workflows/sdk-rust.yml
@@ -22,6 +22,7 @@ jobs:
     secrets: inherit
     with:
       function: sdk rust lint
+      dev-engine: true
       timeout: 10
 
   test:
@@ -29,4 +30,5 @@ jobs:
     secrets: inherit
     with:
       function: sdk rust test
+      dev-engine: true
       timeout: 10

--- a/.github/workflows/sdk-typescript.yml
+++ b/.github/workflows/sdk-typescript.yml
@@ -22,6 +22,7 @@ jobs:
     secrets: inherit
     with:
       function: sdk typescript lint
+      dev-engine: true
       timeout: 10
 
   test:
@@ -29,6 +30,7 @@ jobs:
     secrets: inherit
     with:
       function: sdk typescript test
+      dev-engine: true
       timeout: 10
 
   test-publish:


### PR DESCRIPTION
https://github.com/dagger/dagger/pull/7315 made some simplifications that got rid of corner cases involving overlapping nested engine OTEL spans which were causing a lot of SDK test+lint workflows to hang on OTEL draining. 

This updates those workflows to use the dev engine+cli exclusively so that they can pick up those fixes before the next release.

There's little harm in doing this now and the long term, though I do question whether we can + should just make our whole CI more consistent in whether we always exclusively use the dev engine (only *building* it from stable) or continue to have a mix of workflows.
* However, in the short term this appears to fix the problem (sdk test + lint workflows passed 5 times in a row), so seems like the right move now
* There's also quite a few tricky corner cases + potential catch 22's involved here, so need to tread cautiously on the long term approach.