### PR TITLE
fix(helm): ensure appVersion is always semver

### DIFF
--- a/dev/helm.go
+++ b/dev/helm.go
@@ -57,7 +57,7 @@ func (h *Helm) SetVersion(
 
 	version = strings.TrimPrefix(version, "v")
 	meta.Version = version
-	meta.AppVersion = "v" + version
+	meta.AppVersion = version
 
 	err = meta.Validate()
 	if err != nil {

--- a/helm/dagger/Chart.yaml
+++ b/helm/dagger/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v0.12.0
+appVersion: 0.12.0
 description: Dagger Helm chart
 name: dagger-helm
 type: application

--- a/helm/dagger/templates/_helpers.tpl
+++ b/helm/dagger/templates/_helpers.tpl
@@ -37,7 +37,7 @@ Common labels
 helm.sh/chart: {{ include "dagger.chart" . }}
 {{ include "dagger.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: v{{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: {{ template "dagger.name" . }}


### PR DESCRIPTION
Fixes #7916 (which is a regression from #7854), follow-up to #7906

We should ensure that both fields are semver, and have no "v" prefix - then we can add the v prefix ourselves in the templated code.