### PR TITLE
core: fix Directory.glob doesn't seem to be working as expected

### DIFF
--- a/.changes/unreleased/Fixed-20240805-164529.yaml
+++ b/.changes/unreleased/Fixed-20240805-164529.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: 'engine: fix `Directory.Glob` doesn''t seem to be working as expected'
+time: 2024-08-05T16:45:29.636669914-07:00
+custom:
+    Author: khrisrichardson
+    PR: "8108"

--- a/core/directory.go
+++ b/core/directory.go
@@ -311,7 +311,7 @@ func (dir *Directory) Glob(ctx context.Context, src string, pattern string) ([]s
 
 	entries, err := ref.ReadDir(ctx, bkgw.ReadDirRequest{
 		Path:           path.Join(dir.Dir, src),
-		IncludePattern: pattern,
+		IncludePattern: filepath.Join("**", filepath.Base(pattern)),
 	})
 	if err != nil {
 		return nil, err

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -1093,6 +1093,15 @@ func (DirectorySuite) TestGlob(ctx context.Context, t *testctx.T) {
 					"subdir2/TESTING.md", "subdir/subsubdir/JS.md",
 				})
 			})
+
+			t.Run("recursive with complex pattern that include only markdown", func(ctx context.Context, t *testctx.T) {
+				entries, err := tc.src.Glob(ctx, "subdir/**/*.md")
+
+				require.NoError(t, err)
+				require.ElementsMatch(t, entries, []string{
+					"subdir/README.md", "subdir/subsubdir/JS.md",
+				})
+			})
 		})
 	}
 


### PR DESCRIPTION
`IncludePattern` was added to the `ReadDirRequest` options as per [this discussion](https://github.com/dagger/dagger/pull/5824#pullrequestreview-1644134442) during the initial implementation of `Directory.Glob`, and set to the same value as the `Directory.Glob` `pattern` argument.

While this works as intended for globstar patterns like `**/*.md`, it has the unintended side-effect of excluding sub-directories from being recursed for less well behaved patterns. Take a simple example: if the pattern is `core/**/*.go`, as soon as the recursive call to `Glob` encounters the `core/` sub-directory, reads of that sub-directory with the same pattern will fail unless it also has a sub-directory named `core`.

As confirmed by running an [engine service](https://github.com/dagger/dagger/tree/main/dev#run-the-engine-service) with this commit, updating `IncludePattern` to only consider the rightmost part of the pattern fixes the behavior identified in https://github.com/dagger/dagger/issues/7169.

It seems the `patternmatcher.MatchesOrParentMatches` is more geared to exclusion, so to overcome the cases where the parent matches the pattern (as the name of the function alludes) but the base does not, filtering `ReadDir` with the `IncludePattern` manipulated as described ensures the base is also considered when evaluating the glob.

It's probably worthwhile considering whether negated patterns are intended to work, because if so none of the integration tests cover that scenario and this workaround will probably not have the intended effect.