### PR TITLE
Fix forced simplification infinite progress loop on high verbosity settings

### DIFF
--- a/.changes/unreleased/Fixed-20240617-161718.yaml
+++ b/.changes/unreleased/Fixed-20240617-161718.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: 'cli: fixed infinite loop when simplifying on high verbosity levels'
+time: 2024-06-17T16:17:18.410399574+01:00
+custom:
+  Author: jedevc
+  PR: "7679"

--- a/dagql/idtui/db.go
+++ b/dagql/idtui/db.go
@@ -385,7 +385,7 @@ func (db *DB) Simplify(call *callpbv1.Call, force bool) (smallest *callpbv1.Call
 
 	creators, ok := db.OutputOf[call.Digest]
 	if !ok {
-		return
+		return smallest
 	}
 	simplified := false
 
@@ -417,7 +417,7 @@ loop:
 	if simplified {
 		return db.Simplify(smallest, false)
 	}
-	return
+	return smallest
 }
 
 func getAttr(attrs []attribute.KeyValue, key attribute.Key) (attribute.Value, bool) {

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -147,12 +147,12 @@ func (r renderer) renderCall(out *termenv.Output, span *Span, call *callpbv1.Cal
 				val := arg.GetValue()
 				fmt.Fprint(out, " ")
 				if argDig := val.GetCallDigest(); argDig != "" {
-					var argSpan *Span
-					var argInternal bool
-					if span != nil {
-						argSpan = r.db.MostInterestingSpan(argDig)
-						if argSpan != nil {
-							argInternal = argSpan.Internal
+					argSpan := r.db.MostInterestingSpan(argDig)
+					argInternal := false
+					if argSpan != nil {
+						argInternal = argSpan.Internal
+						if span == nil {
+							argSpan = nil
 						}
 					}
 					argCall := r.db.Simplify(r.db.MustCall(argDig), argInternal)

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -74,7 +74,7 @@ func DumpID(out *termenv.Output, id *call.ID) error {
 		db:    db,
 		width: -1,
 	}
-	return r.renderCall(out, nil, id.Call(), "", 0, false)
+	return r.renderCall(out, nil, id.Call(), "", 0, false, false)
 }
 
 type renderer struct {
@@ -108,7 +108,7 @@ func (r renderer) renderIDBase(out *termenv.Output, call *callpbv1.Call) error {
 	return nil
 }
 
-func (r renderer) renderCall(out *termenv.Output, span *Span, call *callpbv1.Call, prefix string, depth int, inline bool) error {
+func (r renderer) renderCall(out *termenv.Output, span *Span, call *callpbv1.Call, prefix string, depth int, inline bool, internal bool) error {
 	if !inline {
 		fmt.Fprint(out, prefix)
 		r.indent(out, depth)
@@ -147,16 +147,18 @@ func (r renderer) renderCall(out *termenv.Output, span *Span, call *callpbv1.Cal
 				val := arg.GetValue()
 				fmt.Fprint(out, " ")
 				if argDig := val.GetCallDigest(); argDig != "" {
+					forceSimplify := false
+					internal := internal
 					argSpan := r.db.MostInterestingSpan(argDig)
-					argInternal := false
 					if argSpan != nil {
-						argInternal = argSpan.Internal
+						forceSimplify = argSpan.Internal && !internal // only for the first internal call (not it's children)
+						internal = internal || argSpan.Internal
 						if span == nil {
 							argSpan = nil
 						}
 					}
-					argCall := r.db.Simplify(r.db.MustCall(argDig), argInternal)
-					if err := r.renderCall(out, argSpan, argCall, prefix, depth-1, true); err != nil {
+					argCall := r.db.Simplify(r.db.MustCall(argDig), forceSimplify)
+					if err := r.renderCall(out, argSpan, argCall, prefix, depth-1, true, internal); err != nil {
 						return err
 					}
 				} else {

--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -418,7 +418,7 @@ func (fe *frontendPlain) renderStep(span *Span, depth int, done bool) {
 			call.Args = nil
 			call.Type = nil
 		}
-		r.renderCall(fe.output, nil, call, prefix, depth, false)
+		r.renderCall(fe.output, nil, call, prefix, depth, false, span.Internal)
 	} else {
 		r.renderVertex(fe.output, nil, span.Name(), prefix, depth)
 	}

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -518,7 +518,7 @@ func (fe *frontendPretty) renderStep(out *termenv.Output, span *Span, depth int)
 
 	id := span.Call
 	if id != nil {
-		if err := r.renderCall(out, span, id, "", depth, false); err != nil {
+		if err := r.renderCall(out, span, id, "", depth, false, span.Internal); err != nil {
 			return err
 		}
 	} else if span != nil {


### PR DESCRIPTION
Reported by @vito in an internal discord: https://discord.com/channels/707636530424053791/1250122361131499664/1250193357683163208

> huh, running that command with --debug or -vvv seems to cause the CLI to eat up all of my memory, seems like a bug with the call simplification code
>
> last time this came up it was because of a call simplifying to itself or something and ending up in a loop, all the memory usage is from trying to render the indentation

Turns out, the changes to call simplification to get `blob`s to never show was a little faulty.

For, example, on high verbosity settings, the following could happen:
- `moduleSource.resolveDependency` is an identity function (for git sources), taking an argument and returning it unmodified.
- Arguments in a call to `moduleSource.resolveDependency(dep: ...)` (from an unrelated function) will be forced to be simplified, since it's an internal function.
- There are no reasonable simplifications for the `dep` argument here - so since it must be simplified, it is simplified to `moduleSource.resolveDependency(dep: ...)` (since `resolveDependency` is an identity function.
- This recurses infinitely, with `dep` being expanded to it's parent.

There are two fixes in this PR (they both separately solve the issue, but both of them are logic issues).

1. The first fix ensures that we *always* return a valid simplification, and never a complexification, even when `force`d to `Simplify`. So we'll never expand it to a "parent".
2. The second fix tries to be a little bit less aggressive in using the `force` option, by only enforcing it for the first internal call we see, not for all the internal calls recursively (which is a bit too aggressive, and arguably, not super useful).