### PR TITLE
docs: add docs for proxy+CA support

### DIFF
--- a/docs/current_docs/manuals/administrator/engine/custom-ca.mdx
+++ b/docs/current_docs/manuals/administrator/engine/custom-ca.mdx
@@ -1,0 +1,30 @@
+---
+slug: /manuals/administrator/custom-ca
+---
+
+# Configure the Engine to use Custom Certificate Authorities
+
+The Dagger Engine can be configured to use custom certificate authorities (CAs) when communicating with external services like container registries, Git repositories, etc.
+
+There is additional *best-effort* support for automatic installation of these custom CAs in user containers.
+
+Configuring the engine with custom CAs currently requires [provisioning a custom engine](./custom-runner.mdx).
+
+To be applied, the custom CAs should be placed in the `/usr/local/share/ca-certificates/` directory of the Engine container. No further commands are necessary; the CAs will be automatically installed on Engine startup if found in that directory.
+
+## Configuration Applied to User Containers
+
+As mentioned above, there is *best-effort* support for automatically installing the Engine's custom CAs in all Containers created by user pipelines (i.e. those created via a `withExec` API call).
+
+This is useful so that Dagger code you are not in direct control of (e.g. an external Module dependency) does not need to be forked and updated to use your custom CAs in order to operate in your network where those CAs may be strictly required.
+
+The support is best-effort because CAs are not standardized, which means the exact way they are configured depends on base image of the Container.
+
+Currently, the Engine supports automatically installing custom CAs in images with the following base distributions:
+- Alpine
+- Debian-based (e.g. `debian` and `ubuntu`)
+- Redhat-based (e.g. `rhel`, `fedora`, `centos`, etc.)
+
+If custom CAs are installed and the engine detects one of these base images are being used, it will attempt to install the custom CAs into the container before executing it.
+* If the installation fails, the error is logged but execution continues without the CA being installed.
+* When the container exits, the CAs are also automatically removed to prevent them from leaking into the cache or into any published images.

--- a/docs/current_docs/manuals/administrator/engine/index.mdx
+++ b/docs/current_docs/manuals/administrator/engine/index.mdx
@@ -8,3 +8,5 @@ This section provides information to help you customize and adapt your usage of 
 
 - [Use a custom runner](./custom-runner.mdx)
 - [Use a custom registry](./custom-registry.mdx)
+- [Configure proxy settings](./proxy.mdx)
+- [Configure custom certificate authorities](./custom-ca.mdx)

--- a/docs/current_docs/manuals/administrator/engine/proxy.mdx
+++ b/docs/current_docs/manuals/administrator/engine/proxy.mdx
@@ -1,0 +1,28 @@
+---
+slug: /manuals/administrator/proxy
+---
+
+# Configure the Engine to use Proxies
+
+The Dagger Engine can be configured to use HTTP(S) proxies to connect to external HTTP services. This configuration applies to "core" operations like pulling container images, cloning Git repositories, etc. and is also supplied to user containers in the form of standard environment variables.
+
+The engine supports the following standard environment variables:
+- `HTTP_PROXY`
+- `HTTPS_PROXY`
+- `NO_PROXY`
+- `ALL_PROXY`
+- `FTP_PROXY`
+
+Configuring the engine with these settings currently requires [provisioning a custom engine](./custom-runner.mdx).
+
+To be applied, one or more of the environment variables listed above just need to be set on the custom engine container.
+
+## Configuration Applied to User Containers
+
+As mentioned above, these proxy environment variables set on the Engine will also be automatically set on all Containers created by user pipelines (i.e. those created via a `withExec` API call).
+
+This is useful so that Dagger code you are not in direct control of (e.g. an external Module dependency) does not need to be forked and updated to use your proxies in order to operate in your network where those proxy settings may be strictly required.
+
+The values of these environment variables do *not* impact the caching of those containers and are not persisted in Dagger's cache. Changing the value of the settings won't invalidate the cache of the container's execution.
+
+Additionally, if the `withEnvVariable` API is used to explicitly set any of those proxy environment variable values, those will override any settings inherited from the Engine's proxy configuration.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -462,6 +462,16 @@ module.exports = {
               "type": "doc",
               "label": "Custom Registry",
               "id": "manuals/administrator/engine/custom-registry"
+            },
+            {
+              "type": "doc",
+              "label": "Proxy Configuration",
+              "id": "manuals/administrator/engine/proxy"
+            },
+            {
+              "type": "doc",
+              "label": "Custom Certificate Authorities",
+              "id": "manuals/administrator/engine/custom-ca"
             }
           ]
         },


### PR DESCRIPTION
(Not sure who to request reviews from while Vikram is on PTO, just chose a couple obvious candidates)

Filling in docs on this support now that it has baked with reports of successful usage for a bit.

NOTE: I'm purposely leaving out the experimental GOPROXY support from here for now since it's still in the "hacky _DAGGER_ENGINE_SYSTEMENV_GOPROXY" stage that is more of a bandaid than the http proxy+CA support, pending further work to formalize and stabilize it (https://github.com/dagger/dagger/issues/6599).
* If we're okay with including stuff like that in our official docs, happy to update this with it too