### PR TITLE
test: update snapshot in dagql TestIntrospection

### DIFF
--- a/dagql/testdata/introspection.json
+++ b/dagql/testdata/introspection.json
@@ -1538,5 +1538,6 @@
         "isRepeatable": false
       }
     ]
-  }
+  },
+  "__schemaVersion": ""
 }


### PR DESCRIPTION
The `__schemaVersion` is now included in introspection.json file but it didn't get update in tests. Cause test `TestIntrospection` failure.