### PR TITLE
tests: fix race in assigning to err in TestDaggerUp

### DIFF
--- a/core/integration/module_up_test.go
+++ b/core/integration/module_up_test.go
@@ -57,7 +57,7 @@ type Test struct {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 
-		err = cmd.Start()
+		err := cmd.Start()
 		require.NoError(t, err)
 		cleanupExec(t, cmd)
 
@@ -138,7 +138,7 @@ type Test struct {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 
-		err = cmd.Start()
+		err := cmd.Start()
 		require.NoError(t, err)
 		cleanupExec(t, cmd)
 
@@ -171,7 +171,7 @@ type Test struct {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 
-		err = cmd.Start()
+		err := cmd.Start()
 		require.NoError(t, err)
 		cleanupExec(t, cmd)
 


### PR DESCRIPTION
This was introduced #7532 in, by adding a `t.Parallel` to these tests. However, the multiple assignment of `err` has been present from before that.

See the failure: https://dagger.cloud/dagger/traces/c71cecd3d42758687c7437e4b7ec98d1?span=6c83cd34e0be3b36&logs#6c83cd34e0be3b36:L1290