### PR TITLE
Use dynamically sized dind runners for SDK and testdev

### DIFF
--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -65,15 +65,17 @@ runs:
           echo "docker is not installed"
           exit 1
         fi
-        ./hack/dev
 
-        # put env variables in /tmp/actions/call/local-envs instead of $GITHUB_ENV to avoid
-        # leaking into parent workflow
-        echo "export PATH=$PWD/bin:$PATH" >> /tmp/actions/call/local-envs
-        echo "export _EXPERIMENTAL_DAGGER_CLI_BIN=$PWD/bin/dagger" >> /tmp/actions/call/local-envs
-        echo "export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev" >> /tmp/actions/call/local-envs
+        # put env variables in /tmp/actions/call/local-envs instead of
+        # $GITHUB_ENV to avoid leaking into parent workflow
+        (cd ci/mage; go run main.go -w ../.. engine:dev) | tee /tmp/actions/call/local-envs
 
         echo "::endgroup::"
+      env:
+        # create separate outputs and containers for each workflow (to prevent
+        # collisions with shared docker containers)
+        _EXPERIMENTAL_DAGGER_DEV_OUTPUT: ./bin/dev-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-${{ github.job }}
+        _EXPERIMENTAL_DAGGER_DEV_CONTAINER: dagger-engine.dev-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-${{ github.job }}
 
     - name: Wait for dagger to be ready
       shell: bash

--- a/.github/workflows/_sdk_check.yml
+++ b/.github/workflows/_sdk_check.yml
@@ -32,7 +32,7 @@ on:
 
 jobs:
   check:
-    runs-on: "${{ github.repository == 'dagger/dagger' && (inputs.dev-engine && 'dagger-v0-11-8-dind' || 'dagger-v0-11-8-4c-nvme') || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && (inputs.dev-engine && 'dagger-v0-11-8-8c-dind' || 'dagger-v0-11-8-4c-nvme') || 'ubuntu-latest' }}"
     timeout-minutes: "${{ inputs.timeout }}"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -49,7 +49,7 @@ jobs:
   # Only run a subset of important test cases since we just need to verify basic
   # functionality rather than repeat every test already run in the other targets.
   testdev:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-8-dind' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-8-32c-dind' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/ci/mage/engine.go
+++ b/ci/mage/engine.go
@@ -16,10 +16,29 @@ import (
 	"github.com/dagger/dagger/engine/distconsts"
 )
 
+var (
+	OutputDir           = ""
+	EngineContainerName = "dagger-engine.dev"
+)
+
+func init() {
+	if v, ok := os.LookupEnv(util.DevContainerEnvName); ok {
+		EngineContainerName = v
+	}
+	if v, ok := os.LookupEnv(util.DevOutputEnvName); ok {
+		OutputDir = v
+	}
+}
+
 type Engine mg.Namespace
 
 // Dev builds and starts an Engine & CLI from local source code
 func (t Engine) Dev(ctx context.Context) error {
+	binDir := OutputDir
+	if binDir == "" {
+		binDir = filepath.Join(os.Getenv("DAGGER_SRC_ROOT"), "bin")
+	}
+
 	gpuSupport := os.Getenv(util.GPUSupportEnvName) != ""
 	trace := os.Getenv(util.TraceEnvName) != ""
 	race := os.Getenv(util.RaceEnvName) != ""
@@ -34,7 +53,7 @@ func (t Engine) Dev(ctx context.Context) error {
 	if race {
 		args = append(args, "with-race")
 	}
-	tarPath := "./bin/engine.tar"
+	tarPath := filepath.Join(binDir, "engine.tar")
 	args = append(args, "container", "export", "--path="+tarPath)
 	args = append(args, "--forced-compression=Gzip") // use gzip to avoid incompatibility w/ older docker versions
 	err := util.DaggerCall(ctx, args...)
@@ -42,8 +61,9 @@ func (t Engine) Dev(ctx context.Context) error {
 		return err
 	}
 
-	volumeName := util.EngineContainerName
-	imageName := fmt.Sprintf("localhost/%s:latest", util.EngineContainerName)
+	containerName := EngineContainerName
+	volumeName := EngineContainerName
+	imageName := fmt.Sprintf("localhost/%s:latest", EngineContainerName)
 
 	// #nosec
 	loadCmd := exec.CommandContext(ctx, "docker", "load", "-i", tarPath)
@@ -68,11 +88,10 @@ func (t Engine) Dev(ctx context.Context) error {
 		return fmt.Errorf("docker tag %s %s: %w: %s", imageID, imageName, err, output)
 	}
 
-	//nolint:gosec
 	if output, err := exec.CommandContext(ctx, "docker",
 		"rm",
 		"-fv",
-		util.EngineContainerName,
+		containerName,
 	).CombinedOutput(); err != nil {
 		return fmt.Errorf("docker rm: %w: %s", err, output)
 	}
@@ -92,8 +111,8 @@ func (t Engine) Dev(ctx context.Context) error {
 		"-e", "DAGGER_CLOUD_URL",
 		"-e", util.GPUSupportEnvName,
 		"-v", volumeName + ":" + distconsts.EngineDefaultStateDir,
-		"-p", "6060:6060",
-		"--name", util.EngineContainerName,
+		// "-p", "6060:6060",
+		"--name", containerName,
 		"--privileged",
 	}...)
 
@@ -104,7 +123,7 @@ func (t Engine) Dev(ctx context.Context) error {
 	}
 
 	// build the CLI and export locally so it can be used to connect to the Engine
-	binDest := filepath.Join(os.Getenv("DAGGER_SRC_ROOT"), "bin", "dagger")
+	binDest := filepath.Join(binDir, "dagger")
 	if runtime.GOOS == "windows" {
 		binDest += ".exe"
 	}
@@ -116,6 +135,27 @@ func (t Engine) Dev(ctx context.Context) error {
 	}
 
 	fmt.Println("export _EXPERIMENTAL_DAGGER_CLI_BIN=" + binDest)
-	fmt.Println("export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://" + util.EngineContainerName)
+	fmt.Println("export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://" + containerName)
+	fmt.Println("export _DAGGER_TESTS_ENGINE_TAR=" + filepath.Join(binDir, "engine.tar"))
+	fmt.Println("export PATH=" + binDir + ":$PATH")
+
 	return nil
+}
+
+// Get environment variable updates for running dagger
+func (t Engine) DevEnv(ctx context.Context) {
+	binDir := OutputDir
+	if binDir == "" {
+		binDir = filepath.Join(os.Getenv("DAGGER_SRC_ROOT"), "bin")
+	}
+
+	binDest := filepath.Join(binDir, "dagger")
+	if runtime.GOOS == "windows" {
+		binDest += ".exe"
+	}
+
+	fmt.Println("export _EXPERIMENTAL_DAGGER_CLI_BIN=" + binDest)
+	fmt.Println("export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://" + EngineContainerName)
+	fmt.Println("export _DAGGER_TESTS_ENGINE_TAR=" + filepath.Join(binDir, "engine.tar"))
+	fmt.Println("export PATH=" + binDir + ":$PATH")
 }

--- a/ci/mage/util/const.go
+++ b/ci/mage/util/const.go
@@ -1,7 +1,8 @@
 package util
 
 const (
-	EngineContainerName = "dagger-engine.dev"
+	DevContainerEnvName = "_EXPERIMENTAL_DAGGER_DEV_CONTAINER"
+	DevOutputEnvName    = "_EXPERIMENTAL_DAGGER_DEV_OUTPUT"
 
 	CacheConfigEnvName = "_EXPERIMENTAL_DAGGER_CACHE_CONFIG"
 	GPUSupportEnvName  = "_EXPERIMENTAL_DAGGER_GPU_SUPPORT"

--- a/ci/mage/util/dagger.go
+++ b/ci/mage/util/dagger.go
@@ -24,9 +24,9 @@ func DaggerCall(ctx context.Context, args ...string) error {
 	cmd.Args = append(cmd.Args, args...)
 
 	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
+	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
-	fmt.Println(">", strings.Join(cmd.Args, " "))
+	fmt.Fprintln(os.Stderr, ">", strings.Join(cmd.Args, " "))
 	return cmd.Run()
 }
 

--- a/hack/dev
+++ b/hack/dev
@@ -1,19 +1,12 @@
 #!/usr/bin/env bash
 
-set -e -u -x
+set -e -u
 
-DAGGER_SRC_ROOT="$(cd $(dirname $(realpath "${BASH_SOURCE[0]}"))/.. && pwd)"
-MAGEDIR="$DAGGER_SRC_ROOT/ci/mage"
+export DAGGER_SRC_ROOT="$(cd $(dirname $(realpath "${BASH_SOURCE[0]}"))/.. && pwd)"
+export MAGEDIR="$DAGGER_SRC_ROOT/ci/mage"
 
 pushd $MAGEDIR
-go run main.go -w $DAGGER_SRC_ROOT engine:dev
+eval $(go run main.go -w $DAGGER_SRC_ROOT engine:dev)
 popd
-
-export _EXPERIMENTAL_DAGGER_CLI_BIN=$DAGGER_SRC_ROOT/bin/dagger
-export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev
-export _DAGGER_TESTS_ENGINE_TAR=$DAGGER_SRC_ROOT/bin/engine.tar
-
-# support ./hack/dev dagger run foo
-export PATH=$DAGGER_SRC_ROOT/bin:$PATH
 
 exec "$@"

--- a/hack/with-dev
+++ b/hack/with-dev
@@ -2,12 +2,11 @@
 
 set -e -u
 
-DAGGER_SRC_ROOT="$(cd $(dirname $(realpath "${BASH_SOURCE[0]}"))/.. && pwd)"
+export DAGGER_SRC_ROOT="$(cd $(dirname $(realpath "${BASH_SOURCE[0]}"))/.. && pwd)"
+export MAGEDIR="$DAGGER_SRC_ROOT/ci/mage"
 
-export _EXPERIMENTAL_DAGGER_CLI_BIN=$DAGGER_SRC_ROOT/bin/dagger
-export _EXPERIMENTAL_DAGGER_RUNNER_HOST=docker-container://dagger-engine.dev
-export _DAGGER_TESTS_ENGINE_TAR=$DAGGER_SRC_ROOT/bin/engine.tar
-
-export PATH=$DAGGER_SRC_ROOT/bin:$PATH
+pushd $MAGEDIR
+eval $(go run main.go -w $DAGGER_SRC_ROOT engine:devenv)
+popd
 
 exec "$@"


### PR DESCRIPTION
As was discussed [here](https://github.com/dagger/dagger/pull/7483#discussion_r1636854755), since [#7628](https://github.com/dagger/dagger/pull/7628) got merged we are using dind runners for SDK jobs. Default dind runners have 32c and 16Gi, which for SDK jobs is excessive. Since we now have support for dynamically sized dind runners, we migrate SDK jobs to 4c (like we used to run it) and we leave testdev with 32c jobs.