### PR TITLE
ci: use legacy iptables instead of nf_tables

### DIFF
--- a/ci/build/builder.go
+++ b/ci/build/builder.go
@@ -163,13 +163,17 @@ func (build *Builder) Engine(ctx context.Context) (*dagger.Container, error) {
 				// for Buildkit
 				"git", "openssh", "pigz", "xz",
 				// for CNI
-				"dnsmasq",
+				"dnsmasq", "iptables", "ip6tables", "iptables-legacy",
 			}).
-			WithExec([]string{
-				"apk", "add",
-				"-X", "https://dl-cdn.alpinelinux.org/alpine/v3.18/main",
-				"iptables=1.8.9-r2", "ip6tables=1.8.9-r2",
-			}).
+			WithExec([]string{"sh", "-c", `
+				set -e
+				ln -s /sbin/iptables-legacy /usr/sbin/iptables
+				ln -s /sbin/iptables-legacy-save /usr/sbin/iptables-save
+				ln -s /sbin/iptables-legacy-restore /usr/sbin/iptables-restore
+				ln -s /sbin/ip6tables-legacy /usr/sbin/ip6tables
+				ln -s /sbin/ip6tables-legacy-save /usr/sbin/ip6tables-save
+				ln -s /sbin/ip6tables-legacy-restore /usr/sbin/ip6tables-restore
+			`}).
 			WithoutEnvVariable("DAGGER_APK_CACHE_BUSTER")
 	case "ubuntu":
 		base = dag.Container(dagger.ContainerOpts{Platform: build.platform}).

--- a/ci/build/builder.go
+++ b/ci/build/builder.go
@@ -163,7 +163,12 @@ func (build *Builder) Engine(ctx context.Context) (*dagger.Container, error) {
 				// for Buildkit
 				"git", "openssh", "pigz", "xz",
 				// for CNI
-				"iptables", "ip6tables", "dnsmasq",
+				"dnsmasq",
+			}).
+			WithExec([]string{
+				"apk", "add",
+				"-X", "https://dl-cdn.alpinelinux.org/alpine/v3.18/main",
+				"iptables=1.8.9-r2", "ip6tables=1.8.9-r2",
 			}).
 			WithoutEnvVariable("DAGGER_APK_CACHE_BUSTER")
 	case "ubuntu":
@@ -176,6 +181,14 @@ func (build *Builder) Engine(ctx context.Context) (*dagger.Container, error) {
 				"apt-get", "install", "-y",
 				"iptables", "git", "dnsmasq-base", "network-manager",
 				"gpg", "curl",
+			}).
+			WithExec([]string{
+				"update-alternatives",
+				"--set", "iptables", "/usr/sbin/iptables-legacy",
+			}).
+			WithExec([]string{
+				"update-alternatives",
+				"--set", "ip6tables", "/usr/sbin/ip6tables-legacy",
 			}).
 			WithoutEnvVariable("DAGGER_APT_CACHE_BUSTER")
 	case "wolfi":


### PR DESCRIPTION
the v0.11.7 release bumped the base images that the engine uses which
caused a newer version of iptables to be used. This newer version of
iptables which uses nftables is still not widely supported and it's
currently causing issues for some users.

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>

cc @iximiuz 

ref: https://discord.com/channels/707636530424053791/1251537699903639623
