### PR TITLE
ci: update DAGGER_CLOUD_TOKEN

### DIFF
--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -108,7 +108,7 @@ runs:
           dagger -m "${{ inputs.module }}" call ${{ inputs.function }}
         fi
       env:
-        DAGGER_CLOUD_TOKEN: "p.eyJ1IjogIjFiZjEwMmRjLWYyZmQtNDVhNi1iNzM1LTgxNzI1NGFkZDU2ZiIsICJpZCI6ICIwYzhmMGY2Yy00YjY1LTRhODktYTI0YS0yN2NjNWNhNzNmNTcifQ.Em92UDP-KmcNd80Y-euTS2IrRkIE8qTisP3SXYkQi3c"
+        DAGGER_CLOUD_TOKEN: "dag_dagger_sBIv6DsjNerWvTqt2bSFeigBUqWxp9bhh3ONSSgeFnw"
 
     - name: Capture dev engine logs
       if: always() && inputs.dev-engine == 'true'


### PR DESCRIPTION
Updates our special telemetry-only token to use the new format, so we don't get *constantly* prompted to rotate our creds.

Thanks @marcosnils for the token :tada: