### PR TITLE
fix using enum in constructor

### DIFF
--- a/.changes/unreleased/Fixed-20240813-152129.yaml
+++ b/.changes/unreleased/Fixed-20240813-152129.yaml
@@ -1,0 +1,9 @@
+kind: Fixed
+body: |-
+  Fixed referring to module's own objects/interfaces/enums in constructor signature
+
+  Previously, modules would fail to launch if they declared a constructor that contained a reference to a type from it's own module in it's args.
+time: 2024-08-13T15:21:29.694564346+01:00
+custom:
+  Author: jedevc
+  PR: "8115"

--- a/core/integration/module_test.go
+++ b/core/integration/module_test.go
@@ -3128,7 +3128,16 @@ const (
 	Inactive Status = "INACTIVE"
 )
 
-type Test struct{}
+func New(
+	// +default="INACTIVE"
+	status Status,
+) *Test {
+	return &Test{Status: status}
+}
+
+type Test struct {
+	Status Status
+}
 
 func (m *Test) FromStatus(status Status) string {
 	return string(status)
@@ -3153,6 +3162,8 @@ class Status(dagger.Enum):
 
 @dagger.object_type
 class Test:
+    status: Status = dagger.field(default=Status.INACTIVE)
+
     @dagger.function
     def from_status(self, status: Status) -> str:
         return str(status)
@@ -3191,6 +3202,14 @@ class Status {
 @object()
 export class Test {
   @func()
+  status: Status
+
+  // FIXME: this should be Status.Inactive instead of "INACTIVE"
+  constructor(status: Status = "INACTIVE") {
+    this.status = status
+  }
+
+  @func()
   fromStatus(status: Status): string {
     return status as string
   }
@@ -3212,6 +3231,10 @@ export class Test {
 				out, err := modGen.With(daggerQuery(`{test{fromStatus(status: "ACTIVE")}}`)).Stdout(ctx)
 				require.NoError(t, err)
 				require.Equal(t, "ACTIVE", gjson.Get(out, "test.fromStatus").String())
+
+				out, err = modGen.With(daggerQuery(`{test{status}}`)).Stdout(ctx)
+				require.NoError(t, err)
+				require.Equal(t, "INACTIVE", gjson.Get(out, "test.status").String())
 
 				_, err = modGen.With(daggerQuery(`{test{fromStatus(status: "INVALID")}}`)).Stdout(ctx)
 				require.ErrorContains(t, err, "invalid enum value")

--- a/core/module.go
+++ b/core/module.go
@@ -606,6 +606,19 @@ func (mod *Module) namespaceTypeDef(ctx context.Context, typeDef *TypeDef) error
 				}
 			}
 		}
+
+		if obj.Constructor.Valid {
+			if err := mod.namespaceTypeDef(ctx, obj.Constructor.Value.ReturnType); err != nil {
+				return err
+			}
+
+			for _, arg := range obj.Constructor.Value.Args {
+				if err := mod.namespaceTypeDef(ctx, arg.TypeDef); err != nil {
+					return err
+				}
+			}
+		}
+
 	case TypeDefKindInterface:
 		iface := typeDef.AsInterface.Value
 


### PR DESCRIPTION
Reported by @sagikazarmark in [Discord](https://discord.com/channels/707636530424053791/1123687185837740053/1270438030284689539).

Enum doesn't work in constructors:
```
Error: make request: input: failed to get schema: failed to get schema for module "test": failed to install constructor: failed to create function: failed to find mod type for function "" arg "status" type
```

See failing tests. Affects all SDKs, the problem is in core (modfunc).