### PR TITLE
DagQL ID optimizations

### DIFF
--- a/core/telemetry.go
+++ b/core/telemetry.go
@@ -46,9 +46,9 @@ func AroundFunc(ctx context.Context, self dagql.Object, id *call.ID) (context.Co
 		}
 		attrs = append(attrs, attribute.StringSlice(telemetry.DagInputsAttr, inputs))
 	}
-	// if dagql.IsInternal(ctx) {
-	// 	attrs = append(attrs, attribute.Bool(telemetry.UIInternalAttr, true))
-	// }
+	if dagql.IsInternal(ctx) {
+		attrs = append(attrs, attribute.Bool(telemetry.UIInternalAttr, true))
+	}
 
 	ctx, span := dagql.Tracer().Start(ctx, spanName, trace.WithAttributes(attrs...))
 

--- a/core/telemetry.go
+++ b/core/telemetry.go
@@ -46,9 +46,9 @@ func AroundFunc(ctx context.Context, self dagql.Object, id *call.ID) (context.Co
 		}
 		attrs = append(attrs, attribute.StringSlice(telemetry.DagInputsAttr, inputs))
 	}
-	if dagql.IsInternal(ctx) {
-		attrs = append(attrs, attribute.Bool(telemetry.UIInternalAttr, true))
-	}
+	// if dagql.IsInternal(ctx) {
+	// 	attrs = append(attrs, attribute.Bool(telemetry.UIInternalAttr, true))
+	// }
 
 	ctx, span := dagql.Tracer().Start(ctx, spanName, trace.WithAttributes(attrs...))
 

--- a/dagql/call/id.go
+++ b/dagql/call/id.go
@@ -163,6 +163,15 @@ func (id *ID) Modules() []*Module {
 	return deduped
 }
 
+func (id *ID) PathNamesOnly() string {
+	buf := new(bytes.Buffer)
+	if id.base != nil {
+		fmt.Fprintf(buf, "%s.", id.base.PathNamesOnly())
+	}
+	fmt.Fprint(buf, id.Field())
+	return buf.String()
+}
+
 func (id *ID) Path() string {
 	buf := new(bytes.Buffer)
 	if id.base != nil {

--- a/dagql/objects.go
+++ b/dagql/objects.go
@@ -88,6 +88,16 @@ func (class Class[T]) Field(name string) (Field[T], bool) {
 	return *field, ok
 }
 
+func (class Class[T]) FieldSpec(name string) (FieldSpec, bool) {
+	class.fieldsL.Lock()
+	defer class.fieldsL.Unlock()
+	field, ok := class.fields[name]
+	if !ok {
+		return FieldSpec{}, false
+	}
+	return field.Spec, ok
+}
+
 func (class Class[T]) Install(fields ...Field[T]) {
 	class.fieldsL.Lock()
 	defer class.fieldsL.Unlock()

--- a/dagql/types.go
+++ b/dagql/types.go
@@ -48,6 +48,8 @@ type ObjectType interface {
 	// Unlike natively added fields, the extended func is limited to the external
 	// Object interface.
 	Extend(FieldSpec, FieldFunc)
+	// FieldSpec returns the field spec for the given field name.
+	FieldSpec(string) (FieldSpec, bool)
 }
 
 type IDType interface {


### PR DESCRIPTION
* Detect when a query's sole purpose is to get an ID, and just statically return it rather than evaluating each intermediate call
* Look deeply within a query for ID inputs and evaluate them all in parallel