### PR TITLE
feat: improve license generation

### DIFF
--- a/.changes/unreleased/Added-20240613-221441.yaml
+++ b/.changes/unreleased/Added-20240613-221441.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Generate license only if code has been generated
+time: 2024-06-13T22:14:41.883445+02:00
+custom:
+  Author: TomChv
+  PR: "7658"

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -162,8 +162,12 @@ The "--source" flag allows controlling the directory in which the actual module 
 				return fmt.Errorf("failed to generate code: %w", err)
 			}
 
-			if err := findOrCreateLicense(ctx, modConf.LocalRootSourcePath); err != nil {
-				return err
+			if sdk != "" {
+				// If we're generating code by setting a SDK, we should also generate a license
+				// if it doesn't already exists.
+				if err := findOrCreateLicense(ctx, modConf.LocalRootSourcePath); err != nil {
+					return err
+				}
 			}
 
 			fmt.Fprintln(cmd.OutOrStdout(), "Initialized module", moduleName, "in", srcRootPath)
@@ -374,6 +378,11 @@ If not updating source or SDK, this is only required for IDE auto-completion/LSP
 				Export(ctx, modConf.LocalContextPath)
 			if err != nil {
 				return fmt.Errorf("failed to generate code: %w", err)
+			}
+
+			// If no license has been created yet, we should create one.
+			if err := findOrCreateLicense(ctx, modConf.LocalRootSourcePath); err != nil {
+				return err
 			}
 
 			return nil

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -479,6 +479,29 @@ func TestModuleInitLICENSE(t *testing.T) {
 		require.Contains(t, content, "Apache License, Version 2.0")
 	})
 
+	t.Run("do not bootstrap LICENSE file if no sdk is specified", func(t *testing.T) {
+		t.Parallel()
+
+		c, ctx := connect(t)
+
+		modGen := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work").
+			With(daggerExec("init", "--name=no-license"))
+
+		content, err := modGen.Directory(".").Entries(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, content, "LICENSE")
+
+		t.Run("bootstrap a license after sdk is set on dagger develop", func(t *testing.T) {
+			modGen = modGen.With(daggerExec("develop", "--sdk=go"))
+
+			content, err := modGen.File("LICENSE").Contents(ctx)
+			require.NoError(t, err)
+			require.Contains(t, content, "Apache License, Version 2.0")
+		})
+	})
+
 	t.Run("creates LICENSE file in the directory specified by arg", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
This changes the  `dagger init` command to  not generate `LICENSE` if no code has been generated (when `--sdk`) is not specified.

It also generates a license if then `dagger develop` is executed with `--sdk` flag.

Fixes #6666
Close DEV-3989