### PR TITLE
chore(dev/ruff): refactor base image for ruff module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
           - "*"
 
   - package-ecosystem: "gomod"
-    directory: "/ci"
+    directory: "/dev"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -98,7 +98,23 @@ updates:
           - "*"
 
   - package-ecosystem: "docker"
-    directory: "/sdk/python"
+    directory: "/sdk/python/runtime"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "UTC"
+    labels:
+      - "kind/dependencies"
+      - "area/sdk/python"
+    groups:
+      sdk-python:
+        applies-to: version-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/dev/ruff/build"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/dev/ruff/build/Dockerfile
+++ b/dev/ruff/build/Dockerfile
@@ -1,0 +1,2 @@
+# For dependabot
+FROM ghcr.io/astral-sh/ruff:0.5.2@sha256:032fae62673afdd753c5288a6ab55f6228842bfeea40f2c921c7b14d21e36876

--- a/dev/ruff/main.go
+++ b/dev/ruff/main.go
@@ -10,14 +10,6 @@ import (
 	"github.com/dagger/dagger/dev/ruff/internal/dagger"
 )
 
-var (
-	pythonVersion     = "3.11"
-	pythonImageRepo   = "docker.io/library/python"
-	pythonImageTag    = fmt.Sprintf("%s-slim", pythonVersion)
-	pythonImageDigest = "sha256:fc39d2e68b554c3f0a5cb8a776280c0b3d73b4c04b83dbade835e2a171ca27ef"
-	pythonImage       = pythonImageRepo + ":" + pythonImageTag + "@" + pythonImageDigest
-)
-
 // Ruff is a fast Python linter implemented in Rust
 type Ruff struct{}
 
@@ -41,17 +33,17 @@ type LintRun struct {
 // Return a JSON report file for this run
 func (run LintRun) Report() *dagger.File {
 	cmd := []string{
-		"ruff", "check",
+		"/ruff", "check",
 		"--exit-zero",
 		"--output-format", "json",
 		".",
 	}
 	return dag.
-		Container().
-		From(pythonImage).
-		WithExec([]string{"pip", "install", "ruff==0.4.9"}).
-		WithMountedDirectory("/src", run.Source).
-		WithWorkdir("/src").
+		CurrentModule().
+		Source().
+		Directory("build").
+		DockerBuild().
+		WithMountedDirectory("", run.Source).
 		WithExec(cmd, dagger.ContainerWithExecOpts{RedirectStdout: "ruff-report.json"}).
 		File("ruff-report.json")
 }


### PR DESCRIPTION
Ruff is a single binary that doesn't need Python to install or even use. 
It has a docker image which is the best way to install it with Dagger. 
Used a Dockerfile so that dependabot can help keep it up to date.