### PR TITLE
Fix nested client filesync incorrect deduplication

### DIFF
--- a/.changes/unreleased/Fixed-20240718-223638.yaml
+++ b/.changes/unreleased/Fixed-20240718-223638.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fix rare condition in which clients could use wrong files in filesync
+time: 2024-07-18T22:36:38.877691456-07:00
+custom:
+  Author: sipsma
+  PR: "7900"

--- a/cmd/engine/logger.go
+++ b/cmd/engine/logger.go
@@ -46,9 +46,6 @@ var ignoredMessagePrefixes = []string{
 	"sending sigkill to process in container",
 	"diffcopy took",
 	"Using single walk diff for",
-	"reusing ref for",
-	"not reusing ref",
-	"new ref for local",
 }
 
 func (h *noiseReductionHook) Fire(entry *logrus.Entry) error {

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -79,6 +79,7 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 		execMD = *opts.NestedExecMetadata
 	}
 	execMD.CallID = dagql.CurrentID(ctx)
+	execMD.CallerClientID = clientMetadata.ClientID
 	execMD.ExecID = identity.NewID()
 	execMD.SessionID = clientMetadata.SessionID
 	if execMD.HostAliases == nil {
@@ -119,10 +120,6 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 
 		if execMD.CachePerSession {
 			// include the SessionID here so that we bust cache once-per-session
-			clientMetadata, err := engine.ClientMetadataFromContext(ctx)
-			if err != nil {
-				return nil, err
-			}
 			runOpts = append(runOpts, llb.AddEnv(buildkit.DaggerSessionIDEnv, clientMetadata.SessionID))
 		}
 	}

--- a/core/container_exec.go
+++ b/core/container_exec.go
@@ -108,10 +108,6 @@ func (container *Container) WithExec(ctx context.Context, opts ContainerExecOpts
 		if execMD.ClientID == "" {
 			execMD.ClientID = identity.NewID()
 		}
-		if execMD.CallerClientID == "" {
-			execMD.CallerClientID = clientMetadata.ClientID
-		}
-
 		// include the engine version so that these execs get invalidated if the engine/API change
 		runOpts = append(runOpts, llb.AddEnv(buildkit.DaggerEngineVersionEnv, engine.Version))
 

--- a/core/integration/client_test.go
+++ b/core/integration/client_test.go
@@ -121,3 +121,21 @@ func (ClientSuite) TestMultiSameTrace(ctx context.Context, t *testctx.T) {
 	require.Equal(t, 1, strings.Count(out3.String(), "echoed: "+c3msg))
 	require.NotContains(t, out3.String(), c1msg)
 }
+
+func (ClientSuite) TestClientStableID(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	devEngine := devEngineContainer(c)
+	clientCtr, err := engineClientContainer(ctx, t, c, devEngine.AsService())
+	require.NoError(t, err)
+
+	// just run any dagger cli command that connects to the engine
+	stableID, err := clientCtr.
+		WithExec([]string{"adduser", "-u", "1234", "-D", "auser"}).
+		WithUser("auser").
+		WithWorkdir("/work").
+		WithExec([]string{"dagger", "init", "--sdk=go"}).
+		File("/home/auser/.local/state/dagger/stable_client_id").
+		Contents(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, stableID)
+}

--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -42,11 +42,16 @@ import (
 )
 
 type ExecutionMetadata struct {
-	ClientID       string
-	CallerClientID string
-	SessionID      string
-	SecretToken    string
-	Hostname       string
+	ClientID    string
+	SessionID   string
+	SecretToken string
+	Hostname    string
+
+	// The "stable" ID of the client that is used to identify filesync cache refs
+	// across different clients running on the same host.
+	// For now, nested execs are just always given a random unique ID each exec (as
+	// opposed to clients running on the host which re-use a persisted ID).
+	ClientStableID string
 
 	// Unique (random) ID for this execution.
 	// This is used to deduplicate the same execution that gets evaluated multiple times.

--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -877,6 +877,8 @@ func (w *Worker) setupNestedClient(ctx context.Context, state *execState) (rerr 
 
 	state.spec.Process.Env = append(state.spec.Process.Env, DaggerSessionTokenEnv+"="+w.execMD.SecretToken)
 
+	w.execMD.ClientStableID = randid.NewID()
+
 	filesyncer, err := client.NewFilesyncer(
 		state.rootfsPath,
 		strings.TrimPrefix(state.spec.Process.Cwd, "/"),

--- a/engine/buildkit/filesync.go
+++ b/engine/buildkit/filesync.go
@@ -50,7 +50,7 @@ func (c *Client) LocalImport(
 		llb.SharedKeyHint(strings.Join([]string{clientMetadata.ClientHostname, srcPath}, " ")),
 	}
 
-	localName := fmt.Sprintf("upload %s from %s (client id: %s)", srcPath, clientMetadata.ClientHostname, clientMetadata.ClientID)
+	localName := fmt.Sprintf("upload %s from %s (client id: %s, session id: %s)", srcPath, clientMetadata.ClientHostname, clientMetadata.ClientID, clientMetadata.SessionID)
 	if len(excludePatterns) > 0 {
 		localName += fmt.Sprintf(" (exclude: %s)", strings.Join(excludePatterns, ", "))
 		localOpts = append(localOpts, llb.ExcludePatterns(excludePatterns))

--- a/engine/client/stableid.go
+++ b/engine/client/stableid.go
@@ -1,0 +1,65 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/adrg/xdg"
+	"github.com/dagger/dagger/engine/slog"
+	"github.com/moby/buildkit/identity"
+)
+
+const StableIDFileName = "stable_client_id"
+
+// GetHostStableID returns a random ID that's persisted in the caller's XDG state directory.
+// It's currently used to identify clients that are executing on the same host in order to
+// tell buildkit which filesync cache ref to re-use when syncing dirs+files to the engine.
+func GetHostStableID(lg *slog.Logger) string {
+	id, err := internalGetStableID(filepath.Join(xdg.StateHome, "dagger"))
+	if err != nil {
+		lg.Warn("failed to get stable ID, defaulting to random value", "error", err)
+		return identity.NewID()
+	}
+	return id
+}
+
+func internalGetStableID(parentDirPath string) (string, error) {
+	if parentDirPath == "" {
+		return "", errors.New("parentDirPath is not set")
+	}
+
+	stableIDPath := filepath.Join(parentDirPath, StableIDFileName)
+	if stableID, err := os.ReadFile(stableIDPath); err == nil {
+		// already exists
+		return string(stableID), nil
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("failed to read stable ID: %w", err)
+	}
+
+	if err := os.MkdirAll(parentDirPath, 0o700); err != nil {
+		return "", fmt.Errorf("failed to create parent directory: %w", err)
+	}
+
+	// there's a race in the (obscure) case of clients concurrently running here,
+	// but the worst case is some of the clients using different IDs, which is
+	// just a temporary mild performance deficiency, so not worth more complication
+	tmpFile, err := os.CreateTemp(parentDirPath, StableIDFileName)
+	if err != nil {
+		return "", fmt.Errorf("failed to create stable ID temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+
+	stableID := identity.NewID()
+	if _, err := tmpFile.WriteString(stableID); err != nil {
+		return "", fmt.Errorf("failed to write stable ID: %w", err)
+	}
+
+	if err := os.Rename(tmpFile.Name(), stableIDPath); err != nil {
+		return "", fmt.Errorf("failed to rename stable ID temp file: %w", err)
+	}
+
+	return stableID, nil
+}

--- a/engine/opts.go
+++ b/engine/opts.go
@@ -48,11 +48,13 @@ type ClientMetadata struct {
 	SessionID string `json:"session_id"`
 
 	// ClientHostname is the hostname of the client that made the request. It's
-	// used opportunistically as a best-effort, semi-stable identifier for the
-	// client across multiple sessions, which can be useful for debugging and for
-	// minimizing occurrences of both excessive cache misses and excessive cache
-	// matches.
+	// used to help identify clients in the logs more clearly; nothing functional.
 	ClientHostname string `json:"client_hostname"`
+
+	// ClientStableID is an ID that's persisted in a client's XDG state directory.
+	// It's currently used to identify clients that are executing on the same host in order to
+	// tell buildkit which filesync cache ref to re-use when syncing dirs+files to the engine.
+	ClientStableID string `json:"client_stable_id"`
 
 	// ClientVersion is the version string of the client that make the request.
 	ClientVersion string `json:"client_version"`

--- a/engine/server/session.go
+++ b/engine/server/session.go
@@ -711,6 +711,7 @@ func (srv *Server) ServeHTTPToNestedClient(w http.ResponseWriter, r *http.Reques
 			ClientSecretToken: execMD.SecretToken,
 			SessionID:         execMD.SessionID,
 			ClientHostname:    execMD.Hostname,
+			ClientStableID:    execMD.ClientStableID,
 			Labels:            map[string]string{},
 		},
 		CallID:              execMD.CallID,


### PR DESCRIPTION
As detailed in #7900, certain obscure corner cases can result in
separate clients on separate hosts (or separate nested exec containers)
from re-using each others' filesync cache refs unexpectedly and, if
files happen to match metadata precisely, end up with incorrect
file contents being used in the sync.

The requirements for this to happen are as obscure as it gets, but it is
impacting our CI and causing flakes, so needs a fix. It is *technically*
possible for users to hit this too, so may as well solve it for them.

Previously part of the cause here was that we used hostname as a
semi-stable host identifier, but nested clients mostly have the same
default container hostname.
* There was much more to it than this, but this is the part we can
  address.

The fix here replaces the hostname with an ID that is persisted in the
client's XDG state dir (i.e. `~/.local/state/dagger/`). It's random when
newly initialized but re-used after that.

That solves this problem for non-nested clients. For nested clients, we
just set this to a random ID in each exec for now.
* It would also be possible to try to persist this in the nested exec,
  but it's not clear yet if that's worth the complication in that case,
  so keeping it simple for now.