### PR TITLE
pipeline: bump docusaurus module

### DIFF
--- a/dev/dagger.json
+++ b/dev/dagger.json
@@ -8,7 +8,7 @@
     },
     {
       "name": "docusaurus",
-      "source": "github.com/levlaz/daggerverse/docusaurus@72ec19206da7dbe2815da94c62e491b54935b633"
+      "source": "github.com/levlaz/daggerverse/docusaurus@e494cec1aa8f9faab1e0f12b2e5eea4a2321f2de"
     },
     {
       "name": "go",


### PR DESCRIPTION
I recently updated the docusaurus module to be compatible with v0.12, this commit updates it for this this project as well. I tested this out locally to make sure it is working as expected.

`dagger call -m dev --source . docs server as-service up`