### PR TITLE
fix: don't make cli default to "main" branch

### DIFF
--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -227,7 +227,14 @@ func (v *directoryValue) Get(ctx context.Context, dag *dagger.Client, modSrc *da
 		if authSock, ok := os.LookupEnv("SSH_AUTH_SOCK"); ok {
 			gitOpts.SSHAuthSocket = dag.Host().UnixSocket(authSock)
 		}
-		gitDir := dag.Git(parsedGit.Remote, gitOpts).Branch(parsedGit.Fragment.Ref).Tree()
+		git := dag.Git(parsedGit.Remote, gitOpts)
+		var gitRef *dagger.GitRef
+		if parsedGit.Fragment.Ref == "" {
+			gitRef = git.Head()
+		} else {
+			gitRef = git.Branch(parsedGit.Fragment.Ref)
+		}
+		gitDir := gitRef.Tree()
 		if subdir := parsedGit.Fragment.Subdir; subdir != "" {
 			gitDir = gitDir.Directory(subdir)
 		}
@@ -258,11 +265,6 @@ func parseGit(urlStr string) (*gitutil.GitURL, error) {
 	}
 	if u.Fragment == nil {
 		u.Fragment = &gitutil.GitURLFragment{}
-	}
-	if u.Fragment.Ref == "" {
-		// FIXME: default branch can be remotely looked up, but that would
-		// require 1) a context, 2) a way to return an error, 3) more time than I have :)
-		u.Fragment.Ref = "main"
 	}
 	return u, nil
 }
@@ -303,7 +305,14 @@ func (v *fileValue) Get(_ context.Context, dag *dagger.Client, _ *dagger.ModuleS
 		if authSock, ok := os.LookupEnv("SSH_AUTH_SOCK"); ok {
 			gitOpts.SSHAuthSocket = dag.Host().UnixSocket(authSock)
 		}
-		gitDir := dag.Git(parsedGit.Remote, gitOpts).Branch(parsedGit.Fragment.Ref).Tree()
+		git := dag.Git(parsedGit.Remote, gitOpts)
+		var gitRef *dagger.GitRef
+		if parsedGit.Fragment.Ref == "" {
+			gitRef = git.Head()
+		} else {
+			gitRef = git.Branch(parsedGit.Fragment.Ref)
+		}
+		gitDir := gitRef.Tree()
 		path := parsedGit.Fragment.Subdir
 		if path == "" {
 			return nil, fmt.Errorf("expected path selection for git repo")

--- a/cmd/dagger/module_test.go
+++ b/cmd/dagger/module_test.go
@@ -59,7 +59,7 @@ func TestParseGit(t *testing.T) {
 				Host:   "github.com",
 				Path:   "/shykes/daggerverse",
 				Fragment: &gitutil.GitURLFragment{
-					Ref: "main",
+					Ref: "",
 				},
 				Remote: "ssh://git@github.com/shykes/daggerverse",
 			},
@@ -72,7 +72,7 @@ func TestParseGit(t *testing.T) {
 				Host:   "github.com",
 				Path:   "/shykes/daggerverse.git",
 				Fragment: &gitutil.GitURLFragment{
-					Ref: "main",
+					Ref: "",
 				},
 				Remote: "ssh://git@github.com/shykes/daggerverse.git",
 			},
@@ -139,7 +139,7 @@ func TestParseGit(t *testing.T) {
 				Host:   "github.com",
 				Path:   "sipsma/daggerverse",
 				Fragment: &gitutil.GitURLFragment{
-					Ref: "main",
+					Ref: "",
 				},
 				Remote: "git@github.com:sipsma/daggerverse",
 			},
@@ -152,7 +152,7 @@ func TestParseGit(t *testing.T) {
 				Host:   "github.com",
 				Path:   "sipsma/daggerverse.git",
 				Fragment: &gitutil.GitURLFragment{
-					Ref: "main",
+					Ref: "",
 				},
 				Remote: "git@github.com:sipsma/daggerverse.git",
 			},


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/7684.

Previously, we didn't use to have a way to get the "default" branch - however, now we do, we can just do `.Head()` on a git repository. (note: this is just as lazy as all the other git calls).

So we don't need to assume "main" at any point.