### PR TITLE
chore(ts): use private cache for bun

### DIFF
--- a/sdk/typescript/runtime/main.go
+++ b/sdk/typescript/runtime/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"main/internal/dagger"
 	"path"
 	"path/filepath"
 	"slices"
@@ -180,7 +181,9 @@ func (t *TypescriptSdk) Base(runtime SupportedTSRuntime, version string) (*Conta
 
 		return ctr.
 			WithoutEntrypoint().
-			WithMountedCache("/root/.bun/install/cache", dag.CacheVolume(fmt.Sprintf("mod-bun-cache-%s", bunVersion))), nil
+			WithMountedCache("/root/.bun/install/cache", dag.CacheVolume(fmt.Sprintf("mod-bun-cache-%s", bunVersion)), dagger.ContainerWithMountedCacheOpts{
+				Sharing: dagger.Private,
+			}), nil
 	case Node:
 		if version != "" {
 			ctr = ctr.From(fmt.Sprintf("%s:%s-alpine", Node, version))


### PR DESCRIPTION
We keep seeing this error over-and-over: https://dagger.cloud/dagger/traces/fac54672078ee95878b8684af05a814b?span=4c9874e76c2371de#ca88400300bc5d96

Lots of things of the form:

```
	            	error: moving "binary-extensions" to cache dir failed: PathAlreadyExists

	            	  From: .544670b85583f3c2binary-extensions

	            	    To: binary-extensions@2.3.0
```

Something doesn't seem very right there, but given it's flakiness, I suspect it's something to do with concurrent cache access - so we can just give bun access to Private cache.