### PR TITLE
cli: add quickstart flow for new users

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -15,6 +15,7 @@ import (
 	"unicode"
 
 	"dagger.io/dagger/telemetry"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/mattn/go-isatty"
 	"github.com/muesli/reflow/indent"
 	"github.com/muesli/reflow/wordwrap"
@@ -165,6 +166,23 @@ var rootCmd = &cobra.Command{
 		}
 
 		return nil
+	},
+	PersistentPostRun: func(cmd *cobra.Command, args []string) {
+		highlight := lipgloss.NewStyle().
+			Bold(true).
+			Underline(true)
+		_, _, ok := enginetel.URLForTrace(cmd.Context())
+		switch {
+		case !ok &&
+			cmd.Flags().Changed("verbose") ||
+			cmd.Flags().Changed("debug") ||
+			cmd == moduleInitCmd:
+			fmt.Fprintf(cmd.ErrOrStderr(), `
+Log-in or create an account to visualize %s in Dagger Cloud:
+https://dagger.cloud/signup?quickstart=true
+
+`, highlight.Render(`pipeline traces`))
+		}
 	},
 }
 

--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -288,7 +288,6 @@ var moduleInstallCmd = &cobra.Command{
 					"source_kind":   "local",
 					"local_subpath": depRootSubpath,
 				})
-
 			}
 
 			return nil

--- a/cmd/dagger/version.go
+++ b/cmd/dagger/version.go
@@ -13,9 +13,8 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print dagger version",
 	// Disable version hook here to avoid double version check
-	PersistentPreRun:  func(*cobra.Command, []string) {},
-	PersistentPostRun: func(*cobra.Command, []string) {},
-	Args:              cobra.NoArgs,
+	PersistentPreRun: func(*cobra.Command, []string) {},
+	Args:             cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(long())
 	},

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5284,7 +5284,7 @@ func (ModuleSuite) TestDaggerListen(ctx context.Context, t *testctx.T) {
 		for range limitTicker(time.Second, 60) {
 			callCmd := hostDaggerCommand(ctx, t, modDir, "--debug", "call", "container-echo", "--string-arg=hi", "stdout")
 			callCmd.Env = append(callCmd.Env, "DAGGER_SESSION_PORT=12456", "DAGGER_SESSION_TOKEN=lol")
-			out, err = callCmd.CombinedOutput()
+			out, err = callCmd.Output()
 			if err == nil {
 				lines := strings.Split(string(out), "\n")
 				lastLine := lines[len(lines)-2]
@@ -5313,7 +5313,7 @@ func (ModuleSuite) TestDaggerListen(ctx context.Context, t *testctx.T) {
 				callCmd := hostDaggerCommand(ctx, t, modDir, "--debug", "query")
 				callCmd.Stdin = strings.NewReader(fmt.Sprintf(`query{container{from(address:"%s"){file(path:"/etc/alpine-release"){contents}}}}`, alpineImage))
 				callCmd.Env = append(callCmd.Env, "DAGGER_SESSION_PORT=12457", "DAGGER_SESSION_TOKEN=lol")
-				out, err = callCmd.CombinedOutput()
+				out, err = callCmd.Output()
 				if err == nil {
 					require.Contains(t, string(out), distconsts.AlpineVersion)
 					return
@@ -5336,7 +5336,7 @@ func (ModuleSuite) TestDaggerListen(ctx context.Context, t *testctx.T) {
 				callCmd := hostDaggerCommand(ctx, t, tmpdir, "--debug", "query")
 				callCmd.Stdin = strings.NewReader(fmt.Sprintf(`query{container{from(address:"%s"){file(path:"/etc/alpine-release"){contents}}}}`, alpineImage))
 				callCmd.Env = append(callCmd.Env, "DAGGER_SESSION_PORT=12458", "DAGGER_SESSION_TOKEN=lol")
-				out, err = callCmd.CombinedOutput()
+				out, err = callCmd.Output()
 				if err == nil {
 					require.Contains(t, string(out), distconsts.AlpineVersion)
 					return

--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -3,10 +3,9 @@ package idtui
 import (
 	"context"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
-
-	"os"
 	"sync"
 	"time"
 

--- a/engine/telemetry/cloud.go
+++ b/engine/telemetry/cloud.go
@@ -17,13 +17,15 @@ import (
 	"golang.org/x/oauth2"
 )
 
-var configuredCloudSpanExporter sdktrace.SpanExporter
-var configuredCloudLogsExporter sdklog.Exporter
-var configuredCloudTelemetry bool
-var ocnfiguredCloudExportersOnce sync.Once
+var (
+	configuredCloudSpanExporter  sdktrace.SpanExporter
+	configuredCloudLogsExporter  sdklog.Exporter
+	configuredCloudTelemetry     bool
+	configuredCloudExportersOnce sync.Once
+)
 
 func ConfiguredCloudExporters(ctx context.Context) (sdktrace.SpanExporter, sdklog.Exporter, bool) {
-	ocnfiguredCloudExportersOnce.Do(func() {
+	configuredCloudExportersOnce.Do(func() {
 		var (
 			authHeader string
 			token      *oauth2.Token


### PR DESCRIPTION
This commit changes the CLI so it prints a custom Dagger Cloud trace URL
when the user is not logged in or no `DAGGER_CLOUD_TOKEN` has been set.

Additionally, a custom message gets printed at the end of `dagger init`
and fro any commands that the user supplied the `-v` or `--debug` flags.

Fixes [DEV-4269](https://linear.app/dagger/issue/DEV-4269) [DEV-4268](https://linear.app/dagger/issue/DEV-4268)

Here's some screenshots about how the feature looks:

Log-in message when `init` is called and CLI is not authenticated
![image](https://github.com/dagger/dagger/assets/1578458/a05577e8-986d-4a55-bc1c-178f4bb0454b)

Full logged out trace URL: 
![image](https://github.com/dagger/dagger/assets/1578458/f289f018-1302-4785-9773-216904801d47)


Log-in message when `-v` is supplied: 
![image](https://github.com/dagger/dagger/assets/1578458/ff771fcf-7569-4475-8405-db11357cf5a7)


The custom `/traces/$id` URL will take the user to the quickstart flow which will create a Dagger Cloud organization after logging in.

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
