### PR TITLE
Use runner.name as unique id for dev engine

### DIFF
--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -73,9 +73,10 @@ runs:
         echo "::endgroup::"
       env:
         # create separate outputs and containers for each workflow (to prevent
-        # collisions with shared docker containers)
-        _EXPERIMENTAL_DAGGER_DEV_OUTPUT: ./bin/dev-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-${{ github.job }}
-        _EXPERIMENTAL_DAGGER_DEV_CONTAINER: dagger-engine.dev-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-${{ github.job }}
+        # collisions with shared docker containers). With `arc` the runner name
+        # is the name of the pod, and each pod runs a single dedicated job.
+        _EXPERIMENTAL_DAGGER_DEV_OUTPUT: ./bin/dev-${{ runner.name }}
+        _EXPERIMENTAL_DAGGER_DEV_CONTAINER: dagger-engine.dev-${{ runner.name }}
 
     - name: Wait for dagger to be ready
       shell: bash


### PR DESCRIPTION
We want each dev engine to be used only by the job it is being created. With arc, the name of the runner is the name of the pod and each pod runs a single dedicated job.