### PR TITLE
cli: correct mod cmd help to point to dir not file

### DIFF
--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -57,7 +57,7 @@ const (
 )
 
 func init() {
-	moduleFlags.StringVarP(&moduleURL, "mod", "m", "", "Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. \"/path/to/some/dir\") or a github repo (e.g. \"github.com/dagger/dagger/path/to/some/subdir\")")
+	moduleFlags.StringVarP(&moduleURL, "mod", "m", "", "Path to the module directory containing the dagger.json config file. Either local path (e.g. \"/path/to/some/dir\") or a github repo (e.g. \"github.com/dagger/dagger/path/to/some/subdir\")")
 
 	listenCmd.PersistentFlags().AddFlagSet(moduleFlags)
 	queryCmd.PersistentFlags().AddFlagSet(moduleFlags)

--- a/docs/current_docs/reference/cli.mdx
+++ b/docs/current_docs/reference/cli.mdx
@@ -46,7 +46,7 @@ dagger call [options]
 
 ```
   -j, --json            Present result as JSON
-  -m, --mod string      Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
+  -m, --mod string      Path to the module directory containing the dagger.json config file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
   -o, --output string   Save the result to a local file or directory
 ```
 
@@ -88,7 +88,7 @@ dagger config -m github.com/dagger/hello-dagger
 
 ```
       --json         output in JSON format
-  -m, --mod string   Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
+  -m, --mod string   Path to the module directory containing the dagger.json config file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
 ```
 
 ### Options inherited from parent commands
@@ -134,7 +134,7 @@ dagger develop [options]
 
 ```
       --license string   License identifier to generate - see https://spdx.org/licenses/ (default "Apache-2.0")
-  -m, --mod string       Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
+  -m, --mod string       Path to the module directory containing the dagger.json config file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
       --sdk string       New SDK for the module
       --source string    Directory to store the module implementation source code in
 ```
@@ -173,7 +173,7 @@ dagger functions [options] [function]...
 ### Options
 
 ```
-  -m, --mod string   Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
+  -m, --mod string   Path to the module directory containing the dagger.json config file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
 ```
 
 ### Options inherited from parent commands
@@ -264,7 +264,7 @@ dagger install github.com/shykes/daggerverse/ttlsh@16e40ec244966e55e36a13cb6e1ff
 ### Options
 
 ```
-  -m, --mod string    Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
+  -m, --mod string    Path to the module directory containing the dagger.json config file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
   -n, --name string   Name to use for the dependency in the module. Defaults to the name of the module being installed.
 ```
 
@@ -368,7 +368,7 @@ EOF
 
 ```
       --doc string        Read query from file (defaults to reading from stdin)
-  -m, --mod string        Path to dagger.json config file for the module or a directory containing that file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
+  -m, --mod string        Path to the module directory containing the dagger.json config file. Either local path (e.g. "/path/to/some/dir") or a github repo (e.g. "github.com/dagger/dagger/path/to/some/subdir")
       --var strings       List of query variables, in key=value format
       --var-json string   Query variables in JSON format (overrides --var)
 ```


### PR DESCRIPTION
Previously the `-m` help suggested that you could point to the `dagger.json` file, but we expect a path to the _directory_ containing that file. This PR fixes that.


Notice: `not a directory` below 👇 
```
/tmp ➤ dagger call -m ./foo/dagger.json container-echo --string-arg "hi" stdout
Full trace at https://dagger.cloud/dagger/traces/dc3b6b41e71da24f381266d02dede97f

✔ connect 1.3s
  ✔ connecting to engine 0.3s
  ✔ starting session 0.2s
✘ initialize 0.3s
! failed to get configured module: error trying to find config path for ./foo/dagger.json: failed to lstat foo/dagger.json/dagger.json: lstat foo/dagger.json/dagger.json: not a directory

Error: failed to get configured module: error trying to find config path for ./foo/dagger.json: failed to lstat foo/dagger.json/dagger.json: lstat foo/dagger.json/dagger.json: not a directory
```
```
/tmp ➤ dagger call -m ./foo/ container-echo --string-arg "hi" stdout
hi
```