### PR TITLE
docs: chain terminal to dev shell example

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -50,7 +50,7 @@ Run a specific test (e.g. `TestModuleNamespacing`):
 
 Start a little dev shell with dagger-in-dagger:
 
-    dagger call -m dev --source=.:default dev
+    dagger call -m dev --source=.:default dev terminal
 
 ## Engine & CLI
 


### PR DESCRIPTION
Right now the dev shell sample returns a container, adding terminal makes this a one liner that someone can use to actually get into a shell.