### PR TITLE
feat(ts-sdk) upgrade decorator to non-experimental

### DIFF
--- a/sdk/typescript/.changes/unreleased/Breaking-20240717-005918.yaml
+++ b/sdk/typescript/.changes/unreleased/Breaking-20240717-005918.yaml
@@ -1,0 +1,6 @@
+kind: Breaking
+body: Use no-experimental decorators
+time: 2024-07-17T00:59:18.691911+02:00
+custom:
+  Author: TomChv
+  PR: "7944"

--- a/sdk/typescript/.changes/unreleased/Breaking-20240717-005918.yaml
+++ b/sdk/typescript/.changes/unreleased/Breaking-20240717-005918.yaml
@@ -1,4 +1,4 @@
-kind: Breaking
+kind: Added
 body: Use no-experimental decorators
 time: 2024-07-17T00:59:18.691911+02:00
 custom:

--- a/sdk/typescript/.changes/unreleased/Changed-20240717-005918.yaml
+++ b/sdk/typescript/.changes/unreleased/Changed-20240717-005918.yaml
@@ -1,4 +1,4 @@
-kind: Added
+kind: Changed
 body: Use no-experimental decorators
 time: 2024-07-17T00:59:18.691911+02:00
 custom:

--- a/sdk/typescript/introspector/registry/registry.ts
+++ b/sdk/typescript/introspector/registry/registry.ts
@@ -39,11 +39,14 @@ export class Registry {
    * class module that must be exposed to the Dagger API.
    *
    */
-  object = (): (<T extends Class>(constructor: T) => T) => {
-    return <T extends Class>(constructor: T): T => {
-      Reflect.defineMetadata(constructor.name, { class_: constructor }, this)
+  object = (): (<T extends Class>(
+    target: T,
+    context: ClassDecoratorContext,
+  ) => T) => {
+    return <T extends Class>(target: T, context: ClassDecoratorContext): T => {
+      Reflect.defineMetadata(target.name, { class_: target }, this)
 
-      return constructor
+      return target
     }
   }
 
@@ -51,9 +54,12 @@ export class Registry {
    * The definition of the @enum decorator that should be on top of any
    * class module that must be exposed to the Dagger API as enumeration.
    */
-  enumType = (): (<T extends Class>(constructor: T) => T) => {
-    return <T extends Class>(constructor: T): T => {
-      return constructor
+  enumType = (): (<T extends Class>(
+    target: T,
+    context: ClassDecoratorContext,
+  ) => T) => {
+    return <T extends Class>(target: T, context: ClassDecoratorContext): T => {
+      return target
     }
   }
 
@@ -64,8 +70,10 @@ export class Registry {
    * @deprecated In favor of `@func`
    * @param alias The alias to use for the field when exposed on the API.
    */
-  field = (alias?: string): ((target: object, propertyKey: string) => void) => {
-    return (target: object, propertyKey: string) => {
+  field = (
+    alias?: string,
+  ): ((target: any, context: ClassFieldDecoratorContext) => void) => {
+    return (target: any, context: ClassFieldDecoratorContext) => {
       // A placeholder to declare field in the registry.
     }
   }
@@ -77,14 +85,12 @@ export class Registry {
   func = (
     alias?: string,
   ): ((
-    target: object,
-    propertyKey: string | symbol,
-    descriptor?: PropertyDescriptor,
+    target: any,
+    context: ClassMethodDecoratorContext | ClassFieldDecoratorContext,
   ) => void) => {
     return (
-      target: object,
-      propertyKey: string | symbol,
-      descriptor?: PropertyDescriptor,
+      target: any,
+      context: ClassMethodDecoratorContext | ClassFieldDecoratorContext,
     ) => {
       // The logic is done in the object constructor since it's not possible to
       // access the class parent's name from a method constructor without calling

--- a/sdk/typescript/runtime/bin/__tsconfig.updator.ts
+++ b/sdk/typescript/runtime/bin/__tsconfig.updator.ts
@@ -13,7 +13,6 @@ if (!fs.existsSync(tsConfigPath)) {
     compilerOptions: {
       target: "ES2022",
       moduleResolution: "Node",
-      experimentalDecorators: true,
       paths: {
         "@dagger.io/dagger": ["./sdk"],
         "@dagger.io/dagger/telemetry": ["./sdk/telemetry"],
@@ -58,8 +57,13 @@ if (
   !tsconfig.compilerOptions.paths[daggerTelemetryPathAlias] ||
   !tsconfig.compilerOptions.paths[daggerTelemetryPathAlias].includes(
     daggerTelemetryPath,
-  )
+  ) ||
+  tsconfig.compilerOptions.experimentalDecorators ||
+  tsconfig.compilerOptions.emitDecoratorMetadata
 ) {
+  delete tsconfig.compilerOptions.experimentalDecorators
+  delete tsconfig.compilerOptions.emitDecoratorMetadata
+
   tsconfig.compilerOptions.paths[daggerPathAlias] = [daggerPath]
   tsconfig.compilerOptions.paths[daggerTelemetryPathAlias] = [
     daggerTelemetryPath,

--- a/sdk/typescript/runtime/template/package.json
+++ b/sdk/typescript/runtime/template/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "typescript": "^5.3.2",
+    "typescript": "^5.4.5",
     "@dagger.io/dagger": "./sdk"
   }
 }

--- a/sdk/typescript/runtime/template/tsconfig.json
+++ b/sdk/typescript/runtime/template/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "ES2022",
     "moduleResolution": "Node",
-    "experimentalDecorators": true,
     "paths": {
       "@dagger.io/dagger": ["./sdk"],
       "@dagger.io/dagger/telemetry": ["./sdk/telemetry"]

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -18,8 +18,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "Node16",
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
     "declaration": true,
     "declarationMap": true
   },


### PR DESCRIPTION
This commit is a breaking change on decorators.
It removes the `experimentalDecorators` setting in the `tsconfig.json` to use the official released.

This changes the prototypes of decorators to now take the target and the context as argument.

This commit also updates the generated template and has a script to update existing tsconfig.

Fixes #7499 