### PR TITLE
chore/fix(core): add integration tests to other VCS

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5217,15 +5217,16 @@ func (m *Test) Fn() string {
 		require.Equal(t, "true", strings.TrimSpace(out))
 	})
 
-	t.Run("git", func(ctx context.Context, t *testctx.T) {
-		c := connect(ctx, t)
+	testOnMultipleVCS(t, func(ctx context.Context, t *testctx.T, tc vcsTestCase) {
+		t.Run("git", func(ctx context.Context, t *testctx.T) {
+			c := connect(ctx, t)
 
-		ctr := c.Container().From(golangImage).
-			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
-			WithWorkdir("/work").
-			With(daggerExec("init", "--source=.", "--name=test", "--sdk="+testGitModuleRef("cool-sdk"))).
-			WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
-				Contents: `package main
+			ctr := c.Container().From(golangImage).
+				WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+				WithWorkdir("/work").
+				With(daggerExec("init", "--source=.", "--name=test", "--sdk="+testGitModuleRef(tc, "cool-sdk"))).
+				WithNewFile("main.go", dagger.ContainerWithNewFileOpts{
+					Contents: `package main
 
 import "os"
 
@@ -5235,14 +5236,15 @@ func (m *Test) Fn() string {
 	return os.Getenv("COOL")
 }
 `,
-			})
+				})
 
-		out, err := ctr.
-			With(daggerCall("fn")).
-			Stdout(ctx)
+			out, err := ctr.
+				With(daggerCall("fn")).
+				Stdout(ctx)
 
-		require.NoError(t, err)
-		require.Equal(t, "true", strings.TrimSpace(out))
+			require.NoError(t, err)
+			require.Equal(t, "true", strings.TrimSpace(out))
+		})
 	})
 }
 

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -447,11 +448,17 @@ func (src *GitModuleSource) Symbolic() string {
 }
 
 func (src *GitModuleSource) HTMLURL() string {
-	u := "https://" + src.Root + "/tree/" + src.Commit
-	if subPath := src.RootSubpath; subPath != "" {
-		u += "/" + subPath
+	parsedURL, err := url.Parse(src.CloneURL)
+	if err != nil {
+		return src.CloneURL + path.Join("/src", src.Commit, src.RootSubpath)
 	}
-	return u
+
+	pathPrefix := "/src"
+	if parsedURL.Host == "github.com" || parsedURL.Host == "gitlab.com" {
+		pathPrefix = "/tree"
+	}
+
+	return src.CloneURL + path.Join(pathPrefix, src.Commit, src.RootSubpath)
 }
 
 type ModuleSourceView struct {

--- a/core/schema/modulesource_test.go
+++ b/core/schema/modulesource_test.go
@@ -42,7 +42,7 @@ func TestParsePublicRefString(t *testing.T) {
 			want: &parsedRefString{
 				modPath:        "github.com/shykes/daggerverse.git/ci",
 				kind:           core.ModuleSourceKindGit,
-				repoRoot:       &vcs.RepoRoot{Root: "github.com/shykes/daggerverse.git", Repo: "https://github.com/shykes/daggerverse.git"},
+				repoRoot:       &vcs.RepoRoot{Root: "github.com/shykes/daggerverse.git", Repo: "https://github.com/shykes/daggerverse"},
 				repoRootSubdir: "ci",
 			},
 		},
@@ -51,7 +51,7 @@ func TestParsePublicRefString(t *testing.T) {
 			want: &parsedRefString{
 				modPath:        "github.com/shykes/daggerverse.git/../../",
 				kind:           core.ModuleSourceKindGit,
-				repoRoot:       &vcs.RepoRoot{Root: "github.com/shykes/daggerverse.git", Repo: "https://github.com/shykes/daggerverse.git"},
+				repoRoot:       &vcs.RepoRoot{Root: "github.com/shykes/daggerverse.git", Repo: "https://github.com/shykes/daggerverse"},
 				repoRootSubdir: "../../",
 			},
 		},
@@ -61,7 +61,7 @@ func TestParsePublicRefString(t *testing.T) {
 			want: &parsedRefString{
 				modPath:        "gitlab.com/testguigui1/dagger-public-sub/mywork/depth1/depth2",
 				kind:           core.ModuleSourceKindGit,
-				repoRoot:       &vcs.RepoRoot{Root: "gitlab.com/testguigui1/dagger-public-sub/mywork", Repo: "https://gitlab.com/testguigui1/dagger-public-sub/mywork.git"},
+				repoRoot:       &vcs.RepoRoot{Root: "gitlab.com/testguigui1/dagger-public-sub/mywork", Repo: "https://gitlab.com/testguigui1/dagger-public-sub/mywork"},
 				repoRootSubdir: "depth1/depth2",
 			},
 		},
@@ -89,7 +89,7 @@ func TestParsePublicRefString(t *testing.T) {
 			want: &parsedRefString{
 				modPath:        "bitbucket.org/test-travail/test.git/depth1",
 				kind:           core.ModuleSourceKindGit,
-				repoRoot:       &vcs.RepoRoot{Root: "bitbucket.org/test-travail/test.git", Repo: "https://bitbucket.org/test-travail/test.git"},
+				repoRoot:       &vcs.RepoRoot{Root: "bitbucket.org/test-travail/test.git", Repo: "https://bitbucket.org/test-travail/test"},
 				repoRootSubdir: "depth1",
 			},
 		},

--- a/engine/vcs/vcs_test.go
+++ b/engine/vcs/vcs_test.go
@@ -31,13 +31,15 @@ func TestRepoRootForImportPath(t *testing.T) {
 			&RepoRoot{
 				VCS:  vcsGit,
 				Repo: "https://github.com/golang/groupcache",
+				Root: "github.com/golang/groupcache",
 			},
 		},
 		{
 			"github.com/golang/groupcache.git/foo",
 			&RepoRoot{
 				VCS:  vcsGit,
-				Repo: "https://github.com/golang/groupcache.git",
+				Repo: "https://github.com/golang/groupcache",
+				Root: "github.com/golang/groupcache.git",
 			},
 		},
 		{
@@ -45,6 +47,7 @@ func TestRepoRootForImportPath(t *testing.T) {
 			&RepoRoot{
 				VCS:  vcsGit,
 				Repo: "https://github.com/dagger/dagger-test-modules",
+				Root: "github.com/dagger/dagger-test-modules",
 			},
 		},
 		{
@@ -52,6 +55,7 @@ func TestRepoRootForImportPath(t *testing.T) {
 			&RepoRoot{
 				VCS:  vcsGit,
 				Repo: "https://github.com/dagger/dagger-test-modules",
+				Root: "github.com/dagger/dagger-test-modules",
 			},
 		},
 		// Unicode letters are allowed in import paths.
@@ -61,6 +65,7 @@ func TestRepoRootForImportPath(t *testing.T) {
 			&RepoRoot{
 				VCS:  vcsGit,
 				Repo: "https://github.com/user/unicode",
+				Root: "github.com/user/unicode",
 			},
 		},
 		// IBM DevOps Services tests
@@ -69,6 +74,7 @@ func TestRepoRootForImportPath(t *testing.T) {
 			&RepoRoot{
 				VCS:  vcsGit,
 				Repo: "https://hub.jazz.net/git/user1/pkgname",
+				Root: "hub.jazz.net/git/user1/pkgname",
 			},
 		},
 		{
@@ -76,6 +82,7 @@ func TestRepoRootForImportPath(t *testing.T) {
 			&RepoRoot{
 				VCS:  vcsGit,
 				Repo: "https://hub.jazz.net/git/user1/pkgname",
+				Root: "hub.jazz.net/git/user1/pkgname",
 			},
 		},
 		// Trailing .git is less preferred but included for
@@ -86,6 +93,7 @@ func TestRepoRootForImportPath(t *testing.T) {
 			&RepoRoot{
 				VCS:  vcsGit,
 				Repo: "https://git.openstack.org/openstack/swift.git",
+				Root: "git.openstack.org/openstack/swift.git",
 			},
 		},
 		{
@@ -93,6 +101,7 @@ func TestRepoRootForImportPath(t *testing.T) {
 			&RepoRoot{
 				VCS:  vcsGit,
 				Repo: "https://git.openstack.org/openstack/swift",
+				Root: "git.openstack.org/openstack/swift",
 			},
 		},
 		{
@@ -100,6 +109,7 @@ func TestRepoRootForImportPath(t *testing.T) {
 			&RepoRoot{
 				VCS:  vcsGit,
 				Repo: "https://git.apache.org/package-name.git",
+				Root: "git.apache.org/package-name.git",
 			},
 		},
 		{
@@ -107,6 +117,7 @@ func TestRepoRootForImportPath(t *testing.T) {
 			&RepoRoot{
 				VCS:  vcsGit,
 				Repo: "https://git.apache.org/package-name_2.x.git",
+				Root: "git.apache.org/package-name_2.x.git",
 			},
 		},
 		{
@@ -114,6 +125,7 @@ func TestRepoRootForImportPath(t *testing.T) {
 			&RepoRoot{
 				VCS:  vcsGit,
 				Repo: "https://git.sr.ht/~jacqueline/tangara-fw",
+				Root: "git.sr.ht/~jacqueline/tangara-fw",
 			},
 		},
 		// { FAILS as returns 404 without tags
@@ -128,6 +140,7 @@ func TestRepoRootForImportPath(t *testing.T) {
 			&RepoRoot{
 				VCS:  vcsGit,
 				Repo: "https://bitbucket.org/workspace/pkgname",
+				Root: "bitbucket.org/workspace/pkgname",
 			},
 		},
 		{
@@ -135,6 +148,7 @@ func TestRepoRootForImportPath(t *testing.T) {
 			&RepoRoot{
 				VCS:  vcsGit,
 				Repo: "https://bitbucket.org/workspace/pkgname",
+				Root: "bitbucket.org/workspace/pkgname",
 			},
 		},
 		{
@@ -142,13 +156,15 @@ func TestRepoRootForImportPath(t *testing.T) {
 			&RepoRoot{
 				VCS:  vcsGit,
 				Repo: "https://bitbucket.org/workspace/pkgname",
+				Root: "bitbucket.org/workspace/pkgname",
 			},
 		},
 		{
 			"bitbucket.org/workspace/pkgname.git",
 			&RepoRoot{
 				VCS:  vcsGit,
-				Repo: "https://bitbucket.org/workspace/pkgname.git",
+				Repo: "https://bitbucket.org/workspace/pkgname",
+				Root: "bitbucket.org/workspace/pkgname.git",
 			},
 		},
 		// GitLab public repo
@@ -156,14 +172,16 @@ func TestRepoRootForImportPath(t *testing.T) {
 			"gitlab.com/testguigui1/dagger-public-sub/mywork/depth1/depth2",
 			&RepoRoot{
 				VCS:  vcsGit,
-				Repo: "https://gitlab.com/testguigui1/dagger-public-sub/mywork.git",
+				Repo: "https://gitlab.com/testguigui1/dagger-public-sub/mywork",
+				Root: "gitlab.com/testguigui1/dagger-public-sub/mywork",
 			},
 		},
 		{
-			"gitlab.com/testguigui1/dagger-public-sub/mywork/depth1/depth2",
+			"gitlab.com/testguigui1/dagger-public-sub/mywork.git/depth1/depth2",
 			&RepoRoot{
 				VCS:  vcsGit,
-				Repo: "https://gitlab.com/testguigui1/dagger-public-sub/mywork.git",
+				Repo: "https://gitlab.com/testguigui1/dagger-public-sub/mywork",
+				Root: "gitlab.com/testguigui1/dagger-public-sub/mywork.git",
 			},
 		},
 		// GitLab private repo
@@ -190,6 +208,7 @@ func TestRepoRootForImportPath(t *testing.T) {
 			&RepoRoot{
 				VCS:  vcsGit,
 				Repo: "https://github.com/dagger/dagger-go-sdk",
+				Root: "dagger.io/dagger",
 			},
 		},
 		{
@@ -197,6 +216,7 @@ func TestRepoRootForImportPath(t *testing.T) {
 			&RepoRoot{
 				VCS:  vcsGit,
 				Repo: "https://bitbucket.org/workspace/pkgname",
+				Root: "bitbucket.org/workspace/pkgname",
 			},
 		},
 		{
@@ -204,6 +224,7 @@ func TestRepoRootForImportPath(t *testing.T) {
 			&RepoRoot{
 				VCS:  vcsGit,
 				Repo: "https://codeberg.org/workspace/pkgname",
+				Root: "codeberg.org/workspace/pkgname",
 			},
 		},
 	}


### PR DESCRIPTION
This extends the integration tests to other VCS.

To do so, it relies on a mirror of dagger-module-tests:
- https://gitlab.com/dagger-modules/test/more/dagger-test-modules-public (auto-sync to-be-done)
- https://bitbucket.org/dagger-modules/dagger-test-modules-public/
(more could be added over time, but most use provider behavior is contained in GitHub, GitLab and Bitbucket)

Current implementation extends the test suite, fixes a few inconsistencies around the VCS URL (URL should almost never contain the .git if present in the ref, as providers do not like them).

It also contains a naive change `HTMLURL()` to make it compatible with all VCS. I wonder if we should not add an enum field representing the VCS inside the `gitSourceModule` type, what do you all think ? 

Now, all integration test needed to run against GitHub should be run against vcsTests, with a helper function provided for ease of testing: [testOnMultipleVCS](https://github.com/dagger/dagger/pull/7663/files#diff-2f09d96afa5c2fcd508142d24e636c3d7555c89f8e06bfafaecc0c0f1c94e83cR1250)

⚠️ This increases the integration test suite time linearly (with cache though)


TODO (guillaume), but non blocking:
- [ ] Add automatic syncing (followup PR on both repo, after private repo support is done)