### PR TITLE
ci: Publish nightly as `main/head`

### DIFF
--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -9,6 +9,14 @@ nightly:
 
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
+    id: sha
+    files:
+      - LICENSE
+    format_overrides:
+      - goos: windows
+        format: zip
+  - name_template: "{{ .ProjectName }}_head_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
+    id: head
     files:
       - LICENSE
     format_overrides:
@@ -17,6 +25,14 @@ archives:
 
 blobs:
   - provider: s3
+    ids:
+      - sha
     region: "{{ .Env.AWS_REGION }}"
     bucket: "{{ .Env.AWS_BUCKET }}"
     folder: "dagger/main/{{ .Version }}"
+  - provider: s3
+    ids:
+      - head
+    region: "{{ .Env.AWS_REGION }}"
+    bucket: "{{ .Env.AWS_BUCKET }}"
+    folder: "dagger/main/head"

--- a/install.sh
+++ b/install.sh
@@ -267,10 +267,10 @@ latest_version() {
 base_url() {
   os="$(uname_os)"
   arch="$(uname_arch)"
-  if [ -n "$DAGGER_VERSION" ]; then
-    path="releases/${DAGGER_VERSION}"
-  elif [ -n "$DAGGER_COMMIT" ]; then
+  if [ -n "$DAGGER_COMMIT" ]; then
     path="main/${DAGGER_COMMIT}"
+  elif [ -n "$DAGGER_VERSION" ]; then
+    path="releases/${DAGGER_VERSION}"
   else
     path="releases/$(latest_version)"
   fi
@@ -281,10 +281,10 @@ base_url() {
 tarball() {
   os="$(uname_os)"
   arch="$(uname_arch)"
-  if [ -n "$DAGGER_VERSION" ]; then
-    version="v${DAGGER_VERSION}"
-  elif [ -n "$DAGGER_COMMIT" ]; then
+  if [ -n "$DAGGER_COMMIT" ]; then
     version="${DAGGER_COMMIT}"
+  elif [ -n "$DAGGER_VERSION" ]; then
+    version="v${DAGGER_VERSION}"
   else
     version="v$(latest_version)"
   fi


### PR DESCRIPTION
So that we can reference it in our `runs-on` CI runner configurations.

Setting `DAGGER_COMMIT=head` will pull the latest CLI built from `main`. We are not templating the branch name on purpose. When we introduce release branches, we should revisit this. For now, we are keeping this as simple as possible for as long as possible.

After this gets merged:
- [ ] Update `https://dl.dagger.io/dagger/install.sh`

---
Tested after running it locally against the release destination replica:
<img width="1067" alt="image" src="https://github.com/user-attachments/assets/156ab265-4423-48fc-9478-f8a6749f2f62">