### PR TITLE
engine: fix terminal in combination w/ custom CAs

### DIFF
--- a/engine/buildkit/executor_spec.go
+++ b/engine/buildkit/executor_spec.go
@@ -1050,6 +1050,7 @@ func (w *Worker) installCACerts(ctx context.Context, state *execState) error {
 		caExecState.spec.Process.User.UID = 0
 		caExecState.spec.Process.User.GID = 0
 		caExecState.spec.Process.Cwd = "/"
+		caExecState.spec.Process.Terminal = false
 
 		started := make(chan struct{}, 1)
 		if err := w.run(ctx, caExecState, started); err != nil {


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/7910

Custom CAs were not working with Terminal due to the fact that
installing custom CAs required running setup/teardown execs. Those execs
were getting inconsistent configuration that partly configured terminals
to be setup but also partially not (specifically, runc was told to setup
a tty but did not find /dev/tty).

The fix here is to just fully disable terminals on those setup/teardown
execs.

Majority of the diff here is to add integ test coverage, which starts a
terminal in a nested engine configured w/ custom CAs and does a curl of
a nginx server configured with those custom CAs. If the CAs aren't setup
or an error is hit the test fails too.