### PR TITLE
rust sdk/refactor/function warnings

### DIFF
--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -329,6 +329,7 @@ dependencies = [
  "serde",
  "serde_graphql_input",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]

--- a/sdk/rust/crates/dagger-bootstrap/src/cli_generate.rs
+++ b/sdk/rust/crates/dagger-bootstrap/src/cli_generate.rs
@@ -30,7 +30,7 @@ impl GenerateCommand {
 
         if let Some(output) = arg_matches.get_one::<String>("output") {
             let mut file = std::fs::File::create(output)?;
-            file.write(code.as_bytes())?;
+            file.write_all(code.as_bytes())?;
         } else {
             println!("{}", code);
         }

--- a/sdk/rust/crates/dagger-codegen/Cargo.toml
+++ b/sdk/rust/crates/dagger-codegen/Cargo.toml
@@ -17,6 +17,7 @@ eyre = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_graphql_input = { workspace = true }
+tracing.workspace = true
 
 genco.workspace = true
 convert_case.workspace = true

--- a/sdk/rust/crates/dagger-codegen/src/rust/mod.rs
+++ b/sdk/rust/crates/dagger-codegen/src/rust/mod.rs
@@ -14,6 +14,7 @@ use crate::visitor::{VisitHandlers, Visitor};
 
 use self::format::FormatTypeFunc;
 use self::templates::enum_tmpl::render_enum;
+use self::templates::heading_tmpl::render_heading;
 use self::templates::input_tmpl::render_input;
 use self::templates::object_tmpl::render_object;
 use self::templates::scalar_tmpl::render_scalar;
@@ -24,7 +25,8 @@ impl Generator for RustGenerator {
     fn generate(&self, schema: Schema) -> eyre::Result<String> {
         let render = Arc::new(Mutex::new(rust::Tokens::new()));
         let common_funcs = Arc::new(CommonFunctions::new(Arc::new(FormatTypeFunc {})));
-        println!("generating dagger for rust");
+
+        tracing::info!("generating dagger for rust");
 
         let visitor = Visitor {
             schema,
@@ -33,7 +35,7 @@ impl Generator for RustGenerator {
                     let render = render.clone();
 
                     move |t| {
-                        println!("generating scalar");
+                        tracing::debug!("generating scalar");
                         let rendered_scalar = render_scalar(t)?;
 
                         let mut render = render.lock().unwrap();
@@ -41,7 +43,7 @@ impl Generator for RustGenerator {
                         render.append(rendered_scalar);
                         render.push();
 
-                        println!("generated scalar");
+                        tracing::debug!("generated scalar");
 
                         Ok(())
                     }
@@ -51,14 +53,14 @@ impl Generator for RustGenerator {
                     let common_funcs = common_funcs.clone();
 
                     move |t| {
-                        println!("generating object");
+                        tracing::debug!("generating object");
                         let rendered_scalar = render_object(&common_funcs, t)?;
 
                         let mut render = render.lock().unwrap();
 
                         render.append(rendered_scalar);
                         render.push();
-                        println!("generated object");
+                        tracing::debug!("generated object");
 
                         Ok(())
                     }
@@ -68,14 +70,14 @@ impl Generator for RustGenerator {
                     let common_funcs = common_funcs.clone();
 
                     move |t| {
-                        println!("generating input");
+                        tracing::debug!("generating input");
                         let rendered_scalar = render_input(&common_funcs, t)?;
 
                         let mut render = render.lock().unwrap();
 
                         render.append(rendered_scalar);
                         render.push();
-                        println!("generated input");
+                        tracing::debug!("generated input");
 
                         Ok(())
                     }
@@ -85,14 +87,14 @@ impl Generator for RustGenerator {
                     let _common_funcs = common_funcs.clone();
 
                     move |t| {
-                        println!("generating enum");
+                        tracing::debug!("generating enum");
                         let rendered_scalar = render_enum(t)?;
 
                         let mut render = render.lock().unwrap();
 
                         render.append(rendered_scalar);
                         render.push();
-                        println!("generated enum");
+                        tracing::debug!("generated enum");
 
                         Ok(())
                     }
@@ -102,12 +104,18 @@ impl Generator for RustGenerator {
 
         visitor.run()?;
 
-        println!("done generating objects");
+        tracing::info!("done generating objects");
 
         let rendered = render.lock().unwrap();
 
-        rendered
+        let body = rendered
             .to_file_string()
-            .context("could not render to file string")
+            .context("could not render to file string")?;
+
+        let heading = render_heading()
+            .to_string()
+            .context("failed to render heaing")?;
+
+        Ok(format!("{heading}\n\n{body}"))
     }
 }

--- a/sdk/rust/crates/dagger-codegen/src/rust/templates/enum_tmpl.rs
+++ b/sdk/rust/crates/dagger-codegen/src/rust/templates/enum_tmpl.rs
@@ -13,15 +13,14 @@ fn render_enum_values(values: &FullType) -> Option<rust::Tokens> {
         .enum_values
         .as_ref()
         .into_iter()
-        .map(|values| {
-            values.into_iter().sorted_by_key(|a| &a.name).map(|val| {
+        .flat_map(|values| {
+            values.iter().sorted_by_key(|a| &a.name).map(|val| {
                 quote! {
                     #[serde(rename = $(val.name.as_ref().map(|n| format!("\"{}\"", n))))]
                     $(val.name.as_ref().map(|n| format_name(n))),
                 }
             })
         })
-        .flatten()
         .collect::<Vec<_>>();
 
     let mut tokens = rust::Tokens::new();

--- a/sdk/rust/crates/dagger-codegen/src/rust/templates/heading_tmpl.rs
+++ b/sdk/rust/crates/dagger-codegen/src/rust/templates/heading_tmpl.rs
@@ -1,0 +1,7 @@
+use genco::{lang::rust, quote};
+
+pub fn render_heading() -> rust::Tokens {
+    quote! {
+       #![allow(clippy::needless_lifetimes)]
+    }
+}

--- a/sdk/rust/crates/dagger-codegen/src/rust/templates/mod.rs
+++ b/sdk/rust/crates/dagger-codegen/src/rust/templates/mod.rs
@@ -1,4 +1,5 @@
 pub mod enum_tmpl;
+pub mod heading_tmpl;
 pub mod input_tmpl;
 pub mod object_tmpl;
 pub mod scalar_tmpl;

--- a/sdk/rust/crates/dagger-codegen/src/rust/templates/object_tmpl.rs
+++ b/sdk/rust/crates/dagger-codegen/src/rust/templates/object_tmpl.rs
@@ -33,15 +33,14 @@ pub fn render_object(funcs: &CommonFunctions, t: &FullType) -> eyre::Result<rust
 
 fn render_optional_args(
     funcs: &CommonFunctions,
-    fields: &Vec<FullTypeFields>,
+    fields: &[FullTypeFields],
 ) -> Option<rust::Tokens> {
     let rendered_fields = fields
         .iter()
-        .map(|f| render_optional_arg(funcs, f))
-        .flatten()
+        .filter_map(|f| render_optional_arg(funcs, f))
         .collect::<Vec<_>>();
 
-    if rendered_fields.len() == 0 {
+    if rendered_fields.is_empty() {
         None
     } else {
         Some(quote! {
@@ -73,13 +72,13 @@ fn render_optional_arg(funcs: &CommonFunctions, field: &FullTypeFields) -> Optio
 
 pub fn render_optional_field_args(
     funcs: &CommonFunctions,
-    args: &Vec<&FullTypeFieldsArgs>,
+    args: &[&FullTypeFieldsArgs],
 ) -> Option<(rust::Tokens, bool)> {
-    if args.len() == 0 {
+    if args.is_empty() {
         return None;
     }
     let mut contains_lifetime = false;
-    let rendered_args = args.into_iter().map(|a| &a.input_value).map(|a| {
+    let rendered_args = args.iter().map(|a| &a.input_value).map(|a| {
         let type_ = funcs.format_immutable_input_type(&a.type_);
         if type_.contains("str") {
             contains_lifetime = true;
@@ -99,13 +98,13 @@ pub fn render_optional_field_args(
     ))
 }
 
-fn render_functions(funcs: &CommonFunctions, fields: &Vec<FullTypeFields>) -> Option<rust::Tokens> {
+fn render_functions(funcs: &CommonFunctions, fields: &[FullTypeFields]) -> Option<rust::Tokens> {
     let rendered_functions = fields
         .iter()
         .map(|f| render_function(funcs, f))
         .collect::<Vec<_>>();
 
-    if rendered_functions.len() > 0 {
+    if !rendered_functions.is_empty() {
         Some(quote! {
             $(for func in rendered_functions join ($['\r']) => $func)
         })

--- a/sdk/rust/crates/dagger-codegen/src/utility.rs
+++ b/sdk/rust/crates/dagger-codegen/src/utility.rs
@@ -10,9 +10,6 @@ impl<'t, T: 't> OptionExt<'t, T> for Option<T> {
     where
         F: FnOnce(&'t T) -> U,
     {
-        match *self {
-            Some(ref x) => Some(f(x)),
-            None => None,
-        }
+        (*self).as_ref().map(f)
     }
 }

--- a/sdk/rust/crates/dagger-codegen/src/visitor.rs
+++ b/sdk/rust/crates/dagger-codegen/src/visitor.rs
@@ -67,7 +67,7 @@ impl Visitor {
             .types
             .as_ref()
             .unwrap()
-            .into_iter()
+            .iter()
             .map(|t| t.as_ref().unwrap())
             .filter(|t| match t.full_type.kind.as_ref().unwrap() == &item.kind {
                 true => match (item.ignore.as_ref(), t.full_type.name.as_ref()) {
@@ -79,13 +79,13 @@ impl Visitor {
                             return false;
                         }
 
-                        return true;
+                        true
                     }
                     (None, Some(name)) => {
                         if name.starts_with("__") {
                             return false;
                         }
-                        return true;
+                        true
                     }
                     _ => false,
                 },
@@ -96,7 +96,7 @@ impl Visitor {
                     .name
                     .as_ref()
                     .unwrap()
-                    .cmp(&b.full_type.name.as_ref().unwrap())
+                    .cmp(b.full_type.name.as_ref().unwrap())
             })
             .map(|t| (*item.handler)(&t.full_type))
             .collect::<eyre::Result<Vec<_>>>()?;

--- a/sdk/rust/crates/dagger-sdk/src/client.rs
+++ b/sdk/rust/crates/dagger-sdk/src/client.rs
@@ -1,7 +1,4 @@
-use std::pin::Pin;
 use std::sync::Arc;
-
-use futures::Future;
 
 use crate::core::config::Config;
 use crate::core::engine::Engine as DaggerEngine;

--- a/sdk/rust/crates/dagger-sdk/src/core/downloader.rs
+++ b/sdk/rust/crates/dagger-sdk/src/core/downloader.rs
@@ -2,7 +2,7 @@ use std::{
     fs::File,
     io::{copy, Write},
     os::unix::prelude::PermissionsExt,
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 use eyre::Context;
@@ -50,16 +50,15 @@ pub struct TempFile {
 
 #[allow(dead_code)]
 impl TempFile {
-    pub fn new(prefix: &str, directory: &PathBuf) -> eyre::Result<Self> {
+    pub fn new(prefix: &str, directory: &Path) -> eyre::Result<Self> {
         let prefix = prefix.to_string();
-        let directory = directory.clone();
 
         let file = tempfile()?;
 
         Ok(Self {
             prefix,
-            directory,
             file,
+            directory: directory.to_path_buf(),
         })
     }
 }

--- a/sdk/rust/crates/dagger-sdk/src/core/engine.rs
+++ b/sdk/rust/crates/dagger-sdk/src/core/engine.rs
@@ -14,6 +14,7 @@ impl Engine {
         Self {}
     }
 
+    #[allow(clippy::wrong_self_convention)]
     async fn from_cli(&self, cfg: &Config) -> eyre::Result<(ConnectParams, DaggerSessionProc)> {
         let cli = Downloader::new(DAGGER_ENGINE_VERSION.into())
             .get_cli()
@@ -43,6 +44,7 @@ impl Engine {
         Ok((conn, Some(proc)))
     }
 
+    #[allow(clippy::wrong_self_convention)]
     async fn from_session_env(&self) -> eyre::Result<ConnectParams> {
         let port = std::env::var("DAGGER_SESSION_PORT").map(|p| p.parse::<u64>())??;
         let token = std::env::var("DAGGER_SESSION_TOKEN")?;
@@ -53,6 +55,7 @@ impl Engine {
         })
     }
 
+    #[allow(clippy::wrong_self_convention)]
     async fn from_local_cli(
         &self,
         cfg: &Config,

--- a/sdk/rust/crates/dagger-sdk/src/core/gql_client.rs
+++ b/sdk/rust/crates/dagger-sdk/src/core/gql_client.rs
@@ -208,7 +208,6 @@ impl GQLClient {
         let _headers: HashMap<String, String> = headers
             .iter()
             .map(|(name, value)| (name.to_string(), value.to_string()))
-            .into_iter()
             .collect();
         Self {
             config: ClientConfig {

--- a/sdk/rust/crates/dagger-sdk/src/core/graphql_client.rs
+++ b/sdk/rust/crates/dagger-sdk/src/core/graphql_client.rs
@@ -43,7 +43,7 @@ impl DefaultGraphQLClient {
 impl GraphQLClient for DefaultGraphQLClient {
     async fn query(&self, query: &str) -> Result<Option<serde_json::Value>, GraphQLError> {
         let res: Option<serde_json::Value> =
-            self.client.query(&query).await.map_err(map_graphql_error)?;
+            self.client.query(query).await.map_err(map_graphql_error)?;
 
         return Ok(res);
     }

--- a/sdk/rust/crates/dagger-sdk/src/core/mod.rs
+++ b/sdk/rust/crates/dagger-sdk/src/core/mod.rs
@@ -1,4 +1,4 @@
-pub const DAGGER_ENGINE_VERSION: &'static str = "0.11.9";
+pub const DAGGER_ENGINE_VERSION: &str = "0.11.9";
 
 pub mod cli_session;
 pub mod config;
@@ -11,11 +11,3 @@ pub mod introspection;
 pub mod logger;
 pub mod schema;
 pub mod session;
-
-pub struct Scalar(String);
-
-pub struct Boolean(bool);
-
-pub struct Int(isize);
-
-pub trait Input {}

--- a/sdk/rust/crates/dagger-sdk/src/core/session.rs
+++ b/sdk/rust/crates/dagger-sdk/src/core/session.rs
@@ -17,6 +17,7 @@ use crate::core::{
 )]
 struct IntrospectionQuery;
 
+#[derive(Default)]
 pub struct Session;
 
 impl Session {

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::needless_lifetimes)]
+
 use crate::core::cli_session::DaggerSessionProc;
 use crate::core::graphql_client::DynGraphQLClient;
 use crate::errors::DaggerError;
@@ -1662,11 +1664,11 @@ impl Container {
     /// Retrieves the list of environment variables passed to commands.
     pub fn env_variables(&self) -> Vec<EnvVariable> {
         let query = self.selection.select("envVariables");
-        return vec![EnvVariable {
+        vec![EnvVariable {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// EXPERIMENTAL API! Subject to change/removal at any time.
     /// Configures all available GPUs on the host to be accessible to this container.
@@ -1746,11 +1748,11 @@ impl Container {
     /// This includes ports already exposed by the image, even if not explicitly added with dagger.
     pub fn exposed_ports(&self) -> Vec<Port> {
         let query = self.selection.select("exposedPorts");
-        return vec![Port {
+        vec![Port {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// Retrieves a file at the given path.
     /// Mounts are included.
@@ -1855,11 +1857,11 @@ impl Container {
     /// Retrieves the list of labels passed to container.
     pub fn labels(&self) -> Vec<Label> {
         let query = self.selection.select("labels");
-        return vec![Label {
+        vec![Label {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// Retrieves the list of paths where a directory is mounted.
     pub async fn mounts(&self) -> Result<Vec<String>, DaggerError> {
@@ -3976,11 +3978,11 @@ impl EnumTypeDef {
     /// The values of the enum.
     pub fn values(&self) -> Vec<EnumValueTypeDef> {
         let query = self.selection.select("values");
-        return vec![EnumValueTypeDef {
+        vec![EnumValueTypeDef {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
 }
 #[derive(Clone)]
@@ -4178,11 +4180,11 @@ impl Function {
     /// Arguments accepted by the function, if any.
     pub fn args(&self) -> Vec<FunctionArg> {
         let query = self.selection.select("args");
-        return vec![FunctionArg {
+        vec![FunctionArg {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// A doc string for the function, if any.
     pub async fn description(&self) -> Result<String, DaggerError> {
@@ -4332,11 +4334,11 @@ impl FunctionCall {
     /// The argument values the function is being invoked with.
     pub fn input_args(&self) -> Vec<FunctionCallArgValue> {
         let query = self.selection.select("inputArgs");
-        return vec![FunctionCallArgValue {
+        vec![FunctionCallArgValue {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// The name of the function being called.
     pub async fn name(&self) -> Result<String, DaggerError> {
@@ -4899,11 +4901,11 @@ impl InputTypeDef {
     /// Static fields defined on this input object, if any.
     pub fn fields(&self) -> Vec<FieldTypeDef> {
         let query = self.selection.select("fields");
-        return vec![FieldTypeDef {
+        vec![FieldTypeDef {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// A unique identifier for this InputTypeDef.
     pub async fn id(&self) -> Result<InputTypeDefId, DaggerError> {
@@ -4931,11 +4933,11 @@ impl InterfaceTypeDef {
     /// Functions defined on this interface, if any.
     pub fn functions(&self) -> Vec<Function> {
         let query = self.selection.select("functions");
-        return vec![Function {
+        vec![Function {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// A unique identifier for this InterfaceTypeDef.
     pub async fn id(&self) -> Result<InterfaceTypeDefId, DaggerError> {
@@ -5035,20 +5037,20 @@ impl Module {
     /// Modules used by this module.
     pub fn dependencies(&self) -> Vec<Module> {
         let query = self.selection.select("dependencies");
-        return vec![Module {
+        vec![Module {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// The dependencies as configured by the module.
     pub fn dependency_config(&self) -> Vec<ModuleDependency> {
         let query = self.selection.select("dependencyConfig");
-        return vec![ModuleDependency {
+        vec![ModuleDependency {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// The doc string of the module, if any
     pub async fn description(&self) -> Result<String, DaggerError> {
@@ -5058,11 +5060,11 @@ impl Module {
     /// Enumerations served by this module.
     pub fn enums(&self) -> Vec<TypeDef> {
         let query = self.selection.select("enums");
-        return vec![TypeDef {
+        vec![TypeDef {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// The generated files and directories made on top of the module source's context directory.
     pub fn generated_context_diff(&self) -> Directory {
@@ -5099,11 +5101,11 @@ impl Module {
     /// Interfaces served by this module.
     pub fn interfaces(&self) -> Vec<TypeDef> {
         let query = self.selection.select("interfaces");
-        return vec![TypeDef {
+        vec![TypeDef {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// The name of the module
     pub async fn name(&self) -> Result<String, DaggerError> {
@@ -5113,11 +5115,11 @@ impl Module {
     /// Objects served by this module.
     pub fn objects(&self) -> Vec<TypeDef> {
         let query = self.selection.select("objects");
-        return vec![TypeDef {
+        vec![TypeDef {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile.
     pub fn runtime(&self) -> Container {
@@ -5320,11 +5322,11 @@ impl ModuleSource {
     /// The dependencies of the module source. Includes dependencies from the configuration and any extras from withDependencies calls.
     pub fn dependencies(&self) -> Vec<ModuleDependency> {
         let query = self.selection.select("dependencies");
-        return vec![ModuleDependency {
+        vec![ModuleDependency {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// The directory containing the module configuration and source code (source code may be in a subdir).
     ///
@@ -5458,11 +5460,11 @@ impl ModuleSource {
     /// The named views defined for this module source, which are sets of directory filters that can be applied to directory arguments provided to functions.
     pub fn views(&self) -> Vec<ModuleSourceView> {
         let query = self.selection.select("views");
-        return vec![ModuleSourceView {
+        vec![ModuleSourceView {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// Update the module source with a new context directory. Only valid for local sources.
     ///
@@ -5614,20 +5616,20 @@ impl ObjectTypeDef {
     /// Static fields defined on this object, if any.
     pub fn fields(&self) -> Vec<FieldTypeDef> {
         let query = self.selection.select("fields");
-        return vec![FieldTypeDef {
+        vec![FieldTypeDef {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// Functions defined on this object, if any.
     pub fn functions(&self) -> Vec<Function> {
         let query = self.selection.select("functions");
-        return vec![Function {
+        vec![Function {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// A unique identifier for this ObjectTypeDef.
     pub async fn id(&self) -> Result<ObjectTypeDefId, DaggerError> {
@@ -5857,11 +5859,11 @@ impl Query {
     /// The TypeDef representations of the objects currently being served in the session.
     pub fn current_type_defs(&self) -> Vec<TypeDef> {
         let query = self.selection.select("currentTypeDefs");
-        return vec![TypeDef {
+        vec![TypeDef {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// The default platform of the engine.
     pub async fn default_platform(&self) -> Result<Platform, DaggerError> {
@@ -6948,11 +6950,11 @@ impl Service {
     /// Retrieves the list of ports provided by the service.
     pub fn ports(&self) -> Vec<Port> {
         let query = self.selection.select("ports");
-        return vec![Port {
+        vec![Port {
             proc: self.proc.clone(),
             selection: query,
             graphql_client: self.graphql_client.clone(),
-        }];
+        }]
     }
     /// Start the service and wait for its health checks to succeed.
     /// Services bound to a Container do not need to be manually started.

--- a/sdk/rust/crates/dagger-sdk/src/logging.rs
+++ b/sdk/rust/crates/dagger-sdk/src/logging.rs
@@ -6,13 +6,8 @@ pub fn default_logging() -> eyre::Result<()> {
     Ok(())
 }
 
+#[derive(Default)]
 pub struct StdLogger {}
-
-impl Default for StdLogger {
-    fn default() -> Self {
-        Self {}
-    }
-}
 
 impl Logger for StdLogger {
     fn stdout(&self, output: &str) -> eyre::Result<()> {
@@ -28,13 +23,8 @@ impl Logger for StdLogger {
     }
 }
 
+#[derive(Default)]
 pub struct TracingLogger {}
-
-impl Default for TracingLogger {
-    fn default() -> Self {
-        Self {}
-    }
-}
 
 impl Logger for TracingLogger {
     fn stdout(&self, output: &str) -> eyre::Result<()> {
@@ -50,16 +40,9 @@ impl Logger for TracingLogger {
     }
 }
 
+#[derive(Default)]
 pub struct AggregateLogger {
     pub loggers: Vec<DynLogger>,
-}
-
-impl Default for AggregateLogger {
-    fn default() -> Self {
-        Self {
-            loggers: Vec::new(),
-        }
-    }
 }
 
 impl Logger for AggregateLogger {

--- a/sdk/rust/crates/dagger-sdk/src/querybuilder.rs
+++ b/sdk/rust/crates/dagger-sdk/src/querybuilder.rs
@@ -189,6 +189,7 @@ impl Selection {
         }
     }
 
+    #[allow(clippy::only_used_in_recursion)]
     fn unpack_resp_value<D>(&self, r: serde_json::Value) -> Result<D, DaggerError>
     where
         D: for<'de> Deserialize<'de>,


### PR DESCRIPTION
This fixes up some nasty code in the internal codegen of the rust sdk. It not only makes it more ideomatic, but also faster because of fewer allocations. 

I also yak shaved a bit as I went, so I removed all the warnings in the codebase that had been around for a while. Clippy sometimes adds new lints, which we can optionally implement. Some of them are more relevant than others.
