### PR TITLE
💥 codegen: don't return `Void`

### DIFF
--- a/cmd/codegen/generator/functions.go
+++ b/cmd/codegen/generator/functions.go
@@ -32,11 +32,12 @@ type FormatTypeFuncs interface {
 
 // CommonFunctions formatting function with global shared template functions.
 type CommonFunctions struct {
+	schemaVersion   string
 	formatTypeFuncs FormatTypeFuncs
 }
 
-func NewCommonFunctions(formatTypeFuncs FormatTypeFuncs) *CommonFunctions {
-	return &CommonFunctions{formatTypeFuncs: formatTypeFuncs}
+func NewCommonFunctions(schemaVersion string, formatTypeFuncs FormatTypeFuncs) *CommonFunctions {
+	return &CommonFunctions{schemaVersion: schemaVersion, formatTypeFuncs: formatTypeFuncs}
 }
 
 // IsSelfChainable returns true if an object type has any fields that return that same type.
@@ -227,6 +228,6 @@ func (c *CommonFunctions) formatType(r *introspection.TypeRef, scope string, inp
 	return "", fmt.Errorf("unexpected type kind %s", r.Kind)
 }
 
-func (c *CommonFunctions) CheckVersionCompatibility(version string, minVersion string) bool {
-	return engine.CheckVersionCompatibility(version, minVersion) == nil
+func (c *CommonFunctions) CheckVersionCompatibility(minVersion string) bool {
+	return engine.CheckVersionCompatibility(c.schemaVersion, minVersion) == nil
 }

--- a/cmd/codegen/generator/go/generator.go
+++ b/cmd/codegen/generator/go/generator.go
@@ -271,7 +271,7 @@ func generateCode(
 	fset *token.FileSet,
 	pass int,
 ) error {
-	funcs := templates.GoTemplateFuncs(ctx, schema, cfg.ModuleName, pkg, fset, pass)
+	funcs := templates.GoTemplateFuncs(ctx, schema, schemaVersion, cfg.ModuleName, pkg, fset, pass)
 	tmpls := templates.Templates(funcs)
 
 	for k, tmpl := range tmpls {

--- a/cmd/codegen/generator/go/templates/functions.go
+++ b/cmd/codegen/generator/go/templates/functions.go
@@ -245,9 +245,12 @@ func (funcs goTemplateFuncs) fieldFunction(f introspection.Field, topLevel bool,
 	if err != nil {
 		return "", err
 	}
-	if f.TypeRef.IsScalar() || f.TypeRef.IsList() {
+	switch {
+	case f.TypeRef.IsVoid():
+		retType = "error"
+	case f.TypeRef.IsScalar() || f.TypeRef.IsList():
 		retType = fmt.Sprintf("(%s, error)", retType)
-	} else {
+	default:
 		retType = "*" + retType
 	}
 	signature += " " + retType

--- a/cmd/codegen/generator/go/templates/module_objects.go
+++ b/cmd/codegen/generator/go/templates/module_objects.go
@@ -448,7 +448,7 @@ func (spec *parsedObjectType) concreteFieldTypeCode(typeSpec ParsedType) (*State
 		s.Id(typeName(typeSpec))
 
 	case *parsedIfaceTypeReference:
-		s.Op("*").Id(formatIfaceImplName(typeSpec.name))
+		s.Op("*").Id(formatIfaceImplName(typeName(typeSpec)))
 
 	default:
 		return nil, fmt.Errorf("unsupported concrete field type %T", typeSpec)

--- a/cmd/codegen/generator/go/templates/modules.go
+++ b/cmd/codegen/generator/go/templates/modules.go
@@ -331,8 +331,7 @@ func dispatch(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("marshal: %w", err)
 	}
-	_, err = fnCall.ReturnValue(ctx, dagger.JSON(resultBytes))
-	if err != nil {
+	if err = fnCall.ReturnValue(ctx, dagger.JSON(resultBytes)); err != nil {
 		return fmt.Errorf("store return value: %w", err)
 	}
 	return nil

--- a/cmd/codegen/generator/go/templates/src/_dagger.gen.go/module.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_dagger.gen.go/module.go.tmpl
@@ -29,7 +29,7 @@ type DaggerObject = dagger.DaggerObject
 type ExecError = dagger.ExecError
 
 {{/* module aliases have been removed in v0.12.0 */}}
-{{ if not (CheckVersionCompatibility .SchemaVersion "v0.12.0") }}
+{{ if not (CheckVersionCompatibility "v0.12.0") }}
 {{ range .Types }}
 {{ $name := .Name | FormatName }}
 

--- a/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
@@ -66,7 +66,11 @@ type {{ $field | FieldOptionsStructName }} struct {
 
     {{- if and ($field.TypeRef.IsScalar) (ne $field.ParentObject.Name "Query") (not $convertID) }}
     if r.{{ $field.Name }} != nil {
+        {{- if $field.TypeRef.IsVoid }}
+        return nil
+        {{- else }}
         return *r.{{ $field.Name }}, nil
+        {{- end }}
     }
     {{- end }}
 	q := r.query.Select("{{ $field.Name }}")
@@ -91,14 +95,16 @@ type {{ $field | FieldOptionsStructName }} struct {
 	{{- end }}
 	{{- end }}
 	{{- $typeName := $field.TypeRef | FormatOutputType }}
-    {{ if $convertID }}
-    var id {{ $typeName }}
-    if err := q.Bind(&id).Execute(ctx); err != nil {
-        return nil, err
-    }
+	{{ if $field.TypeRef.IsVoid }}
+    return q.Execute(ctx)
+	{{- else if $convertID }}
+	var id {{ $typeName }}
+	if err := q.Bind(&id).Execute(ctx); err != nil {
+		return nil, err
+	}
 	return &{{ $field.ParentObject.Name }} {
-        query: q.Root().Select("load{{ $field.ParentObject.Name }}FromID").Arg("id", id),
-    }, nil
+		query: q.Root().Select("load{{ $field.ParentObject.Name }}FromID").Arg("id", id),
+	}, nil
 
 	{{- else if $field.TypeRef.IsObject }}
 	return &{{ $typeName }} {

--- a/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
@@ -57,7 +57,8 @@ type {{ $field | FieldOptionsStructName }} struct {
 {{ $field.DeprecationReason | FormatDeprecation }}
 {{- end }}
 {{- $convertID := $field | ConvertID }}
-{{ FieldFunction $field false }} {
+{{- $supportsVoid := CheckVersionCompatibility "v0.12.0" }}
+{{ FieldFunction $field false $supportsVoid }} {
 	{{- range $arg := $field.Args }}
 	    {{- if and (IsPointer $arg) (not $arg.TypeRef.IsOptional) }}
         assertNotNil("{{ $arg.Name}}", {{ $arg.Name }})
@@ -66,7 +67,7 @@ type {{ $field | FieldOptionsStructName }} struct {
 
     {{- if and ($field.TypeRef.IsScalar) (ne $field.ParentObject.Name "Query") (not $convertID) }}
     if r.{{ $field.Name }} != nil {
-        {{- if $field.TypeRef.IsVoid }}
+        {{- if and $supportsVoid $field.TypeRef.IsVoid }}
         return nil
         {{- else }}
         return *r.{{ $field.Name }}, nil
@@ -95,8 +96,8 @@ type {{ $field | FieldOptionsStructName }} struct {
 	{{- end }}
 	{{- end }}
 	{{- $typeName := $field.TypeRef | FormatOutputType }}
-	{{ if $field.TypeRef.IsVoid }}
-    return q.Execute(ctx)
+	{{ if and $supportsVoid $field.TypeRef.IsVoid }}
+		return q.Execute(ctx)
 	{{- else if $convertID }}
 	var id {{ $typeName }}
 	if err := q.Bind(&id).Execute(ctx); err != nil {

--- a/cmd/codegen/generator/go/templates/src/dag/dag.gen.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/dag/dag.gen.go.tmpl
@@ -52,7 +52,8 @@ func Close() error {
 //
 {{ $field.DeprecationReason | FormatDeprecation }}
 {{- end }}
-{{ FieldFunction $field true "dagger" }} {
+{{- $supportsVoid := CheckVersionCompatibility "v0.12.0" }}
+{{ FieldFunction $field true $supportsVoid "dagger" }} {
 	client := initClient()
 	return client.{{ .Name | FormatName }}(
 		{{- if not $field.TypeRef.IsObject -}}

--- a/cmd/codegen/generator/typescript/generator.go
+++ b/cmd/codegen/generator/typescript/generator.go
@@ -43,7 +43,7 @@ func (g *TypeScriptGenerator) Generate(_ context.Context, schema *introspection.
 		})
 	}
 
-	tmpl := templates.New()
+	tmpl := templates.New(schemaVersion)
 	data := struct {
 		Schema        *introspection.Schema
 		SchemaVersion string

--- a/cmd/codegen/generator/typescript/templates/functions.go
+++ b/cmd/codegen/generator/typescript/templates/functions.go
@@ -12,9 +12,11 @@ import (
 	"github.com/dagger/dagger/cmd/codegen/introspection"
 )
 
-var (
-	commonFunc = generator.NewCommonFunctions(&FormatTypeFunc{})
-	funcMap    = template.FuncMap{
+func TypescriptTemplateFuncs(
+	schemaVersion string,
+) template.FuncMap {
+	commonFunc := generator.NewCommonFunctions(schemaVersion, &FormatTypeFunc{})
+	return template.FuncMap{
 		"CommentToLines":            commentToLines,
 		"FormatDeprecation":         formatDeprecation,
 		"FormatReturnType":          commonFunc.FormatReturnType,
@@ -46,7 +48,7 @@ var (
 		"GetEnumValues":             getEnumValues,
 		"CheckVersionCompatibility": commonFunc.CheckVersionCompatibility,
 	}
-)
+}
 
 // pascalCase change a type name into pascalCase
 func pascalCase(name string) string {

--- a/cmd/codegen/generator/typescript/templates/src/helper_test.go
+++ b/cmd/codegen/generator/typescript/templates/src/helper_test.go
@@ -27,5 +27,5 @@ func updateAndGetFixtures(t *testing.T, filepath, got string) string {
 
 func templateHelper(t *testing.T) *template.Template {
 	t.Helper()
-	return templates.New()
+	return templates.New("")
 }

--- a/cmd/codegen/generator/typescript/templates/src/method_solve.ts.gtpl
+++ b/cmd/codegen/generator/typescript/templates/src/method_solve.ts.gtpl
@@ -27,12 +27,16 @@
 	{{- end }}
 
 	{{- /* Write return type */ -}}
-	{{- "" }}): Promise<{{ . | FormatReturnType }}> => {
+	{{- "" }}): Promise<{{ if .TypeRef.IsVoid }}void{{ else }}{{ . | FormatReturnType }}{{ end }}> => {
 
     {{- /* If it's a scalar, make possible to return its already filled value */ -}}
     {{- if and (.TypeRef.IsScalar) (ne .ParentObject.Name "Query") (not $convertID) }}
     if (this._{{ .Name }}) {
+        {{- if .TypeRef.IsVoid }}
+      return
+        {{- else }}
       return this._{{ .Name }}
+        {{- end }}
     }
 {{ "" }}
     {{- end }}
@@ -62,7 +66,7 @@
 	{{- end }}
 
 	{{- if .TypeRef }}
-    const response: Awaited<{{ if $convertID }}{{ .TypeRef | FormatOutputType }}{{ else }}{{ $promiseRetType }}{{ end }}> = await computeQuery(
+    {{ if not .TypeRef.IsVoid }}const response: Awaited<{{ if $convertID }}{{ .TypeRef | FormatOutputType }}{{ else }}{{ $promiseRetType }}{{ end }}> = {{ end }}await computeQuery(
       [
         ...this._queryTree,
         {
@@ -102,7 +106,7 @@
       ],
       ctx: this._ctx,
     })
-    {{- else -}}
+    {{- else if not .TypeRef.IsVoid -}}
         {{- if and .TypeRef.IsList (IsListOfObject .TypeRef) }}
     return response.map(
       (r) => new {{ . | FormatReturnType | ToSingleType }}(

--- a/cmd/codegen/generator/typescript/templates/templates.go
+++ b/cmd/codegen/generator/typescript/templates/templates.go
@@ -10,7 +10,7 @@ import (
 var srcs embed.FS
 
 // New creates a new template with all the template dependencies set up.
-func New() *template.Template {
+func New(schemaVersion string) *template.Template {
 	topLevelTemplate := "api"
 	templateDeps := []string{
 		topLevelTemplate, "header", "objects", "object", "method", "method_solve", "call_args", "method_comment", "types", "args", "default",
@@ -21,6 +21,7 @@ func New() *template.Template {
 		fileNames = append(fileNames, fmt.Sprintf("src/%s.ts.gtpl", tmpl))
 	}
 
-	tmpl := template.Must(template.New(topLevelTemplate).Funcs(funcMap).ParseFS(srcs, fileNames...))
+	funcs := TypescriptTemplateFuncs(schemaVersion)
+	tmpl := template.Must(template.New(topLevelTemplate).Funcs(funcs).ParseFS(srcs, fileNames...))
 	return tmpl
 }

--- a/cmd/codegen/introspection/introspection.go
+++ b/cmd/codegen/introspection/introspection.go
@@ -85,6 +85,7 @@ const (
 	ScalarFloat   = Scalar("Float")
 	ScalarString  = Scalar("String")
 	ScalarBoolean = Scalar("Boolean")
+	ScalarVoid    = Scalar("Void")
 )
 
 type Type struct {
@@ -223,6 +224,14 @@ func (r TypeRef) IsList() bool {
 		return true
 	}
 	return false
+}
+
+func (r TypeRef) IsVoid() bool {
+	ref := r
+	if r.Kind == TypeKindNonNull {
+		ref = *ref.OfType
+	}
+	return ref.Kind == TypeKindScalar && ref.Name == string(ScalarVoid)
 }
 
 func (r TypeRef) ReferencesType(typeName string) bool {

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -406,7 +406,7 @@ func (fc *FuncCommand) initializeModule(ctx context.Context) (rerr error) {
 	mod := modConf.Source.AsModule().Initialize()
 
 	serveCtx, serveSpan := Tracer().Start(ctx, "installing module", telemetry.Encapsulate())
-	_, err = mod.Serve(serveCtx)
+	err = mod.Serve(serveCtx)
 	telemetry.End(serveSpan, func() error { return err })
 	if err != nil {
 		return err

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -741,7 +741,7 @@ func optionalModCmdWrapper(
 			var loadedMod *dagger.Module
 			if modConf.FullyInitialized() {
 				loadedMod = modConf.Source.AsModule().Initialize()
-				_, err := loadedMod.Serve(ctx)
+				err := loadedMod.Serve(ctx)
 				if err != nil {
 					return fmt.Errorf("failed to serve module: %w", err)
 				}

--- a/core/integration/legacy_test.go
+++ b/core/integration/legacy_test.go
@@ -359,13 +359,14 @@ func (LegacySuite) TestReturnVoid(ctx context.Context, t *testctx.T) {
 	// Changed in dagger/dagger#7773
 	//
 	// Ensure that the old schemas return Void next to error, instead of
-    // just an error. Only Go is a breaking change. Not necessary to test
-    // the others.
+	// just an error. Only Go is a breaking change. Not necessary to test
+	// the others.
 
 	c := connect(ctx, t)
 
-    out, err := daggerCliBase(t, c).
+	out, err := daggerCliBase(t, c).
 		With(daggerExec("init", "--name=test", "--sdk=go", "--source=.")).
+		WithWorkdir("/work").
 		WithNewFile("dagger.json", `{"name": "test", "sdk": "go", "source": ".", "engineVersion": "v0.11.9"}`).
 		WithNewFile("main.go", `package main
 
@@ -378,8 +379,8 @@ func (m *Test) Test(ctx context.Context) (string, error) {
     return string(val), err
 }
 `,
-        ).
-        WithWorkdir("/work/dep").
+		).
+		WithWorkdir("/work/dep").
 		With(daggerExec("init", "--name=dep", "--sdk=go")).
 		With(sdkSource("go", `package main
 
@@ -389,12 +390,12 @@ func (m *Dep) Dummy() error {
     return nil
 }
 `,
-        )).
-        WithWorkdir("/work").
+		)).
+		WithWorkdir("/work").
+		With(daggerExec("install", "./dep")).
 		With(daggerQuery(`{test{test}}`)).
 		Stdout(ctx)
 
 	require.NoError(t, err)
 	require.JSONEq(t, `{"test": {"test": ""}}`, out)
 }
-

--- a/core/integration/localcache_test.go
+++ b/core/integration/localcache_test.go
@@ -219,7 +219,7 @@ func (EngineSuite) TestLocalCacheManualGC(ctx context.Context, t *testctx.T) {
 	}
 
 	// prune everything
-	_, err = c2.DaggerEngine().LocalCache().Prune(ctx)
+	err = c2.DaggerEngine().LocalCache().Prune(ctx)
 	require.NoError(t, err)
 	newEnts, err := c2.DaggerEngine().LocalCache().EntrySet().Entries(ctx)
 	require.NoError(t, err)

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5632,11 +5632,11 @@ func (t *Toplevel) Attempt(ctx context.Context, uniq string) error {
 	if err != nil {
 		return err
 	}
-	_, err = dag.Leaker().Leak(ctx)
+	err = dag.Leaker().Leak(ctx)
 	if err != nil {
 		return err
 	}
-	_, err = dag.LeakerBuild().Leak(ctx)
+	err = dag.LeakerBuild().Leak(ctx)
 	if err != nil {
 		return err
 	}

--- a/core/integration/testdata/modules/go/ifaces/dagger.json
+++ b/core/integration/testdata/modules/go/ifaces/dagger.json
@@ -12,5 +12,5 @@
     }
   ],
   "source": ".",
-  "engineVersion": "dev-0ae56705b6931d473333a1281105edff5f19a9d2"
+  "engineVersion": "v0.12.0"
 }

--- a/core/integration/testdata/modules/go/ifaces/main_test.go
+++ b/core/integration/testdata/modules/go/ifaces/main_test.go
@@ -26,7 +26,7 @@ func TestIface(t *testing.T) {
 
 	t.Run("void", func(t *testing.T) {
 		t.Parallel()
-		_, err := test.Void(ctx, impl.AsTestCustomIface())
+		err := test.Void(ctx, impl.AsTestCustomIface())
 		require.NoError(t, err)
 	})
 

--- a/sdk/go/.changes/unreleased/Breaking-20240627-142405.yaml
+++ b/sdk/go/.changes/unreleased/Breaking-20240627-142405.yaml
@@ -1,0 +1,6 @@
+kind: Breaking
+body: "codegen: don't return `Void`"
+time: 2024-06-27T14:24:05.170038Z
+custom:
+    Author: helderco
+    PR: "7773"

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -2005,16 +2005,13 @@ func (r *DaggerEngineCache) KeepBytes(ctx context.Context) (int, error) {
 }
 
 // Prune the cache of releaseable entries
-func (r *DaggerEngineCache) Prune(ctx context.Context) (Void, error) {
+func (r *DaggerEngineCache) Prune(ctx context.Context) error {
 	if r.prune != nil {
-		return *r.prune, nil
+		return nil
 	}
 	q := r.query.Select("prune")
 
-	var response Void
-
-	q = q.Bind(&response)
-	return response, q.Execute(ctx)
+	return q.Execute(ctx)
 }
 
 // An individual cache entry in a cache entry set
@@ -3674,17 +3671,14 @@ func (r *FunctionCall) ParentName(ctx context.Context) (string, error) {
 }
 
 // Set the return value of the function call to the provided value.
-func (r *FunctionCall) ReturnValue(ctx context.Context, value JSON) (Void, error) {
+func (r *FunctionCall) ReturnValue(ctx context.Context, value JSON) error {
 	if r.returnValue != nil {
-		return *r.returnValue, nil
+		return nil
 	}
 	q := r.query.Select("returnValue")
 	q = q.Arg("value", value)
 
-	var response Void
-
-	q = q.Bind(&response)
-	return response, q.Execute(ctx)
+	return q.Execute(ctx)
 }
 
 // A value passed as a named argument to a function call.
@@ -5185,16 +5179,13 @@ func (r *Module) SDK(ctx context.Context) (string, error) {
 // Serve a module's API in the current session.
 //
 // Note: this can only be called once per session. In the future, it could return a stream or service to remove the side effect.
-func (r *Module) Serve(ctx context.Context) (Void, error) {
+func (r *Module) Serve(ctx context.Context) error {
 	if r.serve != nil {
-		return *r.serve, nil
+		return nil
 	}
 	q := r.query.Select("serve")
 
-	var response Void
-
-	q = q.Bind(&response)
-	return response, q.Execute(ctx)
+	return q.Execute(ctx)
 }
 
 // The source for the module.
@@ -7254,9 +7245,9 @@ type ServiceUpOpts struct {
 }
 
 // Creates a tunnel that forwards traffic from the caller's network to this service.
-func (r *Service) Up(ctx context.Context, opts ...ServiceUpOpts) (Void, error) {
+func (r *Service) Up(ctx context.Context, opts ...ServiceUpOpts) error {
 	if r.up != nil {
-		return *r.up, nil
+		return nil
 	}
 	q := r.query.Select("up")
 	for i := len(opts) - 1; i >= 0; i-- {
@@ -7270,10 +7261,7 @@ func (r *Service) Up(ctx context.Context, opts ...ServiceUpOpts) (Void, error) {
 		}
 	}
 
-	var response Void
-
-	q = q.Bind(&response)
-	return response, q.Execute(ctx)
+	return q.Execute(ctx)
 }
 
 // A Unix or TCP/IP socket that can be mounted into a container.

--- a/sdk/python/.changes/unreleased/Breaking-20240627-142254.yaml
+++ b/sdk/python/.changes/unreleased/Breaking-20240627-142254.yaml
@@ -1,0 +1,6 @@
+kind: Breaking
+body: "codegen: don't return `Void`"
+time: 2024-06-27T14:22:54.515212Z
+custom:
+    Author: helderco
+    PR: "7773"

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -2219,7 +2219,7 @@ class DaggerEngineCache(Type):
         """
         _args: list[Arg] = []
         _ctx = self._select("prune", _args)
-        return await _ctx.execute(Void | None)
+        await _ctx.execute()
 
 
 @typecheck

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -3863,7 +3863,7 @@ class FunctionCall(Type):
             Arg("value", value),
         ]
         _ctx = self._select("returnValue", _args)
-        return await _ctx.execute(Void | None)
+        await _ctx.execute()
 
 
 @typecheck
@@ -5193,7 +5193,7 @@ class Module(Type):
         """
         _args: list[Arg] = []
         _ctx = self._select("serve", _args)
-        return await _ctx.execute(Void | None)
+        await _ctx.execute()
 
     def source(self) -> "ModuleSource":
         """The source for the module."""
@@ -7190,7 +7190,7 @@ class Service(Type):
             Arg("random", random, False),
         ]
         _ctx = self._select("up", _args)
-        return await _ctx.execute(Void | None)
+        await _ctx.execute()
 
 
 @typecheck

--- a/sdk/typescript/.changes/unreleased/Breaking-20240627-142448.yaml
+++ b/sdk/typescript/.changes/unreleased/Breaking-20240627-142448.yaml
@@ -1,0 +1,6 @@
+kind: Breaking
+body: "codegen: don't return `Void`"
+time: 2024-06-27T14:24:48.77892Z
+custom:
+    Author: helderco
+    PR: "7773"

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -3074,12 +3074,12 @@ export class DaggerEngineCache extends BaseClient {
   /**
    * Prune the cache of releaseable entries
    */
-  prune = async (): Promise<Void> => {
+  prune = async (): Promise<void> => {
     if (this._prune) {
-      return this._prune
+      return
     }
 
-    const response: Awaited<Void> = await computeQuery(
+    await computeQuery(
       [
         ...this._queryTree,
         {
@@ -3088,8 +3088,6 @@ export class DaggerEngineCache extends BaseClient {
       ],
       await this._ctx.connection(),
     )
-
-    return response
   }
 }
 
@@ -4949,12 +4947,12 @@ export class FunctionCall extends BaseClient {
    * Set the return value of the function call to the provided value.
    * @param value JSON serialization of the return value.
    */
-  returnValue = async (value: JSON): Promise<Void> => {
+  returnValue = async (value: JSON): Promise<void> => {
     if (this._returnValue) {
-      return this._returnValue
+      return
     }
 
-    const response: Awaited<Void> = await computeQuery(
+    await computeQuery(
       [
         ...this._queryTree,
         {
@@ -4964,8 +4962,6 @@ export class FunctionCall extends BaseClient {
       ],
       await this._ctx.connection(),
     )
-
-    return response
   }
 }
 
@@ -6658,12 +6654,12 @@ export class Module_ extends BaseClient {
    *
    * Note: this can only be called once per session. In the future, it could return a stream or service to remove the side effect.
    */
-  serve = async (): Promise<Void> => {
+  serve = async (): Promise<void> => {
     if (this._serve) {
-      return this._serve
+      return
     }
 
-    const response: Awaited<Void> = await computeQuery(
+    await computeQuery(
       [
         ...this._queryTree,
         {
@@ -6672,8 +6668,6 @@ export class Module_ extends BaseClient {
       ],
       await this._ctx.connection(),
     )
-
-    return response
   }
 
   /**
@@ -9359,12 +9353,12 @@ export class Service extends BaseClient {
    * Frontend is the port accepting traffic on the host, backend is the service port.
    * @param opts.random Bind each tunnel port to a random port on the host.
    */
-  up = async (opts?: ServiceUpOpts): Promise<Void> => {
+  up = async (opts?: ServiceUpOpts): Promise<void> => {
     if (this._up) {
-      return this._up
+      return
     }
 
-    const response: Awaited<Void> = await computeQuery(
+    await computeQuery(
       [
         ...this._queryTree,
         {
@@ -9374,8 +9368,6 @@ export class Service extends BaseClient {
       ],
       await this._ctx.connection(),
     )
-
-    return response
   }
 }
 


### PR DESCRIPTION
> [!WARNING]
> This is a **breaking change** in Go! 💥

Fixes https://github.com/dagger/dagger/issues/6868

When depending on a module's function that doesn't return a value (returns only error or nothing):

```go
func (m *SomeModule) DoSomething() error {
    // do something that may return an error
}
```

Generated client bindings will now return only the error, and not the useless `Void` value (which is always an empty string):

```go
// ❌ before
_, err := dag.SomeModule().DoSomething(ctx)

// ✅ after
err := dag.SomeModule().DoSomething(ctx)
```


## Todo

- [ ] Add backwards compatibility in modules with schema version