### PR TITLE
fix: plain progress should never use hyperlinks

### DIFF
--- a/.changes/unreleased/Fixed-20240625-161626.yaml
+++ b/.changes/unreleased/Fixed-20240625-161626.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: 'tui: plain progress output should not use hyperlinks (these are not visible in GitHub actions and similar providers)'
+time: 2024-06-25T16:16:26.06113027+01:00
+custom:
+  Author: jedevc
+  PR: "7754"

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -104,11 +104,7 @@ func traceMessage(profile termenv.Profile, url string, msg string) string {
 	out := NewOutput(buffer, termenv.WithProfile(profile))
 
 	fmt.Fprint(buffer, out.String("Full trace at ").Bold().String())
-	if out.Profile == termenv.Ascii {
-		fmt.Fprint(buffer, url)
-	} else {
-		fmt.Fprint(buffer, out.Hyperlink(url, url))
-	}
+	fmt.Fprint(buffer, url)
 	if msg != "" {
 		fmt.Fprintf(buffer, " (%s)", msg)
 	}

--- a/engine/telemetry/url_test.go
+++ b/engine/telemetry/url_test.go
@@ -1,0 +1,34 @@
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseDaggerToken(t *testing.T) {
+	tc := []struct {
+		src      string
+		ok       bool
+		expected daggerToken
+	}{
+		{
+			src:      "bad",
+			ok:       false,
+			expected: daggerToken{},
+		},
+		{
+			src:      "dag_org_token",
+			ok:       true,
+			expected: daggerToken{orgName: "org", token: "token"},
+		},
+	}
+
+	for _, tc := range tc {
+		t.Run(tc.src, func(t *testing.T) {
+			res, ok := parseDaggerToken(tc.src)
+			assert.Equal(t, tc.ok, ok)
+			assert.Equal(t, tc.expected, res)
+		})
+	}
+}


### PR DESCRIPTION
Github actions doesn't support them :cry:

See https://github.com/openmeterio/openmeter/actions/runs/9572449099/job/26391770769?pr=1031#step:3:2161.

In the raw logs, we can see:

> 2024-06-18T21:40:49.1751535Z [1mFull trace at [0m]8;;https://dagger.cloud/\https://dagger.cloud/]8;;\ (rotate dagger.cloud token for full url)

We just can't have hyperlinks here, I missed this before.

---

I've also added a sanity test for the `DAGGER_CLOUD_TOKEN` format, since I was suspicious that this might not be doing the right thing.