### PR TITLE
bump Helm chart to v0.12.2

### DIFF
--- a/helm/dagger/Chart.yaml
+++ b/helm/dagger/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 0.12.1
+appVersion: 0.12.2
 description: Dagger Helm chart
 name: dagger-helm
 type: application
-version: 0.12.1
+version: 0.12.2


### PR DESCRIPTION
Not sure what's supposed to do this normally, but it was missed during the release process.