### PR TITLE
ci: fix broken cli publishing from upgrade to v0.12

### DIFF
--- a/dev/cli.go
+++ b/dev/cli.go
@@ -91,7 +91,9 @@ func (cli *CLI) Publish(
 			return ctr
 		}).
 		WithEntrypoint([]string{"/sbin/tini", "--", "/entrypoint.sh"}).
-		WithExec(args).
+		WithExec(args, dagger.ContainerWithExecOpts{
+			UseEntrypoint: true,
+		}).
 		Sync(ctx)
 	return err
 }


### PR DESCRIPTION
Follow-up to https://github.com/dagger/dagger/pull/7939

We need to use the entrypoint explicitly here, see https://github.com/dagger/dagger/actions/runs/9971938618/job/27554089721#step:8:453