### PR TITLE
feat: Support custom objects in PHP SDK runtime

### DIFF
--- a/sdk/php/composer.json
+++ b/sdk/php/composer.json
@@ -7,6 +7,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=8.2",
+        "jms/serializer": "^3.30",
         "roave/better-reflection": "^6.25",
         "symfony/process": "^6.3|^7.0",
         "symfony/console": "^6.3|^7.0",

--- a/sdk/php/composer.lock
+++ b/sdk/php/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "febf91fe2cf901eb7b90fe83ba07d2f9",
+    "content-hash": "4d863ad66018cacf5f9c67d671a01e28",
     "packages": [
         {
             "name": "carnage/php-graphql-client",
@@ -70,6 +70,153 @@
                 "source": "https://github.com/carnage/php-graphql-client/tree/1.14.0"
             },
             "time": "2024-06-17T12:14:59+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^11",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-30T00:23:10+00:00"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd",
+                "reference": "31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^12",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^10.5",
+                "psalm/plugin-phpunit": "^0.18.3",
+                "vimeo/psalm": "^5.21"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "lexer",
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/lexer/issues",
+                "source": "https://github.com/doctrine/lexer/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-02-05T11:56:58+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -444,6 +591,167 @@
             "time": "2024-03-07T11:03:05+00:00"
         },
         {
+            "name": "jms/metadata",
+            "version": "2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/schmittjoh/metadata.git",
+                "reference": "7ca240dcac0c655eb15933ee55736ccd2ea0d7a6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/schmittjoh/metadata/zipball/7ca240dcac0c655eb15933ee55736ccd2ea0d7a6",
+                "reference": "7ca240dcac0c655eb15933ee55736ccd2ea0d7a6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "require-dev": {
+                "doctrine/cache": "^1.0",
+                "doctrine/coding-standard": "^8.0",
+                "mikey179/vfsstream": "^1.6.7",
+                "phpunit/phpunit": "^8.5|^9.0",
+                "psr/container": "^1.0|^2.0",
+                "symfony/cache": "^3.1|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.1|^4.0|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Metadata\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Johannes M. Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                }
+            ],
+            "description": "Class/method/property metadata management in PHP",
+            "keywords": [
+                "annotations",
+                "metadata",
+                "xml",
+                "yaml"
+            ],
+            "support": {
+                "issues": "https://github.com/schmittjoh/metadata/issues",
+                "source": "https://github.com/schmittjoh/metadata/tree/2.8.0"
+            },
+            "time": "2023-02-15T13:44:18+00:00"
+        },
+        {
+            "name": "jms/serializer",
+            "version": "3.30.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/schmittjoh/serializer.git",
+                "reference": "bf1105358123d7c02ee6cad08ea33ab535a09d5e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/schmittjoh/serializer/zipball/bf1105358123d7c02ee6cad08ea33ab535a09d5e",
+                "reference": "bf1105358123d7c02ee6cad08ea33ab535a09d5e",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.3.1 || ^2.0",
+                "doctrine/lexer": "^2.0 || ^3.0",
+                "jms/metadata": "^2.6",
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpdoc-parser": "^1.20"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.14 || ^2.0",
+                "doctrine/coding-standard": "^12.0",
+                "doctrine/orm": "^2.14 || ^3.0",
+                "doctrine/persistence": "^2.5.2 || ^3.0",
+                "doctrine/phpcr-odm": "^1.5.2 || ^2.0",
+                "ext-pdo_sqlite": "*",
+                "jackalope/jackalope-doctrine-dbal": "^1.3",
+                "ocramius/proxy-manager": "^1.0 || ^2.0",
+                "phpbench/phpbench": "^1.0",
+                "phpstan/phpstan": "^1.0.2",
+                "phpunit/phpunit": "^9.0 || ^10.0",
+                "psr/container": "^1.0 || ^2.0",
+                "rector/rector": "^0.19.0",
+                "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
+                "symfony/expression-language": "^5.4 || ^6.0 || ^7.0",
+                "symfony/filesystem": "^5.4 || ^6.0 || ^7.0",
+                "symfony/form": "^5.4 || ^6.0 || ^7.0",
+                "symfony/translation": "^5.4 || ^6.0 || ^7.0",
+                "symfony/uid": "^5.4 || ^6.0 || ^7.0",
+                "symfony/validator": "^5.4 || ^6.0 || ^7.0",
+                "symfony/yaml": "^5.4 || ^6.0 || ^7.0",
+                "twig/twig": "^1.34 || ^2.4 || ^3.0"
+            },
+            "suggest": {
+                "doctrine/collections": "Required if you like to use doctrine collection types as ArrayCollection.",
+                "symfony/cache": "Required if you like to use cache functionality.",
+                "symfony/uid": "Required if you'd like to serialize UID objects.",
+                "symfony/yaml": "Required if you'd like to use the YAML metadata format."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JMS\\Serializer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Johannes M. Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                }
+            ],
+            "description": "Library for (de-)serializing data of any complexity; supports XML, and JSON.",
+            "homepage": "http://jmsyst.com/libs/serializer",
+            "keywords": [
+                "deserialization",
+                "jaxb",
+                "json",
+                "serialization",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/schmittjoh/serializer/issues",
+                "source": "https://github.com/schmittjoh/serializer/tree/3.30.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/goetas",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-02-24T14:12:14+00:00"
+        },
+        {
             "name": "nikic/php-parser",
             "version": "v5.1.0",
             "source": {
@@ -500,6 +808,53 @@
                 "source": "https://github.com/nikic/PHP-Parser/tree/v5.1.0"
             },
             "time": "2024-07-01T20:03:41+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.29.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "fcaefacf2d5c417e928405b71b400d4ce10daaf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fcaefacf2d5c417e928405b71b400d4ce10daaf4",
+                "reference": "fcaefacf2d5c417e928405b71b400d4ce10daaf4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^4.15",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.29.1"
+            },
+            "time": "2024-05-31T08:52:43+00:00"
         },
         {
             "name": "psr/container",
@@ -879,16 +1234,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.1.2",
+            "version": "v7.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "0aa29ca177f432ab68533432db0de059f39c92ae"
+                "reference": "cb1dcb30ebc7005c29864ee78adb47b5fb7c3cd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/0aa29ca177f432ab68533432db0de059f39c92ae",
-                "reference": "0aa29ca177f432ab68533432db0de059f39c92ae",
+                "url": "https://api.github.com/repos/symfony/console/zipball/cb1dcb30ebc7005c29864ee78adb47b5fb7c3cd9",
+                "reference": "cb1dcb30ebc7005c29864ee78adb47b5fb7c3cd9",
                 "shasum": ""
             },
             "require": {
@@ -952,7 +1307,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.1.2"
+                "source": "https://github.com/symfony/console/tree/v7.1.3"
             },
             "funding": [
                 {
@@ -968,7 +1323,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-28T10:03:55+00:00"
+            "time": "2024-07-26T12:41:01+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -1357,16 +1712,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.1.1",
+            "version": "v7.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "febf90124323a093c7ee06fdb30e765ca3c20028"
+                "reference": "7f2f542c668ad6c313dc4a5e9c3321f733197eca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/febf90124323a093c7ee06fdb30e765ca3c20028",
-                "reference": "febf90124323a093c7ee06fdb30e765ca3c20028",
+                "url": "https://api.github.com/repos/symfony/process/zipball/7f2f542c668ad6c313dc4a5e9c3321f733197eca",
+                "reference": "7f2f542c668ad6c313dc4a5e9c3321f733197eca",
                 "shasum": ""
             },
             "require": {
@@ -1398,7 +1753,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.1.1"
+                "source": "https://github.com/symfony/process/tree/v7.1.3"
             },
             "funding": [
                 {
@@ -1414,7 +1769,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:57:53+00:00"
+            "time": "2024-07-26T12:44:47+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -1501,16 +1856,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.1.2",
+            "version": "v7.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "14221089ac66cf82e3cf3d1c1da65de305587ff8"
+                "reference": "ea272a882be7f20cad58d5d78c215001617b7f07"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/14221089ac66cf82e3cf3d1c1da65de305587ff8",
-                "reference": "14221089ac66cf82e3cf3d1c1da65de305587ff8",
+                "url": "https://api.github.com/repos/symfony/string/zipball/ea272a882be7f20cad58d5d78c215001617b7f07",
+                "reference": "ea272a882be7f20cad58d5d78c215001617b7f07",
                 "shasum": ""
             },
             "require": {
@@ -1568,7 +1923,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.1.2"
+                "source": "https://github.com/symfony/string/tree/v7.1.3"
             },
             "funding": [
                 {
@@ -1584,7 +1939,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-28T09:27:18+00:00"
+            "time": "2024-07-22T10:25:37+00:00"
         }
     ],
     "packages-dev": [
@@ -2297,16 +2652,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.2.8",
+            "version": "11.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a7a29e8d3113806f18f99d670f580a30e8ffff39"
+                "reference": "c197bbaaca360efda351369bf1fd9cc1ca6bcbf7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a7a29e8d3113806f18f99d670f580a30e8ffff39",
-                "reference": "a7a29e8d3113806f18f99d670f580a30e8ffff39",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c197bbaaca360efda351369bf1fd9cc1ca6bcbf7",
+                "reference": "c197bbaaca360efda351369bf1fd9cc1ca6bcbf7",
                 "shasum": ""
             },
             "require": {
@@ -2377,7 +2732,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.2.8"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.2.9"
             },
             "funding": [
                 {
@@ -2393,7 +2748,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-18T14:56:37+00:00"
+            "time": "2024-07-30T11:09:23+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/sdk/php/src/Service/Serialisation/AbstractScalarHandler.php
+++ b/sdk/php/src/Service/Serialisation/AbstractScalarHandler.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dagger\Service\Serialisation;
+
+use Dagger\Client\AbstractScalar;
+use JMS\Serializer\Context;
+use JMS\Serializer\GraphNavigatorInterface;
+use JMS\Serializer\Handler\SubscribingHandlerInterface;
+use JMS\Serializer\JsonDeserializationVisitor;
+use JMS\Serializer\JsonSerializationVisitor;
+
+final readonly class AbstractScalarHandler implements SubscribingHandlerInterface
+{
+    /**
+     * @return array<array{
+     *     direction: 1|2,
+     *     format: string,
+     *     type: string,
+     *     method: string,
+     * }>
+     */
+    public static function getSubscribingMethods(): array
+    {
+        return [
+            [
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
+                'format' => 'json',
+                'type' => AbstractScalar::class,
+                'method' => 'serialise',
+            ],
+            [
+                'direction' => GraphNavigatorInterface::DIRECTION_DESERIALIZATION,
+                'format' => 'json',
+                'type' => AbstractScalar::class,
+                'method' => 'deserialise'
+            ],
+        ];
+
+    }
+
+    public function serialise(
+        JsonSerializationVisitor $visitor,
+        AbstractScalar $abstractScalar,
+        array $type,
+        Context $context
+    ): string {
+        return (string) $abstractScalar;
+    }
+
+    public function deserialise(
+        JsonDeserializationVisitor $visitor,
+        string $abstractScalar,
+        array $type,
+        Context $context
+    ): AbstractScalar {
+        $originalClassName = $type['params'][
+            AbstractScalarSubscriber::ORIGINAL_CLASS_NAME
+        ];
+
+        return new $originalClassName($abstractScalar);
+    }
+}

--- a/sdk/php/src/Service/Serialisation/AbstractScalarSubscriber.php
+++ b/sdk/php/src/Service/Serialisation/AbstractScalarSubscriber.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dagger\Service\Serialisation;
+
+use Dagger\Client\AbstractScalar;
+use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
+use JMS\Serializer\EventDispatcher\PreDeserializeEvent;
+use JMS\Serializer\EventDispatcher\PreSerializeEvent;
+
+final readonly class AbstractScalarSubscriber implements EventSubscriberInterface
+{
+    public const ORIGINAL_CLASS_NAME =
+        'The original class name before ' .
+        'being changed to ' .
+        AbstractScalar::class;
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            [
+                'event' => 'serializer.pre_serialize',
+                'method' => 'onPreSerialize',
+                'format' => 'json',
+                'priority' => 0,
+            ],
+            [
+                'event' => 'serializer.pre_deserialize',
+                'method' => 'onPreDeserialize',
+                'format' => 'json',
+                'priority' => 0,
+            ],
+        ];
+    }
+
+    public function onPreSerialize(PreSerializeEvent $event): void
+    {
+        if ($event->getObject() instanceof AbstractScalar) {
+            $event->setType(AbstractScalar::class);
+        }
+    }
+
+    public function onPreDeserialize(PreDeserializeEvent $event): void
+    {
+        $className = $event->getType()['name'];
+
+        if (
+            !class_exists($className)
+            || !in_array(AbstractScalar::class, class_parents($className))
+        ) {
+            return;
+        }
+
+        $event->setType(AbstractScalar::class, array_merge_recursive(
+            $event->getType()['params'],
+            [self::ORIGINAL_CLASS_NAME => $className]
+        ));
+    }
+}

--- a/sdk/php/src/Service/Serialisation/IdableHandler.php
+++ b/sdk/php/src/Service/Serialisation/IdableHandler.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dagger\Service\Serialisation;
+
+use Dagger\Client;
+use Dagger\Client\AbstractScalar;
+use Dagger\Client\IdAble;
+use JMS\Serializer\Context;
+use JMS\Serializer\GraphNavigatorInterface;
+use JMS\Serializer\Handler\SubscribingHandlerInterface;
+use JMS\Serializer\JsonDeserializationVisitor;
+use JMS\Serializer\JsonSerializationVisitor;
+use ReflectionClass;
+
+final readonly class IdableHandler implements SubscribingHandlerInterface
+{
+    public function __construct(
+        private Client $client,
+    ) {}
+
+    /**
+     * @return array<array{
+     *     direction: 1|2,
+     *     format: string,
+     *     type: string,
+     *     method: string,
+     * }>
+     */
+    public static function getSubscribingMethods(): array
+    {
+        return [
+            [
+                'direction' => GraphNavigatorInterface::DIRECTION_SERIALIZATION,
+                'format' => 'json',
+                'type' => IdAble::class,
+                'method' => 'serialise',
+            ],
+            [
+                'direction' => GraphNavigatorInterface::DIRECTION_DESERIALIZATION,
+                'format' => 'json',
+                'type' => IdAble::class,
+                'method' => 'deserialise'
+            ],
+        ];
+
+    }
+
+    public function serialise(
+        JsonSerializationVisitor $visitor,
+        IdAble $idAble,
+        array $type,
+        Context $context
+    ): string {
+        return (string) $idAble->id();
+    }
+
+    public function deserialise(
+        JsonDeserializationVisitor $visitor,
+        string $idAble,
+        array $type,
+        Context $context,
+    ): IdAble {
+        $originalClassName = $type['params'][
+            IdableSubscriber::ORIGINAL_CLASS_NAME
+        ];
+
+        $shortName = (new ReflectionClass($originalClassName))->getShortName();
+        $method = sprintf('load%sFromId', $shortName);
+        $id = sprintf('%sId', $originalClassName);
+
+        return $this->client->$method(new $id($idAble));
+    }
+}

--- a/sdk/php/src/Service/Serialisation/IdableSubscriber.php
+++ b/sdk/php/src/Service/Serialisation/IdableSubscriber.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dagger\Service\Serialisation;
+
+use Dagger\Client\AbstractScalar;
+use Dagger\Client\IdAble;
+use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
+use JMS\Serializer\EventDispatcher\PreDeserializeEvent;
+use JMS\Serializer\EventDispatcher\PreSerializeEvent;
+
+final readonly class IdableSubscriber implements EventSubscriberInterface
+{
+    public const ORIGINAL_CLASS_NAME =
+        'The original class name before ' .
+        'being changed to ' .
+        IdAble::class;
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            [
+                'event' => 'serializer.pre_serialize',
+                'method' => 'onPreSerialize',
+                'format' => 'json',
+                'priority' => 0,
+            ],
+            [
+                'event' => 'serializer.pre_deserialize',
+                'method' => 'onPreDeserialize',
+                'format' => 'json',
+                'priority' => 0,
+            ],
+        ];
+    }
+
+    public function onPreSerialize(PreSerializeEvent $event): void
+    {
+        if ($event->getObject() instanceof IdAble) {
+            $event->setType(IdAble::class);
+        }
+    }
+
+    public function onPreDeserialize(PreDeserializeEvent $event): void
+    {
+        $className = $event->getType()['name'];
+
+        if (
+            !class_exists($className)
+            || !in_array(IdAble::class, class_implements($className))
+        ) {
+            return;
+        }
+
+        $event->setType(IdAble::class, array_merge_recursive(
+            $event->getType()['params'],
+            [self::ORIGINAL_CLASS_NAME => $className]
+        ));
+    }
+}

--- a/sdk/php/src/Service/Serialisation/Serialiser.php
+++ b/sdk/php/src/Service/Serialisation/Serialiser.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dagger\Service\Serialisation;
+
+use JMS\Serializer\EventDispatcher\EventDispatcher;
+use JMS\Serializer\EventDispatcher\PreDeserializeEvent;
+use JMS\Serializer\EventDispatcher\PreSerializeEvent;
+use JMS\Serializer\Handler\HandlerRegistry;
+use JMS\Serializer\Handler\SubscribingHandlerInterface;
+use JMS\Serializer\SerializationContext;
+use JMS\Serializer\Serializer;
+use JMS\Serializer\SerializerBuilder;
+
+final readonly class Serialiser
+{
+    private Serializer $serializer;
+
+    /**
+     * @param \JMS\Serializer\EventDispatcher\EventSubscriberInterface[] $subscribers
+     * @param \JMS\Serializer\Handler\SubscribingHandlerInterface[] $handlers
+     */
+    public function __construct(array $subscribers = [], array $handlers = [])
+    {
+        $this->serializer = SerializerBuilder::create()
+            ->configureListeners(
+                function(EventDispatcher $dispatcher) use ($subscribers) {
+                    foreach ($subscribers as $subscriber) {
+                        $dispatcher->addSubscriber($subscriber);
+                    }
+                }
+            )
+            ->configureHandlers(
+                function(HandlerRegistry $registry) use ($handlers) {
+                    foreach ($handlers as $handler) {
+                        $registry->registerSubscribingHandler($handler);
+                    }
+                }
+            )
+            ->addDefaultHandlers()
+            ->build();
+    }
+
+    public function serialise(mixed $value): string
+    {
+        return $this->serializer->serialize(
+            $value,
+            'json',
+            SerializationContext::create()->setSerializeNull(true),
+        );
+    }
+
+    public function deserialise(string $value, string $type): mixed
+    {
+        if ($value === 'null') {
+            return null;
+        }
+
+        return $this->serializer->deserialize(
+            $value,
+            $type,
+            'json',
+        );
+    }
+}

--- a/sdk/php/tests/Unit/Service/Serialisation/SerialiserTest.php
+++ b/sdk/php/tests/Unit/Service/Serialisation/SerialiserTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Dagger\tests\Unit\Service\Serialisation;
+
+use Dagger\Client;
+use Dagger\ContainerId;
+use Dagger\Json;
+use Dagger\Platform;
+use Dagger\Service\Serialisation\AbstractScalarHandler;
+use Dagger\Service\Serialisation\AbstractScalarSubscriber;
+use Dagger\Service\Serialisation\Serialiser;
+use Generator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[Group('unit')]
+#[CoversClass(Serialiser::class)]
+class SerialiserTest extends TestCase
+{
+    #[Test, DataProvider('provideScalars')]
+    public function itSerialisesScalars(mixed $value, string $valueAsJSON): void
+    {
+        self::assertSame($valueAsJSON, (new Serialiser())->serialise($value));
+    }
+
+    #[Test, DataProvider('provideScalars')]
+    public function itDeserialisesScalars(mixed $value, string $valueAsJSON): void
+    {
+        $sut = new Serialiser();
+
+        self::assertEquals($value, $sut->deserialise($valueAsJSON, gettype($value)));
+    }
+
+    #[Test, DataProvider('provideLists')]
+    public function itSerialisesLists(?array $value, string $valueAsJSON): void
+    {
+        self::assertSame($valueAsJSON, (new Serialiser())->serialise($value));
+    }
+
+    #[Test, DataProvider('provideLists')]
+    public function itDeserialisesLists(?array $value, string $valueAsJSON): void
+    {
+        $sut = new Serialiser();
+
+        self::assertEquals($value, $sut->deserialise($valueAsJSON, 'array'));
+    }
+
+    #[Test, DataProvider('provideAbstractScalars')]
+    public function itSerialisesAbstractScalars(
+        Client\AbstractScalar $value,
+        string $valueAsJSON,
+    ): void {
+        $sut = new Serialiser(
+            [new AbstractScalarSubscriber()],
+            [new AbstractScalarHandler()]
+        );
+
+        self::assertSame($valueAsJSON, $sut->serialise($value));
+    }
+
+    #[Test, DataProvider('provideAbstractScalars')]
+    public function itDeserialisesAbstractScalars(
+        Client\AbstractScalar $value,
+        string $valueAsJSON,
+    ): void {
+        $sut = new Serialiser(
+            [new AbstractScalarSubscriber()],
+            [new AbstractScalarHandler()]
+        );
+
+        self::assertEquals($value, $sut->deserialise($valueAsJSON, $value::class));
+    }
+
+    /** @return Generator<array{ 0: mixed, 1: string }> */
+    public static function provideScalars(): Generator
+    {
+        $cases = [
+            true,
+            false,
+            123,
+            null,
+            'expected',
+            'null',
+        ];
+
+        foreach ($cases as $case) {
+            $type = gettype($case);
+            yield "($type) $case" => [$case, json_encode($case)];
+        }
+    }
+
+    /** @return Generator<array{ 0: ?array, 1: string }> */
+    public static function provideLists(): Generator
+    {
+        yield 'string[]' => [['hello', 'world'], '["hello","world"]'];
+
+        yield 'null' => [null, 'null'];
+
+        yield ' null[]' => [[null, null], '[null,null]'];
+    }
+
+    /**
+     * @return \Generator<array{
+     *     0: \Dagger\Client\AbstractScalar|null,
+     *     1: string,
+     * }>
+     */
+    public static function provideAbstractScalars(): Generator
+    {
+        yield Platform::class => [
+            new Platform('linux/amd64'),
+            '"linux\/amd64"',
+        ];
+
+        yield Json::class => [
+            new Json('{"bool_field":true}'),
+            '"{\"bool_field\":true}"',
+        ];
+
+        yield ContainerId::class => [
+            new ContainerId('1234-567-89'),
+            '"1234-567-89"',
+        ];
+    }
+}


### PR DESCRIPTION
Add support for custom objects in the PHP SDK runtime.

Tested this manually with the following three classes in a module called Potato:

```php
#[DaggerObject]
class Potato
{
    #[DaggerFunction('Get Chips')]
    public function getChips(): Chips
    {
        return new Chips(
            dag()->container()->from('alpine:latest'),
            dag()->defaultPlatform(),
            new Sauce('mayo'),
        );
    }
}
```

```php
#[DaggerObject]
class Chips
{
    public function __construct(
        private readonly Container $container,
        private readonly Platform $platform,
        private readonly Sauce $sauce,
    ) {
    }

    #[DaggerFunction('Serve the chips')]
     public function serve(): string
     {
         return $this->container
             ->withExec(['echo', sprintf(
                 'Chips with a side of %s, covered in %s',
                 $this->platform->getValue(),
                 $this->sauce->type,
             )])
             ->stdout();
     }
}
```

```php
final class Sauce
{
    public function __construct(
        public readonly string $type
    ) {}
}
```

I was able to call `dagger call get-chips serve` and receive the following output:
```
Chips with a side of linux/amd64, covered in mayo
```