### PR TITLE
fix: extend multi git server support to Azure devOps

### DIFF
--- a/.changes/unreleased/Fixed-20240731-061239.yaml
+++ b/.changes/unreleased/Fixed-20240731-061239.yaml
@@ -2,7 +2,7 @@ kind: Fixed
 body: |
     feat: extend multi git server support to Azure devOps
 
-    Our support for Azure refs is broken on monorepos, as Azure returns a 500 when we query a ref containing a subpath with `go-get=1`. Instead, we rely on regexes to infer the root of the repo and the subpath from the ref
+    Our support for Azure refs was broken on monorepos. We special-case Azure DevOps since it doesn't work with the go standard convention of discovering the root of a git repository
 time: 2024-07-31T06:12:39.205696046Z
 custom:
     Author: grouville

--- a/.changes/unreleased/Fixed-20240731-061239.yaml
+++ b/.changes/unreleased/Fixed-20240731-061239.yaml
@@ -1,0 +1,9 @@
+kind: Fixed
+body: |
+    feat: extend multi git server support to Azure devOps
+
+    Our support for Azure refs is broken on monorepos, as Azure returns a 500 when we query a ref containing a subpath with `go-get=1`. Instead, we rely on regexes to infer the root of the repo and the subpath from the ref
+time: 2024-07-31T06:12:39.205696046Z
+custom:
+    Author: grouville
+    PR: "8063"

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -1390,6 +1390,14 @@ var vcsTestCases = []vcsTestCase{
 		expectedBaseHTMLURL:      "bitbucket.org/dagger-modules/dagger-test-modules-public",
 		expectedURLPathComponent: "src",
 	},
+	{
+		name:                     "Azure DevOps without .git",
+		gitTestRepoRef:           "dev.azure.com/daggere2e/public/_git/dagger-test-modules",
+		gitTestRepoCommit:        "8723e276a45b2e620ba3185cb07dc35e2be5bc86",
+		expectedHost:             "dev.azure.com",
+		expectedBaseHTMLURL:      "dev.azure.com/daggere2e/public/_git/dagger-test-modules",
+		expectedURLPathComponent: "commit",
+	},
 }
 
 func testOnMultipleVCS(t *testctx.T, testFunc func(ctx context.Context, t *testctx.T, tc vcsTestCase)) {
@@ -1421,7 +1429,13 @@ func (ModuleSuite) TestDaggerGitRefs(ctx context.Context, t *testctx.T) {
 
 			htmlURL, err := rootModSrc.AsGitSource().HTMLURL(ctx)
 			require.NoError(t, err)
-			require.Equal(t, fmt.Sprintf("https://%s/%s/%s", tc.expectedBaseHTMLURL, tc.expectedURLPathComponent, tc.gitTestRepoCommit), htmlURL)
+			var expectedURL string
+			if tc.expectedHost == "dev.azure.com" {
+				expectedURL = fmt.Sprintf("https://%s/%s/%s", tc.expectedBaseHTMLURL, tc.expectedURLPathComponent, tc.gitTestRepoCommit)
+			} else {
+				expectedURL = fmt.Sprintf("https://%s/%s/%s", tc.expectedBaseHTMLURL, tc.expectedURLPathComponent, tc.gitTestRepoCommit)
+			}
+			require.Equal(t, expectedURL, htmlURL)
 			resp, err := http.Get(htmlURL)
 			require.NoError(t, err)
 			defer resp.Body.Close()
@@ -1444,7 +1458,13 @@ func (ModuleSuite) TestDaggerGitRefs(ctx context.Context, t *testctx.T) {
 			topLevelModSrc := c.ModuleSource(testGitModuleRef(tc, "top-level"))
 			htmlURL, err := topLevelModSrc.AsGitSource().HTMLURL(ctx)
 			require.NoError(t, err)
-			require.Equal(t, fmt.Sprintf("https://%s/%s/%s/top-level", tc.expectedBaseHTMLURL, tc.expectedURLPathComponent, tc.gitTestRepoCommit), htmlURL)
+			var expectedURL string
+			if tc.expectedHost == "dev.azure.com" {
+				expectedURL = fmt.Sprintf("https://%s/%s/%s?path=/top-level", tc.expectedBaseHTMLURL, tc.expectedURLPathComponent, tc.gitTestRepoCommit)
+			} else {
+				expectedURL = fmt.Sprintf("https://%s/%s/%s/top-level", tc.expectedBaseHTMLURL, tc.expectedURLPathComponent, tc.gitTestRepoCommit)
+			}
+			require.Equal(t, expectedURL, htmlURL)
 
 			resp, err := http.Get(htmlURL)
 			require.NoError(t, err)
@@ -1468,7 +1488,13 @@ func (ModuleSuite) TestDaggerGitRefs(ctx context.Context, t *testctx.T) {
 			subdirDepModSrc := c.ModuleSource(testGitModuleRef(tc, "subdir/dep2"))
 			htmlURL, err := subdirDepModSrc.AsGitSource().HTMLURL(ctx)
 			require.NoError(t, err)
-			require.Equal(t, fmt.Sprintf("https://%s/%s/%s/subdir/dep2", tc.expectedBaseHTMLURL, tc.expectedURLPathComponent, tc.gitTestRepoCommit), htmlURL)
+			var expectedURL string
+			if tc.expectedHost == "dev.azure.com" {
+				expectedURL = fmt.Sprintf("https://%s/%s/%s?path=/subdir/dep2", tc.expectedBaseHTMLURL, tc.expectedURLPathComponent, tc.gitTestRepoCommit)
+			} else {
+				expectedURL = fmt.Sprintf("https://%s/%s/%s/subdir/dep2", tc.expectedBaseHTMLURL, tc.expectedURLPathComponent, tc.gitTestRepoCommit)
+			}
+			require.Equal(t, expectedURL, htmlURL)
 
 			resp, err := http.Get(htmlURL)
 			require.NoError(t, err)

--- a/core/integration/module_config_test.go
+++ b/core/integration/module_config_test.go
@@ -1362,6 +1362,8 @@ type vcsTestCase struct {
 	expectedBaseHTMLURL string
 	// path separator to access `tree` view of src at commit, per provider
 	expectedURLPathComponent string
+	// Azure needs a path prefix
+	expectedPathPrefix string
 }
 
 var vcsTestCases = []vcsTestCase{
@@ -1373,6 +1375,7 @@ var vcsTestCases = []vcsTestCase{
 		expectedHost:             "github.com",
 		expectedBaseHTMLURL:      "github.com/dagger/dagger-test-modules",
 		expectedURLPathComponent: "tree",
+		expectedPathPrefix:       "",
 	},
 	{
 		name:                     "GitLab without .git",
@@ -1381,6 +1384,7 @@ var vcsTestCases = []vcsTestCase{
 		expectedHost:             "gitlab.com",
 		expectedBaseHTMLURL:      "gitlab.com/dagger-modules/test/more/dagger-test-modules-public",
 		expectedURLPathComponent: "tree",
+		expectedPathPrefix:       "",
 	},
 	{
 		name:                     "BitBucket without .git",
@@ -1389,6 +1393,7 @@ var vcsTestCases = []vcsTestCase{
 		expectedHost:             "bitbucket.org",
 		expectedBaseHTMLURL:      "bitbucket.org/dagger-modules/dagger-test-modules-public",
 		expectedURLPathComponent: "src",
+		expectedPathPrefix:       "",
 	},
 	{
 		name:                     "Azure DevOps without .git",
@@ -1397,6 +1402,7 @@ var vcsTestCases = []vcsTestCase{
 		expectedHost:             "dev.azure.com",
 		expectedBaseHTMLURL:      "dev.azure.com/daggere2e/public/_git/dagger-test-modules",
 		expectedURLPathComponent: "commit",
+		expectedPathPrefix:       "?path=",
 	},
 }
 
@@ -1429,12 +1435,7 @@ func (ModuleSuite) TestDaggerGitRefs(ctx context.Context, t *testctx.T) {
 
 			htmlURL, err := rootModSrc.AsGitSource().HTMLURL(ctx)
 			require.NoError(t, err)
-			var expectedURL string
-			if tc.expectedHost == "dev.azure.com" {
-				expectedURL = fmt.Sprintf("https://%s/%s/%s", tc.expectedBaseHTMLURL, tc.expectedURLPathComponent, tc.gitTestRepoCommit)
-			} else {
-				expectedURL = fmt.Sprintf("https://%s/%s/%s", tc.expectedBaseHTMLURL, tc.expectedURLPathComponent, tc.gitTestRepoCommit)
-			}
+			expectedURL := fmt.Sprintf("https://%s/%s/%s", tc.expectedBaseHTMLURL, tc.expectedURLPathComponent, tc.gitTestRepoCommit)
 			require.Equal(t, expectedURL, htmlURL)
 			resp, err := http.Get(htmlURL)
 			require.NoError(t, err)
@@ -1458,12 +1459,7 @@ func (ModuleSuite) TestDaggerGitRefs(ctx context.Context, t *testctx.T) {
 			topLevelModSrc := c.ModuleSource(testGitModuleRef(tc, "top-level"))
 			htmlURL, err := topLevelModSrc.AsGitSource().HTMLURL(ctx)
 			require.NoError(t, err)
-			var expectedURL string
-			if tc.expectedHost == "dev.azure.com" {
-				expectedURL = fmt.Sprintf("https://%s/%s/%s?path=/top-level", tc.expectedBaseHTMLURL, tc.expectedURLPathComponent, tc.gitTestRepoCommit)
-			} else {
-				expectedURL = fmt.Sprintf("https://%s/%s/%s/top-level", tc.expectedBaseHTMLURL, tc.expectedURLPathComponent, tc.gitTestRepoCommit)
-			}
+			expectedURL := fmt.Sprintf("https://%s/%s/%s%s/top-level", tc.expectedBaseHTMLURL, tc.expectedURLPathComponent, tc.gitTestRepoCommit, tc.expectedPathPrefix)
 			require.Equal(t, expectedURL, htmlURL)
 
 			resp, err := http.Get(htmlURL)
@@ -1488,12 +1484,7 @@ func (ModuleSuite) TestDaggerGitRefs(ctx context.Context, t *testctx.T) {
 			subdirDepModSrc := c.ModuleSource(testGitModuleRef(tc, "subdir/dep2"))
 			htmlURL, err := subdirDepModSrc.AsGitSource().HTMLURL(ctx)
 			require.NoError(t, err)
-			var expectedURL string
-			if tc.expectedHost == "dev.azure.com" {
-				expectedURL = fmt.Sprintf("https://%s/%s/%s?path=/subdir/dep2", tc.expectedBaseHTMLURL, tc.expectedURLPathComponent, tc.gitTestRepoCommit)
-			} else {
-				expectedURL = fmt.Sprintf("https://%s/%s/%s/subdir/dep2", tc.expectedBaseHTMLURL, tc.expectedURLPathComponent, tc.gitTestRepoCommit)
-			}
+			expectedURL := fmt.Sprintf("https://%s/%s/%s%s/subdir/dep2", tc.expectedBaseHTMLURL, tc.expectedURLPathComponent, tc.gitTestRepoCommit, tc.expectedPathPrefix)
 			require.Equal(t, expectedURL, htmlURL)
 
 			resp, err := http.Get(htmlURL)

--- a/core/modulesource.go
+++ b/core/modulesource.go
@@ -475,12 +475,17 @@ func (src *GitModuleSource) HTMLURL() string {
 		return src.CloneURL + path.Join("/src", src.Commit, src.RootSubpath)
 	}
 
-	pathPrefix := "/src"
-	if parsedURL.Host == "github.com" || parsedURL.Host == "gitlab.com" {
-		pathPrefix = "/tree"
+	switch parsedURL.Host {
+	case "github.com", "gitlab.com":
+		return src.CloneURL + path.Join("/tree", src.Commit, src.RootSubpath)
+	case "dev.azure.com":
+		if src.RootSubpath != "" {
+			return fmt.Sprintf("%s/commit/%s?path=/%s", src.CloneURL, src.Commit, src.RootSubpath)
+		}
+		return src.CloneURL + path.Join("/commit", src.Commit)
+	default:
+		return src.CloneURL + path.Join("/src", src.Commit, src.RootSubpath)
 	}
-
-	return src.CloneURL + path.Join(pathPrefix, src.Commit, src.RootSubpath)
 }
 
 type ModuleSourceView struct {

--- a/engine/vcs/vcs.go
+++ b/engine/vcs/vcs.go
@@ -652,6 +652,30 @@ var vcsPaths = []*vcsPath{
 		repo:   "https://{root}",
 	},
 
+	// Azure DevOps
+	// HTTPS ref
+	{
+		prefix: "dev.azure.com/",
+		re:     `^(?P<root>dev\.azure\.com/(?P<account>[A-Za-z0-9_.\-]+)(/(?P<project>[A-Za-z0-9_.\-]+))?/_git/(?P<repo>[A-Za-z0-9_.\-]+)(\.git)?)(/[\p{L}0-9_.\-]+)*(/.*)?$`,
+		vcs:    "git",
+		repo:   "https://{root}",
+		check: func(match map[string]string) error {
+			match["repo"] = strings.TrimSuffix(match["repo"], ".git")
+			return nil
+		},
+	},
+	// SSH ref
+	{
+		prefix: "ssh.dev.azure.com/",
+		re:     `^(?P<root>ssh\.dev\.azure\.com/v\d+/(?P<account>[A-Za-z0-9_.\-]+)/(?P<project>[A-Za-z0-9_.\-]+)/(?P<repo>[A-Za-z0-9_.\-]+))(/[\p{L}0-9_.\-]+)*(/.*)?$`,
+		vcs:    "git",
+		repo:   "https://dev.azure.com/{account}/{project}/_git/{repo}",
+		check: func(match map[string]string) error {
+			match["repo"] = strings.TrimSuffix(match["repo"], ".git")
+			return nil
+		},
+	},
+
 	// General syntax for any server.
 	{
 		re:   `^(?P<root>(?P<repo>([a-z0-9.\-]+\.)+[a-z0-9.\-]+(:[0-9]+)?/[A-Za-z0-9_.\-/]*?)\.(?P<vcs>bzr|git|hg|svn))(/[A-Za-z0-9_.\-]+)*(/.*)?$`,

--- a/engine/vcs/vcs_test.go
+++ b/engine/vcs/vcs_test.go
@@ -227,6 +227,63 @@ func TestRepoRootForImportPath(t *testing.T) {
 				Root: "codeberg.org/workspace/pkgname",
 			},
 		},
+
+		// Azure DevOps
+		// short HTTPS ref, with format: user, org and where repo name == org name
+		{
+			"dev.azure.com/dagger-e2e/_git/dagger-modules-test-public/depth1/depth2",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://dev.azure.com/dagger-e2e/_git/dagger-modules-test-public",
+				Root: "dev.azure.com/dagger-e2e/_git/dagger-modules-test-public",
+			},
+		},
+		{
+			"dev.azure.com/dagger-e2e/_git/dagger-modules-test-public.git/depth1/depth2",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://dev.azure.com/dagger-e2e/_git/dagger-modules-test-public",
+				Root: "dev.azure.com/dagger-e2e/_git/dagger-modules-test-public.git",
+			},
+		},
+
+		// HTTPS ref, with format: user, org and repo name != org name
+		{
+			"dev.azure.com/daggere2e/public/_git/dagger-test-modules/depth1/depth2",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://dev.azure.com/daggere2e/public/_git/dagger-test-modules",
+				Root: "dev.azure.com/daggere2e/public/_git/dagger-test-modules",
+			},
+		},
+		// ⚠️ Azure requires auth when cloning on this format, will have to be used conjointly with PAT
+		{
+			"dev.azure.com/daggere2e/public/_git/dagger-test-modules.git/depth1/depth2",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://dev.azure.com/daggere2e/public/_git/dagger-test-modules",
+				Root: "dev.azure.com/daggere2e/public/_git/dagger-test-modules.git",
+			},
+		},
+
+		// SSH ref - new ref style
+		// https://learn.microsoft.com/en-us/azure/devops/repos/git/use-ssh-keys-to-authenticate?view=azure-devops
+		{
+			"ssh.dev.azure.com/v3/daggere2e/private/dagger-test-modules/depth1/depth2",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://dev.azure.com/daggere2e/private/_git/dagger-test-modules",
+				Root: "ssh.dev.azure.com/v3/daggere2e/private/dagger-test-modules",
+			},
+		},
+		{
+			"ssh.dev.azure.com/v3/daggere2e/private/dagger-test-modules.git/depth1/depth2",
+			&RepoRoot{
+				VCS:  vcsGit,
+				Repo: "https://dev.azure.com/daggere2e/private/_git/dagger-test-modules",
+				Root: "ssh.dev.azure.com/v3/daggere2e/private/dagger-test-modules.git",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -248,6 +305,9 @@ func TestRepoRootForImportPath(t *testing.T) {
 		}
 		if got.VCS.Name != want.VCS.Name || got.Repo != want.Repo {
 			t.Errorf("RepoRootForImportPath(%q) = VCS(%s) Repo(%s), want VCS(%s) Repo(%s)", test.path, got.VCS, got.Repo, want.VCS, want.Repo)
+		}
+		if got.Root != want.Root {
+			t.Errorf("RepoRootForImportPath(%q) = VCS(%s) Root(%s), want VCS(%s) Root(%s)", test.path, got.VCS, got.Root, want.VCS, want.Root)
 		}
 	}
 }


### PR DESCRIPTION
When working on private SSH support, I realized that our support for Azure refs is broken on monorepos.

**Why ?**
 Azure's handling of `go-get=1` is not foolproof:
1. `repoRootForImportPath` does work well on refs leading to a repo, infering properly the vcs provider used
2. But,  `go-get=1` returns a 500 when a subpath is included
3. Azure ref's style is explicit with the vcs being used: git is mentioned for a git based repo

If we are ok with this explicitness, we should not try to infer the vcs based on the go-get for Azure and rely on regexes