### PR TITLE
docs: fixup linters examples with ruff

### DIFF
--- a/docs/current_docs/manuals/user/artifacts/consumption/export.mdx
+++ b/docs/current_docs/manuals/user/artifacts/consumption/export.mdx
@@ -26,10 +26,10 @@ Instead of exporting an entire directory, you can also export a file. Here is an
 dagger -m github.com/kpenfound/dagger-modules/golang@v0.2.0 call build --source=https://github.com/dagger/dagger --args=./cmd/dagger file --path=dagger export --path=./my-binary-file
 ```
 
-Here is another example, this time exporting the rules file used by a linter Dagger Function as `/tmp/rules` on the host:
+Here is another example, this time exporting the results of a `ruff` linter Dagger Function as `/tmp/report.json` on the host:
 
 ```shell
-dagger -m github.com/dagger/dagger/linters/markdown@88d89e8d15ab6ad9ca4043a920d3cd735a6405fd call rules export --path=/tmp/rules
+dagger call -m github.com/dagger/dagger/dev/ruff@a29dadbb5d9968784847a15fccc5629daf2985ae lint --source https://github.com/dagger/dagger report export --path=/tmp/report.json
 ```
 
 Here is an example of exporting a container returned by a Wolfi container builder Dagger Function as an OCI tarball named `/tmp/tarball.tar.gz` on the host:

--- a/docs/current_docs/manuals/user/artifacts/production/files.mdx
+++ b/docs/current_docs/manuals/user/artifacts/production/files.mdx
@@ -14,18 +14,18 @@ Just-in-time files might be produced by a Dagger Function that:
 Here is an example of a linter Dagger Function that returns the linting rules used by it as a file:
 
 ```shell
-dagger -m github.com/dagger/dagger/linters/markdown@88d89e8d15ab6ad9ca4043a920d3cd735a6405fd call rules
+dagger call -m github.com/dagger/dagger/dev/ruff@a29dadbb5d9968784847a15fccc5629daf2985ae lint --source https://github.com/dagger/dagger report
 ```
 
-Once the command completes, you should see this output:
+Once the command completes, you should see something like this output:
 
 ```shell
 _type: File
-name: markdownlint.yaml
-size: 593
+name: ruff-report.json
+size: 1476
 ```
 
-This means that the function succeeded, and a `File` type representing the linting rules file was returned.
+This means that the function succeeded, and a `File` type representing the linting report file was returned.
 
 Here is another example of a file builder Dagger Function that returns a ZIP archive of the `cmd/dagger` directory in the Dagger GitHub repository:
 

--- a/docs/current_docs/manuals/user/artifacts/production/inspect.mdx
+++ b/docs/current_docs/manuals/user/artifacts/production/inspect.mdx
@@ -12,10 +12,10 @@ For example, the `Directory` object exposes an `Entries()` function, which lists
 dagger -m github.com/kpenfound/dagger-modules/golang@v0.2.0 call build --source=https://github.com/dagger/dagger --args=./cmd/dagger entries
 ```
 
-Similarly, the `File` object exposes a `Contents()` function, which prints the contents of the corresponding file. Here is an example of using it to print the linting rules file returned by a linter Dagger Function, by chaining a `Contents()` function call to the returned `File` object:
+Similarly, the `File` object exposes a `Contents()` function, which prints the contents of the corresponding file. Here is an example of using it to print the JSON report of a `ruff` linter Dagger Function, by chaining a `Contents()` function call to the returned `File` object:
 
 ```shell
-dagger -m github.com/dagger/dagger/linters/markdown@88d89e8d15ab6ad9ca4043a920d3cd735a6405fd call rules contents
+dagger call -m github.com/dagger/dagger/dev/ruff@a29dadbb5d9968784847a15fccc5629daf2985ae lint --source https://github.com/dagger/dagger report contents
 ```
 
 Similar, the `File` object exposes a `Size()` function, which returns the size of the corresponding file. Here is an example of obtaining the size of the ZIP file returned by a file archiving Dagger Function, by chaining a `Size()` function call to the returned `File` object:

--- a/docs/current_docs/manuals/user/functions/chaining.mdx
+++ b/docs/current_docs/manuals/user/functions/chaining.mdx
@@ -21,7 +21,7 @@ Here are a few examples of function chaining in action:
 - Print the contents of a file returned by a Dagger Function, by chaining a call to the `File` object's `Contents()` function:
 
     ```shell
-    dagger -m github.com/dagger/dagger/linters/markdown@88d89e8d15ab6ad9ca4043a920d3cd735a6405fd call rules contents
+dagger call -m github.com/dagger/dagger/dev/ruff@a29dadbb5d9968784847a15fccc5629daf2985ae lint --source https://github.com/dagger/dagger report contents
     ```
 
 - Publish a container image of a container returned by a Dagger Function, by chaining a call to the `Container` object's `Publish()` function:


### PR DESCRIPTION
These example had issues due to a change in the Dagger CI modules layout and an older dependency. Changed to using `ruff` module instead. Otherwise, very similar.