### PR TITLE
chore: remove `checkVersionCompatibility` field

### DIFF
--- a/.changes/unreleased/Breaking-20240625-151850.yaml
+++ b/.changes/unreleased/Breaking-20240625-151850.yaml
@@ -1,0 +1,6 @@
+kind: Breaking
+body: 'api: removed checkVersionCompatibility field (versioning checks are now automatically performed on all connections)'
+time: 2024-06-25T15:18:50.201460548+01:00
+custom:
+  Author: jedevc
+  PR: "7751"

--- a/cmd/codegen/main.go
+++ b/cmd/codegen/main.go
@@ -54,7 +54,7 @@ func init() {
 
 func ClientGen(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-	dag, err := dagger.Connect(ctx, dagger.WithSkipCompatibilityCheck())
+	dag, err := dagger.Connect(ctx)
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func ClientGen(cmd *cobra.Command, args []string) error {
 
 func Introspect(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-	dag, err := dagger.Connect(ctx, dagger.WithSkipCompatibilityCheck())
+	dag, err := dagger.Connect(ctx)
 	if err != nil {
 		return err
 	}

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -2219,14 +2219,6 @@ type Query {
   ): CacheVolume!
 
   """
-  Checks if the current Dagger Engine is compatible with an SDK's required version.
-  """
-  checkVersionCompatibility(
-    """Version required by the SDK."""
-    version: String!
-  ): Boolean!
-
-  """
   Creates a scratch container.
   
   Optional platform argument initializes new containers to execute and publish

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -531,7 +531,7 @@ func (c *Client) daggerConnect(ctx context.Context) error {
 	c.daggerClient, err = dagger.Connect(
 		context.WithoutCancel(ctx),
 		dagger.WithConn(EngineConn(c)),
-		dagger.WithSkipCompatibilityCheck())
+	)
 	return err
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
 	github.com/a-h/templ v0.2.707
 	github.com/adrg/xdg v0.4.0
-	github.com/blang/semver v3.5.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/charmbracelet/bubbletea v0.26.5
 	github.com/charmbracelet/lipgloss v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,6 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
-github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=

--- a/sdk/elixir/lib/dagger.ex
+++ b/sdk/elixir/lib/dagger.ex
@@ -64,14 +64,6 @@ defmodule Dagger do
         selection: Dagger.Core.QueryBuilder.Selection.query()
       }
 
-      case Dagger.Client.check_version_compatibility(
-             client,
-             Dagger.Core.EngineConn.engine_version()
-           ) do
-        {:error, reason} -> IO.warn("failed to check version compatibility: #{inspect(reason)}")
-        _ -> nil
-      end
-
       {:ok, client}
     end
   end

--- a/sdk/elixir/lib/dagger/gen/client.ex
+++ b/sdk/elixir/lib/dagger/gen/client.ex
@@ -49,15 +49,6 @@ defmodule Dagger.Client do
     }
   end
 
-  @doc "Checks if the current Dagger Engine is compatible with an SDK's required version."
-  @spec check_version_compatibility(t(), String.t()) :: {:ok, boolean()} | {:error, term()}
-  def check_version_compatibility(%__MODULE__{} = client, version) do
-    selection =
-      client.selection |> select("checkVersionCompatibility") |> put_arg("version", version)
-
-    execute(selection, client.client)
-  end
-
   @doc """
   Creates a scratch container.
 

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -2,9 +2,7 @@ package dagger
 
 import (
 	"context"
-	"fmt"
 	"io"
-	"os"
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/vektah/gqlparser/v2/gqlerror"
@@ -53,13 +51,6 @@ func WithConn(conn engineconn.EngineConn) ClientOpt {
 	})
 }
 
-// WithSkipCompatibilityCheck disables the version compatibility check
-func WithSkipCompatibilityCheck() ClientOpt {
-	return clientOptFunc(func(cfg *engineconn.Config) {
-		cfg.SkipCompatibilityCheck = true
-	})
-}
-
 // Connect to a Dagger Engine
 func Connect(ctx context.Context, opts ...ClientOpt) (*Client, error) {
 	cfg := &engineconn.Config{}
@@ -79,15 +70,6 @@ func Connect(ctx context.Context, opts ...ClientOpt) (*Client, error) {
 		client: gql,
 		conn:   conn,
 	}
-
-	if !cfg.SkipCompatibilityCheck {
-		// Call version compatibility.
-		// If versions are not compatible, a warning will be displayed.
-		if _, err = c.CheckVersionCompatibility(ctx, engineconn.CLIVersion); err != nil {
-			fmt.Fprintln(os.Stderr, "failed to check version compatibility:", err)
-		}
-	}
-
 	return c, nil
 }
 

--- a/sdk/go/dag/dag.gen.go
+++ b/sdk/go/dag/dag.gen.go
@@ -58,12 +58,6 @@ func CacheVolume(key string) *dagger.CacheVolume {
 	return client.CacheVolume(key)
 }
 
-// Checks if the current Dagger Engine is compatible with an SDK's required version.
-func CheckVersionCompatibility(ctx context.Context, version string) (bool, error) {
-	client := initClient()
-	return client.CheckVersionCompatibility(ctx, version)
-}
-
 // Creates a scratch container.
 //
 // Optional platform argument initializes new containers to execute and publish as that platform. Platform defaults to that of the builder's host.

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -5709,17 +5709,6 @@ func (r *Client) CacheVolume(key string) *CacheVolume {
 	}
 }
 
-// Checks if the current Dagger Engine is compatible with an SDK's required version.
-func (r *Client) CheckVersionCompatibility(ctx context.Context, version string) (bool, error) {
-	q := r.query.Select("checkVersionCompatibility")
-	q = q.Arg("version", version)
-
-	var response bool
-
-	q = q.Bind(&response)
-	return response, q.Execute(ctx)
-}
-
 // ContainerOpts contains options for Client.Container
 type ContainerOpts struct {
 	// DEPRECATED: Use `loadContainerFromID` instead.

--- a/sdk/go/internal/engineconn/engineconn.go
+++ b/sdk/go/internal/engineconn/engineconn.go
@@ -25,8 +25,6 @@ type Config struct {
 	Workdir   string
 	LogOutput io.Writer
 	Conn      EngineConn
-
-	SkipCompatibilityCheck bool
 }
 
 type ConnectParams struct {

--- a/sdk/php/generated/Client.php
+++ b/sdk/php/generated/Client.php
@@ -47,16 +47,6 @@ class Client extends Client\AbstractClient
     }
 
     /**
-     * Checks if the current Dagger Engine is compatible with an SDK's required version.
-     */
-    public function checkVersionCompatibility(string $version): bool
-    {
-        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('checkVersionCompatibility');
-        $leafQueryBuilder->setArgument('version', $version);
-        return (bool)$this->queryLeaf($leafQueryBuilder, 'checkVersionCompatibility');
-    }
-
-    /**
      * Creates a scratch container.
      *
      * Optional platform argument initializes new containers to execute and publish as that platform. Platform defaults to that of the builder's host.

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -5760,33 +5760,6 @@ class Client(Root):
         _ctx = self._select("cacheVolume", _args)
         return CacheVolume(_ctx)
 
-    async def check_version_compatibility(self, version: str) -> bool:
-        """Checks if the current Dagger Engine is compatible with an SDK's
-        required version.
-
-        Parameters
-        ----------
-        version:
-            Version required by the SDK.
-
-        Returns
-        -------
-        bool
-            The `Boolean` scalar type represents `true` or `false`.
-
-        Raises
-        ------
-        ExecuteTimeoutError
-            If the time to execute the query exceeds the configured timeout.
-        QueryError
-            If the API returns an error.
-        """
-        _args = [
-            Arg("version", version),
-        ]
-        _ctx = self._select("checkVersionCompatibility", _args)
-        return await _ctx.execute(bool)
-
     def container(
         self,
         *,

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -5803,19 +5803,6 @@ impl Query {
             graphql_client: self.graphql_client.clone(),
         }
     }
-    /// Checks if the current Dagger Engine is compatible with an SDK's required version.
-    ///
-    /// # Arguments
-    ///
-    /// * `version` - Version required by the SDK.
-    pub async fn check_version_compatibility(
-        &self,
-        version: impl Into<String>,
-    ) -> Result<bool, DaggerError> {
-        let mut query = self.selection.select("checkVersionCompatibility");
-        query = query.arg("version", version.into());
-        query.execute(self.graphql_client.clone()).await
-    }
     /// Creates a scratch container.
     /// Optional platform argument initializes new containers to execute and publish as that platform. Platform defaults to that of the builder's host.
     ///

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -7336,7 +7336,6 @@ export class Port extends BaseClient {
  * The root of the DAG.
  */
 export class Client extends BaseClient {
-  private readonly _checkVersionCompatibility?: boolean = undefined
   private readonly _defaultPlatform?: Platform = undefined
   private readonly _version?: string = undefined
 
@@ -7345,13 +7344,11 @@ export class Client extends BaseClient {
    */
   constructor(
     parent?: { queryTree?: QueryTree[]; ctx: Context },
-    _checkVersionCompatibility?: boolean,
     _defaultPlatform?: Platform,
     _version?: string,
   ) {
     super(parent)
 
-    this._checkVersionCompatibility = _checkVersionCompatibility
     this._defaultPlatform = _defaultPlatform
     this._version = _version
   }
@@ -7420,25 +7417,6 @@ export class Client extends BaseClient {
       ],
       ctx: this._ctx,
     })
-  }
-
-  /**
-   * Checks if the current Dagger Engine is compatible with an SDK's required version.
-   * @param version Version required by the SDK.
-   */
-  checkVersionCompatibility = async (version: string): Promise<boolean> => {
-    const response: Awaited<boolean> = await computeQuery(
-      [
-        ...this._queryTree,
-        {
-          operation: "checkVersionCompatibility",
-          args: { version },
-        },
-      ],
-      await this._ctx.connection(),
-    )
-
-    return response
   }
 
   /**

--- a/sdk/typescript/connect.ts
+++ b/sdk/typescript/connect.ts
@@ -3,7 +3,6 @@ import * as opentelemetry from "@opentelemetry/api"
 import { Client } from "./api/client.gen.js"
 import { ConnectOpts } from "./connectOpts.js"
 import { Context, defaultContext } from "./context/context.js"
-import { CLI_VERSION } from "./provisioning/index.js"
 import * as telemetry from "./telemetry/telemetry.js"
 
 export type CallbackFct = (client: Client) => Promise<void>
@@ -70,7 +69,7 @@ export async function connect(
 
   // Warning shall be throw if versions are not compatible
   try {
-    await client.checkVersionCompatibility(CLI_VERSION)
+    await client.version()
   } catch (e) {
     console.error("failed to check version compatibility:", e)
   }


### PR DESCRIPTION
Part of #7640 and co.

With changes to how we do version compatibility checks, we no longer need this check in the engine. Thankfully - we can just remove it: all of the SDKs were treating this as a warning level, and not causing a fatal error - this means that if the method is removed, it should not cause a build to fail.

The Go SDK also removes the `WithoutVersionCompatibilityCheck` - since now this option is always the case.