### PR TITLE
chore(dev): remove python modules from list of modules to source

### DIFF
--- a/dev/main.go
+++ b/dev/main.go
@@ -96,8 +96,7 @@ func (dev *DaggerDev) Source() *dagger.Directory {
 		"dev/markdown",
 		"dev/shellcheck",
 		"sdk/elixir/runtime",
-		// FIXME: broken
-		// "sdk/python/dev",
+		"sdk/python/dev",
 		"sdk/python/runtime",
 		"sdk/typescript/dev",
 		"sdk/typescript/dev/node",

--- a/dev/main.go
+++ b/dev/main.go
@@ -96,7 +96,6 @@ func (dev *DaggerDev) Source() *dagger.Directory {
 		"dev/markdown",
 		"dev/shellcheck",
 		"sdk/elixir/runtime",
-		"sdk/python/dev",
 		"sdk/python/runtime",
 		"sdk/typescript/dev",
 		"sdk/typescript/dev/node",


### PR DESCRIPTION
Python's dev module is no longer broken.