### PR TITLE
chore(docs): update daggerverse modules

### DIFF
--- a/docs/current_docs/manuals/developer/module-dependencies.mdx
+++ b/docs/current_docs/manuals/developer/module-dependencies.mdx
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 Modules can call each other. To add a dependency to your module, you can use `dagger install`, as in the following example:
 
 ```sh
-dagger install github.com/shykes/daggerverse/helloWorld@26f8ed9f1748ec8c9345281add850fd392441990
+dagger install github.com/shykes/daggerverse/hello@v0.3.0
 ```
 
 This module will be added to your `dagger.json`:
@@ -21,8 +21,8 @@ This module will be added to your `dagger.json`:
 ...
 "dependencies": [
   {
-    "name": "helloWorld",
-    "source": "github.com/shykes/daggerverse/helloWorld@26f8ed9f1748ec8c9345281add850fd392441990"
+    "name": "hello",
+    "source": "github.com/shykes/daggerverse/hello@54d86c6002d954167796e41886a47c47d95a626d"
   }
 ]
 ```

--- a/docs/current_docs/manuals/user/artifacts/consumption/exec.mdx
+++ b/docs/current_docs/manuals/user/artifacts/consumption/exec.mdx
@@ -9,13 +9,13 @@ The Dagger CLI can add follow-up processing to a just-in-time container, essenti
 Here is an example of chaining a `WithExec()` function call to a container returned by a Wolfi container builder Dagger Function, to execute a command that displays the contents of the `/etc/` directory:
 
 ```shell
-dagger -m github.com/shykes/daggerverse/wolfi@v0.1.2 call container with-exec --args="ls","/etc/" stdout
+dagger -m github.com/shykes/daggerverse/wolfi@v0.1.4 call container with-exec --args="ls","/etc/" stdout
 ```
 
 Here is an example of chaining a `WithExec()` function call to a container returned by a Wolfi container builder Dagger Function, to execute a command that displays the contents of the `/etc/os-release` file:
 
 ```shell
-dagger -m github.com/shykes/daggerverse/wolfi@v0.1.2 call container with-exec --args="cat","/etc/os-release" stdout
+dagger -m github.com/shykes/daggerverse/wolfi@v0.1.4 call container with-exec --args="cat","/etc/os-release" stdout
 ```
 
 Here is an example of chaining a `WithExec()` function call to modify a container returned by a Wolfi container builder Dagger Function, by adding the current directory from the host to the container filesysytem at `/src`:
@@ -25,17 +25,17 @@ The example below uploads the entire current directory to the container filesyst
 :::
 
 ```shell
-dagger -m github.com/shykes/daggerverse/wolfi@v0.1.2 call container with-directory --path=/src --directory=. with-exec --args="ls","/src" stdout
+dagger -m github.com/shykes/daggerverse/wolfi@v0.1.4 call container with-directory --path=/src --directory=. with-exec --args="ls","/src" stdout
 ```
 
 Here is an example of chaining a `WithExec()` function call to do the reverse: modify a container returned by a Wolfi container builder Dagger Function, by removing the `/etc/os-release` file from the container filesysytem:
 
 ```shell
-dagger -m github.com/shykes/daggerverse/wolfi@v0.1.2 call container with-exec --args="rm","/etc/os-release" with-exec --args="ls","/etc" stdout
+dagger -m github.com/shykes/daggerverse/wolfi@v0.1.4 call container with-exec --args="rm","/etc/os-release" with-exec --args="ls","/etc" stdout
 ```
 
 Here is another example which chains multiple `WithExec()` calls to install the `curl` package in a Wolfi container, send an HTTP request, and return the output:
 
 ```shell
-dagger -m github.com/shykes/daggerverse/wolfi@v0.1.2 call container with-exec --args="apk,add,curl" with-exec --args="curl,-L,dagger.io" stdout
+dagger -m github.com/shykes/daggerverse/wolfi@v0.1.4 call container with-exec --args="apk,add,curl" with-exec --args="curl,-L,dagger.io" stdout
 ```

--- a/docs/current_docs/manuals/user/artifacts/consumption/export.mdx
+++ b/docs/current_docs/manuals/user/artifacts/consumption/export.mdx
@@ -35,5 +35,5 @@ dagger -m github.com/dagger/dagger/linters/markdown@88d89e8d15ab6ad9ca4043a920d3
 Here is an example of exporting a container returned by a Wolfi container builder Dagger Function as an OCI tarball named `/tmp/tarball.tar.gz` on the host:
 
 ```shell
-dagger call -m github.com/shykes/daggerverse/wolfi@v0.1.2 container export --path=./tarball.tar.gz
+dagger call -m github.com/shykes/daggerverse/wolfi@v0.1.4 container export --path=./tarball.tar.gz
 ```

--- a/docs/current_docs/manuals/user/artifacts/consumption/publish.mdx
+++ b/docs/current_docs/manuals/user/artifacts/consumption/publish.mdx
@@ -9,5 +9,5 @@ Every `Container` object exposes a `Publish()` function, which publishes the con
 Here is an example of publishing the container returned by a Wolfi container builder Dagger Function to the `ttl.sh` registry, by chaining a `Publish()` function call to the container:
 
 ```shell
-dagger call -m github.com/shykes/daggerverse/wolfi@v0.1.2 container publish --address=ttl.sh/my-wolfi
+dagger call -m github.com/shykes/daggerverse/wolfi@v0.1.4 container publish --address=ttl.sh/my-wolfi
 ```

--- a/docs/current_docs/manuals/user/artifacts/consumption/terminal.mdx
+++ b/docs/current_docs/manuals/user/artifacts/consumption/terminal.mdx
@@ -11,11 +11,11 @@ To start an interactive session for a container returned by a Dagger Function, u
 Here is an example of starting an interactive terminal with the Wolfi base container returned by the `Container()` function of the `wolfi` module:
 
 ```shell
-dagger call -m github.com/shykes/daggerverse/wolfi@v0.1.2 container --packages=cowsay terminal
+dagger call -m github.com/shykes/daggerverse/wolfi@v0.1.4 container --packages=cowsay terminal
 ```
 
 To start the same terminal with the `zsh` shell, use:
 
 ```shell
-dagger call -m github.com/shykes/daggerverse/wolfi@v0.1.2 container --packages=cowsay,zsh terminal --cmd=zsh
+dagger call -m github.com/shykes/daggerverse/wolfi@v0.1.4 container --packages=cowsay,zsh terminal --cmd=zsh
 ```

--- a/docs/current_docs/manuals/user/artifacts/production/containers.mdx
+++ b/docs/current_docs/manuals/user/artifacts/production/containers.mdx
@@ -19,7 +19,7 @@ You can think of a just-in-time container, and the `Container` type that represe
 Here is an example of a Wolfi container builder Dagger Function that returns a base Wolfi container image with a list of additional specified packages:
 
 ```shell
-dagger -m github.com/shykes/daggerverse/wolfi@v0.1.2 call container --packages=cowsay
+dagger -m github.com/shykes/daggerverse/wolfi@v0.1.4 call container --packages=cowsay
 ```
 
 Once the command completes, you should see this output:

--- a/docs/current_docs/manuals/user/artifacts/production/directories.mdx
+++ b/docs/current_docs/manuals/user/artifacts/production/directories.mdx
@@ -17,7 +17,7 @@ Just-in-time directories might be produced by a Dagger Function that:
 Here is an example of a Go builder Dagger Function that accepts a remote Git address (the address of Dagger's open-source repository) as a `Directory` argument, builds a Go binary from the source code in that repository, and returns the build directory containing the compiled binary.
 
 ```shell
-dagger -m github.com/kpenfound/dagger-modules/golang call build --project=https://github.com/dagger/dagger --args=./cmd/dagger
+dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=https://github.com/dagger/dagger --args=./cmd/dagger
 ```
 
 Once the command completes, you should see this output:

--- a/docs/current_docs/manuals/user/artifacts/production/inspect.mdx
+++ b/docs/current_docs/manuals/user/artifacts/production/inspect.mdx
@@ -27,5 +27,5 @@ dagger -m github.com/sagikazarmark/daggerverse/arc@40057665476af62e617cc8def9ef5
 `Container` objects expose a `WithExec()` function, which lets you execute a command in the corresponding container. Here is an example of chaining this function call to a container returned by a Wolfi container builder Dagger Function, to execute the `cowsay` command:
 
 ```shell
-dagger -m github.com/shykes/daggerverse/wolfi@v0.1.2 call container --packages=cowsay with-exec --args=cowsay,dagger stdout
+dagger -m github.com/shykes/daggerverse/wolfi@v0.1.4 call container --packages=cowsay with-exec --args=cowsay,dagger stdout
 ```

--- a/docs/current_docs/manuals/user/functions/arguments.mdx
+++ b/docs/current_docs/manuals/user/functions/arguments.mdx
@@ -13,7 +13,7 @@ To pass a string argument to a Dagger Function, add the corresponding flag to th
 Here is an example of passing two string arguments to a "hello world" Dagger Function. The Dagger Function uses the arguments to adjust its output message accordingly:
 
 ```shell
-dagger -m github.com/shykes/daggerverse/hello@v0.1.2 call hello --greeting=bonjour --name=daggernaut
+dagger -m github.com/shykes/daggerverse/hello@v0.3.0 call hello --greeting=bonjour --name=daggernaut
 ```
 
 ## Boolean arguments
@@ -26,7 +26,7 @@ To pass a Boolean argument to a Dagger Function, simply add the corresponding fl
 Here is an example of passing a a Boolean argument to the same "hello world" Dagger Function. The Boolean argument controls the size ("giant" or normal) of the output message returned by the Dagger Function:
 
 ```shell
-dagger -m github.com/shykes/daggerverse/hello@v0.1.2 call hello --giant
+dagger -m github.com/shykes/daggerverse/hello@v0.3.0 call hello --giant
 ```
 
 ## Directory arguments

--- a/docs/current_docs/manuals/user/functions/call.mdx
+++ b/docs/current_docs/manuals/user/functions/call.mdx
@@ -9,7 +9,7 @@ The simplest and most common way to call Dagger Functions is to use the Dagger C
 Here is an example of calling a Dagger Function using the Dagger CLI:
 
 ```shell
-dagger -m github.com/shykes/daggerverse/hello@v0.1.2 call hello
+dagger -m github.com/shykes/daggerverse/hello@v0.3.0 call hello
 ```
 
 Here's what you should see:

--- a/docs/current_docs/manuals/user/functions/chaining.mdx
+++ b/docs/current_docs/manuals/user/functions/chaining.mdx
@@ -27,19 +27,19 @@ Here are a few examples of function chaining in action:
 - Publish a container image of a container returned by a Dagger Function, by chaining a call to the `Container` object's `Publish()` function:
 
     ```shell
-    dagger call -m github.com/shykes/daggerverse/wolfi@v0.1.2 container publish --address=ttl.sh/my-wolfi
+    dagger call -m github.com/shykes/daggerverse/wolfi@v0.1.4 container publish --address=ttl.sh/my-wolfi
     ```
 
 - Add labels to a container image before publishing it, by chaining additional calls to the `Container` object's `WithLabel()` function:
 
     ```shell
-    dagger -m github.com/shykes/daggerverse/wolfi@v0.1.2 call container --packages=curl with-label --name=version --value=1.0 with-label --name=vendor --value="Unknown Corp" publish --address=ttl.sh/my-wolfi
+    dagger -m github.com/shykes/daggerverse/wolfi@v0.1.4 call container --packages=curl with-label --name=version --value=1.0 with-label --name=vendor --value="Unknown Corp" publish --address=ttl.sh/my-wolfi
     ```
 
 - Display and return the contents of the `/etc/os-release` file in a container, by chaining calls to the `Container` object's `WithExec()` and `Stdout()` functions:
 
     ```shell
-    dagger -m github.com/shykes/daggerverse/wolfi@v0.1.2 call container with-exec --args="cat","/etc/os-release" stdout
+    dagger -m github.com/shykes/daggerverse/wolfi@v0.1.4 call container with-exec --args="cat","/etc/os-release" stdout
     ```
 
 - Expose a service returned by a Dagger Function on a specified host port, by chaining a call to the `Service` object's `Up()` function:

--- a/docs/current_docs/manuals/user/host/host-env.mdx
+++ b/docs/current_docs/manuals/user/host/host-env.mdx
@@ -12,7 +12,7 @@ Here is an example of passing a host environment variable containing a string va
 
 ```shell
 export GREETING=bonjour
-dagger -m github.com/shykes/daggerverse/hello@v0.1.2 call hello --greeting=$GREETING
+dagger -m github.com/shykes/daggerverse/hello@v0.3.0 call hello --greeting=$GREETING
 ```
 
 To pass a secret stored in a host environment variable as arguments when invoking a Dagger Function, add the `env:` prefix to the environment variable name.

--- a/docs/current_docs/manuals/user/host/host-fs.mdx
+++ b/docs/current_docs/manuals/user/host/host-fs.mdx
@@ -18,7 +18,7 @@ dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.8 call build --source=
 Here is an example of passing a host file to a container builder Dagger Function using the `WithFile()` function:
 
 ```shell
-dagger -m github.com/shykes/daggerverse/wolfi@v0.1.2 call container with-file --path=/README.md --source=./README.md with-exec --args="cat","/README.md" stdout
+dagger -m github.com/shykes/daggerverse/wolfi@v0.1.4 call container with-file --path=/README.md --source=./README.md with-exec --args="cat","/README.md" stdout
 ```
 
 Here is another example of passing a host file as argument to a checksum Dagger Function:


### PR DESCRIPTION
Some modules in our docs aren't working in Dagger v0.12.0, most likely due to dev `engineVersion` (@shykes) or old Go version in `go.mod` (@kpenfound).

## TODO

- [ ] Missing update for [github.com/kpenfound/dagger-modules/golang](https://github.com/kpenfound/dagger-modules/tree/main/golang) \cc @kpenfound 
- [ ] Check others