### PR TITLE
fix: fix missing quote in dagger run example

### DIFF
--- a/cmd/dagger/run.go
+++ b/cmd/dagger/run.go
@@ -36,7 +36,7 @@ jq -n '{query:"{container{id}}"}' | \
     -u $DAGGER_SESSION_TOKEN: \
     -H "content-type:application/json" \
     -d @- \
-    http://127.0.0.1:$DAGGER_SESSION_PORT/query
+    http://127.0.0.1:$DAGGER_SESSION_PORT/query'
 ´´´`,
 		"´",
 		"`",

--- a/docs/current_docs/reference/cli.mdx
+++ b/docs/current_docs/reference/cli.mdx
@@ -406,7 +406,7 @@ jq -n '{query:"{container{id}}"}' | \
     -u $DAGGER_SESSION_TOKEN: \
     -H "content-type:application/json" \
     -d @- \
-    http://127.0.0.1:$DAGGER_SESSION_PORT/query
+    http://127.0.0.1:$DAGGER_SESSION_PORT/query'
 ```
 
 ```


### PR DESCRIPTION
Just found during testing dotnet-sdk. The single quote is missing after `/query` path.