### PR TITLE
chore: restore default view to top-level dagger module

### DIFF
--- a/dagger.json
+++ b/dagger.json
@@ -1,0 +1,16 @@
+{
+ "name": "dagger",
+ "views": [
+  {
+    "name": "default",
+    "patterns": [
+      "!bin",
+      "!.git",
+      "!**/node_modules",
+      "!**/.venv",
+      "!**/__pycache__"
+    ]
+  }
+ ]
+}
+

--- a/dev/dagger.json
+++ b/dev/dagger.json
@@ -20,17 +20,5 @@
     }
   ],
   "source": ".",
-  "engineVersion": "v0.11.6",
-  "views": [
-    {
-      "name": "default",
-      "patterns": [
-        "!bin",
-        "!.git",
-        "!**/node_modules",
-        "!**/.venv",
-        "!**/__pycache__"
-      ]
-    }
-  ]
+  "engineVersion": "v0.11.6"
 }


### PR DESCRIPTION
In #7766 we moved `dagger.json` from `./` to `./dev/`. But we forgot to leave the `views` behind - those apply specifically to the root of the repo.