### PR TITLE
sdk(typescript): handle required enum options

### DIFF
--- a/cmd/codegen/generator/typescript/templates/src/method_solve.ts.gtpl
+++ b/cmd/codegen/generator/typescript/templates/src/method_solve.ts.gtpl
@@ -81,8 +81,9 @@
 
       		{{- with $optionals }}
       			{{- if $required }}, {{ end }}
-				{{- "" }}...opts{{- if gt (len $enums) 0 -}}, __metadata: metadata{{- end -}}
+				{{- "" }}...opts
 			{{- end }}
+      {{- if gt (len $enums) 0 -}}, __metadata: metadata{{- end -}}
 {{- "" }} },
 		{{- end }}
         },


### PR DESCRIPTION
:cherries: Cherry-picked out of #7438, since that one is kinda stalled, not really sure what to do with it.

In the process of the above PR, I'd attempted to add a required enum arg, which the typescript codegen hadn't previously covered - so I added this case.

While this isn't used by any API at the moment, it's useful to cover it anyway, so when we inevitably do, we don't spend any time on hunting down why it's not working.