### PR TITLE
core: cap healthcheck retries at max of 10s interval

### DIFF
--- a/.changes/unreleased/Fixed-20240708-120146.yaml
+++ b/.changes/unreleased/Fixed-20240708-120146.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: 'core: prevent service healthchecks from using too long a retry interval'
+time: 2024-07-08T12:01:46.491293587-07:00
+custom:
+  Author: sipsma
+  PR: "7848"

--- a/core/healthcheck.go
+++ b/core/healthcheck.go
@@ -54,7 +54,10 @@ func (d *portHealthChecker) Check(ctx context.Context) (rerr error) {
 	}
 
 	for _, port := range ports {
-		retry := backoff.NewExponentialBackOff(backoff.WithInitialInterval(100 * time.Millisecond))
+		retry := backoff.NewExponentialBackOff(
+			backoff.WithInitialInterval(100*time.Millisecond),
+			backoff.WithMaxInterval(10*time.Second),
+		)
 		endpoint, err := backoff.RetryWithData(func() (string, error) {
 			return buildkit.RunInNetNS(ctx, d.bk, d.ns, func() (string, error) {
 				// NB(vito): it's a _little_ silly to dial a UDP network to see that it's


### PR DESCRIPTION
Otherwise the exponential backoff can keep going indefinitely and wait too long.

Fixes https://github.com/dagger/dagger/issues/7775