### PR TITLE
cli: propagate exit code from function

### DIFF
--- a/.changes/unreleased/Added-20240723-171437.yaml
+++ b/.changes/unreleased/Added-20240723-171437.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: 'cli: propagate exit code from function'
+time: 2024-07-23T17:14:37.925014Z
+custom:
+    Author: helderco
+    PR: "8019"

--- a/cmd/dagger/functions.go
+++ b/cmd/dagger/functions.go
@@ -279,8 +279,14 @@ func (fc *FuncCommand) Command() *cobra.Command {
 					if err := fc.execute(c, a); err != nil {
 						// We've already handled printing the error in `fc.execute`
 						// because we want to show the usage for the right sub-command.
-						// Returning Fail here will prevent the error from being printed
+						// Returning ExitError here will prevent the error from being printed
 						// twice on main().
+
+						// Return the same ExecError exit code.
+						var ex *dagger.ExecError
+						if errors.As(err, &ex) {
+							return ExitError{Code: ex.ExitCode}
+						}
 						return Fail
 					}
 

--- a/core/integration/module_call_test.go
+++ b/core/integration/module_call_test.go
@@ -2165,3 +2165,24 @@ func (m *Test) FromStatus(status Status) string {
 		require.ErrorContains(t, err, "enum value must not be empty")
 	})
 }
+
+func (ModuleSuite) TestCallExit(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	_, err := modInit(t, c, "go", `package main
+
+import "os"
+
+type Test struct {}
+
+func (m *Test) Quit() {
+	os.Exit(6)
+}
+`,
+	).
+		With(daggerCall("quit")).
+		Sync(ctx)
+
+	var exErr *dagger.ExecError
+	require.ErrorAs(t, err, &exErr)
+	require.Equal(t, 6, exErr.ExitCode)
+}


### PR DESCRIPTION
A while ago in Discord, a user expected that `dagger call` exited with the same exit code of the test suite tool they were using in the function. I thought why not, and it's easy to add.