### PR TITLE
ci: fix upload engine logs with multiple dev-engine jobs

### DIFF
--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -120,7 +120,7 @@ runs:
       if: always() && inputs.dev-engine == 'true'
       uses: actions/upload-artifact@v4
       with:
-        name: engine-logs
+        name: engine-logs-${{ runner.name }}
         path: /tmp/actions/call/engine.logs
 
     - name: Cleanup


### PR DESCRIPTION
Followup to https://github.com/dagger/dagger/pull/7933 (cc @vito)

If a single workflow run contains multiple `dev-engine` jobs, then uploading the artifacts will fail. To do this, we can make them unique using the runner name.

See the failing job on main: https://github.com/dagger/dagger/actions/runs/9970998498/job/27551091011#step:3:5005