### PR TITLE
fix: ensure we serve nested clients the correct schema version

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -6068,7 +6068,11 @@ func (ModuleSuite) TestModuleSchemaVersion(ctx context.Context, t *testctx.T) {
 			With(daggerQuery("{__schemaVersion}")).
 			Stdout(ctx)
 		require.NoError(t, err)
-		require.JSONEq(t, `{"__schemaVersion":""}`, out)
+		if semver.IsValid(engine.Version) {
+			require.JSONEq(t, `{"__schemaVersion":"`+engine.Version+`"}`, out)
+		} else {
+			require.JSONEq(t, `{"__schemaVersion":""}`, out)
+		}
 	})
 
 	t.Run("cli", func(ctx context.Context, t *testctx.T) {
@@ -6238,7 +6242,11 @@ func (ModuleSuite) TestModuleDevelopVersion(ctx context.Context, t *testctx.T) {
 
 		out, err := work.With(daggerQuery("{__schemaVersion}")).Stdout(ctx)
 		require.NoError(t, err)
+		if semver.IsValid(engine.Version) {
+			require.JSONEq(t, `{"__schemaVersion":"`+engine.Version+`"}`, out)
+		} else {
 		require.JSONEq(t, `{"__schemaVersion":""}`, out)
+		}
 	})
 
 	t.Run("from high", func(ctx context.Context, t *testctx.T) {
@@ -6262,7 +6270,11 @@ func (ModuleSuite) TestModuleDevelopVersion(ctx context.Context, t *testctx.T) {
 
 		out, err = work.With(daggerQuery("{__schemaVersion}")).Stdout(ctx)
 		require.NoError(t, err)
+		if semver.IsValid(engine.Version) {
+			require.JSONEq(t, `{"__schemaVersion":"`+engine.Version+`"}`, out)
+		} else {
 		require.JSONEq(t, `{"__schemaVersion":""}`, out)
+		}
 	})
 
 	t.Run("from missing", func(ctx context.Context, t *testctx.T) {
@@ -6286,7 +6298,11 @@ func (ModuleSuite) TestModuleDevelopVersion(ctx context.Context, t *testctx.T) {
 
 		out, err = work.With(daggerQuery("{__schemaVersion}")).Stdout(ctx)
 		require.NoError(t, err)
+		if semver.IsValid(engine.Version) {
+			require.JSONEq(t, `{"__schemaVersion":"`+engine.Version+`"}`, out)
+		} else {
 		require.JSONEq(t, `{"__schemaVersion":""}`, out)
+		}
 	})
 }
 

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/moby/buildkit/identity"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
+	"golang.org/x/mod/semver"
 	"golang.org/x/sync/errgroup"
 
 	"dagger.io/dagger"
@@ -6075,6 +6076,20 @@ func (ModuleSuite) TestModuleSchemaVersion(ctx context.Context, t *testctx.T) {
 		}
 	})
 
+	t.Run("standalone dev", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		work := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithEnvVariable("_EXPERIMENTAL_DAGGER_VERSION", "v2.0.0").
+			WithWorkdir("/work")
+		out, err := work.
+			With(daggerQuery("{__schemaVersion}")).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"__schemaVersion":"v2.0.0"}`, out)
+	})
+
 	t.Run("cli", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)
 
@@ -6245,7 +6260,7 @@ func (ModuleSuite) TestModuleDevelopVersion(ctx context.Context, t *testctx.T) {
 		if semver.IsValid(engine.Version) {
 			require.JSONEq(t, `{"__schemaVersion":"`+engine.Version+`"}`, out)
 		} else {
-		require.JSONEq(t, `{"__schemaVersion":""}`, out)
+			require.JSONEq(t, `{"__schemaVersion":""}`, out)
 		}
 	})
 
@@ -6273,7 +6288,7 @@ func (ModuleSuite) TestModuleDevelopVersion(ctx context.Context, t *testctx.T) {
 		if semver.IsValid(engine.Version) {
 			require.JSONEq(t, `{"__schemaVersion":"`+engine.Version+`"}`, out)
 		} else {
-		require.JSONEq(t, `{"__schemaVersion":""}`, out)
+			require.JSONEq(t, `{"__schemaVersion":""}`, out)
 		}
 	})
 
@@ -6301,7 +6316,7 @@ func (ModuleSuite) TestModuleDevelopVersion(ctx context.Context, t *testctx.T) {
 		if semver.IsValid(engine.Version) {
 			require.JSONEq(t, `{"__schemaVersion":"`+engine.Version+`"}`, out)
 		} else {
-		require.JSONEq(t, `{"__schemaVersion":""}`, out)
+			require.JSONEq(t, `{"__schemaVersion":""}`, out)
 		}
 	})
 }

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -677,10 +677,15 @@ func (srv *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // in http headers since it includes arbitrary values from users in the function call metadata, which can exceed max header
 // size.
 func (srv *Server) ServeHTTPToNestedClient(w http.ResponseWriter, r *http.Request, execMD *buildkit.ExecutionMetadata) {
+	clientVersion := engine.Version
+	if md, _ := engine.ClientMetadataFromHTTPHeaders(r.Header); md != nil {
+		clientVersion = md.ClientVersion
+	}
+
 	httpHandlerFunc(srv.serveHTTPToClient, &ClientInitOpts{
 		ClientMetadata: &engine.ClientMetadata{
 			ClientID:          execMD.ClientID,
-			ClientVersion:     engine.Version,
+			ClientVersion:     clientVersion,
 			ClientSecretToken: execMD.SecretToken,
 			SessionID:         execMD.SessionID,
 			ClientHostname:    execMD.Hostname,


### PR DESCRIPTION
Follow up from #7889

We should also serve generalized nested clients the right client API - and then have tests for this.