### PR TITLE
fix(codegen): load object when output needs to be converted from ID in Go and TypeScript

### DIFF
--- a/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
@@ -90,12 +90,18 @@ type {{ $field | FieldOptionsStructName }} struct {
 	q = q.Arg("{{ $arg.Name }}", {{ $arg.Name }})
 	{{- end }}
 	{{- end }}
+	{{- $typeName := $field.TypeRef | FormatOutputType }}
     {{ if $convertID }}
-	return r, q.Execute(ctx)
+    var id {{ $typeName }}
+    if err := q.Bind(&id).Execute(ctx); err != nil {
+        return nil, err
+    }
+	return &{{ $field.ParentObject.Name }} {
+        query: q.Root().Select("load{{ $field.ParentObject.Name }}FromID").Arg("id", id),
+    }, nil
 
 	{{- else if $field.TypeRef.IsObject }}
-	{{ $typeName := $field.TypeRef | FormatOutputType }}
-	return &{{ $field.TypeRef | FormatOutputType }} {
+	return &{{ $typeName }} {
 		query: q,
 		{{- if eq $typeName "Client" }}
 		client: r.client,

--- a/cmd/codegen/generator/typescript/templates/src/method_solve.ts.gtpl
+++ b/cmd/codegen/generator/typescript/templates/src/method_solve.ts.gtpl
@@ -62,7 +62,7 @@
 	{{- end }}
 
 	{{- if .TypeRef }}
-    {{ if not $convertID }}const response: Awaited<{{ $promiseRetType }}> = {{ end }}await computeQuery(
+    const response: Awaited<{{ if $convertID }}{{ .TypeRef | FormatOutputType }}{{ else }}{{ $promiseRetType }}{{ end }}> = await computeQuery(
       [
         ...this._queryTree,
         {
@@ -93,7 +93,15 @@
     )
 
     {{ if $convertID -}}
-    return this
+    return new {{ $promiseRetType }}({
+      queryTree: [
+        {
+          operation: "load{{ $promiseRetType }}FromID",
+          args: { id: response },
+        },
+      ],
+      ctx: this._ctx,
+    })
     {{- else -}}
         {{- if and .TypeRef.IsList (IsListOfObject .TypeRef) }}
     return response.map(

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -925,7 +925,13 @@ func (r *Container) Stdout(ctx context.Context) (string, error) {
 func (r *Container) Sync(ctx context.Context) (*Container, error) {
 	q := r.query.Select("sync")
 
-	return r, q.Execute(ctx)
+	var id ContainerID
+	if err := q.Bind(&id).Execute(ctx); err != nil {
+		return nil, err
+	}
+	return &Container{
+		query: q.Root().Select("loadContainerFromID").Arg("id", id),
+	}, nil
 }
 
 // ContainerTerminalOpts contains options for Container.Terminal
@@ -2511,7 +2517,13 @@ func (r *Directory) Pipeline(name string, opts ...DirectoryPipelineOpts) *Direct
 func (r *Directory) Sync(ctx context.Context) (*Directory, error) {
 	q := r.query.Select("sync")
 
-	return r, q.Execute(ctx)
+	var id DirectoryID
+	if err := q.Bind(&id).Execute(ctx); err != nil {
+		return nil, err
+	}
+	return &Directory{
+		query: q.Root().Select("loadDirectoryFromID").Arg("id", id),
+	}, nil
 }
 
 // DirectoryTerminalOpts contains options for Directory.Terminal
@@ -3224,7 +3236,13 @@ func (r *File) Size(ctx context.Context) (int, error) {
 func (r *File) Sync(ctx context.Context) (*File, error) {
 	q := r.query.Select("sync")
 
-	return r, q.Execute(ctx)
+	var id FileID
+	if err := q.Bind(&id).Execute(ctx); err != nil {
+		return nil, err
+	}
+	return &File{
+		query: q.Root().Select("loadFileFromID").Arg("id", id),
+	}, nil
 }
 
 // Retrieves this file with its name set to the given name.
@@ -7249,7 +7267,13 @@ func (r *Service) Ports(ctx context.Context) ([]Port, error) {
 func (r *Service) Start(ctx context.Context) (*Service, error) {
 	q := r.query.Select("start")
 
-	return r, q.Execute(ctx)
+	var id ServiceID
+	if err := q.Bind(&id).Execute(ctx); err != nil {
+		return nil, err
+	}
+	return &Service{
+		query: q.Root().Select("loadServiceFromID").Arg("id", id),
+	}, nil
 }
 
 // ServiceStopOpts contains options for Service.Stop
@@ -7268,7 +7292,13 @@ func (r *Service) Stop(ctx context.Context, opts ...ServiceStopOpts) (*Service, 
 		}
 	}
 
-	return r, q.Execute(ctx)
+	var id ServiceID
+	if err := q.Bind(&id).Execute(ctx); err != nil {
+		return nil, err
+	}
+	return &Service{
+		query: q.Root().Select("loadServiceFromID").Arg("id", id),
+	}, nil
 }
 
 // ServiceUpOpts contains options for Service.Up

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -1931,7 +1931,7 @@ export class Container extends BaseClient {
    * It doesn't run the default command if no exec has been set.
    */
   sync = async (): Promise<Container> => {
-    await computeQuery(
+    const response: Awaited<ContainerID> = await computeQuery(
       [
         ...this._queryTree,
         {
@@ -1941,7 +1941,15 @@ export class Container extends BaseClient {
       await this._ctx.connection(),
     )
 
-    return this
+    return new Container({
+      queryTree: [
+        {
+          operation: "loadContainerFromID",
+          args: { id: response },
+        },
+      ],
+      ctx: this._ctx,
+    })
   }
 
   /**
@@ -3624,7 +3632,7 @@ export class Directory extends BaseClient {
    * Force evaluation in the engine.
    */
   sync = async (): Promise<Directory> => {
-    await computeQuery(
+    const response: Awaited<DirectoryID> = await computeQuery(
       [
         ...this._queryTree,
         {
@@ -3634,7 +3642,15 @@ export class Directory extends BaseClient {
       await this._ctx.connection(),
     )
 
-    return this
+    return new Directory({
+      queryTree: [
+        {
+          operation: "loadDirectoryFromID",
+          args: { id: response },
+        },
+      ],
+      ctx: this._ctx,
+    })
   }
 
   /**
@@ -4412,7 +4428,7 @@ export class File extends BaseClient {
    * Force evaluation in the engine.
    */
   sync = async (): Promise<File> => {
-    await computeQuery(
+    const response: Awaited<FileID> = await computeQuery(
       [
         ...this._queryTree,
         {
@@ -4422,7 +4438,15 @@ export class File extends BaseClient {
       await this._ctx.connection(),
     )
 
-    return this
+    return new File({
+      queryTree: [
+        {
+          operation: "loadFileFromID",
+          args: { id: response },
+        },
+      ],
+      ctx: this._ctx,
+    })
   }
 
   /**
@@ -9343,7 +9367,7 @@ export class Service extends BaseClient {
    * Services bound to a Container do not need to be manually started.
    */
   start = async (): Promise<Service> => {
-    await computeQuery(
+    const response: Awaited<ServiceID> = await computeQuery(
       [
         ...this._queryTree,
         {
@@ -9353,7 +9377,15 @@ export class Service extends BaseClient {
       await this._ctx.connection(),
     )
 
-    return this
+    return new Service({
+      queryTree: [
+        {
+          operation: "loadServiceFromID",
+          args: { id: response },
+        },
+      ],
+      ctx: this._ctx,
+    })
   }
 
   /**
@@ -9361,7 +9393,7 @@ export class Service extends BaseClient {
    * @param opts.kill Immediately kill the service without waiting for a graceful exit
    */
   stop = async (opts?: ServiceStopOpts): Promise<Service> => {
-    await computeQuery(
+    const response: Awaited<ServiceID> = await computeQuery(
       [
         ...this._queryTree,
         {
@@ -9372,7 +9404,15 @@ export class Service extends BaseClient {
       await this._ctx.connection(),
     )
 
-    return this
+    return new Service({
+      queryTree: [
+        {
+          operation: "loadServiceFromID",
+          args: { id: response },
+        },
+      ],
+      ctx: this._ctx,
+    })
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/7788

Didn't affect just `sync`. Not sure if the affected fields in `Service` had issues before this.