### PR TITLE
chore: fix helm versions to keep semver in version field

### DIFF
--- a/dev/helm.go
+++ b/dev/helm.go
@@ -41,7 +41,7 @@ func (h *Helm) chart() *Container {
 func (h *Helm) SetVersion(
 	ctx context.Context,
 
-	// Version to set the chart & app to, e.g. --version=0.12.0
+	// Version to set the chart & app to, e.g. --version=v0.12.0
 	version string,
 ) (*File, error) {
 	c := h.chart()
@@ -55,8 +55,9 @@ func (h *Helm) SetVersion(
 		return nil, err
 	}
 
+	version = strings.TrimPrefix(version, "v")
 	meta.Version = version
-	meta.AppVersion = version
+	meta.AppVersion = "v" + version
 
 	err = meta.Validate()
 	if err != nil {

--- a/helm/dagger/Chart.yaml
+++ b/helm/dagger/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v0.12.0
 description: Dagger Helm chart
 name: dagger-helm
 type: application
-version: v0.12.0
+version: 0.12.0


### PR DESCRIPTION
Without this, the following steps from `RELEASING.md` create the wrong tag name:

```
export HELM_CHART_VERSION="$(awk '/^version: / { print $2 }' helm/dagger/Chart.yaml)"
git tag "helm/chart/v${HELM_CHART_VERSION:?must be set}" "${SDK_GIT_SHA:?must be set}"
```

This creates `helm/chart/vv0.12.0` (with two `v`s). According to https://helm.sh/docs/topics/charts/, the `version` field must be semver, no `v` prefix is allowed.