### PR TITLE
ci: run dry-run publishing for each sdk we publish

### DIFF
--- a/.github/workflows/_sdk_check.yml
+++ b/.github/workflows/_sdk_check.yml
@@ -8,6 +8,11 @@ on:
         type: string
         required: true
 
+      test-publish:
+        description: "Whether to test-publish an SDK"
+        type: boolean
+        default: true
+
       version:
         type: string
         default: "v0.11.6"
@@ -45,7 +50,7 @@ jobs:
           dev-engine: "${{ inputs.dev-engine }}"
       - name: "${{ inputs.sdk }} test publish"
         uses: ./.github/actions/call
-        if: contains(fromJson('["go", "python", "typescript"]'), inputs.sdk)
+        if: inputs.test-publish
         with:
           function: "sdk ${{ inputs.sdk }} publish --dry-run=true --tag=$GITHUB_REF"
           version: "${{ inputs.version }}"

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -43,6 +43,7 @@ jobs:
     uses: ./.github/workflows/_sdk_check.yml
     with:
       sdk: java
+      test-publish: false # java doesn't have an automated publish step to test
       dev-engine: true
 
   elixir:

--- a/ci/sdk_rust.go
+++ b/ci/sdk_rust.go
@@ -94,10 +94,13 @@ func (r RustSDK) Publish(
 	// +optional
 	cargoRegistryToken *Secret,
 ) error {
-	var (
-		version = strings.TrimPrefix(tag, "sdk/rust/v")
-		crate   = "dagger-sdk"
-	)
+	version := strings.TrimPrefix(tag, "sdk/rust/v")
+	if dryRun {
+		// just pick any version, it's a dry-run
+		version = "--bump=rc"
+	}
+
+	crate := "dagger-sdk"
 
 	base := r.
 		rustBase(rustDockerStable).


### PR DESCRIPTION
We originally started to run these in [`9bb57fc` (#7554)](https://github.com/dagger/dagger/pull/7554/commits/9bb57fcf8f8d0141acb91b286cf35ffaf169ae05) and [`8421636` (#7554)](https://github.com/dagger/dagger/pull/7554/commits/8421636acaaa7cd312eb3546f6b3b1870090d83c), however, I only fixed the `--dry-run` publishing for python, typescript and go.

In this PR, I've fixed it for elixir and rust as well, and enabled it for those (as well as PHP). This should hopefully help to avoid future release misfortunes.