### PR TITLE
fix: only initialize telemetry when connecting to engine

### DIFF
--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -2,11 +2,15 @@ package main
 
 import (
 	"context"
-	"log/slog"
+	"os"
 
 	"dagger.io/dagger/telemetry"
 	"github.com/dagger/dagger/engine"
 	"github.com/dagger/dagger/engine/client"
+	"github.com/dagger/dagger/engine/slog"
+	enginetel "github.com/dagger/dagger/engine/telemetry"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 type runClientCallback func(context.Context, *client.Client) error
@@ -16,37 +20,85 @@ func withEngine(
 	params client.Params,
 	fn runClientCallback,
 ) error {
-	if debug {
-		params.LogLevel = slog.LevelDebug
-	}
+	return Frontend.Run(ctx, opts, func(ctx context.Context) (rerr error) {
+		// Init tracing as early as possible and shutdown after the command
+		// completes, ensuring progress is fully flushed to the frontend.
+		cleanupTelemetry := initEngineTelemetry(ctx)
+		defer cleanupTelemetry(rerr)
 
-	if params.RunnerHost == "" {
-		var err error
-		params.RunnerHost, err = engine.RunnerHost()
+		if debug {
+			params.LogLevel = slog.LevelDebug
+		}
+
+		if params.RunnerHost == "" {
+			var err error
+			params.RunnerHost, err = engine.RunnerHost()
+			if err != nil {
+				return err
+			}
+		}
+
+		params.DisableHostRW = disableHostRW
+
+		params.EngineCallback = Frontend.ConnectedToEngine
+		params.CloudURLCallback = Frontend.SetCloudURL
+
+		params.EngineTrace = telemetry.SpanForwarder{
+			Processors: telemetry.SpanProcessors,
+		}
+		params.EngineLogs = telemetry.LogForwarder{
+			Processors: telemetry.LogProcessors,
+		}
+		params.WithTerminal = withTerminal
+		params.Interactive = interactive
+
+		// Connect to and run with the engine
+		sess, ctx, err := client.Connect(ctx, params)
 		if err != nil {
 			return err
 		}
+		defer sess.Close()
+
+		return fn(ctx, sess)
+	})
+}
+
+func initEngineTelemetry(ctx context.Context) func(error) {
+	// Setup telemetry config
+	telemetryCfg := telemetry.Config{
+		Detect:   true,
+		Resource: Resource(),
+
+		LiveTraceExporters: []sdktrace.SpanExporter{Frontend.SpanExporter()},
+		LiveLogExporters:   []sdklog.Exporter{Frontend.LogExporter()},
 	}
-
-	params.DisableHostRW = disableHostRW
-
-	params.EngineCallback = Frontend.ConnectedToEngine
-	params.CloudURLCallback = Frontend.SetCloudURL
-
-	params.EngineTrace = telemetry.SpanForwarder{
-		Processors: telemetry.SpanProcessors,
+	if spans, logs, ok := enginetel.ConfiguredCloudExporters(ctx); ok {
+		telemetryCfg.LiveTraceExporters = append(telemetryCfg.LiveTraceExporters, spans)
+		telemetryCfg.LiveLogExporters = append(telemetryCfg.LiveLogExporters, logs)
 	}
-	params.EngineLogs = telemetry.LogForwarder{
-		Processors: telemetry.LogProcessors,
-	}
-	params.WithTerminal = withTerminal
-	params.Interactive = interactive
+	ctx = telemetry.Init(ctx, telemetryCfg)
 
-	sess, ctx, err := client.Connect(ctx, params)
-	if err != nil {
-		return err
-	}
-	defer sess.Close()
+	// Set the full command string as the name of the root span.
+	//
+	// If you pass credentials in plaintext, yes, they will be leaked; don't do
+	// that, since they will also be leaked in various other places (like the
+	// process tree). Use Secret arguments instead.
+	ctx, span := Tracer().Start(ctx, spanName(os.Args))
 
-	return fn(ctx, sess)
+	// Set up global slog to log to the primary span output.
+	slog.SetDefault(slog.SpanLogger(ctx, InstrumentationLibrary))
+
+	// Set the span as the primary span for the frontend.
+	Frontend.SetPrimary(span.SpanContext().SpanID())
+
+	// Direct command stdout/stderr to span stdio via OpenTelemetry.
+	stdio := telemetry.SpanStdio(ctx, InstrumentationLibrary)
+	rootCmd.SetOut(stdio.Stdout)
+	rootCmd.SetErr(stdio.Stderr)
+
+	return func(rerr error) {
+		stdio.Close()
+		telemetry.End(span, func() error { return rerr })
+		telemetry.Close()
+	}
 }

--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -23,7 +23,7 @@ func withEngine(
 	return Frontend.Run(ctx, opts, func(ctx context.Context) (rerr error) {
 		// Init tracing as early as possible and shutdown after the command
 		// completes, ensuring progress is fully flushed to the frontend.
-		cleanupTelemetry := initEngineTelemetry(ctx)
+		ctx, cleanupTelemetry := initEngineTelemetry(ctx)
 		defer cleanupTelemetry(rerr)
 
 		if debug {
@@ -63,7 +63,7 @@ func withEngine(
 	})
 }
 
-func initEngineTelemetry(ctx context.Context) func(error) {
+func initEngineTelemetry(ctx context.Context) (context.Context, func(error)) {
 	// Setup telemetry config
 	telemetryCfg := telemetry.Config{
 		Detect:   true,
@@ -96,7 +96,7 @@ func initEngineTelemetry(ctx context.Context) func(error) {
 	rootCmd.SetOut(stdio.Stdout)
 	rootCmd.SetErr(stdio.Stderr)
 
-	return func(rerr error) {
+	return ctx, func(rerr error) {
 		stdio.Close()
 		telemetry.End(span, func() error { return rerr })
 		telemetry.Close()


### PR DESCRIPTION
This goes someway towards fixing https://github.com/dagger/dagger/issues/7856.

Only commands that connect to a running engine upload telemetry, while commands that don't, like `version`, `login`/`logout`, and the top-level dagger command (as well as non-existent commands, like running `dagger nope-this-doesnt-exist`) won't initialize telemetry to send to cloud, or the frontend to display it.