### PR TITLE
Fix invalid dagger develop command

### DIFF
--- a/docs/current_docs/manuals/developer/module-structure.mdx
+++ b/docs/current_docs/manuals/developer/module-structure.mdx
@@ -119,7 +119,7 @@ A new Dagger module is initialized by calling `dagger init`. This creates a new 
 Once a module is initialized, `dagger develop --sdk=...` sets up or updates all the resources needed to develop the module locally. By default, the module source code will be stored in a directory named `dagger`, unless an alternative is specified with the `--source` argument.
 
 :::info
-At any point, running `dagger develop...` regenerates the module's code based on dependencies and the current state of the module.
+At any point, running `dagger develop ...` regenerates the module's code based on dependencies and the current state of the module.
 :::
 
 <Tabs groupId="language">

--- a/docs/current_docs/manuals/developer/module-structure.mdx
+++ b/docs/current_docs/manuals/developer/module-structure.mdx
@@ -119,7 +119,7 @@ A new Dagger module is initialized by calling `dagger init`. This creates a new 
 Once a module is initialized, `dagger develop --sdk=...` sets up or updates all the resources needed to develop the module locally. By default, the module source code will be stored in a directory named `dagger`, unless an alternative is specified with the `--source` argument.
 
 :::info
-At any point, running `dagger develop ...` regenerates the module's code based on dependencies and the current state of the module.
+At any point, running `dagger develop` regenerates the module's code based on dependencies and the current state of the module.
 :::
 
 <Tabs groupId="language">


### PR DESCRIPTION
The command is invalid, and I suspect it's missing a space.

```
❯ dagger develop...
Error: unknown command "develop..." for "dagger"
```