### PR TITLE
fix: ensure dagger version uses otel output

### DIFF
--- a/cmd/dagger/version.go
+++ b/cmd/dagger/version.go
@@ -16,7 +16,7 @@ var versionCmd = &cobra.Command{
 	PersistentPreRun: func(*cobra.Command, []string) {},
 	Args:             cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(long())
+		fmt.Fprintln(cmd.OutOrStdout(), long())
 	},
 }
 


### PR DESCRIPTION
Fixes #7914 (thanks @nipuna-perera!)

We were avoiding direct use of Stdout/Stderr *pretty* well, however, not for `dagger version`. If we write directly to it, it has the potential to overlap with the TUI, which can cause the output to be weirdly cleared.