### PR TITLE
Feat/context directory

### DIFF
--- a/.changes/unreleased/Added-20240703-151521.yaml
+++ b/.changes/unreleased/Added-20240703-151521.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Implements context directory support
+time: 2024-07-03T15:15:21.5117+02:00
+custom:
+  Author: TomChv
+  PR: "7744"

--- a/cmd/codegen/generator/go/templates/module_funcs.go
+++ b/cmd/codegen/generator/go/templates/module_funcs.go
@@ -301,10 +301,6 @@ func (ps *parseState) parseParamSpecVar(field *types.Var, docComment string, lin
 
 	ignore := []string{}
 	if v, ok := pragmas["ignore"]; ok {
-		if strings.HasPrefix(v, `"`) && strings.HasSuffix(v, `"`) {
-			v = v[1 : len(v)-1]
-		}
-
 		if err := json.Unmarshal([]byte(v), &ignore); err != nil {
 			return paramSpec{}, fmt.Errorf("ignore pragma '%s', must be a valid JSON array: %w", v, err)
 		}

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -7053,7 +7053,7 @@ class Test {
 				t.Run("absolute and relative root context dir", func(ctx context.Context, t *testctx.T) {
 					out, err := modGen.With(daggerCallAt("ci", "dirs")).Stdout(ctx)
 					require.NoError(t, err)
-					require.Equal(t, "backend\nci\nfrontend\nLICENSE\ndagger\ndagger.json\n", out)
+					require.Equal(t, ".git\nbackend\nci\nfrontend\nLICENSE\ndagger\ndagger.json\n", out)
 				})
 
 				t.Run("dir ignore", func(ctx context.Context, t *testctx.T) {
@@ -7317,7 +7317,7 @@ class Test {
 				t.Run("absolute and relative root context dir", func(ctx context.Context, t *testctx.T) {
 					out, err := modGen.With(daggerCall("dirs")).Stdout(ctx)
 					require.NoError(t, err)
-					require.Equal(t, "LICENSE\nbackend\ndagger\ndagger.json\nfrontend\nLICENSE\nbackend\ndagger\ndagger.json\nfrontend\n", out)
+					require.Equal(t, ".git\nLICENSE\nbackend\ndagger\ndagger.json\nfrontend\n.git\nLICENSE\nbackend\ndagger\ndagger.json\nfrontend\n", out)
 				})
 
 				t.Run("absolute context dir subpath", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -6905,6 +6905,74 @@ func (t *Test) Files(
 `,
 			},
 			{
+				sdk: "python",
+				source: `from typing import Annotated
+
+import dagger
+from dagger import DefaultPath, Ignore, function, object_type
+
+
+@object_type
+class Test:
+    @function
+    async def dirs(
+        self,
+        root: Annotated[dagger.Directory, DefaultPath("/")],
+        relativeRoot: Annotated[dagger.Directory, DefaultPath(".")],
+    ) -> list[str]:
+        return [
+            *(await root.entries()),
+            *(await relativeRoot.entries()),
+       ]
+
+    @function
+    async def dirs_ignore(
+        self,
+        root: Annotated[dagger.Directory, DefaultPath("/"), Ignore(["!backend", "!frontend"])],
+        relativeRoot: Annotated[dagger.Directory, DefaultPath("."), Ignore(["dagger.json", "LICENSE"])],
+    ) -> list[str]:
+        return [
+            *(await root.entries()),
+            *(await relativeRoot.entries()),
+        ]
+
+    @function
+    async def root_dir_path(
+        self,
+        backend: Annotated[dagger.Directory, DefaultPath("/backend")],
+        frontend: Annotated[dagger.Directory, DefaultPath("/frontend")],
+        mod_src_dir: Annotated[dagger.Directory, DefaultPath("/ci/dagger/sub")],
+    ) -> list[str]:
+        return [
+            *(await backend.entries()),
+            *(await frontend.entries()),
+            *(await mod_src_dir.entries()),
+        ]
+
+    @function
+    async def relative_dir_path(
+        self,
+        mod_src_dir: Annotated[dagger.Directory, DefaultPath("./dagger/sub")],
+        backend: Annotated[dagger.Directory, DefaultPath("../backend")],
+    ) -> list[str]:
+        return [
+            *(await mod_src_dir.entries()),
+            *(await backend.entries()),
+        ]
+
+    @function
+    async def files(
+        self,
+        license: Annotated[dagger.File, DefaultPath("/ci/LICENSE")],
+        index: Annotated[dagger.File, DefaultPath("./dagger/sub/sub.txt")],
+    ) -> list[str]:
+        return [
+            await license.name(),
+            await index.name(),
+        ]
+`,
+			},
+			{
 				sdk: "typescript",
 				source: `import { Directory, File, object, func, argument } from "@dagger.io/dagger"
 
@@ -6931,8 +6999,8 @@ class Test {
 
   @func()
   async rootDirPath(
-    @argument({ defaultPath: "/backend" }) backend: Directory, 
-    @argument({ defaultPath: "/frontend" }) frontend: Directory, 
+    @argument({ defaultPath: "/backend" }) backend: Directory,
+    @argument({ defaultPath: "/frontend" }) frontend: Directory,
     @argument({ defaultPath: "/ci/dagger/sub" }) modSrcDir: Directory,
   ): Promise<string[]> {
     const backendFiles = await backend.entries()
@@ -6944,7 +7012,7 @@ class Test {
 
   @func()
   async relativeDirPath(
-    @argument({ defaultPath: "./dagger/sub" }) modSrcDir: Directory, 
+    @argument({ defaultPath: "./dagger/sub" }) modSrcDir: Directory,
     @argument({ defaultPath: "../backend" }) backend: Directory,
   ): Promise<string[]> {
     const modSrcDirFiles = await modSrcDir.entries()
@@ -7120,6 +7188,62 @@ func (t *Test) Files(
 `,
 			},
 			{
+				sdk: "python",
+				source: `from typing import Annotated
+
+import dagger
+from dagger import DefaultPath, function, object_type
+
+@object_type
+class Test:
+    @function
+    async def dirs(
+        self,
+        root: Annotated[dagger.Directory, DefaultPath("/")],
+        relative_root: Annotated[dagger.Directory, DefaultPath(".")],
+    ) -> list[str]:
+        return [
+            *(await root.entries()),
+            *(await relative_root.entries()),
+        ]
+
+    @function
+    async def root_dir_path(
+        self,
+        backend: Annotated[dagger.Directory, DefaultPath("/backend")],
+        frontend: Annotated[dagger.Directory, DefaultPath("/frontend")],
+        mod_src_dir: Annotated[dagger.Directory, DefaultPath("/dagger/sub")],
+    ) -> list[str]:
+        return [
+            *(await backend.entries()),
+            *(await frontend.entries()),
+            *(await mod_src_dir.entries()),
+        ]
+
+    @function
+    async def relative_dir_path(
+        self,
+        mod_src_dir: Annotated[dagger.Directory, DefaultPath("./dagger/sub")],
+        backend: Annotated[dagger.Directory, DefaultPath("./backend")],
+    ) -> list[str]:
+        return [
+            *(await mod_src_dir.entries()),
+            *(await backend.entries()),
+        ]
+
+    @function
+    async def files(
+        self,
+        license: Annotated[dagger.File, DefaultPath("/LICENSE")],
+        index: Annotated[dagger.File, DefaultPath("./dagger.json")],
+    ) -> list[str]:
+        return [
+            await license.name(),
+            await index.name(),
+        ]
+`,
+			},
+			{
 				sdk: "typescript",
 				source: `import { Directory, File, object, func, argument } from "@dagger.io/dagger"
 
@@ -7127,7 +7251,7 @@ func (t *Test) Files(
 class Test {
   @func()
   async dirs(
-    @argument({ defaultPath: "/" }) root: Directory, 
+    @argument({ defaultPath: "/" }) root: Directory,
     @argument({ defaultPath: "." }) relativeRoot: Directory,
   ): Promise<string[]> {
     const res = await root.entries()
@@ -7139,7 +7263,7 @@ class Test {
   @func()
   async rootDirPath(
     @argument({ defaultPath: "/backend" }) backend: Directory,
-    @argument({ defaultPath: "/frontend" }) frontend: Directory, 
+    @argument({ defaultPath: "/frontend" }) frontend: Directory,
     @argument({ defaultPath: "/dagger/sub" }) modSrcDir: Directory,
   ): Promise<string[]> {
     const backendFiles = await backend.entries()
@@ -7266,6 +7390,48 @@ func (t *Test) NonExistingFile(
 `,
 			},
 			{
+				sdk: "python",
+				source: `from typing import Annotated
+
+import dagger
+from dagger import DefaultPath, function, object_type
+
+@object_type
+class Test:
+    @function
+    async def too_high_relative_dir_path(
+        self,
+        backend: Annotated[dagger.Directory, DefaultPath("../../")],
+    ) -> list[str]:
+        # The engine should throw an error
+        return []
+
+    @function
+    async def non_existing_path(
+        self,
+        dir: Annotated[dagger.Directory, DefaultPath("/invalid")],
+    ) -> list[str]:
+        # The engine should throw an error
+        return []
+
+    @function
+    async def too_high_relative_file_path(
+        self,
+        backend: Annotated[dagger.File, DefaultPath("../../file.txt")],
+    ) -> str:
+        # The engine should throw an error
+        return ""
+
+    @function
+    async def non_existing_file(
+        self,
+        file: Annotated[dagger.File, DefaultPath("/invalid")],
+    ) -> str:
+        # The engine should throw an error
+        return ""
+`,
+			},
+			{
 				sdk: "typescript",
 				source: `import { Directory, File,object, func, argument } from "@dagger.io/dagger"
 @object()
@@ -7292,7 +7458,7 @@ class Test {
     // The engine should throw an error
     return ""
   }
-}			
+}
 `,
 			},
 		} {

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -7609,7 +7609,7 @@ func (m *Dep) GetSource(
 }
 
 func (m *Dep) GetRelSource(
-	// +defaultPath="."
+	// +defaultPath="./dep"
 	// +ignore=["!yo"]
 	source *dagger.Directory,
 ) *dagger.Directory {
@@ -7669,7 +7669,7 @@ func (m *Test) GetRelDepSource(ctx context.Context, src *dagger.Directory) (*dag
 
 	type DirectoryIDRes struct {
 		Dep struct {
-			GetSource struct {
+			GetRelSource struct {
 				ID string
 			}
 		}

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -6813,11 +6813,11 @@ func (t *Test) DirsIgnore(
   ctx context.Context,
 
   // +defaultPath="/"
-  // +ignore="["!backend", "!frontend"]"
+  // +ignore=["!backend", "!frontend"]
   root *Directory,
 
   // +defaultPath="."
-  // +ignore="["dagger.json", "LICENSE"]"
+  // +ignore=["dagger.json", "LICENSE"]
   relativeRoot *Directory,
 ) ([]string, error) {
   res, err := root.Entries(ctx)

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -6784,6 +6784,7 @@ func (ModuleSuite) TestContextDirectory(ctx context.Context, t *testctx.T) {
 
 import (
   "context"
+	"dagger/test/internal/dagger"
 )
 
 type Test struct {}
@@ -6792,10 +6793,10 @@ func (t *Test) Dirs(
   ctx context.Context,
 
   // +defaultPath="/"
-  root *Directory,
+  root *dagger.Directory,
 
   // +defaultPath="."
-  relativeRoot *Directory,
+  relativeRoot *dagger.Directory,
 ) ([]string, error) {
   res, err := root.Entries(ctx)
   if err != nil {
@@ -6814,11 +6815,11 @@ func (t *Test) DirsIgnore(
 
   // +defaultPath="/"
   // +ignore=["!backend", "!frontend"]
-  root *Directory,
+  root *dagger.Directory,
 
   // +defaultPath="."
   // +ignore=["dagger.json", "LICENSE"]
-  relativeRoot *Directory,
+  relativeRoot *dagger.Directory,
 ) ([]string, error) {
   res, err := root.Entries(ctx)
   if err != nil {
@@ -6835,13 +6836,13 @@ func (t *Test) RootDirPath(
   ctx context.Context,
 
   // +defaultPath="/backend"
-  backend *Directory,
+  backend *dagger.Directory,
 
   // +defaultPath="/frontend"
-  frontend *Directory,
+  frontend *dagger.Directory,
 
   // +defaultPath="/ci/dagger/sub"
-  modSrcDir *Directory,
+  modSrcDir *dagger.Directory,
 ) ([]string, error) {
   backendFiles, err := backend.Entries(ctx)
   if err != nil {
@@ -6865,10 +6866,10 @@ func (t *Test) RelativeDirPath(
   ctx context.Context,
 
   // +defaultPath="./dagger/sub"
-  modSrcDir *Directory,
+  modSrcDir *dagger.Directory,
 
   // +defaultPath="../backend"
-  backend *Directory,
+  backend *dagger.Directory,
 ) ([]string, error) {
   modSrcDirFiles, err := modSrcDir.Entries(ctx)
   if err != nil {
@@ -6886,10 +6887,10 @@ func (t *Test) Files(
   ctx context.Context,
 
   // +defaultPath="/ci/LICENSE"
-  license *File,
+  license *dagger.File,
 
   // +defaultPath="./dagger/sub/sub.txt"
-  index *File,
+  index *dagger.File,
 ) ([]string, error) {
   licenseName, err := license.Name(ctx)
   if err != nil {
@@ -7043,7 +7044,8 @@ class Test {
 					WithDirectory("/work/backend", c.Directory().WithNewFile("foo.txt", "foo")).
 					WithDirectory("/work/frontend", c.Directory().WithNewFile("bar.txt", "bar")).
 					WithWorkdir("/work/ci").
-					With(daggerExec("init", "--name=test", "--sdk="+tc.sdk)).
+					With(daggerExec("init", "--name=test", "--sdk="+tc.sdk, "--source=dagger")).
+					WithWorkdir("/work/ci/dagger").
 					With(sdkSource(tc.sdk, tc.source)).
 					WithDirectory("/work/ci/dagger/sub", c.Directory().WithNewFile("sub.txt", "sub")).
 					WithWorkdir("/work")
@@ -7089,6 +7091,7 @@ class Test {
 
 import (
   "context"
+	"dagger/test/internal/dagger"
 )
 
 type Test struct {}
@@ -7097,10 +7100,10 @@ func (t *Test) Dirs(
   ctx context.Context,
 
   // +defaultPath="/"
-  root *Directory,
+  root *dagger.Directory,
 
   // +defaultPath="."
-  relativeRoot *Directory,
+  relativeRoot *dagger.Directory,
 ) ([]string, error) {
   res, err := root.Entries(ctx)
   if err != nil {
@@ -7118,13 +7121,13 @@ func (t *Test) RootDirPath(
   ctx context.Context,
 
   // +defaultPath="/backend"
-  backend *Directory,
+  backend *dagger.Directory,
 
   // +defaultPath="/frontend"
-  frontend *Directory,
+  frontend *dagger.Directory,
 
   // +defaultPath="/dagger/sub"
-  modSrcDir *Directory,
+  modSrcDir *dagger.Directory,
 ) ([]string, error) {
   backendFiles, err := backend.Entries(ctx)
   if err != nil {
@@ -7148,10 +7151,10 @@ func (t *Test) RelativeDirPath(
   ctx context.Context,
 
   // +defaultPath="./dagger/sub"
-  modSrcDir *Directory,
+  modSrcDir *dagger.Directory,
 
   // +defaultPath="./backend"
-  backend *Directory,
+  backend *dagger.Directory,
 ) ([]string, error) {
   modSrcDirFiles, err := modSrcDir.Entries(ctx)
   if err != nil {
@@ -7169,10 +7172,10 @@ func (t *Test) Files(
   ctx context.Context,
 
   // +defaultPath="/LICENSE"
-  license *File,
+  license *dagger.File,
 
   // +defaultPath="./dagger.json"
-  index *File,
+  index *dagger.File,
 ) ([]string, error) {
   licenseName, err := license.Name(ctx)
   if err != nil {
@@ -7305,9 +7308,11 @@ class Test {
 					WithWorkdir("/work").
 					WithDirectory("/work/backend", c.Directory().WithNewFile("foo.txt", "foo")).
 					WithDirectory("/work/frontend", c.Directory().WithNewFile("bar.txt", "bar")).
-					With(daggerExec("init", "--name=test", "--sdk="+tc.sdk)).
+					With(daggerExec("init", "--name=test", "--sdk="+tc.sdk, "--source=dagger")).
 					WithDirectory("/work/dagger/sub", c.Directory().WithNewFile("sub.txt", "sub")).
-					With(sdkSource(tc.sdk, tc.source))
+					WithWorkdir("/work/dagger").
+					With(sdkSource(tc.sdk, tc.source)).
+					WithWorkdir("/work")
 
 				t.Run("absolute and relative root context dir", func(ctx context.Context, t *testctx.T) {
 					out, err := modGen.With(daggerCall("dirs")).Stdout(ctx)
@@ -7344,6 +7349,7 @@ class Test {
 
 import (
 	"context"
+	"dagger/test/internal/dagger"
 )
 
 type Test struct {}
@@ -7352,7 +7358,7 @@ func (t *Test) TooHighRelativeDirPath(
 	ctx context.Context,
 
 	// +defaultPath="../../"
-	backend *Directory,
+	backend *dagger.Directory,
 ) ([]string, error) {
   // The engine should throw an error
 	return []string{}, nil
@@ -7362,7 +7368,7 @@ func (t *Test) NonExistingPath(
 	ctx context.Context,
 
 	// +defaultPath="/invalid"
-	dir *Directory,
+	dir *dagger.Directory,
 ) ([]string, error) {
   // The engine should throw an error
 	return []string{}, nil
@@ -7372,7 +7378,7 @@ func (t *Test) TooHighRelativeFilePath(
 	ctx context.Context,
 
 	// +defaultPath="../../file.txt"
-	backend *File,
+	backend *dagger.File,
 ) (string, error) {
   // The engine should throw an error
 	return "", nil
@@ -7382,7 +7388,7 @@ func (t *Test) NonExistingFile(
 	ctx context.Context,
 
 	// +defaultPath="/invalid"
-	file *File,
+	file *dagger.File,
 ) (string, error) {
   // The engine should throw an error
 	return "", nil
@@ -7470,21 +7476,23 @@ class Test {
 				modGen := goGitBase(t, c).
 					WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
 					WithWorkdir("/work").
-					With(daggerExec("init", "--name=test", "--sdk="+tc.sdk)).
-					With(sdkSource(tc.sdk, tc.source))
+					With(daggerExec("init", "--name=test", "--sdk="+tc.sdk, "--source=dagger")).
+					WithWorkdir("/work/dagger").
+					With(sdkSource(tc.sdk, tc.source)).
+					WithWorkdir("/work")
 
 				t.Run("too high relative context dir path", func(ctx context.Context, t *testctx.T) {
 					out, err := modGen.With(daggerCall("too-high-relative-dir-path")).Stdout(ctx)
 					require.Empty(t, out)
 					require.Error(t, err)
-					require.ErrorContains(t, err, `escapes workdir; use an absolute path instead`)
+					require.ErrorContains(t, err, `path should be relative to the context directory`)
 				})
 
 				t.Run("too high relative context file path", func(ctx context.Context, t *testctx.T) {
 					out, err := modGen.With(daggerCall("too-high-relative-file-path")).Stdout(ctx)
 					require.Empty(t, out)
 					require.Error(t, err)
-					require.ErrorContains(t, err, `escapes workdir; use an absolute path instead`)
+					require.ErrorContains(t, err, `path should be relative to the context directory`)
 				})
 
 				t.Run("non existing dir path", func(ctx context.Context, t *testctx.T) {

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -7687,7 +7687,7 @@ func (m *Test) GetRelDepSource(ctx context.Context, src *dagger.Directory) (*dag
 	}
 
 
-	return dag.LoadDirectoryFromID(dagger.DirectoryID(directoryIDRes.Dep.GetSource.ID)), nil
+	return dag.LoadDirectoryFromID(dagger.DirectoryID(directoryIDRes.Dep.GetRelSource.ID)), nil
 }
 			`,
 			)

--- a/core/interface.go
+++ b/core/interface.go
@@ -278,6 +278,7 @@ func (iface *InterfaceType) Install(ctx context.Context, dag *dagql.Server) erro
 					Inputs:       callInputs,
 					ParentTyped:  runtimeVal,
 					ParentFields: runtimeVal.Fields,
+					Server:       dag,
 				})
 				if err != nil {
 					return nil, fmt.Errorf("failed to call interface function %s.%s: %w", ifaceName, fieldDef.Name, err)

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"dagger.io/dagger/telemetry"
@@ -18,6 +19,7 @@ import (
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine/buildkit"
+	"github.com/dagger/dagger/engine/slog"
 )
 
 type ModuleFunction struct {
@@ -154,6 +156,7 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Typ
 		hasArg[name] = true
 	}
 
+	// Load default value
 	for _, arg := range fn.metadata.Args {
 		name := arg.OriginalName
 		if hasArg[name] || arg.DefaultValue == nil {
@@ -162,6 +165,29 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Typ
 		callInputs = append(callInputs, &FunctionCallArgValue{
 			Name:  name,
 			Value: arg.DefaultValue,
+		})
+
+		hasArg[name] = true
+	}
+
+	// Load contextual arguments
+	for _, arg := range fn.metadata.Args {
+		name := arg.OriginalName
+
+		// Skip contextual arguments if already set.
+		if hasArg[name] || arg.DefaultPath == "" {
+			continue
+		}
+
+		// Load contextual argument value.
+		ctxVal, err := fn.loadContextualArg(ctx, arg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load contextual arg %q: %w", arg.Name, err)
+		}
+
+		callInputs = append(callInputs, &FunctionCallArgValue{
+			Name:  name,
+			Value: ctxVal,
 		})
 	}
 
@@ -382,4 +408,73 @@ func (fn *ModuleFunction) linkDependencyBlobs(ctx context.Context, cacheResult *
 		return fmt.Errorf("failed to add dependency blob: %w", err)
 	}
 	return nil
+}
+
+// loadContextualArg loads a contextual argument from the module context directory.
+//
+// For Directory, it will load the directory from the module context directory.
+// For file, it will loa the directory containing the file and then query the file ID from this directory.
+//
+// This functions returns the ID of the loaded object.
+func (fn *ModuleFunction) loadContextualArg(ctx context.Context, arg *FunctionArg) (JSON, error) {
+	if arg.TypeDef.Kind != TypeDefKindObject {
+		return nil, fmt.Errorf("contextual argument %q must be a Directory or a File", arg.OriginalName)
+	}
+
+	switch arg.TypeDef.AsObject.Value.Name {
+	case "Directory":
+		slog.Debug("moduleFunction.loadContextualArg: loading contextual directory", "fn", arg.Name, "dir", arg.DefaultPath)
+
+		dir, err := fn.mod.Source.Self.LoadContext(ctx, fn.mod.Server, arg.DefaultPath, arg.Ignore)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load contextual directory %q: %w", arg.DefaultPath, err)
+		}
+
+		dirID, err := dir.ID().Encode()
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode dir ID: %w", err)
+		}
+
+		return JSON(fmt.Sprintf(`"%s"`, dirID)), nil
+	case "File":
+		slog.Debug("moduleFunction.loadContextualArg: loading contextual file", "fn", arg.Name, "file", arg.DefaultPath)
+
+		// We first load the directory from the context path, then we load the file from the path relative to the directory.
+		dirPath := filepath.Dir(arg.DefaultPath)
+		filePath := filepath.Base(arg.DefaultPath)
+
+		// Load the directory containing the file.
+		dir, err := fn.mod.Source.Self.LoadContext(ctx, fn.mod.Server, dirPath, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load contextual directory %q: %w", dirPath, err)
+		}
+
+		var fileID FileID
+
+		// We need to load the fileID from the directory itself, because `*File` doesn't have a `ID` field,
+		// we use select instead.
+		err = fn.mod.Server.Select(ctx, dir, &fileID,
+			dagql.Selector{
+				Field: "file",
+				Args: []dagql.NamedInput{
+					{Name: "path", Value: dagql.String(filePath)},
+				},
+			},
+			dagql.Selector{
+				Field: "id",
+			},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load contextual file %q: %w", filePath, err)
+		}
+
+		encodedFileID, err := fileID.Encode()
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode file ID: %w", err)
+		}
+
+		return JSON(fmt.Sprintf(`"%s"`, encodedFileID)), nil
+	default:
+		return nil, fmt.Errorf("unknown contextual argument type %q", arg.TypeDef.AsObject.Value.Name)
+	}
 }

--- a/core/module.go
+++ b/core/module.go
@@ -63,9 +63,6 @@ type Module struct {
 
 	// InstanceID is the ID of the initialized module.
 	InstanceID *call.ID
-
-	// Server is the dagql server
-	Server *dagql.Server
 }
 
 func (*Module) Type() *ast.Type {
@@ -129,7 +126,6 @@ func (mod *Module) Initialize(ctx context.Context, oldID *call.ID, newID *call.I
 	modName := mod.Name()
 	newMod := mod.Clone()
 	newMod.InstanceID = oldID // updated to newID once the call to initialize is done
-	newMod.Server = dag
 
 	// construct a special function with no object or function name, which tells
 	// the SDK to return the module's definition (in terms of objects, fields and
@@ -148,7 +144,7 @@ func (mod *Module) Initialize(ctx context.Context, oldID *call.ID, newID *call.I
 		return nil, fmt.Errorf("failed to create module definition function for module %q: %w", modName, err)
 	}
 
-	result, err := getModDefFn.Call(ctx, &CallOpts{Cache: true, SkipSelfSchema: true})
+	result, err := getModDefFn.Call(ctx, &CallOpts{Cache: true, SkipSelfSchema: true, Server: dag})
 	if err != nil {
 		return nil, fmt.Errorf("failed to call module %q to get functions: %w", modName, err)
 	}

--- a/core/module.go
+++ b/core/module.go
@@ -63,6 +63,9 @@ type Module struct {
 
 	// InstanceID is the ID of the initialized module.
 	InstanceID *call.ID
+
+	// Server is the dagql server
+	Server *dagql.Server
 }
 
 func (*Module) Type() *ast.Type {
@@ -122,10 +125,11 @@ func (mod *Module) IDModule() *call.Module {
 	return call.NewModule(mod.InstanceID, mod.Name(), ref)
 }
 
-func (mod *Module) Initialize(ctx context.Context, oldID *call.ID, newID *call.ID) (*Module, error) {
+func (mod *Module) Initialize(ctx context.Context, oldID *call.ID, newID *call.ID, dag *dagql.Server) (*Module, error) {
 	modName := mod.Name()
 	newMod := mod.Clone()
 	newMod.InstanceID = oldID // updated to newID once the call to initialize is done
+	newMod.Server = dag
 
 	// construct a special function with no object or function name, which tells
 	// the SDK to return the module's definition (in terms of objects, fields and

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -292,8 +292,7 @@ func (src *ModuleSource) AutomaticGitignore(ctx context.Context) (*bool, error) 
 // If the module is git, it will load the directory from the git repository
 // using its context directory.
 func (src *ModuleSource) LoadContext(ctx context.Context, dag *dagql.Server, path string, ignore []string) (inst dagql.Instance[*Directory], err error) {
-	// We exclude .git by default because it's not useful and tends to invalidate the cache.
-	excludes := []string{"**/.git"}
+	excludes := []string{}
 	includes := []string{}
 
 	for _, p := range ignore {

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -18,7 +18,6 @@ import (
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
-	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/buildkit"
 	"github.com/dagger/dagger/engine/slog"
 )

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -374,20 +374,11 @@ func (src *ModuleSource) ResolveContextPathFromCaller(ctx context.Context) (cont
 
 	slog.Error("moduleSource.ResolveContextPathFromCaller.rootSubpath", "rootSubPath", rootSubpath)
 
-	
-	// Resolve rootSubpath to an absolute path
-	absRootSubpath, err := filepath.Abs(rootSubpath)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to resolve absolute path for root subpath: %w", err)
-	}
-
-	slog.Error("moduleSource.ResolveContextPathFromCaller.absRootSubPath", "absRootSubPath", absRootSubpath)
-
 	bk, err := src.Query.Buildkit(ctx)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to get buildkit client: %w", err)
 	}
-	sourceRootStat, err := bk.StatCallerHostPath(ctx, absRootSubpath, true)
+	sourceRootStat, err := bk.StatCallerHostPath(ctx, rootSubpath, true)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to stat source root: %w", err)
 	}

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -319,7 +319,7 @@ func (src *ModuleSource) LoadContext(ctx context.Context, dag *dagql.Server, pat
 
 		// Retrieve the absolute path to the context directory (.git or dagger.json)
 		// and the module root directory (dagger.json)
-		ctxPath, _, err := src.ResolveContextPathFromModule(localSourceCtx)
+		ctxPath, modPath, err := src.ResolveContextPathFromModule(localSourceCtx)
 		if err != nil {
 			return inst, fmt.Errorf("failed to resolve context path: %w", err)
 		}
@@ -327,7 +327,7 @@ func (src *ModuleSource) LoadContext(ctx context.Context, dag *dagql.Server, pat
 		// If path is not absolute, it's relative to the module root directory.
 		// If path is absolute, it's relative to the context directory.
 		if !filepath.IsAbs(path) {
-			path = filepath.Join(ctxPath, src.AsLocalSource.Value.RootSubpath, path)
+			path = filepath.Join(modPath, path)
 		} else {
 			path = filepath.Join(ctxPath, path)
 		}
@@ -421,6 +421,10 @@ func (src *ModuleSource) ResolveContextPathFromModule(ctx context.Context) (cont
 	if !contextFound {
 		// default to restricting to the source root dir, make it abs though for consistency
 		contextAbsPath = moduleRootAbsPath
+	} else {
+		// If context is found, we can create the module root path by joining the 
+		// context path with the module root subpath
+		moduleRootAbsPath = filepath.Join(contextAbsPath, src.AsLocalSource.Value.RootSubpath)
 	}
 
 	return contextAbsPath, moduleRootAbsPath, nil

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -319,7 +319,7 @@ func (src *ModuleSource) LoadContext(ctx context.Context, dag *dagql.Server, pat
 
 		// Retrieve the absolute path to the context directory (.git or dagger.json)
 		// and the module root directory (dagger.json)
-		ctxPath, modPath, err := src.ResolveContextPathFromModule(localSourceCtx)
+		ctxPath, _, err := src.ResolveContextPathFromModule(localSourceCtx)
 		if err != nil {
 			return inst, fmt.Errorf("failed to resolve context path: %w", err)
 		}
@@ -327,7 +327,7 @@ func (src *ModuleSource) LoadContext(ctx context.Context, dag *dagql.Server, pat
 		// If path is not absolute, it's relative to the module root directory.
 		// If path is absolute, it's relative to the context directory.
 		if !filepath.IsAbs(path) {
-			path = filepath.Join(modPath, path)
+			path = filepath.Join(ctxPath, src.AsLocalSource.Value.RootSubpath, path)
 		} else {
 			path = filepath.Join(ctxPath, path)
 		}

--- a/core/query.go
+++ b/core/query.go
@@ -93,6 +93,11 @@ type Server interface {
 	// A map of unique IDs for the result of a given cache entry set query, allowing further queries on the result
 	// to operate on a stable result rather than the live state.
 	EngineCacheEntrySetMap(context.Context) (*sync.Map, error)
+
+	// The nearest ancestor client that is not a module (either a caller from the host like the CLI
+	// or a nested exec). Useful for figuring out where local sources should be resolved from through
+	// chains of dependency modules.
+	NonModuleParentClientMetadata(context.Context) (*engine.ClientMetadata, error)
 }
 
 func NewRoot(srv Server) *Query {

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -35,6 +35,7 @@ func (s *moduleSchema) Install() {
 		dagql.Func("moduleSource", s.moduleSource).
 			Doc(`Create a new module source instance from a source ref string.`).
 			ArgDoc("refString", `The string ref representation of the module source`).
+			ArgDoc("relHostPath", `The relative path to the module root from the host directory`).
 			ArgDoc("stable", `If true, enforce that the source is a stable version for source kinds that support versioning.`),
 
 		dagql.Func("moduleDependency", s.moduleDependency).

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -757,6 +758,8 @@ func (s *moduleSchema) moduleSourceResolveFromCaller(
 		return inst, err
 	}
 
+	slog.Error("moduleSourceResolveFromCaller", "contextAbsPath", contextAbsPath, "sourceRootAbsPath", sourceRootAbsPath)
+
 	sourceRootRelPath, err := filepath.Rel(contextAbsPath, sourceRootAbsPath)
 	if err != nil {
 		return inst, fmt.Errorf("failed to get source root relative path: %w", err)
@@ -765,6 +768,8 @@ func (s *moduleSchema) moduleSourceResolveFromCaller(
 	// even when subdir relative to git source has ref structure
 	// (cf. test TestRefFormat)
 	sourceRootRelPath = "./" + sourceRootRelPath
+
+	slog.Error("moduleSourceResolveFromCaller", "sourceRootRelPath", sourceRootRelPath)
 
 	collectedDeps := dagql.NewCacheMap[string, *callerLocalDep]()
 	if err := s.collectCallerLocalDeps(ctx, src.Query, contextAbsPath, sourceRootAbsPath, true, src, collectedDeps); err != nil {

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -112,7 +112,7 @@ func (fn *Function) WithDescription(desc string) *Function {
 	return fn
 }
 
-func (fn *Function) WithArg(name string, typeDef *TypeDef, desc string, defaultValue JSON) *Function {
+func (fn *Function) WithArg(name string, typeDef *TypeDef, desc string, defaultValue JSON, defaultPath string, ignore []string) *Function {
 	fn = fn.Clone()
 	fn.Args = append(fn.Args, &FunctionArg{
 		Name:         strcase.ToLowerCamel(name),
@@ -120,6 +120,8 @@ func (fn *Function) WithArg(name string, typeDef *TypeDef, desc string, defaultV
 		TypeDef:      typeDef,
 		DefaultValue: defaultValue,
 		OriginalName: name,
+		DefaultPath:  defaultPath,
+		Ignore:       ignore,
 	})
 	return fn
 }
@@ -183,6 +185,8 @@ type FunctionArg struct {
 	Description  string   `field:"true" doc:"A doc string for the argument, if any."`
 	TypeDef      *TypeDef `field:"true" doc:"The type of the argument."`
 	DefaultValue JSON     `field:"true" doc:"A default value to use for this argument when not explicitly set by the caller, if any."`
+	DefaultPath  string   `field:"true" doc:"Only applies to arguments of type File or Directory. If the argument is not set, load it from the given path in the context directory"`
+	Ignore       []string `field:"true" doc:"Only applies to arguments of type Directory. The ignore patterns are applied to the input directory, and matching entries are filtered out, in a cache-efficient manner."`
 
 	// Below are not in public API
 

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -1444,12 +1444,20 @@ type Function {
   """Returns the function with the provided argument"""
   withArg(
     """
+    If the argument is a Directory or File type, default to load path from context directory, relative to root directory.
+    """
+    defaultPath: String = ""
+
+    """
     A default value to use for this argument if not explicitly set by the caller, if any
     """
     defaultValue: JSON
 
     """A doc string for the argument, if any"""
     description: String = ""
+
+    """Patterns to ignore when loading the contextual argument value."""
+    ignore: [String!] = []
 
     """The name of the argument"""
     name: String!
@@ -1472,6 +1480,12 @@ This is a specification for an argument at function definition time, not an argu
 """
 type FunctionArg {
   """
+  Only applies to arguments of type File or Directory. If the argument is not
+  set, load it from the given path in the context directory
+  """
+  defaultPath: String!
+
+  """
   A default value to use for this argument when not explicitly set by the caller, if any.
   """
   defaultValue: JSON!
@@ -1481,6 +1495,13 @@ type FunctionArg {
 
   """A unique identifier for this FunctionArg."""
   id: FunctionArgID!
+
+  """
+  Only applies to arguments of type Directory. The ignore patterns are applied
+  to the input directory, and matching entries are filtered out, in a
+  cache-efficient manner.
+  """
+  ignore: [String!]!
 
   """The name of the argument in lowerCamelCase format."""
   name: String!

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -1925,6 +1925,9 @@ type LocalModuleSource {
   """A unique identifier for this LocalModuleSource."""
   id: LocalModuleSourceID!
 
+  """The relative path to the module root from the host directory"""
+  relHostPath: String!
+
   """
   The path to the root of the module source under the context directory. This
   directory contains its configuration file. It also contains its source code
@@ -2580,6 +2583,9 @@ type Query {
   moduleSource(
     """The string ref representation of the module source"""
     refString: String!
+
+    """The relative path to the module root from the host directory"""
+    relHostPath: String = ""
 
     """
     If true, enforce that the source is a stable version for source kinds that support versioning.

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -3194,6 +3194,12 @@
                       </tr>
                       <tr>
                         <td>
+                          <span class="property-name"><code>relHostPath</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span>
+                        </td>
+                        <td> The relative path to the module root from the host directory. Default = <code>""</code> </td>
+                      </tr>
+                      <tr>
+                        <td>
                           <span class="property-name"><code>stable</code></span> - <span class="property-type"><a href="#definition-Boolean"><code>Boolean</code></a></span>
                         </td>
                         <td> If true, enforce that the source is a stable version for source kinds that support versioning. Default = <code>false</code> </td>
@@ -7326,6 +7332,10 @@
                         <td> A unique identifier for this LocalModuleSource. </td>
                       </tr>
                       <tr>
+                        <td data-property-name=""><a class="property-name" id="LocalModuleSource-relHostPath" href="#LocalModuleSource-relHostPath"><code>relHostPath</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
+                        <td> The relative path to the module root from the host directory </td>
+                      </tr>
+                      <tr>
                         <td data-property-name=""><a class="property-name" id="LocalModuleSource-rootSubpath" href="#LocalModuleSource-rootSubpath"><code>rootSubpath</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
                         <td> The path to the root of the module source under the context directory. This directory contains its configuration file. It also contains its source code (possibly as a subdirectory). </td>
                       </tr>
@@ -8294,7 +8304,7 @@
                   <h5>Example</h5>
                   <html>
                     <head></head>
-                    <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"backend"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"frontend"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"protocol"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"TCP"</span><span class="hljs-punctuation">}</span>
+                    <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"backend"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"frontend"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"protocol"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"TCP"</span><span class="hljs-punctuation">}</span>
 </code></pre>
                     </body>
                   </html>

--- a/docs/static/api/reference/index.html
+++ b/docs/static/api/reference/index.html
@@ -6097,12 +6097,20 @@
                             <h5 class="field-arguments-heading"> Arguments </h5>
                             <div class="field-argument-list">
                               <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>defaultPath</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span></h6>
+                                <p>If the argument is a Directory or File type, default to load path from context directory, relative to root directory.</p>
+                              </div>
+                              <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>defaultValue</code></span> - <span class="property-type"><a href="#definition-JSON"><code>JSON</code></a></span></h6>
                                 <p>A default value to use for this argument if not explicitly set by the caller, if any</p>
                               </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>description</code></span> - <span class="property-type"><a href="#definition-String"><code>String</code></a></span></h6>
                                 <p>A doc string for the argument, if any</p>
+                              </div>
+                              <div class="field-argument">
+                                <h6 class="field-argument-name"><span class="property-name"><code>ignore</code></span> - <span class="property-type"><a href="#definition-String"><code>[String!]</code></a></span></h6>
+                                <p>Patterns to ignore when loading the contextual argument value.</p>
                               </div>
                               <div class="field-argument">
                                 <h6 class="field-argument-name"><span class="property-name"><code>name</code></span> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span></h6>
@@ -6162,6 +6170,10 @@
                     </thead>
                     <tbody>
                       <tr>
+                        <td data-property-name=""><a class="property-name" id="FunctionArg-defaultPath" href="#FunctionArg-defaultPath"><code>defaultPath</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
+                        <td> Only applies to arguments of type File or Directory. If the argument is not set, load it from the given path in the context directory </td>
+                      </tr>
+                      <tr>
                         <td data-property-name=""><a class="property-name" id="FunctionArg-defaultValue" href="#FunctionArg-defaultValue"><code>defaultValue</code></a> - <span class="property-type"><a href="#definition-JSON"><code>JSON!</code></a></span> </td>
                         <td> A default value to use for this argument when not explicitly set by the caller, if any. </td>
                       </tr>
@@ -6172,6 +6184,10 @@
                       <tr>
                         <td data-property-name=""><a class="property-name" id="FunctionArg-id" href="#FunctionArg-id"><code>id</code></a> - <span class="property-type"><a href="#definition-FunctionArgID"><code>FunctionArgID!</code></a></span> </td>
                         <td> A unique identifier for this FunctionArg. </td>
+                      </tr>
+                      <tr>
+                        <td data-property-name=""><a class="property-name" id="FunctionArg-ignore" href="#FunctionArg-ignore"><code>ignore</code></a> - <span class="property-type"><a href="#definition-String"><code>[String!]!</code></a></span> </td>
+                        <td> Only applies to arguments of type Directory. The ignore patterns are applied to the input directory, and matching entries are filtered out, in a cache-efficient manner. </td>
                       </tr>
                       <tr>
                         <td data-property-name=""><a class="property-name" id="FunctionArg-name" href="#FunctionArg-name"><code>name</code></a> - <span class="property-type"><a href="#definition-String"><code>String!</code></a></span> </td>
@@ -8278,7 +8294,7 @@
                   <h5>Example</h5>
                   <html>
                     <head></head>
-                    <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"backend"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"frontend"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"protocol"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"TCP"</span><span class="hljs-punctuation">}</span>
+                    <body><pre><code class="hljs language-json"><span class="hljs-punctuation">{</span><span class="hljs-attr">"backend"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">987</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"frontend"</span><span class="hljs-punctuation">:</span> <span class="hljs-number">123</span><span class="hljs-punctuation">,</span> <span class="hljs-attr">"protocol"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"TCP"</span><span class="hljs-punctuation">}</span>
 </code></pre>
                     </body>
                   </html>

--- a/sdk/elixir/lib/dagger/gen/client.ex
+++ b/sdk/elixir/lib/dagger/gen/client.ex
@@ -740,13 +740,17 @@ defmodule Dagger.Client do
   end
 
   @doc "Create a new module source instance from a source ref string."
-  @spec module_source(t(), String.t(), [{:stable, boolean() | nil}]) :: Dagger.ModuleSource.t()
+  @spec module_source(t(), String.t(), [
+          {:stable, boolean() | nil},
+          {:rel_host_path, String.t() | nil}
+        ]) :: Dagger.ModuleSource.t()
   def module_source(%__MODULE__{} = client, ref_string, optional_args \\ []) do
     query_builder =
       client.query_builder
       |> QB.select("moduleSource")
       |> QB.put_arg("refString", ref_string)
       |> QB.maybe_put_arg("stable", optional_args[:stable])
+      |> maybe_put_arg("relHostPath", optional_args[:rel_host_path])
 
     %Dagger.ModuleSource{
       query_builder: query_builder,

--- a/sdk/elixir/lib/dagger/gen/client.ex
+++ b/sdk/elixir/lib/dagger/gen/client.ex
@@ -750,7 +750,7 @@ defmodule Dagger.Client do
       |> QB.select("moduleSource")
       |> QB.put_arg("refString", ref_string)
       |> QB.maybe_put_arg("stable", optional_args[:stable])
-      |> maybe_put_arg("relHostPath", optional_args[:rel_host_path])
+      |> QB.maybe_put_arg("relHostPath", optional_args[:rel_host_path])
 
     %Dagger.ModuleSource{
       query_builder: query_builder,

--- a/sdk/elixir/lib/dagger/gen/function.ex
+++ b/sdk/elixir/lib/dagger/gen/function.ex
@@ -89,8 +89,8 @@ defmodule Dagger.Function do
       |> QB.put_arg("typeDef", Dagger.ID.id!(type_def))
       |> QB.maybe_put_arg("description", optional_args[:description])
       |> QB.maybe_put_arg("defaultValue", optional_args[:default_value])
-      |> maybe_put_arg("defaultPath", optional_args[:default_path])
-      |> maybe_put_arg("ignore", optional_args[:ignore])
+      |> QB.maybe_put_arg("defaultPath", optional_args[:default_path])
+      |> QB.maybe_put_arg("ignore", optional_args[:ignore])
 
     %Dagger.Function{
       query_builder: query_builder,

--- a/sdk/elixir/lib/dagger/gen/function.ex
+++ b/sdk/elixir/lib/dagger/gen/function.ex
@@ -77,7 +77,9 @@ defmodule Dagger.Function do
   @doc "Returns the function with the provided argument"
   @spec with_arg(t(), String.t(), Dagger.TypeDef.t(), [
           {:description, String.t() | nil},
-          {:default_value, Dagger.JSON.t() | nil}
+          {:default_value, Dagger.JSON.t() | nil},
+          {:default_path, String.t() | nil},
+          {:ignore, [String.t()]}
         ]) :: Dagger.Function.t()
   def with_arg(%__MODULE__{} = function, name, type_def, optional_args \\ []) do
     query_builder =
@@ -87,6 +89,8 @@ defmodule Dagger.Function do
       |> QB.put_arg("typeDef", Dagger.ID.id!(type_def))
       |> QB.maybe_put_arg("description", optional_args[:description])
       |> QB.maybe_put_arg("defaultValue", optional_args[:default_value])
+      |> maybe_put_arg("defaultPath", optional_args[:default_path])
+      |> maybe_put_arg("ignore", optional_args[:ignore])
 
     %Dagger.Function{
       query_builder: query_builder,

--- a/sdk/elixir/lib/dagger/gen/function_arg.ex
+++ b/sdk/elixir/lib/dagger/gen/function_arg.ex
@@ -15,6 +15,15 @@ defmodule Dagger.FunctionArg do
 
   @type t() :: %__MODULE__{}
 
+  @doc "Only applies to arguments of type File or Directory. If the argument is not set, load it from the given path in the context directory"
+  @spec default_path(t()) :: {:ok, String.t()} | {:error, term()}
+  def default_path(%__MODULE__{} = function_arg) do
+    selection =
+      function_arg.selection |> select("defaultPath")
+
+    execute(selection, function_arg.client)
+  end
+
   @doc "A default value to use for this argument when not explicitly set by the caller, if any."
   @spec default_value(t()) :: {:ok, Dagger.JSON.t()} | {:error, term()}
   def default_value(%__MODULE__{} = function_arg) do
@@ -40,6 +49,15 @@ defmodule Dagger.FunctionArg do
       function_arg.query_builder |> QB.select("id")
 
     Client.execute(function_arg.client, query_builder)
+  end
+
+  @doc "Only applies to arguments of type Directory. The ignore patterns are applied to the input directory, and matching entries are filtered out, in a cache-efficient manner."
+  @spec ignore(t()) :: {:ok, [String.t()]} | {:error, term()}
+  def ignore(%__MODULE__{} = function_arg) do
+    selection =
+      function_arg.selection |> select("ignore")
+
+    execute(selection, function_arg.client)
   end
 
   @doc "The name of the argument in lowerCamelCase format."

--- a/sdk/elixir/lib/dagger/gen/function_arg.ex
+++ b/sdk/elixir/lib/dagger/gen/function_arg.ex
@@ -18,10 +18,10 @@ defmodule Dagger.FunctionArg do
   @doc "Only applies to arguments of type File or Directory. If the argument is not set, load it from the given path in the context directory"
   @spec default_path(t()) :: {:ok, String.t()} | {:error, term()}
   def default_path(%__MODULE__{} = function_arg) do
-    selection =
-      function_arg.selection |> select("defaultPath")
+    query_builder =
+      function_arg.query_builder |> QB.select("defaultPath")
 
-    execute(selection, function_arg.client)
+    Client.execute(function_arg.client, query_builder)
   end
 
   @doc "A default value to use for this argument when not explicitly set by the caller, if any."
@@ -54,10 +54,10 @@ defmodule Dagger.FunctionArg do
   @doc "Only applies to arguments of type Directory. The ignore patterns are applied to the input directory, and matching entries are filtered out, in a cache-efficient manner."
   @spec ignore(t()) :: {:ok, [String.t()]} | {:error, term()}
   def ignore(%__MODULE__{} = function_arg) do
-    selection =
-      function_arg.selection |> select("ignore")
+    query_builder =
+      function_arg.query_builder |> QB.select("ignore")
 
-    execute(selection, function_arg.client)
+    Client.execute(function_arg.client, query_builder)
   end
 
   @doc "The name of the argument in lowerCamelCase format."

--- a/sdk/elixir/lib/dagger/gen/local_module_source.ex
+++ b/sdk/elixir/lib/dagger/gen/local_module_source.ex
@@ -32,6 +32,15 @@ defmodule Dagger.LocalModuleSource do
     Client.execute(local_module_source.client, query_builder)
   end
 
+  @doc "The relative path to the module root from the host directory"
+  @spec rel_host_path(t()) :: {:ok, String.t()} | {:error, term()}
+  def rel_host_path(%__MODULE__{} = local_module_source) do
+    selection =
+      local_module_source.selection |> select("relHostPath")
+
+    execute(selection, local_module_source.client)
+  end
+
   @doc "The path to the root of the module source under the context directory. This directory contains its configuration file. It also contains its source code (possibly as a subdirectory)."
   @spec root_subpath(t()) :: {:ok, String.t()} | {:error, term()}
   def root_subpath(%__MODULE__{} = local_module_source) do

--- a/sdk/elixir/lib/dagger/gen/local_module_source.ex
+++ b/sdk/elixir/lib/dagger/gen/local_module_source.ex
@@ -35,10 +35,10 @@ defmodule Dagger.LocalModuleSource do
   @doc "The relative path to the module root from the host directory"
   @spec rel_host_path(t()) :: {:ok, String.t()} | {:error, term()}
   def rel_host_path(%__MODULE__{} = local_module_source) do
-    selection =
-      local_module_source.selection |> select("relHostPath")
+    query_builder =
+      local_module_source.query_builder |> QB.select("relHostPath")
 
-    execute(selection, local_module_source.client)
+    Client.execute(local_module_source.client, query_builder)
   end
 
   @doc "The path to the root of the module source under the context directory. This directory contains its configuration file. It also contains its source code (possibly as a subdirectory)."

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -3431,6 +3431,10 @@ type FunctionWithArgOpts struct {
 	Description string
 	// A default value to use for this argument if not explicitly set by the caller, if any
 	DefaultValue JSON
+	// If the argument is a Directory or File type, default to load path from context directory, relative to root directory.
+	DefaultPath string
+	// Patterns to ignore when loading the contextual argument value.
+	Ignore []string
 }
 
 // Returns the function with the provided argument
@@ -3445,6 +3449,14 @@ func (r *Function) WithArg(name string, typeDef *TypeDef, opts ...FunctionWithAr
 		// `defaultValue` optional argument
 		if !querybuilder.IsZeroValue(opts[i].DefaultValue) {
 			q = q.Arg("defaultValue", opts[i].DefaultValue)
+		}
+		// `defaultPath` optional argument
+		if !querybuilder.IsZeroValue(opts[i].DefaultPath) {
+			q = q.Arg("defaultPath", opts[i].DefaultPath)
+		}
+		// `ignore` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Ignore) {
+			q = q.Arg("ignore", opts[i].Ignore)
 		}
 	}
 	q = q.Arg("name", name)
@@ -3471,6 +3483,7 @@ func (r *Function) WithDescription(description string) *Function {
 type FunctionArg struct {
 	query *querybuilder.Selection
 
+	defaultPath  *string
 	defaultValue *JSON
 	description  *string
 	id           *FunctionArgID
@@ -3481,6 +3494,19 @@ func (r *FunctionArg) WithGraphQLQuery(q *querybuilder.Selection) *FunctionArg {
 	return &FunctionArg{
 		query: q,
 	}
+}
+
+// Only applies to arguments of type File or Directory. If the argument is not set, load it from the given path in the context directory
+func (r *FunctionArg) DefaultPath(ctx context.Context) (string, error) {
+	if r.defaultPath != nil {
+		return *r.defaultPath, nil
+	}
+	q := r.query.Select("defaultPath")
+
+	var response string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
 }
 
 // A default value to use for this argument when not explicitly set by the caller, if any.
@@ -3547,6 +3573,16 @@ func (r *FunctionArg) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	return json.Marshal(id)
+}
+
+// Only applies to arguments of type Directory. The ignore patterns are applied to the input directory, and matching entries are filtered out, in a cache-efficient manner.
+func (r *FunctionArg) Ignore(ctx context.Context) ([]string, error) {
+	q := r.query.Select("ignore")
+
+	var response []string
+
+	q = q.Bind(&response)
+	return response, q.Execute(ctx)
 }
 
 // The name of the argument in lowerCamelCase format.

--- a/sdk/php/generated/Client.php
+++ b/sdk/php/generated/Client.php
@@ -604,12 +604,15 @@ class Client extends Client\AbstractClient
     /**
      * Create a new module source instance from a source ref string.
      */
-    public function moduleSource(string $refString, ?bool $stable = false): ModuleSource
+    public function moduleSource(string $refString, ?bool $stable = false, ?string $relHostPath = ''): ModuleSource
     {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('moduleSource');
         $innerQueryBuilder->setArgument('refString', $refString);
         if (null !== $stable) {
         $innerQueryBuilder->setArgument('stable', $stable);
+        }
+        if (null !== $relHostPath) {
+        $innerQueryBuilder->setArgument('relHostPath', $relHostPath);
         }
         return new \Dagger\ModuleSource($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }

--- a/sdk/php/generated/FunctionArg.php
+++ b/sdk/php/generated/FunctionArg.php
@@ -16,6 +16,15 @@ namespace Dagger;
 class FunctionArg extends Client\AbstractObject implements Client\IdAble
 {
     /**
+     * Only applies to arguments of type File or Directory. If the argument is not set, load it from the given path in the context directory
+     */
+    public function defaultPath(): string
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('defaultPath');
+        return (string)$this->queryLeaf($leafQueryBuilder, 'defaultPath');
+    }
+
+    /**
      * A default value to use for this argument when not explicitly set by the caller, if any.
      */
     public function defaultValue(): Json
@@ -40,6 +49,15 @@ class FunctionArg extends Client\AbstractObject implements Client\IdAble
     {
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('id');
         return new \Dagger\FunctionArgId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
+    }
+
+    /**
+     * Only applies to arguments of type Directory. The ignore patterns are applied to the input directory, and matching entries are filtered out, in a cache-efficient manner.
+     */
+    public function ignore(): array
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('ignore');
+        return (array)$this->queryLeaf($leafQueryBuilder, 'ignore');
     }
 
     /**

--- a/sdk/php/generated/Function_.php
+++ b/sdk/php/generated/Function_.php
@@ -68,6 +68,8 @@ class Function_ extends Client\AbstractObject implements Client\IdAble
         TypeDefId|TypeDef $typeDef,
         ?string $description = '',
         ?Json $defaultValue = null,
+        ?string $defaultPath = '',
+        ?array $ignore = null,
     ): Function_ {
         $innerQueryBuilder = new \Dagger\Client\QueryBuilder('withArg');
         $innerQueryBuilder->setArgument('name', $name);
@@ -77,6 +79,12 @@ class Function_ extends Client\AbstractObject implements Client\IdAble
         }
         if (null !== $defaultValue) {
         $innerQueryBuilder->setArgument('defaultValue', $defaultValue);
+        }
+        if (null !== $defaultPath) {
+        $innerQueryBuilder->setArgument('defaultPath', $defaultPath);
+        }
+        if (null !== $ignore) {
+        $innerQueryBuilder->setArgument('ignore', $ignore);
         }
         return new \Dagger\Function_($this->client, $this->queryBuilderChain->chain($innerQueryBuilder));
     }

--- a/sdk/php/generated/LocalModuleSource.php
+++ b/sdk/php/generated/LocalModuleSource.php
@@ -32,6 +32,15 @@ class LocalModuleSource extends Client\AbstractObject implements Client\IdAble
     }
 
     /**
+     * The relative path to the module root from the host directory
+     */
+    public function relHostPath(): string
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('relHostPath');
+        return (string)$this->queryLeaf($leafQueryBuilder, 'relHostPath');
+    }
+
+    /**
      * The path to the root of the module source under the context directory. This directory contains its configuration file. It also contains its source code (possibly as a subdirectory).
      */
     public function rootSubpath(): string

--- a/sdk/python/docs/module.rst
+++ b/sdk/python/docs/module.rst
@@ -13,10 +13,12 @@ Experimental Dagger modules support.
 
 .. autodecorator:: enum_type
 
+.. autoclass:: DefaultPath
+
+.. autoclass:: Ignore
+
 .. autoclass:: Enum
 
 .. autoclass:: Name
-
-.. autoclass:: Arg
 
 .. autoclass:: Doc

--- a/sdk/python/src/dagger/__init__.py
+++ b/sdk/python/src/dagger/__init__.py
@@ -27,7 +27,9 @@ from dagger._connection import close as close
 
 # Modules.
 from dagger.mod import Arg as Arg
+from dagger.mod import DefaultPath as DefaultPath
 from dagger.mod import Doc as Doc
+from dagger.mod import Ignore as Ignore
 from dagger.mod import Enum as Enum
 from dagger.mod import Name as Name
 from dagger.mod import enum_type as enum_type

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -3631,6 +3631,8 @@ class Function(Type):
         *,
         description: str | None = "",
         default_value: JSON | None = None,
+        default_path: str | None = "",
+        ignore: list[str] | None = None,
     ) -> Self:
         """Returns the function with the provided argument
 
@@ -3645,12 +3647,19 @@ class Function(Type):
         default_value:
             A default value to use for this argument if not explicitly set by
             the caller, if any
+        default_path:
+            If the argument is a Directory or File type, default to load path
+            from context directory, relative to root directory.
+        ignore:
+            Patterns to ignore when loading the contextual argument value.
         """
         _args = [
             Arg("name", name),
             Arg("typeDef", type_def),
             Arg("description", description, ""),
             Arg("defaultValue", default_value, None),
+            Arg("defaultPath", default_path, ""),
+            Arg("ignore", [] if ignore is None else ignore),
         ]
         _ctx = self._select("withArg", _args)
         return Function(_ctx)
@@ -3682,6 +3691,28 @@ class FunctionArg(Type):
     """An argument accepted by a function.  This is a specification for an
     argument at function definition time, not an argument passed at
     function call time."""
+
+    async def default_path(self) -> str:
+        """Only applies to arguments of type File or Directory. If the argument
+        is not set, load it from the given path in the context directory
+
+        Returns
+        -------
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("defaultPath", _args)
+        return await _ctx.execute(str)
 
     async def default_value(self) -> JSON:
         """A default value to use for this argument when not explicitly set by
@@ -3747,6 +3778,29 @@ class FunctionArg(Type):
         _args: list[Arg] = []
         _ctx = self._select("id", _args)
         return await _ctx.execute(FunctionArgID)
+
+    async def ignore(self) -> list[str]:
+        """Only applies to arguments of type Directory. The ignore patterns are
+        applied to the input directory, and matching entries are filtered out,
+        in a cache-efficient manner.
+
+        Returns
+        -------
+        list[str]
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("ignore", _args)
+        return await _ctx.execute(list[str])
 
     async def name(self) -> str:
         """The name of the argument in lowerCamelCase format.

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -5077,6 +5077,27 @@ class LocalModuleSource(Type):
         _ctx = self._select("id", _args)
         return await _ctx.execute(LocalModuleSourceID)
 
+    async def rel_host_path(self) -> str:
+        """The relative path to the module root from the host directory
+
+        Returns
+        -------
+        str
+            The `String` scalar type represents textual data, represented as
+            UTF-8 character sequences. The String type is most often used by
+            GraphQL to represent free-form human-readable text.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("relHostPath", _args)
+        return await _ctx.execute(str)
+
     async def root_subpath(self) -> str:
         """The path to the root of the module source under the context directory.
         This directory contains its configuration file. It also contains its
@@ -6892,6 +6913,7 @@ class Client(Root):
         ref_string: str,
         *,
         stable: bool | None = False,
+        rel_host_path: str | None = "",
     ) -> ModuleSource:
         """Create a new module source instance from a source ref string.
 
@@ -6902,10 +6924,13 @@ class Client(Root):
         stable:
             If true, enforce that the source is a stable version for source
             kinds that support versioning.
+        rel_host_path:
+            The relative path to the module root from the host directory
         """
         _args = [
             Arg("refString", ref_string),
             Arg("stable", stable, False),
+            Arg("relHostPath", rel_host_path, ""),
         ]
         _ctx = self._select("moduleSource", _args)
         return ModuleSource(_ctx)

--- a/sdk/python/src/dagger/mod/__init__.py
+++ b/sdk/python/src/dagger/mod/__init__.py
@@ -1,6 +1,8 @@
 from typing_extensions import Doc
 
 from dagger.mod._arguments import Arg
+from dagger.mod._arguments import DefaultPath
+from dagger.mod._arguments import Ignore
 from dagger.mod._arguments import Name
 from dagger.mod._module import Module
 from dagger.mod._types import Enum
@@ -21,7 +23,9 @@ def default_module() -> Module:
 
 __all__ = [
     "Arg",
+    "DefaultPath",
     "Doc",  # Only re-exported because it's in `typing_extensions`.
+    "Ignore",
     "Enum",
     "Name",
     "enum_type",

--- a/sdk/python/src/dagger/mod/_arguments.py
+++ b/sdk/python/src/dagger/mod/_arguments.py
@@ -43,10 +43,10 @@ class DefaultPath:
     Mutually exclusive with setting a default value for the parameter. When
     used within Python, the parameter should be required.
 
-    Example usage:
+    Example usage::
 
-    >>> @function
-    ... def build(src: Annotated[dagger.Directory, DefaultPath(".")]): ...
+        @function
+        def build(src: Annotated[dagger.Directory, DefaultPath("..")]): ...
     """
 
     from_context: ContextPath
@@ -65,10 +65,10 @@ class Ignore:
     Useful if it's known in advance which files or directories should be
     excluded when loading the directory.
 
-    Example usage:
+    Example usage::
 
-    >>> @function
-    ... def build(src: Annotated[dagger.Directory, Ignore([".venv"])]):
+        @function
+        def build(src: Annotated[dagger.Directory, Ignore([".venv"])]): ...
     """
 
     patterns: list[str]

--- a/sdk/python/src/dagger/mod/_arguments.py
+++ b/sdk/python/src/dagger/mod/_arguments.py
@@ -92,11 +92,8 @@ class Parameter:
 
     @property
     def has_default(self) -> bool:
-        return (
-            self.signature.default is not inspect.Parameter.empty
-            or self.default_path is not None
-        )
+        return self.signature.default is not inspect.Parameter.empty
 
     @property
     def is_optional(self) -> bool:
-        return self.has_default or self.is_nullable
+        return self.has_default or self.default_path is not None or self.is_nullable

--- a/sdk/python/src/dagger/mod/_resolver.py
+++ b/sdk/python/src/dagger/mod/_resolver.py
@@ -177,11 +177,7 @@ class FunctionResolver(Generic[P, R]):
         return typedef.with_function(fn) if self.name else typedef.with_constructor(fn)
 
     def _serialize_default_value(self, param: Parameter) -> dagger.JSON | None:
-        if (
-            not param.has_default
-            # It's redundant to have a default value of `null` in a nullable type.
-            or (param.is_nullable and param.signature.default is None)
-        ):
+        if not param.has_default:
             return None
         return dagger.JSON(json.dumps(param.signature.default))
 

--- a/sdk/python/src/dagger/mod/_types.py
+++ b/sdk/python/src/dagger/mod/_types.py
@@ -5,6 +5,7 @@ from dagger.client import base
 
 PythonName: TypeAlias = str
 APIName: TypeAlias = str
+ContextPath: TypeAlias = str
 
 
 @dataclasses.dataclass(slots=True)

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -692,6 +692,16 @@ export type FunctionWithArgOpts = {
    * A default value to use for this argument if not explicitly set by the caller, if any
    */
   defaultValue?: JSON
+
+  /**
+   * If the argument is a Directory or File type, default to load path from context directory, relative to root directory.
+   */
+  defaultPath?: string
+
+  /**
+   * Patterns to ignore when loading the contextual argument value.
+   */
+  ignore?: string[]
 }
 
 /**
@@ -4659,6 +4669,8 @@ export class Function_ extends BaseClient {
    * @param typeDef The type of the argument
    * @param opts.description A doc string for the argument, if any
    * @param opts.defaultValue A default value to use for this argument if not explicitly set by the caller, if any
+   * @param opts.defaultPath If the argument is a Directory or File type, default to load path from context directory, relative to root directory.
+   * @param opts.ignore Patterns to ignore when loading the contextual argument value.
    */
   withArg = (
     name: string,
@@ -4711,6 +4723,7 @@ export class Function_ extends BaseClient {
  */
 export class FunctionArg extends BaseClient {
   private readonly _id?: FunctionArgID = undefined
+  private readonly _defaultPath?: string = undefined
   private readonly _defaultValue?: JSON = undefined
   private readonly _description?: string = undefined
   private readonly _name?: string = undefined
@@ -4721,6 +4734,7 @@ export class FunctionArg extends BaseClient {
   constructor(
     parent?: { queryTree?: QueryTree[]; ctx: Context },
     _id?: FunctionArgID,
+    _defaultPath?: string,
     _defaultValue?: JSON,
     _description?: string,
     _name?: string,
@@ -4728,6 +4742,7 @@ export class FunctionArg extends BaseClient {
     super(parent)
 
     this._id = _id
+    this._defaultPath = _defaultPath
     this._defaultValue = _defaultValue
     this._description = _description
     this._name = _name
@@ -4746,6 +4761,27 @@ export class FunctionArg extends BaseClient {
         ...this._queryTree,
         {
           operation: "id",
+        },
+      ],
+      await this._ctx.connection(),
+    )
+
+    return response
+  }
+
+  /**
+   * Only applies to arguments of type File or Directory. If the argument is not set, load it from the given path in the context directory
+   */
+  defaultPath = async (): Promise<string> => {
+    if (this._defaultPath) {
+      return this._defaultPath
+    }
+
+    const response: Awaited<string> = await computeQuery(
+      [
+        ...this._queryTree,
+        {
+          operation: "defaultPath",
         },
       ],
       await this._ctx.connection(),
@@ -4788,6 +4824,23 @@ export class FunctionArg extends BaseClient {
         ...this._queryTree,
         {
           operation: "description",
+        },
+      ],
+      await this._ctx.connection(),
+    )
+
+    return response
+  }
+
+  /**
+   * Only applies to arguments of type Directory. The ignore patterns are applied to the input directory, and matching entries are filtered out, in a cache-efficient manner.
+   */
+  ignore = async (): Promise<string[]> => {
+    const response: Awaited<string[]> = await computeQuery(
+      [
+        ...this._queryTree,
+        {
+          operation: "ignore",
         },
       ],
       await this._ctx.connection(),

--- a/sdk/typescript/entrypoint/register.ts
+++ b/sdk/typescript/entrypoint/register.ts
@@ -119,6 +119,13 @@ function addArg(args: Arguments): (fct: Function_) => Function_ {
         typeDef = typeDef.withOptional(true)
       }
 
+      // Check if both values are used, return an error if so.
+      if (arg.defaultValue && arg.defaultPath) {
+        throw new Error(
+          "cannot set both default value and default path from context",
+        )
+      }
+
       // We do not set the default value if it's not a primitive type, we let TypeScript
       // resolve the default value during the runtime instead.
       // If it has a default value but is not primitive, we set the value as optional
@@ -130,6 +137,16 @@ function addArg(args: Arguments): (fct: Function_) => Function_ {
         } else {
           typeDef = typeDef.withOptional(true)
         }
+      }
+
+      // If the argument is a contextual argument, it becomes optional.
+      if (arg.defaultPath) {
+        opts.defaultPath = arg.defaultPath
+        typeDef = typeDef.withOptional(true)
+      }
+
+      if (arg.ignore) {
+        opts.ignore = arg.ignore
       }
 
       fct = fct.withArg(arg.name, typeDef, opts)

--- a/sdk/typescript/introspector/decorators/decorators.ts
+++ b/sdk/typescript/introspector/decorators/decorators.ts
@@ -3,10 +3,50 @@
  */
 import { registry } from "../registry/registry.js"
 
-export const object = registry.object
-export const func = registry.func
 /**
+ * The definition of the `@object` decorator that should be on top of any
+ * class module that must be exposed to the Dagger API.
+ *
+ */
+export const object = registry.object
+
+/**
+ * The definition of @func decorator that should be on top of any
+ * class' method that must be exposed to the Dagger API.
+ *
+ * @param alias The alias to use for the field when exposed on the API.
+ */
+export const func = registry.func
+
+/**
+ * The definition of @field decorator that should be on top of any
+ * class' property that must be exposed to the Dagger API.
+ *
  * @deprecated In favor of `@func`
+ * @param alias The alias to use for the field when exposed on the API.
  */
 export const field = registry.field
+
+/**
+ * The definition of the `@enumType` decorator that should be on top of any
+ * class module that must be exposed to the Dagger API as enumeration.
+ */
 export const enumType = registry.enumType
+
+/**
+ * Add a `@argument` decorator to an argument of type `Directory` or `File` to load
+ * its contents from the module context directory.
+ *
+ * The context directory is the git repository containing the module.
+ * If there's no git repository, the context directory is the directory containing
+ * the module source code.
+ *
+ * @param opts.defaultPath Only applies to arguments of type File or Directory. If the argument is not set,
+ * load it from the given path in the context directory.
+ * @param opts.ignore Only applies to arguments of type Directory. The ignore patterns are applied to the input directory,
+ * and matching entries are filtered out, in a cache-efficient manner..
+ *
+ * Relative paths are relative to the current source files.
+ * Absolute paths are rooted to the module context directory.
+ */
+export const argument = registry.argument

--- a/sdk/typescript/introspector/registry/registry.ts
+++ b/sdk/typescript/introspector/registry/registry.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
+// @experimentalDecorators
+// @emitDecoratorMetadata
 import "reflect-metadata"
 
 import { UnknownDaggerError } from "../../common/errors/UnknownDaggerError.js"
@@ -17,6 +19,25 @@ export type Args = Record<string, unknown>
  */
 type RegistryClass = {
   class_: Class
+}
+
+export type ArgumentOptions = {
+  /**
+   * The contextual value to use for the argument.
+   *
+   * This should only be used for Directory or File types.
+   *
+   * An abslute path would be related to the context source directory (the git repo root or the module source root).
+   * A relative path would be relative to the module source root.
+   */
+  defaultPath?: string
+
+  /**
+   * Patterns to ignore when loading the contextual argument value.
+   *
+   * This should only be used for Directory types.
+   */
+  ignore?: string[]
 }
 
 /**
@@ -37,7 +58,6 @@ export class Registry {
   /**
    * The definition of the @object decorator that should be on top of any
    * class module that must be exposed to the Dagger API.
-   *
    */
   object = (): (<T extends Class>(constructor: T) => T) => {
     return <T extends Class>(constructor: T): T => {
@@ -85,11 +105,17 @@ export class Registry {
       target: object,
       propertyKey: string | symbol,
       descriptor?: PropertyDescriptor,
-    ) => {
-      // The logic is done in the object constructor since it's not possible to
-      // access the class parent's name from a method constructor without calling
-      // the method itself
-    }
+    ) => {}
+  }
+
+  argument = (
+    opts?: ArgumentOptions,
+  ): ((
+    target: object,
+    propertyKey: string,
+    parameterIndex: number,
+  ) => void) => {
+    return (target: object, propertyKey: string, parameterIndex: number) => {}
   }
 
   /**

--- a/sdk/typescript/introspector/test/scan.spec.ts
+++ b/sdk/typescript/introspector/test/scan.spec.ts
@@ -83,6 +83,10 @@ describe("scan static TypeScript", function () {
       name: "Should correctly scan core enums",
       directory: "coreEnums",
     },
+    {
+      name: "Should correctly scan contextual arguments",
+      directory: "context",
+    },
   ]
 
   for (const test of testCases) {

--- a/sdk/typescript/introspector/test/testdata/context/expected.json
+++ b/sdk/typescript/introspector/test/testdata/context/expected.json
@@ -1,0 +1,58 @@
+{
+  "name": "Context",
+  "objects": {
+    "Context": {
+      "name": "Context",
+      "description": "",
+      "methods": {
+        "helloWorld": {
+          "name": "helloWorld",
+          "description": "",
+          "arguments": {
+            "dir": {
+              "name": "dir",
+              "description": "",
+              "type": {
+                "kind": "OBJECT_KIND",
+                "name": "Directory"
+              },
+              "isVariadic": false,
+              "isNullable": false,
+              "isOptional": false,
+              "defaultPath": "."
+            }
+          },
+          "returnType": {
+            "kind": "STRING_KIND"
+          }
+        },
+        "helloWorldIgnored": {
+          "name": "helloWorldIgnored",
+          "description": "",
+          "arguments": {
+            "dir": {
+              "name": "dir",
+              "description": "",
+              "type": {
+                "kind": "OBJECT_KIND",
+                "name": "Directory"
+              },
+              "isVariadic": false,
+              "isNullable": false,
+              "isOptional": false,
+              "defaultPath": ".",
+              "ignore": [
+                "dir"
+              ]
+            }
+          },
+          "returnType": {
+            "kind": "STRING_KIND"
+          }
+        }
+      },
+      "properties": {}
+    }
+  },
+  "enums": {}
+}

--- a/sdk/typescript/introspector/test/testdata/context/index.ts
+++ b/sdk/typescript/introspector/test/testdata/context/index.ts
@@ -1,0 +1,22 @@
+import { func, object, argument } from "../../../decorators/decorators.js"
+import { Directory } from "../../../../api/client.gen.js"
+import { dag } from "../../../../api/client.gen.js"
+
+@object()
+export class Context {
+  @func()
+  helloWorld(
+    @argument({ defaultPath: "." }) 
+    dir: Directory,
+  ): string {
+    return `hello ${name}`
+  }
+
+  @func()
+  helloWorldIgnored(
+    @argument({ defaultPath: ".", ignore: ["dir"] }) 
+    dir: Directory,
+  ): string {
+    return `hello ${name}`
+  }
+}

--- a/sdk/typescript/introspector/test/testdata/generate_expected_scan.ts
+++ b/sdk/typescript/introspector/test/testdata/generate_expected_scan.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "url"
 
 import { scan } from "../../scanner/scan.js"
 import { listFiles } from "../../utils/files.js"
+import { DaggerModule } from "../../scanner/abtractions/module.js"
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -20,7 +21,14 @@ async function generateExpectedScan() {
 
     console.info(`* Generating expected scan file for directory: ${entry}`)
     const files = await listFiles(`${__dirname}/${entry}`)
-    const result = scan(files, `${entry}`)
+
+    let result: DaggerModule
+    try {
+      result = scan(files, `${entry}`)
+    } catch (e) {
+      console.error(`Failed to scan ${entry}: ${e}`)
+      continue
+    }
 
     const expectedPath = path.join(__dirname, entry, expectedFilename)
     const diffExpectedPath = path.join(__dirname, entry, diffExpectedFileName)


### PR DESCRIPTION
This is an implementation of https://github.com/dagger/dagger/issues/7647

### API changes

This PR updates the `Function` and `FunctionArg` from our engine API to support `defaultPathFromContext`

```gql
# Function

  withArg(
    """
    If the argument is a Directory or File type, default to load path from context directory, relative to root directory.
    """
    defaultPath String = ""

   ignore: [String!]
# }

# FunctionArg {

  """
  If the argument is a Directory or File type, default to load path from context directory, relative to root directory.
  """
  defaultPath: String!

  ignore: [String!]
# }
```

### Engine changes

- Update `Call` to load contextual values and insert it as input.
- Add a `loadContextualArg` function that take the typedef and retrieve its contextual default value.
- Add a function `loadContext` to load from `git` or `local` source the contextual path.
  This implements the spec designed in #7647
  For git: we load it from the context directory since it includes the whole repo.
  For local: we load it from `importLocal` with the specific directory specified so we never load the full repo expect for `/`

**Current progress**

- [x] Loading directory
- [x] Get `*Directory` to `ID`: I found a workaround with `Blob` but it's not okay for `File`, I will check if I can use select instead.
- [x] Load File, using `Select` actually works!
- [x] Handle relative path
- [x] Write tests
- [x] Complete all SDK support

**Spec Reminder**
- [x] The context directory is the git repository containing the module. If there is not git repository, the context is simply the module.
- [x] Relative paths are relative to the current source file, scoped to the context directory for security
- [x] Absolute paths are rooted in the context directory
- [x] There is no limit to the number of directories which can have default values of this sort
- [x] Optionally, directories can be filtered with a gitignore-style annotation

### SDKs support

- [x] Go using pragmas directive on `Directory` or `File` type ⌛ 

- [x] Typescript using `@argument({ defaultPath: "path", ignore: ["xx", "!xx"] })` ✅
Example

```typescript
@func()
build(
  @argument({ defaultPath:"./frontend/src" }) frontend: Directory,
  @argument({ defaultPath:"./backend/app/src" }) backend: Directory,
  @argument({ defaultPath: "./tools/builder.conf" }) buildConfig: File,
): Directory {}
```

- [x] Python using annotations 


Fixes #7647 
