### PR TITLE
docs: Fix uv flag in language dependencies manual.

### DIFF
--- a/docs/current_docs/manuals/developer/language-dependencies.mdx
+++ b/docs/current_docs/manuals/developer/language-dependencies.mdx
@@ -51,7 +51,7 @@ Check [compatibility with `pip` and `pip-tools`](https://github.com/astral-sh/uv
 The lock file is only created automatically for new modules. For existing modules that don't have it, it can be created (and updated) manually. For example:
 
 ```console
-uv pip compile --generate-hashes --update-all -o requirements.lock pyproject.toml sdk/pyproject.toml
+uv pip compile --generate-hashes --upgrade -o requirements.lock pyproject.toml sdk/pyproject.toml
 ```
 
 The above command pulls in dependencies from `pyproject.toml` and `sdk/pyproject.toml`, gets their latest compatible versions, and writes them to `requirements.lock` with added hashes to verify integrity when downloading during install.


### PR DESCRIPTION
I ran into the following error trying to regenerate the `requirements.lock` file as described [here](https://docs.dagger.io/manuals/developer/language-dependencies#lock-file) (under the Python tab). I think `--update-all` should be `--upgrade`.

Additionally, it might be worth adding the `--quiet` flag to the docs in the same vein as #7270.

```
❯ uv version
uv 0.2.13

❯ uv pip compile \
    --generate-hashes \
    --update-all \
    -o requirements.lock \
    pyproject.toml sdk/pyproject.toml
    
error: unexpected argument '--update-all' found

  tip: to pass '--update-all' as a value, use '-- --update-all'

Usage: uv pip compile --generate-hashes <SRC_FILE>...

For more information, try '--help'.
```