### PR TITLE
chore: tag all releases with semver

### DIFF
--- a/.changes/.next
+++ b/.changes/.next
@@ -1,0 +1,11 @@
+# This file is a custom file we use to indicate the next version of dagger -
+# this version is used to determine how dev versions should be tagged.
+#
+# For example, if set to vX.Y.Z, then dev versions will be tagged as
+# vX.Y.Z-<prerelease> using go pseudoversioning.
+#
+# This file can also be left empty - if it is, then the next version is
+# automagically determined from release note entries (and then adding to the
+# patch release).
+
+v0.12.4

--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -21,6 +21,11 @@ inputs:
     default: "false"
     required: false
 
+  redirect:
+    description: "Filepath to redirect result to"
+    default: "/dev/null"
+    required: false
+
 runs:
   using: "composite"
   steps:
@@ -100,12 +105,12 @@ runs:
         if [[ "${{ inputs.module }}" == "dev" ]]; then
           # set some sane defaults for the current module
           if [[ -f $HOME/.docker/config.json ]]; then
-            dagger -m "${{ inputs.module }}" call --source=".:default" --docker-cfg=file:"$HOME/.docker/config.json" ${{ inputs.function }}
+            dagger -m "${{ inputs.module }}" call --source=".:default" --docker-cfg=file:"$HOME/.docker/config.json" ${{ inputs.function }} | tee "${{ inputs.redirect }}"
           else
-            dagger -m "${{ inputs.module }}" call --source=".:default" ${{ inputs.function }}
+            dagger -m "${{ inputs.module }}" call --source=".:default" ${{ inputs.function }} | tee "${{ inputs.redirect }}"
           fi
         else
-          dagger -m "${{ inputs.module }}" call ${{ inputs.function }}
+          dagger -m "${{ inputs.module }}" call ${{ inputs.function }} | tee "${{ inputs.redirect }}"
         fi
       env:
         DAGGER_CLOUD_TOKEN: "dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw"

--- a/.github/workflows/engine-and-cli-publish.yml
+++ b/.github/workflows/engine-and-cli-publish.yml
@@ -27,11 +27,24 @@ jobs:
         with:
           go-version: "1.22"
           cache-dependency-path: "dev/go.sum"
+      - name: "Determine tag"
+        run: |
+          mkdir -p /tmp/publish
+          echo "${{ github.ref_name == 'main' && github.sha || github.ref_name }}" > /tmp/publish/tag
+      - name: "Determine version"
+        uses: ./.github/actions/call
+        with:
+          # determine the version before releasing any components - this keeps
+          # it consistent across all components (since pre-releases might have
+          # timestamps)
+          function: --version="$(cat /tmp/publish/tag)" version string
+          redirect: "/tmp/publish/version"
       - name: "Publish Engine"
         uses: ./.github/actions/call
         with:
           function: |
-            --version="${{ github.ref_name == 'main' && github.sha || github.ref_name }}" \
+            --version="$(cat /tmp/publish/version)" \
+            --tag="$(cat /tmp/publish/tag)" \
             engine \
             publish \
             --platform="linux/amd64" --platform="linux/arm64" \
@@ -49,7 +62,8 @@ jobs:
         uses: ./.github/actions/call
         with:
           function: |
-            --version="${{ github.ref_name == 'main' && github.sha || github.ref_name }}" \
+            --version="$(cat /tmp/publish/version)" \
+            --tag="$(cat /tmp/publish/tag)" \
             engine with-base --image=ubuntu --gpu-support=true \
             publish \
             --platform="linux/amd64" \
@@ -67,7 +81,8 @@ jobs:
         uses: ./.github/actions/call
         with:
           function: |
-            --version="${{ github.ref_name == 'main' && github.sha || github.ref_name }}" \
+            --version="$(cat /tmp/publish/version)" \
+            --tag="$(cat /tmp/publish/tag)" \
             engine with-base --image=wolfi \
             publish \
             --platform="linux/amd64" \
@@ -85,7 +100,8 @@ jobs:
         uses: ./.github/actions/call
         with:
           function: |
-            --version="${{ github.ref_name == 'main' && github.sha || github.ref_name }}" \
+            --version="$(cat /tmp/publish/version)" \
+            --tag="$(cat /tmp/publish/tag)" \
             engine with-base --image=wolfi --gpu-support=true \
             publish \
             --platform="linux/amd64" \
@@ -103,7 +119,8 @@ jobs:
         uses: ./.github/actions/call
         with:
           function: |
-            --version="${{ github.ref_name == 'main' && github.sha || github.ref_name }}" \
+            --version="$(cat /tmp/publish/version)" \
+            --tag="$(cat /tmp/publish/tag)" \
             cli \
             publish \
             --git-dir=./.git \

--- a/.goreleaser.common.yml
+++ b/.goreleaser.common.yml
@@ -12,6 +12,7 @@ builds:
     ldflags:
       - -s -w
       - -X github.com/dagger/dagger/engine.Version={{.Env.ENGINE_VERSION}}
+      - -X github.com/dagger/dagger/engine.Tag={{.Env.ENGINE_TAG}}
     goos:
       - linux
       - windows

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -417,6 +417,9 @@ cd ..
   - The worker runner versions (of the form `dagger-v<major>-<minor>-<patch>-<worker>`)
   - e.g. if bumping 0.12.2->0.12.3, can run `find .github/ -type f -exec sed -i 's/0-12-2/0-12-3/g; s/0\.12\.2/0\.12\.3/g' {} +`
 
+- [ ] Update `.changes/.next` with the next release number if known -
+     otherwise, make the file empty (but don't remove it).
+
 - [ ] Open a PR with the title `Improve Releasing during $ENGINE_VERSION`
 
 ```console

--- a/cmd/codegen/generator/functions.go
+++ b/cmd/codegen/generator/functions.go
@@ -6,7 +6,7 @@ import (
 	"unicode"
 
 	"github.com/dagger/dagger/cmd/codegen/introspection"
-	"github.com/dagger/dagger/engine"
+	"golang.org/x/mod/semver"
 )
 
 const (
@@ -229,5 +229,5 @@ func (c *CommonFunctions) formatType(r *introspection.TypeRef, scope string, inp
 }
 
 func (c *CommonFunctions) CheckVersionCompatibility(minVersion string) bool {
-	return engine.CheckVersionCompatibility(c.schemaVersion, minVersion) == nil
+	return semver.Compare(c.schemaVersion, minVersion) >= 0
 }

--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -31,11 +31,7 @@ func withEngine(
 		}
 
 		if params.RunnerHost == "" {
-			var err error
-			params.RunnerHost, err = engine.RunnerHost()
-			if err != nil {
-				return err
-			}
+			params.RunnerHost = engine.RunnerHost()
 		}
 
 		params.DisableHostRW = disableHostRW

--- a/core/integration/engine_test.go
+++ b/core/integration/engine_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -292,229 +293,308 @@ func (ClientSuite) TestSendsLabelsInTelemetry(ctx context.Context, t *testctx.T)
 func (EngineSuite) TestVersionCompat(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
-	devEngineVersion := "v2.0.0"
-	devEngineSvc := devEngineContainer(c, func(c *dagger.Container) *dagger.Container {
-		return c.
-			WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", devEngineVersion).
-			WithEnvVariable("_EXPERIMENTAL_DAGGER_MIN_VERSION", "v2.0.0")
-	}).AsService()
+	tcs := []struct {
+		name string
 
-	clientCtr, err := engineClientContainer(ctx, t, c, devEngineSvc)
-	require.NoError(t, err)
+		engineVersion    string
+		engineMinVersion string
+		clientVersion    string
+		clientMinVersion string
 
-	// versions are compatible!
-	stderr, err := clientCtr.
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", "v2.0.0").
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_MIN_VERSION", "v2.0.0").
-		WithNewFile("/query.graphql", `{ version }`).
-		WithExec([]string{"sh", "-c", "dagger query --debug --doc /query.graphql"}).
-		Stderr(ctx)
-	require.NoError(t, err)
-	require.Contains(t, stderr, devEngineVersion)
-	require.NotContains(t, stderr, "incompatible")
+		errs []string
+	}{
+		{
+			// v2.0.0 > v1.0.0 for both client and engine
+			name:             "compatible",
+			engineVersion:    "v2.0.0",
+			engineMinVersion: "v1.0.0",
+			clientVersion:    "v2.0.0",
+			clientMinVersion: "v1.0.0",
+		},
+		{
+			// v2.0.0 > v1.0.0 for both client and engine
+			name:             "compatible",
+			engineVersion:    "v2.0.0",
+			engineMinVersion: "v2.0.0",
+			clientVersion:    "v2.0.0",
+			clientMinVersion: "v2.0.0",
+		},
+		{
+			// v2.0.0 < v3.0.0 for the client
+			name:             "client incompatible",
+			engineVersion:    "v2.0.0",
+			engineMinVersion: "v1.0.0",
+			clientVersion:    "v2.0.0",
+			clientMinVersion: "v3.0.0",
+			errs: []string{
+				"incompatible client version",
+			},
+		},
+		{
+			// v2.0.0 < v3.0.0 for the engine
+			name:             "engine incompatible",
+			engineVersion:    "v2.0.0",
+			engineMinVersion: "v3.0.0",
+			clientVersion:    "v2.0.0",
+			clientMinVersion: "v1.0.0",
+			errs: []string{
+				"incompatible engine version",
+			},
+		},
+		{
+			// v2.0.0 < v3.0.0 for both client and engine
+			name:             "client and engine incompatible",
+			engineVersion:    "v2.0.0",
+			engineMinVersion: "v3.0.0",
+			clientVersion:    "v2.0.0",
+			clientMinVersion: "v3.0.0",
+			errs: []string{
+				"incompatible engine version",
+			},
+		},
+		{
+			// v2.0.1-foobar > v2.0.0 for both client and engine
+			name:             "new dev version",
+			engineVersion:    "v2.0.1-foobar",
+			engineMinVersion: "v2.0.0",
+			clientVersion:    "v2.0.1-foobar",
+			clientMinVersion: "v2.0.0",
+		},
+		{
+			// v2.0.1-foobar > v2.0.0 for both client and engine
+			name:             "old dev version",
+			engineVersion:    "v2.0.0-foobar",
+			engineMinVersion: "v2.0.0",
+			clientVersion:    "v2.0.0-foobar",
+			clientMinVersion: "v2.0.0",
+			errs: []string{
+				"incompatible engine version",
+			},
+		},
 
-	// version is empty
-	stderr, err = clientCtr.
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", "").
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_MIN_VERSION", "v2.0.0").
-		WithNewFile("/query.graphql", `{ version }`).
-		WithExec([]string{"sh", "-c", "dagger query --debug --doc /query.graphql"}).
-		Stderr(ctx)
-	require.NoError(t, err)
-	require.Contains(t, stderr, devEngineVersion)
-	require.NotContains(t, stderr, "incompatible")
+		{
+			// dev versions for the same version are happily compatible (even
+			// if not a perfect match)
+			name:             "compatible dev versions",
+			engineVersion:    "v2.0.0-dev-123",
+			engineMinVersion: "v2.0.0-dev-456",
+			clientVersion:    "v2.0.0-dev-456",
+			clientMinVersion: "v2.0.0-dev-123",
+		},
+		{
+			// but for different versions, they're incompatible
+			name:             "incompatible dev versions",
+			engineVersion:    "v2.0.0-dev-123",
+			engineMinVersion: "v2.0.1-dev-456",
+			clientVersion:    "v2.0.1-dev-456",
+			clientMinVersion: "v2.0.0-dev-123",
+			errs: []string{
+				"incompatible engine version",
+			},
+		},
 
-	// client version is too old (v1.0.0 < v2.0.0)
-	stderr, err = clientCtr.
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", "v1.0.0").
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_MIN_VERSION", "v2.0.0").
-		WithNewFile("/query.graphql", `{ version }`).
-		WithExec([]string{"sh", "-c", "! dagger query --debug --doc /query.graphql"}).
-		Stderr(ctx)
-	require.NoError(t, err)
-	require.Contains(t, stderr, "incompatible client version")
+		{
+			// pre-releases match if they're exactly the same
+			name:             "compatible prereleases",
+			engineVersion:    "v2.0.0-foo-123",
+			engineMinVersion: "v2.0.0-foo-123",
+			clientVersion:    "v2.0.0-foo-123",
+			clientMinVersion: "v2.0.0-foo-123",
+		},
+		{
+			// but can't not be a perfect match (unlike dev versions)
+			name:             "incompatible prereleases",
+			engineVersion:    "v2.0.0-foo-123",
+			engineMinVersion: "v2.0.0-foo-456",
+			clientVersion:    "v2.0.0-foo-456",
+			clientMinVersion: "v2.0.0-foo-123",
+			errs: []string{
+				"incompatible engine version",
+			},
+		},
 
-	// server version is too old (v2.0.0 < v3.0.0)
-	stderr, err = clientCtr.
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", "v2.0.0").
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_MIN_VERSION", "v3.0.0").
-		WithNewFile("/query.graphql", `{ version }`).
-		WithExec([]string{"sh", "-c", "! dagger query --debug --doc /query.graphql"}).
-		Stderr(ctx)
-	require.NoError(t, err)
-	require.Contains(t, stderr, "incompatible engine version")
+		// empty clients/engines can happen with manual builds
+		{
+			name:             "compatible empty client",
+			engineVersion:    "v2.0.0",
+			engineMinVersion: "v1.0.0",
+			clientVersion:    "",
+			clientMinVersion: "v1.0.0",
+		},
+		{
+			name:             "compatible empty engine",
+			engineVersion:    "",
+			engineMinVersion: "v1.0.0",
+			clientVersion:    "v2.0.0",
+			clientMinVersion: "v1.0.0",
+		},
+	}
 
-	// both versions are too old
-	stderr, err = clientCtr.
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", "v1.0.0").
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_MIN_VERSION", "v3.0.0").
-		WithNewFile("/query.graphql", `{ version }`).
-		WithExec([]string{"sh", "-c", "! dagger query --debug --doc /query.graphql"}).
-		Stderr(ctx)
-	require.NoError(t, err)
-	require.Contains(t, stderr, "incompatible engine version")
+	engines := map[string]*dagger.Service{}
+	enginesMu := sync.Mutex{}
 
-	// client version is a new development version
-	stderr, err = clientCtr.
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", "v2.0.1-dev").
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_MIN_VERSION", "v2.0.0").
-		WithNewFile("/query.graphql", `{ version }`).
-		WithExec([]string{"sh", "-c", "dagger query --debug --doc /query.graphql"}).
-		Stderr(ctx)
-	require.NoError(t, err)
-	require.Contains(t, stderr, devEngineVersion)
-	require.NotContains(t, stderr, "incompatible")
+	for _, tc := range tcs {
+		// get a cached engine if possible (saves spinning up more engines than we need to)
+		tc := tc
+		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
+			devEngineSvcKey := tc.engineVersion + " " + tc.clientMinVersion
+			enginesMu.Lock()
+			devEngineSvc, ok := engines[devEngineSvcKey]
+			if !ok {
+				devEngineSvc = devEngineContainer(c, func(c *dagger.Container) *dagger.Container {
+					return c.
+						WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", tc.engineVersion).
+						WithEnvVariable("_EXPERIMENTAL_DAGGER_MIN_VERSION", tc.clientMinVersion)
+				}).AsService()
+				engines[devEngineSvcKey] = devEngineSvc
+			}
+			enginesMu.Unlock()
 
-	// client version is an old development version
-	stderr, err = clientCtr.
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", "v2.0.0-dev").
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_MIN_VERSION", "v2.0.0").
-		WithNewFile("/query.graphql", `{ version }`).
-		WithExec([]string{"sh", "-c", "! dagger query --debug --doc /query.graphql"}).
-		Stderr(ctx)
-	require.NoError(t, err)
-	require.Contains(t, stderr, "incompatible client version") // v2.0.0-dev < v2.0.0
+			clientCtr, err := engineClientContainer(ctx, t, c, devEngineSvc)
+			require.NoError(t, err)
 
-	// client version is an old-style development version
-	stderr, err = clientCtr.
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", "dev-foobar").
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_MIN_VERSION", "v2.0.0").
-		WithNewFile("/query.graphql", `{ version }`).
-		WithExec([]string{"sh", "-c", "! dagger query --debug --doc /query.graphql"}).
-		Stderr(ctx)
-	require.NoError(t, err)
-	require.Contains(t, stderr, "incompatible client version")
-	require.Contains(t, stderr, "v0.11.9") // old-style dev versions are equivalent to v0.11.9
-}
+			clientCtr = clientCtr.
+				WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", tc.clientVersion).
+				WithEnvVariable("_EXPERIMENTAL_DAGGER_MIN_VERSION", tc.engineMinVersion)
 
-func (EngineSuite) TestVersionCompatDev(ctx context.Context, t *testctx.T) {
-	c := connect(ctx, t)
+			if tc.errs == nil {
+				clientCtr = clientCtr.
+					WithNewFile("/query.graphql", `{ version }`).
+					WithExec([]string{"sh", "-c", "dagger version && dagger query --debug --doc /query.graphql"})
+			} else {
+				clientCtr = clientCtr.
+					WithNewFile("/query.graphql", `{ version }`).
+					WithExec([]string{"sh", "-c", "! dagger query --debug --doc /query.graphql"})
+			}
 
-	devEngineVersion := "v2.0.0-dev-123"
-	devEngineSvc := devEngineContainer(c, func(c *dagger.Container) *dagger.Container {
-		return c.
-			WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", devEngineVersion).
-			WithEnvVariable("_EXPERIMENTAL_DAGGER_MIN_VERSION", "v2.0.0")
-	}).AsService()
+			if tc.errs == nil {
+				stdout, err := clientCtr.Stdout(ctx)
+				require.NoError(t, err)
 
-	clientCtr, err := engineClientContainer(ctx, t, c, devEngineSvc)
-	require.NoError(t, err)
+				// check that both the client and engine versions appear
+				// somewhere in the combined output
+				require.Contains(t, stdout, tc.clientVersion)
+				require.Contains(t, stdout, tc.engineVersion)
+			} else {
+				stderr, err := clientCtr.Stderr(ctx)
+				require.NoError(t, err)
 
-	// versions are compatible!
-	stderr, err := clientCtr.
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", devEngineVersion).
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_MIN_VERSION", "v2.0.0").
-		WithNewFile("/query.graphql", `{ version }`).
-		WithExec([]string{"sh", "-c", "dagger query --debug --doc /query.graphql"}).
-		Stderr(ctx)
-	require.NoError(t, err)
-	require.Contains(t, stderr, devEngineVersion)
-	require.NotContains(t, stderr, "incompatible")
-
-	// versions are compatible!
-	// NOTE: technically, v2.0.0-dev-121 < v2.0.0-dev-123, but we handle this
-	// case, and allow them to work
-	stderr, err = clientCtr.
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", "v2.0.0-dev-121").
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_MIN_VERSION", "v2.0.0").
-		WithNewFile("/query.graphql", `{ version }`).
-		WithExec([]string{"sh", "-c", "dagger query --debug --doc /query.graphql"}).
-		Stderr(ctx)
-	require.NoError(t, err)
-	require.Contains(t, stderr, devEngineVersion)
-	require.NotContains(t, stderr, "incompatible")
-
-	// version is empty
-	stderr, err = clientCtr.
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", "").
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_MIN_VERSION", "v2.0.0").
-		WithNewFile("/query.graphql", `{ version }`).
-		WithExec([]string{"sh", "-c", "dagger query --debug --doc /query.graphql"}).
-		Stderr(ctx)
-	require.NoError(t, err)
-	require.Contains(t, stderr, devEngineVersion)
-	require.NotContains(t, stderr, "incompatible")
-
-	// client version is too old (v1.0.0-dev-121 < v2.0.0-dev-123)
-	stderr, err = clientCtr.
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", "v1.0.0-dev-121").
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_MIN_VERSION", "v2.0.0").
-		WithNewFile("/query.graphql", `{ version }`).
-		WithExec([]string{"sh", "-c", "! dagger query --debug --doc /query.graphql"}).
-		Stderr(ctx)
-	require.NoError(t, err)
-	require.Contains(t, stderr, "incompatible client version")
-
-	// server version is too old (v2.0.0-dev-123 < v3.0.0-dev-121)
-	stderr, err = clientCtr.
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", "v2.0.0-dev-121").
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_MIN_VERSION", "v3.0.0").
-		WithNewFile("/query.graphql", `{ version }`).
-		WithExec([]string{"sh", "-c", "! dagger query --debug --doc /query.graphql"}).
-		Stderr(ctx)
-	require.NoError(t, err)
-	require.Contains(t, stderr, "incompatible engine version")
+				// check the error is contained
+				for _, tcerr := range tc.errs {
+					require.Contains(t, stderr, tcerr)
+				}
+				// check that both the client and engine versions are present
+				// in the error message
+				require.Contains(t, stderr, tc.clientVersion)
+				require.Contains(t, stderr, tc.engineVersion)
+			}
+		})
+	}
 }
 
 func (EngineSuite) TestModuleVersionCompat(ctx context.Context, t *testctx.T) {
 	c := connect(ctx, t)
 
-	devEngineVersion := "v2.0.0"
-	devEngineSvc := devEngineContainer(c, func(c *dagger.Container) *dagger.Container {
-		return c.
-			WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", devEngineVersion).
-			WithEnvVariable("_EXPERIMENTAL_DAGGER_MIN_VERSION", "v2.0.0")
-	}).AsService()
+	tcs := []struct {
+		name string
 
-	clientCtr, err := engineClientContainer(ctx, t, c, devEngineSvc)
-	require.NoError(t, err)
-	clientCtr = clientCtr.
-		WithWorkdir("/work").
-		// set version to empty, this makes it the latest, we don't want to
-		// test client compat (that's the previous tests)
-		WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", "").
-		With(daggerExec("init", "--name=bare", "--sdk=go"))
+		engineVersion    string
+		moduleVersion    string
+		moduleMinVersion string
 
-	// versions are compatible!
-	stderr, err := clientCtr.
-		WithNewFile("/work/dagger.json", `{"name": "bare", "sdk": "go", "engineVersion": "v2.0.0"}`).
-		WithNewFile("/query.graphql", `{bare{containerEcho(stringArg:"hello"){stdout}}}`).
-		WithExec([]string{"sh", "-c", "dagger query --debug --doc /query.graphql"}).
-		Stderr(ctx)
-	require.NoError(t, err)
-	require.Contains(t, stderr, devEngineVersion)
-	require.NotContains(t, stderr, "module requires")
+		errs []string
+	}{
+		{
+			name:             "compatible equal",
+			engineVersion:    "v2.0.0",
+			moduleVersion:    "v2.0.0",
+			moduleMinVersion: "v1.0.0",
+		},
+		{
+			name:             "compatible less",
+			engineVersion:    "v2.0.0",
+			moduleVersion:    "v1.0.0",
+			moduleMinVersion: "v1.0.0",
+		},
+		{
+			name:             "incompatible too old",
+			engineVersion:    "v2.0.0",
+			moduleVersion:    "v0.9.0",
+			moduleMinVersion: "v1.0.0",
+			errs: []string{
+				"module requires incompatible engine",
+				"does not meet required version",
+			},
+		},
+		{
+			name:             "incompatible too new",
+			engineVersion:    "v2.0.0",
+			moduleVersion:    "v2.0.1",
+			moduleMinVersion: "v1.0.0",
+			errs: []string{
+				"module requires incompatible engine",
+				"greater than supported version",
+			},
+		},
+		{
+			name:             "old style dev version",
+			engineVersion:    "v2.0.0",
+			moduleVersion:    "badbadbad",
+			moduleMinVersion: "v1.0.0",
+			errs: []string{
+				"module requires incompatible engine",
+				"does not meet required version",
+				"v0.11.9", // old-style dev versions are equivalent to v0.11.9
+			},
+		},
+	}
 
-	// module version is asking for a too old version
-	stderr, err = clientCtr.
-		WithNewFile("/work/dagger.json", `{"name": "bare", "sdk": "go", "engineVersion": "v1.0.0"}`).
-		WithNewFile("/query.graphql", `{bare{containerEcho(stringArg:"hello"){stdout}}}`).
-		WithExec([]string{"sh", "-c", "! dagger query --debug --doc /query.graphql"}).
-		Stderr(ctx)
-	require.NoError(t, err)
-	require.Contains(t, stderr, devEngineVersion)
-	require.Contains(t, stderr, "module requires incompatible engine")
-	require.Contains(t, stderr, "does not meet required version")
+	engines := map[string]*dagger.Service{}
+	enginesMu := sync.Mutex{}
 
-	// module version is asking for a too new version
-	stderr, err = clientCtr.
-		WithNewFile("/work/dagger.json", `{"name": "bare", "sdk": "go", "engineVersion": "v3.0.0"}`).
-		WithNewFile("/query.graphql", `{bare{containerEcho(stringArg:"hello"){stdout}}}`).
-		WithExec([]string{"sh", "-c", "! dagger query --debug --doc /query.graphql"}).
-		Stderr(ctx)
-	require.NoError(t, err)
-	require.Contains(t, stderr, devEngineVersion)
-	require.Contains(t, stderr, "module requires incompatible engine")
-	require.Contains(t, stderr, "greater than supported version")
+	for _, tc := range tcs {
+		// get a cached engine if possible (saves spinning up more engines than we need to)
+		tc := tc
+		t.Run(tc.name, func(ctx context.Context, t *testctx.T) {
+			devEngineSvcKey := tc.engineVersion + " " + tc.moduleMinVersion
+			enginesMu.Lock()
+			devEngineSvc, ok := engines[devEngineSvcKey]
+			if !ok {
+				devEngineSvc = devEngineContainer(c, func(c *dagger.Container) *dagger.Container {
+					return c.
+						WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", tc.engineVersion).
+						WithEnvVariable("_EXPERIMENTAL_DAGGER_MIN_VERSION", tc.moduleMinVersion)
+				}).AsService()
+				engines[devEngineSvcKey] = devEngineSvc
+			}
+			enginesMu.Unlock()
 
-	// module version is an old-style development version
-	stderr, err = clientCtr.
-		WithNewFile("/work/dagger.json", `{"name": "bare", "sdk": "go", "engineVersion": "dev-foobar"}`).
-		WithNewFile("/query.graphql", `{bare{containerEcho(stringArg:"hello"){stdout}}}`).
-		WithExec([]string{"sh", "-c", "! dagger query --debug --doc /query.graphql"}).
-		Stderr(ctx)
-	require.NoError(t, err)
-	require.Contains(t, stderr, devEngineVersion)
-	require.Contains(t, stderr, "v0.11.9") // old-style dev versions are equivalent to v0.11.9
-	require.Contains(t, stderr, "module requires incompatible engine")
+			clientCtr, err := engineClientContainer(ctx, t, c, devEngineSvc)
+			require.NoError(t, err)
+			clientCtr = clientCtr.
+				WithWorkdir("/work").
+				// set version to empty, this makes it the latest, we don't want to
+				// test client compat (that's the previous tests)
+				WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", "").
+				With(daggerExec("init", "--name=bare", "--sdk=go"))
+
+			clientCtr = clientCtr.
+				WithNewFile("/work/dagger.json", `{"name": "bare", "sdk": "go", "engineVersion": "`+tc.moduleVersion+`"}`).
+				WithNewFile("/query.graphql", `{bare{containerEcho(stringArg:"hello"){stdout}}}`)
+
+			if tc.errs == nil {
+				clientCtr = clientCtr.
+					WithExec([]string{"sh", "-c", "dagger query --debug --doc /query.graphql"})
+			} else {
+				clientCtr = clientCtr.
+					WithExec([]string{"sh", "-c", "! dagger query --debug --doc /query.graphql"})
+			}
+
+			stderr, err := clientCtr.Stderr(ctx)
+			require.NoError(t, err)
+			for _, tcerr := range tc.errs {
+				require.Contains(t, stderr, tcerr)
+			}
+		})
+	}
 }

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -12,12 +12,10 @@ import (
 
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/vektah/gqlparser/v2/ast"
-	"golang.org/x/mod/semver"
 
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
-	"github.com/dagger/dagger/engine"
 )
 
 type ModuleSourceKind string
@@ -225,15 +223,6 @@ func (src *ModuleSource) ModuleEngineVersion(ctx context.Context) (string, error
 		return "", fmt.Errorf("module config: %w", err)
 	}
 	if !ok {
-		return "", nil
-	}
-	if cfg.EngineVersion == "" {
-		// older versions of dagger might not produce an engine version - so
-		// return the version that engineVersion was introduced in
-		return engine.MinimumModuleVersion, nil
-	}
-	if !semver.IsValid(cfg.EngineVersion) {
-		// filter out non-semver values to simplify calling code
 		return "", nil
 	}
 	return cfg.EngineVersion, nil

--- a/core/schema/util.go
+++ b/core/schema/util.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 
 	"github.com/iancoleman/strcase"
+	"golang.org/x/mod/semver"
 
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/introspection"
-	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/buildkit"
 )
 
@@ -86,7 +86,10 @@ var AllVersion = dagql.AllView{}
 type AfterVersion string
 
 func (minVersion AfterVersion) Contains(version string) bool {
-	return engine.CheckVersionCompatibility(version, string(minVersion)) == nil
+	if version == "" {
+		return true
+	}
+	return semver.Compare(version, string(minVersion)) >= 0
 }
 
 // BeforeVersion is a view that checks if a target version is less than the
@@ -94,5 +97,8 @@ func (minVersion AfterVersion) Contains(version string) bool {
 type BeforeVersion string
 
 func (maxVersion BeforeVersion) Contains(version string) bool {
-	return engine.CheckVersionCompatibility(version, string(maxVersion)) != nil
+	if version == "" {
+		return false
+	}
+	return semver.Compare(version, string(maxVersion)) < 0
 }

--- a/dev/cli.go
+++ b/dev/cli.go
@@ -34,7 +34,9 @@ func (cli *CLI) Binary(
 	if err != nil {
 		return nil, err
 	}
-	builder = builder.WithVersion(cli.Dagger.Version.String())
+	builder = builder.
+		WithVersion(cli.Dagger.Version.String()).
+		WithTag(cli.Dagger.Tag)
 	if platform != "" {
 		builder = builder.WithPlatform(platform)
 	}
@@ -65,8 +67,8 @@ func (cli *CLI) Publish(
 	artefactsFQDN *dagger.Secret,
 ) error {
 	args := []string{"release", "--clean", "--skip-validate", "--debug"}
-	if cli.Dagger.Version.Tag != "" {
-		args = append(args, "--release-notes", fmt.Sprintf(".changes/%s.md", cli.Dagger.Version.Tag))
+	if cli.Dagger.Tag != "" {
+		args = append(args, "--release-notes", fmt.Sprintf(".changes/%s.md", cli.Dagger.Tag))
 	} else {
 		// if this isn't an official semver version, do a dev release
 		args = append(args,
@@ -92,6 +94,7 @@ func (cli *CLI) Publish(
 		WithSecretVariable("AWS_BUCKET", awsBucket).
 		WithSecretVariable("ARTEFACTS_FQDN", artefactsFQDN).
 		WithEnvVariable("ENGINE_VERSION", cli.Dagger.Version.String()).
+		WithEnvVariable("ENGINE_TAG", cli.Dagger.Tag).
 		With(func(ctr *dagger.Container) *dagger.Container {
 			if cli.Dagger.Version.Tag == "" {
 				// goreleaser refuses to run if there isn't a tag, so set it to a dummy but valid semver
@@ -121,7 +124,9 @@ func (cli *CLI) TestPublish(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	builder = builder.WithVersion(cli.Dagger.Version.String())
+	builder = builder.
+		WithVersion(cli.Dagger.Version.String()).
+		WithTag(cli.Dagger.Tag)
 
 	var eg errgroup.Group
 	for _, os := range oses {

--- a/dev/engine.go
+++ b/dev/engine.go
@@ -86,6 +86,7 @@ func (e *Engine) Container(
 	}
 	builder = builder.
 		WithVersion(e.Dagger.Version.String()).
+		WithTag(e.Dagger.Tag).
 		WithRace(e.Race)
 	if platform != "" {
 		builder = builder.WithPlatform(platform)

--- a/dev/internal/build/builder.go
+++ b/dev/internal/build/builder.go
@@ -24,6 +24,7 @@ type Builder struct {
 	source *dagger.Directory
 
 	version string
+	tag     string
 
 	platform     dagger.Platform
 	platformSpec ocispecs.Platform
@@ -83,6 +84,12 @@ func NewBuilder(ctx context.Context, source *dagger.Directory) (*Builder, error)
 func (build *Builder) WithVersion(version string) *Builder {
 	b := *build
 	b.version = version
+	return &b
+}
+
+func (build *Builder) WithTag(tag string) *Builder {
+	b := *build
+	b.tag = tag
 	return &b
 }
 
@@ -312,6 +319,9 @@ func (build *Builder) binary(pkg string, version bool, race bool) *dagger.File {
 	}
 	if version && build.version != "" {
 		ldflags = append(ldflags, "-X", "github.com/dagger/dagger/engine.Version="+build.version)
+	}
+	if version && build.tag != "" {
+		ldflags = append(ldflags, "-X", "github.com/dagger/dagger/engine.Tag="+build.tag)
 	}
 
 	output := filepath.Join("./bin/", filepath.Base(pkg))

--- a/dev/mage/engine.go
+++ b/dev/mage/engine.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	OutputDir           = ""
-	EngineContainerName = "dagger-engine.dev"
+	EngineContainerName = distconsts.EngineContainerName
 )
 
 func init() {

--- a/dev/main.go
+++ b/dev/main.go
@@ -13,6 +13,7 @@ import (
 type DaggerDev struct {
 	Src     *dagger.Directory // +private
 	Version *VersionInfo
+	Tag     string
 	// When set, module codegen is automatically applied when retrieving the Dagger source code
 	ModCodegen bool
 
@@ -28,6 +29,9 @@ func New(
 	// +optional
 	version string,
 	// +optional
+	tag string,
+
+	// +optional
 	dockerCfg *dagger.Secret,
 ) (*DaggerDev, error) {
 	versionInfo, err := newVersion(ctx, source, version)
@@ -38,6 +42,7 @@ func New(
 	return &DaggerDev{
 		Src:       source,
 		Version:   versionInfo,
+		Tag:       tag,
 		DockerCfg: dockerCfg,
 	}, nil
 }

--- a/dev/test.go
+++ b/dev/test.go
@@ -96,6 +96,7 @@ func (t *Test) test(
 	// Add ldflags
 	ldflags := []string{
 		"-X", "github.com/dagger/dagger/engine.Version=" + t.Dagger.Version.String(),
+		"-X", "github.com/dagger/dagger/engine.Tag=" + t.Dagger.Tag,
 	}
 	args = append(args, "-ldflags", strings.Join(ldflags, " "))
 

--- a/dev/version.go
+++ b/dev/version.go
@@ -5,16 +5,29 @@ import (
 	"crypto/sha1" //nolint:gosec
 	"encoding/hex"
 	"fmt"
+	"path/filepath"
 	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/dagger/dagger/dev/internal/dagger"
 	"golang.org/x/mod/semver"
 )
 
+// VersionInfo is a helper for passing version information around.
+//
+// In general, it attempts to follow go's psedudoversioning:
+// https://go.dev/doc/modules/version-numbers
+
 type VersionInfo struct {
-	Tag    string
-	Commit string
-	Dev    string
+	Tag string
+
+	NextVersion string
+	Timestamp   string
+	Commit      string
+	Dev         string
 }
 
 var commitRegexp = regexp.MustCompile("^[0-9a-f]{40}$")
@@ -22,19 +35,31 @@ var commitRegexp = regexp.MustCompile("^[0-9a-f]{40}$")
 func newVersion(ctx context.Context, dir *dagger.Directory, version string) (*VersionInfo, error) {
 	switch {
 	case version == "":
-		id, err := dir.ID(ctx)
+		dgst, err := dirhash(ctx, dir)
 		if err != nil {
 			return nil, err
 		}
-
-		h := sha1.New() //nolint:gosec
-		h.Write([]byte(id))
-		dgst := hex.EncodeToString(h.Sum(nil))
-		return &VersionInfo{Dev: dgst}, nil
+		next, err := nextVersion(ctx, dir)
+		if err != nil {
+			return nil, err
+		}
+		return &VersionInfo{
+			Dev:         dgst,
+			NextVersion: next,
+			Timestamp:   pseudoversionTimestamp(time.Time{}),
+		}, nil
+	case commitRegexp.MatchString(version):
+		next, err := nextVersion(ctx, dir)
+		if err != nil {
+			return nil, err
+		}
+		return &VersionInfo{
+			Commit:      version,
+			NextVersion: next,
+			Timestamp:   pseudoversionTimestamp(time.Now().UTC()),
+		}, nil
 	case semver.IsValid(version):
 		return &VersionInfo{Tag: version}, nil
-	case commitRegexp.MatchString(version):
-		return &VersionInfo{Commit: version}, nil
 	default:
 		return nil, fmt.Errorf("could not parse version info %q", version)
 	}
@@ -44,11 +69,114 @@ func (info *VersionInfo) String() string {
 	if info.Tag != "" {
 		return info.Tag
 	}
-	if info.Commit != "" {
-		return info.Commit
+
+	nextVersion := info.NextVersion
+	if nextVersion == "" {
+		nextVersion = "v0.0.0"
 	}
-	if info.Dev != "" {
-		return "dev-" + info.Dev
+	timestamp := info.Timestamp
+	if timestamp == "" {
+		timestamp = pseudoversionTimestamp(time.Time{})
 	}
-	return "dev-unknown"
+
+	var rest string
+	switch {
+	case info.Commit != "":
+		rest = info.Commit[:12]
+	case info.Dev != "":
+		rest = "dev-" + info.Dev[:12]
+	default:
+		rest = "dev-" + strings.Repeat("0", 12)
+	}
+	return fmt.Sprintf("%s-%s-%s", nextVersion, timestamp, rest)
+}
+
+// nextVersion determines the "next" version to be released.
+//
+// It first attempts to use the version in .changes/.next, but if this fails,
+// or that version seems to have already been released, then we automagically
+// calculate the next patch release in the current series.
+func nextVersion(ctx context.Context, dir *dagger.Directory) (string, error) {
+	// this is kinda meh, since it assumes changie releases match up with git
+	// tags - thankfully this is true for us (otherwise, we'd have to look at
+	// *all* the tags in the source, which would be slow)
+	entries, err := dir.Directory(".changes").Entries(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	// if there's a defined next version, try and use that
+	var definedNextVersion string
+	if slices.Contains(entries, ".next") {
+		content, err := dir.File(".changes/.next").Contents(ctx)
+		if err != nil {
+			return "", err
+		}
+		for _, line := range strings.Split(content, "\n") {
+			line = strings.TrimSpace(line)
+			if len(line) == 0 {
+				// empty
+				continue
+			}
+			if strings.HasPrefix(line, "#") {
+				// comment
+				continue
+			}
+
+			definedNextVersion = baseVersion(line)
+			break
+		}
+	}
+
+	// also try and determine what the last version was, so we can
+	// auto-determine a next version from that
+	var lastVersion string
+	for _, entry := range entries {
+		entry, _ := strings.CutSuffix(entry, filepath.Ext(entry))
+		if semver.Compare(entry, lastVersion) > 0 {
+			lastVersion = entry
+		}
+	}
+	if lastVersion == "" {
+		return "", fmt.Errorf("could not find any valid versions")
+	}
+	lastVersion = baseVersion(lastVersion)
+
+	majorMinor := semver.MajorMinor(lastVersion)
+	patchStr, _ := strings.CutPrefix(lastVersion, majorMinor+".")
+	patch, err := strconv.Atoi(patchStr)
+	if err != nil {
+		return "", err
+	}
+	nextVersion := fmt.Sprintf("%s.%d", majorMinor, patch+1)
+
+	if semver.Compare(definedNextVersion, nextVersion) > 0 {
+		// if the defined next version is larger than the auto-generated one,
+		// override it - this'll be the case for when we plan to bump to a
+		// minor version
+		nextVersion = definedNextVersion
+	}
+	return nextVersion, nil
+}
+
+func dirhash(ctx context.Context, dir *dagger.Directory) (string, error) {
+	id, err := dir.ID(ctx)
+	if err != nil {
+		return "", err
+	}
+	h := sha1.New() //nolint:gosec
+	h.Write([]byte(id))
+	dgst := hex.EncodeToString(h.Sum(nil))
+	return dgst, nil
+}
+
+func pseudoversionTimestamp(t time.Time) string {
+	// go time formatting is bizarre - this translates to "yymmddhhmmss"
+	return t.Format("060102150405")
+}
+
+func baseVersion(version string) string {
+	version = strings.TrimSuffix(version, semver.Build(version))
+	version = strings.TrimSuffix(version, semver.Prerelease(version))
+	return version
 }

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -203,7 +203,7 @@ func Connect(ctx context.Context, params Params) (_ *Client, _ context.Context, 
 	if err := c.startEngine(connectCtx); err != nil {
 		return nil, nil, fmt.Errorf("start engine: %w", err)
 	}
-	err = engine.CheckVersionCompatibility(c.bkVersion, engine.MinimumEngineVersion)
+	err = engine.CheckVersionCompatibility(engine.NormalizeVersion(c.bkVersion), engine.MinimumEngineVersion)
 	if err != nil {
 		return nil, nil, fmt.Errorf("incompatible engine version: %w", err)
 	}

--- a/engine/distconsts/consts.go
+++ b/engine/distconsts/consts.go
@@ -6,6 +6,10 @@
 package distconsts
 
 const (
+	EngineContainerName = "dagger-engine.dev"
+)
+
+const (
 	RuncPath     = "/usr/local/bin/runc"
 	DumbInitPath = "/usr/local/bin/dumb-init"
 

--- a/engine/version.go
+++ b/engine/version.go
@@ -3,6 +3,8 @@ package engine
 import (
 	"fmt"
 	"os"
+	"slices"
+	"strings"
 
 	"golang.org/x/mod/semver"
 )
@@ -61,14 +63,24 @@ func normalizeVersion(v string) string {
 }
 
 func CheckVersionCompatibility(version string, minVersion string) error {
-	if !semver.IsValid(version) {
-		return nil // probably a dev version
+	if isDevVersion(version) || isDevVersion(minVersion) {
+		// assume that a dev version in either direction is *always* compatible
+		return nil
 	}
-	if !semver.IsValid(minVersion) {
-		return nil // probably a dev version
-	}
+
 	if semver.Compare(version, minVersion) < 0 {
 		return fmt.Errorf("version %s does not meet required version %s", version, minVersion)
 	}
 	return nil
+}
+
+func isDevVersion(version string) bool {
+	if !semver.IsValid(version) {
+		// probably an old dev version
+		return true
+	}
+
+	// a more "modern" dev version
+	parts := strings.Split(semver.Prerelease(version), "-")
+	return slices.Contains(parts, "dev")
 }

--- a/engine/version.go
+++ b/engine/version.go
@@ -14,9 +14,11 @@ var (
 	//
 	// Note: this is filled at link-time.
 	//
-	// - For official tagged releases, this is simple semver like x.y.z
-	// - For builds off our repo's main branch, this is the git commit sha
-	// - For local dev builds, this is a content hash of the source directory
+	// - For official tagged releases, this is simple semver like vX.Y.Z
+	// - For builds off our repo's main branch, this is a pre-release of the
+	//   form vX.Y.Z-<timestamp>-<commit>
+	// - For local dev builds with no other specified version, this is a
+	//   pre-release of the form vX.Y.Z-<timestamp>-dev-<dirhash>
 	Version string
 
 	// MinimumEngineVersion is used by the client to determine the minimum
@@ -36,26 +38,42 @@ var (
 	MinimumModuleVersion = "v0.9.9"
 )
 
+var (
+	presemverModuleVersion = "v0.11.9"
+)
+
 func init() {
+	// The minimum version is greater than our current version this is weird,
+	// and shouldn't generally be intentional - but can happen if we set it to
+	// vX.Y.Z in anticipation of the next release being vX.Y.Z.
+	//
+	// To avoid this causing huge issues in dev builds no longer being able
+	// to connect to each other, in this scenario, we cap the minVersion at
+	// the current version.
+	if semver.Compare(Version, MinimumClientVersion) < 0 {
+		MinimumClientVersion = Version
+	}
+	if semver.Compare(Version, MinimumEngineVersion) < 0 {
+		MinimumEngineVersion = Version
+	}
+	if semver.Compare(Version, MinimumModuleVersion) < 0 {
+		MinimumModuleVersion = Version
+	}
+
 	// hack: dynamically populate version env vars
-	// we use these during tests, but not really for anything else
+	// we use these during tests, but not really for anything else - this is
+	// why it's okay to skip the previous validation
 	if v, ok := os.LookupEnv(DaggerVersionEnv); ok {
-		Version = v
+		Version = cleanVersion(v)
 	}
 	if v, ok := os.LookupEnv(DaggerMinimumVersionEnv); ok {
-		MinimumClientVersion = v
-		MinimumEngineVersion = v
-		MinimumModuleVersion = v
+		MinimumClientVersion = cleanVersion(v)
+		MinimumEngineVersion = cleanVersion(v)
+		MinimumModuleVersion = cleanVersion(v)
 	}
-
-	// normalize version strings
-	Version = normalizeVersion(Version)
-	MinimumClientVersion = normalizeVersion(MinimumClientVersion)
-	MinimumEngineVersion = normalizeVersion(MinimumEngineVersion)
-	MinimumModuleVersion = normalizeVersion(MinimumModuleVersion)
 }
 
-func normalizeVersion(v string) string {
+func cleanVersion(v string) string {
 	if semver.IsValid("v" + v) {
 		return "v" + v
 	}
@@ -63,24 +81,58 @@ func normalizeVersion(v string) string {
 }
 
 func CheckVersionCompatibility(version string, minVersion string) error {
-	if isDevVersion(version) || isDevVersion(minVersion) {
-		// assume that a dev version in either direction is *always* compatible
-		return nil
+	v := version
+	if isDevVersion(v) && isDevVersion(Version) {
+		// Both our version and our target version are dev versions - in this
+		// case, strip pre-release info from our target, we should pretend it's
+		// just the real thing here.
+		v = BaseVersion(v)
 	}
-
-	if semver.Compare(version, minVersion) < 0 {
+	if semver.Compare(v, minVersion) < 0 {
 		return fmt.Errorf("version %s does not meet required version %s", version, minVersion)
 	}
 	return nil
 }
 
+func CheckMaxVersionCompatibility(version string, maxVersion string) error {
+	v := version
+	if isDevVersion(v) && isDevVersion(Version) {
+		// see CheckVersionCompatibility
+		v = BaseVersion(v)
+	}
+	if semver.Compare(v, maxVersion) > 0 {
+		return fmt.Errorf("version %s is greater than supported version %s", version, maxVersion)
+	}
+	return nil
+}
+
+func NormalizeVersion(version string) string {
+	version = cleanVersion(version)
+	switch {
+	case version == "":
+		// if the target version is empty, this is weird, but probably because
+		// someone did a manual build - so just assume they know what they're
+		// doing, and set it to be the latest we know about
+		return Version
+	case !semver.IsValid(version):
+		// older versions of dagger don't all use semver, so if it's a
+		// non-semver version, assume it's v0.11.9 (not perfect, but it's a
+		// pretty good guess)
+		return presemverModuleVersion
+	default:
+		return version
+	}
+}
+
+func BaseVersion(version string) string {
+	version = strings.TrimSuffix(version, semver.Build(version))
+	version = strings.TrimSuffix(version, semver.Prerelease(version))
+	return version
+}
+
 func isDevVersion(version string) bool {
-	if !semver.IsValid(version) {
-		// probably an old dev version
+	if version == "" {
 		return true
 	}
-
-	// a more "modern" dev version
-	parts := strings.Split(semver.Prerelease(version), "-")
-	return slices.Contains(parts, "dev")
+	return slices.Contains(strings.Split(semver.Prerelease(version), "-"), "dev")
 }

--- a/engine/version_test.go
+++ b/engine/version_test.go
@@ -1,0 +1,154 @@
+package engine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/mod/semver"
+)
+
+func TestVersionCompatibility(t *testing.T) {
+	tc := []struct {
+		targetVersion  string
+		minVersion     string
+		currentVersion string
+		compatible     bool
+	}{
+		// fairly normal release versions
+		{
+			// v0.2.0 > v0.1.0
+			targetVersion: "v0.2.0",
+			minVersion:    "v0.1.0",
+			compatible:    true,
+		},
+		{
+			// v0.2.0 == v0.2.0
+			targetVersion: "v0.2.0",
+			minVersion:    "v0.2.0",
+			compatible:    true,
+		},
+		{
+			// v0.2.0 < v0.3.0
+			targetVersion: "v0.2.0",
+			minVersion:    "v0.3.0",
+			compatible:    false,
+		},
+
+		// more complicated pre-releases
+		{
+			// v0.2.0-123 < v0.2.0
+			targetVersion: "v0.2.0-123",
+			minVersion:    "v0.2.0",
+			compatible:    false,
+		},
+		{
+			// v0.2.0-123 ~= v0.2.0
+			targetVersion:  "v0.2.0-123",
+			minVersion:     "v0.2.0",
+			currentVersion: "v0.2.0-123",
+			compatible:     true,
+		},
+		{
+			// v0.2.0-123 !~= v0.2.0
+			targetVersion:  "v0.2.0-123",
+			minVersion:     "v0.2.0",
+			currentVersion: "v0.2.0-456",
+			compatible:     false,
+		},
+
+		// even more complicated dev versions
+		{
+			// v0.2.0-dev-123 ~= v0.2.0
+			targetVersion:  "v0.2.0-dev-123",
+			minVersion:     "v0.2.0",
+			currentVersion: "v0.2.0-dev-123",
+			compatible:     true,
+		},
+		{
+			// v0.2.0-dev-123 ~= v0.2.0
+			targetVersion:  "v0.2.0-dev-123",
+			minVersion:     "v0.2.0",
+			currentVersion: "v0.2.0-dev-456",
+			compatible:     true,
+		},
+	}
+
+	for _, tc := range tc {
+		var name string
+		if tc.compatible {
+			name = fmt.Sprintf("%s is compatible with %s", tc.targetVersion, tc.minVersion)
+		} else {
+			name = fmt.Sprintf("%s is not compatible with %s", tc.targetVersion, tc.minVersion)
+		}
+		t.Run(name, func(t *testing.T) {
+			// if no version is explicitly asked for, just assume it's the same
+			// as the minVersion, just keeps our test cases smaller
+			currentVersion := tc.currentVersion
+			if currentVersion == "" {
+				currentVersion = tc.minVersion
+			}
+			setVersion(t, currentVersion)
+
+			// this is to replicate the logic in capping the minimum version logic
+			minVersion := tc.minVersion
+			if semver.Compare(currentVersion, minVersion) < 0 {
+				minVersion = currentVersion
+			}
+
+			err := CheckVersionCompatibility(tc.targetVersion, minVersion)
+			if tc.compatible {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestNormalizeVersion(t *testing.T) {
+	setVersion(t, "v0.3.0")
+	tc := []struct {
+		version string
+		result  string
+	}{
+		{version: "v0.2.0", result: "v0.2.0"},
+		{version: "0.2.0", result: "v0.2.0"},
+		{version: "v0.2.0-123", result: "v0.2.0-123"},
+		{version: "", result: "v0.3.0"},
+		{version: "foobar", result: presemverModuleVersion},
+	}
+	for _, tc := range tc {
+		t.Run(tc.version, func(t *testing.T) {
+			require.Equal(t, tc.result, NormalizeVersion(tc.version))
+		})
+	}
+}
+
+func TestBaseVersion(t *testing.T) {
+	tc := []struct {
+		version string
+		result  string
+	}{
+		{version: "v0.2.0", result: "v0.2.0"},
+		{version: "v0.2.0-123", result: "v0.2.0"},
+		{version: "v0.2.0-123+456", result: "v0.2.0"},
+		{version: "v0.2.0+456", result: "v0.2.0"},
+		{version: "", result: ""},
+		{version: "foobar", result: "foobar"},
+	}
+	for _, tc := range tc {
+		t.Run(tc.version, func(t *testing.T) {
+			require.Equal(t, tc.result, BaseVersion(tc.version))
+		})
+	}
+}
+
+func setVersion(t *testing.T, version string) {
+	t.Helper()
+	oldVersion := Version
+	Version = version
+	t.Cleanup(func() {
+		Version = oldVersion
+	})
+}


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/7760

Instead of just using commit hashes and directory IDs, which produces nearly incomprehensible versions (which is more of a pain, now that `engineVersion` is actually important). This makes it a *bit* clearer when and where a non-tagged build came from by using changie to get the last release we built.

Frustratingly, it seems non-trivial to do version comparison on these, so we keep skipping these. In the future, we should work out on compromise. For an example of why this is hard: suppose that we add a MinVersion of v0.12.0 - the next pre-release will end up being something like "v0.11.10-dev-240709191414-1ccb8772510a". So this version will fail these checks.

We could add a little piece of code to note what the *next* release will be - which would make these comparison a lot simpler (essentially, we'd treat pre-releases of vX as equivalent to X). But this would require too much extra maintainance for now - but maybe we could dupe this with MinVersion numbers in `version.go` today.

![image](https://github.com/dagger/dagger/assets/7352848/2fe5ad72-07d5-4602-a2be-911441bf5e8a)

You get a semver tag!