### PR TITLE
Keep plain progress default verbosity neat

### DIFF
--- a/dagql/idtui/frontend_plain.go
+++ b/dagql/idtui/frontend_plain.go
@@ -623,6 +623,9 @@ func sampleContext(rows []*TraceTree) []int {
 
 	// don't ever sample the current row
 	rows = rows[:len(rows)-1]
+	if len(rows) == 0 {
+		return nil
+	}
 
 	// NB: break glass for all the context
 	// all := make([]int, len(rows))
@@ -631,27 +634,24 @@ func sampleContext(rows []*TraceTree) []int {
 	// }
 	// return all
 
-	// find the first vertex
-	first := -1
-	if len(rows) > 0 {
-		first = 0
+	result := []int{}
+
+	// find the first call
+	for i := 0; i < len(rows); i++ {
+		row := rows[i]
+		result = append(result, i)
+		if row.Span.Call != nil {
+			break
+		}
 	}
 	// iterate backwards to find the last call
-	last := -1
-	for i := len(rows) - 1; i > first; i-- {
+	for i := len(rows) - 1; i > result[len(result)-1]; i-- {
 		row := rows[i]
 		if row.Span.Call != nil {
-			last = i
+			result = append(result, i)
 			break
 		}
 	}
 
-	switch {
-	case first == -1:
-		return []int{}
-	case last == -1:
-		return []int{first}
-	default:
-		return []int{first, last}
-	}
+	return result
 }


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/7913

This contains two main fixes:
- The first fixes context sampling, so that we always take everything *up to* the first call. This means we can keep `initializing module` under `initializing`.
- The second fixes the effect wake-up by removing it - we don't actually need it for plain progress, there should never be a case when the plain progress will *stop* rendering for a span (it's assumed to live forever really). This was causing a lot of wake-ups deep under `initialize`, which was causing the "increased verbosity" (introduced in [`14ae071` (#7686)](https://github.com/dagger/dagger/pull/7686/commits/14ae07195f6ac07b42792b38cfb6b060c4fc3101))