### PR TITLE
test(sdk/elixir): port integration tests from core/integration to the sdk

### DIFF
--- a/sdk/elixir/dagger_integration_test/.formatter.exs
+++ b/sdk/elixir/dagger_integration_test/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/sdk/elixir/dagger_integration_test/.gitignore
+++ b/sdk/elixir/dagger_integration_test/.gitignore
@@ -1,0 +1,26 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+dagger_integration_test-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/

--- a/sdk/elixir/dagger_integration_test/README.md
+++ b/sdk/elixir/dagger_integration_test/README.md
@@ -1,0 +1,10 @@
+# DaggerIntegrationTest
+
+Integration tests suite for Elixir Dagger SDK by using `core/ingtegration/module_python_test.go`
+and `core/integration/module_typescript_test.go` as a reference.
+
+Test suite can be run by:
+
+```
+$ DAG_EX_SDK=<path to sdk> mix test
+```

--- a/sdk/elixir/dagger_integration_test/lib/dagger_test_helper.ex
+++ b/sdk/elixir/dagger_integration_test/lib/dagger_test_helper.ex
@@ -1,0 +1,105 @@
+defmodule Dagger.TestHelper do
+  @moduledoc """
+  Dagger integration tests suite for Dagger Elixir SDK. 
+  """
+
+  def sdk(), do: System.fetch_env!("DAG_EX_SDK")
+
+  def dagger_cli_path() do
+    System.find_executable("dagger") || raise "Cannot find `dagger` binary"
+  end
+
+  def dagger_cli_file(dag) do
+    dag
+    |> Dagger.Client.host()
+    |> Dagger.Host.file(dagger_cli_path())
+  end
+
+  def dagger_cli_base(dag) do
+    dag
+    |> Dagger.Client.container()
+    |> Dagger.Container.from("golang:1.22.5-alpine")
+    |> Dagger.Container.with_mounted_file("/bin/dagger", dagger_cli_file(dag))
+    |> Dagger.Container.with_workdir("/work")
+  end
+
+  def dagger_init(container), do: dagger_init(container, [])
+
+  def dagger_init(container, args) do
+    dagger_init(container, "", args)
+  end
+
+  def dagger_init(container, mod_path, args) do
+    dagger_init(container, mod_path, args, sdk())
+  end
+
+  def dagger_init(container, mod_path, args, sdk) do
+    exec_args = ["init", "--sdk=#{sdk}"]
+
+    exec_args =
+      if length(args) == 0 do
+        exec_args ++ ["--name=test"]
+      end
+
+    exec_args =
+      if mod_path != "" do
+        exec_args ++ ["--source=#{mod_path}", mod_path]
+      else
+        exec_args ++ ["--source=."]
+      end
+
+    dagger_exec(container, exec_args)
+  end
+
+  def dagger_exec(container, args) do
+    container
+    |> Dagger.Container.with_exec(["dagger", "--debug" | args],
+      experimental_privileged_nesting: true
+    )
+  end
+
+  def dagger_call(container, args), do: dagger_call(container, "", args)
+
+  def dagger_call(container, mod_path, args) do
+    exec_args = ["dagger", "--debug", "call"]
+
+    exec_args =
+      if mod_path != "" do
+        exec_args ++ ["-m", mod_path]
+      else
+        exec_args
+      end
+
+    container
+    |> Dagger.Container.with_exec(exec_args ++ args,
+      use_entrypoint: true,
+      experimental_privileged_nesting: true
+    )
+  end
+
+  def dagger_query(container, query), do: dagger_query(container, "", query)
+
+  def dagger_query(container, mod_path, query) do
+    exec_args = ["dagger", "--debug", "query"]
+
+    exec_args =
+      if mod_path != "" do
+        exec_args ++ ["-m", mod_path]
+      else
+        exec_args
+      end
+
+    container
+    |> Dagger.Container.with_exec(exec_args,
+      stdin: query,
+      experimental_privileged_nesting: true
+    )
+  end
+
+  def dagger_with_source(container, path, contents) do
+    container
+    |> Dagger.Container.with_new_file(path, contents)
+  end
+
+  defdelegate stdout(container), to: Dagger.Container
+end

--- a/sdk/elixir/dagger_integration_test/mix.exs
+++ b/sdk/elixir/dagger_integration_test/mix.exs
@@ -1,0 +1,29 @@
+defmodule DaggerIntegrationTest.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :dagger_integration_test,
+      version: "0.1.0",
+      elixir: "~> 1.17",
+      start_permanent: Mix.env() == :prod,
+      elixirc_paths: elixirc_paths(Mix.env()),
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  def elixirc_paths(:test), do: ["lib", "test/support"]
+  def elixirc_paths(:dev), do: ["lib"]
+
+  defp deps do
+    [
+      {:dagger, path: ".."}
+    ]
+  end
+end

--- a/sdk/elixir/dagger_integration_test/mix.lock
+++ b/sdk/elixir/dagger_integration_test/mix.lock
@@ -1,0 +1,4 @@
+%{
+  "jason": {:hex, :jason, "1.4.4", "b9226785a9aa77b6857ca22832cffa5d5011a667207eb2a0ad56adb5db443b8a", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "c5eb0cab91f094599f94d55bc63409236a8ec69a21a67814529e8d5f6cc90b3b"},
+  "nimble_options": {:hex, :nimble_options, "1.1.1", "e3a492d54d85fc3fd7c5baf411d9d2852922f66e69476317787a7b2bb000a61b", [:mix], [], "hexpm", "821b2470ca9442c4b6984882fe9bb0389371b8ddec4d45a9504f00a66f650b44"},
+}

--- a/sdk/elixir/dagger_integration_test/test/module_function_test.exs
+++ b/sdk/elixir/dagger_integration_test/test/module_function_test.exs
@@ -1,0 +1,134 @@
+defmodule Dagger.ModuleFunctionTest do
+  use Dagger.Case, async: true
+
+  import Dagger.TestHelper
+
+  test "signatures", %{dag: dag} do
+    mod =
+      dag
+      |> dagger_cli_base()
+      |> dagger_init()
+      |> dagger_with_source("test/lib/test.ex", """
+      defmodule Test do
+        use Dagger.Mod.Object, name: "Test"
+
+        function [], String.t()
+        def hello(_args), do: "hello"
+
+        function [msg: String.t()], String.t()
+        def echo(args), do: args.msg
+
+        function [msg: list(String.t())], String.t()
+        def echo_list(args), do: Enum.join(args.msg, "+")
+
+        function [msg: [String.t()]], String.t()
+        def echo_list2(args), do: Enum.join(args.msg, "+")
+      end
+      """)
+
+    assert query(mod, """
+           {
+             test {
+               hello
+             }
+           }
+           """) ==
+             """
+             {
+                 "test": {
+                     "hello": "hello"
+                 }
+             }
+             """
+
+    assert query(mod, """
+           {
+             test {
+               echo(msg: "world")
+             }
+           }
+           """) == """
+           {
+               "test": {
+                   "echo": "world"
+               }
+           }
+           """
+
+    assert query(mod, """
+           {
+             test {
+               echoList(msg: ["a", "b", "c"])
+             }
+           }
+           """) == """
+           {
+               "test": {
+                   "echoList": "a+b+c"
+               }
+           }
+           """
+
+    assert query(mod, """
+           {
+             test {
+               echoList2(msg: ["a", "b", "c"])
+             }
+           }
+           """) == """
+           {
+               "test": {
+                   "echoList2": "a+b+c"
+               }
+           }
+           """
+  end
+
+  test "signatures builtin types", %{dag: dag} do
+    mod =
+      dag
+      |> dagger_cli_base()
+      |> dagger_init()
+      |> dagger_with_source("test/lib/test.ex", """
+      defmodule Test do
+        use Dagger.Mod.Object, name: "Test"
+
+        function [dir: Dagger.Directory.t()], String.t()
+        def read(args) do
+          args.dir
+          |> Dagger.Directory.file( "foo")
+          |> Dagger.File.contents()
+        end
+      end
+      """)
+
+    assert {:ok, dir_id} =
+             dag
+             |> Dagger.Client.directory()
+             |> Dagger.Directory.with_new_file("foo", "bar")
+             |> Dagger.Directory.id()
+
+    assert query(mod, """
+           {
+             test {
+               read(dir: "#{dir_id}")
+             }
+           }
+           """) == """
+           {
+               "test": {
+                   "read": "bar"
+               }
+           }
+           """
+  end
+
+  defp query(mod, q) do
+    assert {:ok, output} =
+             mod
+             |> dagger_query(q)
+             |> stdout()
+
+    output
+  end
+end

--- a/sdk/elixir/dagger_integration_test/test/module_project_test.exs
+++ b/sdk/elixir/dagger_integration_test/test/module_project_test.exs
@@ -1,0 +1,39 @@
+defmodule Dagger.ModuleTest do
+  use Dagger.Case, async: true
+
+  import Dagger.TestHelper
+
+  test "init from scratch", %{dag: dag} do
+    assert {:ok, output} =
+             dag
+             |> dagger_cli_base()
+             |> dagger_init()
+             |> dagger_call(["container-echo", "--string-arg", "hello", "stdout"])
+             |> stdout()
+
+    assert output == "hello\n"
+  end
+
+  test "init with different root", %{dag: dag} do
+    assert {:ok, output} =
+             dag
+             |> dagger_cli_base()
+             |> dagger_init("child", [])
+             |> dagger_call("child", ["container-echo", "--string-arg", "hello", "stdout"])
+             |> stdout()
+
+    assert output == "hello\n"
+  end
+
+  test "run init and develop", %{dag: dag} do
+    assert {:ok, output} =
+             dag
+             |> dagger_cli_base()
+             |> dagger_exec(["init"])
+             |> dagger_exec(["develop", "--sdk=#{sdk()}", "--source=."])
+             |> dagger_call(["container-echo", "--string-arg", "hello", "stdout"])
+             |> stdout()
+
+    assert output == "hello\n"
+  end
+end

--- a/sdk/elixir/dagger_integration_test/test/support/dagger_case.ex
+++ b/sdk/elixir/dagger_integration_test/test/support/dagger_case.ex
@@ -1,0 +1,9 @@
+defmodule Dagger.Case do
+  use ExUnit.CaseTemplate
+
+  setup do
+    dag = Dagger.connect!()
+    on_exit(fn -> Dagger.close(dag) end)
+    %{dag: dag}
+  end
+end

--- a/sdk/elixir/dagger_integration_test/test/test_helper.exs
+++ b/sdk/elixir/dagger_integration_test/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
I try port the integration tests from `core/integration` to the Elixir SDK by using Python and TypeScript as a role model. 

The hard part is that I cannot use `--sdk=..` is not working since we merged the relocated runtime Pull Request. I'm not sure why it is not working though. So I decided to set the SDK path and commit though the environment variable and let the test suite run against that version.