### PR TITLE
synchronize terminal test on prompt, avoid panic

### DIFF
--- a/core/integration/module_terminal_test.go
+++ b/core/integration/module_terminal_test.go
@@ -143,6 +143,9 @@ type Test struct {
 		err = cmd.Start()
 		require.NoError(t, err)
 
+		_, err = console.ExpectString(" $ ")
+		require.NoError(t, err)
+
 		_, err = console.SendLine("pwd")
 		require.NoError(t, err)
 

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -69,11 +69,15 @@ func New() Frontend {
 	profile := ColorProfile()
 	view := new(strings.Builder)
 	return &frontendPretty{
-		db:   db,
-		logs: newPrettyLogs(),
-
+		db:        db,
+		logs:      newPrettyLogs(),
 		autoFocus: true,
 
+		// set empty initial row state to avoid nil checks
+		rowsView: &RowsView{},
+		rows:     &Rows{BySpan: map[trace.SpanID]*TraceRow{}},
+
+		// initial TUI state
 		window:  tea.WindowSizeMsg{Width: -1, Height: -1}, // be clear that it's not set
 		fps:     30,                                       // sane default, fine-tune if needed
 		profile: profile,


### PR DESCRIPTION
Fixes a test race/panic introduced by the combination of #7671 and the terminal support.