### PR TITLE
ci: Allow skipping specific tests - e.g. TestModule - or only run specific ones

### DIFF
--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -134,7 +134,7 @@ runs:
       if: always() && inputs.upload-logs == 'true'
       uses: actions/upload-artifact@v4
       with:
-        name: call-logs-${{ runner.name }}-${{ inputs.function }}
+        name: call-logs-${{ runner.name }}-${{ github.job }}
         path: /tmp/actions/call/call.log
         overwrite: true
 

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -46,6 +46,28 @@ jobs:
           function: "test all --race=true --parallel=16"
           upload-logs: true
 
+  test-modules:
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-5-16c-st-od' || 'ubuntu-latest' }}"
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: "test"
+        uses: ./.github/actions/call
+        with:
+          function: "test specific --run=TestModule --race=true --parallel=16"
+          upload-logs: true
+
+  test-everything-else:
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-5-16c-st-od' || 'ubuntu-latest' }}"
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: "test"
+        uses: ./.github/actions/call
+        with:
+          function: "test specific --skip=TestModule --race=true --parallel=16"
+          upload-logs: true
+
   # Run Engine tests in dev Engine so that we can spot integration failures early
   # Only run a subset of important test cases since we just need to verify basic
   # functionality rather than repeat every test already run in the other targets.
@@ -57,7 +79,7 @@ jobs:
       - name: "testdev"
         uses: ./.github/actions/call
         with:
-          function: "test important --race=true --parallel=16"
+          function: "test specific --run='TestModule|TestContainer' --race=true --parallel=16"
           dev-engine: true
           upload-logs: true
 


### PR DESCRIPTION
> [!NOTE]
> While this PR started by splitting our Engine & CLI tests in `TestModule` and everything else, it has since been changed. We are keeping the existing test suite **as is**, while adding two new test suites:
> 1. `test-module`
> 2. `test-everything-else`
>
> This is meant to inform the next steps for:
> - https://github.com/dagger/dagger/issues/8184

---

This PR replaces the `test custom` subcommand with `test specific`, e.g.:

```console
dagger call --source=.:default test specific --skip=TestModule
```

In the example above, we run all tests **except** the `TestModule` ones. To **only** run `TestModule` tests, the command is:

```console
dagger call --source=.:default test specific --run=TestModule
```

Also, `test important` is now:

```console
dagger call --source=.:default test specific --run='TestModule|TestContainer'
```

Here are a few more examples:

```console
# Only run TestContainer, TestDirectory and TestFile tests
dagger call --source=.:default test specific --run="TestContainer|TestDirectory|TestFile"

# Skip all tests starting with TestLoad
dagger call --source=.:default test specific --skip="TestLoad"

# Skip all tests starting with TestC, TestD, TestE, ..., TestZ
dagger call --source=.:default test specific --skip="Test[C-Z]"
```

All tests are now running in verbose `-v` mode so that we can see the `go test` output in addition to the Dagger Cloud Traces. We can't fully trust those yet **in this context**. [FTR](https://github.com/dagger/dagger/issues/8184).

The other useful feature about the `--skip` flag is that now we can add additional metadata to these runs. In the following example, I am running all tests and capturing the specific instance properties in the `--skip` flag (somewhat hacky, but essential for distinguishing runs in Dagger Cloud):

```console
dagger call --source=.:default test specific --skip="32C-6548N|64GB-DDR5|VIRTIO-NVME"
```

This also adds a new test subcommand which lists all top-level tests in alphabetical order:

```console
dagger call --source=.:default test list

TestBaseVersion
TestBasic
TestBuiltins
TestCache
TestCacheMapConcurrent
TestCacheMapErrors
TestCacheMapRecursiveCall
TestCheckResponse
TestClient
TestContainer
TestCoreModTypeDefs
TestDefToDAG
TestDefaults
TestDirectory
TestEmptyID
TestEngine
TestEngineNameLabel
TestEnums
TestFile
TestFromDir
TestGPU
TestGit
TestHTTP
TestHost
TestIDFormat
TestIDsDoNotContainSensitiveValues
TestIDsReflectQuery
TestImpureIDsReEvaluate
TestInputObjects
TestIntrospection
TestIsSemver
TestLegacy
TestLexicalRelativePath
TestListResults
TestLoadCircleCILabels
TestLoadClientLabels
TestLoadGitHubLabels
TestLoadGitLabLabels
TestLoadGitLabels
TestLoadGitRefEnvLabels
TestLoadJenkinsLabels
TestLoadSecretsToScrubFromEnv
TestLoadSecretsToScrubFromFiles
TestLoadServerLabels
TestLoadingFromID
TestMatchGoImport
TestMatchVersion
TestModule
TestNamespaceObjects
TestNormalizeVersion
TestNullableResults
TestObject
TestObjects
TestOriginToPath
TestParallelism
TestParallelismFlag
TestParseAuthAddress
TestParseDaggerToken
TestParseGit
TestParseMetaGoImports
TestParsePragmaComment
TestParsePublicRefString
TestPassingObjectsAround
TestPlatform
TestPureIDsDoNotReEvaluate
TestRegistryAuthProvider
TestRemoteCache
TestRepoRootForImportPath
TestScrubSecretLogLatency
TestScrubSecretWrite
TestSecret
TestSecretScrubWriterWrite
TestSecretStore
TestSecretStoreNotFound
TestService
TestServicesStartConcurrentHappy
TestServicesStartConcurrentSad
TestServicesStartConcurrentSadThenHappy
TestServicesStartHappy
TestServicesStartHappyDifferentServers
TestServicesStartSad
TestSortInputFields
TestSpanName
TestSplitRequiredOptionalArgs
TestTelemetry
TestTrie
TestTrieExtend
TestTrieReinsert
TestType
TestTypeDefConversions
TestValidateRepoRoot
TestVersionCompatibility
TestViews
TestViewsCaching
TestViewsIntrospection
```

---

> [!NOTE]
> While this is how this PR started, I am only keeping it here so that the first several comments make sense. Only the content above this line is relevant for the merged changes.

This PR splits our Engine & CLI tests into:

We now run them as separate CI jobs which splits the test data and makes it easier to understand where the slowness is coming from. It should also make it easier to focus our test refactoring efforts on module tests since the rest of our test suite doesn't seem to be a problem.

Furthermore, before this change, running all these tests in CI was putting pressure on a bunch of components as they generate **a lot** (>200MB) of output. Even though https://dagger.cloud processes all this data, we then keep stalling the browser tab since it cannot handle a DOM that large. Yup, hundreds of megabytes.

When I run module tests locally, they take over 1h which makes them impractical. All other tests complete within 10 minutes (regardless whether we use `-race` or not). This is what I've learned:

### TestModule
- `3642s` (timed out) @ Wed 10 Jul 08:42:25 BST 2024
- `3632s` (timed out) @ Wed 10 Jul 10:12:09 BST 2024

### TestContainer
- `442s` @ Wed 10 Jul 08:49:47 BST 2024
- `280s` @ Wed 10 Jul 12:06:55 BST 2024

### TestEngine
- `141s` @ Wed 10 Jul 08:52:08 BST 2024
- `120s` @ Wed 10 Jul 12:12:53 BST 2024
- `115s` @ Wed 10 Jul 12:15:21 BST 2024

### All other test suites combined
- `166s` @ Wed 10 Jul 07:38:34 BST 2024
- `146s` @ Wed 10 Jul 07:41:43 BST 2024
- `145s` @ Wed 10 Jul 10:43:38 BST 2024
- `136s` @ Wed 10 Jul 11:55:14 BST 2024

This PR also changes:
- adds `dagger call ... test list`
- `dagger call ... test custom` is now `dagger call ... test specific`
- removes `dagger call ... test important`
- `important` tests now means everything else apart from modules, which we know are the heavy part of our test suite

---

Another interesting observation when running `TestModule` **only** locally: the NVMe disk gets fully saturated (22k writes @ 26MB/s gives us an average of 1KB / write operation). All other resources (CPU / memory / network) are plenty:

<img width="1548" alt="Screenshot 2024-07-10 at 16 46 15" src="https://github.com/dagger/dagger/assets/3342/0542a2e4-22b1-4f71-b79f-efef8c8d8597">

<img width="1548" alt="Screenshot 2024-07-10 at 16 49 29" src="https://github.com/dagger/dagger/assets/3342/a913fb7f-0af3-40af-ad96-233339ee741f">

---

I am keen to see how this behaves in our CI. I am also curious to hear what others think about this change, especially @sipsma & @jedevc that have been doing a lot of work in this area recently.