### PR TITLE
tests: add retries to waiting for log output

### DIFF
--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -1915,9 +1915,9 @@ func (c *Container) Echo(ctx context.Context, msg string) (string, error) {
 			With(daggerQuery(`{container{from(address:"` + alpineImage + `"){echo(msg:"echo!"){stdout}}}}`)).
 			Sync(ctx)
 		require.Error(t, err)
-		require.NoError(t, c.Close())
-		t.Log(logs.String())
-		require.Contains(t, logs.String(), "cannot define methods on objects from outside this module")
+		require.NoError(t, logs.WaitForContents(ctx, 100*time.Millisecond, 10*time.Second,
+			"cannot define methods on objects from outside this module",
+		))
 	})
 
 	t.Run("in same mod name", func(ctx context.Context, t *testctx.T) {
@@ -1931,9 +1931,9 @@ func (c *Container) Echo(ctx context.Context, msg string) (string, error) {
 			With(daggerQuery(`{container{from(address:"` + alpineImage + `"){echo(msg:"echo!"){stdout}}}}`)).
 			Sync(ctx)
 		require.Error(t, err)
-		require.NoError(t, c.Close())
-		t.Log(logs.String())
-		require.Contains(t, logs.String(), "cannot define methods on objects from outside this module")
+		require.NoError(t, logs.WaitForContents(ctx, 100*time.Millisecond, 10*time.Second,
+			"cannot define methods on objects from outside this module",
+		))
 	})
 }
 


### PR DESCRIPTION
Possibly fixes https://github.com/dagger/dagger/issues/7979 (to be confirmed in CI since that's the only place I can get it to happen).

I also am not sure yet if this is handling expected behavior more robustly vs. just avoiding a bug. If it's just avoiding a bug we shouldn't go with it.

Basically, I noticed that these flakes appear to just be cutting off the output while it's still being received. If you look in the logs you can see most of the expected output there but not all of it, which results in the error message expected not showing up.

cc @vito @jedevc on confirming whether it's expected that if you close a client while output is still being received then it is expected you might be cutting off some of the output, since you've worked on that whole are more than I