### PR TITLE
docs: make quickstart conclusion go to adopting dagger

### DIFF
--- a/docs/current_docs/quickstart/conclusion.mdx
+++ b/docs/current_docs/quickstart/conclusion.mdx
@@ -1,7 +1,6 @@
 ---
 slug: /quickstart/conclusion
 hide_table_of_contents: true
-pagination_next: null
 title: "Conclusion"
 ---
 


### PR DESCRIPTION
fixes https://linear.app/dagger/issue/DOCS-304/add-adopting-dagger-page-to-end-of-quickstart

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
