### PR TITLE
engine: update minimum engine+client version

### DIFF
--- a/engine/version.go
+++ b/engine/version.go
@@ -19,11 +19,11 @@ var (
 
 	// MinimumEngineVersion is used by the client to determine the minimum
 	// allowed engine version that can be used by that client.
-	MinimumEngineVersion = "v0.11.7"
+	MinimumEngineVersion = "v0.11.8"
 
 	// MinimumClientVersion is used by the engine to determine the minimum
 	// allowed client version that can connect to that engine.
-	MinimumClientVersion = "v0.11.7"
+	MinimumClientVersion = "v0.11.8"
 )
 
 func init() {


### PR DESCRIPTION
[PR 7315](https://github.com/dagger/dagger/pull/7315) that reworked how sessions connect breaks client-server compat, mainly because the engine API is now just HTTP rather than gRPC-tunneled HTTP, so we need to update the min compatible versions.