### PR TITLE
feat(sdk/python): normalize names to avoid escape hatch for reserved keywords

### DIFF
--- a/sdk/python/.changes/unreleased/Added-20240723-134519.yaml
+++ b/sdk/python/.changes/unreleased/Added-20240723-134519.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: normalize names in a module to avoid escape hatch for reserved keywords
+time: 2024-07-23T13:45:19.961089Z
+custom:
+    Author: helderco
+    PR: "8014"

--- a/sdk/python/src/dagger/mod/_module.py
+++ b/sdk/python/src/dagger/mod/_module.py
@@ -43,6 +43,7 @@ from dagger.mod._types import APIName, FieldDefinition, ObjectDefinition
 from dagger.mod._utils import (
     asyncify,
     get_doc,
+    normalize_name,
     to_pascal_case,
     transform_error,
 )
@@ -496,7 +497,7 @@ class Module:
             field_def: FieldDefinition | None
             if field_def := field.metadata.get(FIELD_DEF_KEY, None):
                 r = FieldResolver(
-                    name=field_def.name or field.name,
+                    name=field_def.name or normalize_name(field.name),
                     original_name=field.name,
                     doc=get_doc(field.type),
                     type_annotation=types[field.name],

--- a/sdk/python/src/dagger/mod/_resolver.py
+++ b/sdk/python/src/dagger/mod/_resolver.py
@@ -33,6 +33,7 @@ from ._utils import (
     get_alt_constructor,
     get_arg_name,
     get_doc,
+    normalize_name,
     transform_error,
 )
 
@@ -269,7 +270,7 @@ class FunctionResolver(Resolver, Generic[P, R]):
                 annotation = annotation.type
 
             parameter = Parameter(
-                name=get_arg_name(param.annotation) or param.name,
+                name=get_arg_name(param.annotation) or normalize_name(param.name),
                 signature=param,
                 resolved_type=annotation,
                 doc=get_doc(param.annotation),
@@ -357,6 +358,9 @@ class Function(Generic[P, R]):
 
     def __post_init__(self):
         original_name = self.func.__name__
+        normalized_name = normalize_name(original_name)
+        if self.name is None and normalized_name != original_name:
+            self.name = normalized_name
         name = original_name if self.name is None else self.name
         origin = None
 

--- a/sdk/python/src/dagger/mod/_utils.py
+++ b/sdk/python/src/dagger/mod/_utils.py
@@ -68,6 +68,13 @@ def to_camel_case(s: str) -> str:
     return snake_to_camel(s.replace("-", "_"), upper=False)
 
 
+def normalize_name(name: str) -> str:
+    """Remove the last underscore, used to avoid conflicts with reserved words."""
+    if name.endswith("_") and name[-2] != "_" and not name.startswith("_"):
+        return name.removesuffix("_")
+    return name
+
+
 def get_doc(obj: Any) -> str | None:
     """Get the last Doc() in an annotated type or the docstring of an object."""
     if is_annotated(obj):

--- a/sdk/python/tests/modules/test_utils.py
+++ b/sdk/python/tests/modules/test_utils.py
@@ -6,7 +6,13 @@ from typing_extensions import Doc, Self
 
 from dagger import Arg, field
 from dagger.mod import Module
-from dagger.mod._utils import get_arg_name, get_doc, is_nullable, non_null
+from dagger.mod._utils import (
+    get_arg_name,
+    get_doc,
+    is_nullable,
+    non_null,
+    normalize_name,
+)
 
 
 @pytest.mark.parametrize(
@@ -106,6 +112,19 @@ def test_no_dataclass_default_doc():
         bar: str = field()
 
     assert get_doc(Foo) is None
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("with_", "with"),
+        ("__init__", "__init__"),
+        ("_private_", "_private_"),
+        ("mangled__", "mangled__"),
+    ],
+)
+def test_normalize_name(name: str, expected: str):
+    assert normalize_name(name) == expected
 
 
 def test_get_arg_name():


### PR DESCRIPTION
## Before

Name overrides were created as an escape hatch to allow using function, attribute, and parameter names that conflict with Python reserved words:

```python
from typing import Annotated
import dagger

@dagger.object_type
class Test:
    from_: str = dagger.field(name="from")

    @dagger.function(name="with")
    def with_(self, import_: Annotated[str, dagger.Arg("import")] = "") -> str:
        return import_
```

## After

Since the convention in these cases is to add an underscore to the end, we can remove it automatically when registering the name with Dagger:

```python
import dagger

@dagger.object_type
class Test:
    from_: str = dagger.field()

    @dagger.function
     def with_(self, import_: str = "") -> str:
         return import_
```

This avoids the need to override the name in a way that's not documented.

It applies to names that only have a single underscore in the end, so we don't make too many assumptions about what's intended. The escape hatch is still available for now in any case, but might get deprecated at some point, because not all SDKs have it.