### PR TITLE
ci: add actions check for checking changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,46 @@
+name: needs/changelog
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - labeled
+      - unlabeled
+
+jobs:
+  check-for-changelog:
+    if: contains(github.event.pull_request.labels.*.name, 'needs/changelog')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if PR needs a changelog
+        id: check
+        run: |
+          set -x
+          shopt -s globstar
+
+          diff=$(git diff --name-only origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF -- **/.changes/unreleased)
+          diffReturn=$?
+          if [ $diffReturn -ne 0 ]; then
+            exit $diffReturn
+          fi
+
+          if [ -z "$diff" ]; then
+            echo 'Changelog is required, but was not created.
+            exit 1
+          else
+            echo "Changelog exists."
+          fi
+
+      - name: Add comment
+        uses: thollander/actions-comment-pull-request@v2
+        if: always() && github.event.action == 'labeled' && steps.check.outcome != 'success'
+        with:
+          message: |
+            This PR has been marked with `needs/changelog`, but no changelog has been created.
+
+            Run `changie new` to generate one (see [CONTRIBUTING.md](https://github.com/dagger/dagger/blob/main/CONTRIBUTING.md) for details).


### PR DESCRIPTION
This PR adds a check that if a PR is labelled with `needs/changelog`, then the job will fail and add a comment if no changelog was generated as part of the PR.

This should help us automate some of our changelog writing.

See an example run of this in https://github.com/jedevc/dagger/pull/5.