### PR TITLE
ci: fix changelog checking pr

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,6 +7,10 @@ on:
       - synchronize
       - labeled
       - unlabeled
+      
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   check-for-changelog:
@@ -23,7 +27,7 @@ jobs:
           set -x
           shopt -s globstar
 
-          diff=$(git diff --name-only origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF -- **/.changes/unreleased)
+          diff=$(git diff --name-only origin/$GITHUB_BASE_REF...origin/$GITHUB_REF -- **/.changes/unreleased)
           diffReturn=$?
           if [ $diffReturn -ne 0 ]; then
             exit $diffReturn


### PR DESCRIPTION
Fix https://github.com/dagger/dagger/pull/7750.

See run in https://github.com/dagger/dagger/actions/runs/9697150564/job/26760624393?pr=7744.

This wasn't caught in my example runs, since I was running a PR inside a single fork.

The issues fixed here:
- Added permissions to this workflow to mirror other workflows - we need to be able to write to the pull request to be able to add a comment
- Modified `GITHUB_HEAD_REF` to `GITHUB_REF` to get the current state of the PR as resolved by the merge.