### PR TITLE
engine: log buildkit solve error stack traces

### DIFF
--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -140,6 +140,8 @@ func (c *Client) Solve(ctx context.Context, req bkgw.SolveRequest) (_ *Result, r
 	}
 	llbRes, err := gw.Solve(ctx, req, c.ID())
 	if err != nil {
+		// writing log w/ %+v so that we can see stack traces embedded in err by buildkit's usage of pkg/errors
+		bklog.G(ctx).Errorf("solve error: %+v", err)
 		return nil, wrapError(ctx, err, c.ID())
 	}
 

--- a/engine/buildkit/ref.go
+++ b/engine/buildkit/ref.go
@@ -92,6 +92,8 @@ func (r *ref) Evaluate(ctx context.Context) error {
 	}
 	_, err := r.Result(ctx)
 	if err != nil {
+		// writing log w/ %+v so that we can see stack traces embedded in err by buildkit's usage of pkg/errors
+		bklog.G(ctx).Errorf("ref evaluate error: %+v", err)
 		return err
 	}
 	return nil


### PR DESCRIPTION
Buildkit does all sorts of special context.Cause error handling but still sets all the errors to just be context.Canceled, only difference being wrapping them with hidden stack traces from the github.com/pkg/errors package.

To help debug where context canceled errors are coming from, it's useful to see these stack traces so we can get more than "context canceled". To do this we need to log the errors with the formatting directive %+v.

---

Related to https://github.com/dagger/dagger/issues/7699, have been banging my head trying to either repro this locally or figure out by reading buildkit solver code but neither is leading anywhere, so hoping that if we hit it again this will at least give us more chances of debugging it provided it occurs in a place in CI where the engine logs are actually obtainable.