### PR TITLE
fix(helm): ensure appVersion is correctly quoted

### DIFF
--- a/helm/dagger/templates/_helpers.tpl
+++ b/helm/dagger/templates/_helpers.tpl
@@ -37,7 +37,7 @@ Common labels
 helm.sh/chart: {{ include "dagger.chart" . }}
 {{ include "dagger.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: v{{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ printf "v%s" .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: {{ template "dagger.name" . }}


### PR DESCRIPTION
Reported in https://discord.com/channels/707636530424053791/1122942037096927353/1262387498156298250

The fix in https://github.com/dagger/dagger/pull/7917 was bad.

It would generate a bad label for `app.kubernetes.io/version`:

```yaml
---
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: release-name-dagger-helm-engine
  namespace: dagger
  labels:
    helm.sh/chart: dagger-helm-0.12.0
    app.kubernetes.io/name: dagger-helm
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: v"0.12.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: dagger-helm
```

This is now fixed:

```yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: release-name-dagger-helm-engine
  namespace: dagger
  labels:
    helm.sh/chart: dagger-helm-0.12.0
    app.kubernetes.io/name: dagger-helm
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.12.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: dagger-helm
```
