### PR TITLE
engine: prevent dagql cache cross-talk of Query object

### DIFF
--- a/core/container.go
+++ b/core/container.go
@@ -281,7 +281,10 @@ func (mnts ContainerMounts) With(newMnt ContainerMount) ContainerMounts {
 }
 
 func (container *Container) From(ctx context.Context, addr string) (*Container, error) {
-	bk := container.Query.Buildkit
+	bk, err := container.Query.Buildkit(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get buildkit client: %w", err)
+	}
 
 	container = container.Clone()
 
@@ -357,8 +360,14 @@ func (container *Container) Build(
 	// set image ref to empty string
 	container.ImageRef = ""
 
-	svcs := container.Query.Services
-	bk := container.Query.Buildkit
+	svcs, err := container.Query.Services(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get services: %w", err)
+	}
+	bk, err := container.Query.Buildkit(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get buildkit client: %w", err)
+	}
 
 	detach, _, err := svcs.StartBindings(ctx, container.Services)
 	if err != nil {
@@ -757,8 +766,14 @@ func (container *Container) Directory(ctx context.Context, dirPath string) (*Dir
 		return nil, err
 	}
 
-	svcs := container.Query.Services
-	bk := container.Query.Buildkit
+	svcs, err := container.Query.Services(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get services: %w", err)
+	}
+	bk, err := container.Query.Buildkit(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get buildkit client: %w", err)
+	}
 
 	// check that the directory actually exists so the user gets an error earlier
 	// rather than when the dir is used
@@ -912,7 +927,11 @@ func (container *Container) chown(
 			return nil, "", err
 		}
 
-		ref, err := bkRef(ctx, container.Query.Buildkit, def.ToPB())
+		bk, err := container.Query.Buildkit(ctx)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to get buildkit client: %w", err)
+		}
+		ref, err := bkRef(ctx, bk, def.ToPB())
 		if err != nil {
 			return nil, "", err
 		}
@@ -1010,9 +1029,11 @@ func (container Container) Evaluate(ctx context.Context) (*buildkit.Result, erro
 		return nil, nil
 	}
 
-	root := container.Query
-
-	detach, _, err := root.Services.StartBindings(ctx, container.Services)
+	svcs, err := container.Query.Services(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get services: %w", err)
+	}
+	detach, _, err := svcs.StartBindings(ctx, container.Services)
 	if err != nil {
 		return nil, err
 	}
@@ -1028,7 +1049,11 @@ func (container Container) Evaluate(ctx context.Context) (*buildkit.Result, erro
 		return nil, err
 	}
 
-	return root.Buildkit.Solve(ctx, bkgw.SolveRequest{
+	bk, err := container.Query.Buildkit(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get buildkit client: %w", err)
+	}
+	return bk.Solve(ctx, bkgw.SolveRequest{
 		Evaluate:   true,
 		Definition: def.ToPB(),
 	})
@@ -1089,8 +1114,14 @@ func (container *Container) Publish(
 		opts[string(exptypes.OptKeyForceCompression)] = strconv.FormatBool(true)
 	}
 
-	svcs := container.Query.Services
-	bk := container.Query.Buildkit
+	svcs, err := container.Query.Services(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get services: %w", err)
+	}
+	bk, err := container.Query.Buildkit(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get buildkit client: %w", err)
+	}
 
 	detach, _, err := svcs.StartBindings(ctx, services)
 	if err != nil {
@@ -1133,8 +1164,14 @@ func (container *Container) Export(
 	forcedCompression ImageLayerCompression,
 	mediaTypes ImageMediaTypes,
 ) error {
-	svcs := container.Query.Services
-	bk := container.Query.Buildkit
+	svcs, err := container.Query.Services(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get services: %w", err)
+	}
+	bk, err := container.Query.Buildkit(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get buildkit client: %w", err)
+	}
 
 	if mediaTypes == "" {
 		// Modern registry implementations support oci types and docker daemons
@@ -1200,9 +1237,15 @@ func (container *Container) AsTarball(
 	forcedCompression ImageLayerCompression,
 	mediaTypes ImageMediaTypes,
 ) (*File, error) {
-	bk := container.Query.Buildkit
-	svcs := container.Query.Services
-	engineHostPlatform := container.Query.Platform
+	bk, err := container.Query.Buildkit(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get buildkit client: %w", err)
+	}
+	svcs, err := container.Query.Services(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get services: %w", err)
+	}
+	engineHostPlatform := container.Query.Platform()
 
 	if mediaTypes == "" {
 		mediaTypes = OCIMediaTypes
@@ -1266,9 +1309,12 @@ func (container *Container) Import(
 	source *File,
 	tag string,
 ) (*Container, error) {
-	bk := container.Query.Buildkit
-	store := container.Query.OCIStore
-	lm := container.Query.LeaseManager
+	bk, err := container.Query.Buildkit(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get buildkit client: %w", err)
+	}
+	store := container.Query.OCIStore()
+	lm := container.Query.LeaseManager()
 
 	container = container.Clone()
 
@@ -1464,7 +1510,11 @@ func (container *Container) ownership(ctx context.Context, owner string) (*Owner
 		return nil, err
 	}
 
-	return resolveUIDGID(ctx, fsSt, container.Query.Buildkit, container.Platform, owner)
+	bk, err := container.Query.Buildkit(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get buildkit client: %w", err)
+	}
+	return resolveUIDGID(ctx, fsSt, bk, container.Platform, owner)
 }
 
 func (container *Container) command(opts ContainerExecOpts) ([]string, error) {

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -50,7 +50,7 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 	mounts := container.Mounts
 	platform := container.Platform
 	if platform.OS == "" {
-		platform = container.Query.Platform
+		platform = container.Query.Platform()
 	}
 
 	args, err := container.command(opts)

--- a/core/file.go
+++ b/core/file.go
@@ -118,8 +118,14 @@ func (file *File) State() (llb.State, error) {
 }
 
 func (file *File) Evaluate(ctx context.Context) (*buildkit.Result, error) {
-	svcs := file.Query.Services
-	bk := file.Query.Buildkit
+	svcs, err := file.Query.Services(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get services: %w", err)
+	}
+	bk, err := file.Query.Buildkit(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get buildkit client: %w", err)
+	}
 
 	detach, _, err := svcs.StartBindings(ctx, file.Services)
 	if err != nil {
@@ -135,8 +141,14 @@ func (file *File) Evaluate(ctx context.Context) (*buildkit.Result, error) {
 
 // Contents handles file content retrieval
 func (file *File) Contents(ctx context.Context) ([]byte, error) {
-	svcs := file.Query.Services
-	bk := file.Query.Buildkit
+	svcs, err := file.Query.Services(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get services: %w", err)
+	}
+	bk, err := file.Query.Buildkit(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get buildkit client: %w", err)
+	}
 
 	detach, _, err := svcs.StartBindings(ctx, file.Services)
 	if err != nil {
@@ -188,8 +200,14 @@ func (file *File) Contents(ctx context.Context) ([]byte, error) {
 }
 
 func (file *File) Stat(ctx context.Context) (*fstypes.Stat, error) {
-	svcs := file.Query.Services
-	bk := file.Query.Buildkit
+	svcs, err := file.Query.Services(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get services: %w", err)
+	}
+	bk, err := file.Query.Buildkit(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get buildkit client: %w", err)
+	}
 
 	detach, _, err := svcs.StartBindings(ctx, file.Services)
 	if err != nil {
@@ -253,8 +271,14 @@ func (file *File) WithTimestamps(ctx context.Context, unix int) (*File, error) {
 }
 
 func (file *File) Open(ctx context.Context) (io.ReadCloser, error) {
-	bk := file.Query.Buildkit
-	svcs := file.Query.Services
+	bk, err := file.Query.Buildkit(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get buildkit client: %w", err)
+	}
+	svcs, err := file.Query.Services(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get services: %w", err)
+	}
 
 	detach, _, err := svcs.StartBindings(ctx, file.Services)
 	if err != nil {
@@ -271,8 +295,14 @@ func (file *File) Open(ctx context.Context) (io.ReadCloser, error) {
 }
 
 func (file *File) Export(ctx context.Context, dest string, allowParentDirPath bool) (rerr error) {
-	svcs := file.Query.Services
-	bk := file.Query.Buildkit
+	svcs, err := file.Query.Services(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get services: %w", err)
+	}
+	bk, err := file.Query.Buildkit(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get buildkit client: %w", err)
+	}
 
 	src, err := file.State()
 	if err != nil {

--- a/core/git.go
+++ b/core/git.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/moby/buildkit/client/llb"
 	"github.com/pkg/errors"
@@ -66,7 +67,10 @@ func (ref *GitRef) Tree(ctx context.Context) (*Directory, error) {
 }
 
 func (ref *GitRef) Commit(ctx context.Context) (string, error) {
-	bk := ref.Query.Buildkit
+	bk, err := ref.Query.Buildkit(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get buildkit client: %w", err)
+	}
 	st, err := ref.getState(ctx)
 	if err != nil {
 		return "", err

--- a/core/modfunc.go
+++ b/core/modfunc.go
@@ -208,7 +208,7 @@ func (fn *ModuleFunction) Call(ctx context.Context, opts *CallOpts) (t dagql.Typ
 
 	ctr := fn.runtime
 
-	metaDir := NewScratchDirectory(mod.Query, mod.Query.Platform)
+	metaDir := NewScratchDirectory(mod.Query, mod.Query.Platform())
 	ctr, err = ctr.WithMountedDirectory(ctx, modMetaDirPath, metaDir, "", false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to mount mod metadata directory: %w", err)

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -521,7 +521,7 @@ func (s *containerSchema) container(ctx context.Context, parent *core.Query, arg
 	if args.Platform.Valid {
 		platform = args.Platform.Value
 	} else {
-		platform = parent.Platform
+		platform = parent.Platform()
 	}
 	return parent.NewContainer(platform), nil
 }
@@ -1221,7 +1221,10 @@ func (s *containerSchema) export(ctx context.Context, parent *core.Container, ar
 	if err != nil {
 		return "", err
 	}
-	bk := parent.Query.Buildkit
+	bk, err := parent.Query.Buildkit(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get buildkit: %w", err)
+	}
 	stat, err := bk.StatCallerHostPath(ctx, args.Path, true)
 	if err != nil {
 		return "", err
@@ -1277,12 +1280,20 @@ func (s *containerSchema) withRegistryAuth(ctx context.Context, parent *core.Con
 		return nil, err
 	}
 
-	secretBytes, err := parent.Query.Secrets.GetSecret(ctx, secret.Self.Accessor)
+	secretStore, err := parent.Query.Secrets(ctx)
+	if err != nil {
+		return nil, err
+	}
+	secretBytes, err := secretStore.GetSecret(ctx, secret.Self.Accessor)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := parent.Query.Auth.AddCredential(args.Address, args.Username, string(secretBytes)); err != nil {
+	auth, err := parent.Query.Auth(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := auth.AddCredential(args.Address, args.Username, string(secretBytes)); err != nil {
 		return nil, err
 	}
 
@@ -1293,8 +1304,12 @@ type containerWithoutRegistryAuthArgs struct {
 	Address string
 }
 
-func (s *containerSchema) withoutRegistryAuth(_ context.Context, parent *core.Container, args containerWithoutRegistryAuthArgs) (*core.Container, error) {
-	if err := parent.Query.Auth.RemoveCredential(args.Address); err != nil {
+func (s *containerSchema) withoutRegistryAuth(ctx context.Context, parent *core.Container, args containerWithoutRegistryAuthArgs) (*core.Container, error) {
+	auth, err := parent.Query.Auth(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := auth.RemoveCredential(args.Address); err != nil {
 		return nil, err
 	}
 

--- a/core/schema/file.go
+++ b/core/schema/file.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 
 	"github.com/dagger/dagger/core"
@@ -98,7 +99,10 @@ func (s *fileSchema) export(ctx context.Context, parent *core.File, args fileExp
 	if err != nil {
 		return "", err
 	}
-	bk := parent.Query.Buildkit
+	bk, err := parent.Query.Buildkit(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get buildkit client: %w", err)
+	}
 	stat, err := bk.StatCallerHostPath(ctx, args.Path, true)
 	if err != nil {
 		return "", err

--- a/core/schema/git.go
+++ b/core/schema/git.go
@@ -111,7 +111,7 @@ func (s *gitSchema) git(ctx context.Context, parent *core.Query, args gitArgs) (
 		SSHKnownHosts: args.SSHKnownHosts,
 		SSHAuthSocket: authSock,
 		Services:      svcs,
-		Platform:      parent.Platform,
+		Platform:      parent.Platform(),
 	}, nil
 }
 

--- a/core/schema/http.go
+++ b/core/schema/http.go
@@ -66,5 +66,5 @@ func (s *httpSchema) http(ctx context.Context, parent *core.Query, args httpArgs
 	}
 
 	st := httpdns.HTTP(args.URL, clientMetadata.SessionID, opts...)
-	return core.NewFileSt(ctx, parent, st, filename, parent.Platform, svcs)
+	return core.NewFileSt(ctx, parent, st, filename, parent.Platform(), svcs)
 }

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -820,7 +820,11 @@ func (s *moduleSchema) updateDeps(
 		return fmt.Errorf("failed to initialize dependency modules: %w", err)
 	}
 
-	mod.Deps = core.NewModDeps(src.Self.Query, src.Self.Query.DefaultDeps.Mods)
+	defaultDeps, err := src.Self.Query.DefaultDeps(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get default dependencies: %w", err)
+	}
+	mod.Deps = core.NewModDeps(src.Self.Query, defaultDeps.Mods)
 	for _, dep := range mod.DependenciesField {
 		mod.Deps = mod.Deps.Append(dep.Self)
 	}

--- a/core/schema/platform.go
+++ b/core/schema/platform.go
@@ -23,5 +23,5 @@ func (s *platformSchema) Install() {
 }
 
 func (s *platformSchema) defaultPlatform(ctx context.Context, parent *core.Query, _ struct{}) (core.Platform, error) {
-	return parent.Platform, nil
+	return parent.Platform(), nil
 }

--- a/core/schema/secret.go
+++ b/core/schema/secret.go
@@ -70,7 +70,11 @@ func (s *secretSchema) setSecret(ctx context.Context, parent *core.Query, args s
 	if err != nil {
 		return i, err
 	}
-	if err := parent.Secrets.AddSecret(ctx, accessor, []byte(args.Plaintext)); err != nil {
+	secretStore, err := parent.Secrets(ctx)
+	if err != nil {
+		return i, err
+	}
+	if err := secretStore.AddSecret(ctx, accessor, []byte(args.Plaintext)); err != nil {
 		return i, err
 	}
 
@@ -100,7 +104,11 @@ func (s *secretSchema) name(ctx context.Context, secret *core.Secret, args struc
 }
 
 func (s *secretSchema) plaintext(ctx context.Context, secret *core.Secret, args struct{}) (dagql.String, error) {
-	bytes, err := secret.Query.Secrets.GetSecret(ctx, secret.Accessor)
+	secretStore, err := secret.Query.Secrets(ctx)
+	if err != nil {
+		return "", err
+	}
+	bytes, err := secretStore.GetSecret(ctx, secret.Accessor)
 	if err != nil {
 		if errors.Is(err, secrets.ErrNotFound) {
 			return "", errors.Wrapf(secrets.ErrNotFound, "secret %s", secret.Name)

--- a/core/schema/service.go
+++ b/core/schema/service.go
@@ -143,7 +143,11 @@ func (s *serviceSchema) up(ctx context.Context, svc dagql.Instance[*core.Service
 		return void, fmt.Errorf("failed to select host service: %w", err)
 	}
 
-	runningSvc, err := hostSvc.Self.Query.Services.Start(ctx, hostSvc.ID(), hostSvc.Self)
+	svcs, err := hostSvc.Self.Query.Services(ctx)
+	if err != nil {
+		return void, fmt.Errorf("failed to get host services: %w", err)
+	}
+	runningSvc, err := svcs.Start(ctx, hostSvc.ID(), hostSvc.Self)
 	if err != nil {
 		return void, fmt.Errorf("failed to start host service: %w", err)
 	}

--- a/core/terminal.go
+++ b/core/terminal.go
@@ -33,7 +33,11 @@ func (container *Container) Terminal(
 	svcID *call.ID,
 	args *TerminalArgs,
 ) error {
-	term, err := container.Query.Buildkit.OpenTerminal(ctx)
+	bk, err := container.Query.Buildkit(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get buildkit client: %w", err)
+	}
+	term, err := bk.OpenTerminal(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to open terminal: %w", err)
 	}

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -1065,7 +1065,11 @@ func (fnCall *FunctionCall) ReturnValue(ctx context.Context, val JSON) error {
 	// filesystem. This ensures that the result is cached as part of the module
 	// function's Exec while also keeping SDKs as agnostic as possible to the
 	// format + location of that result.
-	return fnCall.Query.Buildkit.IOReaderExport(
+	bk, err := fnCall.Query.Buildkit(ctx)
+	if err != nil {
+		return fmt.Errorf("get buildkit client: %w", err)
+	}
+	return bk.IOReaderExport(
 		ctx,
 		bytes.NewReader(val),
 		filepath.Join(modMetaDirPath, modMetaOutputPath),


### PR DESCRIPTION
(Spinning this commit out of https://github.com/dagger/dagger/pull/7804 because it's super tedious+boring and bloating that other PR too much on top the actual interesting parts.)

To fully isolate client-specific resources within a session, we need to move off of storing things like the SecretStore as fields on Query. This is because the dagql cache is shared across a session, meaning it can return objects from other clients that should not be used.

I just went ahead and got rid of all the fields on Query and turned them into methods. *Technically* it wasn't necessary for all of them, but it's more consistent this way and sets us up for cross-session dagql caching if ever needed.
