### PR TITLE
Update chaining.mdx

### DIFF
--- a/docs/current_docs/manuals/user/functions/chaining.mdx
+++ b/docs/current_docs/manuals/user/functions/chaining.mdx
@@ -21,7 +21,7 @@ Here are a few examples of function chaining in action:
 - Print the contents of a file returned by a Dagger Function, by chaining a call to the `File` object's `Contents()` function:
 
     ```shell
-dagger call -m github.com/dagger/dagger/dev/ruff@a29dadbb5d9968784847a15fccc5629daf2985ae lint --source https://github.com/dagger/dagger report contents
+    dagger call -m github.com/dagger/dagger/dev/ruff@a29dadbb5d9968784847a15fccc5629daf2985ae lint --source https://github.com/dagger/dagger report contents
     ```
 
 - Publish a container image of a container returned by a Dagger Function, by chaining a call to the `Container` object's `Publish()` function:


### PR DESCRIPTION
fix layout: The file and contents example was not indented enough so its was not fitting the codepreview box.