### PR TITLE
core(git): add git tags API

### DIFF
--- a/.changes/unreleased/Added-20240702-171323.yaml
+++ b/.changes/unreleased/Added-20240702-171323.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: 'core(git): add git tags API '
+time: 2024-07-02T17:13:23.775184623Z
+custom:
+    Author: grouville
+    PR: "7742"

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -323,21 +323,17 @@ func (GitSuite) TestServiceStableDigest(ctx context.Context, t *testctx.T) {
 	require.Equal(t, hostname(c1), hostname(c2))
 }
 
-func TestGitTags(t *testing.T) {
-	t.Parallel()
+func (GitSuite) TestGitTags(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
 
-	c, ctx := connect(t)
-
-	t.Run("all tags", func(t *testing.T) {
-		t.Parallel()
+	t.Run("all tags", func(ctx context.Context, t *testctx.T) {
 		tags, err := c.Git("https://github.com/dagger/dagger").Tags(ctx)
 		require.NoError(t, err)
 		require.Contains(t, tags, "v0.9.3")
 		require.Contains(t, tags, "sdk/go/v0.9.3")
 	})
 
-	t.Run("tag pattern", func(t *testing.T) {
-		t.Parallel()
+	t.Run("tag pattern", func(ctx context.Context, t *testctx.T) {
 		tags, err := c.Git("https://github.com/dagger/dagger").Tags(ctx, dagger.GitRepositoryTagsOpts{
 			Patterns: []string{"v*"},
 		})
@@ -346,8 +342,7 @@ func TestGitTags(t *testing.T) {
 		require.Contains(t, tags, "sdk/go/v0.9.3")
 	})
 
-	t.Run("ref-qualified tag pattern", func(t *testing.T) {
-		t.Parallel()
+	t.Run("ref-qualified tag pattern", func(ctx context.Context, t *testctx.T) {
 		tags, err := c.Git("https://github.com/dagger/dagger").Tags(ctx, dagger.GitRepositoryTagsOpts{
 			Patterns: []string{"refs/tags/v*"},
 		})
@@ -356,8 +351,7 @@ func TestGitTags(t *testing.T) {
 		require.NotContains(t, tags, "sdk/go/v0.9.3")
 	})
 
-	t.Run("prefix-qualified tag pattern", func(t *testing.T) {
-		t.Parallel()
+	t.Run("prefix-qualified tag pattern", func(ctx context.Context, t *testctx.T) {
 		tags, err := c.Git("https://github.com/dagger/dagger").Tags(ctx, dagger.GitRepositoryTagsOpts{
 			Patterns: []string{"sdk/go/v*"},
 		})

--- a/core/integration/git_test.go
+++ b/core/integration/git_test.go
@@ -322,3 +322,47 @@ func (GitSuite) TestServiceStableDigest(ctx context.Context, t *testctx.T) {
 	c2 := connect(ctx, t)
 	require.Equal(t, hostname(c1), hostname(c2))
 }
+
+func TestGitTags(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := connect(t)
+
+	t.Run("all tags", func(t *testing.T) {
+		t.Parallel()
+		tags, err := c.Git("https://github.com/dagger/dagger").Tags(ctx)
+		require.NoError(t, err)
+		require.Contains(t, tags, "v0.9.3")
+		require.Contains(t, tags, "sdk/go/v0.9.3")
+	})
+
+	t.Run("tag pattern", func(t *testing.T) {
+		t.Parallel()
+		tags, err := c.Git("https://github.com/dagger/dagger").Tags(ctx, dagger.GitRepositoryTagsOpts{
+			Patterns: []string{"v*"},
+		})
+		require.NoError(t, err)
+		require.Contains(t, tags, "v0.9.3")
+		require.Contains(t, tags, "sdk/go/v0.9.3")
+	})
+
+	t.Run("ref-qualified tag pattern", func(t *testing.T) {
+		t.Parallel()
+		tags, err := c.Git("https://github.com/dagger/dagger").Tags(ctx, dagger.GitRepositoryTagsOpts{
+			Patterns: []string{"refs/tags/v*"},
+		})
+		require.NoError(t, err)
+		require.Contains(t, tags, "v0.9.3")
+		require.NotContains(t, tags, "sdk/go/v0.9.3")
+	})
+
+	t.Run("prefix-qualified tag pattern", func(t *testing.T) {
+		t.Parallel()
+		tags, err := c.Git("https://github.com/dagger/dagger").Tags(ctx, dagger.GitRepositoryTagsOpts{
+			Patterns: []string{"sdk/go/v*"},
+		})
+		require.NoError(t, err)
+		require.NotContains(t, tags, "v0.9.3")
+		require.Contains(t, tags, "sdk/go/v0.9.3")
+	})
+}

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -175,7 +175,6 @@ type tagsArgs struct {
 }
 
 func (s *gitSchema) tags(ctx context.Context, parent *core.GitRepository, args tagsArgs) ([]string, error) {
-	// TODO: exec git with an equivalent of gitdns.git(), to inherently handle auth via the socket
 	queryArgs := []string{
 		"ls-remote",
 		"--tags", // we only want tags
@@ -297,28 +296,6 @@ func defaultBranch(ctx context.Context, repoURL string) (string, error) {
 	}
 
 	return "", fmt.Errorf("could not deduce default branch from output:\n%s", string(stdoutBytes))
-}
-
-// find all git tags for a given repo
-func gitTags(ctx context.Context, repoURL string) ([]string, error) {
-	stdoutBytes, err := exec.CommandContext(ctx, "git", "ls-remote", "--refs", "--tags", "--symref", repoURL).Output()
-	if err != nil {
-		return nil, fmt.Errorf("failed to run git: %w", err)
-	}
-
-	scanner := bufio.NewScanner(bytes.NewBuffer(stdoutBytes))
-
-	tags := []string{}
-	for scanner.Scan() {
-		fields := strings.Fields(scanner.Text())
-		if len(fields) < 2 {
-			continue
-		}
-
-		tags = append(tags, strings.TrimPrefix(fields[1], "refs/tags/"))
-	}
-
-	return tags, nil
 }
 
 func isSemver(ver string) bool {

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -1578,6 +1578,12 @@ type GitRepository {
     name: String!
   ): GitRef!
 
+  """tags that match any of the given glob patterns."""
+  tags(
+    """Glob patterns (e.g., "refs/tags/v*")."""
+    patterns: [String!]
+  ): [String!]!
+
   """Header to authenticate the remote with."""
   withAuthHeader(
     """Secret used to populate the Authorization HTTP header"""

--- a/sdk/elixir/lib/dagger/gen/git_repository.ex
+++ b/sdk/elixir/lib/dagger/gen/git_repository.ex
@@ -79,6 +79,17 @@ defmodule Dagger.GitRepository do
     }
   end
 
+  @doc "tags that match any of the given glob patterns."
+  @spec tags(t(), [{:patterns, [String.t()]}]) :: {:ok, [String.t()]} | {:error, term()}
+  def tags(%__MODULE__{} = git_repository, optional_args \\ []) do
+    selection =
+      git_repository.selection
+      |> select("tags")
+      |> maybe_put_arg("patterns", optional_args[:patterns])
+
+    execute(selection, git_repository.client)
+  end
+
   @doc "Header to authenticate the remote with."
   @spec with_auth_header(t(), Dagger.Secret.t()) :: Dagger.GitRepository.t()
   def with_auth_header(%__MODULE__{} = git_repository, header) do

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -3799,6 +3799,28 @@ func (r *GitRepository) Tag(name string) *GitRef {
 	}
 }
 
+// GitRepositoryTagsOpts contains options for GitRepository.Tags
+type GitRepositoryTagsOpts struct {
+	// Glob patterns (e.g., "refs/tags/v*").
+	Patterns []string
+}
+
+// tags that match any of the given glob patterns.
+func (r *GitRepository) Tags(ctx context.Context, opts ...GitRepositoryTagsOpts) ([]string, error) {
+	q := r.query.Select("tags")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `patterns` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Patterns) {
+			q = q.Arg("patterns", opts[i].Patterns)
+		}
+	}
+
+	var response []string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
+}
+
 // Header to authenticate the remote with.
 func (r *GitRepository) WithAuthHeader(header *Secret) *GitRepository {
 	assertNotNil("header", header)

--- a/sdk/php/generated/GitRepository.php
+++ b/sdk/php/generated/GitRepository.php
@@ -72,6 +72,18 @@ class GitRepository extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * tags that match any of the given glob patterns.
+     */
+    public function tags(?array $patterns = null): array
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('tags');
+        if (null !== $patterns) {
+        $leafQueryBuilder->setArgument('patterns', $patterns);
+        }
+        return (array)$this->queryLeaf($leafQueryBuilder, 'tags');
+    }
+
+    /**
      * Header to authenticate the remote with.
      */
     public function withAuthHeader(SecretId|Secret $header): GitRepository

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -3998,6 +3998,38 @@ class GitRepository(Type):
         _ctx = self._select("tag", _args)
         return GitRef(_ctx)
 
+    async def tags(
+        self,
+        *,
+        patterns: list[str] | None = None,
+    ) -> list[str]:
+        """tags that match any of the given glob patterns.
+
+        Parameters
+        ----------
+        patterns:
+            Glob patterns (e.g., "refs/tags/v*").
+
+        Returns
+        -------
+        list[str]
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args = [
+            Arg("patterns", patterns, None),
+        ]
+        _ctx = self._select("tags", _args)
+        return await _ctx.execute(list[str])
+
     def with_auth_header(self, header: "Secret") -> Self:
         """Header to authenticate the remote with.
 

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -4564,6 +4564,12 @@ pub struct GitRepository {
     pub selection: Selection,
     pub graphql_client: DynGraphQLClient,
 }
+#[derive(Builder, Debug, PartialEq)]
+pub struct GitRepositoryTagsOpts<'a> {
+    /// Glob patterns (e.g., "refs/tags/v*").
+    #[builder(setter(into, strip_option), default)]
+    pub patterns: Option<Vec<&'a str>>,
+}
 impl GitRepository {
     /// Returns details of a branch.
     ///
@@ -4634,6 +4640,30 @@ impl GitRepository {
             selection: query,
             graphql_client: self.graphql_client.clone(),
         }
+    }
+    /// tags that match any of the given glob patterns.
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub async fn tags(&self) -> Result<Vec<String>, DaggerError> {
+        let query = self.selection.select("tags");
+        query.execute(self.graphql_client.clone()).await
+    }
+    /// tags that match any of the given glob patterns.
+    ///
+    /// # Arguments
+    ///
+    /// * `opt` - optional argument, see inner type for documentation, use <func>_opts to use
+    pub async fn tags_opts<'a>(
+        &self,
+        opts: GitRepositoryTagsOpts<'a>,
+    ) -> Result<Vec<String>, DaggerError> {
+        let mut query = self.selection.select("tags");
+        if let Some(patterns) = opts.patterns {
+            query = query.arg("patterns", patterns);
+        }
+        query.execute(self.graphql_client.clone()).await
     }
     /// Header to authenticate the remote with.
     ///

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -707,6 +707,13 @@ export type GitRefTreeOpts = {
  */
 export type GitRefID = string & { __GitRefID: never }
 
+export type GitRepositoryTagsOpts = {
+  /**
+   * Glob patterns (e.g., "refs/tags/v*").
+   */
+  patterns?: string[]
+}
+
 /**
  * The `GitRepositoryID` scalar type represents an identifier for an object of type GitRepository.
  */
@@ -5083,6 +5090,25 @@ export class GitRepository extends BaseClient {
       ],
       ctx: this._ctx,
     })
+  }
+
+  /**
+   * tags that match any of the given glob patterns.
+   * @param opts.patterns Glob patterns (e.g., "refs/tags/v*").
+   */
+  tags = async (opts?: GitRepositoryTagsOpts): Promise<string[]> => {
+    const response: Awaited<string[]> = await computeQuery(
+      [
+        ...this._queryTree,
+        {
+          operation: "tags",
+          args: { ...opts },
+        },
+      ],
+      await this._ctx.connection(),
+    )
+
+    return response
   }
 
   /**


### PR DESCRIPTION
This is the draft implementation to support a new `git.Tags` API, with corresponding tests, which enables us to retrieve the tags of a remote.

It has been mostly adapted from https://github.com/dagger/dagger/pull/6187/commits/260bde5070780b3ce267bde79de3a66c73eca6a6 (from @vito)

**TODO**
- find a way to exec git with the mounted socket / use the gitdns.git implementation ?

#### Questions
cc @sipsma, I am a bit stuck on the auth part for this API. Does it have to live inside the core/schema implementation ? If yes, how to use the mounted auth socket inside the core/schema package ?

You referenced privately, and in the past, this BuildKit call: https://github.com/sipsma/dagger/blob/64f4aaa2f794f4cb92ae0a833b61a953bc63df6f/engine/sources/gitdns/source.go#L286-L286, but there is also a wrapper that exists inside the gitdns package: newGitCLI.