### PR TITLE
cli: improve UX to show cloud URL

### DIFF
--- a/cmd/dagger/cloud.go
+++ b/cmd/dagger/cloud.go
@@ -116,7 +116,7 @@ func (cli *CloudCLI) Login(cmd *cobra.Command, args []string) error {
 }
 
 func createNewOrg(ctx context.Context, cli *cloud.Client, w io.Writer) (*auth.Org, error) {
-	url := "https://dagger.cloud/signup?quickstart=true"
+	url := "https://dagger.cloud/traces/setup"
 	err := browser.OpenURL(url)
 	if err != nil {
 		fmt.Fprintf(w, "Unable to open browser automatically, please visit %s to create an organization.\n", url)

--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -31,7 +31,7 @@ func withEngine(
 	params.DisableHostRW = disableHostRW
 
 	params.EngineCallback = Frontend.ConnectedToEngine
-	params.CloudCallback = Frontend.ConnectedToCloud
+	params.CloudURLCallback = Frontend.SetCloudURL
 
 	params.EngineTrace = telemetry.SpanForwarder{
 		Processors: telemetry.SpanProcessors,

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -29,7 +29,8 @@ import (
 var skipLoggedOutTraceMsgEnvs = []string{"NOTHANKS", "SHUTUP", "GOAWAY", "STOPIT"}
 
 //nolint:gosec
-var loggedOutTraceMsg = fmt.Sprintf("Setup full trace at %%s.\nTo turn this off, export %s=1",
+// Keep this to one line, and 80 characters max (longest env var name is NOTHANKS)
+var loggedOutTraceMsg = fmt.Sprintf("Setup tracing at %%s. To hide: export %s=1",
 	skipLoggedOutTraceMsgEnvs[rand.Intn(len(skipLoggedOutTraceMsgEnvs))])
 
 type FrontendOpts struct {

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -28,6 +28,7 @@ import (
 // having a bit of fun with these. cc @vito @jedevc
 var skipLoggedOutTraceMsgEnvs = []string{"NOTHANKS", "SHUTUP", "GOAWAY", "STOPIT"}
 
+//nolint:gosec
 var loggedOutTraceMsg = fmt.Sprintf("Setup full trace at %%s.\nTo turn this off, export %s=1",
 	skipLoggedOutTraceMsgEnvs[rand.Intn(len(skipLoggedOutTraceMsgEnvs))])
 

--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -131,9 +131,9 @@ func (fe *frontendPlain) SetCloudURL(ctx context.Context, url string, msg string
 	}
 	fe.addVirtualLog(trace.SpanFromContext(ctx), "cloud", "url", url)
 	if logged {
-		fmt.Fprintln(os.Stderr, traceMessage(fe.profile, url, msg))
+		fmt.Fprintln(os.Stderr, traceMessage(fe.profile, url, msg)+"\n")
 	} else if !skipLoggedOutTraceMsg() {
-		fmt.Fprintf(os.Stderr, loggedOutTraceMsg, url)
+		fmt.Fprintf(os.Stderr, loggedOutTraceMsg+"\n\n", url)
 	}
 }
 

--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dagger/dagger/dagql/call/callpbv1"
 	"github.com/dagger/dagger/engine/slog"
 	"github.com/muesli/termenv"
+	"github.com/pkg/browser"
 	"go.opentelemetry.io/otel/codes"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -119,12 +120,21 @@ func (fe *frontendPlain) ConnectedToEngine(ctx context.Context, name string, ver
 	fe.addVirtualLog(trace.SpanFromContext(ctx), "engine", "name", name, "version", version, "client", clientID)
 }
 
-func (fe *frontendPlain) ConnectedToCloud(ctx context.Context, url string, msg string) {
+func (fe *frontendPlain) SetCloudURL(ctx context.Context, url string, msg string, logged bool) {
+	if fe.OpenWeb {
+		if err := browser.OpenURL(url); err != nil {
+			slog.Warn("failed to open URL", "url", url, "err", err)
+		}
+	}
 	if fe.Silent {
 		return
 	}
 	fe.addVirtualLog(trace.SpanFromContext(ctx), "cloud", "url", url)
-	fmt.Fprintln(&fe.msgsBuffer, traceMessage(fe.profile, url, msg))
+	if logged {
+		fmt.Fprintln(os.Stderr, traceMessage(fe.profile, url, msg))
+	} else if !skipLoggedOutTraceMsg() {
+		fmt.Fprintf(os.Stderr, loggedOutTraceMsg, url)
+	}
 }
 
 // addVirtualLog attaches a fake log row to a given span

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -337,7 +337,7 @@ func (fe *frontendPretty) renderKeymap(out *termenv.Output, style lipgloss.Style
 
 	// Blank line prior to keymap
 	for i, key := range []keyHelp{
-		{out.Hyperlink(fe.cloudURL, "Web"), []string{"w"}, fe.cloudURL != ""},
+		{out.Hyperlink(fe.cloudURL, "web"), []string{"w"}, fe.cloudURL != ""},
 		{"move", []string{"←↑↓→", "up", "down", "left", "right", "h", "j", "k", "l"}, true},
 		{"first", []string{"home"}, true},
 		{"last", []string{"end", " "}, true},

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -53,12 +53,13 @@ type frontendPretty struct {
 	cloudURL string
 
 	// TUI state/config
-	restore func()  // restore terminal
-	fps     float64 // frames per second
-	profile termenv.Profile
-	window  tea.WindowSizeMsg // set by BubbleTea
-	view    *strings.Builder  // rendered async
-	viewOut *termenv.Output
+	restore    func()  // restore terminal
+	fps        float64 // frames per second
+	profile    termenv.Profile
+	window     tea.WindowSizeMsg // set by BubbleTea
+	view       *strings.Builder  // rendered async
+	viewOut    *termenv.Output
+	browserBuf *strings.Builder // logs if browser fails
 
 	// held to synchronize tea.Model with updates
 	mu sync.Mutex
@@ -81,11 +82,12 @@ func New() Frontend {
 		rows:     &Rows{BySpan: map[trace.SpanID]*TraceRow{}},
 
 		// initial TUI state
-		window:  tea.WindowSizeMsg{Width: -1, Height: -1}, // be clear that it's not set
-		fps:     30,                                       // sane default, fine-tune if needed
-		profile: profile,
-		view:    view,
-		viewOut: NewOutput(view, termenv.WithProfile(profile)),
+		window:     tea.WindowSizeMsg{Width: -1, Height: -1}, // be clear that it's not set
+		fps:        30,                                       // sane default, fine-tune if needed
+		profile:    profile,
+		view:       view,
+		viewOut:    NewOutput(view, termenv.WithProfile(profile)),
+		browserBuf: new(strings.Builder),
 	}
 }
 
@@ -190,6 +192,10 @@ func (fe *frontendPretty) runWithTUI(ctx context.Context, ttyIn *os.File, ttyOut
 		tea.WithoutCatchPanics(),
 		tea.WithMouseCellMotion(),
 	)
+
+	// prevent browser.OpenURL from breaking the TUI if it fails
+	browser.Stdout = fe.browserBuf
+	browser.Stderr = fe.browserBuf
 
 	// run the program, which starts the callback async
 	if _, err := fe.program.Run(); err != nil {
@@ -711,7 +717,10 @@ func (fe *frontendPretty) update(msg tea.Msg) (*frontendPretty, tea.Cmd) { //nol
 			}
 			return fe, func() tea.Msg {
 				if err := browser.OpenURL(url); err != nil {
-					slog.Warn("failed to open URL", "url", url, "err", err)
+					slog.Warn("failed to open URL",
+						"url", url,
+						"err", err,
+						"output", fe.browserBuf.String())
 				}
 				return nil
 			}

--- a/dagql/idtui/frontend_pretty.go
+++ b/dagql/idtui/frontend_pretty.go
@@ -225,11 +225,9 @@ func (fe *frontendPretty) finalRender() error {
 	fe.recalculateViewLocked()
 
 	if fe.Debug || fe.Verbosity >= ShowCompletedVerbosity || fe.err != nil {
-		var msg string
 		if fe.msgPreFinalRender.Len() > 0 {
-			fmt.Fprintln(os.Stderr, fe.msgPreFinalRender.String())
+			fmt.Fprintf(os.Stderr, fe.msgPreFinalRender.String()+"\n\n")
 		}
-		fmt.Fprintln(os.Stderr, msg)
 		// Render progress to stderr so stdout stays clean.
 		out := NewOutput(os.Stderr, termenv.WithProfile(fe.profile))
 		if fe.renderProgress(out, true, fe.window.Height, "") {

--- a/docs/current_docs/reference/cli.mdx
+++ b/docs/current_docs/reference/cli.mdx
@@ -18,6 +18,7 @@ The Dagger CLI provides a command-line interface to Dagger.
   -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
   -s, --silent            Do not show progress at all
   -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
+  -w, --web               open trace URL in default browser
 ```
 
 ### SEE ALSO
@@ -59,6 +60,7 @@ dagger call [options]
   -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
   -s, --silent            Do not show progress at all
   -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
+  -w, --web               open trace URL in default browser
 ```
 
 ### SEE ALSO
@@ -100,6 +102,7 @@ dagger config -m github.com/dagger/hello-dagger
   -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
   -s, --silent            Do not show progress at all
   -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
+  -w, --web               open trace URL in default browser
 ```
 
 ### SEE ALSO
@@ -148,6 +151,7 @@ dagger develop [options]
   -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
   -s, --silent            Do not show progress at all
   -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
+  -w, --web               open trace URL in default browser
 ```
 
 ### SEE ALSO
@@ -185,6 +189,7 @@ dagger functions [options] [function]...
   -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
   -s, --silent            Do not show progress at all
   -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
+  -w, --web               open trace URL in default browser
 ```
 
 ### SEE ALSO
@@ -237,6 +242,7 @@ dagger init --name=hello --sdk=python --source=some/subdir
   -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
   -s, --silent            Do not show progress at all
   -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
+  -w, --web               open trace URL in default browser
 ```
 
 ### SEE ALSO
@@ -277,6 +283,7 @@ dagger install github.com/shykes/daggerverse/ttlsh@16e40ec244966e55e36a13cb6e1ff
   -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
   -s, --silent            Do not show progress at all
   -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
+  -w, --web               open trace URL in default browser
 ```
 
 ### SEE ALSO
@@ -300,6 +307,7 @@ dagger login [options] [org]
   -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
   -s, --silent            Do not show progress at all
   -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
+  -w, --web               open trace URL in default browser
 ```
 
 ### SEE ALSO
@@ -323,6 +331,7 @@ dagger logout
   -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
   -s, --silent            Do not show progress at all
   -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
+  -w, --web               open trace URL in default browser
 ```
 
 ### SEE ALSO
@@ -382,6 +391,7 @@ EOF
   -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
   -s, --silent            Do not show progress at all
   -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
+  -w, --web               open trace URL in default browser
 ```
 
 ### SEE ALSO
@@ -438,6 +448,7 @@ dagger run python main.py
   -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
   -s, --silent            Do not show progress at all
   -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
+  -w, --web               open trace URL in default browser
 ```
 
 ### SEE ALSO
@@ -461,6 +472,7 @@ dagger version
   -q, --quiet count       Reduce verbosity (show progress, but clean up at the end)
   -s, --silent            Do not show progress at all
   -v, --verbose count     Increase verbosity (use -vv or -vvv for more)
+  -w, --web               open trace URL in default browser
 ```
 
 ### SEE ALSO

--- a/engine/client/client.go
+++ b/engine/client/client.go
@@ -68,8 +68,8 @@ type Params struct {
 
 	DisableHostRW bool
 
-	EngineCallback func(context.Context, string, string, string)
-	CloudCallback  func(context.Context, string, string)
+	EngineCallback   func(context.Context, string, string, string)
+	CloudURLCallback func(context.Context, string, string, bool)
 
 	EngineTrace sdktrace.SpanExporter
 	EngineLogs  sdklog.Exporter
@@ -322,9 +322,11 @@ func (c *Client) startEngine(ctx context.Context) (rerr error) {
 	if c.EngineCallback != nil {
 		c.EngineCallback(ctx, bkInfo.BuildkitVersion.Revision, bkInfo.BuildkitVersion.Version, c.ID)
 	}
-	if c.CloudCallback != nil {
+	if c.CloudURLCallback != nil {
 		if url, msg, ok := enginetel.URLForTrace(ctx); ok {
-			c.CloudCallback(ctx, url, msg)
+			c.CloudURLCallback(ctx, url, msg, ok)
+		} else {
+			c.CloudURLCallback(ctx, "https://dagger.cloud/traces/setup", "", ok)
 		}
 	}
 


### PR DESCRIPTION
this commit introduces the following changes:

- Keystroke for web visualization is now `w` for both logged-in and
  logged-out clients.
- New `--web` global flag visualize trace in web browser.
- Trace URL display:
	- logged in: URL gets printed at the top honoring -q and -s
	  flags
	- logged out: Same as logged in with the ability to disable the
	  message by setting an environment variable.

Screenshots below:

<details>

<summary>Logged out</summary>

- dagger command with TUI shows `w` action
![image](https://github.com/dagger/dagger/assets/1578458/be7a73e2-e6c9-4ccc-aeab-d20014ee6ef3)


-  dagger command with TUI message lingers at the top
![image](https://github.com/dagger/dagger/assets/1578458/b34145d9-5839-445e-8428-0cd4fab04013)

- dagger command `-q` with TUI  message is not printed
![image](https://github.com/dagger/dagger/assets/1578458/ce825233-9c9e-4037-954e-dcac21825b2b)

- dagger command `--progress plain` message is printed at the top
![image](https://github.com/dagger/dagger/assets/1578458/0e5f06cc-712f-4a83-83a4-ca1b339ec19e)

- setting env var skips logged out message
![image](https://github.com/dagger/dagger/assets/1578458/d7a80485-fe53-4fe2-be62-fe3b01fa5606)

</details>

<details>

<summary>Logged in</summary>

-  dagger command with TUI message lingers at the top
![image](https://github.com/dagger/dagger/assets/1578458/665b3d48-f87c-44f3-a154-d585b526bac4)

- dagger command `-q` with TUI  message is not printed
![image](https://github.com/dagger/dagger/assets/1578458/ba2cb5ef-9e68-46b5-9bd1-fd62dd6a19e8)


- dagger command `--progress plain` message is printed at the top
![image](https://github.com/dagger/dagger/assets/1578458/093f2307-d205-4b1e-8a59-454b50f5b16d)

</details>


