### PR TITLE
chore: fix dependabot for docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,7 +50,7 @@ updates:
           - "*"
 
   - package-ecosystem: "npm"
-    directory: "/website"
+    directory: "/docs"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -60,7 +60,7 @@ updates:
       - "kind/dependencies"
       - "area/documentation"
     groups:
-      website:
+      docs:
         applies-to: version-updates
         patterns:
           - "*"


### PR DESCRIPTION
We no longer have a `website` dir since:
- https://github.com/dagger/dagger/pull/6164

It's been merged into `docs`.