### PR TITLE
ci: fix cli publish for untagged releases (take 2)

### DIFF
--- a/dev/sdk.go
+++ b/dev/sdk.go
@@ -170,7 +170,8 @@ func gitPublish(ctx context.Context, opts gitPublishOpts) error {
 			WithEnvVariable("CACHEBUSTER", identity.NewID()).
 			WithWorkdir("/src/dagger").
 			WithExec([]string{"git", "clone", opts.dest, "."}).
-			WithExec([]string{"git", "switch", opts.destTag}).
+			WithExec([]string{"git", "fetch", "origin", "-v", "--update-head-ok", fmt.Sprintf("refs/*%[1]s:refs/*%[1]s", strings.TrimPrefix(opts.destTag, "refs/"))}).
+			WithExec([]string{"git", "checkout", opts.destTag, "--"}).
 			WithExec([]string{"git", "rev-parse", "HEAD"}).
 			Stdout(ctx)
 		if err != nil {


### PR DESCRIPTION
Properly unset the tag, so that we don't attempt to generate release notes for a nightly release: https://github.com/dagger/dagger/actions/runs/10198799780/job/28214455568#step:10:510

Follow-up to #8075