### PR TITLE
tui: better durations, less spammy errors, tweak `-v`

### DIFF
--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -394,10 +394,11 @@ func (r renderer) renderDuration(out *termenv.Output, span *Span) {
 const (
 	HideCompletedVerbosity    = 0
 	ShowCompletedVerbosity    = 1
-	ShowInternalVerbosity     = 2
-	ShowEncapsulatedVerbosity = 2
-	ShowSpammyVerbosity       = 3
-	ShowDigestsVerbosity      = 3
+	ExpandCompletedVerbosity  = 2
+	ShowInternalVerbosity     = 3
+	ShowEncapsulatedVerbosity = 3
+	ShowSpammyVerbosity       = 4
+	ShowDigestsVerbosity      = 4
 )
 
 func (opts FrontendOpts) ShouldShow(tree *TraceTree) bool {
@@ -422,7 +423,7 @@ func (opts FrontendOpts) ShouldShow(tree *TraceTree) bool {
 		// show running steps
 		return true
 	}
-	if tree.Parent != nil && (opts.TooFastThreshold > 0 && span.Duration() < opts.TooFastThreshold && opts.Verbosity < ShowSpammyVerbosity) {
+	if tree.Parent != nil && (opts.TooFastThreshold > 0 && span.ActiveDuration(time.Now()) < opts.TooFastThreshold && opts.Verbosity < ShowSpammyVerbosity) {
 		// ignore fast steps; signal:noise is too poor
 		return false
 	}

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -93,8 +93,8 @@ func (d *Dump) DumpID(out *termenv.Output, id *call.ID) error {
 type renderer struct {
 	FrontendOpts
 
-	newline string
-
+	now           time.Time
+	newline       string
 	db            *DB
 	maxLiteralLen int
 	rendering     map[string]bool
@@ -103,6 +103,7 @@ type renderer struct {
 func newRenderer(db *DB, maxLiteralLen int, fe FrontendOpts) renderer {
 	return renderer{
 		FrontendOpts:  fe,
+		now:           time.Now(),
 		db:            db,
 		maxLiteralLen: maxLiteralLen,
 		rendering:     map[string]bool{},
@@ -342,7 +343,7 @@ func (r renderer) renderStatus(out *termenv.Output, span *Span, focused bool) {
 
 func (r renderer) renderDuration(out *termenv.Output, span *Span) {
 	fmt.Fprint(out, " ")
-	duration := out.String(fmtDuration(span.Duration()))
+	duration := out.String(fmtDuration(span.ActiveDuration(r.now)))
 	if span.IsRunning() {
 		duration = duration.Foreground(termenv.ANSIYellow)
 	} else {

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -215,6 +215,13 @@ func (fe *frontendPretty) finalRender() error {
 		}
 	}
 
+	if fe.err != nil {
+		// Counter-intuitively, we don't want to render the primary output
+		// when there's an error, because the error is better represented by
+		// the progress output.
+		return nil
+	}
+
 	// Replay the primary output log to stdout/stderr.
 	return renderPrimaryOutput(fe.db)
 }

--- a/dagql/idtui/types.go
+++ b/dagql/idtui/types.go
@@ -164,7 +164,7 @@ func (lv *RowsView) Rows(opts FrontendOpts) *Rows {
 			rows.BySpan[tree.Span.ID] = row
 			depth++
 		}
-		if tree.IsRunningOrChildRunning || tree.Span.Failed() {
+		if tree.IsRunningOrChildRunning || tree.Span.Failed() || opts.Verbosity >= ExpandCompletedVerbosity {
 			for _, child := range tree.Children {
 				walk(child, depth)
 			}


### PR DESCRIPTION
Verbosity adjustments + a couple of tweaks to align the TUI with Cloud.

* `-v` expands completed items; `-vv` and `-vvv` now same as before
* use "active duration" (including effects) to calcualte span duration
* hide primary output on error (same as Cloud)