### PR TITLE
ci: make dind use with-dev

### DIFF
--- a/.github/workflows/_dagger_call.yml
+++ b/.github/workflows/_dagger_call.yml
@@ -130,7 +130,7 @@ jobs:
           DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
       - name: Waiting for Dagger Dev Engine to be ready...
         run: |
-          dagger call --help
+          ./hack/with-dev dagger call --help
       - name: Export secrets
         run: |
           echo "$SECRET_CONTEXT" | jq -r 'to_entries | .[] | "\(.key | ascii_upcase)=\(.value)"' >> $GITHUB_ENV
@@ -140,9 +140,9 @@ jobs:
         run: |
           set -x
           if [ -f $HOME/.docker/config.json ]; then
-            dagger call --source=".:default" --host-docker-config=file:"$HOME/.docker/config.json" ${{ inputs.function }}
+            ./hack/with-dev dagger call --source=".:default" --host-docker-config=file:"$HOME/.docker/config.json" ${{ inputs.function }}
           else
-            dagger call --source=".:default" ${{ inputs.function }}
+            ./hack/with-dev dagger call --source=".:default" ${{ inputs.function }}
           fi
         env:
           DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"


### PR DESCRIPTION
https://github.com/dagger/dagger/pull/7349/files#diff-57d0a87a3ee76e3f54076848756b333683e6bdb5ae34463f3a5240b04942ce0b was a bad refactor.

See https://github.com/dagger/dagger/actions/runs/9481418789/job/26124166243#step:7:36.

Since the bad refactor, we've not been actually running the testdev tests in the dev container - we've been using the top-level one.

https://github.com/dagger/dagger/pull/7483 will replace the need for this.