### PR TITLE
fix: ensure gc policy percentage is correct

### DIFF
--- a/.changes/unreleased/Fixed-20240625-110428.yaml
+++ b/.changes/unreleased/Fixed-20240625-110428.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: 'core: correctly set new engine gc policy defaults'
+time: 2024-06-25T11:04:28.792928791+01:00
+custom:
+  Author: jedevc
+  PR: "7749"

--- a/cmd/engine/main.go
+++ b/cmd/engine/main.go
@@ -212,7 +212,7 @@ func addFlags(app *cli.App) {
 			Value: func() int64 {
 				keep := defaultConf.Workers.OCI.GCKeepStorage.AsBytes(defaultConf.Root)
 				if keep == 0 {
-					keep = config.DiskSpace{Percentage: 75}.AsBytes(defaultConf.Root)
+					keep = config.DiskSpace{Percentage: server.DiskSpacePercentage}.AsBytes(defaultConf.Root)
 				}
 				return keep / 1e6
 			}(),

--- a/engine/server/gc.go
+++ b/engine/server/gc.go
@@ -140,7 +140,7 @@ func getGCPolicy(cfg config.GCConfig, root string) []bkclient.PruneInfo {
 		return nil
 	}
 	if len(cfg.GCPolicy) == 0 {
-		cfg.GCPolicy = config.DefaultGCPolicy(cfg.GCKeepStorage)
+		cfg.GCPolicy = defaultGCPolicy(cfg.GCKeepStorage)
 	}
 	out := make([]bkclient.PruneInfo, 0, len(cfg.GCPolicy))
 	for _, rule := range cfg.GCPolicy {
@@ -153,3 +153,33 @@ func getGCPolicy(cfg config.GCConfig, root string) []bkclient.PruneInfo {
 	}
 	return out
 }
+
+func defaultGCPolicy(keep config.DiskSpace) []config.GCPolicy {
+	if keep == (config.DiskSpace{}) {
+		keep = config.DiskSpace{Percentage: DiskSpacePercentage}
+	}
+	return []config.GCPolicy{
+		// if build cache uses more than 512MB delete the most easily reproducible data after it has not been used for 2 days
+		{
+			Filters:      []string{"type==source.local,type==exec.cachemount,type==source.git.checkout"},
+			KeepDuration: config.Duration{Duration: time.Duration(48) * time.Hour}, // 48h
+			KeepBytes:    config.DiskSpace{Bytes: 512 * 1e6},                       // 512MB
+		},
+		// remove any data not used for 60 days
+		{
+			KeepDuration: config.Duration{Duration: time.Duration(60) * 24 * time.Hour}, // 60d
+			KeepBytes:    keep,
+		},
+		// keep the unshared build cache under cap
+		{
+			KeepBytes: keep,
+		},
+		// if previous policies were insufficient start deleting internal data to keep build cache under cap
+		{
+			All:       true,
+			KeepBytes: keep,
+		},
+	}
+}
+
+const DiskSpacePercentage int64 = 75


### PR DESCRIPTION
When originally updating this in #7563, we only updated the default CLI option - however, this is confusing, and isn't exactly how that works - my suggested refactor wasn't actually correct.

Because we use `GlobalIsSet`, this default is never actually the one that's used. So, we can refactor this, and set a global const to define the default gc policy ourselves, outside of buildkit.

This also opens us up to modifying the gc policy in more detail in the future.