### PR TITLE
tests: attempt to deflake proxy tests

### DIFF
--- a/core/integration/proxy_test.go
+++ b/core/integration/proxy_test.go
@@ -233,6 +233,7 @@ http_access allow localhost
 					test.proxyLogTest(t, c, func(ctx context.Context) (string, error) {
 						return c.Container().From(alpineImage).
 							WithMountedCache("/var/log/squidaccess", squidLogsVolume).
+							WithEnvVariable("CACHEBUSTER", identity.NewID()).
 							WithExec([]string{"cat", "/var/log/squidaccess/access.log"}).
 							Stdout(ctx)
 					})


### PR DESCRIPTION
I couldn't repro this locally but there were occasional CI flakes in the proxy test that pulls a git repo and verifies the proxy logs show a connection to github.com (needed to verify that git ops correctly use proxy settings).

My best guess is that the squid logs were just not always flushed by the time they were read for the test assertion, so this updates the tests to explicitly start/stop the squid service and do some retries on reading the logs.

Will have to see if this actually fixes the problem. If not there's more complicated options like starting a separate custom git service, intercepting traffic and asserting there. Would prefer to avoid complicating these already complicated tests further if possible though.