### PR TITLE
Some very small version compat follow-ups

### DIFF
--- a/cmd/dagger/module.go
+++ b/cmd/dagger/module.go
@@ -333,7 +333,7 @@ If not updating source or SDK, this is only required for IDE auto-completion/LSP
 			// ResolveFromCaller call first
 			modConf.Source = modConf.Source.ResolveFromCaller()
 
-			modSDK, err := modConf.Source.AsModule().SDK(ctx)
+			modSDK, err := modConf.Source.AsModule(dagger.ModuleSourceAsModuleOpts{EngineVersion: modules.EngineVersionLatest}).SDK(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to get module SDK: %w", err)
 			}

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -17,7 +17,6 @@ import (
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
-	"github.com/dagger/dagger/engine"
 )
 
 type ModuleSourceKind string
@@ -226,11 +225,6 @@ func (src *ModuleSource) ModuleEngineVersion(ctx context.Context) (string, error
 	}
 	if !ok {
 		return "", nil
-	}
-	if cfg.EngineVersion == "" {
-		// older versions of dagger might not produce an engine version - so
-		// return the version that engineVersion was introduced in
-		return engine.MinimumModuleVersion, nil
 	}
 	if !semver.IsValid(cfg.EngineVersion) {
 		// filter out non-semver values to simplify calling code

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dagger/dagger/core/modules"
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
+	"github.com/dagger/dagger/engine"
 )
 
 type ModuleSourceKind string
@@ -225,6 +226,11 @@ func (src *ModuleSource) ModuleEngineVersion(ctx context.Context) (string, error
 	}
 	if !ok {
 		return "", nil
+	}
+	if cfg.EngineVersion == "" {
+		// older versions of dagger might not produce an engine version - so
+		// return the version that engineVersion was introduced in
+		return engine.MinimumModuleVersion, nil
 	}
 	if !semver.IsValid(cfg.EngineVersion) {
 		// filter out non-semver values to simplify calling code

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -1070,7 +1070,7 @@ func (s *moduleSchema) updateDaggerConfig(
 		return nil, "", fmt.Errorf("failed to get module config: %w", err)
 	}
 	if !ok {
-		modCfg = &modules.ModuleConfig{}
+		modCfg = &modules.ModuleConfig{EngineVersion: engine.Version}
 	}
 
 	modCfg.Name = mod.OriginalName
@@ -1079,13 +1079,9 @@ func (s *moduleSchema) updateDaggerConfig(
 	case modules.EngineVersionLatest:
 		modCfg.EngineVersion = engine.Version
 	case "":
-		engineVersion, err := src.Self.ModuleEngineVersion(ctx)
-		if err != nil {
-			return nil, "", fmt.Errorf("failed to get module config: %w", err)
-		}
-		modCfg.EngineVersion = engineVersion
 		if modCfg.EngineVersion == "" {
-			modCfg.EngineVersion = engine.Version
+			// only update engineVersion field if it's not set
+			modCfg.EngineVersion = engine.MinimumModuleVersion
 		}
 	default:
 		modCfg.EngineVersion = engineVersion

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -721,17 +721,6 @@ func (s *moduleSchema) moduleWithSource(ctx context.Context, mod *core.Module, a
 		return nil, fmt.Errorf("failed to decode module source: %w", err)
 	}
 
-	engineVersion, err := src.Self.ModuleEngineVersion(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load module config: %w", err)
-	}
-	if err := engine.CheckVersionCompatibility(engineVersion, engine.MinimumModuleVersion); err != nil {
-		return nil, fmt.Errorf("module requires incompatible engine version: %w", err)
-	}
-	if err := engine.CheckVersionCompatibility(engine.Version, engineVersion); err != nil {
-		return nil, fmt.Errorf("module requires newer engine version: %w", err)
-	}
-
 	mod = mod.Clone()
 	mod.Source = src
 	mod.NameField, err = src.Self.ModuleName(ctx)
@@ -751,6 +740,12 @@ func (s *moduleSchema) moduleWithSource(ctx context.Context, mod *core.Module, a
 	modCfg, modCfgPath, err := s.updateDaggerConfig(ctx, string(args.EngineVersion.Value), mod, src)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update dagger.json: %w", err)
+	}
+	if err := engine.CheckVersionCompatibility(modCfg.EngineVersion, engine.MinimumModuleVersion); err != nil {
+		return nil, fmt.Errorf("module requires incompatible engine version: %w", err)
+	}
+	if err := engine.CheckVersionCompatibility(engine.Version, modCfg.EngineVersion); err != nil {
+		return nil, fmt.Errorf("module requires newer engine version: %w", err)
 	}
 	if err := s.updateDeps(ctx, mod, modCfg, src); err != nil {
 		return nil, fmt.Errorf("failed to update module dependencies: %w", err)

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -1070,7 +1070,7 @@ func (s *moduleSchema) updateDaggerConfig(
 		return nil, "", fmt.Errorf("failed to get module config: %w", err)
 	}
 	if !ok {
-		modCfg = &modules.ModuleConfig{EngineVersion: engine.Version}
+		modCfg = &modules.ModuleConfig{}
 	}
 
 	modCfg.Name = mod.OriginalName
@@ -1079,9 +1079,13 @@ func (s *moduleSchema) updateDaggerConfig(
 	case modules.EngineVersionLatest:
 		modCfg.EngineVersion = engine.Version
 	case "":
+		engineVersion, err := src.Self.ModuleEngineVersion(ctx)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to get module config: %w", err)
+		}
+		modCfg.EngineVersion = engineVersion
 		if modCfg.EngineVersion == "" {
-			// only update engineVersion field if it's not set
-			modCfg.EngineVersion = engine.MinimumModuleVersion
+			modCfg.EngineVersion = engine.Version
 		}
 	default:
 		modCfg.EngineVersion = engineVersion

--- a/dev/test.go
+++ b/dev/test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/moby/buildkit/identity"
 
@@ -91,6 +92,12 @@ func (t *Test) test(
 		"go",
 		"test",
 	}
+
+	// Add ldflags
+	ldflags := []string{
+		"-X", "github.com/dagger/dagger/engine.Version=" + t.Dagger.Version.String(),
+	}
+	args = append(args, "-ldflags", strings.Join(ldflags, " "))
 
 	// All following are go test flags
 	if failfast {

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -32,6 +32,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/mod/semver"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/dagger/dagger/analytics"
@@ -446,7 +447,11 @@ func (srv *Server) initializeDaggerClient(
 
 	if opts.EncodedModuleID == "" {
 		client.deps = core.NewModDeps(client.dagqlRoot, []core.Mod{coreMod})
-		coreMod.Dag.View = client.clientVersion
+		clientVersion := client.clientVersion
+		if !semver.IsValid(clientVersion) {
+			clientVersion = ""
+		}
+		coreMod.Dag.View = clientVersion
 	} else {
 		modID := new(call.ID)
 		if err := modID.Decode(opts.EncodedModuleID); err != nil {

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -101,6 +101,7 @@ const (
 type daggerClient struct {
 	daggerSession *daggerSession
 	clientID      string
+	clientVersion string
 	secretToken   string
 
 	state   daggerClientState
@@ -445,6 +446,7 @@ func (srv *Server) initializeDaggerClient(
 
 	if opts.EncodedModuleID == "" {
 		client.deps = core.NewModDeps(client.dagqlRoot, []core.Mod{coreMod})
+		coreMod.Dag.View = client.clientVersion
 	} else {
 		modID := new(call.ID)
 		if err := modID.Decode(opts.EncodedModuleID); err != nil {
@@ -586,6 +588,7 @@ func (srv *Server) getOrInitClient(
 			state:         clientStateUninitialized,
 			daggerSession: sess,
 			clientID:      clientID,
+			clientVersion: opts.ClientVersion,
 			secretToken:   token,
 		}
 		sess.clients[clientID] = client
@@ -672,6 +675,7 @@ func (srv *Server) ServeHTTPToNestedClient(w http.ResponseWriter, r *http.Reques
 	httpHandlerFunc(srv.serveHTTPToClient, &ClientInitOpts{
 		ClientMetadata: &engine.ClientMetadata{
 			ClientID:          execMD.ClientID,
+			ClientVersion:     engine.Version,
 			ClientSecretToken: execMD.SecretToken,
 			SessionID:         execMD.SessionID,
 			ClientHostname:    execMD.Hostname,


### PR DESCRIPTION
Some cherry-picks and pieces from #7858, since that one has some issues, and is risky!

Specifically:
- Fix the process of updating a `dagger.json` during `dagger develop` in certain edge cases with low engine versions (this was broken before, and now has some tests as well)
- The engine should serve the CLI the API that it's `clientVersion` indicates it has - this isn't super useful right now, but is quite nice in the context of #7858.