### PR TITLE
github: upload dev engine logs

### DIFF
--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -110,6 +110,19 @@ runs:
       env:
         DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
 
+    - name: Capture dev engine logs
+      if: always() && inputs.dev-engine == 'true'
+      shell: bash
+      run: |
+        docker logs dagger-engine.dev-${{ runner.name }} &> /tmp/actions/call/engine.logs
+
+    - name: Archive engine logs
+      if: always() && inputs.dev-engine == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: engine-logs
+        path: /tmp/actions/call/engine.logs
+
     - name: Cleanup
       shell: bash
       run: |


### PR DESCRIPTION
Seeing some runs that seem to hang for a while after they supposedly complete. Ideally we could do this for all jobs, not just `testdev`, but it's easy to start with it.

note: thought about making this only run on failure, but it seems like we can just do it always; the `.zip` is ~7MB for a successful run and afaik doesn't cost us anything.