### PR TITLE
docs: Fix 'tool.dagger' toml table name.

### DIFF
--- a/docs/current_docs/manuals/developer/module-structure.mdx
+++ b/docs/current_docs/manuals/developer/module-structure.mdx
@@ -27,7 +27,7 @@ The runtime container is currently hardcoded to run in Go 1.21  (although this m
 The runtime container is currently hardcoded to run in Python 3.11.1 using the [python:3.11-slim](https://hub.docker.com/_/python/tags?name=3.11-slim) base image by default. This can be overridden in `pyproject.toml` since [Dagger v0.11][v11]:
 
 ```toml
-[dagger.tool]
+[tool.dagger]
 base-image = "acme/python:3.11"
 ```
 


### PR DESCRIPTION
The Runtime Container documentation ([here](https://docs.dagger.io/manuals/developer/module-structure/#runtime-container) - Python tab.) has `[dagger.tool]` instead of `[tool.dagger]`. 

Per the discussion [in discord](https://discord.com/channels/707636530424053791/1250370138226819152/1250439736951308288) (and my testing) it should be the latter.