### PR TITLE
fix(sdk/elixir): fix codegen break the runtime

### DIFF
--- a/sdk/elixir/dagger_codegen/lib/dagger/codegen/introspection/types/type.ex
+++ b/sdk/elixir/dagger_codegen/lib/dagger/codegen/introspection/types/type.ex
@@ -8,21 +8,27 @@ defmodule Dagger.Codegen.Introspection.Types.Type do
     :name
   ]
 
-  def from_map(%{
-        "description" => description,
-        "enumValues" => enum_values,
-        "fields" => fields,
-        "inputFields" => input_fields,
-        "kind" => kind,
-        "name" => name
-      }) do
+  def from_map(
+        %{
+          "description" => description,
+          "kind" => kind,
+          "name" => name
+        } = type
+      ) do
     %__MODULE__{
       description: description,
       enum_values:
-        Enum.map(enum_values, &Dagger.Codegen.Introspection.Types.EnumValue.from_map/1),
-      fields: Enum.map(fields, &Dagger.Codegen.Introspection.Types.Field.from_map/1),
+        Enum.map(
+          type["enumValues"] || [],
+          &Dagger.Codegen.Introspection.Types.EnumValue.from_map/1
+        ),
+      fields:
+        Enum.map(type["fields"] || [], &Dagger.Codegen.Introspection.Types.Field.from_map/1),
       input_fields:
-        Enum.map(input_fields, &Dagger.Codegen.Introspection.Types.InputValue.from_map/1),
+        Enum.map(
+          type["inputFields"] || [],
+          &Dagger.Codegen.Introspection.Types.InputValue.from_map/1
+        ),
       kind: kind,
       name: name
     }

--- a/sdk/elixir/dagger_codegen/lib/dagger/codegen/introspection/types/type_ref.ex
+++ b/sdk/elixir/dagger_codegen/lib/dagger/codegen/introspection/types/type_ref.ex
@@ -5,13 +5,13 @@ defmodule Dagger.Codegen.Introspection.Types.TypeRef do
     :of_type
   ]
 
-  def from_map(%{"kind" => kind, "name" => name, "ofType" => of_type}) do
+  def from_map(%{"kind" => kind} = type_ref) do
     %__MODULE__{
       kind: kind,
-      name: name,
+      name: type_ref["name"],
       of_type:
-        unless is_nil(of_type) do
-          Dagger.Codegen.Introspection.Types.TypeRef.from_map(of_type)
+        unless is_nil(type_ref["ofType"]) do
+          Dagger.Codegen.Introspection.Types.TypeRef.from_map(type_ref["ofType"])
         end
     }
   end

--- a/sdk/elixir/dagger_codegen/test/dagger/codegen/elixir_generator/object_renderer_test.exs
+++ b/sdk/elixir/dagger_codegen/test/dagger/codegen/elixir_generator/object_renderer_test.exs
@@ -150,13 +150,14 @@ defmodule Dagger.Codegen.ElixirGenerator.ObjectRendererTest do
             container.selection |> select("sync")
 
           with {:ok, id} <- execute(selection, container.client) do
-            %Dagger.Container{
-              selection:
-                query()
-                |> select("loadContainerFromID")
-                |> arg("id", id),
-              client: container.client
-            }
+            {:ok,
+             %Dagger.Container{
+               selection:
+                 query()
+                 |> select("loadContainerFromID")
+                 |> arg("id", id),
+               client: container.client
+             }}
           end
         end
       end\


### PR DESCRIPTION
Some fields in introspection json are not guarantee to present when it's optional. It cause the codegen crash because it expected those fields to have it. Fixed by make it optional by getting it via `[key]` instead.

And in this fix, include update outdated snapshot tests.