### PR TITLE
Publish Wolfi Engine variants - with & without NVIDIA drivers support

### DIFF
--- a/.github/workflows/engine-and-cli-publish.yml
+++ b/.github/workflows/engine-and-cli-publish.yml
@@ -44,12 +44,46 @@ jobs:
           DAGGER_ENGINE_IMAGE_REGISTRY: ghcr.io
           DAGGER_ENGINE_IMAGE_USERNAME: ${{ github.actor }}
           DAGGER_ENGINE_IMAGE_PASSWORD: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}
-      - name: "Publish Engine (GPU)"
+      - name: "Publish Engine - Ubuntu with NVIDIA variant"
         uses: ./.github/actions/call
         with:
           function: |
             --version="${{ github.ref_name == 'main' && github.sha || github.ref_name }}" \
             engine with-base --image=ubuntu --gpu-support=true \
+            publish \
+            --platform="linux/amd64" \
+            --image="$DAGGER_ENGINE_IMAGE" \
+            --registry="$DAGGER_ENGINE_IMAGE_REGISTRY" \
+            --registry-username="$DAGGER_ENGINE_IMAGE_USERNAME" \
+            --registry-password=env:DAGGER_ENGINE_IMAGE_PASSWORD
+        env:
+          DAGGER_ENGINE_IMAGE: ${{ secrets.RELEASE_DAGGER_ENGINE_IMAGE }}
+          DAGGER_ENGINE_IMAGE_REGISTRY: ghcr.io
+          DAGGER_ENGINE_IMAGE_USERNAME: ${{ github.actor }}
+          DAGGER_ENGINE_IMAGE_PASSWORD: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}
+      - name: "Publish Engine - Wolfi variant"
+        uses: ./.github/actions/call
+        with:
+          function: |
+            --version="${{ github.ref_name == 'main' && github.sha || github.ref_name }}" \
+            engine with-base --image=wolfi \
+            publish \
+            --platform="linux/amd64" \
+            --image="$DAGGER_ENGINE_IMAGE" \
+            --registry="$DAGGER_ENGINE_IMAGE_REGISTRY" \
+            --registry-username="$DAGGER_ENGINE_IMAGE_USERNAME" \
+            --registry-password=env:DAGGER_ENGINE_IMAGE_PASSWORD
+        env:
+          DAGGER_ENGINE_IMAGE: ${{ secrets.RELEASE_DAGGER_ENGINE_IMAGE }}
+          DAGGER_ENGINE_IMAGE_REGISTRY: ghcr.io
+          DAGGER_ENGINE_IMAGE_USERNAME: ${{ github.actor }}
+          DAGGER_ENGINE_IMAGE_PASSWORD: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}
+      - name: "Publish Engine - Wolfi with NVIDIA variant"
+        uses: ./.github/actions/call
+        with:
+          function: |
+            --version="${{ github.ref_name == 'main' && github.sha || github.ref_name }}" \
+            engine with-base --image=wolfi --gpu-support=true \
             publish \
             --platform="linux/amd64" \
             --image="$DAGGER_ENGINE_IMAGE" \

--- a/ci/engine.go
+++ b/ci/engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/containerd/containerd/platforms"
 	"github.com/dagger/dagger/engine/distconsts"
@@ -206,6 +207,10 @@ func (e *Engine) Publish(
 	}
 
 	ref := fmt.Sprintf("%s:%s", image, e.Dagger.Version)
+	if strings.Contains(e.ImageBase, "wolfi") {
+		ref += "-wolfi"
+	}
+
 	if e.GPUSupport {
 		ref += "-gpu"
 	}


### PR DESCRIPTION
This publishes two new image variants:
1. `*-wolfi`
2. `*-wolfi-gpu`

We want to take this through the paces - automated & manual tests - and check if it's feasible to consolidate all images into a single one: Wolfi with NVIDIA.

I have also made it clearer in workflow descriptions that this isn't a GPU image variant. While NVIDIA is the dominant GPU vendor today, Intel & AMD are still relevant and in some cases ahead (e.g. Aurora & Frontier supercomputers). A bunch of homelabbers (including myself) have Intel GPUs which we would expect the GPU variant to just work with. I don't think that's the case today.

While this doesn't close https://github.com/dagger/dagger/issues/5668, it's the second step in that direction.

cc @amouat 