### PR TITLE
fix: ensure glob works with subdir recursive entries

### DIFF
--- a/.changes/unreleased/Fixed-20240807-103813.yaml
+++ b/.changes/unreleased/Fixed-20240807-103813.yaml
@@ -1,0 +1,9 @@
+kind: Fixed
+body: |
+  Fix Directory.glob to correctly handle globs with subdir prefixes
+
+  Previously, attempting to glob with a prefix subdir in a pattern like "<subdir>/*" would not match any files. This should now be fixed, and files in `<subdir>` will now be correctly matched.
+time: 2024-08-07T10:38:13.123294283+01:00
+custom:
+  Author: jedevc
+  PR: "8110"

--- a/core/integration/directory_test.go
+++ b/core/integration/directory_test.go
@@ -1093,18 +1093,33 @@ func (DirectorySuite) TestGlob(ctx context.Context, t *testctx.T) {
 					"subdir2/TESTING.md", "subdir/subsubdir/JS.md",
 				})
 			})
+
+			t.Run("recursive with complex pattern that include only markdown", func(ctx context.Context, t *testctx.T) {
+				entries, err := tc.src.Glob(ctx, "subdir/**/*.md")
+
+				require.NoError(t, err)
+				require.ElementsMatch(t, entries, []string{
+					"subdir/README.md", "subdir/subsubdir/JS.md",
+				})
+			})
 		})
 	}
 
 	t.Run("recursive with directories in the pattern", func(ctx context.Context, t *testctx.T) {
 		srcDir := c.Directory().
-			WithNewFile("foo/bar.md/x.md", "").
-			WithNewFile("foo/bar.md/y.go", "")
+			WithNewFile("foo/bar.md/w.md", "").
+			WithNewFile("foo/bar.md/x.go", "").
+			WithNewFile("foo/baz.go/y.md", "").
+			WithNewFile("foo/baz.go/z.go", "")
 
 		entries, err := srcDir.Glob(ctx, "**/*.md")
 
 		require.NoError(t, err)
-		require.ElementsMatch(t, entries, []string{"foo/bar.md", "foo/bar.md/x.md"})
+		require.ElementsMatch(t, entries, []string{
+			"foo/bar.md",
+			"foo/bar.md/w.md",
+			"foo/baz.go/y.md",
+		})
 	})
 
 	t.Run("sub directory in path", func(ctx context.Context, t *testctx.T) {

--- a/core/schema/directory.go
+++ b/core/schema/directory.go
@@ -189,7 +189,7 @@ type globArgs struct {
 }
 
 func (s *directorySchema) glob(ctx context.Context, parent *core.Directory, args globArgs) ([]string, error) {
-	return parent.Glob(ctx, ".", args.Pattern)
+	return parent.Glob(ctx, args.Pattern)
 }
 
 type dirFileArgs struct {


### PR DESCRIPTION
> [!NOTE]
> 
> This is an alternative to https://github.com/dagger/dagger/pull/8108 - thanks @khrisrichardson for doing most of the hard investigation, but I think it was worth doing the restructuring of glob entirely, it needed doing here anyways. I've added you as a co-author to this PR :tada:

Fixes https://github.com/dagger/dagger/issues/7169

Globs weren't correctly working - the root issue here was that `IncludePatterns` is interpreted as relative to the `Path` passed into `ReadDir`.

This is kinda not great, since we keep the same `IncludePatterns`, but continually adjust `Path` to go deeper.

To fix the issue, we entirely restructure globbing - now the entire filesystem is only mounted once (hopefully a performance improvement in its own right), and we apply a custom walking function, instead of needing to call `ReadDir` multiple times.

One thing that also seems to have been broken was using `MatchesOrParentMatches` - this potentially included things in the glob that we didn't want. To fix this, we instead switch to *only* matching on the full pathname - which is the behavior we wanted in the first place.