### PR TITLE
Overlooked docs reference merged in PR #7483

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -18,7 +18,7 @@ Available functionality:
 > [!NOTE]
 >
 > For best results, use the same version of dagger (both the CLI, and the
-> engine) as defined in [`.github/workflows/_dagger_call.yml`](../.github/workflows/_dagger_call.yml).
+> engine) as defined in [`.github/actions/call/action.yml`](../.github/actions/call/action.yml).
 > Without this, you may hit unexpected errors or other weird behavior.
 
 ## Developing after a fresh clone


### PR DESCRIPTION
From the context of the documentation I believe this is the right file to reference post-refactor (https://github.com/dagger/dagger/pull/7483).

Please let me know if you need anything else.