### PR TITLE
Interactive Debugging

### DIFF
--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -40,6 +40,7 @@ func withEngine(
 		Processors: telemetry.LogProcessors,
 	}
 	params.WithTerminal = withTerminal
+	params.Interactive = interactive
 
 	sess, ctx, err := client.Connect(ctx, params)
 	if err != nil {

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -51,11 +51,12 @@ var (
 
 	workdir string
 
-	silent   bool
-	verbose  int
-	quiet, _ = strconv.Atoi(os.Getenv("DAGGER_QUIET"))
-	debug    bool
-	progress string
+	silent      bool
+	verbose     int
+	quiet, _    = strconv.Atoi(os.Getenv("DAGGER_QUIET"))
+	debug       bool
+	progress    string
+	interactive bool
 
 	stdoutIsTTY = isatty.IsTerminal(os.Stdout.Fd())
 	stderrIsTTY = isatty.IsTerminal(os.Stderr.Fd())
@@ -199,6 +200,7 @@ func installGlobalFlags(flags *pflag.FlagSet) {
 	flags.BoolVarP(&silent, "silent", "s", silent, "Do not show progress at all")
 	flags.BoolVarP(&debug, "debug", "d", debug, "Show debug logs and full verbosity")
 	flags.StringVar(&progress, "progress", "auto", "Progress output format (auto, plain, tty)")
+	flags.BoolVarP(&interactive, "interactive", "i", false, "interactive mode will spawn a terminal on container exec failure")
 
 	for _, fl := range []string{"workdir"} {
 		if err := flags.MarkHidden(fl); err != nil {

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -73,6 +73,7 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 	if opts.NestedExecMetadata != nil {
 		execMD = *opts.NestedExecMetadata
 	}
+	execMD.ExecID = identity.NewID()
 	execMD.SessionID = clientMetadata.SessionID
 	if execMD.HostAliases == nil {
 		execMD.HostAliases = make(map[string][]string)

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -73,6 +73,7 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 	if opts.NestedExecMetadata != nil {
 		execMD = *opts.NestedExecMetadata
 	}
+	execMD.CallID = dagql.CurrentID(ctx)
 	execMD.ExecID = identity.NewID()
 	execMD.SessionID = clientMetadata.SessionID
 	if execMD.HostAliases == nil {

--- a/core/integration/module_terminal_test.go
+++ b/core/integration/module_terminal_test.go
@@ -461,6 +461,68 @@ type Test struct {
 		err = cmd.Wait()
 		require.NoError(t, err)
 	})
+
+	t.Run("on failure", func(ctx context.Context, t *testctx.T) {
+		modDir := t.TempDir()
+		err := os.WriteFile(filepath.Join(modDir, "main.go"), []byte(fmt.Sprintf(`package main
+	import "context"
+
+	func New(ctx context.Context) *Test {
+		return &Test{
+			Ctr: dag.Container().
+				From("%s").
+				WithExec([]string{"sh", "-c", "echo breakpoint > /fail && exit 42"}),
+		}
+	}
+
+	type Test struct {
+		Ctr *Container
+	}
+	`, alpineImage)), 0644)
+		require.NoError(t, err)
+
+		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "init", "--source=.", "--name=test", "--sdk=go")
+		require.NoError(t, err)
+
+		// cache the module load itself so there's less to wait for in the shell invocation below
+		_, err = hostDaggerExec(ctx, t, modDir, "--debug", "functions")
+		require.NoError(t, err)
+
+		// timeout for waiting for each expected line is very generous in case CI is under heavy load or something
+		console, err := newTUIConsole(t, 60*time.Second)
+		require.NoError(t, err)
+		defer console.Close()
+
+		tty := console.Tty()
+
+		// We want the size to be big enough to fit the output we're expecting, but increasing
+		// the size also eventually slows down the tests due to more output being generated and
+		// needing parsing.
+		err = pty.Setsize(tty, &pty.Winsize{Rows: 6, Cols: 16})
+		require.NoError(t, err)
+
+		cmd := hostDaggerCommand(ctx, t, modDir, "--interactive", "call", "ctr")
+		cmd.Stdin = tty
+		cmd.Stdout = tty
+		cmd.Stderr = tty
+
+		err = cmd.Start()
+		require.NoError(t, err)
+
+		_, err = console.SendLine("cat /fail")
+		require.NoError(t, err)
+
+		err = console.ExpectLineRegex(ctx, "breakpoint")
+		require.NoError(t, err)
+
+		_, err = console.SendLine("exit")
+		require.NoError(t, err)
+
+		go console.ExpectEOF()
+
+		err = cmd.Wait()
+		require.Error(t, err)
+	})
 }
 
 // tuiConsole wraps expect.Console with methods that allow us to enforce

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -179,6 +179,7 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Typ
 
 	execMD := buildkit.ExecutionMetadata{
 		CachePerSession: !opts.Cache,
+		Internal:        true,
 	}
 	if spanCtx := trace.SpanContextFromContext(ctx); spanCtx.IsValid() {
 		execMD.SpanContext = propagation.MapCarrier{}

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	bkgw "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/util/bklog"
 	"github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -178,6 +179,7 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Typ
 	}
 
 	execMD := buildkit.ExecutionMetadata{
+		ExecID:          identity.NewID(),
 		CachePerSession: !opts.Cache,
 		Internal:        true,
 	}

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -179,6 +179,7 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Typ
 	}
 
 	execMD := buildkit.ExecutionMetadata{
+		CallID:          dagql.CurrentID(ctx),
 		ExecID:          identity.NewID(),
 		CachePerSession: !opts.Cache,
 		Internal:        true,

--- a/core/service.go
+++ b/core/service.go
@@ -325,7 +325,7 @@ func (svc *Service) startContainer(
 
 	pbPlatform := pb.PlatformFromSpec(ctr.Platform.Spec())
 
-	mounts := make([]bkgw.Mount, len(execOp.Mounts))
+	mounts := make([]buildkit.ContainerMount, len(execOp.Mounts))
 	for i, m := range execOp.Mounts {
 		mount := bkgw.Mount{
 			Selector:  m.Selector,
@@ -357,7 +357,9 @@ func (svc *Service) startContainer(
 			mount.Ref = res.Ref
 		}
 
-		mounts[i] = mount
+		mounts[i] = buildkit.ContainerMount{
+			Mount: &mount,
+		}
 	}
 
 	gc, err := bk.NewContainer(ctx, buildkit.NewContainerRequest{

--- a/core/service.go
+++ b/core/service.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	bkgw "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/identity"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/vektah/gqlparser/v2/ast"
 	"go.opentelemetry.io/otel/attribute"
@@ -285,6 +286,7 @@ func (svc *Service) startContainer(
 	}
 	if !ok {
 		execMD = &buildkit.ExecutionMetadata{
+			ExecID:    identity.NewID(),
 			SessionID: clientMetadata.SessionID,
 		}
 	}

--- a/dagql/call/id.go
+++ b/dagql/call/id.go
@@ -276,6 +276,22 @@ func (id *ID) Encode() (string, error) {
 	return base64.StdEncoding.EncodeToString(proto), nil
 }
 
+func (id ID) MarshalJSON() ([]byte, error) {
+	enc, err := id.Encode()
+	if err != nil {
+		return nil, err
+	}
+	return []byte(`"` + enc + `"`), nil
+}
+
+func (id *ID) UnmarshalJSON(data []byte) error {
+	if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
+		return fmt.Errorf("invalid JSON string")
+	}
+	enc := string(data[1 : len(data)-1])
+	return id.Decode(enc)
+}
+
 // NOTE: use with caution, any mutations to the returned proto can corrupt the ID
 func (id *ID) ToProto() (*callpbv1.DAG, error) {
 	dagPB := &callpbv1.DAG{

--- a/docs/current_docs/reference/cli.mdx
+++ b/docs/current_docs/reference/cli.mdx
@@ -13,6 +13,7 @@ The Dagger CLI provides a command-line interface to Dagger.
 
 ```
   -d, --debug             Show debug logs and full verbosity
+  -i, --interactive       interactive mode will spawn a terminal on container exec failure
       --progress string   Progress output format (auto, plain, tty) (default "auto")
   -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
   -s, --silent            Do not show progress at all
@@ -53,6 +54,7 @@ dagger call [options]
 
 ```
   -d, --debug             Show debug logs and full verbosity
+  -i, --interactive       interactive mode will spawn a terminal on container exec failure
       --progress string   Progress output format (auto, plain, tty) (default "auto")
   -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
   -s, --silent            Do not show progress at all
@@ -93,6 +95,7 @@ dagger config -m github.com/dagger/hello-dagger
 
 ```
   -d, --debug             Show debug logs and full verbosity
+  -i, --interactive       interactive mode will spawn a terminal on container exec failure
       --progress string   Progress output format (auto, plain, tty) (default "auto")
   -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
   -s, --silent            Do not show progress at all
@@ -140,6 +143,7 @@ dagger develop [options]
 
 ```
   -d, --debug             Show debug logs and full verbosity
+  -i, --interactive       interactive mode will spawn a terminal on container exec failure
       --progress string   Progress output format (auto, plain, tty) (default "auto")
   -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
   -s, --silent            Do not show progress at all
@@ -176,6 +180,7 @@ dagger functions [options] [function]...
 
 ```
   -d, --debug             Show debug logs and full verbosity
+  -i, --interactive       interactive mode will spawn a terminal on container exec failure
       --progress string   Progress output format (auto, plain, tty) (default "auto")
   -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
   -s, --silent            Do not show progress at all
@@ -227,6 +232,7 @@ dagger init --name=hello --sdk=python --source=some/subdir
 
 ```
   -d, --debug             Show debug logs and full verbosity
+  -i, --interactive       interactive mode will spawn a terminal on container exec failure
       --progress string   Progress output format (auto, plain, tty) (default "auto")
   -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
   -s, --silent            Do not show progress at all
@@ -266,6 +272,7 @@ dagger install github.com/shykes/daggerverse/ttlsh@16e40ec244966e55e36a13cb6e1ff
 
 ```
   -d, --debug             Show debug logs and full verbosity
+  -i, --interactive       interactive mode will spawn a terminal on container exec failure
       --progress string   Progress output format (auto, plain, tty) (default "auto")
   -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
   -s, --silent            Do not show progress at all
@@ -288,6 +295,7 @@ dagger login [options] [org]
 
 ```
   -d, --debug             Show debug logs and full verbosity
+  -i, --interactive       interactive mode will spawn a terminal on container exec failure
       --progress string   Progress output format (auto, plain, tty) (default "auto")
   -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
   -s, --silent            Do not show progress at all
@@ -310,6 +318,7 @@ dagger logout
 
 ```
   -d, --debug             Show debug logs and full verbosity
+  -i, --interactive       interactive mode will spawn a terminal on container exec failure
       --progress string   Progress output format (auto, plain, tty) (default "auto")
   -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
   -s, --silent            Do not show progress at all
@@ -368,6 +377,7 @@ EOF
 
 ```
   -d, --debug             Show debug logs and full verbosity
+  -i, --interactive       interactive mode will spawn a terminal on container exec failure
       --progress string   Progress output format (auto, plain, tty) (default "auto")
   -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
   -s, --silent            Do not show progress at all
@@ -423,6 +433,7 @@ dagger run python main.py
 
 ```
   -d, --debug             Show debug logs and full verbosity
+  -i, --interactive       interactive mode will spawn a terminal on container exec failure
       --progress string   Progress output format (auto, plain, tty) (default "auto")
   -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
   -s, --silent            Do not show progress at all
@@ -445,6 +456,7 @@ dagger version
 
 ```
   -d, --debug             Show debug logs and full verbosity
+  -i, --interactive       interactive mode will spawn a terminal on container exec failure
       --progress string   Progress output format (auto, plain, tty) (default "auto")
   -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
   -s, --silent            Do not show progress at all

--- a/engine/buildkit/blob.go
+++ b/engine/buildkit/blob.go
@@ -43,7 +43,7 @@ func (c *Client) DefToBlob(
 	}
 	cachedRes, err := resultProxy.Result(ctx)
 	if err != nil {
-		return nil, desc, wrapError(ctx, err, c.ID())
+		return nil, desc, wrapError(ctx, err, c)
 	}
 	workerRef, ok := cachedRes.Sys().(*bkworker.WorkerRef)
 	if !ok {
@@ -90,7 +90,7 @@ func (c *Client) DefToBlob(
 		Evaluate:   true,
 	})
 	if err != nil {
-		return nil, desc, fmt.Errorf("failed to solve blobsource: %w", wrapError(ctx, err, c.ID()))
+		return nil, desc, fmt.Errorf("failed to solve blobsource: %w", wrapError(ctx, err, c))
 	}
 
 	return blobPB, desc, nil

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -88,6 +88,7 @@ type Client struct {
 	closeCtx context.Context
 	cancel   context.CancelFunc
 	closeMu  sync.RWMutex
+	execMap  sync.Map
 }
 
 func NewClient(ctx context.Context, opts *Opts) (*Client, error) {
@@ -97,6 +98,7 @@ func NewClient(ctx context.Context, opts *Opts) (*Client, error) {
 		Opts:     opts,
 		closeCtx: ctx,
 		cancel:   cancel,
+		execMap:  sync.Map{},
 	}
 
 	return client, nil

--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -46,6 +46,12 @@ type ExecutionMetadata struct {
 	SecretToken string
 	Hostname    string
 
+	// Unique (random) ID for this execution.
+	// This is used to deduplicate the same execution that gets evaluated multiple times.
+	ExecID string
+
+	// Internal execution initiated by dagger and not the user.
+	// Used when executing the module runtime itself.
 	Internal bool
 
 	EncodedModuleID     string

--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/containerd/console"
 	runc "github.com/containerd/go-runc"
+	"github.com/dagger/dagger/dagql/call"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/executor"
 	"github.com/moby/buildkit/executor/oci"
@@ -54,6 +55,8 @@ type ExecutionMetadata struct {
 	// Used when executing the module runtime itself.
 	Internal bool
 
+	// TODO: can rm EncodedModuleID now
+	CallID              *call.ID
 	EncodedModuleID     string
 	EncodedFunctionCall json.RawMessage
 

--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -46,6 +46,8 @@ type ExecutionMetadata struct {
 	SecretToken string
 	Hostname    string
 
+	Internal bool
+
 	EncodedModuleID     string
 	EncodedFunctionCall json.RawMessage
 

--- a/engine/buildkit/ref.go
+++ b/engine/buildkit/ref.go
@@ -423,7 +423,11 @@ func debugContainer(ctx context.Context, execOp *bksolverpb.ExecOp, execErr *llb
 
 	output := idtui.NewOutput(term.Stderr)
 	fmt.Fprintf(term.Stderr,
-		output.String(idtui.IconFailure).Foreground(termenv.ANSIRed).String()+" Exec failed, attaching terminal\r\n")
+		output.String(idtui.IconFailure).Foreground(termenv.ANSIRed).String()+" Exec failed, attaching terminal: ")
+	if err := idtui.DumpID(output, execMd.CallID); err != nil {
+		return fmt.Errorf("failed to serialize service ID: %w", err)
+	}
+	fmt.Fprintf(term.Stderr, "\r\n")
 	fmt.Fprintf(term.Stderr,
 		output.String("! %s\r\n\n").Foreground(termenv.ANSIYellow).String(), execErr.Error())
 

--- a/engine/buildkit/ref.go
+++ b/engine/buildkit/ref.go
@@ -422,14 +422,17 @@ func debugContainer(ctx context.Context, execOp *bksolverpb.ExecOp, execErr *llb
 	}
 
 	output := idtui.NewOutput(term.Stderr)
-	fmt.Fprintf(term.Stderr,
+	fmt.Fprint(term.Stderr,
 		output.String(idtui.IconFailure).Foreground(termenv.ANSIRed).String()+" Exec failed, attaching terminal: ")
-	if err := idtui.DumpID(output, execMd.CallID); err != nil {
+	dump := idtui.Dump{Newline: "\r\n", Prefix: "    "}
+	fmt.Fprint(term.Stderr, dump.Newline)
+	if err := dump.DumpID(output, execMd.CallID); err != nil {
 		return fmt.Errorf("failed to serialize service ID: %w", err)
 	}
-	fmt.Fprintf(term.Stderr, "\r\n")
+	fmt.Fprint(term.Stderr, dump.Newline)
 	fmt.Fprintf(term.Stderr,
-		output.String("! %s\r\n\n").Foreground(termenv.ANSIYellow).String(), execErr.Error())
+		output.String("! %s").Foreground(termenv.ANSIYellow).String(), execErr.Error())
+	fmt.Fprint(term.Stderr, dump.Newline)
 
 	dbgShell, err := dbgCtr.Start(ctx, bkgw.StartRequest{
 		// We need to hardcode a shell since we don't have access to `withDefaultTerminalCmd` here.

--- a/engine/buildkit/ref.go
+++ b/engine/buildkit/ref.go
@@ -9,10 +9,12 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd/leases"
+	"github.com/dagger/dagger/dagql/idtui"
 	bkcache "github.com/moby/buildkit/cache"
 	cacheutil "github.com/moby/buildkit/cache/util"
 	"github.com/moby/buildkit/client/llb"
 	bkgw "github.com/moby/buildkit/frontend/gateway/client"
+	bkgwpb "github.com/moby/buildkit/frontend/gateway/pb"
 	bksession "github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/snapshot"
 	bksolver "github.com/moby/buildkit/solver"
@@ -23,6 +25,7 @@ import (
 	solverresult "github.com/moby/buildkit/solver/result"
 	"github.com/moby/buildkit/util/bklog"
 	bkworker "github.com/moby/buildkit/worker"
+	"github.com/muesli/termenv"
 	"github.com/opencontainers/go-digest"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	fstypes "github.com/tonistiigi/fsutil/types"
@@ -201,7 +204,7 @@ func (r *ref) Result(ctx context.Context) (bksolver.CachedResult, error) {
 	ctx = withOutgoingContext(ctx)
 	res, err := r.resultProxy.Result(ctx)
 	if err != nil {
-		return nil, wrapError(ctx, err, r.c.ID())
+		return nil, wrapError(ctx, err, r.c)
 	}
 	return res, nil
 }
@@ -254,7 +257,7 @@ func ConvertToWorkerCacheResult(ctx context.Context, res *solverresult.Result[*r
 	})
 }
 
-func wrapError(ctx context.Context, baseErr error, sessionID string) error {
+func wrapError(ctx context.Context, baseErr error, client *Client) error {
 	var slowCacheErr *bksolver.SlowCacheError
 	if errors.As(baseErr, &slowCacheErr) {
 		if slowCacheErr.Result != nil {
@@ -313,7 +316,7 @@ func wrapError(ctx context.Context, baseErr error, sessionID string) error {
 	if !ok {
 		return errors.Join(baseErr, fmt.Errorf("invalid ref type: %T", metaMountResult.Sys()))
 	}
-	mntable, err := workerRef.ImmutableRef.Mount(ctx, true, bksession.NewGroup(sessionID))
+	mntable, err := workerRef.ImmutableRef.Mount(ctx, true, bksession.NewGroup(client.ID()))
 	if err != nil {
 		return errors.Join(err, baseErr)
 	}
@@ -339,6 +342,11 @@ func wrapError(ctx context.Context, baseErr error, sessionID string) error {
 		}
 	}
 
+	// Start a debug container if the exec failed
+	if err := debugContainer(ctx, execOp.Exec, execErr, client); err != nil {
+		bklog.G(ctx).Debugf("debug terminal error: %v", err)
+	}
+
 	return &ExecError{
 		original: baseErr,
 		Cmd:      execOp.Exec.Meta.Args,
@@ -346,6 +354,101 @@ func wrapError(ctx context.Context, baseErr error, sessionID string) error {
 		Stdout:   strings.TrimSpace(string(stdoutBytes)),
 		Stderr:   strings.TrimSpace(string(stderrBytes)),
 	}
+}
+
+func debugContainer(ctx context.Context, execOp *bksolverpb.ExecOp, execErr *llberror.ExecError, client *Client) error {
+	if !client.Opts.Interactive {
+		return nil
+	}
+
+	// If this is the (internal) exec of the module itself, we don't want to spawn a terminal.
+	for _, env := range execOp.Meta.Env {
+		if strings.HasPrefix(env, "_DAGGER_CALL_DIGEST=") {
+			return nil
+		}
+	}
+
+	mounts := []ContainerMount{}
+	for i, m := range execOp.Mounts {
+		mountID := execErr.Mounts[i]
+		if mountID == nil {
+			continue
+		}
+
+		workerRef, ok := mountID.Sys().(*bkworker.WorkerRef)
+		if !ok {
+			continue
+		}
+
+		mounts = append(mounts, ContainerMount{
+			WorkerRef: workerRef,
+			Mount: &bkgw.Mount{
+				Dest:      m.Dest,
+				Selector:  m.Selector,
+				Readonly:  m.Readonly,
+				MountType: m.MountType,
+				CacheOpt:  m.CacheOpt,
+				SecretOpt: m.SecretOpt,
+				SSHOpt:    m.SSHOpt,
+				ResultID:  mountID.ID(),
+			},
+		})
+	}
+
+	dbgCtr, err := client.NewContainer(ctx, NewContainerRequest{
+		Hostname: execOp.Meta.Hostname,
+		Mounts:   mounts,
+	})
+	if err != nil {
+		return err
+	}
+	term, err := client.OpenTerminal(ctx)
+	if err != nil {
+		return err
+	}
+
+	output := idtui.NewOutput(term.Stderr)
+	fmt.Fprintf(term.Stderr,
+		output.String(idtui.IconFailure).Foreground(termenv.ANSIRed).String()+" Exec failed, attaching terminal\r\n")
+	fmt.Fprintf(term.Stderr,
+		output.String("! %s\r\n\n").Foreground(termenv.ANSIYellow).String(), execErr.Error())
+
+	dbgShell, err := dbgCtr.Start(ctx, bkgw.StartRequest{
+		// We need to hardcode a shell since we don't have access to `withDefaultTerminalCmd` here.
+		//
+		// We could use `sh` instead of `/bin/sh`, but then we'd be relying on $PATH to be set up correctly.
+		// It's more likely for `sh` to be in `/bin/sh` than for the container to have a correct $PATH.
+		Args: []string{"/bin/sh"},
+
+		Env:          execOp.Meta.Env,
+		Cwd:          execOp.Meta.Cwd,
+		User:         execOp.Meta.User,
+		SecurityMode: execOp.Security,
+		SecretEnv:    execOp.Secretenv,
+
+		Tty:    true,
+		Stdin:  term.Stdin,
+		Stdout: term.Stdout,
+		Stderr: term.Stderr,
+	})
+	if err != nil {
+		return err
+	}
+	go func() {
+		for resize := range term.ResizeCh {
+			dbgShell.Resize(ctx, resize)
+		}
+	}()
+	waitErr := dbgShell.Wait()
+	termExitCode := 0
+	if waitErr != nil {
+		termExitCode = 1
+		var exitErr *bkgwpb.ExitError
+		if errors.As(waitErr, &exitErr) {
+			termExitCode = int(exitErr.ExitCode)
+		}
+	}
+	return term.Close(termExitCode)
 }
 
 func getExecMetaFile(ctx context.Context, mntable snapshot.Mountable, fileName string) ([]byte, error) {

--- a/engine/buildkit/ref.go
+++ b/engine/buildkit/ref.go
@@ -369,6 +369,14 @@ func debugContainer(ctx context.Context, execOp *bksolverpb.ExecOp, execErr *llb
 		// containers created by buildkit internals like the dockerfile frontend
 		return nil
 	}
+
+	// Ensure we only spawn one terminal per exec.
+	if execMd.ExecID != "" {
+		if _, exists := client.execMap.LoadOrStore(execMd.ExecID, struct{}{}); exists {
+			return nil
+		}
+	}
+
 	// If this is the (internal) exec of the module itself, we don't want to spawn a terminal.
 	if execMd.Internal {
 		return nil

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -77,6 +77,8 @@ type Params struct {
 	// Log level (0 = INFO)
 	LogLevel slog.Level
 
+	Interactive bool
+
 	WithTerminal session.WithTerminalFunc
 }
 
@@ -1009,6 +1011,7 @@ func (c *Client) clientMetadata() engine.ClientMetadata {
 		Labels:                    c.labels,
 		CloudToken:                os.Getenv("DAGGER_CLOUD_TOKEN"),
 		DoNotTrack:                analytics.DoNotTrack(),
+		Interactive:               c.Interactive,
 	}
 }
 

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -57,6 +57,9 @@ type ClientMetadata struct {
 	// (Optional) Pipeline labels for e.g. vcs info like branch, commit, etc.
 	Labels map[string]string `json:"labels"`
 
+	// Interactive mode
+	Interactive bool `json:"interactive"`
+
 	// Import configuration for Buildkit's remote cache
 	UpstreamCacheImportConfig []*controlapi.CacheOptionsEntry
 

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -86,6 +86,8 @@ type daggerSession struct {
 
 	dagqlCache       dagql.Cache
 	cacheEntrySetMap *sync.Map
+
+	interactive bool
 }
 
 type daggerSessionState string
@@ -161,6 +163,7 @@ func (srv *Server) initializeDaggerSession(
 	sess.dagqlCache = dagql.NewCache()
 	sess.cacheEntrySetMap = &sync.Map{}
 	sess.telemetryPubSub = srv.telemetryPubSub
+	sess.interactive = clientMetadata.Interactive
 
 	sess.analytics = analytics.New(analytics.Config{
 		DoNotTrack: clientMetadata.DoNotTrack || analytics.DoNotTrack(),
@@ -420,6 +423,8 @@ func (srv *Server) initializeDaggerClient(
 		ContainersMu: &client.daggerSession.containersMu,
 
 		SpanCtx: client.spanCtx,
+
+		Interactive: client.daggerSession.interactive,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create buildkit client: %w", err)


### PR DESCRIPTION
Add a `--interactive` (`-i`) option to `dagger call` which will spawn
a terminal when a container execution fails
