### PR TITLE
fix(sdk/go): consider default values when grouping optional arguments in codegen

### DIFF
--- a/cmd/codegen/generator/go/templates/functions.go
+++ b/cmd/codegen/generator/go/templates/functions.go
@@ -214,7 +214,7 @@ func (funcs goTemplateFuncs) fieldFunction(f introspection.Field, topLevel bool,
 		args = append(args, "ctx context.Context")
 	}
 	for _, arg := range f.Args {
-		if arg.TypeRef.IsOptional() {
+		if arg.IsOptional() {
 			continue
 		}
 

--- a/cmd/codegen/generator/go/templates/functions.go
+++ b/cmd/codegen/generator/go/templates/functions.go
@@ -73,6 +73,8 @@ func (funcs goTemplateFuncs) FuncMap() template.FuncMap {
 		"SortEnumFields":          funcs.sortEnumFields,
 		"FieldOptionsStructName":  funcs.fieldOptionsStructName,
 		"FieldFunction":           funcs.fieldFunction,
+		"IsArgOptional":           funcs.isArgOptional,
+		"HasOptionals":            funcs.hasOptionals,
 		"IsEnum":                  funcs.isEnum,
 		"IsPointer":               funcs.isPointer,
 		"FormatArrayField":        funcs.formatArrayField,
@@ -187,6 +189,31 @@ func (funcs goTemplateFuncs) fieldOptionsStructName(f introspection.Field, scope
 	return scope + formatName(f.ParentObject.Name) + formatName(f.Name) + "Opts"
 }
 
+// hasOptionals returns true if a field has optional arguments
+//
+// Note: This is only necessary to simplify backwards compatibility of a breaking change.
+func (funcs goTemplateFuncs) hasOptionals(i introspection.InputValues) bool {
+	if funcs.CheckVersionCompatibility("v0.13.0") {
+		return i.HasOptionals()
+	}
+	for _, v := range i {
+		if funcs.isArgOptional(v) {
+			return true
+		}
+	}
+	return false
+}
+
+// isArgOptional returns true if a field argument is optional
+//
+// Note: This is only necessary to simplify backwards compatibility of a breaking change.
+func (funcs goTemplateFuncs) isArgOptional(arg introspection.InputValue) bool {
+	if funcs.CheckVersionCompatibility("v0.13.0") {
+		return arg.IsOptional()
+	}
+	return arg.TypeRef.IsOptional()
+}
+
 // fieldFunction converts a field into a function signature
 // Example: `contents: String!` -> `func (r *File) Contents(ctx context.Context) (string, error)`
 func (funcs goTemplateFuncs) fieldFunction(f introspection.Field, topLevel bool, supportsVoid bool, scopes ...string) (string, error) {
@@ -214,7 +241,7 @@ func (funcs goTemplateFuncs) fieldFunction(f introspection.Field, topLevel bool,
 		args = append(args, "ctx context.Context")
 	}
 	for _, arg := range f.Args {
-		if arg.IsOptional() {
+		if funcs.isArgOptional(arg) {
 			continue
 		}
 
@@ -236,7 +263,7 @@ func (funcs goTemplateFuncs) fieldFunction(f introspection.Field, topLevel bool,
 	}
 
 	// Options (e.g. DirectoryContentsOptions -> <Object><Field>Options)
-	if f.Args.HasOptionals() {
+	if funcs.hasOptionals(f.Args) {
 		args = append(
 			args,
 			fmt.Sprintf("opts ...%s", funcs.fieldOptionsStructName(f, scopes...)),

--- a/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
@@ -38,7 +38,7 @@ func (r *{{ .Name | FormatName }}) WithGraphQLQuery(q *querybuilder.Selection) *
 // {{ $field | FieldOptionsStructName }} contains options for {{ $.Name | FormatName }}.{{ $field.Name | FormatName }}
 type {{ $field | FieldOptionsStructName }} struct {
 	{{- range $arg := $field.Args }}
-	{{- if $arg.TypeRef.IsOptional }}
+	{{- if $arg.IsOptional }}
 	{{ $arg.Description | Comment }}
 	{{- if and (eq $arg.Name "id") (eq $.Name "Query") }}
 	{{ $arg.Name | FormatName }} {{ $arg.TypeRef | FormatOutputType }}
@@ -60,7 +60,7 @@ type {{ $field | FieldOptionsStructName }} struct {
 {{- $supportsVoid := CheckVersionCompatibility "v0.12.0" }}
 {{ FieldFunction $field false $supportsVoid }} {
 	{{- range $arg := $field.Args }}
-	    {{- if and (IsPointer $arg) (not $arg.TypeRef.IsOptional) }}
+	    {{- if and (IsPointer $arg) (not $arg.IsOptional) }}
         assertNotNil("{{ $arg.Name}}", {{ $arg.Name }})
         {{- end }}
     {{- end }}
@@ -79,7 +79,7 @@ type {{ $field | FieldOptionsStructName }} struct {
 	{{- if $field.Args.HasOptionals }}
 	for i := len(opts) - 1; i >= 0; i-- {
 	{{- range $arg := $field.Args }}
-	{{- if $arg.TypeRef.IsOptional }}
+	{{- if $arg.IsOptional }}
 	// `{{ $arg.Name }}` optional argument
 	if !querybuilder.IsZeroValue(opts[i].{{ $arg.Name | FormatName }}) {
 		q = q.Arg("{{ $arg.Name }}", opts[i].{{ $arg.Name | FormatName }})
@@ -91,7 +91,7 @@ type {{ $field | FieldOptionsStructName }} struct {
 
 
 	{{- range $arg := $field.Args }}
-	{{- if not $arg.TypeRef.IsOptional }}
+	{{- if not $arg.IsOptional }}
 	q = q.Arg("{{ $arg.Name }}", {{ $arg.Name }})
 	{{- end }}
 	{{- end }}

--- a/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
+++ b/cmd/codegen/generator/go/templates/src/_types/object.go.tmpl
@@ -34,11 +34,11 @@ func (r *{{ .Name | FormatName }}) WithGraphQLQuery(q *querybuilder.Selection) *
 }
 
 {{ range $field := .Fields }}
-{{- if $field.Args.HasOptionals }}
+{{- if HasOptionals $field.Args }}
 // {{ $field | FieldOptionsStructName }} contains options for {{ $.Name | FormatName }}.{{ $field.Name | FormatName }}
 type {{ $field | FieldOptionsStructName }} struct {
 	{{- range $arg := $field.Args }}
-	{{- if $arg.IsOptional }}
+	{{- if IsArgOptional $arg }}
 	{{ $arg.Description | Comment }}
 	{{- if and (eq $arg.Name "id") (eq $.Name "Query") }}
 	{{ $arg.Name | FormatName }} {{ $arg.TypeRef | FormatOutputType }}
@@ -60,7 +60,7 @@ type {{ $field | FieldOptionsStructName }} struct {
 {{- $supportsVoid := CheckVersionCompatibility "v0.12.0" }}
 {{ FieldFunction $field false $supportsVoid }} {
 	{{- range $arg := $field.Args }}
-	    {{- if and (IsPointer $arg) (not $arg.IsOptional) }}
+	    {{- if and (IsPointer $arg) (not (IsArgOptional $arg)) }}
         assertNotNil("{{ $arg.Name}}", {{ $arg.Name }})
         {{- end }}
     {{- end }}
@@ -76,10 +76,10 @@ type {{ $field | FieldOptionsStructName }} struct {
     {{- end }}
 	q := r.query.Select("{{ $field.Name }}")
 
-	{{- if $field.Args.HasOptionals }}
+	{{- if HasOptionals $field.Args }}
 	for i := len(opts) - 1; i >= 0; i-- {
 	{{- range $arg := $field.Args }}
-	{{- if $arg.IsOptional }}
+	{{- if IsArgOptional $arg }}
 	// `{{ $arg.Name }}` optional argument
 	if !querybuilder.IsZeroValue(opts[i].{{ $arg.Name | FormatName }}) {
 		q = q.Arg("{{ $arg.Name }}", opts[i].{{ $arg.Name | FormatName }})
@@ -91,7 +91,7 @@ type {{ $field | FieldOptionsStructName }} struct {
 
 
 	{{- range $arg := $field.Args }}
-	{{- if not $arg.IsOptional }}
+	{{- if not (IsArgOptional $arg) }}
 	q = q.Arg("{{ $arg.Name }}", {{ $arg.Name }})
 	{{- end }}
 	{{- end }}

--- a/cmd/codegen/generator/typescript/templates/functions.go
+++ b/cmd/codegen/generator/typescript/templates/functions.go
@@ -214,7 +214,7 @@ func formatEnum(s string) string {
 // They are, if all of there InputValues are optional.
 func isArgOptional(values introspection.InputValues) bool {
 	for _, v := range values {
-		if (v.TypeRef != nil && !v.TypeRef.IsOptional()) && v.DefaultValue == nil {
+		if !v.IsOptional() {
 			return false
 		}
 	}
@@ -223,7 +223,7 @@ func isArgOptional(values introspection.InputValues) bool {
 
 func splitRequiredOptionalArgs(values introspection.InputValues) (required introspection.InputValues, optionals introspection.InputValues) {
 	for i, v := range values {
-		if (v.TypeRef != nil && !v.TypeRef.IsOptional()) && v.DefaultValue == nil {
+		if !v.IsOptional() {
 			continue
 		}
 

--- a/cmd/codegen/introspection/introspection.go
+++ b/cmd/codegen/introspection/introspection.go
@@ -245,7 +245,7 @@ type InputValues []InputValue
 
 func (i InputValues) HasOptionals() bool {
 	for _, v := range i {
-		if v.TypeRef.IsOptional() {
+		if v.IsOptional() {
 			return true
 		}
 	}
@@ -257,6 +257,10 @@ type InputValue struct {
 	Description  string   `json:"description"`
 	DefaultValue *string  `json:"defaultValue"`
 	TypeRef      *TypeRef `json:"type"`
+}
+
+func (v InputValue) IsOptional() bool {
+	return v.DefaultValue != nil || (v.TypeRef != nil && v.TypeRef.IsOptional())
 }
 
 type EnumValue struct {

--- a/dagql/introspection/query.go
+++ b/dagql/introspection/query.go
@@ -160,7 +160,7 @@ type ResponseInputValues []ResponseInputValue
 
 func (i ResponseInputValues) HasOptionals() bool {
 	for _, v := range i {
-		if v.TypeRef.IsOptional() {
+		if v.IsOptional() {
 			return true
 		}
 	}
@@ -174,6 +174,10 @@ type ResponseInputValue struct {
 	TypeRef           *ResponseTypeRef `json:"type"`
 	IsDeprecated      bool             `json:"isDeprecated"`
 	DeprecationReason string           `json:"deprecationReason"`
+}
+
+func (v ResponseInputValue) IsOptional() bool {
+	return v.DefaultValue != nil || (v.TypeRef != nil && v.TypeRef.IsOptional())
 }
 
 type ResponseEnumValue struct {

--- a/sdk/go/.changes/unreleased/Breaking-20240805-181259.yaml
+++ b/sdk/go/.changes/unreleased/Breaking-20240805-181259.yaml
@@ -1,0 +1,9 @@
+kind: Breaking
+body: |-
+    Fix optional function arguments being generated as required in codegen
+
+    If there's a Module dependency with a non-null function argument, it will change from required to optional, in the generated client bindings.
+time: 2024-08-05T18:12:59.542179Z
+custom:
+    Author: helderco
+    PR: "8106"


### PR DESCRIPTION
- Part of https://github.com/dagger/dagger/issues/6749
- Fixes https://github.com/dagger/dagger/issues/6964

> [!warning]
> This is a breaking change for **Go SDK** users when depending on a module that has a non-null function argument with a default value. With this change, the argument will change from required to optional in the client bindings (`dagger.gen.go`).

## Example

If a Go Module depends on another Module that has a non-null Function argument with a default value, the generated client bindings would consider that argument required because it didn’t consider having a default, just that it was nullable or not:

```go
// ❌ Before v0.13.0 it's a required argument
dag.Greeter("Dagger").Greeting(ctx)

// ✅ After v0.13.0 it's an optional argument
dag.Greeter().Greeting(ctx)                             // output: Hello, World!
dag.Greeter(GreeterOpts{Name: "Dagger"}).Greeting(ctx)  // output: Hello, Dagger!
```

Example Python code for the *Greeter* dependency:
```python
import dagger

@dagger.object_type
class Greeter:
    name: str = "World"

    @dagger.function
    def greeting(self) -> str:
        return f"Hello, {self.name}!"                
```

And corresponding generated API schema (for the constructor):
```graphql
type Query {
    greeter(name: String! = "World")
}
```


