### PR TITLE
helm: Propagate daemonset labels to the pods too

### DIFF
--- a/helm/dagger/templates/engine-daemonset.yaml
+++ b/helm/dagger/templates/engine-daemonset.yaml
@@ -23,6 +23,7 @@ spec:
       {{- end }}
       labels:
         name: {{ include "dagger.fullname" . }}-engine
+        {{- include "dagger.labels" . | nindent 8 }}
     spec:
       {{- with .Values.engine.tolerations }}
       tolerations:


### PR DESCRIPTION
We needed to get the logs for all Engine pods which match specific labels & were missing this.