### PR TITLE
Improve releasing during v0.12.1

### DIFF
--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -13,7 +13,7 @@ inputs:
 
   version:
     description: "Dagger version to run against"
-    default: "v0.12.0"
+    default: "v0.12.1"
     required: false
 
   dev-engine:

--- a/.github/workflows/_sdk_check.yml
+++ b/.github/workflows/_sdk_check.yml
@@ -15,7 +15,7 @@ on:
 
       version:
         type: string
-        default: "v0.12.0"
+        default: "v0.12.1"
         required: false
 
       dev-engine:
@@ -32,7 +32,7 @@ on:
 
 jobs:
   check:
-    runs-on: "${{ github.repository == 'dagger/dagger' && (inputs.dev-engine && 'dagger-v0-12-0-8c-dind' || 'dagger-v0-12-0-4c-nvme') || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && (inputs.dev-engine && 'dagger-v0-12-1-8c-dind' || 'dagger-v0-12-1-4c-nvme') || 'ubuntu-latest' }}"
     timeout-minutes: "${{ inputs.timeout }}"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-0-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-1-4c-nvme' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/engine-and-cli-publish.yml
+++ b/.github/workflows/engine-and-cli-publish.yml
@@ -20,7 +20,7 @@ jobs:
   publish:
     if: ${{ github.repository == 'dagger/dagger' && github.event_name == 'push' }}
     # Use our own Dagger runner when running in the dagger/dagger repo (including PRs)
-    runs-on: dagger-v0-12-0-16c-nvme
+    runs-on: dagger-v0-12-1-16c-nvme
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -158,7 +158,7 @@ jobs:
           discord-webhook: ${{ secrets.NEW_RELEASE_DISCORD_WEBHOOK }}
 
   scan-engine:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-0-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-1-4c-nvme' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/engine-and-cli-publish.yml
+++ b/.github/workflows/engine-and-cli-publish.yml
@@ -150,6 +150,8 @@ jobs:
           delete-branch: true
           branch: bump-engine
           draft: true
+          token: ${{ secrets.RELEASE_DAGGER_CI_TOKEN }}
+          push-to-fork: dagger-ci/dagger
       - name: "Notify"
         uses: ./.github/actions/notify
         if: github.ref_name != 'main'

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-0-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-1-4c-nvme' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
           function: "scripts lint"
 
   test:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-0-16c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-1-16c-nvme' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -49,7 +49,7 @@ jobs:
   # Only run a subset of important test cases since we just need to verify basic
   # functionality rather than repeat every test already run in the other targets.
   testdev:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-0-32c-dind' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-1-32c-dind' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
           dev-engine: true
 
   test-publish:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-0-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-1-4c-nvme' || 'ubuntu-latest' }}"
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
           function: "engine with-base --image=ubuntu --gpu-support=true test-publish"
 
   scan-engine:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-0-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-1-4c-nvme' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-0-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-1-4c-nvme' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -27,7 +27,7 @@ jobs:
     # only run this on tag push events, not in PRs
     if: github.event_name == 'push' && github.repository == 'dagger/dagger' && github.ref_type == 'tag'
     needs: test
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-0-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-1-4c-nvme' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "helm publish"

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-0-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-1-4c-nvme' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sdk-elixir-publish.yml
+++ b/.github/workflows/sdk-elixir-publish.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-0-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-1-4c-nvme' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "elixir publish"

--- a/.github/workflows/sdk-go-publish.yml
+++ b/.github/workflows/sdk-go-publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-0-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-1-4c-nvme' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "go publish"

--- a/.github/workflows/sdk-php-publish.yml
+++ b/.github/workflows/sdk-php-publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-0-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-1-4c-nvme' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "php publish"

--- a/.github/workflows/sdk-python-publish.yml
+++ b/.github/workflows/sdk-python-publish.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-0-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-1-4c-nvme' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "python publish"

--- a/.github/workflows/sdk-rust-publish.yml
+++ b/.github/workflows/sdk-rust-publish.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-0-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-1-4c-nvme' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "go publish"

--- a/.github/workflows/sdk-typescript-publish.yml
+++ b/.github/workflows/sdk-typescript-publish.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-0-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-1-4c-nvme' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "typescript publish"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -389,6 +389,7 @@ go mod edit -require dagger.io/dagger@${GO_SDK_VERSION:?must be set}
 go mod edit -require github.com/dagger/dagger/engine/distconsts@${GO_SDK_VERSION:?must be set}
 go mod tidy
 cd dev
+dagger develop
 go mod edit -require github.com/dagger/dagger/engine/distconsts@${ENGINE_VERSION:?must be set}
 go mod tidy
 cd ..

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -233,8 +233,6 @@ Setup the local branch to align with the remote branch being released
 git checkout "${RELEASE_BRANCH:?must be set}"
 
 git pull $DAGGER_REPO_REMOTE "${RELEASE_BRANCH:?must be set}"
-
-export ENGINE_GIT_SHA="$(git rev-parse --verify HEAD)"
 ```
 
 <details>
@@ -261,13 +259,18 @@ You will also want to ensure you _always_ cherry-pick a few special commits:
   - 🚨 Non-main branch release only: This PR will also include the cherry-picked commits mentioned above.
 - [ ] Get the PR reviewed & merged. The merge commit is what gets tagged in the next step.
   - 🚨 Non-main branch release only: Ideally use "Rebase and Merge" rather than squashing commits when merging so we can more easily preserve the history of the cherry-picked commits.
-- [ ] Ensure that all checks are green ✅ for the `<ENGINE_GIT_SHA>` on the
+- [ ] Ensure that all checks are green ✅ on the
       `<RELEASE_BRANCH>` that you are about to release.
   - 🚨 Non-main branch release only: currently, CI does not run on non-main branches and some of the workflows are currently hardcoded with `main` so it's not safe to manually run them. So for now this has to be skipped in this case.
 - [ ] `30mins` When you have confirmed that all checks are green, run the following:
 
 ```console
+git checkout "${RELEASE_BRANCH:?must be set}"
+git pull $DAGGER_REPO_REMOTE "${RELEASE_BRANCH:?must be set}"
+
+export ENGINE_GIT_SHA="$(git rev-parse --verify HEAD)"
 export ENGINE_VERSION="$(changie latest)"
+
 git tag "${ENGINE_VERSION:?must be set}" "${ENGINE_GIT_SHA:?must be set}"
 
 git push "${DAGGER_REPO_REMOTE:?must be set}" "${ENGINE_VERSION:?must be set}"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -249,13 +249,13 @@ You will also want to ensure you _always_ cherry-pick a few special commits:
 
 </details>
 
-- [ ] Create e.g. `.changes/v0.12.0.md` by either running `changie batch patch`
+- [ ] Create e.g. `.changes/v0.12.1.md` by either running `changie batch patch`
       (or `changie batch minor` if this is a new minor).
 
 - [ ] Make any necessary edits to the newly generated file, e.g.
-      `.changes/v0.12.0.md`
+      `.changes/v0.12.1.md`
 - [ ] Update `CHANGELOG.md` by running `changie merge`.
-- [ ] `30 mins` Submit a PR - e.g. `add-v0.12.0-release-notes` with the new release notes so that they can be used in the new release.
+- [ ] `30 mins` Submit a PR - e.g. `add-v0.12.1-release-notes` with the new release notes so that they can be used in the new release.
   - 🚨 Non-main branch release only: This PR will also include the cherry-picked commits mentioned above.
 - [ ] Get the PR reviewed & merged. The merge commit is what gets tagged in the next step.
   - 🚨 Non-main branch release only: Ideally use "Rebase and Merge" rather than squashing commits when merging so we can more easily preserve the history of the cherry-picked commits.
@@ -421,10 +421,10 @@ Ensure that all the workflows succeed before continuing (specifically `test` and
       release process using the just-released CLI.
 
 ```console
-curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin DAGGER_VERSION=0.12.0 sh
-# install the cli to dagger-0.12.0, and symlink dagger to it
-mv ~/.local/bin/dagger{,-0.12.0}
-ln -s ~/.local/bin/dagger{-0.12.0,}
+curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin DAGGER_VERSION=0.12.1 sh
+# install the cli to dagger-0.12.1, and symlink dagger to it
+mv ~/.local/bin/dagger{,-0.12.1}
+ln -s ~/.local/bin/dagger{-0.12.1,}
 
 dagger version
 ```

--- a/dev/go.mod
+++ b/dev/go.mod
@@ -4,7 +4,7 @@ go 1.22.0
 
 toolchain go1.22.5
 
-require github.com/dagger/dagger/engine/distconsts v0.12.0
+require github.com/dagger/dagger/engine/distconsts v0.12.1
 
 replace github.com/dagger/dagger/engine/distconsts => ../engine/distconsts
 

--- a/go.mod
+++ b/go.mod
@@ -258,8 +258,8 @@ require (
 )
 
 require (
-	dagger.io/dagger v0.12.0
-	github.com/dagger/dagger/engine/distconsts v0.12.0
+	dagger.io/dagger v0.12.1
+	github.com/dagger/dagger/engine/distconsts v0.12.1
 )
 
 replace (


### PR DESCRIPTION
More follow-ups once release is done:
- [x] Fix ordering of instructions to ensure that the changelog PR is always included in engine+cli tag: https://discord.com/channels/707636530424053791/1262430315683647578/1263590457188028527
- [x] I have to run `dagger develop` before the instructions on updating `dev/` with go mod edit/tidy fully work. Was an issue this time because I had recently run `git clean`, which resulted in errors
- [x] We really need to fix the permissions issue with the bump engine PR (or at the very minimum add the instructions for manually creating it)
   - I attempted a fix for this here, details in commit message: https://github.com/dagger/dagger/pull/7983/commits/49670c60801087745951be532ad01a7184a4158a
- [x] Figure out why engine tests are not automatically running in this PR (???)