### PR TITLE
engine: close session shutdown chan only when main client is gone

### DIFF
--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -879,13 +879,14 @@ func (srv *Server) serveShutdown(w http.ResponseWriter, r *http.Request, client 
 			}
 			bklog.G(ctx).Debugf("done running cache export for client %s", client.clientID)
 		}
+
+		sess.closeShutdownOnce.Do(func() {
+			close(sess.shutdownCh)
+		})
 	}
 
 	telemetry.Flush(ctx)
 
-	sess.closeShutdownOnce.Do(func() {
-		close(sess.shutdownCh)
-	})
 	return nil
 }
 


### PR DESCRIPTION
Noticed that while debugging some flakiness in https://github.com/dagger/dagger/pull/7804

https://github.com/dagger/dagger/commit/ae1175dbaf1026511403943eb49132012dc6a942 (merged earlier today) improved session shutdown to happen quicker by disconnecting the attachables right when `/shutdown` is called.

`/shutdown` isn't called by nested module clients. However, it's valid when using other nested execs with a full blown CLI for them to call `/shutdown`. This wasn't handled well by that change because we closed the new shutdownCh on any call to /shutdown, resulting in everyone's session attachables getting closed when any of the nested execs shutdown.

The fix is to just only close that shutdownCh when the main client caller calls /shutdown.

Somewhat fascinatingly, our existing tests seem to have been resilient to this as I didn't notice any extra flakiness. However, https://github.com/dagger/dagger/pull/7804 got hit hard by it, so we'll have coverage from there.