### PR TITLE
chore: remove accidental Echo method

### DIFF
--- a/cmd/codegen/generator/go/generator.go
+++ b/cmd/codegen/generator/go/generator.go
@@ -394,10 +394,6 @@ import (
 
 type %[1]s struct{}
 
-func (m *%[1]s) Echo(stringArg string) string {
-	return stringArg
-}
-
 // Returns a container that echoes whatever string argument is provided
 func (m *%[1]s) ContainerEcho(stringArg string) *dagger.Container {
 	return dag.Container().From("alpine:latest").WithExec([]string{"echo", stringArg})


### PR DESCRIPTION
This seems to have been accidentally added when removing go aliases (https://github.com/dagger/dagger/pull/7831/files#diff-9071102708f2192ab3f79607ad8aa444993a76461970710294b407e9db34289cR397-R399)

That was a mistake, and it shouldn't be there.