### PR TITLE
feat: add elixir/php sdk aliases

### DIFF
--- a/.changes/unreleased/Added-20240731-134929.yaml
+++ b/.changes/unreleased/Added-20240731-134929.yaml
@@ -1,0 +1,9 @@
+kind: Added
+body: |-
+  New SDK aliases for `elixir` and `php`
+
+  SDKs with experimental module support (elixir and php) can now be accessed using `--sdk=<sdk>` (such as `--sdk=elixir` and `--sdk=php` respectively) instead of the full form `--sdk=github.com/dagger/dagger/sdk/<sdk>@<version>`.
+time: 2024-07-31T13:49:29.069938099+01:00
+custom:
+  Author: jedevc
+  PR: "8067"

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -426,6 +426,100 @@ func (m *HasNotMainGo) Hello() string { return "Hello, world!" }
 	})
 }
 
+func (ModuleSuite) TestElixirInit(ctx context.Context, t *testctx.T) {
+	t.Run("from upstream", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		modGen := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work").
+			With(daggerExec("init", "--name=bare", "--sdk=github.com/dagger/dagger/sdk/elixir"))
+
+		out, err := modGen.
+			With(daggerQuery(`{bare{containerEcho(stringArg:"hello"){stdout}}}`)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"bare":{"containerEcho":{"stdout":"hello\n"}}}`, out)
+	})
+
+	t.Run("from alias", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		modGen := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work").
+			With(daggerExec("init", "--name=bare", "--sdk=elixir"))
+
+		out, err := modGen.
+			With(daggerQuery(`{bare{containerEcho(stringArg:"hello"){stdout}}}`)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"bare":{"containerEcho":{"stdout":"hello\n"}}}`, out)
+	})
+
+	t.Run("from alias with ref", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		modGen := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work").
+			With(daggerExec("init", "--name=bare", "--sdk=elixir@main"))
+
+		out, err := modGen.
+			With(daggerQuery(`{bare{containerEcho(stringArg:"hello"){stdout}}}`)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"bare":{"containerEcho":{"stdout":"hello\n"}}}`, out)
+	})
+}
+
+func (ModuleSuite) TestPHPInit(ctx context.Context, t *testctx.T) {
+	t.Run("from upstream", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		modGen := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work").
+			With(daggerExec("init", "--name=bare", "--sdk=github.com/dagger/dagger/sdk/php"))
+
+		out, err := modGen.
+			With(daggerQuery(`{bare{containerEcho(stringArg:"hello"){stdout}}}`)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"bare":{"containerEcho":{"stdout":"hello\n"}}}`, out)
+	})
+
+	t.Run("from alias", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		modGen := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work").
+			With(daggerExec("init", "--name=bare", "--sdk=php"))
+
+		out, err := modGen.
+			With(daggerQuery(`{bare{containerEcho(stringArg:"hello"){stdout}}}`)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"bare":{"containerEcho":{"stdout":"hello\n"}}}`, out)
+	})
+
+	t.Run("from alias with ref", func(ctx context.Context, t *testctx.T) {
+		c := connect(ctx, t)
+
+		modGen := c.Container().From(golangImage).
+			WithMountedFile(testCLIBinPath, daggerCliFile(t, c)).
+			WithWorkdir("/work").
+			With(daggerExec("init", "--name=bare", "--sdk=php@main"))
+
+		out, err := modGen.
+			With(daggerQuery(`{bare{containerEcho(stringArg:"hello"){stdout}}}`)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"bare":{"containerEcho":{"stdout":"hello\n"}}}`, out)
+	})
+}
+
 func (ModuleSuite) TestInitLICENSE(ctx context.Context, t *testctx.T) {
 	t.Run("bootstraps Apache-2.0 LICENSE file if none found", func(ctx context.Context, t *testctx.T) {
 		c := connect(ctx, t)

--- a/sdk/php/runtime/template/src/Example.php
+++ b/sdk/php/runtime/template/src/Example.php
@@ -21,7 +21,7 @@ class Example
          return dag()
              ->container()
              ->from('alpine:latest')
-             ->withExec(['echo', $value]);
+             ->withExec(['echo', $stringArg]);
      }
 
     #[DaggerFunction('Returns lines that match a pattern in the files of the provided Directory')]
@@ -34,7 +34,7 @@ class Example
          return dag()
              ->container()
              ->from('alpine:latest')
-             ->withMountedDirectory('/mnt', $directory)
+             ->withMountedDirectory('/mnt', $directoryArg)
              ->withWorkdir('/mnt')
              ->withExec(["grep", '-R', $pattern, '.'])
              ->stdout();


### PR DESCRIPTION
This allows users to use `elixir` to use the elixir SDK, and `php` to use the php SDK, without needing the full `github.com/dagger/dagger/sdk/<sdk>/runtime@<version>` URL which is very unieldy.

~~:warning: requires https://github.com/dagger/dagger/pull/7858 so that we can access `engine.Tag` which is the version of the release, so the v0.12.4 release will correctly point this to `github.com/dagger/dagger/sdk/<sdk>/runtime@v0.12.4`.~~