### PR TITLE
feat: add explicit stop to dagger process

### DIFF
--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -28,47 +28,48 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -76,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "ascii"
@@ -88,20 +89,20 @@ checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
 name = "async-trait"
-version = "0.1.79"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
@@ -147,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.4"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byteorder"
@@ -165,9 +166,9 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "c891175c3fb232128f48de6590095e59198bbeb8620c310be349bfc3afd12c7b"
 
 [[package]]
 name = "cfg-if"
@@ -177,18 +178,18 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -198,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "color-eyre"
@@ -231,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "combine"
@@ -284,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
@@ -466,15 +467,15 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.33"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
 ]
@@ -487,9 +488,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -507,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "filetime"
@@ -519,15 +520,15 @@ checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -604,7 +605,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -639,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "genco"
-version = "0.17.8"
+version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98d7af598790738fee616426e669360fa361273b1b9c9b7f30c92fa627605cad"
+checksum = "afac3cbb14db69ac9fef9cdb60d8a87e39a7a527f85a81a923436efa40ad42c6"
 dependencies = [
  "genco-macros",
  "relative-path",
@@ -650,13 +651,13 @@ dependencies = [
 
 [[package]]
 name = "genco-macros"
-version = "0.17.8"
+version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4cf186fea4af17825116f72932fe52cce9a13bae39ff63b4dc0cfdb3fb4bde1"
+checksum = "553630feadf7b76442b0849fd25fdf89b860d933623aec9693fed19af0400c78"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -671,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.13"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06fddc2749e0528d2813f95e050e87e52c8cbbae56223b9babf73b3e53b0cc6"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -766,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
@@ -818,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -830,9 +831,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -905,6 +906,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,15 +937,15 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libredox"
@@ -952,15 +959,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -983,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mime"
@@ -995,9 +1002,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -1068,9 +1075,9 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1078,15 +1085,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.2",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -1109,9 +1116,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "platform-info"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6259c4860e53bf665016f1b2f46a8859cadfa717581dc9d597ae4069de6300f"
+checksum = "d5ff316b9c4642feda973c18f0decd6c8b0919d4722566f6e4337cce0dd88217"
 dependencies = [
  "libc",
  "winapi",
@@ -1135,18 +1142,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1191,6 +1198,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,14 +1219,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -1224,13 +1240,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -1241,15 +1257,15 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "relative-path"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
@@ -1311,15 +1327,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -1361,9 +1377,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "scopeguard"
@@ -1383,22 +1399,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1416,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
@@ -1459,9 +1475,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -1483,9 +1499,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1522,9 +1538,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1560,9 +1576,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
 dependencies = [
  "filetime",
  "libc",
@@ -1583,22 +1599,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1628,9 +1644,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1647,13 +1663,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1668,16 +1684,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -1706,7 +1721,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1760,11 +1775,10 @@ dependencies = [
 
 [[package]]
 name = "tracing-test"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a2c0ff408fe918a94c428a3f2ad04e4afd5c95bbc08fcf868eff750c15728a4"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
 dependencies = [
- "lazy_static",
  "tracing-core",
  "tracing-subscriber",
  "tracing-test-macro",
@@ -1772,13 +1786,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-test-macro"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bc1c4f8e2e73a977812ab339d503e6feeb92700f6d07a6de4d321522d5c08"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
- "lazy_static",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1837,9 +1850,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1848,9 +1861,9 @@ dependencies = [
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"
@@ -1906,7 +1919,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.68",
  "wasm-bindgen-shared",
 ]
 
@@ -1940,7 +1953,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.68",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2017,7 +2030,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -2037,17 +2050,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -2058,9 +2072,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2070,9 +2084,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2082,9 +2096,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2094,9 +2114,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2106,9 +2126,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2118,9 +2138,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2130,9 +2150,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winreg"

--- a/sdk/rust/crates/dagger-codegen/src/rust/templates/object_tmpl.rs
+++ b/sdk/rust/crates/dagger-codegen/src/rust/templates/object_tmpl.rs
@@ -11,14 +11,14 @@ use crate::utility::OptionExt;
 
 pub fn render_object(funcs: &CommonFunctions, t: &FullType) -> eyre::Result<rust::Tokens> {
     let selection = rust::import("crate::querybuilder", "Selection");
-    let child = rust::import("tokio::process", "Child");
+    let session_proc = rust::import("crate::core::cli_session", "DaggerSessionProc");
     let graphql_client = rust::import("crate::core::graphql_client", "DynGraphQLClient");
     let arc = rust::import("std::sync", "Arc");
 
     Ok(quote! {
         #[derive(Clone)]
         pub struct $(t.name.pipe(|s| format_name(s))) {
-            pub proc: Option<$arc<$child>>,
+            pub proc: Option<$arc<$session_proc>>,
             pub selection: $selection,
             pub graphql_client: $graphql_client
         }

--- a/sdk/rust/crates/dagger-sdk/Cargo.toml
+++ b/sdk/rust/crates/dagger-sdk/Cargo.toml
@@ -35,7 +35,6 @@ tar.workspace = true
 tempfile.workspace = true
 async-trait.workspace = true
 
-
 [dev-dependencies]
 pretty_assertions.workspace = true
 rand.workspace = true

--- a/sdk/rust/crates/dagger-sdk/examples/build-the-application/main.rs
+++ b/sdk/rust/crates/dagger-sdk/examples/build-the-application/main.rs
@@ -2,36 +2,37 @@ use dagger_sdk::HostDirectoryOpts;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    let client = dagger_sdk::connect().await?;
+    dagger_sdk::connect(|client| async move {
+        let host_source_dir = client.host().directory_opts(
+            "examples/build-the-application/app",
+            HostDirectoryOpts {
+                exclude: Some(vec!["node_modules", "ci/"]),
+                include: None,
+            },
+        );
 
-    let host_source_dir = client.host().directory_opts(
-        "examples/build-the-application/app",
-        HostDirectoryOpts {
-            exclude: Some(vec!["node_modules".into(), "ci/".into()]),
-            include: None,
-        },
-    );
+        let source = client
+            .container()
+            .from("node:16")
+            .with_mounted_directory("/src", host_source_dir);
 
-    let source = client
-        .container()
-        .from("node:16")
-        .with_mounted_directory("/src", host_source_dir);
+        let runner = source
+            .with_workdir("/src")
+            .with_exec(vec!["npm", "install"]);
 
-    let runner = source
-        .with_workdir("/src")
-        .with_exec(vec!["npm", "install"]);
+        let test = runner.with_exec(vec!["npm", "test", "--", "--watchAll=false"]);
 
-    let test = runner.with_exec(vec!["npm", "test", "--", "--watchAll=false"]);
+        let build_dir = test
+            .with_exec(vec!["npm", "run", "build"])
+            .directory("./build");
 
-    let build_dir = test
-        .with_exec(vec!["npm", "run", "build"])
-        .directory("./build");
+        let entries = build_dir.entries().await;
 
-    let _ = build_dir.export("./build");
+        println!("build dir contents: \n {:?}", entries);
 
-    let entries = build_dir.entries().await;
-
-    println!("build dir contents: \n {:?}", entries);
+        Ok(())
+    })
+    .await?;
 
     Ok(())
 }

--- a/sdk/rust/crates/dagger-sdk/examples/caching/main.rs
+++ b/sdk/rust/crates/dagger-sdk/examples/caching/main.rs
@@ -2,43 +2,46 @@ use rand::Rng;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    let client = dagger_sdk::connect().await?;
+    dagger_sdk::connect(|client| async move {
+        let host_source_dir = client.host().directory_opts(
+            "./examples/caching/app",
+            dagger_sdk::HostDirectoryOptsBuilder::default()
+                .exclude(vec!["node_modules/", "ci/"])
+                .build()?,
+        );
 
-    let host_source_dir = client.host().directory_opts(
-        "./examples/caching/app",
-        dagger_sdk::HostDirectoryOptsBuilder::default()
-            .exclude(vec!["node_modules/", "ci/"])
-            .build()?,
-    );
+        let node_cache = client.cache_volume("node");
 
-    let node_cache = client.cache_volume("node");
+        let source = client
+            .container()
+            .from("node:16")
+            .with_mounted_directory("/src", host_source_dir)
+            .with_mounted_cache("/src/node_modules", node_cache);
 
-    let source = client
-        .container()
-        .from("node:16")
-        .with_mounted_directory("/src", host_source_dir)
-        .with_mounted_cache("/src/node_modules", node_cache);
+        let runner = source
+            .with_workdir("/src")
+            .with_exec(vec!["npm", "install"]);
 
-    let runner = source
-        .with_workdir("/src")
-        .with_exec(vec!["npm", "install"]);
+        let test = runner.with_exec(vec!["npm", "test", "--", "--watchAll=false"]);
 
-    let test = runner.with_exec(vec!["npm", "test", "--", "--watchAll=false"]);
+        let build_dir = test
+            .with_exec(vec!["npm", "run", "build"])
+            .directory("./build");
 
-    let build_dir = test
-        .with_exec(vec!["npm", "run", "build"])
-        .directory("./build");
+        let mut rng = rand::thread_rng();
 
-    let mut rng = rand::thread_rng();
+        let r#ref = client
+            .container()
+            .from("nginx")
+            .with_directory("/usr/share/nginx/html", build_dir)
+            .publish(format!("ttl.sh/hello-dagger-sdk-{}:1h", rng.gen::<u64>()))
+            .await?;
 
-    let ref_ = client
-        .container()
-        .from("nginx")
-        .with_directory("/usr/share/nginx/html", build_dir)
-        .publish(format!("ttl.sh/hello-dagger-sdk-{}:1h", rng.gen::<u64>()))
-        .await?;
+        println!("published image to: {}", r#ref);
 
-    println!("published image to: {}", ref_);
+        Ok(())
+    })
+    .await?;
 
     Ok(())
 }

--- a/sdk/rust/crates/dagger-sdk/examples/existing-dockerfile/main.rs
+++ b/sdk/rust/crates/dagger-sdk/examples/existing-dockerfile/main.rs
@@ -4,19 +4,22 @@ use rand::Rng;
 async fn main() -> eyre::Result<()> {
     let mut rng = rand::thread_rng();
 
-    let client = dagger_sdk::connect().await?;
+    dagger_sdk::connect(|client| async move {
+        let context_dir = client
+            .host()
+            .directory("./examples/existing-dockerfile/app");
 
-    let context_dir = client
-        .host()
-        .directory("./examples/existing-dockerfile/app");
+        let ref_ = client
+            .container()
+            .build(context_dir)
+            .publish(format!("ttl.sh/hello-dagger-sdk-{}:1h", rng.gen::<u64>()))
+            .await?;
 
-    let ref_ = client
-        .container()
-        .build(context_dir)
-        .publish(format!("ttl.sh/hello-dagger-sdk-{}:1h", rng.gen::<u64>()))
-        .await?;
+        println!("published image to: {}", ref_);
 
-    println!("published image to: {}", ref_);
+        Ok(())
+    })
+    .await?;
 
     Ok(())
 }

--- a/sdk/rust/crates/dagger-sdk/examples/first-pipeline/main.rs
+++ b/sdk/rust/crates/dagger-sdk/examples/first-pipeline/main.rs
@@ -2,16 +2,19 @@
 async fn main() -> eyre::Result<()> {
     tracing_subscriber::fmt::init();
 
-    let client = dagger_sdk::connect().await?;
+    dagger_sdk::connect(|client| async move {
+        let version = client
+            .container()
+            .from("golang:1.19")
+            .with_exec(vec!["go", "version"])
+            .stdout()
+            .await?;
 
-    let version = client
-        .container()
-        .from("golang:1.19")
-        .with_exec(vec!["go", "version"])
-        .stdout()
-        .await?;
+        println!("Hello from Dagger and {}", version.trim());
 
-    println!("Hello from Dagger and {}", version.trim());
+        Ok(())
+    })
+    .await?;
 
     Ok(())
 }

--- a/sdk/rust/crates/dagger-sdk/examples/first-pipeline/main.rs
+++ b/sdk/rust/crates/dagger-sdk/examples/first-pipeline/main.rs
@@ -1,5 +1,7 @@
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
+    tracing_subscriber::fmt::init();
+
     let client = dagger_sdk::connect().await?;
 
     let version = client

--- a/sdk/rust/crates/dagger-sdk/examples/logging/main.rs
+++ b/sdk/rust/crates/dagger-sdk/examples/logging/main.rs
@@ -7,43 +7,46 @@ use dagger_sdk::HostDirectoryOpts;
 async fn main() -> eyre::Result<()> {
     dagger_sdk::logging::default_logging()?;
 
-    let client = dagger_sdk::connect_opts(dagger_sdk::Config {
-        workdir_path: None,
-        config_path: None,
-        timeout_ms: 1000,
-        execute_timeout_ms: None,
-        logger: Some(Arc::new(TracingLogger::default())),
-    })
-    .await?;
-
-    let host_source_dir = client.host().directory_opts(
-        "examples/build-the-application/app",
-        HostDirectoryOpts {
-            exclude: Some(vec!["node_modules".into(), "ci/".into()]),
-            include: None,
+    dagger_sdk::connect_opts(
+        dagger_sdk::Config {
+            workdir_path: None,
+            config_path: None,
+            timeout_ms: 1000,
+            execute_timeout_ms: None,
+            logger: Some(Arc::new(TracingLogger::default())),
         },
-    );
+        |client| async move {
+            let host_source_dir = client.host().directory_opts(
+                "examples/build-the-application/app",
+                HostDirectoryOpts {
+                    exclude: Some(vec!["node_modules", "ci/"]),
+                    include: None,
+                },
+            );
 
-    let source = client
-        .container()
-        .from("node:16")
-        .with_mounted_directory("/src", host_source_dir);
+            let source = client
+                .container()
+                .from("node:16")
+                .with_mounted_directory("/src", host_source_dir);
 
-    let runner = source
-        .with_workdir("/src")
-        .with_exec(vec!["npm", "install"]);
+            let runner = source
+                .with_workdir("/src")
+                .with_exec(vec!["npm", "install"]);
 
-    let test = runner.with_exec(vec!["npm", "test", "--", "--watchAll=false"]);
+            let test = runner.with_exec(vec!["npm", "test", "--", "--watchAll=false"]);
 
-    let build_dir = test
-        .with_exec(vec!["npm", "run", "build"])
-        .directory("./build");
+            let build_dir = test
+                .with_exec(vec!["npm", "run", "build"])
+                .directory("./build");
 
-    let _ = build_dir.export("./build");
+            let entries = build_dir.entries().await;
 
-    let entries = build_dir.entries().await;
+            println!("build dir contents: \n {:?}", entries);
 
-    println!("build dir contents: \n {:?}", entries);
+            Ok(())
+        },
+    )
+    .await?;
 
     Ok(())
 }

--- a/sdk/rust/crates/dagger-sdk/examples/multi-stage-build/main.rs
+++ b/sdk/rust/crates/dagger-sdk/examples/multi-stage-build/main.rs
@@ -3,41 +3,44 @@ use rand::Rng;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    let client = dagger_sdk::connect().await?;
+    dagger_sdk::connect(|client| async move {
+        let host_source_dir = client.host().directory_opts(
+            "examples/publish-the-application/app",
+            HostDirectoryOpts {
+                exclude: Some(vec!["node_modules", "ci/"]),
+                include: None,
+            },
+        );
 
-    let host_source_dir = client.host().directory_opts(
-        "examples/publish-the-application/app",
-        HostDirectoryOpts {
-            exclude: Some(vec!["node_modules", "ci/"]),
-            include: None,
-        },
-    );
+        let source = client
+            .container()
+            .from("node:16")
+            .with_mounted_directory("/src", host_source_dir);
 
-    let source = client
-        .container()
-        .from("node:16")
-        .with_mounted_directory("/src", host_source_dir);
+        let runner = source
+            .with_workdir("/src")
+            .with_exec(vec!["npm", "install"]);
 
-    let runner = source
-        .with_workdir("/src")
-        .with_exec(vec!["npm", "install"]);
+        let test = runner.with_exec(vec!["npm", "test", "--", "--watchAll=false"]);
 
-    let test = runner.with_exec(vec!["npm", "test", "--", "--watchAll=false"]);
+        let build_dir = test
+            .with_exec(vec!["npm", "run", "build"])
+            .directory("./build");
 
-    let build_dir = test
-        .with_exec(vec!["npm", "run", "build"])
-        .directory("./build");
+        let mut rng = rand::thread_rng();
 
-    let mut rng = rand::thread_rng();
+        let ref_ = client
+            .container()
+            .from("nginx")
+            .with_directory("/usr/share/nginx/html", build_dir)
+            .publish(format!("ttl.sh/hello-dagger-sdk-{}:1h", rng.gen::<u64>()))
+            .await?;
 
-    let ref_ = client
-        .container()
-        .from("nginx")
-        .with_directory("/usr/share/nginx/html", build_dir)
-        .publish(format!("ttl.sh/hello-dagger-sdk-{}:1h", rng.gen::<u64>()))
-        .await?;
+        println!("published image to: {}", ref_);
 
-    println!("published image to: {}", ref_);
+        Ok(())
+    })
+    .await?;
 
     Ok(())
 }

--- a/sdk/rust/crates/dagger-sdk/examples/publish-the-application/main.rs
+++ b/sdk/rust/crates/dagger-sdk/examples/publish-the-application/main.rs
@@ -3,43 +3,50 @@ use rand::Rng;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    let client = dagger_sdk::connect().await?;
-    let output = "examples/publish-the-application/app/build";
+    dagger_sdk::connect(|client| async move {
+        let output = "examples/publish-the-application/app/build";
 
-    let host_source_dir = client.host().directory_opts(
-        "examples/publish-the-application/app",
-        HostDirectoryOpts {
-            exclude: Some(vec!["node_modules", "ci/"]),
-            include: None,
-        },
-    );
+        let host_source_dir = client.host().directory_opts(
+            "examples/publish-the-application/app",
+            HostDirectoryOpts {
+                exclude: Some(vec!["node_modules", "ci/"]),
+                include: None,
+            },
+        );
 
-    let source = client
-        .container()
-        .from("node:16")
-        .with_mounted_directory("/src", host_source_dir);
+        let source = client
+            .container()
+            .from("node:16")
+            .with_mounted_directory("/src", host_source_dir);
 
-    let runner = source
-        .with_workdir("/src")
-        .with_exec(vec!["npm", "install"]);
+        let runner = source
+            .with_workdir("/src")
+            .with_exec(vec!["npm", "install"]);
 
-    let test = runner.with_exec(vec!["npm", "test", "--", "--watchAll=false"]);
+        runner
+            .with_exec(vec!["npm", "test", "--", "--watchAll=false"])
+            .sync()
+            .await?;
 
-    let _ = test
-        .with_exec(vec!["npm", "run", "build"])
-        .directory("./build")
-        .export(output);
+        // let _ = test
+        //     .with_exec(vec!["npm", "run", "build"])
+        //     .directory("./build")
+        //     .export(output);
 
-    let mut rng = rand::thread_rng();
+        let mut rng = rand::thread_rng();
 
-    let ref_ = client
-        .container()
-        .from("nginx")
-        .with_directory("/usr/share/nginx/html", client.host().directory(output))
-        .publish(format!("ttl.sh/hello-dagger-sdk-{}:1h", rng.gen::<u64>()))
-        .await?;
+        let ref_ = client
+            .container()
+            .from("nginx")
+            .with_directory("/usr/share/nginx/html", client.host().directory(output))
+            .publish(format!("ttl.sh/hello-dagger-sdk-{}:1h", rng.gen::<u64>()))
+            .await?;
 
-    println!("published image to: {}", ref_);
+        println!("published image to: {}", ref_);
+
+        Ok(())
+    })
+    .await?;
 
     Ok(())
 }

--- a/sdk/rust/crates/dagger-sdk/examples/test-the-application/main.rs
+++ b/sdk/rust/crates/dagger-sdk/examples/test-the-application/main.rs
@@ -2,31 +2,34 @@ use dagger_sdk::HostDirectoryOpts;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    let client = dagger_sdk::connect().await?;
+    dagger_sdk::connect(|client| async move {
+        let host_source_dir = client.host().directory_opts(
+            "examples/test-the-application/app",
+            HostDirectoryOpts {
+                exclude: Some(vec!["node_modules", "ci/"]),
+                include: None,
+            },
+        );
 
-    let host_source_dir = client.host().directory_opts(
-        "examples/test-the-application/app",
-        HostDirectoryOpts {
-            exclude: Some(vec!["node_modules", "ci/"]),
-            include: None,
-        },
-    );
+        let source = client
+            .container()
+            .from("node:16")
+            .with_mounted_directory("/src", host_source_dir);
 
-    let source = client
-        .container()
-        .from("node:16")
-        .with_mounted_directory("/src", host_source_dir);
+        let runner = source
+            .with_workdir("/src")
+            .with_exec(vec!["npm", "install"]);
 
-    let runner = source
-        .with_workdir("/src")
-        .with_exec(vec!["npm", "install"]);
+        let out = runner
+            .with_exec(vec!["npm", "test", "--", "--watchAll=false"])
+            .stderr()
+            .await?;
 
-    let out = runner
-        .with_exec(vec!["npm", "test", "--", "--watchAll=false"])
-        .stderr()
-        .await?;
+        println!("{}", out);
 
-    println!("{}", out);
+        Ok(())
+    })
+    .await?;
 
     Ok(())
 }

--- a/sdk/rust/crates/dagger-sdk/src/client.rs
+++ b/sdk/rust/crates/dagger-sdk/src/client.rs
@@ -1,4 +1,7 @@
+use std::pin::Pin;
 use std::sync::Arc;
+
+use futures::Future;
 
 use crate::core::config::Config;
 use crate::core::engine::Engine as DaggerEngine;
@@ -11,23 +14,43 @@ use crate::querybuilder::query;
 
 pub type DaggerConn = Query;
 
-pub async fn connect() -> Result<DaggerConn, ConnectError> {
+pub async fn connect<F, Fut>(dagger: F) -> Result<(), ConnectError>
+where
+    F: FnOnce(DaggerConn) -> Fut + 'static,
+    Fut: futures::Future<Output = eyre::Result<()>> + 'static,
+{
     let cfg = Config::new(None, None, None, None, Some(Arc::new(StdLogger::default())));
 
-    connect_opts(cfg).await
+    connect_opts(cfg, dagger).await
 }
 
-pub async fn connect_opts(cfg: Config) -> Result<DaggerConn, ConnectError> {
+pub async fn connect_opts<F, Fut>(cfg: Config, dagger: F) -> Result<(), ConnectError>
+where
+    F: FnOnce(DaggerConn) -> Fut + 'static,
+    Fut: futures::Future<Output = eyre::Result<()>> + 'static,
+{
     let (conn, proc) = DaggerEngine::new()
         .start(&cfg)
         .await
         .map_err(ConnectError::FailedToConnect)?;
 
-    Ok(Query {
-        proc: proc.map(Arc::new),
+    let proc = proc.map(Arc::new);
+
+    let client = Query {
+        proc: proc.clone(),
         selection: query(),
         graphql_client: Arc::new(DefaultGraphQLClient::new(&conn)),
-    })
+    };
+
+    dagger(client).await.map_err(ConnectError::DaggerContext)?;
+
+    if let Some(proc) = &proc {
+        proc.shutdown()
+            .await
+            .map_err(ConnectError::FailedToShutdown)?;
+    }
+
+    Ok(())
 }
 
 // Conn will automatically close on drop of proc
@@ -36,19 +59,21 @@ pub async fn connect_opts(cfg: Config) -> Result<DaggerConn, ConnectError> {
 mod test {
     use super::connect;
 
-    //#[tokio::test(flavor = "multi_thread")]
     #[tokio::test]
     async fn test_connect() -> eyre::Result<()> {
         tracing_subscriber::fmt::init();
 
-        let something = connect().await?;
+        connect(|client| async move {
+            client
+                .container()
+                .from("alpine:latest")
+                .with_exec(vec!["echo", "1"])
+                .sync()
+                .await?;
 
-        something
-            .container()
-            .from("alpine:latest")
-            .with_exec(vec!["echo", "1"])
-            .sync()
-            .await?;
+            Ok(())
+        })
+        .await?;
 
         Ok(())
     }

--- a/sdk/rust/crates/dagger-sdk/src/client.rs
+++ b/sdk/rust/crates/dagger-sdk/src/client.rs
@@ -36,8 +36,20 @@ pub async fn connect_opts(cfg: Config) -> Result<DaggerConn, ConnectError> {
 mod test {
     use super::connect;
 
+    //#[tokio::test(flavor = "multi_thread")]
     #[tokio::test]
-    async fn test_connect() {
-        let _ = connect().await.unwrap();
+    async fn test_connect() -> eyre::Result<()> {
+        tracing_subscriber::fmt::init();
+
+        let something = connect().await?;
+
+        something
+            .container()
+            .from("alpine:latest")
+            .with_exec(vec!["echo", "1"])
+            .sync()
+            .await?;
+
+        Ok(())
     }
 }

--- a/sdk/rust/crates/dagger-sdk/src/core/cli_session.rs
+++ b/sdk/rust/crates/dagger-sdk/src/core/cli_session.rs
@@ -1,12 +1,18 @@
-use std::{fs::canonicalize, path::PathBuf, process::Stdio, sync::Arc};
+use std::{fs::canonicalize, path::Path, process::Stdio, sync::Arc};
 
-use tokio::io::AsyncBufReadExt;
+use tokio::{io::AsyncBufReadExt, sync::broadcast};
 
 use crate::core::{config::Config, connect_params::ConnectParams};
 
 #[derive(Clone, Debug)]
 pub struct CliSession {
     inner: Arc<InnerCliSession>,
+}
+
+impl Default for CliSession {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl CliSession {
@@ -19,9 +25,61 @@ impl CliSession {
     pub async fn connect(
         &self,
         config: &Config,
-        cli_path: &PathBuf,
-    ) -> eyre::Result<(ConnectParams, tokio::process::Child)> {
+        cli_path: &Path,
+    ) -> eyre::Result<(ConnectParams, DaggerSessionProc)> {
         self.inner.connect(config, cli_path).await
+    }
+}
+
+pub struct DaggerSessionProc {
+    shutdown: broadcast::Sender<()>,
+
+    inner: tokio::process::Child,
+}
+
+impl DaggerSessionProc {
+    pub fn subscribe_shutdown(&self) -> broadcast::Receiver<()> {
+        self.shutdown.subscribe()
+    }
+}
+
+impl Drop for DaggerSessionProc {
+    fn drop(&mut self) {
+        std::thread::scope(|s| {
+            s.spawn(|| {
+                // FIXME: This is a bit of a hack, we spawn a neutral runtime, which doesn't automatically prune blocking tasks.
+                // This should be removed when async_drop is made stable
+
+                let runtime = tokio::runtime::Builder::new_multi_thread().build().unwrap();
+
+                runtime.block_on(async move {
+                    tracing::trace!("waiting for dagger subprocess to shutdown");
+
+                    // tracing::trace!("sending shutdown signal");
+                    // if let Err(e) = self.shutdown.send(()) {
+                    //     tracing::warn!("failed to send shutdown signal: {}", e);
+                    // }
+
+                    // tracing::trace!("closing stdin");
+                    if let Err(e) = self.inner.wait().await {
+                        tracing::warn!("failed to shutdown session: {}", e);
+                    }
+
+                    tracing::trace!("dagger subprocess shutdown");
+                });
+            });
+        })
+    }
+}
+
+impl From<tokio::process::Child> for DaggerSessionProc {
+    fn from(value: tokio::process::Child) -> Self {
+        let (tx, _) = broadcast::channel::<()>(1);
+
+        Self {
+            inner: value,
+            shutdown: tx,
+        }
     }
 }
 
@@ -32,14 +90,15 @@ impl InnerCliSession {
     pub async fn connect(
         &self,
         config: &Config,
-        cli_path: &PathBuf,
-    ) -> eyre::Result<(ConnectParams, tokio::process::Child)> {
+        cli_path: &Path,
+    ) -> eyre::Result<(ConnectParams, DaggerSessionProc)> {
         let proc = self.start(config, cli_path)?;
         let params = self.get_conn(proc, config).await?;
+
         Ok(params)
     }
 
-    fn start(&self, config: &Config, cli_path: &PathBuf) -> eyre::Result<tokio::process::Child> {
+    fn start(&self, config: &Config, cli_path: &Path) -> eyre::Result<tokio::process::Child> {
         let mut args: Vec<String> = vec!["session".into()];
         if let Some(workspace) = &config.workdir_path {
             let abs_path = canonicalize(workspace)?;
@@ -53,7 +112,7 @@ impl InnerCliSession {
         args.extend(["--label".into(), "dagger.io/sdk.name:rust".into()]);
         args.extend([
             "--label".into(),
-            format!("dagger.io/sdk.version:{}", env!("CARGO_PKG_VERSION")).into(),
+            format!("dagger.io/sdk.version:{}", env!("CARGO_PKG_VERSION")),
         ]);
 
         let proc = tokio::process::Command::new(
@@ -69,14 +128,14 @@ impl InnerCliSession {
 
         //TODO: Add retry mechanism
 
-        return Ok(proc);
+        Ok(proc)
     }
 
     async fn get_conn(
         &self,
         mut proc: tokio::process::Child,
         config: &Config,
-    ) -> eyre::Result<(ConnectParams, tokio::process::Child)> {
+    ) -> eyre::Result<(ConnectParams, DaggerSessionProc)> {
         let stdout = proc
             .stdout
             .take()
@@ -87,37 +146,67 @@ impl InnerCliSession {
             .take()
             .ok_or(eyre::anyhow!("could not acquire stderr from child process"))?;
 
-        let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
+        let session: DaggerSessionProc = proc.into();
 
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
         let logger = config.logger.as_ref().map(|p| p.clone());
+        let mut rx = session.subscribe_shutdown();
+
         tokio::spawn(async move {
             let mut stdout_bufr = tokio::io::BufReader::new(stdout).lines();
-            while let Ok(Some(line)) = stdout_bufr.next_line().await {
-                if let Ok(conn) = serde_json::from_str::<ConnectParams>(&line) {
-                    sender.send(conn).await.unwrap();
-                    continue;
-                }
+            loop {
+                tokio::select! {
+                    line = stdout_bufr.next_line() => {
+                        if let Ok(Some(line)) = line {
+                            if let Ok(conn) = serde_json::from_str::<ConnectParams>(&line) {
+                                sender.send(conn).await.unwrap();
+                                continue;
+                            }
 
-                if let Some(logger) = &logger {
-                    logger.stdout(&line).unwrap();
-                }
+                            if let Some(logger) = &logger {
+                                logger.stdout(&line).unwrap();
+                            }
+                        }
+                    },
+                    _ = rx.recv() => {
+                        drop(stdout_bufr);
+                        tracing::trace!("shutting down stdout");
+                        break;
+                    },
+                };
             }
+
+            tracing::trace!("closing stdout for dagger session");
         });
 
+        let mut rx = session.subscribe_shutdown();
         let logger = config.logger.as_ref().map(|p| p.clone());
         tokio::spawn(async move {
             let mut stderr_bufr = tokio::io::BufReader::new(stderr).lines();
-            while let Ok(Some(line)) = stderr_bufr.next_line().await {
-                if let Some(logger) = &logger {
-                    logger.stdout(&line).unwrap();
-                }
+            loop {
+                tokio::select! {
+                    line = stderr_bufr.next_line() => {
+                        if let Ok(Some(line)) = line {
+                            if let Some(logger) = &logger {
+                                logger.stderr(&line).unwrap();
+                            }
+                        }
+                    },
+                    _ = rx.recv() => {
+                        drop(stderr_bufr);
+                        tracing::trace!("shutting down stderr");
+                        break;
+                    },
+                };
             }
+
+            tracing::trace!("closing stderr for dagger session");
         });
 
         let conn = receiver.recv().await.ok_or(eyre::anyhow!(
             "could not receive ok signal from dagger-engine"
         ))?;
 
-        Ok((conn, proc))
+        Ok((conn, session))
     }
 }

--- a/sdk/rust/crates/dagger-sdk/src/core/gql_client.rs
+++ b/sdk/rust/crates/dagger-sdk/src/core/gql_client.rs
@@ -182,6 +182,7 @@ impl GQLClient {
         if let Some(proxy) = &self.config.proxy {
             builder = builder.proxy(proxy.clone().try_into()?);
         }
+
         builder
             .build()
             .map_err(|e| GraphQLError::with_text(format!("Can not create client: {:?}", e)))

--- a/sdk/rust/crates/dagger-sdk/src/errors.rs
+++ b/sdk/rust/crates/dagger-sdk/src/errors.rs
@@ -4,6 +4,12 @@ use thiserror::Error;
 pub enum ConnectError {
     #[error("failed to connect to dagger engine")]
     FailedToConnect(#[source] eyre::Error),
+
+    #[error("an error occurred from the dagger context call")]
+    DaggerContext(#[source] eyre::Error),
+
+    #[error("failed to shutdown the dagger connection")]
+    FailedToShutdown(#[source] eyre::Error),
 }
 
 #[derive(Error, Debug)]

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -1,3 +1,4 @@
+use crate::core::cli_session::DaggerSessionProc;
 use crate::core::graphql_client::DynGraphQLClient;
 use crate::errors::DaggerError;
 use crate::id::IntoID;
@@ -5,7 +6,6 @@ use crate::querybuilder::Selection;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tokio::process::Child;
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct CacheVolumeId(pub String);
@@ -1244,7 +1244,7 @@ pub struct PortForward {
 }
 #[derive(Clone)]
 pub struct CacheVolume {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -1257,7 +1257,7 @@ impl CacheVolume {
 }
 #[derive(Clone)]
 pub struct Container {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -3203,7 +3203,7 @@ impl Container {
 }
 #[derive(Clone)]
 pub struct CurrentModule {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -3293,7 +3293,7 @@ impl CurrentModule {
 }
 #[derive(Clone)]
 pub struct Directory {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -3950,7 +3950,7 @@ impl Directory {
 }
 #[derive(Clone)]
 pub struct EnumTypeDef {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -3987,7 +3987,7 @@ impl EnumTypeDef {
 }
 #[derive(Clone)]
 pub struct EnumValueTypeDef {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -4010,7 +4010,7 @@ impl EnumValueTypeDef {
 }
 #[derive(Clone)]
 pub struct EnvVariable {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -4033,7 +4033,7 @@ impl EnvVariable {
 }
 #[derive(Clone)]
 pub struct FieldTypeDef {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -4065,7 +4065,7 @@ impl FieldTypeDef {
 }
 #[derive(Clone)]
 pub struct File {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -4163,7 +4163,7 @@ impl File {
 }
 #[derive(Clone)]
 pub struct Function {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -4284,7 +4284,7 @@ impl Function {
 }
 #[derive(Clone)]
 pub struct FunctionArg {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -4321,7 +4321,7 @@ impl FunctionArg {
 }
 #[derive(Clone)]
 pub struct FunctionCall {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -4368,7 +4368,7 @@ impl FunctionCall {
 }
 #[derive(Clone)]
 pub struct FunctionCallArgValue {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -4391,7 +4391,7 @@ impl FunctionCallArgValue {
 }
 #[derive(Clone)]
 pub struct GeneratedCode {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -4449,7 +4449,7 @@ impl GeneratedCode {
 }
 #[derive(Clone)]
 pub struct GitModuleSource {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -4501,7 +4501,7 @@ impl GitModuleSource {
 }
 #[derive(Clone)]
 pub struct GitRef {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -4560,7 +4560,7 @@ impl GitRef {
 }
 #[derive(Clone)]
 pub struct GitRepository {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -4678,7 +4678,7 @@ impl GitRepository {
 }
 #[derive(Clone)]
 pub struct Host {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -4893,7 +4893,7 @@ impl Host {
 }
 #[derive(Clone)]
 pub struct InputTypeDef {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -4920,7 +4920,7 @@ impl InputTypeDef {
 }
 #[derive(Clone)]
 pub struct InterfaceTypeDef {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -4957,7 +4957,7 @@ impl InterfaceTypeDef {
 }
 #[derive(Clone)]
 pub struct Label {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -4980,7 +4980,7 @@ impl Label {
 }
 #[derive(Clone)]
 pub struct ListTypeDef {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -5002,7 +5002,7 @@ impl ListTypeDef {
 }
 #[derive(Clone)]
 pub struct LocalModuleSource {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -5029,7 +5029,7 @@ impl LocalModuleSource {
 }
 #[derive(Clone)]
 pub struct Module {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -5235,7 +5235,7 @@ impl Module {
 }
 #[derive(Clone)]
 pub struct ModuleDependency {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -5262,7 +5262,7 @@ impl ModuleDependency {
 }
 #[derive(Clone)]
 pub struct ModuleSource {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -5571,7 +5571,7 @@ impl ModuleSource {
 }
 #[derive(Clone)]
 pub struct ModuleSourceView {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -5594,7 +5594,7 @@ impl ModuleSourceView {
 }
 #[derive(Clone)]
 pub struct ObjectTypeDef {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -5649,7 +5649,7 @@ impl ObjectTypeDef {
 }
 #[derive(Clone)]
 pub struct Port {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -5682,7 +5682,7 @@ impl Port {
 }
 #[derive(Clone)]
 pub struct Query {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -6838,7 +6838,7 @@ impl Query {
 }
 #[derive(Clone)]
 pub struct ScalarTypeDef {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -6866,7 +6866,7 @@ impl ScalarTypeDef {
 }
 #[derive(Clone)]
 pub struct Secret {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -6889,7 +6889,7 @@ impl Secret {
 }
 #[derive(Clone)]
 pub struct Service {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -7023,7 +7023,7 @@ impl Service {
 }
 #[derive(Clone)]
 pub struct Socket {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
@@ -7036,7 +7036,7 @@ impl Socket {
 }
 #[derive(Clone)]
 pub struct TypeDef {
-    pub proc: Option<Arc<Child>>,
+    pub proc: Option<Arc<DaggerSessionProc>>,
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }

--- a/sdk/rust/crates/dagger-sdk/tests/mod.rs
+++ b/sdk/rust/crates/dagger-sdk/tests/mod.rs
@@ -3,80 +3,100 @@ use pretty_assertions::assert_eq;
 
 #[tokio::test]
 async fn test_example_container() {
-    let client = connect().await.unwrap();
+    connect(|client| async move {
+        let alpine = client.container().from("alpine:3.16.2");
 
-    let alpine = client.container().from("alpine:3.16.2");
+        let out = alpine
+            .with_exec(vec!["cat", "/etc/alpine-release"])
+            .stdout()
+            .await
+            .unwrap();
 
-    let out = alpine
-        .with_exec(vec!["cat", "/etc/alpine-release"])
-        .stdout()
-        .await
-        .unwrap();
+        assert_eq!(out, "3.16.2\n".to_string());
 
-    assert_eq!(out, "3.16.2\n".to_string())
+        Ok(())
+    })
+    .await
+    .unwrap();
 }
 
 #[tokio::test]
 async fn test_directory() {
-    let c = connect().await.unwrap();
+    connect(|client| async move {
+        let contents = client
+            .directory()
+            .with_new_file("/hello.txt", "world")
+            .file("/hello.txt")
+            .contents()
+            .await
+            .unwrap();
 
-    let contents = c
-        .directory()
-        .with_new_file("/hello.txt", "world")
-        .file("/hello.txt")
-        .contents()
-        .await
-        .unwrap();
+        assert_eq!("world", contents);
 
-    assert_eq!("world", contents)
+        Ok(())
+    })
+    .await
+    .unwrap();
 }
 
 #[tokio::test]
 async fn test_git() {
-    let c = connect().await.unwrap();
+    connect(|client| async move {
+        let tree = client.git("github.com/dagger/dagger").branch("main").tree();
 
-    let tree = c.git("github.com/dagger/dagger").branch("main").tree();
+        let _ = tree
+            .entries()
+            .await
+            .unwrap()
+            .iter()
+            .find(|f| f.as_str() == "README.md")
+            .unwrap();
 
-    let _ = tree
-        .entries()
-        .await
-        .unwrap()
-        .iter()
-        .find(|f| f.as_str() == "README.md")
-        .unwrap();
+        let readme_file = tree.file("README.md");
 
-    let readme_file = tree.file("README.md");
+        let readme = readme_file.contents().await.unwrap();
+        assert_eq!(true, readme.contains("Dagger"));
 
-    let readme = readme_file.contents().await.unwrap();
-    assert_eq!(true, readme.find("Dagger").is_some());
+        let other_readme = client
+            .load_file_from_id(readme_file)
+            .contents()
+            .await
+            .unwrap();
 
-    let other_readme = c.load_file_from_id(readme_file).contents().await.unwrap();
+        assert_eq!(readme, other_readme);
 
-    assert_eq!(readme, other_readme);
+        Ok(())
+    })
+    .await
+    .unwrap();
 }
 
 #[tokio::test]
 async fn test_container() {
-    let client = connect().await.unwrap();
+    connect(|client| async move {
+        let alpine = client.container().from("alpine:3.16.2");
 
-    let alpine = client.container().from("alpine:3.16.2");
+        let contents = alpine.file("/etc/alpine-release").contents().await.unwrap();
+        assert_eq!(contents, "3.16.2\n".to_string());
 
-    let contents = alpine.file("/etc/alpine-release").contents().await.unwrap();
-    assert_eq!(contents, "3.16.2\n".to_string());
+        let out = alpine
+            .with_exec(vec!["cat", "/etc/alpine-release"])
+            .stdout()
+            .await
+            .unwrap();
+        assert_eq!(out, "3.16.2\n".to_string());
 
-    let out = alpine
-        .with_exec(vec!["cat", "/etc/alpine-release"])
-        .stdout()
-        .await
-        .unwrap();
-    assert_eq!(out, "3.16.2\n".to_string());
+        let id = alpine.id().await.unwrap();
+        let contents = client
+            .load_container_from_id(id)
+            .file("/etc/alpine-release")
+            .contents()
+            .await
+            .unwrap();
+        assert_eq!(contents, "3.16.2\n".to_string());
 
-    let id = alpine.id().await.unwrap();
-    let contents = client
-        .load_container_from_id(id)
-        .file("/etc/alpine-release")
-        .contents()
-        .await
-        .unwrap();
-    assert_eq!(contents, "3.16.2\n".to_string());
+        Ok(())
+    })
+    .await
+    .unwrap();
 }


### PR DESCRIPTION
Add explicit cleanup for the dagger child process if started from the rust dagger sdk itself. This requires a breaking change to the connect, as we're missing a few features from rust that are currently only available on nightly.

BREAKING: change for the dagger sdk:

```rust

let client = dagger_sdk::connect().await?;
// use client

// breaking change to:

dagger_sdk::connect(|client| async move {
  // use client

  Ok(())
}).await?;
```

The reason for the breaking change is that we
didn't properly clean up the dagger session.

I initialy attempted an async drop functionality.

However it didn't work because async drop is nightly.
With a single threaded runtime we'd deadlock the thread.

Unlike sqlx which has the same behavior, I cannot count
on the dagger session being available after the last call.

Sqlx spawns a background thread to cleanup, usually dagger_sdk is the
only thing called and as such it will never get a chance to actually
cleanup

We had 3 options:

1. Require multithreaded runtimes such that a
   homegrown async drop could be implemented.
   This was too buggy, and would lead to unintuitive usage
2. Require nightly for async drop functionality.
   async drop is fairly new so I didn't want to be hooked on that feature
   I don't want the dagger-sdk to only be available on nightly
3. Implement a cleanup closure, this is what is done in many such
   tasks, it does lead to some not so nice ergonomics, but this is
   what I accepted do to it being a known pattern.