### PR TITLE
fix: print to otel span for dagger login

### DIFF
--- a/cmd/dagger/cloud.go
+++ b/cmd/dagger/cloud.go
@@ -57,7 +57,7 @@ func (cli *CloudCLI) Login(cmd *cobra.Command, args []string) error {
 		orgName = args[0]
 	}
 
-	if err := auth.Login(ctx); err != nil {
+	if err := auth.Login(ctx, outW); err != nil {
 		return err
 	}
 

--- a/internal/cloud/auth/auth.go
+++ b/internal/cloud/auth/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -35,7 +36,7 @@ var authConfig = &oauth2.Config{
 
 // Login logs the user in and stores the credentials for later use.
 // Interactive messages are printed to w.
-func Login(ctx context.Context) error {
+func Login(ctx context.Context, out io.Writer) error {
 	// If the user is already authenticated, skip the login process.
 	if _, err := Token(ctx); err == nil {
 		return nil
@@ -46,7 +47,7 @@ func Login(ctx context.Context) error {
 		return err
 	}
 
-	fmt.Fprintf(os.Stderr, "\nTo authenticate, visit:\n\t%s\n\n", deviceAuth.VerificationURIComplete)
+	fmt.Fprintf(out, "\nTo authenticate, visit:\n\t%s\n\n", deviceAuth.VerificationURIComplete)
 
 	token, err := authConfig.DeviceAccessToken(ctx, deviceAuth)
 	if err != nil {


### PR DESCRIPTION
Without this, we're just writing directly on top of the TUI, oops!

Before:

```
❯ dagger login jedevc

─   ←↑↓→: move  home: first  end: last  enter: zoom  +/-: verbosity=1  q: quit ────────────────────────
To authenticate, visit:
                       	https://auth.dagger.cloud/activate?user_code=XHSW-TXFD
Success.
```

After, this all collapses down neatly.