### PR TITLE
tui: add `-q`/`$DAGGER_QUIET`, better durations + errors

### DIFF
--- a/.changes/unreleased/Added-20240704-183832.yaml
+++ b/.changes/unreleased/Added-20240704-183832.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: "cli: add -q flag and DAGGER_QUIET=1 to restore previous verbosity default"
+time: 2024-07-04T18:38:32.603222928-04:00
+custom:
+  Author: vito
+  PR: "7822"

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -53,7 +53,7 @@ var (
 	debug     bool
 	verbosity int
 	silent    bool
-	quiet     bool
+	quiet     bool = os.Getenv("DAGGER_QUIET") != ""
 	progress  string
 
 	stdoutIsTTY = isatty.IsTerminal(os.Stdout.Fd())

--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -11,6 +11,7 @@ import (
 	"runtime/pprof"
 	runtimetrace "runtime/trace"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 
@@ -50,11 +51,11 @@ var (
 
 	workdir string
 
-	debug     bool
-	verbosity int
-	silent    bool
-	quiet     bool = os.Getenv("DAGGER_QUIET") != ""
-	progress  string
+	silent   bool
+	verbose  int
+	quiet, _ = strconv.Atoi(os.Getenv("DAGGER_QUIET"))
+	debug    bool
+	progress string
 
 	stdoutIsTTY = isatty.IsTerminal(os.Stdout.Fd())
 	stderrIsTTY = isatty.IsTerminal(os.Stderr.Fd())
@@ -193,11 +194,11 @@ https://dagger.cloud/signup?quickstart=true
 
 func installGlobalFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&workdir, "workdir", ".", "The host workdir loaded into dagger")
-	flags.CountVarP(&verbosity, "verbose", "v", "increase verbosity (use -vv or -vvv for more)")
-	flags.BoolVarP(&debug, "debug", "d", debug, "show debug logs and full verbosity")
-	flags.BoolVarP(&silent, "silent", "s", silent, "do not show progress")
-	flags.BoolVarP(&quiet, "quiet", "q", quiet, "show progress, clean it up at the end")
-	flags.StringVar(&progress, "progress", "auto", "progress output format (auto, plain, tty)")
+	flags.CountVarP(&verbose, "verbose", "v", "Increase verbosity (use -vv or -vvv for more)")
+	flags.CountVarP(&quiet, "quiet", "q", "Reduce verbosity (show progress, but clean up at the end)")
+	flags.BoolVarP(&silent, "silent", "s", silent, "Do not show progress at all")
+	flags.BoolVarP(&debug, "debug", "d", debug, "Show debug logs and full verbosity")
+	flags.StringVar(&progress, "progress", "auto", "Progress output format (auto, plain, tty)")
 
 	for _, fl := range []string{"workdir"} {
 		if err := flags.MarkHidden(fl); err != nil {
@@ -262,20 +263,15 @@ func (e ExitError) Error() string {
 
 const InstrumentationLibrary = "dagger.io/cli"
 
+var opts idtui.FrontendOpts
+
 func main() {
 	parseGlobalFlags()
-
-	var baseVerbosity int
-	if quiet {
-		baseVerbosity = idtui.HideCompletedVerbosity
-	} else {
-		baseVerbosity = idtui.ShowCompletedVerbosity
-	}
-	opts := idtui.FrontendOpts{
-		Silent:    silent,
-		Verbosity: baseVerbosity + verbosity,
-		Debug:     debug,
-	}
+	opts.Verbosity += idtui.ShowCompletedVerbosity // keep progress by default
+	opts.Verbosity += verbose                      // raise verbosity with -v
+	opts.Verbosity -= quiet                        // lower verbosity with -q
+	opts.Silent = silent                           // show no progress
+	opts.Debug = debug                             // show everything
 	if progress == "auto" {
 		if hasTTY {
 			progress = "tty"

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -392,13 +392,12 @@ func (r renderer) renderDuration(out *termenv.Output, span *Span) {
 // }
 
 const (
+	HideCompletedVerbosity    = 0
 	ShowCompletedVerbosity    = 1
 	ShowInternalVerbosity     = 2
 	ShowEncapsulatedVerbosity = 2
 	ShowSpammyVerbosity       = 3
 	ShowDigestsVerbosity      = 3
-
-	DefaultVerbosity = ShowCompletedVerbosity
 )
 
 func (opts FrontendOpts) ShouldShow(tree *TraceTree) bool {

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -127,19 +127,8 @@ func (fe *frontendPretty) Run(ctx context.Context, opts FrontendOpts, run func(c
 	// can show the TUI on stderr.
 	ttyIn, ttyOut := findTTYs()
 
-	var runErr error
-	if fe.Silent {
-		// no TTY found; set a reasonable screen size for logs, and just run the
-		// function
-		fe.setWindowSizeLocked(tea.WindowSizeMsg{
-			Width:  300, // influences vterm width
-			Height: 100, // theoretically noop, since we always render full logs
-		})
-		runErr = run(ctx)
-	} else {
-		// run the TUI until it exits and cleans up the TTY
-		runErr = fe.runWithTUI(ctx, ttyIn, ttyOut, run)
-	}
+	// run the function wrapped in the TUI
+	runErr := fe.runWithTUI(ctx, ttyIn, ttyOut, run)
 
 	// print the final output display to stderr
 	if renderErr := fe.finalRender(); renderErr != nil {
@@ -213,13 +202,9 @@ func (fe *frontendPretty) finalRender() error {
 	fe.zoomed = fe.db.PrimarySpan
 	fe.focused = trace.SpanID{}
 	fe.focusedIdx = -1
-	if fe.Verbosity < 1 {
-		// likely only intended to filter out noise, so print as we normally would
-		fe.Verbosity = 1
-	}
 	fe.recalculateViewLocked()
 
-	if fe.Debug || fe.Verbosity > 0 || fe.err != nil {
+	if fe.Debug || fe.Verbosity >= ShowCompletedVerbosity || fe.err != nil {
 		// Render progress to stderr so stdout stays clean.
 		out := NewOutput(os.Stderr, termenv.WithProfile(fe.profile))
 		if fe.renderProgress(out, true, fe.window.Height, "") {

--- a/docs/current_docs/reference/cli.mdx
+++ b/docs/current_docs/reference/cli.mdx
@@ -12,10 +12,11 @@ The Dagger CLI provides a command-line interface to Dagger.
 ### Options
 
 ```
-  -d, --debug             show debug logs and full verbosity
-      --progress string   progress output format (auto, plain, tty) (default "auto")
-  -s, --silent            disable terminal UI and progress output
-  -v, --verbose count     increase verbosity (use -vv or -vvv for more)
+  -d, --debug             Show debug logs and full verbosity
+      --progress string   Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent            Do not show progress at all
+  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -51,10 +52,11 @@ dagger call [options]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug             show debug logs and full verbosity
-      --progress string   progress output format (auto, plain, tty) (default "auto")
-  -s, --silent            disable terminal UI and progress output
-  -v, --verbose count     increase verbosity (use -vv or -vvv for more)
+  -d, --debug             Show debug logs and full verbosity
+      --progress string   Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent            Do not show progress at all
+  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -90,10 +92,11 @@ dagger config -m github.com/dagger/hello-dagger
 ### Options inherited from parent commands
 
 ```
-  -d, --debug             show debug logs and full verbosity
-      --progress string   progress output format (auto, plain, tty) (default "auto")
-  -s, --silent            disable terminal UI and progress output
-  -v, --verbose count     increase verbosity (use -vv or -vvv for more)
+  -d, --debug             Show debug logs and full verbosity
+      --progress string   Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent            Do not show progress at all
+  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -136,10 +139,11 @@ dagger develop [options]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug             show debug logs and full verbosity
-      --progress string   progress output format (auto, plain, tty) (default "auto")
-  -s, --silent            disable terminal UI and progress output
-  -v, --verbose count     increase verbosity (use -vv or -vvv for more)
+  -d, --debug             Show debug logs and full verbosity
+      --progress string   Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent            Do not show progress at all
+  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -171,10 +175,11 @@ dagger functions [options] [function]...
 ### Options inherited from parent commands
 
 ```
-  -d, --debug             show debug logs and full verbosity
-      --progress string   progress output format (auto, plain, tty) (default "auto")
-  -s, --silent            disable terminal UI and progress output
-  -v, --verbose count     increase verbosity (use -vv or -vvv for more)
+  -d, --debug             Show debug logs and full verbosity
+      --progress string   Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent            Do not show progress at all
+  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -221,10 +226,11 @@ dagger init --name=hello --sdk=python --source=some/subdir
 ### Options inherited from parent commands
 
 ```
-  -d, --debug             show debug logs and full verbosity
-      --progress string   progress output format (auto, plain, tty) (default "auto")
-  -s, --silent            disable terminal UI and progress output
-  -v, --verbose count     increase verbosity (use -vv or -vvv for more)
+  -d, --debug             Show debug logs and full verbosity
+      --progress string   Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent            Do not show progress at all
+  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -259,10 +265,11 @@ dagger install github.com/shykes/daggerverse/ttlsh@16e40ec244966e55e36a13cb6e1ff
 ### Options inherited from parent commands
 
 ```
-  -d, --debug             show debug logs and full verbosity
-      --progress string   progress output format (auto, plain, tty) (default "auto")
-  -s, --silent            disable terminal UI and progress output
-  -v, --verbose count     increase verbosity (use -vv or -vvv for more)
+  -d, --debug             Show debug logs and full verbosity
+      --progress string   Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent            Do not show progress at all
+  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -280,10 +287,11 @@ dagger login [options] [org]
 ### Options inherited from parent commands
 
 ```
-  -d, --debug             show debug logs and full verbosity
-      --progress string   progress output format (auto, plain, tty) (default "auto")
-  -s, --silent            disable terminal UI and progress output
-  -v, --verbose count     increase verbosity (use -vv or -vvv for more)
+  -d, --debug             Show debug logs and full verbosity
+      --progress string   Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent            Do not show progress at all
+  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -301,10 +309,11 @@ dagger logout
 ### Options inherited from parent commands
 
 ```
-  -d, --debug             show debug logs and full verbosity
-      --progress string   progress output format (auto, plain, tty) (default "auto")
-  -s, --silent            disable terminal UI and progress output
-  -v, --verbose count     increase verbosity (use -vv or -vvv for more)
+  -d, --debug             Show debug logs and full verbosity
+      --progress string   Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent            Do not show progress at all
+  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -358,10 +367,11 @@ EOF
 ### Options inherited from parent commands
 
 ```
-  -d, --debug             show debug logs and full verbosity
-      --progress string   progress output format (auto, plain, tty) (default "auto")
-  -s, --silent            disable terminal UI and progress output
-  -v, --verbose count     increase verbosity (use -vv or -vvv for more)
+  -d, --debug             Show debug logs and full verbosity
+      --progress string   Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent            Do not show progress at all
+  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -412,10 +422,11 @@ dagger run python main.py
 ### Options inherited from parent commands
 
 ```
-  -d, --debug             show debug logs and full verbosity
-      --progress string   progress output format (auto, plain, tty) (default "auto")
-  -s, --silent            disable terminal UI and progress output
-  -v, --verbose count     increase verbosity (use -vv or -vvv for more)
+  -d, --debug             Show debug logs and full verbosity
+      --progress string   Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent            Do not show progress at all
+  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO
@@ -433,10 +444,11 @@ dagger version
 ### Options inherited from parent commands
 
 ```
-  -d, --debug             show debug logs and full verbosity
-      --progress string   progress output format (auto, plain, tty) (default "auto")
-  -s, --silent            disable terminal UI and progress output
-  -v, --verbose count     increase verbosity (use -vv or -vvv for more)
+  -d, --debug             Show debug logs and full verbosity
+      --progress string   Progress output format (auto, plain, tty) (default "auto")
+  -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
+  -s, --silent            Do not show progress at all
+  -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
CLI verbosity scheme is now:

* `-s`/`--silent`: total silence, no progress displayed ever
* `-q`/`--quiet`/`$DAGGER_QUIET`: show progress, clean up completed progress
* default: show progress, keep completed items
* `-v`: show internal and encapsulated progress
* `-vv`: show spammy progress, reveal digests
* `-d`/`--debug`: show everything, set debug log level, reveal span IDs and other misc things

WIth `$DAGGER_QUIET` set, use `-v` to achieve the original default, which also matches the v0.11.x behavior.

Some fixes along the way:

* Final render now respects `-s`