### PR TITLE
feat(sdk/elixir): make dag instance be global

### DIFF
--- a/sdk/elixir/.changes/unreleased/Added-20240814-172542.yaml
+++ b/sdk/elixir/.changes/unreleased/Added-20240814-172542.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: "Make Dagger client global and introduce `dag/0` to access the global instance. \n\nThe function first argument is now deprecated but the runtime still set this global instance into the struct. "
+time: 2024-08-14T17:25:42.765556+07:00
+custom:
+    Author: wingyplus
+    PR: "8099"

--- a/sdk/elixir/lib/dagger/global.ex
+++ b/sdk/elixir/lib/dagger/global.ex
@@ -1,0 +1,39 @@
+defmodule Dagger.Global do
+  @moduledoc false
+
+  use GenServer
+
+  @doc """
+  Starting the process and connecting it to the Dagger.
+  """
+  def start_link(_opts \\ []) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @doc """
+  Get the Dagger client.
+  """
+  def dag() do
+    GenServer.call(__MODULE__, :dag)
+  end
+
+  @doc """
+  Close the Dagger client.
+  """
+  def close() do
+    GenServer.stop(__MODULE__, :normal)
+  end
+
+  @impl GenServer
+  def init([]) do
+    Dagger.connect()
+  end
+
+  @impl GenServer
+  def handle_call(:dag, _from, dag), do: {:reply, dag, dag}
+
+  @impl GenServer
+  def terminate(_reason, dag) do
+    Dagger.close(dag)
+  end
+end

--- a/sdk/elixir/lib/dagger/mod.ex
+++ b/sdk/elixir/lib/dagger/mod.ex
@@ -106,7 +106,14 @@ defmodule Dagger.Mod do
   @doc """
   Invoke a function.
   """
-  def invoke(dag \\ Dagger.connect!()) do
+  def invoke() do
+    case Dagger.Global.start_link() do
+      {:ok, _} -> invoke(Dagger.Global.dag())
+      otherwise -> otherwise
+    end
+  end
+
+  def invoke(dag) do
     fn_call = Dagger.Client.current_function_call(dag)
 
     with {:ok, parent_name} <- Dagger.FunctionCall.parent_name(fn_call),
@@ -122,7 +129,7 @@ defmodule Dagger.Mod do
         System.halt(2)
     end
   after
-    Dagger.close(dag)
+    Dagger.Global.close()
   end
 
   def invoke(dag, _parent, "", _fn_name, _input_args) do
@@ -260,6 +267,7 @@ defmodule Dagger.Mod do
       use GenServer
 
       import Dagger.Mod
+      import Dagger.Global, only: [dag: 0]
 
       @name name
       @on_definition Dagger.Mod

--- a/sdk/elixir/runtime/template.exs
+++ b/sdk/elixir/runtime/template.exs
@@ -88,8 +88,8 @@ defmodule Main do
     @doc \"\"\"
     Returns a container that echoes whatever string argument is provided.
     \"\"\"
-    def container_echo(self, args) do
-      self.dag
+    def container_echo(_self, args) do
+      dag()
       |> Dagger.Client.container()
       |> Dagger.Container.from("alpine:latest")
       |> Dagger.Container.with_exec(~w"echo \#{args.string_arg}")
@@ -105,8 +105,8 @@ defmodule Main do
     @doc \"\"\"
     Returns lines that match a pattern in the files of the provided Directory.
     \"\"\"
-    def grep_dir(self, %{directory_arg: directory, pattern: pattern}) do
-      self.dag
+    def grep_dir(_self, %{directory_arg: directory, pattern: pattern}) do
+      dag()
       |> Dagger.Client.container()
       |> Dagger.Container.from("alpine:latest")
       |> Dagger.Container.with_mounted_directory("/mnt", directory)

--- a/sdk/elixir/test/dagger/global_test.exs
+++ b/sdk/elixir/test/dagger/global_test.exs
@@ -1,0 +1,8 @@
+defmodule Dagger.GlobalTest do
+  use ExUnit.Case, async: true
+
+  test "dag/0" do
+    start_supervised!(Dagger.Global)
+    assert %Dagger.Client{} = Dagger.Global.dag()
+  end
+end


### PR DESCRIPTION
~NOTE: This requires #8094 to be merge before review this PR.~

Instead of setting `dag` to the struct of the object type, use GenServer
to store it during invoke the function. 

This changeset still passing support using dag instance via a struct but the code from codegen changes to use `dag()` function and ignore the struct.

~This is another breaking changes, since user don't need to declare a struct 
that containing dag instance and function parameters is reduce to only 1 parameter.~