### PR TITLE
engine: prune local cache after sessions disconnect

### DIFF
--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -199,6 +199,11 @@ func (srv *Server) removeDaggerSession(ctx context.Context, sess *daggerSession)
 		"session", sess.sessionID,
 	)
 
+	// check if the local cache needs pruning after session is removed, prune if so
+	defer func() {
+		time.AfterFunc(time.Second, srv.throttledGC)
+	}()
+
 	srv.daggerSessionsMu.Lock()
 	delete(srv.daggerSessions, sess.sessionID)
 	srv.daggerSessionsMu.Unlock()


### PR DESCRIPTION
We used to prune the local cache after sessions ended, but this got dropped during recent refactoring so now the local cache is only being pruned at engine startup.

This re-adds that gc call on session disconnect.

This is obviously in dire need of integration tests, but setting those up is a decent chunk of work so prioritizing the fix first and will follow-up immediately with that test coverage.

For now, I verified the fix manually with a local test that runs an exec that consumes more disk space than my local engines max keep bytes config. Before, the state was never cleared but now I see in the engine logs and in `df` output that it is.