### PR TITLE
tests: avoid GHA slowdown from huge single line strings

### DIFF
--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -84,17 +84,17 @@ func DumpID(out *termenv.Output, id *call.ID) error {
 type renderer struct {
 	FrontendOpts
 
-	db        *DB
-	width     int
-	rendering map[string]bool
+	db            *DB
+	maxLiteralLen int
+	rendering     map[string]bool
 }
 
-func newRenderer(db *DB, width int, fe FrontendOpts) renderer {
+func newRenderer(db *DB, maxLiteralLen int, fe FrontendOpts) renderer {
 	return renderer{
-		FrontendOpts: fe,
-		db:           db,
-		width:        width,
-		rendering:    map[string]bool{},
+		FrontendOpts:  fe,
+		db:            db,
+		maxLiteralLen: maxLiteralLen,
+		rendering:     map[string]bool{},
 	}
 }
 
@@ -263,7 +263,7 @@ func (r renderer) renderLiteral(out *termenv.Output, lit *callpbv1.Literal) {
 	case *callpbv1.Literal_Float:
 		fmt.Fprint(out, out.String(fmt.Sprintf("%f", val.Float)).Foreground(termenv.ANSIRed))
 	case *callpbv1.Literal_String_:
-		if r.width != -1 && len(val.Value()) > r.width {
+		if r.maxLiteralLen != -1 && len(val.Value()) > r.maxLiteralLen {
 			display := string(digest.FromString(val.Value()))
 			fmt.Fprint(out, out.String("ETOOBIG:"+display).Foreground(termenv.ANSIYellow))
 			return

--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -20,6 +20,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+const plainMaxLiteralLen = 256 // same value as cloud currently
+
 type frontendPlain struct {
 	FrontendOpts
 
@@ -462,7 +464,7 @@ func (fe *frontendPlain) renderStep(span *Span, depth int, done bool) {
 		spanDt.idx = fe.idx
 	}
 
-	r := newRenderer(fe.db, -1, fe.FrontendOpts)
+	r := newRenderer(fe.db, plainMaxLiteralLen, fe.FrontendOpts)
 
 	prefix := fe.stepPrefix(span, spanDt)
 	if span.Call != nil {
@@ -509,7 +511,7 @@ func (fe *frontendPlain) renderLogs(row *TraceTree, depth int) {
 	span := row.Span
 	spanDt := fe.data[span.ID]
 
-	r := newRenderer(fe.db, -1, fe.FrontendOpts)
+	r := newRenderer(fe.db, plainMaxLiteralLen, fe.FrontendOpts)
 
 	prefix := fe.stepPrefix(span, spanDt)
 


### PR DESCRIPTION
*Possibly* fixes, or at least helps, https://github.com/dagger/dagger/issues/7786 by avoiding https://github.com/actions/runner/issues/1031