### PR TITLE
feat: add --compat flag to dagger to specify api version

### DIFF
--- a/.changes/unreleased/Added-20240717-101724.yaml
+++ b/.changes/unreleased/Added-20240717-101724.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: 'cli: new --compat flag for develop to target a specific api version'
+time: 2024-07-17T10:17:24.1005004+01:00
+custom:
+  Author: jedevc
+  PR: "7948"

--- a/docs/current_docs/reference/cli.mdx
+++ b/docs/current_docs/reference/cli.mdx
@@ -136,10 +136,11 @@ dagger develop [options]
 ### Options
 
 ```
-      --license string   License identifier to generate - see https://spdx.org/licenses/ (default "Apache-2.0")
-  -m, --mod string       Path to the module directory containing the dagger.json config file. Either local path or a remote git repo
-      --sdk string       New SDK for the module
-      --source string    Directory to store the module implementation source code in
+      --compat string[="skip"]   Engine API version to target (default "latest")
+      --license string           License identifier to generate - see https://spdx.org/licenses/ (default "Apache-2.0")
+  -m, --mod string               Path to the module directory containing the dagger.json config file. Either local path or a remote git repo
+      --sdk string               New SDK for the module
+      --source string            Directory to store the module implementation source code in
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
We removed this last minute in https://github.com/dagger/dagger/pull/7759/#discussion_r1668419158.

However, it does seem like we need *something* here - so proposing this back in. Let the bikeshedding of naming/etc begin, I don't have particularly strong opinions here :tada: