### PR TITLE
feat: expand tilde in secret, directory and file argument

### DIFF
--- a/.changes/unreleased/Added-20240708-220148.yaml
+++ b/.changes/unreleased/Added-20240708-220148.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Expand tilde (`~`) in file, directory and secret file argument
+time: 2024-07-08T22:01:48.402755244+07:00
+custom:
+    Author: wingyplus
+    PR: "7818"

--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/csv"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -285,6 +286,10 @@ func (v *directoryValue) Get(ctx context.Context, dag *dagger.Client, modSrc *da
 	// POSIX "portable filename character set":
 	// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282
 	path, viewName, _ := strings.Cut(path, ":")
+	path, err = expandHomeDir(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to expand home directory: %w", err)
+	}
 	path = filepath.ToSlash(path) // make windows paths usable in the Linux engine container
 
 	return modSrc.ResolveDirectoryFromCaller(path, dagger.ModuleSourceResolveDirectoryFromCallerOpts{
@@ -359,11 +364,16 @@ func (v *fileValue) Get(_ context.Context, dag *dagger.Client, _ *dagger.ModuleS
 	vStr = strings.TrimPrefix(vStr, "file://")
 	if !filepath.IsAbs(vStr) {
 		var err error
+		vStr, err = expandHomeDir(vStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to expand home directory: %w", err)
+		}
 		vStr, err = filepath.Abs(vStr)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve absolute path: %w", err)
 		}
 	}
+
 	vStr = filepath.ToSlash(vStr) // make windows paths usable in the Linux engine container
 	return dag.Host().File(vStr), nil
 }
@@ -424,14 +434,9 @@ func (v *secretValue) Get(ctx context.Context, c *dagger.Client, _ *dagger.Modul
 		plaintext = envPlaintext
 
 	case fileSecretSource:
-		sourceVal := v.sourceVal
-		// For unix, automatic expand tilde (~) to $HOME
-		if sourceVal[0] == '~' {
-			homeDir, err := os.UserHomeDir()
-			if err != nil {
-				return nil, err
-			}
-			sourceVal = strings.Replace(sourceVal, "~", homeDir, 1)
+		sourceVal, err := expandHomeDir(v.sourceVal)
+		if err != nil {
+			return nil, err
 		}
 		filePlaintext, err := os.ReadFile(sourceVal)
 		if err != nil {
@@ -861,4 +866,19 @@ func writeAsCSV(vals []string) (string, error) {
 	}
 	w.Flush()
 	return strings.TrimSuffix(b.String(), "\n"), nil
+}
+
+func expandHomeDir(path string) (string, error) {
+	if path[0] != '~' {
+		return path, nil
+	}
+	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
+		return "", errors.New("cannot expand home directory")
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return strings.Replace(path, "~", homeDir, 1), nil
 }

--- a/cmd/dagger/flags.go
+++ b/cmd/dagger/flags.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"reflect"
 	"strconv"
@@ -427,12 +426,12 @@ func (v *secretValue) Get(ctx context.Context, c *dagger.Client, _ *dagger.Modul
 	case fileSecretSource:
 		sourceVal := v.sourceVal
 		// For unix, automatic expand tilde (~) to $HOME
-		if strings.HasPrefix(sourceVal, "~") {
-			usr, err := user.Current()
+		if sourceVal[0] == '~' {
+			homeDir, err := os.UserHomeDir()
 			if err != nil {
 				return nil, err
 			}
-			sourceVal = strings.Replace(sourceVal, "~", usr.HomeDir, 1)
+			sourceVal = strings.Replace(sourceVal, "~", homeDir, 1)
 		}
 		filePlaintext, err := os.ReadFile(sourceVal)
 		if err != nil {

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -426,7 +426,8 @@ func (m *Test) Insecure(ctx context.Context, token *Secret) (string, error) {
 `,
 			}).
 			WithEnvVariable("TOPSECRET", "shhh").
-			WithNewFile("/mysupersecret", dagger.ContainerWithNewFileOpts{Contents: "file shhh"})
+			WithNewFile("/mysupersecret", dagger.ContainerWithNewFileOpts{Contents: "file shhh"}).
+			WithNewFile("/root/homesupersecret", dagger.ContainerWithNewFileOpts{Contents: "file shhh"})
 
 		t.Run("explicit env", func(ctx context.Context, t *testctx.T) {
 			t.Run("happy", func(ctx context.Context, t *testctx.T) {
@@ -457,6 +458,11 @@ func (m *Test) Insecure(ctx context.Context, token *Secret) (string, error) {
 				out, err := modGen.With(daggerCall("insecure", "--token", "file:/mysupersecret")).Stdout(ctx)
 				require.NoError(t, err)
 				require.Equal(t, "file shhh", out)
+
+				out, err = modGen.With(daggerCall("insecure", "--token", "file:~/homesupersecret")).Stdout(ctx)
+				require.NoError(t, err)
+				require.Equal(t, "file shhh", out)
+
 			})
 			t.Run("sad", func(ctx context.Context, t *testctx.T) {
 				_, err := modGen.With(daggerCall("insecure", "--token", "file:/nowheretobefound")).Stdout(ctx)

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -257,7 +257,6 @@ func (m *Test) Fn(dir *Directory) *Directory {
 				out, err = modGen.With(daggerCall("fn", "--dir", "~/subdir", "entries")).Stdout(ctx)
 				require.NoError(t, err)
 				require.Equal(t, "bar.txt\n", out)
-
 			})
 
 			t.Run("rel path", func(ctx context.Context, t *testctx.T) {
@@ -423,7 +422,6 @@ func (m *Test) Fn(file *File) *File {
 			out, err := modGen.With(daggerCall("fn", "--file", "~/foo.txt", "contents")).Stdout(ctx)
 			require.NoError(t, err)
 			require.Equal(t, "foo", out)
-
 		})
 
 		t.Run("rel path", func(ctx context.Context, t *testctx.T) {
@@ -523,7 +521,6 @@ func (m *Test) Insecure(ctx context.Context, token *Secret) (string, error) {
 				out, err = modGen.With(daggerCall("insecure", "--token", "file:~/homesupersecret")).Stdout(ctx)
 				require.NoError(t, err)
 				require.Equal(t, "file shhh", out)
-
 			})
 			t.Run("sad", func(ctx context.Context, t *testctx.T) {
 				_, err := modGen.With(daggerCall("insecure", "--token", "file:/nowheretobefound")).Stdout(ctx)


### PR DESCRIPTION
In this PR, add expand tilde (`~`) to home directory on directory, file and secret file source argument. The home directory rely on `os.UserHomeDir()` that using `$HOME` for unix and `$env:USERPROFILE` on Windows. 

Ref for discussion: https://discord.com/channels/707636530424053791/1003718839739105300/1258097710851162145