### PR TITLE
ci: fix go linter

### DIFF
--- a/cmd/dagger/main.go
+++ b/cmd/dagger/main.go
@@ -286,9 +286,9 @@ func main() {
 	ctx = slog.ContextWithColorMode(ctx, termenv.EnvNoColor())
 	ctx = slog.ContextWithDebugMode(ctx, debug)
 	ctx, stop := signal.NotifyContext(ctx, os.Interrupt)
-	defer stop()
 
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
+		stop()
 		var exit ExitError
 		if errors.As(err, &exit) {
 			os.Exit(exit.Code)

--- a/cmd/dagger/span_name.go
+++ b/cmd/dagger/span_name.go
@@ -57,6 +57,7 @@ func spanName(args []string) string {
 				}
 			} else {
 				// we're a flag preceding any command (maybe --debug); drop
+				continue
 			}
 			continue
 		}

--- a/dev/docs.go
+++ b/dev/docs.go
@@ -16,7 +16,7 @@ type Docs struct {
 const (
 	generatedSchemaPath       = "docs/docs-graphql/schema.graphqls"
 	generatedCliZenPath       = "docs/current_docs/reference/cli.mdx"
-	generatedApiReferencePath = "docs/static/api/reference/index.html"
+	generatedAPIReferencePath = "docs/static/api/reference/index.html"
 )
 
 const cliZenFrontmatter = `---
@@ -156,5 +156,5 @@ func (d Docs) GenerateAPIReference() *dagger.Directory {
 		WithExec([]string{"yarn", "add", "spectaql"}).
 		WithExec([]string{"yarn", "run", "spectaql", "./docs-graphql/config.yml", "-t", "."}).
 		File("index.html")
-	return dag.Directory().WithFile(generatedApiReferencePath, generatedHTML)
+	return dag.Directory().WithFile(generatedAPIReferencePath, generatedHTML)
 }

--- a/dev/engine.go
+++ b/dev/engine.go
@@ -163,8 +163,6 @@ func (e *Engine) Service(
 // Lint the engine
 func (e *Engine) Lint(
 	ctx context.Context,
-	// +optional
-	all bool,
 ) error {
 	eg, ctx := errgroup.WithContext(ctx)
 
@@ -193,7 +191,7 @@ func (e *Engine) Lint(
 
 		return e.Dagger.Go().
 			WithCodegen(codegen).
-			Lint(ctx, packages, all)
+			Lint(ctx, packages)
 	})
 
 	eg.Go(func() error {

--- a/dev/go/main.go
+++ b/dev/go/main.go
@@ -80,7 +80,6 @@ func (p *Go) Lint(
 	ctx context.Context,
 
 	pkgs []string, // +optional
-	all bool, // +optional
 ) error {
 	eg, ctx := errgroup.WithContext(ctx)
 	for _, pkg := range pkgs {

--- a/dev/main.go
+++ b/dev/main.go
@@ -45,7 +45,7 @@ func (dev *DaggerDev) Check(ctx context.Context) error {
 	if err := dev.Docs().Lint(ctx); err != nil {
 		return err
 	}
-	if err := dev.Engine().Lint(ctx, false); err != nil {
+	if err := dev.Engine().Lint(ctx); err != nil {
 		return err
 	}
 	if err := dev.Test().All(
@@ -104,12 +104,9 @@ func (gtc *GoToolchain) Env() *dagger.Container {
 func (gtc *GoToolchain) Lint(
 	ctx context.Context,
 	packages []string,
-	// +optional
-	all bool,
 ) error {
 	return gtc.Go.Lint(ctx, dagger.GoLintOpts{
 		Pkgs: packages,
-		All:  all,
 	})
 }
 

--- a/dev/sdk_go.go
+++ b/dev/sdk_go.go
@@ -22,7 +22,7 @@ type GoSDK struct {
 func (t GoSDK) Lint(ctx context.Context) error {
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
-		return t.Dagger.Go().Lint(ctx, []string{"sdk/go"}, false)
+		return t.Dagger.Go().Lint(ctx, []string{"sdk/go"})
 	})
 	eg.Go(func() error {
 		return util.DiffDirectoryF(ctx, t.Dagger.Source, t.Generate, "sdk/go")

--- a/dev/sdk_python.go
+++ b/dev/sdk_python.go
@@ -63,7 +63,7 @@ func (t PythonSDK) Lint(ctx context.Context) error {
 		return t.Dagger.
 			Go().
 			WithCodegen([]string{pythonRuntimeSubdir}).
-			Lint(ctx, []string{pythonRuntimeSubdir}, false)
+			Lint(ctx, []string{pythonRuntimeSubdir})
 	})
 
 	return eg.Wait()

--- a/dev/sdk_typescript.go
+++ b/dev/sdk_typescript.go
@@ -70,7 +70,7 @@ func (t TypescriptSDK) Lint(ctx context.Context) error {
 		return t.Dagger.
 			Go().
 			WithCodegen([]string{typescriptRuntimeSubdir}).
-			Lint(ctx, []string{typescriptRuntimeSubdir}, false)
+			Lint(ctx, []string{typescriptRuntimeSubdir})
 	})
 
 	return eg.Wait()

--- a/sdk/python/runtime/main.go
+++ b/sdk/python/runtime/main.go
@@ -150,7 +150,6 @@ func (m *PythonSdk) Common(
 		WithTemplate().
 		WithSDK(introspectionJSON).
 		WithSource(), nil
-
 }
 
 // Get all the needed information from the module's metadata and source files


### PR DESCRIPTION
Noticed in https://github.com/dagger/dagger/pull/7872#discussion_r1680759963

There are two issues:
- Some errors have an empty "Severity" - not entirely sure why, but some of the code was handling this correctly, but Assert wasn't.
- The `GOLANGCI_LINT_CONFIG` doesn't seem to have been being respected, I can't find any reference to it. So we can just use the suggested use of from the docs.