### PR TITLE
feat(ts-sdk): throw explicit error on invalid primitive types

### DIFF
--- a/sdk/typescript/.changes/unreleased/Fixed-20240618-195123.yaml
+++ b/sdk/typescript/.changes/unreleased/Fixed-20240618-195123.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Throw error when using primitives types like `String`, `Number` and `Boolean`
+time: 2024-06-18T19:51:23.151898+02:00
+custom:
+  Author: TomChv
+  PR: "7693"

--- a/sdk/typescript/introspector/scanner/utils.ts
+++ b/sdk/typescript/introspector/scanner/utils.ts
@@ -85,13 +85,6 @@ export function typeToTypedef(
     }
   }
 
-  if (type.symbol?.name && type.isClassOrInterface()) {
-    return {
-      kind: TypeDefKind.ObjectKind,
-      name: type.symbol.name,
-    }
-  }
-
   const strType = checker.typeToString(type)
 
   switch (strType) {
@@ -103,7 +96,28 @@ export function typeToTypedef(
       return { kind: TypeDefKind.BooleanKind }
     case "void":
       return { kind: TypeDefKind.VoidKind }
+    // Intercept primitive types and throw error in this case
+    case "String":
+      throw new Error(
+        "Use of primitive String type detected, did you mean string?",
+      )
+    case "Number":
+      throw new Error(
+        "Use of primitive Number type detected, did you mean number?",
+      )
+    case "Boolean":
+      throw new Error(
+        "Use of primitive Boolean type detected, did you mean boolean?",
+      )
     default:
+      // If it's a class or interface, it's an object
+      if (type.symbol?.name && type.isClassOrInterface()) {
+        return {
+          kind: TypeDefKind.ObjectKind,
+          name: strType,
+        }
+      }
+
       // If it's a union, then it's a scalar type
       if (type.isUnionOrIntersection()) {
         return {

--- a/sdk/typescript/introspector/test/scan.spec.ts
+++ b/sdk/typescript/introspector/test/scan.spec.ts
@@ -122,5 +122,22 @@ describe("scan static TypeScript", function () {
         assert.equal(e.message, "no objects found in the module")
       }
     })
+
+    it("Should throw an error if a primitive type is used", async function () {
+      try {
+        const files = await listFiles(`${rootDirectory}/primitives`)
+
+        const f = scan(files, "primitives")
+        // Trigger the module resolution with a strigify
+        JSON.stringify(f, null, 2)
+
+        assert.fail("Should throw an error")
+      } catch (e: any) {
+        assert.equal(
+          e.message,
+          "Use of primitive String type detected, did you mean string?",
+        )
+      }
+    })
   })
 })

--- a/sdk/typescript/introspector/test/testdata/list/expected.json
+++ b/sdk/typescript/introspector/test/testdata/list/expected.json
@@ -1,8 +1,8 @@
 {
   "name": "List",
   "objects": {
-    "Number": {
-      "name": "Number",
+    "Integer": {
+      "name": "Integer",
       "description": "",
       "constructor": {
         "args": {
@@ -65,7 +65,7 @@
             "kind": "LIST_KIND",
             "typeDef": {
               "kind": "OBJECT_KIND",
-              "name": "Number"
+              "name": "Integer"
             }
           }
         }

--- a/sdk/typescript/introspector/test/testdata/list/index.ts
+++ b/sdk/typescript/introspector/test/testdata/list/index.ts
@@ -1,7 +1,7 @@
 import { func, object, field } from "../../../decorators/decorators.js"
 
 @object()
-class Number {
+class Integer {
   @field()
   value: number
 
@@ -20,7 +20,7 @@ class Number {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 class List {
   @func()
-  create(...n: number[]): Number[] {
-    return n.map((v) => new Number(v))
+  create(...n: number[]): Integer[] {
+    return n.map((v) => new Integer(v))
   }
 }

--- a/sdk/typescript/introspector/test/testdata/primitives/index.ts
+++ b/sdk/typescript/introspector/test/testdata/primitives/index.ts
@@ -1,0 +1,19 @@
+import { func, object, field } from "../../../decorators/decorators.js"
+
+@object()
+class Primitives {
+  @func()
+  str(v: String): String {
+    return v
+  }
+
+  @func()
+  bool(v: Boolean): Boolean {
+    return v
+  }
+
+  @func()
+  integer(v: Number): Number {
+    return v
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/7687 by returning an explicit error in case the user uses primitive types in Typescript such as `String`, `Boolean` or `Number`.

The error returned will be of shape (example with `Boolean`):

```
Use of primitive Boolean type detected, did you mean boolean?
```