### PR TITLE
chore: install.sh should not prompt to install completions in ci

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -298,6 +298,20 @@ tarball() {
 }
 
 install_shell_completion() {
+  # don't prompt shell completion installations in CI
+  if [ -n "$CI" ]; then
+    # GitHub Actions, Travis CI, CircleCI, Cirrus CI, GitLab CI, AppVeyor, CodeShip, dsari
+    return 0
+  fi
+  if [ -n "$BUILD_NUMBER" ]; then
+    # Jenkins, TeamCity
+    return 0
+  fi
+  if [ -n "$RUN_ID" ]; then
+    # TaskCluster, dsari
+    return 0
+  fi
+
   echo "
 ${binexe} has built-in shell completion. This is how you can install it for:
 


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/7769.

List of env variables to detect this from is pulled from out own telemetry code:

https://github.com/dagger/dagger/blob/a9155f4b4e68c264e673bbb2a0271701d76c5eb3/engine/telemetry/labels.go#L406-L410