### PR TITLE
Nomad Engine for dagger

### DIFF
--- a/dagger-nomad-packs/CHANGELOG.md
+++ b/dagger-nomad-packs/CHANGELOG.md
@@ -1,0 +1,3 @@
+## Version v0.0.1 (Unreleased)
+
+Initial Release

--- a/dagger-nomad-packs/README.md
+++ b/dagger-nomad-packs/README.md
@@ -1,0 +1,6 @@
+## Nomad Pack Registry - dagger-nomad-packs
+This repository is meant to be used as a reference when writing custom pack
+registries for Nomad Pack.
+
+To get started writing your own pack, make a directory with your pack name.
+See the documentation on Writing Packs and Registries for more information.

--- a/dagger-nomad-packs/packs/nomad_dagger_engine/CHANGELOG.md
+++ b/dagger-nomad-packs/packs/nomad_dagger_engine/CHANGELOG.md
@@ -1,0 +1,3 @@
+## Version v0.0.1 (Unreleased)
+
+Initial Release

--- a/dagger-nomad-packs/packs/nomad_dagger_engine/README.md
+++ b/dagger-nomad-packs/packs/nomad_dagger_engine/README.md
@@ -1,0 +1,3 @@
+# nomad_dagger_engine
+
+TOOD...

--- a/dagger-nomad-packs/packs/nomad_dagger_engine/metadata.hcl
+++ b/dagger-nomad-packs/packs/nomad_dagger_engine/metadata.hcl
@@ -1,0 +1,8 @@
+app {
+  url = ""
+}
+pack {
+  name        = "nomad_dagger_engine"
+  description = "A pack to deploy the Dagger engine on Nomad as a system job"
+  version     = "0.12.0"
+}

--- a/dagger-nomad-packs/packs/nomad_dagger_engine/outputs.tpl
+++ b/dagger-nomad-packs/packs/nomad_dagger_engine/outputs.tpl
@@ -1,0 +1,1 @@
+Congrats! You deployed the nomad_dagger_engine pack on Nomad.

--- a/dagger-nomad-packs/packs/nomad_dagger_engine/templates/_helpers.tpl
+++ b/dagger-nomad-packs/packs/nomad_dagger_engine/templates/_helpers.tpl
@@ -1,0 +1,48 @@
+[[- /*
+
+## `job_name` helper
+
+*/ -]]
+
+[[- define "job_name" -]]
+[[ coalesce ( var "job_name" .) (meta "pack.name" .) | quote ]]
+[[- end -]]
+
+[[- /*
+
+## `region` helper
+
+*/ -]]
+
+[[ define "region" -]]
+[[- if var "region" . -]]
+  region = "[[ var "region" . ]]"
+[[- end -]]
+[[- end -]]
+
+[[- /*
+
+## `node_pool` helper
+
+*/ -]]
+
+[[ define "node_pool" -]]
+[[- if var "node_pool" . -]]
+  node_pool = "[[ var "node_pool" . ]]"
+[[- end -]]
+[[- end -]]
+
+[[- /*
+
+## `resources` helper
+
+*/ -]]
+
+[[ define "resources" -]]
+[[- if var "resources" . ]]
+    resources {
+      cpu    = [[ var "resources.cpu" . ]]
+      memory = [[ var "resources.memory" . ]]
+    }
+[[- end ]]
+[[- end -]]

--- a/dagger-nomad-packs/packs/nomad_dagger_engine/templates/nomad_dagger_engine.nomad.tpl
+++ b/dagger-nomad-packs/packs/nomad_dagger_engine/templates/nomad_dagger_engine.nomad.tpl
@@ -1,0 +1,28 @@
+job [[ template "job_name" . ]] {
+  [[ template "region" . ]]
+  [[ template "node_pool" . ]]
+  datacenters = [[ var "datacenters" . | toStringList ]]
+  type = "system"
+
+  group "engine" {
+
+    restart {
+      attempts = 2
+      interval = "30m"
+      delay = "15s"
+      mode = "fail"
+    }
+
+    task "engine" {
+      driver = "docker"
+
+      config {
+        image = [[ var "dagger_image" . | quote ]]        
+        cap_add    = ["sys_admin"]
+        privileged = true
+
+      }
+      [[- template "resources" . ]]
+    }
+  }
+}

--- a/dagger-nomad-packs/packs/nomad_dagger_engine/variables.hcl
+++ b/dagger-nomad-packs/packs/nomad_dagger_engine/variables.hcl
@@ -1,0 +1,42 @@
+variable "job_name" {
+  # If "", the pack name will be used
+  description = "The name to use as the job name which overrides using the pack name"
+  type        = string
+  default     = "dagger-engine"
+}
+
+variable "region" {
+  description = "The region where jobs will be deployed"
+  type        = string
+  default     = ""
+}
+
+variable "datacenters" {
+  description = "A list of datacenters in the region which are eligible for task placement"
+  type        = list(string)
+  default     = ["*"]
+}
+
+variable "node_pool" {
+  description = "The pool to use for task placement"
+  type        = string
+  default     = ""
+}
+
+variable "dagger_image" {
+  description = "The Dagger image to use for the job"
+  type        = string
+  default     = "registry.dagger.io/engine:v0.12.0"
+}
+
+variable "resources" {
+  description = "The resource to assign to the dagger engine."
+  type = object({
+    cpu    = number
+    memory = number
+  })
+  default = {
+    cpu    = 500,
+    memory = 4096
+  }
+}

--- a/engine/client/drivers/dial.go
+++ b/engine/client/drivers/dial.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strings"
 
+	nomadalloc "github.com/dagger/dagger/engine/client/drivers/nomad"
 	connh "github.com/moby/buildkit/client/connhelper"
 	connhDocker "github.com/moby/buildkit/client/connhelper/dockercontainer"
 	connhKube "github.com/moby/buildkit/client/connhelper/kubepod"
@@ -21,6 +22,7 @@ func init() {
 	register("docker-container", &dialDriver{connhDocker.Helper})
 	register("kube-pod", &dialDriver{connhKube.Helper})
 	register("podman-container", &dialDriver{connhPodman.Helper})
+	register("nomad-alloc", &dialDriver{nomadalloc.Helper})
 }
 
 // dialDriver uses the buildkit connhelpers to directly connect

--- a/engine/client/drivers/nomad/nomad_alloc.go
+++ b/engine/client/drivers/nomad/nomad_alloc.go
@@ -1,0 +1,97 @@
+package nomadalloc
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/url"
+
+	"github.com/docker/cli/cli/connhelper/commandconn"
+
+	"github.com/moby/buildkit/client/connhelper"
+)
+
+func init() {
+	connhelper.Register("nomad-alloc", Helper)
+}
+
+// Helper returns helper for connecting to a Nomad alloc.
+// Requires BuildKit v0.5.0 or later in the alloc.
+
+// inspired by github.com/moby/buildkit/client/connhelper/kubepod
+// using nomad exec to connect to a nomad alloc and run buildctl dial-stdio
+func Helper(u *url.URL) (*connhelper.ConnectionHelper, error) {
+	sp, err := SpecFromURL(u)
+	if err != nil {
+		return nil, err
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &connhelper.ConnectionHelper{
+		ContextDialer: func(ctx context.Context, addr string) (net.Conn, error) {
+			// using background context because context remains active for the duration of the process, after dial has completed
+			// for nomad
+
+			args := []string{"alloc", "exec"}
+			if sp.Alloc != "" {
+				args = append(args, sp.Alloc)
+			}
+			if sp.Job != "" {
+				args = append(args, "-job")
+				args = append(args, sp.Job)
+			}
+			if sp.Task != "" {
+				args = append(args, "-task")
+				args = append(args, sp.Task)
+			}
+			if sp.Namespace != "" {
+				args = append(args, "-namespace")
+				args = append(args, sp.Namespace)
+
+			}
+			if sp.Region != "" {
+				args = append(args, "-region")
+				args = append(args, sp.Region)
+			}
+			args = append(args, "buildctl", "dial-stdio")
+			return commandconn.New(context.Background(), "nomad", args...)
+		},
+	}, nil
+
+}
+
+// Nomad Spec to connect for "nomad exec"
+type Spec struct {
+	Alloc     string
+	Job       string
+	Task      string
+	Namespace string
+	Region    string
+}
+
+// SpecFromURL creates Spec from URL.
+// URL is like nomad-alloc://<alloc>?namespace=<namespace>&region=<region>&task=<task>&job=<job> .
+// either <alloc> or <job> is mandatory.
+func SpecFromURL(u *url.URL) (*Spec, error) {
+	q := u.Query()
+	sp := Spec{
+		Alloc: u.Hostname(),
+
+		Namespace: q.Get("namespace"),
+		Region:    q.Get("region"),
+		Task:      q.Get("task"),
+		Job:       q.Get("job"),
+	}
+
+	if sp.Alloc != "" && sp.Job != "" {
+		return nil, errors.New("url should not have both alloc and job")
+	}
+	if sp.Alloc == "" && sp.Job == "" {
+		return nil, errors.New("url should have either alloc or job")
+	}
+
+	return &sp, nil
+}

--- a/engine/client/drivers/nomad/nomad_alloc.go
+++ b/engine/client/drivers/nomad/nomad_alloc.go
@@ -50,7 +50,6 @@ func Helper(u *url.URL) (*connhelper.ConnectionHelper, error) {
 			if sp.Namespace != "" {
 				args = append(args, "-namespace")
 				args = append(args, sp.Namespace)
-
 			}
 			if sp.Region != "" {
 				args = append(args, "-region")
@@ -60,7 +59,6 @@ func Helper(u *url.URL) (*connhelper.ConnectionHelper, error) {
 			return commandconn.New(context.Background(), "nomad", args...)
 		},
 	}, nil
-
 }
 
 // Nomad Spec to connect for "nomad exec"

--- a/engine/client/drivers/nomad/nomad_alloc_test.go
+++ b/engine/client/drivers/nomad/nomad_alloc_test.go
@@ -1,0 +1,193 @@
+package nomadalloc
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpecFromURL(t *testing.T) {
+	// table test for SpecFromURL input is a string and expected output is a Spec struct
+
+	tests := []struct {
+		name     string
+		input    string
+		expected Spec
+	}{
+		{
+			name:  "simple",
+			input: "nomad-alloc://alloc123",
+			expected: Spec{
+				Alloc: "alloc123",
+			},
+		},
+		{
+			name:  "without-alloc",
+			input: "nomad-alloc://",
+			expected: Spec{
+				Alloc: "",
+			},
+		},
+
+		{
+			name:  "with-namespace",
+			input: "nomad-alloc://alloc123?namespace=ns1",
+			expected: Spec{
+				Alloc:     "alloc123",
+				Namespace: "ns1",
+			},
+		},
+		{
+			name:  "with-region",
+			input: "nomad-alloc://alloc123?region=reg1",
+			expected: Spec{
+				Alloc:  "alloc123",
+				Region: "reg1",
+			},
+		},
+		{
+			name:  "with-job",
+			input: "nomad-alloc://?job=job1",
+			expected: Spec{
+
+				Job: "job1",
+			},
+		},
+		{
+			name:  "with-task",
+			input: "nomad-alloc://alloc123?task=task1",
+			expected: Spec{
+				Alloc: "alloc123",
+				Task:  "task1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.input)
+
+			if err != nil {
+				t.Fatal(err)
+			}
+			spec, err := SpecFromURL(u)
+
+			if err != nil {
+				t.Fatal(err)
+			}
+			require.Equal(t, tt.expected, *spec)
+		})
+	}
+
+}
+func TestSpecFromURLErrors(t *testing.T) {
+
+	tt := []struct {
+		name     string
+		input    string
+		expected error
+	}{
+		{
+			name:     "alloc-missing",
+			input:    "nomad-alloc://?namespace=ns1",
+			expected: errors.New("url should have either alloc or job"),
+		},
+		{
+			name:     "alloc-and-job",
+			input:    "nomad-alloc://",
+			expected: errors.New("url should not have both alloc and job"),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := url.Parse(tc.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = SpecFromURL(u)
+			require.Equal(t, tc.expected, err)
+		})
+	}
+}
+func TestHelper(t *testing.T) {
+
+	os.Setenv("NOMAD_ADDR", "http://localhost:4646")
+
+	nomadAddr := os.Getenv("NOMAD_ADDR")
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	if nomadAddr == "" {
+		t.Skip("NOMAD_ADDR not set")
+	}
+	// cleanup := launchNomadJob(t)
+	// defer cleanup()
+
+	u, err := url.Parse("nomad-alloc://testengine")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch, err := Helper(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ch == nil {
+		t.Fatal("expected con to be not nil")
+	}
+	con, err := ch.ContextDialer(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if con == nil {
+		t.Fatal("expected con to be not nil")
+	}
+
+}
+
+func launchNomadJob(t *testing.T) func() {
+	t.Helper()
+
+	job := `
+	job "testengine" {
+		datacenters = ["*"]
+		
+		group "group1" {
+			count = 1
+			task "task1" {
+				driver = "docker"
+				config {
+					image = "registry.dagger.io/engine:v0.12.0"
+
+					cap_add = ["sys_admin"]
+					privileged = true
+					
+					volumes = ["alloc/data/runner:/var/lib/dagger"]
+				}
+				
+			}
+		}
+	}
+	`
+	// exec nomad run job - <<EOF
+	// $job
+	// EOF
+
+	err := exec.Command("nomad", "run", "-", "<<EOF", job, "EOF").Run()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return func() {
+
+		exec.Command("nomad", "stop", "testengine", "-purge").Run()
+	}
+
+	// launch a nomad job
+}

--- a/engine/client/drivers/nomad/nomad_alloc_test.go
+++ b/engine/client/drivers/nomad/nomad_alloc_test.go
@@ -1,11 +1,8 @@
 package nomadalloc
 
 import (
-	"context"
 	"errors"
 	"net/url"
-	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -83,10 +80,8 @@ func TestSpecFromURL(t *testing.T) {
 			require.Equal(t, tt.expected, *spec)
 		})
 	}
-
 }
 func TestSpecFromURLErrors(t *testing.T) {
-
 	tt := []struct {
 		name     string
 		input    string
@@ -114,80 +109,4 @@ func TestSpecFromURLErrors(t *testing.T) {
 			require.Equal(t, tc.expected, err)
 		})
 	}
-}
-func TestHelper(t *testing.T) {
-
-	os.Setenv("NOMAD_ADDR", "http://localhost:4646")
-
-	nomadAddr := os.Getenv("NOMAD_ADDR")
-	if testing.Short() {
-		t.Skip("skipping test in short mode.")
-	}
-	if nomadAddr == "" {
-		t.Skip("NOMAD_ADDR not set")
-	}
-	// cleanup := launchNomadJob(t)
-	// defer cleanup()
-
-	u, err := url.Parse("nomad-alloc://testengine")
-	if err != nil {
-		t.Fatal(err)
-	}
-	ch, err := Helper(u)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ch == nil {
-		t.Fatal("expected con to be not nil")
-	}
-	con, err := ch.ContextDialer(context.Background(), "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if con == nil {
-		t.Fatal("expected con to be not nil")
-	}
-
-}
-
-func launchNomadJob(t *testing.T) func() {
-	t.Helper()
-
-	job := `
-	job "testengine" {
-		datacenters = ["*"]
-		
-		group "group1" {
-			count = 1
-			task "task1" {
-				driver = "docker"
-				config {
-					image = "registry.dagger.io/engine:v0.12.0"
-
-					cap_add = ["sys_admin"]
-					privileged = true
-					
-					volumes = ["alloc/data/runner:/var/lib/dagger"]
-				}
-				
-			}
-		}
-	}
-	`
-	// exec nomad run job - <<EOF
-	// $job
-	// EOF
-
-	err := exec.Command("nomad", "run", "-", "<<EOF", job, "EOF").Run()
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return func() {
-
-		exec.Command("nomad", "stop", "testengine", "-purge").Run()
-	}
-
-	// launch a nomad job
 }


### PR DESCRIPTION
This is a WIP PR to integrate to run the Dagger engine on HashiCorp's Nomad

It provides another dial protocol `nomad-alloc://` that can be used via the `_EXPERIMENTAL_DAGGER_RUNNER_HOST`

e.g. `nomad-alloc://<some-alloc-id>` or just via the job `nomad-alloc://?job=<the-job-with-the-engine>`

## Demo

### Nomad Config
```hcl
plugin "docker" {
  config {
    allow_privileged = true
    allow_caps = [
        "all" # or a defaults + sys_admin
    ]
  }
}
```

### Deploying the engine via [nomad-pack](https://github.com/hashicorp/nomad-pack)

```sh
cd dagger-nomad-packs/packs/nomad_dagger_engine
nomad-pack run .
```

### Export dagger runner & run in a project

```sh
export _EXPERIMENTAL_DAGGER_RUNNER_HOST="nomad-alloc://?job=dagger-engine"
# now e.g in the hello-dagger example assuming the dagger binary is build with this extra dial protocol
dagger call publish --source=.
```

## Current problems

To my knowledge Nomad doesn't support overlayfs mounts :/