### PR TITLE
Chore: improve how we lint

### DIFF
--- a/ci/dirdiff/dirdiff.go
+++ b/ci/dirdiff/dirdiff.go
@@ -7,6 +7,25 @@ import (
 
 type Dirdiff struct{}
 
+// Return the raw output of executing 'diff -r' against two directories.
+// No difference = empty output
+func (dd Dirdiff) DiffRaw(
+	ctx context.Context,
+	// The first directory to compare
+	a *Directory,
+	// The second directory to compare
+	b *Directory,
+) (string, error) {
+	return dag.
+		Wolfi().
+		Container().
+		WithMountedDirectory("/mnt/a", a).
+		WithMountedDirectory("/mnt/b", b).
+		WithWorkdir("/mnt").
+		WithExec([]string{"sh", "-c", "diff -r a b || true"}).
+		Stdout(ctx)
+}
+
 // Return an error if two directories are not identical at the given paths.
 // Paths not specified in the arguments are not compared.
 func (dd *Dirdiff) AssertEqual(

--- a/ci/engine.go
+++ b/ci/engine.go
@@ -159,31 +159,16 @@ func (e *Engine) Service(
 }
 
 // Lint the engine
-func (e *Engine) Lint(
-	ctx context.Context,
-	// +optional
-	all bool,
-) error {
-	// Packages to lint
-	packages := []string{
-		"",
-		// FIXME: should the CI lint itself?
-		"ci",
-		"ci/dirdiff",
-		"ci/std/go",
-		"ci/std/graphql",
+func (e *Engine) Lint(ctx context.Context) error {
+	src, err := e.Dagger.Generate(ctx)
+	if err != nil {
+		return err
 	}
-	// Packages that need codegen
-	codegen := []string{
-		"",
-		"ci/dirdiff",
-		"ci/std/go",
-		"ci/std/graphql",
+	report, err := new(GoLint).Lint(ctx, src)
+	if err != nil {
+		return err
 	}
-
-	return e.Dagger.Go().
-		WithCodegen(codegen).
-		Lint(ctx, packages, all)
+	return report.AssertPass(ctx)
 }
 
 // Publish all engine images to a registry

--- a/ci/go.mod
+++ b/ci/go.mod
@@ -23,7 +23,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.27.0
 	go.opentelemetry.io/otel/sdk/log v0.3.0
 	go.opentelemetry.io/otel/trace v1.27.0
-	go.opentelemetry.io/proto/otlp v1.2.0
+	go.opentelemetry.io/proto/otlp v1.3.1
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842
 	golang.org/x/mod v0.17.0
 	golang.org/x/sync v0.7.0

--- a/ci/go.sum
+++ b/ci/go.sum
@@ -76,8 +76,8 @@ go.opentelemetry.io/otel/sdk/log v0.3.0 h1:GEjJ8iftz2l+XO1GF2856r7yYVh74URiF9JMc
 go.opentelemetry.io/otel/sdk/log v0.3.0/go.mod h1:BwCxtmux6ACLuys1wlbc0+vGBd+xytjmjajwqqIul2g=
 go.opentelemetry.io/otel/trace v1.27.0 h1:IqYb813p7cmbHk0a5y6pD5JPakbVfftRXABGt5/Rscw=
 go.opentelemetry.io/otel/trace v1.27.0/go.mod h1:6RiD1hkAprV4/q+yd2ln1HG9GoPx39SuvvstaLBl+l4=
-go.opentelemetry.io/proto/otlp v1.2.0 h1:pVeZGk7nXDC9O2hncA6nHldxEjm6LByfA2aN8IOkz94=
-go.opentelemetry.io/proto/otlp v1.2.0/go.mod h1:gGpR8txAl5M03pDhMC79G6SdqNV26naRm/KDsgaHD8A=
+go.opentelemetry.io/proto/otlp v1.3.1 h1:TrMUixzpM0yuc/znrFTP9MMRh8trP93mkCiDVeXrui0=
+go.opentelemetry.io/proto/otlp v1.3.1/go.mod h1:0X1WI4de4ZsLrrJNLAQbFeLCm3T7yBkR0XqQ7niQU+8=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 h1:vr/HnozRka3pE4EsMEg1lgkXJkTFJCVUX+S/ZT6wYzM=

--- a/ci/lint.go
+++ b/ci/lint.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+)
+
+const (
+	golangCiLintImage = "docker.io/golangci/golangci-lint@sha256:b5f8712114561f1e2fbe74d04ed07ddfd992768705033a6251f3c7b848eac38e"
+)
+
+// A linting report
+type LintReport struct {
+	mu     sync.Mutex
+	Issues []LintIssue
+	// +private
+	LLReport *File `json:"-"`
+}
+
+// An individual linting issue
+type LintIssue struct {
+	// The name of the tool that produced the issue
+	Tool string
+	// True if the issue is an error, false if it's a warning'
+	IsError bool
+	// The text explaining the issue
+	Text string
+	// FIXME add more fields
+}
+
+// Return the linting report as a JSON file
+func (lr *LintReport) JSON(
+	ctx context.Context,
+	// Return the low-level linting tool's report instead of the high-level one
+	// +optional
+	ll bool,
+) (*File, error) {
+	if ll {
+		if lr.LLReport == nil {
+			return nil, fmt.Errorf("no low-level report available")
+		}
+		return lr.LLReport, nil
+	}
+	data, err := json.MarshalIndent(lr, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	f := dag.
+		Directory().
+		WithNewFile("lint.json", string(data)).
+		File("lint.json")
+	return f, nil
+}
+
+// Return the total number of linting errors
+func (lr *LintReport) ErrorCount() int {
+	var count int
+	for _, issue := range lr.Issues {
+		if issue.IsError {
+			count += 1
+		}
+	}
+	return count
+}
+
+// Return the total number of linting warnings
+func (lr *LintReport) WarningCount() int {
+	var count int
+	for _, issue := range lr.Issues {
+		if !issue.IsError {
+			count += 1
+		}
+	}
+	return count
+}
+
+// Return the total number of linting issues (errors and warnings)
+func (lr *LintReport) IssueCount() int {
+	return len(lr.Issues)
+}
+
+// Return an error if there are errors
+func (lr *LintReport) AssertPass(ctx context.Context) error {
+	if count := lr.ErrorCount(); count > 0 {
+		return fmt.Errorf("linting failed with %d errors", count)
+	}
+	return nil
+}
+
+func (lr *LintReport) merge(other *LintReport) error {
+	lr.mu.Lock()
+	defer lr.mu.Unlock()
+	lr.Issues = append(lr.Issues, other.Issues...)
+	return nil
+}
+
+func (lr *LintReport) WithIssue(text string, isError bool) *LintReport {
+	return &LintReport{
+		Issues: append(lr.Issues, LintIssue{
+			IsError: isError,
+			Text:    text,
+		}),
+	}
+}

--- a/ci/lint_go.go
+++ b/ci/lint_go.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// A go linter
+type GoLint struct{}
+
+// Lint a go codebae
+func (gl GoLint) Lint(
+	ctx context.Context,
+	// The Go source directory to lint
+	source *Directory,
+) (*LintReport, error) {
+	config := dag.CurrentModule().Source().File("lint_go_config.yml")
+	cmd := []string{
+		"golangci-lint", "run",
+		"-v",
+		"--timeout", "5m",
+		// Disable limits, we can filter the report instead
+		"--max-issues-per-linter", "0",
+		"--max-same-issues", "0",
+		"--out-format", "json",
+		"--issues-exit-code", "0",
+		"./...",
+	}
+	llreportFile := dag.
+		Container().
+		From(golangCiLintImage).
+		WithFile("/etc/golangci.yml", config).
+		WithEnvVariable("GOLANGCI_LINT_CONFIG", "/etc/golangci.yml").
+		WithMountedDirectory("/src", source).
+		WithWorkdir("/src").
+		WithExec(cmd, ContainerWithExecOpts{RedirectStdout: "golangci-lint-report.json"}).
+		File("golangci-lint-report.json")
+	llreportJSON, err := llreportFile.Contents(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// Unmarshal the low-level report from linting tool
+	var llreport struct {
+		Issues []struct {
+			Text        string   `json:"Text"`
+			FromLinter  string   `json:"FromLinter"`
+			SourceLines []string `json:"SourceLines"`
+			Replacement *struct {
+				Text string `json:"Text"`
+			} `json:"Replacement,omitempty"`
+			Pos struct {
+				Filename string `json:"Filename"`
+				Offset   int    `json:"Offset"`
+				Line     int    `json:"Line"`
+				Column   int    `json:"Column"`
+			} `json:"Pos"`
+			ExpectedNoLint bool   `json:"ExpectedNoLint"`
+			Severity       string `json:"Severity"`
+		} `json:"Issues"`
+	}
+	if err := json.Unmarshal([]byte(llreportJSON), &llreport); err != nil {
+		return nil, err
+	}
+	report := &LintReport{
+		Issues:   make([]LintIssue, len(llreport.Issues)),
+		LLReport: llreportFile, // Keep the low-level report just in case
+	}
+	for i := range llreport.Issues {
+		report.Issues[i].Text = llreport.Issues[i].Text
+		if llreport.Issues[i].Severity == "error" {
+			report.Issues[i].IsError = true
+		}
+		report.Issues[i].Tool = "golangci-lint"
+	}
+	return report, nil
+}

--- a/ci/lint_go_config.yml
+++ b/ci/lint_go_config.yml
@@ -27,6 +27,7 @@ linters:
     - unused
     - unparam
     - whitespace
+    - gomodguard
 
 issues:
   exclude-rules:

--- a/ci/lint_python.go
+++ b/ci/lint_python.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// A Python linter
+type PythonLint struct{}
+
+func (pl PythonLint) Lint(
+	ctx context.Context,
+	// The Python source directory to lint
+	source *Directory,
+) (*LintReport, error) {
+	var (
+		version    = "3.11"
+		baseDigest = "sha256:fc39d2e68b554c3f0a5cb8a776280c0b3d73b4c04b83dbade835e2a171ca27ef"
+		cmd        = []string{
+			"ruff", "check",
+			"--exit-zero",
+			"--output-format", "json",
+			".",
+		}
+	)
+	llreportFile := dag.
+		Container().
+		From(fmt.Sprintf("docker.io/library/python:%s-slim@%s", version, baseDigest)).
+		WithExec([]string{"pip", "install", "ruff==0.4.9"}).
+		WithMountedDirectory("/src", source).
+		WithWorkdir("/src").
+		//		WithEnvVariable("PIPX_BIN_DIR", "/usr/local/bin").
+		//		WithMountedCache("/root/.cache/pip", dag.CacheVolume("pip_cache_"+version)).
+		//		WithMountedCache("/root/.local/pipx/cache", dag.CacheVolume("pipx_cache_"+version)).
+		//		WithMountedCache("/root/.cache/hatch", dag.CacheVolume("hatch_cache_"+version)).
+		//		WithMountedFile("/pipx.pyz", dag.HTTP("https://github.com/pypa/pipx/releases/download/1.2.0/pipx.pyz")).
+		//		WithExec([]string{"python", "/pipx.pyz", "install", "hatch==1.7.0"}).
+		//		WithExec([]string{"python", "-m", "venv", "/opt/venv"}).
+		//		WithEnvVariable("VIRTUAL_ENV", "/opt/venv").
+		//		WithEnvVariable(
+		//			"PATH",
+		//			"$VIRTUAL_ENV/bin:$PATH",
+		//			dagger.ContainerWithEnvVariableOpts{Expand: true},
+		//		).
+		//		WithEnvVariable("HATCH_ENV_TYPE_VIRTUAL_PATH", "/opt/venv").
+		//		WithMountedFile("requirements.txt", source.File("requirements.txt")).
+		//		WithExec([]string{"pip", "install", "-r", "requirements.txt"}).
+		WithExec(cmd, ContainerWithExecOpts{RedirectStdout: "ruff-report.json"}).
+		File("ruff-report.json")
+	llreportJSON, err := llreportFile.Contents(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var llreport []struct {
+		Cell        *string `json:"cell"`
+		Code        string  `json:"code"`
+		EndLocation struct {
+			Column int `json:"column"`
+			Row    int `json:"row"`
+		} `json:"end_location"`
+		Filename string `json:"filename"`
+		Fix      struct {
+			Applicability string `json:"applicability"`
+			Edits         []struct {
+				Content     string `json:"content"`
+				EndLocation struct {
+					Column int `json:"column"`
+					Row    int `json:"row"`
+				} `json:"end_location"`
+				Location struct {
+					Column int `json:"column"`
+					Row    int `json:"row"`
+				} `json:"location"`
+			} `json:"edits"`
+			Message string `json:"message"`
+		} `json:"fix"`
+		Location struct {
+			Column int `json:"column"`
+			Row    int `json:"row"`
+		} `json:"location"`
+		Message string `json:"message"`
+		NoqaRow int    `json:"noqa_row"`
+		URL     string `json:"url"`
+	}
+	if err := json.Unmarshal([]byte(llreportJSON), &llreport); err != nil {
+		return nil, err
+	}
+	report := &LintReport{
+		Issues:   []LintIssue{},
+		LLReport: llreportFile, // Keep the low-level report just in case
+	}
+	for _, llissue := range llreport {
+		report.Issues = append(report.Issues, LintIssue{
+			Text:    llissue.Message,
+			IsError: true, // No concept of error/warning
+			Tool:    "ruff",
+		})
+	}
+	return report, nil
+}

--- a/ci/lint_typescript.go
+++ b/ci/lint_typescript.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/dagger/dagger/ci/internal/dagger"
+)
+
+// A typescript linter
+type TypescriptLint struct {
+	Cfg *File // +private
+}
+
+func (tl TypescriptLint) WithConfig(config *File) TypescriptLint {
+	tl.Cfg = config
+	return tl
+}
+
+// Lint a typescript codebae
+func (tl TypescriptLint) Lint(
+	ctx context.Context,
+	// The source directory to lint
+	source *Directory,
+) (*LintReport, error) {
+	var (
+		eslintPkg = "https://registry.yarnpkg.com/eslint/-/eslint-9.5.0.tgz#11856034b94a9e1a02cfcc7e96a9f0956963cd2f"
+		config    = tl.Cfg
+	)
+	if config == nil {
+		config = source.File("eslint.config.js")
+	}
+	llreportFile := dag.
+		Wolfi().
+		Container(dagger.WolfiContainerOpts{
+			Packages: []string{"nodejs", "yarn"},
+		}).
+		WithFile("eslint.config.js", config).
+		WithMountedDirectory("/src", source).
+		WithWorkdir("/src").
+		WithExec([]string{"yarn", "add", eslintPkg}).
+		WithExec([]string{
+			"sh", "-c",
+			"yarn eslint --max-warnings=0 -f json -o eslint-report.json . || true",
+		}).
+		File("eslint-report.json")
+	llreportJSON, err := llreportFile.Contents(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// Unmarshal the low-level report from linting tool
+	var llreport []struct {
+		FilePath string `json:"filePath"`
+		Messages []struct {
+			RuleID    string `json:"ruleId"`
+			Severity  int    `json:"severity"`
+			Message   string `json:"message"`
+			Line      int    `json:"line"`
+			Column    int    `json:"column"`
+			NodeType  string `json:"nodeType"`
+			MessageID string `json:"messageId"`
+			EndLine   int    `json:"endLine"`
+			EndColumn int    `json:"endColumn"`
+		} `json:"messages"`
+		ErrorCount          int    `json:"errorCount"`
+		WarningCount        int    `json:"warningCount"`
+		FixableErrorCount   int    `json:"fixableErrorCount"`
+		FixableWarningCount int    `json:"fixableWarningCount"`
+		Source              string `json:"source"`
+	}
+	if err := json.Unmarshal([]byte(llreportJSON), &llreport); err != nil {
+		return nil, err
+	}
+	report := new(LintReport)
+	report.LLReport = llreportFile // Keep the low-level report just in case
+	for _, llissue := range llreport {
+		for _, message := range llissue.Messages {
+			report.Issues = append(report.Issues, LintIssue{
+				Text:    message.Message,
+				IsError: true, // FIXME: parse severity
+				Tool:    "eslint",
+			})
+		}
+	}
+	return report, nil
+}

--- a/ci/main.go
+++ b/ci/main.go
@@ -4,6 +4,8 @@ package main
 
 import (
 	"context"
+	"path/filepath"
+	"strings"
 
 	"github.com/dagger/dagger/ci/internal/dagger"
 )
@@ -45,7 +47,7 @@ func (ci *Dagger) Check(ctx context.Context) error {
 	if err := ci.Docs().Lint(ctx); err != nil {
 		return err
 	}
-	if err := ci.Engine().Lint(ctx, false); err != nil {
+	if err := ci.Engine().Lint(ctx); err != nil {
 		return err
 	}
 	if err := ci.Test().All(
@@ -66,6 +68,36 @@ func (ci *Dagger) Check(ctx context.Context) error {
 	}
 	// FIXME: port all other function calls from Github Actions YAML
 	return nil
+}
+
+// Generate all source files, across all dagger modules in the source
+func (ci *Dagger) Generate(ctx context.Context) (*Directory, error) {
+	// Find all dagger modules in the source
+	src := ci.Source
+	daggerJSONs, err := src.Glob(ctx, "**/dagger.json")
+	if err != nil {
+		return nil, err
+	}
+	// FIXME: parallelize
+	for _, daggerJSON := range daggerJSONs {
+		// Skip test data, which contains test modules
+		if strings.HasPrefix(daggerJSON, "core/integration/testdata") {
+			continue
+		}
+		modPath := filepath.Dir(daggerJSON)
+		mod := src.AsModule(DirectoryAsModuleOpts{SourceRootPath: modPath})
+		src = src.WithDirectory("/", mod.GeneratedContextDirectory())
+	}
+	return src, nil
+}
+
+func isSubPath(basePath, checkPath string) bool {
+	basePath = filepath.Clean(basePath)
+	checkPath = filepath.Clean(checkPath)
+	if basePath != "/" {
+		basePath = basePath + string(filepath.Separator)
+	}
+	return strings.HasPrefix(checkPath, basePath)
 }
 
 // Develop the Dagger CLI
@@ -99,18 +131,6 @@ func (gtc *GoToolchain) WithCodegen(subdirs []string) *GoToolchain {
 
 func (gtc *GoToolchain) Env() *Container {
 	return gtc.Go.Env()
-}
-
-func (gtc *GoToolchain) Lint(
-	ctx context.Context,
-	packages []string,
-	// +optional
-	all bool,
-) error {
-	_, err := gtc.Go.Lint(ctx, packages, dagger.GoLintOpts{
-		All: all,
-	})
-	return err
 }
 
 // Develop the Dagger engine container

--- a/ci/sdk_go.go
+++ b/ci/sdk_go.go
@@ -7,26 +7,21 @@ import (
 	"strings"
 
 	"github.com/moby/buildkit/identity"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/dagger/dagger/ci/consts"
-	"github.com/dagger/dagger/ci/util"
 )
 
 type GoSDK struct {
 	Dagger *Dagger // +private
 }
 
-// Lint the Go SDK
+// Lint the Go SDK source code
 func (t GoSDK) Lint(ctx context.Context) error {
-	eg, ctx := errgroup.WithContext(ctx)
-	eg.Go(func() error {
-		return t.Dagger.Go().Lint(ctx, []string{"sdk/go"}, false)
-	})
-	eg.Go(func() error {
-		return util.DiffDirectoryF(ctx, t.Dagger.Source, t.Generate, "sdk/go")
-	})
-	return eg.Wait()
+	report, err := new(GoLint).Lint(ctx, t.Dagger.Source.Directory("sdk/go"))
+	if err != nil {
+		return err
+	}
+	return report.AssertPass(ctx)
 }
 
 // Test the Go SDK

--- a/ci/sdk_python.go
+++ b/ci/sdk_python.go
@@ -8,7 +8,6 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/dagger/dagger/ci/internal/dagger"
-	"github.com/dagger/dagger/ci/util"
 )
 
 // TODO: use dev module (this is just the mage port)
@@ -28,45 +27,81 @@ type PythonSDK struct {
 	Dagger *Dagger // +private
 }
 
-// Lint the Python SDK
+// Lint the Python SDK, and return an error in case of issue
 func (t PythonSDK) Lint(ctx context.Context) error {
-	eg, ctx := errgroup.WithContext(ctx)
-
-	base := t.pythonBase(pythonDefaultVersion, true)
-
-	eg.Go(func() error {
-		path := "docs/current_docs"
-		_, err := base.
-			WithDirectory(
-				fmt.Sprintf("/%s", path),
-				t.Dagger.Source.Directory(path),
-				dagger.ContainerWithDirectoryOpts{
-					Include: []string{
-						"**/*.py",
-						".ruff.toml",
-					},
-				},
-			).
-			WithExec([]string{"ruff", "check", "--show-source", ".", "/docs"}).
-			WithExec([]string{"black", "--check", "--diff", ".", "/docs"}).
-			Sync(ctx)
+	report, err := t.LintReport(ctx)
+	if err != nil {
 		return err
-	})
+	}
+	return report.AssertPass(ctx)
+}
 
+// Produce a lint report for the Python SDK
+// FIXME: rename this to Lint soon, it's a better interface
+func (t PythonSDK) LintReport(ctx context.Context) (*LintReport, error) {
+	goSource := t.Dagger.Source.Directory("sdk/python/runtime")
+	pySource := dag.Directory().WithDirectory(
+		"/",
+		t.Dagger.Source,
+		DirectoryWithDirectoryOpts{Include: []string{
+			"**/*.py",
+			"**/.ruff.toml",
+			"**/pyproject.toml",
+		}},
+	)
+	return t.lintReport(ctx, goSource, pySource)
+}
+
+// Produce a lint report for the Python SDK
+// This is a private implementation because it simulates future support
+// for context directories, which makes its API cleaner.
+// FIXME: when context directories ship, make this public
+func (t PythonSDK) lintReport(
+	ctx context.Context,
+	// Source code of the Python runtime (written in Go)
+	// +default="/sdk/python/runtime"
+	goSource *dagger.Directory,
+
+	// Python source code across SDK and docs
+	// +default="/"
+	// +ignore=["*", "!**/*.py", "!**/.ruff.toml", "!**/pyproject.toml"]
+	pySource *dagger.Directory,
+) (*LintReport, error) {
+	report := new(LintReport)
+	eg, ctx := errgroup.WithContext(ctx)
+	ctx, span := Tracer().Start(ctx, "lint the Dagger Python SDK")
+	defer span.End()
+	// Lint the python source
 	eg.Go(func() error {
-		return util.DiffDirectoryF(ctx, t.Dagger.Source, t.Generate, pythonGeneratedAPIPath)
+		ctx, span := Tracer().Start(ctx, "lint the python code (client library + associated tooling + docs snippets)")
+		defer span.End()
+		pyReport, err := new(PythonLint).Lint(ctx, pySource)
+		if err != nil {
+			return err
+		}
+		return report.merge(pyReport)
 	})
-
+	// Check that core client library (generated) is up-to-date
 	eg.Go(func() error {
-		// Call `dagger develop` on the python sdk module
-		// FIXME: this goes away when we spin out each SDK pipeline into its own module
-		return t.Dagger.
-			Go().
-			WithCodegen([]string{pythonRuntimeSubdir}).
-			Lint(ctx, []string{pythonRuntimeSubdir}, false)
+		ctx, span := Tracer().Start(ctx, "Check that generated client library is up-to-date")
+		defer span.End()
+		codegenReport, err := t.CheckGenerated(ctx)
+		if err != nil {
+			return err
+		}
+		return report.merge(codegenReport)
 	})
-
-	return eg.Wait()
+	// Lint the code of the Python runtime (which is written in Go)
+	eg.Go(func() error {
+		ctx, span := Tracer().Start(ctx, "Lint the python runtime (which is written in Go)")
+		defer span.End()
+		goReport, err := new(GoLint).Lint(ctx, goSource.AsModule().GeneratedContextDirectory())
+		if err != nil {
+			return err
+		}
+		return report.merge(goReport)
+	})
+	return report, eg.Wait()
 }
 
 // Test the Python SDK
@@ -133,6 +168,34 @@ func (t PythonSDK) Generate(ctx context.Context) (*dagger.Directory, error) {
 	return dag.Directory().WithFile(pythonGeneratedAPIPath, generated), nil
 }
 
+// Check whether the generated python client library is up-to-date
+func (t PythonSDK) CheckGenerated(ctx context.Context) (*LintReport, error) {
+	before := dag.
+		Directory().
+		WithDirectory(
+			"/",
+			t.Dagger.Source,
+			dagger.DirectoryWithDirectoryOpts{Include: []string{pythonGeneratedAPIPath}},
+		)
+	after, err := t.Generate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	diff, err := dag.Dirdiff().DiffRaw(ctx, before, after)
+	if err != nil {
+		return nil, err
+	}
+	report := new(LintReport)
+	if len(diff) > 0 {
+		report.Issues = append(report.Issues, LintIssue{
+			Text:    pythonGeneratedAPIPath + ": generated python client is not up-to-date",
+			IsError: true,
+			Tool:    "PythonSDK.checkGenerated",
+		})
+	}
+	return report, nil
+}
+
 // Publish the Python SDK
 func (t PythonSDK) Publish(
 	ctx context.Context,
@@ -177,6 +240,13 @@ func (t PythonSDK) Bump(ctx context.Context, version string) (*dagger.Directory,
 	// NOTE: if you change this path, be sure to update .github/workflows/publish.yml so that
 	// provision tests run whenever this file changes.
 	return dag.Directory().WithNewFile("sdk/python/src/dagger/_engine/_version.py", engineReference), nil
+}
+
+// Build a container
+// returns a python container with the Python SDK source files
+// added and dependencies installed.
+func (t PythonSDK) Base(version string, install bool) *Container {
+	return t.pythonBase(version, install)
 }
 
 // pythonBase returns a python container with the Python SDK source files

--- a/dagger.json
+++ b/dagger.json
@@ -7,6 +7,10 @@
       "source": "ci/std/shellcheck"
     },
     {
+      "name": "dirdiff",
+      "source": "ci/dirdiff"
+    },
+    {
       "name": "docusaurus",
       "source": "github.com/levlaz/daggerverse/docusaurus@72ec19206da7dbe2815da94c62e491b54935b633"
     },
@@ -17,10 +21,14 @@
     {
       "name": "graphql",
       "source": "ci/std/graphql"
+    },
+    {
+      "name": "wolfi",
+      "source": "github.com/shykes/daggerverse/wolfi@dfb1f91fa463b779021d65011f0060f7decda0ba"
     }
   ],
   "source": "ci",
-  "engineVersion": "v0.11.7",
+  "engineVersion": "v0.11.8",
   "views": [
     {
       "name": "default",

--- a/docs/current_docs/.ruff.toml
+++ b/docs/current_docs/.ruff.toml
@@ -2,7 +2,7 @@
 # and very doc specific rules in the SDK's pyproject.toml.
 extend = "../../sdk/python/pyproject.toml"
 
-ignore = [
+lint.ignore = [
     "D1",    # docstrings
     "E501",  # line too long
     "S108",  # probable insecure usage of temporary file or directory


### PR DESCRIPTION
- Define a new linting framework, with common types for producing and querying lint reports: `LintReport` and `LintIssue`. (`lint.go`)
- Integrate our Python linter, Ruff, into the new framework (`lint_python.go`)
- Integrate our Go linter, golangci-lint, into the new framework (`lint_go.go`)
- Integrate our Typescript linter, eslint, into the new framework (`lint_typescript.go`)
- Start using the new implementations in some of our CI pipelines, but not all. Note, backwards compatibility is preserved (`sdk_typescript.go`, `sdk_python.go`, `engine.go`)