### PR TITLE
fix: various core dynamic schema follow-ups

### DIFF
--- a/core/moddeps.go
+++ b/core/moddeps.go
@@ -46,8 +46,12 @@ type ModDeps struct {
 func NewModDeps(root *Query, mods []Mod) *ModDeps {
 	return &ModDeps{
 		root: root,
-		Mods: mods,
+		Mods: append([]Mod{}, mods...),
 	}
+}
+
+func (d *ModDeps) Clone() *ModDeps {
+	return NewModDeps(d.root, append([]Mod{}, d.Mods...))
 }
 
 func (d *ModDeps) Prepend(mods ...Mod) *ModDeps {

--- a/core/module.go
+++ b/core/module.go
@@ -746,6 +746,10 @@ func (mod Module) Clone() *Module {
 		cp.DependenciesField[i].Self = dep.Self.Clone()
 	}
 
+	if mod.Deps != nil {
+		cp.Deps = mod.Deps.Clone()
+	}
+
 	cp.ObjectDefs = make([]*TypeDef, len(mod.ObjectDefs))
 	for i, def := range mod.ObjectDefs {
 		cp.ObjectDefs[i] = def.Clone()

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -226,6 +226,13 @@ func (src *ModuleSource) ModuleEngineVersion(ctx context.Context) (string, error
 	if !ok {
 		return "", nil
 	}
+	if cfg.EngineVersion == "" {
+		// older versions of dagger might not produce an engine version - so
+		// return the version that engineVersion was introduced in
+		// TODO: replace once dagger/dagger#7692 is merged
+		// return engine.MinimumModuleVersion, nil
+		return "v0.9.9", nil
+	}
 	if !semver.IsValid(cfg.EngineVersion) {
 		// filter out non-semver values to simplify calling code
 		return "", nil

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -1073,6 +1073,11 @@ func (s *moduleSchema) updateDaggerConfig(
 	case modules.EngineVersionLatest:
 		modCfg.EngineVersion = engine.Version
 	case "":
+		engineVersion, err := src.Self.ModuleEngineVersion(ctx)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to get module config: %w", err)
+		}
+		modCfg.EngineVersion = engineVersion
 		if modCfg.EngineVersion == "" {
 			modCfg.EngineVersion = engine.Version
 		}

--- a/dagql/testdata/introspection.json
+++ b/dagql/testdata/introspection.json
@@ -1538,5 +1538,6 @@
         "isRepeatable": false
       }
     ]
-  }
+  },
+  "__schemaVersion": ""
 }

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -451,24 +451,22 @@ func (srv *Server) initializeDaggerClient(
 		}
 		client.mod = modInst.Self
 
+		// this is needed to set the view of the core api as compatible
+		// with the module we're currently calling from
 		engineVersion, err := client.mod.Source.Self.ModuleEngineVersion(ctx)
 		if err != nil {
 			return err
 		}
-		if engineVersion != "" {
-			// this is needed to set the view of the core api as compatible
-			// with the module we're currently calling from
-			coreMod.Dag.View = engineVersion
+		coreMod.Dag.View = engineVersion
 
-			// NOTE: *technically* we should reload the module here, so that we can
-			// use the new typedefs api - but at this point we likely would
-			// have failed to load the module in the first place anyways?
-			// modInst, err = dagql.NewID[*core.Module](modID).Load(ctx, coreMod.Dag)
-			// if err != nil {
-			// 	return fmt.Errorf("failed to load module: %w", err)
-			// }
-			// client.mod = modInst.Self
-		}
+		// NOTE: *technically* we should reload the module here, so that we can
+		// use the new typedefs api - but at this point we likely would
+		// have failed to load the module in the first place anyways?
+		// modInst, err = dagql.NewID[*core.Module](modID).Load(ctx, coreMod.Dag)
+		// if err != nil {
+		// 	return fmt.Errorf("failed to load module: %w", err)
+		// }
+		// client.mod = modInst.Self
 
 		client.deps = core.NewModDeps(client.dagqlRoot, client.mod.Deps.Mods)
 		// if the module has any of it's own objects defined, serve its schema to itself too

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -470,7 +470,7 @@ func (srv *Server) initializeDaggerClient(
 			// client.mod = modInst.Self
 		}
 
-		client.deps = client.mod.Deps
+		client.deps = core.NewModDeps(client.dagqlRoot, client.mod.Deps.Mods)
 		// if the module has any of it's own objects defined, serve its schema to itself too
 		if len(client.mod.ObjectDefs) > 0 {
 			client.deps = client.deps.Append(client.mod)
@@ -991,7 +991,7 @@ func (srv *Server) DefaultDeps(ctx context.Context) (*core.ModDeps, error) {
 	if err != nil {
 		return nil, err
 	}
-	return client.defaultDeps, nil
+	return client.defaultDeps.Clone(), nil
 }
 
 // The DagQL query cache for the current client's session


### PR DESCRIPTION
Collection of various follow ups from #7759:

- Cloning issues - without doing cloning in the right way, we can get all sorts of fun issues, where deps are shared in confusing ways.
- Update golden testdata for dagql
- Elegantly handle a dagger.json without an `engineVersion` (assume it's from an older dagger version, before we had `engineVersion`)