### PR TITLE
fix: print current directory without parameter expansion

### DIFF
--- a/core/terminal.go
+++ b/core/terminal.go
@@ -58,7 +58,7 @@ func (container *Container) Terminal(
 	// Inject a custom shell prompt `dagger:<cwd>$`
 	container.Config.Env = append(container.Config.Env, fmt.Sprintf("PS1=%s %s $ ",
 		output.String("dagger").Foreground(termenv.ANSIYellow).String(),
-		output.String(`\w`).Faint().String(),
+		output.String(`$(pwd | sed "s|^$HOME|~|")`).Faint().String(),
 	))
 	container, err = container.WithExec(ctx, ContainerExecOpts{
 		Args:                          args.Cmd,


### PR DESCRIPTION
When getting a terminal in Debian based containers, the working directory does not show up correctly:
![image](https://github.com/user-attachments/assets/5c954b3c-c967-49fe-b666-df85f8411281)

This is especially visible when using non alpine golang or debian images.

To reproduce simply do `dag.Container().From("golang").Terminal()`

This change in PS1 does not use parameter expansion but `pwd` and `sed` to replicate the same behavior.