### PR TITLE
ci: fix multiline function calls

### DIFF
--- a/.github/workflows/engine-and-cli-publish.yml
+++ b/.github/workflows/engine-and-cli-publish.yml
@@ -42,7 +42,7 @@ jobs:
       - name: "Publish Engine"
         uses: ./.github/actions/call
         with:
-          function: |
+          function: |-
             --version="$(cat /tmp/publish/version)" \
             --tag="$(cat /tmp/publish/tag)" \
             engine \
@@ -61,7 +61,7 @@ jobs:
       - name: "Publish Engine - Ubuntu with NVIDIA variant"
         uses: ./.github/actions/call
         with:
-          function: |
+          function: |-
             --version="$(cat /tmp/publish/version)" \
             --tag="$(cat /tmp/publish/tag)" \
             engine with-base --image=ubuntu --gpu-support=true \
@@ -80,7 +80,7 @@ jobs:
       - name: "Publish Engine - Wolfi variant"
         uses: ./.github/actions/call
         with:
-          function: |
+          function: |-
             --version="$(cat /tmp/publish/version)" \
             --tag="$(cat /tmp/publish/tag)" \
             engine with-base --image=wolfi \
@@ -99,7 +99,7 @@ jobs:
       - name: "Publish Engine - Wolfi with NVIDIA variant"
         uses: ./.github/actions/call
         with:
-          function: |
+          function: |-
             --version="$(cat /tmp/publish/version)" \
             --tag="$(cat /tmp/publish/tag)" \
             engine with-base --image=wolfi --gpu-support=true \
@@ -118,7 +118,7 @@ jobs:
       - name: "Publish CLI"
         uses: ./.github/actions/call
         with:
-          function: |
+          function: |-
             --version="$(cat /tmp/publish/version)" \
             --tag="$(cat /tmp/publish/tag)" \
             cli \


### PR DESCRIPTION
Fixes the failing publish job on main: https://github.com/dagger/dagger/actions/runs/10196735570/job/28208078629 (introduced by merging #7858)

We need to strip the newline at the end, otherwise we end up with the trailing `tee` on a line by itself (which isn't what we want).