### PR TITLE
chore: encourage multiline changie bodies

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -5,7 +5,15 @@ changelogPath: CHANGELOG.md
 versionExt: md
 versionFormat: '## {{.Version}} - {{.Time.Format "2006-01-02"}}'
 kindFormat: '### {{.Kind}}'
-changeFormat: '- {{.Body}} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}'
+changeFormat: |
+  {{- $lines := .Body | splitn "\n" 2 -}}
+  - {{ $lines._0 }} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}
+  {{- with $lines._1 -}}
+    {{ " " }}\{{ "\n" }}
+    {{- . | trim | indent 2 }}
+  {{- end -}}
+body:
+  block: true
 custom:
   - key: PR
     label: GitHub PR

--- a/helm/dagger/.changie.yaml
+++ b/helm/dagger/.changie.yaml
@@ -5,7 +5,15 @@ changelogPath: CHANGELOG.md
 versionExt: md
 versionFormat: '## {{.Version}} - {{.Time.Format "2006-01-02"}}'
 kindFormat: '### {{.Kind}}'
-changeFormat: '- {{.Body}} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}'
+changeFormat: |
+  {{- $lines := .Body | splitn "\n" 2 -}}
+  - {{ $lines._0 }} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}
+  {{- with $lines._1 -}}
+    {{ " " }}\{{ "\n" }}
+    {{- . | trim | indent 2 }}
+  {{- end -}}
+body:
+  block: true
 custom:
   - key: PR
     label: GitHub PR

--- a/sdk/elixir/.changie.yaml
+++ b/sdk/elixir/.changie.yaml
@@ -5,7 +5,15 @@ changelogPath: CHANGELOG.md
 versionExt: md
 versionFormat: '## sdk/elixir/{{.Version}} - {{.Time.Format "2006-01-02"}}'
 kindFormat: '### {{.Kind}}'
-changeFormat: '- {{.Body}} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}'
+changeFormat: |
+  {{- $lines := .Body | splitn "\n" 2 -}}
+  - {{ $lines._0 }} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}
+  {{- with $lines._1 -}}
+    {{ " " }}\{{ "\n" }}
+    {{- . | trim | indent 2 }}
+  {{- end -}}
+body:
+  block: true
 custom:
   - key: PR
     label: GitHub PR

--- a/sdk/go/.changie.yaml
+++ b/sdk/go/.changie.yaml
@@ -5,7 +5,15 @@ changelogPath: CHANGELOG.md
 versionExt: md
 versionFormat: '## sdk/go/{{.Version}} - {{.Time.Format "2006-01-02"}}'
 kindFormat: '### {{.Kind}}'
-changeFormat: '- {{.Body}} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}'
+changeFormat: |
+  {{- $lines := .Body | splitn "\n" 2 -}}
+  - {{ $lines._0 }} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}
+  {{- with $lines._1 -}}
+    {{ " " }}\{{ "\n" }}
+    {{- . | trim | indent 2 }}
+  {{- end -}}
+body:
+  block: true
 custom:
   - key: PR
     label: GitHub PR

--- a/sdk/php/.changie.yaml
+++ b/sdk/php/.changie.yaml
@@ -5,7 +5,15 @@ changelogPath: CHANGELOG.md
 versionExt: md
 versionFormat: '## sdk/php/{{.Version}} - {{.Time.Format "2006-01-02"}}'
 kindFormat: '### {{.Kind}}'
-changeFormat: '- {{.Body}} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}'
+changeFormat: |
+  {{- $lines := .Body | splitn "\n" 2 -}}
+  - {{ $lines._0 }} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}
+  {{- with $lines._1 -}}
+    {{ " " }}\{{ "\n" }}
+    {{- . | trim | indent 2 }}
+  {{- end -}}
+body:
+  block: true
 custom:
   - key: PR
     label: GitHub PR

--- a/sdk/python/.changie.yaml
+++ b/sdk/python/.changie.yaml
@@ -5,7 +5,15 @@ changelogPath: CHANGELOG.md
 versionExt: md
 versionFormat: '## sdk/python/{{.Version}} - {{.Time.Format "2006-01-02"}}'
 kindFormat: '### {{.Kind}}'
-changeFormat: '- {{.Body}} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}'
+changeFormat: |
+  {{- $lines := .Body | splitn "\n" 2 -}}
+  - {{ $lines._0 }} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}
+  {{- with $lines._1 -}}
+    {{ " " }}\{{ "\n" }}
+    {{- . | trim | indent 2 }}
+  {{- end -}}
+body:
+  block: true
 custom:
   - key: PR
     label: GitHub PR

--- a/sdk/rust/.changie.yaml
+++ b/sdk/rust/.changie.yaml
@@ -5,7 +5,15 @@ changelogPath: CHANGELOG.md
 versionExt: md
 versionFormat: '## sdk/rust/{{.Version}} - {{.Time.Format "2006-01-02"}}'
 kindFormat: '### {{.Kind}}'
-changeFormat: '- {{.Body}} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}'
+changeFormat: |
+  {{- $lines := .Body | splitn "\n" 2 -}}
+  - {{ $lines._0 }} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}
+  {{- with $lines._1 -}}
+    {{ " " }}\{{ "\n" }}
+    {{- . | trim | indent 2 }}
+  {{- end -}}
+body:
+  block: true
 custom:
   - key: PR
     label: GitHub PR

--- a/sdk/typescript/.changie.yaml
+++ b/sdk/typescript/.changie.yaml
@@ -5,7 +5,15 @@ changelogPath: CHANGELOG.md
 versionExt: md
 versionFormat: '## sdk/typescript/{{.Version}} - {{.Time.Format "2006-01-02"}}'
 kindFormat: '### {{.Kind}}'
-changeFormat: '- {{.Body}} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}'
+changeFormat: |
+  {{- $lines := .Body | splitn "\n" 2 -}}
+  - {{ $lines._0 }} by @{{.Custom.Author}} in https://github.com/dagger/dagger/pull/{{.Custom.PR}}
+  {{- with $lines._1 -}}
+    {{ " " }}\{{ "\n" }}
+    {{- . | trim | indent 2 }}
+  {{- end -}}
+body:
+  block: true
 custom:
   - key: PR
     label: GitHub PR


### PR DESCRIPTION
This is part of an effort to start writing better changelogs! Just added some people to review who I've chatted to about this before :tada:

Changie supports multiline bodies, that looks something like this:

![image](https://github.com/user-attachments/assets/9d902b2d-50b0-434f-924a-b5a0cba34a6d)

The idea is to have more extensive changelogs as we go forward, essentially *trying* to follow something like a "git commit" format:
- The first line should be a summary of the change
- Any other details afterward can provide more details about the contents of the change, e.g. for breaking changes, information on how to migrate

After allowing these multiline bodies, we also need to update the output format so that the author and PR appear on the first line, while the details appear below - essentially the format we used for v0.12.0 for the breaking changes (which I quite liked): https://github.com/dagger/dagger/blob/1a28a7a467b25b863a4d62b6d18c18e24fd01b1e/.changes/v0.12.0.md#L10-L11