### PR TITLE
fix: ctr / dir terminal race condition

### DIFF
--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -1412,6 +1412,8 @@ func (s *containerSchema) terminal(
 	ctr dagql.Instance[*core.Container],
 	args containerTerminalArgs,
 ) (dagql.Instance[*core.Container], error) {
+	copyCtr := dagql.Instance[*core.Container]{Self: ctr.Self.Clone()}
+
 	if args.Cmd == nil || len(args.Cmd) == 0 {
 		args.Cmd = ctr.Self.DefaultTerminalCmd.Args
 	}
@@ -1431,7 +1433,7 @@ func (s *containerSchema) terminal(
 
 	err := ctr.Self.Terminal(ctx, ctr.ID(), &args.TerminalArgs)
 	if err != nil {
-		return ctr, err
+		return copyCtr, err
 	}
 
 	return ctr, nil

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -330,6 +330,8 @@ func (s *directorySchema) terminal(
 	dir dagql.Instance[*core.Directory],
 	args directoryTerminalArgs,
 ) (dagql.Instance[*core.Directory], error) {
+	copyDir := dagql.Instance[*core.Directory]{Self: dir.Self.Clone()}
+
 	if len(args.Cmd) == 0 {
 		args.Cmd = []string{"sh"}
 	}
@@ -339,14 +341,14 @@ func (s *directorySchema) terminal(
 	if args.Container.Valid {
 		inst, err := args.Container.Value.Load(ctx, s.srv)
 		if err != nil {
-			return dir, err
+			return copyDir, err
 		}
 		ctr = inst.Self
 	}
 
 	err := dir.Self.Terminal(ctx, dir.ID(), ctr, &args.TerminalArgs)
 	if err != nil {
-		return dir, err
+		return copyDir, err
 	}
 
 	return dir, nil


### PR DESCRIPTION
Experiment to try fixing race condition that seems to have been introduced by https://github.com/dagger/dagger/commit/82b67892fa47038e85f7bf226e25dfedce0aa320.

cf. corresponding trace: https://dagger.cloud/dagger/traces/c71cecd3d42758687c7437e4b7ec98d1?span=1302c9920a784c73

Not the best implementation but fixes the go races