### PR TITLE
feat(sdk/elixir): make GraphQL API be more accessible

### DIFF
--- a/sdk/elixir/.changes/unreleased/Added-20240804-163849.yaml
+++ b/sdk/elixir/.changes/unreleased/Added-20240804-163849.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Make GraphQL API more accessible
+time: 2024-08-04T16:38:49.709544587+07:00
+custom:
+    Author: wingyplus
+    PR: "8101"

--- a/sdk/elixir/lib/dagger.ex
+++ b/sdk/elixir/lib/dagger.ex
@@ -40,12 +40,27 @@ defmodule Dagger do
      and calling a command `elixir` with flag `--version`, get the standard
      output from latest command and printing it to standard output.
   4. Close the connection.
+
+  ## Accessing GraphQL API
+
+  In case you want to execute GraphQL directly, the SDK provides `Dagger.Core.Client`,
+  the client interface to the Dagger engine. The module provides 2 APIs for you:
+
+  1. `Dagger.Core.Client.query/2` - to execute a GraphQL query to the Dagger engine.
+  2. `Dagger.Core.Client.execute/2` - to execute a GraphQL query that produces by `Dagger.Core.QueryBuilder`.
+
+  By default, every object types (`Dagger.Container`, `Dagger.Directory`, etc.) has
+  a field `client` which is an instance of `Dagger.Core.Client`, you can use that instance
+  from the object type without initialize connection by yourself.
+
+  Please note that this API is an internal API, it may break from version to version. So
+  please use with cautions.
   """
 
   @doc """
   Connecting to Dagger.
 
-  When calling this function, it try to connect in ordered:
+  When calling this function, it try to connect in order:
 
   1. Use session from `DAGGER_SESSION_PORT` and `DAGGER_SESSION_TOKEN` shell
      environment variables.
@@ -58,10 +73,10 @@ defmodule Dagger do
   #{NimbleOptions.docs(Dagger.Core.Client.connect_schema())}
   """
   def connect(opts \\ []) do
-    with {:ok, graphql_client} <- Dagger.Core.Client.connect(opts) do
+    with {:ok, engine_client} <- Dagger.Core.Client.connect(opts) do
       client = %Dagger.Client{
-        client: graphql_client,
-        selection: Dagger.Core.QueryBuilder.Selection.query()
+        client: engine_client,
+        query_builder: Dagger.Core.QueryBuilder.query()
       }
 
       {:ok, client}

--- a/sdk/elixir/lib/dagger/core/error.ex
+++ b/sdk/elixir/lib/dagger/core/error.ex
@@ -1,0 +1,5 @@
+defmodule Dagger.Core.QueryError do
+  @moduledoc false
+
+  defstruct [:errors]
+end

--- a/sdk/elixir/lib/dagger/core/query_builder.ex
+++ b/sdk/elixir/lib/dagger/core/query_builder.ex
@@ -1,4 +1,4 @@
-defmodule Dagger.Core.QueryBuilder.Selection do
+defmodule Dagger.Core.QueryBuilder do
   @moduledoc false
 
   defstruct [:name, :args, :prev, alias: ""]
@@ -16,11 +16,6 @@ defmodule Dagger.Core.QueryBuilder.Selection do
       alias: alias,
       prev: selection
     }
-  end
-
-  # TODO: Remove me.
-  def arg(selection, name, value) do
-    put_arg(selection, name, value)
   end
 
   def put_arg(%__MODULE__{args: args} = selection, name, value) when is_binary(name) do
@@ -106,15 +101,4 @@ defmodule Dagger.QueryError do
   @moduledoc false
 
   defstruct [:errors]
-end
-
-defmodule Dagger.Core.QueryBuilder do
-  @moduledoc false
-
-  defmacro __using__(_opts) do
-    quote do
-      import Dagger.Core.QueryBuilder.Selection
-      import Dagger.Core.Client, only: [execute: 2]
-    end
-  end
 end

--- a/sdk/elixir/lib/dagger/gen/cache_volume.ex
+++ b/sdk/elixir/lib/dagger/gen/cache_volume.ex
@@ -2,20 +2,21 @@
 defmodule Dagger.CacheVolume do
   @moduledoc "A directory whose contents persist across runs."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "A unique identifier for this CacheVolume."
   @spec id(t()) :: {:ok, Dagger.CacheVolumeID.t()} | {:error, term()}
   def id(%__MODULE__{} = cache_volume) do
-    selection =
-      cache_volume.selection |> select("id")
+    query_builder =
+      cache_volume.query_builder |> QB.select("id")
 
-    execute(selection, cache_volume.client)
+    Client.execute(cache_volume.client, query_builder)
   end
 end

--- a/sdk/elixir/lib/dagger/gen/current_module.ex
+++ b/sdk/elixir/lib/dagger/gen/current_module.ex
@@ -2,40 +2,41 @@
 defmodule Dagger.CurrentModule do
   @moduledoc "Reflective module API provided to functions at runtime."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "A unique identifier for this CurrentModule."
   @spec id(t()) :: {:ok, Dagger.CurrentModuleID.t()} | {:error, term()}
   def id(%__MODULE__{} = current_module) do
-    selection =
-      current_module.selection |> select("id")
+    query_builder =
+      current_module.query_builder |> QB.select("id")
 
-    execute(selection, current_module.client)
+    Client.execute(current_module.client, query_builder)
   end
 
   @doc "The name of the module being executed in"
   @spec name(t()) :: {:ok, String.t()} | {:error, term()}
   def name(%__MODULE__{} = current_module) do
-    selection =
-      current_module.selection |> select("name")
+    query_builder =
+      current_module.query_builder |> QB.select("name")
 
-    execute(selection, current_module.client)
+    Client.execute(current_module.client, query_builder)
   end
 
   @doc "The directory containing the module's source code loaded into the engine (plus any generated code that may have been created)."
   @spec source(t()) :: Dagger.Directory.t()
   def source(%__MODULE__{} = current_module) do
-    selection =
-      current_module.selection |> select("source")
+    query_builder =
+      current_module.query_builder |> QB.select("source")
 
     %Dagger.Directory{
-      selection: selection,
+      query_builder: query_builder,
       client: current_module.client
     }
   end
@@ -44,15 +45,15 @@ defmodule Dagger.CurrentModule do
   @spec workdir(t(), String.t(), [{:exclude, [String.t()]}, {:include, [String.t()]}]) ::
           Dagger.Directory.t()
   def workdir(%__MODULE__{} = current_module, path, optional_args \\ []) do
-    selection =
-      current_module.selection
-      |> select("workdir")
-      |> put_arg("path", path)
-      |> maybe_put_arg("exclude", optional_args[:exclude])
-      |> maybe_put_arg("include", optional_args[:include])
+    query_builder =
+      current_module.query_builder
+      |> QB.select("workdir")
+      |> QB.put_arg("path", path)
+      |> QB.maybe_put_arg("exclude", optional_args[:exclude])
+      |> QB.maybe_put_arg("include", optional_args[:include])
 
     %Dagger.Directory{
-      selection: selection,
+      query_builder: query_builder,
       client: current_module.client
     }
   end
@@ -60,11 +61,11 @@ defmodule Dagger.CurrentModule do
   @doc "Load a file from the module's scratch working directory, including any changes that may have been made to it during module function execution.Load a file from the module's scratch working directory, including any changes that may have been made to it during module function execution."
   @spec workdir_file(t(), String.t()) :: Dagger.File.t()
   def workdir_file(%__MODULE__{} = current_module, path) do
-    selection =
-      current_module.selection |> select("workdirFile") |> put_arg("path", path)
+    query_builder =
+      current_module.query_builder |> QB.select("workdirFile") |> QB.put_arg("path", path)
 
     %Dagger.File{
-      selection: selection,
+      query_builder: query_builder,
       client: current_module.client
     }
   end

--- a/sdk/elixir/lib/dagger/gen/dagger_engine.ex
+++ b/sdk/elixir/lib/dagger/gen/dagger_engine.ex
@@ -2,31 +2,32 @@
 defmodule Dagger.DaggerEngine do
   @moduledoc "The Dagger engine configuration and state"
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "A unique identifier for this DaggerEngine."
   @spec id(t()) :: {:ok, Dagger.DaggerEngineID.t()} | {:error, term()}
   def id(%__MODULE__{} = dagger_engine) do
-    selection =
-      dagger_engine.selection |> select("id")
+    query_builder =
+      dagger_engine.query_builder |> QB.select("id")
 
-    execute(selection, dagger_engine.client)
+    Client.execute(dagger_engine.client, query_builder)
   end
 
   @doc "The local (on-disk) cache for the Dagger engine"
   @spec local_cache(t()) :: Dagger.DaggerEngineCache.t()
   def local_cache(%__MODULE__{} = dagger_engine) do
-    selection =
-      dagger_engine.selection |> select("localCache")
+    query_builder =
+      dagger_engine.query_builder |> QB.select("localCache")
 
     %Dagger.DaggerEngineCache{
-      selection: selection,
+      query_builder: query_builder,
       client: dagger_engine.client
     }
   end

--- a/sdk/elixir/lib/dagger/gen/dagger_engine_cache.ex
+++ b/sdk/elixir/lib/dagger/gen/dagger_engine_cache.ex
@@ -2,22 +2,23 @@
 defmodule Dagger.DaggerEngineCache do
   @moduledoc "A cache storage for the Dagger engine"
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "The current set of entries in the cache"
   @spec entry_set(t()) :: Dagger.DaggerEngineCacheEntrySet.t()
   def entry_set(%__MODULE__{} = dagger_engine_cache) do
-    selection =
-      dagger_engine_cache.selection |> select("entrySet")
+    query_builder =
+      dagger_engine_cache.query_builder |> QB.select("entrySet")
 
     %Dagger.DaggerEngineCacheEntrySet{
-      selection: selection,
+      query_builder: query_builder,
       client: dagger_engine_cache.client
     }
   end
@@ -25,28 +26,28 @@ defmodule Dagger.DaggerEngineCache do
   @doc "A unique identifier for this DaggerEngineCache."
   @spec id(t()) :: {:ok, Dagger.DaggerEngineCacheID.t()} | {:error, term()}
   def id(%__MODULE__{} = dagger_engine_cache) do
-    selection =
-      dagger_engine_cache.selection |> select("id")
+    query_builder =
+      dagger_engine_cache.query_builder |> QB.select("id")
 
-    execute(selection, dagger_engine_cache.client)
+    Client.execute(dagger_engine_cache.client, query_builder)
   end
 
   @doc "The maximum bytes to keep in the cache without pruning, after which automatic pruning may kick in."
   @spec keep_bytes(t()) :: {:ok, integer()} | {:error, term()}
   def keep_bytes(%__MODULE__{} = dagger_engine_cache) do
-    selection =
-      dagger_engine_cache.selection |> select("keepBytes")
+    query_builder =
+      dagger_engine_cache.query_builder |> QB.select("keepBytes")
 
-    execute(selection, dagger_engine_cache.client)
+    Client.execute(dagger_engine_cache.client, query_builder)
   end
 
   @doc "Prune the cache of releaseable entries"
   @spec prune(t()) :: :ok | {:error, term()}
   def prune(%__MODULE__{} = dagger_engine_cache) do
-    selection =
-      dagger_engine_cache.selection |> select("prune")
+    query_builder =
+      dagger_engine_cache.query_builder |> QB.select("prune")
 
-    case execute(selection, dagger_engine_cache.client) do
+    case Client.execute(dagger_engine_cache.client, query_builder) do
       {:ok, _} -> :ok
       error -> error
     end

--- a/sdk/elixir/lib/dagger/gen/dagger_engine_cache_entry.ex
+++ b/sdk/elixir/lib/dagger/gen/dagger_engine_cache_entry.ex
@@ -2,65 +2,66 @@
 defmodule Dagger.DaggerEngineCacheEntry do
   @moduledoc "An individual cache entry in a cache entry set"
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "Whether the cache entry is actively being used."
   @spec actively_used(t()) :: {:ok, boolean()} | {:error, term()}
   def actively_used(%__MODULE__{} = dagger_engine_cache_entry) do
-    selection =
-      dagger_engine_cache_entry.selection |> select("activelyUsed")
+    query_builder =
+      dagger_engine_cache_entry.query_builder |> QB.select("activelyUsed")
 
-    execute(selection, dagger_engine_cache_entry.client)
+    Client.execute(dagger_engine_cache_entry.client, query_builder)
   end
 
   @doc "The time the cache entry was created, in Unix nanoseconds."
   @spec created_time_unix_nano(t()) :: {:ok, integer()} | {:error, term()}
   def created_time_unix_nano(%__MODULE__{} = dagger_engine_cache_entry) do
-    selection =
-      dagger_engine_cache_entry.selection |> select("createdTimeUnixNano")
+    query_builder =
+      dagger_engine_cache_entry.query_builder |> QB.select("createdTimeUnixNano")
 
-    execute(selection, dagger_engine_cache_entry.client)
+    Client.execute(dagger_engine_cache_entry.client, query_builder)
   end
 
   @doc "The description of the cache entry."
   @spec description(t()) :: {:ok, String.t()} | {:error, term()}
   def description(%__MODULE__{} = dagger_engine_cache_entry) do
-    selection =
-      dagger_engine_cache_entry.selection |> select("description")
+    query_builder =
+      dagger_engine_cache_entry.query_builder |> QB.select("description")
 
-    execute(selection, dagger_engine_cache_entry.client)
+    Client.execute(dagger_engine_cache_entry.client, query_builder)
   end
 
   @doc "The disk space used by the cache entry."
   @spec disk_space_bytes(t()) :: {:ok, integer()} | {:error, term()}
   def disk_space_bytes(%__MODULE__{} = dagger_engine_cache_entry) do
-    selection =
-      dagger_engine_cache_entry.selection |> select("diskSpaceBytes")
+    query_builder =
+      dagger_engine_cache_entry.query_builder |> QB.select("diskSpaceBytes")
 
-    execute(selection, dagger_engine_cache_entry.client)
+    Client.execute(dagger_engine_cache_entry.client, query_builder)
   end
 
   @doc "A unique identifier for this DaggerEngineCacheEntry."
   @spec id(t()) :: {:ok, Dagger.DaggerEngineCacheEntryID.t()} | {:error, term()}
   def id(%__MODULE__{} = dagger_engine_cache_entry) do
-    selection =
-      dagger_engine_cache_entry.selection |> select("id")
+    query_builder =
+      dagger_engine_cache_entry.query_builder |> QB.select("id")
 
-    execute(selection, dagger_engine_cache_entry.client)
+    Client.execute(dagger_engine_cache_entry.client, query_builder)
   end
 
   @doc "The most recent time the cache entry was used, in Unix nanoseconds."
   @spec most_recent_use_time_unix_nano(t()) :: {:ok, integer()} | {:error, term()}
   def most_recent_use_time_unix_nano(%__MODULE__{} = dagger_engine_cache_entry) do
-    selection =
-      dagger_engine_cache_entry.selection |> select("mostRecentUseTimeUnixNano")
+    query_builder =
+      dagger_engine_cache_entry.query_builder |> QB.select("mostRecentUseTimeUnixNano")
 
-    execute(selection, dagger_engine_cache_entry.client)
+    Client.execute(dagger_engine_cache_entry.client, query_builder)
   end
 end

--- a/sdk/elixir/lib/dagger/gen/dagger_engine_cache_entry_set.ex
+++ b/sdk/elixir/lib/dagger/gen/dagger_engine_cache_entry_set.ex
@@ -2,37 +2,38 @@
 defmodule Dagger.DaggerEngineCacheEntrySet do
   @moduledoc "A set of cache entries returned by a query to a cache"
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "The total disk space used by the cache entries in this set."
   @spec disk_space_bytes(t()) :: {:ok, integer()} | {:error, term()}
   def disk_space_bytes(%__MODULE__{} = dagger_engine_cache_entry_set) do
-    selection =
-      dagger_engine_cache_entry_set.selection |> select("diskSpaceBytes")
+    query_builder =
+      dagger_engine_cache_entry_set.query_builder |> QB.select("diskSpaceBytes")
 
-    execute(selection, dagger_engine_cache_entry_set.client)
+    Client.execute(dagger_engine_cache_entry_set.client, query_builder)
   end
 
   @doc "The list of individual cache entries in the set"
   @spec entries(t()) :: {:ok, [Dagger.DaggerEngineCacheEntry.t()]} | {:error, term()}
   def entries(%__MODULE__{} = dagger_engine_cache_entry_set) do
-    selection =
-      dagger_engine_cache_entry_set.selection |> select("entries") |> select("id")
+    query_builder =
+      dagger_engine_cache_entry_set.query_builder |> QB.select("entries") |> QB.select("id")
 
-    with {:ok, items} <- execute(selection, dagger_engine_cache_entry_set.client) do
+    with {:ok, items} <- Client.execute(dagger_engine_cache_entry_set.client, query_builder) do
       {:ok,
        for %{"id" => id} <- items do
          %Dagger.DaggerEngineCacheEntry{
-           selection:
-             query()
-             |> select("loadDaggerEngineCacheEntryFromID")
-             |> arg("id", id),
+           query_builder:
+             QB.query()
+             |> QB.select("loadDaggerEngineCacheEntryFromID")
+             |> QB.put_arg("id", id),
            client: dagger_engine_cache_entry_set.client
          }
        end}
@@ -42,18 +43,18 @@ defmodule Dagger.DaggerEngineCacheEntrySet do
   @doc "The number of cache entries in this set."
   @spec entry_count(t()) :: {:ok, integer()} | {:error, term()}
   def entry_count(%__MODULE__{} = dagger_engine_cache_entry_set) do
-    selection =
-      dagger_engine_cache_entry_set.selection |> select("entryCount")
+    query_builder =
+      dagger_engine_cache_entry_set.query_builder |> QB.select("entryCount")
 
-    execute(selection, dagger_engine_cache_entry_set.client)
+    Client.execute(dagger_engine_cache_entry_set.client, query_builder)
   end
 
   @doc "A unique identifier for this DaggerEngineCacheEntrySet."
   @spec id(t()) :: {:ok, Dagger.DaggerEngineCacheEntrySetID.t()} | {:error, term()}
   def id(%__MODULE__{} = dagger_engine_cache_entry_set) do
-    selection =
-      dagger_engine_cache_entry_set.selection |> select("id")
+    query_builder =
+      dagger_engine_cache_entry_set.query_builder |> QB.select("id")
 
-    execute(selection, dagger_engine_cache_entry_set.client)
+    Client.execute(dagger_engine_cache_entry_set.client, query_builder)
   end
 end

--- a/sdk/elixir/lib/dagger/gen/enum_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/enum_type_def.ex
@@ -2,64 +2,65 @@
 defmodule Dagger.EnumTypeDef do
   @moduledoc "A definition of a custom enum defined in a Module."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "A doc string for the enum, if any."
   @spec description(t()) :: {:ok, String.t()} | {:error, term()}
   def description(%__MODULE__{} = enum_type_def) do
-    selection =
-      enum_type_def.selection |> select("description")
+    query_builder =
+      enum_type_def.query_builder |> QB.select("description")
 
-    execute(selection, enum_type_def.client)
+    Client.execute(enum_type_def.client, query_builder)
   end
 
   @doc "A unique identifier for this EnumTypeDef."
   @spec id(t()) :: {:ok, Dagger.EnumTypeDefID.t()} | {:error, term()}
   def id(%__MODULE__{} = enum_type_def) do
-    selection =
-      enum_type_def.selection |> select("id")
+    query_builder =
+      enum_type_def.query_builder |> QB.select("id")
 
-    execute(selection, enum_type_def.client)
+    Client.execute(enum_type_def.client, query_builder)
   end
 
   @doc "The name of the enum."
   @spec name(t()) :: {:ok, String.t()} | {:error, term()}
   def name(%__MODULE__{} = enum_type_def) do
-    selection =
-      enum_type_def.selection |> select("name")
+    query_builder =
+      enum_type_def.query_builder |> QB.select("name")
 
-    execute(selection, enum_type_def.client)
+    Client.execute(enum_type_def.client, query_builder)
   end
 
   @doc "If this EnumTypeDef is associated with a Module, the name of the module. Unset otherwise."
   @spec source_module_name(t()) :: {:ok, String.t()} | {:error, term()}
   def source_module_name(%__MODULE__{} = enum_type_def) do
-    selection =
-      enum_type_def.selection |> select("sourceModuleName")
+    query_builder =
+      enum_type_def.query_builder |> QB.select("sourceModuleName")
 
-    execute(selection, enum_type_def.client)
+    Client.execute(enum_type_def.client, query_builder)
   end
 
   @doc "The values of the enum."
   @spec values(t()) :: {:ok, [Dagger.EnumValueTypeDef.t()]} | {:error, term()}
   def values(%__MODULE__{} = enum_type_def) do
-    selection =
-      enum_type_def.selection |> select("values") |> select("id")
+    query_builder =
+      enum_type_def.query_builder |> QB.select("values") |> QB.select("id")
 
-    with {:ok, items} <- execute(selection, enum_type_def.client) do
+    with {:ok, items} <- Client.execute(enum_type_def.client, query_builder) do
       {:ok,
        for %{"id" => id} <- items do
          %Dagger.EnumValueTypeDef{
-           selection:
-             query()
-             |> select("loadEnumValueTypeDefFromID")
-             |> arg("id", id),
+           query_builder:
+             QB.query()
+             |> QB.select("loadEnumValueTypeDefFromID")
+             |> QB.put_arg("id", id),
            client: enum_type_def.client
          }
        end}

--- a/sdk/elixir/lib/dagger/gen/enum_value_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/enum_value_type_def.ex
@@ -2,38 +2,39 @@
 defmodule Dagger.EnumValueTypeDef do
   @moduledoc "A definition of a value in a custom enum defined in a Module."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "A doc string for the enum value, if any."
   @spec description(t()) :: {:ok, String.t()} | {:error, term()}
   def description(%__MODULE__{} = enum_value_type_def) do
-    selection =
-      enum_value_type_def.selection |> select("description")
+    query_builder =
+      enum_value_type_def.query_builder |> QB.select("description")
 
-    execute(selection, enum_value_type_def.client)
+    Client.execute(enum_value_type_def.client, query_builder)
   end
 
   @doc "A unique identifier for this EnumValueTypeDef."
   @spec id(t()) :: {:ok, Dagger.EnumValueTypeDefID.t()} | {:error, term()}
   def id(%__MODULE__{} = enum_value_type_def) do
-    selection =
-      enum_value_type_def.selection |> select("id")
+    query_builder =
+      enum_value_type_def.query_builder |> QB.select("id")
 
-    execute(selection, enum_value_type_def.client)
+    Client.execute(enum_value_type_def.client, query_builder)
   end
 
   @doc "The name of the enum value."
   @spec name(t()) :: {:ok, String.t()} | {:error, term()}
   def name(%__MODULE__{} = enum_value_type_def) do
-    selection =
-      enum_value_type_def.selection |> select("name")
+    query_builder =
+      enum_value_type_def.query_builder |> QB.select("name")
 
-    execute(selection, enum_value_type_def.client)
+    Client.execute(enum_value_type_def.client, query_builder)
   end
 end

--- a/sdk/elixir/lib/dagger/gen/env_variable.ex
+++ b/sdk/elixir/lib/dagger/gen/env_variable.ex
@@ -2,38 +2,39 @@
 defmodule Dagger.EnvVariable do
   @moduledoc "An environment variable name and value."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "A unique identifier for this EnvVariable."
   @spec id(t()) :: {:ok, Dagger.EnvVariableID.t()} | {:error, term()}
   def id(%__MODULE__{} = env_variable) do
-    selection =
-      env_variable.selection |> select("id")
+    query_builder =
+      env_variable.query_builder |> QB.select("id")
 
-    execute(selection, env_variable.client)
+    Client.execute(env_variable.client, query_builder)
   end
 
   @doc "The environment variable name."
   @spec name(t()) :: {:ok, String.t()} | {:error, term()}
   def name(%__MODULE__{} = env_variable) do
-    selection =
-      env_variable.selection |> select("name")
+    query_builder =
+      env_variable.query_builder |> QB.select("name")
 
-    execute(selection, env_variable.client)
+    Client.execute(env_variable.client, query_builder)
   end
 
   @doc "The environment variable value."
   @spec value(t()) :: {:ok, String.t()} | {:error, term()}
   def value(%__MODULE__{} = env_variable) do
-    selection =
-      env_variable.selection |> select("value")
+    query_builder =
+      env_variable.query_builder |> QB.select("value")
 
-    execute(selection, env_variable.client)
+    Client.execute(env_variable.client, query_builder)
   end
 end

--- a/sdk/elixir/lib/dagger/gen/field_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/field_type_def.ex
@@ -6,49 +6,50 @@ defmodule Dagger.FieldTypeDef do
   A field on an object has a static value, as opposed to a function on an object whose value is computed by invoking code (and can accept arguments).
   """
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "A doc string for the field, if any."
   @spec description(t()) :: {:ok, String.t()} | {:error, term()}
   def description(%__MODULE__{} = field_type_def) do
-    selection =
-      field_type_def.selection |> select("description")
+    query_builder =
+      field_type_def.query_builder |> QB.select("description")
 
-    execute(selection, field_type_def.client)
+    Client.execute(field_type_def.client, query_builder)
   end
 
   @doc "A unique identifier for this FieldTypeDef."
   @spec id(t()) :: {:ok, Dagger.FieldTypeDefID.t()} | {:error, term()}
   def id(%__MODULE__{} = field_type_def) do
-    selection =
-      field_type_def.selection |> select("id")
+    query_builder =
+      field_type_def.query_builder |> QB.select("id")
 
-    execute(selection, field_type_def.client)
+    Client.execute(field_type_def.client, query_builder)
   end
 
   @doc "The name of the field in lowerCamelCase format."
   @spec name(t()) :: {:ok, String.t()} | {:error, term()}
   def name(%__MODULE__{} = field_type_def) do
-    selection =
-      field_type_def.selection |> select("name")
+    query_builder =
+      field_type_def.query_builder |> QB.select("name")
 
-    execute(selection, field_type_def.client)
+    Client.execute(field_type_def.client, query_builder)
   end
 
   @doc "The type of the field."
   @spec type_def(t()) :: Dagger.TypeDef.t()
   def type_def(%__MODULE__{} = field_type_def) do
-    selection =
-      field_type_def.selection |> select("typeDef")
+    query_builder =
+      field_type_def.query_builder |> QB.select("typeDef")
 
     %Dagger.TypeDef{
-      selection: selection,
+      query_builder: query_builder,
       client: field_type_def.client
     }
   end

--- a/sdk/elixir/lib/dagger/gen/file.ex
+++ b/sdk/elixir/lib/dagger/gen/file.ex
@@ -24,12 +24,12 @@ defmodule Dagger.File do
   @spec digest(t(), [{:exclude_metadata, boolean() | nil}]) ::
           {:ok, String.t()} | {:error, term()}
   def digest(%__MODULE__{} = file, optional_args \\ []) do
-    selection =
-      file.selection
-      |> select("digest")
-      |> maybe_put_arg("excludeMetadata", optional_args[:exclude_metadata])
+    query_builder =
+      file.query_builder
+      |> QB.select("digest")
+      |> QB.maybe_put_arg("excludeMetadata", optional_args[:exclude_metadata])
 
-    execute(selection, file.client)
+    Client.execute(file.client, query_builder)
   end
 
   @doc "Writes the file to a file path on the host."

--- a/sdk/elixir/lib/dagger/gen/file.ex
+++ b/sdk/elixir/lib/dagger/gen/file.ex
@@ -2,21 +2,22 @@
 defmodule Dagger.File do
   @moduledoc "A file."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
   @derive Dagger.Sync
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "Retrieves the contents of the file."
   @spec contents(t()) :: {:ok, String.t()} | {:error, term()}
   def contents(%__MODULE__{} = file) do
-    selection =
-      file.selection |> select("contents")
+    query_builder =
+      file.query_builder |> QB.select("contents")
 
-    execute(selection, file.client)
+    Client.execute(file.client, query_builder)
   end
 
   @doc "Return the file's digest. The format of the digest is not guaranteed to be stable between releases of Dagger. It is guaranteed to be stable between invocations of the same Dagger engine."
@@ -35,55 +36,55 @@ defmodule Dagger.File do
   @spec export(t(), String.t(), [{:allow_parent_dir_path, boolean() | nil}]) ::
           {:ok, String.t()} | {:error, term()}
   def export(%__MODULE__{} = file, path, optional_args \\ []) do
-    selection =
-      file.selection
-      |> select("export")
-      |> put_arg("path", path)
-      |> maybe_put_arg("allowParentDirPath", optional_args[:allow_parent_dir_path])
+    query_builder =
+      file.query_builder
+      |> QB.select("export")
+      |> QB.put_arg("path", path)
+      |> QB.maybe_put_arg("allowParentDirPath", optional_args[:allow_parent_dir_path])
 
-    execute(selection, file.client)
+    Client.execute(file.client, query_builder)
   end
 
   @doc "A unique identifier for this File."
   @spec id(t()) :: {:ok, Dagger.FileID.t()} | {:error, term()}
   def id(%__MODULE__{} = file) do
-    selection =
-      file.selection |> select("id")
+    query_builder =
+      file.query_builder |> QB.select("id")
 
-    execute(selection, file.client)
+    Client.execute(file.client, query_builder)
   end
 
   @doc "Retrieves the name of the file."
   @spec name(t()) :: {:ok, String.t()} | {:error, term()}
   def name(%__MODULE__{} = file) do
-    selection =
-      file.selection |> select("name")
+    query_builder =
+      file.query_builder |> QB.select("name")
 
-    execute(selection, file.client)
+    Client.execute(file.client, query_builder)
   end
 
   @doc "Retrieves the size of the file, in bytes."
   @spec size(t()) :: {:ok, integer()} | {:error, term()}
   def size(%__MODULE__{} = file) do
-    selection =
-      file.selection |> select("size")
+    query_builder =
+      file.query_builder |> QB.select("size")
 
-    execute(selection, file.client)
+    Client.execute(file.client, query_builder)
   end
 
   @doc "Force evaluation in the engine."
   @spec sync(t()) :: {:ok, Dagger.File.t()} | {:error, term()}
   def sync(%__MODULE__{} = file) do
-    selection =
-      file.selection |> select("sync")
+    query_builder =
+      file.query_builder |> QB.select("sync")
 
-    with {:ok, id} <- execute(selection, file.client) do
+    with {:ok, id} <- Client.execute(file.client, query_builder) do
       {:ok,
        %Dagger.File{
-         selection:
-           query()
-           |> select("loadFileFromID")
-           |> arg("id", id),
+         query_builder:
+           QB.query()
+           |> QB.select("loadFileFromID")
+           |> QB.put_arg("id", id),
          client: file.client
        }}
     end
@@ -92,11 +93,11 @@ defmodule Dagger.File do
   @doc "Retrieves this file with its name set to the given name."
   @spec with_name(t(), String.t()) :: Dagger.File.t()
   def with_name(%__MODULE__{} = file, name) do
-    selection =
-      file.selection |> select("withName") |> put_arg("name", name)
+    query_builder =
+      file.query_builder |> QB.select("withName") |> QB.put_arg("name", name)
 
     %Dagger.File{
-      selection: selection,
+      query_builder: query_builder,
       client: file.client
     }
   end
@@ -104,11 +105,11 @@ defmodule Dagger.File do
   @doc "Retrieves this file with its created/modified timestamps set to the given time."
   @spec with_timestamps(t(), integer()) :: Dagger.File.t()
   def with_timestamps(%__MODULE__{} = file, timestamp) do
-    selection =
-      file.selection |> select("withTimestamps") |> put_arg("timestamp", timestamp)
+    query_builder =
+      file.query_builder |> QB.select("withTimestamps") |> QB.put_arg("timestamp", timestamp)
 
     %Dagger.File{
-      selection: selection,
+      query_builder: query_builder,
       client: file.client
     }
   end

--- a/sdk/elixir/lib/dagger/gen/function.ex
+++ b/sdk/elixir/lib/dagger/gen/function.ex
@@ -6,28 +6,29 @@ defmodule Dagger.Function do
   A function always evaluates against a parent object and is given a set of named arguments.
   """
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "Arguments accepted by the function, if any."
   @spec args(t()) :: {:ok, [Dagger.FunctionArg.t()]} | {:error, term()}
   def args(%__MODULE__{} = function) do
-    selection =
-      function.selection |> select("args") |> select("id")
+    query_builder =
+      function.query_builder |> QB.select("args") |> QB.select("id")
 
-    with {:ok, items} <- execute(selection, function.client) do
+    with {:ok, items} <- Client.execute(function.client, query_builder) do
       {:ok,
        for %{"id" => id} <- items do
          %Dagger.FunctionArg{
-           selection:
-             query()
-             |> select("loadFunctionArgFromID")
-             |> arg("id", id),
+           query_builder:
+             QB.query()
+             |> QB.select("loadFunctionArgFromID")
+             |> QB.put_arg("id", id),
            client: function.client
          }
        end}
@@ -37,38 +38,38 @@ defmodule Dagger.Function do
   @doc "A doc string for the function, if any."
   @spec description(t()) :: {:ok, String.t()} | {:error, term()}
   def description(%__MODULE__{} = function) do
-    selection =
-      function.selection |> select("description")
+    query_builder =
+      function.query_builder |> QB.select("description")
 
-    execute(selection, function.client)
+    Client.execute(function.client, query_builder)
   end
 
   @doc "A unique identifier for this Function."
   @spec id(t()) :: {:ok, Dagger.FunctionID.t()} | {:error, term()}
   def id(%__MODULE__{} = function) do
-    selection =
-      function.selection |> select("id")
+    query_builder =
+      function.query_builder |> QB.select("id")
 
-    execute(selection, function.client)
+    Client.execute(function.client, query_builder)
   end
 
   @doc "The name of the function."
   @spec name(t()) :: {:ok, String.t()} | {:error, term()}
   def name(%__MODULE__{} = function) do
-    selection =
-      function.selection |> select("name")
+    query_builder =
+      function.query_builder |> QB.select("name")
 
-    execute(selection, function.client)
+    Client.execute(function.client, query_builder)
   end
 
   @doc "The type returned by the function."
   @spec return_type(t()) :: Dagger.TypeDef.t()
   def return_type(%__MODULE__{} = function) do
-    selection =
-      function.selection |> select("returnType")
+    query_builder =
+      function.query_builder |> QB.select("returnType")
 
     %Dagger.TypeDef{
-      selection: selection,
+      query_builder: query_builder,
       client: function.client
     }
   end
@@ -79,16 +80,16 @@ defmodule Dagger.Function do
           {:default_value, Dagger.JSON.t() | nil}
         ]) :: Dagger.Function.t()
   def with_arg(%__MODULE__{} = function, name, type_def, optional_args \\ []) do
-    selection =
-      function.selection
-      |> select("withArg")
-      |> put_arg("name", name)
-      |> put_arg("typeDef", Dagger.ID.id!(type_def))
-      |> maybe_put_arg("description", optional_args[:description])
-      |> maybe_put_arg("defaultValue", optional_args[:default_value])
+    query_builder =
+      function.query_builder
+      |> QB.select("withArg")
+      |> QB.put_arg("name", name)
+      |> QB.put_arg("typeDef", Dagger.ID.id!(type_def))
+      |> QB.maybe_put_arg("description", optional_args[:description])
+      |> QB.maybe_put_arg("defaultValue", optional_args[:default_value])
 
     %Dagger.Function{
-      selection: selection,
+      query_builder: query_builder,
       client: function.client
     }
   end
@@ -96,11 +97,13 @@ defmodule Dagger.Function do
   @doc "Returns the function with the given doc string."
   @spec with_description(t(), String.t()) :: Dagger.Function.t()
   def with_description(%__MODULE__{} = function, description) do
-    selection =
-      function.selection |> select("withDescription") |> put_arg("description", description)
+    query_builder =
+      function.query_builder
+      |> QB.select("withDescription")
+      |> QB.put_arg("description", description)
 
     %Dagger.Function{
-      selection: selection,
+      query_builder: query_builder,
       client: function.client
     }
   end

--- a/sdk/elixir/lib/dagger/gen/function_arg.ex
+++ b/sdk/elixir/lib/dagger/gen/function_arg.ex
@@ -6,58 +6,59 @@ defmodule Dagger.FunctionArg do
   This is a specification for an argument at function definition time, not an argument passed at function call time.
   """
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "A default value to use for this argument when not explicitly set by the caller, if any."
   @spec default_value(t()) :: {:ok, Dagger.JSON.t()} | {:error, term()}
   def default_value(%__MODULE__{} = function_arg) do
-    selection =
-      function_arg.selection |> select("defaultValue")
+    query_builder =
+      function_arg.query_builder |> QB.select("defaultValue")
 
-    execute(selection, function_arg.client)
+    Client.execute(function_arg.client, query_builder)
   end
 
   @doc "A doc string for the argument, if any."
   @spec description(t()) :: {:ok, String.t()} | {:error, term()}
   def description(%__MODULE__{} = function_arg) do
-    selection =
-      function_arg.selection |> select("description")
+    query_builder =
+      function_arg.query_builder |> QB.select("description")
 
-    execute(selection, function_arg.client)
+    Client.execute(function_arg.client, query_builder)
   end
 
   @doc "A unique identifier for this FunctionArg."
   @spec id(t()) :: {:ok, Dagger.FunctionArgID.t()} | {:error, term()}
   def id(%__MODULE__{} = function_arg) do
-    selection =
-      function_arg.selection |> select("id")
+    query_builder =
+      function_arg.query_builder |> QB.select("id")
 
-    execute(selection, function_arg.client)
+    Client.execute(function_arg.client, query_builder)
   end
 
   @doc "The name of the argument in lowerCamelCase format."
   @spec name(t()) :: {:ok, String.t()} | {:error, term()}
   def name(%__MODULE__{} = function_arg) do
-    selection =
-      function_arg.selection |> select("name")
+    query_builder =
+      function_arg.query_builder |> QB.select("name")
 
-    execute(selection, function_arg.client)
+    Client.execute(function_arg.client, query_builder)
   end
 
   @doc "The type of the argument."
   @spec type_def(t()) :: Dagger.TypeDef.t()
   def type_def(%__MODULE__{} = function_arg) do
-    selection =
-      function_arg.selection |> select("typeDef")
+    query_builder =
+      function_arg.query_builder |> QB.select("typeDef")
 
     %Dagger.TypeDef{
-      selection: selection,
+      query_builder: query_builder,
       client: function_arg.client
     }
   end

--- a/sdk/elixir/lib/dagger/gen/function_call_arg_value.ex
+++ b/sdk/elixir/lib/dagger/gen/function_call_arg_value.ex
@@ -2,38 +2,39 @@
 defmodule Dagger.FunctionCallArgValue do
   @moduledoc "A value passed as a named argument to a function call."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "A unique identifier for this FunctionCallArgValue."
   @spec id(t()) :: {:ok, Dagger.FunctionCallArgValueID.t()} | {:error, term()}
   def id(%__MODULE__{} = function_call_arg_value) do
-    selection =
-      function_call_arg_value.selection |> select("id")
+    query_builder =
+      function_call_arg_value.query_builder |> QB.select("id")
 
-    execute(selection, function_call_arg_value.client)
+    Client.execute(function_call_arg_value.client, query_builder)
   end
 
   @doc "The name of the argument."
   @spec name(t()) :: {:ok, String.t()} | {:error, term()}
   def name(%__MODULE__{} = function_call_arg_value) do
-    selection =
-      function_call_arg_value.selection |> select("name")
+    query_builder =
+      function_call_arg_value.query_builder |> QB.select("name")
 
-    execute(selection, function_call_arg_value.client)
+    Client.execute(function_call_arg_value.client, query_builder)
   end
 
   @doc "The value of the argument represented as a JSON serialized string."
   @spec value(t()) :: {:ok, Dagger.JSON.t()} | {:error, term()}
   def value(%__MODULE__{} = function_call_arg_value) do
-    selection =
-      function_call_arg_value.selection |> select("value")
+    query_builder =
+      function_call_arg_value.query_builder |> QB.select("value")
 
-    execute(selection, function_call_arg_value.client)
+    Client.execute(function_call_arg_value.client, query_builder)
   end
 end

--- a/sdk/elixir/lib/dagger/gen/generated_code.ex
+++ b/sdk/elixir/lib/dagger/gen/generated_code.ex
@@ -2,22 +2,23 @@
 defmodule Dagger.GeneratedCode do
   @moduledoc "The result of running an SDK's codegen."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "The directory containing the generated code."
   @spec code(t()) :: Dagger.Directory.t()
   def code(%__MODULE__{} = generated_code) do
-    selection =
-      generated_code.selection |> select("code")
+    query_builder =
+      generated_code.query_builder |> QB.select("code")
 
     %Dagger.Directory{
-      selection: selection,
+      query_builder: query_builder,
       client: generated_code.client
     }
   end
@@ -25,38 +26,40 @@ defmodule Dagger.GeneratedCode do
   @doc "A unique identifier for this GeneratedCode."
   @spec id(t()) :: {:ok, Dagger.GeneratedCodeID.t()} | {:error, term()}
   def id(%__MODULE__{} = generated_code) do
-    selection =
-      generated_code.selection |> select("id")
+    query_builder =
+      generated_code.query_builder |> QB.select("id")
 
-    execute(selection, generated_code.client)
+    Client.execute(generated_code.client, query_builder)
   end
 
   @doc "List of paths to mark generated in version control (i.e. .gitattributes)."
   @spec vcs_generated_paths(t()) :: {:ok, [String.t()]} | {:error, term()}
   def vcs_generated_paths(%__MODULE__{} = generated_code) do
-    selection =
-      generated_code.selection |> select("vcsGeneratedPaths")
+    query_builder =
+      generated_code.query_builder |> QB.select("vcsGeneratedPaths")
 
-    execute(selection, generated_code.client)
+    Client.execute(generated_code.client, query_builder)
   end
 
   @doc "List of paths to ignore in version control (i.e. .gitignore)."
   @spec vcs_ignored_paths(t()) :: {:ok, [String.t()]} | {:error, term()}
   def vcs_ignored_paths(%__MODULE__{} = generated_code) do
-    selection =
-      generated_code.selection |> select("vcsIgnoredPaths")
+    query_builder =
+      generated_code.query_builder |> QB.select("vcsIgnoredPaths")
 
-    execute(selection, generated_code.client)
+    Client.execute(generated_code.client, query_builder)
   end
 
   @doc "Set the list of paths to mark generated in version control."
   @spec with_vcs_generated_paths(t(), [String.t()]) :: Dagger.GeneratedCode.t()
   def with_vcs_generated_paths(%__MODULE__{} = generated_code, paths) do
-    selection =
-      generated_code.selection |> select("withVCSGeneratedPaths") |> put_arg("paths", paths)
+    query_builder =
+      generated_code.query_builder
+      |> QB.select("withVCSGeneratedPaths")
+      |> QB.put_arg("paths", paths)
 
     %Dagger.GeneratedCode{
-      selection: selection,
+      query_builder: query_builder,
       client: generated_code.client
     }
   end
@@ -64,11 +67,13 @@ defmodule Dagger.GeneratedCode do
   @doc "Set the list of paths to ignore in version control."
   @spec with_vcs_ignored_paths(t(), [String.t()]) :: Dagger.GeneratedCode.t()
   def with_vcs_ignored_paths(%__MODULE__{} = generated_code, paths) do
-    selection =
-      generated_code.selection |> select("withVCSIgnoredPaths") |> put_arg("paths", paths)
+    query_builder =
+      generated_code.query_builder
+      |> QB.select("withVCSIgnoredPaths")
+      |> QB.put_arg("paths", paths)
 
     %Dagger.GeneratedCode{
-      selection: selection,
+      query_builder: query_builder,
       client: generated_code.client
     }
   end

--- a/sdk/elixir/lib/dagger/gen/git_module_source.ex
+++ b/sdk/elixir/lib/dagger/gen/git_module_source.ex
@@ -2,40 +2,41 @@
 defmodule Dagger.GitModuleSource do
   @moduledoc "Module source originating from a git repo."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "The URL to clone the root of the git repo from"
   @spec clone_url(t()) :: {:ok, String.t()} | {:error, term()}
   def clone_url(%__MODULE__{} = git_module_source) do
-    selection =
-      git_module_source.selection |> select("cloneURL")
+    query_builder =
+      git_module_source.query_builder |> QB.select("cloneURL")
 
-    execute(selection, git_module_source.client)
+    Client.execute(git_module_source.client, query_builder)
   end
 
   @doc "The resolved commit of the git repo this source points to."
   @spec commit(t()) :: {:ok, String.t()} | {:error, term()}
   def commit(%__MODULE__{} = git_module_source) do
-    selection =
-      git_module_source.selection |> select("commit")
+    query_builder =
+      git_module_source.query_builder |> QB.select("commit")
 
-    execute(selection, git_module_source.client)
+    Client.execute(git_module_source.client, query_builder)
   end
 
   @doc "The directory containing everything needed to load load and use the module."
   @spec context_directory(t()) :: Dagger.Directory.t()
   def context_directory(%__MODULE__{} = git_module_source) do
-    selection =
-      git_module_source.selection |> select("contextDirectory")
+    query_builder =
+      git_module_source.query_builder |> QB.select("contextDirectory")
 
     %Dagger.Directory{
-      selection: selection,
+      query_builder: query_builder,
       client: git_module_source.client
     }
   end
@@ -43,45 +44,45 @@ defmodule Dagger.GitModuleSource do
   @doc "The URL to the source's git repo in a web browser"
   @spec html_url(t()) :: {:ok, String.t()} | {:error, term()}
   def html_url(%__MODULE__{} = git_module_source) do
-    selection =
-      git_module_source.selection |> select("htmlURL")
+    query_builder =
+      git_module_source.query_builder |> QB.select("htmlURL")
 
-    execute(selection, git_module_source.client)
+    Client.execute(git_module_source.client, query_builder)
   end
 
   @doc "A unique identifier for this GitModuleSource."
   @spec id(t()) :: {:ok, Dagger.GitModuleSourceID.t()} | {:error, term()}
   def id(%__MODULE__{} = git_module_source) do
-    selection =
-      git_module_source.selection |> select("id")
+    query_builder =
+      git_module_source.query_builder |> QB.select("id")
 
-    execute(selection, git_module_source.client)
+    Client.execute(git_module_source.client, query_builder)
   end
 
   @doc "The clean module name of the root of the module"
   @spec root(t()) :: {:ok, String.t()} | {:error, term()}
   def root(%__MODULE__{} = git_module_source) do
-    selection =
-      git_module_source.selection |> select("root")
+    query_builder =
+      git_module_source.query_builder |> QB.select("root")
 
-    execute(selection, git_module_source.client)
+    Client.execute(git_module_source.client, query_builder)
   end
 
   @doc "The path to the root of the module source under the context directory. This directory contains its configuration file. It also contains its source code (possibly as a subdirectory)."
   @spec root_subpath(t()) :: {:ok, String.t()} | {:error, term()}
   def root_subpath(%__MODULE__{} = git_module_source) do
-    selection =
-      git_module_source.selection |> select("rootSubpath")
+    query_builder =
+      git_module_source.query_builder |> QB.select("rootSubpath")
 
-    execute(selection, git_module_source.client)
+    Client.execute(git_module_source.client, query_builder)
   end
 
   @doc "The specified version of the git repo this source points to."
   @spec version(t()) :: {:ok, String.t()} | {:error, term()}
   def version(%__MODULE__{} = git_module_source) do
-    selection =
-      git_module_source.selection |> select("version")
+    query_builder =
+      git_module_source.query_builder |> QB.select("version")
 
-    execute(selection, git_module_source.client)
+    Client.execute(git_module_source.client, query_builder)
   end
 end

--- a/sdk/elixir/lib/dagger/gen/git_ref.ex
+++ b/sdk/elixir/lib/dagger/gen/git_ref.ex
@@ -2,40 +2,41 @@
 defmodule Dagger.GitRef do
   @moduledoc "A git ref (tag, branch, or commit)."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "The resolved commit id at this ref."
   @spec commit(t()) :: {:ok, String.t()} | {:error, term()}
   def commit(%__MODULE__{} = git_ref) do
-    selection =
-      git_ref.selection |> select("commit")
+    query_builder =
+      git_ref.query_builder |> QB.select("commit")
 
-    execute(selection, git_ref.client)
+    Client.execute(git_ref.client, query_builder)
   end
 
   @doc "A unique identifier for this GitRef."
   @spec id(t()) :: {:ok, Dagger.GitRefID.t()} | {:error, term()}
   def id(%__MODULE__{} = git_ref) do
-    selection =
-      git_ref.selection |> select("id")
+    query_builder =
+      git_ref.query_builder |> QB.select("id")
 
-    execute(selection, git_ref.client)
+    Client.execute(git_ref.client, query_builder)
   end
 
   @doc "The filesystem tree at this ref."
   @spec tree(t()) :: Dagger.Directory.t()
   def tree(%__MODULE__{} = git_ref) do
-    selection =
-      git_ref.selection |> select("tree")
+    query_builder =
+      git_ref.query_builder |> QB.select("tree")
 
     %Dagger.Directory{
-      selection: selection,
+      query_builder: query_builder,
       client: git_ref.client
     }
   end

--- a/sdk/elixir/lib/dagger/gen/git_repository.ex
+++ b/sdk/elixir/lib/dagger/gen/git_repository.ex
@@ -2,22 +2,23 @@
 defmodule Dagger.GitRepository do
   @moduledoc "A git repository."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "Returns details of a branch."
   @spec branch(t(), String.t()) :: Dagger.GitRef.t()
   def branch(%__MODULE__{} = git_repository, name) do
-    selection =
-      git_repository.selection |> select("branch") |> put_arg("name", name)
+    query_builder =
+      git_repository.query_builder |> QB.select("branch") |> QB.put_arg("name", name)
 
     %Dagger.GitRef{
-      selection: selection,
+      query_builder: query_builder,
       client: git_repository.client
     }
   end
@@ -25,11 +26,11 @@ defmodule Dagger.GitRepository do
   @doc "Returns details of a commit."
   @spec commit(t(), String.t()) :: Dagger.GitRef.t()
   def commit(%__MODULE__{} = git_repository, id) do
-    selection =
-      git_repository.selection |> select("commit") |> put_arg("id", id)
+    query_builder =
+      git_repository.query_builder |> QB.select("commit") |> QB.put_arg("id", id)
 
     %Dagger.GitRef{
-      selection: selection,
+      query_builder: query_builder,
       client: git_repository.client
     }
   end
@@ -37,11 +38,11 @@ defmodule Dagger.GitRepository do
   @doc "Returns details for HEAD."
   @spec head(t()) :: Dagger.GitRef.t()
   def head(%__MODULE__{} = git_repository) do
-    selection =
-      git_repository.selection |> select("head")
+    query_builder =
+      git_repository.query_builder |> QB.select("head")
 
     %Dagger.GitRef{
-      selection: selection,
+      query_builder: query_builder,
       client: git_repository.client
     }
   end
@@ -49,20 +50,20 @@ defmodule Dagger.GitRepository do
   @doc "A unique identifier for this GitRepository."
   @spec id(t()) :: {:ok, Dagger.GitRepositoryID.t()} | {:error, term()}
   def id(%__MODULE__{} = git_repository) do
-    selection =
-      git_repository.selection |> select("id")
+    query_builder =
+      git_repository.query_builder |> QB.select("id")
 
-    execute(selection, git_repository.client)
+    Client.execute(git_repository.client, query_builder)
   end
 
   @doc "Returns details of a ref."
   @spec ref(t(), String.t()) :: Dagger.GitRef.t()
   def ref(%__MODULE__{} = git_repository, name) do
-    selection =
-      git_repository.selection |> select("ref") |> put_arg("name", name)
+    query_builder =
+      git_repository.query_builder |> QB.select("ref") |> QB.put_arg("name", name)
 
     %Dagger.GitRef{
-      selection: selection,
+      query_builder: query_builder,
       client: git_repository.client
     }
   end
@@ -70,11 +71,11 @@ defmodule Dagger.GitRepository do
   @doc "Returns details of a tag."
   @spec tag(t(), String.t()) :: Dagger.GitRef.t()
   def tag(%__MODULE__{} = git_repository, name) do
-    selection =
-      git_repository.selection |> select("tag") |> put_arg("name", name)
+    query_builder =
+      git_repository.query_builder |> QB.select("tag") |> QB.put_arg("name", name)
 
     %Dagger.GitRef{
-      selection: selection,
+      query_builder: query_builder,
       client: git_repository.client
     }
   end
@@ -82,24 +83,24 @@ defmodule Dagger.GitRepository do
   @doc "tags that match any of the given glob patterns."
   @spec tags(t(), [{:patterns, [String.t()]}]) :: {:ok, [String.t()]} | {:error, term()}
   def tags(%__MODULE__{} = git_repository, optional_args \\ []) do
-    selection =
-      git_repository.selection
-      |> select("tags")
-      |> maybe_put_arg("patterns", optional_args[:patterns])
+    query_builder =
+      git_repository.query_builder
+      |> QB.select("tags")
+      |> QB.maybe_put_arg("patterns", optional_args[:patterns])
 
-    execute(selection, git_repository.client)
+    Client.execute(git_repository.client, query_builder)
   end
 
   @doc "Header to authenticate the remote with."
   @spec with_auth_header(t(), Dagger.Secret.t()) :: Dagger.GitRepository.t()
   def with_auth_header(%__MODULE__{} = git_repository, header) do
-    selection =
-      git_repository.selection
-      |> select("withAuthHeader")
-      |> put_arg("header", Dagger.ID.id!(header))
+    query_builder =
+      git_repository.query_builder
+      |> QB.select("withAuthHeader")
+      |> QB.put_arg("header", Dagger.ID.id!(header))
 
     %Dagger.GitRepository{
-      selection: selection,
+      query_builder: query_builder,
       client: git_repository.client
     }
   end
@@ -107,13 +108,13 @@ defmodule Dagger.GitRepository do
   @doc "Token to authenticate the remote with."
   @spec with_auth_token(t(), Dagger.Secret.t()) :: Dagger.GitRepository.t()
   def with_auth_token(%__MODULE__{} = git_repository, token) do
-    selection =
-      git_repository.selection
-      |> select("withAuthToken")
-      |> put_arg("token", Dagger.ID.id!(token))
+    query_builder =
+      git_repository.query_builder
+      |> QB.select("withAuthToken")
+      |> QB.put_arg("token", Dagger.ID.id!(token))
 
     %Dagger.GitRepository{
-      selection: selection,
+      query_builder: query_builder,
       client: git_repository.client
     }
   end

--- a/sdk/elixir/lib/dagger/gen/interface_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/interface_type_def.ex
@@ -2,37 +2,38 @@
 defmodule Dagger.InterfaceTypeDef do
   @moduledoc "A definition of a custom interface defined in a Module."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "The doc string for the interface, if any."
   @spec description(t()) :: {:ok, String.t()} | {:error, term()}
   def description(%__MODULE__{} = interface_type_def) do
-    selection =
-      interface_type_def.selection |> select("description")
+    query_builder =
+      interface_type_def.query_builder |> QB.select("description")
 
-    execute(selection, interface_type_def.client)
+    Client.execute(interface_type_def.client, query_builder)
   end
 
   @doc "Functions defined on this interface, if any."
   @spec functions(t()) :: {:ok, [Dagger.Function.t()]} | {:error, term()}
   def functions(%__MODULE__{} = interface_type_def) do
-    selection =
-      interface_type_def.selection |> select("functions") |> select("id")
+    query_builder =
+      interface_type_def.query_builder |> QB.select("functions") |> QB.select("id")
 
-    with {:ok, items} <- execute(selection, interface_type_def.client) do
+    with {:ok, items} <- Client.execute(interface_type_def.client, query_builder) do
       {:ok,
        for %{"id" => id} <- items do
          %Dagger.Function{
-           selection:
-             query()
-             |> select("loadFunctionFromID")
-             |> arg("id", id),
+           query_builder:
+             QB.query()
+             |> QB.select("loadFunctionFromID")
+             |> QB.put_arg("id", id),
            client: interface_type_def.client
          }
        end}
@@ -42,27 +43,27 @@ defmodule Dagger.InterfaceTypeDef do
   @doc "A unique identifier for this InterfaceTypeDef."
   @spec id(t()) :: {:ok, Dagger.InterfaceTypeDefID.t()} | {:error, term()}
   def id(%__MODULE__{} = interface_type_def) do
-    selection =
-      interface_type_def.selection |> select("id")
+    query_builder =
+      interface_type_def.query_builder |> QB.select("id")
 
-    execute(selection, interface_type_def.client)
+    Client.execute(interface_type_def.client, query_builder)
   end
 
   @doc "The name of the interface."
   @spec name(t()) :: {:ok, String.t()} | {:error, term()}
   def name(%__MODULE__{} = interface_type_def) do
-    selection =
-      interface_type_def.selection |> select("name")
+    query_builder =
+      interface_type_def.query_builder |> QB.select("name")
 
-    execute(selection, interface_type_def.client)
+    Client.execute(interface_type_def.client, query_builder)
   end
 
   @doc "If this InterfaceTypeDef is associated with a Module, the name of the module. Unset otherwise."
   @spec source_module_name(t()) :: {:ok, String.t()} | {:error, term()}
   def source_module_name(%__MODULE__{} = interface_type_def) do
-    selection =
-      interface_type_def.selection |> select("sourceModuleName")
+    query_builder =
+      interface_type_def.query_builder |> QB.select("sourceModuleName")
 
-    execute(selection, interface_type_def.client)
+    Client.execute(interface_type_def.client, query_builder)
   end
 end

--- a/sdk/elixir/lib/dagger/gen/label.ex
+++ b/sdk/elixir/lib/dagger/gen/label.ex
@@ -2,38 +2,39 @@
 defmodule Dagger.Label do
   @moduledoc "A simple key value object that represents a label."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "A unique identifier for this Label."
   @spec id(t()) :: {:ok, Dagger.LabelID.t()} | {:error, term()}
   def id(%__MODULE__{} = label) do
-    selection =
-      label.selection |> select("id")
+    query_builder =
+      label.query_builder |> QB.select("id")
 
-    execute(selection, label.client)
+    Client.execute(label.client, query_builder)
   end
 
   @doc "The label name."
   @spec name(t()) :: {:ok, String.t()} | {:error, term()}
   def name(%__MODULE__{} = label) do
-    selection =
-      label.selection |> select("name")
+    query_builder =
+      label.query_builder |> QB.select("name")
 
-    execute(selection, label.client)
+    Client.execute(label.client, query_builder)
   end
 
   @doc "The label value."
   @spec value(t()) :: {:ok, String.t()} | {:error, term()}
   def value(%__MODULE__{} = label) do
-    selection =
-      label.selection |> select("value")
+    query_builder =
+      label.query_builder |> QB.select("value")
 
-    execute(selection, label.client)
+    Client.execute(label.client, query_builder)
   end
 end

--- a/sdk/elixir/lib/dagger/gen/list_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/list_type_def.ex
@@ -2,22 +2,23 @@
 defmodule Dagger.ListTypeDef do
   @moduledoc "A definition of a list type in a Module."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "The type of the elements in the list."
   @spec element_type_def(t()) :: Dagger.TypeDef.t()
   def element_type_def(%__MODULE__{} = list_type_def) do
-    selection =
-      list_type_def.selection |> select("elementTypeDef")
+    query_builder =
+      list_type_def.query_builder |> QB.select("elementTypeDef")
 
     %Dagger.TypeDef{
-      selection: selection,
+      query_builder: query_builder,
       client: list_type_def.client
     }
   end
@@ -25,9 +26,9 @@ defmodule Dagger.ListTypeDef do
   @doc "A unique identifier for this ListTypeDef."
   @spec id(t()) :: {:ok, Dagger.ListTypeDefID.t()} | {:error, term()}
   def id(%__MODULE__{} = list_type_def) do
-    selection =
-      list_type_def.selection |> select("id")
+    query_builder =
+      list_type_def.query_builder |> QB.select("id")
 
-    execute(selection, list_type_def.client)
+    Client.execute(list_type_def.client, query_builder)
   end
 end

--- a/sdk/elixir/lib/dagger/gen/local_module_source.ex
+++ b/sdk/elixir/lib/dagger/gen/local_module_source.ex
@@ -2,22 +2,23 @@
 defmodule Dagger.LocalModuleSource do
   @moduledoc "Module source that that originates from a path locally relative to an arbitrary directory."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "The directory containing everything needed to load load and use the module."
   @spec context_directory(t()) :: Dagger.Directory.t() | nil
   def context_directory(%__MODULE__{} = local_module_source) do
-    selection =
-      local_module_source.selection |> select("contextDirectory")
+    query_builder =
+      local_module_source.query_builder |> QB.select("contextDirectory")
 
     %Dagger.Directory{
-      selection: selection,
+      query_builder: query_builder,
       client: local_module_source.client
     }
   end
@@ -25,18 +26,18 @@ defmodule Dagger.LocalModuleSource do
   @doc "A unique identifier for this LocalModuleSource."
   @spec id(t()) :: {:ok, Dagger.LocalModuleSourceID.t()} | {:error, term()}
   def id(%__MODULE__{} = local_module_source) do
-    selection =
-      local_module_source.selection |> select("id")
+    query_builder =
+      local_module_source.query_builder |> QB.select("id")
 
-    execute(selection, local_module_source.client)
+    Client.execute(local_module_source.client, query_builder)
   end
 
   @doc "The path to the root of the module source under the context directory. This directory contains its configuration file. It also contains its source code (possibly as a subdirectory)."
   @spec root_subpath(t()) :: {:ok, String.t()} | {:error, term()}
   def root_subpath(%__MODULE__{} = local_module_source) do
-    selection =
-      local_module_source.selection |> select("rootSubpath")
+    query_builder =
+      local_module_source.query_builder |> QB.select("rootSubpath")
 
-    execute(selection, local_module_source.client)
+    Client.execute(local_module_source.client, query_builder)
   end
 end

--- a/sdk/elixir/lib/dagger/gen/module.ex
+++ b/sdk/elixir/lib/dagger/gen/module.ex
@@ -2,28 +2,29 @@
 defmodule Dagger.Module do
   @moduledoc "A Dagger module."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "Modules used by this module."
   @spec dependencies(t()) :: {:ok, [Dagger.Module.t()]} | {:error, term()}
   def dependencies(%__MODULE__{} = module) do
-    selection =
-      module.selection |> select("dependencies") |> select("id")
+    query_builder =
+      module.query_builder |> QB.select("dependencies") |> QB.select("id")
 
-    with {:ok, items} <- execute(selection, module.client) do
+    with {:ok, items} <- Client.execute(module.client, query_builder) do
       {:ok,
        for %{"id" => id} <- items do
          %Dagger.Module{
-           selection:
-             query()
-             |> select("loadModuleFromID")
-             |> arg("id", id),
+           query_builder:
+             QB.query()
+             |> QB.select("loadModuleFromID")
+             |> QB.put_arg("id", id),
            client: module.client
          }
        end}
@@ -33,17 +34,17 @@ defmodule Dagger.Module do
   @doc "The dependencies as configured by the module."
   @spec dependency_config(t()) :: {:ok, [Dagger.ModuleDependency.t()]} | {:error, term()}
   def dependency_config(%__MODULE__{} = module) do
-    selection =
-      module.selection |> select("dependencyConfig") |> select("id")
+    query_builder =
+      module.query_builder |> QB.select("dependencyConfig") |> QB.select("id")
 
-    with {:ok, items} <- execute(selection, module.client) do
+    with {:ok, items} <- Client.execute(module.client, query_builder) do
       {:ok,
        for %{"id" => id} <- items do
          %Dagger.ModuleDependency{
-           selection:
-             query()
-             |> select("loadModuleDependencyFromID")
-             |> arg("id", id),
+           query_builder:
+             QB.query()
+             |> QB.select("loadModuleDependencyFromID")
+             |> QB.put_arg("id", id),
            client: module.client
          }
        end}
@@ -53,26 +54,26 @@ defmodule Dagger.Module do
   @doc "The doc string of the module, if any"
   @spec description(t()) :: {:ok, String.t()} | {:error, term()}
   def description(%__MODULE__{} = module) do
-    selection =
-      module.selection |> select("description")
+    query_builder =
+      module.query_builder |> QB.select("description")
 
-    execute(selection, module.client)
+    Client.execute(module.client, query_builder)
   end
 
   @doc "Enumerations served by this module."
   @spec enums(t()) :: {:ok, [Dagger.TypeDef.t()]} | {:error, term()}
   def enums(%__MODULE__{} = module) do
-    selection =
-      module.selection |> select("enums") |> select("id")
+    query_builder =
+      module.query_builder |> QB.select("enums") |> QB.select("id")
 
-    with {:ok, items} <- execute(selection, module.client) do
+    with {:ok, items} <- Client.execute(module.client, query_builder) do
       {:ok,
        for %{"id" => id} <- items do
          %Dagger.TypeDef{
-           selection:
-             query()
-             |> select("loadTypeDefFromID")
-             |> arg("id", id),
+           query_builder:
+             QB.query()
+             |> QB.select("loadTypeDefFromID")
+             |> QB.put_arg("id", id),
            client: module.client
          }
        end}
@@ -82,11 +83,11 @@ defmodule Dagger.Module do
   @doc "The generated files and directories made on top of the module source's context directory."
   @spec generated_context_diff(t()) :: Dagger.Directory.t()
   def generated_context_diff(%__MODULE__{} = module) do
-    selection =
-      module.selection |> select("generatedContextDiff")
+    query_builder =
+      module.query_builder |> QB.select("generatedContextDiff")
 
     %Dagger.Directory{
-      selection: selection,
+      query_builder: query_builder,
       client: module.client
     }
   end
@@ -94,11 +95,11 @@ defmodule Dagger.Module do
   @doc "The module source's context plus any configuration and source files created by codegen."
   @spec generated_context_directory(t()) :: Dagger.Directory.t()
   def generated_context_directory(%__MODULE__{} = module) do
-    selection =
-      module.selection |> select("generatedContextDirectory")
+    query_builder =
+      module.query_builder |> QB.select("generatedContextDirectory")
 
     %Dagger.Directory{
-      selection: selection,
+      query_builder: query_builder,
       client: module.client
     }
   end
@@ -106,20 +107,20 @@ defmodule Dagger.Module do
   @doc "A unique identifier for this Module."
   @spec id(t()) :: {:ok, Dagger.ModuleID.t()} | {:error, term()}
   def id(%__MODULE__{} = module) do
-    selection =
-      module.selection |> select("id")
+    query_builder =
+      module.query_builder |> QB.select("id")
 
-    execute(selection, module.client)
+    Client.execute(module.client, query_builder)
   end
 
   @doc "Retrieves the module with the objects loaded via its SDK."
   @spec initialize(t()) :: Dagger.Module.t()
   def initialize(%__MODULE__{} = module) do
-    selection =
-      module.selection |> select("initialize")
+    query_builder =
+      module.query_builder |> QB.select("initialize")
 
     %Dagger.Module{
-      selection: selection,
+      query_builder: query_builder,
       client: module.client
     }
   end
@@ -127,17 +128,17 @@ defmodule Dagger.Module do
   @doc "Interfaces served by this module."
   @spec interfaces(t()) :: {:ok, [Dagger.TypeDef.t()]} | {:error, term()}
   def interfaces(%__MODULE__{} = module) do
-    selection =
-      module.selection |> select("interfaces") |> select("id")
+    query_builder =
+      module.query_builder |> QB.select("interfaces") |> QB.select("id")
 
-    with {:ok, items} <- execute(selection, module.client) do
+    with {:ok, items} <- Client.execute(module.client, query_builder) do
       {:ok,
        for %{"id" => id} <- items do
          %Dagger.TypeDef{
-           selection:
-             query()
-             |> select("loadTypeDefFromID")
-             |> arg("id", id),
+           query_builder:
+             QB.query()
+             |> QB.select("loadTypeDefFromID")
+             |> QB.put_arg("id", id),
            client: module.client
          }
        end}
@@ -147,26 +148,26 @@ defmodule Dagger.Module do
   @doc "The name of the module"
   @spec name(t()) :: {:ok, String.t()} | {:error, term()}
   def name(%__MODULE__{} = module) do
-    selection =
-      module.selection |> select("name")
+    query_builder =
+      module.query_builder |> QB.select("name")
 
-    execute(selection, module.client)
+    Client.execute(module.client, query_builder)
   end
 
   @doc "Objects served by this module."
   @spec objects(t()) :: {:ok, [Dagger.TypeDef.t()]} | {:error, term()}
   def objects(%__MODULE__{} = module) do
-    selection =
-      module.selection |> select("objects") |> select("id")
+    query_builder =
+      module.query_builder |> QB.select("objects") |> QB.select("id")
 
-    with {:ok, items} <- execute(selection, module.client) do
+    with {:ok, items} <- Client.execute(module.client, query_builder) do
       {:ok,
        for %{"id" => id} <- items do
          %Dagger.TypeDef{
-           selection:
-             query()
-             |> select("loadTypeDefFromID")
-             |> arg("id", id),
+           query_builder:
+             QB.query()
+             |> QB.select("loadTypeDefFromID")
+             |> QB.put_arg("id", id),
            client: module.client
          }
        end}
@@ -176,11 +177,11 @@ defmodule Dagger.Module do
   @doc "The container that runs the module's entrypoint. It will fail to execute if the module doesn't compile."
   @spec runtime(t()) :: Dagger.Container.t()
   def runtime(%__MODULE__{} = module) do
-    selection =
-      module.selection |> select("runtime")
+    query_builder =
+      module.query_builder |> QB.select("runtime")
 
     %Dagger.Container{
-      selection: selection,
+      query_builder: query_builder,
       client: module.client
     }
   end
@@ -188,10 +189,10 @@ defmodule Dagger.Module do
   @doc "The SDK used by this module. Either a name of a builtin SDK or a module source ref string pointing to the SDK's implementation."
   @spec sdk(t()) :: {:ok, String.t()} | {:error, term()}
   def sdk(%__MODULE__{} = module) do
-    selection =
-      module.selection |> select("sdk")
+    query_builder =
+      module.query_builder |> QB.select("sdk")
 
-    execute(selection, module.client)
+    Client.execute(module.client, query_builder)
   end
 
   @doc """
@@ -201,10 +202,10 @@ defmodule Dagger.Module do
   """
   @spec serve(t()) :: :ok | {:error, term()}
   def serve(%__MODULE__{} = module) do
-    selection =
-      module.selection |> select("serve")
+    query_builder =
+      module.query_builder |> QB.select("serve")
 
-    case execute(selection, module.client) do
+    case Client.execute(module.client, query_builder) do
       {:ok, _} -> :ok
       error -> error
     end
@@ -213,11 +214,11 @@ defmodule Dagger.Module do
   @doc "The source for the module."
   @spec source(t()) :: Dagger.ModuleSource.t()
   def source(%__MODULE__{} = module) do
-    selection =
-      module.selection |> select("source")
+    query_builder =
+      module.query_builder |> QB.select("source")
 
     %Dagger.ModuleSource{
-      selection: selection,
+      query_builder: query_builder,
       client: module.client
     }
   end
@@ -225,11 +226,13 @@ defmodule Dagger.Module do
   @doc "Retrieves the module with the given description"
   @spec with_description(t(), String.t()) :: Dagger.Module.t()
   def with_description(%__MODULE__{} = module, description) do
-    selection =
-      module.selection |> select("withDescription") |> put_arg("description", description)
+    query_builder =
+      module.query_builder
+      |> QB.select("withDescription")
+      |> QB.put_arg("description", description)
 
     %Dagger.Module{
-      selection: selection,
+      query_builder: query_builder,
       client: module.client
     }
   end
@@ -237,11 +240,11 @@ defmodule Dagger.Module do
   @doc "This module plus the given Enum type and associated values"
   @spec with_enum(t(), Dagger.TypeDef.t()) :: Dagger.Module.t()
   def with_enum(%__MODULE__{} = module, enum) do
-    selection =
-      module.selection |> select("withEnum") |> put_arg("enum", Dagger.ID.id!(enum))
+    query_builder =
+      module.query_builder |> QB.select("withEnum") |> QB.put_arg("enum", Dagger.ID.id!(enum))
 
     %Dagger.Module{
-      selection: selection,
+      query_builder: query_builder,
       client: module.client
     }
   end
@@ -249,11 +252,13 @@ defmodule Dagger.Module do
   @doc "This module plus the given Interface type and associated functions"
   @spec with_interface(t(), Dagger.TypeDef.t()) :: Dagger.Module.t()
   def with_interface(%__MODULE__{} = module, iface) do
-    selection =
-      module.selection |> select("withInterface") |> put_arg("iface", Dagger.ID.id!(iface))
+    query_builder =
+      module.query_builder
+      |> QB.select("withInterface")
+      |> QB.put_arg("iface", Dagger.ID.id!(iface))
 
     %Dagger.Module{
-      selection: selection,
+      query_builder: query_builder,
       client: module.client
     }
   end
@@ -261,11 +266,13 @@ defmodule Dagger.Module do
   @doc "This module plus the given Object type and associated functions."
   @spec with_object(t(), Dagger.TypeDef.t()) :: Dagger.Module.t()
   def with_object(%__MODULE__{} = module, object) do
-    selection =
-      module.selection |> select("withObject") |> put_arg("object", Dagger.ID.id!(object))
+    query_builder =
+      module.query_builder
+      |> QB.select("withObject")
+      |> QB.put_arg("object", Dagger.ID.id!(object))
 
     %Dagger.Module{
-      selection: selection,
+      query_builder: query_builder,
       client: module.client
     }
   end
@@ -274,14 +281,14 @@ defmodule Dagger.Module do
   @spec with_source(t(), Dagger.ModuleSource.t(), [{:engine_version, String.t() | nil}]) ::
           Dagger.Module.t()
   def with_source(%__MODULE__{} = module, source, optional_args \\ []) do
-    selection =
-      module.selection
-      |> select("withSource")
-      |> put_arg("source", Dagger.ID.id!(source))
-      |> maybe_put_arg("engineVersion", optional_args[:engine_version])
+    query_builder =
+      module.query_builder
+      |> QB.select("withSource")
+      |> QB.put_arg("source", Dagger.ID.id!(source))
+      |> QB.maybe_put_arg("engineVersion", optional_args[:engine_version])
 
     %Dagger.Module{
-      selection: selection,
+      query_builder: query_builder,
       client: module.client
     }
   end

--- a/sdk/elixir/lib/dagger/gen/module_dependency.ex
+++ b/sdk/elixir/lib/dagger/gen/module_dependency.ex
@@ -2,40 +2,41 @@
 defmodule Dagger.ModuleDependency do
   @moduledoc "The configuration of dependency of a module."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "A unique identifier for this ModuleDependency."
   @spec id(t()) :: {:ok, Dagger.ModuleDependencyID.t()} | {:error, term()}
   def id(%__MODULE__{} = module_dependency) do
-    selection =
-      module_dependency.selection |> select("id")
+    query_builder =
+      module_dependency.query_builder |> QB.select("id")
 
-    execute(selection, module_dependency.client)
+    Client.execute(module_dependency.client, query_builder)
   end
 
   @doc "The name of the dependency module."
   @spec name(t()) :: {:ok, String.t()} | {:error, term()}
   def name(%__MODULE__{} = module_dependency) do
-    selection =
-      module_dependency.selection |> select("name")
+    query_builder =
+      module_dependency.query_builder |> QB.select("name")
 
-    execute(selection, module_dependency.client)
+    Client.execute(module_dependency.client, query_builder)
   end
 
   @doc "The source for the dependency module."
   @spec source(t()) :: Dagger.ModuleSource.t()
   def source(%__MODULE__{} = module_dependency) do
-    selection =
-      module_dependency.selection |> select("source")
+    query_builder =
+      module_dependency.query_builder |> QB.select("source")
 
     %Dagger.ModuleSource{
-      selection: selection,
+      query_builder: query_builder,
       client: module_dependency.client
     }
   end

--- a/sdk/elixir/lib/dagger/gen/module_source_view.ex
+++ b/sdk/elixir/lib/dagger/gen/module_source_view.ex
@@ -2,38 +2,39 @@
 defmodule Dagger.ModuleSourceView do
   @moduledoc "A named set of path filters that can be applied to directory arguments provided to functions."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "A unique identifier for this ModuleSourceView."
   @spec id(t()) :: {:ok, Dagger.ModuleSourceViewID.t()} | {:error, term()}
   def id(%__MODULE__{} = module_source_view) do
-    selection =
-      module_source_view.selection |> select("id")
+    query_builder =
+      module_source_view.query_builder |> QB.select("id")
 
-    execute(selection, module_source_view.client)
+    Client.execute(module_source_view.client, query_builder)
   end
 
   @doc "The name of the view"
   @spec name(t()) :: {:ok, String.t()} | {:error, term()}
   def name(%__MODULE__{} = module_source_view) do
-    selection =
-      module_source_view.selection |> select("name")
+    query_builder =
+      module_source_view.query_builder |> QB.select("name")
 
-    execute(selection, module_source_view.client)
+    Client.execute(module_source_view.client, query_builder)
   end
 
   @doc "The patterns of the view used to filter paths"
   @spec patterns(t()) :: {:ok, [String.t()]} | {:error, term()}
   def patterns(%__MODULE__{} = module_source_view) do
-    selection =
-      module_source_view.selection |> select("patterns")
+    query_builder =
+      module_source_view.query_builder |> QB.select("patterns")
 
-    execute(selection, module_source_view.client)
+    Client.execute(module_source_view.client, query_builder)
   end
 end

--- a/sdk/elixir/lib/dagger/gen/object_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/object_type_def.ex
@@ -2,22 +2,23 @@
 defmodule Dagger.ObjectTypeDef do
   @moduledoc "A definition of a custom object defined in a Module."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "The function used to construct new instances of this object, if any"
   @spec constructor(t()) :: Dagger.Function.t() | nil
   def constructor(%__MODULE__{} = object_type_def) do
-    selection =
-      object_type_def.selection |> select("constructor")
+    query_builder =
+      object_type_def.query_builder |> QB.select("constructor")
 
     %Dagger.Function{
-      selection: selection,
+      query_builder: query_builder,
       client: object_type_def.client
     }
   end
@@ -25,26 +26,26 @@ defmodule Dagger.ObjectTypeDef do
   @doc "The doc string for the object, if any."
   @spec description(t()) :: {:ok, String.t()} | {:error, term()}
   def description(%__MODULE__{} = object_type_def) do
-    selection =
-      object_type_def.selection |> select("description")
+    query_builder =
+      object_type_def.query_builder |> QB.select("description")
 
-    execute(selection, object_type_def.client)
+    Client.execute(object_type_def.client, query_builder)
   end
 
   @doc "Static fields defined on this object, if any."
   @spec fields(t()) :: {:ok, [Dagger.FieldTypeDef.t()]} | {:error, term()}
   def fields(%__MODULE__{} = object_type_def) do
-    selection =
-      object_type_def.selection |> select("fields") |> select("id")
+    query_builder =
+      object_type_def.query_builder |> QB.select("fields") |> QB.select("id")
 
-    with {:ok, items} <- execute(selection, object_type_def.client) do
+    with {:ok, items} <- Client.execute(object_type_def.client, query_builder) do
       {:ok,
        for %{"id" => id} <- items do
          %Dagger.FieldTypeDef{
-           selection:
-             query()
-             |> select("loadFieldTypeDefFromID")
-             |> arg("id", id),
+           query_builder:
+             QB.query()
+             |> QB.select("loadFieldTypeDefFromID")
+             |> QB.put_arg("id", id),
            client: object_type_def.client
          }
        end}
@@ -54,17 +55,17 @@ defmodule Dagger.ObjectTypeDef do
   @doc "Functions defined on this object, if any."
   @spec functions(t()) :: {:ok, [Dagger.Function.t()]} | {:error, term()}
   def functions(%__MODULE__{} = object_type_def) do
-    selection =
-      object_type_def.selection |> select("functions") |> select("id")
+    query_builder =
+      object_type_def.query_builder |> QB.select("functions") |> QB.select("id")
 
-    with {:ok, items} <- execute(selection, object_type_def.client) do
+    with {:ok, items} <- Client.execute(object_type_def.client, query_builder) do
       {:ok,
        for %{"id" => id} <- items do
          %Dagger.Function{
-           selection:
-             query()
-             |> select("loadFunctionFromID")
-             |> arg("id", id),
+           query_builder:
+             QB.query()
+             |> QB.select("loadFunctionFromID")
+             |> QB.put_arg("id", id),
            client: object_type_def.client
          }
        end}
@@ -74,27 +75,27 @@ defmodule Dagger.ObjectTypeDef do
   @doc "A unique identifier for this ObjectTypeDef."
   @spec id(t()) :: {:ok, Dagger.ObjectTypeDefID.t()} | {:error, term()}
   def id(%__MODULE__{} = object_type_def) do
-    selection =
-      object_type_def.selection |> select("id")
+    query_builder =
+      object_type_def.query_builder |> QB.select("id")
 
-    execute(selection, object_type_def.client)
+    Client.execute(object_type_def.client, query_builder)
   end
 
   @doc "The name of the object."
   @spec name(t()) :: {:ok, String.t()} | {:error, term()}
   def name(%__MODULE__{} = object_type_def) do
-    selection =
-      object_type_def.selection |> select("name")
+    query_builder =
+      object_type_def.query_builder |> QB.select("name")
 
-    execute(selection, object_type_def.client)
+    Client.execute(object_type_def.client, query_builder)
   end
 
   @doc "If this ObjectTypeDef is associated with a Module, the name of the module. Unset otherwise."
   @spec source_module_name(t()) :: {:ok, String.t()} | {:error, term()}
   def source_module_name(%__MODULE__{} = object_type_def) do
-    selection =
-      object_type_def.selection |> select("sourceModuleName")
+    query_builder =
+      object_type_def.query_builder |> QB.select("sourceModuleName")
 
-    execute(selection, object_type_def.client)
+    Client.execute(object_type_def.client, query_builder)
   end
 end

--- a/sdk/elixir/lib/dagger/gen/port.ex
+++ b/sdk/elixir/lib/dagger/gen/port.ex
@@ -2,56 +2,57 @@
 defmodule Dagger.Port do
   @moduledoc "A port exposed by a container."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "The port description."
   @spec description(t()) :: {:ok, String.t() | nil} | {:error, term()}
   def description(%__MODULE__{} = port) do
-    selection =
-      port.selection |> select("description")
+    query_builder =
+      port.query_builder |> QB.select("description")
 
-    execute(selection, port.client)
+    Client.execute(port.client, query_builder)
   end
 
   @doc "Skip the health check when run as a service."
   @spec experimental_skip_healthcheck(t()) :: {:ok, boolean()} | {:error, term()}
   def experimental_skip_healthcheck(%__MODULE__{} = port) do
-    selection =
-      port.selection |> select("experimentalSkipHealthcheck")
+    query_builder =
+      port.query_builder |> QB.select("experimentalSkipHealthcheck")
 
-    execute(selection, port.client)
+    Client.execute(port.client, query_builder)
   end
 
   @doc "A unique identifier for this Port."
   @spec id(t()) :: {:ok, Dagger.PortID.t()} | {:error, term()}
   def id(%__MODULE__{} = port) do
-    selection =
-      port.selection |> select("id")
+    query_builder =
+      port.query_builder |> QB.select("id")
 
-    execute(selection, port.client)
+    Client.execute(port.client, query_builder)
   end
 
   @doc "The port number."
   @spec port(t()) :: {:ok, integer()} | {:error, term()}
   def port(%__MODULE__{} = port) do
-    selection =
-      port.selection |> select("port")
+    query_builder =
+      port.query_builder |> QB.select("port")
 
-    execute(selection, port.client)
+    Client.execute(port.client, query_builder)
   end
 
   @doc "The transport layer protocol."
   @spec protocol(t()) :: Dagger.NetworkProtocol.t()
   def protocol(%__MODULE__{} = port) do
-    selection =
-      port.selection |> select("protocol")
+    query_builder =
+      port.query_builder |> QB.select("protocol")
 
-    execute(selection, port.client)
+    Client.execute(port.client, query_builder)
   end
 end

--- a/sdk/elixir/lib/dagger/gen/scalar_type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/scalar_type_def.ex
@@ -2,47 +2,48 @@
 defmodule Dagger.ScalarTypeDef do
   @moduledoc "A definition of a custom scalar defined in a Module."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "A doc string for the scalar, if any."
   @spec description(t()) :: {:ok, String.t()} | {:error, term()}
   def description(%__MODULE__{} = scalar_type_def) do
-    selection =
-      scalar_type_def.selection |> select("description")
+    query_builder =
+      scalar_type_def.query_builder |> QB.select("description")
 
-    execute(selection, scalar_type_def.client)
+    Client.execute(scalar_type_def.client, query_builder)
   end
 
   @doc "A unique identifier for this ScalarTypeDef."
   @spec id(t()) :: {:ok, Dagger.ScalarTypeDefID.t()} | {:error, term()}
   def id(%__MODULE__{} = scalar_type_def) do
-    selection =
-      scalar_type_def.selection |> select("id")
+    query_builder =
+      scalar_type_def.query_builder |> QB.select("id")
 
-    execute(selection, scalar_type_def.client)
+    Client.execute(scalar_type_def.client, query_builder)
   end
 
   @doc "The name of the scalar."
   @spec name(t()) :: {:ok, String.t()} | {:error, term()}
   def name(%__MODULE__{} = scalar_type_def) do
-    selection =
-      scalar_type_def.selection |> select("name")
+    query_builder =
+      scalar_type_def.query_builder |> QB.select("name")
 
-    execute(selection, scalar_type_def.client)
+    Client.execute(scalar_type_def.client, query_builder)
   end
 
   @doc "If this ScalarTypeDef is associated with a Module, the name of the module. Unset otherwise."
   @spec source_module_name(t()) :: {:ok, String.t()} | {:error, term()}
   def source_module_name(%__MODULE__{} = scalar_type_def) do
-    selection =
-      scalar_type_def.selection |> select("sourceModuleName")
+    query_builder =
+      scalar_type_def.query_builder |> QB.select("sourceModuleName")
 
-    execute(selection, scalar_type_def.client)
+    Client.execute(scalar_type_def.client, query_builder)
   end
 end

--- a/sdk/elixir/lib/dagger/gen/secret.ex
+++ b/sdk/elixir/lib/dagger/gen/secret.ex
@@ -2,38 +2,39 @@
 defmodule Dagger.Secret do
   @moduledoc "A reference to a secret value, which can be handled more safely than the value itself."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "A unique identifier for this Secret."
   @spec id(t()) :: {:ok, Dagger.SecretID.t()} | {:error, term()}
   def id(%__MODULE__{} = secret) do
-    selection =
-      secret.selection |> select("id")
+    query_builder =
+      secret.query_builder |> QB.select("id")
 
-    execute(selection, secret.client)
+    Client.execute(secret.client, query_builder)
   end
 
   @doc "The name of this secret."
   @spec name(t()) :: {:ok, String.t()} | {:error, term()}
   def name(%__MODULE__{} = secret) do
-    selection =
-      secret.selection |> select("name")
+    query_builder =
+      secret.query_builder |> QB.select("name")
 
-    execute(selection, secret.client)
+    Client.execute(secret.client, query_builder)
   end
 
   @doc "The value of this secret."
   @spec plaintext(t()) :: {:ok, String.t()} | {:error, term()}
   def plaintext(%__MODULE__{} = secret) do
-    selection =
-      secret.selection |> select("plaintext")
+    query_builder =
+      secret.query_builder |> QB.select("plaintext")
 
-    execute(selection, secret.client)
+    Client.execute(secret.client, query_builder)
   end
 end

--- a/sdk/elixir/lib/dagger/gen/socket.ex
+++ b/sdk/elixir/lib/dagger/gen/socket.ex
@@ -2,20 +2,21 @@
 defmodule Dagger.Socket do
   @moduledoc "A Unix or TCP/IP socket that can be mounted into a container."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "A unique identifier for this Socket."
   @spec id(t()) :: {:ok, Dagger.SocketID.t()} | {:error, term()}
   def id(%__MODULE__{} = socket) do
-    selection =
-      socket.selection |> select("id")
+    query_builder =
+      socket.query_builder |> QB.select("id")
 
-    execute(selection, socket.client)
+    Client.execute(socket.client, query_builder)
   end
 end

--- a/sdk/elixir/lib/dagger/gen/terminal.ex
+++ b/sdk/elixir/lib/dagger/gen/terminal.ex
@@ -2,21 +2,22 @@
 defmodule Dagger.Terminal do
   @moduledoc "An interactive terminal that clients can connect to."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
   @derive Dagger.Sync
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "A unique identifier for this Terminal."
   @spec id(t()) :: {:ok, Dagger.TerminalID.t()} | {:error, term()}
   def id(%__MODULE__{} = terminal) do
-    selection =
-      terminal.selection |> select("id")
+    query_builder =
+      terminal.query_builder |> QB.select("id")
 
-    execute(selection, terminal.client)
+    Client.execute(terminal.client, query_builder)
   end
 
   @doc """
@@ -26,16 +27,16 @@ defmodule Dagger.Terminal do
   """
   @spec sync(t()) :: {:ok, Dagger.Terminal.t()} | {:error, term()}
   def sync(%__MODULE__{} = terminal) do
-    selection =
-      terminal.selection |> select("sync")
+    query_builder =
+      terminal.query_builder |> QB.select("sync")
 
-    with {:ok, id} <- execute(selection, terminal.client) do
+    with {:ok, id} <- Client.execute(terminal.client, query_builder) do
       {:ok,
        %Dagger.Terminal{
-         selection:
-           query()
-           |> select("loadTerminalFromID")
-           |> arg("id", id),
+         query_builder:
+           QB.query()
+           |> QB.select("loadTerminalFromID")
+           |> QB.put_arg("id", id),
          client: terminal.client
        }}
     end

--- a/sdk/elixir/lib/dagger/gen/type_def.ex
+++ b/sdk/elixir/lib/dagger/gen/type_def.ex
@@ -2,22 +2,23 @@
 defmodule Dagger.TypeDef do
   @moduledoc "A definition of a parameter or return type in a Module."
 
-  use Dagger.Core.QueryBuilder
+  alias Dagger.Core.Client
+  alias Dagger.Core.QueryBuilder, as: QB
 
   @derive Dagger.ID
 
-  defstruct [:selection, :client]
+  defstruct [:query_builder, :client]
 
   @type t() :: %__MODULE__{}
 
   @doc "If kind is ENUM, the enum-specific type definition. If kind is not ENUM, this will be null."
   @spec as_enum(t()) :: Dagger.EnumTypeDef.t() | nil
   def as_enum(%__MODULE__{} = type_def) do
-    selection =
-      type_def.selection |> select("asEnum")
+    query_builder =
+      type_def.query_builder |> QB.select("asEnum")
 
     %Dagger.EnumTypeDef{
-      selection: selection,
+      query_builder: query_builder,
       client: type_def.client
     }
   end
@@ -25,11 +26,11 @@ defmodule Dagger.TypeDef do
   @doc "If kind is INPUT, the input-specific type definition. If kind is not INPUT, this will be null."
   @spec as_input(t()) :: Dagger.InputTypeDef.t() | nil
   def as_input(%__MODULE__{} = type_def) do
-    selection =
-      type_def.selection |> select("asInput")
+    query_builder =
+      type_def.query_builder |> QB.select("asInput")
 
     %Dagger.InputTypeDef{
-      selection: selection,
+      query_builder: query_builder,
       client: type_def.client
     }
   end
@@ -37,11 +38,11 @@ defmodule Dagger.TypeDef do
   @doc "If kind is INTERFACE, the interface-specific type definition. If kind is not INTERFACE, this will be null."
   @spec as_interface(t()) :: Dagger.InterfaceTypeDef.t() | nil
   def as_interface(%__MODULE__{} = type_def) do
-    selection =
-      type_def.selection |> select("asInterface")
+    query_builder =
+      type_def.query_builder |> QB.select("asInterface")
 
     %Dagger.InterfaceTypeDef{
-      selection: selection,
+      query_builder: query_builder,
       client: type_def.client
     }
   end
@@ -49,11 +50,11 @@ defmodule Dagger.TypeDef do
   @doc "If kind is LIST, the list-specific type definition. If kind is not LIST, this will be null."
   @spec as_list(t()) :: Dagger.ListTypeDef.t() | nil
   def as_list(%__MODULE__{} = type_def) do
-    selection =
-      type_def.selection |> select("asList")
+    query_builder =
+      type_def.query_builder |> QB.select("asList")
 
     %Dagger.ListTypeDef{
-      selection: selection,
+      query_builder: query_builder,
       client: type_def.client
     }
   end
@@ -61,11 +62,11 @@ defmodule Dagger.TypeDef do
   @doc "If kind is OBJECT, the object-specific type definition. If kind is not OBJECT, this will be null."
   @spec as_object(t()) :: Dagger.ObjectTypeDef.t() | nil
   def as_object(%__MODULE__{} = type_def) do
-    selection =
-      type_def.selection |> select("asObject")
+    query_builder =
+      type_def.query_builder |> QB.select("asObject")
 
     %Dagger.ObjectTypeDef{
-      selection: selection,
+      query_builder: query_builder,
       client: type_def.client
     }
   end
@@ -73,11 +74,11 @@ defmodule Dagger.TypeDef do
   @doc "If kind is SCALAR, the scalar-specific type definition. If kind is not SCALAR, this will be null."
   @spec as_scalar(t()) :: Dagger.ScalarTypeDef.t() | nil
   def as_scalar(%__MODULE__{} = type_def) do
-    selection =
-      type_def.selection |> select("asScalar")
+    query_builder =
+      type_def.query_builder |> QB.select("asScalar")
 
     %Dagger.ScalarTypeDef{
-      selection: selection,
+      query_builder: query_builder,
       client: type_def.client
     }
   end
@@ -85,40 +86,40 @@ defmodule Dagger.TypeDef do
   @doc "A unique identifier for this TypeDef."
   @spec id(t()) :: {:ok, Dagger.TypeDefID.t()} | {:error, term()}
   def id(%__MODULE__{} = type_def) do
-    selection =
-      type_def.selection |> select("id")
+    query_builder =
+      type_def.query_builder |> QB.select("id")
 
-    execute(selection, type_def.client)
+    Client.execute(type_def.client, query_builder)
   end
 
   @doc "The kind of type this is (e.g. primitive, list, object)."
   @spec kind(t()) :: Dagger.TypeDefKind.t()
   def kind(%__MODULE__{} = type_def) do
-    selection =
-      type_def.selection |> select("kind")
+    query_builder =
+      type_def.query_builder |> QB.select("kind")
 
-    execute(selection, type_def.client)
+    Client.execute(type_def.client, query_builder)
   end
 
   @doc "Whether this type can be set to null. Defaults to false."
   @spec optional(t()) :: {:ok, boolean()} | {:error, term()}
   def optional(%__MODULE__{} = type_def) do
-    selection =
-      type_def.selection |> select("optional")
+    query_builder =
+      type_def.query_builder |> QB.select("optional")
 
-    execute(selection, type_def.client)
+    Client.execute(type_def.client, query_builder)
   end
 
   @doc "Adds a function for constructing a new instance of an Object TypeDef, failing if the type is not an object."
   @spec with_constructor(t(), Dagger.Function.t()) :: Dagger.TypeDef.t()
   def with_constructor(%__MODULE__{} = type_def, function) do
-    selection =
-      type_def.selection
-      |> select("withConstructor")
-      |> put_arg("function", Dagger.ID.id!(function))
+    query_builder =
+      type_def.query_builder
+      |> QB.select("withConstructor")
+      |> QB.put_arg("function", Dagger.ID.id!(function))
 
     %Dagger.TypeDef{
-      selection: selection,
+      query_builder: query_builder,
       client: type_def.client
     }
   end
@@ -130,14 +131,14 @@ defmodule Dagger.TypeDef do
   """
   @spec with_enum(t(), String.t(), [{:description, String.t() | nil}]) :: Dagger.TypeDef.t()
   def with_enum(%__MODULE__{} = type_def, name, optional_args \\ []) do
-    selection =
-      type_def.selection
-      |> select("withEnum")
-      |> put_arg("name", name)
-      |> maybe_put_arg("description", optional_args[:description])
+    query_builder =
+      type_def.query_builder
+      |> QB.select("withEnum")
+      |> QB.put_arg("name", name)
+      |> QB.maybe_put_arg("description", optional_args[:description])
 
     %Dagger.TypeDef{
-      selection: selection,
+      query_builder: query_builder,
       client: type_def.client
     }
   end
@@ -145,14 +146,14 @@ defmodule Dagger.TypeDef do
   @doc "Adds a static value for an Enum TypeDef, failing if the type is not an enum."
   @spec with_enum_value(t(), String.t(), [{:description, String.t() | nil}]) :: Dagger.TypeDef.t()
   def with_enum_value(%__MODULE__{} = type_def, value, optional_args \\ []) do
-    selection =
-      type_def.selection
-      |> select("withEnumValue")
-      |> put_arg("value", value)
-      |> maybe_put_arg("description", optional_args[:description])
+    query_builder =
+      type_def.query_builder
+      |> QB.select("withEnumValue")
+      |> QB.put_arg("value", value)
+      |> QB.maybe_put_arg("description", optional_args[:description])
 
     %Dagger.TypeDef{
-      selection: selection,
+      query_builder: query_builder,
       client: type_def.client
     }
   end
@@ -161,15 +162,15 @@ defmodule Dagger.TypeDef do
   @spec with_field(t(), String.t(), Dagger.TypeDef.t(), [{:description, String.t() | nil}]) ::
           Dagger.TypeDef.t()
   def with_field(%__MODULE__{} = type_def, name, type_def, optional_args \\ []) do
-    selection =
-      type_def.selection
-      |> select("withField")
-      |> put_arg("name", name)
-      |> put_arg("typeDef", Dagger.ID.id!(type_def))
-      |> maybe_put_arg("description", optional_args[:description])
+    query_builder =
+      type_def.query_builder
+      |> QB.select("withField")
+      |> QB.put_arg("name", name)
+      |> QB.put_arg("typeDef", Dagger.ID.id!(type_def))
+      |> QB.maybe_put_arg("description", optional_args[:description])
 
     %Dagger.TypeDef{
-      selection: selection,
+      query_builder: query_builder,
       client: type_def.client
     }
   end
@@ -177,11 +178,13 @@ defmodule Dagger.TypeDef do
   @doc "Adds a function for an Object or Interface TypeDef, failing if the type is not one of those kinds."
   @spec with_function(t(), Dagger.Function.t()) :: Dagger.TypeDef.t()
   def with_function(%__MODULE__{} = type_def, function) do
-    selection =
-      type_def.selection |> select("withFunction") |> put_arg("function", Dagger.ID.id!(function))
+    query_builder =
+      type_def.query_builder
+      |> QB.select("withFunction")
+      |> QB.put_arg("function", Dagger.ID.id!(function))
 
     %Dagger.TypeDef{
-      selection: selection,
+      query_builder: query_builder,
       client: type_def.client
     }
   end
@@ -189,14 +192,14 @@ defmodule Dagger.TypeDef do
   @doc "Returns a TypeDef of kind Interface with the provided name."
   @spec with_interface(t(), String.t(), [{:description, String.t() | nil}]) :: Dagger.TypeDef.t()
   def with_interface(%__MODULE__{} = type_def, name, optional_args \\ []) do
-    selection =
-      type_def.selection
-      |> select("withInterface")
-      |> put_arg("name", name)
-      |> maybe_put_arg("description", optional_args[:description])
+    query_builder =
+      type_def.query_builder
+      |> QB.select("withInterface")
+      |> QB.put_arg("name", name)
+      |> QB.maybe_put_arg("description", optional_args[:description])
 
     %Dagger.TypeDef{
-      selection: selection,
+      query_builder: query_builder,
       client: type_def.client
     }
   end
@@ -204,11 +207,11 @@ defmodule Dagger.TypeDef do
   @doc "Sets the kind of the type."
   @spec with_kind(t(), Dagger.TypeDefKind.t()) :: Dagger.TypeDef.t()
   def with_kind(%__MODULE__{} = type_def, kind) do
-    selection =
-      type_def.selection |> select("withKind") |> put_arg("kind", kind)
+    query_builder =
+      type_def.query_builder |> QB.select("withKind") |> QB.put_arg("kind", kind)
 
     %Dagger.TypeDef{
-      selection: selection,
+      query_builder: query_builder,
       client: type_def.client
     }
   end
@@ -216,13 +219,13 @@ defmodule Dagger.TypeDef do
   @doc "Returns a TypeDef of kind List with the provided type for its elements."
   @spec with_list_of(t(), Dagger.TypeDef.t()) :: Dagger.TypeDef.t()
   def with_list_of(%__MODULE__{} = type_def, element_type) do
-    selection =
-      type_def.selection
-      |> select("withListOf")
-      |> put_arg("elementType", Dagger.ID.id!(element_type))
+    query_builder =
+      type_def.query_builder
+      |> QB.select("withListOf")
+      |> QB.put_arg("elementType", Dagger.ID.id!(element_type))
 
     %Dagger.TypeDef{
-      selection: selection,
+      query_builder: query_builder,
       client: type_def.client
     }
   end
@@ -234,14 +237,14 @@ defmodule Dagger.TypeDef do
   """
   @spec with_object(t(), String.t(), [{:description, String.t() | nil}]) :: Dagger.TypeDef.t()
   def with_object(%__MODULE__{} = type_def, name, optional_args \\ []) do
-    selection =
-      type_def.selection
-      |> select("withObject")
-      |> put_arg("name", name)
-      |> maybe_put_arg("description", optional_args[:description])
+    query_builder =
+      type_def.query_builder
+      |> QB.select("withObject")
+      |> QB.put_arg("name", name)
+      |> QB.maybe_put_arg("description", optional_args[:description])
 
     %Dagger.TypeDef{
-      selection: selection,
+      query_builder: query_builder,
       client: type_def.client
     }
   end
@@ -249,11 +252,11 @@ defmodule Dagger.TypeDef do
   @doc "Sets whether this type can be set to null."
   @spec with_optional(t(), boolean()) :: Dagger.TypeDef.t()
   def with_optional(%__MODULE__{} = type_def, optional) do
-    selection =
-      type_def.selection |> select("withOptional") |> put_arg("optional", optional)
+    query_builder =
+      type_def.query_builder |> QB.select("withOptional") |> QB.put_arg("optional", optional)
 
     %Dagger.TypeDef{
-      selection: selection,
+      query_builder: query_builder,
       client: type_def.client
     }
   end
@@ -261,14 +264,14 @@ defmodule Dagger.TypeDef do
   @doc "Returns a TypeDef of kind Scalar with the provided name."
   @spec with_scalar(t(), String.t(), [{:description, String.t() | nil}]) :: Dagger.TypeDef.t()
   def with_scalar(%__MODULE__{} = type_def, name, optional_args \\ []) do
-    selection =
-      type_def.selection
-      |> select("withScalar")
-      |> put_arg("name", name)
-      |> maybe_put_arg("description", optional_args[:description])
+    query_builder =
+      type_def.query_builder
+      |> QB.select("withScalar")
+      |> QB.put_arg("name", name)
+      |> QB.maybe_put_arg("description", optional_args[:description])
 
     %Dagger.TypeDef{
-      selection: selection,
+      query_builder: query_builder,
       client: type_def.client
     }
   end

--- a/sdk/elixir/test/dagger/client_test.exs
+++ b/sdk/elixir/test/dagger/client_test.exs
@@ -11,10 +11,11 @@ defmodule Dagger.ClientTest do
     GitRef,
     GitRepository,
     Host,
-    QueryError,
     Secret,
     Sync
   }
+
+  alias Dagger.Core.QueryError
 
   setup_all do
     client = Dagger.connect!(connect_timeout: :timer.seconds(60))


### PR DESCRIPTION
I found the GraphQL API can be accessible by default because the struct always public, anyone can accessing it. The SDK also provides 2 types of the API, `query` for executing raw query, and `execute` that execute the query builder and get value from the leaf node. So I add the document to it to the `Dagger` module.

And I also do some refactoring by:

1. Make `Dagger.Core.Client.execute` API be consistent with the `Dagger.Core.Client.query` function.
2. `Dagger.Core.QueryBuilder.Selection` is now rename to `Dagger.Core.QueryBuilder`.
3. The `use Dagger.Core.QueryBuilder` is now eliminated. Every object types are now use alias instead.

Closes #7152