### PR TITLE
Do not use `quote` in labels to make it a valid string

### DIFF
--- a/helm/dagger/templates/_helpers.tpl
+++ b/helm/dagger/templates/_helpers.tpl
@@ -37,7 +37,7 @@ Common labels
 helm.sh/chart: {{ include "dagger.chart" . }}
 {{ include "dagger.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: v{{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: v{{ .Chart.AppVersion }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: {{ template "dagger.name" . }}


### PR DESCRIPTION
In https://github.com/dagger/dagger/commit/3bedee341e04a8d92a8c9161e6e72a8ad19e1170 we introduced a change that breaks the chart when installing it since it tries to create a label of `v"0.12.0"` which is not a valid value:
![2024-07-15-12:49:58](https://github.com/user-attachments/assets/0854fdb1-cb57-4908-a4fd-781f1091ee29)

We don't need to apply the quote in this case, it will be treated as a string. With the fix I can install it successfully:
![2024-07-15-12:51:17](https://github.com/user-attachments/assets/77f0a3ba-d4e9-462e-92c7-2b924a18a015)
