### PR TITLE
fix dev module custom test running documentation

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -44,7 +44,7 @@ Run all tests:
 
 Run a specific test (e.g. `TestModuleNamespacing`):
 
-    dagger call -m dev --source=.:default test custom --pkg="./core/integration" --run="^TestModuleNamespacing"
+    dagger call -m dev --source=.:default test custom --pkg="./core/integration" --run="^TestModule/TestNamespacing"
 
 ## Dev environment
 


### PR DESCRIPTION
The existing dev module documentation instructs developers to run a test which doesn't exist. This PR updates the example to point at the renamed test, with the added side benefit of making it clear that many core/integration tests are subtests. 