### PR TITLE
python: Deprecate `Arg` in modules

### DIFF
--- a/sdk/python/.changes/unreleased/Deprecated-20240806-105313.yaml
+++ b/sdk/python/.changes/unreleased/Deprecated-20240806-105313.yaml
@@ -1,0 +1,9 @@
+kind: Deprecated
+body: |-
+    `Arg` has been renamed to `Name`
+
+    For code that currently uses `Arg` to avoid a naming conflict with a reserved keyword, it can be removed since the SDK will strip the last `_` in an argument's name when interfacing with the API. For other needs, just rename `Arg` to `Name`.
+time: 2024-08-06T10:53:13.480927Z
+custom:
+    Author: helderco
+    PR: "8109"

--- a/sdk/python/docs/module.rst
+++ b/sdk/python/docs/module.rst
@@ -11,7 +11,11 @@ Experimental Dagger modules support.
 
 .. autodecorator:: function
 
+.. autodecorator:: enum_type
+
 .. autoclass:: Arg
+
+.. autoclass:: Name
 
 .. autoclass:: Doc
 

--- a/sdk/python/src/dagger/__init__.py
+++ b/sdk/python/src/dagger/__init__.py
@@ -1,38 +1,39 @@
 # Make sure to place exceptions first as they're dependencies of other imports.
 import contextlib
-from ._exceptions import VersionMismatch as VersionMismatch
-from ._exceptions import DaggerError as DaggerError
-from ._exceptions import ProvisionError as ProvisionError
-from ._exceptions import DownloadError as DownloadError
-from ._exceptions import SessionError as SessionError
-from ._exceptions import ClientError as ClientError
-from ._exceptions import ClientConnectionError as ClientConnectionError
-from ._exceptions import TransportError as TransportError
-from ._exceptions import ExecuteTimeoutError as ExecuteTimeoutError
-from ._exceptions import InvalidQueryError as InvalidQueryError
-from ._exceptions import QueryError as QueryError
-from ._exceptions import ExecError as ExecError
+from dagger._exceptions import VersionMismatch as VersionMismatch
+from dagger._exceptions import DaggerError as DaggerError
+from dagger._exceptions import ProvisionError as ProvisionError
+from dagger._exceptions import DownloadError as DownloadError
+from dagger._exceptions import SessionError as SessionError
+from dagger._exceptions import ClientError as ClientError
+from dagger._exceptions import ClientConnectionError as ClientConnectionError
+from dagger._exceptions import TransportError as TransportError
+from dagger._exceptions import ExecuteTimeoutError as ExecuteTimeoutError
+from dagger._exceptions import InvalidQueryError as InvalidQueryError
+from dagger._exceptions import QueryError as QueryError
+from dagger._exceptions import ExecError as ExecError
 
 # Make sure Config is first as it's a dependency in Connection.
-from ._config import Config as Config
-from ._config import Retry as Retry
-from ._config import Timeout as Timeout
+from dagger._config import Config as Config
+from dagger._config import Retry as Retry
+from dagger._config import Timeout as Timeout
 
 # We need the star import since this is a generated module.
-from .client.gen import *
-from ._connection import Connection as Connection
-from ._connection import connection as connection
-from ._connection import connect as connect
-from ._connection import close as close
+from dagger.client.gen import *
+from dagger._connection import Connection as Connection
+from dagger._connection import connection as connection
+from dagger._connection import connect as connect
+from dagger._connection import close as close
 
 # Modules.
-from .mod import Arg as Arg
-from .mod import Doc as Doc
-from .mod import Enum as Enum
-from .mod import enum_type as enum_type
-from .mod import field as field
-from .mod import function as function
-from .mod import object_type as object_type
+from dagger.mod import Arg as Arg
+from dagger.mod import Doc as Doc
+from dagger.mod import Enum as Enum
+from dagger.mod import Name as Name
+from dagger.mod import enum_type as enum_type
+from dagger.mod import field as field
+from dagger.mod import function as function
+from dagger.mod import object_type as object_type
 
 # Re-export imports so they look like they live directly in this package.
 for _value in list(locals().values()):

--- a/sdk/python/src/dagger/mod/__init__.py
+++ b/sdk/python/src/dagger/mod/__init__.py
@@ -1,9 +1,10 @@
 from typing_extensions import Doc
 
+from dagger.mod._arguments import Arg
+from dagger.mod._arguments import Name
+from dagger.mod._module import Module
+from dagger.mod._types import Enum
 
-from ._arguments import Arg as Arg
-from ._module import Module as Module
-from ._types import Enum as Enum
 
 _default_mod = Module()
 
@@ -22,6 +23,7 @@ __all__ = [
     "Arg",
     "Doc",  # Only re-exported because it's in `typing_extensions`.
     "Enum",
+    "Name",
     "enum_type",
     "field",
     "function",

--- a/sdk/python/src/dagger/mod/_arguments.py
+++ b/sdk/python/src/dagger/mod/_arguments.py
@@ -1,32 +1,13 @@
 import dataclasses
 import inspect
 
-from beartype.door import TypeHint
+from typing_extensions import deprecated
 
-from ._types import APIName
-
-
-@dataclasses.dataclass(slots=True, kw_only=True)
-class Parameter:
-    """Parameter from function signature in :py:class:`FunctionResolver`."""
-
-    name: APIName
-    signature: inspect.Parameter
-    resolved_type: type
-    doc: str | None
-
-    has_default: bool = dataclasses.field(init=False)
-    is_optional: bool = dataclasses.field(init=False)
-
-    def __post_init__(self):
-        from ._utils import is_nullable
-
-        self.has_default = self.signature.default is not inspect.Signature.empty
-        self.is_optional = self.has_default or is_nullable(TypeHint(self.resolved_type))
+from dagger.mod._types import APIName
 
 
 @dataclasses.dataclass(slots=True, frozen=True)
-class Arg:
+class Name:
     """An alternative name when exposing a function argument to the API.
 
     Useful to avoid conflicts with reserved words.
@@ -34,7 +15,41 @@ class Arg:
     Example usage:
 
     >>> @function
-    ... def pull(from_: Annotated[str, Arg("from")]): ...
+    ... def pull(from_: Annotated[str, Name("from")]): ...
     """
 
     name: APIName
+
+    def __str__(self) -> str:
+        return self.name
+
+
+@deprecated("Arg is deprecated, use Name instead.")
+def Arg(name: str) -> Name:  # noqa: N802
+    return Name(name)
+
+
+Arg.__doc__ = Name.__doc__
+
+
+@dataclasses.dataclass(slots=True, frozen=True, kw_only=True)
+class Parameter:
+    """Parameter from function signature in :py:class:`FunctionResolver`."""
+
+    name: APIName
+
+    # Inspect
+    signature: inspect.Parameter
+    resolved_type: type
+    is_nullable: bool
+
+    # Metadata
+    doc: str | None
+
+    @property
+    def has_default(self) -> bool:
+        return self.signature.default is not inspect.Parameter.empty
+
+    @property
+    def is_optional(self) -> bool:
+        return self.has_default or self.is_nullable

--- a/sdk/python/src/dagger/mod/_arguments.py
+++ b/sdk/python/src/dagger/mod/_arguments.py
@@ -25,11 +25,12 @@ class Name:
 
 
 @deprecated("Arg is deprecated, use Name instead.")
-def Arg(name: str) -> Name:  # noqa: N802
-    return Name(name)
+class Arg(Name):
+    """An alternative name when exposing a function argument to the API.
 
-
-Arg.__doc__ = Name.__doc__
+    .. deprecated::
+        Use :py:class:`Name` instead.
+    """
 
 
 @dataclasses.dataclass(slots=True, frozen=True, kw_only=True)

--- a/sdk/python/src/dagger/mod/_converter.py
+++ b/sdk/python/src/dagger/mod/_converter.py
@@ -9,8 +9,8 @@ from collections.abc import Collection
 from beartype.door import TypeHint
 from cattrs.preconf.json import make_converter as make_json_converter
 
-from ._types import ObjectDefinition
-from ._utils import (
+from dagger.mod._types import ObjectDefinition
+from dagger.mod._utils import (
     get_doc,
     is_annotated,
     is_nullable,

--- a/sdk/python/src/dagger/mod/_module.py
+++ b/sdk/python/src/dagger/mod/_module.py
@@ -7,7 +7,6 @@ import inspect
 import json
 import logging
 import textwrap
-import types
 import typing
 import warnings
 from collections import Counter, defaultdict
@@ -107,7 +106,7 @@ class Module:
 
             if resolver.origin is None:
                 if isinstance(resolver, FunctionResolver):
-                    func: types.FunctionType = resolver.wrapped_func
+                    func: Func = resolver.wrapped_func
                     qualname = func.__qualname__.split("<locals>.", 1)[-1]
                     if "." in qualname:
                         msg = (
@@ -507,7 +506,7 @@ class Module:
         for field in dataclasses.fields(cls):
             field_def: FieldDefinition | None
             if field_def := field.metadata.get(FIELD_DEF_KEY, None):
-                r = FieldResolver(
+                r: Resolver = FieldResolver(
                     name=field_def.name or normalize_name(field.name),
                     original_name=field.name,
                     doc=get_doc(field.type),

--- a/sdk/python/tests/modules/test_utils.py
+++ b/sdk/python/tests/modules/test_utils.py
@@ -4,10 +4,10 @@ import pytest
 from beartype.door import TypeHint
 from typing_extensions import Doc, Self
 
-from dagger import Arg, field
+from dagger import Name, field
 from dagger.mod import Module
 from dagger.mod._utils import (
-    get_arg_name,
+    get_alt_name,
     get_doc,
     is_nullable,
     non_null,
@@ -97,7 +97,7 @@ async def async_func_without_docstring(): ...
         str,
         str | None,
         Annotated[str, "Not supported"],
-        Annotated[str, Arg("foo")],
+        Annotated[str, Name("foo")],
     ],
 )
 def test_no_annotated_doc(annotation):
@@ -127,12 +127,12 @@ def test_normalize_name(name: str, expected: str):
     assert normalize_name(name) == expected
 
 
-def test_get_arg_name():
-    assert get_arg_name(Annotated[str, Arg("foo")]) == "foo"
+def test_get_alt_name():
+    assert get_alt_name(Annotated[str, Name("foo")]) == "foo"
 
 
-def test_get_last_arg_name():
-    assert get_arg_name(Annotated[str, Arg("foo"), Arg("bar")]) == "bar"
+def test_get_last_alt_name():
+    assert get_alt_name(Annotated[str, Name("foo"), Name("bar")]) == "bar"
 
 
 @pytest.mark.parametrize(
@@ -142,5 +142,5 @@ def test_get_last_arg_name():
         Annotated[str, Doc("foo")],
     ],
 )
-def test_no_get_arg_name(annotation):
-    assert get_arg_name(annotation) is None
+def test_no_get_alt_name(annotation):
+    assert get_alt_name(annotation) is None


### PR DESCRIPTION
## Refactor

This was split from https://github.com/dagger/dagger/pull/7744 in order to make the changes clearer in that PR, which includes a deprecation, but also a few more type checking fixes.

### `Arg` deprecation

`Arg` as been deprecated in favor of `Name`, in preparation for supporting more metadata to arguments. The initial idea was to add them to `Arg`, but [there's a reason](https://peps.python.org/pep-0727/) for wanting a separate `Doc` and it's strange to have one specific metadata split from the others in `Arg`.

Note however that the use of `Arg` has been removed from the documentation for a while now, and after https://github.com/dagger/dagger/pull/8014, the need for `Name` has been greatly reduced. Users that have `Arg` because of reserved keywords should remove the explicit name override.