### PR TITLE
feat: identify and set Jenkins metadata

### DIFF
--- a/engine/telemetry/labels.go
+++ b/engine/telemetry/labels.go
@@ -367,14 +367,18 @@ func (labels Labels) WithJenkinsLabels() Labels {
 	if len(os.Getenv("JENKINS_HOME")) == 0 {
 		return labels
 	}
-	remoteBranch := os.Getenv("GIT_BRANCH")
-	if remoteBranch != "" {
-		if _, branch, ok := strings.Cut(remoteBranch, "/"); ok {
-			labels["dagger.io/vcs.change.branch"] = branch
-		}
-	}
-	labels["dagger.io/vcs.change.head_sha"] = os.Getenv("GIT_COMMIT")
+	// in Jenkins, vcs labels take precedence over provider env variables
+	_, ok := labels["dagger.io/git.branch"]
 
+	if !ok {
+		remoteBranch := os.Getenv("GIT_BRANCH")
+		if remoteBranch != "" {
+			if _, branch, ok := strings.Cut(remoteBranch, "/"); ok {
+				labels["dagger.io/git.branch"] = branch
+			}
+		}
+		labels["dagger.io/git.ref"] = os.Getenv("GIT_COMMIT")
+	}
 	return labels
 }
 

--- a/engine/telemetry/labels_test.go
+++ b/engine/telemetry/labels_test.go
@@ -405,8 +405,8 @@ func TestLoadJenkinsLabels(t *testing.T) {
 				"GIT_COMMIT":   "abc123",
 			},
 			Labels: telemetry.Labels{
-				"dagger.io/vcs.change.branch":   "test-feature",
-				"dagger.io/vcs.change.head_sha": "abc123",
+				"dagger.io/git.branch":   "test-feature",
+				"dagger.io/git.ref": "abc123",
 			},
 		},
 	} {

--- a/engine/telemetry/labels_test.go
+++ b/engine/telemetry/labels_test.go
@@ -405,8 +405,8 @@ func TestLoadJenkinsLabels(t *testing.T) {
 				"GIT_COMMIT":   "abc123",
 			},
 			Labels: telemetry.Labels{
-				"dagger.io/git.branch":   "test-feature",
-				"dagger.io/git.ref": "abc123",
+				"dagger.io/git.branch": "test-feature",
+				"dagger.io/git.ref":    "abc123",
 			},
 		},
 	} {


### PR DESCRIPTION
This PR sets two basic Jenkins labels when the engine runs in a Jenkins context.

This is needed to complement missing Git metadata when case Jenkins runs [without an explicitly checked-out branch](https://www.jenkins.io/doc/pipeline/steps/git/#git-git) when running a [pipeline](https://www.jenkins.io/doc/book/pipeline/).
For more context on this see #7776 

## Caveats
- As opposed to the other package functions such as `WithGitHubLabels`, we cannot look up a `JENKINS=true` env variable, so the most appropriate and consistent label to identify Jenkins as the context Dagger is running on is `JENKINS_HOME`. 
- No other labels are being added as they are not needed for a basic integration with Dagger Cloud.