### PR TITLE
fix infinite logging loop (and CPUPROFILE)

### DIFF
--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -253,10 +253,6 @@ func (fe plainLogExporter) Export(ctx context.Context, logs []sdklog.Record) err
 	fe.mu.Lock()
 	defer fe.mu.Unlock()
 
-	// NOTE: if we log in here we'll just go into a loop, so...
-	// let's just hope everything is working by now :D
-	// slog.Debug("frontend exporting logs", "logs", len(logs))
-
 	err := fe.db.LogExporter().Export(ctx, logs)
 	if err != nil {
 		return err

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -268,7 +268,6 @@ type prettyLogExporter struct {
 func (fe prettyLogExporter) Export(ctx context.Context, logs []sdklog.Record) error {
 	fe.mu.Lock()
 	defer fe.mu.Unlock()
-	slog.Debug("frontend exporting logs", "logs", len(logs))
 	if err := fe.db.LogExporter().Export(ctx, logs); err != nil {
 		return err
 	}
@@ -886,8 +885,6 @@ func newPrettyLogs() *prettyLogs {
 
 func (l *prettyLogs) Export(ctx context.Context, logs []sdklog.Record) error {
 	for _, log := range logs {
-		slog.Debug("exporting log", "span", log.SpanID, "body", log.Body().AsString())
-
 		// render vterm for TUI
 		_, _ = fmt.Fprint(l.spanLogs(log.SpanID()), log.Body().AsString())
 	}


### PR DESCRIPTION
Currently if you run with `--debug` the CLI will go into a loop constantly logging the same log line repeatedly until it's eventually just a bunch of `\\\\\\\\\\`s from escaping strings in strings.

This was introduced by the recent TUI changes which directed logs to go to the primary span rather than to a separate TUI-only pane. Unfortunately, as part of the log handling (TUI consumes logs), we were logging at debug level, hence `--debug` introducing an infinite loop for any log line printed.

I think I can live without these logs now that draining seems fixed (knock on wood) so we'll just remove them. This was already done for the plain TUI, just not the pretty one.

(Also, fixes `$CPUPROFILE` along the way, since it's been broken for a while.)