### PR TITLE
[WIP] daggerize sdk changelog generation

### DIFF
--- a/dev/sdk_elixir.go
+++ b/dev/sdk_elixir.go
@@ -143,6 +143,11 @@ func (t ElixirSDK) Bump(ctx context.Context, version string) (*dagger.Directory,
 	return dag.Directory().WithNewFile(elixirSDKVersionFilePath, newContents), nil
 }
 
+// Generate the Elixir SDK changelogs
+func (t ElixirSDK) GenerateChangelogs(ctx context.Context, version string, bumpEnginePR string) (*dagger.Directory, error) {
+	return t.Dagger.generateSDKChangelogs(elixirSDKPath, version, bumpEnginePR)
+}
+
 func (t ElixirSDK) elixirBase(elixirVersion string) *dagger.Container {
 	src := t.Dagger.Source().Directory(elixirSDKPath)
 	mountPath := "/" + elixirSDKPath

--- a/dev/sdk_go.go
+++ b/dev/sdk_go.go
@@ -124,6 +124,11 @@ const CLIVersion = %q
 	return dir, nil
 }
 
+// Generate the Go SDK changelogs
+func (t GoSDK) GenerateChangelogs(ctx context.Context, version string, bumpEnginePR string) (*dagger.Directory, error) {
+	return t.Dagger.generateSDKChangelogs("sdk/go", version, bumpEnginePR)
+}
+
 type gitPublishOpts struct {
 	source, dest       string
 	sourceTag, destTag string

--- a/dev/sdk_java.go
+++ b/dev/sdk_java.go
@@ -115,6 +115,11 @@ func (t JavaSDK) Bump(ctx context.Context, version string) (*dagger.Directory, e
 	return dir, nil
 }
 
+// Generate the Java SDK changelogs
+func (t JavaSDK) GenerateChangelogs(ctx context.Context, version string, bumpEnginePR string) (*dagger.Directory, error) {
+	return t.Dagger.generateSDKChangelogs(javaSDKPath, version, bumpEnginePR)
+}
+
 func (t JavaSDK) javaBase() *dagger.Container {
 	src := t.Dagger.Source().Directory(javaSDKPath)
 	mountPath := "/" + javaSDKPath

--- a/dev/sdk_php.go
+++ b/dev/sdk_php.go
@@ -97,6 +97,11 @@ func (t PHPSDK) Bump(ctx context.Context, version string) (*dagger.Directory, er
 	return dir, nil
 }
 
+// Generate the PHP SDK changelogs
+func (t PHPSDK) GenerateChangelogs(ctx context.Context, version string, bumpEnginePR string) (*dagger.Directory, error) {
+	return t.Dagger.generateSDKChangelogs(phpSDKPath, version, bumpEnginePR)
+}
+
 // phpBase returns a PHP container with the PHP SDK source files
 // added and dependencies installed.
 func (t PHPSDK) phpBase() *dagger.Container {

--- a/dev/sdk_python.go
+++ b/dev/sdk_python.go
@@ -166,3 +166,8 @@ func (t PythonSDK) Bump(ctx context.Context, version string) (*dagger.Directory,
 	// provision tests run whenever this file changes.
 	return dag.Directory().WithNewFile("sdk/python/src/dagger/_engine/_version.py", engineReference), nil
 }
+
+// Generate the Python SDK changelogs
+func (t PythonSDK) GenerateChangelogs(ctx context.Context, version string, bumpEnginePR string) (*dagger.Directory, error) {
+	return t.Dagger.generateSDKChangelogs(pythonSubdir, version, bumpEnginePR)
+}

--- a/dev/sdk_rust.go
+++ b/dev/sdk_rust.go
@@ -157,6 +157,11 @@ func (r RustSDK) Bump(ctx context.Context, version string) (*dagger.Directory, e
 	return dag.Directory().WithNewFile(rustVersionFilePath, versionBumpedContents), nil
 }
 
+// Generate the Rust SDK changelogs
+func (r RustSDK) GenerateChangelogs(ctx context.Context, version string, bumpEnginePR string) (*dagger.Directory, error) {
+	return r.Dagger.generateSDKChangelogs("sdk/rust", version, bumpEnginePR)
+}
+
 func (r RustSDK) rustBase(image string) *dagger.Container {
 	const appDir = "sdk/rust"
 

--- a/dev/sdk_typescript.go
+++ b/dev/sdk_typescript.go
@@ -184,6 +184,11 @@ func (t TypescriptSDK) Bump(ctx context.Context, version string) (*dagger.Direct
 	return dag.Directory().WithNewFile("sdk/typescript/provisioning/default.ts", engineReference), nil
 }
 
+// Generate the Typescript SDK changelogs
+func (t TypescriptSDK) GenerateChangelogs(ctx context.Context, version string, bumpEnginePR string) (*dagger.Directory, error) {
+	return t.Dagger.generateSDKChangelogs("sdk/typescript", version, bumpEnginePR)
+}
+
 func (t TypescriptSDK) nodeJsBase() *dagger.Container {
 	// Use the LTS version by default
 	return t.nodeJsBaseFromVersion(nodeVersionMaintenance)


### PR DESCRIPTION
Spinning this out from https://github.com/dagger/dagger/pull/8040

In the effort of slowly automating our release process towards being one-click (or at least "few-click"), this automates the SDK changelog generation, which is currently a manual step in RELEASING.md (among many others we should gradually squash over time).

I hit my timebox on this today, so a few TODOs left.
- [ ] Figure out how to **_safely_** export deleted files (e.g. `sdk/<name>/.changes/unreleased/*`) back to the caller
   - Emphasis on "safely" because while trying this I used the `--wipe` option on export and accidentally deleted my `.git` dir, which was mildly devastating 🥲
 - [ ] Add to CI. Only tricky part is these changelogs need the PR number of the bump engine PR, so we need to first create the PR, generate these changelogs, and then update the PR with the extra diff
 - [ ] Update RELEASING.md (delete a big chunk of instructions)

cc @shykes @jedevc