### PR TITLE
docs: Updating git language

### DIFF
--- a/docs/current_docs/index.mdx
+++ b/docs/current_docs/index.mdx
@@ -48,4 +48,4 @@ The simplest and most common way to use Dagger Functions is via the Dagger CLI. 
 
 Dagger Functions are packaged, shared and reused using modules. The [Daggerverse](https://daggerverse.dev) is a free service run by Dagger, which indexes all publicly available Dagger modules, and lets you easily search and consume them.
 
-Modules don't need to be installed locally. Dagger lets you consume modules from GitHub repositories as well. You call functions from external modules in exactly the same way as you call core functions.
+Modules don't need to be installed locally. Dagger lets you consume modules from Git repositories such as GitHub, GitLab, Bitbucket and any other managed or self-hosted Git server as well. You call functions from external modules in exactly the same way as you call core functions.


### PR DESCRIPTION
v0.12 adds support for Git servers beyond Github. Updating docs to reflect this new capability.