### PR TITLE
ci: fix linting flake from no clone issue

### DIFF
--- a/dev/main.go
+++ b/dev/main.go
@@ -43,8 +43,9 @@ func New(
 
 // Enable module auto-codegen when retrieving the dagger source code
 func (dev *DaggerDev) WithModCodegen() *DaggerDev {
-	dev.ModCodegen = true
-	return dev
+	clone := *dev
+	clone.ModCodegen = true
+	return &clone
 }
 
 // Check that everything works. Use this as CI entrypoint.


### PR DESCRIPTION
Fixes the following flake:
- Github actions: https://github.com/dagger/dagger/actions/runs/10149286653/job/28063879193
- Dagger trace: https://dagger.cloud/dagger/traces/3081ce038ac6bdc1af29ca8b3925a226

```
Error: response from query: input: daggerDev.engine.lint resolve: call function "Lint": process "/runtime" did not complete successfully: exit code: 2

Stdout:
invoke: input: dirdiff.assertEqual resolve: call function "AssertEqual": process "/runtime" did not complete successfully: exit code: 2

Stdout:
invoke: input: container.import.withMountedTemp.withMountedTemp.withWorkdir.withMountedDirectory.withMountedDirectory.withWorkdir.withExec.sync resolve: process "diff -r a b" did not complete successfully: exit code: 1

Stdout:
Only in b/dev: dagger.gen.go
Only in b/dev/dirdiff: dagger.gen.go
Only in b/dev/dirdiff: internal
Only in b/dev/go: dagger.gen.go
Only in b/dev/go: internal
Only in b/dev/golangci: dagger.gen.go
Only in b/dev/golangci: internal
Only in b/dev/graphql: dagger.gen.go
Only in b/dev/graphql: internal
Only in b/dev/internal: dagger
Only in b/dev/internal: querybuilder
Only in b/dev/internal: telemetry
Only in b/dev/markdown: dagger.gen.go
Only in b/dev/markdown: internal
Only in b/dev/shellcheck: dagger.gen.go
Only in b/dev/shellcheck: internal
Error: Process completed with exit code 2.
```

This flake occurs because `WithModCodegen` modifies the `dev` object - however, it is used in multiple different linters, one with the expectation that `ModCodegen` is set, and one without that expectation. This could cause a race condition where most of the time tests would pass, but occasionally they'd fail because the code executes concurrently and `ModCodegen` would end up set in the wrong place.