### PR TITLE
fix: dagger develop generate license only if --sdk is set

### DIFF
--- a/.changes/unreleased/Fixed-20240621-183433.yaml
+++ b/.changes/unreleased/Fixed-20240621-183433.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: generate `LICENSE` only if `--sdk` is set on `dagger develop`
+time: 2024-06-21T18:34:33.532664+02:00
+custom:
+  Author: TomChv
+  PR: "7719"

--- a/cmd/dagger/licenses.go
+++ b/cmd/dagger/licenses.go
@@ -60,25 +60,27 @@ var licenseFiles = []string{
 	"UNLICENCE",
 }
 
-func findOrCreateLicense(ctx context.Context, dir string) error {
+func findOrCreateLicense(ctx context.Context, dir string, searchExisting bool) error {
+	// Empty license means no license
+	if licenseID == "" {
+		return nil
+	}
+
 	slog := slog.SpanLogger(ctx, InstrumentationLibrary)
 
-	id := licenseID
-	if id == defaultLicense {
+	if searchExisting {
 		if foundLicense, err := searchForLicense(dir); err == nil {
 			slog.Debug("found existing LICENSE file", "path", foundLicense)
 			return nil
 		}
-
-		id = defaultLicense
 	}
 
 	slog.Warn("no LICENSE file found; generating one for you, feel free to change or remove",
-		"license", id)
+		"license", licenseID)
 
-	license, err := spdx.License(id)
+	license, err := spdx.License(licenseID)
 	if err != nil {
-		return fmt.Errorf("failed to get license: %w", err)
+		return fmt.Errorf("failed to get license %q: %w", licenseID, err)
 	}
 
 	newLicense := filepath.Join(dir, "LICENSE")

--- a/cmd/dagger/licenses.go
+++ b/cmd/dagger/licenses.go
@@ -64,7 +64,7 @@ func findOrCreateLicense(ctx context.Context, dir string) error {
 	slog := slog.SpanLogger(ctx, InstrumentationLibrary)
 
 	id := licenseID
-	if id == "" {
+	if id == defaultLicense {
 		if foundLicense, err := searchForLicense(dir); err == nil {
 			slog.Debug("found existing LICENSE file", "path", foundLicense)
 			return nil

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -163,10 +163,11 @@ The "--source" flag allows controlling the directory in which the actual module 
 				return fmt.Errorf("failed to generate code: %w", err)
 			}
 
-			if sdk != "" && licenseID != "" {
+			if sdk != "" {
 				// If we're generating code by setting a SDK, we should also generate a license
 				// if it doesn't already exists.
-				if err := findOrCreateLicense(ctx, modConf.LocalRootSourcePath); err != nil {
+				searchExisting := !cmd.Flags().Lookup("license").Changed
+				if err := findOrCreateLicense(ctx, modConf.LocalRootSourcePath, searchExisting); err != nil {
 					return err
 				}
 			}
@@ -382,8 +383,9 @@ If not updating source or SDK, this is only required for IDE auto-completion/LSP
 			}
 
 			// If no license has been created yet, and SDK is set, we should create one.
-			if developSDK != "" && licenseID != "" {
-				if err := findOrCreateLicense(ctx, modConf.LocalRootSourcePath); err != nil {
+			if developSDK != "" {
+				searchExisting := !cmd.Flags().Lookup("license").Changed
+				if err := findOrCreateLicense(ctx, modConf.LocalRootSourcePath, searchExisting); err != nil {
 					return err
 				}
 			}

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -65,7 +65,7 @@ func init() {
 	moduleInitCmd.Flags().StringVar(&sdk, "sdk", "", "Optionally initialize module for development in the given SDK")
 	moduleInitCmd.Flags().StringVar(&moduleName, "name", "", "Name of the new module (defaults to parent directory name)")
 	moduleInitCmd.Flags().StringVar(&moduleSourcePath, "source", "", "Directory to store the module implementation source code in (defaults to \"dagger/ if \"--sdk\" is provided)")
-	moduleInitCmd.Flags().StringVar(&licenseID, "license", "", "License identifier to generate - see https://spdx.org/licenses/")
+	moduleInitCmd.Flags().StringVar(&licenseID, "license", defaultLicense, "License identifier to generate - see https://spdx.org/licenses/")
 
 	modulePublishCmd.Flags().BoolVarP(&force, "force", "f", false, "Force publish even if the git repository is not clean")
 	modulePublishCmd.Flags().AddFlagSet(moduleFlags)
@@ -75,6 +75,7 @@ func init() {
 
 	moduleDevelopCmd.Flags().StringVar(&developSDK, "sdk", "", "New SDK for the module")
 	moduleDevelopCmd.Flags().StringVar(&developSourcePath, "source", "", "Directory to store the module implementation source code in")
+	moduleDevelopCmd.Flags().StringVar(&licenseID, "license", defaultLicense, "License identifier to generate - see https://spdx.org/licenses/")
 	moduleDevelopCmd.PersistentFlags().AddFlagSet(moduleFlags)
 }
 
@@ -162,7 +163,7 @@ The "--source" flag allows controlling the directory in which the actual module 
 				return fmt.Errorf("failed to generate code: %w", err)
 			}
 
-			if sdk != "" {
+			if sdk != "" && licenseID != "" {
 				// If we're generating code by setting a SDK, we should also generate a license
 				// if it doesn't already exists.
 				if err := findOrCreateLicense(ctx, modConf.LocalRootSourcePath); err != nil {
@@ -381,7 +382,7 @@ If not updating source or SDK, this is only required for IDE auto-completion/LSP
 			}
 
 			// If no license has been created yet, and SDK is set, we should create one.
-			if developSDK != "" {
+			if developSDK != "" && licenseID != "" {
 				if err := findOrCreateLicense(ctx, modConf.LocalRootSourcePath); err != nil {
 					return err
 				}

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -380,9 +380,11 @@ If not updating source or SDK, this is only required for IDE auto-completion/LSP
 				return fmt.Errorf("failed to generate code: %w", err)
 			}
 
-			// If no license has been created yet, we should create one.
-			if err := findOrCreateLicense(ctx, modConf.LocalRootSourcePath); err != nil {
-				return err
+			// If no license has been created yet, and SDK is set, we should create one.
+			if developSDK != "" {
+				if err := findOrCreateLicense(ctx, modConf.LocalRootSourcePath); err != nil {
+					return err
+				}
 			}
 
 			return nil

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -489,8 +489,9 @@ func TestModuleInitLICENSE(t *testing.T) {
 			WithWorkdir("/work").
 			With(daggerExec("init", "--name=empty-license", "--sdk=go", "--license="))
 
-		_, err := modGen.File("LICENSE").Contents(ctx)
-		require.Error(t, err)
+		files, err := modGen.Directory(".").Entries(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, files, "LICENSE")
 	})
 
 	t.Run("do not bootstrap LICENSE file if no sdk is specified", func(t *testing.T) {
@@ -503,24 +504,24 @@ func TestModuleInitLICENSE(t *testing.T) {
 			WithWorkdir("/work").
 			With(daggerExec("init", "--name=no-license"))
 
-		content, err := modGen.Directory(".").Entries(ctx)
+		files, err := modGen.Directory(".").Entries(ctx)
 		require.NoError(t, err)
-		require.NotContains(t, content, "LICENSE")
+		require.NotContains(t, files, "LICENSE")
 
 		t.Run("do not bootstrap LICENSE file if no sdk is specified", func(t *testing.T) {
 			modGen = modGen.With(daggerExec("develop", "--source=dagger"))
 
-			content, err := modGen.Directory(".").Entries(ctx)
+			files, err := modGen.Directory(".").Entries(ctx)
 			require.NoError(t, err)
-			require.NotContains(t, content, "LICENSE")
+			require.NotContains(t, files, "LICENSE")
 		})
 
 		t.Run("do not bootstrap LICENSE file if license is empty", func(t *testing.T) {
 			modGen = modGen.With(daggerExec("develop", "--source=dagger", `--license=""`))
 
-			content, err := modGen.Directory(".").Entries(ctx)
+			files, err := modGen.Directory(".").Entries(ctx)
 			require.NoError(t, err)
-			require.NotContains(t, content, "LICENSE")
+			require.NotContains(t, files, "LICENSE")
 		})
 
 		t.Run("bootstrap a license after sdk is set on dagger develop", func(t *testing.T) {

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -479,6 +479,20 @@ func TestModuleInitLICENSE(t *testing.T) {
 		require.Contains(t, content, "Apache License, Version 2.0")
 	})
 
+	t.Run("do not boostrap LICENSE file if license is set empty", func(t *testing.T) {
+		t.Parallel()
+
+		c, ctx := connect(t)
+
+		modGen := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work").
+			With(daggerExec("init", "--name=empty-license", "--sdk=go", "--license="))
+
+		_, err := modGen.File("LICENSE").Contents(ctx)
+		require.Error(t, err)
+	})
+
 	t.Run("do not bootstrap LICENSE file if no sdk is specified", func(t *testing.T) {
 		t.Parallel()
 
@@ -501,12 +515,28 @@ func TestModuleInitLICENSE(t *testing.T) {
 			require.NotContains(t, content, "LICENSE")
 		})
 
+		t.Run("do not bootstrap LICENSE file if license is empty", func(t *testing.T) {
+			modGen = modGen.With(daggerExec("develop", "--source=dagger", `--license=""`))
+
+			content, err := modGen.Directory(".").Entries(ctx)
+			require.NoError(t, err)
+			require.NotContains(t, content, "LICENSE")
+		})
+
 		t.Run("bootstrap a license after sdk is set on dagger develop", func(t *testing.T) {
 			modGen = modGen.With(daggerExec("develop", "--sdk=go"))
 
 			content, err := modGen.File("LICENSE").Contents(ctx)
 			require.NoError(t, err)
 			require.Contains(t, content, "Apache License, Version 2.0")
+		})
+
+		t.Run("boostrap custom LICENSE file if sdk and license are specified", func(t *testing.T) {
+			modGen = modGen.With(daggerExec("develop", "--sdk=go", `--license=MIT`))
+
+			content, err := modGen.File("LICENSE").Contents(ctx)
+			require.NoError(t, err)
+			require.Contains(t, content, "MIT License")
 		})
 	})
 
@@ -537,7 +567,7 @@ func TestModuleInitLICENSE(t *testing.T) {
 				Contents: "doesnt matter",
 			}).
 			WithWorkdir("/work/sub").
-			With(daggerExec("init", "--name=licensed-to-ill", "--sdk=go"))
+			With(daggerExec("init", "--name=licensed-to-ill", "--sdk=go", `--license=""`))
 
 		_, err := modGen.File("LICENSE").Contents(ctx)
 		require.Error(t, err)

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -574,7 +574,7 @@ func TestModuleInitLICENSE(t *testing.T) {
 		require.NoError(t, err)
 		require.NotContains(t, files, "LICENSE")
 
-		// Check that the parent directory actualy has a LICENSE file.
+		// Check that the parent directory actually has a LICENSE file.
 		files, err = modGen.Directory("/work").Entries(ctx)
 		require.NoError(t, err)
 		require.Contains(t, files, "LICENSE")

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -567,10 +567,17 @@ func TestModuleInitLICENSE(t *testing.T) {
 				Contents: "doesnt matter",
 			}).
 			WithWorkdir("/work/sub").
-			With(daggerExec("init", "--name=licensed-to-ill", "--sdk=go", `--license=""`))
+			With(daggerExec("init", "--name=licensed-to-ill", "--sdk=go"))
 
-		_, err := modGen.File("LICENSE").Contents(ctx)
-		require.Error(t, err)
+		// Check that the license file is not generated in the sub directory.
+		files, err := modGen.Directory("/work/sub").Entries(ctx)
+		require.NoError(t, err)
+		require.NotContains(t, files, "LICENSE")
+
+		// Check that the parent directory actualy has a LICENSE file.
+		files, err = modGen.Directory("/work").Entries(ctx)
+		require.NoError(t, err)
+		require.Contains(t, files, "LICENSE")
 	})
 
 	t.Run("does not bootstrap LICENSE file if it exists in an arbitrary parent dir", func(t *testing.T) {

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -493,6 +493,14 @@ func TestModuleInitLICENSE(t *testing.T) {
 		require.NoError(t, err)
 		require.NotContains(t, content, "LICENSE")
 
+		t.Run("do not bootstrap LICENSE file if no sdk is specified", func(t *testing.T) {
+			modGen = modGen.With(daggerExec("develop", "--source=dagger"))
+
+			content, err := modGen.Directory(".").Entries(ctx)
+			require.NoError(t, err)
+			require.NotContains(t, content, "LICENSE")
+		})
+
 		t.Run("bootstrap a license after sdk is set on dagger develop", func(t *testing.T) {
 			modGen = modGen.With(daggerExec("develop", "--sdk=go"))
 

--- a/docs/current_docs/reference/cli.mdx
+++ b/docs/current_docs/reference/cli.mdx
@@ -147,9 +147,10 @@ dagger develop [options]
 ### Options
 
 ```
-  -m, --mod string      Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
-      --sdk string      New SDK for the module
-      --source string   Directory to store the module implementation source code in
+      --license string   License identifier to generate - see https://spdx.org/licenses/ (default "Apache-2.0")
+  -m, --mod string       Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
+      --sdk string       New SDK for the module
+      --source string    Directory to store the module implementation source code in
 ```
 
 ### Options inherited from parent commands
@@ -231,7 +232,7 @@ dagger init --name=hello --sdk=python --source=some/subdir
 ### Options
 
 ```
-      --license string   License identifier to generate - see https://spdx.org/licenses/
+      --license string   License identifier to generate - see https://spdx.org/licenses/ (default "Apache-2.0")
       --name string      Name of the new module (defaults to parent directory name)
       --sdk string       Optionally initialize module for development in the given SDK
       --source string    Directory to store the module implementation source code in (defaults to "dagger/ if "--sdk" is provided)


### PR DESCRIPTION
A `LICENSE` will only be generated now if `--sdk` is set on `dagger develop`, like in `dagger init`. It's also possible to explictly disable creating a license by providing an empty `--license=`.

Fixes #7703

It will be followed up by #7715 after discussion