### PR TITLE
core: fix missing secrets+sockets from parent object fields

### DIFF
--- a/.changes/unreleased/Fixed-20240722-232708.yaml
+++ b/.changes/unreleased/Fixed-20240722-232708.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: Fix missing secret errors when secrets are set in objects fields during chained
+  function calls
+time: 2024-07-22T23:27:08.45115791-07:00
+custom:
+  Author: sipsma
+  PR: "8011"

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -5587,6 +5587,47 @@ func (t *Test) GetCensored(ctx context.Context) (string, error) {
 		})
 	})
 
+	t.Run("parent fields", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+		ctr := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c))
+
+		ctr = ctr.
+			WithWorkdir("/work").
+			With(daggerExec("init", "--name=test", "--sdk=go", "--source=.")).
+			WithNewFile("main.go", `package main
+
+import (
+	"context"
+	"dagger/test/internal/dagger"
+)
+
+type Test struct {
+	Ctr *dagger.Container
+}
+
+func (t *Test) FnA() *Test {
+	secret := dag.SetSecret("FOO", "omg")
+	t.Ctr = dag.Container().From("`+alpineImage+`").
+		WithSecretVariable("SECRET", secret)
+	return t
+}
+
+func (t *Test) FnB(ctx context.Context) (string, error) {
+	return t.Ctr.
+		WithExec([]string{"sh", "-c", "echo $SECRET | base64"}).
+		Stdout(ctx)
+}
+`,
+			)
+
+		encodedOut, err := ctr.With(daggerCall("fn-a", "fn-b")).Stdout(ctx)
+		require.NoError(t, err)
+		decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(encodedOut))
+		require.NoError(t, err)
+		require.Equal(t, "omg\n", string(decoded))
+	})
+
 	t.Run("duplicate secret names", func(ctx context.Context, t *testctx.T) {
 		// check that each module has it's own segmented secret store, by
 		// writing secrets with the same name

--- a/core/interface.go
+++ b/core/interface.go
@@ -277,8 +277,9 @@ func (iface *InterfaceType) Install(ctx context.Context, dag *dagql.Server) erro
 				}
 
 				res, err := callable.Call(ctx, &CallOpts{
-					Inputs:    callInputs,
-					ParentVal: runtimeVal.Fields,
+					Inputs:       callInputs,
+					ParentTyped:  runtimeVal,
+					ParentFields: runtimeVal.Fields,
 				})
 				if err != nil {
 					return nil, fmt.Errorf("failed to call interface function %s.%s: %w", ifaceName, fieldDef.Name, err)

--- a/engine/buildkit/executor.go
+++ b/engine/buildkit/executor.go
@@ -34,6 +34,7 @@ import (
 	"github.com/moby/buildkit/util/entitlements"
 	"github.com/moby/buildkit/util/stack"
 	"github.com/moby/sys/signal"
+	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
@@ -60,6 +61,12 @@ type ExecutionMetadata struct {
 	EncodedModuleID     string
 	EncodedFunctionCall json.RawMessage
 	CallerClientID      string
+
+	// Client resource IDs passed to this client from parent object fields.
+	// Needed to handle finding any secrets, sockets or other client resources
+	// that this client should have access to due to being set in the parent
+	// object.
+	ParentIDs map[digest.Digest]*call.ID
 
 	CachePerSession bool
 


### PR DESCRIPTION
The recent change to isolate secrets+sockets works by tracking which resources a given client should have access to based on inputs+outputs to/from function calls.

Unfortunately, on the input-side, this only handled arg value inputs, but I missed the other source of inputs: fields set in the parent object. If you had a module object with a Secret (or a Container with an embedded Secret, etc.) field, then trying to use that Secret in chained function calls usually failed.

The fix is straightforward and re-uses existing plumbing to walk values and find all the IDs embedded in them; it's just now also called on the parent object fields (if any).

Also includes integ test coverage for this case.

---

Fixes https://github.com/dagger/dagger/issues/8010