### PR TITLE
ci: fix git publish (for go and php)

### DIFF
--- a/ci/sdk_go.go
+++ b/ci/sdk_go.go
@@ -174,7 +174,7 @@ func gitPublish(ctx context.Context, opts gitPublishOpts) error {
 			"push",
 			"-f",
 			opts.dest,
-			fmt.Sprintf("%s:%s", opts.sourceTag, opts.destTag),
+			fmt.Sprintf("%s:%s", tmpBranch, opts.destTag),
 		})
 	}
 	_, err := result.Sync(ctx)


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/7630.

Introduced in [`8421636` (#7554)](https://github.com/dagger/dagger/pull/7554/commits/8421636acaaa7cd312eb3546f6b3b1870090d83c).

This caused the https://github.com/dagger/dagger-go-sdk read-only copy to include the full dagger/dagger repo, instead of the filtered one.