### PR TITLE
chore: ensure spans during module initialization make sense

### DIFF
--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -394,20 +394,19 @@ func (fc *FuncCommand) initializeModule(ctx context.Context) (rerr error) {
 	defer telemetry.End(span, func() error { return rerr })
 
 	resolveCtx, resolveSpan := Tracer().Start(ctx, "resolving module ref", telemetry.Encapsulate())
-	defer telemetry.End(resolveSpan, func() error { return rerr })
 	modConf, err := getDefaultModuleConfiguration(resolveCtx, dag, true, true)
+	telemetry.EndNow(resolveSpan, err)
 	if err != nil {
 		return fmt.Errorf("failed to get configured module: %w", err)
 	}
 	if !modConf.FullyInitialized() {
 		return fmt.Errorf("module at source dir %q doesn't exist or is invalid", modConf.LocalRootSourcePath)
 	}
-	resolveSpan.End()
 	mod := modConf.Source.AsModule().Initialize()
 
 	serveCtx, serveSpan := Tracer().Start(ctx, "installing module", telemetry.Encapsulate())
 	err = mod.Serve(serveCtx)
-	telemetry.End(serveSpan, func() error { return err })
+	telemetry.EndNow(serveSpan, err)
 	if err != nil {
 		return err
 	}

--- a/sdk/go/telemetry/span.go
+++ b/sdk/go/telemetry/span.go
@@ -43,3 +43,12 @@ func End(span trace.Span, fn func() error) {
 	}
 	span.End()
 }
+
+// EndNow is equivalent to End, but doesn't take a function.
+func EndNow(span trace.Span, err error) {
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+	span.End()
+}


### PR DESCRIPTION
These were previously able to overlap / end multiple times, which is confusing. This was introduced in #7881 in v0.12.0.

Maybe this isn't the cause of *all* the weird failures in https://github.com/dagger/dagger/issues/7954, but this isn't quite right. 

The `resolveSpan` could be ended multiple times.