### PR TITLE
fix: secret scrubber should remove whitespace-trimmed secrets

### DIFF
--- a/engine/buildkit/secret_scrub.go
+++ b/engine/buildkit/secret_scrub.go
@@ -231,7 +231,9 @@ func (t *Trie) Insert(key []byte, value []byte) {
 		}
 		node = node.children[ch]
 	}
-	if node.direct != nil {
+	if node.direct == nil {
+		node.direct = []byte{}
+	} else {
 		node.branch()
 	}
 	node.value = value

--- a/engine/buildkit/secret_scrub.go
+++ b/engine/buildkit/secret_scrub.go
@@ -48,6 +48,7 @@ func NewSecretScrubReader(
 	}
 	transformer := &censor{
 		trieRoot: trie,
+		trie:     trie.Iter(),
 		// NOTE: keep these sizes the same as the default transform sizes
 		srcBuf: make([]byte, 0, 4096),
 		dstBuf: make([]byte, 0, 4096),
@@ -102,8 +103,9 @@ type censor struct {
 	// trieRoot is the root of the trie
 	trieRoot *Trie
 	// trie is the current node we are at in the trie
-	trie     *Trie
-	match    *Trie
+	trie *TrieIter
+	// match is the last trie node that we found a match from
+	match    *TrieIter
 	matchLen int
 
 	// srcBuf is the source buffer, which contains bytes read from the src that
@@ -153,7 +155,7 @@ func (c *censor) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err err
 				// flush the secret replacement and the rest of the source
 				// buffer
 				if c.match != nil {
-					c.trie = c.trieRoot
+					c.trie = c.trieRoot.Iter()
 					c.dstBuf = append(c.dstBuf, c.match.Value()...)
 					c.dstBuf = append(c.dstBuf, c.srcBuf[c.matchLen:]...)
 					c.srcBuf = c.srcBuf[:0]
@@ -171,7 +173,7 @@ func (c *censor) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err err
 				// no match possible, so flush the source buffer into the
 				// destination buffer
 				if len(c.srcBuf) != 0 {
-					c.trie = c.trieRoot
+					c.trie = c.trieRoot.Iter()
 					c.dstBuf = append(c.dstBuf, c.srcBuf...)
 					c.srcBuf = c.srcBuf[:0]
 
@@ -184,10 +186,10 @@ func (c *censor) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err err
 				// the source buffer, depending on whether it's a partial match
 				c.trie = c.trieRoot.Step(ch)
 				if c.trie == nil {
-					c.trie = c.trieRoot
+					c.trie = c.trieRoot.Iter()
 					c.dstBuf = append(c.dstBuf, ch)
 				} else if replace := c.trie.Value(); replace != nil {
-					c.trie = c.trieRoot
+					c.trie = c.trieRoot.Iter()
 					c.dstBuf = append(c.dstBuf, replace...)
 				} else {
 					c.srcBuf = append(c.srcBuf, ch)
@@ -220,7 +222,7 @@ func (c *censor) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err err
 }
 
 func (c *censor) Reset() {
-	c.trie = c.trieRoot
+	c.trie = c.trieRoot.Iter()
 	c.srcBuf = c.srcBuf[:0]
 	c.dstBuf = c.dstBuf[:0]
 }
@@ -237,103 +239,153 @@ type Trie struct {
 
 	// children is a byte-indexed slice of child nodes
 	children []*Trie
-	// direct is an alternative shortcut for a list of children that helps save
-	// us some memory (note, it currently only appears in leaf nodes, and
-	// contains suffixes)
+	// direct is a prefix that every child in this node has - this is the
+	// compressed part of the compressed trie, and it saves us a huge amount of
+	// memory and performance
 	direct []byte
 }
 
+func (t *Trie) Iter() *TrieIter {
+	return &TrieIter{Trie: t}
+}
+
 func (t *Trie) Insert(key []byte, value []byte) {
-	node := t
-	for i, ch := range key {
-		if node.children == nil {
-			if node.direct == nil || bytes.Equal(node.direct, key[i:]) {
-				node.direct = key[i:]
-				node.value = value
-				return
-			}
-			node.branch()
-		}
-		if node.children[ch] == nil {
-			node.children[ch] = &Trie{}
-		}
-		node = node.children[ch]
-	}
-	if node.direct == nil {
-		node.direct = []byte{}
-	} else {
-		node.branch()
-	}
-	node.value = value
+	t.Iter().insert(key, value)
 }
 
-// branch takes a node in the trie and converts it from a leaf node into a
-// branch node.
-func (t *Trie) branch() {
-	if t.children != nil {
-		return
-	}
-
-	// why a slice instead of a map? surely it uses more space?
-	// well, doing a lookup on a slice like this is *super* quick, but
-	// doing so on a map is *much* slower - since this is in the
-	// hotpath, it makes sense to waste the memory here (and since the
-	// trie is compressed, it doesn't seem to be that much in practice)
-	t.children = make([]*Trie, 256)
-
-	// since we potentially create children here, we have to re-insert the
-	// direct shortcuts to preserve internally consistency
-	if len(t.direct) > 0 {
-		t.children[t.direct[0]] = &Trie{
-			direct: t.direct[1:],
-			value:  t.value,
-		}
-		t.value = nil
-	}
-	t.direct = nil
-}
-
-// Step selects a node that was previously inserted.
-func (t *Trie) Step(ch byte) *Trie {
-	if t.children != nil {
-		return t.children[ch]
-	}
-	if len(t.direct) > 0 && t.direct[0] == ch {
-		// this is a "virtual node" - it doesn't actually exist in the trie,
-		// but can still used for traversal
-		return &Trie{
-			direct: t.direct[1:],
-			value:  t.value,
-		}
-	}
-	return nil
-}
-
-// Value gets the value previously inserted at this node.
-func (t *Trie) Value() []byte {
-	if t == nil {
-		return nil
-	}
-	if len(t.direct) == 0 {
-		return t.value
-	}
-	return nil
+func (t *Trie) Step(ch byte) *TrieIter {
+	return t.Iter().Step(ch)
 }
 
 // String prints a debuggable representation of the trie.
 func (t Trie) String() string {
 	lines := ""
-	if t.value != nil {
-		lines += fmt.Sprintf("%s (%s)\n", t.direct, t.value)
-	}
+	lines += fmt.Sprintf("%s (%s)\n", t.direct, t.value)
 
 	for ch, child := range t.children {
 		if child != nil {
-			lines += fmt.Sprintf("%c\n", ch)
+			lines += fmt.Sprintf("- %c ->\n", ch)
 			for _, line := range strings.Split(child.String(), "\n") {
 				lines += "  " + line + "\n"
 			}
 		}
 	}
 	return strings.TrimSpace(lines)
+}
+
+// TrieIter is an iterator that allows navigating through a Trie.
+//
+// This is used so that we can navigate through the compressed Trie structure
+// easily - not every node "exists", but the TrieIter handles this case. For
+// example, a node might have a direct of `foo`, so the node `fo` is virtual.
+type TrieIter struct {
+	*Trie
+
+	// idx is the current index of this node into direct
+	idx int
+}
+
+func (t *TrieIter) insert(key []byte, value []byte) {
+	if t == nil {
+		panic("cannot insert into nil tree")
+	}
+
+	if len(key) == 0 || t.direct == nil {
+		// we're done, this is where we shall store the data!
+		t = t.materialize().Iter()
+		if t.direct == nil {
+			t.direct = key
+		}
+		t.value = value
+		return
+	}
+
+	next := t.Step(key[0])
+	if next == nil {
+		t = t.materialize().Iter()
+		t.branch()
+		child := t.children[key[0]]
+		if child == nil {
+			child = &Trie{}
+			t.children[key[0]] = child
+		}
+		next = child.Iter()
+	}
+
+	next.insert(key[1:], value)
+}
+
+// materialize is the main magic of how insertion works.
+//
+// This function can take any iterable part of the trie, and if the node is
+// virtual, then it will modify the trie to make it "real". This means that
+// this node can then store data, or can be given it's own children.
+func (t *TrieIter) materialize() *Trie {
+	if t.idx == len(t.direct) {
+		// already materialized
+		return t.Trie
+	}
+
+	direct := t.direct
+	child := &Trie{
+		direct:   direct[t.idx+1:],
+		children: t.children,
+		value:    t.value,
+	}
+	t.direct = direct[:t.idx]
+	t.children = nil
+	t.value = nil
+
+	t.branch()
+	t.children[direct[t.idx]] = child
+
+	return t.Trie
+}
+
+// branch takes a node in the trie and converts it from a leaf node into a
+// branch node (if it wasn't already)
+func (t *Trie) branch() {
+	// why a slice instead of a map? surely it uses more space?
+	// well, doing a lookup on a slice like this is *super* quick, but
+	// doing so on a map is *much* slower - since this is in the
+	// hotpath, it makes sense to waste the memory here (and since the
+	// trie is compressed, it doesn't seem to be that much in practice)
+	if t.children != nil {
+		return
+	}
+	t.children = make([]*Trie, 256)
+}
+
+// Step selects a node that was previously inserted.
+func (t *TrieIter) Step(ch byte) *TrieIter {
+	if t == nil {
+		return nil
+	}
+	if t.idx < len(t.direct) {
+		if t.direct[t.idx] == ch {
+			return &TrieIter{
+				Trie: t.Trie,
+				idx:  t.idx + 1,
+			}
+		}
+		return nil
+	}
+	if t.children != nil {
+		child := t.children[ch]
+		if child != nil {
+			return &TrieIter{Trie: child}
+		}
+	}
+	return nil
+}
+
+// Value gets the value previously inserted at this node.
+func (t *TrieIter) Value() []byte {
+	if t == nil {
+		return nil
+	}
+	if t.idx == len(t.direct) {
+		return t.value
+	}
+	return nil
 }

--- a/engine/buildkit/secret_scrub_test.go
+++ b/engine/buildkit/secret_scrub_test.go
@@ -106,6 +106,7 @@ func TestScrubSecretWrite(t *testing.T) {
 	envMap := map[string]string{
 		"secret1":      "secret1 value",
 		"secret2":      "secret2",
+		"secret2b":     "secret2 more",
 		"sshSecretKey": sshSecretKey,
 		"sshPublicKey": sshPublicKey,
 	}
@@ -118,6 +119,7 @@ func TestScrubSecretWrite(t *testing.T) {
 	secretEnvs := []string{
 		"secret1",
 		"secret2",
+		"secret2b",
 		"sshSecretKey",
 		"sshPublicKey",
 	}
@@ -127,6 +129,7 @@ func TestScrubSecretWrite(t *testing.T) {
 			"aaa\n" + sshSecretKey + "\nbbb\nccc": "aaa\n***\nbbb\nccc",
 			"aaa" + sshSecretKey + "bbb\nccc":     "aaa***bbb\nccc",
 			sshSecretKey:                          "***",
+			strings.TrimSpace(sshSecretKey):       "***",
 		} {
 			var buf bytes.Buffer
 			r, err := NewSecretScrubReader(&buf, env, secretEnvs, []string{})
@@ -138,6 +141,7 @@ func TestScrubSecretWrite(t *testing.T) {
 			require.Equal(t, expectedOutput, string(out))
 		}
 	})
+
 	t.Run("single line secret", func(t *testing.T) {
 		var buf bytes.Buffer
 		r, err := NewSecretScrubReader(&buf, env, secretEnvs, []string{})
@@ -159,9 +163,11 @@ func TestScrubSecretWrite(t *testing.T) {
 		inputLines := []string{
 			"secret1 value",
 			"secret2",
+			"secret2 more",
 			"nonsecret",
 		}
 		outputLines := []string{
+			"***",
 			"***",
 			"***",
 			"nonsecret",

--- a/engine/buildkit/secret_scrub_test.go
+++ b/engine/buildkit/secret_scrub_test.go
@@ -513,6 +513,33 @@ func TestTrieExtend(t *testing.T) {
 	fmt.Println(trie)
 	require.Equal(t, []byte("bar"), trie.Step('f').Step('o').Step('o').Value())
 	require.Equal(t, []byte("bax"), trie.Step('f').Step('o').Step('o').Step('b').Value())
+
+	trie = Trie{}
+	trie.Insert([]byte("foo"), []byte("bar"))
+	trie.Insert([]byte("foobar"), []byte("qux"))
+	trie.Insert([]byte("foob"), []byte("bax"))
+	fmt.Println(trie)
+	require.Equal(t, []byte("bar"), trie.Step('f').Step('o').Step('o').Value())
+	require.Equal(t, []byte("bax"), trie.Step('f').Step('o').Step('o').Step('b').Value())
+	require.Equal(t, []byte("qux"), trie.Step('f').Step('o').Step('o').Step('b').Step('a').Step('r').Value())
+
+	trie = Trie{}
+	trie.Insert([]byte("foo"), []byte("bar"))
+	trie.Insert([]byte("foob"), []byte("bax"))
+	trie.Insert([]byte("foobar"), []byte("qux"))
+	fmt.Println(trie)
+	require.Equal(t, []byte("bar"), trie.Step('f').Step('o').Step('o').Value())
+	require.Equal(t, []byte("bax"), trie.Step('f').Step('o').Step('o').Step('b').Value())
+	require.Equal(t, []byte("qux"), trie.Step('f').Step('o').Step('o').Step('b').Step('a').Step('r').Value())
+
+	trie = Trie{}
+	trie.Insert([]byte("foo1"), []byte("bar"))
+	trie.Insert([]byte("foo2"), []byte("bax"))
+	trie.Insert([]byte("fax"), []byte("qux"))
+	fmt.Println(trie)
+	require.Equal(t, []byte("bar"), trie.Step('f').Step('o').Step('o').Step('1').Value())
+	require.Equal(t, []byte("bax"), trie.Step('f').Step('o').Step('o').Step('2').Value())
+	require.Equal(t, []byte("qux"), trie.Step('f').Step('a').Step('x').Value())
 }
 
 func TestTrieReinsert(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/dagger/dagger/issues/8032, and other assorted issues.

Imagine we have a secret like `foo\n` - we should also attempt to censor it in the output if we see `foo`. However, this is trickier than it initially seems - if we see `foo\n`, we should replace it with `***` - not `***\n`.
    
To do this, we modify the secret scrubber to be greedy, instead of eager. We now keep track of matches, and keep looking for more, instead of immediately replacing it.

Additionally, I've reworked the trie implementation to be more memory efficient (since having similar key prefixes in the above was starting to strain the implementation). On the way, I also discovered a nasty bug in which sometimes values could be silently dropped from the trie - I've fixed that and added a new test.

More detail available in each commit.