### PR TITLE
fix(core): allow local module ref with @

### DIFF
--- a/.changes/unreleased/Fixed-20240711-221446.yaml
+++ b/.changes/unreleased/Fixed-20240711-221446.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: 'core: local module name can have @'
+time: 2024-07-11T22:14:46.605886241Z
+custom:
+    Author: grouville
+    PR: "7891"

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -244,11 +244,9 @@ func parseRefString(ctx context.Context, bk buildkitClient, refString string) pa
 
 	// We do a stat in case the mod path github.com/username is a local directory
 	stat, err := bk.StatCallerHostPath(ctx, parsed.modPath, false)
-	if err == nil {
-		if !parsed.hasVersion && stat.IsDir() {
-			parsed.kind = core.ModuleSourceKindLocal
-			return parsed
-		}
+	if err == nil && stat.IsDir() {
+		parsed.kind = core.ModuleSourceKindLocal
+		return parsed
 	}
 
 	parsed.modPath, parsed.modVersion, parsed.hasVersion = strings.Cut(refString, "@")

--- a/core/schema/modulesource.go
+++ b/core/schema/modulesource.go
@@ -240,7 +240,7 @@ type buildkitClient interface {
 // - if nothing worked, fallback as local ref, as before
 func parseRefString(ctx context.Context, bk buildkitClient, refString string) parsedRefString {
 	var parsed parsedRefString
-	parsed.modPath, parsed.modVersion, parsed.hasVersion = strings.Cut(refString, "@")
+	parsed.modPath = refString
 
 	// We do a stat in case the mod path github.com/username is a local directory
 	stat, err := bk.StatCallerHostPath(ctx, parsed.modPath, false)
@@ -250,6 +250,8 @@ func parseRefString(ctx context.Context, bk buildkitClient, refString string) pa
 			return parsed
 		}
 	}
+
+	parsed.modPath, parsed.modVersion, parsed.hasVersion = strings.Cut(refString, "@")
 
 	// we try to isolate the root of the git repo
 	repoRoot, err := vcs.RepoRootForImportPath(parsed.modPath, false)
@@ -262,6 +264,7 @@ func parseRefString(ctx context.Context, bk buildkitClient, refString string) pa
 		return parsed
 	}
 
+	parsed.modPath = refString
 	parsed.kind = core.ModuleSourceKindLocal
 	return parsed
 }


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/7762

Current implementation of parseRefString does not allow local refs to have @, as it considers this character as the module version separator

However, this is not supposed to be true for local refs, to which the notion of version is not relevant