### PR TITLE
Improve releasing during v0.11.9

### DIFF
--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -13,7 +13,7 @@ inputs:
 
   version:
     description: "Dagger version to run against"
-    default: "v0.11.8"
+    default: "v0.11.9"
     required: false
 
   dev-engine:

--- a/.github/workflows/_sdk_check.yml
+++ b/.github/workflows/_sdk_check.yml
@@ -15,7 +15,7 @@ on:
 
       version:
         type: string
-        default: "v0.11.8"
+        default: "v0.11.9"
         required: false
 
       dev-engine:
@@ -32,7 +32,7 @@ on:
 
 jobs:
   check:
-    runs-on: "${{ github.repository == 'dagger/dagger' && (inputs.dev-engine && 'dagger-v0-11-8-dind' || 'dagger-v0-11-8-4c-nvme') || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && (inputs.dev-engine && 'dagger-v0-11-9-dind' || 'dagger-v0-11-9-4c-nvme') || 'ubuntu-latest' }}"
     timeout-minutes: "${{ inputs.timeout }}"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-8-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-9-4c-nvme' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/engine-and-cli-publish.yml
+++ b/.github/workflows/engine-and-cli-publish.yml
@@ -20,7 +20,7 @@ jobs:
   publish:
     if: ${{ github.repository == 'dagger/dagger' && github.event_name == 'push' }}
     # Use our own Dagger runner when running in the dagger/dagger repo (including PRs)
-    runs-on: dagger-v0-11-8-16c-nvme
+    runs-on: dagger-v0-11-9-16c-nvme
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -115,7 +115,7 @@ jobs:
           discord-webhook: ${{ secrets.NEW_RELEASE_DISCORD_WEBHOOK }}
 
   scan-engine:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-8-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-9-4c-nvme' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-8-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-9-4c-nvme' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
           function: "scripts lint"
 
   test:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-8-16c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-9-16c-nvme' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -49,7 +49,7 @@ jobs:
   # Only run a subset of important test cases since we just need to verify basic
   # functionality rather than repeat every test already run in the other targets.
   testdev:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-8-dind' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-9-dind' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
           dev-engine: true
 
   test-publish:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-8-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-9-4c-nvme' || 'ubuntu-latest' }}"
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
           function: "engine with-base --image=ubuntu --gpu-support=true test-publish"
 
   scan-engine:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-8-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-9-4c-nvme' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-8-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-9-4c-nvme' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -27,7 +27,7 @@ jobs:
     # only run this on tag push events, not in PRs
     if: github.event_name == 'push' && github.repository == 'dagger/dagger' && github.ref_type == 'tag'
     needs: test
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-8-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-9-4c-nvme' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "helm publish"

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-8-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-9-4c-nvme' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sdk-elixir-publish.yml
+++ b/.github/workflows/sdk-elixir-publish.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-8-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-9-4c-nvme' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "elixir publish"

--- a/.github/workflows/sdk-go-publish.yml
+++ b/.github/workflows/sdk-go-publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-8-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-9-4c-nvme' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "go publish"

--- a/.github/workflows/sdk-php-publish.yml
+++ b/.github/workflows/sdk-php-publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-8-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-9-4c-nvme' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "php publish"

--- a/.github/workflows/sdk-python-publish.yml
+++ b/.github/workflows/sdk-python-publish.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-8-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-9-4c-nvme' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "go publish"

--- a/.github/workflows/sdk-rust-publish.yml
+++ b/.github/workflows/sdk-rust-publish.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-8-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-9-4c-nvme' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "go publish"

--- a/.github/workflows/sdk-typescript-publish.yml
+++ b/.github/workflows/sdk-typescript-publish.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-8-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-11-9-4c-nvme' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "go publish"

--- a/ci/go.mod
+++ b/ci/go.mod
@@ -2,7 +2,7 @@ module github.com/dagger/dagger/ci
 
 go 1.22
 
-require github.com/dagger/dagger/engine/distconsts v0.11.8
+require github.com/dagger/dagger/engine/distconsts v0.11.9
 
 replace github.com/dagger/dagger/engine/distconsts => ../engine/distconsts
 
@@ -23,7 +23,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.27.0
 	go.opentelemetry.io/otel/sdk/log v0.3.0
 	go.opentelemetry.io/otel/trace v1.27.0
-	go.opentelemetry.io/proto/otlp v1.2.0
+	go.opentelemetry.io/proto/otlp v1.3.1
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842
 	golang.org/x/mod v0.17.0
 	golang.org/x/sync v0.7.0

--- a/ci/go.sum
+++ b/ci/go.sum
@@ -76,8 +76,8 @@ go.opentelemetry.io/otel/sdk/log v0.3.0 h1:GEjJ8iftz2l+XO1GF2856r7yYVh74URiF9JMc
 go.opentelemetry.io/otel/sdk/log v0.3.0/go.mod h1:BwCxtmux6ACLuys1wlbc0+vGBd+xytjmjajwqqIul2g=
 go.opentelemetry.io/otel/trace v1.27.0 h1:IqYb813p7cmbHk0a5y6pD5JPakbVfftRXABGt5/Rscw=
 go.opentelemetry.io/otel/trace v1.27.0/go.mod h1:6RiD1hkAprV4/q+yd2ln1HG9GoPx39SuvvstaLBl+l4=
-go.opentelemetry.io/proto/otlp v1.2.0 h1:pVeZGk7nXDC9O2hncA6nHldxEjm6LByfA2aN8IOkz94=
-go.opentelemetry.io/proto/otlp v1.2.0/go.mod h1:gGpR8txAl5M03pDhMC79G6SdqNV26naRm/KDsgaHD8A=
+go.opentelemetry.io/proto/otlp v1.3.1 h1:TrMUixzpM0yuc/znrFTP9MMRh8trP93mkCiDVeXrui0=
+go.opentelemetry.io/proto/otlp v1.3.1/go.mod h1:0X1WI4de4ZsLrrJNLAQbFeLCm3T7yBkR0XqQ7niQU+8=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 h1:vr/HnozRka3pE4EsMEg1lgkXJkTFJCVUX+S/ZT6wYzM=

--- a/dagger.json
+++ b/dagger.json
@@ -3,10 +3,6 @@
   "sdk": "go",
   "dependencies": [
     {
-      "name": "shellcheck",
-      "source": "ci/std/shellcheck"
-    },
-    {
       "name": "docusaurus",
       "source": "github.com/levlaz/daggerverse/docusaurus@72ec19206da7dbe2815da94c62e491b54935b633"
     },
@@ -17,10 +13,14 @@
     {
       "name": "graphql",
       "source": "ci/std/graphql"
+    },
+    {
+      "name": "shellcheck",
+      "source": "ci/std/shellcheck"
     }
   ],
   "source": "ci",
-  "engineVersion": "v0.11.7",
+  "engineVersion": "v0.11.8",
   "views": [
     {
       "name": "default",

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/dagger/dagger
 go 1.22
 
 require (
-	dagger.io/dagger v0.11.8
-	github.com/dagger/dagger/engine/distconsts v0.11.8
+	dagger.io/dagger v0.11.9
+	github.com/dagger/dagger/engine/distconsts v0.11.9
 )
 
 replace (


### PR DESCRIPTION
Opening this against the `release-v0.11.9` branch for now. We will want to "forward-port" it to `main` also, will handle that along-side forward-porting https://github.com/dagger/dagger/pull/7745
* tbh I'm not 100% sure how necessary it is to merge this to the `release-v0.11.9` branch vs. only doing it to main, but doing it anyways during the first run-through of "publish from non-main branch" out of caution

TODOs (these are only strictly required for the `main` branch, so may end up just splitting out as separate commit there):
- [ ] Update `RELEASING.md` with instructions and current workarounds needed for releasing from non-main branch