### PR TITLE
ci: overwrite artifacts if already there

### DIFF
--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -122,6 +122,7 @@ runs:
       with:
         name: engine-logs-${{ runner.name }}
         path: /tmp/actions/call/engine.logs
+        overwrite: true
 
     - name: Cleanup
       shell: bash


### PR DESCRIPTION
A bunch of the SDK dev tests fail because different steps try to upload the dev engine logs but get an error since the logs artifact already exists.

I *think* that setting overwrite to true will avoid this, but can't know until I merge.

Example of failures: https://github.com/dagger/dagger/actions/runs/9997156850/job/27633082976