### PR TITLE
Improve releasing during v0.12.3

### DIFF
--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -13,7 +13,7 @@ inputs:
 
   version:
     description: "Dagger version to run against"
-    default: "v0.12.2"
+    default: "v0.12.3"
     required: false
 
   dev-engine:

--- a/.github/workflows/_sdk_check.yml
+++ b/.github/workflows/_sdk_check.yml
@@ -15,7 +15,7 @@ on:
 
       version:
         type: string
-        default: "v0.12.2"
+        default: "v0.12.3"
         required: false
 
       dev-engine:
@@ -32,7 +32,7 @@ on:
 
 jobs:
   check:
-    runs-on: "${{ github.repository == 'dagger/dagger' && (inputs.dev-engine && 'dagger-v0-12-2-8c-dind' || 'dagger-v0-12-2-4c-nvme') || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && (inputs.dev-engine && 'dagger-v0-12-3-8c-dind' || 'dagger-v0-12-3-4c-nvme') || 'ubuntu-latest' }}"
     timeout-minutes: "${{ inputs.timeout }}"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-2-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-3-4c-nvme' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/engine-and-cli-publish.yml
+++ b/.github/workflows/engine-and-cli-publish.yml
@@ -20,7 +20,7 @@ jobs:
   publish:
     if: ${{ github.repository == 'dagger/dagger' && github.event_name == 'push' }}
     # Use our own Dagger runner when running in the dagger/dagger repo (including PRs)
-    runs-on: dagger-v0-12-2-16c-nvme
+    runs-on: dagger-v0-12-3-16c-nvme
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -162,7 +162,7 @@ jobs:
           discord-webhook: ${{ secrets.NEW_RELEASE_DISCORD_WEBHOOK }}
 
   scan-engine:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-2-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-3-4c-nvme' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-2-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-3-4c-nvme' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
           function: "scripts lint"
 
   test:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-2-16c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-3-16c-nvme' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -49,7 +49,7 @@ jobs:
   # Only run a subset of important test cases since we just need to verify basic
   # functionality rather than repeat every test already run in the other targets.
   testdev:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-2-32c-dind' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-3-32c-dind' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
           dev-engine: true
 
   test-publish:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-2-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-3-4c-nvme' || 'ubuntu-latest' }}"
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
           function: "engine with-base --image=ubuntu --gpu-support=true test-publish"
 
   scan-engine:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-2-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-3-4c-nvme' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-2-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-3-4c-nvme' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -27,7 +27,7 @@ jobs:
     # only run this on tag push events, not in PRs
     if: github.event_name == 'push' && github.repository == 'dagger/dagger' && github.ref_type == 'tag'
     needs: test
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-2-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-3-4c-nvme' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "helm publish"

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-2-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-3-4c-nvme' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sdk-elixir-publish.yml
+++ b/.github/workflows/sdk-elixir-publish.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-2-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-3-4c-nvme' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "elixir publish"

--- a/.github/workflows/sdk-go-publish.yml
+++ b/.github/workflows/sdk-go-publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-2-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-3-4c-nvme' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "go publish"

--- a/.github/workflows/sdk-php-publish.yml
+++ b/.github/workflows/sdk-php-publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-2-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-3-4c-nvme' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "php publish"

--- a/.github/workflows/sdk-python-publish.yml
+++ b/.github/workflows/sdk-python-publish.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-2-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-3-4c-nvme' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "python publish"

--- a/.github/workflows/sdk-rust-publish.yml
+++ b/.github/workflows/sdk-rust-publish.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-2-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-3-4c-nvme' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "go publish"

--- a/.github/workflows/sdk-typescript-publish.yml
+++ b/.github/workflows/sdk-typescript-publish.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-2-4c-nvme' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-v0-12-3-4c-nvme' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "typescript publish"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -345,8 +345,9 @@ changie merge
 cd ../..
 ```
 
-- [ ] Commit and push the changes with the message `Add SDK release notes`
 - [ ] Update all dagger versions in `docs/current_docs/partials/_install-cli.mdx` to `$ENGINE_VERSION`
+  - e.g. if bumping 0.12.2->0.12.3, can run `sed -i 's/0\.12\.2/0\.12\.3/g' docs/current_docs/partials/_install-cli.mdx`
+- [ ] Commit and push the changes with the message `Add SDK release notes`
 - [ ] `30mins` Open this draft PR in
       [github.com/dagger/dagger/pulls](https://github.com/dagger/dagger/pulls) &
       click on **Ready to review**.
@@ -401,6 +402,7 @@ cd ..
 
   - The version numbers (of the form `<major>.<minor>.<patch>`) should be updated to the new version
   - The worker runner versions (of the form `dagger-v<major>-<minor>-<patch>-<worker>`)
+  - e.g. if bumping 0.12.2->0.12.3, can run `find .github/ -type f -exec sed -i 's/0-12-2/0-12-3/g; s/0\.12\.2/0\.12\.3/g' {} +`
 
 - [ ] Open a PR with the title `Improve Releasing during $ENGINE_VERSION`
 
@@ -674,6 +676,7 @@ update once there's a new release of the Dagger Engine.
 
 - [ ] Submit PR with the version bump, e.g.
       https://github.com/dagger/dagger-for-github/pull/123
+  - e.g. if bumping 0.12.2->0.12.3, can run `find . -type f -exec sed -i 's/0\.12\.2/0\.12\.3/g' {} +`
 - [ ] Ask @gerhard or @jpadams to review it
 
 > [!TIP]

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -382,6 +382,19 @@ workflow](https://github.com/dagger/dagger/actions/workflows/sdk-go-publish.yml)
 which publishes to [🐙
 github.com/dagger/dagger-go-sdk](https://github.com/dagger/dagger-go-sdk/tags).
 
+- [ ] Download and install the latest release, and continue the rest of the
+      release process using the just-released CLI. This is needed now so the
+      `dev` module updated below will get `dagger.json`'s engine version bumped.
+
+```console
+curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin DAGGER_VERSION=0.12.1 sh
+# install the cli to dagger-0.12.1, and symlink dagger to it
+mv ~/.local/bin/dagger{,-0.12.1}
+ln -s ~/.local/bin/dagger{-0.12.1,}
+
+dagger version
+```
+
 - [ ] `20mins` Bump the Go SDK version in our internal CI targets & check
       that Engine tests pass locally. If everything looks good, submit a new PR
       with this change so that we can check that all our workflows pass with the new
@@ -421,18 +434,6 @@ Change the branch the PR is being merged into from `main` to the `release-vX.Y.Z
 </details>
 
 Ensure that all the workflows succeed before continuing (specifically `test` and `testdev`)!
-
-- [ ] Download and install the latest release, and continue the rest of the
-      release process using the just-released CLI.
-
-```console
-curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin DAGGER_VERSION=0.12.1 sh
-# install the cli to dagger-0.12.1, and symlink dagger to it
-mv ~/.local/bin/dagger{,-0.12.1}
-ln -s ~/.local/bin/dagger{-0.12.1,}
-
-dagger version
-```
 
 - [ ] After you confirm that our internal tooling works with the new Go SDK
       release, [🐙 github.com/dagger/dagger-go-sdk](https://github.com/dagger/dagger-go-sdk/tags),

--- a/dev/dagger.json
+++ b/dev/dagger.json
@@ -28,7 +28,7 @@
     }
   ],
   "source": ".",
-  "engineVersion": "v0.12.2",
+  "engineVersion": "v0.12.3",
   "views": [
     {
       "name": "default",

--- a/dev/go.mod
+++ b/dev/go.mod
@@ -4,7 +4,7 @@ go 1.22.0
 
 toolchain go1.22.5
 
-require github.com/dagger/dagger/engine/distconsts v0.12.2
+require github.com/dagger/dagger/engine/distconsts v0.12.3
 
 replace github.com/dagger/dagger/engine/distconsts => ../engine/distconsts
 

--- a/go.mod
+++ b/go.mod
@@ -260,8 +260,8 @@ require (
 )
 
 require (
-	dagger.io/dagger v0.12.2
-	github.com/dagger/dagger/engine/distconsts v0.12.2
+	dagger.io/dagger v0.12.3
+	github.com/dagger/dagger/engine/distconsts v0.12.3
 )
 
 replace (


### PR DESCRIPTION
TODOs after release is done:
- [x] Update instructions to include `dagger.json` version bumps
- [x] Fix ordering of "Update all dagger versions in docs/current_docs/partials/_install-cli.mdx to $ENGINE_VERSION" 
- [x] Include one-liner command to update all the github yamls with new engine version, to save on toil
   - `find .github/ -type f -exec sed -i 's/0-12-2/0-12-3/g; s/0\.12\.2/0\.12\.3/g' {} +`
   - Can do same for the dagger-for-github updates
- (Maybe if time) chisel away at one manual step, e.g. automate the SDK changelog generation + engine version bump in CLI docs so that the bump PR doesn't need extra pushes w/ manual changes
   - Going to do this but decided to spin out to different PR after working on it since it has some meaningful changes in the `dev/` module that I don't want to block this PR on
   - separate PR here https://github.com/dagger/dagger/pull/8043