### PR TITLE
fix: ensure terminal dump id is readable

### DIFF
--- a/cmd/dump-id/main.go
+++ b/cmd/dump-id/main.go
@@ -19,7 +19,7 @@ func main() {
 		panic(err)
 	}
 
-	if err := idtui.DumpID(idtui.NewOutput(os.Stdout), &idp); err != nil {
+	if err := new(idtui.Dump).DumpID(idtui.NewOutput(os.Stdout), &idp); err != nil {
 		panic(err)
 	}
 }

--- a/core/terminal.go
+++ b/core/terminal.go
@@ -42,14 +42,16 @@ func (container *Container) Terminal(
 		return fmt.Errorf("failed to open terminal: %w", err)
 	}
 	output := idtui.NewOutput(term.Stderr)
-	fmt.Fprintf(
+	fmt.Fprint(
 		term.Stderr,
 		output.String(idtui.DotFilled).Foreground(termenv.ANSIYellow).String()+" Attaching terminal: ",
 	)
-	if err := idtui.DumpID(output, svcID); err != nil {
+	dump := idtui.Dump{Newline: "\r\n", Prefix: "    "}
+	fmt.Fprint(term.Stderr, dump.Newline)
+	if err := dump.DumpID(output, svcID); err != nil {
 		return fmt.Errorf("failed to serialize service ID: %w", err)
 	}
-	fmt.Fprintf(term.Stderr, "\r\n\n")
+	fmt.Fprint(term.Stderr, dump.Newline)
 
 	container = container.Clone()
 	// Inject a custom shell prompt `dagger:<cwd>$`


### PR DESCRIPTION
Previously, `DumpID` was producing bad output, after lots of refactors to the frontend. Specifically, we were no longer sending newlines after `renderCall` which meant that everything appeared on the same line (additionally, `DumpID` wasn't taking into account that the client terminal is in raw mode, so needs `\r` at each newline).

To resolve this, we create a new little helper struct called `Dump`, which allows configuration of basic options, and can be configured by the dagger engine to get some more readable output.

Before:

	❯ dagger call container-echo --string-arg=x terminal
	● Attaching terminal: container: Container!Container.from(address: "alpine:latest"): Container!Container.withExec(args: ["echo", "x"]): Container!

	dagger / $

After:

	❯ dagger call container-echo --string-arg=x terminal
	● Attaching terminal:
	    container: Container!
	    Container.from(address: "alpine:latest"): Container!
	    Container.withExec(args: ["echo", "x"]): Container!

	dagger / $

There's still future possible improvements of course, but this is a *lot* more readable than just squashing everything into one horrible to read line.