### PR TITLE
login: open browser automatically

### DIFF
--- a/internal/cloud/auth/auth.go
+++ b/internal/cloud/auth/auth.go
@@ -7,8 +7,10 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/adrg/xdg"
+	"github.com/pkg/browser"
 	"golang.org/x/oauth2"
 )
 
@@ -47,7 +49,16 @@ func Login(ctx context.Context, out io.Writer) error {
 		return err
 	}
 
-	fmt.Fprintf(out, "\nTo authenticate, visit:\n\t%s\n\n", deviceAuth.VerificationURIComplete)
+	authURL := deviceAuth.VerificationURIComplete
+
+	browserBuf := new(strings.Builder)
+	browser.Stdout = browserBuf
+	browser.Stderr = browserBuf
+	if err := browser.OpenURL(authURL); err != nil {
+		fmt.Fprintf(out, "\nFailed to open browser: %s\n\n%s", err, browserBuf.String())
+	}
+
+	fmt.Fprintf(out, "\nTo authenticate, visit:\n\t%s\n\n", authURL)
 
 	token, err := authConfig.DeviceAccessToken(ctx, deviceAuth)
 	if err != nil {


### PR DESCRIPTION
Implements part 2 of @shykes' solution in https://github.com/dagger/dagger/issues/7920

We already integrate with the browser in other places, so why not extend it to `login`. This way we don't have to worry about whether the URL is clickable/selectable.