### PR TITLE
cache: skip uploading cache mounts that already exist

### DIFF
--- a/engine/cache/mountsync.go
+++ b/engine/cache/mountsync.go
@@ -163,6 +163,12 @@ func (m *manager) StartCacheMountSynchronization(ctx context.Context) error {
 					if err != nil {
 						return fmt.Errorf("failed to get cache mount upload url: %w", err)
 					}
+
+					if getURLResp.Skip {
+						bklog.G(ctx).Debugf("skipped pushing cache mount %s", cacheMountName)
+						return nil
+					}
+
 					contentReader := io.NewSectionReader(contentReaderAt, 0, contentLength)
 					httpReq, err := http.NewRequestWithContext(ctx, http.MethodPut, getURLResp.URL, contentReader)
 					if err != nil {

--- a/engine/cache/service.go
+++ b/engine/cache/service.go
@@ -204,6 +204,7 @@ type GetCacheMountUploadURLRequest struct {
 type GetCacheMountUploadURLResponse struct {
 	URL     string
 	Headers map[string]string
+	Skip    bool
 }
 
 type client struct {


### PR DESCRIPTION
The cache manager leverages a check, provided by the cache service, to prevent pushing layers that were previously pushed. In this PR we implement the same behavior for cache mounts. If the cache mount already exists we skip pushing it. 
This will significantly reduce the time it takes to shut down an engine for orgs that have a high number of cache volumes, like ourselves.