### PR TITLE
pipelines: streamline codegen

### DIFF
--- a/dev/cli.go
+++ b/dev/cli.go
@@ -21,7 +21,7 @@ func (cli *CLI) File(
 	// +optional
 	platform dagger.Platform,
 ) (*dagger.File, error) {
-	builder, err := build.NewBuilder(ctx, cli.Dagger.Source)
+	builder, err := build.NewBuilder(ctx, cli.Dagger.Source())
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (cli *CLI) Publish(
 	}
 	_, err = ctr.
 		WithWorkdir("/app").
-		WithMountedDirectory("/app", cli.Dagger.Source).
+		WithMountedDirectory("/app", cli.Dagger.Source()).
 		WithDirectory("/app/.git", gitDir).
 		WithEnvVariable("GH_ORG_NAME", githubOrgName).
 		WithSecretVariable("GITHUB_TOKEN", githubToken).
@@ -106,7 +106,7 @@ func (cli *CLI) TestPublish(ctx context.Context) error {
 	oses := []string{"linux", "windows", "darwin"}
 	arches := []string{"amd64", "arm64", "arm"}
 
-	builder, err := build.NewBuilder(ctx, cli.Dagger.Source)
+	builder, err := build.NewBuilder(ctx, cli.Dagger.Source())
 	if err != nil {
 		return err
 	}

--- a/dev/go/main.go
+++ b/dev/go/main.go
@@ -78,11 +78,10 @@ func (p *Go) Env() *dagger.Container {
 // Lint the project
 func (p *Go) Lint(
 	ctx context.Context,
-
-	pkgs []string, // +optional
+	packages []string, // +optional
 ) error {
 	eg, ctx := errgroup.WithContext(ctx)
-	for _, pkg := range pkgs {
+	for _, pkg := range packages {
 		pkg := pkg
 		eg.Go(func() error {
 			ctx, span := Tracer().Start(ctx, "lint "+path.Clean(pkg))

--- a/dev/scripts.go
+++ b/dev/scripts.go
@@ -11,6 +11,6 @@ type Scripts struct {
 // Lint scripts files
 func (s Scripts) Lint(ctx context.Context) error {
 	return dag.Shellcheck().
-		Check(s.Dagger.Source.File("install.sh")).
+		Check(s.Dagger.Source().File("install.sh")).
 		Assert(ctx)
 }

--- a/dev/sdk.go
+++ b/dev/sdk.go
@@ -81,7 +81,7 @@ func (dev *DaggerDev) installer(ctx context.Context, name string) (func(*dagger.
 }
 
 func (dev *DaggerDev) introspection(ctx context.Context, installer func(*dagger.Container) *dagger.Container) (*dagger.File, error) {
-	builder, err := build.NewBuilder(ctx, dev.Source)
+	builder, err := build.NewBuilder(ctx, dev.Source())
 	if err != nil {
 		return nil, err
 	}

--- a/dev/sdk_elixir.go
+++ b/dev/sdk_elixir.go
@@ -106,7 +106,7 @@ func (t ElixirSDK) Publish(
 	ctr := t.elixirBase(elixirVersions[1])
 
 	if !dryRun {
-		mixExs, err := t.Dagger.Source.File(mixFile).Contents(ctx)
+		mixExs, err := t.Dagger.Source().File(mixFile).Contents(ctx)
 		if err != nil {
 			return err
 		}
@@ -132,7 +132,7 @@ var elixirVersionRe = regexp.MustCompile(`@dagger_cli_version "([0-9\.-a-zA-Z]+)
 
 // Bump the Elixir SDK's Engine dependency
 func (t ElixirSDK) Bump(ctx context.Context, version string) (*dagger.Directory, error) {
-	contents, err := t.Dagger.Source.File(elixirSDKVersionFilePath).Contents(ctx)
+	contents, err := t.Dagger.Source().File(elixirSDKVersionFilePath).Contents(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +144,7 @@ func (t ElixirSDK) Bump(ctx context.Context, version string) (*dagger.Directory,
 }
 
 func (t ElixirSDK) elixirBase(elixirVersion string) *dagger.Container {
-	src := t.Dagger.Source.Directory(elixirSDKPath)
+	src := t.Dagger.Source().Directory(elixirSDKPath)
 	mountPath := "/" + elixirSDKPath
 
 	return dag.Container().

--- a/dev/sdk_go.go
+++ b/dev/sdk_go.go
@@ -22,10 +22,12 @@ type GoSDK struct {
 func (t GoSDK) Lint(ctx context.Context) error {
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
-		return t.Dagger.Go().Lint(ctx, []string{"sdk/go"})
+		return dag.
+			Go(t.Dagger.Source()).
+			Lint(ctx, dagger.GoLintOpts{Packages: []string{"sdk/go"}})
 	})
 	eg.Go(func() error {
-		return util.DiffDirectoryF(ctx, t.Dagger.Source, t.Generate, "sdk/go")
+		return util.DiffDirectoryF(ctx, t.Dagger.Source(), t.Generate, "sdk/go")
 	})
 	return eg.Wait()
 }

--- a/dev/sdk_java.go
+++ b/dev/sdk_java.go
@@ -103,7 +103,7 @@ var javaVersionRe = regexp.MustCompile(`<daggerengine\.version>([0-9\.\-a-zA-Z]+
 
 // Bump the Java SDK's Engine dependency
 func (t JavaSDK) Bump(ctx context.Context, version string) (*dagger.Directory, error) {
-	contents, err := t.Dagger.Source.File(javaSDKVersionPomPath).Contents(ctx)
+	contents, err := t.Dagger.Source().File(javaSDKVersionPomPath).Contents(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (t JavaSDK) Bump(ctx context.Context, version string) (*dagger.Directory, e
 }
 
 func (t JavaSDK) javaBase() *dagger.Container {
-	src := t.Dagger.Source.Directory(javaSDKPath)
+	src := t.Dagger.Source().Directory(javaSDKPath)
 	mountPath := "/" + javaSDKPath
 
 	return dag.Container().

--- a/dev/sdk_php.go
+++ b/dev/sdk_php.go
@@ -22,7 +22,7 @@ type PHPSDK struct {
 
 // Lint the PHP SDK
 func (t PHPSDK) Lint(ctx context.Context) error {
-	return util.DiffDirectoryF(ctx, t.Dagger.Source, t.Generate, filepath.Join(phpSDKPath, phpSDKGeneratedDir))
+	return util.DiffDirectoryF(ctx, t.Dagger.Source(), t.Generate, filepath.Join(phpSDKPath, phpSDKGeneratedDir))
 }
 
 // Test the PHP SDK
@@ -95,7 +95,7 @@ func (t PHPSDK) Bump(ctx context.Context, version string) (*dagger.Directory, er
 // phpBase returns a PHP container with the PHP SDK source files
 // added and dependencies installed.
 func (t PHPSDK) phpBase() *dagger.Container {
-	src := t.Dagger.Source.Directory(phpSDKPath)
+	src := t.Dagger.Source().Directory(phpSDKPath)
 	return dag.Container().
 		From("php:8.2-zts-bookworm").
 		WithExec([]string{"apt-get", "update"}).

--- a/dev/sdk_rust.go
+++ b/dev/sdk_rust.go
@@ -45,7 +45,7 @@ func (r RustSDK) Lint(ctx context.Context) error {
 	})
 
 	eg.Go(func() error {
-		return util.DiffDirectoryF(ctx, r.Dagger.Source, r.Generate, "sdk/rust")
+		return util.DiffDirectoryF(ctx, r.Dagger.Source(), r.Generate, "sdk/rust")
 	})
 
 	return eg.Wait()
@@ -80,7 +80,7 @@ func (r RustSDK) Generate(ctx context.Context) (*dagger.Directory, error) {
 		File(strings.TrimPrefix(rustGeneratedAPIPath, "sdk/rust/"))
 
 	return dag.Directory().
-		WithDirectory("sdk/rust", r.Dagger.Source.Directory("sdk/rust")).
+		WithDirectory("sdk/rust", r.Dagger.Source().Directory("sdk/rust")).
 		WithFile(rustGeneratedAPIPath, generated), nil
 }
 
@@ -134,7 +134,7 @@ func (r RustSDK) Bump(ctx context.Context, version string) (*dagger.Directory, e
 	versionStrf := `pub const DAGGER_ENGINE_VERSION: &'static str = "%s";`
 	version = strings.TrimPrefix(version, "v")
 
-	versionContents, err := r.Dagger.Source.File(rustVersionFilePath).Contents(ctx)
+	versionContents, err := r.Dagger.Source().File(rustVersionFilePath).Contents(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func (r RustSDK) Bump(ctx context.Context, version string) (*dagger.Directory, e
 func (r RustSDK) rustBase(image string) *dagger.Container {
 	const appDir = "sdk/rust"
 
-	src := dag.Directory().WithDirectory("/", r.Dagger.Source.Directory(appDir))
+	src := dag.Directory().WithDirectory("/", r.Dagger.Source().Directory(appDir))
 
 	mountPath := fmt.Sprintf("/%s", appDir)
 


### PR DESCRIPTION
## Problem

- The source code of Dagger includes some Dagger pipelines
- Therefore our CI/CD pipelines sometimes process the source code of Dagger Modules - for example to lint them
- This processing sometimes requires invoking Dagger codegen against those modules - the equivalent of `dagger develop`
- So far our pipelines have done this on a case-by-case basis, but that makes the source code harder to read

## Solution

- all access to the Dagger source code from any part of the pipeline, is gated by `DaggerDev.source()` which ~~*always*~~ optionally applies codegen on all dagger modules.
- The list of modules is manually maintained for now, but should be made dynamic in a follow-up improvement
- ~~This can probably be optimized (not all pipelines that access the dagger source code actually need codegen, but they all trigger it). But for now I propose we pay the slight performance tax (which gets absorbed by caching), for the sake of much-needed simplification. Then we can gradually optimize.~~
