### PR TITLE
fix: correct exposed port from 8080 to 80

### DIFF
--- a/docs/current_docs/quickstart/snippets/build/python/__init__.py
+++ b/docs/current_docs/quickstart/snippets/build/python/__init__.py
@@ -23,5 +23,5 @@ class HelloDagger:
             # copy the build output directory to the container
             .with_directory("/usr/share/nginx/html", build)
             # expose the container port
-            .with_exposed_port(8080)
+            .with_exposed_port(80)
         )

--- a/docs/current_docs/quickstart/snippets/build/typescript/index.ts
+++ b/docs/current_docs/quickstart/snippets/build/typescript/index.ts
@@ -22,7 +22,7 @@ class HelloDagger {
         // copy the build output directory to the container
         .withDirectory("/usr/share/nginx/html", build)
         // expose the container port
-        .withExposedPort(8080)
+        .withExposedPort(80)
     )
   }
 }

--- a/docs/current_docs/quickstart/snippets/daggerize/python/__init__.py
+++ b/docs/current_docs/quickstart/snippets/daggerize/python/__init__.py
@@ -26,7 +26,7 @@ class HelloDagger:
             dag.container()
             .from_("nginx:1.25-alpine")
             .with_directory("/usr/share/nginx/html", build)
-            .with_exposed_port(8080)
+            .with_exposed_port(80)
         )
 
     @function

--- a/docs/current_docs/quickstart/snippets/daggerize/typescript/index.ts
+++ b/docs/current_docs/quickstart/snippets/daggerize/typescript/index.ts
@@ -25,7 +25,7 @@ class HelloDagger {
       .container()
       .from("nginx:1.25-alpine")
       .withDirectory("/usr/share/nginx/html", build)
-      .withExposedPort(8080)
+      .withExposedPort(80)
   }
 
   /**


### PR DESCRIPTION
In the quickstart, the Go SDK example has the correct exposed Nginx port of 80, but the Python and TypeScript examples incorrectly have 8080.

This means that if a user follows the TS or Python examples and runs this as a service by following

`dagger call build --source=. as-service up --ports 8080:80`

They will never get to connect to Nginx from their local browser.

