### PR TITLE
feat: add module versioning compat checks

### DIFF
--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
+	"github.com/dagger/dagger/engine"
 )
 
 type ModuleSourceKind string
@@ -229,9 +230,7 @@ func (src *ModuleSource) ModuleEngineVersion(ctx context.Context) (string, error
 	if cfg.EngineVersion == "" {
 		// older versions of dagger might not produce an engine version - so
 		// return the version that engineVersion was introduced in
-		// TODO: replace once dagger/dagger#7692 is merged
-		// return engine.MinimumModuleVersion, nil
-		return "v0.9.9", nil
+		return engine.MinimumModuleVersion, nil
 	}
 	if !semver.IsValid(cfg.EngineVersion) {
 		// filter out non-semver values to simplify calling code

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -721,6 +721,17 @@ func (s *moduleSchema) moduleWithSource(ctx context.Context, mod *core.Module, a
 		return nil, fmt.Errorf("failed to decode module source: %w", err)
 	}
 
+	engineVersion, err := src.Self.ModuleEngineVersion(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load module config: %w", err)
+	}
+	if err := engine.CheckVersionCompatibility(engineVersion, engine.MinimumModuleVersion); err != nil {
+		return nil, fmt.Errorf("module requires incompatible engine version: %w", err)
+	}
+	if err := engine.CheckVersionCompatibility(engine.Version, engineVersion); err != nil {
+		return nil, fmt.Errorf("module requires newer engine version: %w", err)
+	}
+
 	mod = mod.Clone()
 	mod.Source = src
 	mod.NameField, err = src.Self.ModuleName(ctx)

--- a/engine/version.go
+++ b/engine/version.go
@@ -24,6 +24,14 @@ var (
 	// MinimumClientVersion is used by the engine to determine the minimum
 	// allowed client version that can connect to that engine.
 	MinimumClientVersion = "v0.12.0"
+
+	// MinimumModuleVersion is used by the engine to determine the minimum
+	// allowed module engine version that can connect to this engine.
+	//
+	// Set to v0.9.9, because this was when the engineVersion field was
+	// introduced - if it's present and not a dev version, it must be higher
+	// than v0.9.9.
+	MinimumModuleVersion = "v0.9.9"
 )
 
 func init() {
@@ -35,12 +43,14 @@ func init() {
 	if v, ok := os.LookupEnv(DaggerMinimumVersionEnv); ok {
 		MinimumClientVersion = v
 		MinimumEngineVersion = v
+		MinimumModuleVersion = v
 	}
 
 	// normalize version strings
 	Version = normalizeVersion(Version)
 	MinimumClientVersion = normalizeVersion(MinimumClientVersion)
 	MinimumEngineVersion = normalizeVersion(MinimumEngineVersion)
+	MinimumModuleVersion = normalizeVersion(MinimumModuleVersion)
 }
 
 func normalizeVersion(v string) string {


### PR DESCRIPTION
As discussed in https://github.com/dagger/dagger/issues/7640.

This is a follow-up to https://github.com/dagger/dagger/pull/5315, which will allow us to add a backwards compatibility check if/when we make breaking changes to the module API, etc.

This uses the `engineVersion` field introduced in [`1377f13` (#6469)](https://github.com/dagger/dagger/pull/6469/commits/1377f132cfbf280c21f6e29af88451ecf8273c38).