### PR TITLE
tui: associate effects to their origin, not their unlazier

### DIFF
--- a/cmd/engine/telemetry.go
+++ b/cmd/engine/telemetry.go
@@ -16,6 +16,7 @@ import (
 
 	"dagger.io/dagger/telemetry"
 	"github.com/dagger/dagger/engine"
+	"github.com/dagger/dagger/engine/buildkit"
 	enginetel "github.com/dagger/dagger/engine/telemetry"
 )
 
@@ -81,6 +82,9 @@ func InitTelemetry(ctx context.Context) (context.Context, *enginetel.PubSub) {
 		Detect: false,
 
 		SpanProcessors: []sdktrace.SpanProcessor{
+			// Install a span processor that modifies spans created by Buildkit to
+			// fit our ideal format.
+			buildkit.SpanProcessor{},
 			// Install a span processor that annotates each span with the client ID
 			// that it came from.
 			pubsub.Processor(),

--- a/core/container.go
+++ b/core/container.go
@@ -1450,7 +1450,7 @@ func (container *Container) Service(ctx context.Context) (*Service, error) {
 			return nil, err
 		}
 	}
-	return container.Query.NewContainerService(container), nil
+	return container.Query.NewContainerService(ctx, container), nil
 }
 
 func (container *Container) ownership(ctx context.Context, owner string) (*Ownership, error) {

--- a/core/query.go
+++ b/core/query.go
@@ -117,14 +117,16 @@ func (q *Query) NewModule() *Module {
 	}
 }
 
-func (q *Query) NewContainerService(ctr *Container) *Service {
+func (q *Query) NewContainerService(ctx context.Context, ctr *Container) *Service {
+	connectServiceEffect(ctx)
 	return &Service{
 		Query:     q,
 		Container: ctr,
 	}
 }
 
-func (q *Query) NewTunnelService(upstream dagql.Instance[*Service], ports []PortForward) *Service {
+func (q *Query) NewTunnelService(ctx context.Context, upstream dagql.Instance[*Service], ports []PortForward) *Service {
+	connectServiceEffect(ctx)
 	return &Service{
 		Query:          q,
 		TunnelUpstream: &upstream,
@@ -132,7 +134,8 @@ func (q *Query) NewTunnelService(upstream dagql.Instance[*Service], ports []Port
 	}
 }
 
-func (q *Query) NewHostService(upstream string, ports []PortForward, sessionID string) *Service {
+func (q *Query) NewHostService(ctx context.Context, upstream string, ports []PortForward, sessionID string) *Service {
+	connectServiceEffect(ctx)
 	return &Service{
 		Query:         q,
 		HostUpstream:  upstream,

--- a/core/schema/host.go
+++ b/core/schema/host.go
@@ -276,7 +276,7 @@ func (s *hostSchema) tunnel(ctx context.Context, parent *core.Host, args hostTun
 		return nil, errors.New("no ports to forward")
 	}
 
-	return parent.Query.NewTunnelService(inst, ports), nil
+	return parent.Query.NewTunnelService(ctx, inst, ports), nil
 }
 
 type hostServiceArgs struct {
@@ -334,6 +334,7 @@ func (s *hostSchema) internalService(ctx context.Context, parent *core.Host, arg
 	}
 
 	return parent.Query.NewHostService(
+		ctx,
 		args.Host,
 		collectInputsSlice(args.Ports),
 		args.SessionID,

--- a/core/telemetry.go
+++ b/core/telemetry.go
@@ -107,7 +107,7 @@ func AroundFunc(ctx context.Context, self dagql.Object, id *call.ID) (context.Co
 						ops = append(ops, dig.String())
 					}
 				}
-				span.SetAttributes(attribute.StringSlice(telemetry.LLBDigestsAttr, ops))
+				span.SetAttributes(attribute.StringSlice(telemetry.EffectIDsAttr, ops))
 			}
 		}
 	}
@@ -131,4 +131,13 @@ func isIntrospection(id *call.ID) bool {
 	} else {
 		return isIntrospection(id.Base())
 	}
+}
+
+func serviceEffect(id *call.ID) string {
+	return id.Digest().String() + "-service"
+}
+
+// Tell telemetry about the associated effect for when the service starts.
+func connectServiceEffect(ctx context.Context) {
+	trace.SpanFromContext(ctx).SetAttributes(attribute.StringSlice(telemetry.EffectIDsAttr, []string{serviceEffect(dagql.CurrentID(ctx))}))
 }

--- a/dagql/idtui/db.go
+++ b/dagql/idtui/db.go
@@ -268,7 +268,7 @@ func (db *DB) maybeRecordSpan(traceData *Trace, span sdktrace.ReadOnlySpan) { //
 		case telemetry.DagInputsAttr:
 			spanData.Inputs = attr.Value.AsStringSlice()
 
-		case telemetry.LLBDigestsAttr:
+		case telemetry.EffectIDsAttr:
 			// NOTE: avoid processing this twice so we can preserve order in EffectSites
 			// without resorting to a map, just in case we want to add a reverse nav
 			if len(spanData.Effects) == 0 {
@@ -301,7 +301,7 @@ func (db *DB) maybeRecordSpan(traceData *Trace, span sdktrace.ReadOnlySpan) { //
 		case "rpc.service":
 			spanData.Passthrough = true
 
-		case "vertex":
+		case telemetry.EffectIDAttr:
 			// NOTE: this is set by Buildkit, and we overload it as the effect ID
 			spanData.EffectID = attr.Value.AsString()
 			db.Effects[spanData.EffectID] = spanData

--- a/dagql/idtui/db.go
+++ b/dagql/idtui/db.go
@@ -302,7 +302,6 @@ func (db *DB) maybeRecordSpan(traceData *Trace, span sdktrace.ReadOnlySpan) { //
 			spanData.Passthrough = true
 
 		case telemetry.EffectIDAttr:
-			// NOTE: this is set by Buildkit, and we overload it as the effect ID
 			spanData.EffectID = attr.Value.AsString()
 			db.Effects[spanData.EffectID] = spanData
 			for _, dependentSpan := range db.EffectSites[spanData.EffectID] {

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -12,7 +12,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"
 	"github.com/opencontainers/go-digest"
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/log"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
@@ -236,13 +235,13 @@ func (r renderer) renderSpan(
 	fmt.Fprint(out, prefix)
 	r.indent(out, depth)
 
+	style := lipgloss.NewStyle()
 	if span != nil {
 		r.renderStatus(out, span, focused)
-	}
 
-	style := lipgloss.NewStyle()
-	if span.EffectID != "" {
-		style = style.Italic(true)
+		if span.EffectID != "" {
+			style = style.Italic(true)
+		}
 	}
 	fmt.Fprint(out, style.Render(name))
 
@@ -302,13 +301,13 @@ func (r renderer) renderStatus(out *termenv.Output, span *Span, focused bool) {
 	var symbol string
 	var color termenv.Color
 	switch {
-	case span.IsRunning:
+	case span.IsRunning():
 		symbol = DotFilled
 		color = termenv.ANSIYellow
 	case span.Canceled:
 		symbol = IconSkipped
 		color = termenv.ANSIBrightBlack
-	case span.Status().Code == codes.Error:
+	case span.Failed():
 		symbol = IconFailure
 		color = termenv.ANSIRed
 	default:
@@ -332,7 +331,7 @@ func (r renderer) renderStatus(out *termenv.Output, span *Span, focused bool) {
 func (r renderer) renderDuration(out *termenv.Output, span *Span) {
 	fmt.Fprint(out, " ")
 	duration := out.String(fmtDuration(span.Duration()))
-	if span.IsRunning {
+	if span.IsRunning() {
 		duration = duration.Foreground(termenv.ANSIYellow)
 	} else {
 		duration = duration.Faint()

--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -317,11 +317,13 @@ func (fe *frontendPlain) ForceFlush(context.Context) error {
 }
 
 func (fe *frontendPlain) wakeUpEffect(effectID string) {
-	for _, effectSpan := range fe.db.EffectSites[effectID] {
-		effectDt, ok := fe.data[effectSpan.ID]
-		if ok {
-			effectDt.mustShow = true
-		}
+	effectSpan := fe.db.EffectSite[effectID]
+	if effectSpan == nil {
+		return
+	}
+	effectDt, ok := fe.data[effectSpan.ID]
+	if ok {
+		effectDt.mustShow = true
 	}
 }
 

--- a/dagql/idtui/types.go
+++ b/dagql/idtui/types.go
@@ -120,6 +120,7 @@ func (db *DB) WalkSpans(spans []*Span, f func(*TraceTree)) {
 		lastRow = row
 		for _, effectID := range span.Effects {
 			if effect, ok := db.Effects[effectID]; ok {
+				// reparent so we can step out of the effect
 				effect.ParentSpan = row.Span
 				walk(effect, row)
 				if effect.IsRunning() || effect.Failed() {

--- a/dagql/idtui/types.go
+++ b/dagql/idtui/types.go
@@ -104,7 +104,7 @@ func (db *DB) WalkSpans(spans []*Span, f func(*TraceTree)) {
 		if span.Base != nil && lastRow != nil {
 			row.Chained = span.Base.Digest == lastRow.Span.Digest
 		}
-		if span.IsRunning() || span.Failed() {
+		if span.IsRunning() {
 			row.setRunning()
 		}
 		f(row)
@@ -127,7 +127,7 @@ func (db *DB) WalkSpans(spans []*Span, f func(*TraceTree)) {
 				// reparent so we can step out of the effect
 				effect.ParentSpan = row.Span
 				walk(effect, row)
-				if effect.IsRunning() || effect.Failed() {
+				if effect.IsRunning() {
 					row.setRunning()
 				}
 			}

--- a/dagql/idtui/types.go
+++ b/dagql/idtui/types.go
@@ -104,7 +104,7 @@ func (db *DB) WalkSpans(spans []*Span, f func(*TraceTree)) {
 		if span.Base != nil && lastRow != nil {
 			row.Chained = span.Base.Digest == lastRow.Span.Digest
 		}
-		if span.IsRunning || span.Failed() {
+		if span.IsRunning() || span.Failed() {
 			row.setRunning()
 		}
 		f(row)
@@ -122,7 +122,7 @@ func (db *DB) WalkSpans(spans []*Span, f func(*TraceTree)) {
 			if effect, ok := db.Effects[effectID]; ok {
 				effect.ParentSpan = row.Span
 				walk(effect, row)
-				if effect.IsRunning || effect.Failed() {
+				if effect.IsRunning() || effect.Failed() {
 					row.setRunning()
 				}
 			}

--- a/dagql/idtui/types.go
+++ b/dagql/idtui/types.go
@@ -111,7 +111,7 @@ func (db *DB) WalkSpans(spans []*Span, f func(*TraceTree)) {
 		lastRow = row
 		seen[spanID] = true
 		for _, child := range span.ChildSpans {
-			if child.EffectID != "" && len(db.EffectSites[child.EffectID]) > 0 {
+			if child.EffectID != "" && db.EffectSite[child.EffectID] != nil {
 				// let it show up at the call sites instead
 				continue
 			}
@@ -119,6 +119,10 @@ func (db *DB) WalkSpans(spans []*Span, f func(*TraceTree)) {
 		}
 		lastRow = row
 		for _, effectID := range span.Effects {
+			if db.EffectSite[effectID] != span {
+				// only show effects that we are the first 'site' of
+				continue
+			}
 			if effect, ok := db.Effects[effectID]; ok {
 				// reparent so we can step out of the effect
 				effect.ParentSpan = row.Span

--- a/dagql/idtui/types.go
+++ b/dagql/idtui/types.go
@@ -120,6 +120,7 @@ func (db *DB) WalkSpans(spans []*Span, f func(*TraceTree)) {
 		lastRow = row
 		for _, effectID := range span.Effects {
 			if effect, ok := db.Effects[effectID]; ok {
+				effect.ParentSpan = row.Span
 				walk(effect, row)
 				if effect.IsRunning || effect.Failed() {
 					row.setRunning()

--- a/engine/buildkit/telemetry.go
+++ b/engine/buildkit/telemetry.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"strings"
 
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/embedded"
 
@@ -40,25 +42,16 @@ type buildkitTracer struct {
 	provider *buildkitTraceProvider
 }
 
+const TelemetryComponent = "buildkit"
+
 func (t *buildkitTracer) Start(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-	opts = append([]trace.SpanStartOption{}, opts...)
-
-	if rest, ok := strings.CutPrefix(spanName, InternalPrefix); ok {
-		spanName = rest
-		opts = append(opts, telemetry.Internal())
-	} else if rest, ok := strings.CutPrefix(spanName, "load cache: "+InternalPrefix); ok {
-		spanName = "load cache: " + rest
-		opts = append(opts, telemetry.Internal())
-	}
-
-	if spanName == "remotes.docker.resolver.HTTPRequest" {
-		opts = append(opts, telemetry.Encapsulated())
-	}
-	if spanName == "HTTP GET" {
-		// HACK: resolver.do is wrapped with a new span, resolver.authorize isn't :)
-		// so we need this special case, to make sure to catch the auth requests
-		opts = append(opts, telemetry.Encapsulated())
-	}
+	opts = append([]trace.SpanStartOption{
+		// Sprinkle an attribute on these spans so we can mess with them in the SpanProcessor.
+		//
+		// Ideally Buildkit would just set an appropriate scope name, but it doesn't, so we
+		// have to make do.
+		trace.WithAttributes(attribute.Bool("buildkit", true)),
+	}, opts...)
 
 	ctx, span := t.tracer.Start(ctx, spanName, opts...)
 	newSpan := buildkitSpan{Span: span, provider: t.provider}
@@ -73,3 +66,62 @@ type buildkitSpan struct {
 func (s buildkitSpan) TracerProvider() trace.TracerProvider {
 	return s.provider
 }
+
+// SpanProcessor modifies spans coming from the Buildkit component to integrate
+// them with Dagger's telemetry stack.
+//
+// It must be used in combination with the buildkitTraceProvider.
+type SpanProcessor struct{}
+
+var _ sdktrace.SpanProcessor = SpanProcessor{}
+
+func (sp SpanProcessor) OnStart(ctx context.Context, span sdktrace.ReadWriteSpan) {
+	var isBuildkit bool
+	var vertex string
+	for _, attr := range span.Attributes() {
+		switch attr.Key {
+		case "buildkit":
+			isBuildkit = attr.Value.AsBool()
+		case "vertex":
+			vertex = attr.Value.AsString()
+		}
+	}
+	if !isBuildkit {
+		return
+	}
+	spanName := span.Name()
+
+	attrs := []attribute.KeyValue{}
+
+	// convert [internal] prefix into internal attribute
+	if rest, ok := strings.CutPrefix(spanName, InternalPrefix); ok {
+		span.SetName(rest)
+		attrs = append(attrs, attribute.Bool(telemetry.UIInternalAttr, true))
+	} else if rest, ok := strings.CutPrefix(spanName, "load cache: "+InternalPrefix); ok {
+		span.SetName("load cache: " + rest)
+		attrs = append(attrs, attribute.Bool(telemetry.UIInternalAttr, true))
+	}
+
+	// silence noisy registry lookups
+	if spanName == "remotes.docker.resolver.HTTPRequest" {
+		attrs = append(attrs, attribute.Bool(telemetry.UIEncapsulatedAttr, true))
+	}
+	if spanName == "HTTP GET" {
+		// HACK: resolver.do is wrapped with a new span, resolver.authorize isn't :)
+		// so we need this special case, to make sure to catch the auth requests
+		attrs = append(attrs, attribute.Bool(telemetry.UIEncapsulatedAttr, true))
+	}
+
+	// remap vertex attr to standard effect ID attr
+	if vertex != "" {
+		attrs = append(attrs, attribute.String(telemetry.EffectIDAttr, vertex))
+	}
+
+	if len(attrs) > 0 {
+		span.SetAttributes(attrs...)
+	}
+}
+
+func (sp SpanProcessor) OnEnd(sdktrace.ReadOnlySpan)      {}
+func (sp SpanProcessor) ForceFlush(context.Context) error { return nil }
+func (sp SpanProcessor) Shutdown(context.Context) error   { return nil }

--- a/sdk/go/telemetry/attrs.go
+++ b/sdk/go/telemetry/attrs.go
@@ -58,9 +58,14 @@ const (
 	// span represents.
 	LLBOpAttr = "dagger.io/llb.op"
 
+	// The IDs of effects which will be correlated to this span.
+	//
 	// The digests of the LLB operations that this span depends on, allowing the
 	// UI to attribute their future "cost."
-	LLBDigestsAttr = "dagger.io/llb.digests"
+	EffectIDsAttr = "dagger.io/llb.digests" // TODO: backwards compat.
+
+	// The ID of the effect that this span represents.
+	EffectIDAttr = "vertex" // TODO: backwards-compat. and cross-compat. with Buildkit.
 
 	// The amount of progress that needs to be reached.
 	ProgressTotalAttr = "dagger.io/progress.total"

--- a/sdk/go/telemetry/attrs.go
+++ b/sdk/go/telemetry/attrs.go
@@ -60,12 +60,11 @@ const (
 
 	// The IDs of effects which will be correlated to this span.
 	//
-	// The digests of the LLB operations that this span depends on, allowing the
-	// UI to attribute their future "cost."
-	EffectIDsAttr = "dagger.io/llb.digests" // TODO: backwards compat.
+	// This is typically a list of LLB operation digests, but can be any string.
+	EffectIDsAttr = "dagger.io/effect.ids"
 
 	// The ID of the effect that this span represents.
-	EffectIDAttr = "vertex" // TODO: backwards-compat. and cross-compat. with Buildkit.
+	EffectIDAttr = "dagger.io/effect.id"
 
 	// The amount of progress that needs to be reached.
 	ProgressTotalAttr = "dagger.io/progress.total"


### PR DESCRIPTION
The place where something becomes un-lazied is not that useful. Better to show effects at their point of origin instead. This is a bit of :sparkles: movie magic :sparkles:  but it's a lot more useful than telling "the truth" (arguably an implementation detail of our telemetry plumbing).

This also effectively works around a Buildkit bug that ends up associating LLB to incorrect spans[^1], which would sometimes put a failed span beneath a succeeding one, making it especially hard to find.

[^1]: possibly from [here](https://github.com/moby/buildkit/blob/master/solver/jobs.go#L696) which the race detector is also unhappy with)

* [x] Bikeshed the attribute name? We overload Buildkit's `vertex` attribute, but we have the power to translate that to something like `dagger.io/effect.id`.
  * There's now a SpanProcessor that translates the attribute as described. New scheme:
    * `vertex` -> `dagger.io/effect.id`
    * `dagger.io/llb.digests` -> `dagger.io/effect.ids`
  * These attributes are set by services now too, so it makes sense to decouple from Buildkit's naming.
  * [x] Update Cloud to handle new attribute names
    * https://github.com/dagger/dagger.io/pull/3806