### PR TITLE
fix(ts-sdk): correctly resolve non-primitive default value

### DIFF
--- a/core/integration/module_typescript_test.go
+++ b/core/integration/module_typescript_test.go
@@ -486,6 +486,10 @@ func TestModuleTypescriptOptional(t *testing.T) {
 	out, err = modGen.With(daggerQuery(`{minimal{isEmpty}}`)).Stdout(ctx)
 	require.NoError(t, err)
 	require.JSONEq(t, `{"minimal": {"isEmpty": true}}`, out)
+
+	out, err = modGen.With(daggerQuery(`{minimal{resolveValue}}`)).Stdout(ctx)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"minimal": {"resolveValue": "hello world"}}`, out)
 }
 
 func TestModuleTypescriptRuntimeDetection(t *testing.T) {

--- a/core/integration/testdata/modules/typescript/optional/index.ts
+++ b/core/integration/testdata/modules/typescript/optional/index.ts
@@ -1,4 +1,4 @@
-import { Directory, object, func } from "@dagger.io/dagger";
+import { dag, Directory, object, func } from "@dagger.io/dagger";
 
 @object()
 class Minimal {
@@ -28,5 +28,10 @@ class Minimal {
     }
 
     return "";
+  }
+
+  @func()
+  async resolveValue(dir: Directory = dag.directory().withNewFile("foo.txt", "hello world")): Promise<string> {
+    return dir.file("foo.txt").contents();
   }
 }

--- a/sdk/typescript/.changes/unreleased/Fixed-20240625-191158.yaml
+++ b/sdk/typescript/.changes/unreleased/Fixed-20240625-191158.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Correctly resolve non-primitive default value
+time: 2024-06-25T19:11:58.349957+02:00
+custom:
+  Author: TomChv
+  PR: "7740"

--- a/sdk/typescript/entrypoint/register.ts
+++ b/sdk/typescript/entrypoint/register.ts
@@ -114,13 +114,22 @@ function addArg(args: Arguments): (fct: Function_) => Function_ {
         description: arg.description,
       }
 
-      if (arg.defaultValue) {
-        opts.defaultValue = arg.defaultValue as string & { __JSON: never }
-      }
-
       let typeDef = addTypeDef(arg.type)
       if (arg.isOptional) {
         typeDef = typeDef.withOptional(true)
+      }
+
+      // We do not set the default value if it's not a primitive type, we let typescript
+      // resolves the default value during the runtime instead.
+      // If it has a default value but is not primitive, we set the value as optional
+      // to workaround the fact that the API isn't aware of the default value and will
+      // expect it to be set as required input.
+      if (arg.defaultValue) {
+        if (isPrimitiveType(arg.type)) {
+          opts.defaultValue = arg.defaultValue as string & { __JSON: never }
+        } else {
+          typeDef = typeDef.withOptional(true)
+        }
       }
 
       fct = fct.withArg(arg.name, typeDef, opts)
@@ -155,4 +164,13 @@ function addTypeDef(type: ScannerTypeDef<TypeDefKind>): TypeDef {
     default:
       return dag.typeDef().withKind(type.kind)
   }
+}
+
+function isPrimitiveType(type: ScannerTypeDef<TypeDefKind>): boolean {
+  return (
+    type.kind === TypeDefKind.BooleanKind ||
+    type.kind === TypeDefKind.IntegerKind ||
+    type.kind === TypeDefKind.StringKind ||
+    type.kind === TypeDefKind.EnumKind
+  )
 }

--- a/sdk/typescript/entrypoint/register.ts
+++ b/sdk/typescript/entrypoint/register.ts
@@ -119,8 +119,8 @@ function addArg(args: Arguments): (fct: Function_) => Function_ {
         typeDef = typeDef.withOptional(true)
       }
 
-      // We do not set the default value if it's not a primitive type, we let typescript
-      // resolves the default value during the runtime instead.
+      // We do not set the default value if it's not a primitive type, we let TypeScript
+      // resolve the default value during the runtime instead.
       // If it has a default value but is not primitive, we set the value as optional
       // to workaround the fact that the API isn't aware of the default value and will
       // expect it to be set as required input.

--- a/sdk/typescript/introspector/scanner/abtractions/argument.ts
+++ b/sdk/typescript/introspector/scanner/abtractions/argument.ts
@@ -162,6 +162,14 @@ export class Argument {
     return this.formatDefaultValue(this.param.initializer.getText())
   }
 
+  /**
+   * Return true if the parameter is optional.
+   *
+   * A parameter is considered optional if he fits one of the following:
+   * - It has a question token (e.g. `foo?: <type>`).
+   * - It's variadic (e.g. `...foo: <type>[]`).
+   * - It's nullable (e.g. `foo: <type> | null`).
+   */
   private loadIsOptional(): boolean {
     return (
       this.param.questionToken !== undefined ||

--- a/sdk/typescript/introspector/scanner/abtractions/argument.ts
+++ b/sdk/typescript/introspector/scanner/abtractions/argument.ts
@@ -165,7 +165,7 @@ export class Argument {
   /**
    * Return true if the parameter is optional.
    *
-   * A parameter is considered optional if he fits one of the following:
+   * A parameter is considered optional if:
    * - It has a question token (e.g. `foo?: <type>`).
    * - It's variadic (e.g. `...foo: <type>[]`).
    * - It's nullable (e.g. `foo: <type> | null`).


### PR DESCRIPTION
There was an issue that created an error when a non-primitive default value was set to a function like

```typescript
@object()
class Default {
  @func()
  a(
    dir: Directory = dag.directory()
      .withNewFile("/foo", "hello world")
    ): Container {
    return dag.container().withMountedDirectory("/dir", dir)
  }
}
```

This commit fixes the issue to ignore the default value registration if it's not a primitive type and let the TypeScript runtime resolve it during the execution.

It's a workaround to accomplish the result because resolving the value during the registration requires to run the TS code in a custom runtime that must contains all user's dependency which may be resource consumming + complex to resolve.