### PR TITLE
fix: `Module.serve` should not modify the caller's core module

### DIFF
--- a/cmd/dagger/call.go
+++ b/cmd/dagger/call.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"dagger.io/dagger"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -45,13 +44,13 @@ var callCmd = &FuncCommand{
 		// There's no fields in `Container` that trigger container execution so
 		// we use `sync` first to evaluate, and then load the new `Container`
 		// from that response before continuing.
-		if typeName == Container {
-			var cid dagger.ContainerID
+		if typeName == Container || typeName == Terminal {
+			var id string
 			fc.Select("sync")
-			if err := fc.Request(ctx, &cid); err != nil {
+			if err := fc.Request(ctx, &id); err != nil {
 				return err
 			}
-			fc.q = fc.q.Root().Select("loadContainerFromID").Arg("id", cid)
+			fc.q = fc.q.Root().Select(fmt.Sprintf("load%sFromID", typeName)).Arg("id", id)
 		}
 
 		// Add the object's name so we always have something to show.

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -31,6 +31,7 @@ const (
 	Module       string = "Module"
 	Platform     string = "Platform"
 	Socket       string = "Socket"
+	Terminal     string = "Terminal"
 )
 
 var (

--- a/core/schema/container.go
+++ b/core/schema/container.go
@@ -576,6 +576,10 @@ func (s *containerSchema) Install() {
 	}.Install(s.srv)
 
 	dagql.Fields[*coreTerminalLegacy]{
+		Syncer[*coreTerminalLegacy]().
+			Doc(`Forces evaluation of the pipeline in the engine.`,
+				`It doesn't run the default command if no exec has been set.`),
+
 		dagql.Func("websocketEndpoint", s.terminalLegacyWebsocketEndpoint).
 			View(BeforeVersion("v0.12.0")).
 			Deprecated("Use newer dagger to access the terminal").
@@ -1677,6 +1681,10 @@ func (*coreTerminalLegacy) Type() *ast.Type {
 
 func (*coreTerminalLegacy) TypeDescription() string {
 	return "An interactive terminal that clients can connect to."
+}
+
+func (*coreTerminalLegacy) Evaluate(ctx context.Context) (*buildkit.Result, error) {
+	return nil, nil
 }
 
 func (s *containerSchema) terminalLegacyWebsocketEndpoint(ctx context.Context, parent *coreTerminalLegacy, args struct{}) (string, error) {

--- a/core/schema/module.go
+++ b/core/schema/module.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"golang.org/x/mod/semver"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/dagger/dagger/core"
@@ -856,7 +857,11 @@ func (s *moduleSchema) updateDeps(
 			// this is needed so that a module's dependency on the core
 			// uses the correct schema version
 			dag := *coreMod.Dag
-			dag.View = modCfg.EngineVersion
+			engineVersion := modCfg.EngineVersion
+			if !semver.IsValid(engineVersion) {
+				engineVersion = ""
+			}
+			dag.View = engineVersion
 			mod.Deps.Mods[i] = &CoreMod{Dag: &dag}
 		}
 	}

--- a/docs/docs-graphql/schema.graphqls
+++ b/docs/docs-graphql/schema.graphqls
@@ -2695,6 +2695,13 @@ scalar SocketID
 type Terminal {
   """A unique identifier for this Terminal."""
   id: TerminalID!
+
+  """
+  Forces evaluation of the pipeline in the engine.
+  
+  It doesn't run the default command if no exec has been set.
+  """
+  sync: TerminalID!
 }
 
 """

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -937,23 +937,10 @@ func (srv *Server) ServeModule(ctx context.Context, mod *core.Module) error {
 		return err
 	}
 
-	engineVersion, err := mod.Source.Self.ModuleEngineVersion(ctx)
-	if err != nil {
-		return err
-	}
-
 	client.stateMu.Lock()
 	defer client.stateMu.Unlock()
 
 	client.deps = client.deps.Append(mod)
-	for _, depMod := range client.deps.Mods {
-		if coreMod, ok := depMod.(*schema.CoreMod); ok {
-			// this is needed so that when the cli serves a module, that we
-			// serve the coreMod schema associated with that module
-			coreMod.Dag.View = engineVersion
-			break
-		}
-	}
 	return nil
 }
 

--- a/sdk/elixir/lib/dagger/gen/terminal.ex
+++ b/sdk/elixir/lib/dagger/gen/terminal.ex
@@ -5,7 +5,7 @@ defmodule Dagger.Terminal do
   use Dagger.Core.QueryBuilder
 
   @derive Dagger.ID
-
+  @derive Dagger.Sync
   defstruct [:selection, :client]
 
   @type t() :: %__MODULE__{}
@@ -17,5 +17,27 @@ defmodule Dagger.Terminal do
       terminal.selection |> select("id")
 
     execute(selection, terminal.client)
+  end
+
+  @doc """
+  Forces evaluation of the pipeline in the engine.
+
+  It doesn't run the default command if no exec has been set.
+  """
+  @spec sync(t()) :: {:ok, Dagger.Terminal.t()} | {:error, term()}
+  def sync(%__MODULE__{} = terminal) do
+    selection =
+      terminal.selection |> select("sync")
+
+    with {:ok, id} <- execute(selection, terminal.client) do
+      {:ok,
+       %Dagger.Terminal{
+         selection:
+           query()
+           |> select("loadTerminalFromID")
+           |> arg("id", id),
+         client: terminal.client
+       }}
+    end
   end
 end

--- a/sdk/go/dagger.gen.go
+++ b/sdk/go/dagger.gen.go
@@ -7321,7 +7321,8 @@ func (r *Socket) MarshalJSON() ([]byte, error) {
 type Terminal struct {
 	query *querybuilder.Selection
 
-	id *TerminalID
+	id   *TerminalID
+	sync *TerminalID
 }
 
 func (r *Terminal) WithGraphQLQuery(q *querybuilder.Selection) *Terminal {
@@ -7368,6 +7369,21 @@ func (r *Terminal) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	return json.Marshal(id)
+}
+
+// Forces evaluation of the pipeline in the engine.
+//
+// It doesn't run the default command if no exec has been set.
+func (r *Terminal) Sync(ctx context.Context) (*Terminal, error) {
+	q := r.query.Select("sync")
+
+	var id TerminalID
+	if err := q.Bind(&id).Execute(ctx); err != nil {
+		return nil, err
+	}
+	return &Terminal{
+		query: q.Root().Select("loadTerminalFromID").Arg("id", id),
+	}, nil
 }
 
 // A definition of a parameter or return type in a Module.

--- a/sdk/php/generated/Terminal.php
+++ b/sdk/php/generated/Terminal.php
@@ -21,4 +21,15 @@ class Terminal extends Client\AbstractObject implements Client\IdAble
         $leafQueryBuilder = new \Dagger\Client\QueryBuilder('id');
         return new \Dagger\TerminalId((string)$this->queryLeaf($leafQueryBuilder, 'id'));
     }
+
+    /**
+     * Forces evaluation of the pipeline in the engine.
+     *
+     * It doesn't run the default command if no exec has been set.
+     */
+    public function sync(): TerminalId
+    {
+        $leafQueryBuilder = new \Dagger\Client\QueryBuilder('sync');
+        return new \Dagger\TerminalId((string)$this->queryLeaf($leafQueryBuilder, 'sync'));
+    }
 }

--- a/sdk/python/src/dagger/client/gen.py
+++ b/sdk/python/src/dagger/client/gen.py
@@ -7250,6 +7250,27 @@ class Terminal(Type):
         _ctx = self._select("id", _args)
         return await _ctx.execute(TerminalID)
 
+    async def sync(self) -> Self:
+        """Forces evaluation of the pipeline in the engine.
+
+        It doesn't run the default command if no exec has been set.
+
+        Raises
+        ------
+        ExecuteTimeoutError
+            If the time to execute the query exceeds the configured timeout.
+        QueryError
+            If the API returns an error.
+        """
+        _args: list[Arg] = []
+        _ctx = self._select("sync", _args)
+        _id = await _ctx.execute(TerminalID)
+        _ctx = Client.from_context(_ctx)._select("loadTerminalFromID", [Arg("id", _id)])
+        return Terminal(_ctx)
+
+    def __await__(self):
+        return self.sync().__await__()
+
 
 @typecheck
 class TypeDef(Type):

--- a/sdk/rust/crates/dagger-sdk/src/gen.rs
+++ b/sdk/rust/crates/dagger-sdk/src/gen.rs
@@ -7445,6 +7445,12 @@ impl Terminal {
         let query = self.selection.select("id");
         query.execute(self.graphql_client.clone()).await
     }
+    /// Forces evaluation of the pipeline in the engine.
+    /// It doesn't run the default command if no exec has been set.
+    pub async fn sync(&self) -> Result<TerminalId, DaggerError> {
+        let query = self.selection.select("sync");
+        query.execute(self.graphql_client.clone()).await
+    }
 }
 #[derive(Clone)]
 pub struct TypeDef {

--- a/sdk/typescript/api/client.gen.ts
+++ b/sdk/typescript/api/client.gen.ts
@@ -9416,6 +9416,7 @@ export class Socket extends BaseClient {
  */
 export class Terminal extends BaseClient {
   private readonly _id?: TerminalID = undefined
+  private readonly _sync?: TerminalID = undefined
 
   /**
    * Constructor is used for internal usage only, do not create object from it.
@@ -9423,10 +9424,12 @@ export class Terminal extends BaseClient {
   constructor(
     parent?: { queryTree?: QueryTree[]; ctx: Context },
     _id?: TerminalID,
+    _sync?: TerminalID,
   ) {
     super(parent)
 
     this._id = _id
+    this._sync = _sync
   }
 
   /**
@@ -9448,6 +9451,33 @@ export class Terminal extends BaseClient {
     )
 
     return response
+  }
+
+  /**
+   * Forces evaluation of the pipeline in the engine.
+   *
+   * It doesn't run the default command if no exec has been set.
+   */
+  sync = async (): Promise<Terminal> => {
+    const response: Awaited<TerminalID> = await computeQuery(
+      [
+        ...this._queryTree,
+        {
+          operation: "sync",
+        },
+      ],
+      await this._ctx.connection(),
+    )
+
+    return new Terminal({
+      queryTree: [
+        {
+          operation: "loadTerminalFromID",
+          args: { id: response },
+        },
+      ],
+      ctx: this._ctx,
+    })
   }
 }
 


### PR DESCRIPTION
Fixes #7907.

The client is expecting a given API - loading a module *shouldn't* update the version of the API that it's served. This was a minor design mistake, and just doesn't make sense as is.

With that patch, there are now *no* fields on the `Terminal` type that are served to a v0.12 CLI. This is an issue, because now, nothing forces the evaluation of the type!
    
To avoid this, we add `Terminal.sync`, which allows the CLI to force execution of a `Terminal` type, with a special field just for this. The fact that this seemed to work before at all is pretty much coincidence (because we kept the `websocketEndpoint` field).