### PR TITLE
fix root span never failing

### DIFF
--- a/cmd/dagger/engine.go
+++ b/cmd/dagger/engine.go
@@ -24,7 +24,7 @@ func withEngine(
 		// Init tracing as early as possible and shutdown after the command
 		// completes, ensuring progress is fully flushed to the frontend.
 		ctx, cleanupTelemetry := initEngineTelemetry(ctx)
-		defer cleanupTelemetry(rerr)
+		defer func() { cleanupTelemetry(rerr) }()
 
 		if debug {
 			params.LogLevel = slog.LevelDebug


### PR DESCRIPTION
A silly var capture issue. :grimacing: 

If ever there were a time for a linter to help...

Fortunately the command itself still fails, so everyone's CI should be doing the right thing, but traces in Cloud and GitHub checks currently never fail.