### PR TITLE
tui: navigation, scrolling, optimizations

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -305,6 +305,9 @@ func main() {
 		ctx, span := Tracer().Start(ctx, strings.Join(os.Args, " "))
 		defer telemetry.End(span, func() error { return rerr })
 
+		// Set up global slog to log to the primary span output.
+		slog.SetDefault(slog.SpanLogger(ctx, InstrumentationLibrary))
+
 		// Set the span as the primary span for the frontend.
 		Frontend.SetPrimary(span.SpanContext().SpanID())
 

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -322,6 +322,8 @@ func main() {
 		var exit ExitError
 		if errors.As(err, &exit) {
 			os.Exit(exit.Code)
+		} else if errors.Is(err, context.Canceled) {
+			os.Exit(2)
 		} else {
 			fmt.Fprintln(os.Stderr, rootCmd.ErrPrefix(), err)
 			os.Exit(1)

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -50,7 +50,7 @@ var (
 	workdir string
 
 	debug     bool
-	verbosity int
+	verbosity int = idtui.DefaultVerbosity
 	silent    bool
 	progress  string
 
@@ -242,9 +242,12 @@ func main() {
 	parseGlobalFlags()
 
 	opts := idtui.FrontendOpts{
-		Debug:     debug,
-		Silent:    silent,
-		Verbosity: verbosity,
+		Debug:  debug,
+		Silent: silent,
+
+		// NOTE: the verbosity flag is actually a delta to apply to the
+		// internal default verbosity level
+		Verbosity: idtui.DefaultVerbosity + verbosity,
 	}
 
 	if progress == "auto" {

--- a/dagql/idtui/db.go
+++ b/dagql/idtui/db.go
@@ -134,7 +134,7 @@ func (db *DB) SetPrimarySpan(span trace.SpanID) {
 	db.PrimarySpan = span
 }
 
-func (db *DB) maybeRecordSpan(traceData *Trace, span sdktrace.ReadOnlySpan) {
+func (db *DB) maybeRecordSpan(traceData *Trace, span sdktrace.ReadOnlySpan) { //nolint: gocyclo
 	spanID := span.SpanContext().SpanID()
 
 	spanData, found := db.Spans[spanID]

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -224,7 +224,7 @@ func (r renderer) renderCall(
 	return nil
 }
 
-func (r renderer) renderVertex(
+func (r renderer) renderSpan(
 	out *termenv.Output,
 	span *Span,
 	name string,

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -403,11 +403,7 @@ func (opts FrontendOpts) ShouldShow(tree *TraceTree) bool {
 		// show errors
 		return true
 	}
-	if opts.TooFastThreshold > 0 && span.Duration() < opts.TooFastThreshold && opts.Verbosity < ShowSpammyVerbosity {
-		// TODO(vito): bring this back
-		// if tree.Parent != nil && tree.Parent.Span.SpanContext().SpanID() != opts.PrimarySpan {
-		// 	return false
-		// }
+	if tree.Parent != nil && (opts.TooFastThreshold > 0 && span.Duration() < opts.TooFastThreshold && opts.Verbosity < ShowSpammyVerbosity) {
 		// ignore fast steps; signal:noise is too poor
 		return false
 	}

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -108,7 +108,7 @@ func (r renderer) indent(out io.Writer, depth int) {
 	fmt.Fprint(out, strings.Repeat("  ", depth))
 }
 
-func (r renderer) renderIDBase(out *termenv.Output, call *callpbv1.Call) error {
+func (r renderer) renderIDBase(out *termenv.Output, call *callpbv1.Call) {
 	typeName := call.Type.ToAST().Name()
 	parent := out.String(typeName)
 	if call.Module != nil {
@@ -118,7 +118,6 @@ func (r renderer) renderIDBase(out *termenv.Output, call *callpbv1.Call) error {
 	if r.Verbosity > 2 && call.ReceiverDigest != "" {
 		fmt.Fprint(out, out.String(fmt.Sprintf("@%s", call.ReceiverDigest)).Foreground(faintColor))
 	}
-	return nil
 }
 
 func (r renderer) renderCall(
@@ -147,9 +146,7 @@ func (r renderer) renderCall(
 	}
 
 	if call.ReceiverDigest != "" {
-		if err := r.renderIDBase(out, r.db.MustCall(call.ReceiverDigest)); err != nil {
-			return err
-		}
+		r.renderIDBase(out, r.db.MustCall(call.ReceiverDigest))
 		fmt.Fprint(out, ".")
 	}
 

--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -152,13 +152,6 @@ func (fe *frontendPlain) Run(ctx context.Context, opts FrontendOpts, run func(co
 	}
 	fe.FrontendOpts = opts
 
-	// redirect slog to the logs pane
-	level := slog.LevelInfo
-	if fe.Debug {
-		level = slog.LevelDebug
-	}
-	slog.SetDefault(slog.PrettyLogger(os.Stderr, fe.profile, level))
-
 	if !fe.Silent {
 		go func() {
 		loop:
@@ -244,7 +237,9 @@ func (fe plainLogExporter) Export(ctx context.Context, logs []sdklog.Record) err
 	fe.mu.Lock()
 	defer fe.mu.Unlock()
 
-	slog.Debug("frontend exporting logs", "logs", len(logs))
+	// NOTE: if we log in here we'll just go into a loop, so...
+	// let's just hope everything is working by now :D
+	// slog.Debug("frontend exporting logs", "logs", len(logs))
 
 	err := fe.db.LogExporter().Export(ctx, logs)
 	if err != nil {

--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -120,7 +120,7 @@ func (fe *frontendPlain) ConnectedToCloud(ctx context.Context, url string, msg s
 		return
 	}
 	fe.addVirtualLog(trace.SpanFromContext(ctx), "cloud", "url", url)
-	fmt.Fprintln(&fe.msgsBuffer, traceMessage(fe.output, url, msg))
+	fmt.Fprintln(&fe.msgsBuffer, traceMessage(fe.profile, url, msg))
 }
 
 // addVirtualLog attaches a fake log row to a given span

--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -437,7 +437,7 @@ func (fe *frontendPlain) renderStep(span *Span, depth int, done bool) {
 		spanDt.idx = fe.idx
 	}
 
-	r := renderer{db: fe.db, width: -1, FrontendOpts: fe.FrontendOpts}
+	r := newRenderer(fe.db, -1, fe.FrontendOpts)
 
 	prefix := fe.stepPrefix(span, spanDt)
 	if span.Call != nil {
@@ -484,7 +484,7 @@ func (fe *frontendPlain) renderLogs(row *TraceRow, depth int) {
 	span := row.Span
 	spanDt := fe.data[span.SpanContext().SpanID()]
 
-	r := renderer{db: fe.db, width: -1, FrontendOpts: fe.FrontendOpts}
+	r := newRenderer(fe.db, -1, fe.FrontendOpts)
 
 	prefix := fe.stepPrefix(span, spanDt)
 

--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -334,8 +334,7 @@ func (fe *frontendPlain) finalRender() {
 }
 
 func (fe *frontendPlain) renderProgress() {
-	steps := CollectSpans(fe.db, trace.TraceID{})
-	tree := CollectTree(steps)
+	tree := CollectTree(fe.db.SpanOrder)
 	logsView := CollectRowsView(tree)
 
 	// quickly sanity check the context - if a span from it has gone missing

--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -441,9 +441,9 @@ func (fe *frontendPlain) renderStep(span *Span, depth int, done bool) {
 			call.Args = nil
 			call.Type = nil
 		}
-		r.renderCall(fe.output, nil, call, prefix, depth, false, span.Internal)
+		r.renderCall(fe.output, nil, call, prefix, depth, false, span.Internal, false)
 	} else {
-		r.renderVertex(fe.output, nil, span.Name(), prefix, depth)
+		r.renderVertex(fe.output, nil, span.Name(), prefix, depth, false)
 	}
 	if done {
 		if span.Status().Code == codes.Error {

--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -334,8 +334,7 @@ func (fe *frontendPlain) finalRender() {
 }
 
 func (fe *frontendPlain) renderProgress() {
-	tree := CollectTree(fe.db.SpanOrder)
-	logsView := CollectRowsView(tree)
+	rowsView := fe.db.RowsView(fe.db.PrimarySpan)
 
 	// quickly sanity check the context - if a span from it has gone missing
 	// from the db, or has been marked as passthrough, it will no longer appear
@@ -359,7 +358,7 @@ func (fe *frontendPlain) renderProgress() {
 		fe.lastContextLock = newLock
 	}
 
-	for _, row := range logsView.Body {
+	for _, row := range rowsView.Body {
 		fe.renderRow(row)
 	}
 }

--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -443,7 +443,7 @@ func (fe *frontendPlain) renderStep(span *Span, depth int, done bool) {
 		}
 		r.renderCall(fe.output, nil, call, prefix, depth, false, span.Internal, false)
 	} else {
-		r.renderVertex(fe.output, nil, span.Name(), prefix, depth, false)
+		r.renderSpan(fe.output, nil, span.Name(), prefix, depth, false)
 	}
 	if done {
 		if span.Status().Code == codes.Error {

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -316,16 +316,17 @@ func (fe *frontendPretty) renderKeymap(out *termenv.Output, style lipgloss.Style
 	} else {
 		quitMsg = "quit"
 	}
+
 	// Blank line prior to keymap
 	for i, key := range []keyHelp{
 		{quitMsg, []string{"q", "ctrl+c"}, true},
+		{out.Hyperlink(fe.cloudURL, "Cloud"), []string{"c"}, fe.cloudURL != ""},
 		{"move", []string{"←↑↓→", "up", "down", "left", "right", "h", "j", "k", "l"}, true},
 		{"first", []string{"home"}, true},
 		{"last", []string{"end", " "}, true},
 		{"zoom", []string{"enter"}, true},
 		{"reset", []string{"esc"}, true},
 		{fmt.Sprintf("verbosity=%d", fe.Verbosity), []string{"+/-", "+", "-"}, true},
-		{"Cloud", []string{"c"}, fe.cloudURL != ""},
 	} {
 		if !key.show {
 			continue

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -647,12 +647,14 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) {
 			return fe, nil
 		case "+":
 			fe.FrontendOpts.Verbosity++
+			fe.recalculateViewLocked()
 			return fe, nil
 		case "-":
 			fe.FrontendOpts.Verbosity--
 			if fe.FrontendOpts.Verbosity < 0 {
 				fe.FrontendOpts.Verbosity = 0
 			}
+			fe.recalculateViewLocked()
 			return fe, nil
 		case "c":
 			if fe.cloudURL != "" {

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -608,7 +608,7 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) {
 
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "q", "esc", "ctrl+c":
+		case "q", "ctrl+c":
 			if fe.interrupted {
 				slog.Warn("exiting immediately")
 				return fe, tea.Quit
@@ -639,6 +639,9 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) {
 			return fe, nil
 		case "end", "space":
 			fe.goEnd()
+			return fe, nil
+		case "esc":
+			fe.zoomed = trace.SpanID{}
 			return fe, nil
 		case "+":
 			fe.FrontendOpts.Verbosity++

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -618,6 +618,7 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) {
 			return fe, nil
 		// case "l", "right":
 		case "home":
+			fe.autoFocus = false
 			if len(fe.rows) > 0 {
 				fe.focus(fe.rows[0])
 			}

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -758,12 +758,14 @@ func (fe *frontendPretty) renderStep(out *termenv.Output, span *Span, depth int)
 	fmt.Fprintln(out)
 
 	if span.Status().Code == codes.Error && span.Status().Description != "" {
-		r.indent(out, depth+1) // HACK: +1 for focus prefix
-		// print error description above it
-		fmt.Fprintf(out,
-			out.String("! %s\n").Foreground(termenv.ANSIYellow).String(),
-			span.Status().Description,
-		)
+		for _, line := range strings.Split(span.Status().Description, "\n") {
+			r.indent(out, depth+1) // HACK: +1 for focus prefix
+			fmt.Fprintf(out,
+				out.String("! %s").Foreground(termenv.ANSIYellow).String(),
+				line,
+			)
+			fmt.Fprintln(out)
+		}
 	}
 
 	return nil

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -637,7 +637,7 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) {
 		case "home":
 			fe.goStart()
 			return fe, nil
-		case "end", "space":
+		case "end", " ":
 			fe.goEnd()
 			return fe, nil
 		case "esc":

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -716,30 +716,24 @@ func (fe *frontendPretty) goDown() {
 
 func (fe *frontendPretty) goOut() {
 	fe.autoFocus = false
-	slog.Warn("goin out")
 	focused := fe.db.Spans[fe.focused]
 	if focused.ParentSpan == nil {
-		slog.Warn("no parent span")
 		return
 	}
 	fe.focused = focused.ParentSpan.ID
 	// TODO: handle passthrough
 	if fe.focused == fe.zoomed {
-		slog.Warn("unzooming")
 		// targeted the zoomed span; zoom on its parent isntead
 		zoomedParent := fe.db.Spans[fe.zoomed].ParentSpan
 		for zoomedParent != nil && zoomedParent.Passthrough {
 			zoomedParent = zoomedParent.ParentSpan
 		}
 		if zoomedParent != nil {
-			slog.Warn("zooming on parent", "id", zoomedParent.ID)
 			fe.zoomed = zoomedParent.ID
 		} else {
-			slog.Warn("unzooming completely")
 			fe.zoomed = trace.SpanID{}
 		}
 	}
-	slog.Warn("focused", "id", fe.focused)
 	fe.recalculateViewLocked()
 }
 

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -602,7 +602,7 @@ func (fe *frontendPretty) spawn() (msg tea.Msg) {
 
 type backgroundDoneMsg struct{}
 
-func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) {
+func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) { //nolint: gocyclo
 	switch msg := msg.(type) {
 	case doneMsg: // run finished
 		slog.Debug("run finished", "err", msg.err)

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -514,7 +514,7 @@ func (fe *frontendPretty) renderRow(out *termenv.Output, row *TraceRow, depth in
 }
 
 func (fe *frontendPretty) renderStep(out *termenv.Output, span *Span, depth int) error {
-	r := renderer{db: fe.db, width: fe.window.Width, FrontendOpts: fe.FrontendOpts}
+	r := newRenderer(fe.db, fe.window.Width, fe.FrontendOpts)
 
 	id := span.Call
 	if id != nil {

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -696,10 +696,19 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) {
 			fe.recalculateViewLocked()
 			return fe, nil
 		case "c":
-			if fe.cloudURL != "" {
-				browser.OpenURL(fe.cloudURL)
+			if fe.cloudURL == "" {
+				return fe, nil
 			}
-			return fe, nil
+			url := fe.cloudURL
+			if fe.zoomed != fe.db.PrimarySpan {
+				url += "?span=" + fe.zoomed.String()
+			}
+			return fe, func() tea.Msg {
+				if err := browser.OpenURL(url); err != nil {
+					slog.Warn("failed to open URL", "url", url, "err", err)
+				}
+				return nil
+			}
 		case "enter":
 			fe.zoomed = fe.focused
 			fe.recalculateViewLocked()

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -213,6 +213,10 @@ func (fe *frontendPretty) finalRender() error {
 	fe.zoomed = fe.db.PrimarySpan
 	fe.focused = trace.SpanID{}
 	fe.focusedIdx = -1
+	if fe.Verbosity < 1 {
+		// likely only intended to filter out noise, so print as we normally would
+		fe.Verbosity = 1
+	}
 	fe.recalculateViewLocked()
 
 	if fe.Debug || fe.Verbosity > 0 || fe.err != nil {

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -304,8 +304,6 @@ func (fe *frontendPretty) Background(cmd tea.ExecCommand) error {
 
 var KeymapStyle = lipgloss.NewStyle().
 	Foreground(lipgloss.ANSIColor(termenv.ANSIBrightBlack))
-	// Background(lipgloss.ANSIColor(termenv.ANSIBlue)).
-	// Foreground(lipgloss.ANSIColor(termenv.ANSIBlack))
 
 func (fe *frontendPretty) renderKeymap(out *termenv.Output, style lipgloss.Style) int {
 	w := new(strings.Builder)
@@ -323,14 +321,14 @@ func (fe *frontendPretty) renderKeymap(out *termenv.Output, style lipgloss.Style
 
 	// Blank line prior to keymap
 	for i, key := range []keyHelp{
-		{quitMsg, []string{"q", "ctrl+c"}, true},
 		{out.Hyperlink(fe.cloudURL, "Cloud"), []string{"c"}, fe.cloudURL != ""},
 		{"move", []string{"←↑↓→", "up", "down", "left", "right", "h", "j", "k", "l"}, true},
 		{"first", []string{"home"}, true},
 		{"last", []string{"end", " "}, true},
 		{"zoom", []string{"enter"}, true},
-		{"reset", []string{"esc"}, true},
+		{"unzoom", []string{"esc"}, fe.zoomed.IsValid() && fe.zoomed != fe.db.PrimarySpan},
 		{fmt.Sprintf("verbosity=%d", fe.Verbosity), []string{"+/-", "+", "-"}, true},
+		{quitMsg, []string{"q", "ctrl+c"}, true},
 	} {
 		if !key.show {
 			continue

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -216,8 +216,11 @@ func (fe *frontendPretty) finalRender() error {
 	if fe.Debug || fe.Verbosity > 0 || fe.err != nil {
 		// Render progress to stderr so stdout stays clean.
 		out := NewOutput(os.Stderr, termenv.WithProfile(fe.profile))
-		if fe.renderProgress(out, true, fe.window.Height) && fe.logs.Logs[fe.db.PrimarySpan] != nil {
-			fmt.Fprintln(os.Stderr)
+		if fe.renderProgress(out, true, fe.window.Height) {
+			logs := fe.logs.Logs[fe.db.PrimarySpan]
+			if logs != nil && logs.UsedHeight() > 0 {
+				fmt.Fprintln(os.Stderr)
+			}
 		}
 	}
 

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -341,8 +341,7 @@ func (fe *frontendPretty) Render(out *termenv.Output) error {
 }
 
 func (fe *frontendPretty) recalculateViewLocked() {
-	steps := CollectSpans(fe.db, trace.TraceID{})
-	tree := CollectTree(steps)
+	tree := CollectTree(fe.db.SpanOrder)
 	fe.rowsView = CollectRowsView(tree)
 }
 

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -132,13 +132,6 @@ func (fe *frontendPretty) Run(ctx context.Context, opts FrontendOpts, run func(c
 	}
 	fe.FrontendOpts = opts
 
-	// redirect slog to the logs pane
-	level := slog.LevelInfo
-	if fe.Debug {
-		level = slog.LevelDebug
-	}
-	slog.SetDefault(slog.PrettyLogger(fe.logsPanel, fe.profile, level))
-
 	// find a TTY anywhere in stdio. stdout might be redirected, in which case we
 	// can show the TUI on stderr.
 	ttyIn, ttyOut := findTTYs()

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -795,7 +795,7 @@ func (fe *frontendPretty) renderStep(out *termenv.Output, span *Span, depth int)
 			return err
 		}
 	} else if span != nil {
-		if err := r.renderVertex(out, span, span.Name(), "", depth, isFocused); err != nil {
+		if err := r.renderSpan(out, span, span.Name(), "", depth, isFocused); err != nil {
 			return err
 		}
 	}
@@ -815,7 +815,7 @@ func (fe *frontendPretty) renderStep(out *termenv.Output, span *Span, depth int)
 	return nil
 }
 
-func (fe *frontendPretty) renderLogs(out *termenv.Output, logs *Vterm, depth int, height int) bool {
+func (fe *frontendPretty) renderLogs(out *termenv.Output, logs *Vterm, depth int, height int) {
 	pipe := out.String(VertBoldBar).Foreground(termenv.ANSIBrightBlack)
 	if depth == -1 {
 		// clear prefix when zoomed
@@ -825,7 +825,6 @@ func (fe *frontendPretty) renderLogs(out *termenv.Output, logs *Vterm, depth int
 	}
 	logs.SetHeight(height)
 	fmt.Fprint(out, logs.View())
-	return logs.UsedHeight() > 0
 }
 
 type prettyLogs struct {

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -631,6 +631,15 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) {
 		case "end", "space":
 			fe.goEnd()
 			return fe, nil
+		case "+":
+			fe.FrontendOpts.Verbosity++
+			return fe, nil
+		case "-":
+			fe.FrontendOpts.Verbosity--
+			if fe.FrontendOpts.Verbosity < 0 {
+				fe.FrontendOpts.Verbosity = 0
+			}
+			return fe, nil
 		case "enter":
 			fe.zoomed = fe.focused
 			fe.recalculateViewLocked()

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -101,12 +101,12 @@ func (fe *frontendPretty) ConnectedToEngine(ctx context.Context, name string, ve
 }
 
 func (fe *frontendPretty) ConnectedToCloud(ctx context.Context, url string, msg string) {
-	out := NewOutput(nil, termenv.WithProfile(fe.profile))
-	fmt.Fprintln(fe.msgsPanel, traceMessage(out, url, msg))
+	fmt.Fprintln(fe.msgsPanel, traceMessage(fe.profile, url, msg))
 }
 
-func traceMessage(out *termenv.Output, url string, msg string) string {
+func traceMessage(profile termenv.Profile, url string, msg string) string {
 	buffer := &bytes.Buffer{}
+	out := NewOutput(buffer, termenv.WithProfile(profile))
 
 	fmt.Fprint(buffer, out.String("Full trace at ").Bold().String())
 	if out.Profile == termenv.Ascii {

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -373,7 +373,7 @@ func (fe *frontendPretty) Render(out *termenv.Output) error {
 		fmt.Fprint(countOut, KeymapStyle.Render(strings.Repeat(HorizBar, rest)))
 	}
 
-	if logs := fe.logs.Logs[fe.db.PrimarySpan]; logs != nil && logs.UsedHeight() > 0 {
+	if logs := fe.logs.Logs[fe.zoomed]; logs != nil && logs.UsedHeight() > 0 {
 		fmt.Fprintln(below)
 		fe.renderLogs(countOut, logs, -1, fe.window.Height/3)
 	}

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -759,7 +759,7 @@ func (fe *frontendPretty) renderLocked() {
 func (fe *frontendPretty) renderRow(out *termenv.Output, row *TraceRow) {
 	fe.renderStep(out, row.Span, row.Depth)
 	if row.IsRunningOrChildRunning {
-		fe.renderLogs(out, row.Span, row.Depth+1) // HACK: extra depth to account for focus indicator
+		fe.renderLogs(out, row.Span, row.Depth)
 	}
 }
 
@@ -768,20 +768,13 @@ func (fe *frontendPretty) renderStep(out *termenv.Output, span *Span, depth int)
 
 	isFocused := span.ID == fe.focused
 
-	var prefix string
-	if isFocused && !fe.done {
-		prefix = termenv.String("▐ ").Foreground(termenv.ANSIYellow).String()
-	} else {
-		prefix = "  "
-	}
-
 	id := span.Call
 	if id != nil {
-		if err := r.renderCall(out, span, id, prefix, depth, false, span.Internal); err != nil {
+		if err := r.renderCall(out, span, id, "", depth, false, span.Internal, isFocused); err != nil {
 			return err
 		}
 	} else if span != nil {
-		if err := r.renderVertex(out, span, span.Name(), prefix, depth); err != nil {
+		if err := r.renderVertex(out, span, span.Name(), "", depth, isFocused); err != nil {
 			return err
 		}
 	}
@@ -789,7 +782,7 @@ func (fe *frontendPretty) renderStep(out *termenv.Output, span *Span, depth int)
 
 	if span.Status().Code == codes.Error && span.Status().Description != "" {
 		for _, line := range strings.Split(span.Status().Description, "\n") {
-			r.indent(out, depth+1) // HACK: +1 for focus prefix
+			r.indent(out, depth)
 			fmt.Fprintf(out,
 				out.String("! %s").Foreground(termenv.ANSIYellow).String(),
 				line,

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -769,7 +769,7 @@ func (fe *frontendPretty) renderLocked() {
 
 func (fe *frontendPretty) renderRow(out *termenv.Output, row *TraceRow, full bool) {
 	fe.renderStep(out, row.Span, row.Depth)
-	if row.IsRunningOrChildRunning || row.Span.Failed() {
+	if row.IsRunningOrChildRunning || row.Span.Failed() || fe.Verbosity >= ShowSpammyVerbosity {
 		if logs := fe.logs.Logs[row.Span.ID]; logs != nil {
 			logLimit := fe.window.Height / 3
 			if full {

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -800,14 +800,14 @@ func (fe *frontendPretty) renderStep(out *termenv.Output, span *Span, depth int)
 	fmt.Fprintln(out)
 
 	if span.Status().Code == codes.Error && span.Status().Description != "" {
-		for _, line := range strings.Split(span.Status().Description, "\n") {
-			r.indent(out, depth)
-			fmt.Fprintf(out,
-				out.String("! %s").Foreground(termenv.ANSIYellow).String(),
-				line,
-			)
-			fmt.Fprintln(out)
-		}
+		// only print the first line
+		line := strings.Split(span.Status().Description, "\n")[0]
+		r.indent(out, depth)
+		fmt.Fprintf(out,
+			out.String("! %s").Foreground(termenv.ANSIYellow).String(),
+			line,
+		)
+		fmt.Fprintln(out)
 	}
 
 	return nil

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -473,27 +473,34 @@ func (fe *frontendPretty) renderProgress(out *termenv.Output, full bool, height 
 	}
 
 	// fill in context surrounding the focused row
-	contextLines := (height - len(lines)) / 2
-	for len(beforeLines) < contextLines && len(before) > 0 {
+	contextLines := (height - len(lines))
+	beforeTargetLines := contextLines / 2
+	var afterTargetLines int
+	if contextLines%2 == 0 {
+		afterTargetLines = beforeTargetLines
+	} else {
+		afterTargetLines = beforeTargetLines + 1
+	}
+	for len(beforeLines) < beforeTargetLines && len(before) > 0 {
 		renderBefore()
 	}
-	for len(afterLines) < contextLines && len(after) > 0 {
+	for len(afterLines) < afterTargetLines && len(after) > 0 {
 		renderAfter()
 	}
 
 	if total := totalLines(); total > height {
 		extra := total - height
-		if len(beforeLines) >= contextLines && len(afterLines) >= contextLines {
+		if len(beforeLines) >= beforeTargetLines && len(afterLines) >= afterTargetLines {
 			// exceeded the height, so trim the context
-			if len(beforeLines) > contextLines {
-				beforeLines = beforeLines[len(beforeLines)-contextLines:]
+			if len(beforeLines) > beforeTargetLines {
+				beforeLines = beforeLines[len(beforeLines)-beforeTargetLines:]
 			}
-			if len(afterLines) > contextLines {
-				afterLines = afterLines[:contextLines]
+			if len(afterLines) > afterTargetLines {
+				afterLines = afterLines[:afterTargetLines]
 			}
-		} else if len(beforeLines) >= contextLines {
+		} else if len(beforeLines) >= beforeTargetLines {
 			beforeLines = beforeLines[extra:]
-		} else if len(afterLines) >= contextLines {
+		} else if len(afterLines) >= afterTargetLines {
 			afterLines = afterLines[:len(afterLines)-extra]
 		}
 	} else {

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -767,7 +767,7 @@ func (fe *frontendPretty) renderLocked() {
 
 func (fe *frontendPretty) renderRow(out *termenv.Output, row *TraceRow, full bool) {
 	fe.renderStep(out, row.Span, row.Depth)
-	if row.IsRunningOrChildRunning {
+	if row.IsRunningOrChildRunning || row.Span.Failed() {
 		if logs := fe.logs.Logs[row.Span.ID]; logs != nil {
 			logLimit := fe.window.Height / 3
 			if full {

--- a/dagql/idtui/spans.go
+++ b/dagql/idtui/spans.go
@@ -33,7 +33,6 @@ type Span struct {
 	Canceled bool
 	Inputs   []string
 
-	Primary      bool
 	Encapsulate  bool
 	Encapsulated bool
 	Mask         bool

--- a/dagql/idtui/spans.go
+++ b/dagql/idtui/spans.go
@@ -68,6 +68,11 @@ func (span *Span) Name() string {
 // 	return nil
 // }
 
+func (span *Span) Failed() bool {
+	status := span.Status()
+	return status.Code == codes.Error
+}
+
 func (span *Span) Err() error {
 	status := span.Status()
 	if status.Code == codes.Error {

--- a/dagql/idtui/types.go
+++ b/dagql/idtui/types.go
@@ -104,7 +104,7 @@ func (lv *RowsView) Rows(opts FrontendOpts) *Rows {
 			rows.BySpan[tree.Span.ID] = row
 			depth++
 		}
-		if tree.IsRunningOrChildRunning {
+		if tree.IsRunningOrChildRunning || tree.Span.Failed() {
 			for _, child := range tree.Children {
 				walk(child, depth)
 			}

--- a/dagql/idtui/types.go
+++ b/dagql/idtui/types.go
@@ -161,7 +161,7 @@ func WalkSteps(spans []*Span, f func(*TraceTree)) {
 			return
 		}
 		if span.Passthrough {
-			for _, child := range span.Children() {
+			for _, child := range span.ChildSpans {
 				walk(child, parent)
 			}
 			return
@@ -179,7 +179,7 @@ func WalkSteps(spans []*Span, f func(*TraceTree)) {
 		f(row)
 		lastRow = row
 		seen[spanID] = true
-		for _, child := range span.Children() {
+		for _, child := range span.ChildSpans {
 			walk(child, row)
 		}
 		lastRow = row

--- a/dagql/idtui/types.go
+++ b/dagql/idtui/types.go
@@ -61,17 +61,17 @@ type TraceRow struct {
 }
 
 type RowsView struct {
-	Primary *Span
-	Body    []*TraceTree
+	Zoomed *Span
+	Body   []*TraceTree
 }
 
-func (db *DB) RowsView(spanID trace.SpanID) *RowsView {
+func (db *DB) RowsView(zoomedID trace.SpanID) *RowsView {
 	view := &RowsView{
-		Primary: db.Spans[spanID],
+		Zoomed: db.Spans[zoomedID],
 	}
 	var spans []*Span
-	if view.Primary != nil {
-		spans = view.Primary.ChildSpans
+	if view.Zoomed != nil {
+		spans = view.Zoomed.ChildSpans
 	} else {
 		spans = db.SpanOrder
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,16 +3,6 @@ module github.com/dagger/dagger
 go 1.22
 
 require (
-	dagger.io/dagger v0.11.8
-	github.com/dagger/dagger/engine/distconsts v0.11.8
-)
-
-replace (
-	dagger.io/dagger => ./sdk/go
-	github.com/dagger/dagger/engine/distconsts => ./engine/distconsts
-)
-
-require (
 	github.com/99designs/gqlgen v0.17.49
 	github.com/Khan/genqlient v0.7.0
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
@@ -226,7 +216,7 @@ require (
 	github.com/opencontainers/selinux v1.11.0 // indirect
 	github.com/package-url/packageurl-go v0.1.1-0.20220428063043-89078438f170 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
-	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pkg/profile v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
@@ -267,4 +257,14 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20240521202816-d264139d666e // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240521202816-d264139d666e // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+)
+
+require (
+	dagger.io/dagger v0.11.8
+	github.com/dagger/dagger/engine/distconsts v0.11.8
+)
+
+replace (
+	dagger.io/dagger => ./sdk/go
+	github.com/dagger/dagger/engine/distconsts => ./engine/distconsts
 )


### PR DESCRIPTION
[![asciicast](https://asciinema.org/a/vdUEqRXX0K6Dw9zqLjkwlCxNc.svg)](https://asciinema.org/a/vdUEqRXX0K6Dw9zqLjkwlCxNc)

* ~~Now shows effects at their origin (`withExec`) rather than their unlazying point (`sync`).~~
  * Moved to separate PR: #7686 
* Now supports navigation, instead of being stuck with the bottom of the visible region
  * `hjkl` or arrow keys to move around
  * `enter` to "zoom in" to the selected span
  * `end` or `space` to follow the bottom of the screen
  * `home` to go to beginning
* Instead of having spans disappear after a second, we just collapse them when they finish.
* Now supports mouse scroll wheel again
  * I initially skipped this because I found it occasionally annoying for the TUI to steal mouse input. But you can just press Shift to bypass it.
* Now only renders the visible region, instead of rendering everything and cutting it off
  * This was a lot of work, but seems obviously worth it for large traces.
  * It's now possible to run our full integration suite without the TUI starting to lag. It used to get _real_ bad before.
* Now only renders logs when the logs need to be painted, rather than when the CLI receives them
* Tons of optimizations in the UI rendering loop to avoid repeated computations
* Avoid pushing cloud URL offscreen (it was also messing up the TUI a bit by printing directly to stdio)
* Now detects inifnite loop when printing simplified spans to avoid RAM usage explosion (cc @jedevc this should buy us some time)
* Now shows a keymap for better discoverability
* Now supports `+` and `-` keybinds increase and decrease verbosity at runtime
  * Want to know what's going on under `initialize`? Just hold `+`!

Here's a profile comparison for `dagger -m . call --source=.:default test important --race=true` after letting it run for ~9 minutes:

Before:

![image](https://github.com/dagger/dagger/assets/1880/af86c7e5-d8c0-4d6e-b55c-6d1fbcfa29ca)

After:

![image](https://github.com/dagger/dagger/assets/1880/b19b2244-339b-4089-9217-b76e112e2ab2)

Still spending a chunk of time in `WalkSpans`, but the total time in CPU is much shorter (23.58s -> 3.04s), and there's much less going on in there now (mostly just map usage).