### PR TITLE
Fix enum list in CLI

### DIFF
--- a/.changes/unreleased/Fixed-20240808-180607.yaml
+++ b/.changes/unreleased/Fixed-20240808-180607.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fixed enum lists in modules
+time: 2024-08-08T18:06:07.0133Z
+custom:
+    Author: helderco
+    PR: "8096"

--- a/core/enum.go
+++ b/core/enum.go
@@ -104,9 +104,8 @@ func (m *ModuleEnumType) getDecoder(ctx context.Context) (dagql.InputDecoder, er
 }
 
 type ModuleEnum struct {
-	TypeDef       *EnumTypeDef
-	Value         string
-	OriginalValue string
+	TypeDef *EnumTypeDef
+	Value   string
 }
 
 func (e *ModuleEnum) TypeName() string {
@@ -171,11 +170,10 @@ func (e *ModuleEnum) DecodeInput(val any) (dagql.Input, error) {
 
 func (e *ModuleEnum) Lookup(val string) (dagql.Input, error) {
 	for _, possible := range e.TypeDef.Values {
-		if val == possible.Name || val == possible.OriginalName {
+		if val == possible.Name {
 			return &ModuleEnum{
-				TypeDef:       e.TypeDef,
-				Value:         possible.Name,
-				OriginalValue: possible.OriginalName,
+				TypeDef: e.TypeDef,
+				Value:   possible.Name,
 			}, nil
 		}
 	}
@@ -184,5 +182,5 @@ func (e *ModuleEnum) Lookup(val string) (dagql.Input, error) {
 }
 
 func (e *ModuleEnum) MarshalJSON() ([]byte, error) {
-	return json.Marshal(e.OriginalValue)
+	return json.Marshal(e.Value)
 }

--- a/core/typedef.go
+++ b/core/typedef.go
@@ -507,7 +507,7 @@ func (typeDef *TypeDef) WithEnumValue(name, desc string) (*TypeDef, error) {
 
 	// Verify if the enum value is duplicated.
 	for _, v := range typeDef.AsEnum.Value.Values {
-		if v.OriginalName == name {
+		if v.Name == name {
 			return nil, fmt.Errorf("enum value %q is already defined", name)
 		}
 	}
@@ -917,7 +917,7 @@ func (enum *EnumTypeDef) ListValues() ast.EnumValueList {
 
 	for _, val := range enum.Values {
 		values = append(values, &ast.EnumValueDefinition{
-			Name:        val.OriginalName,
+			Name:        val.Name,
 			Description: val.Description,
 		})
 	}
@@ -947,11 +947,6 @@ func (enum EnumTypeDef) Clone() *EnumTypeDef {
 type EnumValueTypeDef struct {
 	Name        string `field:"true" doc:"The name of the enum value."`
 	Description string `field:"true" doc:"A doc string for the enum value, if any."`
-
-	// Below are not in public API
-
-	// The original name of the enum value as provided by the SDK that defined it, used
-	OriginalName string
 }
 
 func (*EnumValueTypeDef) Type() *ast.Type {
@@ -967,9 +962,8 @@ func (*EnumValueTypeDef) TypeDescription() string {
 
 func NewEnumValueTypeDef(name, description string) *EnumValueTypeDef {
 	return &EnumValueTypeDef{
-		Name:         strcase.ToScreamingSnake(name),
-		OriginalName: name,
-		Description:  description,
+		Name:        name,
+		Description: description,
 	}
 }
 


### PR DESCRIPTION
Reported by user in [Discord](https://discord.com/channels/707636530424053791/1266410249565372498).


> something changed, and ive been out of loop for some time as i was not paying full attention, i was defining a go type, to simulate an enum in some ways, i.e type lang = string and then lang = Go, lang = "Csharp" etc etc, I was then using this custom type (which still is a string) as part of the dagger function API, since upgrading it no longer works and ive just rid of that concept and used pure strings instead. I'm more of a c# person, but im still interested to know if it was expected?
>
> ```go
> type Language string
> 
> const (
>     CSharp Language = "CSharp"
>     Go     Language = "Go"
>     Java   Language = "Java"
>     Python Language = "Python"
> )
> 
> ...
> 
> GenerateKiotaClients(
>     ctx context.Context,
>     languages []Language, ... )
> ```
>
> this used to work, now i replaced with []string instead