### PR TITLE
Improve releasing during v0.12.4

### DIFF
--- a/.github/actions/call/action.yml
+++ b/.github/actions/call/action.yml
@@ -13,7 +13,7 @@ inputs:
 
   version:
     description: "Dagger version to run against"
-    default: "v0.12.3"
+    default: "v0.12.4"
     required: false
 
   dev-engine:

--- a/.github/workflows/_sdk_check.yml
+++ b/.github/workflows/_sdk_check.yml
@@ -15,7 +15,7 @@ on:
 
       version:
         type: string
-        default: "v0.12.3"
+        default: "v0.12.4"
         required: false
 
       dev-engine:
@@ -32,7 +32,7 @@ on:
 
 jobs:
   check:
-    runs-on: "${{ github.repository == 'dagger/dagger' && (inputs.dev-engine && 'dagger-g2-v0-12-3-8c-dind' || 'dagger-g2-v0-12-3-4c') || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && (inputs.dev-engine && 'dagger-g2-v0-12-4-8c-dind' || 'dagger-g2-v0-12-4-4c') || 'ubuntu-latest' }}"
     timeout-minutes: "${{ inputs.timeout }}"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-3-4c' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-4-4c' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/engine-and-cli-publish.yml
+++ b/.github/workflows/engine-and-cli-publish.yml
@@ -20,7 +20,7 @@ jobs:
   publish:
     if: ${{ github.repository == 'dagger/dagger' && github.event_name == 'push' }}
     # Use our own Dagger runner when running in the dagger/dagger repo (including PRs)
-    runs-on: dagger-g2-v0-12-3-16c-od
+    runs-on: dagger-g2-v0-12-4-16c-od
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -149,7 +149,7 @@ jobs:
           discord-webhook: ${{ secrets.NEW_RELEASE_DISCORD_WEBHOOK }}
 
   scan-engine:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-3-4c' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-4-4c' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/engine-and-cli.yml
+++ b/.github/workflows/engine-and-cli.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-3-4c' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-4-4c' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
           function: "scripts lint"
 
   test:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-3-16c-st-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-4-16c-st-od' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -49,7 +49,7 @@ jobs:
   # Only run a subset of important test cases since we just need to verify basic
   # functionality rather than repeat every test already run in the other targets.
   testdev:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-3-32c-dind-st-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-4-32c-dind-st-od' || 'ubuntu-latest' }}"
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
           dev-engine: true
 
   test-publish:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-3-4c' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-4-4c' || 'ubuntu-latest' }}"
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
           function: "engine with-base --image=ubuntu --gpu-support=true test-publish"
 
   scan-engine:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-3-4c' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-4-4c' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-3-4c-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-4-4c-od' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -27,7 +27,7 @@ jobs:
     # only run this on tag push events, not in PRs
     if: github.event_name == 'push' && github.repository == 'dagger/dagger' && github.ref_type == 'tag'
     needs: test
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-3-4c-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-4-4c-od' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "helm publish"

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-3-4c' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-4-4c' || 'ubuntu-latest' }}"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sdk-elixir-publish.yml
+++ b/.github/workflows/sdk-elixir-publish.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-3-4c-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-4-4c-od' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "elixir publish"

--- a/.github/workflows/sdk-go-publish.yml
+++ b/.github/workflows/sdk-go-publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-3-4c-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-4-4c-od' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "go publish"

--- a/.github/workflows/sdk-php-publish.yml
+++ b/.github/workflows/sdk-php-publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-3-4c-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-4-4c-od' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "php publish"

--- a/.github/workflows/sdk-python-publish.yml
+++ b/.github/workflows/sdk-python-publish.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-3-4c-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-4-4c-od' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "python publish"

--- a/.github/workflows/sdk-rust-publish.yml
+++ b/.github/workflows/sdk-rust-publish.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-3-4c-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-4-4c-od' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "go publish"

--- a/.github/workflows/sdk-typescript-publish.yml
+++ b/.github/workflows/sdk-typescript-publish.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish:
     if: github.repository == 'dagger/dagger'
-    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-3-4c-od' || 'ubuntu-latest' }}"
+    runs-on: "${{ github.repository == 'dagger/dagger' && 'dagger-g2-v0-12-4-4c-od' || 'ubuntu-latest' }}"
     steps:
       - uses: actions/checkout@v4
       - name: "typescript publish"

--- a/dev/dagger.json
+++ b/dev/dagger.json
@@ -32,7 +32,7 @@
     }
   ],
   "source": ".",
-  "engineVersion": "v0.12.3",
+  "engineVersion": "v0.12.4",
   "views": [
     {
       "name": "default",

--- a/dev/go.mod
+++ b/dev/go.mod
@@ -4,7 +4,7 @@ go 1.22.0
 
 toolchain go1.22.5
 
-require github.com/dagger/dagger/engine/distconsts v0.12.3
+require github.com/dagger/dagger/engine/distconsts v0.12.4
 
 replace github.com/dagger/dagger/engine/distconsts => ../engine/distconsts
 

--- a/docs/current_docs/partials/_install-cli.mdx
+++ b/docs/current_docs/partials/_install-cli.mdx
@@ -30,17 +30,17 @@ If you do not have Homebrew installed, or you want to install a specific version
 
 ```shell
 cd /usr/local
-curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.12.3 sh
+curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.12.4 sh
 
 ./bin/dagger version
-dagger v0.12.3 (registry.dagger.io/engine) darwin/arm64
+dagger v0.12.4 (registry.dagger.io/engine:v0.12.4) darwin/arm64
 ```
 
 If your user account doesn't have sufficient privileges to install in `/usr/local` and `sudo` is available, use the following command instead:
 
 ```shell
 cd /usr/local
-curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.12.3 sudo sh
+curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.12.4 sudo sh
 ```
 
 </TabItem>
@@ -63,10 +63,10 @@ dagger is $HOME/.local/bin/dagger
 If you want to install a specific version of `dagger`, you can run:
 
 ```shell
-curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.12.3 sh
+curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=0.12.4 sh
 
 ./bin/dagger version
-dagger v0.12.3 (registry.dagger.io/engine) linux/amd64
+dagger v0.12.4 (registry.dagger.io/engine:v0.12.4) linux/amd64
 ```
 
 </TabItem>
@@ -92,7 +92,7 @@ To install a specific version of Dagger, specify the version with the `-DaggerVe
 
 ```powershell
 Invoke-WebRequest -UseBasicParsing -Uri https://dl.dagger.io/dagger/install.ps1 | Invoke-Expression;
-Install-Dagger -DaggerVersion 0.12.3
+Install-Dagger -DaggerVersion 0.12.4
 ```
 
 For an interactive installation process, include the `-Interactive` switch.

--- a/go.mod
+++ b/go.mod
@@ -260,8 +260,8 @@ require (
 )
 
 require (
-	dagger.io/dagger v0.12.3
-	github.com/dagger/dagger/engine/distconsts v0.12.3
+	dagger.io/dagger v0.12.4
+	github.com/dagger/dagger/engine/distconsts v0.12.4
 )
 
 replace (

--- a/sdk/rust/.changie.yaml
+++ b/sdk/rust/.changie.yaml
@@ -28,7 +28,7 @@ kinds:
   - label: Fixed
   - label: Dependencies
 headerFormat: |
-  This SDK uses 🚙 Engine + 🚗 CLI version `{{.Env.ENGINE_VERSION}}`.[See what changed in that release]](https://github.com/dagger/dagger/releases/tag/{{.Env.ENGINE_VERSION}}).
+  This SDK uses 🚙 Engine + 🚗 CLI version `{{.Env.ENGINE_VERSION}}`. [See what changed in that release](https://github.com/dagger/dagger/releases/tag/{{.Env.ENGINE_VERSION}}).
   ⬢ https://crates.io/crates/dagger-sdk/{{ trimPrefix "v" .Version }}
   📒 https://docs.rs/dagger-sdk/{{ trimPrefix "v" .Version }}/dagger-sdk
 footerFormat: |


### PR DESCRIPTION
This is a bit more of a restructure than usual, taking into account the changes introduced in https://github.com/dagger/dagger/pull/7705.

The big parts are:
- No more `bump-engine` PR
	- Steps that were performed there are moved forwards to the new "prep" step.
	- Now there's no tricky wait for CI to pass/etc, we can shave off a huge amount of time here now.
- Go SDK release is sped up a lot
	- I realized we don't need to wait for our tests to pass in this specific step - the reason for this is, now we ourselves consume the modularized go SDK, not the external one. So technically this wasn't adding any coverage.
	- The tests would already have fun on `main` before releasing - we're okay to skip it here.
- Added a tooling section to aggregate all the tooling that should be installed prior to starting the release
- Split out dedicated sub-sections for improving releasing as we go, which makes it clearer what's going on.

This was actually a really fast release! I tagged v0.12.4 at 11:44 BST, and finished releasing all the SDKs and helm chart at 12:43 BST. Really happy with the new format, it felt much smoother and less stressful.

There are some next steps I'd like to take:
- Github release notes uploads should be automatic, I'd like to not do these manually anymore. Each SDK should just be tag+push (and we could even parallelize these).
- Add commands for *every* step - it should be possible to copy-paste the entire release process for standard releases off of `main`.
- Automate PRs for post-release:
	- Our github action: https://github.com/dagger/dagger-for-github
	- Our internal infra: Playground, Daggerverse, Cloud API + Magicache (cc @matipan)