### PR TITLE
docs: update golang module version

### DIFF
--- a/docs/current_docs/integrations/snippets/Jenkinsfile
+++ b/docs/current_docs/integrations/snippets/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
       steps {
         sh '''
             curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin sh
-            dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=. --args=.
+            dagger -m github.com/kpenfound/dagger-modules/golang@v0.2.0 call build --project=. --args=.
         '''
       }
     }

--- a/docs/current_docs/integrations/snippets/actions.yml
+++ b/docs/current_docs/integrations/snippets/actions.yml
@@ -18,7 +18,7 @@ jobs:
           verb: call
           # assumes a Go project
           # modify to use different function(s) as needed
-          module: github.com/kpenfound/dagger-modules/golang@v0.1.5
+          module: github.com/kpenfound/dagger-modules/golang@v0.2.0
           args: build --project=. --args=.
           # assumes the Dagger Cloud token is in
           # a repository secret named DAGGER_CLOUD_TOKEN

--- a/docs/current_docs/integrations/snippets/argo-workflow.yaml
+++ b/docs/current_docs/integrations/snippets/argo-workflow.yaml
@@ -46,7 +46,7 @@ spec:
         command: ["sh", "-c"]
         # assumes a Go project
         # modify to use different function(s) as needed
-        args: ["dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.10 call test --source=."]
+        args: ["dagger -m github.com/kpenfound/dagger-modules/golang@v0.2.0 call test --source=."]
         workingDir: /work
         env:
         - name: "_EXPERIMENTAL_DAGGER_RUNNER_HOST"

--- a/docs/current_docs/integrations/snippets/azure-pipelines.yml
+++ b/docs/current_docs/integrations/snippets/azure-pipelines.yml
@@ -10,7 +10,7 @@ steps:
   displayName: 'Install Dagger CLI'
   # assumes a Go project
   # modify to use different function(s) as needed
-- script: dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=. --args=.
+- script: dagger -m github.com/kpenfound/dagger-modules/golang@v0.2.0 call build --project=. --args=.
   displayName: 'Call Dagger Function'
   env:
     # assumes the Dagger Cloud token is

--- a/docs/current_docs/integrations/snippets/buildspec.yml
+++ b/docs/current_docs/integrations/snippets/buildspec.yml
@@ -18,4 +18,4 @@ phases:
   build:
     commands:
       - echo "Calling Dagger Function"
-      - dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=. --args=.
+      - dagger -m github.com/kpenfound/dagger-modules/golang@v0.2.0 call build --project=. --args=.

--- a/docs/current_docs/integrations/snippets/circle.yml
+++ b/docs/current_docs/integrations/snippets/circle.yml
@@ -19,7 +19,7 @@ jobs:
           # assumes a Go project
           # modify to use different function(s) as needed
           name: Call Dagger Function
-          command: dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=. --args=.
+          command: dagger -m github.com/kpenfound/dagger-modules/golang@v0.2.0 call build --project=. --args=.
       # for ephemeral runners only: override the default docker stop timeout and
       # give the Dagger Engine more time to push cache data to Dagger Cloud
       - run:

--- a/docs/current_docs/integrations/snippets/gitlab-docker.yml
+++ b/docs/current_docs/integrations/snippets/gitlab-docker.yml
@@ -23,7 +23,7 @@ build:
   script:
     # assumes a Go project
     # modify to use different function(s) as needed
-    - dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=. --args=.
+    - dagger -m github.com/kpenfound/dagger-modules/golang@v0.2.0 call build --project=. --args=.
     # for ephemeral runners only: override the default docker stop timeout and
     # give the Dagger Engine more time to push cache data to Dagger Cloud
     - docker stop -t 300 $(docker ps --filter name="dagger-engine-*" -q)

--- a/docs/current_docs/integrations/snippets/gitlab-kubernetes.yml
+++ b/docs/current_docs/integrations/snippets/gitlab-kubernetes.yml
@@ -13,7 +13,7 @@ build:
   script:
     # assumes a Go project
     # modify to use different function(s) as needed
-    - dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=. --args=.
+    - dagger -m github.com/kpenfound/dagger-modules/golang@v0.2.0 call build --project=. --args=.
     # for ephemeral runners only: override the default docker stop timeout and
     # give the Dagger Engine more time to push cache data to Dagger Cloud
     - docker stop -t 300 $(docker ps --filter name="dagger-engine-*" -q)

--- a/docs/current_docs/integrations/snippets/tekton-dagger-task.yaml
+++ b/docs/current_docs/integrations/snippets/tekton-dagger-task.yaml
@@ -42,7 +42,7 @@ spec:
       #!/usr/bin/env sh
       apk add curl
       curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=/usr/local/bin sh
-      dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=. --args=.
+      dagger -m github.com/kpenfound/dagger-modules/golang@v0.2.0 call build --project=. --args=.
     volumeMounts:
       - mountPath: /var/run/dagger
         name: dagger-socket

--- a/docs/current_docs/manuals/user/artifacts/consumption/export.mdx
+++ b/docs/current_docs/manuals/user/artifacts/consumption/export.mdx
@@ -9,7 +9,7 @@ Just-in-time artifacts such as containers, directories and files expose an `Expo
 Here is an example of exporting the directory returned by a Go builder Dagger Function to the `./my-build` directory on the host:
 
 ```shell
-dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.10 call build --source=https://github.com/dagger/dagger --args=./cmd/dagger export --path=./my-build
+dagger -m github.com/kpenfound/dagger-modules/golang@v0.2.0 call build --source=https://github.com/dagger/dagger --args=./cmd/dagger export --path=./my-build
 ```
 
 By default, the `Export()` function exports the files that exist in the returned directory to the host, but it does not modify or delete any files that already exist at that host path. To replace the contents of the target host directory, such that it exactly matches the directory being exported, add the `--wipe` argument.
@@ -17,13 +17,13 @@ By default, the `Export()` function exports the files that exist in the returned
 Here is an example of exporting the build directory returned by the same Dagger Function above, deleting and replacing files as needed in the `./my-build` directory on the host:
 
 ```shell
-dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.10 call build --source=https://github.com/dagger/dagger --args=./cmd/dagger export --path=./my-build --wipe
+dagger -m github.com/kpenfound/dagger-modules/golang@v0.2.0 call build --source=https://github.com/dagger/dagger --args=./cmd/dagger export --path=./my-build --wipe
 ```
 
 Instead of exporting an entire directory, you can also export a file. Here is an example of exporting a single file from the directory returned by the same Go builder Dagger Function, as `./my-binary-file` on the host:
 
 ```shell
-dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.10 call build --source=https://github.com/dagger/dagger --args=./cmd/dagger file --path=dagger export --path=./my-binary-file
+dagger -m github.com/kpenfound/dagger-modules/golang@v0.2.0 call build --source=https://github.com/dagger/dagger --args=./cmd/dagger file --path=dagger export --path=./my-binary-file
 ```
 
 Here is another example, this time exporting the rules file used by a linter Dagger Function as `/tmp/rules` on the host:

--- a/docs/current_docs/manuals/user/artifacts/production/directories.mdx
+++ b/docs/current_docs/manuals/user/artifacts/production/directories.mdx
@@ -17,7 +17,7 @@ Just-in-time directories might be produced by a Dagger Function that:
 Here is an example of a Go builder Dagger Function that accepts a remote Git address (the address of Dagger's open-source repository) as a `Directory` argument, builds a Go binary from the source code in that repository, and returns the build directory containing the compiled binary.
 
 ```shell
-dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=https://github.com/dagger/dagger --args=./cmd/dagger
+dagger -m github.com/kpenfound/dagger-modules/golang@v0.2.0 call build --source=https://github.com/dagger/dagger --args=./cmd/dagger
 ```
 
 Once the command completes, you should see this output:

--- a/docs/current_docs/manuals/user/artifacts/production/inspect.mdx
+++ b/docs/current_docs/manuals/user/artifacts/production/inspect.mdx
@@ -9,7 +9,7 @@ Just-in-time artifacts such as containers, directories and files are represented
 For example, the `Directory` object exposes an `Entries()` function, which lists the contents of the directory. Here is an example of using it, by chaining an `Entries()` function call to the returned `Directory` object of a Go builder Dagger Function:
 
 ```shell
-dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=https://github.com/dagger/dagger --args=./cmd/dagger entries
+dagger -m github.com/kpenfound/dagger-modules/golang@v0.2.0 call build --source=https://github.com/dagger/dagger --args=./cmd/dagger entries
 ```
 
 Similarly, the `File` object exposes a `Contents()` function, which prints the contents of the corresponding file. Here is an example of using it to print the linting rules file returned by a linter Dagger Function, by chaining a `Contents()` function call to the returned `File` object:

--- a/docs/current_docs/manuals/user/functions/arguments.mdx
+++ b/docs/current_docs/manuals/user/functions/arguments.mdx
@@ -89,6 +89,6 @@ dagger -m github.com/aweris/daggerverse/gh@99a1336f8091ff43bf833778a324de1cadcf2
 To list all the arguments accepted by a function, add the `--help` suffix at any point in the `dagger call` command to obtain context-sensitive help. For example, to list the arguments available for the `Build()` function of the `golang` module, use:
 
 ```shell
-dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.8 call build --help
+dagger -m github.com/kpenfound/dagger-modules/golang@v0.2.0 call build --help
 ```
 :::

--- a/docs/current_docs/manuals/user/functions/chaining.mdx
+++ b/docs/current_docs/manuals/user/functions/chaining.mdx
@@ -15,7 +15,7 @@ Here are a few examples of function chaining in action:
 - List the contents of the build directory returned by a Dagger Function, by chaining a call to the `Directory` object's `Entries()` function:
 
     ```shell
-    dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=https://github.com/dagger/dagger --args=./cmd/dagger entries
+    dagger -m github.com/kpenfound/dagger-modules/golang@v0.2.0 call build --source=https://github.com/dagger/dagger --args=./cmd/dagger entries
     ```
 
 - Print the contents of a file returned by a Dagger Function, by chaining a call to the `File` object's `Contents()` function:

--- a/docs/current_docs/manuals/user/host/host-fs.mdx
+++ b/docs/current_docs/manuals/user/host/host-fs.mdx
@@ -12,7 +12,7 @@ Here is an example of passing a host directory as argument to a Go builder Dagge
 
 ```shell
 git clone https://github.com/golang/example
-dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.8 call build --source=./example/hello --args=. directory --path=. entries
+dagger -m github.com/kpenfound/dagger-modules/golang@v0.2.0 call build --source=./example/hello --args=. directory --path=. entries
 ```
 
 Here is an example of passing a host file to a container builder Dagger Function using the `WithFile()` function:

--- a/docs/current_docs/manuals/user/remotes/remote-repositories.mdx
+++ b/docs/current_docs/manuals/user/remotes/remote-repositories.mdx
@@ -9,5 +9,5 @@ Dagger Functions that accept directory arguments are equally comfortable receivi
 Here is an example of a Go builder Dagger Function that accepts a remote Git address (the address of Dagger's open-source repository) as a `Directory` argument, builds a binary version of the Dagger CLI and exports the build directory to the host filesystem as `./build`:
 
 ```shell
-dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.5 call build --project=https://github.com/dagger/dagger --args=./cmd/dagger export --path=./build
+dagger -m github.com/kpenfound/dagger-modules/golang@v0.2.0 call build --source=https://github.com/dagger/dagger --args=./cmd/dagger export --path=./build
 ```

--- a/docs/current_docs/manuals/user/visualization/cloud-get-started.mdx
+++ b/docs/current_docs/manuals/user/visualization/cloud-get-started.mdx
@@ -212,7 +212,7 @@ To see this in action, commit a change to your forked and locally-cloned Dagger 
 ```shell
 echo "test on local host" >> README.md
 git commit -a -m "Updated README"
-dagger -m github.com/kpenfound/dagger-modules/golang@v0.1.8 call build --source=. --args=./cmd/dagger
+dagger -m github.com/kpenfound/dagger-modules/golang@v0.2.0 call build --source=. --args=./cmd/dagger
 ```
 
 :::info Multiple Dagger Cloud organizations


### PR DESCRIPTION
We just updated https://github.com/kpenfound/dagger-modules/releases/tag/golang%2Fv0.2.0 and this PR updates the docs to use the new version.
Examples were tested as they were changed. 👍 
https://gist.github.com/jpadams/f3c851a129f879bbbb6990f5cf3ddde4