### PR TITLE
Bring back `cached` labels in TUI

### DIFF
--- a/core/telemetry.go
+++ b/core/telemetry.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dagger/dagger/dagql"
 	"github.com/dagger/dagger/dagql/call"
 	"github.com/dagger/dagger/engine/slog"
+	"github.com/moby/buildkit/solver/pb"
 	"github.com/opencontainers/go-digest"
 )
 
@@ -104,6 +105,19 @@ func AroundFunc(ctx context.Context, self dagql.Object, id *call.ID) (context.Co
 							continue
 						}
 						seen[dig] = true
+
+						var d pb.Op
+						err := d.Unmarshal(op)
+						if err != nil {
+							slog.Warn("failed to unmarshal LLB", "err", err)
+							continue
+						}
+						if d.Op == nil {
+							// the last def should always be an empty op with
+							// the previous as an input
+							continue
+						}
+
 						ops = append(ops, dig.String())
 					}
 				}

--- a/dagql/idtui/frontend.go
+++ b/dagql/idtui/frontend.go
@@ -245,6 +245,7 @@ func (r renderer) renderCall(
 
 	if span != nil {
 		r.renderDuration(out, span)
+		r.renderCached(out, span)
 	}
 
 	return nil
@@ -275,6 +276,7 @@ func (r renderer) renderSpan(
 		// TODO: when a span has child spans that have progress, do 2-d progress
 		// fe.renderVertexTasks(out, span, depth)
 		r.renderDuration(out, span)
+		r.renderCached(out, span)
 	}
 
 	return nil
@@ -336,6 +338,9 @@ func (r renderer) renderStatus(out *termenv.Output, span *Span, focused bool) {
 	case span.Failed():
 		symbol = IconFailure
 		color = termenv.ANSIRed
+	case span.IsPending():
+		symbol = DotFilled
+		color = termenv.ANSIBlue
 	default:
 		symbol = IconSuccess
 		color = termenv.ANSIGreen
@@ -363,6 +368,12 @@ func (r renderer) renderDuration(out *termenv.Output, span *Span) {
 		duration = duration.Faint()
 	}
 	fmt.Fprint(out, duration)
+}
+
+func (r renderer) renderCached(out *termenv.Output, span *Span) {
+	if !span.IsRunning() && span.IsCached() {
+		fmt.Fprintf(out, " %s", out.String("[CACHED]").Faint())
+	}
 }
 
 // var (

--- a/dagql/idtui/spans.go
+++ b/dagql/idtui/spans.go
@@ -33,10 +33,11 @@ type Span struct {
 	Canceled bool
 	EffectID string
 
-	Inputs         []string
-	Effects        []string
-	RunningEffects map[string]*Span
-	FailedEffects  map[string]*Span
+	Inputs            []string
+	Effects           []string
+	RunningEffects    map[string]*Span
+	SuccessfulEffects map[string]*Span
+	FailedEffects     map[string]*Span
 
 	Encapsulate  bool
 	Encapsulated bool
@@ -50,6 +51,40 @@ type Span struct {
 
 func (span *Span) IsRunning() bool {
 	return span.IsSelfRunning || len(span.RunningEffects) > 0
+}
+
+func (span *Span) IsPending() bool {
+	// TODO: work out how to implement this properly
+	// for some reason it looks like some spans we're waiting on *never* show up?
+	if span.IsRunning() {
+		return false
+	}
+	spanEffects := span.EffectSpans()
+	return len(spanEffects) < len(span.Effects)
+}
+
+func (span *Span) IsCached() bool {
+	// XXX: this is a horrendously inefficient way to do this, and also isn't a
+	// very good heuristic.
+
+	if span.Cached {
+		return true
+	}
+
+	if len(span.ChildSpans)+len(span.EffectSpans()) == 0 {
+		return false
+	}
+	for _, child := range span.ChildSpans {
+		if !child.IsCached() {
+			return false
+		}
+	}
+	for _, effect := range span.EffectSpans() {
+		if !effect.IsCached() {
+			return false
+		}
+	}
+	return true
 }
 
 func (span *Span) HasParent(parent *Span) bool {

--- a/engine/buildkit/client.go
+++ b/engine/buildkit/client.go
@@ -78,6 +78,9 @@ type Client struct {
 	cancel   context.CancelFunc
 	closeMu  sync.RWMutex
 	execMap  sync.Map
+
+	ops   map[digest.Digest]*op
+	opsmu sync.RWMutex
 }
 
 func NewClient(ctx context.Context, opts *Opts) (*Client, error) {
@@ -88,6 +91,7 @@ func NewClient(ctx context.Context, opts *Opts) (*Client, error) {
 		closeCtx: ctx,
 		cancel:   cancel,
 		execMap:  sync.Map{},
+		ops:      make(map[digest.Digest]*op),
 	}
 
 	return client, nil
@@ -122,7 +126,22 @@ func (c *Client) Solve(ctx context.Context, req bkgw.SolveRequest) (_ *Result, r
 		return nil, err
 	}
 	defer cancel()
-	ctx = withOutgoingContext(ctx)
+	ctx = withOutgoingContext(c, ctx)
+
+	dag, err := DefToDAG(req.Definition)
+	if err != nil {
+		return nil, err
+	}
+	c.opsmu.Lock()
+	dag.Walk(func(od *OpDAG) error {
+		c.ops[*od.OpDigest] = &op{
+			Digest: *od.OpDigest,
+			Def:    *od.Op,
+			Meta:   *od.Metadata,
+		}
+		return nil
+	})
+	c.opsmu.Unlock()
 
 	// include upstream cache imports, if any
 	req.CacheImports = c.UpstreamCacheImports
@@ -166,7 +185,7 @@ func (c *Client) ResolveImageConfig(ctx context.Context, ref string, opt sourcer
 		return "", "", nil, err
 	}
 	defer cancel()
-	ctx = withOutgoingContext(ctx)
+	ctx = withOutgoingContext(c, ctx)
 
 	imr := sourceresolver.NewImageMetaResolver(c.LLBBridge)
 	return imr.ResolveImageConfig(ctx, ref, opt)
@@ -178,7 +197,7 @@ func (c *Client) ResolveSourceMetadata(ctx context.Context, op *bksolverpb.Sourc
 		return nil, err
 	}
 	defer cancel()
-	ctx = withOutgoingContext(ctx)
+	ctx = withOutgoingContext(c, ctx)
 
 	return c.LLBBridge.ResolveSourceMetadata(ctx, op, opt)
 }
@@ -213,7 +232,7 @@ func (c *Client) NewContainer(ctx context.Context, req NewContainerRequest) (*Co
 		return nil, err
 	}
 	defer cancel()
-	ctx = withOutgoingContext(ctx)
+	ctx = withOutgoingContext(c, ctx)
 	ctrReq := bkcontainer.NewContainerRequest{
 		ContainerID: containerID,
 		Hostname:    req.Hostname,
@@ -689,13 +708,21 @@ func (c *Client) OpenTerminal(
 	}, nil
 }
 
-func withOutgoingContext(ctx context.Context) context.Context {
+func withOutgoingContext(c *Client, ctx context.Context) context.Context {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if ok {
 		ctx = metadata.NewOutgoingContext(ctx, md)
 	}
-	ctx = buildkitTelemetryContext(ctx)
+	ctx = buildkitTelemetryContext(c, ctx)
 	return ctx
+}
+
+type op struct {
+	Digest digest.Digest
+	Def    bksolverpb.Op
+	Meta   bksolverpb.OpMetadata
+
+	seen bool
 }
 
 // filteringGateway is a helper gateway that filters+converts various

--- a/engine/buildkit/containerimage.go
+++ b/engine/buildkit/containerimage.go
@@ -30,7 +30,7 @@ func (c *Client) PublishContainerImage(
 	inputByPlatform map[string]ContainerExport,
 	opts map[string]string, // TODO: make this an actual type, this leaks too much untyped buildkit api
 ) (map[string]string, error) {
-	ctx = buildkitTelemetryContext(ctx)
+	ctx = buildkitTelemetryContext(c, ctx)
 	ctx, cancel, err := c.withClientCloseCancel(ctx)
 	if err != nil {
 		return nil, err
@@ -68,7 +68,7 @@ func (c *Client) ExportContainerImage(
 	destPath string,
 	opts map[string]string, // TODO: make this an actual type, this leaks too much untyped buildkit api
 ) (map[string]string, error) {
-	ctx = buildkitTelemetryContext(ctx)
+	ctx = buildkitTelemetryContext(c, ctx)
 	ctx, cancel, err := c.withClientCloseCancel(ctx)
 	if err != nil {
 		return nil, err
@@ -127,7 +127,7 @@ func (c *Client) ContainerImageToTarball(
 	inputByPlatform map[string]ContainerExport,
 	opts map[string]string,
 ) (*bksolverpb.Definition, error) {
-	ctx = buildkitTelemetryContext(ctx)
+	ctx = buildkitTelemetryContext(c, ctx)
 	ctx, cancel, err := c.withClientCloseCancel(ctx)
 	if err != nil {
 		return nil, err

--- a/engine/buildkit/telemetry.go
+++ b/engine/buildkit/telemetry.go
@@ -2,12 +2,16 @@ package buildkit
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
+	"github.com/moby/buildkit/solver/pb"
+	"github.com/opencontainers/go-digest"
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/embedded"
+	"go.opentelemetry.io/otel/trace/noop"
 
 	"dagger.io/dagger/telemetry"
 )
@@ -15,18 +19,19 @@ import (
 // buildkitTelemetryContext returns a context with a wrapped span that has a
 // TracerProvider that can process spans produced by buildkit. This works,
 // because of how buildkit heavily relies on trace.SpanFromContext.
-func buildkitTelemetryContext(ctx context.Context) context.Context {
+func buildkitTelemetryContext(client *Client, ctx context.Context) context.Context {
 	if ctx == nil {
 		return nil
 	}
 	sp := trace.SpanFromContext(ctx)
-	sp = buildkitSpan{Span: sp, provider: &buildkitTraceProvider{tp: sp.TracerProvider()}}
+	sp = buildkitSpan{Span: sp, provider: &buildkitTraceProvider{tp: sp.TracerProvider(), client: client}}
 	return trace.ContextWithSpan(ctx, sp)
 }
 
 type buildkitTraceProvider struct {
 	embedded.TracerProvider
-	tp trace.TracerProvider
+	tp     trace.TracerProvider
+	client *Client
 }
 
 func (tp *buildkitTraceProvider) Tracer(name string, options ...trace.TracerOption) trace.Tracer {
@@ -53,9 +58,140 @@ func (t *buildkitTracer) Start(ctx context.Context, spanName string, opts ...tra
 		trace.WithAttributes(attribute.Bool("buildkit", true)),
 	}, opts...)
 
+	if strings.HasPrefix(spanName, "cache request: ") {
+		// these wrap calls to CacheMap (set deep inside buildkit)
+		// we can discard these, they're not super useful to show to users
+		return noop.NewTracerProvider().Tracer("").Start(ctx, spanName, opts...)
+	}
+
+	if strings.HasPrefix(spanName, "load cache: ") {
+		cfg := trace.NewSpanStartConfig(opts...)
+		for _, attr := range cfg.Attributes() {
+			if attr.Key != "vertex" {
+				continue
+			}
+			dgst := digest.Digest(attr.Value.AsString())
+
+			t.provider.client.opsmu.Lock()
+			llbop, ok := t.provider.client.ops[dgst]
+			if ok {
+				llbop.seen = true
+			}
+			t.provider.client.opsmu.Unlock()
+
+			if ok {
+				for _, input := range llbop.Def.Inputs {
+					t.walk(ctx, input.Digest, func(llbop *op) {
+						_, span := t.tracer.Start(ctx, t.name(llbop.Digest), trace.WithAttributes(
+							attribute.Bool("buildkit", true),
+							attribute.Bool("dagger.io/dag.virtual", true),
+							attribute.Bool(telemetry.CachedAttr, true),
+							attribute.String("vertex", string(llbop.Digest)),
+						))
+						span.End()
+					})
+				}
+			}
+			break
+		}
+	}
+
 	ctx, span := t.tracer.Start(ctx, spanName, opts...)
 	newSpan := buildkitSpan{Span: span, provider: t.provider}
 	return trace.ContextWithSpan(ctx, newSpan), newSpan
+}
+
+func (t *buildkitTracer) walk(ctx context.Context, digest digest.Digest, cb func(*op)) {
+	t.provider.client.opsmu.RLock()
+	op, ok := t.provider.client.ops[digest]
+	seen := op.seen
+	t.provider.client.opsmu.RUnlock()
+	if !ok || seen {
+		return
+	}
+
+	for _, input := range op.Def.Inputs {
+		t.walk(ctx, input.Digest, cb)
+	}
+
+	cb(op)
+
+	t.provider.client.opsmu.Lock()
+	op.seen = true
+	t.provider.client.opsmu.Unlock()
+}
+
+func (t *buildkitTracer) name(d digest.Digest) string {
+	t.provider.client.opsmu.RLock()
+	op := t.provider.client.ops[d]
+	t.provider.client.opsmu.RUnlock()
+
+	name, ok := op.Meta.Description["llb.customname"]
+	if ok {
+		return name
+	}
+
+	name, err := llbOpName(op, t.name)
+	if err != nil {
+		panic(err)
+	}
+	return name
+}
+
+func llbOpName(llbop *op, basename func(digest.Digest) string) (string, error) {
+	switch op := llbop.Def.Op.(type) {
+	case *pb.Op_Source:
+		return op.Source.Identifier, nil
+	case *pb.Op_Exec:
+		return strings.Join(op.Exec.Meta.Args, " "), nil
+	case *pb.Op_File:
+		return fileOpName(op.File.Actions), nil
+	case *pb.Op_Build:
+		return "build", nil
+	case *pb.Op_Merge:
+		subnames := make([]string, len(llbop.Def.Inputs))
+		for i, inp := range llbop.Def.Inputs {
+			subvtx := basename(inp.Digest)
+			subnames[i] = subvtx
+		}
+		return "merge " + fmt.Sprintf("(%s)", strings.Join(subnames, ", ")), nil
+	case *pb.Op_Diff:
+		var lowerName string
+		if op.Diff.Lower.Input == -1 {
+			lowerName = "scratch"
+		} else {
+			lowerVtx := basename(llbop.Def.Inputs[op.Diff.Lower.Input].Digest)
+			lowerName = fmt.Sprintf("(%s)", lowerVtx)
+		}
+		var upperName string
+		if op.Diff.Upper.Input == -1 {
+			upperName = "scratch"
+		} else {
+			upperVtx := basename(llbop.Def.Inputs[op.Diff.Upper.Input].Digest)
+			upperName = fmt.Sprintf("(%s)", upperVtx)
+		}
+		return "diff " + lowerName + " -> " + upperName, nil
+	default:
+		return "unknown", nil
+	}
+}
+
+func fileOpName(actions []*pb.FileAction) string {
+	names := make([]string, 0, len(actions))
+	for _, action := range actions {
+		switch a := action.Action.(type) {
+		case *pb.FileAction_Mkdir:
+			names = append(names, fmt.Sprintf("mkdir %s", a.Mkdir.Path))
+		case *pb.FileAction_Mkfile:
+			names = append(names, fmt.Sprintf("mkfile %s", a.Mkfile.Path))
+		case *pb.FileAction_Rm:
+			names = append(names, fmt.Sprintf("rm %s", a.Rm.Path))
+		case *pb.FileAction_Copy:
+			names = append(names, fmt.Sprintf("copy %s %s", a.Copy.Src, a.Copy.Dest))
+		}
+	}
+
+	return strings.Join(names, ", ")
 }
 
 type buildkitSpan struct {
@@ -93,12 +229,16 @@ func (sp SpanProcessor) OnStart(ctx context.Context, span sdktrace.ReadWriteSpan
 
 	attrs := []attribute.KeyValue{}
 
+	// convert cache prefixes into cached attribute (this is set deep inside buildkit)
+	spanName, cached := strings.CutPrefix(spanName, "load cache: ")
+	if cached {
+		span.SetName(spanName)
+		attrs = append(attrs, attribute.Bool(telemetry.CachedAttr, true))
+	}
+
 	// convert [internal] prefix into internal attribute
 	if rest, ok := strings.CutPrefix(spanName, InternalPrefix); ok {
 		span.SetName(rest)
-		attrs = append(attrs, attribute.Bool(telemetry.UIInternalAttr, true))
-	} else if rest, ok := strings.CutPrefix(spanName, "load cache: "+InternalPrefix); ok {
-		span.SetName("load cache: " + rest)
 		attrs = append(attrs, attribute.Bool(telemetry.UIInternalAttr, true))
 	}
 


### PR DESCRIPTION
> [!WARNING]
>
> This PR is a work-in-progress! Currently, tracking which buildkit operations were cached is fairly trivial (and is implemented). But, working out whether a call should be marked as cached, and how this interacts with dagql's own caching is still undetermined.