### PR TITLE
docs: fix typescript snippets in Entrypoint Function page

### DIFF
--- a/docs/current_docs/manuals/developer/entrypoint-function.mdx
+++ b/docs/current_docs/manuals/developer/entrypoint-function.mdx
@@ -99,7 +99,7 @@ Here is an example of a Dagger module with a default constructor argument of typ
 
 This default value can also be assigned directly in the field:
 
-```typescript file=./snippets/entrypoint/typescript/default-object/index.ts
+```typescript file=./snippets/entrypoint/typescript/default-object-in-field/index.ts
 ```
 
 :::note

--- a/docs/current_docs/manuals/developer/snippets/entrypoint/typescript/default-object-in-field/index.ts
+++ b/docs/current_docs/manuals/developer/snippets/entrypoint/typescript/default-object-in-field/index.ts
@@ -2,7 +2,6 @@ import { dag, Container, object, func } from "@dagger.io/dagger"
 
 @object()
 class MyModule {
-  @func()
   ctr: Container = dag.container().from("alpine:3.14.0")
 
   constructor(ctr?: Container) {

--- a/docs/current_docs/manuals/developer/snippets/entrypoint/typescript/default-object/index.ts
+++ b/docs/current_docs/manuals/developer/snippets/entrypoint/typescript/default-object/index.ts
@@ -2,7 +2,6 @@ import { dag, Container, object, func } from "@dagger.io/dagger"
 
 @object()
 class MyModule {
-  @func()
   ctr: Container
 
   constructor(ctr?: Container) {


### PR DESCRIPTION
There's no need to introduce `@func` in object properties in [Entrypoint Function](https://docs.dagger.io/manuals/developer/entrypoint-function#default-values-for-complex-types) since it hasn't been introduced yet. 
Only added confusion because it appears it's needed for the constructor.

🔎 [Preview](https://deploy-preview-7967--devel-docs-dagger-io.netlify.app/manuals/developer/entrypoint-function#default-values-for-complex-types)