### PR TITLE
feat: downgrade ts runtime to LTS

### DIFF
--- a/sdk/typescript/.changes/unreleased/Changed-20240709-123212.yaml
+++ b/sdk/typescript/.changes/unreleased/Changed-20240709-123212.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: Downgrade TS runtime version to LTS (v20.15.1)
+time: 2024-07-09T12:32:12.220276+02:00
+custom:
+  Author: TomChv
+  PR: "7850"

--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -13,9 +13,9 @@ import (
 
 const (
 	bunVersion  = "1.1.12"
-	nodeVersion = "21.3"
+	nodeVersion = "20" // LTS version, IRON (https://nodejs.org/en/about/previous-releases)
 
-	nodeImageDigest = "sha256:3dab5cc219983a5f1904d285081cceffc9d181e64bed2a4a18855d2d62c64ccb"
+	nodeImageDigest = "sha256:df01469346db2bf1cfc1f7261aeab86b2960efa840fe2bd46d83ff339f463665"
 	bunImageDigest  = "sha256:6568a679b87107d3d7d46b829f614c443e73bbe3bf7d6ea5c9ceb8f845869c96"
 
 	nodeImageRef = "node:" + nodeVersion + "-alpine@" + nodeImageDigest


### PR DESCRIPTION
fixes #7433 

We'll need to bump to v22 in October 2024

Based on multiples Discord message, we cannot ignore this dependency issue anymore, I'm fixing this now so we do not hit this issue anymore. 