### PR TITLE
fix(sdk/elixir): fix runtime image cannot run on arm64

### DIFF
--- a/sdk/elixir/.changes/unreleased/Fixed-20240614-092810.yaml
+++ b/sdk/elixir/.changes/unreleased/Fixed-20240614-092810.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fix runtime broken on aarch64 machine
+time: 2024-06-14T09:28:10.112453764+07:00
+custom:
+    Author: wingyplus
+    PR: "7661"

--- a/sdk/elixir/runtime/main.go
+++ b/sdk/elixir/runtime/main.go
@@ -12,7 +12,7 @@ const (
 	sdkSrc           = "/sdk"
 	genDir           = "dagger_sdk"
 	schemaPath       = "/schema.json"
-	elixirImage      = "hexpm/elixir:1.16.2-erlang-26.2.4-debian-bookworm-20240423-slim@sha256:279f65ecc3e57a683362e62a46fcfb502ea156b0de76582c2f8e5cdccccbdd54"
+	elixirImage      = "hexpm/elixir:1.16.3-erlang-26.2.5-debian-bookworm-20240612-slim@sha256:5aed25e4525ae7a5c96a8a880673bcc66d99b6f2a590161e42c8370fbebc4235"
 )
 
 func New(


### PR DESCRIPTION
I found out that Elixir runtime cannot run on my Apple M1 machine and realize that the image in Elixir runtime has only amd64 architecture. :(
 
So I do fix by bump image to a new version that have both amd64 and aarch64 architectures.