### PR TITLE
More OTel fixes, mostly service-related

### DIFF
--- a/core/service.go
+++ b/core/service.go
@@ -386,10 +386,6 @@ func (svc *Service) startContainer(
 	var exitErr error
 	exited := make(chan struct{})
 	go func() {
-		// terminate the span; we're not interested in setting an error, since
-		// services return a benign error like `exit status 1` on exit
-		defer span.End()
-
 		defer func() {
 			if stdinClient != nil {
 				stdinClient.Close()
@@ -402,6 +398,10 @@ func (svc *Service) startContainer(
 			}
 			close(exited)
 		}()
+
+		// terminate the span; we're not interested in setting an error, since
+		// services return a benign error like `exit status 1` on exit
+		defer span.End()
 
 		exitErr = svcProc.Wait()
 

--- a/core/service.go
+++ b/core/service.go
@@ -204,6 +204,12 @@ func (svc *Service) Start(
 
 func (svc *Service) startSpan(ctx context.Context, id *call.ID, name string) (context.Context, trace.Span) {
 	return Tracer().Start(ctx, "start "+name, trace.WithAttributes(
+		// assign service spans to the _main_ client caller, since their lifespan is tied
+		// to the session level, independent of which client happened to start it.
+		//
+		// otherwise, this span gets associated to whichever client happened to start it.
+		// when that client goes away, we don't want to reap this span.
+		attribute.String(telemetry.ClientIDAttr, svc.Query.MainClientCallerID),
 		attribute.String(telemetry.EffectIDAttr, serviceEffect(id))))
 }
 

--- a/core/services.go
+++ b/core/services.go
@@ -279,9 +279,9 @@ func (ss *Services) Stop(ctx context.Context, id *call.ID, kill bool) error {
 	}
 }
 
-// StopClientServices stops all of the services being run by the given server.
+// StopSessionServices stops all of the services being run by the given server.
 // It is called when a server is closing.
-func (ss *Services) StopClientServices(ctx context.Context, sessionID string) error {
+func (ss *Services) StopSessionServices(ctx context.Context, sessionID string) error {
 	ss.l.Lock()
 	var svcs []*RunningService
 	for _, svc := range ss.running {

--- a/core/util.go
+++ b/core/util.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"fmt"
-	"io"
 	"io/fs"
 	"path"
 	"strconv"
@@ -302,14 +301,6 @@ func mergeImageConfig(dst, src specs.ImageConfig) specs.ImageConfig {
 	res.ExposedPorts = mergeMap(dst.ExposedPorts, src.ExposedPorts)
 
 	return res
-}
-
-type nopCloser struct {
-	io.Writer
-}
-
-func (nopCloser) Close() error {
-	return nil
 }
 
 func resolveProvenance(ctx context.Context, bk *buildkit.Client, st llb.State) (*provenance.Capture, error) {

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -585,10 +585,6 @@ func (srv *Server) getOrInitClient(
 			return nil
 		}
 
-		// notify the telemetry pub/sub to clean up draining for any of the
-		// client's unfinished spans/log streams
-		sess.telemetryPubSub.ClientDisconnected(client.clientID)
-
 		// if the main client caller has no more active calls, cleanup the whole session
 		if clientID != sess.mainClientCallerID {
 			return nil

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -209,7 +209,7 @@ func (srv *Server) removeDaggerSession(ctx context.Context, sess *daggerSession)
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 60*time.Second)
 	defer cancel()
 
-	if err := sess.services.StopClientServices(ctx, sess.sessionID); err != nil {
+	if err := sess.services.StopSessionServices(ctx, sess.sessionID); err != nil {
 		errs = errors.Join(errs, fmt.Errorf("stop client services: %w", err))
 	}
 
@@ -842,7 +842,7 @@ func (srv *Server) serveShutdown(w http.ResponseWriter, r *http.Request, client 
 	if client.clientID == sess.mainClientCallerID {
 		// Stop services, since the main client is going away, and we
 		// want the client to see them stop.
-		sess.services.StopClientServices(ctx, sess.sessionID)
+		sess.services.StopSessionServices(ctx, sess.sessionID)
 
 		// Start draining telemetry
 		srv.telemetryPubSub.Drain(sess.mainClientCallerID, immediate)

--- a/engine/telemetry/pubsub.go
+++ b/engine/telemetry/pubsub.go
@@ -85,62 +85,6 @@ func (ps *PubSub) Processor() sdktrace.SpanProcessor {
 	return clientTracker{ps}
 }
 
-// ClientDisconnected is called when a client disconnects from the server.
-//
-// This hook is necessary for draining any dependent clients who were waiting
-// for the client's spans or logs to complete.
-func (ps *PubSub) ClientDisconnected(clientID string) {
-	ps.clientsL.Lock()
-	client, ok := ps.clients[clientID]
-	ps.clientsL.Unlock()
-	if !ok {
-		return
-	}
-	slog.Warn("draining client spans immediately due to disconnect",
-		"client", clientID)
-	client.eachSpan(func(traceID trace.TraceID, spanID trace.SpanID) {
-		for _, affected := range ps.clientsFor(traceID, spanID) {
-			slog.Warn("dropping span due to disconnect",
-				"client", affected,
-				"trace", traceID,
-				"span", spanID)
-			if affectedClient, active := ps.clients[affected]; active {
-				affectedClient.dropSpan(spanID)
-			}
-		}
-	})
-}
-
-func (c *activeClient) eachSpan(f func(trace.TraceID, trace.SpanID)) {
-	c.cond.L.Lock()
-	seen := map[spanKey]bool{}
-	for _, span := range c.spans {
-		seen[spanKey{
-			TraceID: span.SpanContext().TraceID(),
-			SpanID:  span.SpanContext().SpanID(),
-		}] = true
-	}
-	for stream := range c.logStreams {
-		seen[stream.span] = true
-	}
-	c.cond.L.Unlock()
-	for key := range seen {
-		f(key.TraceID, key.SpanID)
-	}
-}
-
-func (c *activeClient) dropSpan(spanID trace.SpanID) {
-	c.cond.L.Lock()
-	defer c.cond.L.Unlock()
-	delete(c.spans, spanID)
-	for stream := range c.logStreams {
-		if stream.span.SpanID == spanID {
-			delete(c.logStreams, stream)
-		}
-	}
-	c.cond.Broadcast()
-}
-
 type clientTracker struct{ *PubSub }
 
 // OnStart keeps track of the client ID and parent span ID for each span,
@@ -215,6 +159,15 @@ func (ps *PubSub) clientsFor(traceID trace.TraceID, spanID trace.SpanID) []strin
 		ids = append(ids, id)
 	}
 	return ids
+}
+
+func (ps *PubSub) clientFor(traceID trace.TraceID, spanID trace.SpanID) string {
+	ps.spansL.Lock()
+	defer ps.spansL.Unlock()
+	return ps.spanClients[spanKey{
+		TraceID: traceID,
+		SpanID:  spanID,
+	}]
 }
 
 func (ps *PubSub) trackSpans(spans []sdktrace.ReadOnlySpan) {
@@ -410,12 +363,24 @@ func (ps SpansPubSub) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnly
 	slog.ExtraDebug("exporting spans to pubsub", "call", export, "spans", len(spans))
 
 	byExporter := map[sdktrace.SpanExporter][]sdktrace.ReadOnlySpan{}
+
 	updated := map[*activeClient]struct{}{}
+	defer func() {
+		// notify anyone waiting to drain after all client updates are applied
+		// NOTE: finishSpan below uses defer, so this must be deferred sooner
+		for client := range updated {
+			slog.Trace("broadcasting to client", "client", client.id)
+			client.cond.Broadcast()
+		}
+	}()
 
 	for _, s := range spans {
-		var subs []sdktrace.SpanExporter
-
 		affectedClients := ps.clientsFor(
+			s.SpanContext().TraceID(),
+			s.SpanContext().SpanID(),
+		)
+
+		selfClient := ps.clientFor(
 			s.SpanContext().TraceID(),
 			s.SpanContext().SpanID(),
 		)
@@ -426,6 +391,8 @@ func (ps SpansPubSub) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnly
 			"endTime", s.EndTime(),
 			"status", s.Status().Code,
 		)
+
+		var subs []sdktrace.SpanExporter
 
 		if len(affectedClients) > 0 {
 			for _, clientID := range affectedClients {
@@ -438,13 +405,14 @@ func (ps SpansPubSub) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnly
 					strings.HasSuffix(LogsSource_Subscribe_FullMethodName, s.Name()) {
 					// HACK: don't get stuck waiting on ourselves
 					slog.ExtraDebug("avoiding waiting for ourselves")
-				} else {
+				} else if clientID == selfClient {
 					if s.EndTime().Before(s.StartTime()) {
 						slog.Trace("starting span", "client", client.id)
 						client.startSpan(s)
 					} else {
 						slog.Trace("finishing span", "client", client.id)
-						client.finishSpan(s)
+						// NOTE: finish *after* exporting to consumers
+						defer client.finishSpan(s)
 					}
 				}
 
@@ -470,14 +438,6 @@ func (ps SpansPubSub) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnly
 			byExporter[exp] = append(byExporter[exp], s)
 		}
 	}
-
-	defer func() {
-		// notify anyone waiting to drain
-		for client := range updated {
-			slog.Trace("broadcasting to client", "client", client.id)
-			client.cond.Broadcast()
-		}
-	}()
 
 	eg := pool.New().WithErrors()
 
@@ -532,6 +492,11 @@ func (ps LogsPubSub) Export(ctx context.Context, logs []sdklog.Record) error {
 			{TraceID: rec.TraceID()}: {},
 		}
 
+		selfClient := ps.clientFor(
+			rec.TraceID(),
+			rec.SpanID(),
+		)
+
 		// Publish to all clients involved, or the full trace if none.
 		for _, clientID := range ps.clientsFor(rec.TraceID(), rec.SpanID()) {
 			topics[Topic{
@@ -539,9 +504,11 @@ func (ps LogsPubSub) Export(ctx context.Context, logs []sdklog.Record) error {
 				ClientID: clientID,
 			}] = struct{}{}
 
-			client, found := ps.lookupClient(clientID)
-			if found {
-				client.trackLogStream(rec)
+			if clientID == selfClient {
+				client, found := ps.lookupClient(clientID)
+				if found {
+					client.trackLogStream(rec)
+				}
 			}
 		}
 


### PR DESCRIPTION
A few more fixes/simplifications for OTel + draining found in the process of working on #7532. With these changes I'm finally able to reliably run our instrumented integration tests without any spans "left behind" (even services).

```
✔ connect 0.2s
✔ initialize 13.0s
✔ prepare 0.8s
✔ ModuleSource.resolveFromCaller: ModuleSource! 0.1s
✔ ModuleSource.resolveDirectoryFromCaller(path: ".", viewName: "default"): Directory! 0.0s
✔ dagger(
    source: ✔ ModuleSource.resolveDirectoryFromCaller(path: ".", viewName: "default"): Directory! 0.0s
  ): Dagger! 0.7s
✔ Dagger.test: DaggerTest! 0.3s
✔ DaggerTest.custom(run: "Container"): Void 3m37.6s
```

:smiling_face_with_tear: 